### PR TITLE
Kickstart test prereqs

### DIFF
--- a/tests/kickstart_tests/functions.sh
+++ b/tests/kickstart_tests/functions.sh
@@ -16,6 +16,11 @@
 #
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 
+prereqs() {
+    # No prereqs by default
+    echo
+}
+
 kernel_args() {
     echo vnc debug=1 inst.debug
 }

--- a/tests/kickstart_tests/proxy-auth.ks.in
+++ b/tests/kickstart_tests/proxy-auth.ks.in
@@ -1,4 +1,4 @@
-url --url=http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/$basearch/os/ --proxy=http://anaconda:qweqwe@127.0.0.1:8080
+url @KSTEST_URL@ --proxy=http://anaconda:qweqwe@127.0.0.1:8080
 repo --name=kstest-http --baseurl=HTTP-ADDON-REPO --proxy=http://anaconda:qweqwe@127.0.0.1:8080 --install
 install
 network --bootproto=dhcp

--- a/tests/kickstart_tests/proxy-auth.sh
+++ b/tests/kickstart_tests/proxy-auth.sh
@@ -21,6 +21,10 @@ TESTTYPE="method proxy"
 
 . ${KSTESTDIR}/functions.sh
 
+prereqs() {
+    echo proxy-common.ks
+}
+
 prepare() {
     ks=$1
     tmpdir=$2

--- a/tests/kickstart_tests/proxy-cmdline.ks.in
+++ b/tests/kickstart_tests/proxy-cmdline.ks.in
@@ -1,4 +1,4 @@
-url --url=http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/$basearch/os/
+url @KSTEST_URL@
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/proxy-cmdline.sh
+++ b/tests/kickstart_tests/proxy-cmdline.sh
@@ -21,6 +21,10 @@ TESTTYPE="method proxy"
 
 . ${KSTESTDIR}/functions.sh
 
+prereqs() {
+    echo proxy-common.ks
+}
+
 kernel_args() {
     echo vnc inst.proxy=http://127.0.0.1:8080
 }

--- a/tests/kickstart_tests/proxy-kickstart.ks.in
+++ b/tests/kickstart_tests/proxy-kickstart.ks.in
@@ -1,4 +1,4 @@
-url --url=http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/$basearch/os/ --proxy=127.0.0.1:8080
+url @KSTEST_URL@ --proxy=127.0.0.1:8080
 repo --name=kstest-http --baseurl=HTTP-ADDON-REPO --proxy=127.0.0.1:8080 --install
 install
 network --bootproto=dhcp

--- a/tests/kickstart_tests/proxy-kickstart.sh
+++ b/tests/kickstart_tests/proxy-kickstart.sh
@@ -21,6 +21,10 @@ TESTTYPE="method proxy"
 
 . ${KSTESTDIR}/functions.sh
 
+prereqs() {
+    echo proxy-common.ks
+}
+
 prepare() {
     ks=$1
     tmpdir=$2

--- a/tests/kickstart_tests/scripts/Makefile.prereqs
+++ b/tests/kickstart_tests/scripts/Makefile.prereqs
@@ -11,3 +11,14 @@
 
 # This is a regular Makefile without any automake weirdness, so just keep it
 # friendly.
+
+proxy-common.ks: proxy.py
+	@# Wrap the proxy server in a %pre script that writes the server file to
+	@# to location in the installer environment and runs it in the background
+	@server_py="$$(< proxy.py)"; \
+	echo '%pre --erroronfail' > $@
+	echo 'cat - << "EOF" > /tmp/proxy-test.py' >> $@
+	cat proxy.py >> $@
+	echo 'EOF' >> $@
+	echo 'python3 /tmp/proxy-test.py > /dev/null 2>&1 &' >> $@
+	echo '%end' >> $@

--- a/tests/kickstart_tests/scripts/Makefile.prereqs
+++ b/tests/kickstart_tests/scripts/Makefile.prereqs
@@ -22,3 +22,7 @@ proxy-common.ks: proxy.py
 	echo 'EOF' >> $@
 	echo 'python3 /tmp/proxy-test.py > /dev/null 2>&1 &' >> $@
 	echo '%end' >> $@
+
+install.img: ${IMAGE}
+	@# Extract the install.img from a boot.iso
+	isoinfo -i $${IMAGE} -R -x /images/install.img > $@

--- a/tests/kickstart_tests/scripts/Makefile.prereqs
+++ b/tests/kickstart_tests/scripts/Makefile.prereqs
@@ -1,0 +1,13 @@
+# Use this Makefile and the prereqs() function to define any objects that need
+# to be built for a particular kickstart test that could be shared by multiple
+# tests. The Makefile is run with PWD = .../kickstart_tests/scripts. The
+# following environment variables are available:
+#
+# IMAGE - the boot.iso
+# KSTESTDIR - the absolute path to the kickstart_tests directory, sans scripts/
+#
+# This file is used before gaining root privileges but sudo probably works if
+# you need it.
+
+# This is a regular Makefile without any automake weirdness, so just keep it
+# friendly.

--- a/tests/kickstart_tests/scripts/proxy.py
+++ b/tests/kickstart_tests/scripts/proxy.py
@@ -1,8 +1,11 @@
+#!/usr/bin/python3
+
 # Start a super-simple proxy server on localhost
 # A list of proxied requests will be saved to /tmp/proxy.log
-%pre --erroronfail
-# Write the proxy script to a file in /tmp
-cat - << "EOF" > /tmp/proxy-test.py
+
+# Ignore any interruptible calls
+# pylint: disable=interruptible-system-call
+
 from http.server import SimpleHTTPRequestHandler
 import socketserver
 from urllib.request import urlopen
@@ -72,8 +75,3 @@ class ProxyServer(socketserver.TCPServer):
         socketserver.TCPServer.__init__(self, ('', 8080), ProxyHandler)
 
 ProxyServer().serve_forever()
-EOF
-
-# Run the server in the background and exit
-python3 /tmp/proxy-test.py > /dev/null 2>&1 &
-%end

--- a/tests/kickstart_tests/selinux-disabled.ks.in
+++ b/tests/kickstart_tests/selinux-disabled.ks.in
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/$basearch/os/"
+url @KSTEST_URL@
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/selinux-enforcing.ks.in
+++ b/tests/kickstart_tests/selinux-enforcing.ks.in
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/$basearch/os/"
+url @KSTEST_URL@
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/selinux-permissive.ks.in
+++ b/tests/kickstart_tests/selinux-permissive.ks.in
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/$basearch/os/"
+url @KSTEST_URL@
 install
 network --bootproto=dhcp
 

--- a/tests/kickstart_tests/services.ks.in
+++ b/tests/kickstart_tests/services.ks.in
@@ -1,5 +1,5 @@
 #version=DEVEL
-url --url="http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/$basearch/os/"
+url @KSTEST_URL@
 install
 network --bootproto=dhcp
 


### PR DESCRIPTION
The prereqs idea is laying the groundwork for DUD tests that I haven't written yet.

The idea is that shared, or potentially sharable, files can be built by run_kickstart_tests before the tests are run. Building the prereq files is defined in Makefile.prereqs, and selecting the prereqs is handled by the prereqs function in <test>.sh which just echos what it wants.

The liveimg payload is only used by one test, so I could move that the prepare of liveimg.sh if anyone has opinions on that. Either way, it's two fewer environment variables that the kickstart tests need, leaving just the ostree repo and the NFS stuff.

The last two commits are because I tried testing one of the proxy tests and it ran real slow because it wasn't using the local mirror.