### PR TITLE
Add kickstart tests for %packages --instLangs

### DIFF
--- a/tests/kickstart_tests/packages-instlangs-1.ks
+++ b/tests/kickstart_tests/packages-instlangs-1.ks
@@ -1,0 +1,45 @@
+#version=DEVEL
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-rawhide&arch=$basearch
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+autopart
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+# Only install the en_US locale
+%packages --instLangs=en_US
+%end
+
+%post
+# Make sure no non-english .mo files were installed
+molist="$(find /usr/share/locale \( -name 'en' -type d -prune \) -o \( -name 'en[@_]*' -type d -prune \) -o \( -name '*.mo' -print \) )"
+if [ -n "$molist" ]; then
+    echo "*** non-en .mo files were installed" >> /root/RESULT
+fi
+
+# Check that the en_US locale was installed
+localedef --list-archive | grep -a -q '^en_US$'
+if [ $? != 0 ]; then
+    echo "*** en_US was not installed" >> /root/RESULT
+fi
+
+# Check that only the en_US locale and related encodings were installed
+# Use grep -a to force text mode, since sometimes a character will end up in the
+# output that makes grep think it's binary
+other_locales="$(localedef --list-archive | grep -a -v '^en_US$' | grep -a -v '^en_US\.')"
+if [ -n "$other_locales" ]; then
+    echo "*** non-en locales were installed" >> /root/RESULT
+fi
+
+if [ ! -f /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/tests/kickstart_tests/packages-instlangs-1.sh
+++ b/tests/kickstart_tests/packages-instlangs-1.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+TESTTYPE="packaging"
+
+. ${KSTESTDIR}/functions.sh

--- a/tests/kickstart_tests/packages-instlangs-2.ks
+++ b/tests/kickstart_tests/packages-instlangs-2.ks
@@ -1,0 +1,37 @@
+#version=DEVEL
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-rawhide&arch=$basearch
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+autopart
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+# Install no locales
+%packages --instLangs=
+%end
+
+%post
+# Make sure no .mo files were installed
+molist="$(find /usr/share/locale -name '*.mo')"
+if [ -n "$molist" ]; then
+    echo "*** .mo files were installed" >> /root/RESULT
+fi
+
+# Check that no locales were installed.
+other_locales="$(localedef --list-archive)"
+if [ -n "$other_locales" ]; then
+    echo "*** locales were installed" >> /root/RESULT
+fi
+
+if [ ! -f /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/tests/kickstart_tests/packages-instlangs-2.sh
+++ b/tests/kickstart_tests/packages-instlangs-2.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+TESTTYPE="packaging"
+
+. ${KSTESTDIR}/functions.sh

--- a/tests/kickstart_tests/packages-instlangs-3.ks
+++ b/tests/kickstart_tests/packages-instlangs-3.ks
@@ -1,0 +1,73 @@
+#version=DEVEL
+url --mirror=http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-rawhide&arch=$basearch
+install
+network --bootproto=dhcp
+
+bootloader --timeout=1
+zerombr
+clearpart --all --initlabel
+autopart
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+# Install a short list of languages
+# Use ones with translations in blivet to make them easy to find.
+%packages --instLangs=es:fr:it
+python3-blivet
+%end
+
+%post
+# Make sure the locales we asked for are installed
+if [ ! -f /usr/share/locale/es/LC_MESSAGES/blivet.mo ]; then
+    echo "*** Spanish translations were not installed" >> /root/RESULT
+fi
+
+if [ ! -f /usr/share/locale/fr/LC_MESSAGES/blivet.mo ]; then
+    echo "*** French translations were not installed" >> /root/RESULT
+fi
+
+if [ ! -f /usr/share/locale/it/LC_MESSAGES/blivet.mo ]; then
+    echo "*** Italian translations were not installed" >> /root/RESULT
+fi
+
+# Make sure nothing else got installed
+molist="$(find /usr/share/locale \( -name 'fr' -type d -prune \) -o \
+          \( -name 'es' -type d -prune \) -o \
+          \( -name 'it' -type d -prune \) -o \
+	  -o \( -name 'blivet.mo' -print \) )"
+if [ -n "$molist" ]; then
+    echo "*** unrequested .mo files were installed" >> /root/RESULT
+fi
+
+# Check that the requested locales were installed
+localedef --list-archive | grep -a -q '^es_'
+if [ $? != 0 ]; then
+    echo "*** es locales were not installed" >> /root/RESULT
+fi
+
+localedef --list-archive | grep -a -q '^fr_'
+if [ $? != 0 ]; then
+    echo "*** fr locales were not installed" >> /root/RESULT
+fi
+
+localedef --list-archive | grep -a -q '^it_'
+if [ $? != 0 ]; then
+    echo "*** it locales were not installed" >> /root/RESULT
+fi
+
+# Check that only the requested locales were installed
+# Use grep -a to force text mode, since sometimes a character will end up in the
+# output that makes grep think it's binary
+other_locales="$(localedef --list-archive | grep -a -v '^fr_' | grep -a -v '^es_' | grep -a -v '^it_')"
+if [ -n "$other_locales" ]; then
+    echo "*** unrequested locales were installed" >> /root/RESULT
+fi
+
+if [ ! -f /root/RESULT ]; then
+    echo SUCCESS > /root/RESULT
+fi
+%end

--- a/tests/kickstart_tests/packages-instlangs-3.sh
+++ b/tests/kickstart_tests/packages-instlangs-3.sh
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Chris Lumens <clumens@redhat.com>
+
+TESTTYPE="packaging"
+
+. ${KSTESTDIR}/functions.sh


### PR DESCRIPTION
None of this actually succeeds yet. See also https://github.com/rhinstaller/pykickstart/pull/34 and https://bugzilla.redhat.com/show_bug.cgi?id=1262040