### PR TITLE
Decode wifi SSIDs into strings. (#1240398)

### DIFF
--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -659,8 +659,7 @@ def _settings_for_ap(ssid):
        :return: list of paths of settings of access point
        :rtype: list
 `   """
-    return _find_settings(ssid, '802-11-wireless', 'ssid',
-            format_value=lambda ba: "".join(chr(b) for b in ba))
+    return _find_settings(ssid, '802-11-wireless', 'ssid')
 
 def _settings_for_hwaddr(hwaddr):
     """Return list of object paths of settings of device specified by hw address.

--- a/pyanaconda/ui/gui/spokes/network.glade
+++ b/pyanaconda/ui/gui/spokes/network.glade
@@ -158,6 +158,8 @@
       <column type="guint"/>
       <!-- column-name security -->
       <column type="guint"/>
+      <!-- column-name ssid -->
+      <column type="PyObject"/>
     </columns>
   </object>
   <object class="AnacondaSpokeWindow" id="networkWindow">


### PR DESCRIPTION
Use the chardet module to try to detect what encoding the SSID uses.
Add a column to the wireless network ListStore in the network spoke to
store the original byte sequence (also encoded as a string because GLib
is awful at storing byte sequences).