### PR TITLE
Add support for chrony pool directive

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1676,9 +1676,9 @@ class Timezone(commands.timezone.F18_Timezone):
         # write out NTP configuration (if set)
         if not self.nontp and self.ntpservers:
             chronyd_conf_path = os.path.normpath(iutil.getSysroot() + ntp.NTP_CONFIG_FILE)
+            pools, servers = ntp.internal_to_pools_and_servers(self.ntpservers)
             try:
-                ntp.save_servers_to_config(self.ntpservers,
-                                           conf_file_path=chronyd_conf_path)
+                ntp.save_servers_to_config(pools, servers, conf_file_path=chronyd_conf_path)
             except ntp.NTPconfigError as ntperr:
                 log.warning("Failed to save NTP configuration: %s", ntperr)
 

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.glade
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.18.3 -->
 <interface>
-  <requires lib="gtk+" version="3.2"/>
+  <requires lib="gtk+" version="3.12"/>
   <requires lib="AnacondaWidgets" version="1.0"/>
   <requires lib="TimezoneMap" version="0.4"/>
   <object class="GtkImage" id="addImage">
@@ -83,6 +83,8 @@
     <columns>
       <!-- column-name hostname -->
       <column type="gchararray"/>
+      <!-- column-name pool -->
+      <column type="gboolean"/>
       <!-- column-name working -->
       <column type="gint"/>
       <!-- column-name use -->
@@ -143,8 +145,8 @@
           <object class="GtkLabel" id="configHeadingLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Add and mark for usage NTP servers</property>
             <property name="xalign">0</property>
+            <property name="label" translatable="yes">Add and mark for usage NTP servers</property>
             <attributes>
               <attribute name="font-desc" value="Sans Bold 12"/>
             </attributes>
@@ -204,6 +206,21 @@
           </packing>
         </child>
         <child>
+          <object class="GtkCheckButton" id="poolCheckButton">
+            <property name="label" translatable="yes">This URL refers to a pool of NTP servers</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="xalign">0</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkScrolledWindow" id="scrolledWindow">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
@@ -235,6 +252,19 @@
                   </object>
                 </child>
                 <child>
+                  <object class="GtkTreeViewColumn" id="pool">
+                    <property name="title" translatable="yes">Pool</property>
+                    <child>
+                      <object class="GtkCellRendererToggle" id="poolRenderer">
+                        <signal name="toggled" handler="on_pool_toggled" swapped="no"/>
+                      </object>
+                      <attributes>
+                        <attribute name="active">1</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                </child>
+                <child>
                   <object class="GtkTreeViewColumn" id="workingColumn">
                     <property name="title" translatable="yes">Working</property>
                     <child>
@@ -250,7 +280,7 @@
                         <signal name="toggled" handler="on_use_server_toggled" swapped="no"/>
                       </object>
                       <attributes>
-                        <attribute name="active">2</attribute>
+                        <attribute name="active">3</attribute>
                       </attributes>
                     </child>
                   </object>
@@ -261,7 +291,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>
@@ -716,9 +746,9 @@
                                           <object class="GtkLabel" id="amPmLabel">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">PM</property>
                                             <property name="margin_top">4</property>
                                             <property name="margin_bottom">5</property>
+                                            <property name="label" translatable="yes">PM</property>
                                             <attributes>
                                               <attribute name="scale" value="1.5"/>
                                             </attributes>
@@ -749,7 +779,7 @@
                                           </packing>
                                         </child>
                                       </object>
