### PR TITLE
Ellipsize the file system type combo box (#1212615)

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.glade
+++ b/pyanaconda/ui/gui/spokes/custom.glade
@@ -41,6 +41,12 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="fileSystemStore">
+    <columns>
+      <!-- column-name fs_type -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
   <object class="GtkListStore" id="mountPointStore">
     <columns>
       <!-- column-name path -->
@@ -714,11 +720,20 @@
                                                       </packing>
                                                     </child>
                                                     <child>
-                                                      <object class="GtkComboBoxText" id="fileSystemTypeCombo">
+                                                      <object class="GtkComboBox" id="fileSystemTypeCombo">
                                                         <property name="visible">True</property>
                                                         <property name="can_focus">False</property>
+                                                        <property name="model">fileSystemStore</property>
                                                         <signal name="changed" handler="on_fs_type_changed" swapped="no"/>
                                                         <signal name="changed" handler="on_value_changed" swapped="no"/>
+                                                        <child>
+                                                          <object class="GtkCellRendererText" id="fileSystemRenderer">
+                                                            <property name="ellipsize">end</property>
+                                                          </object>
+                                                          <attributes>
+                                                            <attribute name="text">0</attribute>
+                                                          </attributes>
+                                                        </child>
                                                       </object>
                                                       <packing>
                                                         <property name="expand">False</property>

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -140,7 +140,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
     builderObjects = ["customStorageWindow", "containerStore", "deviceTypeStore",
                       "partitionStore", "raidStoreFiltered", "raidLevelStore",
                       "addImage", "removeImage", "settingsImage",
-                      "mountPointCompletion", "mountPointStore"]
+                      "mountPointCompletion", "mountPointStore", "fileSystemStore"]
     mainWidgetName = "customStorageWindow"
     uiFile = "spokes/custom.glade"
     helpFile = "CustomSpoke.xml"
@@ -240,6 +240,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         # Detailed configuration stuff
         self._encryptCheckbox = self.builder.get_object("encryptCheckbox")
         self._fsCombo = self.builder.get_object("fileSystemTypeCombo")
+        self._fsStore = self.builder.get_object("fileSystemStore")
         self._labelEntry = self.builder.get_object("labelEntry")
         self._mountPointEntry = self.builder.get_object("mountPointEntry")
         self._nameEntry = self.builder.get_object("nameEntry")
@@ -436,6 +437,14 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         if self._current_selector:
             self._current_selector.set_chosen(False)
             self._current_selector = None
+
+    def _get_fstype(self, fstypeCombo):
+        itr = fstypeCombo.get_active_iter()
+        if not itr:
+            return None
+
+        model = fstypeCombo.get_model()
+        return model[itr][0]
 
     def _get_autopart_type(self, autopartTypeCombo):
         itr = autopartTypeCombo.get_active_iter()
@@ -1336,9 +1345,9 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         names.sort()
 
         # Add all desired fileystem type names to the box, sorted alphabetically
-        self._fsCombo.remove_all()
+        self._fsStore.clear()
         for ty in names:
-            self._fsCombo.append_text(ty)
+            self._fsStore.append([ty])
 
         # set the active filesystem type
         idx = next(i for i, data in enumerate(self._fsCombo.get_model()) if data[0] == type_name)
@@ -2405,10 +2414,12 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         if not self._initialized:
             return
 
-        new_type = combo.get_active_text()
-        if new_type is None:
+        itr = combo.get_active_iter()
+        if not itr:
             return
-        log.debug("fs type changed: %s", new_type)
+
+        new_type = self._get_fstype(combo)
+
         fmt = getFormat(new_type)
         fancy_set_sensitive(self._mountPointEntry, fmt.mountable)
 
@@ -2510,12 +2521,14 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
             This method is idempotent, and must remain so.
         """
         # Find unique instance of btrfs in fsCombo, if any.
-        btrfs_idx = next((idx for idx, data in enumerate(self._fsCombo.get_model()) if data[0] == "btrfs"), None)
+        model = self._fsCombo.get_model()
+        btrfs_iter = ((idx, row) for idx, row in enumerate(model) if row[0] == "btrfs")
+        btrfs_idx, btrfs_row = next(btrfs_iter, (None, None))
 
         if device_type == DEVICE_TYPE_BTRFS:
             # If no btrfs entry, add one, and select the new entry
             if btrfs_idx is None:
-                self._fsCombo.append_text("btrfs")
+                self._fsStore.append(["btrfs"])
                 active_index = len(self._fsCombo.get_model()) - 1
             # Otherwise, select the already located btrfs entry
             else:
@@ -2526,7 +2539,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
             # If there is a btrfs entry, remove and adjust active_index
             if btrfs_idx is not None:
-                self._fsCombo.remove(btrfs_idx)
+                self._fsStore.remove(btrfs_row.iter)
 
                 # If btrfs previously selected, select default filesystem
                 if active_index == btrfs_idx:


### PR DESCRIPTION
The PPC architecture has unusually long filesystem type names, which
blows out the window when running at 800x600. Ellipsize long names in
the combo box, which means the GtkComboBoxtext has to be downgraded to a
GtkComboBox and the model and renderer handled ourselves.

Resolves: rhbz#1212615
(cherry picked from commit ba9f0d15a3bb2bce4651a6ab28b681fec008535b,
sort of)