### PR TITLE
Enable multiselection in Custom spoke

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.glade
+++ b/pyanaconda/ui/gui/spokes/custom.glade
@@ -253,7 +253,7 @@
                                 <property name="show_tabs">False</property>
                                 <property name="show_border">False</property>
                                 <child>
-                                  <object class="GtkLabel" id="whenCreateLabel">
+                                  <object class="GtkLabel" id="pageLabel">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="wrap">True</property>

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -83,7 +83,7 @@ from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.helpers import StorageChecker
 from pyanaconda.ui.gui.spokes.lib.cart import SelectedDisksDialog
 from pyanaconda.ui.gui.spokes.lib.passphrase import PassphraseDialog
-from pyanaconda.ui.gui.spokes.lib.accordion import updateSelectorFromDevice, Accordion, Page, CreateNewPage, UnknownPage
+from pyanaconda.ui.gui.spokes.lib.accordion import update_selector_from_device, Accordion, Page, CreateNewPage, UnknownPage
 from pyanaconda.ui.gui.spokes.lib.refresh import RefreshDialog
 from pyanaconda.ui.gui.spokes.lib.summary import ActionSummaryDialog
 
@@ -469,7 +469,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
     def _populate_accordion(self):
         # Make sure we start with a clean state.
-        self._accordion.removeAllPages()
+        self._accordion.remove_all_pages()
 
         new_devices = self.get_new_devices()
 
@@ -487,7 +487,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                                  self.on_create_clicked,
                                  self._change_autopart_type,
                                  partitionsToReuse=bool(ui_roots) or bool(self.unusedDevices))
