### PR TITLE
Backport pyanaconda_tests/keyboard_test.py updates from master

### DIFF
--- a/tests/pyanaconda_tests/keyboard_test.py
+++ b/tests/pyanaconda_tests/keyboard_test.py
@@ -55,6 +55,24 @@ class ParsingAndJoiningTests(unittest.TestCase):
         with self.assertRaises(keyboard.InvalidLayoutVariantSpec):
             layout, variant = keyboard.parse_layout_variant("cz (&*&*)")
 
+    def layout_variant_joining_test(self):
+        """Should correctly join keyboard layout and variant to a string spec."""
+
+        # both layout and variant specified
+        self.assertEqual(keyboard._join_layout_variant("cz", "qwerty"),
+                         "cz (qwerty)")
+
+        # no variant specified
+        self.assertEqual(keyboard._join_layout_variant("cz"), "cz")
+
+    def layout_variant_parse_join_test(self):
+        """Parsing and joining valid layout and variant spec should have no effect."""
+
+        specs = ("cz", "cz (qwerty)")
+        for spec in specs:
+            (layout, variant) = keyboard.parse_layout_variant(spec)
+            self.assertEqual(spec, keyboard._join_layout_variant(layout, variant))
+
     def layout_variant_normalize_test(self):
         """Normalizing layout and variant strings should work as expected."""
 


### PR DESCRIPTION
Seems OK (nosetests passes) but there's one thing on master that worries me:

commit 45a05d0a16014e9a46a625bc2f418888d3bdeb7d
Author: Vratislav Podzimek
Date:   Thu Jul 17 16:12:14 2014 +0200

    Prevent crashes due to accessing X server from multiple threads



I don't know how that applies to rhel7-branch. Please comment. 