### PR TITLE
autopart root snapshot support

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -299,9 +299,9 @@ class Authconfig(commands.authconfig.FC3_Authconfig):
         except RuntimeError as msg:
             log.error("Error running %s %s: %s", cmd, args, msg)
 
-class AutoPart(commands.autopart.F21_AutoPart):
+class AutoPart(commands.autopart.F23_AutoPart):
     def parse(self, args):
-        retval = commands.autopart.F21_AutoPart.parse(self, args)
+        retval = commands.autopart.F23_AutoPart.parse(self, args)
 
         if self.fstype:
             fmt = blivet.formats.getFormat(self.fstype)


### PR DESCRIPTION
After installing the system, take a snapshot of the root device and
reconfigure the system to use the snapshot as the root device.

This is only supported with thinp and btrfs autopart.

Resolves: rhbz#1113207

Related to rhinstaller/blivet/pull/166 and rhinstaller/pykickstart/pull/29