### PR TITLE
Make sure proper installclass selected for RHEL installs.

### DIFF
--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -29,7 +29,7 @@ from blivet.size import Size
 
 class RHELBaseInstallClass(BaseInstallClass):
     name = "Red Hat Enterprise Linux"
-    sortPriority = 10000
+    sortPriority = 20000
     if not productName.startswith("Red Hat "):
         hidden = True
     defaultFS = "xfs"


### PR DESCRIPTION
product.img is no longer being provided, and Fedora installclass
was being selected for installation. Bump the priority of the RHEL
installclass to ensure it gets selected instead.

Related: rhbz#1196721
(cherry picked from commit 859b10c8673052ca09169860ec1a5c161f46a1ac)