### PR TITLE
Enable test coverage in CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+# http://nedbatchelder.com/code/coverage/config.html
+
+[run]
+branch = True
+parallel = True

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ tests/*/*.log
 tests/*/*.trs
 tests/*.log
 tests/*.trs
+tests/.coverage.*
 tests/pylint/.pylint.d
 tests/test-suite.log
 updates.img
@@ -98,3 +99,4 @@ _sources
 .buildinfo
 modules.rst
 pyanaconda.*rst
+.coverage

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,9 @@ ZANATA_PUSH_ARGS = --srcdir $(srcdir)/po/ --push-type source --force
 RC_RELEASE ?= $(shell date -u +0.1.%Y%m%d%H%M%S)
 MOCKCHROOT ?= fedora-rawhide-$(shell uname -m)
 
+COVERAGE ?= coverage3
+USER_SITE_PACKAGES ?= $(shell $(PYTHON) $(srcdir)/utils/user-site-packages)
+
 tag:
 	@git tag -s -a -m "Tag as $(ARCHIVE_TAG)" $(ARCHIVE_TAG)
 	@echo "Tagged as $(ARCHIVE_TAG)"
@@ -155,9 +158,18 @@ runglade:
 	glade ${GLADE_FILE}
 
 ci: rc-release
+	@mkdir -p $(USER_SITE_PACKAGES)
+	@cp $(abs_builddir)/tests/usercustomize.py $(USER_SITE_PACKAGES)
 	$(MAKE) -C utils/dd
-	$(MAKE) TMPDIR=/var/tmp check
+	$(MAKE) TMPDIR=/var/tmp COVERAGE_PROCESS_START=$(abs_builddir)/.coveragerc check
 	@mkdir -p repo
 	@mv *rpm repo
 	@createrepo -p repo
-	@sudo $(MAKE) TMPDIR=/var/tmp TESTS=install/run_install_test.sh TEST_ANACONDA_REPO=file://$(abs_builddir)/repo/ check
+	@sudo $(MAKE) TMPDIR=/var/tmp TESTS=install/run_install_test.sh TEST_ANACONDA_REPO=file://$(abs_builddir)/repo/ COVERAGE_PROCESS_START=$(abs_builddir)/.coveragerc check
+	@rm -f $(USER_SITE_PACKAGES)/usercustomize.py
+	$(MAKE) coverage-report
+
+coverage-report:
+	$(COVERAGE) combine tests/.coverage.*
+	$(COVERAGE) report --include="pyanaconda/*" > tests/coverage-report.log
+	@cat tests/coverage-report.log

--- a/tests/usercustomize.py
+++ b/tests/usercustomize.py
@@ -1,0 +1,8 @@
+# Enable Python coverage for subprocesses. See:
+# http://nedbatchelder.com/code/coverage/subprocess.html
+
+try:
+    import coverage
+    coverage.process_startup()
+except ImportError:
+    pass

--- a/utils/user-site-packages
+++ b/utils/user-site-packages
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+vi = sys.version_info
+home = "~"
+if 'HOME' in os.environ:
+    home=os.environ['HOME']
+
+path = os.path.join(home, ".local/lib/python%d.%d/site-packages/" % (vi.major, vi.minor))
+print(path)


### PR DESCRIPTION
The important files resulting from this are .coverage and tests/coverage-report.log. 

In case the ci target fails there's a coverage-report target so you can combine the data files and do the reports manually.