### PR TITLE
Add kickstart tests for proxy usage.

### DIFF
--- a/tests/kickstart_tests/proxy-cmdline.ks
+++ b/tests/kickstart_tests/proxy-cmdline.ks
@@ -1,0 +1,78 @@
+# Start a super-simple proxy server on localhost
+# A list of proxied requests will be saved to /tmp/proxy.log
+%pre --erroronfail
+# Write the proxy script to a file in /tmp
+cat - << "EOF" > /tmp/proxy-test.py
+from six.moves import SimpleHTTPServer, socketserver
+from six.moves.urllib.request import urlopen
+import os, sys
+
+import logging
+log = logging.getLogger("proxy_test")
+log_handler = logging.FileHandler('/tmp/proxy.log')
+log.setLevel(logging.INFO)
+log.addHandler(log_handler)
+
+class ProxyHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    def do_GET(self):
+	# Log the path then proxy the request via urllib
+	log.info(self.path)
+        data = urlopen(self.path).read()
+        self.send_response(200)
+        self.send_header('Content-Length', str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+class ProxyServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+    def __init__(self):
+        socketserver.TCPServer.__init__(self, ('', 8080), ProxyHandler)
+
+ProxyServer().serve_forever()
+EOF
+
+# Run the server in the background and exit
+python /tmp/proxy-test.py > /dev/null 2>&1 &
+%end
+
+url --url=http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+part --fstype=ext4 --size=4400 /
+part --fstype=ext4 --size=500 /boot
+part --fstype=swap --size=500 swap
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+# Just install @core
+%packages
+%end
+
+%post --nochroot
+# Look for the following as evidence that a proxy was used:
+# a .treeinfo request
+# primary.xml from the repodata
+# a package. Let's say kernel, there should definitely have been a kernel
+
+if ! grep -q '\.treeinfo$' /tmp/proxy.log; then
+    result='.treeinfo request was not proxied'
+elif ! grep -q 'repodata/.*primary.xml' /tmp/proxy.log; then
+    result='repodata requests were not proxied'
+elif ! grep -q 'kernel-.*\.rpm' /tmp/proxy.log; then
+    result='package requests were not proxied'
+else
+    result='SUCCESS'
+fi
+
+# Write the result to the installed /root
+echo "$result" > $ANA_INSTALL_PATH/root/RESULT
+%end

--- a/tests/kickstart_tests/proxy-cmdline.sh
+++ b/tests/kickstart_tests/proxy-cmdline.sh
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+kernel_args() {
+    echo vnc inst.proxy=http://127.0.0.1:8080
+}
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    echo ${ks}
+}
+
+validate() {
+    img=$1
+
+    # There should be a /root/RESULT file with results in it. Check
+    # its contents and decide whether the test finally succeeded or
+    # not.
+    result=$(virt-cat -a ${img} -m /dev/sda2 /root/RESULT)
+    if [[ $? != 0 ]]; then
+        status=1
+        echo '*** /root/RESULT does not exist in VM image.'
+    elif [[ "${result}" != "SUCCESS" ]]; then
+        status=1
+        echo "${result}"
+    fi
+
+    return ${status}
+}

--- a/tests/kickstart_tests/proxy-kickstart.ks
+++ b/tests/kickstart_tests/proxy-kickstart.ks
@@ -1,0 +1,82 @@
+# Start a super-simple proxy server on localhost
+# A list of proxied requests will be saved to /tmp/proxy.log
+%pre --erroronfail
+# Write the proxy script to a file in /tmp
+cat - << "EOF" > /tmp/proxy-test.py
+from six.moves import SimpleHTTPServer, socketserver
+from six.moves.urllib.request import urlopen
+import os, sys
+
+import logging
+log = logging.getLogger("proxy_test")
+log_handler = logging.FileHandler('/tmp/proxy.log')
+log.setLevel(logging.INFO)
+log.addHandler(log_handler)
+
+class ProxyHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    def do_GET(self):
+	# Log the path then proxy the request via urllib
+	log.info(self.path)
+        data = urlopen(self.path).read()
+        self.send_response(200)
+        self.send_header('Content-Length', str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+class ProxyServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+    def __init__(self):
+        socketserver.TCPServer.__init__(self, ('', 8080), ProxyHandler)
+
+ProxyServer().serve_forever()
+EOF
+
+# Run the server in the background and exit
+python /tmp/proxy-test.py > /dev/null 2>&1 &
+%end
+
+url --url=http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/ --proxy=127.0.0.1:8080
+repo --name=kstest-http --baseurl=HTTP-ADDON-REPO --proxy=127.0.0.1:8080
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+part --fstype=ext4 --size=4400 /
+part --fstype=ext4 --size=500 /boot
+part --fstype=swap --size=500 swap
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+# Install @core, which will also pull in testpkg-http-core from the addon repo
+%packages
+%end
+
+%post --nochroot
+# Look for the following as evidence that a proxy was used:
+# a .treeinfo request
+# primary.xml from the repodata
+# the kernel package from the Fedora repo
+# testpkg-http-core from the addon repo
+
+if ! grep -q '\.treeinfo$' /tmp/proxy.log; then
+    result='.treeinfo request was not proxied'
+elif ! grep -q 'repodata/.*primary.xml' /tmp/proxy.log; then
+    result='repodata requests were not proxied'
+elif ! grep -q 'kernel-.*\.rpm' /tmp/proxy.log; then
+    result='base repo package requests were not proxied'
+elif ! grep -q 'testpkg-http-core.*\.rpm' /tmp/proxy.log; then
+    result='addon repo package requests were not proxied'
+else
+    result='SUCCESS'
+fi
+
+# Write the result to the installed /root
+echo "$result" > $ANA_INSTALL_PATH/root/RESULT
+%end

--- a/tests/kickstart_tests/proxy-kickstart.sh
+++ b/tests/kickstart_tests/proxy-kickstart.sh
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+kernel_args() {
+    echo vnc
+}
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    if [[ "${KSTEST_ADDON_HTTP_REPO}" == "" ]]; then
+        echo \$KSTEST_ADDON_HTTP_REPO is not set.
+        return 1.
+    fi
+
+    sed -e "/^repo/ s|HTTP-ADD-REPO|${KSTEST_ADDON_HTTP_REPO}|" ${ks} > ${tmpdir}/kickstart.ks
+    echo ${tmpdir}/kickstart.ks
+}
+
+validate() {
+    img=$1
+
+    # There should be a /root/RESULT file with results in it. Check
+    # its contents and decide whether the test finally succeeded or
+    # not.
+    result=$(virt-cat -a ${img} -m /dev/sda2 /root/RESULT)
+    if [[ $? != 0 ]]; then
+        status=1
+        echo '*** /root/RESULT does not exist in VM image.'
+    elif [[ "${result}" != "SUCCESS" ]]; then
+        status=1
+        echo "${result}"
+    fi
+
+    return ${status}
+}


### PR DESCRIPTION
One test sets a proxy via inst.proxy, and the other through --proxy
arguments in the kickstart. Both tests use a simple python-based proxy
running on localhost and launched via %pre.