### PR TITLE
Fix set size to partition in custom spoke

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -74,7 +74,7 @@ CONTAINER_TYPE_NAMES = {DEVICE_TYPE_LVM: N_("Volume Group"),
 system_mountpoints = ["/dev", "/proc", "/run", "/sys"]
 
 def size_from_entry(entry):
-    size_text = entry.get_text().decode("utf-8").strip()
+    size_text = entry.get_text().strip()
     return size_from_input(size_text)
 
 def populate_mountpoint_store(store, used_mountpoints):


### PR DESCRIPTION
Setting size for custom partition was broken. Blivet now needs normal string instead of unicode.

@dwlehman from what I found this change is need at top of your [commit](https://github.com/rhinstaller/blivet/commit/ee1802babf7ae0ec3abfee4d5cf92a510149210b). Could you please look on it.