### PR TITLE
dracut: accept inst.dd=[file:]/dd.iso (#1268792)

### DIFF
--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -30,7 +30,10 @@ Usage is one of:
     driver-updates --disk DISKSTR DEVNODE
 
         DISKSTR is the string passed by the user ('/dev/sda3', 'LABEL=DD', etc.)
-        DEVNODE is the actual device node (/dev/sda3, /dev/sr0, etc.)
+        DEVNODE is the actual device node or image (/dev/sda3, /dev/sr0, etc.)
+
+        DEVNODE must be mountable, but need not actually be a block device
+        (e.g. /dd.iso is valid if the user has inserted /dd.iso into initrd)
 
     driver-updates --net URL LOCALFILE
 

--- a/dracut/parse-anaconda-dd.sh
+++ b/dracut/parse-anaconda-dd.sh
@@ -19,8 +19,10 @@ for dd in $(getargs dd= inst.dd=); do
         http:*|https:*|ftp:*|nfs:*|nfs4:*) echo $dd >> /tmp/dd_net ;;
         # disks: strip "cdrom:" or "hd:" and add to dd_disk
         cdrom:*|hd:*) echo ${dd#*:} >> /tmp/dd_disk ;;
-        # anything else is assumed to be a disk
-        *) echo $dd >> /tmp/dd_disk
+        # images crammed into initrd: strip "file:" or "path:"
+        file:*|path:*) echo ${dd#*:} >> /tmp/dd_disk ;;
+        # anything else is assumed to be a disk (or disk image)
+        *) echo $dd >> /tmp/dd_disk ;;
     esac
 done
 


### PR DESCRIPTION
Like with inst.ks=/ks.cfg, some users want to be able to inject the
driver disk into the initramfs and load it from there.

The mechanisms for doing this are already basically present, we just
need to handle it the same way we do when the kickstart is already
inside the initramfs: check to see if the requested file exists, and if
it's already present, use it as-is.

The canonical form of this argument is:

    inst.dd=file:/path/to/dd.iso

`dd.iso` can be an ISO or a driver RPM, which must be injected into the
initramfs.
`file:` may be omitted, although that practice is discouraged.
`path:` can be used instead of `file:`, but that's also discouraged.

Resolves: rhbz#1268792