### PR TITLE
Wait forever for kickstarts on CDROM (#1168902)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,7 @@ ZANATA_PULL_ARGS = --transdir $(srcdir)/po/
 ZANATA_PUSH_ARGS = --srcdir $(srcdir)/po/ --push-type source --force
 
 RC_RELEASE ?= $(shell date -u +0.1.%Y%m%d%H%M%S)
-MOCKCHROOT ?= fedora-rawhide-x86_64
+MOCKCHROOT ?= fedora-rawhide-$(shell uname -m)
 
 tag:
 	@git tag -s -a -m "Tag as $(ARCHIVE_TAG)" $(ARCHIVE_TAG)
@@ -153,3 +153,11 @@ runglade:
 	GLADE_CATALOG_SEARCH_PATH=$(srcdir)/widgets/glade \
 	GLADE_MODULE_SEARCH_PATH=$(builddir)/widgets/src/.libs \
 	glade ${GLADE_FILE}
+
+ci: rc-release
+	$(MAKE) -C utils/dd
+	$(MAKE) TMPDIR=/var/tmp check
+	@mkdir -p repo
+	@mv *rpm repo
+	@createrepo -p repo
+	@sudo $(MAKE) TMPDIR=/var/tmp TESTS=install/run_install_test.sh TEST_ANACONDA_REPO=file://$(builddir)/repo/ check

--- a/Makefile.am
+++ b/Makefile.am
@@ -160,4 +160,4 @@ ci: rc-release
 	@mkdir -p repo
 	@mv *rpm repo
 	@createrepo -p repo
-	@sudo $(MAKE) TMPDIR=/var/tmp TESTS=install/run_install_test.sh TEST_ANACONDA_REPO=file://$(builddir)/repo/ check
+	@sudo $(MAKE) TMPDIR=/var/tmp TESTS=install/run_install_test.sh TEST_ANACONDA_REPO=file://$(abs_builddir)/repo/ check

--- a/data/systemd/anaconda.target
+++ b/data/systemd/anaconda.target
@@ -11,3 +11,4 @@ Wants=plymouth-quit.service plymouth-quit-wait.service
 Wants=anaconda-direct.service anaconda.service
 Wants=anaconda-sshd.service
 Wants=zram.service
+Wants=systemd-logind.service

--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -32,6 +32,7 @@ run_checkisomd5() {
 
 dev="$1"
 path="$2" # optional, could be empty
+kickstart="$(getarg ks= inst.ks=)"
 
 [ -e "/dev/root" ] && exit 1 # we already have a root device!
 

--- a/dracut/fetch-kickstart-disk
+++ b/dracut/fetch-kickstart-disk
@@ -6,6 +6,7 @@ command -v getarg >/dev/null || . /lib/dracut-lib.sh
 
 dev="$1"
 path="${2:-/ks.cfg}"
+kickstart="$(getarg ks= inst.ks=)"
 
 [ -e /tmp/ks.cfg.done ] && exit 1
 [ -b "$dev" ] || exit 1

--- a/dracut/kickstart-genrules.sh
+++ b/dracut/kickstart-genrules.sh
@@ -19,6 +19,12 @@ case "${kickstart%%:*}" in
             when_diskdev_appears "$ksdev" \
                 fetch-kickstart-disk \$env{DEVNAME} "$kspath"
         fi
+        # "cdrom:" also means "wait forever for kickstart" because rhbz#1168902
+        if [ "$kstype" = "cdrom" ]; then
+            # if we reset main_loop to 0 every loop, we never hit the timeout.
+            # (see dracut's dracut-initqueue.sh for details on the mainloop)
+            echo "main_loop=0" > "$hookdir/initqueue/ks-cdrom-wait-forever.sh"
+        fi
         wait_for_kickstart
     ;;
     bd) # bd:<dev>:<path> - biospart (TODO... if anyone uses this anymore)

--- a/dracut/repo-genrules.sh
+++ b/dracut/repo-genrules.sh
@@ -14,9 +14,8 @@ case "$root" in
   ;;
   anaconda-auto-cd)
     # special catch-all rule for CDROMs
