### PR TITLE
Fix broken test by infiniband patch (#1177032)

### DIFF
--- a/tests/pyanaconda_tests/network_test.py
+++ b/tests/pyanaconda_tests/network_test.py
@@ -126,7 +126,7 @@ class NetworkTests(unittest.TestCase):
 
     @patch("pyanaconda.network.flags.cmdline",
            {"BOOTIF":"01-11-11-11-11-11-11"})
-    @patch("pyanaconda.nm.nm_device_perm_hwaddress")
+    @patch("pyanaconda.nm.nm_device_valid_hwaddress")
     @patch("pyanaconda.nm.nm_device_carrier",
             lambda dev: dev == "eth1")
     @patch("pyanaconda.nm.nm_devices",


### PR DESCRIPTION
In the [first patch](https://github.com/rhinstaller/anaconda/pull/173) I changed a method which broke network_test in pyanaconda_tests.

*Related: rhbz#1177032*