### PR TITLE
Revert "allow /boot on btrfs subvol or filesystem"

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1407,8 +1407,7 @@ class GRUB2(GRUB):
     terminal_type = "console"
 
     # requirements for boot devices
-    stage2_device_types = ["partition", "mdarray", "lvmlv", "btrfs volume",
-                           "btrfs subvolume"]
+    stage2_device_types = ["partition", "mdarray", "lvmlv"]
     stage2_raid_levels = [raid.RAID0, raid.RAID1, raid.RAID4,
                           raid.RAID5, raid.RAID6, raid.RAID10]
     stage2_raid_metadata = ["0", "0.90", "1.0", "1.2"]


### PR DESCRIPTION
This reverts commit 6dd9f042b607a6dc4e8d299009c62c5f98e6d5d4.

We really don't have support for /boot on btrfs working, turn this off
to prevent bugs.

Related: rhbz#1200539
Related: rhbz#864198
Related: rhbz#1094489