### PR TITLE
Replace <list>.delete() with <list>.remove() in user.py

### DIFF
--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -486,7 +486,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
             if "wheel" not in self._user.groups:
                 self._user.groups.append("wheel")
         elif "wheel" in self._user.groups:
-            self._user.groups.delete("wheel")
+            self._user.groups.remove("wheel")
 
     def _checkPasswordEmpty(self, inputcheck):
         """Check whether a password has been specified at all.


### PR DESCRIPTION
Python doesn't support 'list'.delete() function. This results in an exception during installation when the admin status of an user  is toggled in User creation page during installation. Using 'list'.remove() instead will fix this issue.