### PR TITLE
Tell gettext that anaconda is not a GNU package.

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -19,7 +19,7 @@ Source0: %{name}-%{version}.tar.bz2
 # match the requires versions of things).
 
 # Also update in AM_GNU_GETTEXT_VERSION in configure.ac
-%define gettextver 0.18.3
+%define gettextver 0.19.1
 %define intltoolver 0.31.2-3
 %define pykickstartver 2.9
 %define dnfver 0.6.4

--- a/configure.ac
+++ b/configure.ac
@@ -70,7 +70,7 @@ AC_SUBST(INTLTOOL_DESKTOP_RULE)
 
 AM_GNU_GETTEXT([external])
 # Also update in gettextver in anaconda.spec.in
-AM_GNU_GETTEXT_VERSION([0.18.3])
+AM_GNU_GETTEXT_VERSION([0.19.1])
 
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h stdlib.h string.h sys/time.h unistd.h],

--- a/po/Makevars
+++ b/po/Makevars
@@ -20,6 +20,13 @@ XGETTEXT_OPTIONS = --keyword=_ --keyword=N_ --keyword=P_:1,2 --keyword=C_:1c,2 -
 # their copyright.
 COPYRIGHT_HOLDER = Red Hat, Inc.
 
+# This tells whether or not to prepend "GNU " prefix to the package
+# name that gets inserted into the header of the $(DOMAIN).pot file.
+# Possible values are "yes", "no", or empty.  If it is empty, try to
+# detect it automatically by scanning the files in $(top_srcdir) for
+# "GNU packagename" string.
+PACKAGE_GNU = no
+
 # This is the email address or URL to which the translators shall report
 # bugs in the untranslated strings:
 # - Strings which are not entire sentences, see the maintainer guidelines


### PR DESCRIPTION
This prevents gettext's auto-GNU-detection from picking up, for example,
the "grep 'GNU anaconda'" command that got written to a log file and
then failing in a confusing way.

The PACKAGE_GNU variable was added in gettext 0.19.1, so update the
requirements for autoconf and rpm accordingly.