### PR TITLE
On incomplete ks, don't automatically proceed with install. (#1251978)

### DIFF
--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -84,8 +84,12 @@ class SummaryHub(TUIHub):
             log.error("CmdlineError: %s", errtxt)
             raise CmdlineError(errtxt)
 
+        # if we ever need to halt the flow of a ks install to prompt users for
+        # input, flip off the automatedInstall flag -- this way installation
+        # does not automatically proceed once all spokes are complete, and a
+        # user must confirm they want to begin installation
+        flags.automatedInstall = False
 
-        # override the default prompt since we want to offer the 'b' to begin
         # installation option here
         return _("  Please make your choice from above ['%(quit)s' to quit | '%(begin)s' to begin installation |\n  '%(refresh)s' to refresh]: ") % {
             # TRANSLATORS: 'q' to quit


### PR DESCRIPTION
Mirroring GUI behavior -- if using an incomplete ks file, don't just
proceed with installation once all spokes are completed. Users must
specifically indicate (hitting 'c' to continue) they wish to proceed.

Resolves: rhbz#1251978
(cherry picked from commit 2ef0b136f51a3cbf5d6210c033a5242444a944dc)