### PR TITLE
Fix LVM cache kickstart tests

### DIFF
--- a/tests/kickstart_tests/lvm-cache-1.ks
+++ b/tests/kickstart_tests/lvm-cache-1.ks
@@ -26,65 +26,65 @@ shutdown
 
 %post
 root_lv="/dev/mapper/fedora-root"
-root_uuid="UUID=$(blkid -o value -s UUID $root_lv)"
+root_uuid="UUID=$(blkid -o value -s UUID "$root_lv")"
 home_lv="/dev/mapper/fedora-home"
-home_uuid="UUID=$(blkid -o value -s UUID $home_lv)"
+home_uuid="UUID=$(blkid -o value -s UUID "$home_lv")"
 
 # verify root LV is mounted at /mnt/sysimage
-root_mount="$(grep ^$root_lv\\s/\\s /proc/mounts)"
+root_mount=$(grep ^$root_lv\\s/\\s /proc/mounts)
 if [ -z  "$root_mount" ]; then
     echo "*** lvm lv 'fedora-root' is not mounted at /" >> /root/RESULT
 fi
 
-root_fstype="$(echo $root_mount | cut -d' ' -f3)"
-if [ $root_fstype != "ext4" ]; then
+root_fstype=$(echo "$root_mount" | cut -d' ' -f3)
+if [ "$root_fstype" != "ext4" ]; then
     echo "*** lvm lv 'fedora-root' does not contain an ext4 fs" >> /root/RESULT
 fi
 
 # verify root entry in /etc/fstab is correct
-root_lv_entry="$(grep ^$root_lv\\s/\\s /etc/fstab)"
-root_uuid_entry="$(grep ^$root_uuid\\s/\\s /etc/fstab)"
+root_lv_entry=$(grep ^$root_lv\\s/\\s /etc/fstab)
+root_uuid_entry=$(grep ^$root_uuid\\s/\\s /etc/fstab)
 if [ -z "$root_lv_entry" -a -z "$root_uuid_entry" ] ; then
     echo "*** root LV is not the root entry in /etc/fstab" >> /root/RESULT
 fi
 
 # verify size of root LV
-root_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root)
-if [ $root_lv_size != "4000.00" ]; then
+root_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root|sed -r 's/\s*//')
+if [ "$root_lv_size" != "4000.00" ]; then
     echo "*** root LV has incorrect size" >> /root/RESULT
 fi
 
 # verify home entry in /etc/fstab is correct
-home_lv_entry="$(grep ^$home_lv\\s/home\\s /etc/fstab)"
-home_uuid_entry="$(grep ^$home_uuid\\s/home\\s /etc/fstab)"
+home_lv_entry=$(grep ^$home_lv\\s/home\\s /etc/fstab)
+home_uuid_entry=$(grep ^$home_uuid\\s/home\\s /etc/fstab)
 if [ -z "$home_lv_entry" -a -z "$home_uuid_entry" ] ; then
     echo "*** home LV is not the home entry in /etc/fstab" >> /root/RESULT
 fi
 
 # verify size of home LV
-home_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home)
-if [ $home_lv_size != "2000.00" ]; then
+home_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home|sed -r 's/\s*//')
+if [ "$home_lv_size" != "2000.00" ]; then
     echo "*** home LV has incorrect size" >> /root/RESULT
 fi
 
 # verify swap on lvm is active
 swap_lv="/dev/mapper/fedora-swap"
-swap_uuid="UUID=$(blkid -o value -s UUID $swap_lv)"
-swap_dm="$(basename $(readlink $swap_lv))"
-if ! grep -q $swap_dm /proc/swaps ; then
+swap_uuid="UUID=$(blkid -o value -s UUID "$swap_lv")"
+swap_dm=$(basename $(readlink "$swap_lv"))
+if ! grep -q "$swap_dm" /proc/swaps ; then
     echo "*** lvm lv 'fedora-swap' is not active as swap space" >> /root/RESULT
 fi
 
 # verify swap entry in /etc/fstab is correct
-swap_lv_entry="$(grep ^$swap_lv\\sswap\\s /etc/fstab)"
-swap_uuid_entry="$(grep ^$swap_uuid\\sswap\\s /etc/fstab)"
+swap_lv_entry=$(grep ^$swap_lv\\sswap\\s /etc/fstab)
+swap_uuid_entry=$(grep ^$swap_uuid\\sswap\\s /etc/fstab)
 if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
     echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
 fi
 
 # verify size of swap lv
-swap_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/swap)
-if [ $swap_lv_size != "500.00" ]; then
+swap_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/swap|sed -r 's/\s*//')
+if [ "$swap_lv_size" != "500.00" ]; then
     echo "*** swap lv has incorrect size" >> /root/RESULT
 fi
 
@@ -100,69 +100,69 @@ if [ $? != 0 ]; then
 fi
 
 # verify size of root LV's cache
-root_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache | sed -r 's/([0-9]+)\..*/\1/')
-root_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache_cmeta | sed -r 's/([0-9]+)\..*/\1/')
+root_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache | sed -r 's/\s*([0-9]+)\..*/\1/')
+root_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root_cache_cmeta | sed -r 's/\s*([0-9]+)\..*/\1/')
 root_cache_all=$(($root_cache_size + $root_cache_md_size))
-if [ $root_cache_all != "1500" ]; then
+if [ "$root_cache_all" != "1500" ]; then
     echo "*** root LV's cache has incorrect size" >> /root/RESULT
 fi
 
 # verify size of home LV's cache
