### PR TITLE
Do not encode the geoloc timezone to bytes (#1240812)

### DIFF
--- a/pyanaconda/geoloc.py
+++ b/pyanaconda/geoloc.py
@@ -559,12 +559,6 @@ class FedoraGeoIPProvider(GeolocationBackend):
                 timezone_source = "GeoIP"
                 timezone_code = json_reply.get("time_zone", None)
 
-                if timezone_code is not None:
-                    # the timezone code is returned as Unicode,
-                    # it needs to be converted to UTF-8 encoded string,
-                    # otherwise some string processing in Anaconda might fail
-                    timezone_code = timezone_code.encode("utf8")
-
                 # check if the timezone returned by the API is valid
                 if not is_valid_timezone(timezone_code):
                     # try to get a timezone from the territory code


### PR DESCRIPTION
Yet string that ended up the wrong kind of string after switching to
python 3.