### PR TITLE
network: assume --device=link as default also for ks on hd (#1085310)

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -1175,7 +1175,7 @@ def update_hostname_data(ksdata, hostname):
 
 def get_device_name(network_data):
 
-    ksspec = network_data.device or flags.cmdline.get('ksdevice') or ""
+    ksspec = network_data.device or flags.cmdline.get('ksdevice') or "link"
     dev_name = ks_spec_to_device_name(ksspec)
     if not dev_name:
         return ""


### PR DESCRIPTION
Ie when network is not activated in dracut.

Related: rhbz#1085310

If not overriden by ksdevice.