### PR TITLE
Fix install-requires and install-buildrequires

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -109,17 +109,23 @@ bumpver: po-pull
 
 # Install all packages specified as BuildRequires in the Anaconda specfile
 # -> installs packages needed to build Anaconda
+# don't try to install s390utils-devel on non-s390 arches
 install-buildrequires:
 	srcdir="$(srcdir)" && \
 	: $${srcdir:=.} && \
-	dnf install $$(grep ^BuildRequires: $${srcdir}/anaconda.spec.in | cut -d ' ' -f 2)
+	pkglist="$$(grep ^BuildRequires: $${srcdir}/anaconda.spec.in | cut -d ' ' -f 2)" && \
+	if ! [[ $$(uname -m) =~ s390x? ]]; then \
+		pkglist=$$(echo "$$pkglist" | grep -v s390utils) ; \
+	fi ; \
+	dnf install $$pkglist
 
 # Install all packages specified as Requires in the Anaconda specfile
 # -> installs packages needed to run Anaconda and the Anaconda unit tests
+# Filter out the %{name} entries required by -devel
 install-requires:
 	srcdir="$(srcdir)" && \
 	: $${srcdir:=.} && \
-	dnf install $$(grep ^Requires: $${srcdir}/anaconda.spec.in | cut -d ' ' -f 2 | grep -v ^anaconda)
+	dnf install $$(grep ^Requires: $${srcdir}/anaconda.spec.in | grep -v %{name} | cut -d ' ' -f 2 | grep -v ^anaconda)
 
 # Generate an updates.img based on the changed files since the release
 # was tagged.  Updates are copied to ./updates-img and then the image is


### PR DESCRIPTION
dnf, unlike yum, fails if asked to install a package that does not
exist. Filter the package lists before passing them to dnf.