### PR TITLE
Apply the environment substitutions more liberally in nfs-repo-and-addon

### DIFF
--- a/tests/kickstart_tests/nfs-repo-and-addon.sh
+++ b/tests/kickstart_tests/nfs-repo-and-addon.sh
@@ -43,9 +43,9 @@ prepare() {
         return 1
     fi
 
-    sed -e "/^nfs/ s|NFS-SERVER|${KSTEST_NFS_SERVER}|" \
-        -e "/^nfs/ s|NFS-PATH|${KSTEST_NFS_PATH}|" \
-        -e "/^repo/ s|NFS-ADDON-REPO|${KSTEST_ADDON_NFS_REPO}|" \
-        -e "/^repo/ s|HTTP-ADDON-REPO|${KSTEST_ADDON_HTTP_REPO}|" ${ks} > ${tmpdir}/kickstart.ks
+    sed -e "s|NFS-SERVER|${KSTEST_NFS_SERVER}|" \
+        -e "s|NFS-PATH|${KSTEST_NFS_PATH}|" \
+        -e "s|NFS-ADDON-REPO|${KSTEST_ADDON_NFS_REPO}|" \
+        -e "s|HTTP-ADDON-REPO|${KSTEST_ADDON_HTTP_REPO}|" ${ks} > ${tmpdir}/kickstart.ks
     echo ${tmpdir}/kickstart.ks
 }


### PR DESCRIPTION
Some of the environment variables appear in the tests in %post, so those
need to be substituted as well.