### PR TITLE
Defer to Fedora distro-wide settings for password strength (#1250746)

### DIFF
--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -5,7 +5,7 @@ firstboot --enable
 
 %anaconda
 # Default password policies
-pwpolicy root --strict --minlen=8 --minquality=50 --nochanges --emptyok
-pwpolicy user --strict --minlen=8 --minquality=50 --nochanges --emptyok
-pwpolicy luks --strict --minlen=8 --minquality=50 --nochanges --emptyok
+pwpolicy root --notstrict --minlen=0 --minquality=1 --nochanges --emptyok
+pwpolicy user --notstrict --minlen=0 --minquality=1 --nochanges --emptyok
+pwpolicy luks --notstrict --minlen=0 --minquality=1 --nochanges --emptyok
 %end


### PR DESCRIPTION
Try this again with all the changes.

The alternative proposed was to carry patches in a contrib directory and that didn't really sound any better to me, and also sounded like more work.