### PR TITLE
act on the right objects when stripping URL protocols (#1243962)

### DIFF
--- a/pyanaconda/ui/gui/spokes/source.glade
+++ b/pyanaconda/ui/gui/spokes/source.glade
@@ -1183,7 +1183,6 @@
                                           <item id="nfs">nfs</item>
                                         </items>
                                         <signal name="changed" handler="on_repoProtocolComboBox_changed" swapped="no"/>
-                                        <signal name="changed" handler="on_repoUrl_changed" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="left_attach">0</property>

--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -1137,9 +1137,11 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         self._mirrorlistCheckbox.set_visible(self._http_active())
         self._setup_no_updates()
 
-        # Any changes to the protocol combo box also need to update the check to see
-        # if the protocol now matches (e.g., user puts in a ftp:// URL with http selected
-        # in the combo box, then switches the combo box to ftp).
+        # Any changes to the protocol combo box also need to update the checks.
+        # Emitting the urlEntry 'changed' signal will see if the entered URL
+        # contains the protocol that's just been selected and strip it if so;
+        # _updateURLEntryCheck() does the other validity checks.
+        self._urlEntry.emit("changed")
         self._updateURLEntryCheck()
 
     def _update_payload_repos(self):
@@ -1519,3 +1521,6 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         if itr:
             repo = self._repoStore[itr][REPO_OBJ]
             self._repoChecks[repo.name].proxy_check.update_check_status()
+
+        # Run the URL entry handler too as it might be needed
+        self._repoUrlEntry.emit("changed")


### PR DESCRIPTION
efa549ef introduced a _removeUrlPrefix() method which expected
its 'editable' parameter to be a GtkEntry (either the base repo
URL entry box, or an additional repo's URL entry box). However,
it had the on_repoUrl_changed() handler call _removeUrlPrefix()
with its own 'editable' parameter, and then had the protocol
combo box call the on_repoUrl_changed() handler when it was
changed, as well as the URL entry box. The intent is that if,
say, you paste in 'https://www.repo.com' while the protocol is
set to http://, then change the protocol to https://, the
protocol will get stripped - but because 'editable' in this
case is the GtkComboBoxText, not the GtkEntry, it all goes
wrong and crashes. The crash is reproducible by adding a
supplementary repo, entering a URL, then changing the
protocol.

This adjusts things so the handler functions that call
_removeUrlPrefix() don't pass in their own 'editable' params
but always pass in the appropriate GtkEntry. It also makes
the protocol combo box for the base repo call the appropriate
handler function as well as the text entry box - matching the
behaviour the original commit introduced for the additional
repo widgets (I guess this was simply overlooked at the time).

I've tested this and all four widgets now behave as expected,
and there are no crashes.