### PR TITLE
Relabel the password and group files in %post (#1228489)

### DIFF
--- a/data/post-scripts/80-setfilecons.ks
+++ b/data/post-scripts/80-setfilecons.ks
@@ -11,8 +11,8 @@ restorecon -i /etc/rpm/macros /etc/dasd.conf /etc/zfcp.conf /lib64 /usr/lib64 \
               /etc/blkid.tab* /etc/mtab /etc/fstab /etc/resolv.conf \
               /etc/modprobe.conf* /var/log/*tmp /etc/crypttab \
               /etc/mdadm.conf /etc/sysconfig/network /root/install.log* \
-              /etc/*shadow* /etc/dhcp/dhclient-*.conf /etc/localtime \
-              /etc/hostname /root/install.log*
+              /etc/*shadow* /etc/group* /etc/passwd* /etc/dhcp/dhclient-*.conf \
+              /etc/localtime /etc/hostname /root/install.log*
 
 if [ -e /etc/zipl.conf ]; then
     restorecon -i /etc/zipl.conf


### PR DESCRIPTION
Packages that create new users and groups tend to do so in their rpm
%pre scripts, and these might be run before the selinux-policy packages
are installed.