### PR TITLE
Set the window icon

### DIFF
--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -396,6 +396,10 @@ class MainWindow(Gtk.Window):
         # inside the window, the titlebar text is redundant and should be disabled.
         self.set_title("")
 
+        # Set the icon used in the taskbar of window managers that have a taskbar
+        # The "anaconda" icon is part of fedora-logos
+        self.set_icon_name("anaconda")
+
         # Treat an attempt to close the window the same as hitting quit
         self.connect("delete-event", self._on_delete_event)
 


### PR DESCRIPTION
Non-GNOME live window managers have a taskbar with an icon, and right
now that icon is the default window icon. fedora-logos already contains
an icon that we use for the liveinst launcher, so use it in this
context, too.