### PR TITLE
Change parameter at ks.cfg for fcoe as --nic= (#1225877)

### DIFF
--- a/storage/fcoe.py
+++ b/storage/fcoe.py
@@ -150,7 +150,7 @@ class fcoe(object):
     def writeKS(self, f):
         for nic, dcb, auto_vlan in self.nics:
             if nic in self.ksnics:
-                line = "fcoe --nic %s" % nic
+                line = "fcoe --nic=%s" % nic
                 if dcb:
                     line += " --dcb"
                 if auto_vlan:


### PR DESCRIPTION
We wrote output ks.cfg with ``fcoe --nic eth0`` but it's different from the documentation where we have ``fcoe --nic=eth0``. The output was modified in order to be consistent with the documentation.

I don't have fcoe so I couldn't test it. Could you please have a look on this @rvykydal  if this seems good to you?

*Resolves: rhbz#1225877*