### PR TITLE
Catch blivet formatDevice ValueError in custom (#1240226)

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -851,7 +851,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                                device=device.path)
         try:
             self._storage_playground.formatDevice(device, new_format)
-        except StorageError as e:
+        except (StorageError, ValueError) as e:
             log.error("failed to register device format action: %s", e)
             device.format = old_format
             self._error = e


### PR DESCRIPTION
Trying to format when formatting isn't possible, eg. NTFS as /, raises
ValueError so catch that and pass it on to the user.