### PR TITLE
fix storage writing for live and ostree installs (#1236937)

### DIFF
--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -605,7 +605,7 @@ class Payload(object):
            just the dnfpayload.  Payloads should only implement one of these
            methods by overriding the unneeded one with a pass.
         """
-        if self.data.method.method != "liveimg" and not flags.dirInstall:
+        if not flags.dirInstall:
             self.storage.write()
 
     def writeStorageLate(self):
@@ -614,7 +614,7 @@ class Payload(object):
            every payload except for dnf.  Payloads should only implement one of
            these methods by overriding the unneeded one with a pass.
         """
-        if self.data.method.method == "liveimg" and not flags.dirInstall:
+        if not flags.dirInstall:
             if iutil.getSysroot() != iutil.getTargetPhysicalRoot():
                 setSysroot(iutil.getTargetPhysicalRoot(), iutil.getSysroot())
 

--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -848,3 +848,6 @@ class DNFPayload(packaging.PackagePayload):
                 log.error(e)
 
         super(DNFPayload, self).postInstall()
+
+    def writeStorageLate(self):
+        pass

--- a/pyanaconda/packaging/livepayload.py
+++ b/pyanaconda/packaging/livepayload.py
@@ -201,6 +201,9 @@ class LiveImagePayload(ImagePayload):
     def kernelVersionList(self):
         return self._kernelVersionList
 
+    def writeStorageEarly(self):
+        pass
+
 class DownloadProgress(object):
     """ Provide methods for download progress reporting."""
 
@@ -539,6 +542,3 @@ class LiveImageKSPayload(LiveImagePayload):
             # Strip out vmlinuz- from the names
             return sorted((n.split("/")[-1][8:] for n in names if "boot/vmlinuz-" in n),
                     key=functools.cmp_to_key(versionCmp))
-
-    def writeStorageEarly(self):
-        pass


### PR DESCRIPTION
3e800998 broke storage writing in two cases: regular live installs and ostree installs. The old write_storage_late check checked for flags.livecdInstall and ksdata.ostreesetup.seen as well as ksdata.method.method == "liveimg". The new check in writeStorageLate() dropped those two, only keeping the method check. The method is only 'liveimg' when doing a kickstart-driven install with the 'liveimg' parameter, which is a fairly niche case - the method is not 'liveimg' on a regular live install (it's 'harddrive').