### PR TITLE
F22 urlgrabber

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -31,6 +31,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define yumutilsver 1.1.11-3
 %define mehver 0.23-1
 %define firewalldver 0.3.5-1
+%define pythonurlgrabberver 3.9.1-5
 %define utillinuxver 2.15.1
 %define dracutver 034-7
 %define isomd5sum 1.0.10
@@ -60,6 +61,7 @@ BuildRequires: pykickstart >= %{pykickstartver}
 BuildRequires: python-bugzilla
 %endif
 BuildRequires: python-devel
+BuildRequires: python-urlgrabber >= %{pythonurlgrabberver}
 BuildRequires: python-nose
 BuildRequires: systemd
 BuildRequires: rpm-devel >= %{rpmver}
@@ -90,6 +92,7 @@ Requires: rpm-python >= %{rpmver}
 Requires: parted >= %{partedver}
 Requires: pyparted >= %{pypartedver}
 Requires: yum >= %{yumver}
+Requires: python-urlgrabber >= %{pythonurlgrabberver}
 Requires: python-requests
 Requires: pykickstart >= %{pykickstartver}
 Requires: langtable-data >= %{langtablever}

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -45,8 +45,8 @@ import tempfile
 from pyanaconda.flags import flags, can_touch_runtime_system
 from pyanaconda.constants import ADDON_PATHS, IPMI_ABORTED
 import shlex
-import requests
 import sys
+import urlgrabber
 import pykickstart.commands as commands
 from pyanaconda import keyboard
 from pyanaconda import ntp
@@ -164,18 +164,15 @@ def getEscrowCertificate(escrowCerts, url):
     log.info("escrow: downloading %s", url)
 
     try:
-        request = requests.get(url, verify=True)
-    except requests.exceptions.SSLError as e:
-        msg = _("SSL error while downloading the escrow certificate:\n\n%s") % e
-        raise KickstartError(msg)
-    except requests.exceptions.RequestException as e:
+        f = urlgrabber.urlopen(url)
+    except urlgrabber.grabber.URLGrabError as e:
         msg = _("The following error was encountered while downloading the escrow certificate:\n\n%s") % e
         raise KickstartError(msg)
 
     try:
-        escrowCerts[url] = request.content
+        escrowCerts[url] = f.read()
     finally:
-        request.close()
+        f.close()
 
     return escrowCerts[url]
 

--- a/pyanaconda/packaging/livepayload.py
+++ b/pyanaconda/packaging/livepayload.py
@@ -34,6 +34,8 @@ import stat
 from time import sleep
 from threading import Lock
 import requests
+from urlgrabber.grabber import URLGrabber
+from urlgrabber.grabber import URLGrabError
 from pyanaconda.iutil import ProxyString, ProxyStringError, lowerASCII
 import hashlib
 import glob
@@ -195,19 +197,27 @@ class LiveImagePayload(ImagePayload):
     def kernelVersionList(self):
         return self._kernelVersionList
 
-class DownloadProgress(object):
-    """ Provide methods for download progress reporting."""
+class URLGrabberProgress(object):
+    """ Provide methods for urlgrabber progress."""
+    def start(self, filename, url, basename, size, text):
+        """ Start of urlgrabber download
 
-    def start(self, url, size):
-        """ Start of download
-
-            :param url:      url of the download
-            :type url:       str
+            :param filename: path and file that download will be saved to
+            :type filename:  string
+            :param url:      url to download from
+            :type url:       string
+            :param basename: file that it will be saved to
+            :type basename:  string
             :param size:     length of the file
             :type size:      int
