### PR TITLE
Do not limit ONBOOT default setting to url and nfs installation metho…

### DIFF
--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -52,8 +52,6 @@ class RHELBaseInstallClass(BaseInstallClass):
         self.setDefaultPartitioning(anaconda.storage)
 
     def setNetworkOnbootDefault(self, ksdata):
-        if ksdata.method.method not in ("url", "nfs"):
-            return
         if network.has_some_wired_autoconnect_device():
             return
         # choose the device used during installation


### PR DESCRIPTION
…ds (#1269264)

It is a change of behavior caused by anaconda rebase: on media installs,
device activated in GUI is not activated automatically after reboot.

Resolves: rhbz#1269246