### PR TITLE
Don't set BOOTPROTO= when it isn't set

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -170,7 +170,7 @@ class DriverDisk(commands.driverdisk.F14_DriverDisk, DracutArgsMixin):
 
         return "\n".join(dd_args)
 
-class Network(commands.network.F22_Network, DracutArgsMixin):
+class Network(commands.network.F24_Network, DracutArgsMixin):
     def dracut_args(self, args, lineno, net):
         '''
         NOTE: The first 'network' line get special treatment:
@@ -414,7 +414,8 @@ def ksnet_to_ifcfg(net, filename=None):
     add_s390_settings(dev, ifcfg)
 
     # dhcp etc.
-    ifcfg['BOOTPROTO'] = net.bootProto
+    if net.bootProto != "":
+        ifcfg['BOOTPROTO'] = net.bootProto
     if net.bootProto == 'static':
         ifcfg['IPADDR'] = net.ip
         ifcfg['NETMASK'] = net.netmask

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1084,9 +1084,9 @@ class Logging(commands.logging.FC6_Logging):
                 remote_server = "%s:%s" %(self.host, self.port)
             logger.updateRemote(remote_server)
 
-class Network(commands.network.F22_Network):
+class Network(commands.network.F24_Network):
     def __init__(self, *args, **kwargs):
-        commands.network.F22_Network.__init__(self, *args, **kwargs)
+        commands.network.F24_Network.__init__(self, *args, **kwargs)
         self.packages = []
 
     def setup(self):

--- a/tests/dracut_tests/parse-kickstart_test.py
+++ b/tests/dracut_tests/parse-kickstart_test.py
@@ -234,6 +234,22 @@ network --device br0 --activate --bootproto dhcp --bridgeslaves=eth0 --bridgeopt
             self.assertEqual(bridge_lines[5], "TYPE=Ethernet\n", bridge_lines)
             self.assertTrue(bridge_lines[6].startswith("UUID="), bridge_lines)
 
+    def network_ipv6_only_test(self):
+        with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
+            ks_file.write("""network --noipv4 --hostname=blah.test.com --ipv6=1:2:3:4:5:6:7:8 --device lo --nameserver=1:1:1:1::,2:2:2:2::""")
+            ks_file.flush()
+            lines = self.execParseKickstart(ks_file.name)
+
+            ifcfg_lines = sorted(open(self.tmpdir+"/ifcfg/ifcfg-lo").readlines())
+            self.assertEqual(ifcfg_lines[1], "DEVICE=lo\n", ifcfg_lines)
+            self.assertEqual(ifcfg_lines[2], "DNS1=1:1:1:1::\n", ifcfg_lines)
+            self.assertEqual(ifcfg_lines[3], "DNS2=2:2:2:2::\n", ifcfg_lines)
+            self.assertEqual(ifcfg_lines[4], "IPV6ADDR=1:2:3:4:5:6:7:8\n", ifcfg_lines)
+            self.assertEqual(ifcfg_lines[5], "IPV6INIT=yes\n", ifcfg_lines)
+            self.assertEqual(ifcfg_lines[6], "IPV6_AUTOCONF=no\n", ifcfg_lines)
+            self.assertEqual(ifcfg_lines[7], "ONBOOT=yes\n", ifcfg_lines)
+            self.assertTrue(ifcfg_lines[8].startswith("UUID="), ifcfg_lines)
+
     def network_vlanid_test(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
             ks_file.write("""network --device=link --bootproto=dhcp --activate


### PR DESCRIPTION
BOOTPROTO= is ipv4 specific, so if we don't have an ipv4 configuration this just
confuses network manager.  With the fix to pykickstart we no longer set
net.bootProto if we haven't specified one, so don't write out a blank one to the
ifcfg script.

Signed-off-by: Josef Bacik <jbacik@fb.com>