### PR TITLE
Update partitioning and timeout configuration for gui tests

### DIFF
--- a/tests/gui/anaconda-autogui-testing.ks
+++ b/tests/gui/anaconda-autogui-testing.ks
@@ -10,7 +10,7 @@ rootpw qweqwe
 bootloader --location=mbr
 zerombr
 clearpart --all
-part / --fstype="ext4" --size=6000
+part / --fstype="ext4" --size=10240
 
 %post
 cat >> /etc/rc.d/init.d/livesys << EOF

--- a/tests/gui/make_livecd.sh
+++ b/tests/gui/make_livecd.sh
@@ -54,7 +54,7 @@ REPO="$3"
 # (1) Remove the first two / partitions we inherit.
 # (2) Remove rawhide as a repo because it's already the installation source.
 # (3) Don't remove /boot/initramfs*.  Do what now?
-ksflatten -c anaconda-autogui-testing.ks | sed -e '\|part /.*--size=3.*|,+1 d' \
+ksflatten -c anaconda-autogui-testing.ks | sed -e '\|part /.*--size=4.*|,+1 d' \
                                                -e '/repo --name="rawhide"/ d' \
                                                -e '/^# save a little/,+1 d' > livecd.ks
 
@@ -77,7 +77,7 @@ livemedia-creator --make-iso \
                   --iso "${ISO}" \
                   --title Fedora \
                   --project Fedora \
-                  --releasever 21 \
+                  --releasever 24 \
                   --tmp /var/tmp \
                   --resultdir "${RESULTSDIR}" \
                   --ks livecd.ks \
@@ -86,6 +86,6 @@ livemedia-creator --make-iso \
                   --ram 2048 \
                   --vcpus 2 \
                   --kernel-args nomodeset \
-                  --timeout 90
+                  --timeout 180
 rm livecd.ks
 rm -r ${TEMPLATES}


### PR DESCRIPTION
* I've bumped the size of the root partition but it may be too much; 
* updated the sed regex b/c the underlying kc configs in spin-kickstarts have probably changed. Without this change we end up with 3 root partitions in livecd.ks
* bumped the timeout value b/c it takes about 2:30 hrs only to perform the install.

