### PR TITLE
Add kickstart %pre-install section support

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -21,7 +21,7 @@ Source0: %{name}-%{version}.tar.bz2
 # Also update in AM_GNU_GETTEXT_VERSION in configure.ac
 %define gettextver 0.18.3
 %define intltoolver 0.31.2-3
-%define pykickstartver 2.5
+%define pykickstartver 2.6
 %define yumver 3.4.3-91
 %define dnfver 0.6.4
 %define partedver 1.8.1

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -65,13 +65,13 @@ from pyanaconda.bootloader import GRUB2, get_bootloader
 from pyanaconda.pwpolicy import F22_PwPolicy, F22_PwPolicyData
 
 from pykickstart.constants import CLEARPART_TYPE_NONE, FIRSTBOOT_SKIP, FIRSTBOOT_RECONFIG, KS_SCRIPT_POST, KS_SCRIPT_PRE, \
-                                  KS_SCRIPT_TRACEBACK, SELINUX_DISABLED, SELINUX_ENFORCING, SELINUX_PERMISSIVE
+                                  KS_SCRIPT_TRACEBACK, KS_SCRIPT_PREINSTALL, SELINUX_DISABLED, SELINUX_ENFORCING, SELINUX_PERMISSIVE
 from pykickstart.base import BaseHandler
 from pykickstart.errors import formatErrorMsg, KickstartError, KickstartValueError
 from pykickstart.parser import KickstartParser
 from pykickstart.parser import Script as KSScript
 from pykickstart.sections import Section
-from pykickstart.sections import NullSection, PackageSection, PostScriptSection, PreScriptSection, TracebackScriptSection
+from pykickstart.sections import NullSection, PackageSection, PostScriptSection, PreScriptSection, PreInstallScriptSection, TracebackScriptSection
 from pykickstart.version import returnClassForVersion
 
 import logging
@@ -2010,6 +2010,7 @@ class AnacondaPreParser(KickstartParser):
 
     def setupSections(self):
         self.registerSection(PreScriptSection(self.handler, dataObj=AnacondaKSScript))
+        self.registerSection(NullSection(self.handler, sectionOpen="%pre-install"))
         self.registerSection(NullSection(self.handler, sectionOpen="%post"))
         self.registerSection(NullSection(self.handler, sectionOpen="%traceback"))
         self.registerSection(NullSection(self.handler, sectionOpen="%packages"))
@@ -2031,6 +2032,7 @@ class AnacondaKSParser(KickstartParser):
 
     def setupSections(self):
         self.registerSection(PreScriptSection(self.handler, dataObj=self.scriptClass))
+        self.registerSection(PreInstallScriptSection(self.handler, dataObj=self.scriptClass))
         self.registerSection(PostScriptSection(self.handler, dataObj=self.scriptClass))
         self.registerSection(TracebackScriptSection(self.handler, dataObj=self.scriptClass))
         self.registerSection(PackageSection(self.handler))
@@ -2120,6 +2122,16 @@ def runPreScripts(scripts):
     map(lambda s: s.run("/"), preScripts)
 
     log.info("All kickstart %%pre script(s) have been run")
+
+def runPreInstallScripts(scripts):
+    preInstallScripts = [s for s in scripts if s.type == KS_SCRIPT_PREINSTALL]
+
+    if len(preInstallScripts) == 0:
+        return
+
+    log.info("Running kickstart %%pre-install script(s)")
+    map (lambda s: s.run("/"), preInstallScripts)
+    log.info("All kickstart %%pre-install script(s) have been run")
 
 def runTracebackScripts(scripts):
     log.info("Running kickstart %%traceback script(s)")


### PR DESCRIPTION
The %pre-install section will run scripts after all the filesystems have
been setup and mounted on /mnt/sysimage, but before any packages have
been installed.