### PR TITLE
Fix adding 'boot=' option in FIPS mode

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -800,7 +800,8 @@ class BootLoader(object):
         #
         # FIPS
         #
-        if flags.cmdline.get("fips") == "1":
+        boot_device = storage.mountpoints.get("/boot")
+        if flags.cmdline.get("fips") == "1" and boot_device:
             self.boot_args.add("boot=%s" % self.stage2_device.fstabSpec)
 
         #


### PR DESCRIPTION
'boot=' option shouldn't be added when there is no separate /boot
partition.

Resolves: rhbz#1190146

Signed-off-by: Vojtech Trefny <vtrefny@redhat.com>