+            :param text:     unknown
+            :type text:      unknown
         """
+        self.filename = filename
         self.url = url
+        self.basename = basename
         self.size = size
+        self.text = text
         self._pct = -1
 
     def update(self, bytes_read):
@@ -223,6 +233,7 @@ class DownloadProgress(object):
         if pct == self._pct:
             return
         self._pct = pct
+
         progressQ.send_message(_("Downloading %(url)s (%(pct)d%%)") % \
                 {"url" : self.url, "pct" : pct})
 
@@ -315,37 +326,20 @@ class LiveImageKSPayload(LiveImagePayload):
         ImagePayload.unsetup(self)
 
     def _preInstall_url_image(self):
-        """ Download the image using Requests with progress reporting"""
+        """ Download the image using urlgrabber """
+        # Setup urlgrabber and call back to download image to sysroot
+        progress = URLGrabberProgress()
+        ugopts = {"ssl_verify_peer": not self.data.method.noverifyssl,
+                  "ssl_verify_host": not self.data.method.noverifyssl,
+                  "proxies" : self._proxies,
+                  "progress_obj" : progress,
+                  "copy_local" : True}
 
         error = None
-        progress = DownloadProgress()
         try:
-            log.info("Starting image download")
-            with open(self.image_path, "wb") as f:
-                ssl_verify = not self.data.method.noverifyssl
-                response = requests.get(self.data.method.url, proxies=self._proxies, verify=ssl_verify, stream=True)
-                total_length = response.headers.get('content-length')
-                if total_length is None:  # no content length header
-                    # just download the file in one go and fake the progress reporting once done
-                    log.warning("content-length header is missing for the installation image, "
-                                "download progress reporting will not be available")
-                    f.write(response.content)
-                    size = f.tell()
-                    progress.start(self.data.method.url, size)
-                    progress.end(size)
-                else:
-                    # requests return headers as strings, so convert total_length to int
-                    progress.start(self.data.method.url, int(total_length))
-                    bytes_read = 0
-                    for buf in response.iter_content(1024 * 1024):  # 1 MB chunks
-                        if buf:
-                            f.write(buf)
-                            f.flush()
-                            bytes_read += len(buf)
-                            progress.update(bytes_read)
-                    progress.end(bytes_read)
-                log.info("Image download finished")
-        except requests.exceptions.RequestException as e:
+            ug = URLGrabber()
+            ug.urlgrab(self.data.method.url, self.image_path, **ugopts)
+        except URLGrabError as e:
             log.error("Error downloading liveimg: %s", e)
             error = e
         else:

--- a/pyanaconda/packaging/livepayload.py
+++ b/pyanaconda/packaging/livepayload.py
@@ -33,10 +33,10 @@ import os
 import stat
 from time import sleep
 from threading import Lock
-import requests
 from urlgrabber.grabber import URLGrabber
 from urlgrabber.grabber import URLGrabError
 from pyanaconda.iutil import ProxyString, ProxyStringError, lowerASCII
+import urllib
 import hashlib
 import glob
 
@@ -275,21 +275,21 @@ class LiveImageKSPayload(LiveImagePayload):
 
         error = None
         try:
-            response = requests.get(self.data.method.url, proxies=self._proxies, verify=True)
+            req = urllib.urlopen(self.data.method.url, proxies=self._proxies)
 
             # At this point we know we can get the image and what its size is
             # Make a guess as to minimum size needed:
             # Enough space for image and image * 3
-            if response.headers.get('content-length'):
-                self._min_size = int(response.headers.get('content-length')) * 4
+            if req.info().get("content-length"):
+                self._min_size = int(req.info().get('content-length')) * 4
         except IOError as e:
             log.error("Error opening liveimg: %s", e)
             error = e
         else:
             # If it is a http request we need to check the code
             method = self.data.method.url.split(":", 1)[0]
-            if method.startswith("http") and response.status_code != 200:
-                error = "http request returned %s" % response.getcode()
+            if method.startswith("http") and req.getcode() != 200:
+                error = "http request returned %s" % req.getcode()
 
         return error
 


### PR DESCRIPTION
This is for f22 only. urlgrabber is a problem for the python3 conversion and that needs to be solved but killing ftp and nfs support is not a good way to solve it. In the interest of getting things working again for f22, revert the python-requests changes for f22.

I left in the change in geoloc.py since I assume no one is getting geoloc data over ftp.