### PR TITLE
Add kickstart test to test vlan creation

### DIFF
--- a/tests/kickstart_tests/network-vlan.ks
+++ b/tests/kickstart_tests/network-vlan.ks
@@ -1,0 +1,51 @@
+url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+install
+network --device=link --bootproto=dhcp
+# Create testing vlan interface
+network --device=link --vlanid=150 --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+part --fstype=ext4 --size=4400 /
+part --fstype=ext4 --size=500 /boot
+part --fstype=swap --size=500 swap
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+CONTENT=$(cat /etc/sysconfig/network-scripts/$(ls /etc/sysconfig/network-scripts/ | grep ".150"))
+DEVICE=$(sed -n 's/^PHYSDEV=//p' <<< "$CONTENT")
+
+echo "$CONTENT" > /root/IFCFG_FILE
+echo "$DEVICE" > /root/DEVICE_NAME
+
+if [[ $CONTENT == "" ]]; then
+   echo "ERROR: ifcfg file for vlan missing" >> /root/RESULT
+   exit 0
+fi
+
+if [[ $CONTENT != *"BOOTPROTO=dhcp"* ]]; then
+   echo "ERROR: BOOTPROTO is not present" >> /root/RESULT
+fi
+
+if [[ $CONTENT != *"NAME=${DEVICE}.150"* ]]; then
+   echo "ERROR: NAME is not present" >> /root/RESULT
+fi
+
+if [[ $CONTENT != *"DEVICE=${DEVICE}.150"* ]]; then
+   echo "ERROR: DEVICE is not present" >> /root/RESULT
+fi
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+   echo SUCCESS > /root/RESULT
+fi
+%end

--- a/tests/kickstart_tests/network-vlan.sh
+++ b/tests/kickstart_tests/network-vlan.sh
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+kernel_args() {
+    echo vnc
+}
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    echo ${ks}
+}
+
+validate() {
+    img=$1
+
+    # There should be a /root/RESULT file with results in it.  Check
+    # its contents and decide whether the test finally succeeded or
+    # not.
+    result=$(virt-cat -a ${img} -m /dev/sda2 /root/RESULT)
+    if [[ $? != 0 ]]; then
+        status=1
+        echo '*** /root/RESULT does not exist in VM image.'
+    elif [[ "${result}" != "SUCCESS" ]]; then
+        status=1
+        echo "${result}"
+    fi
+
+    return ${status}
+}
+


### PR DESCRIPTION
Steps of testing:
* create vlan with ``network --device=link --vlanid=150 --bootproto=dhcp`` ks command
* test ifcfg file in post section

I'm saving content of the configuration file and name of the vlan device to special file for debugging purpose.