### PR TITLE
Limit DNF's parallel downloads to 1 connection when using a proxy

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -409,6 +409,9 @@ class DNFPayload(packaging.PackagePayload):
                 if proxy.password:
                     conf.proxy_password = proxy.password
                 log.info("Using %s as proxy", self.data.method.proxy)
+
+                # Prevent parallel downloads from swamping the proxy
+                conf.max_parallel_downloads = 1
             except ProxyStringError as e:
                 log.error("Failed to parse proxy for dnf configure %s: %s",
                           self.data.method.proxy, e)


### PR DESCRIPTION
When using a proxy all connections are funneled through a single system,
parallel downloads can overwhelm the proxy and don't add any
benefit so limit it to 1.