### PR TITLE
Add rpm-build to install-test-requires

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -135,7 +135,7 @@ install-test-requires: install-buildrequires install-requires
 		dnf install bzip2 cppcheck gnome-icon-theme gnome-icon-theme-symbolic \
 		    lorax mock parallel rpm-ostree virt-install pykickstart spin-kickstarts  \
 		    python3-rpmfluff python3-mock python3-pocketlint python3-nose-testconfig \
-		    python3-sphinx_rtd_theme libvirt-python3 python3-lxml
+		    python3-sphinx_rtd_theme libvirt-python3 python3-lxml rpm-build
 
 # Generate an updates.img based on the changed files since the release
 # was tagged.  Updates are copied to ./updates-img and then the image is


### PR DESCRIPTION
It is needed by the rpmfluff tests and I was on a system where it happened to be missing.