### PR TITLE
Fix Repository New_Repository has no mirror or baseurl (#1215963)

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -767,6 +767,13 @@ class DNFPayload(packaging.PackagePayload):
                     repo.enable()
 
         for ksrepo in self.data.repo.dataList():
+            log.debug("repo %s: mirrorlist %s, baseurl %s",
+                      ksrepo.name, ksrepo.mirrorlist, ksrepo.baseurl)
+            # one of these must be set to create new repo
+            if not (ksrepo.mirrorlist or ksrepo.baseurl):
+                raise packaging.PayloadSetupError("Repository %s has no mirror or baseurl set"
+                                                  % ksrepo.name)
+
             self._add_repo(ksrepo)
 
         ksnames = [r.name for r in self.data.repo.dataList()]

--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -1328,6 +1328,8 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         self._repoSelection.select_iter(itr)
         self._repoEntryBox.set_sensitive(True)
 
+        self._repoURLChecks[repo].update_check_status()
+
     def on_removeRepo_clicked(self, button):
         """ Remove the selected repository
         """


### PR DESCRIPTION
Source spoke is set to error state instead of crash with empty
repository.
"URL is empty" warning message is now working correctly. It shows
if new repository is created or url is not set.

*Resolves: rhbz#1215963*