### PR TITLE
Fix branding when iso is downloaded from nfs or hd (#1252756)

### DIFF
--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -86,7 +86,7 @@ anaconda_live_root_dir() {
         iso=${isodir}/${iso#$mnt}
         mount -o loop,ro $iso $repodir
         img=$(find_runtime $repodir) || { warn "$iso has no suitable runtime"; }
-        anaconda_auto_updates $isodir/$path/images
+        anaconda_auto_updates $repodir/images
     fi
     # FIXME: make rd.live.ram clever enough to do this for us
     if [ "$1" = "--copy-to-ram" ]; then


### PR DESCRIPTION
We should load `product.img` and `updates.img` from the same place as `install.img` is loaded which is `/run/install/repo`.

*Resolves: rhbz#1252756*

----------------
I'm still wondering why this was there if it had some special reason. If someone know that please tell me if this patch is alright.