### PR TITLE
Add class diagrams to hubs and spokes & fix some of a documentation compilation problems

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.inheritance_diagram']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -102,6 +102,9 @@ pygments_style = 'sphinx'
 
 autoclass_content = 'both'
 
+# Inheritence diagram graphviz settings
+inheritance_graph_attrs = dict(rankdir="UD", fontsize=14, ratio='auto')
+inheritance_node_attrs = dict(style='rounded', margin='"0.07, 0.07"')
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -56,18 +56,24 @@ class serial_opts(object):
         self.flow = None
 
 def parse_serial_opt(arg):
-    """Parse and split serial console options.
+    """
+    Parse and split serial console options.
 
-    Documentation/kernel-parameters.txt says:
-      ttyS<n>[,options]
-                Use the specified serial port.  The options are of
-                the form "bbbbpnf", where "bbbb" is the baud rate,
-                "p" is parity ("n", "o", or "e"), "n" is number of
-                bits, and "f" is flow control ("r" for RTS or
-                omit it).  Default is "9600n8".
-    but note that everything after the baud rate is optional, so these are
-    all valid: 9600, 19200n, 38400n8, 9600e7r.
-    Also note that the kernel assumes 1 stop bit; this can't be changed.
+    .. NOTE::
+
+       Documentation/kernel-parameters.txt says:
+
+          ttyS<n>[,options]
+
+             Use the specified serial port.  The options are of
+             the form "bbbbpnf", where "bbbb" is the baud rate,
+             "p" is parity ("n", "o", or "e"), "n" is number of
+             bits, and "f" is flow control ("r" for RTS or
+             omit it).  Default is "9600n8".
+
+       but note that everything after the baud rate is optional, so these are
+       all valid: 9600, 19200n, 38400n8, 9600e7r.
+       Also note that the kernel assumes 1 stop bit; this can't be changed.
     """
     opts = serial_opts()
     m = re.match(r'\d+', arg)

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -122,7 +122,7 @@ class BootArgs(OrderedDict):
         Read and parse a filename (or a list of filenames).
         Files that can't be read are silently ignored.
         Returns a list of successfully read files.
-        filenames can contain *, ?, and character ranges expressed with []
+        filenames can contain \*, ?, and character ranges expressed with []
         """
 
         readfiles = []

--- a/pyanaconda/ihelp.py
+++ b/pyanaconda/ihelp.py
@@ -33,12 +33,13 @@ log = logging.getLogger("anaconda")
 yelp_process = None
 
 def _get_best_help_file(help_folder, help_file):
-    """Return the path to the best help file for the current language and available
+    """
+    Return the path to the best help file for the current language and available
     help content
 
     :param str help_folder: a path to folder where we should look for the help files
     :param str help_file: name of the requested help file
-    :return: path to the best help file or None is no match is found
+    :return: path to the best help file or ``None`` is no match is found
     :rtype: str or NoneType
 
     """
@@ -73,9 +74,11 @@ def _get_best_help_file(help_folder, help_file):
         return None
 
 def get_help_path(help_file, instclass):
-    """Return the full path for the given help file name,
+    """
+    Return the full path for the given help file name,
     if the help file path does not exist a fallback path is returned.
     There are actually two possible fallback paths that might be returned:
+
     * first we try to return path to the main page of the installation guide
       (if it exists)
     * if we can't find the main page of the installation page, path to a
@@ -112,7 +115,8 @@ def get_help_path(help_file, instclass):
         return _get_best_help_file(instclass.help_folder, instclass.help_placeholder)
 
 def start_yelp(help_path):
-    """Start a new yelp process and make sure to kill any existing ones
+    """
+    Start a new yelp process and make sure to kill any existing ones
 
     :param help_path: path to the help file yelp should load
     :type help_path: str or NoneType

--- a/pyanaconda/iutil.py
+++ b/pyanaconda/iutil.py
@@ -1067,7 +1067,7 @@ def chown_dir_tree(root, uid, gid, from_uid_only=None, from_gid_only=None):
 def is_unsupported_hw():
     """ Check to see if the hardware is supported or not.
 
-        :returns:   True if this is unsupported hardware, False otherwise
+        :returns:   ``True`` if this is unsupported hardware, ``False`` otherwise
         :rtype:     bool
     """
     try:
@@ -1082,14 +1082,14 @@ def is_unsupported_hw():
 
 def ensure_str(str_or_bytes, keep_none=True):
     """
