### PR TITLE
Set the GUI-selected environment in the ksdata (#1192100)

### DIFF
--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -1032,13 +1032,10 @@ class PackagePayload(Payload):
         if environmentid not in self.environments:
             raise NoSuchGroup(environmentid)
 
+        self.data.packages.environment = environmentid
+
         if excluded is None:
             excluded = []
-
-        # Select each group within the environment, as long as that group was
-        # not explicitly excluded by the user.
-        for groupid in set(self.environmentGroups(environmentid, optional=False)) - set(excluded):
-            self.selectGroup(groupid)
 
     def environmentGroups(self, environmentid, optional=True):
         raise NotImplementedError()

--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -292,7 +292,7 @@ class DNFPayload(packaging.PackagePayload):
 
         if env:
             try:
-                self.selectEnvironment(env, excludedGroups)
+                self._select_environment(env, excludedGroups)
                 log.info("selected env: %s", env)
             except packaging.NoSuchGroup as e:
                 self._miss(e)
@@ -443,6 +443,13 @@ class DNFPayload(packaging.PackagePayload):
         except dnf.exceptions.CompsError as e:
             # DNF raises this when it is already selected
             log.debug(e)
+
+    def _select_environment(self, env_id, excluded):
+        # dnf.base.environment_install excludes on packages instead of groups,
+        # which is unhelpful. Instead, use group_install for each group in
+        # the environment so we can skip the ones that are excluded.
+        for groupid in set(self.environmentGroups(env_id, optional=False)) - set(excluded):
+            self._select_group(groupid)
 
     def _select_kernel_package(self):
         kernels = self.kernelPackages

--- a/pyanaconda/packaging/yumpayload.py
+++ b/pyanaconda/packaging/yumpayload.py
@@ -1092,6 +1092,18 @@ reposdir=%s
             except yum.Errors.GroupsError:
                 raise NoSuchGroup(groupid, required=required)
 
+    def _selectYumEnvironment(self, envid):
+        # select the environment in comps
+        pkg_types = ['mandatory', 'default']
+
+        log.debug("select environment %s", envid)
+
+        with _yum_lock:
+            try:
+                self._yum.selectEnvironment(envid, pkg_types)
+            except yum.Errors.GroupsError:
+                raise NoSuchGroup(envid, required=False)
+
     def _deselectYumGroup(self, groupid):
         # deselect the group in comps
         log.debug("deselect group %s", groupid)
@@ -1214,7 +1226,7 @@ reposdir=%s
 
         if env:
             try:
-                self.selectEnvironment(env)
+                self._selectYumEnvironment(env)
             except NoSuchGroup as e:
                 self._handleMissing(e)
 


### PR DESCRIPTION
This way an environment selected in the GUI and an environment selected
in kickstart are treated in the same way. This fixes the problem where
changing payloads forgets the previous environment selection, and it
changes the generated %packages section of anaconda-ks.cfg to contain
the environment information instead of a list of the groups in the
environment.

This commit restores the dnf _select_environment method removed in
602f47dcd5d7543f66dc6833685d0e810595acb5, but modifies it so that the
environment is both selected in dnf and in the kickstart data.