### PR TITLE
Add pwpolicy kickstart command and %anaconda section

### DIFF
--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -3,7 +3,9 @@
 auth --enableshadow --passalgo=sha512
 firstboot --enable
 
+%anaconda
 # Default password policies
-pwpolicy root --strict --minlen=8 --minquality=50 --changesok --notempty
-pwpolicy user --strict --minlen=8 --minquality=50 --changesok --emptyok
-pwpolicy luks --strict --minlen=10
+pwpolicy root --strict --minlen=8 --minquality=50 --nochanges --emptyok
+pwpolicy user --strict --minlen=8 --minquality=50 --nochanges --emptyok
+pwpolicy luks --strict --minlen=8 --minquality=50 --nochanges --emptyok
+%end

--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -2,3 +2,8 @@
 # This is not loaded if a kickstart file is provided on the command line.
 auth --enableshadow --passalgo=sha512
 firstboot --enable
+
+# Default password policies
+pwpolicy root --strict --minlen=8 --minquality=50 --changesok --notempty
+pwpolicy user --strict --minlen=8 --minquality=50 --changesok --emptyok
+pwpolicy luks --strict --minlen=10

--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -138,11 +138,12 @@ PASSWORD_MIN_LEN = 8
 PASSWORD_EMPTY_ERROR = N_("The password is empty.")
 PASSWORD_CONFIRM_ERROR_GUI = N_("The passwords do not match.")
 PASSWORD_CONFIRM_ERROR_TUI = N_("The passwords you entered were different.  Please try again.")
-PASSWORD_WEAK = N_("The password you have provided is weak. You will have to press Done twice to confirm it.")
-PASSWORD_WEAK_WITH_ERROR = N_("The password you have provided is weak: %s. You will have to press Done twice to confirm it.")
+PASSWORD_WEAK = N_("The password you have provided is weak. %s")
+PASSWORD_WEAK_WITH_ERROR = N_("The password you have provided is weak: %s. %s")
 PASSWORD_WEAK_CONFIRM = N_("You have provided a weak password. Press Done again to use anyway.")
 PASSWORD_WEAK_CONFIRM_WITH_ERROR = N_("You have provided a weak password: %s. Press Done again to use anyway.")
 PASSWORD_ASCII = N_("The password you have provided contains non-ASCII characters. You may not be able to switch between keyboard layouts to login. Press Done to continue.")
+PASSWORD_DONE_TWICE = N_("You will have to press Done twice to confirm it.")
 
 PASSWORD_STRENGTH_DESC = [N_("Empty"), N_("Weak"), N_("Fair"), N_("Good"), N_("Strong")]
 

--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -138,8 +138,10 @@ PASSWORD_MIN_LEN = 8
 PASSWORD_EMPTY_ERROR = N_("The password is empty.")
 PASSWORD_CONFIRM_ERROR_GUI = N_("The passwords do not match.")
 PASSWORD_CONFIRM_ERROR_TUI = N_("The passwords you entered were different.  Please try again.")
-PASSWORD_WEAK = N_("The password you have provided is weak.")
-PASSWORD_WEAK_WITH_ERROR = N_("The password you have provided is weak: %s.")
+PASSWORD_WEAK = N_("The password you have provided is weak. You will have to press Done twice to confirm it.")
+PASSWORD_WEAK_WITH_ERROR = N_("The password you have provided is weak: %s. You will have to press Done twice to confirm it.")
+PASSWORD_WEAK_CONFIRM = N_("You have provided a weak password. Press Done again to use anyway.")
+PASSWORD_WEAK_CONFIRM_WITH_ERROR = N_("You have provided a weak password: %s. Press Done again to use anyway.")
 PASSWORD_ASCII = N_("The password you have provided contains non-ASCII characters. You may not be able to switch between keyboard layouts to login. Press Done to continue.")
 
 PASSWORD_STRENGTH_DESC = [N_("Empty"), N_("Weak"), N_("Fair"), N_("Good"), N_("Strong")]

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -62,12 +62,15 @@ from pyanaconda.i18n import _
 from pyanaconda.ui.common import collect
 from pyanaconda.addons import AddonSection, AddonData, AddonRegistry, collect_addon_paths
 from pyanaconda.bootloader import GRUB2, get_bootloader