-    echo 'ENV{ID_CDROM}=="1",' \
-           'RUN+="/sbin/initqueue --settled --onetime' \
-             '/sbin/anaconda-diskroot $env{DEVNAME}"' >> $rulesfile
+    when_any_cdrom_appears \
+        anaconda-diskroot \$env{DEVNAME}
     # HACK: anaconda demands that CDROMs be mounted at /mnt/install/source
     ln -s repo /run/install/source
   ;;

--- a/pyanaconda/iutil.py
+++ b/pyanaconda/iutil.py
@@ -1334,3 +1334,14 @@ def open_with_perm(path, mode='r', perm=0o777, **kwargs):
         return eintr_retry_call(os.open, path, open_flags, perm)
 
     return open(path, mode, opener=_opener, **kwargs)
+
+def id_generator():
+    """ Id numbers generator.
+        Generating numbers from 0 to X and increments after every call.
+
+        :returns: Generator which gives you unique numbers.
+    """
+    actual_id = 0
+    while(True):
+        yield actual_id
+        actual_id += 1

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1581,6 +1581,7 @@ class RepoData(commands.repo.F21_RepoData):
             :type enabled: bool
         """
         self.enabled = kwargs.pop("enabled", True)
+        self.repo_id = kwargs.pop("repo_id", None)
 
         commands.repo.F21_RepoData.__init__(self, *args, **kwargs)
 

--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -1545,7 +1545,10 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             self._repoChecks[repo.repo_id].proxy_check.update_check_status()
 
         try:
-            proxy = ProxyString(url=url, username=username, password=password)
+            if username and password:
+                proxy = ProxyString(url=url, username=username, password=password)
+            else:
+                proxy = ProxyString(url=url)
             repo.proxy = proxy.url
         except ProxyStringError as e:
             log.error("Failed to parse proxy - %s:%s@%s: %s", username, password, url, e)

--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -959,8 +959,11 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         if is_additional_repo:
             # Input object contains repository name
             repo = self._get_repo_by_id(inputcheck.input_obj)
-            protocol = urlsplit(repo.baseurl)[0]
-            url_string = repo.baseurl.strip()[len(protocol) + 3:]
+            protocol = urlsplit(repo.baseurl)[0] # extract protocol part (http, https, nfs...)
+            if repo.mirrorlist:
+                url_string = repo.mirrorlist.strip()[len(protocol) + 3:] # +3 for "://" part
+            else:
+                url_string = repo.baseurl.strip()[len(protocol) + 3:] # +3 for "://" part
         else:
             url_string = self.get_input(inputcheck.input_obj).strip()
             protocol = combo.get_active_id()

--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -627,7 +627,8 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         # Call InputCheckHandler directly since this check operates on rows of a TreeModel
         # instead of GtkEntry inputs. Updating the check is handled by the signal handlers
         # connected to repoStore.
-        self._duplicateRepoCheck = InputCheckHandler.add_check(self, self._repoStore, self._checkDuplicateRepos)
+        self._duplicateRepoCheck = InputCheckHandler.add_check(self, self._repoStore,
+                                                               self._checkDuplicateRepos)
 
         # Create a dictionary for the checks on fields in individual repos
         # These checks will be added and removed as repos are added and removed from repoStore
@@ -1079,6 +1080,10 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
     def on_back_clicked(self, button):
         """If any input validation checks failed, keep the user on the screen.
            Otherwise, do the usual thing."""
+
+        # Check repositories on bad url
+        for repo in self._repoStore:
+            self._repoChecks[repo[REPO_OBJ].repo_id].url_check.update_check_status()
 
         failed_check = next(self.failed_checks, None)
 


### PR DESCRIPTION
Commit 5d016ef added support for doing cdrom-swapping while doing
"inst.ks=cdrom[:...]". But it turns out that if you're slow to swap the
discs, we'll hit dracut's retry timeout and it'll drop to the emergency
shell.

So, in response to User Requests, we now disable the timeout entirely
when using "inst.ks=cdrom[:...]"; dracut will wait forever for the
kickstart and/or installer media, and if anything goes wrong you're just
stuck and you'll need to reset.

Resolves: rhbz#1168902