### PR TITLE
Install driver-updates@.service as a data instead of a script

### DIFF
--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -43,9 +43,10 @@ dist_dracut_SCRIPTS = module-setup.sh \
 		      anaconda-pre-shutdown.sh \
 		      parse-anaconda-dd.sh \
 		      fetch-driver-net.sh \
-		      driver-updates@.service \
 		      driver-updates-genrules.sh \
 		      anaconda-depmod.sh \
 		      driver_updates.py
+
+dist_dracut_DATA = driver-updates@.service
 
 MAINTAINERCLEANFILES = Makefile.in


### PR DESCRIPTION
This way it doesn't end up with the executable bit set and systemd
doesn't complain about it.