### PR TITLE
Extract xattrs from tar payload (#1195462)

### DIFF
--- a/pyanaconda/packaging/livepayload.py
+++ b/pyanaconda/packaging/livepayload.py
@@ -468,7 +468,7 @@ class LiveImageKSPayload(LiveImagePayload):
 
         cmd = "tar"
         # preserve: ACL's, xattrs, and SELinux context
-        args = ["--selinux", "--acls", "--xattrs",
+        args = ["--selinux", "--acls", "--xattrs", "--xattrs-include", "*",
                 "--exclude", "/dev/", "--exclude", "/proc/",
                 "--exclude", "/sys/", "--exclude", "/run/", "--exclude", "/boot/*rescue*",
                 "--exclude", "/etc/machine-id", "-xaf", self.image_path, "-C", iutil.getSysroot()]


### PR DESCRIPTION
sagarun@gmail.com tracked down the fact that tar actually can extract
the xattrs used by SELinux from a tarfile.