### PR TITLE
Missing local variable check

### DIFF
--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -217,6 +217,7 @@ class Hub(GUIObject, common.Hub):
             self._updateContinue()
 
     def _updateContinue(self):
+        warning = None
         if len(self._incompleteSpokes) == 0:
             if self._checker and not self._checker.check():
                 warning = self._checker.error_message


### PR DESCRIPTION
The "warning" (local variable) is not defined in whole conditions thus
it causes "Not defined" error in
anaconda/pyanaconda/ui/gui/hubs/__init__.py
This solves #34