### PR TITLE
Do not use min_luks_entropy with pre-existing devices (#1206101)

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1040,8 +1040,7 @@ class LogVolData(commands.logvol.F21_LogVolData):
                                           add_backup_passphrase=self.backuppassphrase)
                 luksdev = LUKSDevice("luks%d" % storage.nextID,
                                      fmt=luksformat,
-                                     parents=device,
-                                     min_luks_entropy=MIN_CREATE_ENTROPY)
+                                     parents=device)
             else:
                 luksformat = request.format
                 request.format = getFormat("luks", passphrase=self.passphrase,


### PR DESCRIPTION
If the LUKS device is not being created by anaconda, setting a minimum
entropy for creation doesn't make much sense. Also the parameter was
being passed to the wrong function.