### PR TITLE
set sysroot correctly when setting root password (#1260875)

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1615,7 +1615,7 @@ class RootPw(commands.rootpw.F18_RootPw):
             self.lock = True
 
         algo = getPassAlgo(ksdata.authconfig.authconfig)
-        users.setRootPassword(self.password, self.isCrypted, self.lock, algo)
+        users.setRootPassword(self.password, self.isCrypted, self.lock, algo, iutil.getSysroot())
 
 class SELinux(commands.selinux.FC3_SELinux):
     def execute(self, *args):


### PR DESCRIPTION
as @sgallagher noted, #1260875 happens because the `setRootPassword` call doesn't specify the system root (so we wind up changing the anaconda environment's root password, not the installed system's root password).

The default for `users.setRootPassword` itself could be changed instead of / as well as this, we weren't sure which would be the best place to do it. But this does work, I tested it.