### PR TITLE
Fix Repository New_Repository has no mirror or baseurl (#1215963)

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -767,6 +767,13 @@ class DNFPayload(packaging.PackagePayload):
                     repo.enable()
 
         for ksrepo in self.data.repo.dataList():
+            log.debug("repo %s: mirrorlist %s, baseurl %s",
+                      ksrepo.name, ksrepo.mirrorlist, ksrepo.baseurl)
+            # one of these must be set to create new repo
+            if not (ksrepo.mirrorlist or ksrepo.baseurl):
+                raise packaging.PayloadSetupError("Repository %s has no mirror or baseurl set"
+                                                  % ksrepo.name)
+
             self._add_repo(ksrepo)
 
         ksnames = [r.name for r in self.data.repo.dataList()]


### PR DESCRIPTION
Source spoke is set to error state instead of crash with empty
repository.

*Resolves: rhbz#1215963*

It's base change from this PR https://github.com/rhinstaller/anaconda/pull/128.
I want to make better warnings and I have something already done but the source spoke have so many bugs now that I decide to do this pull request which only fix crash with empty repository.
In future I will create special patch set with reworked Source spoke.