### PR TITLE
Fix Initial PPC PReP Boot Selector Name (#1172755)

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -509,7 +509,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
             for device in new_devices:
                 if device in self.bootLoaderDevices:
-                    mounts[device.format.type] = device
+                    mounts[device.format.name] = device
 
             new_root = Root(mounts=mounts, swaps=swaps, name=translated_new_install_name())
             ui_roots.insert(0, new_root)

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -212,7 +212,7 @@ class Page(Gtk.Box):
 
     def _mountpointType(self, mountpoint):
         if not mountpoint or mountpoint in ["/", "/boot", "/boot/efi", "/tmp", "/usr", "/var",
-                                            "biosboot", "prepboot", "swap"]:
+                                            "swap", "PPC PReP Boot", "BIOS Boot"]:
             return SYSTEM_DEVICE
         else:
             return DATA_DEVICE


### PR DESCRIPTION
The auto partition tool added the PPC PReP Boot partition and named it
prepboot in the selector view in the GUI installer. This was due to the
mountpoint being named by the device format type. Changed the mountpoint
namer so that it is named after the device name instead.

Change required adding BIOS Boot as a name in the mountpoint types to
avoid unexpected behavior as a side effect from this change.

Resolves: rhbz#1172755