### PR TITLE
 Cleaner logging of .treeinfo return conditions in dependant function

### DIFF
--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -405,8 +405,10 @@ class Payload(object):
                 version = "rawhide"
             except configparser.Error:
                 pass
+            log.debug("using treeinfo release version of %s", version)
+        else:
+            log.debug("using default release version of %s", version)
 
-        log.debug("got a release version of %s", version)
         return version
 
     ##


### PR DESCRIPTION
Use of the fall through value should be logged a bit more clearly.