### PR TITLE
fix inst.ks.sendmac for static ip=XXX

### DIFF
--- a/dracut/fetch-kickstart-net.sh
+++ b/dracut/fetch-kickstart-net.sh
@@ -41,6 +41,16 @@ case "$kickstart" in
     nfs*/) kickstart="${kickstart}${new_ip_address}-kickstart" ;;
 esac
 
+# If we're doing sendmac, we need to run after anaconda-ks-sendheaders.sh
+if getargbool 0 inst.ks.sendmac kssendmac; then
+    newjob=$hookdir/initqueue/settled/fetch-ks-${netif}.sh
+else
+    newjob=$hookdir/initqueue/fetch-ks-${netif}.sh
+fi
+
+cat > $newjob <<__EOT__
+. /lib/url-lib.sh
+. /lib/anaconda-lib.sh
 info "anaconda fetching kickstart from $kickstart"
 if fetch_url "$kickstart" /tmp/ks.cfg; then
     parse_kickstart /tmp/ks.cfg
@@ -48,3 +58,5 @@ if fetch_url "$kickstart" /tmp/ks.cfg; then
 else
     warn "failed to fetch kickstart from $kickstart"
 fi
+rm \$job # remove self from initqueue
+__EOT__


### PR DESCRIPTION
inst.ks.sendmac is supposed to make us send HTTP headers of the form:

  X-RHN-Provisioning-MAC-1: <MAC ADDRESS OF NIC #1>
  X-RHN-Provisioning-MAC-2: <MAC ADDRESS OF NIC #2>
  [...]

along with the kickstart request.

This implies that we have to wait until after all modules are loaded
(i.e. all the NICs are visible) before we can add these headers and send
the kickstart request. So commit 35a93dd moved the header setup bit to
the `initqueue/settled` hook.

It turns out there's a race here: the actual kickstart fetch happens in
the `initqueue/online` hook, which runs as soon as a NIC comes online.
If you're using DHCP it takes a few network roundtrips before a NIC is
considered 'online', so this usually happens after udev is settled.

But: with a static IP config your NIC might be 'online' before udev is
settled. Which means we haven't set up the HTTP headers yet, and they
don't get sent.

This commit makes fetch-kickstart-net.sh actually just *schedule* the
kickstart to be fetched in the initqueue:

* if inst.ks.sendmac is enabled, it goes into initqueue/settled (where
  it will happen after anaconda-ks-sendheaders.sh because they run in
  alphanumeric order).

* otherwise, it is added to the normal initqueue, where it will run in
  the next pass of the loop.

NOTE: it could be argued that we should move *any* HTTP operations after
anaconda-ks-sendheaders.sh, but AFAICT the documentation only specifies
that the request for the *kickstart* will contain these headers.

Resolves: rhbz#1190115

(cherry picked from commit e083bbcaf1a39464927ac17c9e34f14795ae6b36)