### PR TITLE
kickstart tests for NFS and FTP repos

### DIFF
--- a/tests/kickstart_tests/basic-ftp-yum.ks
+++ b/tests/kickstart_tests/basic-ftp-yum.ks
@@ -1,0 +1,24 @@
+url --url=ftp://mirrors.kernel.org/fedora/development/$releasever/$basearch/os/
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+part --fstype=ext4 --size=4400 /
+part --fstype=ext4 --size=500 /boot
+part --fstype=swap --size=500 swap
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+# If we made it post, that's good enough
+echo SUCCESS > /root/RESULT
+%end

--- a/tests/kickstart_tests/basic-ftp-yum.sh
+++ b/tests/kickstart_tests/basic-ftp-yum.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+kernel_args() {
+    echo vnc inst.nodnf
+}
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    echo ${ks}
+}
+
+validate() {
+    img=$1
+
+    # There should be a /root/RESULT file with results in it.  Check
+    # its contents and decide whether the test finally succeeded or
+    # not.
+    result=$(virt-cat -a ${img} -m /dev/sda2 /root/RESULT)
+    if [[ $? != 0 ]]; then
+        status=1
+        echo '*** /root/RESULT does not exist in VM image.'
+    elif [[ "${result}" != "SUCCESS" ]]; then
+        status=1
+        echo "${result}"
+    fi
+
+    return ${status}
+}

--- a/tests/kickstart_tests/basic-ftp.ks
+++ b/tests/kickstart_tests/basic-ftp.ks
@@ -1,0 +1,24 @@
+url --url=ftp://mirrors.kernel.org/fedora/development/$releasever/$basearch/os/
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+part --fstype=ext4 --size=4400 /
+part --fstype=ext4 --size=500 /boot
+part --fstype=swap --size=500 swap
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+# If we made it post, that's good enough
+echo SUCCESS > /root/RESULT
+%end

--- a/tests/kickstart_tests/basic-ftp.sh
+++ b/tests/kickstart_tests/basic-ftp.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+kernel_args() {
+    echo vnc
+}
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    echo ${ks}
+}
+
+validate() {
+    img=$1
+
+    # There should be a /root/RESULT file with results in it.  Check
+    # its contents and decide whether the test finally succeeded or
+    # not.
+    result=$(virt-cat -a ${img} -m /dev/sda2 /root/RESULT)
+    if [[ $? != 0 ]]; then
+        status=1
+        echo '*** /root/RESULT does not exist in VM image.'
+    elif [[ "${result}" != "SUCCESS" ]]; then
+        status=1
+        echo "${result}"
+    fi
+
+    return ${status}
+}