-    Returns a str instance for given string or None if requested to keep it.
+    Returns a str instance for given string or ``None`` if requested to keep it.
 
     :param str_or_bytes: string to be kept or converted to str type
     :type str_or_bytes: str or bytes
     :param bool keep_none: whether to keep None as it is or raise ValueError if
-                           None is passed
+                           ``None`` is passed
     :raises ValueError: if applied on an object not being of type bytes nor str
-                        (nor NoneType if :param:`keep_none` is False)
+                        (nor NoneType if ``keep_none`` is ``False``)
     """
 
     if keep_none and str_or_bytes is None:

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -88,7 +88,7 @@ class AnacondaKSScript(KSScript):
         This will write the script to a file named /tmp/ks-script- before
         execution.
         Output is logged by the program logger, the path specified by --log
-        or to /tmp/ks-script-*.log
+        or to /tmp/ks-script-\*.log
     """
     def run(self, chroot):
         """ Run the kickstart script

--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -474,7 +474,7 @@ def nm_device_active_ssid(name):
 
        :param name: name of device
        :type name: str
-       :return ssid of active access point, None if device has no active AP
+       :return: ssid of active access point, ``None`` if device has no active AP
        :rtype: str
        :raise UnknownDeviceError: if device is not found
     """
@@ -501,10 +501,12 @@ def nm_device_ip_config(name, version=4):
        :type version: int
        :return: IP configuration of device, empty list if device is not
                 in ACTIVATED state
-       :rtype: [[[address1, prefix1, gateway1], [address2, prefix2, gateway2], ...],
-                [nameserver1, nameserver2]]
-               addressX, gatewayX: string
-               prefixX: int
+       :rtype:
+               | [[[address1, prefix1, gateway1], [address2, prefix2, gateway2], ...],
+               | [nameserver1, nameserver2]]
+               | addressX, gatewayX: string
+               | prefixX: int
+
        :raise UnknownDeviceError: if device is not found
        :raise PropertyNotFoundError: if ip configuration is not found
     """
@@ -857,17 +859,19 @@ def nm_activate_device_connection(dev_name, con_uuid):
 def nm_add_connection(values):
     """Add new connection specified by values.
 
-       :param values: list of settings with new values and its types
-                      [[key1, key2, value, type_str], ...]
-                      key1: first-level key of setting (eg "connection")
-                      key2: second-level key of setting (eg "uuid")
-                      value: new value
-                      type_str: dbus type of new value (eg "ay")
-       :type values: [[key1, key2, value, type_str], ...]
-                     key1: str
-                     key2: str
-                     value: object
-                     type_str: str
+       :param values:
+                     | list of settings with new values and its types
+                     | [[key1, key2, value, type_str], ...]
+                     | key1: first-level key of setting (eg "connection")
+                     | key2: second-level key of setting (eg "uuid")
+                     | value: new value
+                     | type_str: dbus type of new value (eg "ay")
+       :type values:
+                     | [[key1, key2, value, type_str], ...]
+                     | key1: str
+                     | key2: str
+                     | value: object
+                     | type_str: str
     """
 
     settings = {}
@@ -907,27 +911,31 @@ def nm_update_settings_of_device(name, new_values):
 
        The type of value is determined from existing settings of device.
        If setting for key1, key2 does not exist, default_type_str is used or
-       if None, the type is inferred from the value supplied (string and bool only).
+       if ``None``, the type is inferred from the value supplied (string and bool only).
 
        :param name: name of device
        :type name: str
-       :param new_values: list of settings with new values and its types
-                          [[key1, key2, value, default_type_str]]
-                          key1: first-level key of setting (eg "connection")
-                          key2: second-level key of setting (eg "uuid")
-                          value: new value
-                          default_type_str: dbus type of new value to be used
-                                            if the setting does not already exist;
-                                            if None, the type is inferred from
-                                            value (string and bool only)
-       :type new_values: [[key1, key2, value, default_type_str], ...]
-                         key1: str
-                         key2: str
-                         value:
-                         default_type_str: str
+       :param new_values:
+                          | list of settings with new values and its types
+                          | [[key1, key2, value, default_type_str]]
+                          | key1: first-level key of setting (eg "connection")
+                          | key2: second-level key of setting (eg "uuid")
+                          | value: new value
+                          | default_type_str:
+
+                              dbus type of new value to be used
+                              if the setting does not already exist;
+                              if ``None``, the type is inferred from
+                              value (string and bool only)
+       :type new_values:
+                         | [[key1, key2, value, default_type_str], ...]
+                         | key1: str
+                         | key2: str
+                         | value:
+                         | default_type_str: str
        :raise UnknownDeviceError: if device is not found
        :raise SettingsNotFoundError: if settings were not found
-                                           (eg for "wlan0")
+                                     (eg for "wlan0")
     """
     settings_paths = _device_settings(name)
     if not settings_paths:

