### PR TITLE
Do not create HFS+ EFI partition on Intel Macs

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1119,11 +1119,8 @@ class PartitionData(commands.partition.F18_PartData):
             if self.onPart:
                 ksdata.onPart[kwargs["name"]] = self.onPart
         elif self.mountpoint == "/boot/efi":
-            if blivet.arch.isMactel():
-                ty = "hfs+"
-            else:
-                ty = "EFI System Partition"
-                self.fsopts = "defaults,uid=0,gid=0,umask=0077,shortname=winnt"
+            ty = "EFI System Partition"
+            self.fsopts = "defaults,uid=0,gid=0,umask=0077,shortname=winnt"
         else:
             if self.fstype != "":
                 ty = self.fstype


### PR DESCRIPTION
This commit complements blivet's
c35aafe4b27318faee52b5a0ea44ca9a6fd4a1ec because RHEL7 doesn't support
working with HFS+ partitions.

The HW boots just fine with VFAT EFI system partition. The downside of
using VFAT is that there aren't pretty menus, but I prefer no menus but
working system over non-working system each time.