### PR TITLE
Master missing passphrase

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1030,10 +1030,6 @@ class LogVolData(commands.logvol.F23_LogVolData):
             # before this one to setup the storage.encryptionPassphrase
             self.passphrase = self.passphrase or storage.encryptionPassphrase
 
-            if not self.passphrase:
-                raise KickstartValueError(formatErrorMsg(self.lineno,
-                                                         msg=_("No passphrase given for encrypted LV")))
-
             cert = getEscrowCertificate(storage.escrowCertificates, self.escrowcert)
             if self.preexist:
                 luksformat = fmt
@@ -1359,10 +1355,6 @@ class PartitionData(commands.partition.F23_PartData):
             # XXX: we require the LV/part with --passphrase to be processed
             # before this one to setup the storage.encryptionPassphrase
             self.passphrase = self.passphrase or storage.encryptionPassphrase
-
-            if not self.passphrase:
-                raise KickstartValueError(formatErrorMsg(self.lineno,
-                                                         msg=_("No passphrase given for encrypted part")))
 
             cert = getEscrowCertificate(storage.escrowCertificates, self.escrowcert)
             if self.onPart:

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -529,6 +529,10 @@ class StorageSpoke(NormalSpoke, StorageChecker):
             name = overview.get_property("name")
             overview.set_chosen(name in self.selected_disks)
 
+        # if encrypted is specified in kickstart, select the encryptionCheckbox in the GUI
+        if self.encrypted:
+            self._encrypted.set_active(True)
+
         self._customPart.set_active(not self.autopart)
 
         self._update_summary()

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -257,6 +257,7 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         self.passphrase = ""
         self.selected_disks = self.data.ignoredisk.onlyuse[:]
         self._back_clicked = False
+        self.autopart_missing_passphrase = False
 
         # This list contains all possible disks that can be included in the install.
         # All types of advanced disks should be set up for us ahead of time, so
@@ -295,15 +296,17 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         self.data.autopart.encrypted = self.encrypted
         self.data.autopart.passphrase = self.passphrase
 
-        self.clearPartType = CLEARPART_TYPE_NONE
-
         if self.data.bootloader.bootDrive and \
            self.data.bootloader.bootDrive not in self.selected_disks:
             self.data.bootloader.bootDrive = ""
             self.storage.bootloader.reset()
 
         self.data.clearpart.initAll = True
-        self.data.clearpart.type = self.clearPartType
+
+        if not self.autopart_missing_passphrase:
+            self.clearPartType = CLEARPART_TYPE_NONE
+            self.data.clearpart.type = self.clearPartType
+
         self.storage.config.update(self.data)
         self.storage.autoPartType = self.data.autopart.type
         self.storage.encryptedAutoPart = self.data.autopart.encrypted
@@ -329,6 +332,12 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         # on the off-chance dasdfmt is running, we can't proceed further
         threadMgr.wait(constants.THREAD_DASDFMT)
         hubQ.send_message(self.__class__.__name__, _("Saving storage configuration..."))
+        if flags.automatedInstall and self.data.autopart.encrypted and not self.data.autopart.passphrase:
+            self.autopart_missing_passphrase = True
+            StorageChecker.errors = [_("Passphrase for autopart encryption not specified.")]
+            self._ready = True
+            hubQ.send_ready(self.__class__.__name__, True)
+            return
         try:
             doKickstartStorage(self.storage, self.data, self.instclass)
         except (StorageError, KickstartValueError) as e:
@@ -349,7 +358,8 @@ class StorageSpoke(NormalSpoke, StorageChecker):
             hubQ.send_message(self.__class__.__name__, _("Failed to save storage configuration..."))
             self.data.bootloader.bootDrive = ""
         else:
-            if self.autopart:
+            if self.autopart or (flags.automatedInstall and (self.data.autopart.autopart or self.data.partition.seen)):
+                # run() executes StorageChecker.checkStorage in a seperate threat
                 self.run()
         finally:
             resetCustomStorageData(self.data)
@@ -742,6 +752,11 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         # We can't exit early if it looks like nothing has changed because the
         # user might want to change settings presented in the dialogs shown from
         # within this method.
+
+        if self.autopart_missing_passphrase:
+            self._check_encrypted()
+            NormalSpoke.on_back_clicked(self, button)
+            return
 
         # Do not enter this method multiple times if user clicking multiple times
         # on back button


### PR DESCRIPTION
New version of https://github.com/rhinstaller/anaconda/pull/174 for master. There are two new commits that were not in previous pull request:
-  don't raise KickstartValueError when parsing ks data in Anaconda
-  with autopart + encrypted, just mark the encrypt checkbox in the GUI selected