### PR TITLE
Require the python3 version of iscsi-initiator-utils

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -33,7 +33,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define dracutver 034-7
 %define isomd5sum 1.0.10
 %define fcoeutilsver 1.0.12-3.20100323git
-%define iscsiver 6.2.0.870-3
+%define iscsiver 6.2.0.873-26
 %define rpmver 4.10.0
 %define libarchivever 3.0.4
 %define langtablever 0.0.18-1
@@ -124,7 +124,7 @@ Requires: systemd
 %ifarch %{ix86} x86_64
 Requires: fcoe-utils >= %{fcoeutilsver}
 %endif
-Requires: iscsi-initiator-utils >= %{iscsiver}
+Requires: python3-iscsi-initiator-utils >= %{iscsiver}
 %ifarch %{ix86} x86_64
 %if ! 0%{?rhel}
 Requires: hfsplus-tools


### PR DESCRIPTION
iscsi-initiator-utils now packages the python bindings in separate
packages, so we can choose just the version that we need. The python
package will still pull in iscsi-initiator-utils as a dependency.