### PR TITLE
Only raise thread exceptions once (#1276579)

### DIFF
--- a/pyanaconda/threads.py
+++ b/pyanaconda/threads.py
@@ -253,9 +253,10 @@ class AnacondaThread(threading.Thread):
             threading.Thread.run(self, *args, **kwargs)
         # pylint: disable=bare-except
         except:
-            threadMgr.set_error(self.name, *sys.exc_info())
             if self._fatal:
                 sys.excepthook(*sys.exc_info())
+            else:
+                threadMgr.set_error(self.name, *sys.exc_info())
         finally:
             threadMgr.remove(self.name)
             log.info("Thread Done: %s (%s)", self.name, self.ident)


### PR DESCRIPTION
If the thread is fatal (the default) any exceptions will be processed
through sys.excepthook. If that happens the exception doesn't need to be
saved in threadMgr.

What was happening here is that one thread was waiting for
THREAD_STORAGE to finish, when THREAD_STORAGE raised an error it was
stored in threadMgr, and processed with execpthook. The threadMgr.wait()
saw the error and also passed it on for processing, resulting in 2 error
dialogs and anaconda-tb-* files.