### PR TITLE
Early disk snapshot

### DIFF
--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -444,3 +444,6 @@ class StorageSnapshot(object):
         if dispose:
             self.dispose_snapshot()
 
+# a snapshot of early storage as we got it from scanning disks without doing any
+# changes
+on_disk_storage = StorageSnapshot()

--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -382,3 +382,65 @@ def bound_size(size, device, old_size):
             size = min_size
 
     return size
+
+class StorageSnapshot(object):
+    """R/W snapshot of storage (i.e. a :class:`blivet.Blivet` instance)"""
+
+    def __init__(self, storage=None):
+        """
+        Create new instance of the class
+
+        :param storage: if given, its snapshot is created
+        :type storage: :class:`blivet.Blivet`
+        """
+        if storage:
+            self._storage_snap = storage.copy()
+        else:
+            self._storage_snap = None
+
+    @property
+    def storage(self):
+        return self._storage_snap
+
+    @property
+    def created(self):
+        return bool(self._storage_snap)
+
+    def create_snapshot(self, storage):
+        """Create (and save) snapshot of storage"""
+
+        self._storage_snap = storage.copy()
+
+    def dispose_snapshot(self):
+        """
+        Dispose (unref) the snapshot
+
+        .. note::
+
+            In order to free the memory taken by the snapshot, all references
+            returned by :property:`self.storage` have to be unrefed too.
+        """
+        self._storage_snap = None
+
+    def reset_to_snapshot(self, storage, dispose=False):
+        """
+        Reset storage to snapshot (**modifies :param:`storage` in place**)
+
+        :param storage: :class:`blivet.Blivet` instance to reset to the created snapshot
+        :param bool dispose: whether to dispose the snapshot after reset or not
+        :raises ValueError: if no snapshot is available (was not created before)
+        """
+        if not self.created:
+            raise ValueError("No snapshot created, cannot reset")
+
+        # we need to create a new copy from the snapshot first -- simple
+        # assignment from the snapshot would result in snapshot being modified
+        # by further changes of 'storage'
+        new_copy = self._storage_snap.copy()
+        storage.devicetree = new_copy.devicetree
+        storage.roots = new_copy.roots
+        storage.fsset = new_copy.fsset
+
+        if dispose:
+            self.dispose_snapshot()
+

--- a/pyanaconda/ui/gui/spokes/lib/resize.glade
+++ b/pyanaconda/ui/gui/spokes/lib/resize.glade
@@ -360,7 +360,7 @@
     </child>
     <action-widgets>
       <action-widget response="0">cancelButton</action-widget>
-      <action-widget response="2">resizeButton</action-widget>
+      <action-widget response="1">resizeButton</action-widget>
     </action-widgets>
     <child internal-child="accessible">
       <object class="AtkObject" id="resizeDialog-atkobject">

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -858,6 +858,12 @@ class StorageSpoke(NormalSpoke, StorageChecker):
             NormalSpoke.on_back_clicked(self, button)
             return
 
+        disks = [d for d in self.disks if d.name in self.selected_disks]
+        # No disks selected?  The user wants to back out of the storage spoke.
+        if not disks:
+            NormalSpoke.on_back_clicked(self, button)
+            return
+
         # Remove all non-existing devices if autopart was active when we last
         # refreshed.
         if self._previous_autopart:
@@ -866,12 +872,6 @@ class StorageSpoke(NormalSpoke, StorageChecker):
 
         # hide/unhide disks as requested
         self._hide_unhide_disks()
-
-        disks = [d for d in self.disks if d.name in self.selected_disks]
-        # No disks selected?  The user wants to back out of the storage spoke.
-        if not disks:
-            NormalSpoke.on_back_clicked(self, button)
-            return
 
         # make sure no containers were split up by the user's disk selection
         self.clear_info()

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -74,6 +74,7 @@ from pyanaconda.flags import flags
 from pyanaconda.i18n import _, C_, CN_, P_
 from pyanaconda import constants, iutil, isys
 from pyanaconda.bootloader import BootLoaderError
+from pyanaconda.storage_utils import on_disk_storage
 
 from pykickstart.constants import CLEARPART_TYPE_NONE, AUTOPART_TYPE_LVM
 from pykickstart.errors import KickstartValueError
@@ -264,6 +265,7 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         self.encrypted = False
         self.passphrase = ""
         self.selected_disks = self.data.ignoredisk.onlyuse[:]
