### PR TITLE
don't delete shared/boot parts in deleteAll (#1183880)

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -377,7 +377,7 @@ class ConfirmDeleteDialog(GUIObject):
         self.window.destroy()
 
     # pylint: disable=arguments-differ
-    def refresh(self, mountpoint, device, rootName, snapshots=False):
+    def refresh(self, mountpoint, device, rootName, snapshots=False, bootpart=False):
         GUIObject.refresh(self)
         label = self.builder.get_object("confirmLabel")
 
@@ -385,7 +385,7 @@ class ConfirmDeleteDialog(GUIObject):
             rootName = rootName.replace("_", "__")
         self._removeAll.set_label(
                 C_("GUI|Custom Partitioning|Confirm Delete Dialog",
-                    "Delete _all other file systems in the %s root as well.")
+                    "Delete _all other file systems which are only used by %s as well.")
                 % rootName)
         self._removeAll.set_sensitive(rootName is not None)
 
@@ -394,7 +394,9 @@ class ConfirmDeleteDialog(GUIObject):
         else:
             txt = device
 
-        if not snapshots:
+        if bootpart:
+            label_text = _("%s may be a system boot partition! Deleting it may break other operating systems. Are you sure you want to delete it?") % txt
+        elif not snapshots:
             label_text = _("Are you sure you want to delete all of the data on %s?") % txt
         else:
             label_text = _("Are you sure you want to delete all of the data on %s, including snapshots and/or subvolumes?") % txt


### PR DESCRIPTION
This is one potential approach to help with #1183880 . It
changes the deleteAll behaviour as follows:

* Partitions known to be shared with other OSes won't be deleted
* Boot partitions won't be deleted if there are unknown parts

You can delete these partitions only by specifically targeting
them. It also adds a variant of the ConfirmDeleteDialog for
boot partitions, with text specifically explaining that they
might be needed for other OSes to boot.

This is my alternative to #377 - I'm just providing it as an option. We could pull the ConfirmDeleteDialog change out of this as a standalone to go along with dlehman's minimal change to the 'delete other partitions' text, also?