### PR TITLE
Don't use $LANGUAGE if empty (#1222262)

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -1224,8 +1224,12 @@ if __name__ == "__main__":
     # ability to set the language and locale after startup. If any of, in
     # order, $LANGUAGE, $LC_ALL, or $LC_MESSAGES is in the environment, copy
     # the information to $LANG, and then clear the rest.
+
+    # The variables only count if not empty, and some programs (KDE) insist
+    # on setting empty language variables, which would break if we actually
+    # tried to use them.
     for varname in ("LANGUAGE", "LC_ALL", "LC_MESSAGES"):
-        if varname in os.environ:
+        if varname in os.environ and os.environ[varname]:
             os.environ["LANG"] = os.environ[varname] # pylint: disable=environment-modify
             break
 


### PR DESCRIPTION
KDE sets $LANGUAGE to an empty string for some mysterious reason, and
they know about it, and they ain't gonna fix it. Ignore $LANGUAGE if
it's an empty string because a careful reading of the man page says that
$LANGUAGE only counts if it contains something and an empty $LANGUAGE
breaks everything.