### PR TITLE
add kickstart_tests/driverdisk-auto

### DIFF
--- a/tests/kickstart_tests/driverdisk-auto.ks.in
+++ b/tests/kickstart_tests/driverdisk-auto.ks.in
@@ -1,0 +1,39 @@
+#version=DEVEL
+url @KSTEST_URL@
+install
+network --bootproto=dhcp
+
+keyboard us
+lang en_US.UTF-8
+timezone America/New_York --utc
+rootpw testcase
+shutdown
+
+bootloader --timeout=1
+zerombr
+clearpart --all
+autopart
+
+driverdisk /dev/disk/by-label/TESTDD2
+
+%packages
+@core
+%end
+
+%post --nochroot
+SYSROOT=${ANA_INSTALL_PATH:-/mnt/sysimage}
+RESULTFILE=$SYSROOT/root/RESULT
+fail() { echo "*** $*" >> $RESULTFILE; }
+
+# check if OEMDRV got loaded
+[ -f /lib/modules/`uname -r`/updates/fake-dd.ko ] || fail "OEMDRV not loaded"
+[ -f $SYSROOT/root/fake-dd-2.ko ] || fail "OEMDRV not installed"
+
+# check if the second disk got loaded (it contains binaries)
+[ -f /usr/bin/fake-dd-bin ] || fail "TESTDD2 not loaded"
+
+# write successful result if nothing failed
+if [[ ! -e $RESULTFILE ]]; then
+    echo SUCCESS > $RESULTFILE
+fi
+%end

--- a/tests/kickstart_tests/driverdisk-auto.sh
+++ b/tests/kickstart_tests/driverdisk-auto.sh
@@ -1,0 +1,34 @@
+# Copyright (c) 2015 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author: Will Woods <wwoods@redhat.com>
+
+TESTTYPE="driverdisk"
+
+. ${KSTESTDIR}/functions.sh
+
+prepare_disks() {
+    local diskdir="$1"
+    # main disk
+    qemu-img create -q -f qcow2 ${diskdir}/disk-a.img 10G
+    echo "${diskdir}/disk-a.img"
+
+    # OEMDRV driverdisk containing kernel modules
+    ${KSTESTDIR}/../lib/mkdud.py -k -L OEMDRV ${diskdir}/oemdrv.iso >/dev/null
+    echo "${diskdir}/oemdrv.iso,device=cdrom,readonly=on"
+
+    # second driverdisk contains binaries
+    ${KSTESTDIR}/../lib/mkdud.py -k -L TESTDD2 ${diskdir}/dd2.iso >/dev/null
+}


### PR DESCRIPTION
This test does two things:
1. Test that the installer auto-loads driver disks labeled OEMDRV
2. Test that the installer can load multiple driver disks

Related: rhbz#1268792
