### PR TITLE
Disallow /boot on lvm until grub2 fully supports it. (#1252466)

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1403,7 +1403,7 @@ class GRUB2(GRUB):
     terminal_type = "console"
 
     # requirements for boot devices
-    stage2_device_types = ["partition", "mdarray", "lvmlv", "btrfs volume",
+    stage2_device_types = ["partition", "mdarray", "btrfs volume",
                            "btrfs subvolume"]
     stage2_raid_levels = [raid.RAID0, raid.RAID1, raid.RAID4,
                           raid.RAID5, raid.RAID6, raid.RAID10]


### PR DESCRIPTION
Still not supported. Also see bug 967880

(cherry picked from commit 0b9fe390f07d889d3a01d9d7196eb1fbef462e17)
Resolves: rhbz#1252466