### PR TITLE
Use a disk label to find the filesystem for escrow results

### DIFF
--- a/tests/kickstart_tests/btrfs-1.sh
+++ b/tests/kickstart_tests/btrfs-1.sh
@@ -26,7 +26,7 @@ validate() {
     # There should be a /root/root/RESULT file with results in it.  Check
     # its contents and decide whether the test finally succeeded or
     # not.
-    result=$(virt-cat ${args} -m /dev/sda2 /root/root/RESULT)
+    result=$(virt-cat ${args} -m /dev/disk/by-label/fedora-btrfs /root/root/RESULT)
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /root/RESULT does not exist in VM image.'

--- a/tests/kickstart_tests/btrfs-2.sh
+++ b/tests/kickstart_tests/btrfs-2.sh
@@ -26,7 +26,7 @@ validate() {
     # There should be a /root/root/RESULT file with results in it.  Check
     # its contents and decide whether the test finally succeeded or
     # not.
-    result=$(virt-cat ${args} -m /dev/sda2 /root/root/RESULT)
+    result=$(virt-cat ${args} -m /dev/disk/by-label/fedora-btrfs /root/root/RESULT)
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /root/RESULT does not exist in VM image.'

--- a/tests/kickstart_tests/escrow-cert.ks
+++ b/tests/kickstart_tests/escrow-cert.ks
@@ -5,7 +5,7 @@ network --bootproto=dhcp
 bootloader --timeout=1
 zerombr
 clearpart --all
-part --fstype=ext4 --size=4400 /
+part --fstype=ext4 --size=4400 --label=rootfs /
 part --fstype=ext4 --size=500 /boot
 part --fstype=swap --size=500 swap
 

--- a/tests/kickstart_tests/escrow-cert.sh
+++ b/tests/kickstart_tests/escrow-cert.sh
@@ -19,3 +19,22 @@
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 
 . ${KSTESTDIR}/functions.sh
+
+validate() {
+    disksdir=$1
+    args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
+
+    # There should be a /root/RESULT file with results in it.  Check
+    # its contents and decide whether the test finally succeeded or
+    # not.
+    result=$(virt-cat ${args} -m /dev/disk/by-label/rootfs /root/RESULT)
+    if [[ $? != 0 ]]; then
+        status=1
+        echo '*** /root/RESULT does not exist in VM image.'
+    elif [[ "${result}" != SUCCESS* ]]; then
+        status=1
+        echo "${result}"
+    fi
+
+    return ${status}
+}

--- a/tests/kickstart_tests/raid-1.ks
+++ b/tests/kickstart_tests/raid-1.ks
@@ -16,7 +16,7 @@ part raid.22 --size=1024 --ondisk=sdb
 # Yes, using 0,1,2 is wrong, but /proc/mounts uses /dev/mdX not /dev/md/X
 raid /boot --level=1 --device=0 --fstype=ext4 raid.01 raid.02
 raid swap  --level=1 --device=1 --fstype=swap raid.21 raid.22
-raid /     --level=1 --device=2 --fstype=ext4 raid.11 raid.12
+raid /     --level=1 --device=2 --fstype=ext4 --label=rootfs raid.11 raid.12
 
 keyboard us
 lang en_US.UTF-8

--- a/tests/kickstart_tests/raid-1.sh
+++ b/tests/kickstart_tests/raid-1.sh
@@ -31,12 +31,10 @@ validate() {
     disksdir=$1
     args=$(for d in ${disksdir}/disk-*img; do echo -a ${d}; done)
 
-    # virt-cat doesn't setup /dev/md/* links so cross our fingers that
-    # / always ends up on /dev/md126
     # There should be a /root/RESULT file with results in it.  Check
     # its contents and decide whether the test finally succeeded or
     # not.
-    result=$(virt-cat ${args} -m /dev/md126 /root/RESULT)
+    result=$(virt-cat ${args} -m /dev/disk/by-label/rootfs /root/RESULT)
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /root/RESULT does not exist in VM image.'

--- a/tests/kickstart_tests/tmpfs-fixed_size.ks
+++ b/tests/kickstart_tests/tmpfs-fixed_size.ks
@@ -6,7 +6,7 @@ bootloader --timeout=1
 zerombr
 clearpart --all
 
-part --fstype=ext4 --size=4400 /
+part --fstype=ext4 --size=4400 --label=rootfs /
 part --fstype=ext4 --size=500 /boot
 part --fstype=swap --size=500 swap
 part --fstype=tmpfs --size 5000 /tmp

--- a/tests/kickstart_tests/tmpfs-fixed_size.sh
+++ b/tests/kickstart_tests/tmpfs-fixed_size.sh
@@ -26,7 +26,7 @@ validate() {
     # There should be a /root/RESULT file with results in it.  Check
     # its contents and decide whether the test finally succeeded or
     # not.
-    result=$(virt-cat ${args} -m /dev/sda2 /root/RESULT)
+    result=$(virt-cat ${args} -m /dev/disk/by-label/rootfs /root/RESULT)
     if [[ $? != 0 ]]; then
         status=1
         echo '*** /root/RESULT does not exist in VM image.'


### PR DESCRIPTION
The escrow test does not use autopart, so the root filesystem does not
end up on /dev/mapper/fedora-root like most other tests. Use a label so
we don't have to depend on the partition order.