+from pyanaconda.pwpolicy import F22_PwPolicy, F22_PwPolicyData
 
 from pykickstart.constants import CLEARPART_TYPE_NONE, FIRSTBOOT_SKIP, FIRSTBOOT_RECONFIG, KS_SCRIPT_POST, KS_SCRIPT_PRE, \
                                   KS_SCRIPT_TRACEBACK, SELINUX_DISABLED, SELINUX_ENFORCING, SELINUX_PERMISSIVE
+from pykickstart.base import BaseHandler
 from pykickstart.errors import formatErrorMsg, KickstartError, KickstartValueError
 from pykickstart.parser import KickstartParser
 from pykickstart.parser import Script as KSScript
+from pykickstart.sections import Section
 from pykickstart.sections import NullSection, PackageSection, PostScriptSection, PreScriptSection, TracebackScriptSection
 from pykickstart.version import returnClassForVersion
 
@@ -1821,6 +1824,61 @@ class Upgrade(commands.upgrade.F20_Upgrade):
         sys.exit(1)
 
 ###
+### %anaconda Section
+###
+
+class AnacondaSectionHandler(BaseHandler):
+    """A handler for only the anaconda ection's commands."""
+    commandMap = {
+        "pwpolicy": F22_PwPolicy
+    }
+
+    dataMap = {
+        "PwPolicyData": F22_PwPolicyData
+    }
+
+    def __init__(self):
+        BaseHandler.__init__(self, mapping=self.commandMap, dataMapping=self.dataMap)
+
+    def __str__(self):
+        """Return the %anaconda section"""
+        retval = ""
+        lst = sorted(self._writeOrder.keys())
+        for prio in lst:
+            for obj in self._writeOrder[prio]:
+                retval += str(obj)
+
+        if retval:
+            retval = "\n%anaconda\n" + retval + "%end\n"
+        return retval
+
+class AnacondaSection(Section):
+    """A section for anaconda specific commands."""
+    sectionOpen = "%anaconda"
+
+    def __init__(self, *args, **kwargs):
+        Section.__init__(self, *args, **kwargs)
+        self.cmdno = 0
+
+    def handleLine(self, line):
+        if not self.handler:
+            return
+
+        self.cmdno += 1
+        args = shlex.split(line, comments=True)
+        self.handler.currentCmd = args[0]
+        self.handler.currentLine = self.cmdno
+        return self.handler.dispatcher(args, self.cmdno)
+
+    def handleHeader(self, lineno, args):
+        """Process the arguments to the %anaconda header."""
+        Section.handleHeader(self, lineno, args)
+
+    def finalize(self):
+        """Let %anaconda know no additional data will come."""
+        Section.finalize(self)
+
+###
 ### HANDLERS
 ###
 
@@ -1912,8 +1970,11 @@ class AnacondaKSHandler(superclass):
         # Prepare the final structures for 3rd party addons
         self.addons = AddonRegistry(addons)
 
+        # The %anaconda section uses its own handler for a limited set of commands
+        self.anaconda = AnacondaSectionHandler()
+
     def __str__(self):
-        return superclass.__str__(self) + "\n" +  str(self.addons)
+        return superclass.__str__(self) + "\n" + str(self.addons) + str(self.anaconda)
 
 class AnacondaPreParser(KickstartParser):
     # A subclass of KickstartParser that only looks for %pre scripts and
@@ -1931,6 +1992,7 @@ class AnacondaPreParser(KickstartParser):
         self.registerSection(NullSection(self.handler, sectionOpen="%traceback"))
         self.registerSection(NullSection(self.handler, sectionOpen="%packages"))
         self.registerSection(NullSection(self.handler, sectionOpen="%addon"))
