### PR TITLE
anaconda-dracut: Fix sysroot mount for netroot (#1232411)

### DIFF
--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -97,6 +97,11 @@ anaconda_live_root_dir() {
         umount $repodir
         [ -n "$iso" ] && umount $isodir
     fi
+    anaconda_mount_sysroot $img
+}
+
+anaconda_mount_sysroot() {
+    local img="$1"
     if [ -e "$img" ]; then
         /sbin/dmsquash-live-root $img
         # dracut & systemd only mount things with root=live: so we have to do this ourselves

--- a/dracut/anaconda-netroot.sh
+++ b/dracut/anaconda-netroot.sh
@@ -77,7 +77,7 @@ case $repo in
             [ -n "$updates" ] && unpack_updates_img $updates /updates
             product=$(fetch_url $repo/images/product.img)
             [ -n "$product" ] && unpack_updates_img $product /updates
-            /sbin/dmsquash-live-root $runtime
+            anaconda_mount_sysroot $runtime
         else
             warn "Could not retrieve stage2 image from $repo using $netif"
         fi


### PR DESCRIPTION
Add anaconda_mount_sysroot function and use it everywhere that
dmsquash-live-root is called.