### PR TITLE
Verify downloaded packages using key provided with "repo --gpgkey" option

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1575,7 +1575,7 @@ class RaidData(commands.raid.F23_RaidData):
                                      parents=request)
             storage.createDevice(luksdev)
 
-class RepoData(commands.repo.F21_RepoData):
+class RepoData(commands.repo.F24_RepoData):
     def __init__(self, *args, **kwargs):
         """ Add enabled kwarg
 
@@ -1585,7 +1585,7 @@ class RepoData(commands.repo.F21_RepoData):
         self.enabled = kwargs.pop("enabled", True)
         self.repo_id = kwargs.pop("repo_id", None)
 
-        commands.repo.F21_RepoData.__init__(self, *args, **kwargs)
+        commands.repo.F24_RepoData.__init__(self, *args, **kwargs)
 
 class ReqPart(commands.reqpart.F23_ReqPart):
     def execute(self, storage, ksdata, instClass):

--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -269,6 +269,10 @@ class DNFPayload(packaging.PackagePayload):
         if ksrepo.excludepkgs:
             repo.exclude = ksrepo.excludepkgs
 
+        if ksrepo.gpgkey:
+            repo.gpgkey = ksrepo.gpgkey
+            repo.gpgcheck = True
+
         # If this repo is already known, it's one of two things:
         # (1) The user is trying to do "repo --name=updates" in a kickstart file
         #     and we should just know to enable the already existing on-disk

--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -728,7 +728,13 @@ class DNFPayload(packaging.PackagePayload):
                 _failure_limbo()
 
         # Verify GPG signatures
-        self.gpgsigcheck(pkgs_to_download)
+        try:
+            self.gpgsigcheck(pkgs_to_download)
+        except dnf.exceptions.Error as e:
+            msg = 'Signature verification failed: %s' % str(e)
+            exc = packaging.PayloadInstallError(msg)
+            if errors.errorHandler.cb(exc) == errors.ERROR_RAISE:
+                _failure_limbo()
 
         log.info('Downloading packages finished.')
 


### PR DESCRIPTION
This depends on pykickstart support
https://github.com/rhinstaller/pykickstart/pull/32

The `gpgsigcheck` function is almost 1-1 copy from dnf/cli/cli.py.

Warning: I haven't tested this in this particular case, but very similar code in [pungi](https://pagure.io/pungi/pull-request/63) and [livecd-tools](https://github.com/rhinstaller/livecd-tools/pull/14) works just fine.

One thing I'm not sure about is error reporting: currently signature verification failure causes `dnf.exceptions.Error`, which isn't handled by this code. Should some other exception be used? Or something else (`errors.errorHandler`?)?
