### PR TITLE
anaconda-dracut: Mount /dev/mapper/live-rw (#1232411)

### DIFF
--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -97,7 +97,12 @@ anaconda_live_root_dir() {
         umount $repodir
         [ -n "$iso" ] && umount $isodir
     fi
-    [ -e "$img" ] && /sbin/dmsquash-live-root $img
+    if [ -e "$img" ]; then
+        /sbin/dmsquash-live-root $img
+        # dracut & systemd only mount things with root=live: so we have to do this ourselves
+        # See https://bugzilla.redhat.com/show_bug.cgi?id=1232411
+        printf 'mount /dev/mapper/live-rw %s\n' "$NEWROOT" > $hookdir/mount/01-$$-anaconda.sh
+    fi
 }
 
 # find updates.img/product.img/RHUpdates and unpack/copy them so they'll


### PR DESCRIPTION
systemd added handling of some root=live: cmdline args, dracut adjusted
and started using a systemd generator that is run early, based on the
cmdline, and stopped creating a mount hook when dmsquash-live-root is
called.

There should be a cleaner way for us to interact with dracut, but isn't.
So for now (in the interest of being able to boot and test things) we
will write the dracut mount hook ourselves.