-                                   </child>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="left_attach">4</property>

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -328,11 +328,6 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
 
         """
 
-        for row in self._serversStore:
-            if row[0] == server:
-                #do not add duplicate items
-                return
-
         itr = self._serversStore.append([server, SERVER_QUERY, True])
 
         #do not block UI while starting thread (may take some time)

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -56,6 +56,11 @@ SERVER_OK = 0
 SERVER_NOK = 1
 SERVER_QUERY = 2
 
+SERVER_HOSTNAME = 0
+SERVER_POOL = 1
+SERVER_WORKING = 2
+SERVER_USE = 3
+
 DEFAULT_TZ = "America/New_York"
 
 SPLIT_NUMBER_SUFFIX_RE = re.compile(r'([^0-9]*)([-+])([0-9]+)')
@@ -149,26 +154,27 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
     @property
     def working_server(self):
         for row in self._serversStore:
-            if row[1] == SERVER_OK and row[2]:
+            if row[SERVER_WORKING] == SERVER_OK and row[SERVER_USE]:
                 #server is checked and working
-                return row[0]
+                return row[SERVER_HOSTNAME]
 
         return None
 
     @property
-    def servers(self):
-        ret = list()
+    def pools_servers(self):
+        pools = list()
+        servers = list()
 
-        for row in self._serversStore:
-            if row[2]:
-                #server checked
-                ret.append(row[0])
+        for used_row in (row for row in self._serversStore if row[SERVER_USE]):
+            if used_row[SERVER_POOL]:
+                pools.append(used_row[SERVER_HOSTNAME])
+            else:
+                servers.append(used_row[SERVER_HOSTNAME])
 
-        return ret
+        return (pools, servers)
 
     def _render_working(self, column, renderer, model, itr, user_data=None):
-        #get the value in the second column
-        value = model[itr][1]
+        value = model[itr][SERVER_WORKING]
 
         if value == SERVER_QUERY:
             return "dialog-question"
@@ -190,6 +196,8 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
 
         self._addButton = self.builder.get_object("addButton")
 
+        self._poolCheckButton = self.builder.get_object("poolCheckButton")
+
         # Validate the server entry box
         self._serverCheck = self.add_check(self._serverEntry, self._validateServer)
         self._serverCheck.update_check_status()
@@ -200,14 +208,19 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
         self._serversStore.clear()
 
         if self.data.timezone.ntpservers:
-            for server in self.data.timezone.ntpservers:
-                self._add_server(server)
+            pools, servers = ntp.internal_to_pools_and_servers(self.data.timezone.ntpservers)
         else:
             try:
-                for server in ntp.get_servers_from_config():
-                    self._add_server(server)
+                pools, servers = ntp.get_servers_from_config()
             except ntp.NTPconfigError:
                 log.warning("Failed to load NTP servers configuration")
+                return
+
+        for pool in pools:
+            self._add_server(pool, True)
+        for server in servers:
+            self._add_server(server, False)
+
 
     def _validateServer(self, inputcheck):
         server = self.get_input(inputcheck.input_obj)
@@ -246,15 +259,10 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
 
         #OK clicked
         if rc == 1:
-            new_servers = list()
-
-            for row in self._serversStore:
-                #if server checked
-                if row[2]:
-                    new_servers.append(row[0])
+            new_pools, new_servers = self.pools_servers
 
             if flags.can_touch_runtime_system("save NTP servers configuration"):
-                ntp.save_servers_to_config(new_servers)
+                ntp.save_servers_to_config(new_pools, new_servers)
                 iutil.restart_service(NTP_SERVICE)
 
         #Cancel clicked, window destroyed...
@@ -290,8 +298,8 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
             (store, itr, column, value) = arg_tuple
             store.set_value(itr, column, value)
 
-        orig_hostname = self._serversStore[itr][0]
-        server_working = ntp.ntp_server_working(self._serversStore[itr][0])
+        orig_hostname = self._serversStore[itr][SERVER_HOSTNAME]
+        server_working = ntp.ntp_server_working(self._serversStore[itr][SERVER_HOSTNAME])
 
         #do not let dialog change epoch while we are modifying data
         self._epoch_lock.acquire()
@@ -299,27 +307,27 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
         #check if we are in the same epoch as the dialog (and the serversStore)
         #and if the server wasn't changed meanwhile
         if epoch_started == self._epoch:
-            actual_hostname = self._serversStore[itr][0]
+            actual_hostname = self._serversStore[itr][SERVER_HOSTNAME]
 
             if orig_hostname == actual_hostname:
                 if server_working:
                     set_store_value((self._serversStore,
-                                    itr, 1, SERVER_OK))
+                                    itr, SERVER_WORKING, SERVER_OK))
                 else:
                     set_store_value((self._serversStore,
-                                    itr, 1, SERVER_NOK))
+                                    itr, SERVER_WORKING, SERVER_NOK))
         self._epoch_lock.release()
 
     @gtk_action_nowait
     def _refresh_server_working(self, itr):
         """ Runs a new thread with _set_server_ok_nok(itr) as a taget. """
 
-        self._serversStore.set_value(itr, 1, SERVER_QUERY)
+        self._serversStore.set_value(itr, SERVER_WORKING, SERVER_QUERY)
         threadMgr.add(AnacondaThread(prefix="AnaNTPserver",
                                      target=self._set_server_ok_nok,
                                      args=(itr, self._epoch)))
 
-    def _add_server(self, server):
+    def _add_server(self, server, pool=False):
         """
         Checks if a given server is a valid hostname and if yes, adds it
         to the list of servers.
