### PR TITLE
Don't call setupDiskImages (#1252703)

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -1194,9 +1194,6 @@ if __name__ == "__main__":
         iutil.ipmi_report(constants.IPMI_ABORTED)
         sys.exit(1)
 
-    if image_count:
-        anaconda.storage.setupDiskImages()
-
     from blivet import storageInitialize
     from pyanaconda.packaging import payloadMgr
     from pyanaconda.timezone import time_initialize


### PR DESCRIPTION
storageInitialize handles this itself, and if it is called first the
storageInitialize call resets the devicetree and doesn't re-setup the
images correctly.

Related: rhbz#1252703