### PR TITLE
Kickstart firewall tests.

### DIFF
--- a/tests/kickstart_tests/firewall.ks
+++ b/tests/kickstart_tests/firewall.ks
@@ -1,0 +1,53 @@
+#version=DEVEL
+url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+autopart
+
+keyboard en
+lang en
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+# TEST: firewall
+firewall --enable --port=22001:tcp,6400:udp --service=tftp,smtp
+
+%packages
+%end
+
+%post
+
+## TEST PROCEDURE
+# Test for 22001/TCP
+firewall-offline-cmd --list-ports | grep 22001/tcp
+if [[ $? -ne 0 ]]; then
+    echo "*** Firewall config for 22001/tcp" >> /root/RESULT
+fi
+
+# Test for 6400/UDP
+firewall-offline-cmd --list-ports | grep 6400/udp
+if [[ $? -ne 0 ]]; then
+    echo "*** Firewall config for 6400/udp failed" >> /root/RESULT
+fi
+
+# Test for service tftp
+firewall-offline-cmd --list-services | grep tftp
+if [[ $? -ne 0 ]]; then
+    echo "*** Firewall service tftp not assigned" >> /root/RESULT
+fi
+
+# Test for service smtp
+firewall-offline-cmd --list-services | grep smtp
+if [[ $? -ne 0 ]]; then
+    echo "*** Firewall service smtp not assigned" >> /root/RESULT
+fi
+
+if [[ ! -e /root/RESULT ]]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/tests/kickstart_tests/firewall.sh
+++ b/tests/kickstart_tests/firewall.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Kickstart firewall test script for custom ports and service enabling.

Signed-off-by: Karel Valek <kvalek@redhat.com>