### PR TITLE
Add nospacecheck argument to bypass space checking

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -870,6 +870,7 @@ if __name__ == "__main__":
     flags.selinux = opts.selinux
     flags.eject = opts.eject
     flags.kexec = opts.kexec
+    flags.nospacecheck = opts.nospacecheck
 
     # Switch to tty1 on exception in case something goes wrong during X start.
     # This way if, for example, metacity doesn't start, we switch back to a

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -235,3 +235,9 @@ be retried if there is no listener (ie. won't block the installation).
 kexec
 Reboot the system using kexec with the new kernel and initrd. This will result in
 a faster reboot by skipping the BIOS/Firmware and bootloader steps.
+
+nospacecheck
+Disable space requirement check in the installation. You still get warning message
+when the root partition is too small but the installation process can be started
+anyway.
+This could result in failed installation or the installed system could be broken!

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -587,6 +587,16 @@ Also note that while SELinux is running in the installation environment by
 default, it is running in permissive mode so disabling it there does not make
 much sense.
 
+.. inst.nospacecheck:
+
+inst.nospacecheck
+^^^^^^^^^^^^^^^^^
+
+Disable space requirement check in the installation. You still get warning message
+when the root partition is too small but the installation process can be started
+anyway.
+This could result in failed installation or the installed system could be broken!
+
 Third-party options
 ^^^^^^^^^^^^^^^^^^^
 

--- a/pyanaconda/anaconda_argparse.py
+++ b/pyanaconda/anaconda_argparse.py
@@ -506,6 +506,8 @@ def getArgumentParser(version_string, boot_cmdline=None):
                     help=help_parser.help_text("mpathfriendlynames"))
     ap.add_argument("--kexec", action="store_true", default=False,
                     help=help_parser.help_text("kexec"))
+    ap.add_argument("--nospacecheck", action="store_true", default=False,
+                    help=help_parser.help_text("nospacecheck"))
 
     # some defaults change based on cmdline flags
     if boot_cmdline is not None:

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -78,6 +78,7 @@ class Flags(object):
         self.leavebootorder = False
         self.testing = False
         self.mpathFriendlyNames = True
+        self.nospacecheck = False
         # ksprompt is whether or not to prompt for missing ksdata
         self.ksprompt = True
         self.rescue_mode = False

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -253,7 +253,13 @@ class Hub(GUIObject, common.Hub):
 
     @property
     def continuePossible(self):
-        return len(self._incompleteSpokes) == 0 and len(self._notReadySpokes) == 0 and getattr(self._checker, "success", True)
+        if len(self._incompleteSpokes) == 0 and len(self._notReadySpokes) == 0:
+            if flags.nospacecheck:
+                return True
+            else:
+                return getattr(self._checker, "success", True)
+
+        return False
 
     def _updateContinueButton(self):
         self.window.set_may_continue(self.continuePossible)

--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -126,9 +126,11 @@ class SummaryHub(TUIHub):
                         return False
                 # do a bit of final sanity checking, making sure pkg selection
                 # size < available fs space
+                # only print warning if nospacecheck flag is set
                 if self._checker and not self._checker.check():
                     print(self._checker.error_message)
-                    return False
+                    if not flags.nospacecheck:
+                        return False
                 if self.app._screens:
                     self.app.close_screen()
                     return True


### PR DESCRIPTION
Adding inst.nospacecheck boot option and --nospacecheck argument.

User still gets about the space needed but the installation could be started.

This is some kind of follow-up on space check patches. 