### PR TITLE
Fix crash when protocol combobox changed item

### DIFF
--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -1415,7 +1415,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         self._repoChecks[name].name_check.update_check_status()
 
     def on_repoUrl_changed(self, editable, data=None):
-        """ proxy url or protocol changed
+        """ Additional repository url or protocol changed.
+
+            Note: variable editable could be Gtk.Entry or Gtk.ComboBoxText here.
         """
         itr = self._repoSelection.get_selected()[1]
         if not itr:
@@ -1432,7 +1434,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         self._repoChecks[repo.name].url_check.update_check_status()
 
         # Check for and remove a URL prefix that matches the protocol dropdown
-        self._removeUrlPrefix(editable, self._repoProtocolComboBox, self.on_repoUrl_changed)
+        self._removeUrlPrefix(self._repoUrlEntry, self._repoProtocolComboBox, self.on_repoUrl_changed)
 
     def on_repoMirrorlistCheckbox_toggled(self, *args):
         """ mirror state changed


### PR DESCRIPTION
The method `on_repoUrl_changed` in Source spoke is now called by `Gtk.Entry` and `Gtk.ComboBoxText` too. This caused crash in a method depending on `Gtk.Entry` but sometimes gets `ComboBoxText` instead.