### PR TITLE
Run AnacondaExceptionHandler in cmdline mode (#1256385)

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -1205,10 +1205,8 @@ if __name__ == "__main__":
     else:
         cleanPStore()
 
-    # only install interactive exception handler in interactive modes
-    if ksdata.displaymode.displayMode != DISPLAY_MODE_CMDLINE or flags.debug:
-        from pyanaconda import exception
-        anaconda.mehConfig = exception.initExceptionHandling(anaconda)
+    from pyanaconda import exception
+    anaconda.mehConfig = exception.initExceptionHandling(anaconda)
 
     # add our own additional signal handlers
     signal.signal(signal.SIGUSR1, lambda signum, frame:

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -51,7 +51,7 @@ log = logging.getLogger("anaconda")
 
 class AnacondaExceptionHandler(ExceptionHandler):
 
-    def __init__(self, confObj, intfClass, exnClass, tty_num, gui_lock):
+    def __init__(self, confObj, intfClass, exnClass, tty_num, gui_lock, interactive):
         """
         :see: python-meh's ExceptionHandler
         :param tty_num: the number of tty the interface is running on
@@ -61,6 +61,7 @@ class AnacondaExceptionHandler(ExceptionHandler):
         ExceptionHandler.__init__(self, confObj, intfClass, exnClass)
         self._gui_lock = gui_lock
         self._intf_tty_num = tty_num
+        self._interactive = interactive
 
     def run_handleException(self, dump_info):
         """
@@ -133,15 +134,19 @@ class AnacondaExceptionHandler(ExceptionHandler):
                 # X not running (Gtk cannot be initialized)
                 if threadMgr.in_main_thread():
                     log.debug("In the main thread, running exception handler")
-                    if (issubclass (ty, CmdlineError)):
-
-                        cmdline_error_msg = _("\nThe installation was stopped due to "
-                                              "incomplete spokes detected while running "
-                                              "in non-interactive cmdline mode. Since there "
-                                              "cannot be any questions in cmdline mode, "
-                                              "edit your kickstart file and retry "
-                                              "installation.\nThe exact error message is: "
-                                              "\n\n%s.\n\nThe installer will now terminate.") % str(value)
+                    if issubclass(ty, CmdlineError) or not self._interactive:
+                        if issubclass(ty, CmdlineError):
+                            cmdline_error_msg = _("\nThe installation was stopped due to "
+                                                  "incomplete spokes detected while running "
+                                                  "in non-interactive cmdline mode. Since there "
+                                                  "cannot be any questions in cmdline mode, "
+                                                  "edit your kickstart file and retry "
+                                                  "installation.\nThe exact error message is: "
+                                                  "\n\n%s.\n\nThe installer will now terminate.") % str(value)
+                        else:
+                            cmdline_error_msg = _("\nRunning in cmdline mode, no interactive debugging "
+                                                  "allowed.\nThe exact error message is: "
+                                                  "\n\n%s.\n\nThe installer will now terminate.") % str(value)
 
                         # since there is no UI in cmdline mode and it is completely
                         # non-interactive, we can't show a message window asking the user
@@ -276,9 +281,10 @@ def initExceptionHandling(anaconda):
     if not product.isFinal:
         conf.register_callback("release_type", lambda: "pre-release", attchmnt_only=True)
 
+    interactive = not anaconda.displayMode == 'c'
     handler = AnacondaExceptionHandler(conf, anaconda.intf.meh_interface,
                                        ReverseExceptionDump, anaconda.intf.tty_num,
-                                       anaconda.gui_initialized)
+                                       anaconda.gui_initialized, interactive)
     handler.install(anaconda)
 
     return conf


### PR DESCRIPTION
cmdline mode still needs to have the exception handler run. It exits
anaconda when there are problems, without it you can get stuck in a loop
in the summary hub when there are incomplete spokes.

This adds an interactive argument to it so that when the handler runs in
cmdline mode it only prints out the error and calls sys.exit(1) --
skipping the call to the superclass from meh which tries to run a UI to
prompt for debugging.

(cherry picked from commit 98ec24be63dcc66de695dbfc86ef0fb08ab31f01)

Resolves: rhbz#1256385