### PR TITLE
Equalize capacity & mount point entries (#1212615)

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.glade
+++ b/pyanaconda/ui/gui/spokes/custom.glade
@@ -373,7 +373,8 @@
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">True</property>
                                                     <property name="halign">start</property>
-                                                    <property name="width_chars">20</property>
+                                                    <property name="invisible_char">●</property>
+                                                    <property name="width_chars">10</property>
                                                     <property name="completion">mountPointCompletion</property>
                                                     <signal name="changed" handler="on_value_changed" swapped="no"/>
                                                   </object>


### PR DESCRIPTION
Shorten the mount point entry box to match the width of the capacity entry box.

Resolves: rhbz#1212615

Conflicts:
	pyanaconda/ui/gui/spokes/custom.glade