### PR TITLE
Don't copy the environment when starting metacity.

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -131,8 +131,6 @@ def startX11():
 # function to handle X startup special issues for anaconda
 def doStartupX11Actions():
     """Start window manager"""
-    from copy import copy
-
     # When metacity actually connects to the X server is unknowable, but
     # fortunately it doesn't matter. metacity does not need to be the first
     # connection to Xorg, and if anaconda starts up before metacity, metacity
@@ -140,7 +138,6 @@ def doStartupX11Actions():
     # fingers crossed.
     # Add XDG_DATA_DIRS to the environment to pull in our overridden schema
     # files.
-    env_bak = copy(os.environ)
     if 'XDG_DATA_DIRS' in os.environ:
         xdg_data_dirs = '/usr/share/anaconda/window-manager:' + os.environ['XDG_DATA_DIRS']
     else:
@@ -148,7 +145,6 @@ def doStartupX11Actions():
 
     childproc = iutil.startProgram(["metacity", "--display", ":1", "--sm-disable"],
             env_add={'XDG_DATA_DIRS': xdg_data_dirs})
-    os.environ = env_bak
     iutil.watchProcess(childproc, "metacity")
 
 def set_x_resolution(runres):


### PR DESCRIPTION
This was left in by mistake. The whole point of the env_add parameter to
startProgram was to not have to do this.