--- a/tests/kickstart_tests/nfs-repo-and-addon-yum.ks
+++ b/tests/kickstart_tests/nfs-repo-and-addon-yum.ks
@@ -1,0 +1,80 @@
+nfs --server=NFS-SERVER --dir=NFS-PATH
+
+# The addon repos are setup with the following packages:
+# NFS:
+#   - testpkg-nfs-core, to be installed with @core
+#   - testpkg-nfs-addon, to be installed because we ask for it
+#   - testpkg-share1, contains a file /usr/share/testpkg-2/nfs. To be installed by excluding
+#                     the HTTP version.
+#   - testpkg-share2, contains a file /usr/share/testpkg-3/nfs. To be excluded via cost
+# HTTP:
+#   - testpkg-http-core, to be installed with @core
+#   - testpkg-http-addon, to be installed because we ask for it
+#   - testpkg-share1, contains a file /usr/share/testpkg-2/http. To be excluded via excludepkgs.
+#   - testpkg-share2, contains a file /usr/share/testpkg-3/http. To be included via cost.
+repo --name=kstest-nfs --baseurl=NFS-ADDON-REPO --cost=50 --install
+repo --name=kstest-http --baseurl=HTTP-ADDON-REPO --cost=25 --excludepkgs=testpkg-share2 --install
+
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+part --fstype=ext4 --size=4400 /
+part --fstype=ext4 --size=500 /boot
+part --fstype=swap --size=500 swap
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+testpkg-nfs-addon
+testpkg-http-addon
+testpkg-share1
+testpkg-share2
+%end
+
+%post
+status=0
+
+# Check that all the packages were installed
+for pkg in testpkg-nfs-core testpkg-nfs-addon testpkg-http-core testpkg-http-addon \
+           testpkg-share1 testpkg-share2 ; do
+    if ! rpm -q $pkg ; then
+        echo "*** package $pkg was not installed" >> /root/RESULT
+        status=1
+    fi
+done
+
+if [[ "${status}" -eq 0 ]]; then
+    # Check that the right packages were installed
+    if [[ -e /usr/share/testpkg-1/http ]]; then
+        echo "*** wrong version of testpkg-share1 was installed" >> /root/RESULT
+        status=1
+    fi
+
+    if [[ -e /usr/share/testpkg-2/nfs ]]; then
+        echo "*** wrong version of testpkg-share2 was installed" >> /root/RESULT
+        status=1
+    fi
+
+    # Double check that the correct marker files are in place
+    if [[ -e /usr/share/testpkg-1/nfs ]]; then
+        echo "*** unable to find marker for testpkg-share1" >> /root/RESULT
+        status=1
+    fi
+
+    if [[ -e /usr/share/testpkg-2/http ]]; then
+        echo "*** unable to find marker for testpkg-share2" >> /root/RESULT
+        status=1
+    fi
+fi
+
+if [[ "${status}" -eq 0 ]]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/tests/kickstart_tests/nfs-repo-and-addon-yum.sh
+++ b/tests/kickstart_tests/nfs-repo-and-addon-yum.sh
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+kernel_args() {
+    echo vnc inst.nodnf
+}
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    if [[ "${TEST_ADDON_NFS_REPO}" == "" ]]; then
+        echo \$TEST_ADDON_NFS_REPO is not set.
+        return 1
+    fi
+
+    if [[ "${TEST_ADDON_HTTP_REPO}" == "" ]]; then
+        echo \$TEST_ADDON_HTTP_REPO is not set.
+        return 1
+    fi
+
+    if [[ "${TEST_NFS_SERVER}" == "" ]]; then
+        echo \$TEST_NFS_SERVER is not set
+        return 1
+    fi
+
+    if [[ "${TEST_NFS_PATH}" == "" ]]; then
+        echo \$TEST_NFS_PATH is not set
+        return 1
+    fi
+
+    sed -e "/^nfs/ s|NFS-SERVER|${TEST_NFS_SERVER}|" \
+        -e "/^nfs/ s|NFS-PATH|${TEST_NFS_PATH}|" \
+        -e "/^repo/ s|NFS-ADDON-REPO|${TEST_ADDON_NFS_REPO}|" \
+        -e "/^repo/ s|HTTP-ADDON-REPO|${TEST_ADDON_HTTP_REPO}|" ${ks} > ${tmpdir}/kickstart.ks
+    echo ${tmpdir}/kickstart.ks
+}
+
+validate() {
+    img=$1
+
+    # Check the /root/RESULT file for whether the test succeeded or not
+    result=$(virt-cat -a ${img} -m /dev/sda2 /root/RESULT)
+    if [[ $? != 0 ]]; then
+        status=1
+        echo '*** /root/RESULT does not exist in VM image.'
+    elif [[ "${result}" != "SUCCESS" ]]; then
+        status=1
+        echo "${result}"
+    fi
+
+    return ${status}
+}

