### PR TITLE
Give users a chance to fix unusable initial storage layouts

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -84,7 +84,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 Summary: Core of the Anaconda installer
 Requires: dnf >= %{dnfver}
 Requires: python-dnf >= %{dnfver}
-Requires: python-blivet >= 1:1.1
+Requires: python-blivet >= 1:1.3
 Requires: python-meh >= %{mehver}
 Requires: libreport-anaconda >= 2.0.21-1
 Requires: libselinux-python

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -25,6 +25,12 @@ __all__ = ["ERROR_RAISE", "ERROR_CONTINUE", "ERROR_RETRY",
            "MediaMountError", "ScriptError", "CmdlineError",
            "errorHandler"]
 
+# Only run the pango markup escape if the GUI is available
+try:
+    from pyanaconda.ui.gui.utils import escape_markup
+except ImportError:
+    escape_markup = lambda x: x
+
 class InvalidImageSizeError(Exception):
     def __init__(self, message, filename):
         Exception.__init__(self, message)
@@ -119,6 +125,22 @@ class ErrorHandler(object):
 
         self.ui.showError(message)
         return ERROR_RAISE
+
+    def _storageResetHandler(self, exn):
+        message = (_("There is a problem with your existing storage "
+                     "configuration: <b>%(errortxt)s</b>\n\n"
+                     "You must resolve this matter before the installation can "
+                     "proceed. There is a shell available for use which you "
+                     "can access by pressing ctrl-alt-f1 and then ctrl-b 2."
+                     "\n\nOnce you have resolved the issue you can retry the "
+                     "storage scan. If you do not fix it you will have to exit "
+                     "the installer.") % {"errortxt": escape_markup(exn.message)})
+        details = _(exn.suggestion)
+        buttons = (_("_Exit Installer"), _("_Retry"))
+        if self.ui.showDetailedError(message, details, buttons=buttons):
+            return ERROR_RETRY
+        else:
+            return ERROR_RAISE
 
     def _noDisksHandler(self, exn):
         message = _("An error has occurred - no valid devices were found on "
@@ -284,6 +306,10 @@ class ErrorHandler(object):
 
         _map = {"PartitioningError": self._partitionErrorHandler,
                 "FSResizeError": self._fsResizeHandler,
+                "UnusableConfigurationError": self._storageResetHandler,
+                "DiskLabelScanError": self._storageResetHandler,
+                "CorruptGPTError": self._storageResetHandler,
+                "DuplicateVGError": self._storageResetHandler,
                 "NoDisksError": self._noDisksHandler,
                 "FSTabTypeMismatchError": self._fstabTypeMismatchHandler,
                 "InvalidImageSizeError": self._invalidImageSizeHandler,

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -82,6 +82,8 @@ class AnacondaExceptionHandler(ExceptionHandler):
                              "The installer will now terminate.") % str(value)
             self.intf.messageWindow(_("Hardware error occured"), hw_error_msg)
             sys.exit(0)
+        elif isinstance(value, blivet.errors.UnusableConfigurationError):
+            sys.exit(0)
         else:
             super(AnacondaExceptionHandler, self).handleException(dump_info)
             return False

--- a/pyanaconda/ui/__init__.py
+++ b/pyanaconda/ui/__init__.py
@@ -121,6 +121,9 @@ class UserInterface(object):
         """
         raise NotImplementedError
 
+    def showDetailedError(self, message, details, buttons=None):
+        raise NotImplementedError
+
     def showYesNoQuestion(self, message):
         """Display a dialog with the given message that presents the user a yes
            or no choice.  This method returns True if the yes choice is selected,

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -747,15 +747,16 @@ class GraphicalUserInterface(UserInterface):
         sys.exit(1)
 
     @gtk_action_wait
-    def showDetailedError(self, message, details):
+    def showDetailedError(self, message, details, buttons=None):
         from pyanaconda.ui.gui.spokes.lib.detailederror import DetailedErrorDialog
-        dlg = DetailedErrorDialog(None, buttons=[_("_Quit")],
-                                  label=message)
+        buttons = buttons or [_("_Quit")]
+        dlg = DetailedErrorDialog(None, buttons=buttons, label=message)
 
         with self.mainWindow.enlightbox(dlg.window):
             dlg.refresh(details)
-            dlg.run()
+            rc = dlg.run()
             dlg.window.destroy()
+            return rc
 
     @gtk_action_wait
     def showYesNoQuestion(self, message):

--- a/pyanaconda/ui/gui/spokes/lib/detailederror.glade
+++ b/pyanaconda/ui/gui/spokes/lib/detailederror.glade
@@ -23,6 +23,7 @@
             <property name="margin_bottom">18</property>
             <property name="xalign">0</property>
             <property name="label" translatable="yes">An unknown error occurred during installation.  Details are below.</property>
+            <property name="use_markup">True</property>
             <property name="wrap">True</property>
           </object>
           <packing>

--- a/pyanaconda/ui/gui/spokes/lib/detailederror.py
+++ b/pyanaconda/ui/gui/spokes/lib/detailederror.py
@@ -65,7 +65,7 @@ class DetailedErrorDialog(GUIObject):
         widget.grab_default()
 
         if label:
-            self.builder.get_object("detailedLabel").set_text(label)
+            self.builder.get_object("detailedLabel").set_markup(label)
 
     # pylint: disable=arguments-differ
     def refresh(self, msg):

--- a/pyanaconda/ui/gui/utils.py
+++ b/pyanaconda/ui/gui/utils.py
@@ -56,23 +56,22 @@ def gtk_action_wait(func):
 
     queue = Queue.Queue()
 
-    def _idle_method(q_args):
+    def _idle_method(queue, args, kwargs):
         """This method contains the code for the main loop to execute.
         """
-        queue, args = q_args
-        ret = func(*args)
+        ret = func(*args, **kwargs)
         queue.put(ret)
         return False
 
-    def _call_method(*args):
+    def _call_method(*args, **kwargs):
         """The new body for the decorated method. If needed, it uses closure
            bound queue variable which is valid until the reference to this
            method is destroyed."""
         if threadMgr.in_main_thread():
             # nothing special has to be done in the main thread
-            return func(*args)
+            return func(*args, **kwargs)
 
-        GLib.idle_add(_idle_method, (queue, args))
+        GLib.idle_add(_idle_method, queue, args, kwargs)
         return queue.get()
 
     return _call_method
@@ -92,21 +91,21 @@ def gtk_action_nowait(func):
        thread. The new method does not wait for the callback to finish.
     """
 
-    def _idle_method(args):
+    def _idle_method(args, kwargs):
         """This method contains the code for the main loop to execute.
         """
-        func(*args)
+        func(*args, **kwargs)
         return False
 
-    def _call_method(*args):
+    def _call_method(*args, **kwargs):
         """The new body for the decorated method.
         """
         if threadMgr.in_main_thread():
             # nothing special has to be done in the main thread
-            func(*args)
+            func(*args, **kwargs)
             return
 
-        GLib.idle_add(_idle_method, args)
+        GLib.idle_add(_idle_method, args, kwargs)
 
     return _call_method
 

--- a/pyanaconda/ui/tui/__init__.py
+++ b/pyanaconda/ui/tui/__init__.py
@@ -268,7 +268,7 @@ class TextUserInterface(ui.UserInterface):
         error_window = ErrorDialog(self._app, message)
         self._app.switch_screen_modal(error_window)
 
-    def showDetailedError(self, message, details):
+    def showDetailedError(self, message, details, buttons=None):
         return self._show_message_in_main_thread(self._showDetailedError, (message, details))
 
     def _showDetailedError(self, message, details):


### PR DESCRIPTION
If there is an issue with the initial storage configuration that must be resolved before installation can continue, give the user an opportunity to resolve it. If they do, they can retry the storage scan and proceed with the installation. If not, they have to exit the installer. Limits on input quality are not unreasonable.

This relies on rhinstaller/blivet#76