### PR TITLE
rpmostreepayload: Only add remote if it doesn't exist

### DIFF
--- a/pyanaconda/packaging/rpmostreepayload.py
+++ b/pyanaconda/packaging/rpmostreepayload.py
@@ -141,7 +141,7 @@ class RPMOSTreePayload(ArchivePayload):
 
         # Store this for use in postInstall too, where we need to
         # undo/redo this step.
-        self._base_remote_args = ["remote", "add"]
+        self._base_remote_args = ["remote", "add", "--if-not-exists"]
         if ((hasattr(ostreesetup, 'noGpg') and ostreesetup.noGpg) or
             (hasattr(ostreesetup, 'nogpg') and ostreesetup.nogpg)):
             self._base_remote_args.append("--set=gpg-verify=false")


### PR DESCRIPTION
This is an adaption of a downstream patch I made for CentOS:

https://git.centos.org/blob/rpms!anaconda.git/17adf5cf56966781bc4aa4ee262b99fbddca42ec/SOURCES!9800-rpmostreepayload-Rework-remote-add-handling.patch

which also had a more invasive change to use the OSTree API rather
than just calling out to subprocess. Let's not try to do that right
now, rather just get this small change in.

The core issue here is that CentOS wants to ship the OSTree remote in
a `centos-release-atomic` RPM that ships as part of the ostree commit
itself.

By default, rpmostreepayload tries to add the remote that was
specified in the kickstart file, which will fail if it already exists.
OSTree was enhanced to have an `--if-not-exists` for this exact
reason, we just need to use it.

This would match how Fedora does yum configs, and would make sense,
but at the moment Fedora Atomic Host injects it in the kickstart so we
don't see these bugs there.  Red Hat Enterprise Linux just always uses
subscription-manager.
