### PR TITLE
Fix a DBus InvalidProperty handling

### DIFF
--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -263,7 +263,12 @@ def nm_device_property(name, prop):
             raise UnknownDeviceError(name, e)
         raise
 
-    retval = _get_property(device, prop, ".Device")
+    retval = None
+    try:
+        retval = _get_property(device, prop, ".Device")
+    except GLib.GError as e:
+        if "org.freedesktop.DBus.Error.InvalidArgs" not in e.message:
+            raise
     if not retval:
         # Look in device type based interface
         interface = _device_type_specific_interface(device)


### PR DESCRIPTION
Rawhide anaconda crashing because the new InvalidProperty exception is
now raised.

DBus API is returing exception now so we have to catch the exception
instead of only testing for empty returned variable.