### PR TITLE
Use correct installclass for RHEL Atomic Host (#1265213)

### DIFF
--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -73,8 +73,7 @@ class RHELBaseInstallClass(BaseInstallClass):
 class RHELAtomicInstallClass(RHELBaseInstallClass):
     name = "Red Hat Enterprise Linux Atomic Host"
     sortPriority=21000
-    if not productName.startswith(("RHEL Atomic Host", "Red Hat Enterprise Linux Atomic")):
-        hidden = True
+    hidden = not productName.startswith(("RHEL Atomic Host", "Red Hat Enterprise Linux Atomic"))
 
     def setDefaultPartitioning(self, storage):
         autorequests = [PartSpec(mountpoint="/", fstype=storage.defaultFSType,


### PR DESCRIPTION
RHELAtomicInstallClass inherits from RHELBaseInstallClass so we can't
rely on BaseInstallClass default hidden=False

Resolves: rhbz#1265213