### PR TITLE
Kickstart URL include

### DIFF
--- a/dracut/python-deps
+++ b/dracut/python-deps
@@ -26,7 +26,9 @@ from distutils.sysconfig import get_python_lib, get_config_var, get_makefile_fil
 sitedir = get_python_lib()
 libdir = get_config_var('LIBDEST')
 
-alsoNeeded = dict()
+# stringprep is needed by the idna encoding, and idna is needed by requests.
+# The encoding import is implicit so ModuleFinder doesn't find it right.
+alsoNeeded = {sitedir+"/requests/__init__.py": libdir+"/stringprep.py"}
 
 # A couple helper functions...
 def moduledir(pyfile):

--- a/tests/kickstart_tests/ks-include-post.ks
+++ b/tests/kickstart_tests/ks-include-post.ks
@@ -1,0 +1,4 @@
+%post
+# If this is being run, it's a success
+echo SUCCESS > /root/RESULT
+%end

--- a/tests/kickstart_tests/ks-include.ks
+++ b/tests/kickstart_tests/ks-include.ks
@@ -1,0 +1,20 @@
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-rawhide&arch=$basearch
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+keyboard us
+lang en
+timezone America/New_York
+rootpw qweqwe
+shutdown
+
+%packages
+%end
+
+# Include a kickstart that contains %post
+%include KS-TEST-INCLUDE

--- a/tests/kickstart_tests/ks-include.sh
+++ b/tests/kickstart_tests/ks-include.sh
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): David Shea <dshea@redhat.com>
+
+TESTTYPE="kickstart"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare() {
+    ks=$1
+    tmpdir=$2
+
+    # Copy the included kickstart to a directory in tmpdir
+    mkdir ${tmpdir}/http
+    cp $(dirname ${ks})/ks-include-post.ks ${tmpdir}/http
+
+    # Start a http server to serve the included file
+    start_httpd ${tmpdir}/http $tmpdir
+
+    # Set the URL of the included file
+    sed -e "/^%include/ s|KS-TEST-INCLUDE|${httpd_url}/ks-include-post.ks|" ${ks} > ${tmpdir}/ks.cfg
+    echo ${tmpdir}/ks.cfg
+}
+
+cleanup() {
+    tmpdir=$1
+
+    if [ -f ${tmpdir}/httpd-pid ]; then
+        kill $(cat ${tmpdir}/httpd-pid)
+    fi
+}


### PR DESCRIPTION
The kickstart test depends on https://github.com/rhinstaller/anaconda/pull/344, but I rebased this branch to master so you don't have to look those commits twice.

As far as actually making things work, there's also a pykickstart change that's needed (return .text instead of .content in _load_url), but I haven't created a PR for that yet since I'm still working on adding a test case to pykickstart for it.