### PR TITLE
Do not set user home to / in advanced user dialog (#1245837)

### DIFF
--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -172,11 +172,11 @@ class AdvancedUserDialog(GUIObject, GUIDialogInputCheckHandler):
             # during any earlier run of the dialog, set homedir to the value
             # in the input box.
             homedir = self._tHome.get_text()
+            if not os.path.isabs(homedir):
+                homedir = "/" + homedir
             if self._homeSet or self._origHome != homedir:
                 self._homeSet = True
                 self._user.homedir = homedir
-            if not os.path.isabs(self._user.homedir):
-                self._user.homedir = "/" + self._user.homedir
 
             if self._cUid.get_active():
                 self._user.uid = int(self._uid.get_value())


### PR DESCRIPTION
This was a problem with commit 62246202737b4d0 which should have cherry
picked from 409370c442a. It was setting the user's home to / on exit
from the dialog.

Resolves: rhbz#1245837