### PR TITLE
Use comps.environments instead of comps.environments_iter (#1221736)

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -491,8 +491,7 @@ class DNFPayload(packaging.PackagePayload):
 
     @property
     def environments(self):
-        environments = self._base.comps.environments_iter()
-        return [env.id for env in environments]
+        return [env.id for env in self._base.comps.environments]
 
     @property
     def groups(self):


### PR DESCRIPTION
environments_iter is not ordered, environments is.