### PR TITLE
Generate random hostnames

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # network.py - network configuration install data
 #
@@ -34,6 +35,7 @@ import threading
 import re
 import dbus
 import IPy
+import random
 from uuid import uuid4
 import itertools
 
@@ -158,6 +160,320 @@ def prefix2netmask(prefix):
     netmask = ".".join(str(byte) for byte in _bytes)
     return netmask
 
+def generateRandomHostname():
+    # Word list taken from the Docker.io project:
+    # https://github.com/docker/docker/blob/3fa2ddc452953e0695eda7cda191358010866c7e/pkg/namesgenerator/names-generator.go
+    # Some adjectives dropped to avoid potential negative reception.
+
+    domains = [
+        "admiring",
+        "adoring",
+        "agitated",
+        "boring",
+        "clever",
+        "compassionate",
+        "determined",
+        "distracted",
+        "dreamy",
+        "ecstatic",
+        "elated",
+        "elegant",
+        "fervent",
+        "focused",
+        "furious",
+        "goofy",
+        "grave",
+        "happy",
+        "high",
+        "hopeful",
+        "hungry",
+        "jolly",
+        "jovial",
+        "lonely",
+        "loving",
+        "mad",
+        "modest",
+        "nostalgic",
+        "pensive",
+        "prickly",
+        "reverent",
+        "romantic",
+        "serene",
+        "sharp",
+        "silly",
+        "sleepy",
+        "stoic",
+        "stupefied",
+        "tender",
+        "thirsty",
+        "trusting"
+    ]
+
+    domainname = random.choice(domains)
+
+    hostnames = [
+        # Muhammad ibn Jābir al-Ḥarrānī al-Battānī was a founding father of astronomy. https://en.wikipedia.org/wiki/Mu%E1%B8%A5ammad_ibn_J%C4%81bir_al-%E1%B8%A4arr%C4%81n%C4%AB_al-Batt%C4%81n%C4%AB
+        "albattani",
+
+        # June Almeida - Scottish virologist who took the first pictures of the rubella virus - https://en.wikipedia.org/wiki/June_Almeida
+        "almeida",
+
+        # Archimedes was a physicist, engineer and mathematician who invented too many things to list them here. https://en.wikipedia.org/wiki/Archimedes
+        "archimedes",
+
+        # Maria Ardinghelli - Italian translator, mathematician and physicist - https://en.wikipedia.org/wiki/Maria_Ardinghelli
+        "ardinghelli",
+
+        # Charles Babbage invented the concept of a programmable computer. https://en.wikipedia.org/wiki/Charles_Babbage.
+        "babbage",
+
+        # Stefan Banach - Polish mathematician, was one of the founders of modern functional analysis. https://en.wikipedia.org/wiki/Stefan_Banach
+        "banach",
+
+        # William Shockley, Walter Houser Brattain and John Bardeen co-invented the transistor (thanks Brian Goff).
+        # - https://en.wikipedia.org/wiki/John_Bardeen
+        # - https://en.wikipedia.org/wiki/Walter_Houser_Brattain
+        # - https://en.wikipedia.org/wiki/William_Shockley
+        "bardeen",
+        "brattain",
+        "shockley",
+
+        # Jean Bartik, born Betty Jean Jennings, was one of the original programmers for the ENIAC computer. https://en.wikipedia.org/wiki/Jean_Bartik
+        "bartik",
+
+        # Alexander Graham Bell - an eminent Scottish-born scientist, inventor, engineer and innovator who is credited with inventing the first practical telephone - https://en.wikipedia.org/wiki/Alexander_Graham_Bell
+        "bell",
+
+        # Elizabeth Blackwell - American doctor and first American woman to receive a medical degree - https://en.wikipedia.org/wiki/Elizabeth_Blackwell
+        "blackwell",
+
+        # Niels Bohr is the father of quantum theory. https://en.wikipedia.org/wiki/Niels_Bohr.
+        "bohr",
+
+        # Satyendra Nath Bose - He provided the foundation for Bose–Einstein statistics and the theory of the Bose–Einstein condensate. - https://en.wikipedia.org/wiki/Satyendra_Nath_Bose
+        "bose",
+
+        # Emmett Brown invented time travel. https://en.wikipedia.org/wiki/Emmett_Brown (thanks Brian Goff)
+        "brown",
+
+        # Rachel Carson - American marine biologist and conservationist, her book Silent Spring and other writings are credited with advancing the global environmental movement. https://en.wikipedia.org/wiki/Rachel_Carson
+        "carson",
+
+        # Subrahmanyan Chandrasekhar - Astrophysicist known for his mathematical theory on different stages and evolution in structures of the stars. He has won nobel prize for physics - https://en.wikipedia.org/wiki/Subrahmanyan_Chandrasekhar
+        "chandrasekhar",
+
+        # Jane Colden - American botanist widely considered the first female American botanist - https://en.wikipedia.org/wiki/Jane_Colden
+        "colden",
+
+        # Gerty Theresa Cori - American biochemist who became the third woman—and first American woman—to win a Nobel Prize in science, and the first woman to be awarded the Nobel Prize in Physiology or Medicine. Cori was born in Prague. https://en.wikipedia.org/wiki/Gerty_Cori
+        "cori",
+
+        # Seymour Roger Cray was an American electrical engineer and supercomputer architect who designed a series of computers that were the fastest in the world for decades. https://en.wikipedia.org/wiki/Seymour_Cray
+        "cray",
+
+        # Marie Curie discovered radioactivity. https://en.wikipedia.org/wiki/Marie_Curie.
+        "curie",
+
+        # Charles Darwin established the principles of natural evolution. https://en.wikipedia.org/wiki/Charles_Darwin.
+        "darwin",
+
+        # Leonardo Da Vinci invented too many things to list here. https://en.wikipedia.org/wiki/Leonardo_da_Vinci.
+        "davinci",
+
+        # Albert Einstein invented the general theory of relativity. https://en.wikipedia.org/wiki/Albert_Einstein
+        "einstein",
+
+        # Gertrude Elion - American biochemist, pharmacologist and the 1988 recipient of the Nobel Prize in Medicine - https://en.wikipedia.org/wiki/Gertrude_Elion
+        "elion",
+
+        # Douglas Engelbart gave the mother of all demos: https://en.wikipedia.org/wiki/Douglas_Engelbart
+        "engelbart",
+
+        # Euclid invented geometry. https://en.wikipedia.org/wiki/Euclid
+        "euclid",
+
+        # Pierre de Fermat pioneered several aspects of modern mathematics. https://en.wikipedia.org/wiki/Pierre_de_Fermat
+        "fermat",
+
+        # Enrico Fermi invented the first nuclear reactor. https://en.wikipedia.org/wiki/Enrico_Fermi.
+        "fermi",
+
+        # Richard Feynman was a key contributor to quantum mechanics and particle physics. https://en.wikipedia.org/wiki/Richard_Feynman
+        "feynman",
+
+        # Benjamin Franklin is famous for his experiments in electricity and the invention of the lightning rod.
+        "franklin",
+
+        # Galileo was a founding father of modern astronomy, and faced politics and obscurantism to establish scientific truth.  https://en.wikipedia.org/wiki/Galileo_Galilei
+        "galileo",
+
+        # Adele Goldstine, born Adele Katz, wrote the complete technical description for the first electronic digital computer, ENIAC. https://en.wikipedia.org/wiki/Adele_Goldstine
+        "goldstine",
+
+        # Jane Goodall - British primatologist, ethologist, and anthropologist who is considered to be the world's foremost expert on chimpanzees - https://en.wikipedia.org/wiki/Jane_Goodall
+        "goodall",
+
+        # Stephen Hawking pioneered the field of cosmology by combining general relativity and quantum mechanics. https://en.wikipedia.org/wiki/Stephen_Hawking
+        "hawking",
+
+        # Werner Heisenberg was a founding father of quantum mechanics. https://en.wikipedia.org/wiki/Werner_Heisenberg
+        "heisenberg",
+
+        # Dorothy Hodgkin was a British biochemist, credited with the development of protein crystallography. She was awarded the Nobel Prize in Chemistry in 1964. https://en.wikipedia.org/wiki/Dorothy_Hodgkin
+        "hodgkin",
+
+        # Erna Schneider Hoover revolutionized modern communication by inventing a computerized telephon switching method. https://en.wikipedia.org/wiki/Erna_Schneider_Hoover
+        "hoover",
+
+        # Grace Hopper developed the first compiler for a computer programming language and  is credited with popularizing the term "debugging" for fixing computer glitches. https://en.wikipedia.org/wiki/Grace_Hopper
+        "hopper",
+
+        # Hypatia - Greek Alexandrine Neoplatonist philosopher in Egypt who was one of the earliest mothers of mathematics - https://en.wikipedia.org/wiki/Hypatia
+        "hypatia",
+
+        # Yeong-Sil Jang was a Korean scientist and astronomer during the Joseon Dynasty; he invented the first metal printing press and water gauge. https://en.wikipedia.org/wiki/Jang_Yeong-sil
+        "jang",
+
+        # Karen Spärck Jones came up with the concept of inverse document frequency, which is used in most search engines today. https://en.wikipedia.org/wiki/Karen_Sp%C3%A4rck_Jones
+        "jones",
+
+        # Jack Kilby and Robert Noyce have invented silicone integrated circuits and gave Silicon Valley its name.
+        # - https://en.wikipedia.org/wiki/Jack_Kilby
+        # - https://en.wikipedia.org/wiki/Robert_Noyce
+        "kilby",
+        "noyce",
+
+        # Har Gobind Khorana - Indian-American biochemist who shared the 1968 Nobel Prize for Physiology - https://en.wikipedia.org/wiki/Har_Gobind_Khorana
+        "khorana",
+
+        # Maria Kirch - German astronomer and first woman to discover a comet - https://en.wikipedia.org/wiki/Maria_Margarethe_Kirch
+        "kirch",
+
+        # Sophie Kowalevski - Russian mathematician responsible for important original contributions to analysis, differential equations and mechanics - https://en.wikipedia.org/wiki/Sofia_Kovalevskaya
+        "kowalevski",
+
+        # Marie-Jeanne de Lalande - French astronomer, mathematician and cataloguer of stars - https://en.wikipedia.org/wiki/Marie-Jeanne_de_Lalande
+        "lalande",
+
+        # Mary Leakey - British paleoanthropologist who discovered the first fossilized Proconsul skull - https://en.wikipedia.org/wiki/Mary_Leakey
+        "leakey",
+
+        # Ada Lovelace invented the first algorithm. https://en.wikipedia.org/wiki/Ada_Lovelace (thanks James Turnbull)
+        "lovelace",
+
+        # Auguste and Louis Lumière - the first filmmakers in history - https://en.wikipedia.org/wiki/Auguste_and_Louis_Lumi%C3%A8re
+        "lumiere",
+
+        # Maria Mayer - American theoretical physicist and Nobel laureate in Physics for proposing the nuclear shell model of the atomic nucleus - https://en.wikipedia.org/wiki/Maria_Mayer
+        "mayer",
+
+        # John McCarthy invented LISP: https://en.wikipedia.org/wiki/John_McCarthy_(computer_scientist)
+        "mccarthy",
+
+        # Barbara McClintock - a distinguished American cytogeneticist, 1983 Nobel Laureate in Physiology or Medicine for discovering transposons. https://en.wikipedia.org/wiki/Barbara_McClintock
+        "mcclintock",
+
+        # Malcolm McLean invented the modern shipping container: https://en.wikipedia.org/wiki/Malcom_McLean
+        "mclean",
+
+        # Lise Meitner - Austrian/Swedish physicist who was involved in the discovery of nuclear fission. The element meitnerium is named after her - https://en.wikipedia.org/wiki/Lise_Meitner
+        "meitner",
+
+        # Johanna Mestorf - German prehistoric archaeologist and first female museum director in Germany - https://en.wikipedia.org/wiki/Johanna_Mestorf
+        "mestorf",
+
+        # Samuel Morse - contributed to the invention of a single-wire telegraph system based on European telegraphs and was a co-developer of the Morse code - https://en.wikipedia.org/wiki/Samuel_Morse
+        "morse",
+
+        # Isaac Newton invented classic mechanics and modern optics. https://en.wikipedia.org/wiki/Isaac_Newton
+        "newton",
+
+        # Alfred Nobel - a Swedish chemist, engineer, innovator, and armaments manufacturer (inventor of dynamite) - https://en.wikipedia.org/wiki/Alfred_Nobel
+        "nobel",
+
+        # Cecilia Payne-Gaposchkin was an astronomer and astrophysicist who, in 1925, proposed in her Ph.D. thesis an explanation for the composition of stars in terms of the relative abundances of hydrogen and helium. https://en.wikipedia.org/wiki/Cecilia_Payne-Gaposchkin
+        "payne",
+
+        # Ambroise Pare invented modern surgery. https://en.wikipedia.org/wiki/Ambroise_Par%C3%A9
+        "pare",
+
+        # Louis Pasteur discovered vaccination, fermentation and pasteurization. https://en.wikipedia.org/wiki/Louis_Pasteur.
+        "pasteur",
+
+        # Radia Perlman is a software designer and network engineer and most famous for her invention of the spanning-tree protocol (STP). https://en.wikipedia.org/wiki/Radia_Perlman
+        "perlman",
+
+        # Rob Pike was a key contributor to Unix, Plan 9, the X graphic system, utf-8, and the Go programming language. https://en.wikipedia.org/wiki/Rob_Pike
+        "pike",
+
+        # Henri Poincaré made fundamental contributions in several fields of mathematics. https://en.wikipedia.org/wiki/Henri_Poincar%C3%A9
+        "poincare",
+
+        # Laura Poitras is a director and producer whose work, made possible by open source crypto tools, advances the causes of truth and freedom of information by reporting disclosures by whistleblowers such as Edward Snowden. https://en.wikipedia.org/wiki/Laura_Poitras
+        "poitras",
+
+        # Claudius Ptolemy - a Greco-Egyptian writer of Alexandria, known as a mathematician, astronomer, geographer, astrologer, and poet of a single epigram in the Greek Anthology - https://en.wikipedia.org/wiki/Ptolemy
+        "ptolemy",
+
+        # C. V. Raman - Indian physicist who won the Nobel Prize in 1930 for proposing the Raman effect. - https://en.wikipedia.org/wiki/C._V._Raman
+        "raman",
+
+        # Srinivasa Ramanujan - Indian mathematician and autodidact who made extraordinary contributions to mathematical analysis, number theory, infinite series, and continued fractions. - https://en.wikipedia.org/wiki/Srinivasa_Ramanujan
+        "ramanujan",
+
+        # Dennis Ritchie and Ken Thompson created UNIX and the C programming language.
+        # - https://en.wikipedia.org/wiki/Dennis_Ritchie
+        # - https://en.wikipedia.org/wiki/Ken_Thompson
+        "ritchie",
+        "thompson",
+
+        # Rosalind Franklin - British biophysicist and X-ray crystallographer whose research was critical to the understanding of DNA - https://en.wikipedia.org/wiki/Rosalind_Franklin
+        "rosalind",
+
+        # Meghnad Saha - Indian astrophysicist best known for his development of the Saha equation, used to describe chemical and physical conditions in stars - https://en.wikipedia.org/wiki/Meghnad_Saha
+        "saha",
+
+        # Jean E. Sammet developed FORMAC, the first widely used computer language for symbolic manipulation of mathematical formulas. https://en.wikipedia.org/wiki/Jean_E._Sammet
+        "sammet",
+
+        # Françoise Barré-Sinoussi - French virologist and Nobel Prize Laureate in Physiology or Medicine; her work was fundamental in identifying HIV as the cause of AIDS. https://en.wikipedia.org/wiki/Fran%C3%A7oise_Barr%C3%A9-Sinoussi
+        "sinoussi",
+
+        # Richard Matthew Stallman - the founder of the Free Software movement, the GNU project, the Free Software Foundation, and the League for Programming Freedom. He also invented the concept of copyleft to protect the ideals of this movement, and enshrined this concept in the widely-used GPL (General Public License) for software. https://en.wikiquote.org/wiki/Richard_Stallman
+        "stallman",
+
+        # Aaron Swartz was influential in creating RSS, Markdown, Creative Commons, Reddit, and much of the internet as we know it today. He was devoted to freedom of information on the web. https://en.wikiquote.org/wiki/Aaron_Swartz
+        "swartz",
+
+        # Nikola Tesla invented the AC electric system and every gadget ever used by a James Bond villain. https://en.wikipedia.org/wiki/Nikola_Tesla
+        "tesla",
+
+        # Linus Torvalds invented Linux and Git. https://en.wikipedia.org/wiki/Linus_Torvalds
+        "torvalds",
+
+        # Alan Turing was a founding father of computer science. https://en.wikipedia.org/wiki/Alan_Turing.
+        "turing",
+
+        # Sophie Wilson designed the first Acorn Micro-Computer and the instruction set for ARM processors. https://en.wikipedia.org/wiki/Sophie_Wilson
+        "wilson",
+
+        # Steve Wozniak invented the Apple I and Apple II. https://en.wikipedia.org/wiki/Steve_Wozniak
+        "wozniak",
+
+        # The Wright brothers, Orville and Wilbur - credited with inventing and building the world's first successful airplane and making the first controlled, powered and sustained heavier-than-air human flight - https://en.wikipedia.org/wiki/Wright_brothers
+        "wright",
+
+        # Rosalyn Sussman Yalow - Rosalyn Sussman Yalow was an American medical physicist, and a co-winner of the 1977 Nobel Prize in Physiology or Medicine for development of the radioimmunoassay technique. https://en.wikipedia.org/wiki/Rosalyn_Sussman_Yalow
+        "yalow",
+
+        # Ada Yonath - an Israeli crystallographer, the first woman from the Middle East to win a Nobel prize in the sciences. https://en.wikipedia.org/wiki/Ada_Yonath
+        "yonath"
+    ]
+
+    hostname = random.choice(hostnames)
+
+    return "{}.{}.lan".format(hostname, domainname)
+
 # Try to determine what the hostname should be for this system
 def getHostname():
 
@@ -181,7 +497,7 @@ def getHostname():
         hn = socket.gethostname()
 
     if not hn or hn in ('(none)', 'localhost', 'localhost.localdomain'):
-        hn = DEFAULT_HOSTNAME
+        hn = generateRandomHostname()
 
     return hn
 


### PR DESCRIPTION
Instead of defaulting to localhost.localdomain (which makes joining
an enterprise domain difficult), we will instead generate a random
hostname of the form `<famous_person>.<adjective>.lan`.

Note that if DHCP provides a hostname for this machine, the DHCP-
assigned hostname will be selected, rather than using this
randomly-assigned one.

Testing performed:
Booted two VMs, one bridged to a network which has DHCP-assigned
naming, one NATed with libvirt having no DHCP-assigned names. On
the bridged VM, anaconda selected new-host-4.home as directed by
DHCP. On the NATed VM, it selected newton.elegant.lan as directed
by this random name generation.
