### PR TITLE
Revert "Fix Initial PPC PReP Boot Selector Name (#1172755)"

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -493,7 +493,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
             for device in new_devices:
                 if device in self.bootLoaderDevices:
-                    mounts[device.format.name] = device
+                    mounts[device.format.type] = device
 
             new_root = Root(mounts=mounts, swaps=swaps, name=translated_new_install_name())
             ui_roots.insert(0, new_root)

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -203,7 +203,7 @@ class Page(Gtk.Box):
 
     def _mountpointType(self, mountpoint):
         if not mountpoint or mountpoint in ["/", "/boot", "/boot/efi", "/tmp", "/usr", "/var",
-                                            "swap", "PPC PReP Boot", "BIOS Boot"]:
+                                            "biosboot", "prepboot", "swap"]:
             return SYSTEM_DEVICE
         else:
             return DATA_DEVICE


### PR DESCRIPTION
Reverts rhinstaller/anaconda#240 because it blew away the commit message.