### PR TITLE
dracut: fix boot failure waiting for finished/dd.sh

### DIFF
--- a/dracut/parse-anaconda-dd.sh
+++ b/dracut/parse-anaconda-dd.sh
@@ -25,4 +25,6 @@ for dd in $(getargs dd= inst.dd=); do
 done
 
 # for convenience's sake, mash 'em all into one list
-cat /tmp/dd_net /tmp/dd_disk /tmp/dd_interactive > /tmp/dd_todo
+for dd_f in /tmp/dd_interactive /tmp/dd_net /tmp/dd_disk; do
+    [ -f $dd_f ] && cat $dd_f >> /tmp/dd_todo
+done


### PR DESCRIPTION
parse-anaconda-dd.sh was creating an (empty) /tmp/dd_todo if there was
nothing to do, but that tricked driver-updates-genrules.sh into thinking
there *was* something to do, so we time out waiting for the dd stuff to
finish.

This patch fixes that by ensuring the file is only created if there is
actually one or more tasks to complete.