### PR TITLE
Network protocols don't list Closest mirror first (#1253196)

### DIFF
--- a/pyanaconda/ui/tui/spokes/source.py
+++ b/pyanaconda/ui/tui/spokes/source.py
@@ -268,11 +268,11 @@ class SpecifyRepoSpoke(EditTUISpoke, SourceSwitchHandler):
     def apply(self):
         """ Apply all of our changes. """
         url = None
-        if self.selection == 2 and not self.args.url.startswith("http://"):
+        if self.selection == 1 and not self.args.url.startswith("http://"):
             url = "http://" + self.args.url
-        elif self.selection == 3 and not self.args.url.startswith("https://"):
+        elif self.selection == 2 and not self.args.url.startswith("https://"):
             url = "https://" + self.args.url
-        elif self.selection == 4 and not self.args.url.startswith("ftp://"):
+        elif self.selection == 3 and not self.args.url.startswith("ftp://"):
             url = "ftp://" + self.args.url
         else:
             # protocol either unknown or entry already starts with a protocol


### PR DESCRIPTION
On rhel7-branch, the Closest mirror option is listed last (if listed),
so protocol numbers start from 1.

Resolves: rhbz#1253196

Signed-off-by: Brian C. Lane <bcl@redhat.com>
(cherry picked from commit 9b7b18f62ff9cbed7c29ce26a175705ed168ee6e)