### PR TITLE
make custom partitioning fit in 800x600

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.glade
+++ b/pyanaconda/ui/gui/spokes/custom.glade
@@ -519,7 +519,6 @@
                                                 <property name="xalign">0</property>
                                                 <property name="wrap">True</property>
                                                 <property name="width_chars">35</property>
-                                                <property name="angle">0.01</property>
                                                 <property name="max_width_chars">35</property>
                                               </object>
                                               <packing>

--- a/pyanaconda/ui/gui/spokes/custom.glade
+++ b/pyanaconda/ui/gui/spokes/custom.glade
@@ -518,7 +518,7 @@
                                                 <property name="valign">start</property>
                                                 <property name="xalign">0</property>
                                                 <property name="wrap">True</property>
-                                                <property name="width_chars">35</property>
+                                                <property name="wrap_mode">word-char</property>
                                                 <property name="max_width_chars">35</property>
                                               </object>
                                               <packing>


### PR DESCRIPTION
Some people (ppc64 users, I am looking at you) insist on running anaconda in teeny tiny VNC windows and get confused or angry when we ask them to bump up the size a little bit. Fine. Cram everything into 800x600. It was pretty close to fitting anyway.

Going any smaller will take a lot more work.