+        self.registerSection(NullSection(self.handler.anaconda, sectionOpen="%anaconda"))
 
 
 class AnacondaKSParser(KickstartParser):
@@ -1951,6 +2013,7 @@ class AnacondaKSParser(KickstartParser):
         self.registerSection(TracebackScriptSection(self.handler, dataObj=self.scriptClass))
         self.registerSection(PackageSection(self.handler))
         self.registerSection(AddonSection(self.handler))
+        self.registerSection(AnacondaSection(self.handler.anaconda))
 
 def preScriptPass(f):
     # The first pass through kickstart file processing - look for %pre scripts

--- a/pyanaconda/pwpolicy.py
+++ b/pyanaconda/pwpolicy.py
@@ -1,0 +1,140 @@
+#
+# Brian C. Lane <bcl@redhat.com>
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+from pykickstart.base import BaseData, KickstartCommand
+from pykickstart.errors import KickstartValueError, formatErrorMsg
+from pykickstart.options import KSOptionParser
+
+import warnings
+from pyanaconda.i18n import _
+
+class F22_PwPolicyData(BaseData):
+    """ Kickstart Data object to hold information about pwpolicy. """
+    removedKeywords = BaseData.removedKeywords
+    removedAttrs = BaseData.removedAttrs
+
+    def __init__(self, *args, **kwargs):
+        BaseData.__init__(self, *args, **kwargs)
+        self.name = kwargs.get("name", "")
+        self.minlen = kwargs.get("minlen", 8)
+        self.minquality = kwargs.get("minquality", 50)
+        self.strict = kwargs.get("strict", True)
+        self.changesok = kwargs.get("changesok", False)
+        self.emptyok = kwargs.get("emptyok", True)
+
+    def __eq__(self, y):
+        if not y:
+            return False
+
+        return self.name == y.name
+
+    def __ne__(self, y):
+        return not self == y
+
+    def __str__(self):
+        retval = BaseData.__str__(self)
+
+        if self.name != "":
+            retval += "pwpolicy"
+            retval += self._getArgsAsStr() + "\n"
+
+        return retval
+
+    def _getArgsAsStr(self):
+        retval = ""
+
+        retval += " %s" % self.name
+        retval += " --minlen=%d" % self.minlen
+        retval += " --minquality=%d" % self.minquality
+
+        if self.strict:
+            retval += " --strict"
+        else:
+            retval += " --notstrict"
+        if self.changesok:
+            retval += " --changesok"
+        else:
+            retval += " --nochanges"
+        if self.emptyok:
+            retval += " --emptyok"
+        else:
+            retval += " --notempty"
+
+        return retval
+
+class F22_PwPolicy(KickstartCommand):
+    """ Kickstart command implementing password policy. """
+    removedKeywords = KickstartCommand.removedKeywords
+    removedAttrs = KickstartCommand.removedAttrs
+
+    def __init__(self, writePriority=0, *args, **kwargs):
+        KickstartCommand.__init__(self, writePriority, *args, **kwargs)
+        self.op = self._getParser()
+
+        self.policyList = kwargs.get("policyList", [])
+
+    def __str__(self):
+        retval = ""
+        for policy in self.policyList:
+            retval += policy.__str__()
+
+        return retval
+
+    def _getParser(self):
+        op = KSOptionParser()
+        op.add_option("--minlen", type="int")
+        op.add_option("--minquality", type="int")
+        op.add_option("--strict", action="store_true")
+        op.add_option("--notstrict", dest="strict", action="store_false")
+        op.add_option("--changesok", action="store_true")
+        op.add_option("--nochanges", dest="changesok", action="store_false")
+        op.add_option("--emptyok", action="store_true")
+        op.add_option("--notempty", dest="emptyok", action="store_false")
+        return op
+
+    def parse(self, args):
+        (opts, extra) = self.op.parse_args(args=args, lineno=self.lineno)
+        if len(extra) != 1:
+            raise KickstartValueError(formatErrorMsg(self.lineno, msg=_("policy name required for %s") % "pwpolicy"))
+
+        pd = self.handler.PwPolicyData()
+        self._setToObj(self.op, opts, pd)
+        pd.lineno = self.lineno
+        pd.name = extra[0]
+
+        # Check for duplicates in the data list.
+        if pd in self.dataList():
+            warnings.warn(_("A %s with the name %s has already been defined.") % ("pwpolicy", pd.name))
+
+        return pd
+
+    def dataList(self):
+        return self.policyList
+
+    def get_policy(self, name):
+        """ Get the policy by name
+
+        :param str name: Name of the policy to return.
+
+        """
+        policy = [p for p in self.policyList if p.name == name]
+        if policy:
+            return policy[0]
+        else:
+            return None

