### PR TITLE
Add support for other systemd units to kickstart service command

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1641,15 +1641,9 @@ class SELinux(commands.selinux.FC3_SELinux):
 class Services(commands.services.FC6_Services):
     def execute(self, storage, ksdata, instClass):
         for svc in self.disabled:
-            if not svc.endswith(".service"):
-                svc += ".service"
-
             iutil.execInSysroot("systemctl", ["disable", svc])
 
         for svc in self.enabled:
-            if not svc.endswith(".service"):
-                svc += ".service"
-
             iutil.execInSysroot("systemctl", ["enable", svc])
 
 class SshKey(commands.sshkey.F22_SshKey):


### PR DESCRIPTION
.service isn't the only unit type, stop adding it to the end to allow
units like fstrim.timer to be enabled. If there is no .service suffix
systemctl will figure out the right unit to use.