### PR TITLE
network: Don't set --device link default for hostname only network cm…

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1070,6 +1070,19 @@ class Logging(commands.logging.FC6_Logging):
             logger.updateRemote(remote_server)
 
 class Network(commands.network.RHEL7_Network):
+    def parse(self, args):
+        nd = commands.network.RHEL7_Network.parse(self, args)
+        setting_only_hostname = nd.hostname and len(args) <= 2
+        if not setting_only_hostname:
+            if not nd.device:
+                ksdevice = flags.cmdline.get('ksdevice')
+                if ksdevice:
+                    log.info('network: setting %s from ksdevice for missing kickstart --device', ksdevice)
+                    nd.device = ksdevice
+                else:
+                    log.info('network: setting "link" for missing --device specification in kickstart')
+                    nd.device = "link"
+        return nd
     def execute(self, storage, ksdata, instClass):
         network.write_network_config(storage, ksdata, instClass, iutil.getSysroot())
 

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -1181,7 +1181,7 @@ def update_hostname_data(ksdata, hostname):
 
 def get_device_name(network_data):
 
-    ksspec = network_data.device or flags.cmdline.get('ksdevice') or "link"
+    ksspec = network_data.device or ""
     dev_name = ks_spec_to_device_name(ksspec)
     if not dev_name:
         return ""


### PR DESCRIPTION
…d (#1272274)

network --hostname=blah

used in %pre section could override a device configuration with dhcp which is a
regression caused by commit 7473be3d9c5f0c2b434e4c86231b73e72ffe64f9

Resolves: rhbz#1272274