### PR TITLE
Combine results from all gettext_tests into one log file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -174,6 +174,7 @@ ci: rc-release
 	$(MAKE) TMPDIR=/var/tmp COVERAGE_PROCESS_START=$(abs_builddir)/.coveragerc check
 	@sudo $(MAKE) TMPDIR=/var/tmp COVERAGE_PROCESS_START=$(abs_builddir)/.coveragerc \
 		TESTS=nosetests_root.sh check
+	@tail -n 1 tests/gettext_tests/*.log > tests/gettext_tests/gettext_tests.log
 	@mkdir -p repo
 	@mv *rpm repo
 	@createrepo -p repo


### PR DESCRIPTION
Several of the gettext tests call make which produces very verbose output. Here only the last lines are collected to produce something like:
```
==> tests/gettext_tests/click.py.log <==
PASS gettext_tests/click.py (exit status: 0)

==> tests/gettext_tests/contexts.py.log <==
PASS gettext_tests/contexts.py (exit status: 0)

==> tests/gettext_tests/gettext_potfiles.py.log <==
PASS gettext_tests/gettext_potfiles.py (exit status: 0)

==> tests/gettext_tests/gettext_warnings.log <==
PASS gettext_tests/gettext_warnings.sh (exit status: 0)

==> tests/gettext_tests/style_guide.py.log <==
PASS gettext_tests/style_guide.py (exit status: 0)
```