### PR TITLE
Fix bad IP checker in text installation

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -82,6 +82,10 @@ def check_ip_address(address, version=None):
         return False
     if version and version == ver:
         return True
+    elif not version:
+        return True
+    else:
+        return False
 
 def sanityCheckHostname(hostname):
     """
@@ -421,11 +425,13 @@ def _get_ip_setting_values_from_ksdata(networkdata):
     nss4 = []
     nss6 = []
     if networkdata.nameserver:
-        for ns in networkdata.nameserver.split(","):
-            if ":" in ns:
+        for ns in [str.strip(i) for i in networkdata.nameserver.split(",")]:
+            if check_ip_address(ns, version=6):
                 nss6.append(nm.nm_ipv6_to_dbus_ay(ns))
-            else:
+            elif check_ip_address(ns, version=4):
                 nss4.append(nm.nm_ipv4_to_dbus_int(ns))
+            else:
+                log.error("IP address %s is not valid", ns)
     values.append(["ipv4", "dns", nss4, "au"])
     values.append(["ipv6", "dns", nss6, "aay"])
 

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -110,6 +110,7 @@ class EditTUIDialog(NormalTUISpoke):
         NormalTUISpoke.__init__(self, app, data, storage, payload, instclass)
         self.value = None
         self.policy = None
+        self.wrong_input_message = None
 
         # Configure the password policy, if available. Otherwise use defaults.
         self.policy = self.data.anaconda.pwpolicy.get_policy(policy_name)
@@ -183,8 +184,11 @@ class EditTUIDialog(NormalTUISpoke):
             self.close()
             return True
         else:
-            print(_("You have provided an invalid user name: %s\n"
-                    "Tip: Keep your user name shorter than 32 characters and do not use spaces.\n") % key)
+            if self.wrong_input_message:
+                print(self.wrong_input_message)
+            else:
+                print(_("You have provided an invalid user name: %s\n"
+                        "Tip: Keep your user name shorter than 32 characters and do not use spaces.\n") % key)
             return NormalTUISpoke.input(self, entry, key)
 
 class OneShotEditTUIDialog(EditTUIDialog):

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -295,6 +295,7 @@ class ConfigureNetworkSpoke(EditTUISpoke):
         if self.args.noipv6:
             self.args.ipv6 = "ignore"
         self.args._apply = False
+        self.dialog.wrong_input_message = _("Bad format of the IP address")
 
     def refresh(self, args=None):
         """ Refresh window. """

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -253,6 +253,20 @@ class Fake_RE_IPV6(object):
                 return False
         return network.check_ip_address(addr, version=6)
 
+class Fake_RE_Nameservers(object):
+    def __init__(self, separator):
+        self._separator = separator
+
+    def match(self, value):
+        addresses = [str.strip(i) for i in value.split(self._separator)]
+        if not addresses:
+            return False
+
+        for ip in addresses:
+            if not network.check_ip_address(ip):
+                return False
+        return True
+
 class ConfigureNetworkSpoke(EditTUISpoke):
     """ Spoke to set various configuration options for net devices. """
     title = N_("Device configuration")
@@ -260,14 +274,15 @@ class ConfigureNetworkSpoke(EditTUISpoke):
 
     edit_fields = [
         Entry(N_('IPv4 address or %s for DHCP') % '"dhcp"', "ip",
-              re.compile("^" + IPV4_PATTERN_WITHOUT_ANCHORS + "|dhcp$"), True),
+              re.compile("^(?:" + IPV4_PATTERN_WITHOUT_ANCHORS + "|dhcp)$"), True),
         Entry(N_("IPv4 netmask"), "netmask", re.compile("^" + IPV4_PATTERN_WITHOUT_ANCHORS + "$"), True),
         Entry(N_("IPv4 gateway"), "gateway", re.compile("^" + IPV4_PATTERN_WITHOUT_ANCHORS + "$"), True),
         Entry(N_('IPv6 address or %(auto)s for automatic, %(dhcp)s for DHCP, %(ignore)s to turn off')
               % {"auto": '"auto"', "dhcp": '"dhcp"', "ignore": '"ignore"'}, "ipv6",
               Fake_RE_IPV6(allow_prefix=True, whitelist=["auto", "dhcp", "ignore"]), True),
-        Entry(N_("IPv6 default gateway"), "ipv6gateway", re.compile(".*$"), True),
-        Entry(N_("Nameservers (comma separated)"), "nameserver", re.compile(".*$"), True),
+        Entry(N_("IPv6 default gateway"), "ipv6gateway", Fake_RE_IPV6(), True),
+        Entry(N_("Nameservers (comma separated)"), "nameserver",
+              Fake_RE_Nameservers(separator=","), True),
         Entry(N_("Connect automatically after reboot"), "onboot", EditTUISpoke.CHECK, True),
         Entry(N_("Apply configuration in installer"), "_apply", EditTUISpoke.CHECK, True),
     ]


### PR DESCRIPTION
Fix for crash in text anaconda when user set illegal IP address.
Fix bad warning message when illegal IP is set.
Nameservers option can be now set with whitespaces.

*Updated PR https://github.com/rhinstaller/anaconda/pull/98.*
*Resolves bug (#1217393)*