### PR TITLE
Fix inst.repo=hd: is not working (#1252902)

### DIFF
--- a/pyanaconda/isys/__init__.py
+++ b/pyanaconda/isys/__init__.py
@@ -59,7 +59,7 @@ def isIsoImage(path):
         with open(path, "rb") as isoFile:
             for blockNum in range(16, 100):
                 isoFile.seek(blockNum * ISO_BLOCK_SIZE + 1)
-                if isoFile.read(5) == "CD001":
+                if isoFile.read(5) == b"CD001":
                     return True
     except IOError:
         pass


### PR DESCRIPTION
isys method isIsoImage has problem with comparision of bytes with the
str. Another Python 3 problem.

Resolves: rhbz#1252902