### PR TITLE
Replace execReadlines with check_output in parse-kickstart_test.py

### DIFF
--- a/tests/dracut_tests/parse-kickstart_test.py
+++ b/tests/dracut_tests/parse-kickstart_test.py
@@ -24,7 +24,7 @@ import os
 import unittest
 import tempfile
 import shutil
-from pyanaconda import iutil
+import subprocess
 
 class BaseTestCase(unittest.TestCase):
     def setUp(self):
@@ -52,7 +52,11 @@ class ParseKickstartTestCase(BaseTestCase):
         cls.command = os.path.abspath(os.path.join(os.environ["top_srcdir"], "dracut/parse-kickstart"))
 
     def execParseKickstart(self, ks_file):
-        return list(iutil.execReadlines(self.command, ["--tmpdir", self.tmpdir, ks_file], filter_stderr=True))
+        try:
+            output = subprocess.check_output([self.command, "--tmpdir", self.tmpdir, ks_file], universal_newlines=True)
+        except subprocess.CalledProcessError as e:
+            return str(e).splitlines()
+        return str(output).splitlines()
 
     def cdrom_test(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:


### PR DESCRIPTION
When running from the cmdline with:
PYTHONPATH=../pykickstart/ ./tests/nosetests.sh ./tests/dracut_tests/parse-kickstart_test.py

The PYTHONPATH would get removed, parse-kickstart would fail, but no
traceback was visible because execReadlines raised an error instead of
processing the output.