### PR TITLE
Add kickstart test to test bond interface creation

### DIFF
--- a/tests/kickstart_tests/network-bond.ks
+++ b/tests/kickstart_tests/network-bond.ks
@@ -1,0 +1,66 @@
+url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+install
+network --device=link --bootproto=dhcp
+
+# Create testing bond interface
+network --device=bond0 --bootproto=static --bondslaves=link --ip=192.168.1.1 --netmask=255.255.252.0 --gateway=192.168.1.2 --nameserver=192.168.1.3 --activate
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+part --fstype=ext4 --size=4400 /
+part --fstype=ext4 --size=500 /boot
+part --fstype=swap --size=500 swap
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+%post
+CONTENT=$(cat /etc/sysconfig/network-scripts/ifcfg-bond0)
+
+printf $CONTENT > /root/IFCFG
+
+if [[ $CONTENT == "" ]]; then
+   echo "ERROR: ifcfg file for bond interface missing" > /root/RESULT
+   exit 0
+fi
+
+if [[ $CONTENT != *"DEVICE=bond0"* ]]; then
+   echo "ERROR: DEVICE is not present" >> /root/RESULT
+fi
+
+if [[ $CONTENT != *"TYPE=Bond"* ]]; then
+   echo "ERROR: TYPE is not present" >> /root/RESULT
+fi
+
+if [[ $CONTENT != *"ONBOOT=yes"* ]]; then
+   echo "ERROR: ONBOOT is not present" >> /root/RESULT
+fi
+
+if [[ $CONTENT != *"IPADDR=192.168.1.1"* ]]; then
+   echo "ERROR: IPADDR is not present" >> /root/RESULT
+fi
+
+if [[ $CONTENT != *"PREFIX=22"* ]]; then
+   echo "ERROR: PREFIX is not present" >> /root/RESULT
+fi
+
+if [[ $CONTENT != *"GATEWAY=192.168.1.2"* ]]; then
+   echo "ERROR: GATEWAY is not present" >> /root/RESULT
+fi
+
+if [[ $CONTENT != *"DNS1=192.168.1.3"* ]]; then
+   echo "ERROR: DNS1 is not present" >> /root/RESULT
+fi
+
+# No error was written to /root/RESULT file, everything is OK
+if [[ ! -e /root/RESULT ]]; then
+   echo SUCCESS > /root/RESULT
+fi
+%end

--- a/tests/kickstart_tests/network-bond.sh
+++ b/tests/kickstart_tests/network-bond.sh
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+kernel_args() {
+    echo vnc
+}
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    echo ${ks}
+}
+
+validate() {
+    img=$1
+
+    # There should be a /root/RESULT file with results in it.  Check
+    # its contents and decide whether the test finally succeeded or
+    # not.
+    result=$(virt-cat -a ${img} -m /dev/sda2 /root/RESULT)
+    if [[ $? != 0 ]]; then
+        status=1
+        echo '*** /root/RESULT does not exist in VM image.'
+    elif [[ "${result}" != "SUCCESS" ]]; then
+        status=1
+        echo "${result}"
+    fi
+
+    return ${status}
+}
+


### PR DESCRIPTION
Steps of testing:

* create bond with ``network --device=bond0 --bootproto=static --bondslaves=link --ip=192.168.1.1 --netmask=255.255.252.0 --gateway=192.168.1.2 --nameserver=192.168.1.3 --activate`` ks command
* test ifcfg file in post section

*I'm saving content of the configuration file for the bond0 device to special file for debugging purpose.*