### PR TITLE
Warn user before using Delete all (#1183880)

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -383,9 +383,13 @@ class ConfirmDeleteDialog(GUIObject):
 
         if rootName and "_" in rootName:
             rootName = rootName.replace("_", "__")
+        delete_all_text = (C_("GUI|Custom Partitioning|Confirm Delete Dialog",
+                               "Delete _all other file systems in the %s root as well.") +
+                           "\n" +
+                           C_("GUI|Custom Partitioning|Confirm Delete Dialog",
+                               "(This includes those used by other installed operating systems.)"))
         self._removeAll.set_label(
-                C_("GUI|Custom Partitioning|Confirm Delete Dialog",
-                    "Delete _all other file systems in the %s root as well.")
+                delete_all_text
                 % rootName)
         self._removeAll.set_sensitive(rootName is not None)
 


### PR DESCRIPTION
Warn user that "Delete all" checkbox removes even shared partitions.
Thank you for this patch @dwlehman .

*Resolves: rhbz#1183880*

----------------------------------
This *should* be final patch for this bug to F23 based on https://github.com/rhinstaller/anaconda/pull/377#issuecomment-144808251 .