### PR TITLE
Use yum to install the mock buildroot for now.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -89,9 +89,9 @@ release:
 	$(MAKE) dist && $(MAKE) tag && git checkout -- $(srcdir)/po/$(PACKAGE_NAME).pot
 
 rc-release: scratch-bumpver scratch
-	mock -r $(MOCKCHROOT) --scrub all || exit 1
-	mock -r $(MOCKCHROOT) --buildsrpm  --spec ./$(PACKAGE_NAME).spec --sources . --resultdir $(PWD) || exit 1
-	mock -r $(MOCKCHROOT) --rebuild *src.rpm --resultdir $(PWD) || exit 1
+	mock --yum -r $(MOCKCHROOT) --scrub all || exit 1
+	mock --yum -r $(MOCKCHROOT) --buildsrpm  --spec ./$(PACKAGE_NAME).spec --sources . --resultdir $(PWD) || exit 1
+	mock --yum -r $(MOCKCHROOT) --rebuild *src.rpm --resultdir $(PWD) || exit 1
 
 bumpver: po-pull
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \


### PR DESCRIPTION
Something is busted with dnf and mock, so switch to yum as a workaround
so we can get packages building again.