### PR TITLE
Fix 'cat: /tmp/dd_disk: No such file or directory' (#1251394)

### DIFF
--- a/dracut/driver-updates-genrules.sh
+++ b/dracut/driver-updates-genrules.sh
@@ -14,8 +14,15 @@ else
     DD_OEMDRV="LABEL=OEMDRV"
 fi
 
+DD_DISK=""
+if [ -f /tmp/dd_disk ]; then
+    DD_DISK=$(cat /tmp/dd_disk)
+else
+    debug_msg "/tmp/dd_disk file was not created"
+fi
+
 # Run driver-updates for LABEL=OEMDRV and any other requested disk
-for dd in $DD_OEMDRV $(cat /tmp/dd_disk); do
+for dd in $DD_OEMDRV $DD_DISK; do
     when_diskdev_appears "$(disk_to_dev_path $dd)" \
         driver-updates --disk $dd \$devnode
 done


### PR DESCRIPTION
Missing /tmp/dd_disk file is not an error, changing to debug print instead.

*Resolves: rhbz#1251394*