--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -709,10 +709,10 @@ def collect_categories(mask_paths, displaymode):
     return categories
 
 def collectCategoriesAndSpokes(paths, klass, displaymode):
-    """collects categories and spokes to be displayed on this Hub
+    """Collects categories and spokes to be displayed on this Hub
 
        :param paths: dictionary mapping categories, spokes, and hubs to their
-       their respective search path(s)
+                     their respective search path(s)
        :return: dictionary mapping category class to list of spoke classes
        :rtype: dictionary[category class] -> [ list of spoke classes ]
     """

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -55,6 +55,9 @@ class Hub(GUIObject, common.Hub):
 
        Installation may consist of multiple chained Hubs, or Hubs with
        additional standalone screens either before or after them.
+
+       .. inheritance-diagram:: Hub
+          :parts: 3
     """
 
     def __init__(self, data, storage, payload, instclass):

--- a/pyanaconda/ui/gui/hubs/progress.py
+++ b/pyanaconda/ui/gui/hubs/progress.py
@@ -46,6 +46,10 @@ from pyanaconda.ui.gui.utils import gtk_action_nowait, gtk_call_once
 __all__ = ["ProgressHub"]
 
 class ProgressHub(Hub):
+    """
+       .. inheritance-diagram:: ProgressHub
+          :parts: 3
+    """
     builderObjects = ["progressWindow"]
     mainWidgetName = "progressWindow"
     uiFile = "hubs/progress.glade"

--- a/pyanaconda/ui/gui/hubs/summary.py
+++ b/pyanaconda/ui/gui/hubs/summary.py
@@ -26,6 +26,10 @@ from pyanaconda.flags import flags
 __all__ = ["SummaryHub"]
 
 class SummaryHub(Hub):
+    """
+       .. inheritance-diagram:: SummaryHub
+          :parts: 3
+    """
     builderObjects = ["summaryWindow"]
     mainWidgetName = "summaryWindow"
     uiFile = "hubs/summary.glade"

--- a/pyanaconda/ui/gui/spokes/__init__.py
+++ b/pyanaconda/ui/gui/spokes/__init__.py
@@ -28,6 +28,10 @@ __all__ = ["StandaloneSpoke", "NormalSpoke"]
 # Inherit abstract methods from common.StandaloneSpoke
 # pylint: disable=abstract-method
 class StandaloneSpoke(GUIObject, common.StandaloneSpoke):
+    """
+       .. inheritance-diagram:: StandaloneSpoke
+          :parts: 3
+    """
     def __init__(self, data, storage, payload, instclass):
         GUIObject.__init__(self, data)
         common.StandaloneSpoke.__init__(self, storage, payload, instclass)
@@ -41,6 +45,10 @@ class StandaloneSpoke(GUIObject, common.StandaloneSpoke):
 # Inherit abstract methods from common.NormalSpoke
 # pylint: disable=abstract-method
 class NormalSpoke(GUIObject, common.NormalSpoke):
+    """
+       .. inheritance-diagram:: NormalSpoke
+          :parts: 3
+    """
     def __init__(self, data, storage, payload, instclass):
         GUIObject.__init__(self, data)
         common.NormalSpoke.__init__(self, storage, payload, instclass)

--- a/pyanaconda/ui/gui/spokes/advstorage/dasd.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/dasd.py
@@ -32,6 +32,9 @@ __all__ = ["DASDDialog"]
 class DASDDialog(GUIObject):
     """ Gtk dialog which allows users to manually add DASD devices without
         having previously specified them in a parm file.
+
+       .. inheritance-diagram:: DASDDialog
+          :parts: 3
     """
     builderObjects = ["dasdDialog"]
     mainWidgetName = "dasdDialog"

--- a/pyanaconda/ui/gui/spokes/advstorage/fcoe.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/fcoe.py
@@ -28,6 +28,10 @@ from pyanaconda import nm
 __all__ = ["FCoEDialog"]
 
 class FCoEDialog(GUIObject):
+    """
+       .. inheritance-diagram:: FCoEDialog
+          :parts: 3
+    """
     builderObjects = ["fcoeDialog"]
     mainWidgetName = "fcoeDialog"
     uiFile = "spokes/advstorage/fcoe.glade"

