### PR TITLE
Remove W0123 which is not defined in older pylint and causes traceback

### DIFF
--- a/tests/pylint/runpylint.sh
+++ b/tests/pylint/runpylint.sh
@@ -60,7 +60,6 @@ export NON_STRICT_OPTIONS="--disable=W0212"
 export DISABLED_ERR_OPTIONS="--disable=E1103"
 
 # W0110 - map/filter on lambda could be replaced by comprehension
-# W0123 - Use of eval
 # W0141 - Used builtin function %r
 # W0142 - Used * or ** magic
 # W0511 - Used when a warning note as FIXME or XXX is detected.
@@ -70,7 +69,7 @@ export DISABLED_ERR_OPTIONS="--disable=E1103"
 # I0011 - Locally disabling %s (i.e., pylint: disable)
 # I0012 - Locally enabling %s (i.e., pylint: enable)
 # I0013 - Ignoring entire file (i.e., pylint: skip-file)
-export DISABLED_WARN_OPTIONS="--disable=W0110,W0123,W0141,W0142,W0511,W0603,W0613,W0614,I0011,I0012,I0013"
+export DISABLED_WARN_OPTIONS="--disable=W0110,W0141,W0142,W0511,W0603,W0613,W0614,I0011,I0012,I0013"
 
 usage () {
   echo "usage: `basename $0` [--strict] [--help] [files...]"


### PR DESCRIPTION
Running the test suite on RHEL7 yields:
```
Traceback (most recent call last):
  File "/usr/bin/pylint", line 9, in <module>
    load_entry_point('pylint==1.0.0', 'console_scripts', 'pylint')()
  File "/usr/lib/python2.7/site-packages/pylint/__init__.py", line 21, in run_pylint
    Run(sys.argv[1:])
  File "/usr/lib/python2.7/site-packages/pylint/lint.py", line 990, in __init__
    args = linter.load_command_line_configuration(args)
  File "/usr/lib/python2.7/site-packages/logilab/common/configuration.py", line 685, in load_command_line_configuration
    (options, args) = self.cmdline_parser.parse_args(args=args)
  File "/usr/lib64/python2.7/optparse.py", line 1399, in parse_args
    stop = self._process_args(largs, rargs, values)
  File "/usr/lib64/python2.7/optparse.py", line 1439, in _process_args
    self._process_long_opt(rargs, values)
  File "/usr/lib64/python2.7/optparse.py", line 1514, in _process_long_opt
    option.process(opt, value, values, self)
  File "/usr/lib/python2.7/site-packages/logilab/common/optik_ext.py", line 237, in process
    self.action, self.dest, opt, value, values, parser)
  File "/usr/lib64/python2.7/optparse.py", line 808, in take_action
    self.callback(self, opt, value, parser, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/logilab/common/configuration.py", line 540, in cb_set_provider_option
    self.global_set_option(opt, value)
  File "/usr/lib/python2.7/site-packages/logilab/common/configuration.py", line 544, in global_set_option
    self._all_options[opt].set_option(opt, value)
  File "/usr/lib/python2.7/site-packages/pylint/lint.py", line 383, in set_option
    meth(_id)
  File "/usr/lib/python2.7/site-packages/pylint/utils.py", line 251, in disable
    msg = self.check_message_id(msgid)
  File "/usr/lib/python2.7/site-packages/pylint/utils.py", line 315, in check_message_id
    raise UnknownMessage('No such message id %s' % msgid)
pylint.utils.UnknownMessage: No such message id W0123
```

With this small fix it displays correct results from pylint:

```
FAIL: pylint/runpylint
======================

pylint reports the following issues:
************* Module ../pyanaconda/ui/gui/spokes/lib/resize.py
E0611: 25,0: : No name 'Gdk' in module 'gi.repository'
E0611: 25,0: : No name 'Gtk' in module 'gi.repository'
************* Module ../pyanaconda/anaconda.py
F0401:161,8: Anaconda.dumpState: Unable to import 'meh'
F0401:162,8: Anaconda.dumpState: Unable to import 'meh.dump'
```
