### PR TITLE
Fix bad space needed messages

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -1,7 +1,7 @@
 # dnfpayload.py
 # DNF/rpm software payload management.
 #
-# Copyright (C) 2013  Red Hat, Inc.
+# Copyright (C) 2013-2015  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -18,6 +18,7 @@
 # Red Hat, Inc.
 #
 # Red Hat Author(s): Ales Kozumplik <akozumpl@redhat.com>
+#                    Jiri Konecny   <jkonecny@redhat.com>
 #
 import os
 
@@ -594,6 +595,20 @@ class DNFPayload(packaging.PackagePayload):
         log.debug("Bonus size %s by number of files %s", bonus_size, files_nm)
         log.debug("Total size required %s", total_space)
         return total_space
+
+    def requiredDeviceSize(self, format_class):
+        """ We need to provide information how big device is required to have successful
+            installation. ``format_class`` should be filesystem format
+            class for the **root** filesystem this class carry information about
+            metadata size.
+
+            :param format_class: Class of the filesystem format.
+            :type format_class: Class which inherits :class:`blivet.formats.fs.FS`
+            :returns: Size of the device with given filesystem format.
+            :rtype: :class:`blivet.size.Size`
+        """
+        device_size = format_class.getRequiredSize(self.spaceRequired)
+        return device_size.roundToNearest(Size("1 MiB"))
 
     def _isGroupVisible(self, grpid):
         grp = self._base.comps.group_by_pattern(grpid)

--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -32,6 +32,7 @@ from pyanaconda.i18n import _, C_, N_, P_
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.utils import blockedHandler, escape_markup, timed_action
 from blivet.size import Size
+from blivet.formats.fs import FS
 
 __all__ = ["ResizeDialog"]
 
@@ -84,7 +85,8 @@ class ResizeDialog(GUIObject):
 
         self._required_label = self.builder.get_object("requiredSpaceLabel")
         markup = self._required_label.get_label()
-        self._required_label.set_markup(markup % escape_markup(str(self.payload.spaceRequired)))
+        required_dev_size = self.payload.requiredDeviceSize(FS.biggestOverheadFS())
+        self._required_label.set_markup(markup % escape_markup(str(required_dev_size)))
 
         self._reclaimDescLabel = self.builder.get_object("reclaimDescLabel")
 
@@ -314,7 +316,8 @@ class ResizeDialog(GUIObject):
             self._deleteButton.set_sensitive(False)
 
     def _update_reclaim_button(self, got):
-        self._resizeButton.set_sensitive(got+self._initialFreeSpace >= self.payload.spaceRequired)
+        required_dev_size = self.payload.requiredDeviceSize(FS.biggestOverheadFS())
+        self._resizeButton.set_sensitive(got+self._initialFreeSpace >= required_dev_size)
 
     # pylint: disable=arguments-differ
     def refresh(self, disks):

--- a/pyanaconda/ui/lib/space.py
+++ b/pyanaconda/ui/lib/space.py
@@ -77,7 +77,8 @@ class FileSystemSpaceChecker(object):
         log.info("fs space: %s  needed: %s", free, needed)
         self.success = (free > needed)
         if not self.success:
-            self.deficit = needed - free
+            dev_required_size = self.payload.requiredDeviceSize(self.storage.rootDevice.format)
+            self.deficit = dev_required_size - self.storage.rootDevice.size
             self.error_message = _(self.error_template) % self.deficit
 
         return self.success
@@ -108,7 +109,8 @@ class DirInstallSpaceChecker(FileSystemSpaceChecker):
         log.info("fs space: %s  needed: %s", free, needed)
         self.success = (free > needed)
         if not self.success:
-            self.deficit = needed - free
+            dev_required_size = self.payload.requiredDeviceSize(self.storage.rootDevice.format)
+            self.deficit = dev_required_size - self.storage.rootDevice.size
             self.error_message = _(self.error_template) % self.deficit
 
         return self.success


### PR DESCRIPTION
When we reduce metadata from device size in space check we also
need to tell user how much space he needs on root to get installation
done. That means we need to add metadata in count when calculating this
space deficit.

I need this PR: https://github.com/rhinstaller/blivet/pull/255 in blivet to make this work.