### PR TITLE
Add support for other systemd units to kickstart service command

### DIFF
--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -189,3 +189,7 @@ X_DISPLAY_NUMBER = 1
 PAYLOAD_STATUS_PROBING_STORAGE = N_("Probing storage...")
 PAYLOAD_STATUS_PACKAGE_MD = N_("Downloading package metadata...")
 PAYLOAD_STATUS_GROUP_MD = N_("Downloading group metadata...")
+
+# systemd unit suffixes from http://www.freedesktop.org/software/systemd/man/systemd.unit.html
+SYSTEMD_UNITS = ("service", "socket", "device", "mount", "automount", "swap",
+                 "target", "path", "timer", "snapshot", "slice", "scope")

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -44,7 +44,7 @@ import os
 import os.path
 import tempfile
 from pyanaconda.flags import flags, can_touch_runtime_system
-from pyanaconda.constants import ADDON_PATHS, IPMI_ABORTED
+from pyanaconda.constants import ADDON_PATHS, IPMI_ABORTED, SYSTEMD_UNITS
 import shlex
 import requests
 import sys
@@ -1641,13 +1641,13 @@ class SELinux(commands.selinux.FC3_SELinux):
 class Services(commands.services.FC6_Services):
     def execute(self, storage, ksdata, instClass):
         for svc in self.disabled:
-            if not svc.endswith(".service"):
+            if "." not in svc or svc.rsplit(".", 1)[-1] not in SYSTEMD_UNITS:
                 svc += ".service"
 
             iutil.execInSysroot("systemctl", ["disable", svc])
 
         for svc in self.enabled:
-            if not svc.endswith(".service"):
+            if "." not in svc or svc.rsplit(".", 1)[-1] not in SYSTEMD_UNITS:
                 svc += ".service"
 
             iutil.execInSysroot("systemctl", ["enable", svc])


### PR DESCRIPTION
.service isn't the only unit type, if the user specifies a specific
unit, don't add .service to the end. If no service is specified, add
.service.