### PR TITLE
RHEL7 backport of inst.ks=cdrom fixes

### DIFF
--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -35,6 +35,17 @@ path="$2" # optional, could be empty
 
 [ -e "/dev/root" ] && exit 1 # we already have a root device!
 
+# If we're waiting for a cdrom kickstart, the user might need to swap discs.
+# So if this is a CDROM drive, make a note of it, but don't mount it (yet).
+# Once we get the kickstart either the udev trigger or disk-reinsertion will
+# retrigger this script, and we'll mount the disk as normal.
+if str_starts "$kickstart" "cdrom" && [ ! -e /tmp/ks.cfg.done ]; then
+    if dev_is_cdrom "$dev"; then
+        > /tmp/anaconda-on-cdrom
+        exit 0
+    fi
+fi
+
 info "anaconda using disk root at $dev"
 mount $dev $repodir || warn "Couldn't mount $dev"
 anaconda_live_root_dir $repodir $path

--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -32,6 +32,7 @@ run_checkisomd5() {
 
 dev="$1"
 path="$2" # optional, could be empty
+kickstart="$(getarg ks= inst.ks=)"
 
 [ -e "/dev/root" ] && exit 1 # we already have a root device!
 

--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -165,6 +165,26 @@ when_any_cdrom_appears() {
       >> $rulesfile
 }
 
+plymouth_running() {
+    type plymouth >/dev/null 2>&1 && plymouth --ping 2>/dev/null
+}
+
+# print something to the display (and put it in the log so we know what's up)
+tell_user() {
+    if plymouth_running; then
+        # NOTE: if we're doing graphical splash but we don't have all the
+        # font-rendering libraries, no message will appear.
+        plymouth display-message --text="$*"
+        echo "$*"     # this goes to journal only
+    else
+        echo "$*" >&2 # this goes to journal+console
+    fi
+}
+
+dev_is_cdrom() {
+    udevadm info --query=property --name=$1 | grep -q 'ID_CDROM=1'
+}
+
 # dracut doesn't bring up the network unless:
 #   a) $netroot is set (i.e. you have a network root device), or
 #   b) /tmp/net.ifaces exists.

--- a/dracut/fetch-kickstart-disk
+++ b/dracut/fetch-kickstart-disk
@@ -6,6 +6,7 @@ command -v getarg >/dev/null || . /lib/dracut-lib.sh
 
 dev="$1"
 path="${2:-/ks.cfg}"
+kickstart="$(getarg ks= inst.ks=)"
 
 [ -e /tmp/ks.cfg.done ] && exit 1
 [ -b "$dev" ] || exit 1

--- a/dracut/fetch-kickstart-disk
+++ b/dracut/fetch-kickstart-disk
@@ -14,13 +14,24 @@ info "anaconda: fetching kickstart from $dev:$path"
 mnt="$(find_mount $dev)"
 
 if [ -n "$mnt" ]; then
-    cp $mnt$path /tmp/ks.cfg
+    cp $mnt$path /tmp/ks.cfg 2>&1
 else
     tmpmnt="$(mkuniqdir /run/install tmpmnt)"
     if mount -o ro $dev $tmpmnt; then
-        cp $tmpmnt/$path /tmp/ks.cfg
+        cp $tmpmnt/$path /tmp/ks.cfg 2>&1
         umount $tmpmnt
         rmdir $tmpmnt
+    fi
+fi
+
+
+# if we're waiting for a cdrom kickstart, tell the user so they can swap discs
+if str_starts "$kickstart" "cdrom"; then
+    if [ ! -f /tmp/ks.cfg ]; then
+        tell_user "Please insert CDROM containing '$path'..."
+        exit 0
+    elif [ -f /tmp/anaconda-on-cdrom ]; then
+        tell_user "Kickstart loaded. Please re-insert installation media."
     fi
 fi
 

--- a/dracut/kickstart-genrules.sh
+++ b/dracut/kickstart-genrules.sh
@@ -19,6 +19,12 @@ case "${kickstart%%:*}" in
             when_diskdev_appears "$ksdev" \
                 fetch-kickstart-disk \$env{DEVNAME} "$kspath"
         fi
+        # "cdrom:" also means "wait forever for kickstart" because rhbz#1168902
+        if [ "$kstype" = "cdrom" ]; then
+            # if we reset main_loop to 0 every loop, we never hit the timeout.
+            # (see dracut's dracut-initqueue.sh for details on the mainloop)
+            echo "main_loop=0" > "$hookdir/initqueue/ks-cdrom-wait-forever.sh"
+        fi
         wait_for_kickstart
     ;;
     bd) # bd:<dev>:<path> - biospart (TODO... if anyone uses this anymore)

--- a/dracut/repo-genrules.sh
+++ b/dracut/repo-genrules.sh
@@ -14,9 +14,8 @@ case "$root" in
   ;;
   anaconda-auto-cd)
     # special catch-all rule for CDROMs
-    echo 'ENV{ID_CDROM}=="1",' \
-           'RUN+="/sbin/initqueue --settled --onetime' \
-             '/sbin/anaconda-diskroot $env{DEVNAME}"' >> $rulesfile
+    when_any_cdrom_appears \
+        anaconda-diskroot \$env{DEVNAME}
     # HACK: anaconda demands that CDROMs be mounted at /mnt/install/source
     ln -s repo /run/install/source
   ;;


### PR DESCRIPTION
This is basically the same as #234, except it turns out that a couple of the pre-requisite commits either never made it to RHEL7 or got dropped in the rebase. So I've added bd99015 and 8e5b65d, and now CDROM-swapping with `inst.ks=cdrom` should work in RHEL7. Yaaayyyyyyyyy~~~