### PR TITLE
Lookup IPv6 address without brackets (#1267872)

### DIFF
--- a/pyanaconda/vnc.py
+++ b/pyanaconda/vnc.py
@@ -112,7 +112,7 @@ class VncServer:
             ipstr = self.ip
 
         try:
-            hinfo = socket.gethostbyaddr(ipstr)
+            hinfo = socket.gethostbyaddr(self.ip)
             if len(hinfo) == 3:
                 # Consider as coming from a valid DNS record only if single IP is returned
                 if len(hinfo[2]) == 1:


### PR DESCRIPTION
The brackets are added for display, gethostbyaddr doesn't like them.

Resolves: rhbz#1267872