### PR TITLE
Move some blivet Requires to anaconda.

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -81,7 +81,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 %package core
 Summary: Core of the Anaconda installer
 Requires: python3-dnf >= %{dnfver}
-Requires: python3-blivet >= 1:1.0
+Requires: python3-blivet >= 1:1.4
 Requires: python3-meh >= %{mehver}
 Requires: libreport-anaconda >= 2.0.21-1
 Requires: libselinux-python3

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -53,6 +53,7 @@ from blivet.devicefactory import DEVICE_TYPE_MD
 from blivet.devicefactory import DEVICE_TYPE_DISK
 from blivet.devicefactory import DEVICE_TYPE_LVM_THINP
 from blivet.devicefactory import SIZE_POLICY_AUTO
+from blivet.devicefactory import is_supported_device_type
 from blivet.osinstall import findExistingInstallations, Root
 from blivet.autopart import doAutoPartition
 from blivet.errors import StorageError
@@ -1385,6 +1386,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         # only include disk if the current device is a disk
         if use_dev.isDisk:
             should_appear.add("DEVICE_TYPE_DISK")
+
+        should_appear = set(dt for dt in should_appear if is_supported_device_type(dev_type_from_const(dt)))
 
         # go through the store and remove things that shouldn't be included
         # store.remove() updates or invalidates the passed iterator

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -20,12 +20,13 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 #
 
+from blivet.devicefactory import is_supported_device_type
 
 from pyanaconda.i18n import _
 from pyanaconda.product import productName, productVersion
 from pyanaconda.ui.gui.utils import escape_markup, really_hide, really_show
 from pyanaconda.constants import DEFAULT_AUTOPART_TYPE
-from pyanaconda.storage_utils import AUTOPART_CHOICES
+from pyanaconda.storage_utils import AUTOPART_CHOICES, AUTOPART_DEVICE_TYPES
 
 from gi.repository.AnacondaWidgets import MountpointSelector
 from gi.repository import Gtk
@@ -331,15 +332,18 @@ class CreateNewPage(Page):
         self._createBox.attach(label, 0, 4, 2, 1)
         label.set_mnemonic_widget(combo)
 
-        for item in (AUTOPART_CHOICES):
-            itr = store.append([_(item[0]), item[1]])
-            if item[1] == DEFAULT_AUTOPART_TYPE:
+        autopart_choices = (c for c in AUTOPART_CHOICES if is_supported_device_type(AUTOPART_DEVICE_TYPES[c[1]]))
+        default = None
+        for name, code in autopart_choices:
+            itr = store.append([_(name), code])
+            if code == DEFAULT_AUTOPART_TYPE:
                 default = itr
 
         combo.set_margin_left(18)
         combo.set_margin_right(18)
         combo.set_hexpand(False)
-        combo.set_active_iter(default)
+        combo.set_active_iter(default or store.get_iter_first())
+
         self._createBox.attach(combo, 0, 5, 2, 1)
 
         self.add(self._createBox)


### PR DESCRIPTION
When blivet becomes environment aware, it will not need to require these
packages, since it should not fail in the event that these
packages are not installed.

Presumably anaconda still wants the capabilities these packages provide,
since it is used to having them through blivet, so add these Requires to
anaconda.

Signed-off-by: mulhern <amulhern@redhat.com>