### PR TITLE
Connect viewport adjustments to child focus adjustments (#1192155)

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -213,6 +213,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         self._partitionsViewport = self.builder.get_object("partitionsViewport")
         self._partitionsNotebook = self.builder.get_object("partitionsNotebook")
 
+        # Connect partitionsNotebook focus events to scrolling in the parent viewport
+        partitionsNotebookViewport = self.builder.get_object("partitionsNotebookViewport")
+        self._partitionsNotebook.set_focus_vadjustment(partitionsNotebookViewport.get_vadjustment())
+
         self._whenCreateLabel = self.builder.get_object("whenCreateLabel")
 
         self._availableSpaceLabel = self.builder.get_object("availableSpaceLabel")
@@ -280,6 +284,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
         self._accordion = Accordion()
         self._partitionsViewport.add(self._accordion)
+
+        # Connect viewport scrolling with accordion focus events
+        self._accordion.set_focus_hadjustment(self._partitionsViewport.get_hadjustment())
+        self._accordion.set_focus_vadjustment(self._partitionsViewport.get_vadjustment())
 
         threadMgr.add(AnacondaThread(name=THREAD_CUSTOM_STORAGE_INIT, target=self._initialize))
 

--- a/pyanaconda/ui/gui/spokes/filter.glade
+++ b/pyanaconda/ui/gui/spokes/filter.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.1 -->
+<!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <requires lib="AnacondaWidgets" version="1.0"/>
@@ -112,7 +112,7 @@
                         <property name="can_focus">True</property>
                         <property name="shadow_type">in</property>
                         <child>
-                          <object class="GtkViewport" id="viewport1">
+                          <object class="GtkViewport" id="searchScrolledViewport">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="shadow_type">none</property>
@@ -534,7 +534,7 @@
                         <property name="can_focus">True</property>
                         <property name="shadow_type">in</property>
                         <child>
-                          <object class="GtkViewport" id="viewport2">
+                          <object class="GtkViewport" id="multipathViewport">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="shadow_type">none</property>
@@ -866,7 +866,7 @@
                         <property name="can_focus">True</property>
                         <property name="shadow_type">in</property>
                         <child>
-                          <object class="GtkViewport" id="viewport4">
+                          <object class="GtkViewport" id="otherViewport">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="shadow_type">none</property>
@@ -1189,7 +1189,7 @@
                         <property name="can_focus">True</property>
                         <property name="shadow_type">in</property>
                         <child>
-                          <object class="GtkViewport" id="viewport3">
+                          <object class="GtkViewport" id="zViewport">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="shadow_type">none</property>
@@ -1533,9 +1533,9 @@
                                     <property name="left_attach">1</property>
                                     <property name="top_attach">0</property>
                                     <property name="width">1</property>
-                                     <property name="height">1</property>
-                                   </packing>
-                                 </child>
+                                    <property name="height">1</property>
+                                  </packing>
+                                </child>
                               </object>
                             </child>
                           </object>

--- a/pyanaconda/ui/gui/spokes/filter.py
+++ b/pyanaconda/ui/gui/spokes/filter.py
@@ -497,6 +497,27 @@ class FilterSpoke(NormalSpoke):
         self._store = self.builder.get_object("diskStore")
         self._addDisksButton = self.builder.get_object("addDisksButton")
 
+        # Connect focus events in scrolled viewport children to scrolling on the viewport
+        searchScrolledViewport = self.builder.get_object("searchScrolledViewport")
+        searchGrid = self.builder.get_object("searchGrid")
+        searchGrid.set_focus_hadjustment(searchScrolledViewport.get_hadjustment())
+        searchGrid.set_focus_vadjustment(searchScrolledViewport.get_vadjustment())
+
+        multipathViewport = self.builder.get_object("multipathViewport")
+        multipathGrid = self.builder.get_object("multipathGrid")
+        multipathGrid.set_focus_hadjustment(multipathViewport.get_hadjustment())
+        multipathGrid.set_focus_vadjustment(multipathViewport.get_vadjustment())
+
+        otherViewport = self.builder.get_object("otherViewport")
+        otherGrid = self.builder.get_object("otherGrid")
+        otherGrid.set_focus_hadjustment(otherViewport.get_hadjustment())
+        otherGrid.set_focus_vadjustment(otherViewport.get_vadjustment())
+
+        zViewport = self.builder.get_object("zViewport")
+        zGrid = self.builder.get_object("zGrid")
+        zGrid.set_focus_hadjustment(zViewport.get_hadjustment())
+        zGrid.set_focus_vadjustment(zViewport.get_vadjustment())
+
     def _real_ancestors(self, disk):
         # Return a list of all the ancestors of a disk, but remove the disk
         # itself from this list.

--- a/pyanaconda/ui/gui/spokes/software.py
+++ b/pyanaconda/ui/gui/spokes/software.py
@@ -72,6 +72,12 @@ class SoftwareSelectionSpoke(NormalSpoke):
         self._environmentListBox = self.builder.get_object("environmentListBox")
         self._addonListBox = self.builder.get_object("addonListBox")
 
+        # Connect viewport scrolling with listbox focus events
+        environmentViewport = self.builder.get_object("environmentViewport")
+        addonViewport = self.builder.get_object("addonViewport")
+        self._environmentListBox.set_focus_vadjustment(environmentViewport.get_vadjustment())
+        self._addonListBox.set_focus_vadjustment(addonViewport.get_vadjustment())
+
         # Used to store how the user has interacted with add-ons for the default add-on
         # selection logic. The dictionary keys are group IDs, and the values are selection
         # state constants. See refreshAddons for how the values are used.

--- a/pyanaconda/ui/gui/spokes/source.glade
+++ b/pyanaconda/ui/gui/spokes/source.glade
@@ -508,18 +508,18 @@
                 <property name="vexpand">True</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkScrolledWindow" id="scrolledwindow1">
+                  <object class="GtkScrolledWindow" id="mainScrolledWindow">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="hscrollbar_policy">never</property>
                     <child>
-                      <object class="GtkViewport" id="viewport1">
+                      <object class="GtkViewport" id="mainViewport">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="margin_right">24</property>
                         <property name="shadow_type">none</property>
                         <child>
-                          <object class="GtkBox" id="box4">
+                          <object class="GtkBox" id="mainBox">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>

--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -122,6 +122,11 @@ class ProxyDialog(GUIObject, GUIDialogInputCheckHandler):
         self._proxyValidate = self.add_check(self._proxyURLEntry, self._checkProxyURL)
         self._proxyValidate.update_check_status()
 
+        # Connect scroll events on the viewport with focus events on the box
+        mainViewport = self.builder.get_object("mainViewport")
+        mainBox = self.builder.get_object("mainBox")
+        mainBox.set_focus_vadjustment(mainViewport.get_vadjustment())
+
     def _checkProxyURL(self, inputcheck):
         proxy_string = self.get_input(inputcheck.input_obj)
 

--- a/pyanaconda/ui/gui/spokes/storage.glade
+++ b/pyanaconda/ui/gui/spokes/storage.glade
@@ -482,18 +482,18 @@
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
-                  <object class="GtkScrolledWindow" id="scrolledwindow1">
+                  <object class="GtkScrolledWindow" id="storageScrolledWindow">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="vexpand">True</property>
                     <property name="hscrollbar_policy">never</property>
                     <child>
-                      <object class="GtkViewport" id="viewport1">
+                      <object class="GtkViewport" id="storageViewport">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="shadow_type">none</property>
                         <child>
-                          <object class="GtkBox" id="box3">
+                          <object class="GtkBox" id="storageMainBox">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="orientation">vertical</property>

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -525,6 +525,17 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         self.local_disks_box = self.builder.get_object("local_disks_box")
         self.specialized_disks_box = self.builder.get_object("specialized_disks_box")
 
+        # Connect the viewport adjustments to the child widgets
+        # See also https://bugzilla.gnome.org/show_bug.cgi?id=744721
+        localViewport = self.builder.get_object("localViewport")
+        specializedViewport = self.builder.get_object("specializedViewport")
+        self.local_disks_box.set_focus_hadjustment(localViewport.get_hadjustment())
+        self.specialized_disks_box.set_focus_hadjustment(specializedViewport.get_hadjustment())
+
+        mainViewport = self.builder.get_object("storageViewport")
+        mainBox = self.builder.get_object("storageMainBox")
+        mainBox.set_focus_vadjustment(mainViewport.get_vadjustment())
+
         threadMgr.add(AnacondaThread(name=constants.THREAD_STORAGE_WATCHER,
                       target=self._initialize))
 


### PR DESCRIPTION
In short, fix keyboard navigation in scrolled windows.

If anyone has some bright ideas for how to write a test for something like this I'll do that but trying to connect glade and python initialization code sounds like kind of a nightmare.