--- a/tests/kickstart_tests/nfs-repo-and-addon.ks
+++ b/tests/kickstart_tests/nfs-repo-and-addon.ks
@@ -1,0 +1,80 @@
+nfs --server=NFS-SERVER --dir=NFS-PATH
+
+# The addon repos are setup with the following packages:
+# NFS:
+#   - testpkg-nfs-core, to be installed with @core
+#   - testpkg-nfs-addon, to be installed because we ask for it
+#   - testpkg-share1, contains a file /usr/share/testpkg-2/nfs. To be installed by excluding
+#                     the HTTP version.
+#   - testpkg-share2, contains a file /usr/share/testpkg-3/nfs. To be excluded via cost
+# HTTP:
+#   - testpkg-http-core, to be installed with @core
+#   - testpkg-http-addon, to be installed because we ask for it
+#   - testpkg-share1, contains a file /usr/share/testpkg-2/http. To be excluded via excludepkgs.
+#   - testpkg-share2, contains a file /usr/share/testpkg-3/http. To be included via cost.
+repo --name=kstest-nfs --baseurl=NFS-ADDON-REPO --cost=50 --install
+repo --name=kstest-http --baseurl=HTTP-ADDON-REPO --cost=25 --excludepkgs=testpkg-share2 --install
+
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+part --fstype=ext4 --size=4400 /
+part --fstype=ext4 --size=500 /boot
+part --fstype=swap --size=500 swap
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+testpkg-nfs-addon
+testpkg-http-addon
+testpkg-share1
+testpkg-share2
+%end
+
+%post
+status=0
+
+# Check that all the packages were installed
+for pkg in testpkg-nfs-core testpkg-nfs-addon testpkg-http-core testpkg-http-addon \
+           testpkg-share1 testpkg-share2 ; do
+    if ! rpm -q $pkg ; then
+        echo "*** package $pkg was not installed" >> /root/RESULT
+        status=1
+    fi
+done
+
+if [[ "${status}" -eq 0 ]]; then
+    # Check that the right packages were installed
+    if [[ -e /usr/share/testpkg-1/http ]]; then
+        echo "*** wrong version of testpkg-share1 was installed" >> /root/RESULT
+        status=1
+    fi
+
+    if [[ -e /usr/share/testpkg-2/nfs ]]; then
+        echo "*** wrong version of testpkg-share2 was installed" >> /root/RESULT
+        status=1
+    fi
+
+    # Double check that the correct marker files are in place
+    if [[ -e /usr/share/testpkg-1/nfs ]]; then
+        echo "*** unable to find marker for testpkg-share1" >> /root/RESULT
+        status=1
+    fi
+
+    if [[ -e /usr/share/testpkg-2/http ]]; then
+        echo "*** unable to find marker for testpkg-share2" >> /root/RESULT
+        status=1
+    fi
+fi
+
+if [[ "${status}" -eq 0 ]]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/tests/kickstart_tests/nfs-repo-and-addon.sh
+++ b/tests/kickstart_tests/nfs-repo-and-addon.sh
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+kernel_args() {
+    echo vnc
+}
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    if [[ "${TEST_ADDON_NFS_REPO}" == "" ]]; then
+        echo \$TEST_ADDON_NFS_REPO is not set.
+        return 1
+    fi
+
+    if [[ "${TEST_ADDON_HTTP_REPO}" == "" ]]; then
+        echo \$TEST_ADDON_HTTP_REPO is not set.
+        return 1
+    fi
+
+    if [[ "${TEST_NFS_SERVER}" == "" ]]; then
+        echo \$TEST_NFS_SERVER is not set
+        return 1
+    fi
+
+    if [[ "${TEST_NFS_PATH}" == "" ]]; then
+        echo \$TEST_NFS_PATH is not set
+        return 1
+    fi
+
+    sed -e "/^nfs/ s|NFS-SERVER|${TEST_NFS_SERVER}|" \
+        -e "/^nfs/ s|NFS-PATH|${TEST_NFS_PATH}|" \
+        -e "/^repo/ s|NFS-ADDON-REPO|${TEST_ADDON_NFS_REPO}|" \
+        -e "/^repo/ s|HTTP-ADDON-REPO|${TEST_ADDON_HTTP_REPO}|" ${ks} > ${tmpdir}/kickstart.ks
+    echo ${tmpdir}/kickstart.ks
+}
+
+validate() {
+    img=$1
+
+    # Check the /root/RESULT file for whether the test succeeded or not
+    result=$(virt-cat -a ${img} -m /dev/sda2 /root/RESULT)
+    if [[ $? != 0 ]]; then
+        status=1
+        echo '*** /root/RESULT does not exist in VM image.'
+    elif [[ "${result}" != "SUCCESS" ]]; then
+        status=1
+        echo "${result}"
+    fi
+
+    return ${status}
+}

--- a/tests/kickstart_tests/run_kickstart_tests.sh
+++ b/tests/kickstart_tests/run_kickstart_tests.sh
@@ -74,7 +74,7 @@ KEEPIT=${KEEPIT:-0}
 # NOTE:  You will also need to add these to the list in /etc/sudoers
 # if you are using env_reset there, or they will not get passed from
 # this script to parallel.
-env_args="--env TEST_OSTREE_REPO"
+env_args="--env TEST_OSTREE_REPO --env TEST_NFS_SERVER --env TEST_NFS_PATH --env TEST_ADDON_NFS_REPO --env TEST_ADDON_HTTP_REPO"
 
 # Round up all the kickstart tests we want to run, skipping those that are not
 # executable as well as this file itself.


### PR DESCRIPTION
There were posted to the list earlier. This version removes the unnecessary reboot from the FTP test.