--- a/pyanaconda/ui/gui/spokes/advstorage/iscsi.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/iscsi.py
@@ -111,6 +111,10 @@ def credentials_valid(credentials):
                credentials.rUsername.strip() != "" and credentials.rPassword != ""
 
 class ISCSIDialog(GUIObject):
+    """
+       .. inheritance-diagram:: ISCSIDialog
+          :parts: 3
+    """
     builderObjects = ["iscsiDialog", "nodeStore", "nodeStoreFiltered"]
     mainWidgetName = "iscsiDialog"
     uiFile = "spokes/advstorage/iscsi.glade"

--- a/pyanaconda/ui/gui/spokes/advstorage/zfcp.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/zfcp.py
@@ -32,6 +32,9 @@ __all__ = ["ZFCPDialog"]
 class ZFCPDialog(GUIObject):
     """ Gtk dialog which allows users to manually add zFCP devices without
         having previously specified them in a parm file.
+
+       .. inheritance-diagram:: ZFCPDialog
+          :parts: 3
     """
     builderObjects = ["zfcpDialog"]
     mainWidgetName = "zfcpDialog"

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -137,6 +137,10 @@ def ui_storage_logged(func):
     return decorated
 
 class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
+    """
+       .. inheritance-diagram:: CustomPartitioningSpoke
+          :parts: 3
+    """
     builderObjects = ["customStorageWindow", "containerStore", "deviceTypeStore",
                       "partitionStore", "raidStoreFiltered", "raidLevelStore",
                       "addImage", "removeImage", "settingsImage",

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -396,6 +396,10 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
         self._refresh_server_working(itr)
 
 class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
+    """
+       .. inheritance-diagram:: DatetimeSpoke
+          :parts: 3
+    """
     builderObjects = ["datetimeWindow",
                       "days", "months", "years", "regions", "cities",
                       "upImage", "upImage1", "upImage2", "downImage",

--- a/pyanaconda/ui/gui/spokes/filter.py
+++ b/pyanaconda/ui/gui/spokes/filter.py
@@ -474,6 +474,10 @@ class ZPage(FilterPage):
         return self.ismember(device) and self._filter_func(device)
 
 class FilterSpoke(NormalSpoke):
+    """
+       .. inheritance-diagram:: FilterSpoke
+          :parts: 3
+    """
     builderObjects = ["diskStore", "filterWindow",
                       "searchModel", "multipathModel", "otherModel", "zModel"]
     mainWidgetName = "filterWindow"

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -260,6 +260,10 @@ class ConfigureSwitchingDialog(GUIObject):
 
 
 class KeyboardSpoke(NormalSpoke):
+    """
+       .. inheritance-diagram:: KeyboardSpoke
+          :parts: 3
+    """
     builderObjects = ["addedLayoutStore", "keyboardWindow",
                       "layoutTestBuffer"]
     mainWidgetName = "keyboardWindow"

--- a/pyanaconda/ui/gui/spokes/langsupport.py
+++ b/pyanaconda/ui/gui/spokes/langsupport.py
@@ -47,6 +47,10 @@ __all__ = ["LangsupportSpoke"]
 _HIGHLIGHT_COLOR = Gdk.RGBA(red=0.992157, green=0.984314, blue=0.752941, alpha=1.0)
 
 class LangsupportSpoke(LangLocaleHandler, NormalSpoke):
+    """
+       .. inheritance-diagram:: LangsupportSpoke
+          :parts: 3
+    """
     builderObjects = ["languageStore", "languageStoreFilter", "localeStore", "langsupportWindow"]
     mainWidgetName = "langsupportWindow"
     focusWidgetName = "languageEntry"

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1405,6 +1405,10 @@ def register_secret_agent(spoke):
 
 
 class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
+    """
+       .. inheritance-diagram:: NetworkSpoke
+          :parts: 3
+    """
     builderObjects = ["networkWindow", "liststore_wireless_network", "liststore_devices", "add_device_dialog", "liststore_add_device"]
     mainWidgetName = "networkWindow"
     uiFile = "spokes/network.glade"
@@ -1509,6 +1513,10 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
 
 class NetworkStandaloneSpoke(StandaloneSpoke):
+    """
+       .. inheritance-diagram:: NetworkStandaloneSpoke
+          :parts: 3
+    """
     builderObjects = ["networkStandaloneWindow", "networkControlBox_vbox", "liststore_wireless_network", "liststore_devices", "add_device_dialog", "liststore_add_device"]
     mainWidgetName = "networkStandaloneWindow"
     uiFile = "spokes/network.glade"

--- a/pyanaconda/ui/gui/spokes/password.py
+++ b/pyanaconda/ui/gui/spokes/password.py
@@ -39,6 +39,10 @@ __all__ = ["PasswordSpoke"]
 
 
 class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
+    """
+       .. inheritance-diagram:: PasswordSpoke
+          :parts: 3
+    """
     builderObjects = ["passwordWindow"]
 
     mainWidgetName = "passwordWindow"

--- a/pyanaconda/ui/gui/spokes/software.py
+++ b/pyanaconda/ui/gui/spokes/software.py
@@ -45,6 +45,10 @@ import sys, copy
 __all__ = ["SoftwareSelectionSpoke"]
 
 class SoftwareSelectionSpoke(NormalSpoke):
+    """
+       .. inheritance-diagram:: SoftwareSelectionSpoke
+          :parts: 3
+    """
     builderObjects = ["addonStore", "environmentStore", "softwareWindow"]
     mainWidgetName = "softwareWindow"
     uiFile = "spokes/software.glade"

--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -375,6 +375,10 @@ class IsoChooser(GUIObject):
             chooser.set_current_folder(constants.ISO_DIR)
 
 class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
+    """
+       .. inheritance-diagram:: SourceSpoke
+          :parts: 3
+    """
     builderObjects = ["isoChooser", "isoFilter", "partitionStore", "sourceWindow", "dirImage", "repoStore"]
     mainWidgetName = "sourceWindow"
     uiFile = "spokes/source.glade"

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -235,6 +235,10 @@ class NoSpaceDialog(InstallOptionsDialogBase):
         self._add_modify_watcher(label)
 
 class StorageSpoke(NormalSpoke, StorageChecker):
+    """
+       .. inheritance-diagram:: StorageSpoke
+          :parts: 3
+    """
     builderObjects = ["storageWindow", "addSpecializedImage"]
     mainWidgetName = "storageWindow"
     uiFile = "spokes/storage.glade"

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -44,6 +44,10 @@ from pyanaconda.regexes import GECOS_VALID, USERNAME_VALID, GROUPNAME_VALID, GRO
 __all__ = ["UserSpoke", "AdvancedUserDialog"]
 
 class AdvancedUserDialog(GUIObject, GUIDialogInputCheckHandler):
+    """
+       .. inheritance-diagram:: AdvancedUserDialog
+          :parts: 3
+    """
     builderObjects = ["advancedUserDialog", "uid", "gid"]
     mainWidgetName = "advancedUserDialog"
     uiFile = "spokes/advanced_user.glade"
@@ -222,6 +226,10 @@ class AdvancedUserDialog(GUIObject, GUIDialogInputCheckHandler):
         return False
 
 class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
+    """
+       .. inheritance-diagram:: UserSpoke
+          :parts: 3
+    """
     builderObjects = ["userCreationWindow"]
 
     mainWidgetName = "userCreationWindow"

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -46,6 +46,10 @@ log = logging.getLogger("anaconda")
 __all__ = ["WelcomeLanguageSpoke"]
 
 class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
+    """
+       .. inheritance-diagram:: WelcomeLanguageSpoke
+          :parts: 3
+    """
     mainWidgetName = "welcomeWindow"
     focusWidgetName = "languageEntry"
     uiFile = "spokes/welcome.glade"

--- a/pyanaconda/ui/gui/utils.py
+++ b/pyanaconda/ui/gui/utils.py
@@ -146,11 +146,12 @@ def gtk_batch_map(action, items, args=(), pre_func=None, batch_size=1):
     time. If a pre-processing function is given it is mapped on the items first
     before the action happens in the main thread.
 
-    MUST NOT BE CALLED NOR WAITED FOR FROM THE MAIN THREAD.
+    .. DANGER::
+       MUST NOT BE CALLED NOR WAITED FOR FROM THE MAIN THREAD.
 
     :param action: any action that has to be done on the items in the main
                    thread
-    :type action: (action_item, *args) -> None
+    :type action: (action_item, \*args) -> None
     :param items: an iterable of items that the action should be mapped on
     :type items: iterable
     :param args: additional arguments passed to the action function

--- a/pyanaconda/ui/tui/__init__.py
+++ b/pyanaconda/ui/tui/__init__.py
@@ -54,7 +54,11 @@ def exception_msg_handler(event, data):
     sys.excepthook(*msg_data[0])
 
 class TextUserInterface(ui.UserInterface):
-    """This is the main class for Text user interface."""
+    """This is the main class for Text user interface.
+
+       .. inheritance-diagram:: SourceSpoke
+          :parts: 3
+    """
 
     ENVIRONMENT = "anaconda"
 

--- a/pyanaconda/ui/tui/__init__.py
+++ b/pyanaconda/ui/tui/__init__.py
@@ -56,7 +56,7 @@ def exception_msg_handler(event, data):
 class TextUserInterface(ui.UserInterface):
     """This is the main class for Text user interface.
 
-       .. inheritance-diagram:: SourceSpoke
+       .. inheritance-diagram:: TextUserInterface
           :parts: 3
     """
 

--- a/pyanaconda/ui/tui/hubs/__init__.py
+++ b/pyanaconda/ui/tui/hubs/__init__.py
@@ -26,14 +26,14 @@ from pyanaconda.i18n import _, C_, N_
 
 class TUIHub(TUIObject, common.Hub):
     """Base Hub class implementing the pyanaconda.ui.common.Hub interface.
-    It uses text based categories to look for relevant Spokes and manages
-    all the spokes it finds to have the proper category.
+       It uses text based categories to look for relevant Spokes and manages
+       all the spokes it finds to have the proper category.
 
-    :param categories: list all the spoke categories to be displayed in this Hub
-    :type categories: list of strings
+       :param categories: list all the spoke categories to be displayed in this Hub
+       :type categories: list of strings
 
-    :param title: title for this Hub
-    :type title: str
+       :param title: title for this Hub
+       :type title: str
 
        .. inheritance-diagram:: TUIHub
           :parts: 3

--- a/pyanaconda/ui/tui/hubs/__init__.py
+++ b/pyanaconda/ui/tui/hubs/__init__.py
@@ -35,6 +35,8 @@ class TUIHub(TUIObject, common.Hub):
     :param title: title for this Hub
     :type title: str
 
+       .. inheritance-diagram:: TUIHub
+          :parts: 3
     """
 
     categories = []

--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -32,6 +32,10 @@ import logging
 log = logging.getLogger("anaconda")
 
 class SummaryHub(TUIHub):
+    """
+       .. inheritance-diagram:: SummaryHub
+          :parts: 3
+    """
     title = N_("Installation")
 
     def __init__(self, app, data, storage, payload, instclass):

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -36,14 +36,14 @@ __all__ = ["TUISpoke", "EditTUISpoke", "EditTUIDialog", "EditTUISpokeEntry",
 # pylint: disable=abstract-method
 class TUISpoke(TUIObject, tui.Widget, Spoke):
     """Base TUI Spoke class implementing the pyanaconda.ui.common.Spoke API.
-    It also acts as a Widget so we can easily add it to Hub, where is shows
-    as a summary box with title, description and completed checkbox.
+       It also acts as a Widget so we can easily add it to Hub, where is shows
+       as a summary box with title, description and completed checkbox.
 
-    :param title: title of this spoke
-    :type title: str
+       :param title: title of this spoke
+       :type title: str
 
-    :param category: category this spoke belongs to
-    :type category: string
+       :param category: category this spoke belongs to
+       :type category: string
 
        .. inheritance-diagram:: TUISpoke
           :parts: 3

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -44,6 +44,9 @@ class TUISpoke(TUIObject, tui.Widget, Spoke):
 
     :param category: category this spoke belongs to
     :type category: string
+
+       .. inheritance-diagram:: TUISpoke
+          :parts: 3
     """
 
     title = N_("Default spoke title")
@@ -91,6 +94,10 @@ class TUISpoke(TUIObject, tui.Widget, Spoke):
         self.draw(c)
 
 class NormalTUISpoke(TUISpoke, NormalSpoke):
+    """
+       .. inheritance-diagram:: NormalTUISpoke
+          :parts: 3
+    """
     pass
 
 EditTUISpokeEntry = namedtuple("EditTUISpokeEntry", ["title", "attribute", "aux", "visible"])
@@ -98,7 +105,11 @@ EditTUISpokeEntry = namedtuple("EditTUISpokeEntry", ["title", "attribute", "aux"
 # Inherit abstract methods from NormalTUISpoke
 # pylint: disable=abstract-method
 class EditTUIDialog(NormalTUISpoke):
-    """Spoke/dialog used to read new value of textual or password data"""
+    """Spoke/dialog used to read new value of textual or password data
+
+       .. inheritance-diagram:: EditTUIDialog
+          :parts: 3
+    """
 
     title = N_("New value")
     PASSWORD = re.compile(".*")
@@ -213,6 +224,9 @@ class EditTUISpoke(NormalTUISpoke):
        a list of titles, attribute names and regexps
        that specify the fields of an object the user
        allowed to edit.
+
+       .. inheritance-diagram:: EditTUISpoke
+          :parts: 3
     """
 
     # self.data's subattribute name
@@ -338,4 +352,8 @@ class EditTUISpoke(NormalTUISpoke):
         return NormalTUISpoke.input(self, args, key)
 
 class StandaloneTUISpoke(TUISpoke, StandaloneSpoke):
+    """
+       .. inheritance-diagram:: StandaloneTUISpoke
+          :parts: 3
+    """
     pass

--- a/pyanaconda/ui/tui/spokes/askvnc.py
+++ b/pyanaconda/ui/tui/spokes/askvnc.py
@@ -39,6 +39,10 @@ def exception_msg_handler_and_exit(event, data):
     sys.exit(1)
 
 class AskVNCSpoke(NormalTUISpoke):
+    """
+       .. inheritance-diagram:: AskVNCSpoke
+          :parts: 3
+    """
     title = N_("VNC")
 
     # This spoke is kinda standalone, not meant to be used with a hub
@@ -119,6 +123,10 @@ class AskVNCSpoke(NormalTUISpoke):
         self.data.vnc.enabled = self._usevnc
 
 class VNCPassSpoke(NormalTUISpoke):
+    """
+       .. inheritance-diagram:: VNCPassSpoke
+          :parts: 3
+    """
     title = N_("VNC Password")
 
     def __init__(self, app, data, storage, payload, instclass, message=None):

--- a/pyanaconda/ui/tui/spokes/langsupport.py
+++ b/pyanaconda/ui/tui/spokes/langsupport.py
@@ -34,6 +34,9 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     in text-mode.
 
     Also this doesn't allow for selection of multiple languages like in the GUI.
+
+       .. inheritance-diagram:: LangSpoke
+          :parts: 3
     """
     title = N_("Language settings")
     category = LocalizationCategory

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -42,7 +42,11 @@ __all__ = ["NetworkSpoke"]
 
 
 class NetworkSpoke(EditTUISpoke):
-    """ Spoke used to configure network settings. """
+    """ Spoke used to configure network settings.
+
+       .. inheritance-diagram:: NetworkSpoke
+          :parts: 3
+    """
     title = N_("Network configuration")
     category = SystemCategory
 

--- a/pyanaconda/ui/tui/spokes/password.py
+++ b/pyanaconda/ui/tui/spokes/password.py
@@ -29,6 +29,10 @@ from pyanaconda.flags import flags
 from pyanaconda.i18n import N_, _
 
 class PasswordSpoke(FirstbootSpokeMixIn, EditTUIDialog):
+    """
+       .. inheritance-diagram:: PasswordSpoke
+          :parts: 3
+    """
     title = N_("Root password")
     category = UserSettingsCategory
 

--- a/pyanaconda/ui/tui/spokes/progress.py
+++ b/pyanaconda/ui/tui/spokes/progress.py
@@ -34,6 +34,10 @@ from pyanaconda.ui.tui.simpleline.base import ExitAllMainLoops
 __all__ = ["ProgressSpoke"]
 
 class ProgressSpoke(StandaloneTUISpoke):
+    """
+       .. inheritance-diagram:: ProgressSpoke
+          :parts: 3
+    """
     title = N_("Progress")
 
     postForHub = SummaryHub

--- a/pyanaconda/ui/tui/spokes/shell_spoke.py
+++ b/pyanaconda/ui/tui/spokes/shell_spoke.py
@@ -30,6 +30,10 @@ from pyanaconda.iutil import execConsole
 from blivet import arch
 
 class ShellSpoke(NormalTUISpoke):
+    """
+       .. inheritance-diagram:: ShellSpoke
+          :parts: 3
+    """
     title = N_("Shell")
     category = SystemCategory
 

--- a/pyanaconda/ui/tui/spokes/software.py
+++ b/pyanaconda/ui/tui/spokes/software.py
@@ -36,7 +36,11 @@ __all__ = ["SoftwareSpoke"]
 
 
 class SoftwareSpoke(NormalTUISpoke):
-    """ Spoke used to read new value of text to represent source repo. """
+    """ Spoke used to read new value of text to represent source repo.
+
+       .. inheritance-diagram:: SoftwareSpoke
+          :parts: 3
+    """
     title = N_("Software selection")
     category = SoftwareCategory
 

--- a/pyanaconda/ui/tui/spokes/source.py
+++ b/pyanaconda/ui/tui/spokes/source.py
@@ -51,7 +51,11 @@ LOG = logging.getLogger("anaconda")
 __all__ = ["SourceSpoke"]
 
 class SourceSpoke(EditTUISpoke, SourceSwitchHandler):
-    """ Spoke used to customize the install source repo. """
+    """ Spoke used to customize the install source repo.
+
+       .. inheritance-diagram:: SourceSpoke
+          :parts: 3
+    """
     title = N_("Installation source")
     category = SoftwareCategory
 

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -65,9 +65,11 @@ PARTTYPES = {CLEARALL: CLEARPART_TYPE_ALL, CLEARLINUX: CLEARPART_TYPE_LINUX,
              CLEARNONE: CLEARPART_TYPE_NONE}
 
 class StorageSpoke(NormalTUISpoke):
-    """
-    Storage spoke where users proceed to customize storage features such
-    as disk selection, partitioning, and fs type.
+    """Storage spoke where users proceed to customize storage features such
+       as disk selection, partitioning, and fs type.
+
+       .. inheritance-diagram:: StorageSpoke
+          :parts: 3
     """
     title = N_("Installation Destination")
     category = SystemCategory
@@ -445,7 +447,11 @@ class StorageSpoke(NormalTUISpoke):
         self._ready = True
 
 class AutoPartSpoke(NormalTUISpoke):
-    """ Autopartitioning options are presented here. """
+    """ Autopartitioning options are presented here.
+
+       .. inheritance-diagram:: AutoPartSpoke
+          :parts: 3
+    """
     title = N_("Autopartitioning Options")
     category = SystemCategory
 

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -28,6 +28,10 @@ from pyanaconda.i18n import N_, _
 from pyanaconda.constants_text import INPUT_PROCESSED
 
 class TimeZoneSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
+    """
+       .. inheritance-diagram:: TimeZoneSpoke
+          :parts: 3
+    """
     title = N_("Timezone settings")
     category = LocalizationCategory
 

--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -34,6 +34,10 @@ from pyanaconda.regexes import GECOS_VALID, USERNAME_VALID, GROUPLIST_SIMPLE_VAL
 __all__ = ["UserSpoke"]
 
 class UserSpoke(FirstbootSpokeMixIn, EditTUISpoke):
+    """
+       .. inheritance-diagram:: UserSpoke
+          :parts: 3
+    """
     title = N_("User creation")
     category = UserSettingsCategory
 

--- a/pyanaconda/ui/tui/spokes/warnings_spoke.py
+++ b/pyanaconda/ui/tui/spokes/warnings_spoke.py
@@ -33,6 +33,10 @@ log = logging.getLogger("anaconda")
 __all__ = ["WarningsSpoke"]
 
 class WarningsSpoke(StandaloneTUISpoke):
+    """
+       .. inheritance-diagram:: WarningsSpoke
+          :parts: 3
+    """
     title = N_("Warnings")
 
     preForHub = SummaryHub

--- a/scripts/make-sphinx-docs
+++ b/scripts/make-sphinx-docs
@@ -28,7 +28,7 @@ if [ -z "$DISPLAY" ]; then
 fi
 # Pass the script anything to skip re-initializing the chroot
 [ -z "$1" ] && mock -r $MOCKCFG --init
-mock -r $MOCKCFG -i anaconda-gui -i python3-sphinx -i python3-sphinx_rtd_theme -i ostree
+mock -r $MOCKCFG -i anaconda-gui -i python3-sphinx -i python3-sphinx_rtd_theme -i ostree -i graphviz
 mock -r $MOCKCFG --copyin $PWD /builddir/anaconda/
 # Note that DISPLAY is needed to make GTK happy, so this needs to be run from a system with a GUI
 mock -r $MOCKCFG --chroot "cd /builddir/anaconda/docs/; DISPLAY=$DISPLAY make -f Makefile.am html"


### PR DESCRIPTION
Add class diagrams to existing hubs and spokes. I don't add these globally because they are waste of space in generated documentation if there are only few parents (also I didn't found where to setup that).

I lowered number of the documentation compilation errors and warnings.

Example:
![class_diagram](https://jkonecny.fedorapeople.org/redhat/class%20diagram%20example.png)