### PR TITLE
Start the network before the display (#1240732)

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -1147,6 +1147,12 @@ if __name__ == "__main__":
     import blivet
     blivet.enable_installer_mode()
 
+    # Initialize the network now, in case the display needs it
+    from pyanaconda.network import networkInitialize, wait_for_connecting_NM_thread
+
+    networkInitialize(ksdata)
+    threadMgr.add(AnacondaThread(name=constants.THREAD_WAIT_FOR_CONNECTING_NM, target=wait_for_connecting_NM_thread, args=(ksdata,)))
+
     # now start the interface
     setupDisplay(anaconda, opts, addon_paths)
 
@@ -1198,7 +1204,6 @@ if __name__ == "__main__":
 
     from blivet import storageInitialize
     from pyanaconda.packaging import payloadMgr
-    from pyanaconda.network import networkInitialize, wait_for_connecting_NM_thread
     from pyanaconda.timezone import time_initialize
 
     if flags.rescue_mode:
@@ -1206,14 +1211,12 @@ if __name__ == "__main__":
     else:
         cleanPStore()
 
-    networkInitialize(ksdata)
     if not flags.dirInstall:
         threadMgr.add(AnacondaThread(name=constants.THREAD_STORAGE, target=storageInitialize,
                                      args=(anaconda.storage, ksdata, anaconda.protected)))
         threadMgr.add(AnacondaThread(name=constants.THREAD_TIME_INIT, target=time_initialize,
                                      args=(ksdata.timezone, anaconda.storage, anaconda.bootloader)))
 
-    threadMgr.add(AnacondaThread(name=constants.THREAD_WAIT_FOR_CONNECTING_NM, target=wait_for_connecting_NM_thread, args=(ksdata,)))
 
     # Fallback to default for interactive or for a kickstart with no installation method.
     fallback = not (flags.automatedInstall and ksdata.method.method)


### PR DESCRIPTION
Sometimes the display is on the network.

If there is a kickstart file containing a static network configuration,
and dracut started the network using dhcp (for example, vnc was on the
command line but no ip arguments were), it's possible to change
addresses after VNC has started, which doesn't work real well.

(cherry picked from commit cf50dc459ac756feee59c5bd7d5339ca8d932006)
Resolves: rhbz#1240732