### PR TITLE
Make it possible to run ./anaconda from git

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -179,6 +179,10 @@ def setupPythonUpdates():
     from distutils.sysconfig import get_python_lib
     import gi.overrides
 
+    if "ANACONDA_WIDGETS_OVERRIDES" in os.environ:
+        for path in os.environ["ANACONDA_WIDGETS_OVERRIDES"].split(":"):
+            gi.overrides.__path__.insert(0, os.path.abspath(path))
+
     # Temporary hack for F18 alpha to symlink updates and product directories
     # into tmpfs.  To be removed after beta in order to directly use content
     # from /run/install/ -- JLK

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -633,7 +633,7 @@ class GraphicalUserInterface(UserInterface):
         ANACONDA_WINDOW_GROUP.add_window(self.mainWindow)
 
     basemask = "pyanaconda.ui"
-    basepath = os.path.dirname(__file__)
+    basepath = os.path.dirname(os.path.dirname(__file__))
     updatepath = "/tmp/updates/pyanaconda/ui"
     sitepackages = [os.path.join(dir, "pyanaconda", "ui")
                     for dir in site.getsitepackages()]

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -833,8 +833,10 @@ class GraphicalUserInterface(UserInterface):
             settings.set_property("gtk-icon-theme-name", "gnome")
 
             # Apply the application stylesheet
+            css_path = os.environ.get("ANACONDA_DATA", "/usr/share/anaconda")
+            css_path = os.path.join(css_path, "anaconda-gtk.css")
             provider = Gtk.CssProvider()
-            provider.load_from_path("/usr/share/anaconda/anaconda-gtk.css")
+            provider.load_from_path(css_path)
             Gtk.StyleContext.add_provider_for_screen(Gdk.Screen.get_default(), provider,
                     Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 

--- a/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
+++ b/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
@@ -60,7 +60,7 @@ class LangLocaleHandler(object):
 
     def initialize(self):
         # Render an arrow for the chosen language
-        datadir = os.environ.get("ANACONDA_WIDGETS_DATADIR", "/usr/share/anaconda")
+        datadir = os.environ.get("ANACONDA_WIDGETS_DATA", "/usr/share/anaconda")
         self._right_arrow = Gtk.Image.new_from_file(os.path.join(datadir, "pixmaps", "right-arrow-icon.png"))
         self._left_arrow = Gtk.Image.new_from_file(os.path.join(datadir, "pixmaps", "left-arrow-icon.png"))
         override_cell_property(self._langSelectedColumn, self._langSelectedRenderer,

--- a/pyanaconda/ui/tui/__init__.py
+++ b/pyanaconda/ui/tui/__init__.py
@@ -104,7 +104,7 @@ class TextUserInterface(ui.UserInterface):
         self.quitMessage = quitMessage
 
     basemask = "pyanaconda.ui"
-    basepath = os.path.dirname(__file__)
+    basepath = os.path.dirname(os.path.dirname(__file__))
     updatepath = "/tmp/updates/pyanaconda/ui"
     sitepackages = [os.path.join(dir, "pyanaconda", "ui")
                     for dir in site.getsitepackages()]

--- a/tests/pyanaconda_tests/lang_locale_handler_test.py
+++ b/tests/pyanaconda_tests/lang_locale_handler_test.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Alexander Todorov <atodorov@redhat.com>
+#
+
+from pyanaconda.ui.gui.spokes.lib.lang_locale_handler import LangLocaleHandler
+import unittest
+import mock
+import os
+
+@unittest.skipUnless(os.environ.get("DISPLAY"), "DISPLAY is not defined")
+class LLH(unittest.TestCase):
+    def setUp(self):
+        self.llh = LangLocaleHandler()
+        self.llh._languageStoreFilter = mock.Mock()
+        self.llh._langSelectedRenderer = mock.Mock()
+        self.llh._langSelectedColumn = mock.Mock()
+        self.llh._add_language = mock.Mock()
+
+        self.orig_anaconda_widgets_data = os.environ.get("ANACONDA_WIDGETS_DATA", "")
+        if not "ANACONDA_WIDGETS_DATA" in os.environ:
+            widgets_data = os.path.dirname(os.path.abspath(__file__))
+            widgets_data = os.path.dirname(os.path.dirname(widgets_data))
+            widgets_data = os.path.join(widgets_data, "widgets", "data")
+            # pylint: disable=environment-modify
+            os.environ["ANACONDA_WIDGETS_DATA"] = widgets_data
+
+    def tearDown(self):
+        # pylint: disable=environment-modify
+        os.environ["ANACONDA_WIDGETS_DATA"] = self.orig_anaconda_widgets_data
+
+    def anaconda_widgets_data_test(self):
+        """Test if ANACONDA_WIDGETS_DATA is used if specified."""
+        self.llh.initialize()
+        self.assertEqual(self.llh._right_arrow.get_property('file').find("/usr/share/anaconda"), -1)
+        self.assertEqual(self.llh._left_arrow.get_property('file').find("/usr/share/anaconda"), -1)


### PR DESCRIPTION
Several minor fixes which make it possible to execute ./anaconda from the git checkout without having anaconda RPMs installed on the system. This is strictly for testing purposes. I intend to refactor the Dogtail tests to use `anaconda --image` instead of a VM. 

If you want to play with it you have to add something like this in Makefile.am:

```
runanaconda:
       ANACONDA_DATA=$(abs_srcdir)/data \
       ANACONDA_WIDGETS_OVERRIDES=$(abs_srcdir)/widgets/python \
       ANACONDA_WIDGETS_DATA=$(abs_srcdir)/widgets/data \
       ANACONDA_INSTALL_CLASSES=$(abs_srcdir)/pyanaconda/installclasses \
       PYTHONPATH=$(abs_srcdir):$(abs_builddir)/pyanaconda/isys/.libs:$(abs_srcdir)/widgets/python/:$(abs_builddir)/widgets/src/.libs/ \
       LD_LIBRARY_PATH=$(abs_builddir)/widgets/src/.libs \
       UIPATH=$(abs_srcdir)/pyanaconda/ui/gui/ \
       GI_TYPELIB_PATH=$(abs_builddir)/widgets/src/ \
       GLADE_CATALOG_SEARCH_PATH=$(abs_srcdir)/widgets/glade \
       GLADE_MODULE_SEARCH_PATH=$(abs_builddir)/widgets/src/.libs \
       $(abs_srcdir)/anaconda -G --dirinstall /var/tmp/anaconda-install/
```