### PR TITLE
Use the default mirrorlist instead of fixed repo URL in kickstart tests

### DIFF
--- a/tests/kickstart_tests/bond.ks
+++ b/tests/kickstart_tests/bond.ks
@@ -1,4 +1,4 @@
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --device=link --bootproto=dhcp
 

--- a/tests/kickstart_tests/btrfs-1.ks
+++ b/tests/kickstart_tests/btrfs-1.ks
@@ -1,4 +1,4 @@
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/btrfs-2.ks
+++ b/tests/kickstart_tests/btrfs-2.ks
@@ -1,4 +1,4 @@
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/default-fstype.ks
+++ b/tests/kickstart_tests/default-fstype.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/driverdisk-disk.ks
+++ b/tests/kickstart_tests/driverdisk-disk.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/encrypt-device.ks
+++ b/tests/kickstart_tests/encrypt-device.ks
@@ -1,4 +1,4 @@
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/escrow-cert.ks
+++ b/tests/kickstart_tests/escrow-cert.ks
@@ -1,4 +1,4 @@
-url --url=http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/firewall.ks
+++ b/tests/kickstart_tests/firewall.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/groups-and-envs-1.ks
+++ b/tests/kickstart_tests/groups-and-envs-1.ks
@@ -1,4 +1,4 @@
-url --url=http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/groups-and-envs-2.ks
+++ b/tests/kickstart_tests/groups-and-envs-2.ks
@@ -1,4 +1,4 @@
-url --url=http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/groups-and-envs-3.ks
+++ b/tests/kickstart_tests/groups-and-envs-3.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/hostname.ks
+++ b/tests/kickstart_tests/hostname.ks
@@ -1,4 +1,4 @@
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 # Set hostname for testing

--- a/tests/kickstart_tests/keyboard-addtnl.ks
+++ b/tests/kickstart_tests/keyboard-addtnl.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/keyboard.ks
+++ b/tests/kickstart_tests/keyboard.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/lang.ks
+++ b/tests/kickstart_tests/lang.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/lvm-1.ks
+++ b/tests/kickstart_tests/lvm-1.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/lvm-2.ks
+++ b/tests/kickstart_tests/lvm-2.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/lvm-cache-1.ks
+++ b/tests/kickstart_tests/lvm-cache-1.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/lvm-cache-2.ks
+++ b/tests/kickstart_tests/lvm-cache-2.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/ntp-pools.ks
+++ b/tests/kickstart_tests/ntp-pools.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/packages-and-groups-1.ks
+++ b/tests/kickstart_tests/packages-and-groups-1.ks
@@ -1,4 +1,4 @@
-url --url=http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/packages-default.ks
+++ b/tests/kickstart_tests/packages-default.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/packages-excludedocs.ks
+++ b/tests/kickstart_tests/packages-excludedocs.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/packages-ignoremissing.ks
+++ b/tests/kickstart_tests/packages-ignoremissing.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/packages-multilib.ks
+++ b/tests/kickstart_tests/packages-multilib.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/pre-install.ks
+++ b/tests/kickstart_tests/pre-install.ks
@@ -1,4 +1,4 @@
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 
 install
 

--- a/tests/kickstart_tests/raid-1.ks
+++ b/tests/kickstart_tests/raid-1.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/timezoneLOCAL.ks
+++ b/tests/kickstart_tests/timezoneLOCAL.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/timezoneUTC.ks
+++ b/tests/kickstart_tests/timezoneUTC.ks
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/tmpfs-fixed_size.ks
+++ b/tests/kickstart_tests/tmpfs-fixed_size.ks
@@ -1,4 +1,4 @@
-url --url=http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/user.ks
+++ b/tests/kickstart_tests/user.ks
@@ -1,4 +1,4 @@
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 
 install
 

--- a/tests/kickstart_tests/vlan.ks
+++ b/tests/kickstart_tests/vlan.ks
@@ -1,4 +1,4 @@
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/$releasever/$basearch/os/"
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
 install
 network --device=link --bootproto=dhcp
 # Create testing vlan interface


### PR DESCRIPTION
When we use a fixed repo URL we don't give DNF a chance to try multiple mirrors
if something cannot be downloaded resulting in tests failing because something
cannot be fetched from that particular URL. Mirrors are quite often broken
out-of-date, but by using multiple of them, we should be safe.