### PR TITLE
Fix bad IP checker in text installation

### DIFF
--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -110,6 +110,7 @@ class EditTUIDialog(NormalTUISpoke):
         NormalTUISpoke.__init__(self, app, data, storage, payload, instclass)
         self.value = None
         self.policy = None
+        self.wrong_input_message = None
 
         # Configure the password policy, if available. Otherwise use defaults.
         self.policy = self.data.anaconda.pwpolicy.get_policy(policy_name)
@@ -183,8 +184,11 @@ class EditTUIDialog(NormalTUISpoke):
             self.close()
             return True
         else:
-            print(_("You have provided an invalid user name: %s\n"
-                    "Tip: Keep your user name shorter than 32 characters and do not use spaces.\n") % key)
+            if self.wrong_input_message:
+                print(self.wrong_input_message)
+            else:
+                print(_("You have provided an invalid user name: %s\n"
+                        "Tip: Keep your user name shorter than 32 characters and do not use spaces.\n") % key)
             return NormalTUISpoke.input(self, entry, key)
 
 class OneShotEditTUIDialog(EditTUIDialog):

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -296,6 +296,7 @@ class ConfigureNetworkSpoke(EditTUISpoke):
         if self.args.noipv6:
             self.args.ipv6 = "ignore"
         self.args._apply = False
+        self.dialog.wrong_input_message = _("Bad format of the IP address")
 
     def refresh(self, args=None):
         """ Refresh window. """


### PR DESCRIPTION
Fix for crash in text anaconda when user set illegal IP address.
Fix bad warning message when illegal IP is set.

*Resolves bug (#1217393)*