### PR TITLE
Cancel Container Edit Sensitizes Update (#1168656)

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.glade
+++ b/pyanaconda/ui/gui/spokes/custom.glade
@@ -808,7 +808,6 @@
                                                         <property name="can_focus">False</property>
                                                         <property name="model">containerStore</property>
                                                         <signal name="changed" handler="on_container_changed" swapped="no"/>
-                                                        <signal name="changed" handler="on_value_changed" swapped="no"/>
                                                         <child>
                                                           <object class="GtkCellRendererText" id="descRenderer">
                                                             <property name="ellipsize">middle</property>

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -2176,13 +2176,15 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         container_type_name = _(get_container_type(device_type).name).lower()
         new_text = _(NEW_CONTAINER_TEXT) % {"container_type": container_type_name}
         create_new_container = container_name == new_text
+        user_changed_container = True
         if create_new_container:
             # run the vg editor dialog with a default name and disk set
             hostname = self.data.network.hostname
             name = self._storage_playground.suggestContainerName(hostname=hostname)
-            new = self.run_container_editor(name=name)
+            # user_changed_container flips to False if "cancel" picked
+            user_changed_container = self.run_container_editor(name=name)
             for idx, data in enumerate(self._containerStore):
-                if new and data[0] == new_text:
+                if user_changed_container and data[0] == new_text:
                     c = self._storage_playground.devicetree.getDeviceByName(self._device_container_name)
                     freeSpace = getattr(c, "freeSpace", None)
                     row = self._container_store_row(self._device_container_name, freeSpace)
@@ -2190,11 +2192,15 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                     self._containerStore.insert(idx, row)
                     combo.set_active(idx)   # triggers a call to this method
                     return
-                elif not new and data[0] == self._device_container_name:
+                elif not user_changed_container and data[0] == self._device_container_name:
                     combo.set_active(idx)
                     return
+        # else clause runs if an already existing container is picked
         else:
             self._device_container_name = container_name
+
+        if user_changed_container:
+            self._applyButton.set_sensitive(True)
 
         container = self._storage_playground.devicetree.getDeviceByName(self._device_container_name)
         container_exists = getattr(container, "exists", False)    # might not be in the tree


### PR DESCRIPTION
Settings" button in the custom partition screen would
activate after a user attempted to create a new volume and then
pressed the cancel button. This patch removes the double event
handler which had the unintended side effect of setting the
sensitive property to True no matter what happened in the
container editor dialog box.

Resolves: rhbz#1168656