### PR TITLE
Changes in network state revalidate sources rhbz#1270354

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -313,6 +313,7 @@ class NetworkControlBox(GObject.GObject):
         self.builder = builder
         self._running_nmce = None
         self.spoke = spoke
+        self.settings_changed = False
 
         # button for creating of virtual bond and vlan devices
         self.builder.get_object("add_toolbutton").set_sensitive(True)
@@ -597,6 +598,7 @@ class NetworkControlBox(GObject.GObject):
                 uuid, devname, activate_condition = activate # pylint: disable=unpacking-non-sequence
                 if activate_condition():
                     gtk_call_once(self._activate_connection_cb, uuid, devname)
+            self.settings_changed = True
             network.logIfcfgFiles("nm-c-e run")
 
     def _activate_connection_cb(self, uuid, devname):
@@ -617,6 +619,7 @@ class NetworkControlBox(GObject.GObject):
         if not dev_cfg:
             return
 
+        self.settings_changed = True
         log.info("network: device %s switched %s", dev_cfg.get_iface(), "on" if active else "off")
 
         if dev_cfg.device_type == NetworkManager.DeviceType.WIFI:
@@ -766,6 +769,7 @@ class NetworkControlBox(GObject.GObject):
     def remove_device(self, device):
         # This should not concern wifi and ethernet devices,
         # just virtual devices e.g. vpn probably
+        self.settings_changed = True
         log.debug("network: GUI, device removed: %s" , device.get_iface())
         dev_cfg = self.dev_cfg(device=device)
         if dev_cfg:
@@ -1411,6 +1415,16 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
     def apply(self):
         _update_network_data(self.data, self.network_control_box)
         log.debug("network: apply ksdata %s", self.data.network)
+
+        if self.network_control_box.settings_changed:
+            log.debug("network spoke (apply) refresh payload")
+            from pyanaconda.packaging import payloadMgr
+            payloadMgr.restartThread(self.storage, self.data, self.payload, self.instclass,
+                                     fallback=not anaconda_flags.automatedInstall)
+            self.network_control_box.settings_changed = False
+        else:
+            log.debug("network spoke (apply), no changes detected")
+
         self.network_control_box.kill_nmce(msg="leaving network spoke")
 
     def execute(self):

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -52,6 +52,7 @@ class NetworkSpoke(EditTUISpoke):
         self.hostname_dialog.value = self.data.network.hostname
         self.supported_devices = []
         self.errors = []
+        self._apply = False
 
     def initialize(self):
         self._load_new_devices()
@@ -214,6 +215,7 @@ class NetworkSpoke(EditTUISpoke):
             network.update_settings_with_ksdata(devname, ndata)
 
             if ndata._apply:
+                self._apply = True
                 uuid = nm.nm_device_setting_value(devname, "connection", "uuid")
                 try:
                     nm.nm_activate_device_connection(devname, uuid)
@@ -228,6 +230,12 @@ class NetworkSpoke(EditTUISpoke):
     def apply(self):
         " Apply all of our settings."""
         self._update_network_data()
+
+        if self._apply:
+            self._apply = False
+            from pyanaconda.packaging import payloadMgr
+            payloadMgr.restartThread(self.storage, self.data, self.payload,
+                                     self.instclass, checkmount=False)
 
     def _update_network_data(self):
         hostname = self.data.network.hostname


### PR DESCRIPTION
When altering the network state, it may result in selected
network sources becoming inaccessable due to typos in DNS
or GATEWAY.

With this patch, after the network spoke completes it tells
the software payload to revalidate its state.  If the state
becomes invalid, the source spoke errors will guide towards
what is wrong.

Resolves: rhbz#1270354