### PR TITLE
Use stage2=hd: instead of stage2=live:

### DIFF
--- a/tests/kickstart_tests/kstest-runner
+++ b/tests/kickstart_tests/kstest-runner
@@ -101,7 +101,7 @@ class VirtualInstall(object):
         if kernel_args:
             extra_args += " " + kernel_args
         if iso.stage2:
-            extra_args += " stage2=live:CDLABEL={0}".format(udev_escape(iso.label))
+            extra_args += " stage2=hd:CDLABEL={0}".format(udev_escape(iso.label))
         args.append("--extra-args")
         args.append(extra_args)
 


### PR DESCRIPTION
live: mounts are handled by dracut/systemd, whereas hd: mounts are
handled by anaconda's dracut libs. The latter contains fewer surprises
for anaconda to trip over once repos start getting mounted.