### PR TITLE
Add config for easier combining of kickstart and Jenkins coverage data

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,11 @@
 branch = True
 parallel = True
 source = ..
+
+# used by coverage combine
+# when combining Jenkins and kickstart_tests data
+# doesn't affect combination of pykickstart tests data
+[paths]
+source = .
+        /usr/lib*/python*/site-packages/
+        /usr/sbin/


### PR DESCRIPTION
This config change makes it possible to combine coverage data from both `make ci` and actual kickstart installations by mapping the paths to the local source repo. 