### PR TITLE
network: create ifcfg files in tui if needed (#1267526)

### DIFF
--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -192,6 +192,21 @@ class NetworkSpoke(EditTUISpoke):
             # configure device
             devname = self.supported_devices[num-2]
             ndata = network.ksdata_from_ifcfg(devname)
+            if not ndata:
+                try:
+                    nm.nm_device_setting_value(devname, "connection", "uuid")
+                except nm.SettingsNotFoundError:
+                    pass
+                else:
+                    nm.nm_update_settings_of_device(devname, [['connection', 'id', devname, None]])
+                    log.debug("network: dumping ifcfg file for in-memory connection %s", devname)
+                    ndata = network.ksdata_from_ifcfg(devname)
+
+            if not ndata:
+                log.debug("network: can't find any connection for %s", devname)
+                #self.errors.append(_("Configuration of device not found"))
+                return INPUT_PROCESSED
+
             newspoke = ConfigureNetworkSpoke(self.app, self.data, self.storage,
                                     self.payload, self.instclass, ndata)
             self.app.switch_screen_modal(newspoke)


### PR DESCRIPTION
When a device is activated in dracut and ipv4 dhcp fails, while ipv6
autoconfiguration succeeds (it can happen when no ip= is specified and dracut
tries dhcp4 on all devices), ifcfg file is not created in dracut, and NM
creates in-memory connection for the active device. Installer needs to dump
this connection to ifcfg file for network tui.

In the future we want to get rid of this assumption (NICs have ifcfg files in
installer) and work with NM connections directly.