### PR TITLE
Fix passing ,nfsvers=3 to dracut (#1161820)

### DIFF
--- a/dracut/anaconda-netroot.sh
+++ b/dracut/anaconda-netroot.sh
@@ -36,7 +36,7 @@ case $repo in
         # by defaulting to nfsvers=3 when no version is requested
         nfs_to_var "$repo" $netif
         if [ "$nfs" != "nfs4" ] && ! strstr "$options" "vers="; then
-            repo="nfs:$options,nfsvers=3:$server:$path"
+            repo="nfs:${options:+$options,}nfsvers=3:$server:$path"
         fi
         # END HACK. FIXME: Figure out what is up with nfs4, jeez
         if [ "${repo%.iso}" == "$repo" ]; then


### PR DESCRIPTION
dracut cleans up the leading , but really we should pass it properly.
It now only adds the , if options already contains a value.

Resolves: rhbz#1161820