### PR TITLE
TypeError: argument must be string (#1209414)

### DIFF
--- a/partIntfHelpers.py
+++ b/partIntfHelpers.py
@@ -513,7 +513,7 @@ def drive_iscsi_addition(anaconda, wizard):
 
         except (network.IPMissing, network.IPError) as msg:
             log.info("addIscsiDrive() cancelled due to an invalid IP address.")
-            anaconda.intf.messageWindow(_("iSCSI Error"), msg)
+            anaconda.intf.messageWindow(_("iSCSI Error"), str(msg))
             if step != STEP_DISCOVERY:
                 break
         except (ValueError, IOError) as e:


### PR DESCRIPTION
We tried to show exception object instead of string.
Now the exception is changed to string.

Resolves: rhbz#1209414