### PR TITLE
Kickstart tests for the LVM cache kickstart support

### DIFF
--- a/tests/kickstart_tests/lvm-cache-1.ks
+++ b/tests/kickstart_tests/lvm-cache-1.ks
@@ -1,0 +1,173 @@
+#version=DEVEL
+url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+part /boot --fstype=ext4 --size=300
+part pv.1 --fstype=lvmpv --size=6500
+part pv.2 --fstype=lvmpv --size=3100
+
+volgroup fedora pv.1 pv.2
+logvol swap --name=swap --vgname=fedora --size=500 --fstype=swap
+logvol / --name=root --vgname=fedora --size=4000 --fstype=ext4 --cachepvs=pv.2 --cachesize=1500 --cachemode=writethrough
+logvol /home --name=home --vgname=fedora --size=2000 --fstype=ext4 --cachepvs=pv.2 --cachesize=1500 --cachemode=writeback
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+%packages
+%end
+
+%post
+root_lv="/dev/mapper/fedora-root"
+root_uuid="UUID=$(blkid -o value -s UUID $root_lv)"
+home_lv="/dev/mapper/fedora-home"
+home_uuid="UUID=$(blkid -o value -s UUID $home_lv)"
+
+# verify root LV is mounted at /mnt/sysimage
+root_mount="$(grep ^$root_lv\\s/\\s /proc/mounts)"
+if [ -z  "$root_mount" ]; then
+    echo "*** lvm lv 'fedora-root' is not mounted at /" >> /root/RESULT
+fi
+
+root_fstype="$(echo $root_mount | cut -d' ' -f3)"
+if [ $root_fstype != "ext4" ]; then
+    echo "*** lvm lv 'fedora-root' does not contain an ext4 fs" >> /root/RESULT
+fi
+
+# verify root entry in /etc/fstab is correct
+root_lv_entry="$(grep ^$root_lv\\s/\\s /etc/fstab)"
+root_uuid_entry="$(grep ^$root_uuid\\s/\\s /etc/fstab)"
+if [ -z "$root_lv_entry" -a -z "$root_uuid_entry" ] ; then
+    echo "*** root LV is not the root entry in /etc/fstab" >> /root/RESULT
+fi
+
+# verify size of root LV
+root_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root)
+if [ $root_lv_size != "4000.00" ]; then
+    echo "*** root LV has incorrect size" >> /root/RESULT
+fi
+
+# verify home entry in /etc/fstab is correct
+home_lv_entry="$(grep ^$home_lv\\s/home\\s /etc/fstab)"
+home_uuid_entry="$(grep ^$home_uuid\\s/home\\s /etc/fstab)"
+if [ -z "$home_lv_entry" -a -z "$home_uuid_entry" ] ; then
+    echo "*** home LV is not the home entry in /etc/fstab" >> /root/RESULT
+fi
+
+# verify size of home LV
+home_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home)
+if [ $home_lv_size != "2000.00" ]; then
+    echo "*** home LV has incorrect size" >> /root/RESULT
+fi
+
+# verify swap on lvm is active
+swap_lv="/dev/mapper/fedora-swap"
+swap_uuid="UUID=$(blkid -o value -s UUID $swap_lv)"
+swap_dm="$(basename $(readlink $swap_lv))"
+if ! grep -q $swap_dm /proc/swaps ; then
+    echo "*** lvm lv 'fedora-swap' is not active as swap space" >> /root/RESULT
+fi
+
+# verify swap entry in /etc/fstab is correct
+swap_lv_entry="$(grep ^$swap_lv\\sswap\\s /etc/fstab)"
+swap_uuid_entry="$(grep ^$swap_uuid\\sswap\\s /etc/fstab)"
+if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
+    echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
+fi
+
+# verify size of swap lv
+swap_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/swap)
+if [ $swap_lv_size != "500.00" ]; then
+    echo "*** swap lv has incorrect size" >> /root/RESULT
+fi
+
+## cache-specific checks
+# verify that root and home LVs are cached
+lvs -o lv_attr --noheadings fedora/root|grep -q '^\s\+C'
+if [ $? != 0 ]; then
+    echo "*** root LV is not cached" >> /root/RESULT
+fi
+lvs -o lv_attr --noheadings fedora/home|grep -q '^\s\+C'
+if [ $? != 0 ]; then
+    echo "*** home LV is not cached" >> /root/RESULT
+fi
+
+# verify size of root LV's cache
+root_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache | sed -r 's/([0-9]+)\..*/\1/')
+root_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache_cmeta | sed -r 's/([0-9]+)\..*/\1/')
+root_cache_all=$(($root_cache_size + $root_cache_md_size))
+if [ $root_cache_all != "1500" ]; then
+    echo "*** root LV's cache has incorrect size" >> /root/RESULT
+fi
+
+# verify size of home LV's cache
+home_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache | sed -r 's/([0-9]+)\..*/\1/')
+home_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache_cmeta | sed -r 's/([0-9]+)\..*/\1/')
+home_cache_all=$(($home_cache_size + $home_cache_md_size))
+if [ $home_cache_all != "1500" ]; then
+    echo "*** home LV's cache has incorrect size" >> /root/RESULT
+fi
+
+# verify mode of root LV's cache
+root_cache_mode=$(lvs --noheadings -o cachemode fedora/root)
+if [ $root_cache_mode != "writethrough" ]; then
+    echo "*** root LV's cache has wrong mode" >> /root/RESULT
+fi
+
+# verify mode of home LV's cache
+home_cache_mode=$(lvs --noheadings -o cachemode fedora/home)
+if [ $home_cache_mode != "writeback" ]; then
+    echo "*** home LV's cache has wrong mode" >> /root/RESULT
+fi
+
+# verify caches are using (only) the right (aka "faster") PV for both data and metadata
+fast_pv=$(pvs --noheadings -o name,size --unit m --nosuffix|grep 3100|sed -r 's/\s+(\S+)\s+.*/\1/')
+
+root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cdata|wc -l)
+if [ $root_cache_num_pvs != "1" ]; then
+    echo "*** root LV's cache is using multiple PVs" >> /root/RESULT
+fi
+home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cdata|wc -l)
+if [ $home_cache_num_pvs != "1" ]; then
+    echo "*** home LV's cache is using multiple PVs" >> /root/RESULT
+fi
+
+root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cmeta|wc -l)
+if [ $root_cache_num_pvs != "1" ]; then
+    echo "*** root LV's cache (meta) is using multiple PVs" >> /root/RESULT
+fi
+home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cmeta|wc -l)
+if [ $home_cache_num_pvs != "1" ]; then
+    echo "*** home LV's cache (meta) is using multiple PVs" >> /root/RESULT
+fi
+
+root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cdata|sed -r 's/([^(]+)\(.*/\1/')
+if [ $root_cache_pv != $fast_pv ]; then
+    echo "*** root LV's cache is using wrong PV" >> /root/RESULT
+fi
+home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cdata|sed -r 's/([^(]+)\(.*/\1/')
+if [ $home_cache_pv != $fast_pv ]; then
+    echo "*** home LV's cache is using wrong PV" >> /root/RESULT
+fi
+
+root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cmeta|sed -r 's/([^(]+)\(.*/\1/')
+if [ $root_cache_pv != $fast_pv ]; then
+    echo "*** root LV's cache (meta) is using wrong PV" >> /root/RESULT
+fi
+home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cmeta|sed -r 's/([^(]+)\(.*/\1/')
+if [ $home_cache_pv != $fast_pv ]; then
+    echo "*** home LV's cache (meta) is using wrong PV" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/tests/kickstart_tests/lvm-cache-1.sh
+++ b/tests/kickstart_tests/lvm-cache-1.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+. ${KSTESTDIR}/functions.sh

