### PR TITLE
Enable storage tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -229,6 +229,9 @@ bare-ci:
 	@sudo $(MAKE) TMPDIR=/var/tmp COVERAGE_PROCESS_START=$(abs_builddir)/.coveragerc \
 		TEST_SUITE_LOG=test-suite.log.$$$$ TESTS=nosetests_root.sh \
 		PYTHONUSERBASE=$(USER_SITE_BASE) check
+	@sudo $(MAKE) TMPDIR=/var/tmp COVERAGE_PROCESS_START=$(abs_builddir)/.coveragerc \
+		TEST_SUITE_LOG=test-suite.log.$$$$ TESTS=storage/run_storage_tests.py \
+		PYTHONUSERBASE=$(USER_SITE_BASE) check
 	@mkdir -p repo
 	@mv $(RPM_BUILD_DIR)/*rpm repo
 	@createrepo_c -p repo

--- a/tests/storage/cases/reuse.py
+++ b/tests/storage/cases/reuse.py
@@ -17,7 +17,8 @@
 
 __all__ = ["PartitionReuse_TestCase", "LVMReuse_TestCase", "BTRFSReuse_TestCase", "ThinpReuse_TestCase"]
 
-from . import TestCase, ReusableTestCaseComponent, ReusingTestCaseComponent
+from . import TestCase, ReusableTestCaseComponent, ReusingTestCaseComponent, \
+    LVMReusableTestCaseComponent, LVMReusingTestCaseComponent
 from blivet.size import Size
 
 class FirstPartitionAutopartComponent(ReusableTestCaseComponent):
@@ -61,7 +62,7 @@ result of a previous installation with partition-based autopart works.
 
         self.components = [first, second]
 
-class FirstLVMAutopartComponent(ReusableTestCaseComponent):
+class FirstLVMAutopartComponent(LVMReusableTestCaseComponent):
     name = "FirstLVMAutopart"
 
     def __init__(self, *args, **kwargs):
@@ -77,7 +78,7 @@ clearpart --all --initlabel
 autopart --type=lvm
 """
 
-class SecondLVMAutopartComponent(ReusingTestCaseComponent):
+class SecondLVMAutopartComponent(LVMReusingTestCaseComponent):
     name = "SecondLVMAutopart"
 
     @property
@@ -143,7 +144,7 @@ result of a previous installation with BTRFS-based autopart works.
 
         self.components = [first, second]
 
-class FirstThinpAutopartComponent(ReusableTestCaseComponent):
+class FirstThinpAutopartComponent(LVMReusableTestCaseComponent):
     name = "FirstThinpAutopart"
 
     def __init__(self, *args, **kwargs):
@@ -159,7 +160,7 @@ clearpart --all --initlabel
 autopart --type=thinp
 """
 
-class SecondThinpAutopartComponent(ReusingTestCaseComponent):
+class SecondThinpAutopartComponent(LVMReusingTestCaseComponent):
     name = "SecondThinpAutopart"
 
     @property

--- a/tests/storage/run_storage_tests.py
+++ b/tests/storage/run_storage_tests.py
@@ -4,10 +4,6 @@ import os, sys
 
 from pyanaconda.iutil import collect
 
-# FIXME: Storage tests don't want to work right now, so they are disabled while
-# I debug them so we can get useful data from other tests.
-os._exit(77)
-
 if os.geteuid() != 0:
     sys.stderr.write("You must be root to run the storage tests; skipping.\n")
     # This return code tells the automake test driver that this test was skipped.


### PR DESCRIPTION
Filing this here for more comments. 

All the tests except LVM based ones work. 

Initially the LVM reuse test fails on tear down. Blivet calls kpartx -d -s on the device which fails with device busy. At the same time the VG "blivet" is still active. If I manually deactivate it from the shell and re-execute the kpartx command the all is fine.  This prompted the blockdev.lvm.vgdeactivate() changes in the code.

```
Test 1014545-BTRFSOnNonBTRFS succeeded
Test 1014545-RaidOnNonRaidMembers succeeded
Test 1014545-VolGroupOnNonPVs succeeded
Test 1014545 summary:
    Successes: 3
    Failures:  0

Test PartitionReuse-FirstPartitionAutopart succeeded
Test PartitionReuse-SecondPartitionAutopart succeeded
Test PartitionReuse summary:
    Successes: 2
    Failures:  0

Traceback (most recent call last):
  File "./storage/run_storage_tests.py", line 25, in <module>
    failures += obj.run()
  File "/home/atodorov/anaconda/tests/storage/cases/__init__.py", line 80, in run
    obj._run()
  File "/home/atodorov/anaconda/tests/storage/cases/__init__.py", line 234, in _run
    self.tearDownDisks()
  File "/home/atodorov/anaconda/tests/storage/cases/__init__.py", line 251, in tearDownDisks
    self._blivet.devicetree.teardownDiskImages()
  File "/usr/lib/python3.4/site-packages/blivet/devicetree.py", line 596, in teardownDiskImages
    self._populator.teardownDiskImages()
  File "/usr/lib/python3.4/site-packages/blivet/populator.py", line 1550, in teardownDiskImages
    dm_device.deactivate()
  File "/usr/lib/python3.4/site-packages/blivet/devices/dm.py", line 209, in deactivate
    StorageDevice.teardown(self, recursive=recursive)
  File "/usr/lib/python3.4/site-packages/blivet/devices/storage.py", line 429, in teardown
    self._teardown(recursive=recursive)
  File "/usr/lib/python3.4/site-packages/blivet/devices/dm.py", line 203, in _teardown
    self.teardownPartitions()
  File "/usr/lib/python3.4/site-packages/blivet/devices/dm.py", line 138, in teardownPartitions
    raise errors.DMError("partition deactivation failed for '%s'" % self.name)
blivet.errors.DMError: partition deactivation failed for 'lvm-autopart-disk1'
FAIL storage/run_storage_tests.py (exit status: 1)
```

Note: the additional blivet.reset() calls probably don't have any effect. 

Next with the VG deactivated the test passes on to the second stage, where it tries to create another LVM device on top of existing disk image. This also fails with another error:

```
Test 1014545-BTRFSOnNonBTRFS succeeded
Test 1014545-RaidOnNonRaidMembers succeeded
Test 1014545-VolGroupOnNonPVs succeeded
Test 1014545 summary:
    Successes: 3
    Failures:  0

Test LVMReuse-FirstLVMAutopart succeeded
Traceback (most recent call last):
  File "./storage/run_storage_tests.py", line 25, in <module>
    failures += obj.run()
  File "/home/atodorov/anaconda/tests/storage/cases/__init__.py", line 80, in run
    obj._run()
  File "/home/atodorov/anaconda/tests/storage/cases/__init__.py", line 214, in _run
    self._blivet.doIt()
  File "/usr/lib/python3.4/site-packages/blivet/blivet.py", line 164, in doIt
    self.devicetree.processActions(callbacks=callbacks)
  File "/usr/lib/python3.4/site-packages/blivet/devicetree.py", line 380, in processActions
    callbacks=callbacks)
  File "/usr/lib/python3.4/site-packages/blivet/actionlist.py", line 280, in process
    action.execute(callbacks)
  File "/usr/lib/python3.4/site-packages/blivet/deviceaction.py", line 590, in execute
    options=self.device.formatArgs)
  File "/usr/lib/python3.4/site-packages/blivet/formats/__init__.py", line 388, in create
    self._create(**kwargs)
  File "/usr/lib/python3.4/site-packages/blivet/formats/disklabel.py", line 240, in _create
    self.commit()
  File "/usr/lib/python3.4/site-packages/blivet/formats/disklabel.py", line 253, in commit
    self.partedDisk.commit()
  File "/usr/lib64/python3.4/site-packages/parted/decorators.py", line 42, in new
    ret = fn(*args, **kwds)
  File "/usr/lib64/python3.4/site-packages/parted/disk.py", line 212, in commit
    return self.__disk.commit()
_ped.IOException: Partition(s) 2 on /dev/mapper/lvm-autopart-disk1 have been written, but we have been unable to inform the kernel of the change, probably because it/they are in use.  As a result, the old partition(s) will remain in use.  You should reboot now before making further changes.
FAIL storage/run_storage_tests.py (exit status: 1)
```

This time however all DM devices are successfully removed (there is a try-finally). 

I'm not sure what is the problem and my blivet knowledge is limited to figure it out by myself so please comment on this.
