### PR TITLE
Enforce sane disk selections.

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -46,6 +46,7 @@ pyanaconda/ui/categories/user_settings.py
 # Common stuff
 pyanaconda/ui/lib/space.py
 pyanaconda/ui/lib/entropy.py
+pyanaconda/ui/lib/disks.py
 
 # Text interface
 pyanaconda/ui/tui/hubs/summary.py

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -42,7 +42,7 @@
 from gi.repository import Gdk, GLib, AnacondaWidgets
 
 from pyanaconda.ui.communication import hubQ
-from pyanaconda.ui.lib.disks import getDisks, isLocalDisk, applyDiskSelection
+from pyanaconda.ui.lib.disks import getDisks, isLocalDisk, applyDiskSelection, checkDiskSelection
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.spokes.lib.cart import SelectedDisksDialog
@@ -753,6 +753,16 @@ class StorageSpoke(NormalSpoke, StorageChecker):
                 if not partition.exists and \
                    partition in self.storage.partitions:
                     self.storage.recursiveRemove(partition)
+
+        # make sure no containers were split up by the user's disk selection
+        self.clear_info()
+        self.errors = checkDiskSelection(self.storage, self.selected_disks)
+        if self.errors:
+            # The disk selection has to make sense before we can proceed.
+            self.set_error(_("There was a problem with your disk selection. "
+                             "Click here for details."))
+            self.back_clicked = False
+            return
 
         # hide/unhide disks as requested
         for disk in self.disks:

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -22,7 +22,7 @@
 # which has the same license and authored by David Lehman <dlehman@redhat.com>
 #
 
-from pyanaconda.ui.lib.disks import getDisks, applyDiskSelection
+from pyanaconda.ui.lib.disks import getDisks, applyDiskSelection, checkDiskSelection
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.simpleline import TextWidget, CheckboxWidget
@@ -260,7 +260,7 @@ class StorageSpoke(NormalTUISpoke):
 
     def input(self, args, key):
         """Grab the disk choice and update things"""
-
+        self.errors = []
         try:
             keyid = int(key) - 1
             self.selection = keyid
@@ -280,6 +280,15 @@ class StorageSpoke(NormalTUISpoke):
                         if to_format:
                             self.run_dasdfmt(to_format)
                             return None
+
+                    # make sure no containers were split up by the user's disk
+                    # selection
+                    self.errors.extend(checkDiskSelection(self.storage,
+                                                          self.selected_disks))
+                    if self.errors:
+                        # The disk selection has to make sense before we can
+                        # proceed.
+                        return None
 
                     newspoke = AutoPartSpoke(self.app, self.data, self.storage,
                                              self.payload, self.instclass)


### PR DESCRIPTION
There is no value (and a great deal of trouble) in allowing users to split up an existing md array, lvm vg, or btrfs volume by selecting a subset of the disks it uses.

This practice has led to the filing of several bugs, mainly by individuals engaged in testing the installer. The only bug id I have handy is 1198367, which I'll edit into the commit message for the rhel7-branch commit.

This requires rhinstaller/blivet#63