### PR TITLE
If using pre-existing, no size needs to be specified in ksdata (#1169…

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -832,7 +832,7 @@ class LogVolData(commands.logvol.RHEL7_LogVolData):
             else:
                 ty = storage.defaultFSType
 
-        if size is None:
+        if size is None and not self.preexist:
             if not self.size:
                 raise KickstartValueError(formatErrorMsg(self.lineno,
                     msg="Size can not be decided on from kickstart nor obtained from device."))


### PR DESCRIPTION
…783)

Resolves: rhbz#1169783
Related: rhbz#1196721

Signed-off-by: mulhern <amulhern@redhat.com>