### PR TITLE
Don't pass anything to ./configure.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,8 +19,6 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-AM_DISTCHECK_CONFIGURE_FLAGS = --enable-gtk-doc
-
 SUBDIRS = data docs dracut po pyanaconda scripts tests widgets utils
 
 EXTRA_DIST = config.rpath COPYING

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -226,9 +226,7 @@ runtime on NFS/HTTP/FTP servers or local disks.
 %setup -q
 
 %build
-%configure --disable-static \
-           --enable-introspection \
-           --enable-gtk-doc
+%configure
 %{__make} %{?_smp_mflags}
 
 %install

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,11 @@ m4_define(python_required_version, 2.5)
 
 AC_PREREQ([2.63])
 AC_INIT([anaconda], [23.7], [anaconda-devel-list@redhat.com])
+
+# Disable building static libraries.
+# This needs to be set before initializing automake
+AC_DISABLE_STATIC
+
 AM_INIT_AUTOMAKE([foreign no-dist-gzip dist-bzip2 tar-ustar])
 
 AC_CONFIG_HEADERS([config.h])

--- a/docs/translations.txt
+++ b/docs/translations.txt
@@ -46,8 +46,7 @@ MAKING A RELEASE
 ----------------
 
 git clean -d -x -f
-./autogen.sh && ./configure --disable-static \
---enable-introspection --enable-gtk-doc
+./autogen.sh && ./configure
 make bumpver                      # zanata pull by dependent po-pull target
 git commit -a -m "New version."   # DO NOT run 'git clean -d -x -f' after
 make && make release              # signed tag happens after dist now

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -399,7 +399,7 @@ def checkAutotools(srcdir, builddir):
         if not os.path.isfile('configure'):
             os.system('./autogen.sh')
         os.chdir(builddir)
-        os.system(os.path.join(srcdir, 'configure') + ' --prefix=`rpm --eval %_prefix` --enable-gtk-doc --enable-introspection')
+        os.system(os.path.join(srcdir, 'configure') + ' --prefix=`rpm --eval %_prefix`')
         os.chdir(srcdir)
 
 def copyUpdatedIsys(updates, srcdir, builddir):

--- a/widgets/configure.ac
+++ b/widgets/configure.ac
@@ -21,6 +21,11 @@
 
 AC_PREREQ([2.63])
 AC_INIT([AnacondaWidgets], [3.2], [clumens@redhat.com])
+
+# Disable building static libraries.
+# This needs to be set before initializing automake
+AC_DISABLE_STATIC
+
 AM_INIT_AUTOMAKE([foreign])
 AM_SILENT_RULES([yes])
 

--- a/widgets/src/Makefile.am
+++ b/widgets/src/Makefile.am
@@ -23,8 +23,6 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-DISTCHECK_CONFIGURE_FLAGS = --enable-introspection --enable-gtk-doc
-
 GISOURCES = BaseWindow.c \
 	 DiskOverview.c \
 	 HubWindow.c \


### PR DESCRIPTION
Add a couple of lines to configure.ac to make --disable-static the
default, and everything else we were using is already the default.