### PR TITLE
Hide the places sidebar in the ISO chooser widget.

### DIFF
--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -44,7 +44,7 @@ from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.helpers import GUIDialogInputCheckHandler, GUISpokeInputCheckHandler
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.categories.software import SoftwareCategory
-from pyanaconda.ui.gui.utils import blockedHandler, fire_gtk_action
+from pyanaconda.ui.gui.utils import blockedHandler, fire_gtk_action, find_first_child
 from pyanaconda.iutil import ProxyString, ProxyStringError, cmp_obj_attrs
 from pyanaconda.ui.gui.utils import gtk_call_once, really_hide, really_show, fancy_set_sensitive
 from pyanaconda.threads import threadMgr, AnacondaThread
@@ -328,6 +328,13 @@ class IsoChooser(GUIObject):
     def __init__(self, data):
         GUIObject.__init__(self, data)
         self._chooser = self.builder.get_object("isoChooserDialog")
+
+        # Hide the places sidebar, since it makes no sense in this context
+        # This is discouraged, but the alternative suggested is to reinvent the
+        # wheel. See also https://bugzilla.gnome.org/show_bug.cgi?id=751730
+        places_sidebar = find_first_child(self._chooser, lambda x: isinstance(x, Gtk.PlacesSidebar))
+        if places_sidebar:
+            really_hide(places_sidebar)
 
     # pylint: disable=arguments-differ
     def refresh(self, currentFile=""):

--- a/pyanaconda/ui/gui/utils.py
+++ b/pyanaconda/ui/gui/utils.py
@@ -495,3 +495,28 @@ def override_cell_property(tree_column, cell_renderer, propname, property_func, 
         tree_column.set_cell_data_func(cell_renderer, _cell_data_func)
 
     _override_cell_property_map[(tree_column, cell_renderer)][propname] = (property_func, data)
+
+def find_first_child(parent, match_func):
+    """
+    Find the first child widget of a container matching the given function.
+
+    This method performs a breadth-first search for the widget. match_func
+    takes the widget as a paramter, and the return value will be evaulated as
+    a bool.
+
+    :param GtkContainer parent: the container to search
+    :param function match_func: The function defining the condition to match
+    :return: The first matching widget
+    :rtype: GtkWidget or None
+    """
+    search_list = parent.get_children()
+
+    while search_list:
+        # Pop off the first widget, test it, and add its children to the end
+        widget = search_list.pop()
+        if match_func(widget):
+            return widget
+        if isinstance(widget, Gtk.Container):
+            search_list.extend(widget.get_children())
+
+    return None


### PR DESCRIPTION
The places make no sense in this context, so do not show them.