@@ -328,7 +336,7 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
 
         """
 
-        itr = self._serversStore.append([server, SERVER_QUERY, True])
+        itr = self._serversStore.append([server, pool, SERVER_QUERY, True])
 
         #do not block UI while starting thread (may take some time)
         self._refresh_server_working(itr)
@@ -336,17 +344,24 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
     def on_entry_activated(self, entry, *args):
         # Check that the input check has passed
         if self._serverCheck.check_status == InputCheck.CHECK_OK:
-            self._add_server(entry.get_text())
+            self._add_server(entry.get_text(), self._poolCheckButton.get_active())
             entry.set_text("")
+            self._poolCheckButton.set_active(False)
 
     def on_add_clicked(self, *args):
         self._serverEntry.emit("activate")
 
     def on_use_server_toggled(self, renderer, path, *args):
         itr = self._serversStore.get_iter(path)
-        old_value = self._serversStore[itr][2]
+        old_value = self._serversStore[itr][SERVER_USE]
 
-        self._serversStore.set_value(itr, 2, not old_value)
+        self._serversStore.set_value(itr, SERVER_USE, not old_value)
+
+    def on_pool_toggled(self, renderer, path, *args):
+        itr = self._serversStore.get_iter(path)
+        old_value = self._serversStore[itr][SERVER_POOL]
+
+        self._serversStore.set_value(itr, SERVER_POOL, not old_value)
 
     def on_server_edited(self, renderer, path, new_text, *args):
         if not path:
@@ -359,11 +374,11 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
 
         itr = self._serversStore.get_iter(path)
 
-        if self._serversStore[itr][0] == new_text:
+        if self._serversStore[itr][SERVER_HOSTNAME] == new_text:
             return
 
-        self._serversStore.set_value(itr, 0, new_text)
-        self._serversStore.set_value(itr, 1, SERVER_QUERY)
+        self._serversStore.set_value(itr, SERVER_HOSTNAME, new_text)
+        self._serversStore.set_value(itr, SERVER_WORKING, SERVER_QUERY)
 
         self._refresh_server_working(itr)
 
@@ -1102,7 +1117,8 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
             response = self._config_dialog.run()
 
         if response == 1:
-            self.data.timezone.ntpservers = self._config_dialog.servers
+            pools, servers = self._config_dialog.pools_servers
+            self.data.timezone.ntpservers = ntp.pools_servers_to_internal(pools, servers)
 
             if self._config_dialog.working_server is None:
                 self._show_no_ntp_server_warning()


### PR DESCRIPTION
With chrony-2.0 it is possible to specify a pool of NTP servers instead
of individual servers. It selects four servers from the addresses that
the pool name is resolved to and replaces them automatically when they
are unreachable or falsetickers. This is now used in the default Fedora
chrony configuration.

To avoid extending the ntp API and the date time spoke, pools are simply
presented as four separate servers with the same name.

Resolves: rhbz#1193389