+        self._last_selected_disks = None
         self._back_clicked = False
         self.autopart_missing_passphrase = False
 
@@ -484,15 +486,19 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         self._cur_clicked_overview = overview
 
     def refresh(self):
-        self.disks = getDisks(self.storage.devicetree)
-
         self._back_clicked = False
+
+        self.disks = getDisks(self.storage.devicetree)
 
         # synchronize our local data store with the global ksdata
         disk_names = [d.name for d in self.disks]
-        # don't put disks with hidden formats in selected_disks
         self.selected_disks = [d for d in self.data.ignoredisk.onlyuse
-                                    if d in disk_names]
+                               if d in disk_names]
+
+        # unhide previously hidden disks so that they don't look like being
+        # empty (because of all child devices hidden)
+        self._unhide_disks()
+
         self.autopart = self.data.autopart.autopart
         self.autoPartType = self.data.autopart.type
         if self.autoPartType is None:
@@ -762,14 +768,18 @@ class StorageSpoke(NormalSpoke, StorageChecker):
                partition in self.storage.partitions:
                 self.storage.recursiveRemove(partition)
 
-    def _hide_unhide_disks(self):
+    def _hide_disks(self):
         for disk in self.disks:
             if disk.name not in self.selected_disks and \
                disk in self.storage.devices:
                 self.storage.devicetree.hide(disk)
-            elif disk.name in self.selected_disks and \
-                 disk not in self.storage.devices:
-                self.storage.devicetree.unhide(disk)
+
+    def _unhide_disks(self):
+        if self._last_selected_disks:
+            for disk in self.disks:
+                if disk.name not in self.selected_disks and \
+                   disk.name not in self._last_selected_disks:
+                    self.storage.devicetree.unhide(disk)
 
     def _check_dasd_formats(self):
         rc = DASD_FORMAT_NO_CHANGE
@@ -853,25 +863,42 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         else:
             self._back_clicked = True
 
+        # make sure the snapshot of unmodified on-disk-storage model is created
+        if not on_disk_storage.created:
+            on_disk_storage.create_snapshot(self.storage)
+
         if self.autopart_missing_passphrase:
             self._setup_passphrase()
             NormalSpoke.on_back_clicked(self, button)
             return
 
-        disks = [d for d in self.disks if d.name in self.selected_disks]
         # No disks selected?  The user wants to back out of the storage spoke.
-        if not disks:
+        if not self.selected_disks:
             NormalSpoke.on_back_clicked(self, button)
             return
 
-        # Remove all non-existing devices if autopart was active when we last
-        # refreshed.
-        if self._previous_autopart:
-            self._previous_autopart = False
-            self._remove_nonexistant_partitions()
+        disk_selection_changed = False
+        if self._last_selected_disks:
+            disk_selection_changed = (self._last_selected_disks != set(self.selected_disks))
 
-        # hide/unhide disks as requested
-        self._hide_unhide_disks()
+        # remember the disk selection for future decisions
+        self._last_selected_disks = set(self.selected_disks)
+
+        if disk_selection_changed:
+            # Changing disk selection is really, really complicated and has
+            # always been causing numerous hard bugs. Let's not play the hero
+            # game and just revert everything and start over again.
+            on_disk_storage.reset_to_snapshot(self.storage)
+            self.disks = getDisks(self.storage.devicetree)
+        else:
+            # Remove all non-existing devices if autopart was active when we last
+            # refreshed.
+            if self._previous_autopart:
+                self._previous_autopart = False
+                self._remove_nonexistant_partitions()
+
+        # hide disks as requested
+        self._hide_disks()
 
         # make sure no containers were split up by the user's disk selection
         self.clear_info()
@@ -916,6 +943,7 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         # 3) we are just asked to do autopart => check free space and see if we need
         #                                        user to do anything more
         self.autopart = not self._customPart.get_active()
+        disks = [d for d in self.disks if d.name in self.selected_disks]
         dialog = None
         if not self.autopart:
             self.skipTo = "CustomPartitioningSpoke"


### PR DESCRIPTION
This is the port of the early disk snapshot stuff we implemented for the Fedora 22 on the *f22-branch*. Turns out a better and reliable solution for a number of bugs these changes fixed and prevented won't be available any time soon so I'm porting this to the master branch to prevent serious regressions.

There have been some conflicts, basically all caused by the fixes for kickstart autopart missing passphrase and by changes done for the s390 stuff moved from blivet to libblockdev.