### PR TITLE
Automatically generate sr@latin.po

### DIFF
--- a/po/Rules-sr-latin
+++ b/po/Rules-sr-latin
@@ -1,0 +1,10 @@
+# Generate sr@latin.po
+
+# The Serbian language is written in two scripts: Cyrillic and Latin. The
+# Serbian translators provide the translations in Cyrillic, in sr.po, and
+# these strings can automatically be converted into Latin for sr@latin.po.
+
+DISTFILES.common.extra3 = Rules-sr-latin
+
+sr@latin.po-create: sr.po
+	$(MSGFILTER) -i sr.po -o sr@latin.po recode-sr-latin

--- a/zanata.xml
+++ b/zanata.xml
@@ -70,7 +70,6 @@
     <locale>ro</locale>
     <locale>ru</locale>
     <locale>sr</locale>
-    <locale>sr@latin</locale>
     <locale>si</locale>
     <locale>sk</locale>
     <locale>sl</locale>


### PR DESCRIPTION
The modern Serbian language exhibits synchronic digraphia, which is an
interesting few minutes on Wikipedia and means that it can be written in
two different ways. The Serbian translators provide a translation in
Cyrillic, and from that we can generate the translation in Latin. Stop
pulling sr@latin.po from Zanata, since no one updates it there, and add
a new Makefile rule to generate one from sr.po using a filter program
that comes with gettext.