### PR TITLE
decode package name for /etc/sysconfig/kernel (RHBZ #1261569)

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -2345,7 +2345,7 @@ def writeSysconfigKernel(storage, version, instClass):
         log.error("failed to get package name for default kernel")
         return
 
-    kernel = h.name
+    kernel = h.name.decode()
 
     f = open(iutil.getSysroot() + "/etc/sysconfig/kernel", "w+")
     f.write("# UPDATEDEFAULT specifies if new-kernel-pkg should make\n"


### PR DESCRIPTION
Seems in Python 3 when we get a package name from RPM in this
way it comes out as a bytestring, we need a regular string as
we're going to write it into a text file. Without this fix
/etc/sysconfig/kernel gets a line:

DEFAULTKERNEL=b'kernel-core'

which obviously isn't what we wanted, and means new kernels
sometimes don't get set as the default boot option.