--- a/pyanaconda/ui/gui/spokes/lib/passphrase.py
+++ b/pyanaconda/ui/gui/spokes/lib/passphrase.py
@@ -61,9 +61,9 @@ class PassphraseDialog(GUIObject, GUIInputCheckHandler):
         self._strength_bar.add_offset_value("high", 4)
 
         # Configure the password policy, if available. Otherwise use defaults.
-        self.policy = self.data.pwpolicy.get_policy("luks")
+        self.policy = self.data.anaconda.pwpolicy.get_policy("luks")
         if not self.policy:
-            self.policy = self.data.pwpolicy.handler.PwPolicyData()
+            self.policy = self.data.anaconda.PwPolicyData()
 
         # These will be set up later.
         self._pwq = None

--- a/pyanaconda/ui/gui/spokes/password.py
+++ b/pyanaconda/ui/gui/spokes/password.py
@@ -108,9 +108,9 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self.pw_bar.add_offset_value("high", 4)
 
         # Configure the password policy, if available. Otherwise use defaults.
-        self.policy = self.data.pwpolicy.get_policy("root")
+        self.policy = self.data.anaconda.pwpolicy.get_policy("root")
         if not self.policy:
-            self.policy = self.data.pwpolicy.handler.PwPolicyData()
+            self.policy = self.data.anaconda.PwPolicyData()
 
     def refresh(self):
         # Enable the input checks in case they were disabled on the last exit

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -277,9 +277,9 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         self.pw_bar.add_offset_value("high", 4)
 
         # Configure the password policy, if available. Otherwise use defaults.
-        self.policy = self.data.pwpolicy.get_policy("user")
+        self.policy = self.data.anaconda.pwpolicy.get_policy("user")
         if not self.policy:
-            self.policy = self.data.pwpolicy.handler.PwPolicyData()
+            self.policy = self.data.anaconda.PwPolicyData()
 
         # indicate when the password was set by kickstart
         self._user.password_kickstarted = self.data.user.seen

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -19,7 +19,7 @@
 # Red Hat Author(s): Martin Sivak <msivak@redhat.com>
 #
 from pyanaconda.ui.tui import simpleline as tui
-from pyanaconda.ui.tui.tuiobject import TUIObject
+from pyanaconda.ui.tui.tuiobject import TUIObject, YesNoDialog
 from pyanaconda.ui.common import Spoke, StandaloneSpoke, NormalSpoke
 from pyanaconda.users import validatePassword, cryptPassword
 import re
@@ -27,6 +27,7 @@ from collections import namedtuple
 from pyanaconda.iutil import setdeepattr, getdeepattr
 from pyanaconda.i18n import N_, _
 from pyanaconda.constants import PASSWORD_CONFIRM_ERROR_TUI, PW_ASCII_CHARS
+from pyanaconda.constants import PASSWORD_WEAK, PASSWORD_WEAK_WITH_ERROR
 
 __all__ = ["TUISpoke", "EditTUISpoke", "EditTUIDialog", "EditTUISpokeEntry",
            "StandaloneSpoke", "NormalTUISpoke"]
@@ -102,12 +103,17 @@ class EditTUIDialog(NormalTUISpoke):
     title = N_("New value")
     PASSWORD = re.compile(".*")
 
