### PR TITLE
Stricter LVM --grow kickstart tests

### DIFF
--- a/tests/kickstart_tests/lvm-cache-2.ks
+++ b/tests/kickstart_tests/lvm-cache-2.ks
@@ -48,6 +48,18 @@ if [ -z "$root_lv_entry" -a -z "$root_uuid_entry" ] ; then
     echo "*** root LV is not the root entry in /etc/fstab" >> /root/RESULT
 fi
 
+# verify size of root lv
+root_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root | sed -r 's/\s*([0-9]+)\..*/\1/')
+if [ $root_lv_size -le 4000 ]; then
+    echo "*** root lv has incorrect size" >> /root/RESULT
+fi
+
+# verify size of home lv
+home_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/home | sed -r 's/\s*([0-9]+)\..*/\1/')
+if [ $home_lv_size -le 1000 ]; then
+    echo "*** home lv has incorrect size" >> /result/RESULT
+fi
+
 # verify swap on lvm is active
 swap_lv="/dev/mapper/fedora-swap"
 swap_uuid="UUID=$(blkid -o value -s UUID "$swap_lv")"
@@ -67,6 +79,12 @@ fi
 swap_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/swap | sed -r 's/\s*([0-9]+)\..*/\1/')
 if [ "$swap_lv_size" != "500" ]; then
     echo "*** swap lv has incorrect size" >> /root/RESULT
+fi
+
+# verify that not too much space was left free in the VG
+vg_free="$(vgs -o vg_free_count --noheadings fedora)"
+if [ $vg_free -gt 2 ]; then
+    echo "*** too much free space left in the fedora vg" >> /root/RESULT
 fi
 
 # we don't need to check sizes of grown LVs, the fact that the installation

--- a/tests/kickstart_tests/lvm-cache-2.ks
+++ b/tests/kickstart_tests/lvm-cache-2.ks
@@ -64,11 +64,10 @@ if [ -z "$swap_lv_entry" -a -z "$swap_uuid_entry" ] ; then
 fi
 
 # verify size of swap lv
-# FIXME: this is not true now!
-# swap_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/swap)
-# if [ "$swap_lv_size" != "500.00" ]; then
-#     echo "*** swap lv has incorrect size" >> /root/RESULT
-# fi
+swap_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/swap | sed -r 's/\s*([0-9]+)\..*/\1/')
+if [ "$swap_lv_size" != "500" ]; then
+    echo "*** swap lv has incorrect size" >> /root/RESULT
+fi
 
 # we don't need to check sizes of grown LVs, the fact that the installation
 # reached this point means everything fit into the VG somehow

--- a/tests/kickstart_tests/lvm-raid-1.ks
+++ b/tests/kickstart_tests/lvm-raid-1.ks
@@ -46,11 +46,16 @@ if [ -z "$root_lv_entry" -a -z "$root_uuid_entry" ] ; then
     echo "*** root lv is not the root entry in /etc/fstab" >> /root/RESULT
 fi
 
-# verify size of root lv (do not check any particular size, let's just be happy to see the
-# installation succeed and the LV grown somehow, for now)
+# verify size of root lv
 root_lv_size=$(lvs --noheadings -o size --unit=m --nosuffix fedora/root | sed -r 's/\s*([0-9]+)\..*/\1/')
 if [ $root_lv_size -le 4000 ]; then
     echo "*** root lv has incorrect size" >> /root/RESULT
+fi
+
+# verify that not too much space was left free in the VG
+vg_free="$(vgs -o vg_free_count --noheadings fedora)"
+if [ $vg_free -gt 2 ]; then
+    echo "*** too much free space left in the fedora vg" >> /root/RESULT
 fi
 
 # verify swap on lvm is active


### PR DESCRIPTION
The first patch is already part of the PR #303 which is waiting for a new rawhide build of blivet. The second commit makes our tests that try to grow LVs to a maximum size stricter in a way that it checks the resulting free space in the VG. The requirements are hard, but with [blivet's PR #218] (https://github.com/rhinstaller/blivet/pull/218) merged we should be able to meet them. And that's what tests are good for, right? In case we need to make things more benevolent due to unpredictability of low-level storage calculations we can always update the requirements in our tests. But let's start with the hardest check possible.