### PR TITLE
Driver Update Disk fixes

### DIFF
--- a/dracut/driver-updates-genrules.sh
+++ b/dracut/driver-updates-genrules.sh
@@ -5,13 +5,17 @@ command -v wait_for_dd >/dev/null || . /lib/anaconda-lib.sh
 # Don't leave initqueue until we've finished with the requested dd stuff
 [ -f /tmp/dd_todo ] && wait_for_dd
 
+DD_OEMDRV=""
 if [ -f /tmp/dd_interactive ]; then
     initqueue --onetime --settled --name zz_dd_interactive \
         systemctl start driver-updates@$(find_tty).service
+else
+    # Only process OEMDRV in non-interactive mode
+    DD_OEMDRV="LABEL=OEMDRV"
 fi
 
 # Run driver-updates for LABEL=OEMDRV and any other requested disk
-for dd in LABEL=OEMDRV $(cat /tmp/dd_disk); do
+for dd in $DD_OEMDRV $(cat /tmp/dd_disk); do
     when_diskdev_appears "$(disk_to_dev_path $dd)" \
         driver-updates --disk $dd \$devnode
 done

--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -96,7 +96,7 @@ ANACONDAVER = "19.0"
 ARCH = os.uname()[4]
 KERNELVER = os.uname()[2]
 
-MODULE_UPDATES_DIR = "/lib/modules/%s/updates" % ARCH
+MODULE_UPDATES_DIR = "/lib/modules/%s/updates" % KERNELVER
 FIRMWARE_UPDATES_DIR = "/lib/firmware/updates"
 
 def mkdir_seq(stem):

--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -1008,15 +1008,6 @@ class PackagePayload(Payload):
             if not os.path.isdir(repo):
                 break
 
-            # Drivers are under /<arch>/ or /DD-net/
-            if os.path.isdir(repo+"DD-net"):
-                repo += "DD-net"
-            elif os.path.isdir(repo+blivet.arch.getArch()):
-                repo += blivet.arch.getArch()
-            else:
-                log.debug("No driver repo in %s", repo)
-                continue
-
             # Run createrepo if there are rpms and no repodata
             if not os.path.isdir(repo+"/repodata"):
                 rpms = glob(repo+"/*rpm")

--- a/pyanaconda/packaging/yumpayload.py
+++ b/pyanaconda/packaging/yumpayload.py
@@ -881,7 +881,7 @@ reposdir=%s
         self._groups = None
         self._packages = []
 
-    @refresh_base_repo(lambda s, r_id: r_id in BASE_REPO_NAMES)
+    @refresh_base_repo(lambda s, r_id: r_id.name in BASE_REPO_NAMES)
     def addRepo(self, newrepo):
         """ Add a ksdata repo. """
         log.debug("adding new repo %s", newrepo.name)


### PR DESCRIPTION
There are several issues here, this fixes 2 of them.

1. arch and DD-net are no longer used as part of the DD-x path for the extracted rpms.
2. addRepo's refresh lambda has been broken for a long time, it is only used by driver updates so wasn't noticed in Fedora.

A 3rd problem is that the drivers are extracted 3 times instead of once, resulting in /run/install/DD-1,DD-2,DD-3 still working on figuring that one out.
