### PR TITLE
product.img buildstamp should override distribution buildstamp (#1240238)

### DIFF
--- a/pyanaconda/product.py
+++ b/pyanaconda/product.py
@@ -34,7 +34,7 @@ config.set("Main", "UUID", "")
 config.set("Main", "Version", os.environ.get("ANACONDA_PRODUCTVERSION", "bluesky"))
 
 # Now read in the .buildstamp file, wherever it may be.
-config.read(["/tmp/product/.buildstamp", "/.buildstamp", os.environ.get("PRODBUILDPATH", "")])
+config.read(["/.buildstamp", "/tmp/product/.buildstamp", os.environ.get("PRODBUILDPATH", "")])
 
 # Set up some variables we import throughout, applying a couple transforms as necessary.
 bugUrl = config.get("Main", "BugURL")


### PR DESCRIPTION
config.read() reads all the files in the order given, so later ones with
the same keys override the earlier ones. This changes the order so that
the product.img .buildstamp can be used for re-branding.

Resolves: rhbz#1240238