### PR TITLE
Fix crash when anaconda starts with repository on HDD

### DIFF
--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -826,7 +826,12 @@ class PackagePayload(Payload):
             #     use
             image = findFirstIsoImage(path)
             if not image:
-                device.teardown(recursive=True)
+                # could be mounted as /run/install/repo
+                # when user used inst.repo=hd:LABEL= method
+                if len(blivet.util.get_mount_paths(device.path)) != 1:
+                    blivet.util.umount(path)
+                else:
+                    device.teardown(recursive=True)
                 raise PayloadSetupError("failed to find valid iso image")
 
             if path.endswith(".iso"):


### PR DESCRIPTION
inst.repo=hd:LABEL= method with repositories on HDD (not ISO file)
is unsupported method but the anaconda do not need to crash anyway.