### PR TITLE
Fix crash when entering TUI mode

### DIFF
--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -694,7 +694,10 @@ def collect_spokes(mask_paths, category):
     spokes = []
     for mask, path in mask_paths:
         spokes.extend(collect(mask, path,
-                      lambda obj: hasattr(obj, "category") and obj.category is not None and obj.category.__name__ == category))
+                      lambda obj: hasattr(obj, "category")
+                                  and obj.category is not None
+                                  and hasattr(obj.category,"__name__")
+                                  and obj.category.__name__ == category))
 
     return spokes
 


### PR DESCRIPTION
Anaconda crashed when reading ``__name__`` attribute from str type.

Without this patch TUI mode is unreachable.

*Related: rhbz#1196721*