### PR TITLE
Check minimal memory requirements properly (#1267673)

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -460,7 +460,7 @@ def check_memory(anaconda, options, display_mode=None):
         display_mode = anaconda.displayMode
 
     reason = reason_strict
-    total_ram = int(isys.total_memory())
+    total_ram = int(isys.total_memory() / 1024)
     needed_ram = int(isys.MIN_RAM)
     graphical_ram = int(isys.MIN_GUI_RAM)
 


### PR DESCRIPTION
isys.total_memory() returns memory size in kB, while isys.MIN_RAM and isys.MIN_GUI_RAM are in MB.

Resolves: rhbz#1267673