### PR TITLE
Add a bunch of gi.require_version calls

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -451,6 +451,9 @@ def setupLoggingFromOpts(options):
             log.error("Could not setup remotelog with %s", options.remotelog)
 
 def gtk_warning(title, reason):
+    import gi
+    gi.require_version("Gtk", "3.0")
+
     from gi.repository import Gtk
     dialog = Gtk.MessageDialog(type=Gtk.MessageType.ERROR,
                                buttons=Gtk.ButtonsType.CLOSE,

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -163,6 +163,10 @@ class Anaconda(object):
         if not self._storage:
             import blivet
             import blivet.arch
+
+            import gi
+            gi.require_version("BlockDev", "1.0")
+
             from gi.repository import BlockDev as blockdev
             self._storage = blivet.Blivet(ksdata=self.ksdata)
 

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -27,6 +27,9 @@ __all__ = ["ERROR_RAISE", "ERROR_CONTINUE", "ERROR_RETRY",
 
 # Only run the pango markup escape if the GUI is available
 try:
+    import gi
+    gi.require_version("Gtk", "3.0")
+
     from gi.repository import Gtk
 
     # XXX: Gtk stopped raising RuntimeError if it fails to

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -42,6 +42,9 @@ from pyanaconda.i18n import _
 from pyanaconda import flags
 from pyanaconda import startup_utils
 
+import gi
+gi.require_version("GLib", "2.0")
+
 from gi.repository import GLib
 
 import logging
@@ -106,6 +109,8 @@ class AnacondaExceptionHandler(ExceptionHandler):
         value = dump_info.exc_info.value
 
         try:
+            gi.require_version("Gtk", "3.0")
+
             from gi.repository import Gtk
 
             # XXX: Gtk stopped raising RuntimeError if it fails to

--- a/pyanaconda/iutil.py
+++ b/pyanaconda/iutil.py
@@ -40,6 +40,9 @@ import requests
 from requests_file import FileAdapter
 from requests_ftp import FTPAdapter
 
+import gi
+gi.require_version("GLib", "2.0")
+
 from gi.repository import GLib
 
 from pyanaconda.flags import flags

--- a/pyanaconda/keyboard.py
+++ b/pyanaconda/keyboard.py
@@ -36,6 +36,9 @@ from pyanaconda.constants import DEFAULT_VC_FONT, DEFAULT_KEYBOARD
 from pyanaconda.flags import can_touch_runtime_system
 from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
+import gi
+gi.require_version("GLib", "2.0")
+
 from gi.repository import GLib
 
 import logging

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -24,6 +24,11 @@
 #            David Cantrell <dcantrell@redhat.com>
 #            Radek Vykydal <rvykydal@redhat.com>
 
+import gi
+gi.require_version("NetworkManager", "1.0")
+
+from gi.repository import NetworkManager
+
 import shutil
 from pyanaconda import iutil
 from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
@@ -46,8 +51,6 @@ from pyanaconda import constants
 from pyanaconda.flags import flags, can_touch_runtime_system
 from pyanaconda.i18n import _
 from pyanaconda.regexes import HOSTNAME_PATTERN_WITHOUT_ANCHORS
-
-from gi.repository import NetworkManager
 
 import logging
 log = logging.getLogger("anaconda")

--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -19,6 +19,11 @@
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 #
 
+import gi
+gi.require_version("GLib", "2.0")
+gi.require_version("Gio", "2.0")
+gi.require_version("NetworkManager", "1.0")
+
 from gi.repository import Gio, GLib
 from gi.repository import NetworkManager
 import struct

--- a/pyanaconda/packaging/rpmostreepayload.py
+++ b/pyanaconda/packaging/rpmostreepayload.py
@@ -28,6 +28,12 @@ from pyanaconda import iutil
 from pyanaconda.flags import flags
 from pyanaconda.i18n import _
 from pyanaconda.progress import progressQ
+
+import gi
+gi.require_version("GLib", "2.0")
+gi.require_version("Gio", "2.0")
+gi.require_version("OSTree", "1.0")
+
 from gi.repository import GLib
 from gi.repository import Gio
 

--- a/pyanaconda/safe_dbus.py
+++ b/pyanaconda/safe_dbus.py
@@ -20,8 +20,13 @@
 
 """Module providing thread-safe and mainloop-safe DBus operations."""
 
-import os
+import gi
+gi.require_version("GLib", "2.0")
+gi.require_version("Gio", "2.0")
+
 from gi.repository import GLib, Gio
+
+import os
 from pyanaconda.constants import DEFAULT_DBUS_TIMEOUT
 
 DBUS_PROPS_IFACE = "org.freedesktop.DBus.Properties"

--- a/pyanaconda/screensaver.py
+++ b/pyanaconda/screensaver.py
@@ -20,6 +20,10 @@
 #
 
 from pyanaconda import safe_dbus
+
+import gi
+gi.require_version("GLib", "2.0")
+
 from gi.repository import GLib
 
 import logging

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -23,6 +23,15 @@ import meh.ui.gui
 
 from contextlib import contextmanager
 
+import gi
+gi.require_version("Gdk", "3.0")
+gi.require_version("Gtk", "3.0")
+gi.require_version("AnacondaWidgets", "3.0")
+gi.require_version("Keybinder", "3.0")
+gi.require_version("GdkPixbuf", "2.0")
+gi.require_version("GLib", "2.0")
+gi.require_version("GObject", "2.0")
+
 from gi.repository import Gdk, Gtk, AnacondaWidgets, Keybinder, GdkPixbuf, GLib, GObject
 
 from pyanaconda.i18n import _

--- a/pyanaconda/ui/gui/helpers.py
+++ b/pyanaconda/ui/gui/helpers.py
@@ -23,6 +23,10 @@
 # functionality. See also pyanaconda.ui.helpers.
 
 from abc import ABCMeta, abstractproperty, abstractmethod
+
+import gi
+gi.require_version("Gtk", "3.0")
+
 from gi.repository import Gtk
 
 from pyanaconda.ui.helpers import InputCheck, InputCheckHandler

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -19,6 +19,9 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 #
 
+import gi
+gi.require_version("GLib", "2.0")
+
 from gi.repository import GLib
 
 from pyanaconda.flags import flags
@@ -95,6 +98,9 @@ class Hub(GUIObject, common.Hub):
         self._checker = None
 
     def _createBox(self):
+        gi.require_version("Gtk", "3.0")
+        gi.require_version("AnacondaWidgets", "3.0")
+
         from gi.repository import Gtk, AnacondaWidgets
 
         cats_and_spokes = self._collectCategoriesAndSpokes()
@@ -334,6 +340,7 @@ class Hub(GUIObject, common.Hub):
     ### SIGNAL HANDLERS
 
     def _on_spoke_clicked(self, selector, event, spoke):
+        gi.require_version("Gdk", "3.0")
         from gi.repository import Gdk
 
         # This handler only runs for these two kinds of events, and only for

--- a/pyanaconda/ui/gui/hubs/progress.py
+++ b/pyanaconda/ui/gui/hubs/progress.py
@@ -21,6 +21,10 @@
 
 
 
+import gi
+gi.require_version("GLib", "2.0")
+gi.require_version("Gtk", "3.0")
+
 from gi.repository import GLib, Gtk
 
 import itertools

--- a/pyanaconda/ui/gui/spokes/advstorage/dasd.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/dasd.py
@@ -19,9 +19,13 @@
 # Red Hat Author(s): Samantha N. Bueno <sbueno@redhat.com>
 #
 
+import gi
+gi.require_version("BlockDev", "1.0")
+
+from gi.repository import BlockDev as blockdev
+
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.utils import gtk_action_nowait
-from gi.repository import BlockDev as blockdev
 
 __all__ = ["DASDDialog"]
 

--- a/pyanaconda/ui/gui/spokes/advstorage/iscsi.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/iscsi.py
@@ -21,6 +21,10 @@
 
 from IPy import IP
 from collections import namedtuple
+
+import gi
+gi.require_version("GLib", "2.0")
+
 from gi.repository import GLib
 
 from pyanaconda import constants

--- a/pyanaconda/ui/gui/spokes/advstorage/zfcp.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/zfcp.py
@@ -19,9 +19,13 @@
 # Red Hat Author(s): Samantha N. Bueno <sbueno@redhat.com>
 #
 
+import gi
+gi.require_version("BlockDev", "1.0")
+
+from gi.repository import BlockDev as blockdev
+
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.utils import gtk_action_nowait
-from gi.repository import BlockDev as blockdev
 
 __all__ = ["ZFCPDialog"]
 

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -29,6 +29,14 @@
 # - Implement striping and mirroring for LVM.
 # - Activating reformat should always enable resize for existing devices.
 
+import gi
+gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
+gi.require_version("AnacondaWidgets", "3.0")
+
+from gi.repository import Gdk, Gtk
+from gi.repository.AnacondaWidgets import MountpointSelector
+
 from pykickstart.constants import CLEARPART_TYPE_NONE
 
 from pyanaconda.i18n import _, N_, CP_
@@ -87,9 +95,6 @@ from pyanaconda.ui.gui.spokes.lib.custom_storage_helpers import AddDialog, Confi
 from pyanaconda.ui.gui.utils import setViewportBackground, fancy_set_sensitive, ignoreEscape
 from pyanaconda.ui.gui.utils import really_hide, really_show, timed_action
 from pyanaconda.ui.categories.system import SystemCategory
-
-from gi.repository import Gdk, Gtk
-from gi.repository.AnacondaWidgets import MountpointSelector
 
 from functools import wraps
 from itertools import chain

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -22,6 +22,12 @@
 import logging
 log = logging.getLogger("anaconda")
 
+import gi
+gi.require_version("GLib", "2.0")
+gi.require_version("Gdk", "3.0")
+gi.require_version("Gtk", "3.0")
+gi.require_version("TimezoneMap", "1.0")
+
 from gi.repository import GLib, Gdk, Gtk, TimezoneMap
 
 from pyanaconda.ui.communication import hubQ

--- a/pyanaconda/ui/gui/spokes/filter.py
+++ b/pyanaconda/ui/gui/spokes/filter.py
@@ -19,6 +19,9 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 #
 
+import gi
+gi.require_version("Gtk", "3.0")
+
 from gi.repository import Gtk
 
 from collections import namedtuple

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -20,6 +20,10 @@
 #                    Vratislav Podzimek <vpodzime@redhat.com>
 #
 
+import gi
+gi.require_version("Gkbd", "3.0")
+gi.require_version("Gtk", "3.0")
+
 from gi.repository import Gkbd, Gtk
 
 from pyanaconda.ui.gui import GUIObject

--- a/pyanaconda/ui/gui/spokes/langsupport.py
+++ b/pyanaconda/ui/gui/spokes/langsupport.py
@@ -20,7 +20,12 @@
 #                    Vratislav Podzimek <vpodzime@redhat.com>
 #
 
+import gi
+gi.require_verseion("Pango", "1.0")
+gi.require_version("Gdk", "3.0")
+
 from gi.repository import Pango, Gdk
+
 from pyanaconda.flags import flags
 from pyanaconda.i18n import CN_
 from pyanaconda.ui.gui.spokes import NormalSpoke

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -28,6 +28,10 @@ from pyanaconda.ui.gui.utils import escape_markup, really_hide, really_show
 from pyanaconda.constants import DEFAULT_AUTOPART_TYPE
 from pyanaconda.storage_utils import AUTOPART_CHOICES, AUTOPART_DEVICE_TYPES
 
+import gi
+gi.require_version("AnacondaWidgets", "3.0")
+gi.require_version("Gtk", "3.0")
+
 from gi.repository.AnacondaWidgets import MountpointSelector
 from gi.repository import Gtk
 
@@ -214,6 +218,7 @@ class Page(Gtk.Box):
             return DATA_DEVICE
 
     def _onSelectorClicked(self, selector, event, cb):
+        gi.require_version("Gdk", "3.0")
         from gi.repository import Gdk
 
         if event and not event.type in [Gdk.EventType.BUTTON_PRESS, Gdk.EventType.KEY_RELEASE, Gdk.EventType.FOCUS_CHANGE]:

--- a/pyanaconda/ui/gui/spokes/lib/cart.py
+++ b/pyanaconda/ui/gui/spokes/lib/cart.py
@@ -20,6 +20,9 @@
 #                    Chris Lumens <clumens@redhat.com>
 #
 
+import gi
+gi.require_version("Gtk", "3.0")
+
 from gi.repository import Gtk
 
 from pyanaconda.i18n import C_, P_

--- a/pyanaconda/ui/gui/spokes/lib/dasdfmt.py
+++ b/pyanaconda/ui/gui/spokes/lib/dasdfmt.py
@@ -27,6 +27,9 @@ from pyanaconda import constants
 from pyanaconda.i18n import _
 import threading
 
+import gi
+gi.require_version("BlockDev", "1.0")
+
 from gi.repository import BlockDev as blockdev
 
 import logging

--- a/pyanaconda/ui/gui/spokes/lib/entropy_dialog.py
+++ b/pyanaconda/ui/gui/spokes/lib/entropy_dialog.py
@@ -22,6 +22,10 @@
 import time
 import math
 
+import gi
+gi.require_version("Gtk", "3.0")
+gi.require_version("GLib", "2.0")
+
 from gi.repository import Gtk, GLib
 
 from pyanaconda.i18n import P_

--- a/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
+++ b/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
@@ -24,8 +24,13 @@ screens handling languages or locales configuration.
 
 """
 
-import os
+import gi
+gi.require_version("Gtk", "3.0")
+gi.require_version("Pango", "1.0")
+
 from gi.repository import Gtk, Pango
+
+import os
 from pyanaconda import localization
 from pyanaconda.iutil import strip_accents
 from pyanaconda.ui.gui.utils import set_treeview_selection, timed_action, override_cell_property

--- a/pyanaconda/ui/gui/spokes/lib/passphrase.py
+++ b/pyanaconda/ui/gui/spokes/lib/passphrase.py
@@ -19,6 +19,9 @@
 # Red Hat Author(s): David Lehman <dlehman@redhat.com>
 #
 
+import gi
+gi.require_version("Gtk", "3.0")
+
 from gi.repository import Gtk
 
 import pwquality

--- a/pyanaconda/ui/gui/spokes/lib/refresh.py
+++ b/pyanaconda/ui/gui/spokes/lib/refresh.py
@@ -19,6 +19,9 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 #
 
+import gi
+gi.require_version("GLib", "2.0")
+
 from gi.repository import GLib
 
 from pyanaconda.threads import threadMgr, AnacondaThread

--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -22,6 +22,10 @@
 
 from collections import namedtuple
 
+import gi
+gi.require_version("Gdk", "3.0")
+gi.require_version("Gtk", "3.0")
+
 from gi.repository import Gdk, Gtk
 
 from pyanaconda.i18n import _, C_, N_, P_

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -29,7 +29,17 @@
 # - NMClient.CLIENT_WIRELESS_ENABLED callback (hw switch?) - test
 # - nm-c-e run: blocking? logging?
 
+import gi
+gi.require_version("Gtk", "3.0")
+gi.require_version("GLib", "2.0")
+gi.require_version("GObject", "2.0")
+gi.require_version("Pango", "1.0")
+gi.require_version("Gio", "2.0")
+gi.require_version("NetworkManager", "1.0")
+gi.require_version("NMClient", "1.0")
+
 from gi.repository import Gtk
+from gi.repository import GLib, GObject, Pango, Gio, NetworkManager, NMClient
 
 from pyanaconda.flags import can_touch_runtime_system
 from pyanaconda.i18n import _, N_, C_, CN_
@@ -46,7 +56,6 @@ from pyanaconda.iutil import startProgram
 from pyanaconda import network
 from pyanaconda import nm
 
-from gi.repository import GLib, GObject, Pango, Gio, NetworkManager, NMClient
 import dbus
 import dbus.service
 # Used for ascii_letters and hexdigits constants

--- a/pyanaconda/ui/gui/spokes/software.py
+++ b/pyanaconda/ui/gui/spokes/software.py
@@ -19,6 +19,10 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 #
 
+import gi
+gi.require_version("Gtk", "3.0")
+gi.require_version("Pango", "1.0")
+
 from gi.repository import Gtk, Pango
 
 from pyanaconda.flags import flags

--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -28,6 +28,10 @@ log = logging.getLogger("anaconda")
 import os, signal, re
 from collections import namedtuple
 
+import gi
+gi.require_version("GLib", "2.0")
+gi.require_version("Gtk", "3.0")
+
 from gi.repository import GLib, Gtk
 
 from pyanaconda.flags import flags

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -39,6 +39,12 @@
 
 """
 
+import gi
+gi.require_version("Gdk", "3.0")
+gi.require_version("GLib", "2.0")
+gi.require_version("AnacondaWidgets", "3.0")
+gi.require_version("BlockDev", "1.0")
+
 from gi.repository import Gdk, GLib, AnacondaWidgets
 from gi.repository import BlockDev as blockdev
 

--- a/pyanaconda/ui/gui/utils.py
+++ b/pyanaconda/ui/gui/utils.py
@@ -21,12 +21,18 @@
 #                    Vratislav Podzimek <vpodzime@redhat.com>
 #
 
+import gi
+gi.require_version("Gdk", "3.0")
+gi.require_version("Gtk", "3.0")
+gi.require_version("GLib", "2.0")
+
+from gi.repository import Gdk, Gtk, GLib
+
 from contextlib import contextmanager
 
 from pyanaconda.threads import threadMgr, AnacondaThread
 
 from pyanaconda.constants import NOTICEABLE_FREEZE
-from gi.repository import Gdk, Gtk, GLib
 import queue
 import time
 import threading

--- a/pyanaconda/ui/gui/xkl_wrapper.py
+++ b/pyanaconda/ui/gui/xkl_wrapper.py
@@ -29,9 +29,14 @@ and various modifications of keyboard layouts settings.
 
 """
 
+import gi
+gi.require_version("GdkX11", "3.0")
+gi.require_version("Xkl", "1.0")
+
+from gi.repository import GdkX11, Xkl
+
 import threading
 import gettext
-from gi.repository import GdkX11, Xkl
 from collections import namedtuple
 
 from pyanaconda import flags

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -22,6 +22,11 @@
 # which has the same license and authored by David Lehman <dlehman@redhat.com>
 #
 
+import gi
+gi.require_version("BlockDev", "1.0")
+
+from gi.repository import BlockDev as blockdev
+
 from pyanaconda.ui.lib.disks import getDisks, applyDiskSelection, checkDiskSelection
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
@@ -33,7 +38,6 @@ from blivet import arch
 from blivet.size import Size
 from blivet.errors import StorageError
 from blivet.devices import DASDDevice, FcoeDiskDevice, iScsiDiskDevice, MultipathDevice, ZFCPDiskDevice
-from gi.repository import BlockDev as blockdev
 from pyanaconda.flags import flags
 from pyanaconda.kickstart import doKickstartStorage, resetCustomStorageData
 from pyanaconda.threads import threadMgr, AnacondaThread


### PR DESCRIPTION
pygobject differentiates between different versions of introspectable
libraries in about the dumbest way possible, and now it complains if we
don't play along.