### PR TITLE
Refresh advanced disks after disk summary dialog (#1226354)

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -699,7 +699,7 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         self.selected_disks = [d.name for d in dialog.disks]
 
         # update the UI to reflect changes to self.selected_disks
-        for overview in self.localOverviews:
+        for overview in self.localOverviews + self.advancedOverviews:
             name = overview.get_property("name")
 
             overview.set_chosen(name in self.selected_disks)


### PR DESCRIPTION
The advanced list of disks wasn't being refreshed after exiting the
disk summary dialog. The storage spoke was not updated when removing
a disk with the dialog.

Resolves: rhbz#1226354