### PR TITLE
Display source errors in the spoke's info bar

### DIFF
--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -140,12 +140,16 @@ class Payload(object):
         self.instclass = None
         self.txID = None
 
+        # A list of verbose error strings from the subclass
+        self.verbose_errors = []
+
         self._session = requests_session()
 
     def setup(self, storage, instClass):
         """ Do any payload-specific setup. """
         self.storage = storage
         self.instclass = instClass
+        self.verbose_errors = []
 
     def unsetup(self):
         """ Invalidate a previously setup paylaod. """
@@ -364,6 +368,7 @@ class Payload(object):
                 response = self._session.get("%s/treeinfo" % url, headers=headers, proxies=proxies, verify=sslverify)
             except requests.exceptions.RequestException as e:
                 log.info("Error downloading treeinfo: %s", e)
+                self.verbose_errors.append(str(e))
                 response = None
 
         if response:

--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -480,6 +480,7 @@ class DNFPayload(packaging.PackagePayload):
             id_ = dnf_repo.id
             log.info('_sync_metadata: addon repo error: %s', e)
             self.disableRepo(id_)
+            self.verbose_errors.append(str(e))
 
     @property
     def baseRepo(self):

--- a/pyanaconda/ui/gui/spokes/source.glade
+++ b/pyanaconda/ui/gui/spokes/source.glade
@@ -473,6 +473,7 @@
     <property name="can_focus">False</property>
     <property name="window_name" translatable="yes">INSTALLATION SOURCE</property>
     <signal name="button-clicked" handler="on_back_clicked" swapped="no"/>
+    <signal name="info-bar-clicked" handler="on_info_bar_clicked" swapped="no"/>
     <child internal-child="main_box">
       <object class="GtkBox" id="AnacondaSpokeWindow-main_box1">
         <property name="can_focus">False</property>

--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -76,6 +76,8 @@ REPO_PROTO = {PROTOCOL_HTTP:  "http://",
               PROTOCOL_NFS:   "nfs://"
               }
 
+CLICK_FOR_DETAILS = N_(' <a href="">Click for details.</a>')
+
 def _validateProxy(proxy_string, username_set, password_set):
     """Validate a proxy string and return an input code usable by InputCheck
 
@@ -704,9 +706,12 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         self._error = True
         hubQ.send_message(self.__class__.__name__, payloadMgr.error)
         if not (hasattr(self.data.method, "proxy") and self.data.method.proxy):
-            self._error_msg = _("Failed to set up installation source; check the repo url")
+            self._error_msg = _("Failed to set up installation source; check the repo url.")
         else:
-            self._error_msg = _("Failed to set up installation source; check the repo url and proxy settings")
+            self._error_msg = _("Failed to set up installation source; check the repo url and proxy settings.")
+        if self.payload.verbose_errors:
+            self._error_msg += _(CLICK_FOR_DETAILS)
+
         hubQ.send_ready(self.__class__.__name__, False)
 
     def _initialize(self):
@@ -1069,6 +1074,21 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
 
         self.clear_info()
         NormalSpoke.on_back_clicked(self, button)
+
+    def on_info_bar_clicked(self, *args):
+        log.debug("info bar clicked: %s (%s)", self._error, args)
+        if not self.payload.verbose_errors:
+            return
+
+        dlg = Gtk.MessageDialog(flags=Gtk.DialogFlags.MODAL,
+                                message_type=Gtk.MessageType.ERROR,
+                                buttons=Gtk.ButtonsType.CLOSE,
+                                message_format="\n".join(self.payload.verbose_errors))
+        dlg.set_decorated(False)
+
+        with self.main_window.enlightbox(dlg):
+            dlg.run()
+            dlg.destroy()
 
     def on_chooser_clicked(self, button):
         dialog = IsoChooser(self.data)


### PR DESCRIPTION
also makes it clickable and shows verbose errors in a dialog.
