### PR TITLE
master/f22-branch - Set the default fs label when reformatting (#1141981)

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -977,6 +977,11 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         new_device_info["encrypted"] = encrypted
 
         # FS LABEL
+        # The Linux HFS+ ESP partition needs to have the correct FS label.
+        # Override anything the user sets for it.
+        if fs_type == "macefi":
+            self._labelEntry.set_text(new_fs.label)
+
         label = self._labelEntry.get_text()
         old_label = getattr(device.format, "label", "")
         changed_label = (label != old_label)


### PR DESCRIPTION
If the new format has a default label, and a label hasn't been set by
the user, use the default. This allows the ESP to be reformatted and
used without removing it and recreating it.