### PR TITLE
Mount stage2 cdrom after running driver-updates (#1266478)

### DIFF
--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -47,6 +47,15 @@ if str_starts "$kickstart" "cdrom" && [ ! -e /tmp/ks.cfg.done ]; then
     fi
 fi
 
+# If interactive dd has been requested and this is a cdrom, wait to mount it
+# later. The user may want to swap in a driver update cdrom first.
+if [ -e /tmp/dd_interactive -a ! -e /tmp/dd.done ]; then
+    if dev_is_cdrom "$dev"; then
+        > /tmp/anaconda-dd-on-cdrom
+        exit 0
+    fi
+fi
+
 info "anaconda using disk root at $dev"
 mount $dev $repodir || warn "Couldn't mount $dev"
 anaconda_live_root_dir $repodir $path

--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -617,6 +617,13 @@ def main(args):
 
     finish(request)
 
+    # When using inst.dd and a cdrom stage2 it isn't mounted before running driver-updates
+    # In order to get the stage2 cdrom mounted it either needs to be swapped back in
+    # or we need to re-trigger the block rules.
+    if os.path.exists("/tmp/anaconda-dd-on-cdrom") and not os.path.exists("/dev/root"):
+        cmd = ["udevadm", "trigger", "--action=change", "--subsystem-match=block"]
+        subprocess.check_call(cmd)
+
 if __name__ == '__main__':
     setup_log()
     try:


### PR DESCRIPTION
driver-updates is now running from the initqueue. When booting from an
iso the stage2 would already be mounted, meaning it could not be ejected
to swap in a driver update cdrom.

This patch delays mounting the cdrom until after driver-updates has
been run, allowing it to be swapped for a DUD and swapped back in.

Resolves: rhbz#1266478