### PR TITLE
LVM on RAID kickstart test

### DIFF
--- a/tests/kickstart_tests/lvm-raid-1.ks
+++ b/tests/kickstart_tests/lvm-raid-1.ks
@@ -1,0 +1,81 @@
+#version=DEVEL
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-$releasever&arch=$basearch
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+part /boot --fstype=ext4 --size=500
+part raid.01 --size=8000 --ondisk=sda
+part raid.02 --size=8000 --ondisk=sdb
+part raid.03 --size=8000 --ondisk=sdc
+raid pv.01 --level=RAID5 --device=pv.01 raid.01 raid.02 raid.03
+volgroup fedora pv.01
+logvol swap --name=swap --vgname=fedora --size=500 --fstype=swap
+logvol / --name=root --vgname=fedora --grow --size=4000 --fstype=ext4
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+%packages
+%end
+
+%post
+root_lv="/dev/mapper/fedora-root"
+root_uuid="UUID=$(blkid -o value -s UUID $root_lv)"
+
+# verify root lv is mounted at /mnt/sysimage
+root_mount="$(grep ^$root_lv\\s/\\s /proc/mounts)"
+if [ -z  "$root_mount" ]; then
+    echo "*** lvm lv 'fedora-root' is not mounted at /" >> /root/RESULT
+fi
+
+root_fstype="$(echo $root_mount | cut -d' ' -f3)"
+if [ $root_fstype != "ext4" ]; then
+    echo "*** lvm lv 'fedora-root' does not contain an ext4 fs" >> /root/RESULT
+fi
+
+# verify root entry in /etc/fstab is correct
+root_lv_entry="$(grep ^$root_lv\\s/\\s /etc/fstab)"
+root_uuid_entry="$(grep ^$root_uuid\\s/\\s /etc/fstab)"
+if [ -z "$root_lv_entry" -a -z "$root_uuid_entry" ] ; then
+    echo "*** root lv is not the root entry in /etc/fstab" >> /root/RESULT
+fi
+
+# verify size of root lv (do not check any particular size, let's just be happy to see the
+# installation succeed and the LV grown somehow, for now)
+root_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root | sed -r 's/\s*([0-9]+)\..*/\1/')
+if [ $root_lv_size -le 4000 ]; then
+    echo "*** root lv has incorrect size" >> /root/RESULT
+fi
+
+# verify swap on lvm is active
+swap_lv="/dev/mapper/fedora-swap"
+swap_uuid="UUID=$(blkid -o value -s UUID $swap_lv)"
+swap_dm="$(basename $(readlink $swap_lv))"
+if ! grep -q $swap_dm /proc/swaps ; then
+    echo "*** lvm lv 'fedora-swap' is not active as swap space" >> /root/RESULT
+fi
+
+# verify swap entry in /etc/fstab is correct
+swap_lv_entry="$(grep ^$swap_lv\\sswap\\s /etc/fstab)"
+swap_uuid_entry="$(grep ^$swap_uuid\\sswap\\s /etc/fstab)"
+if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
+    echo "*** swap lv is not in /etc/fstab" >> /root/RESULT
+fi
+
+# verify size of swap lv
+swap_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/swap)
+if [ $swap_lv_size != "500.00" ]; then
+    echo "*** swap lv has incorrect size" >> /root/RESULT
+fi
+
+if [ ! -e /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+
+%end

--- a/tests/kickstart_tests/lvm-raid-1.sh
+++ b/tests/kickstart_tests/lvm-raid-1.sh
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    tmpdir=$1
+
+    # make sure the first disk have some extra space for /boot
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-a.img 9G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-b.img 8G
+    qemu-img create -q -f qcow2 ${tmpdir}/disk-c.img 8G
+
+    echo ${tmpdir}/disk-a.img
+    echo ${tmpdir}/disk-b.img
+    echo ${tmpdir}/disk-c.img
+}


### PR DESCRIPTION
This adds a single kickstart test for installation to LVM on top of MD
RAID. Being one of the most complex storage configurations we support the LVM on
RAID definitely deserves testing. However, since such installation is quite a
bit resource-hungry, it would be great if we could get along with this single
test as running multiple such tests could be a problem for our infrastructure
running kickstart tests. That's why this tests the harder case with one of the
LVs requested to be grown to a maximum possible size (which tests blivet's
calculations of free space in a VG using MD RAID PVs and calculations of MD RAID
metadata size).

Extra info not in the commit message:
My goal here is to make the test stricter and stricter as I go through blivet's sources and remove all weird and magic calculations we do there. Especially once the changes from [blivet's PR #215] (https://github.com/rhinstaller/blivet/pull/215) are effective, this test should also check the free space in the VG because we should do a good-enough job filling it up with the root LV that is requested to grow to a maximum size.