### PR TITLE
Include original kickstart in logs (#1227939)

### DIFF
--- a/data/post-scripts/99-copy-logs.ks
+++ b/data/post-scripts/99-copy-logs.ks
@@ -9,4 +9,6 @@ cp /tmp/ks-script*.log $ANA_INSTALL_PATH/var/log/anaconda/
 journalctl -b > $ANA_INSTALL_PATH/var/log/anaconda/journal.log
 chmod 0600 $ANA_INSTALL_PATH/var/log/anaconda/*
 
+[ -e /run/install/ks.cfg ] && cp /run/install/ks.cfg $ANA_INSTALL_PATH/root/original-ks.cfg
+
 %end


### PR DESCRIPTION
Having the original un-modified kickstart can sometimes be useful,
include it in /var/log/anaconda/ks.cfg

Resolves: rhbz#1227939