--- a/tests/kickstart_tests/lvm-cache-2.ks
+++ b/tests/kickstart_tests/lvm-cache-2.ks
@@ -1,0 +1,158 @@
+#version=DEVEL
+url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+part /boot --fstype=ext4 --size=300
+part pv.1 --fstype=lvmpv --size=6600
+part pv.2 --fstype=lvmpv --size=3100
+
+volgroup fedora pv.1 pv.2
+logvol swap --name=swap --vgname=fedora --size=500 --fstype=swap
+logvol / --name=root --vgname=fedora --size=4000 --grow --fstype=ext4 --cachepvs=pv.2 --cachesize=1000 --cachemode=writethrough
+logvol /home --name=home --vgname=fedora --size=1000 --grow --fstype=ext4 --cachepvs=pv.2 --cachesize=1000 --cachemode=writeback
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+%packages
+%end
+
+%post
+root_lv="/dev/mapper/fedora-root"
+root_uuid="UUID=$(blkid -o value -s UUID $root_lv)"
+home_lv="/dev/mapper/fedora-home"
+home_uuid="UUID=$(blkid -o value -s UUID $home_lv)"
+
+# verify root LV is mounted at /mnt/sysimage
+root_mount="$(grep ^$root_lv\\s/\\s /proc/mounts)"
+if [ -z  "$root_mount" ]; then
+    echo "*** lvm lv 'fedora-root' is not mounted at /" >> /root/RESULT
+fi
+
+root_fstype="$(echo $root_mount | cut -d' ' -f3)"
+if [ $root_fstype != "ext4" ]; then
+    echo "*** lvm lv 'fedora-root' does not contain an ext4 fs" >> /root/RESULT
+fi
+
+# verify root entry in /etc/fstab is correct
+root_lv_entry="$(grep ^$root_lv\\s/\\s /etc/fstab)"
+root_uuid_entry="$(grep ^$root_uuid\\s/\\s /etc/fstab)"
+if [ -z "$root_lv_entry" -a -z "$root_uuid_entry" ] ; then
+    echo "*** root LV is not the root entry in /etc/fstab" >> /root/RESULT
+fi
+
+# verify swap on lvm is active
+swap_lv="/dev/mapper/fedora-swap"
+swap_uuid="UUID=$(blkid -o value -s UUID $swap_lv)"
+swap_dm="$(basename $(readlink $swap_lv))"
+if ! grep -q $swap_dm /proc/swaps ; then
+    echo "*** lvm lv 'fedora-swap' is not active as swap space" >> /root/RESULT
+fi
+
+# verify swap entry in /etc/fstab is correct
+swap_lv_entry="$(grep ^$swap_lv\\sswap\\s /etc/fstab)"
+swap_uuid_entry="$(grep ^$swap_uuid\\sswap\\s /etc/fstab)"
+if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
+    echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
+fi
+
+# verify size of swap lv
+# FIXME: this is not true now!
+# swap_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/swap)
+# if [ $swap_lv_size != "500.00" ]; then
+#     echo "*** swap lv has incorrect size" >> /root/RESULT
+# fi
+
+# we don't need to check sizes of grown LVs, the fact that the installation
+# reached this point means everything fit into the VG somehow
+
+## cache-specific checks
+# verify that root and home LVs are cached
+lvs -o lv_attr --noheadings fedora/root|grep -q '^\s\+C'
+if [ $? != 0 ]; then
+    echo "*** root LV is not cached" >> /root/RESULT
+fi
+lvs -o lv_attr --noheadings fedora/home|grep -q '^\s\+C'
+if [ $? != 0 ]; then
+    echo "*** home LV is not cached" >> /root/RESULT
+fi
+
+# verify size of root LV's cache
+root_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache | sed -r 's/([0-9]+)\..*/\1/')
+root_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache_cmeta | sed -r 's/([0-9]+)\..*/\1/')
+root_cache_all=$(($root_cache_size + $root_cache_md_size))
+if [ $root_cache_all != "1000" ]; then
+    echo "*** root LV's cache has incorrect size" >> /root/RESULT
+fi
+
+# verify size of home LV's cache
+home_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache | sed -r 's/([0-9]+)\..*/\1/')
+home_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache_cmeta | sed -r 's/([0-9]+)\..*/\1/')
+home_cache_all=$(($home_cache_size + $home_cache_md_size))
+if [ $home_cache_all != "1000" ]; then
+    echo "*** home LV's cache has incorrect size" >> /root/RESULT
+fi
+
+# verify mode of root LV's cache
+root_cache_mode=$(lvs --noheadings -o cachemode fedora/root)
+if [ $root_cache_mode != "writethrough" ]; then
+    echo "*** root LV's cache has wrong mode" >> /root/RESULT
+fi
+
+# verify mode of home LV's cache
+home_cache_mode=$(lvs --noheadings -o cachemode fedora/home)
+if [ $home_cache_mode != "writeback" ]; then
+    echo "*** home LV's cache has wrong mode" >> /root/RESULT
+fi
+
+# verify caches are using (only) the right (aka "faster") PV for both data and metadata
+fast_pv=$(pvs --noheadings -o name,size --unit m --nosuffix|grep 3100|sed -r 's/\s+(\S+)\s+.*/\1/')
+
+root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cdata|wc -l)
+if [ $root_cache_num_pvs != "1" ]; then
+    echo "*** root LV's cache is using multiple PVs" >> /root/RESULT
+fi
+home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cdata|wc -l)
+if [ $home_cache_num_pvs != "1" ]; then
+    echo "*** home LV's cache is using multiple PVs" >> /root/RESULT
+fi
+
+root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cmeta|wc -l)
+if [ $root_cache_num_pvs != "1" ]; then
+    echo "*** root LV's cache (meta) is using multiple PVs" >> /root/RESULT
+fi
+home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cmeta|wc -l)
+if [ $home_cache_num_pvs != "1" ]; then
+    echo "*** home LV's cache (meta) is using multiple PVs" >> /root/RESULT
+fi
+
+root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cdata|sed -r 's/([^(]+)\(.*/\1/')
+if [ $root_cache_pv != $fast_pv ]; then
+    echo "*** root LV's cache is using wrong PV" >> /root/RESULT
+fi
+home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cdata|sed -r 's/([^(]+)\(.*/\1/')
+if [ $home_cache_pv != $fast_pv ]; then
+    echo "*** home LV's cache is using wrong PV" >> /root/RESULT
+fi
+
+root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cmeta|sed -r 's/([^(]+)\(.*/\1/')
+if [ $root_cache_pv != $fast_pv ]; then
+    echo "*** root LV's cache (meta) is using wrong PV" >> /root/RESULT
+fi
+home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cmeta|sed -r 's/([^(]+)\(.*/\1/')
+if [ $home_cache_pv != $fast_pv ]; then
+    echo "*** home LV's cache (meta) is using wrong PV" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/tests/kickstart_tests/lvm-cache-2.sh
+++ b/tests/kickstart_tests/lvm-cache-2.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
This adds two tests for the LVM cache kickstart support being added in PR #264 and [blivet's PR #190] (https://github.com/rhinstaller/blivet/pull/190). Please note that the test ``-2`` contains a commented-out check that reveals a minor bug in the LVM cache creation support which should be fixed and the check uncommented, but I don't want to hold everything off just because of that.