### PR TITLE
Enable Anaconda to configure NTP (#1085013)

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1644,12 +1644,22 @@ class Timezone(commands.timezone.F18_Timezone):
 
         # write out NTP configuration (if set)
         if not self.nontp and self.ntpservers:
-            chronyd_conf_path = os.path.normpath(iutil.getSysroot() + ntp.NTP_CONFIG_FILE)
+            chronyd_out_path = os.path.normpath(iutil.getSysroot() + ntp.CHRONY_CONFIG_FILE)
+            ntpd_out_path = os.path.normpath(iutil.getSysroot() + ntp.NTP_CONFIG_FILE)
             try:
                 ntp.save_servers_to_config(self.ntpservers,
-                                           conf_file_path=chronyd_conf_path)
+                                           conf_file_path=ntp.CHRONY_CONFIG_FILE,
+                                           out_file_path=chronyd_out_path)
             except ntp.NTPconfigError as ntperr:
-                log.warning("Failed to save NTP configuration: %s", ntperr)
+                log.warning("Failed to save NTP configuration for chrony: %s", ntperr)
+
+            try:
+                ntp.save_servers_to_config(self.ntpservers,
+                                           conf_file_path=ntp.NTP_CONFIG_FILE,
+                                           out_file_path=ntpd_out_path)
+            except ntp.NTPconfigError as ntperr:
+                log.warning("Failed to save NTP configuration for ntpd: %s", ntperr)
+
 
 class User(commands.user.F19_User):
     def execute(self, storage, ksdata, instClass, users):

--- a/pyanaconda/ntp.py
+++ b/pyanaconda/ntp.py
@@ -35,7 +35,8 @@ from pyanaconda import iutil
 from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.constants import THREAD_SYNC_TIME_BASENAME
 
-NTP_CONFIG_FILE = "/etc/chrony.conf"
+CHRONY_CONFIG_FILE = "/etc/chrony.conf"
+NTP_CONFIG_FILE="/etc/ntp.conf"
 
 #example line:
 #server 0.fedora.pool.ntp.org iburst
@@ -72,7 +73,7 @@ def ntp_server_working(server):
 
     return True
 
-def get_servers_from_config(conf_file_path=NTP_CONFIG_FILE,
+def get_servers_from_config(conf_file_path=CHRONY_CONFIG_FILE,
                             srv_regexp=SRV_LINE_REGEXP):
     """
     Goes through the chronyd's configuration file looking for lines starting
@@ -99,7 +100,7 @@ def get_servers_from_config(conf_file_path=NTP_CONFIG_FILE,
 
     return ret
 
-def save_servers_to_config(servers, conf_file_path=NTP_CONFIG_FILE,
+def save_servers_to_config(servers, conf_file_path=CHRONY_CONFIG_FILE,
                            srv_regexp=SRV_LINE_REGEXP, out_file_path=None):
     """
     Replaces the servers defined in the chronyd's configuration file with

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -254,7 +254,8 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
                     new_servers.append(row[0])
 
             if flags.can_touch_runtime_system("save NTP servers configuration"):
-                ntp.save_servers_to_config(new_servers)
+                ntp.save_servers_to_config(new_servers, conf_file_path=ntp.CHRONY_CONFIG_FILE)
+                ntp.save_servers_to_config(new_servers, conf_file_path=ntp.NTP_CONFIG_FILE)
                 iutil.restart_service(NTP_SERVICE)
 
         #Cancel clicked, window destroyed...


### PR DESCRIPTION
Create configuration file for chrony and ntp.
Now the configuration files are always created if kickstart with ntpservers is present. This behavior is better for user when he installs ntp (chrony) later in the system.

The ntp configuration file is add by this PR https://github.com/rhinstaller/lorax/pull/26 for Lorax.

*Resolves: rhbz#1085013*