### PR TITLE
Force an encoding of utf-8 on liveinst installs (#1217504)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -237,6 +237,10 @@ find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 
 %ifarch %livearches
 desktop-file-install ---dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_datadir}/applications/liveinst.desktop
+
+# Add a sitecustomize.py to be loaded by liveinst
+mkdir -p %{buildroot}%{_datadir}/anaconda/site-python
+install -m 0644 pyanaconda/sitecustomize.py %{buildroot}%{_datadir}/anaconda/site-python/
 %endif
 # NOTE: If you see "error: Installed (but unpackaged) file(s) found" that include liveinst files,
 #       check the IS_LIVEINST_ARCH in configure.ac to make sure your architecture is properly defined

--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -85,6 +85,7 @@ else
 fi
 
 export PATH=/sbin:/usr/sbin:$PATH
+export PYTHONPATH=/usr/share/anaconda/site-python
 
 if [ -x /usr/sbin/getenforce ]; then
     current=$(/usr/sbin/getenforce)


### PR DESCRIPTION
Not saying we shouldn't fix the underlying problem, but this will make the ones we miss go away