-    def __init__(self, app, data, storage, payload, instclass):
+    def __init__(self, app, data, storage, payload, instclass, policy_name=""):
         if self.__class__ is EditTUIDialog:
             raise TypeError("EditTUIDialog is an abstract class")
 
         NormalTUISpoke.__init__(self, app, data, storage, payload, instclass)
         self.value = None
+
+        # Configure the password policy, if available. Otherwise use defaults.
+        self.policy = self.data.pwpolicy.get_policy(policy_name)
+        if not self.policy:
+            self.policy = self.data.pwpolicy.handler.PwPolicyData()
 
     def refresh(self, args = None):
         self._window = []
@@ -135,19 +141,31 @@ class EditTUIDialog(NormalTUISpoke):
                 self.value = ""
                 return None
 
-            valid, strength, message = validatePassword(pw, user=None)
+            valid, strength, message = validatePassword(pw, user=None, minlen=self.policy.minlen)
 
             if not valid:
                 print(message)
                 return None
 
-            if strength < 50:
-                if message:
-                    error = _("You have provided a weak password: %s\n") % message
+            if strength < self.policy.minquality:
+                if self.policy.strict:
+                    done_msg = ""
                 else:
-                    error = _("You have provided a weak password.")
-                print(error)
-                return None
+                    done_msg = _("\nWould you like to use it anyway?")
+
+                if message:
+                    error = _(PASSWORD_WEAK_WITH_ERROR) % (message, done_msg)
+                else:
+                    error = _(PASSWORD_WEAK) % done_msg
+
+                if not self.policy.strict:
+                    question_window = YesNoDialog(self._app, error)
+                    self._app.switch_screen_modal(question_window)
+                    if not question_window.answer:
+                        return None
+                else:
+                    print(error)
+                    return None
 
             if any(char not in PW_ASCII_CHARS for char in pw):
                 print(_("You have provided a password containing non-ASCII characters.\n"
@@ -218,12 +236,12 @@ class EditTUISpoke(NormalTUISpoke):
     edit_fields = [
     ]
 
-    def __init__(self, app, data, storage, payload, instclass):
+    def __init__(self, app, data, storage, payload, instclass, policy_name=""):
         if self.__class__ is EditTUISpoke:
             raise TypeError("EditTUISpoke is an abstract class")
 
         NormalTUISpoke.__init__(self, app, data, storage, payload, instclass)
-        self.dialog = OneShotEditTUIDialog(app, data, storage, payload, instclass)
+        self.dialog = OneShotEditTUIDialog(app, data, storage, payload, instclass, policy_name=policy_name)
 
         # self.args should hold the object this Spoke is supposed
         # to edit

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -111,9 +111,9 @@ class EditTUIDialog(NormalTUISpoke):
         self.value = None
 
         # Configure the password policy, if available. Otherwise use defaults.
-        self.policy = self.data.pwpolicy.get_policy(policy_name)
+        self.policy = self.data.anaconda.pwpolicy.get_policy(policy_name)
         if not self.policy:
-            self.policy = self.data.pwpolicy.handler.PwPolicyData()
+            self.policy = self.data.anaconda.PwPolicyData()
 
     def refresh(self, args = None):
         self._window = []

--- a/pyanaconda/ui/tui/spokes/password.py
+++ b/pyanaconda/ui/tui/spokes/password.py
@@ -33,7 +33,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, EditTUIDialog):
     category = UserSettingsCategory
 
     def __init__(self, app, data, storage, payload, instclass):
-        EditTUIDialog.__init__(self, app, data, storage, payload, instclass)
+        EditTUIDialog.__init__(self, app, data, storage, payload, instclass, "root")
         self._password = None
 
     @property
@@ -42,7 +42,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, EditTUIDialog):
 
     @property
     def showable(self):
-        return not (self.completed and flags.automatedInstall)
+        return not (self.completed and flags.automatedInstall and not self.policy.changesok)
 
     @property
     def mandatory(self):

