### PR TITLE
unbuffered read in python3 only works for binary

### DIFF
--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -552,7 +552,7 @@ def get_firmware_language(text_mode=False):
 
     try:
         n = "/sys/firmware/efi/efivars/PlatformLang-8be4df61-93ca-11d2-aa0d-00e098032b8c"
-        d = open(n, 'r', 0).read()
+        d = open(n, 'r').read()
     except IOError:
         return None
 


### PR DESCRIPTION
and for text files it uses blocks, not lines, so drop ,0 from the UEFI
firmware language read.