### PR TITLE
Fix a DBus InvalidProperty handling

### DIFF
--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -122,7 +122,8 @@ def _get_property(object_path, prop, interface_name_suffix=""):
     try:
         prop = proxy.Get('(ss)', interface_name, prop)
     except GLib.GError as e:
-        if "org.freedesktop.DBus.Error.AccessDenied" in e.message:
+        if ("org.freedesktop.DBus.Error.AccessDenied" in e.message or
+            "org.freedesktop.DBus.Error.InvalidArgs" in e.message):
             return None
         elif "org.freedesktop.DBus.Error.UnknownMethod" in e.message:
             raise UnknownMethodGetError


### PR DESCRIPTION
Rawhide anaconda crashing because the new InvalidProperty exception is
now raised.

DBus API is returing exception now so we have to catch the exception
instead of only testing for empty returned variable.

*Resolves: rhbz#1260239*

This is updated PR of this one https://github.com/rhinstaller/anaconda/pull/350. I have found out it will crash later in the anaconda with the old fix so I'm moving the solution closer to the source to fix both problems. Also it looks nicer here.