### PR TITLE
Remove uses of broad-except.

### DIFF
--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -382,7 +382,7 @@ class RescueMountSpoke(NormalTUISpoke):
                     pass
             except (ValueError, LookupError, SyntaxError, NameError):
                 pass
-            except Exception as e: # pylint: disable=broad-except
+            except (OSError, StorageError) as e:
                 if flags.automatedInstall:
                     msg = _("Run %s to unmount the system when you are finished.\n") % ANACONDA_CLEANUP
 


### PR DESCRIPTION
Catching Exception hides bugs and we should avoid it whenever possible.
Keep the broad excepts in TUI since it's using them to send the
exception elsewhere, and be more particular everywhere else.