-            self._accordion.addPage(page, cb=self.on_page_clicked)
+            self._accordion.add_page(page, cb=self.on_page_clicked)
 
             self._partitionsNotebook.set_current_page(NOTEBOOK_LABEL_PAGE)
             self._whenCreateLabel.set_text(_("When you create mount points for "
@@ -523,7 +523,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                    (root.name != translated_new_install_name() and not device.format.exists):
                     continue
 
-                selector = page.addSelector(device, self.on_selector_clicked,
+                selector = page.add_selector(device, self.on_selector_clicked,
                                             mountpoint=mountpoint)
                 selector.root = root
 
@@ -532,21 +532,21 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                    (root.name != translated_new_install_name() and not device.format.exists):
                     continue
 
-                selector = page.addSelector(device, self.on_selector_clicked)
+                selector = page.add_selector(device, self.on_selector_clicked)
                 selector.root = root
 
             page.show_all()
-            self._accordion.addPage(page, cb=self.on_page_clicked)
+            self._accordion.add_page(page, cb=self.on_page_clicked)
 
         # Anything that doesn't go with an OS we understand?  Put it in the Other box.
         if self.unusedDevices:
             page = UnknownPage(_("Unknown"))
 
             for u in sorted(self.unusedDevices, key=lambda d: d.name):
-                page.addSelector(u, self.on_selector_clicked)
+                page.add_selector(u, self.on_selector_clicked)
 
             page.show_all()
-            self._accordion.addPage(page, cb=self.on_page_clicked)
+            self._accordion.add_page(page, cb=self.on_page_clicked)
 
     def _do_refresh(self, mountpointToShow=None):
         # block mountpoint selector signal handler for now
@@ -563,8 +563,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         # And then open the first page by default.  Most of the time, this will
         # be fine since it'll be the new installation page.
         self._initialized = True
-        firstPage = self._accordion.allPages[0]
-        self._accordion.expandPage(firstPage.pageTitle)
+        firstPage = self._accordion.all_pages[0]
+        self._accordion.expand_page(firstPage.pageTitle)
         self._show_mountpoint(page=firstPage, mountpoint=mountpointToShow)
 
         self._applyButton.set_sensitive(False)
@@ -590,7 +590,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
             devices = list(set(devices))
 
         for _device in devices:
-            page.addSelector(_device, self.on_selector_clicked)
+            page.add_selector(_device, self.on_selector_clicked)
 
         page.show_all()
 
@@ -599,7 +599,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         # we're only updating selectors in the new root. problem?
         page = self._accordion._find_by_title(translated_new_install_name()).get_child()
         for selector in page.members:
-            updateSelectorFromDevice(selector, selector.device)
+            update_selector_from_device(selector, selector.device)
 
     def _replace_device(self, **kwargs):
         """ Create a replacement device and update the device selector. """
@@ -612,21 +612,21 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
         if selector:
             # update the selector with the new device and its size
-            updateSelectorFromDevice(selector, new_device)
+            update_selector_from_device(selector, new_device)
 
     def _update_device_in_selectors(self, old_device, new_device):
-        for s in self._accordion.allSelectors:
+        for s in self._accordion.all_selectors:
             if s._device == old_device:
-                updateSelectorFromDevice(s, new_device)
+                update_selector_from_device(s, new_device)
 
     def _update_all_devices_in_selectors(self):
-        for s in self._accordion.allSelectors:
+        for s in self._accordion.all_selectors:
             for new_device in self._storage_playground.devices:
                 if ((s._device.name == new_device.name) or
                     (getattr(s._device, "req_name", 1) == getattr(new_device, "req_name", 2)) and
                     s._device.type == new_device.type and
                     s._device.format.type == new_device.format.type):
-                    updateSelectorFromDevice(s, new_device)
+                    update_selector_from_device(s, new_device)
                     break
             else:
                 log.warning("failed to replace device: %s", s._device)
@@ -792,7 +792,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
             # The selector shows the visible disk, so it is necessary
             # to use device and size, which are the values visible to
             # the user.
-            for s in self._accordion.allSelectors:
+            for s in self._accordion.all_selectors:
                 if s._device == device:
                     s.size = str(device.size)
 
@@ -857,20 +857,20 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         else:
             # first, remove this selector from any old install page(s)
             new_selector = None
-            for (page, _selector) in self._accordion.allMembers:
+            for (page, _selector) in self._accordion.all_members:
                 if _selector.device in (device, old_device):
                     if page.pageTitle == translated_new_install_name():
                         new_selector = _selector
                         continue
 
-                    page.removeSelector(_selector)
+                    page.remove_selector(_selector)
                     if not page.members:
                         log.debug("removing empty page %s", page.pageTitle)
-                        self._accordion.removePage(page.pageTitle)
+                        self._accordion.remove_page(page.pageTitle)
 
             # either update the existing selector or add a new one
             if new_selector:
-                updateSelectorFromDevice(new_selector, device)
+                update_selector_from_device(new_selector, device)
             else:
                 self.add_new_selector(device)
 
@@ -1208,7 +1208,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                 log.debug("updating mountpoint of %s to %s", device.name, mountpoint)
                 device.format.mountpoint = mountpoint
                 if old_mountpoint:
-                    updateSelectorFromDevice(selector, device)
+                    update_selector_from_device(selector, device)
                 else:
                     # add an entry to the new page but do not remove any entries
                     # from other pages since we haven't altered the filesystem
@@ -1231,7 +1231,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                     use_dev.name = old_name
                     self.set_info(_("Specified name %s already in use.") % new_name)
                 else:
-                    updateSelectorFromDevice(selector, device)
+                    update_selector_from_device(selector, device)
 
         self._populate_right_side(selector)
 
@@ -1903,7 +1903,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
         skip_dialog = False
         is_multiselection = self._accordion.is_multiselection
-        for selector in self._accordion.selectedPages:
+        for selector in self._accordion.selected_pages:
             page = self._current_page
             device = selector.device
             root_name = None

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -469,12 +469,37 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
     def _set_page_label_text(self):
         if self._accordion.is_multiselection:
-            self._pageLabel.set_text(_("Select a single mount point to edit properties."))
+            select_tmpl = _("{fmt_start}{selected}{fmt_end} of "
+                            "{fmt_start}{total}{fmt_end} mount "
+                            "points in {fmt_start}{name}{fmt_end}")
+            color_tmpl = _("<span size='large' weight='bold' fgcolor='{}'>")
+            pages_count = ""
+            for page in self._accordion.all_pages:
+                if not page.members:
+                    continue
+
+                if not page.selected_members:
+                    style = color_tmpl.format("gray")
+                    page_line = "<span fgcolor='gray'>" + select_tmpl + "</span>"
+                else:
+                    style = color_tmpl.format("black")
+                    page_line = select_tmpl
+
+                page_line = page_line.format_map({"selected" : len(page.selected_members),
+                                                  "total"    : len(page.members),
+                                                  "name"     : page.pageTitle,
+                                                  "fmt_start": style,
+                                                  "fmt_end"  : "</span>"})
+                pages_count += page_line + "\n"
+
+            self._pageLabel.set_markup(_("Please select a single mount point to edit properties.\n\n"
+                                         "You have currently selected:\n"
+                                         "{pages}").format_map({"pages" : pages_count}))
         else:
             self._pageLabel.set_text(_("When you create mount points for "
-                    "your %(name)s %(version)s installation, you'll be able to "
-                    "view their details here.") % {"name" : productName,
-                                                   "version" : productVersion})
+                    "your {name} {version} installation, you'll be able to "
+                    "view their details here.").format_map({"name"    : productName,
+                                                            "version" : productVersion}))
     def _populate_accordion(self):
         # Make sure we start with a clean state.
         self._accordion.remove_all_pages()

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -220,6 +220,13 @@ class Accordion(Gtk.Box):
     def selected_items(self):
         return self._active_selectors
 
+    def page_for_selector(self, selector):
+        """ Return page for given selector. """
+        for page in self.all_pages:
+            for s in page.members:
+                if s is selector:
+                    return page
+
     def expand_page(self, pageTitle):
         page = self._find_by_title(pageTitle)
         if not page:
@@ -235,7 +242,9 @@ class Accordion(Gtk.Box):
             return
 
         self._expanders.remove(target)
-        self._active_selectors.remove(target)
+        for s in target.members:
+            if s in self._active_selectors:
+                self._active_selectors.remove(s)
 
         # Then, remove it from the box.
         self.remove(target)
@@ -245,6 +254,8 @@ class Accordion(Gtk.Box):
             self.remove(e)
 
         self._expanders = []
+        self._active_selectors = []
+        self._current_selector = None
 
     def clear_current_selector(self):
         """ If current selector is selected, deselect it

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -37,14 +37,14 @@ from gi.repository.AnacondaWidgets import MountpointSelector
 from gi.repository import Gtk
 
 __all__ = ["DATA_DEVICE", "SYSTEM_DEVICE",
-           "newSelectorFromDevice", "updateSelectorFromDevice",
+           "new_selector_from_device", "update_selector_from_device",
            "Accordion",
            "Page", "UnknownPage", "CreateNewPage"]
 
 DATA_DEVICE = 0
 SYSTEM_DEVICE = 1
 
-def updateSelectorFromDevice(selector, device, mountpoint=""):
+def update_selector_from_device(selector, device, mountpoint=""):
     """Create a MountpointSelector from a Device object template.  This
        method should be used whenever constructing a new selector, or when
        setting a bunch of attributes on an existing selector.  For just
@@ -71,10 +71,10 @@ def updateSelectorFromDevice(selector, device, mountpoint=""):
     selector.props.mountpoint = mp
     selector.device = device
 
-def newSelectorFromDevice(device, mountpoint=""):
+def new_selector_from_device(device, mountpoint=""):
     selector = MountpointSelector(device.name, str(device.size))
     selector._root = None
-    updateSelectorFromDevice(selector, device, mountpoint)
+    update_selector_from_device(selector, device, mountpoint)
 
     return selector
 
@@ -89,7 +89,7 @@ class Accordion(Gtk.Box):
         self._selected_pages = []
         self.current_selector = None
 
-    def addPage(self, contents, cb):
+    def add_page(self, contents, cb):
         label = Gtk.Label(label="""<span size='large' weight='bold' fgcolor='black'>%s</span>""" %
                           escape_markup(contents.pageTitle), use_markup=True,
                           xalign=0, yalign=0.5, wrap=True)
@@ -100,7 +100,7 @@ class Accordion(Gtk.Box):
 
         self.add(expander)
         self._expanders.append(expander)
-        expander.connect("activate", self._onExpanded, cb)
+        expander.connect("activate", self._on_expanded, cb)
         expander.show_all()
 
     def _find_by_title(self, title):
@@ -118,29 +118,29 @@ class Accordion(Gtk.Box):
         if not self.current_selector:
             return None
 
-        for page in self.allPages:
+        for page in self.all_pages:
             if self.current_selector in page.members:
                 return page
 
         return None
 
     @property
-    def allPages(self):
+    def all_pages(self):
         return [e.get_child() for e in self._expanders]
 
     @property
-    def allSelectors(self):
-        return [s for p in self.allPages for s in p.members]
+    def all_selectors(self):
+        return [s for p in self.all_pages for s in p.members]
 
     @property
-    def allMembers(self):
-        for page in self.allPages:
+    def all_members(self):
+        for page in self.all_pages:
             for member in page.members:
                 yield (page, member)
 
     @property
     def is_multiselection(self):
-        return len(self._selectedPages) > 1
+        return len(self._selected_pages) > 1
 
     @property
     def is_selected(self):
@@ -149,10 +149,10 @@ class Accordion(Gtk.Box):
         return False
 
     @property
-    def selectedPages(self):
+    def selected_pages(self):
         return self._selected_pages
 
-    def expandPage(self, pageTitle):
+    def expand_page(self, pageTitle):
         page = self._find_by_title(pageTitle)
         if not page:
             raise LookupError()
@@ -160,7 +160,7 @@ class Accordion(Gtk.Box):
         if not page.get_expanded():
             page.emit("activate")
 
-    def removePage(self, pageTitle):
+    def remove_page(self, pageTitle):
         # First, remove the expander from the list of expanders we maintain.
         target = self._find_by_title(pageTitle)
         if not target:
@@ -172,7 +172,7 @@ class Accordion(Gtk.Box):
         # Then, remove it from the box.
         self.remove(target)
 
-    def removeAllPages(self):
+    def remove_all_pages(self):
         for e in self._expanders:
             self.remove(e)
 
@@ -185,7 +185,7 @@ class Accordion(Gtk.Box):
             self.current_selector.set_chosen(False)
             self.current_selector = None
 
-    def _onExpanded(self, obj, cb=None):
+    def _on_expanded(self, obj, cb=None):
         if cb:
             cb(obj.get_child())
 
@@ -202,8 +202,8 @@ class Page(Gtk.Box):
         self._dataLabel = self._make_category_label(_("DATA"))
         really_hide(self._dataLabel)
         self._dataBox.add(self._dataLabel)
-        self._dataBox.connect("add", self._onSelectorAdded, self._dataLabel)
-        self._dataBox.connect("remove", self._onSelectorRemoved, self._dataLabel)
+        self._dataBox.connect("add", self._on_selector_added, self._dataLabel)
+        self._dataBox.connect("remove", self._on_selector_removed, self._dataLabel)
         self.add(self._dataBox)
 
         # Create the System label and a box to store all its members in.
@@ -211,8 +211,8 @@ class Page(Gtk.Box):
         self._systemLabel = self._make_category_label(_("SYSTEM"))
         really_hide(self._systemLabel)
         self._systemBox.add(self._systemLabel)
-        self._systemBox.connect("add", self._onSelectorAdded, self._systemLabel)
-        self._systemBox.connect("remove", self._onSelectorRemoved, self._systemLabel)
+        self._systemBox.connect("add", self._on_selector_added, self._systemLabel)
+        self._systemBox.connect("remove", self._on_selector_removed, self._systemLabel)
         self.add(self._systemBox)
 
         self.members = []
@@ -226,38 +226,38 @@ class Page(Gtk.Box):
         label.set_margin_left(24)
         return label
 
-    def addSelector(self, device, cb, mountpoint=""):
-        selector = newSelectorFromDevice(device, mountpoint=mountpoint)
-        selector.connect("button-press-event", self._onSelectorClicked, cb)
-        selector.connect("key-release-event", self._onSelectorClicked, cb)
-        selector.connect("focus-in-event", self._onSelectorFocusIn, cb)
+    def add_selector(self, device, cb, mountpoint=""):
+        selector = new_selector_from_device(device, mountpoint=mountpoint)
+        selector.connect("button-press-event", self._on_selector_clicked, cb)
+        selector.connect("key-release-event", self._on_selector_clicked, cb)
+        selector.connect("focus-in-event", self._on_selector_focus_in, cb)
         selector.set_margin_bottom(6)
         self.members.append(selector)
 
         # pylint: disable=no-member
-        if self._mountpointType(selector.props.mountpoint) == DATA_DEVICE:
+        if self._mountpoint_type(selector.props.mountpoint) == DATA_DEVICE:
             self._dataBox.add(selector)
         else:
             self._systemBox.add(selector)
 
         return selector
 
-    def removeSelector(self, selector):
-        if self._mountpointType(selector.props.mountpoint) == DATA_DEVICE:
+    def remove_selector(self, selector):
+        if self._mountpoint_type(selector.props.mountpoint) == DATA_DEVICE:
             self._dataBox.remove(selector)
         else:
             self._systemBox.remove(selector)
 
         self.members.remove(selector)
 
-    def _mountpointType(self, mountpoint):
+    def _mountpoint_type(self, mountpoint):
         if not mountpoint or mountpoint in ["/", "/boot", "/boot/efi", "/tmp", "/usr", "/var",
                                             "swap", "PPC PReP Boot", "BIOS Boot"]:
             return SYSTEM_DEVICE
         else:
             return DATA_DEVICE
 
-    def _onSelectorClicked(self, selector, event, cb):
+    def _on_selector_clicked(self, selector, event, cb):
         gi.require_version("Gdk", "3.0")
         from gi.repository import Gdk
 
@@ -286,15 +286,15 @@ class Page(Gtk.Box):
         # show the details for the newly selected object.
         cb(selector)
 
-    def _onSelectorFocusIn(self, selector, event, cb):
+    def _on_selector_focus_in(self, selector, event, cb):
         # could be simple lambda, but this way it looks more similar to the
-        # _onSelectorClicked
+        # _on_selector_clicked
         cb(selector)
 
-    def _onSelectorAdded(self, container, widget, label):
+    def _on_selector_added(self, container, widget, label):
         really_show(label)
 
-    def _onSelectorRemoved(self, container, widget, label):
+    def _on_selector_removed(self, container, widget, label):
         # This runs before widget is removed from container, so if it's the last
         # item then the container will still not be empty.
         if len(container.get_children()) == 1:
@@ -308,17 +308,17 @@ class UnknownPage(Page):
         self.members = []
         self.pageTitle = title
 
-    def addSelector(self, device, cb, mountpoint=""):
-        selector = newSelectorFromDevice(device, mountpoint=mountpoint)
-        selector.connect("button-press-event", self._onSelectorClicked, cb)
-        selector.connect("key-release-event", self._onSelectorClicked, cb)
+    def add_selector(self, device, cb, mountpoint=""):
+        selector = new_selector_from_device(device, mountpoint=mountpoint)
+        selector.connect("button-press-event", self._on_selector_clicked, cb)
+        selector.connect("key-release-event", self._on_selector_clicked, cb)
 
         self.members.append(selector)
         self.add(selector)
 
         return selector
 
-    def removeSelector(self, selector):
+    def remove_selector(self, selector):
         self.remove(selector)
         self.members.remove(selector)
 

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -126,6 +126,10 @@ class Accordion(Gtk.Box):
     def is_multiselection(self):
         return len(self._selectedPages) > 1
 
+    @property
+    def selectedPages(self):
+        return self._selectedPages
+
     def expandPage(self, pageTitle):
         page = self._find_by_title(pageTitle)
         if not page:
@@ -241,6 +245,7 @@ class Page(Gtk.Box):
                 if selector in accordion._selectedPages:
                     # Unselect actual item and return
                     accordion._selectedPages.remove(selector)
+                    selector.set_chosen(False)
                     return
                 else:
                     accordion._selectedPages.append(selector)

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.19.0 -->
 <interface>
   <requires lib="gtk+" version="3.2"/>
   <object class="GtkDialog" id="confirmDeleteDialog">
@@ -73,7 +73,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkCheckButton" id="removeAllCheckbox">
+          <object class="GtkCheckButton" id="optionalCheckbox">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -41,7 +41,7 @@ from pyanaconda.ui.helpers import InputCheck
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.helpers import GUIDialogInputCheckHandler
 from pyanaconda.ui.gui.utils import fancy_set_sensitive, really_hide, really_show
-from pyanaconda.i18n import _, N_, C_, CN_
+from pyanaconda.i18n import _, N_, CN_
 
 from blivet.size import Size
 from blivet.platform import platform
@@ -367,27 +367,34 @@ class ConfirmDeleteDialog(GUIObject):
 
     def __init__(self, *args, **kwargs):
         GUIObject.__init__(self, *args, **kwargs)
-        self._removeAll = self.builder.get_object("removeAllCheckbox")
+        self._optional_checkbox = self.builder.get_object("optionalCheckbox")
 
     @property
-    def deleteAll(self):
-        return self._removeAll.get_active()
+    def option_checked(self):
+        return self._optional_checkbox.get_active()
 
     def on_delete_confirm_clicked(self, button, *args):
         self.window.destroy()
 
     # pylint: disable=arguments-differ
-    def refresh(self, mountpoint, device, rootName, snapshots=False):
+    def refresh(self, mountpoint, device, checkbox_text = "", snapshots=False):
+        """ Show confirmation dialog with the optional checkbox. If the
+            `checkbox_text` for the checkbox is not set then the checkbox
+            will not be showed.
+
+            :param str mountpoint: Mountpoint for device.
+            :param str device: Name of the device.
+            :param str checkbox_text: Text for checkbox. If nothing set do
+                                      not display the checkbox.
+            :param bool snapshot: If true warn user he's going to delete snapshots too.
+        """
         GUIObject.refresh(self)
         label = self.builder.get_object("confirmLabel")
 
-        if rootName and "_" in rootName:
-            rootName = rootName.replace("_", "__")
-        self._removeAll.set_label(
-                C_("GUI|Custom Partitioning|Confirm Delete Dialog",
-                    "Delete _all other file systems in the %s root as well.")
-                % rootName)
-        self._removeAll.set_sensitive(rootName is not None)
+        if checkbox_text:
+            self._optional_checkbox.set_label(checkbox_text)
+        else:
+            self._optional_checkbox.hide()
 
         if mountpoint:
             txt = "%s (%s)" % (mountpoint, device)

--- a/widgets/src/MountpointSelector.c
+++ b/widgets/src/MountpointSelector.c
@@ -48,12 +48,14 @@
 enum {
     PROP_NAME = 1,
     PROP_SIZE,
-    PROP_MOUNTPOINT
+    PROP_MOUNTPOINT,
+    PROP_SHOW_ARROW
 };
 
 #define DEFAULT_NAME        ""
 #define DEFAULT_SIZE        N_("0 GB")
 #define DEFAULT_MOUNTPOINT  ""
+#define DEFAULT_SHOW_ARROW  TRUE
 
 struct _AnacondaMountpointSelectorPrivate {
     GtkWidget *grid;
@@ -63,6 +65,7 @@ struct _AnacondaMountpointSelectorPrivate {
     GdkCursor *cursor;
 
     gboolean   chosen;
+    gboolean   show_arrow;
     GtkWidget *parent_page;
 };
 
@@ -132,6 +135,22 @@ static void anaconda_mountpoint_selector_class_init(AnacondaMountpointSelectorCl
                                                         P_("mountpoint"),
                                                         P_("Mount point display"),
                                                         DEFAULT_MOUNTPOINT,
+                                                        G_PARAM_READWRITE));
+
+    /**
+     * AnacondaMountpointSelector:show_arrow:
+     *
+     * The #AnacondaMountpointSelector:show_arrow boolean is used when arrow on the left should
+     * or shouldn't be visible.
+     *
+     * Since: 3.4
+     */
+    g_object_class_install_property(object_class,
+                                    PROP_SHOW_ARROW,
+                                    g_param_spec_boolean("show_arrow",
+                                                        P_("show_arrow"),
+                                                        P_("Show arrow when selected"),
+                                                        DEFAULT_SHOW_ARROW,
                                                         G_PARAM_READWRITE));
 
     /**
@@ -288,19 +307,23 @@ static void anaconda_mountpoint_selector_get_property(GObject *object, guint pro
 
     switch (prop_id) {
         case PROP_NAME:
-            g_value_set_string (value, gtk_label_get_text(GTK_LABEL(priv->name_label)));
+            g_value_set_string(value, gtk_label_get_text(GTK_LABEL(priv->name_label)));
             break;
 
         case PROP_SIZE:
-            g_value_set_string (value, gtk_label_get_text(GTK_LABEL(priv->size_label)));
+            g_value_set_string(value, gtk_label_get_text(GTK_LABEL(priv->size_label)));
             break;
 
         case PROP_MOUNTPOINT:
-            g_value_set_string (value, gtk_label_get_text(GTK_LABEL(priv->mountpoint_label)));
+            g_value_set_string(value, gtk_label_get_text(GTK_LABEL(priv->mountpoint_label)));
+            break;
+
+        case PROP_SHOW_ARROW:
+            g_value_set_boolean(value, priv->show_arrow);
             break;
 
         default:
-            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
             break;
     }
 }
@@ -321,8 +344,13 @@ static void anaconda_mountpoint_selector_set_property(GObject *object, guint pro
             format_mountpoint_label(widget, g_value_get_string(value));
             break;
 
+        case PROP_SHOW_ARROW:
+            widget->priv->show_arrow = g_value_get_boolean(value);
+            anaconda_mountpoint_selector_set_chosen(widget, widget->priv->chosen);
+            break;
+
         default:
-            G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
             break;
     }
 }
@@ -365,7 +393,11 @@ void anaconda_mountpoint_selector_set_chosen(AnacondaMountpointSelector *widget,
     anaconda_mountpoint_selector_toggle_background(widget);
 
     if (is_chosen) {
-        gtk_widget_show(GTK_WIDGET(widget->priv->arrow));
+        if (widget->priv->show_arrow)
+            gtk_widget_show(GTK_WIDGET(widget->priv->arrow));
+        else
+            gtk_widget_hide(GTK_WIDGET(widget->priv->arrow));
+
         gtk_widget_grab_focus(GTK_WIDGET(widget));
     }
     else {

--- a/widgets/src/MountpointSelector.h
+++ b/widgets/src/MountpointSelector.h
@@ -65,6 +65,9 @@ GtkWidget  *anaconda_mountpoint_selector_new      ();
 gboolean    anaconda_mountpoint_selector_get_chosen (AnacondaMountpointSelector *widget);
 void        anaconda_mountpoint_selector_set_chosen (AnacondaMountpointSelector *widget, gboolean is_chosen);
 
+GtkWidget  *anaconda_mountpoint_selector_get_page (AnacondaMountpointSelector *widget);
+void        anaconda_mountpoint_selector_set_page (AnacondaMountpointSelector *widget, GtkWidget *parent_page);
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
This series of commits should add multiselection feature to Anaconda.

It supports multiselection when holding CTRL and SHIFT keys and clicking by mouse. I do not support item selection by keyboard but I think it don't work before too, so no difference here.

In these commits I have changed MountpointSelector.[c/h] so new AnacondaWidgets package is mandatory to work with this Custom spoke. 

I have a question should I increment AnacondaWidgets version or this is done by someone after some time? Also ``gi.require_version()`` for Widgets should be changed after the version increment.

Here you found screenshots:
https://jkonecny.fedorapeople.org/redhat/screenshots/multiselection/

*Resolved: 1265620*