### PR TITLE
Force an encoding of utf-8 on liveinst installs (#1257060)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -236,6 +236,10 @@ find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 
 %ifarch %livearches
 desktop-file-install ---dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_datadir}/applications/liveinst.desktop
+
+# Add a sitecustomize.py to be loaded by liveinst
+mkdir -p %{buildroot}%{_datadir}/anaconda/site-python
+install -m 0644 pyanaconda/sitecustomize.py %{buildroot}%{_datadir}/anaconda/site-python/
 %endif
 # NOTE: If you see "error: Installed (but unpackaged) file(s) found" that include liveinst files,
 #       check the IS_LIVEINST_ARCH in configure.ac to make sure your architecture is properly defined

--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -85,6 +85,7 @@ else
 fi
 
 export PATH=/sbin:/usr/sbin:$PATH
+export PYTHONPATH=/usr/share/anaconda/site-python
 
 if [ -x /usr/sbin/getenforce ]; then
     current=$(/usr/sbin/getenforce)


### PR DESCRIPTION
This adds a copy of sitecustomize.py to a directory that can be added
to PYTHONPATH, and adds that directory to PYTHONPATH when running
liveinst. This way anaconda do perform early sys changes while not
affecting python globally and not messing up regular imports too badly.

This does not fix unicode problems for all cases (image/dir install are
still affected), but it papers over them for live installs.

(cherry picked from commit 2615c6d8de2f981262cff4618be38a36284dc9d5)

Resolves: rhbz#1257060