### PR TITLE
Defer to Fedora distro-wide settings for password strength (#1250746)

### DIFF
--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -5,7 +5,7 @@ firstboot --enable
 
 %anaconda
 # Default password policies
-pwpolicy root --strict --minlen=8 --minquality=50 --nochanges --emptyok
-pwpolicy user --strict --minlen=8 --minquality=50 --nochanges --emptyok
-pwpolicy luks --strict --minlen=8 --minquality=50 --nochanges --emptyok
+pwpolicy root --strict --nochanges --emptyok
+pwpolicy user --strict --nochanges --emptyok
+pwpolicy luks --strict --nochanges --emptyok
 %end


### PR DESCRIPTION
Remove the minlen and minquality settings from the default pwpolicy,
and instead pass the buck to libpwquality to determine what is and is
not an acceptable password.