### PR TITLE
Make sure python3.5 code can run in early initrd

### DIFF
--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -215,7 +215,7 @@ set_neednet() {
 }
 
 parse_kickstart() {
-    /sbin/parse-kickstart $1 > /etc/cmdline.d/80-kickstart.conf
+    PYTHONHASHSEED=42 /sbin/parse-kickstart $1 > /etc/cmdline.d/80-kickstart.conf
     unset CMDLINE  # re-read the commandline
     . /tmp/ks.info # save the parsed kickstart
     [ -e "$parsed_kickstart" ] && cp $parsed_kickstart /run/install/ks.cfg

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -25,7 +25,14 @@
 # Authors:
 #   Will Woods <wwoods@redhat.com>
 
-import sys, os
+## XXX HACK - Monkeypatch os.urandom to use /dev/urandom not getrandom()
+## XXX HACK - which will block until pool is initialized which takes forever
+import os
+def ks_random(num_bytes):
+    return open("/dev/urandom", "rb").read(num_bytes)
+os.urandom = ks_random
+
+import sys
 import logging
 import shutil
 import uuid


### PR DESCRIPTION
There are 2 problems with running python3.5 early in the initrd when
entropy is low and the nonblocking pool hasn't been initialized yet:
    
    1. cpython runs getrandom() syscall to see the object id hash. This
    blocks until the pool is initialized and isn't critical from a security
    standpoint. Override this with PYTHONHASHSEED=42
    
    2. Python3.5 uses getrandom() syscall for urandom(), this also blocks
    instead of falling back to reading /dev/urandom like it did in py3.4
    this is fixed by monkeypatching os.urandom to just read /dev/urandom
    in parse-kickstart -- important because we still want unique UUIDs for
    networking.
