### PR TITLE
Allow /boot partition on iscsi with ibft (#1164195)

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -121,6 +121,11 @@ def _is_on_iscsi(device):
     return all(isinstance(disk, blivet.devices.iScsiDiskDevice)
                for disk in device.disks)
 
+def _is_ibft(device):
+    """Tells whether a given device is ibft disk or not."""
+
+    return all(getattr(disk, "ibft", False) for disk in device.disks)
+
 class BootLoaderError(Exception):
     pass
 
@@ -584,7 +589,7 @@ class BootLoader(object):
             log.debug("stage1 device cannot be of type %s", device.type)
             return False
 
-        if _is_on_iscsi(device) and not getattr(device, "ibft", False):
+        if _is_on_iscsi(device) and not _is_ibft(device):
             log.debug("stage1 device cannot be on an iSCSI disk")
             return False
 
@@ -696,7 +701,7 @@ class BootLoader(object):
         if device.protected:
             valid = False
 
-        if _is_on_iscsi(device) and not getattr(device, "ibft", False):
+        if _is_on_iscsi(device) and not _is_ibft(device):
             self.errors.append(_("%s cannot be on an iSCSI disk") % self.stage2_description)
             valid = False
 


### PR DESCRIPTION
Fix testing of ibft attribute on device.

Fix for the [bug 1164195](https://bugzilla.redhat.com/show_bug.cgi?id=1164195) was pushed already but with an issue. When I used iscsi with ibft I have found that I can't add `/boot` on iscsi drive with `ip=ibft` set.

*Related: rhbz#1164195*