### PR TITLE
Fix inconsistencies in the payload messages.

### DIFF
--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -180,3 +180,8 @@ MAX_ENTROPY_WAIT = 10 * 60
 
 # X display number to use
 X_DISPLAY_NUMBER = 1
+
+# Payload status messages
+PAYLOAD_STATUS_PROBING_STORAGE = N_("Probing storage...")
+PAYLOAD_STATUS_PACKAGE_MD = N_("Downloading package metadata...")
+PAYLOAD_STATUS_GROUP_MD = N_("Downloading group metadata...")

--- a/pyanaconda/ui/gui/spokes/software.py
+++ b/pyanaconda/ui/gui/spokes/software.py
@@ -103,10 +103,10 @@ class SoftwareSelectionSpoke(NormalSpoke):
 
     # Payload event handlers
     def _downloading_package_md(self):
-        hubQ.send_message(self.__class__.__name__, _("Downloading package metadata..."))
+        hubQ.send_message(self.__class__.__name__, _(constants.PAYLOAD_STATUS_PACKAGE_MD))
 
     def _downloading_group_md(self):
-        hubQ.send_message(self.__class__.__name__, _("Downloading group metadata..."))
+        hubQ.send_message(self.__class__.__name__, _(constants.PAYLOAD_STATUS_GROUP_MD))
 
     def _payload_finished(self):
         self.environment = self.data.packages.environment

--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -53,7 +53,6 @@ from blivet.util import get_mount_device, get_mount_paths
 __all__ = ["SourceSpoke"]
 
 BASEREPO_SETUP_MESSAGE = N_("Setting up installation source...")
-METADATA_DOWNLOAD_MESSAGE = N_("Downloading package metadata...")
 
 # These need to match the IDs in protocolComboBox and repoProtocolComboBox in source.glade.
 PROTOCOL_HTTP = 'http'
@@ -662,7 +661,8 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         # Register listeners for payload events
         payloadMgr.addListener(payloadMgr.STATE_START, self._payload_refresh)
         payloadMgr.addListener(payloadMgr.STATE_STORAGE, self._probing_storage)
-        payloadMgr.addListener(payloadMgr.STATE_GROUP_MD, self._downloading_package_md)
+        payloadMgr.addListener(payloadMgr.STATE_PACKAGE_MD, self._downloading_package_md)
+        payloadMgr.addListener(payloadMgr.STATE_GROUP_MD, self._downloading_group_md)
         payloadMgr.addListener(payloadMgr.STATE_FINISHED, self._payload_finished)
         payloadMgr.addListener(payloadMgr.STATE_ERROR, self._payload_error)
 
@@ -679,13 +679,16 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         time.sleep(1)
 
     def _probing_storage(self):
-        hubQ.send_message(self.__class__.__name__, _("Probing storage..."))
+        hubQ.send_message(self.__class__.__name__, _(constants.PAYLOAD_STATUS_PROBING_STORAGE))
 
     def _downloading_package_md(self):
         # Reset the error state from previous payloads
         self._error = False
 
-        hubQ.send_message(self.__class__.__name__, _(METADATA_DOWNLOAD_MESSAGE))
+        hubQ.send_message(self.__class__.__name__, _(constants.PAYLOAD_STATUS_PACKAGE_MD))
+
+    def _downloading_group_md(self):
+        hubQ.send_message(self.__class__.__name__, _(constants.PAYLOAD_STATUS_GROUP_MD))
 
     def _payload_finished(self):
         hubQ.send_ready("SoftwareSelectionSpoke", False)

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -587,7 +587,7 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         overview.show_all()
 
     def _initialize(self):
-        hubQ.send_message(self.__class__.__name__, _("Probing storage..."))
+        hubQ.send_message(self.__class__.__name__, _(constants.PAYLOAD_STATUS_PROBING_STORAGE))
 
         threadMgr.wait(constants.THREAD_STORAGE)
         threadMgr.wait(constants.THREAD_CUSTOM_STORAGE_INIT)

--- a/pyanaconda/ui/tui/spokes/source.py
+++ b/pyanaconda/ui/tui/spokes/source.py
@@ -33,6 +33,7 @@ from pyanaconda.iutil import DataHolder
 from pyanaconda.constants import THREAD_SOURCE_WATCHER, THREAD_PAYLOAD
 from pyanaconda.constants import THREAD_STORAGE_WATCHER
 from pyanaconda.constants import THREAD_CHECK_SOFTWARE, ISO_DIR, DRACUT_ISODIR, DRACUT_REPODIR
+from pyanaconda.constants import PAYLOAD_STATUS_PROBING_STORAGE
 from pyanaconda.constants_text import INPUT_PROCESSED
 
 from pyanaconda.ui.helpers import SourceSwitchHandler
@@ -363,7 +364,7 @@ class SelectDeviceSpoke(NormalTUISpoke):
             # storage refresh is running - just report it
             # so that the user can refresh until it is done
             # TODO: refresh once the thread is done ?
-            message = _("Probing storage...")
+            message = _(PAYLOAD_STATUS_PROBING_STORAGE)
             self._window += [TextWidget(message), ""]
             return True
 

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -38,6 +38,7 @@ from pyanaconda.flags import flags
 from pyanaconda.kickstart import doKickstartStorage, resetCustomStorageData
 from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.constants import THREAD_STORAGE, THREAD_STORAGE_WATCHER, THREAD_DASDFMT, DEFAULT_AUTOPART_TYPE
+from pyanaconda.constants import PAYLOAD_STATUS_PROBING_STORAGE
 from pyanaconda.constants_text import INPUT_PROCESSED
 from pyanaconda.i18n import _, P_, N_
 from pyanaconda.bootloader import BootLoaderError
@@ -190,7 +191,7 @@ class StorageSpoke(NormalTUISpoke):
 
         # Join the initialization thread to block on it
         # This print is foul.  Need a better message display
-        print(_("Probing storage..."))
+        print(_(PAYLOAD_STATUS_PROBING_STORAGE))
         threadMgr.wait(THREAD_STORAGE_WATCHER)
 
         # synchronize our local data store with the global ksdata


### PR DESCRIPTION
The software and source spokes were updating their messages on different
payload events, resulting in some confusing message mismatches.

On STATE_PACKAGE_MD, the statuses displayed would be:

  | Probing storage...              | Downloading package metadata...  |

Followed by STATE_GROUP_MD, which updated to:

  | Downloading package metadata... | Downloading group metadata...    |

Change the source spoke to set the package metadata on the right state
and update the status on STATE_GROUP_MD to match the software spoke.
Moved all the actual messages out of the spokes and into constants.py.