### PR TITLE
Kickstart service test: enable / disable.

### DIFF
--- a/tests/kickstart_tests/services.ks
+++ b/tests/kickstart_tests/services.ks
@@ -16,6 +16,9 @@ rootpw testcase
 # Test services
 services --disabled=sshd --enabled=systemd-timesyncd
 
+# Test SELinux
+selinux --enforcing
+
 shutdown
 
 %packages
@@ -24,21 +27,27 @@ shutdown
 %post
 
 # Test enabled
-systemctl is-enabled systemd-timesyncd | grep enabled
+systemctl is-enabled systemd-timesyncd
 if [[ $? -ne 0 ]]; then
     echo "*** systemd-timesyncd is disabled, not enabled" >> /root/RESULT
 fi
 
 # Test disabled
-systemctl is-enabled sshd | grep disabled
-if [[ $? -ne 0 ]]; then
+systemctl is-enabled sshd
+if [[ $? -eq 0 ]]; then
     echo "*** sshd is enabled, not disabled" >> /root/RESULT
 fi
 
 # Test disabled - W/out change
-systemctl is-enabled systemd-networkd | grep disabled
-if [[ $? -ne 0 ]]; then
+systemctl is-enabled systemd-networkd
+if [[ $? -eq 0 ]]; then
     echo "*** systemd-networkd is enabled, should be disabled" >> /root/RESULT
+fi
+
+# SELinux test
+grep 'SELINUX=enforcing' /etc/selinux/config
+if [[ $? -ne 0 ]]; then
+    echo "*** SELinux not in enforcing mode" >> /root/RESULT
 fi
 
 if [[ ! -e /root/RESULT ]]; then

--- a/tests/kickstart_tests/services.ks
+++ b/tests/kickstart_tests/services.ks
@@ -1,0 +1,47 @@
+#version=DEVEL
+url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+autopart
+
+keyboard en
+lang en
+timezone America/New_York --utc
+rootpw testcase
+
+# Test services
+services --disabled=sshd --enabled=systemd-timesyncd
+
+shutdown
+
+%packages
+%end
+
+%post
+
+# Test enabled
+systemctl is-enabled systemd-timesyncd | grep enabled
+if [[ $? -ne 0 ]]; then
+    echo "*** systemd-timesyncd is disabled, not enabled" >> /root/RESULT
+fi
+
+# Test disabled
+systemctl is-enabled sshd | grep disabled
+if [[ $? -ne 0 ]]; then
+    echo "*** sshd is enabled, not disabled" >> /root/RESULT
+fi
+
+# Test disabled - W/out change
+systemctl is-enabled systemd-networkd | grep disabled
+if [[ $? -ne 0 ]]; then
+    echo "*** systemd-networkd is enabled, should be disabled" >> /root/RESULT
+fi
+
+if [[ ! -e /root/RESULT ]]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/tests/kickstart_tests/services.sh
+++ b/tests/kickstart_tests/services.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
Tested services: sshd (disable), systemd-timesyncd (enable),
systemd-networkd (disabled in config, test).

Signed-off-by: Karel Valek <kvalek@redhat.com>