### PR TITLE
Change the generated API indices slightly

### DIFF
--- a/widgets/doc/AnacondaWidgets-docs.xml
+++ b/widgets/doc/AnacondaWidgets-docs.xml
@@ -54,7 +54,18 @@
 
     <index id="api-index-full">
         <title>Index</title>
-        <xi:include href="xml/api-index-full.xml" />
+    </index>
+
+    <index id="api-index-1.0" role="1.0">
+	<title>Index of symbols in 1.0</title>
+    </index>
+
+    <index id="api-index-3.0" role="3.0">
+	<title>Index of new symbols in 3.0</title>
+    </index>
+
+    <index id="api-index-3.1" role="3.1">
+	<title>Index of new symbols in 3.1</title>
     </index>
 
     <xi:include href="xml/annotation-glossary.xml">


### PR DESCRIPTION
gtk-doc doesn't like the xi:include line in the api-index-full section
anymore, so remove it. Add index pages for the AnacondaWidgets versions
that added symbols.