### PR TITLE
Allow overriding password policy check

### DIFF
--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -5,7 +5,7 @@ firstboot --enable
 
 %anaconda
 # Default password policies
-pwpolicy root --strict --minlen=8 --minquality=50 --nochanges --emptyok
-pwpolicy user --strict --minlen=8 --minquality=50 --nochanges --emptyok
-pwpolicy luks --strict --minlen=8 --minquality=50 --nochanges --emptyok
+pwpolicy root --notstrict --minlen=6 --minquality=50 --nochanges --emptyok
+pwpolicy user --notstrict --minlen=6 --minquality=50 --nochanges --emptyok
+pwpolicy luks --notstrict --minlen=6 --minquality=50 --nochanges --emptyok
 %end


### PR DESCRIPTION
The Fedora Engineering Steering Committee decided that Fedora 22 will restore the double-click of "done" to override the password policy check. This is a temporary measure while FESCo works on a distro-wide security policy to be implemented in Fedora 23.

At present, all three passwords (root, user and luks) will retain the same policy: minimum length of 6, minimum pwquality score of 50 and the ability to override this with a double-click of done.

Details:
https://fedorahosted.org/fesco/ticket/1412#comment:40
https://fedoraproject.org/wiki/User:Kevin/Draft_Passwordpolicy