### PR TITLE
Use inst.debug as alternative option to start coverage

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -36,7 +36,7 @@ coverage = None
 # If we get a signal immediately after starting that would be pretty messed up
 proc_cmdline = open("/proc/cmdline", "r").read()    # pylint: disable=interruptible-system-call
 proc_cmdline = proc_cmdline.split()
-if ("debug=1" in proc_cmdline) or ("debug" in proc_cmdline):
+if ("inst.debug=1" in proc_cmdline) or ("inst.debug" in proc_cmdline):
     import coverage
     cov = coverage.coverage(data_file="/mnt/sysimage/root/anaconda.coverage",
                             branch=True,


### PR DESCRIPTION
I've been having troubles with debug=1 and encrypted disks - anaconda seems to wait too long for random data entropy (or seems to be stuck). Using the inst.debug option to start coverage doesn't suffer from this. Maybe debug=1 causes the kernel to generate entropy too slowly. See the IRC log below:

```
(11,43,23) atodorov: hi everyone, I'm having a problem installing RHEL 7.1 on encrypted disk with debug=1. Anaconda seems to be stuck with the message "The system needs more random data entropy" at the progress screen. This is *AFTER* the random data entropy dialog appeared and after I've moved my mouse around enough so that it is happy. I'm on a VM which also has /dev/random added as RNG device. Any ideas how to see what's wrong ? 
(11,46,14) vpodzime: atodorov: does it also happen without debug=1?
(11,56,22) atodorov: vpodzime: w/o debug=1 and even w/o RNG device added to the virtual guest the installation continues significantly faster
(11,56,53) atodorov: it did ask for entropy twice before creating luks devices for swap and root but happily proceeded forward after waiving the mouse a bit
(11,57,07) vpodzime: atodorov: why do you need debug=1?
(11,57,19) atodorov: to collect coverage data
(11,57,21) vpodzime: atodorov: wouldn't inst.debug=1 be enough?
(11,57,43) atodorov: arent these the same ? 
(11,58,14) vpodzime: atodorov: if inst.debug=1 works (which I'm not sure about), it should only affect anaconda
(11,58,31) vpodzime: debug=1 is a system-wide boot option interpreted by kernel, systemd and many other things
(11,58,55) atodorov: vpodzime: inst.debug is a no go, 
(11,59,01) atodorov: if ("debug=1" in proc_cmdline) or ("debug" in proc_cmdline):
(11,59,01) atodorov:                                     import coverage
(11,59,12) atodorov: I'll try with "debug" only
(12,00,18) vpodzime: atodorov: then we should fix that because running in full debug mode just because of debugging the installation is cumbersome
(12,01,08) atodorov: vpodzime: agreed, I will send a PR but which parameter should we rely on ? 
(12,04,43) atodorov: vpodzime: "debug" doesn't work either. I'll make an updates.img to start coverage when inst.debug is provided and see what happens then
(12,06,45) vpodzime: atodorov: I think 'debug=1', 'debug', 'inst.debug' and 'inst.debug=1' should all trigger installation debugging (coverage data included)
(12,07,34) vpodzime: so, basically just check for 'debug' or 'inst.debug' in /proc/cmdline, I don't think you have to care about things like 'debug=0' or 'inst.debug=0'
(12,11,28) vimal|brb сега се казва vimal
(12,14,59) mkolman_: for the record I would like to eventually make this more granular
(12,15,23) mkolman_: something like inst.record.coverage=1
(12,15,29) mkolman_: something like inst.record.trace=1
(12,15,30) mkolman_: etc.
(12,15,52) mkolman_: so that you could turn on the various debugging info collecting features eventually
(12,16,13) atodorov: mkolman_: iirc the team was opposed to adding yet another command line switch when I proposed the coverage functionality, b/c this is something that very little people will use
(12,16,35) atodorov: otherwise I have no problem with naming the key whatever we like
(12,17,20) atodorov: let me kick off a thread on anaconda-devel before submitting any patches
(12,19,06) mkolman_: well, I haven't really started on it yet
(12,19,17) mkolman_: it is more of an general idea
(12,19,43) mkolman_: that we can gather quite many types of information during the install for testing & debugging purposes
(12,19,54) mkolman_: and it should be possible to turn this on per feature
(12,19,55) vpodzime: atodorov: I think a PR with a discussion is better than a discussion on a mailing list. It would get more attention and less noise
(12,20,04) atodorov: vpodzime: fyi: using inst.debug instead is much better wrt random entropy waiting. maybe debug=1 is causing the kernel to gather entropy very slowly
(12,22,41) vpodzime: atodorov: that's what I hope for
(12,22,43) vpodzime: *hoped
(12,22,48) vpodzime: atodorov: thanks for confirmation
(12,24,27) atodorov: vpodzime: so which options to leave enabled both debug and inst.debug or only inst.debug ? 
(12,26,10) vpodzime: atodorov: I think 'debug' should work too as it means something like "debug everything"
(12,26,24) atodorov: vpodzime: ok then, sending a PR
```

Any preference as to what the non "debug" parameter should be called ? Please comment here.