### PR TITLE
Use py3.4 crypt and salt

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -28,6 +28,7 @@ import blivet
 from parted import PARTITION_BIOS_GRUB
 from glob import glob
 from itertools import chain
+import crypt
 
 from pyanaconda import iutil
 from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
@@ -1104,17 +1105,8 @@ class GRUB(BootLoader):
         if not self.password:
             raise BootLoaderError("cannot encrypt empty password")
 
-        # Used for ascii_letters and digits constants
-        import string # pylint: disable=deprecated-module
-        import crypt
-        import random
-        salt = "$6$"
-        salt_len = 16
-        salt_chars = string.ascii_letters + string.digits + './'
-
-        rand_gen = random.SystemRandom()
-        salt += "".join(rand_gen.choice(salt_chars) for i in range(salt_len))
-        self.encrypted_password = crypt.crypt(self.password, salt)
+        # Encrypt using sha512 and 16 character salt
+        self.encrypted_password = crypt.crypt(self.password, crypt.METHOD_SHA512)
 
     def write_config_password(self, config):
         """ Write password-related configuration. """


### PR DESCRIPTION
There was some question as to whether /dev/urandom was being used for
generating user password salts, this switches to using the Python 3.4
crypt.mksalt which uses the /dev/urandom