### PR TITLE
Use /usr/bin/mock for systems where /usr/sbin is listed before /usr/bin in PATH

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -89,9 +89,9 @@ release:
 	$(MAKE) dist && $(MAKE) tag && git checkout -- $(srcdir)/po/$(PACKAGE_NAME).pot
 
 rc-release: scratch-bumpver scratch
-	mock -r $(MOCKCHROOT) --scrub all || exit 1
-	mock -r $(MOCKCHROOT) --buildsrpm  --spec ./$(PACKAGE_NAME).spec --sources . --resultdir $(PWD) || exit 1
-	mock -r $(MOCKCHROOT) --rebuild *src.rpm --resultdir $(PWD) || exit 1
+	/usr/bin/mock -r $(MOCKCHROOT) --scrub all || exit 1
+	/usr/bin/mock -r $(MOCKCHROOT) --buildsrpm  --spec ./$(PACKAGE_NAME).spec --sources . --resultdir $(PWD) || exit 1
+	/usr/bin/mock -r $(MOCKCHROOT) --rebuild *src.rpm --resultdir $(PWD) || exit 1
 
 bumpver: po-pull
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \


### PR DESCRIPTION
When I try `make ci` on a Rawhide system I get the following error:

```
ERROR: [Errno 1] Operation not permitted

ERROR: The most common cause for this error is trying to run /usr/sbin/mock as an unprivileged user.
ERROR: Check your path to make sure that /usr/bin/ is listed before /usr/sbin, or manually run /usr/bin/mock to see if that fixes this problem.

$ echo $PATH
/usr/lib64/qt-3.3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin

$ cat /etc/redhat-release 
Fedora release 24 (Rawhide)
```

Using the full path `/usr/bin/mock` fixes this.