### PR TITLE
Ignore requests to create existing groups (#1261002)

### DIFF
--- a/pyanaconda/users.py
+++ b/pyanaconda/users.py
@@ -208,7 +208,8 @@ class Users(object):
         root = kwargs.get("root", iutil.getSysroot())
 
         if self._groupExists(group_name, root):
-            raise ValueError("Group %s already exists" % group_name)
+            # If the group already exists, skip it
+            return
 
         args = ["-R", root]
         if kwargs.get("gid") is not None:


### PR DESCRIPTION
f23-only, for master I'd like to fix the user GUI spoke to be less overgrown and wrong.

Part of the fallout from removing libuser is that some errors that were
lost somewhere across the fork and chroot are now actually errors. One
of those errors is that you are not allowed to request that a group be
created if that group already exists, so it is written. Unfortunately
the current code to add users to existing groups depends on requests to
create existing groups not crashing, so go back to ignoring the error as
a quick fix for 23.