### PR TITLE
Quit in askvnc should not reboot image and dirinstall (#1255069)

### DIFF
--- a/pyanaconda/ui/tui/spokes/askvnc.py
+++ b/pyanaconda/ui/tui/spokes/askvnc.py
@@ -105,7 +105,11 @@ class AskVNCSpoke(NormalTUISpoke):
             d = YesNoDialog(self.app, _(self.app.quit_message))
             self.app.switch_screen_modal(d)
             if d.answer:
-                execWithRedirect("systemctl", ["--no-wall", "reboot"])
+                from pyanaconda.flags import can_touch_runtime_system
+                if can_touch_runtime_system("reboot"):
+                    execWithRedirect("systemctl", ["--no-wall", "reboot"])
+                else:
+                    sys.exit(1)
         else:
             return key
 


### PR DESCRIPTION
When running in --image or --dirinstallmode answering 'q' to the askvnc
question should not reboot the host machine, it should just exit. The
normal exithandler isn't setup yet, so check flags to decide whether
to reboot or exit(1).

Resolves: rhbz#1255069