### PR TITLE
User operation kickstart tests.

### DIFF
--- a/tests/kickstart_tests/user.ks
+++ b/tests/kickstart_tests/user.ks
@@ -1,0 +1,80 @@
+url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+
+install
+
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+
+clearpart --all
+autopart --type=lvm
+
+keyboard us
+lang en
+timezone America/New_York
+
+rootpw qweqwe
+
+## TEST CREATE USER
+# Create specific user group
+group --name=kosygroup --gid=5001
+
+# Create specific user
+user --name=kosieh --gecos="Kosieh Barter" --homedir=/home/kbarter --password="$6$QsJCB9E6geIjWNvn$UZLEtnHYgKmFgrPo0fY1qNBc/aRi9b01f19w9mpdFm9.MPblckUuFYvpRLSzeYeR/6lO/2uY4WtjhbryC0k2L/" --iscrypted --shell=/bin/bash --uid=4001 --gid=5001
+
+shutdown
+
+%packages
+%end
+
+%post
+
+## TEST CREATE USER CHECK
+# Check group
+cat /etc/group | grep 5001
+if [[ $? -ne 0 ]]; then
+    echo "Group failed to create." >> /root/RESULT
+fi
+
+# Check find username
+cat /etc/passwd | grep kosieh
+if [[ $? -ne 0 ]]; then
+    echo "User is not present in system." >> /root/RESULT
+fi
+
+# Check GEDOS: real name
+cat /etc/passwd | grep kosieh | grep "Kosieh Barter"
+if [[ $? -ne 0 ]]; then
+    echo "User is present, but not all details: REAL NAME (GEDOS)" >> /root/RESULT
+fi
+
+# Check if the user has his/her bash
+cat /etc/passwd | grep kosieh | grep "/bin/bash"
+if [[ $? -ne 0 ]]; then
+    echo "User is present, but /bin/bash is not set" >> /root/RESULT
+fi
+
+# Check if the user has encrypted password
+cat /etc/shadow | grep kosieh | grep "$6$QsJCB9E6geIjWNvn$UZLEtnHYgKmFgrPo0fY1qNBc/aRi9b01f19w9mpdFm9.MPblckUuFYvpRLSzeYeR/6lO/2uY4WtjhbryC0k2L/"
+if [[ $? -ne 0 ]]; then
+    echo "User is present, passwords DO NOT match" >> /root/RESULT
+fi
+
+# Check if the user is in correct group
+cat /etc/passwd | grep kosieh |  grep 5001
+if [[ $? -ne 0 ]]; then
+    echo "User is present, group assignment" >> /root/RESULT
+fi
+
+# Check if the user has PHYSICAL home dir
+ls /home/ | grep kbarter
+if [[ $? -ne 0 ]]; then
+    echo "Home directory not found" >> /root/RESULT
+fi
+
+# Final check
+if [[ ! -e /root/RESULT ]]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/tests/kickstart_tests/user.sh
+++ b/tests/kickstart_tests/user.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Kickstart scripts for adding specified user during installation as well
as check-up if the user was successfully added to the system, including
password, /home/<user> directory and specified group.

Signed-off-by: Karel Valek <kvalek@redhat.com>