### PR TITLE
Fix crash when adding new device in Welcome spoke (#1245960)

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -459,6 +459,12 @@ class NetworkControlBox(GObject.GObject):
         return True
 
     def initialize(self):
+        # There is signal for newly added devices from NetworkManager but this
+        # is registered after the initialize method.
+        # So if someone add new device in Welcome screen ifconf file won't
+        # be created which causing anaconda to crash.
+        log.debug("Dump missing interfaces in NetworkControlBox initialize method")
+        network.dumpMissingDefaultIfcfgs()
         for device in self.client.get_devices():
             self.add_device_to_list(device)
 


### PR DESCRIPTION
When anaconda is starting then existing interfaces dumping their
configurations and after NetworkSpoke is initialized there is registered
signal for new devices to handle this.
Problem happens in Welcome spoke which is after start but before signals
are registered.

*Resolves: rhbz#[1245960](https://bugzilla.redhat.com/show_bug.cgi?id=1245960)*