### PR TITLE
Master port gui spoke to libnm

### DIFF
--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -891,21 +891,6 @@ def nm_add_connection(values):
         raise
     return connection
 
-def nm_delete_connection(uuid):
-    """Delete connection specified by uuid.
-
-       :param uuid: uuid of connection to be deleted
-       :type uuid: str
-       :return: True if connection was deleted, False if it was not found
-       :rtype: bool
-    """
-
-    settings_paths = _find_settings(uuid, "connection", "uuid")
-    if not settings_paths:
-        return False
-    proxy = _get_proxy(object_path=settings_paths[0], interface_name="org.freedesktop.NetworkManager.Settings.Connection")
-    proxy.Delete()
-
 def nm_update_settings_of_device(name, new_values):
     """Update setting of device.
 

--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -653,16 +653,6 @@ def _device_settings(name):
 
     return settings
 
-def _settings_for_ap(ssid):
-    """Return list of object paths of wireless access point settings.
-
-       :param ssid: ssid of access point
-       :type ssid: str
-       :return: list of paths of settings of access point
-       :rtype: list
-`   """
-    return _find_settings(ssid, '802-11-wireless', 'ssid')
-
 def _settings_for_hwaddr(hwaddr):
     """Return list of object paths of settings of device specified by hw address.
 
@@ -754,35 +744,6 @@ def nm_device_setting_value(name, key1, key2):
     settings_paths = _device_settings(name)
     if not settings_paths:
         raise SettingsNotFoundError(name)
-    else:
-        settings_path = settings_paths[0]
-    proxy = _get_proxy(object_path=settings_path, interface_name="org.freedesktop.NetworkManager.Settings.Connection")
-    settings = proxy.GetSettings()
-    try:
-        value = settings[key1][key2]
-    except KeyError:
-        value = None
-    return value
-
-def nm_ap_setting_value(ssid, key1, key2):
-    """Return value of ap's setting specified by key1 and key2.
-
-       :param ssid: name of ap (ssid)
-       :type ssid: str
-       :param key1: first-level key of setting (eg "connection")
-       :type key1: str
-       :param key2: second-level key of setting (eg "uuid")
-       :type key2: str
-       :return: value of setting or None if the setting was not found
-                which means it does not exist or default value is used
-                by NM
-       :rtype: unpacked GDBus variant or None
-       :raise SettingsNotFoundError: if settings were not found
-                                           (eg for "wlan0")
-    """
-    settings_paths = _settings_for_ap(ssid)
-    if not settings_paths:
-        raise SettingsNotFoundError(ssid)
     else:
         settings_path = settings_paths[0]
     proxy = _get_proxy(object_path=settings_path, interface_name="org.freedesktop.NetworkManager.Settings.Connection")
@@ -1137,11 +1098,6 @@ def test():
             print("     Setting value %s %s: %s" % ("ipv7", "method", nm_device_setting_value(devname, "ipv7", "method")))
         except ValueError as e:
             print("     %s" % e)
-
-    ssid = "Red Hat Guest"
-    print("Settings for AP %s: %s" % (ssid, _settings_for_ap(ssid)))
-    ssid = "nonexisting"
-    print("Settings for AP %s: %s" % (ssid, _settings_for_ap(ssid)))
 
     devname = devs[0]
     key1 = "connection"

--- a/pyanaconda/ui/gui/spokes/network.glade
+++ b/pyanaconda/ui/gui/spokes/network.glade
@@ -158,8 +158,6 @@
       <column type="guint"/>
       <!-- column-name security -->
       <column type="guint"/>
-      <!-- column-name ssid -->
-      <column type="PyObject"/>
     </columns>
   </object>
   <object class="AnacondaSpokeWindow" id="networkWindow">

--- a/pyanaconda/ui/gui/spokes/network.glade
+++ b/pyanaconda/ui/gui/spokes/network.glade
@@ -147,7 +147,7 @@
   <object class="GtkListStore" id="liststore_wireless_network">
     <columns>
       <!-- column-name id -->
-      <column type="gchararray"/>
+      <column type="GObject"/>
       <!-- column-name title -->
       <column type="gchararray"/>
       <!-- column-name sortable -->

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -35,11 +35,11 @@ gi.require_version("GLib", "2.0")
 gi.require_version("GObject", "2.0")
 gi.require_version("Pango", "1.0")
 gi.require_version("Gio", "2.0")
-gi.require_version("NetworkManager", "1.0")
+gi.require_version("NM", "1.0")
 gi.require_version("NMClient", "1.0")
 
 from gi.repository import Gtk
-from gi.repository import GLib, GObject, Pango, Gio, NetworkManager, NMClient
+from gi.repository import GLib, GObject, Pango, Gio, NM, NMClient
 
 from pyanaconda.flags import can_touch_runtime_system
 from pyanaconda.i18n import _, N_, C_, CN_
@@ -95,35 +95,35 @@ DEVICES_COLUMN_OBJECT = 3
 def localized_string_of_device_state(device, state):
     s = _("Status unknown (missing)")
 
-    if state == NetworkManager.DeviceState.UNKNOWN:
+    if state == NM.DeviceState.UNKNOWN:
         s = _("Status unknown")
-    elif state == NetworkManager.DeviceState.UNMANAGED:
+    elif state == NM.DeviceState.UNMANAGED:
         s = _("Unmanaged")
-    elif state == NetworkManager.DeviceState.UNAVAILABLE:
+    elif state == NM.DeviceState.UNAVAILABLE:
         if not device:
             s = _("Unavailable")
         elif device.get_firmware_missing():
             s = _("Firmware missing")
         else:
             s = _("Unavailable")
-    elif state == NetworkManager.DeviceState.DISCONNECTED:
-        if (device and device.get_device_type() == NetworkManager.DeviceType.ETHERNET
+    elif state == NM.DeviceState.DISCONNECTED:
+        if (device and device.get_device_type() == NM.DeviceType.ETHERNET
               and not device.get_carrier()):
             s = _("Cable unplugged")
         else:
             s = _("Disconnected")
-    elif state in (NetworkManager.DeviceState.PREPARE,
-                   NetworkManager.DeviceState.CONFIG,
-                   NetworkManager.DeviceState.IP_CONFIG,
-                   NetworkManager.DeviceState.IP_CHECK):
+    elif state in (NM.DeviceState.PREPARE,
+                   NM.DeviceState.CONFIG,
+                   NM.DeviceState.IP_CONFIG,
+                   NM.DeviceState.IP_CHECK):
         s = _("Connecting")
-    elif state == NetworkManager.DeviceState.NEED_AUTH:
+    elif state == NM.DeviceState.NEED_AUTH:
         s = _("Authentication required")
-    elif state == NetworkManager.DeviceState.ACTIVATED:
+    elif state == NM.DeviceState.ACTIVATED:
         s = _("Connected")
-    elif state == NetworkManager.DeviceState.DEACTIVATING:
+    elif state == NM.DeviceState.DEACTIVATING:
         s = _("Disconnecting")
-    elif state == NetworkManager.DeviceState.FAILED:
+    elif state == NM.DeviceState.FAILED:
         s = _("Connection failed")
 
     return s
@@ -222,12 +222,12 @@ class CellRendererSecurity(Gtk.CellRendererPixbuf):
 class DeviceConfiguration(object):
 
     setting_types = {
-        '802-11-wireless': NetworkManager.DeviceType.WIFI,
-        '802-3-ethernet': NetworkManager.DeviceType.ETHERNET,
-        'vlan': NetworkManager.DeviceType.VLAN,
-        'bond': NetworkManager.DeviceType.BOND,
-        'team': NetworkManager.DeviceType.TEAM,
-        'bridge': NetworkManager.DeviceType.BRIDGE,
+        '802-11-wireless': NM.DeviceType.WIFI,
+        '802-3-ethernet': NM.DeviceType.ETHERNET,
+        'vlan': NM.DeviceType.VLAN,
+        'bond': NM.DeviceType.BOND,
+        'team': NM.DeviceType.TEAM,
+        'bridge': NM.DeviceType.BRIDGE,
         }
 
     def __init__(self, device=None, con_uuid=None):
@@ -240,7 +240,7 @@ class DeviceConfiguration(object):
             self.device_type = self._setting_device_type(self.con_uuid)
 
         if not self.con_uuid:
-            if self.device_type != NetworkManager.DeviceType.WIFI:
+            if self.device_type != NM.DeviceType.WIFI:
                 uuid = nm.nm_device_setting_value(device.get_iface(), "connection", "uuid")
                 settings = nm.nm_get_settings(uuid, "connection", "uuid")
                 if settings and 'slave-type' not in settings[0]['connection']:
@@ -286,35 +286,35 @@ class NetworkControlBox(GObject.GObject):
     }
 
     supported_device_types = [
-        NetworkManager.DeviceType.ETHERNET,
-        NetworkManager.DeviceType.WIFI,
-        NetworkManager.DeviceType.TEAM,
-        NetworkManager.DeviceType.BOND,
-        NetworkManager.DeviceType.VLAN,
-        NetworkManager.DeviceType.BRIDGE,
+        NM.DeviceType.ETHERNET,
+        NM.DeviceType.WIFI,
+        NM.DeviceType.TEAM,
+        NM.DeviceType.BOND,
+        NM.DeviceType.VLAN,
+        NM.DeviceType.BRIDGE,
     ]
 
     wired_ui_device_types = [
-        NetworkManager.DeviceType.ETHERNET,
-        NetworkManager.DeviceType.TEAM,
-        NetworkManager.DeviceType.BOND,
-        NetworkManager.DeviceType.VLAN,
-        NetworkManager.DeviceType.BRIDGE,
+        NM.DeviceType.ETHERNET,
+        NM.DeviceType.TEAM,
+        NM.DeviceType.BOND,
+        NM.DeviceType.VLAN,
+        NM.DeviceType.BRIDGE,
     ]
 
     device_type_sort_value = {
-        NetworkManager.DeviceType.ETHERNET : "1",
-        NetworkManager.DeviceType.WIFI : "2",
+        NM.DeviceType.ETHERNET : "1",
+        NM.DeviceType.WIFI : "2",
     }
 
     device_type_name = {
-        NetworkManager.DeviceType.UNKNOWN: N_("Unknown"),
-        NetworkManager.DeviceType.ETHERNET: N_("Ethernet"),
-        NetworkManager.DeviceType.WIFI: N_("Wireless"),
-        NetworkManager.DeviceType.BOND: N_("Bond"),
-        NetworkManager.DeviceType.VLAN: N_("VLAN"),
-        NetworkManager.DeviceType.TEAM: N_("Team"),
-        NetworkManager.DeviceType.BRIDGE: N_("Bridge"),
+        NM.DeviceType.UNKNOWN: N_("Unknown"),
+        NM.DeviceType.ETHERNET: N_("Ethernet"),
+        NM.DeviceType.WIFI: N_("Wireless"),
+        NM.DeviceType.BOND: N_("Bond"),
+        NM.DeviceType.VLAN: N_("VLAN"),
+        NM.DeviceType.TEAM: N_("Team"),
+        NM.DeviceType.BRIDGE: N_("Bridge"),
     }
 
     def __init__(self, builder, spoke=None):
@@ -447,11 +447,11 @@ class NetworkControlBox(GObject.GObject):
             return False
         # Configs for ethernet has been already added,
         # this must be some slave
-        if dev_cfg.device_type == NetworkManager.DeviceType.ETHERNET:
+        if dev_cfg.device_type == NM.DeviceType.ETHERNET:
             log.debug("network: GUI, not adding slave connection %s", uuid)
             return False
         # Wireless settings are handled in scope of its device's dev_cfg
-        if dev_cfg.device_type == NetworkManager.DeviceType.WIFI:
+        if dev_cfg.device_type == NM.DeviceType.WIFI:
             log.debug("network: GUI, not adding wireless connection %s", uuid)
             return False
         self.add_dev_cfg(dev_cfg)
@@ -485,7 +485,7 @@ class NetworkControlBox(GObject.GObject):
 
     def on_device_state_changed(self, device, new_state, *args):
         self.emit("device-state-changed", device.get_iface(), new_state, *args)
-        if new_state == NetworkManager.DeviceState.SECONDARIES:
+        if new_state == NM.DeviceState.SECONDARIES:
             return
         self._refresh_carrier_info()
         dev_cfg = self.selected_dev_cfg()
@@ -555,7 +555,7 @@ class NetworkControlBox(GObject.GObject):
         devname = dev_cfg.get_iface()
         activate = None
 
-        if dev_cfg.device_type == NetworkManager.DeviceType.WIFI:
+        if dev_cfg.device_type == NM.DeviceType.WIFI:
             if self.selected_ssid:
                 try:
                     uuid = nm.nm_ap_setting_value(self.selected_ssid, "connection", "uuid")
@@ -571,7 +571,7 @@ class NetworkControlBox(GObject.GObject):
             log.debug("network: on_edit_connection: can't find connection for device %s", devname)
             return
 
-        if dev_cfg.device_type != NetworkManager.DeviceType.WIFI \
+        if dev_cfg.device_type != NM.DeviceType.WIFI \
            and dev_cfg.get_iface() in nm.nm_activated_devices():
             # Reactivate the connection after configuring it (if it changed)
             settings = nm.nm_get_settings(uuid, "connection", "uuid")
@@ -629,7 +629,7 @@ class NetworkControlBox(GObject.GObject):
 
         log.info("network: device %s switched %s", dev_cfg.get_iface(), "on" if active else "off")
 
-        if dev_cfg.device_type == NetworkManager.DeviceType.WIFI:
+        if dev_cfg.device_type == NM.DeviceType.WIFI:
             self.client.wireless_set_enabled(active)
         else:
             if active:
@@ -728,13 +728,13 @@ class NetworkControlBox(GObject.GObject):
         icon_name = ""
         if dev_cfg.device_type in self.wired_ui_device_types:
             if dev_cfg.device:
-                if dev_cfg.device.get_state() == NetworkManager.DeviceState.UNAVAILABLE:
+                if dev_cfg.device.get_state() == NM.DeviceState.UNAVAILABLE:
                     icon_name = "network-wired-disconnected"
                 else:
                     icon_name = "network-wired"
             else:
                 icon_name = "network-wired-disconnected"
-        elif dev_cfg.device_type == NetworkManager.DeviceType.WIFI:
+        elif dev_cfg.device_type == NM.DeviceType.WIFI:
             icon_name = "network-wireless"
 
         return icon_name
@@ -743,8 +743,8 @@ class NetworkControlBox(GObject.GObject):
         unplugged = ''
 
         if dev_cfg.device:
-            if (dev_cfg.device.get_state() == NetworkManager.DeviceState.UNAVAILABLE
-                and dev_cfg.device.get_device_type() == NetworkManager.DeviceType.ETHERNET
+            if (dev_cfg.device.get_state() == NM.DeviceState.UNAVAILABLE
+                and dev_cfg.device.get_device_type() == NM.DeviceType.ETHERNET
                 and not dev_cfg.device.get_carrier()):
                 # TRANSLATORS: ethernet cable is unplugged
                 unplugged = ', <i>%s</i>' % escape_markup(_("unplugged"))
@@ -802,7 +802,7 @@ class NetworkControlBox(GObject.GObject):
 
         if dev_cfg.device_type in self.wired_ui_device_types:
             dt = "wired"
-        elif dev_cfg.device_type == NetworkManager.DeviceType.WIFI:
+        elif dev_cfg.device_type == NM.DeviceType.WIFI:
             dt = "wireless"
 
         if dev_cfg.device:
@@ -847,12 +847,12 @@ class NetworkControlBox(GObject.GObject):
         return False
 
     def _refresh_ap(self, dev_cfg, state=None):
-        if dev_cfg.device_type != NetworkManager.DeviceType.WIFI:
+        if dev_cfg.device_type != NM.DeviceType.WIFI:
             return
 
         if state is None:
             state = dev_cfg.device.get_state()
-        if state == NetworkManager.DeviceState.UNAVAILABLE:
+        if state == NM.DeviceState.UNAVAILABLE:
             ap_str = None
         else:
             active_ap = dev_cfg.device.get_active_access_point()
@@ -869,7 +869,7 @@ class NetworkControlBox(GObject.GObject):
 
         self._set_device_info_value("wireless", "security", ap_str)
 
-        if state == NetworkManager.DeviceState.UNAVAILABLE:
+        if state == NM.DeviceState.UNAVAILABLE:
             self.builder.get_object("heading_wireless_network_name").hide()
             self.builder.get_object("combobox_wireless_network_name").hide()
         else:
@@ -894,16 +894,16 @@ class NetworkControlBox(GObject.GObject):
             self._updating_device = False
 
     def _refresh_slaves(self, dev_cfg):
-        if dev_cfg.device_type in [NetworkManager.DeviceType.BOND,
-                                   NetworkManager.DeviceType.TEAM,
-                                   NetworkManager.DeviceType.BRIDGE]:
+        if dev_cfg.device_type in [NM.DeviceType.BOND,
+                                   NM.DeviceType.TEAM,
+                                   NM.DeviceType.BRIDGE]:
             slaves = ""
             if dev_cfg.device:
                 slaves = ",".join(s.get_iface() for s in dev_cfg.device.get_slaves())
             self._set_device_info_value("wired", "slaves", slaves)
 
     def _refresh_parent_vlanid(self, dev_cfg):
-        if dev_cfg.device_type == NetworkManager.DeviceType.VLAN:
+        if dev_cfg.device_type == NM.DeviceType.VLAN:
             if dev_cfg.device:
                 vlanid = dev_cfg.device.get_vlan_id()
             else:
@@ -916,20 +916,20 @@ class NetworkControlBox(GObject.GObject):
         dev_type = dev_cfg.device_type
         if dev_type in self.wired_ui_device_types:
             dt = "wired"
-        elif dev_type == NetworkManager.DeviceType.WIFI:
+        elif dev_type == NM.DeviceType.WIFI:
             dt = "wireless"
 
         # Speed
         speed = None
         if dev_cfg.device:
-            if dev_type == NetworkManager.DeviceType.ETHERNET:
+            if dev_type == NM.DeviceType.ETHERNET:
                 speed = dev_cfg.device.get_speed()
-            elif dev_type == NetworkManager.DeviceType.WIFI:
+            elif dev_type == NM.DeviceType.WIFI:
                 speed = dev_cfg.device.get_bitrate() / 1000
             if state is None:
                 state = dev_cfg.device.get_state()
 
-        if not dev_cfg.device or state == NetworkManager.DeviceState.UNAVAILABLE:
+        if not dev_cfg.device or state == NM.DeviceState.UNAVAILABLE:
             speed_str = None
         elif speed:
             speed_str = _("%d Mb/s") % speed
@@ -942,7 +942,7 @@ class NetworkControlBox(GObject.GObject):
 
     def _refresh_device_type_page(self, dev_type):
         notebook = self.builder.get_object("notebook_types")
-        if dev_type == NetworkManager.DeviceType.ETHERNET:
+        if dev_type == NM.DeviceType.ETHERNET:
             notebook.set_current_page(0)
             self.builder.get_object("heading_wired_slaves").hide()
             self.builder.get_object("label_wired_slaves").hide()
@@ -951,9 +951,9 @@ class NetworkControlBox(GObject.GObject):
             self.builder.get_object("heading_wired_parent").hide()
             self.builder.get_object("label_wired_parent").hide()
             self.builder.get_object("remove_toolbutton").set_sensitive(False)
-        elif dev_type in [NetworkManager.DeviceType.BOND,
-                          NetworkManager.DeviceType.TEAM,
-                          NetworkManager.DeviceType.BRIDGE]:
+        elif dev_type in [NM.DeviceType.BOND,
+                          NM.DeviceType.TEAM,
+                          NM.DeviceType.BRIDGE]:
             notebook.set_current_page(0)
             self.builder.get_object("heading_wired_slaves").show()
             self.builder.get_object("label_wired_slaves").show()
@@ -962,7 +962,7 @@ class NetworkControlBox(GObject.GObject):
             self.builder.get_object("heading_wired_parent").hide()
             self.builder.get_object("label_wired_parent").hide()
             self.builder.get_object("remove_toolbutton").set_sensitive(True)
-        elif dev_type == NetworkManager.DeviceType.VLAN:
+        elif dev_type == NM.DeviceType.VLAN:
             notebook.set_current_page(0)
             self.builder.get_object("heading_wired_slaves").hide()
             self.builder.get_object("label_wired_slaves").hide()
@@ -971,7 +971,7 @@ class NetworkControlBox(GObject.GObject):
             self.builder.get_object("heading_wired_parent").show()
             self.builder.get_object("label_wired_parent").show()
             self.builder.get_object("remove_toolbutton").set_sensitive(True)
-        elif dev_type == NetworkManager.DeviceType.WIFI:
+        elif dev_type == NM.DeviceType.WIFI:
             notebook.set_current_page(1)
             self.builder.get_object("button_wireless_options").set_sensitive(self.selected_ssid is not None)
 
@@ -982,7 +982,7 @@ class NetworkControlBox(GObject.GObject):
     def _refresh_header_ui(self, dev_cfg, state=None):
         if dev_cfg.device_type in self.wired_ui_device_types:
             dev_type_str = "wired"
-        elif dev_cfg.device_type == NetworkManager.DeviceType.WIFI:
+        elif dev_cfg.device_type == NM.DeviceType.WIFI:
             dev_type_str = "wireless"
 
         if dev_type_str == "wired":
@@ -997,7 +997,7 @@ class NetworkControlBox(GObject.GObject):
 
         if state is None:
             if not dev_cfg.device:
-                state = NetworkManager.DeviceState.DISCONNECTED
+                state = NM.DeviceState.DISCONNECTED
             else:
                 state = dev_cfg.device.get_state()
 
@@ -1006,14 +1006,14 @@ class NetworkControlBox(GObject.GObject):
 
         switch = self.builder.get_object("device_%s_off_switch" % dev_type_str)
         if dev_type_str == "wired":
-            switch.set_visible(state not in (NetworkManager.DeviceState.UNAVAILABLE,
-                                             NetworkManager.DeviceState.UNMANAGED))
+            switch.set_visible(state not in (NM.DeviceState.UNAVAILABLE,
+                                             NM.DeviceState.UNMANAGED))
             self._updating_device = True
-            switch.set_active(state not in (NetworkManager.DeviceState.UNMANAGED,
-                                            NetworkManager.DeviceState.UNAVAILABLE,
-                                            NetworkManager.DeviceState.DISCONNECTED,
-                                            NetworkManager.DeviceState.DEACTIVATING,
-                                            NetworkManager.DeviceState.FAILED))
+            switch.set_active(state not in (NM.DeviceState.UNMANAGED,
+                                            NM.DeviceState.UNAVAILABLE,
+                                            NM.DeviceState.DISCONNECTED,
+                                            NM.DeviceState.DEACTIVATING,
+                                            NM.DeviceState.FAILED))
             self._updating_device = False
         elif dev_type_str == "wireless":
             self.on_wireless_enabled()
@@ -1052,7 +1052,7 @@ class NetworkControlBox(GObject.GObject):
         store = self.builder.get_object("liststore_wireless_network")
 
         # Decode the SSID (a byte sequence) into something resembling a string
-        ssid_str = NetworkManager.utils_ssid_to_utf8(ssid)
+        ssid_str = NM.utils_ssid_to_utf8(ssid)
 
         # the third column is for sorting
         # the seventh column is the original, actual SSID as a bytes object
@@ -1116,19 +1116,19 @@ class NetworkControlBox(GObject.GObject):
 #
 #        sec_str = ""
 #
-#        if ((flags & NetworkManager.80211ApFlags.PRIVACY) and
-#            wpa_flags == NetworkManager.80211ApSecurityFlags.NONE and
-#            rsn_flags == NetworkManager.80211ApSecurityFlags.NONE):
+#        if ((flags & NM.80211ApFlags.PRIVACY) and
+#            wpa_flags == NM.80211ApSecurityFlags.NONE and
+#            rsn_flags == NM.80211ApSecurityFlags.NONE):
 #            sec_str += "%s, " % _("WEP")
 #
-#        if wpa_flags != NetworkManager.80211ApSecurityFlags.NONE:
+#        if wpa_flags != NM.80211ApSecurityFlags.NONE:
 #            sec_str += "%s, " % _("WPA")
 #
-#        if rsn_flags != NetworkManager.80211ApSecurityFlags.NONE:
+#        if rsn_flags != NM.80211ApSecurityFlags.NONE:
 #            sec_str += "%s, " % _("WPA2")
 #
-#        if ((wpa_flags & NetworkManager.80211ApSecurityFlags.KEY_MGMT_802_1X) or
-#            (rsn_flags & NetworkManager.80211ApSecurityFlags.KEY_MGMT_802_1X)):
+#        if ((wpa_flags & NM.80211ApSecurityFlags.KEY_MGMT_802_1X) or
+#            (rsn_flags & NM.80211ApSecurityFlags.KEY_MGMT_802_1X)):
 #            sec_str += "%s, " % _("Enterprise")
 #
 #        if sec_str:
@@ -1374,14 +1374,14 @@ class SecretAgent(dbus.service.Object):
 
     def _validate_staticwep(self, secret):
         value = secret['value']
-        if secret['wep_key_type'] == NetworkManager.WepKeyType.KEY:
+        if secret['wep_key_type'] == NM.WepKeyType.KEY:
             if len(value) in (10, 26):
                 return all(c in string.hexdigits for c in value)
             elif len(value) in (5, 13):
                 return all(c in string.ascii_letters for c in value)
             else:
                 return False
-        elif secret['wep_key_type'] == NetworkManager.WepKeyType.PASSPHRASE:
+        elif secret['wep_key_type'] == NM.WepKeyType.PASSPHRASE:
             return 0 <= len(value) <= 64
         else:
             return True
@@ -1484,9 +1484,9 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         self._network_change = True
 
     def on_device_state_changed(self, source, device, new_state, *args):
-        if new_state in (NetworkManager.DeviceState.ACTIVATED,
-                         NetworkManager.DeviceState.DISCONNECTED,
-                         NetworkManager.DeviceState.UNAVAILABLE):
+        if new_state in (NM.DeviceState.ACTIVATED,
+                         NM.DeviceState.DISCONNECTED,
+                         NM.DeviceState.UNAVAILABLE):
             gtk_call_once(self._update_status)
         self._network_change = True
 

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -882,9 +882,9 @@ class NetworkControlBox(GObject.GObject):
             if active_ap:
                 combobox = self.builder.get_object("combobox_wireless_network_name")
                 for i in combobox.get_model():
-                    if i[6] == active_ap.get_ssid():
+                    if i[6] == active_ap.get_ssid().get_data():
                         combobox.set_active_iter(i.iter)
-                        self.selected_ssid = active_ap.get_ssid()
+                        self.selected_ssid = active_ap.get_ssid().get_data()
                         break
             self._updating_device = False
 
@@ -1026,7 +1026,7 @@ class NetworkControlBox(GObject.GObject):
 
     # TODO NM_GI_BUGS use glib methods for mode and security (dbus obj or nm obj?)
     def _add_ap(self, ap, active=False):
-        ssid = ap.get_ssid()
+        ssid = ap.get_ssid().get_data()
         if not ssid:
             return
 
@@ -1064,7 +1064,7 @@ class NetworkControlBox(GObject.GObject):
     def _get_strongest_unique_aps(self, access_points):
         strongest_aps = {}
         for ap in access_points:
-            ssid = ap.get_ssid()
+            ssid = ap.get_ssid().get_data()
             if ssid in strongest_aps:
                 if ap.get_strength() > strongest_aps[ssid].get_strength():
                     strongest_aps[ssid] = ap

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -19,16 +19,6 @@
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 #
 
-# TODO:
-
-# - move callback connection to initialize?
-# - Automatically reconnecting wifi after failure
-#   https://bugzilla.redhat.com/show_bug.cgi?id=712778#c1
-# - callback on NM_CLIENT_ACTIVE_CONNECTIONS
-# - support connection to hidden network (ap-other)
-# - NMClient.CLIENT_WIRELESS_ENABLED callback (hw switch?) - test
-# - nm-c-e run: blocking? logging?
-
 import gi
 gi.require_version("Gtk", "3.0")
 gi.require_version("GLib", "2.0")

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -652,7 +652,7 @@ class NetworkControlBox(GObject.GObject):
             return None
         dev_cfg = model[itr][DEVICES_COLUMN_OBJECT]
         model.remove(itr)
-        nm.nm_delete_connection(dev_cfg.con_uuid)
+        self.client.get_connection_by_uuid(dev_cfg.con_uuid).delete()
 
     def add_device(self, ty):
         log.info("network: adding device of type %s", ty)

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -239,17 +239,6 @@ class DeviceConfiguration(object):
         elif con_uuid:
             self.device_type = self._setting_device_type(self.con_uuid)
 
-        # Found device for existing connection
-        if not self.device:
-            if self.device_type == NetworkManager.DeviceType.ETHERNET:
-                client = NMClient.Client.new()
-                dev_name = self.get_iface()
-                for device in client.get_devices():
-                    if dev_name == device.get_iface():
-                        self.device = device
-                        break
-
-        # Found connection for existing device
         if not self.con_uuid:
             if self.device_type != NetworkManager.DeviceType.WIFI:
                 uuid = nm.nm_device_setting_value(device.get_iface(), "connection", "uuid")
@@ -265,11 +254,6 @@ class DeviceConfiguration(object):
         return dev_type
 
     def get_iface(self):
-        """Get interface name
-
-           :return: Interface name or ``None`` if can't find device name for given uuid
-           :rtype: string or NoneType
-        """
         if self.device:
             iface = self.device.get_iface()
         else:
@@ -454,25 +438,22 @@ class NetworkControlBox(GObject.GObject):
         if self.dev_cfg(uuid=uuid):
             log.debug("network: GUI, not adding connection %s, already in list", uuid)
             return False
-
         dev_cfg = DeviceConfiguration(con_uuid=uuid)
-
         if dev_cfg.setting_value("connection", "read-only"):
             log.debug("network: GUI, not adding read-only connection %s", uuid)
             return False
         if dev_cfg.device_type not in self.supported_device_types:
             log.debug("network: GUI, not adding connection %s of unsupported type", uuid)
             return False
-        # skip slaves - only slaves have master
+        # Configs for ethernet has been already added,
+        # this must be some slave
         if dev_cfg.device_type == NetworkManager.DeviceType.ETHERNET:
-            if dev_cfg.setting_value("connection", "master"):
-                log.debug("network: GUI, not adding slave connection %s", uuid)
-                return False
+            log.debug("network: GUI, not adding slave connection %s", uuid)
+            return False
         # Wireless settings are handled in scope of its device's dev_cfg
         if dev_cfg.device_type == NetworkManager.DeviceType.WIFI:
             log.debug("network: GUI, not adding wireless connection %s", uuid)
             return False
-
         self.add_dev_cfg(dev_cfg)
         log.debug("network: GUI, adding connection %s", uuid)
         return True
@@ -737,19 +718,13 @@ class NetworkControlBox(GObject.GObject):
             log.error(e)
             return
         except nm.SettingsNotFoundError:
-            # wireless devices or device without a connection
-            log.debug("network: connection for new device %s was not found", device.get_iface())
+            # wireless devices
             dev_cfg = None
-
         if dev_cfg:
             dev_cfg.device = device
         else:
-            # wireless device
-            if device.get_device_type() == NetworkManager.DeviceType.WIFI:
-                dev_cfg = DeviceConfiguration(device=device)
-                self.add_dev_cfg(dev_cfg)
-            else:
-                log.debug("network: device %s missing connection", device.get_iface())
+            dev_cfg = DeviceConfiguration(device=device)
+            self.add_dev_cfg(dev_cfg)
 
         device.connect("notify::ip4-config", self.on_device_config_changed)
         device.connect("notify::ip6-config", self.on_device_config_changed)

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -513,11 +513,10 @@ class NetworkControlBox(GObject.GObject):
     def on_device_removed(self, client, device, *args):
         self.remove_device(device)
 
-    def _find_first_ap_setting_uuid(self, device, ap):
-        uuid = None
+    def _find_first_ap_setting(self, device, ap):
         for con in device.filter_connections(self.client.get_connections()):
             if con.get_setting_wireless().get_ssid().get_data() == ap.get_ssid().get_data():
-                return con.get_uuid()
+                return con
 
     def on_edit_connection(self, *args):
         dev_cfg = self.selected_dev_cfg()
@@ -525,6 +524,8 @@ class NetworkControlBox(GObject.GObject):
             return
 
         devname = dev_cfg.get_iface()
+        device = dev_cfg.device
+        con = dev_cfg.con
         activate = None
         ssid = ""
 
@@ -532,32 +533,29 @@ class NetworkControlBox(GObject.GObject):
             if not self.selected_ap:
                 return
             ssid = self.selected_ap.get_ssid().get_data()
-            uuid = self._find_first_ap_setting_uuid(dev_cfg.device, self.selected_ap)
-            if uuid:
-                # 871132 auto activate wireless connection after editing if it is not
-                # already activated (assume entering secrets)
-                # TODONM check ssid instead of ap?, is it needed at all?
-                condition = lambda: self.selected_ap != dev_cfg.device.get_active_access_point()
-                activate = (uuid, devname, condition)
-            else:
+            con = self._find_first_ap_setting(device, self.selected_ap)
+            if not con:
                 log.debug("network: on_edit_connection: connection for ap %s not found", self.selected_ap)
                 return
+            # 871132 auto activate wireless connection after editing if it is not
+            # already activated (assume entering secrets)
+            condition = lambda: self.selected_ap != device.get_active_access_point()
+            activate = (con, device, condition)
         else:
-            uuid = dev_cfg.get_uuid()
-            if not uuid:
-                log.debug("network: on_edit_connection: connection for device %s not found", devname)
+            if not con:
+                log.debug("network: on_edit_connection: connection for device %s not found", dev_cfg.get_iface())
                 return
 
             if devname in nm.nm_activated_devices():
                 # Reactivate the connection after configuring it (if it changed)
-                settings = nm.nm_get_settings(uuid, "connection", "uuid")
-                settings_changed = lambda: settings != nm.nm_get_settings(uuid, "connection", "uuid")
-                activate = (uuid, devname, settings_changed)
+                settings = con.to_dbus(NM.ConnectionSerializationFlags.ALL)
+                settings_changed = lambda: settings != con.to_dbus(NM.ConnectionSerializationFlags.ALL)
+                activate = (con, device, settings_changed)
 
         log.info("network: configuring connection %s device %s ssid %s",
-                 uuid, devname, ssid)
+                 con.get_uuid(), dev_cfg.get_iface(), ssid)
         self.kill_nmce(msg="Configure button clicked")
-        proc = startProgram(["nm-connection-editor", "--edit", "%s" % uuid], reset_lang=False)
+        proc = startProgram(["nm-connection-editor", "--edit", "%s" % con.get_uuid()], reset_lang=False)
         self._running_nmce = proc
 
         GLib.child_watch_add(proc.pid, self.on_nmce_exited, activate)
@@ -580,13 +578,13 @@ class NetworkControlBox(GObject.GObject):
         if condition == 0:
             if activate:
                 # The default of None confuses pylint
-                uuid, devname, activate_condition = activate # pylint: disable=unpacking-non-sequence
+                con, device, activate_condition = activate # pylint: disable=unpacking-non-sequence
                 if activate_condition():
-                    gtk_call_once(self._activate_connection_cb, uuid, devname)
+                    gtk_call_once(self._activate_connection_cb, con, device)
             network.logIfcfgFiles("nm-c-e run")
 
-    def _activate_connection_cb(self, uuid, devname):
-        nm.nm_activate_device_connection(devname, uuid)
+    def _activate_connection_cb(self, con, device):
+        self.client.activate_connection_async(con, device, None, None, self.added_con_cb)
 
     def on_wireless_enabled(self, *args):
         switch = self.builder.get_object("device_wireless_off_switch")

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -508,7 +508,17 @@ class NetworkControlBox(GObject.GObject):
         self.add_connection_to_list(connection)
 
     def on_device_added(self, client, device, *args):
-        gtk_call_once(self.add_device_to_list, device)
+        # We need to wait for valid state before adding the device to our list
+        if device.get_state() == NM.DeviceState.UNKNOWN:
+            device.connect("state-changed", self.on_added_device_state_changed)
+        else:
+            gtk_call_once(self.add_device_to_list, device)
+
+    def on_added_device_state_changed(self, device, new_state, *args):
+        # We need to wait for valid state before adding the device to our list
+        if new_state != NM.DeviceState.UNKNOWN:
+            device.disconnect_by_func(self.on_added_device_state_changed)
+            gtk_call_once(self.add_device_to_list, device)
 
     def on_device_removed(self, client, device, *args):
         self.remove_device(device)

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -599,6 +599,8 @@ class NetworkControlBox(GObject.GObject):
         dev_cfg = self.selected_dev_cfg()
         if not dev_cfg:
             return
+        device = dev_cfg.device
+        con = dev_cfg.con
 
         log.info("network: device %s switched %s", dev_cfg.get_iface(), "on" if active else "off")
 
@@ -606,20 +608,17 @@ class NetworkControlBox(GObject.GObject):
             self.client.wireless_set_enabled(active)
         else:
             if active:
-                dev_name = dev_cfg.device and dev_cfg.device.get_iface()
-                if not dev_cfg.con:
+                if not con:
                     log.debug("network: on_device_off_toggled: no connection for %s",
-                               dev_name)
+                               dev_cfg.get_iface())
                     return
-                try:
-                    nm.nm_activate_device_connection(dev_name, dev_cfg.get_uuid())
-                except (nm.UnmanagedDeviceError, nm.UnknownDeviceError, nm.UnknownConnectionError) as e:
-                    log.debug("network: on_device_off_toggled: %s", e)
+
+                self.client.activate_connection_async(con, device, None, None, self.added_con_cb)
             else:
-                try:
-                    nm.nm_disconnect_device(dev_cfg.get_iface())
-                except (nm.UnmanagedDeviceError, nm.DeviceNotActiveError) as e:
-                    log.debug("network: on_device_off_toggled: %s", e)
+                if not device:
+                    log.debug("network: on_device_off_toggled: no device for %s", dev_cfg.get_iface())
+                    return
+                device.disconnect(None)
 
     def on_add_device_clicked(self, *args):
         dialog = self.builder.get_object("add_device_dialog")

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -523,7 +523,6 @@ class NetworkControlBox(GObject.GObject):
         if not dev_cfg:
             return
 
-        devname = dev_cfg.get_iface()
         device = dev_cfg.device
         con = dev_cfg.con
         activate = None
@@ -546,7 +545,7 @@ class NetworkControlBox(GObject.GObject):
                 log.debug("network: on_edit_connection: connection for device %s not found", dev_cfg.get_iface())
                 return
 
-            if devname in nm.nm_activated_devices():
+            if device and device.get_state() == NM.DeviceState.ACTIVATED:
                 # Reactivate the connection after configuring it (if it changed)
                 settings = con.to_dbus(NM.ConnectionSerializationFlags.ALL)
                 settings_changed = lambda: settings != con.to_dbus(NM.ConnectionSerializationFlags.ALL)

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -705,6 +705,8 @@ class NetworkControlBox(GObject.GObject):
             # If we already have a connection for the device
             # it is a virtual device appearing
             self.dev_cfg(uuid=con.get_uuid()).device = device
+            # it might be too late for the callbacks below so refresh now
+            self.refresh_ui()
         else:
             self.add_dev_cfg(DeviceConfiguration(device=device, con=con))
 

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -459,12 +459,6 @@ class NetworkControlBox(GObject.GObject):
         return True
 
     def initialize(self):
-        # There is a signal for newly added devices from NetworkManager but it
-        # is registered after the initialize method.
-        # So if someone adds a new device in the Welcome screen the ifcfg file won't
-        # be created which causes anaconda to crash.
-        log.debug("Dump missing interfaces in NetworkControlBox initialize method")
-        network.dumpMissingDefaultIfcfgs()
         for device in self.client.get_devices():
             self.add_device_to_list(device)
 

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -219,53 +219,30 @@ class DeviceConfiguration(object):
         'bridge': NM.DeviceType.BRIDGE,
         }
 
-    def __init__(self, device=None, con_uuid=None):
+    def __init__(self, device=None, con=None):
         self.device = device
-        self.con_uuid = con_uuid
+        self.con = con
 
-        if device:
-            self.device_type = self.device.get_device_type()
-        elif con_uuid:
-            self.device_type = self._setting_device_type(self.con_uuid)
-
-        if not self.con_uuid:
-            if self.device_type != NM.DeviceType.WIFI:
-                uuid = nm.nm_device_setting_value(device.get_iface(), "connection", "uuid")
-                settings = nm.nm_get_settings(uuid, "connection", "uuid")
-                if settings and 'slave-type' not in settings[0]['connection']:
-                    self.con_uuid = uuid
-
-    def _setting_device_type(self, uuid):
-        settings = nm.nm_get_settings(uuid, "connection", "uuid")
-        if not settings:
-            return None
-        dev_type = self.setting_types.get(settings[0]["connection"]["type"], None)
-        return dev_type
+    def get_device_type(self):
+        if self.device:
+            return self.device.get_device_type()
+        else:
+            return self.setting_types.get(self.con.get_connection_type(), None)
 
     def get_iface(self):
+        iface = None
         if self.device:
             iface = self.device.get_iface()
         else:
-            iface = self.setting_value("connection", "interface-name")
+            iface = self.con.get_setting_connection().get_interface_name()
             if not iface:
-                hwaddr = self.setting_value("802-3-ethernet", "mac-address")
-                if hwaddr:
-                    hwaddr = ":".join("%02X" % b for b in hwaddr)
-                    iface = nm.nm_hwaddr_to_device_name(hwaddr)
+                mac = self.con.get_setting_wired().get_mac_address()
+                if mac:
+                    iface = nm.nm_hwaddr_to_device_name(mac)
         return iface
 
-    def setting_value(self, key1, key2):
-        settings = nm.nm_get_settings(self.con_uuid, "connection", "uuid")
-        try:
-            value = settings[0][key1][key2]
-        except IndexError:
-            log.debug("network: can't find connection with uuid %s",
-                      self.con_uuid)
-        except KeyError:
-            log.debug("network: can't find '%s' '%s' in connection %s",
-                      key1, key2, self.con_uuid)
-        else:
-            return value
+    def get_uuid(self):
+        return self.con and self.con.get_uuid()
 
 class NetworkControlBox(GObject.GObject):
 
@@ -410,26 +387,28 @@ class NetworkControlBox(GObject.GObject):
         col.set_expand(True)
         treeview.append_column(col)
 
-    def add_connection_to_list(self, uuid):
+    def add_connection_to_list(self, con):
+        uuid = con.get_uuid()
         if self.dev_cfg(uuid=uuid):
             log.debug("network: GUI, not adding connection %s, already in list", uuid)
             return False
-        dev_cfg = DeviceConfiguration(con_uuid=uuid)
-        if dev_cfg.setting_value("connection", "read-only"):
+        if con.get_setting_connection().get_read_only():
             log.debug("network: GUI, not adding read-only connection %s", uuid)
             return False
-        if dev_cfg.device_type not in self.supported_device_types:
+        dev_cfg = DeviceConfiguration(con=con)
+        if dev_cfg.get_device_type() not in self.supported_device_types:
             log.debug("network: GUI, not adding connection %s of unsupported type", uuid)
             return False
         # Configs for ethernet has been already added,
         # this must be some slave
-        if dev_cfg.device_type == NM.DeviceType.ETHERNET:
+        if dev_cfg.get_device_type() == NM.DeviceType.ETHERNET:
             log.debug("network: GUI, not adding slave connection %s", uuid)
             return False
         # Wireless settings are handled in scope of its device's dev_cfg
-        if dev_cfg.device_type == NM.DeviceType.WIFI:
+        if dev_cfg.get_device_type() == NM.DeviceType.WIFI:
             log.debug("network: GUI, not adding wireless connection %s", uuid)
             return False
+        # Virtual device settings (bond, team, vlan, ...)
         self.add_dev_cfg(dev_cfg)
         log.debug("network: GUI, adding connection %s", uuid)
         return True
@@ -446,9 +425,8 @@ class NetworkControlBox(GObject.GObject):
         for device in self.client.get_devices():
             self.add_device_to_list(device)
 
-        for setting in nm.nm_get_all_settings():
-            uuid = setting["connection"]["uuid"]
-            self.add_connection_to_list(uuid)
+        for con in self.client.get_connections():
+            self.add_connection_to_list(con)
 
         # select the first device
         treeview = self.builder.get_object("treeview_devices")
@@ -501,8 +479,8 @@ class NetworkControlBox(GObject.GObject):
 
         cons = ap.filter_connections(device.filter_connections(self.client.get_connections()))
         if cons:
-            uuid = cons[0].get_uuid()
-            nm.nm_activate_device_connection(device.get_iface(), uuid)
+            con = cons[0]
+            self.client.activate_connection_async(con, device, ap.get_path(), None, self.added_con_cb)
         else:
             if self._ap_is_enterprise(ap):
                 # Create a connection for the ap and [Configure] it later with nm-c-e
@@ -527,10 +505,10 @@ class NetworkControlBox(GObject.GObject):
         con = client.add_connection_finish(result)
 
     def on_connection_added(self, client, connection):
-        self.add_connection_to_list(connection.get_uuid())
+        self.add_connection_to_list(connection)
 
     def on_device_added(self, client, device, *args):
-        self.add_device_to_list(device)
+        gtk_call_once(self.add_device_to_list, device)
 
     def on_device_removed(self, client, device, *args):
         self.remove_device(device)
@@ -546,12 +524,11 @@ class NetworkControlBox(GObject.GObject):
         if not dev_cfg:
             return
 
-        uuid = dev_cfg.con_uuid
         devname = dev_cfg.get_iface()
         activate = None
         ssid = ""
 
-        if dev_cfg.device_type == NM.DeviceType.WIFI:
+        if dev_cfg.get_device_type() == NM.DeviceType.WIFI:
             if not self.selected_ap:
                 return
             ssid = self.selected_ap.get_ssid().get_data()
@@ -566,7 +543,7 @@ class NetworkControlBox(GObject.GObject):
                 log.debug("network: on_edit_connection: connection for ap %s not found", self.selected_ap)
                 return
         else:
-            uuid = dev_cfg.con_uuid
+            uuid = dev_cfg.get_uuid()
             if not uuid:
                 log.debug("network: on_edit_connection: connection for device %s not found", devname)
                 return
@@ -628,17 +605,17 @@ class NetworkControlBox(GObject.GObject):
 
         log.info("network: device %s switched %s", dev_cfg.get_iface(), "on" if active else "off")
 
-        if dev_cfg.device_type == NM.DeviceType.WIFI:
+        if dev_cfg.get_device_type() == NM.DeviceType.WIFI:
             self.client.wireless_set_enabled(active)
         else:
             if active:
                 dev_name = dev_cfg.device and dev_cfg.device.get_iface()
-                if not dev_cfg.con_uuid:
+                if not dev_cfg.con:
                     log.debug("network: on_device_off_toggled: no connection for %s",
                                dev_name)
                     return
                 try:
-                    nm.nm_activate_device_connection(dev_name, dev_cfg.con_uuid)
+                    nm.nm_activate_device_connection(dev_name, dev_cfg.get_uuid())
                 except (nm.UnmanagedDeviceError, nm.UnknownDeviceError, nm.UnknownConnectionError) as e:
                     log.debug("network: on_device_off_toggled: %s", e)
             else:
@@ -665,7 +642,7 @@ class NetworkControlBox(GObject.GObject):
             return None
         dev_cfg = model[itr][DEVICES_COLUMN_OBJECT]
         model.remove(itr)
-        self.client.get_connection_by_uuid(dev_cfg.con_uuid).delete()
+        dev_cfg.con.delete()
 
     def add_device(self, ty):
         log.info("network: adding device of type %s", ty)
@@ -684,10 +661,10 @@ class NetworkControlBox(GObject.GObject):
 
     def add_dev_cfg(self, dev_cfg):
         log.debug("network: GUI, device configuration added: connection %s device %s",
-                     dev_cfg.con_uuid, dev_cfg.get_iface())
+                     dev_cfg.get_uuid(), dev_cfg.get_iface())
         self.dev_cfg_store.append([
             self._dev_icon_name(dev_cfg),
-            self.device_type_sort_value.get(dev_cfg.device_type, "100"),
+            self.device_type_sort_value.get(dev_cfg.get_device_type(), "100"),
             self._dev_title(dev_cfg),
             dev_cfg
         ])
@@ -700,24 +677,36 @@ class NetworkControlBox(GObject.GObject):
         if device.get_iface().endswith(('-fcoe', '-fco', '-fc', '-f', '-')):
             return
 
-        try:
-            read_only = nm.nm_device_setting_value(device.get_iface(), "connection", "read-only")
-            if read_only:
-                log.debug("network: not adding read-only connection for device %s", device.get_iface())
+        # Ignore devices with active read-only connections (created by NM for iBFT VLAN)
+        ac = device.get_active_connection()
+        if ac:
+            rc = ac.get_connection()
+            # Getting of NMRemoteConnection can fail (None), isn't it a bug in NM?
+            if rc and rc.get_setting_connection().get_read_only():
+                log.debug("network: not adding read-only connection "
+                        "(assuming iBFT) for device %s", device.get_iface())
                 return
-            con_uuid = nm.nm_device_setting_value(device.get_iface(), "connection", "uuid")
-            dev_cfg = self.dev_cfg(uuid=con_uuid)
-        except nm.UnknownDeviceError as e:
-            log.error(e)
-            return
-        except nm.SettingsNotFoundError:
-            # wireless devices
-            dev_cfg = None
-        if dev_cfg:
-            dev_cfg.device = device
+
+        # Find the connection for the device (assuming existence of single ifcfg actually)
+        con = None
+        # Wifi connections are stored in wifi tab combobox
+        if device.get_device_type() != NM.DeviceType.WIFI:
+            cons = device.get_available_connections()
+            for c in cons:
+                if not c.get_setting_connection().get_slave_type():
+                    con = c
+            if len(cons) != 1:
+                log.warning("network: %s has unexpected number of connections: %s",
+                             device.get_iface(), [c.get_uuid() for c in cons])
+            if not con:
+                return
+
+        if con and self.dev_cfg(uuid=con.get_uuid()):
+            # If we already have a connection for the device
+            # it is a virtual device appearing
+            self.dev_cfg(uuid=con.get_uuid()).device = device
         else:
-            dev_cfg = DeviceConfiguration(device=device)
-            self.add_dev_cfg(dev_cfg)
+            self.add_dev_cfg(DeviceConfiguration(device=device, con=con))
 
         device.connect("notify::ip4-config", self.on_device_config_changed)
         device.connect("notify::ip6-config", self.on_device_config_changed)
@@ -725,7 +714,7 @@ class NetworkControlBox(GObject.GObject):
 
     def _dev_icon_name(self, dev_cfg):
         icon_name = ""
-        if dev_cfg.device_type in self.wired_ui_device_types:
+        if dev_cfg.get_device_type() in self.wired_ui_device_types:
             if dev_cfg.device:
                 if dev_cfg.device.get_state() == NM.DeviceState.UNAVAILABLE:
                     icon_name = "network-wired-disconnected"
@@ -733,7 +722,7 @@ class NetworkControlBox(GObject.GObject):
                     icon_name = "network-wired"
             else:
                 icon_name = "network-wired-disconnected"
-        elif dev_cfg.device_type == NM.DeviceType.WIFI:
+        elif dev_cfg.get_device_type() == NM.DeviceType.WIFI:
             icon_name = "network-wireless"
 
         return icon_name
@@ -749,7 +738,7 @@ class NetworkControlBox(GObject.GObject):
                 unplugged = ', <i>%s</i>' % escape_markup(_("unplugged"))
         # pylint: disable=unescaped-markup
         title = '<span size="large">%s (%s%s)</span>' % \
-                 (escape_markup(_(self.device_type_name.get(dev_cfg.device_type, ""))),
+                 (escape_markup(_(self.device_type_name.get(dev_cfg.get_device_type(), ""))),
                   escape_markup(dev_cfg.get_iface()),
                   unplugged)
 
@@ -763,7 +752,7 @@ class NetworkControlBox(GObject.GObject):
         for row in self.dev_cfg_store:
             dev_cfg = row[DEVICES_COLUMN_OBJECT]
             if uuid:
-                if uuid != dev_cfg.con_uuid:
+                if dev_cfg.get_uuid() != uuid:
                     continue
             if device:
                 if not dev_cfg.device \
@@ -789,7 +778,7 @@ class NetworkControlBox(GObject.GObject):
             notebook.set_current_page(5)
             return
 
-        self._refresh_device_type_page(dev_cfg.device_type)
+        self._refresh_device_type_page(dev_cfg.get_device_type())
         self._refresh_header_ui(dev_cfg, state)
         self._refresh_slaves(dev_cfg)
         self._refresh_parent_vlanid(dev_cfg)
@@ -799,9 +788,9 @@ class NetworkControlBox(GObject.GObject):
 
     def _refresh_device_cfg(self, dev_cfg):
 
-        if dev_cfg.device_type in self.wired_ui_device_types:
+        if dev_cfg.get_device_type() in self.wired_ui_device_types:
             dt = "wired"
-        elif dev_cfg.device_type == NM.DeviceType.WIFI:
+        elif dev_cfg.get_device_type() == NM.DeviceType.WIFI:
             dt = "wireless"
 
         if dev_cfg.device:
@@ -843,7 +832,7 @@ class NetworkControlBox(GObject.GObject):
         return False
 
     def _refresh_ap(self, dev_cfg, state=None):
-        if dev_cfg.device_type != NM.DeviceType.WIFI:
+        if dev_cfg.get_device_type() != NM.DeviceType.WIFI:
             return
 
         if state is None:
@@ -883,26 +872,26 @@ class NetworkControlBox(GObject.GObject):
             self._updating_device = False
 
     def _refresh_slaves(self, dev_cfg):
-        if dev_cfg.device_type in [NM.DeviceType.BOND,
-                                   NM.DeviceType.TEAM,
-                                   NM.DeviceType.BRIDGE]:
+        if dev_cfg.get_device_type() in [NM.DeviceType.BOND,
+                                         NM.DeviceType.TEAM,
+                                         NM.DeviceType.BRIDGE]:
             slaves = ""
             if dev_cfg.device:
                 slaves = ",".join(s.get_iface() for s in dev_cfg.device.get_slaves())
             self._set_device_info_value("wired", "slaves", slaves)
 
     def _refresh_parent_vlanid(self, dev_cfg):
-        if dev_cfg.device_type == NM.DeviceType.VLAN:
+        if dev_cfg.get_device_type() == NM.DeviceType.VLAN:
             if dev_cfg.device:
                 vlanid = dev_cfg.device.get_vlan_id()
             else:
-                vlanid = dev_cfg.setting_value("vlan", "id")
-            parent = dev_cfg.setting_value("vlan", "parent")
+                vlanid = dev_cfg.con.get_setting_vlan().get_id()
+            parent = dev_cfg.con.get_setting_vlan().get_parent()
             self._set_device_info_value("wired", "vlanid", str(vlanid))
             self._set_device_info_value("wired", "parent", parent)
 
     def _refresh_speed_hwaddr(self, dev_cfg, state=None):
-        dev_type = dev_cfg.device_type
+        dev_type = dev_cfg.get_device_type()
         if dev_type in self.wired_ui_device_types:
             dt = "wired"
         elif dev_type == NM.DeviceType.WIFI:
@@ -969,9 +958,9 @@ class NetworkControlBox(GObject.GObject):
             i[DEVICES_COLUMN_TITLE] = self._dev_title(i[DEVICES_COLUMN_OBJECT])
 
     def _refresh_header_ui(self, dev_cfg, state=None):
-        if dev_cfg.device_type in self.wired_ui_device_types:
+        if dev_cfg.get_device_type() in self.wired_ui_device_types:
             dev_type_str = "wired"
-        elif dev_cfg.device_type == NM.DeviceType.WIFI:
+        elif dev_cfg.get_device_type() == NM.DeviceType.WIFI:
             dev_type_str = "wireless"
 
         if dev_type_str == "wired":
@@ -980,7 +969,7 @@ class NetworkControlBox(GObject.GObject):
             img.set_from_icon_name(self._dev_icon_name(dev_cfg), Gtk.IconSize.DIALOG)
 
         # TODO: is this necessary? Isn't it static from glade?
-        device_type_label = _(self.device_type_name.get(dev_cfg.device_type, ""))
+        device_type_label = _(self.device_type_name.get(dev_cfg.get_device_type(), ""))
         self.builder.get_object("label_%s_device" % dev_type_str).set_label(
             "%s (%s)" % (device_type_label, dev_cfg.get_iface()))
 
@@ -1552,7 +1541,7 @@ def _update_network_data(data, ncb):
     data.network.network = []
     for dev_cfg in ncb.dev_cfgs:
         devname = dev_cfg.get_iface()
-        nd = network.ksdata_from_ifcfg(devname, dev_cfg.con_uuid)
+        nd = network.ksdata_from_ifcfg(devname, dev_cfg.get_uuid())
         if not nd:
             continue
         if devname in nm.nm_activated_devices():

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -510,17 +510,25 @@ class NetworkControlBox(GObject.GObject):
         else:
             if self._ap_is_enterprise(ap):
                 # Create a connection for the ap and [Configure] it later with nm-c-e
-                values = []
-                values.append(['connection', 'uuid', str(uuid4()), 's'])
-                values.append(['connection', 'id', ssid_target, 's'])
-                values.append(['connection', 'type', '802-11-wireless', 's'])
-                values.append(['802-11-wireless', 'ssid', ssid_bytes, 'ay'])
-                values.append(['802-11-wireless', 'mode', 'infrastructure', 's'])
+                con = NM.SimpleConnection.new()
+                s_con = NM.SettingConnection.new()
+                s_con.set_property('uuid', str(uuid4()))
+                s_con.set_property('id', ssid_target)
+                s_con.set_property('type', '802-11-wireless')
+                s_wireless = NM.SettingWireless.new()
+                s_wireless.set_property('ssid', ap.get_ssid())
+                s_wireless.set_property('mode', 'infrastructure')
                 log.debug("network: adding connection for WPA-Enterprise AP %s", ssid_target)
-                nm.nm_add_connection(values)
+                con.add_setting(s_con)
+                con.add_setting(s_wireless)
+                persistent = True
+                self.client.add_connection_async(con, persistent, None, self.added_con_cb)
                 self.builder.get_object("button_wireless_options").set_sensitive(True)
             else:
-                self.client.add_and_activate_connection_async(None, device, ap.get_path(), None, None)
+                self.client.add_and_activate_connection_async(None, device, ap.get_path(), None, self.added_con_cb)
+
+    def added_con_cb(self, client, result):
+        con = client.add_connection_finish(result)
 
     def on_connection_added(self, client, connection):
         self.add_connection_to_list(connection.get_uuid())

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -804,18 +804,17 @@ class NetworkControlBox(GObject.GObject):
             dt = "wireless"
 
         if dev_cfg.device:
-            try:
-                ipv4cfg = nm.nm_device_ip_config(dev_cfg.device.get_iface(), version=4)
-                ipv6cfg = nm.nm_device_ip_config(dev_cfg.device.get_iface(), version=6)
-            except (nm.UnknownDeviceError, nm.UnknownMethodGetError):
-                ipv4cfg = ipv6cfg = None
+            ipv4cfg = dev_cfg.device.get_ip4_config()
+            ipv6cfg = dev_cfg.device.get_ip6_config()
         else:
             ipv4cfg = ipv6cfg = None
 
-        if ipv4cfg and ipv4cfg[0]:
-            addr_str, prefix, gateway_str = ipv4cfg[0][0]
-            netmask_str = network.prefix2netmask(prefix)
-            dnss_str = " ".join(ipv4cfg[1])
+        if ipv4cfg:
+            addr_str = ",".join("%s/%d" % (a.get_address(), a.get_prefix())
+                                           for a in ipv4cfg.get_addresses())
+            netmask_str = None
+            gateway_str = ipv4cfg.get_gateway()
+            dnss_str = ",".join(ipv4cfg.get_nameservers())
         else:
             addr_str = dnss_str = gateway_str = netmask_str = None
         self._set_device_info_value(dt, "ipv4", addr_str)
@@ -825,13 +824,11 @@ class NetworkControlBox(GObject.GObject):
             self._set_device_info_value(dt, "subnet", netmask_str)
 
         addr6_str = ""
-        if ipv6cfg and ipv6cfg[0]:
-            for ipv6addr in ipv6cfg[0]:
-                addr_str, prefix, gateway_str = ipv6addr
-                # Do not display link-local addresses
-                if not addr_str.startswith("fe80:"):
-                    addr6_str += "%s/%d\n" % (addr_str, prefix)
-
+        if ipv6cfg:
+            addr6_str = ",".join("%s/%d" % (a.get_address(), a.get_prefix())
+                                            for a in ipv6cfg.get_addresses()
+                                            # Do not display link-local addresses
+                                            if not a.get_address().startswith("fe80:"))
         self._set_device_info_value(dt, "ipv6", addr6_str.strip() or None)
 
         if ipv4cfg and addr6_str:

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -402,8 +402,21 @@ class NetworkControlBox(GObject.GObject):
         # Configs for ethernet has been already added,
         # this must be some slave
         if dev_cfg.get_device_type() == NM.DeviceType.ETHERNET:
-            log.debug("network: GUI, not adding slave connection %s", uuid)
-            return False
+            if con.get_setting_connection().get_master():
+                log.debug("network: GUI, not adding slave connection %s", uuid)
+                return False
+            else:
+                existing_dev_cfg = self.dev_cfg(iface=dev_cfg.get_iface())
+                if existing_dev_cfg:
+                    if existing_dev_cfg.con:
+                        log.debug("network: GUI, not adding connection %s, already have %s for device %s",
+                                  uuid, existing_dev_cfg.get_uuid(), existing_dev_cfg.device.get_iface())
+                        return False
+                    else:
+                        existing_dev_cfg.con = con
+                        log.debug("network: GUI, attaching connection %s to device %s",
+                                  uuid, existing_dev_cfg.device.get_iface())
+                        return True
         # Wireless settings are handled in scope of its device's dev_cfg
         if dev_cfg.get_device_type() == NM.DeviceType.WIFI:
             log.debug("network: GUI, not adding wireless connection %s", uuid)
@@ -704,8 +717,6 @@ class NetworkControlBox(GObject.GObject):
             if len(cons) != 1:
                 log.warning("network: %s has unexpected number of connections: %s",
                              device.get_iface(), [c.get_uuid() for c in cons])
-            if not con:
-                return
 
         if con and self.dev_cfg(uuid=con.get_uuid()):
             # If we already have a connection for the device
@@ -756,7 +767,7 @@ class NetworkControlBox(GObject.GObject):
                      escape_markup(dev_cfg.device.get_product() or ""))
         return title
 
-    def dev_cfg(self, uuid=None, device=None):
+    def dev_cfg(self, uuid=None, device=None, iface=None):
         for row in self.dev_cfg_store:
             dev_cfg = row[DEVICES_COLUMN_OBJECT]
             if uuid:
@@ -765,6 +776,10 @@ class NetworkControlBox(GObject.GObject):
             if device:
                 if not dev_cfg.device \
                    or dev_cfg.device.get_udi() != device.get_udi():
+                    continue
+            if iface:
+                if not dev_cfg.device \
+                   or dev_cfg.device.get_iface() != iface:
                     continue
             return dev_cfg
         return None


### PR DESCRIPTION
Port of network gui spoke to new libnm.

- Moves to using libnm objects (connection, device, ap) instead of uuids and names which allows for less amount of more readable and maintainable code.
- Removes python-dbus workarounds for secrets flags (could have been done using older libnm-glib as well, if there were not a bug, reported, and fixed now by NM in libnm-glib. Still NM recommends to use the new libnm
- Also allows to get rid of dependency of NetworkControlBox on nm.py (one instance of nm.py function call is still to be removed). As a follow-up NetworkControlBox could be quite easily split out to a module with a glade file independent of ancaonda code which makes its development a lot less pain.
- Using only single client now, which fixes problems with update of some properties and objects (client.get_connections()).
- The first two revert patches are replaced by two patches on top of the set as the port allowed for (and required) this - I think more robust - approach.
