### PR TITLE
Fix crash when devices and connections are changing (#1245960)

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -478,6 +478,12 @@ class NetworkControlBox(GObject.GObject):
         return True
 
     def initialize(self):
+        # There is a signal for newly added devices from NetworkManager but it
+        # is registered after the initialize method.
+        # So if someone adds a new device in the Welcome screen the ifconf file won't
+        # be created which causes anaconda to crash.
+        log.debug("Dump missing interfaces in NetworkControlBox initialize method")
+        network.dumpMissingDefaultIfcfgs()
         for device in self.client.get_devices():
             self.add_device_to_list(device)
 

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -239,6 +239,17 @@ class DeviceConfiguration(object):
         elif con_uuid:
             self.device_type = self._setting_device_type(self.con_uuid)
 
+        # Found device for existing connection
+        if not self.device:
+            if self.device_type == NetworkManager.DeviceType.ETHERNET:
+                client = NMClient.Client.new()
+                dev_name = self.get_iface()
+                for device in client.get_devices():
+                    if dev_name == device.get_iface():
+                        self.device = device
+                        break
+
+        # Found connection for existing device
         if not self.con_uuid:
             if self.device_type != NetworkManager.DeviceType.WIFI:
                 uuid = nm.nm_device_setting_value(device.get_iface(), "connection", "uuid")
@@ -254,6 +265,11 @@ class DeviceConfiguration(object):
         return dev_type
 
     def get_iface(self):
+        """Get interface name
+
+           :return: Interface name or ``None`` if can't find device name for given uuid
+           :rtype: string or NoneType
+        """
         if self.device:
             iface = self.device.get_iface()
         else:
@@ -438,22 +454,25 @@ class NetworkControlBox(GObject.GObject):
         if self.dev_cfg(uuid=uuid):
             log.debug("network: GUI, not adding connection %s, already in list", uuid)
             return False
+
         dev_cfg = DeviceConfiguration(con_uuid=uuid)
+
         if dev_cfg.setting_value("connection", "read-only"):
             log.debug("network: GUI, not adding read-only connection %s", uuid)
             return False
         if dev_cfg.device_type not in self.supported_device_types:
             log.debug("network: GUI, not adding connection %s of unsupported type", uuid)
             return False
-        # Configs for ethernet has been already added,
-        # this must be some slave
+        # skip slaves - only slaves have master
         if dev_cfg.device_type == NetworkManager.DeviceType.ETHERNET:
-            log.debug("network: GUI, not adding slave connection %s", uuid)
-            return False
+            if dev_cfg.setting_value("connection", "master"):
+                log.debug("network: GUI, not adding slave connection %s", uuid)
+                return False
         # Wireless settings are handled in scope of its device's dev_cfg
         if dev_cfg.device_type == NetworkManager.DeviceType.WIFI:
             log.debug("network: GUI, not adding wireless connection %s", uuid)
             return False
+
         self.add_dev_cfg(dev_cfg)
         log.debug("network: GUI, adding connection %s", uuid)
         return True
@@ -712,13 +731,19 @@ class NetworkControlBox(GObject.GObject):
             log.error(e)
             return
         except nm.SettingsNotFoundError:
-            # wireless devices
+            # wireless devices or device without a connection
+            log.debug("network: connection for new device %s was not found", device.get_iface())
             dev_cfg = None
+
         if dev_cfg:
             dev_cfg.device = device
         else:
-            dev_cfg = DeviceConfiguration(device=device)
-            self.add_dev_cfg(dev_cfg)
+            # wireless device
+            if device.get_device_type() == NetworkManager.DeviceType.WIFI:
+                dev_cfg = DeviceConfiguration(device=device)
+                self.add_dev_cfg(dev_cfg)
+            else:
+                log.debug("network: device %s missing connection", device.get_iface())
 
         device.connect("notify::ip4-config", self.on_device_config_changed)
         device.connect("notify::ip6-config", self.on_device_config_changed)


### PR DESCRIPTION
First when user add new device to started anaconda in Welcome screen then
the anaconda will crash in NetworkSpoke initialization. This happens
because it's not created configuration file for the new device.
Fixed by generating this configuration in NetworkSpoke initialization.

Second when user remove existing ethernet connection for device. This could
happen specially in Live compose. This is fixed now that we skipping
devices without connection and add that device after the connection
appears.

*Resolves: rhbz#1245960*