### PR TITLE
Disable GRUB os_prober on POWER (#1193281)

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -2068,6 +2068,12 @@ class IPSeriesGRUB2(GRUB2):
         defaults = open(defaults_file, "a+")
         # The terminfo's X and Y size, and output location could change in the future
         defaults.write("GRUB_TERMINFO=\"terminfo -g 80x24 console\"\n")
+        # Disable OS Prober on pSeries systems
+        # TODO: This will disable across all POWER platforms. Need to get
+        #       into blivet and rework how it segments the POWER systems
+        #       to allow for differentiation between PowerNV and
+        #       PowerVM / POWER on qemu/kvm
+        defaults.write("GRUB_DISABLE_OS_PROBER=true\n")
         defaults.close()
 
 


### PR DESCRIPTION
The GRUB2 os_prober utility searches for other Linux installations
and the output to the grub config file is parsed incorrectly by
petitboot. This disables the os_prober script on the following
POWER based machine/platform combinations.

        CHRP/pSeries
        CHRP IBM/pSeries
        pSeries/pSeries
        Maple/pSeries,
        Cell/pSeries
        Momentum/pSeries
        PowerNV/pSeries

Resolves: rhbz#1193281