### PR TITLE
two smallish fixes for master/rhel7 (1238987, 1197575)

### DIFF
--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -213,6 +213,15 @@ parse_kickstart() {
     [ -e "$parsed_kickstart" ] && cp $parsed_kickstart /run/install/ks.cfg
 }
 
+# print a list of net devices that dracut says are set up.
+online_netdevs() {
+    local netif=""
+    for netif in /tmp/net.*.did-setup; do
+        netif=${netif#*.}; netif=${netif%.*}
+        [ -d "/sys/class/net/$netif" ] && echo $netif
+    done
+}
+
 # This is where we actually run the kickstart. Whee!
 # We can't just add udev rules (we'll miss devices that are already active),
 # and we can't just run the scripts manually (we'll miss devices that aren't
@@ -236,7 +245,7 @@ run_kickstart() {
     # re-parse new cmdline stuff from the kickstart
     . $hookdir/cmdline/*parse-anaconda-repo.sh
     . $hookdir/cmdline/*parse-livenet.sh
-    # TODO: parse for other stuff ks might set (dd? other stuff?)
+    . $hookdir/cmdline/*parse-anaconda-dd.sh
     case "$repotype" in
         http*|ftp|nfs*) do_net=1 ;;
         cdrom|hd|bd)    do_disk=1 ;;
@@ -266,14 +275,21 @@ run_kickstart() {
         rm /tmp/dd_args_ks
     fi
 
-    # replay udev events to trigger actions
+    # disk: replay udev events to trigger actions
     if [ "$do_disk" ]; then
+        # set up new rules
         . $hookdir/pre-trigger/*repo-genrules.sh
         udevadm control --reload
+        # trigger the rules for all the block devices we see
         udevadm trigger --action=change --subsystem-match=block
     fi
+
+    # net: re-run online hook
     if [ "$do_net" ]; then
         udevadm trigger --action=change --subsystem-match=net
+        for netif in $(online_netdevs); do
+            source_hook initqueue/online $netif
+        done
     fi
 
     # and that's it - we're back to the mainloop.

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1715,8 +1715,8 @@ class Timezone(commands.timezone.F23_Timezone):
         timezone.write_timezone_config(self, iutil.getSysroot())
 
         # write out NTP configuration (if set)
-        if not self.nontp and self.ntpservers:
-            chronyd_conf_path = os.path.normpath(iutil.getSysroot() + ntp.NTP_CONFIG_FILE)
+        chronyd_conf_path = os.path.normpath(iutil.getSysroot() + ntp.NTP_CONFIG_FILE)
+        if self.ntpservers and os.path.exists(chronyd_conf_path):
             pools, servers = ntp.internal_to_pools_and_servers(self.ntpservers)
             try:
                 ntp.save_servers_to_config(pools, servers, conf_file_path=chronyd_conf_path)
@@ -2186,4 +2186,3 @@ def doKickstartStorage(storage, ksdata, instClass):
     ksdata.btrfs.execute(storage, ksdata, instClass)
     # also calls ksdata.bootloader.execute
     storage.setUpBootLoader()
-


### PR DESCRIPTION
1. Fix kickstart-based install startup
2. If the user sets some NTP servers, write them to chronyd.conf (whether or not the service is enabled)