### PR TITLE
don't crash if no environment set in interactive (#1257036)

### DIFF
--- a/pyanaconda/ui/gui/spokes/software.py
+++ b/pyanaconda/ui/gui/spokes/software.py
@@ -306,11 +306,15 @@ class SoftwareSelectionSpoke(NormalSpoke):
             elif not self.environment:
                 return _("Nothing selected")
 
-        if not flags.automatedInstall and not self.environment_valid:
-            # selected environment is not valid, this can happen when a valid environment
-            # is selected (by default, manually or from kickstart) and then the installation
-            # source is switched to one where the selected environment is no longer valid
-            return _("Selected environment is not valid")
+        if not flags.automatedInstall:
+            if not self.environment:
+                # No environment yet set
+                return _("Nothing selected")
+            elif not self.environment_valid:
+                # selected environment is not valid, this can happen when a valid environment
+                # is selected (by default, manually or from kickstart) and then the installation
+                # source is switched to one where the selected environment is no longer valid
+                return _("Selected environment is not valid")
 
         return self.payload.environmentDescription(self.environment)[0]
 


### PR DESCRIPTION
634d2d9 fixed the kickstart case but broke the interactive
'nothing selected' case. Since we want to return "Nothing
selected" for None regardless of whether we're kickstarted or
interactive, just move the 'if not self.environment' check
out of the 'if flags.automatedInstall' block so it applies to
both.