### PR TITLE
Use links in clickable info bar messages

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -106,10 +106,10 @@ NOTEBOOK_INCOMPLETE_PAGE = 4
 NEW_CONTAINER_TEXT = N_("Create a new %(container_type)s ...")
 CONTAINER_TOOLTIP = N_("Create or select %(container_type)s")
 
-DEVICE_CONFIGURATION_ERROR_MSG = N_("Device reconfiguration failed. Click for "
-                                    "details.")
+DEVICE_CONFIGURATION_ERROR_MSG = N_("Device reconfiguration failed. <a href=\"\">Click for "
+                                    "details.</a>")
 UNRECOVERABLE_ERROR_MSG = N_("Storage configuration reset due to unrecoverable "
-                             "error. Click for details.")
+                             "error. <a href=\"\">Click for details.</a>")
 
 def dev_type_from_const(dev_type_const):
     """ Return integer corresponding to name for device type defined as
@@ -773,7 +773,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                 use_dev.size = use_old_size
                 self._error = e
                 self.set_warning(_("Device resize request failed. "
-                                   "Click for details."))
+                                   "<a href=\"\">Click for details.</a>"))
             else:
                 _changed_size = True
 
@@ -846,7 +846,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
             device.format = old_format
             self._error = e
             self.set_warning(_("Device reformat request failed. "
-                               "Click for details."))
+                               "<a href=\"\">Click for details.</a>"))
         else:
             # first, remove this selector from any old install page(s)
             new_selector = None
@@ -1582,9 +1582,9 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         StorageChecker.checkStorage(self)
 
         if self.errors:
-            self.set_warning(_("Error checking storage configuration.  Click for details or press Done again to continue."))
+            self.set_warning(_("Error checking storage configuration.  <a href=\"\">Click for details</a> or press Done again to continue."))
         elif self.warnings:
-            self.set_warning(_("Warning checking storage configuration.  Click for details or press Done again to continue."))
+            self.set_warning(_("Warning checking storage configuration.  <a href=\"\">Click for details</a> or press Done again to continue."))
 
         # on_info_bar_clicked requires self._error to be set, so set it to the
         # list of all errors and warnings that storage checking found.
@@ -1701,8 +1701,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
             if e:
                 self._error = e
-                self.set_error(_("Failed to add new device. Click for "
-                                 "details."))
+                self.set_error(_("Failed to add new device. <a href=\"\">Click for "
+                                 "details.</a>"))
         except OverflowError as e:
             log.error("invalid size set for partition")
             self._error = e
@@ -1813,8 +1813,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         except StorageError as e:
             log.error("failed to schedule device removal: %s", e)
             self._error = e
-            self.set_warning(_("Device removal request failed. Click "
-                               "for details."))
+            self.set_warning(_("Device removal request failed. <a href=\"\">Click "
+                               "for details.</a>"))
         else:
             if is_logical_partition:
                 self._storage_playground.removeEmptyExtendedPartitions()
@@ -2324,8 +2324,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
             log.error("doAutoPartition failed: %s", e)
             self._reset_storage()
             self._error = e
-            self.set_error(_("Automatic partitioning failed. Click "
-                             "for details."))
+            self.set_error(_("Automatic partitioning failed. <a href=\"\">Click "
+                             "for details.</a>"))
         else:
             self._devices = self._storage_playground.devices
             # mark all new containers for automatic size management
@@ -2349,8 +2349,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
             log.error("doAutoPartition failed: %s", messages)
             self._reset_storage()
             self._error = messages
-            self.set_error(_("Automatic partitioning failed. Click "
-                             "for details."))
+            self.set_error(_("Automatic partitioning failed. <a href=\"\">Click "
+                             "for details.</a>"))
 
     def on_create_clicked(self, button, autopartTypeCombo):
         # Then do autopartitioning.  We do not do any clearpart first.  This is
@@ -2657,7 +2657,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
             device.format.passphrase = None
             self._passphraseEntry.set_text("")
             self.set_warning(_("Failed to unlock encrypted block device. "
-                               "Click for details"))
+                               "<a href=\"\">Click for details.</a>"))
             return
 
         log.info("unlocked %s, now going to populate devicetree...", device.name)

--- a/pyanaconda/ui/gui/spokes/software.py
+++ b/pyanaconda/ui/gui/spokes/software.py
@@ -361,7 +361,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
         self._selectFlag = True
 
         if self._errorMsgs:
-            self.set_warning(_("Error checking software dependencies.  Click for details."))
+            self.set_warning(_("Error checking software dependencies.  <a href=\"\">Click for details.</a>"))
         else:
             self.clear_info()
 

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -515,9 +515,9 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         self._update_summary()
 
         if self.errors:
-            self.set_warning(_("Error checking storage configuration.  Click for details."))
+            self.set_warning(_("Error checking storage configuration.  <a href=\"\">Click for details.</a>"))
         elif self.warnings:
-            self.set_warning(_("Warning checking storage configuration.  Click for details."))
+            self.set_warning(_("Warning checking storage configuration.  <a href=\"\">Click for details.</a>"))
 
     def initialize(self):
         NormalSpoke.initialize(self)

--- a/tests/gettext/click.py
+++ b/tests/gettext/click.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python2
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author: David Shea <dshea@redhat.com>
+
+import os, re, sys
+
+# Something like looks more or less like an <a> tag
+link_re = re.compile(r'<\s*a(\s|>)')
+
+# Something that looks like a clickable message
+click_re = re.compile(r'\b[Cc]lick for\b')
+
+# Strings to ignore
+ignore_msgs = ['Click for help.']
+
+# Use polib to parse anaconda.pot
+try:
+    import polib
+except ImportError:
+    print("You need to install the python-polib package to read anaconda.pot")
+    # This return code tells the automake test driver that the test setup failed
+    sys.exit(99)
+
+if "top_srcdir" not in os.environ:
+    sys.stderr.write("$top_srcdir must be defined in the test environment\n")
+    sys.exit(99)
+
+if "top_builddir" not in os.environ:
+    sys.stderr.write("$top_srcdir must be defined in the test environment\n")
+    sys.exit(99)
+
+# Update the .pot file with the latest strings
+if os.system('make -C %s anaconda.pot-update' % (os.environ['top_builddir'] + "/po")) != 0:
+    sys.stderr.write("Unable to update anaconda.pot")
+    sys.exit(1)
+
+# Parse anaconda.pot and rearrange the POFile object into a dict of {msgid: POEntry}
+pofile = polib.pofile(os.environ['top_srcdir'] + "/po/anaconda.pot")
+msgs = {e.msgid: e for e in pofile}
+
+success = True
+for msg in msgs.keys():
+    if msg in ignore_msgs:
+        continue
+
+    # Remove underscores to avoid trouble with underline-based accelerators
+    trimmed_msg = msg.replace('_', '')
+
+    # Look for claims of clickability
+    if click_re.search(trimmed_msg):
+        # Look for something to click
+        if not link_re.search(trimmed_msg):
+            print("String at %s appears to be clickable but has nothing to click." %
+                    " ".join("%s:%s" % (o[0], o[1]) for o in msgs[msg].occurrences))
+            success = False
+
+sys.exit(0 if success else 1)

--- a/widgets/configure.ac
+++ b/widgets/configure.ac
@@ -20,7 +20,7 @@
 #
 
 AC_PREREQ([2.63])
-AC_INIT([AnacondaWidgets], [3.1], [clumens@redhat.com])
+AC_INIT([AnacondaWidgets], [3.2], [clumens@redhat.com])
 AM_INIT_AUTOMAKE([foreign])
 AM_SILENT_RULES([yes])
 

--- a/widgets/glade/AnacondaWidgets.xml
+++ b/widgets/glade/AnacondaWidgets.xml
@@ -1,6 +1,6 @@
 <glade-catalog name="AnacondaWidgets"
-               version="3.1"
-               targetable="3.0,2.0,1.0"
+               version="3.2"
+               targetable="3.1,3.0,2.0,1.0"
                library="AnacondaWidgets"
                domain="glade-3"
                depends="gtk+">

--- a/widgets/src/BaseStandalone.c
+++ b/widgets/src/BaseStandalone.c
@@ -84,7 +84,8 @@ static void anaconda_base_standalone_class_init(AnacondaBaseStandaloneClass *kla
      * AnacondaBaseStandalone::quit-clicked:
      * @window: the window that received the signal
      *
-     * Emitted when the quit button has been activated (pressed and released).
+     * Emitted when the #AnacondaBaseStandalone:quit-button has been activated
+     * (pressed and released).
      *
      * Since: 3.0
      */
@@ -100,7 +101,8 @@ static void anaconda_base_standalone_class_init(AnacondaBaseStandaloneClass *kla
      * AnacondaBaseStandalone::continue-clicked:
      * @window: the window that received the signal
      *
-     * Emitted when the continue button has been activated (pressed and released).
+     * Emitted when the #AnacondaBaseStandalone:continue-button has been
+     * activated (pressed and released).
      *
      * Since: 3.0
      */

--- a/widgets/src/BaseWindow.c
+++ b/widgets/src/BaseWindow.c
@@ -147,7 +147,7 @@ static void anaconda_base_window_class_init(AnacondaBaseWindowClass *klass) {
     /**
      * AnacondaBaseWindow:distribution:
      *
-     * The :distribution string is displayed in the upper right corner of all
+     * The #AnacondaBaseWindow:distribution string is displayed in the upper right corner of all
      * windows throughout installation.
      *
      * Since: 1.0
@@ -610,7 +610,7 @@ static void anaconda_base_window_set_info_bar(AnacondaBaseWindow *win, GtkMessag
  *
  * Causes an info bar to be shown at the bottom of the screen with the provided
  * message.  Only one message may be shown at a time.  In order to show
- * a second message, anaconda_base_window_clear_info must first be called.
+ * a second message, anaconda_base_window_clear_info() must first be called.
  *
  * Since: 1.0
  */
@@ -625,7 +625,7 @@ void anaconda_base_window_set_error(AnacondaBaseWindow *win, const char *msg) {
  *
  * Causes an info bar to be shown at the bottom of the screen with the provided
  * message.  Only one message may be shown at a time.  In order to show
- * a second message, anaconda_base_window_clear_info must first be called.
+ * a second message, anaconda_base_window_clear_info() must first be called.
  *
  * Since: 1.0
  */
@@ -640,7 +640,7 @@ void anaconda_base_window_set_info(AnacondaBaseWindow *win, const char *msg) {
  *
  * Causes an info bar to be shown at the bottom of the screen with the provided
  * message.  Only one message may be shown at a time.  In order to show
- * a second message, anaconda_base_window_clear_info must first be called.
+ * a second message, anaconda_base_window_clear_info() must first be called.
  *
  * Since: 1.0
  */
@@ -663,7 +663,7 @@ static void anaconda_base_window_help_button_clicked(GtkButton *button,
  * @win: a #AnacondaBaseWindow
  *
  * Clear and hide any info bar being shown at the bottom of the screen.  This
- * must be called before a second call to anaconda_base_window_set_info takes
+ * must be called before a second call to anaconda_base_window_set_info() takes
  * effect.
  *
  * Since: 1.0

--- a/widgets/src/DiskOverview.c
+++ b/widgets/src/DiskOverview.c
@@ -98,7 +98,7 @@ static void anaconda_disk_overview_class_init(AnacondaDiskOverviewClass *klass) 
     /**
      * AnacondaDiskOverview:kind:
      *
-     * The :kind string specifies what type of disk device this is, used to
+     * The #AnacondaDiskOverview:kind string specifies what type of disk device this is, used to
      * figure out what icon to be displayed.  This should be something like
      * "drive-harddisk", "drive-removable-media", etc.
      *
@@ -115,7 +115,7 @@ static void anaconda_disk_overview_class_init(AnacondaDiskOverviewClass *klass) 
     /**
      * AnacondaDiskOverview:description:
      *
-     * The :description string is a very basic description of the device
+     * The #AnacondaDiskOverview:description string is a very basic description of the device
      * and is displayed in bold letters under the icon.
      *
      * Since: 1.0
@@ -131,7 +131,7 @@ static void anaconda_disk_overview_class_init(AnacondaDiskOverviewClass *klass) 
     /**
      * AnacondaDiskOverview:capacity:
      *
-     * The :capacity string is the total size of the disk, plus units.
+     * The #AnacondaDiskOverview:capacity string is the total size of the disk, plus units.
      *
      * Since: 1.0
      */
@@ -146,7 +146,7 @@ static void anaconda_disk_overview_class_init(AnacondaDiskOverviewClass *klass) 
     /**
      * AnacondaDiskOverview:free:
      *
-     * The :free string is the amount of free, unpartitioned space on the disk,
+     * The #AnacondaDiskOverview:free string is the amount of free, unpartitioned space on the disk,
      * plus units.
      *
      * Since: 1.0
@@ -162,7 +162,7 @@ static void anaconda_disk_overview_class_init(AnacondaDiskOverviewClass *klass) 
     /**
      * AnacondaDiskOverview:name:
      *
-     * The :name string provides this device's node name (like 'sda').  Note
+     * The #AnacondaDiskOverview:name string provides this device's node name (like 'sda').  Note
      * that these names aren't guaranteed to be consistent across reboots but
      * their use is so ingrained that we need to continue displaying them.
      *
@@ -179,7 +179,7 @@ static void anaconda_disk_overview_class_init(AnacondaDiskOverviewClass *klass) 
     /**
      * AnacondaDiskOverview:popup-info:
      *
-     * The :popup-info string is text that should appear in a tooltip when the
+     * The #AnacondaDiskOverview:popup-info string is text that should appear in a tooltip when the
      * #AnacondaDiskOverview is hovered over.  For normal disk devices, this
      * could be available space information.  For more complex devics, this
      * could be WWID, LUN, and so forth.

--- a/widgets/src/LayoutIndicator.c
+++ b/widgets/src/LayoutIndicator.c
@@ -97,7 +97,7 @@ static void anaconda_layout_indicator_class_init(AnacondaLayoutIndicatorClass *k
     /**
      * AnacondaLayoutIndicator:layout:
      *
-     * The :layout is the currently activated X layout.
+     * The #AnacondaLayoutIndicator:layout is the currently activated X layout.
      *
      * Since: 1.0
      */

--- a/widgets/src/Makefile.am
+++ b/widgets/src/Makefile.am
@@ -63,7 +63,7 @@ lib_LTLIBRARIES = libAnacondaWidgets.la
 libAnacondaWidgets_la_CFLAGS = $(GTK_CFLAGS) $(GLADEUI_CFLAGS) $(LIBXKLAVIER_CFLAGS) -Wall -g\
 			       -DWIDGETS_DATADIR=$(WIDGETSDATA)
 libAnacondaWidgets_la_LIBADD = $(GTK_LIBS) $(GLADEUI_LIBS) $(LIBXKLAVIER_LIBS)
-libAnacondaWidgets_la_LDFLAGS = $(LTLIBINTL) -version-info 3:0:1
+libAnacondaWidgets_la_LDFLAGS = $(LTLIBINTL) -version-info 3:1:1
 libAnacondaWidgets_la_SOURCES = $(SOURCES) $(HDRS) \
 	  glade-adaptor.c
 

--- a/widgets/src/MountpointSelector.c
+++ b/widgets/src/MountpointSelector.c
@@ -40,8 +40,9 @@
  * configuration.
  *
  * As a #AnacondaMountpointSelector is a subclass of a #GtkEventBox, any signals
- * may be caught.  However ::button-press-event is the most important one and is
- * how we determine what should be displayed on the rest of the screen.
+ * may be caught.  However #GtkWidget::button-press-event is the most important
+ * one and is how we determine what should be displayed on the rest of the
+ * screen.
  */
 
 enum {
@@ -84,7 +85,7 @@ static void anaconda_mountpoint_selector_class_init(AnacondaMountpointSelectorCl
     /**
      * AnacondaMountpointSelector:name:
      *
-     * The :name string is the secondary text displayed for this widget.  It is
+     * The #AnacondaMountpointSelector:name string is the secondary text displayed for this widget.  It is
      * commonly going to be the name of the device node containing this
      * mountpoint.
      *
@@ -101,7 +102,7 @@ static void anaconda_mountpoint_selector_class_init(AnacondaMountpointSelectorCl
     /**
      * AnacondaMountpointSelector:size:
      *
-     * The :size string is the size of the mountpoint, including whatever units
+     * The #AnacondaMountpointSelector:size string is the size of the mountpoint, including whatever units
      * it is measured in.
      *
      * Since: 1.0
@@ -117,7 +118,7 @@ static void anaconda_mountpoint_selector_class_init(AnacondaMountpointSelectorCl
     /**
      * AnacondaMountpointSelector:mountpoint:
      *
-     * The :mountpoint string is the primary text displayed for this widget.
+     * The #AnacondaMountpointSelector:mountpoint string is the primary text displayed for this widget.
      * It shows where on the filesystem this device is mounted.
      *
      * Since: 1.0

--- a/widgets/src/SpokeSelector.c
+++ b/widgets/src/SpokeSelector.c
@@ -89,7 +89,7 @@ static void anaconda_spoke_selector_class_init(AnacondaSpokeSelectorClass *klass
     /**
      * AnacondaSpokeSelector:icon:
      *
-     * The :icon string is the standard icon name for an icon to display
+     * The #AnacondaSpokeSelector:icon string is the standard icon name for an icon to display
      * beside this spoke's :title.  It is strongly suggested that one of the
      * "-symbolic" icons be used, as that is consistent with the style we
      * are going for.
@@ -107,10 +107,11 @@ static void anaconda_spoke_selector_class_init(AnacondaSpokeSelectorClass *klass
     /**
      * AnacondaSpokeSelector:status:
      *
-     * The :status string is text displayed underneath the spoke's :title and
-     * also beside the :icon.  This text very briefly describes what has been
-     * selected on the spoke associated with this selector.  For instance, it
-     * might be set up to "English" for a language-related spoke.  Special
+     * The #AnacondaSpokeSelector:status string is text displayed underneath
+     * the spoke's #AnacondaSpokeSelector:title and also beside the
+     * #AnacondaSpokeSelector:icon.  This text very briefly describes what has
+     * been selected on the spoke associated with this selector.  For instance,
+     * it might be set up to "English" for a language-related spoke.  Special
      * formatting will be applied to error status text for incomplete spokes.
      *
      * Since: 1.0


### PR DESCRIPTION
Clicking the info bar is sometimes used to display a dialog with more details, but there is no way to click the info bar using only the keyboard. Adding a link provides something that can be navigated to with the keyboard.

Adding a button to the info bar was another idea, and one that's part of the GtkInfoBar API, but Ryan Lerch pointed out having a button down there is not such a great idea: it would look like that button is the button to leave the spoke, and a link more clearly communicates that it will provide more information but not ultimately go anywhere. Plus we're already fighting Adwaita to get colored info bars and the button colors are a totally different disaster that I don't really want to deal with.