-home_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache | sed -r 's/([0-9]+)\..*/\1/')
-home_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache_cmeta | sed -r 's/([0-9]+)\..*/\1/')
+home_cache_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache | sed -r 's/\s*([0-9]+)\..*/\1/')
+home_cache_md_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home_cache_cmeta | sed -r 's/\s*([0-9]+)\..*/\1/')
 home_cache_all=$(($home_cache_size + $home_cache_md_size))
-if [ $home_cache_all != "1500" ]; then
+if [ "$home_cache_all" != "1500" ]; then
     echo "*** home LV's cache has incorrect size" >> /root/RESULT
 fi
 
 # verify mode of root LV's cache
-root_cache_mode=$(lvs --noheadings -o cachemode fedora/root)
-if [ $root_cache_mode != "writethrough" ]; then
+root_cache_mode=$(lvs --noheadings -o cachemode fedora/root|sed -r 's/\s*//')
+if [ "$root_cache_mode" != "writethrough" ]; then
     echo "*** root LV's cache has wrong mode" >> /root/RESULT
 fi
 
 # verify mode of home LV's cache
-home_cache_mode=$(lvs --noheadings -o cachemode fedora/home)
-if [ $home_cache_mode != "writeback" ]; then
+home_cache_mode=$(lvs --noheadings -o cachemode fedora/home|sed -r 's/\s*//')
+if [ "$home_cache_mode" != "writeback" ]; then
     echo "*** home LV's cache has wrong mode" >> /root/RESULT
 fi
 
 # verify caches are using (only) the right (aka "faster") PV for both data and metadata
-fast_pv=$(pvs --noheadings -o name,size --unit m --nosuffix|grep 3100|sed -r 's/\s+(\S+)\s+.*/\1/')
+fast_pv=$(pvs --noheadings -o name,size --unit m --nosuffix|egrep '3[0-9]{3}'|sed -r 's/\s+(\S+)\s+.*/\1/')
 
 root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cdata|wc -l)
-if [ $root_cache_num_pvs != "1" ]; then
+if [ "$root_cache_num_pvs" != "1" ]; then
     echo "*** root LV's cache is using multiple PVs" >> /root/RESULT
 fi
 home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cdata|wc -l)
-if [ $home_cache_num_pvs != "1" ]; then
+if [ "$home_cache_num_pvs" != "1" ]; then
     echo "*** home LV's cache is using multiple PVs" >> /root/RESULT
 fi
 
 root_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/root_cache_cmeta|wc -l)
-if [ $root_cache_num_pvs != "1" ]; then
+if [ "$root_cache_num_pvs" != "1" ]; then
     echo "*** root LV's cache (meta) is using multiple PVs" >> /root/RESULT
 fi
 home_cache_num_pvs=$(lvs -a --noheadings -o devices fedora/home_cache_cmeta|wc -l)
-if [ $home_cache_num_pvs != "1" ]; then
+if [ "$home_cache_num_pvs" != "1" ]; then
     echo "*** home LV's cache (meta) is using multiple PVs" >> /root/RESULT
 fi
 
-root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cdata|sed -r 's/([^(]+)\(.*/\1/')
-if [ $root_cache_pv != $fast_pv ]; then
+root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cdata|sed -r 's/\s*([^(]+)\(.*/\1/')
+if [ "$root_cache_pv" != "$fast_pv" ]; then
     echo "*** root LV's cache is using wrong PV" >> /root/RESULT
 fi
-home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cdata|sed -r 's/([^(]+)\(.*/\1/')
-if [ $home_cache_pv != $fast_pv ]; then
+home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cdata|sed -r 's/\s*([^(]+)\(.*/\1/')
+if [ "$home_cache_pv" != "$fast_pv" ]; then
     echo "*** home LV's cache is using wrong PV" >> /root/RESULT
 fi
 
-root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cmeta|sed -r 's/([^(]+)\(.*/\1/')
-if [ $root_cache_pv != $fast_pv ]; then
+root_cache_pv=$(lvs -a --noheadings -o devices fedora/root_cache_cmeta|sed -r 's/\s*([^(]+)\(.*/\1/')
+if [ "$root_cache_pv" != "$fast_pv" ]; then
     echo "*** root LV's cache (meta) is using wrong PV" >> /root/RESULT
 fi
-home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cmeta|sed -r 's/([^(]+)\(.*/\1/')
-if [ $home_cache_pv != $fast_pv ]; then
+home_cache_pv=$(lvs -a --noheadings -o devices fedora/home_cache_cmeta|sed -r 's/\s*([^(]+)\(.*/\1/')
+if [ "$home_cache_pv" != "$fast_pv" ]; then
     echo "*** home LV's cache (meta) is using wrong PV" >> /root/RESULT
 fi
 

--- a/tests/kickstart_tests/lvm-cache-1.sh
+++ b/tests/kickstart_tests/lvm-cache-1.sh
@@ -18,3 +18,12 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
 . ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    tmpdir=$1
+
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 10G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-b.img 10G
+    echo ${tmpdir}/disk-a.img
+    echo ${tmpdir}/disk-b.img
+}

--- a/tests/kickstart_tests/lvm-cache-2.sh
+++ b/tests/kickstart_tests/lvm-cache-2.sh
@@ -18,3 +18,12 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
 . ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    tmpdir=$1
+
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 10G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-b.img 10G
+    echo ${tmpdir}/disk-a.img
+    echo ${tmpdir}/disk-b.img
+}


### PR DESCRIPTION
We should double quote variables in conditions to prevent syntax errors in case
something goes wrong, we cannot rely on the PV we expect to be 3100 MiB big to
have this exact size and we need to get rid of whitespace before comparing
strings. We can also use two disks instead of one to prevent issues caused by
everything hardly fitting into one 10GiB disk.