### PR TITLE
allow repo with only a name if it's a pre-defined one (#1277638)

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -876,8 +876,9 @@ class DNFPayload(packaging.PackagePayload):
             log.debug("repo %s: mirrorlist %s, baseurl %s",
                       ksrepo.name, ksrepo.mirrorlist, ksrepo.baseurl)
             # one of these must be set to create new repo
-            if not (ksrepo.mirrorlist or ksrepo.baseurl):
-                raise packaging.PayloadSetupError("Repository %s has no mirror or baseurl set"
+            if not (ksrepo.mirrorlist or ksrepo.baseurl or ksrepo.name in self._base.repos):
+                raise packaging.PayloadSetupError("Repository %s has no mirror or baseurl set "
+                                                  "and is not one of the pre-defined repositories"
                                                   % ksrepo.name)
 
             self._add_repo(ksrepo)


### PR DESCRIPTION
this recently-added check is too broad; a repo without a URL
or mirrorlist is allowed if the name is one of the pre-defined
repos in /etc/anaconda.repos.d , and in fact this style is
specifically mentioned in the documentation, as the way to
use one of the pre-defined-but-disabled-by-default repos.