--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -66,7 +66,7 @@ class UserSpoke(FirstbootSpokeMixIn, EditTUISpoke):
 
     def __init__(self, app, data, storage, payload, instclass):
         FirstbootSpokeMixIn.__init__(self)
-        EditTUISpoke.__init__(self, app, data, storage, payload, instclass)
+        EditTUISpoke.__init__(self, app, data, storage, payload, instclass, "user")
 
         if self.data.user.userList:
             self.args = self.data.user.userList[0]
@@ -99,7 +99,8 @@ class UserSpoke(FirstbootSpokeMixIn, EditTUISpoke):
 
     @property
     def showable(self):
-        return not (self.completed and flags.automatedInstall)
+        return not (self.completed and flags.automatedInstall
+                    and self.data.user.seen and not self.dialog.policy.changesok)
 
     @property
     def mandatory(self):

--- a/pyanaconda/users.py
+++ b/pyanaconda/users.py
@@ -123,7 +123,7 @@ def cryptPassword(password, algo=None):
 
     return cryptpw
 
-def validatePassword(pw, user="root", settings=None):
+def validatePassword(pw, user="root", settings=None, minlen=None):
     """Check the quality of a password.
 
        This function does three things: given a password and an optional
@@ -148,6 +148,8 @@ def validatePassword(pw, user="root", settings=None):
 
        :param settings: an optional PWQSettings object
        :type settings: pwquality.PWQSettings
+       :param int minlen: Minimum acceptable password length. If not passed,
+                          use the default length from PASSWORD_MIN_LEN
 
        :returns: A tuple containing (bool(valid), int(score), str(message))
        :rtype: tuple
@@ -164,6 +166,9 @@ def validatePassword(pw, user="root", settings=None):
             validatePassword.pwqsettings.read_config()
             validatePassword.pwqsettings.minlen = PASSWORD_MIN_LEN
         settings = validatePassword.pwqsettings
+
+    if minlen is not None:
+        settings.minlen = minlen
 
     if valid:
         try:

--- a/tests/pyanaconda_tests/pwpolicy.py
+++ b/tests/pyanaconda_tests/pwpolicy.py
@@ -1,0 +1,51 @@
+#
+# Brian C. Lane <bcl@redhat.com>
+#
+# Copyright 2015 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+from mock import Mock
+import unittest
+
+class BaseTestCase(unittest.TestCase):
+    def setUp(self):
+        import sys
+
+        sys.modules["anaconda_log"] = Mock()
+        sys.modules["block"] = Mock()
+
+        from pyanaconda import kickstart
+        self.kickstart = kickstart
+        self.handler = kickstart.AnacondaKSHandler()
+        self.ksparser = kickstart.AnacondaKSParser(self.handler)
+
+class PwPolicyTestCase(BaseTestCase):
+    ks = """
+%anaconda
+pwpolicy root --strict --minlen=8 --minquality=50 --nochanges --emptyok
+pwpolicy user --strict --minlen=8 --minquality=50 --nochanges --emptyok
+pwpolicy luks --strict --minlen=8 --minquality=50 --nochanges --emptyok
+%end
+"""
+    def pwpolicy_test(self):
+        self.ksparser.readKickstartFromString(self.ks)
+
+        self.assertIsInstance(self.handler, self.kickstart.AnacondaKSHandler)
+        self.assertIsInstance(self.handler.anaconda, self.kickstart.AnacondaSectionHandler)
+
+        eq_template = "pwpolicy %s --minlen=8 --minquality=50 --strict --nochanges --emptyok\n"
+        for name in ["root", "user", "luks"]:
+            self.assertEqual(str(self.handler.anaconda.pwpolicy.get_policy(name)), eq_template % name)    # pylint: disable=no-member


### PR DESCRIPTION
The first 6 patches used a new pykickstart command. The 7th patch moves that command into anaconda and adds the %anaconda kickstart section.

This set allows users to override the root, user and luks password policies using kickstart. eg. products can include a custom copy of interactive-defaults.ks in /usr/share/anaconda/ to set their own policies.