### PR TITLE
Fixes for inst.ks=cdrom

### DIFF
--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -32,6 +32,7 @@ run_checkisomd5() {
 
 dev="$1"
 path="$2" # optional, could be empty
+kickstart="$(getarg ks= inst.ks=)"
 
 [ -e "/dev/root" ] && exit 1 # we already have a root device!
 

--- a/dracut/fetch-kickstart-disk
+++ b/dracut/fetch-kickstart-disk
@@ -6,6 +6,7 @@ command -v getarg >/dev/null || . /lib/dracut-lib.sh
 
 dev="$1"
 path="${2:-/ks.cfg}"
+kickstart="$(getarg ks= inst.ks=)"
 
 [ -e /tmp/ks.cfg.done ] && exit 1
 [ -b "$dev" ] || exit 1

--- a/dracut/kickstart-genrules.sh
+++ b/dracut/kickstart-genrules.sh
@@ -19,6 +19,12 @@ case "${kickstart%%:*}" in
             when_diskdev_appears "$ksdev" \
                 fetch-kickstart-disk \$env{DEVNAME} "$kspath"
         fi
+        # "cdrom:" also means "wait forever for kickstart" because rhbz#1168902
+        if [ "$kstype" = "cdrom" ]; then
+            # if we reset main_loop to 0 every loop, we never hit the timeout.
+            # (see dracut's dracut-initqueue.sh for details on the mainloop)
+            echo "main_loop=0" > "$hookdir/initqueue/ks-cdrom-wait-forever.sh"
+        fi
         wait_for_kickstart
     ;;
     bd) # bd:<dev>:<path> - biospart (TODO... if anyone uses this anymore)

--- a/dracut/repo-genrules.sh
+++ b/dracut/repo-genrules.sh
@@ -14,9 +14,8 @@ case "$root" in
   ;;
   anaconda-auto-cd)
     # special catch-all rule for CDROMs
-    echo 'ENV{ID_CDROM}=="1",' \
-           'RUN+="/sbin/initqueue --settled --onetime' \
-             '/sbin/anaconda-diskroot $env{DEVNAME}"' >> $rulesfile
+    when_any_cdrom_appears \
+        anaconda-diskroot \$env{DEVNAME}
     # HACK: anaconda demands that CDROMs be mounted at /mnt/install/source
     ln -s repo /run/install/source
   ;;


### PR DESCRIPTION
While testing the fix from PR #231 (commit bc6378b here) I found some other problems, so here's a new version with some followup fixes.