### PR TITLE
Do not display curl 404 errors that can be safely ignored

### DIFF
--- a/dracut/anaconda-netroot.sh
+++ b/dracut/anaconda-netroot.sh
@@ -65,17 +65,20 @@ case $repo in
     http*|ftp*)
         . /lib/url-lib.sh
         info "anaconda fetching installer from $repo"
-        treeinfo=$(fetch_url $repo/.treeinfo) && \
+        treeinfo=$(fetch_url $repo/.treeinfo 2> /tmp/treeinfo_err) && \
           stage2=$(config_get stage2 mainimage < $treeinfo)
+        [ -z "$treeinfo" ] && info $(cat /tmp/treeinfo_err)
         if [ -z "$treeinfo" -o -z "$stage2" ]; then
             warn "can't find installer mainimage path in .treeinfo"
             stage2="LiveOS/squashfs.img"
         fi
         if runtime=$(fetch_url $repo/$stage2); then
             # NOTE: Should be the same as anaconda_auto_updates()
-            updates=$(fetch_url $repo/images/updates.img)
+            updates=$(fetch_url $repo/images/updates.img 2> /tmp/updates_err)
+            [ -z "$updates" ] && info $(cat /tmp/updates_err)
             [ -n "$updates" ] && unpack_updates_img $updates /updates
-            product=$(fetch_url $repo/images/product.img)
+            product=$(fetch_url $repo/images/product.img 2> /tmp/product_err)
+            [ -z "$product" ] && info $(cat /tmp/product_err)
             [ -n "$product" ] && unpack_updates_img $product /updates
             /sbin/dmsquash-live-root $runtime
         fi


### PR DESCRIPTION
Hide curl 404 errors while downloading updates.img/product.img/.treeinfo from repository.

Resolves: rhbz#1182776