### PR TITLE
Revert "Use yum to install the mock buildroot for now."

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -89,9 +89,9 @@ release:
 	$(MAKE) dist && $(MAKE) tag && git checkout -- $(srcdir)/po/$(PACKAGE_NAME).pot
 
 rc-release: scratch-bumpver scratch
-	mock --yum -r $(MOCKCHROOT) --scrub all || exit 1
-	mock --yum -r $(MOCKCHROOT) --buildsrpm  --spec ./$(PACKAGE_NAME).spec --sources . --resultdir $(PWD) || exit 1
-	mock --yum -r $(MOCKCHROOT) --rebuild *src.rpm --resultdir $(PWD) || exit 1
+	mock -r $(MOCKCHROOT) --scrub all || exit 1
+	mock -r $(MOCKCHROOT) --buildsrpm  --spec ./$(PACKAGE_NAME).spec --sources . --resultdir $(PWD) || exit 1
+	mock -r $(MOCKCHROOT) --rebuild *src.rpm --resultdir $(PWD) || exit 1
 
 bumpver: po-pull
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \


### PR DESCRIPTION
The yum mode is hopelessly slow, and we can work around the man-db
problem in https://bugzilla.redhat.com/show_bug.cgi?id=1269665 by doing
other people's jobs for them and putting it in a local repo.

This reverts commit 37f36b78c366753b683cf71bd4d1276d48ef789e.