### PR TITLE
Support '%packages --multilib' in dnfpayload.py (#1192628)

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -353,6 +353,9 @@ class DNFPayload(packaging.PackagePayload):
         # transaction, disable it in RPM:
         conf.tsflags.append('nocrypto')
 
+        if self.data.packages.multiLib:
+            conf.multilib_policy = "all"
+
         # Start with an empty comps so we can go ahead and use the environment
         # and group properties. Unset reposdir to ensure dnf has nothing it can
         # check automatically


### PR DESCRIPTION
The /etc/dnf/dnf.conf syntax is similar to yum's, but dnfpayload.py
doesn't write out a temporary configuration file.  It just creates a
configuration object and changes the values.  So do that for
multilib_policy.

Signed-off-by: David Cantrell <dcantrell@redhat.com>