### PR TITLE
Include missing test files and scripts in Makefile.am/tarball

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -19,7 +19,7 @@
 
 scriptsdir = $(libexecdir)/$(PACKAGE_NAME)
 dist_scripts_SCRIPTS = upd-updates run-anaconda zramswapon zramswapoff zram-stats
-dist_noinst_SCRIPTS  = upd-kernel makeupdates
+dist_noinst_SCRIPTS  = upd-kernel makeupdates makebumpver
 
 dist_bin_SCRIPTS = analog anaconda-cleanup instperf anaconda-disable-nm-ibft-plugin
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -33,6 +33,9 @@
 AM_TESTS_ENVIRONMENT = top_srcdir="$(top_srcdir)" top_builddir="$(top_builddir)" ; . $(srcdir)/testenv.sh ;
 TEST_EXTENSIONS = .sh
 
+# files necessary for running the tests (make ci) from a tarball
+EXTRA_DIST = ../.coveragerc README.rst usercustomize.py
+
 # Test scripts need to be listed both here and in TESTS
 dist_check_SCRIPTS = $(srcdir)/glade/*.py \
 		     glade/run_glade_tests.sh \


### PR DESCRIPTION
This makes it possible to run `make ci` inside a tarball and fixes #391