### PR TITLE
Catch blkid failure in driver-updates (#1262963)

### DIFF
--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -399,10 +399,13 @@ class DeviceInfo(object):
         return dev
 
 def blkid():
-    out = subprocess.check_output("blkid -o export -s UUID -s TYPE".split())
-    out = out.decode('ascii')
-    return [dict(kv.split('=',1) for kv in block.splitlines())
-                                 for block in out.split('\n\n')]
+    try:
+        out = subprocess.check_output("blkid -o export -s UUID -s TYPE".split())
+        out = out.decode('ascii')
+        return [dict(kv.split('=',1) for kv in block.splitlines())
+                                     for block in out.split('\n\n')]
+    except subprocess.CalledProcessError:
+        return []
 
 # We use this to get disk labels because blkid's encoding of non-printable and
 # non-ascii characters is weird and doesn't match what you'd expect to see.


### PR DESCRIPTION
Some systems are slow to bring up their devices, it is possible to enter
the DUD UI before they are available. blkid returns a 2 when there is
nothing to output so we need to catch CalledProcessError to give them
the chance to refresh a few times until they show up.

Resolves: rhbz#1262963