### PR TITLE
Add test for liveimg kickstart command

### DIFF
--- a/tests/kickstart_tests/liveimg.ks
+++ b/tests/kickstart_tests/liveimg.ks
@@ -1,0 +1,27 @@
+install
+liveimg --url=LIVEIMG_URL --checksum=LIVEIMG_CHECKSUM
+
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+
+rootpw qweqwe
+
+%post
+if [[ ! -e /etc/passwd ]]; then
+    echo "*** liveimg installation failed ***" > /root/RESULT
+fi
+
+# Final check
+if [[ ! -e /root/RESULT ]]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/tests/kickstart_tests/liveimg.sh
+++ b/tests/kickstart_tests/liveimg.sh
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+. ${KSTESTDIR}/functions.sh
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    if [[ "${KSTEST_LIVEIMG_URL}" == "" ]]; then
+        echo \$KSTEST_LIVEIMG_URL is not set.
+        return 1
+    fi
+
+    if [[ "${KSTEST_LIVEIMG_CHECKSUM}" == "" ]]; then
+        echo \$KSTEST_LIVEIMG_CHECKSUM is not set.
+        return 1
+    fi
+
+    sed -e "/^liveimg / s|LIVEIMG_URL|${KSTEST_LIVEIMG_URL}|" \
+        -e "/^liveimg / s|LIVEIMG_CHECKSUM|${KSTEST_LIVEIMG_CHECKSUM}|" \
+        ${ks} > ${tmpdir}/kickstart.ks
+    echo ${tmpdir}/kickstart.ks
+}


### PR DESCRIPTION
The environment needs to be setup with:
KSTEST_LIVEIMG_URL pointing to an image or .tar.gz file to install
KSTEST_LIVEIMG_CHECKSUM with the sha256 checksum of the image.