### PR TITLE
Modify Installation Source Proxy Label (#11688554)

### DIFF
--- a/pyanaconda/ui/gui/spokes/source.glade
+++ b/pyanaconda/ui/gui/spokes/source.glade
@@ -296,7 +296,7 @@
                       <object class="GtkLabel" id="label5">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes" context="GUI|Software Source|Proxy Dialog">_Proxy URL:</property>
+                        <property name="label" translatable="yes" context="GUI|Software Source|Proxy Dialog">_Proxy Host:</property>
                         <property name="use_underline">True</property>
                         <property name="mnemonic_widget">proxyURLEntry</property>
                         <property name="xalign">0</property>


### PR DESCRIPTION
The label "Proxy URL" is a misnomer because a proxy address is not
specified by a uniform resource locator. Modified the label to
read "Proxy Host" which is a more apropos to its form.

Resolves: rhbz#1168554