### PR TITLE
Replace IPy package by ipaddress

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -100,7 +100,6 @@ Requires: firewalld >= %{firewalldver}
 Requires: util-linux >= %{utillinuxver}
 Requires: python3-dbus
 Requires: python3-pwquality
-Requires: python-IPy-python3
 Requires: python3-pytz
 Requires: realmd
 Requires: teamd

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -38,7 +38,7 @@ import time
 import threading
 import re
 import dbus
-import IPy
+import ipaddress
 from uuid import uuid4
 import itertools
 
@@ -91,15 +91,18 @@ def check_ip_address(address, version=None):
 
     """
     try:
-        _ip, ver = IPy.parseAddress(address)
+        if version == 4:
+            ipaddress.IPv4Address(address)
+        elif version == 6:
+            ipaddress.IPv6Address(address)
+        elif not version: # any of those
+            ipaddress.ip_address(address)
+        else:
+            log.error("IP version %s is not supported", version)
+            return False
+        return True
     except ValueError:
         return False
-    if version and version == ver:
-        return True
-    elif not version:
-        return True
-
-    return False
 
 def sanityCheckHostname(hostname):
     """

--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -535,7 +535,7 @@ def nm_device_ip_config(name, version=4):
 
     addr_list = []
     for addr, prefix, gateway in addresses:
-        # NOTE: There is IPy for python2, ipaddress for python3 but
+        # NOTE: There is an ipaddress for IP validation but
         # byte order of dbus value would need to be switched
         if version == 4:
             addr_str = nm_dbus_int_to_ipv4(addr)

--- a/pyanaconda/ui/gui/spokes/advstorage/iscsi.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/iscsi.py
@@ -19,7 +19,6 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 #
 
-from IPy import IP
 from collections import namedtuple
 
 import gi
@@ -34,6 +33,7 @@ from pyanaconda.ui.gui.utils import escape_markup
 from pyanaconda.i18n import _
 from pyanaconda import nm
 from pyanaconda.regexes import ISCSI_IQN_NAME_REGEX, ISCSI_EUI_NAME_REGEX
+from pyanaconda.network import check_ip_address
 
 __all__ = ["ISCSIDialog"]
 
@@ -304,11 +304,7 @@ class ISCSIDialog(GUIObject):
         widget = self.builder.get_object("targetEntry")
         text = widget.get_text()
 
-        try:
-            IP(text)
-            return True
-        except ValueError:
-            return False
+        return check_ip_address(text)
 
     def _initiator_name_valid(self):
         widget = self.builder.get_object("initiatorEntry")


### PR DESCRIPTION
ipaddress function is from python 3 standard library.
The IPy package requirement from anaconda was removed.