### PR TITLE
Install ca-bundle certs in the initrd (#1259880)

### DIFF
--- a/scripts/mk-images
+++ b/scripts/mk-images
@@ -729,6 +729,7 @@ makeinitrd() {
     mkdir -p $MBD_DIR/sbin
     mkdir -p $MBD_DIR/dev
     mkdir -p $MBD_DIR/etc
+    mkdir -p $MBD_DIR/etc/pki/tls/certs
     mkdir -p $MBD_DIR/etc/udev/rules.d
     mkdir -p $MBD_DIR/lib/udev/rules.d
     mkdir -p $MBD_DIR/proc
@@ -876,6 +877,8 @@ makeinitrd() {
     install -m 644 $IMGPATH/etc/netconfig $MBD_DIR/etc/netconfig
     install -m 644 $IMGPATH/etc/nsswitch.conf $MBD_DIR/etc/nsswitch.conf
     install -m 644 $IMGPATH/etc/hosts $MBD_DIR/etc/hosts
+    install -m 644 $IMGPATH/pki/tls/certs/ca-bundle.crt $MBD_DIR/pki/tls/certs/ca-bundle.crt
+    install -m 644 $IMGPATH/pki/tls/certs/ca-bundle.trust.crt $MBD_DIR/pki/tls/certs/ca-bundle.trust.crt
     mkdir -p $MBD_DIR/usr/lib/locale
     localedef -c -i en_US -f UTF-8 --prefix $MBD_DIR en_US
 


### PR DESCRIPTION
Without these curl cannot verify any CA's from loader.

Resolves: rhbz#1259880