### PR TITLE
F23 dnf root size

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -104,14 +104,19 @@ def _paced(fn):
         return fn(self, *args)
     return paced_fn
 
-def _pick_mpoint(df, requested):
+def _pick_mpoint(df, download_size, install_size):
     def reasonable_mpoint(mpoint):
         return mpoint in DOWNLOAD_MPOINTS
 
-    # reserve extra
-    requested = requested + Size("150 MB")
-    sufficients = {key : val for (key, val) in df.items() if val > requested
-                   and reasonable_mpoint(key)}
+    requested = download_size
+    requested_root = requested + install_size
+    root_mpoint = pyanaconda.iutil.getSysroot()
+    sufficients = {key : val for (key, val) in df.items()
+                   # for root we need to take in count both download and install size
+                   if ((key != root_mpoint and val > requested)
+                   or val > requested_root) and reasonable_mpoint(key)}
+    log.debug('Estimated size: download %s & install %s - df: %s', requested,
+              (requested_root - requested), df)
     log.info('Sufficient mountpoints found: %s', sufficients)
 
     if not len(sufficients):
@@ -423,7 +428,8 @@ class DNFPayload(packaging.PackagePayload):
             return Size(0)
 
         size = sum(tsi.installed.downloadsize for tsi in transaction)
-        return Size(size)
+        # reserve extra
+        return Size(size) + Size("150 MB")
 
     def _install_package(self, pkg_name, required=False):
         try:
@@ -446,11 +452,10 @@ class DNFPayload(packaging.PackagePayload):
             sys.exit(1)
 
     def _pick_download_location(self):
-        required = self._download_space
+        download_size = self._download_space
+        install_size = self._spaceRequired()
         df_map = _df_map()
-        mpoint = _pick_mpoint(df_map, required)
-        log.info("Download space required: %s, use filesystem at: %s", required,
-                 mpoint)
+        mpoint = _pick_mpoint(df_map, download_size, install_size)
         if mpoint is None:
             msg = "Not enough disk space to download the packages."
             raise packaging.PayloadError(msg)
@@ -538,6 +543,27 @@ class DNFPayload(packaging.PackagePayload):
 
     @property
     def spaceRequired(self):
+        size = self._spaceRequired()
+        download_size = self._download_space
+        valid_points = _df_map()
+        future_mpoints = dict()
+        root_mpoint = pyanaconda.iutil.getSysroot()
+        for (key, val) in self.storage.mountpoints.items():
+            new_key = key
+            if key.endswith('/'):
+                new_key = key[:-1]
+            # we can ignore swap
+            if key.startswith('/') and ((root_mpoint + new_key) not in valid_points):
+                valid_points[root_mpoint + new_key] = val.format.freeSpaceEstimate(val.size)
+
+        m_points = _pick_mpoint(valid_points, download_size, size)
+        if not m_points or m_points == root_mpoint:
+            # download and install to the same mount point
+            size = size + download_size
+        log.debug("Instalation space required %s for mpoints %s", size, m_points)
+        return size
+
+    def _spaceRequired(self):
         transaction = self._base.transaction
         if transaction is None:
             return Size("3000 MB")

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -824,9 +824,10 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         log.debug("disk free: %s  fs free: %s  sw needs: %s  auto swap: %s",
                   disk_free, fs_free, required_space, auto_swap)
 
-        if disk_free >= required_space + auto_swap:
+        # compare only to 90% of disk space because fs takes some space for a metadata
+        if (disk_free * 0.9) >= required_space + auto_swap:
             dialog = None
-        elif disks_size >= required_space:
+        elif (disks_size * 0.9) >= required_space:
             dialog = NeedSpaceDialog(self.data, payload=self.payload)
             dialog.refresh(required_space, auto_swap, disk_free, fs_free)
         else:

--- a/pyanaconda/ui/lib/space.py
+++ b/pyanaconda/ui/lib/space.py
@@ -75,7 +75,7 @@ class FileSystemSpaceChecker(object):
         free = Size(self.storage.fileSystemFreeSpace)
         needed = self.payload.spaceRequired
         log.info("fs space: %s  needed: %s", free, needed)
-        self.success = (free >= needed)
+        self.success = (free > needed)
         if not self.success:
             self.deficit = needed - free
             self.error_message = _(self.error_template) % self.deficit
@@ -106,7 +106,7 @@ class DirInstallSpaceChecker(FileSystemSpaceChecker):
         free = Size(stat.f_bsize * stat.f_bfree)
         needed = self.payload.spaceRequired
         log.info("fs space: %s  needed: %s", free, needed)
-        self.success = (free >= needed)
+        self.success = (free > needed)
         if not self.success:
             self.deficit = needed - free
             self.error_message = _(self.error_template) % self.deficit


### PR DESCRIPTION
Anaconda must compute size for downloaded and installed packages when testing free space for installed root. Also use only 90% of disk capacity for required space compare.

*Resolves: rhbz#1224048*