### PR TITLE
Remove descriptions for RAID levels (#959701)

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.glade
+++ b/pyanaconda/ui/gui/spokes/custom.glade
@@ -59,27 +59,27 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes">RAID0 &lt;span foreground="grey"&gt;(Performance)&lt;/span&gt;</col>
+        <col id="0" translatable="yes">RAID0</col>
         <col id="1">raid0</col>
       </row>
       <row>
-        <col id="0" translatable="yes">RAID1 &lt;span foreground="grey"&gt;(Redundancy)&lt;/span&gt;</col>
+        <col id="0" translatable="yes">RAID1</col>
         <col id="1">raid1</col>
       </row>
       <row>
-        <col id="0" translatable="yes">RAID4 &lt;span foreground="grey"&gt;(Error Checking)&lt;/span&gt;</col>
+        <col id="0" translatable="yes">RAID4</col>
         <col id="1">raid4</col>
       </row>
       <row>
-        <col id="0" translatable="yes">RAID5 &lt;span foreground="grey"&gt;(Distributed Error Checking)&lt;/span&gt;</col>
+        <col id="0" translatable="yes">RAID5</col>
         <col id="1">raid5</col>
       </row>
       <row>
-        <col id="0" translatable="yes">RAID6 &lt;span foreground="grey"&gt;(Redundant Error Checking)&lt;/span&gt;</col>
+        <col id="0" translatable="yes">RAID6</col>
         <col id="1">raid6</col>
       </row>
       <row>
-        <col id="0" translatable="yes">RAID10 &lt;span foreground="grey"&gt;(Performance, Redundancy)&lt;/span&gt;</col>
+        <col id="0" translatable="yes">RAID10</col>
         <col id="1">raid10</col>
       </row>
     </data>

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
@@ -532,31 +532,31 @@ use.  Try something else?</property>
         <col id="1">none</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Single &lt;span foreground="grey"&gt;(No Redundancy, No Striping)&lt;/span&gt;</col>
+        <col id="0" translatable="yes">Single</col>
         <col id="1">single</col>
       </row>
       <row>
-        <col id="0" translatable="yes">RAID0 &lt;span foreground="grey"&gt;(Performance)&lt;/span&gt;</col>
+        <col id="0" translatable="yes">RAID0</col>
         <col id="1">raid0</col>
       </row>
       <row>
-        <col id="0" translatable="yes">RAID1 &lt;span foreground="grey"&gt;(Redundancy)&lt;/span&gt;</col>
+        <col id="0" translatable="yes">RAID1</col>
         <col id="1">raid1</col>
       </row>
       <row>
-        <col id="0" translatable="yes">RAID4 &lt;span foreground="grey"&gt;(Error Checking)&lt;/span&gt;</col>
+        <col id="0" translatable="yes">RAID4</col>
         <col id="1">raid4</col>
       </row>
       <row>
-        <col id="0" translatable="yes">RAID5 &lt;span foreground="grey"&gt;(Distributed Error Checking)&lt;/span&gt;</col>
+        <col id="0" translatable="yes">RAID5</col>
         <col id="1">raid5</col>
       </row>
       <row>
-        <col id="0" translatable="yes">RAID6 &lt;span foreground="grey"&gt;(Redundant Error Checking)&lt;/span&gt;</col>
+        <col id="0" translatable="yes">RAID6</col>
         <col id="1">raid6</col>
       </row>
       <row>
-        <col id="0" translatable="yes">RAID10 &lt;span foreground="grey"&gt;(Performance, Redundancy)&lt;/span&gt;</col>
+        <col id="0" translatable="yes">RAID10</col>
         <col id="1">raid10</col>
       </row>
     </data>


### PR DESCRIPTION
Resolves: #959701

Now that inline help is available, the users can refer to the documentation
to try to decide what is the right RAID for them.

Signed-off-by: mulhern <amulhern@redhat.com>