### PR TITLE
Remove special handling for interruptible system calls.

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -36,8 +36,7 @@ import site
 
 coverage = None
 
-# If we get a signal immediately after starting that would be pretty messed up
-proc_cmdline = open("/proc/cmdline", "r").read()    # pylint: disable=interruptible-system-call
+proc_cmdline = open("/proc/cmdline", "r").read()
 proc_cmdline = proc_cmdline.split()
 if ("inst.debug=1" in proc_cmdline) or ("inst.debug" in proc_cmdline):
     import coverage
@@ -734,7 +733,6 @@ if __name__ == "__main__":
     from pyanaconda import ntp
     from pyanaconda import keyboard
     from pyanaconda.iutil import ProxyString, ProxyStringError
-    from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
     verdesc = "%s for %s %s" % (getAnacondaVersionString(),
                                 product.productName, product.productVersion)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,9 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-
 import sys, os
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -66,9 +66,6 @@ During system installation, anaconda will install the packages listed in
 /run/install/dd_packages to the target system.
 """
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-
 import logging
 import sys
 import os

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -51,16 +51,6 @@ log = logging.getLogger('parse-kickstart').addHandler(logging.NullHandler())
 
 TMPDIR = "/tmp"
 
-import functools
-def eintr_retry_call(func, *args, **kwargs):
-    """Retry an interruptible system call if interrupted."""
-    while True:
-        try:
-            return func(*args, **kwargs)
-        except InterruptedError:
-            continue
-open = functools.partial(eintr_retry_call, open) # pylint: disable=redefined-builtin
-
 # Helper function for reading simple files in /sys
 def readsysfile(f):
     '''Return the contents of f, or "" if missing.'''

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -36,7 +36,6 @@ import threading
 from pyanaconda.bootloader import get_bootloader
 from pyanaconda import constants
 from pyanaconda import iutil
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 from pyanaconda import addons
 
 import logging
@@ -213,8 +212,8 @@ class Anaconda(object):
         dump_text = exn.traceback_and_object_dump(self)
         dump_text += threads
         dump_text_bytes = dump_text.encode("utf-8")
-        iutil.eintr_retry_call(os.write, fd, dump_text_bytes)
-        iutil.eintr_ignore(os.close, fd)
+        os.write(fd, dump_text_bytes)
+        os.close(fd)
 
         # append to a given file
         with open("/tmp/anaconda-tb-all.log", "a+") as f:

--- a/pyanaconda/anaconda_argparse.py
+++ b/pyanaconda/anaconda_argparse.py
@@ -33,7 +33,6 @@ import struct
 from argparse import ArgumentParser, ArgumentError, HelpFormatter, Namespace, Action
 
 from pyanaconda.flags import BootArgs
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
 import logging
 log = logging.getLogger("anaconda")

--- a/pyanaconda/anaconda_log.py
+++ b/pyanaconda/anaconda_log.py
@@ -222,8 +222,6 @@ class AnacondaLog:
 
         Requires updating rsyslogd config and restarting rsyslog
         """
-        # Import here instead of at the module level to avoid an import loop
-        from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
         TEMPLATE = "*.* @@%s\n"
 
@@ -236,8 +234,6 @@ class AnacondaLog:
     def setupVirtio(self):
         """Setup virtio rsyslog logging.
         """
-        # Import here instead of at the module level to avoid an import loop
-        from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
         TEMPLATE = "*.* %s;anaconda_syslog\n"
 

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -31,7 +31,6 @@ from itertools import chain
 import crypt
 
 from pyanaconda import iutil
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 from blivet.devicelibs import raid
 from pyanaconda.product import productName
 from pyanaconda.flags import flags, can_touch_runtime_system
@@ -1317,12 +1316,12 @@ class GRUB(BootLoader):
                       "stage1dev": self.grub_device_name(stage1dev),
                       "stage2dev": self.grub_device_name(stage2dev)})
             (pread, pwrite) = os.pipe()
-            iutil.eintr_retry_call(os.write, pwrite, cmd.encode("utf-8"))
-            iutil.eintr_ignore(os.close, pwrite)
+            os.write(pwrite, cmd.encode("utf-8"))
+            os.close(pwrite)
             args = ["--batch", "--no-floppy",
                     "--device-map=%s" % self.device_map_file]
             rc = iutil.execInSysroot("grub", args, stdin=pread)
-            iutil.eintr_ignore(os.close, pread)
+            os.close(pread)
             if rc:
                 raise BootLoaderError("boot loader install failed")
 
@@ -1510,12 +1509,12 @@ class GRUB2(GRUB):
 
         (pread, pwrite) = os.pipe()
         passwords = "%s\n%s\n" % (self.password, self.password)
-        iutil.eintr_retry_call(os.write, pwrite, passwords.encode("utf-8"))
-        iutil.eintr_ignore(os.close, pwrite)
+        os.write(pwrite, passwords.encode("utf-8"))
+        os.close(pwrite)
         buf = iutil.execWithCapture("grub2-mkpasswd-pbkdf2", [],
                                     stdin=pread,
                                     root=iutil.getSysroot())
-        iutil.eintr_ignore(os.close, pread)
+        os.close(pread)
         self.encrypted_password = buf.split()[-1].strip()
         if not self.encrypted_password.startswith("grub.pbkdf2."):
             raise BootLoaderError("failed to encrypt boot loader password")

--- a/pyanaconda/desktop.py
+++ b/pyanaconda/desktop.py
@@ -23,7 +23,6 @@
 import os
 from pyanaconda.constants import RUNLEVELS
 from pyanaconda import iutil
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
 import logging
 log = logging.getLogger("anaconda")

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -224,12 +224,12 @@ class AnacondaExceptionHandler(ExceptionHandler):
                 and self._intf_tty_num != 1:
             iutil.vtActivate(1)
 
-        iutil.eintr_retry_call(os.open, "/dev/console", os.O_RDWR)   # reclaim stdin
-        iutil.eintr_ignore(os.dup2, 0, 1)                        # reclaim stdout
-        iutil.eintr_ignore(os.dup2, 0, 2)                        # reclaim stderr
-        #                      ^
-        #                      |
-        #                      +------ dup2 is magic, I tells ya!
+        os.open("/dev/console", os.O_RDWR)   # reclaim stdin
+        os.dup2(0, 1)                        # reclaim stdout
+        os.dup2(0, 2)                        # reclaim stderr
+        #   ^
+        #   |
+        #   +------ dup2 is magic, I tells ya!
 
         # bring back the echo
         import termios

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -26,18 +26,6 @@ from collections import OrderedDict
 import logging
 log = logging.getLogger("anaconda")
 
-# Importing iutil in this module would cause an import loop, so just
-# reimplement the open override
-import functools
-def eintr_retry_call(func, *args, **kwargs):
-    """Retry an interruptible system call if interrupted."""
-    while True:
-        try:
-            return func(*args, **kwargs)
-        except InterruptedError:
-            continue
-open = functools.partial(eintr_retry_call, open) # pylint: disable=redefined-builtin
-
 # A lot of effort, but it only allows a limited set of flags to be referenced
 class Flags(object):
     def __setattr__(self, attr, val):

--- a/pyanaconda/image.py
+++ b/pyanaconda/image.py
@@ -19,7 +19,6 @@
 
 from pyanaconda import isys
 import os, os.path, stat, tempfile
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
 from pyanaconda.errors import errorHandler, ERROR_RAISE, InvalidImageSizeError, MissingImageError
 

--- a/pyanaconda/isys/__init__.py
+++ b/pyanaconda/isys/__init__.py
@@ -33,7 +33,6 @@ import blivet.arch
 import time
 import datetime
 import pytz
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
 import logging
 log = logging.getLogger("anaconda")

--- a/pyanaconda/keyboard.py
+++ b/pyanaconda/keyboard.py
@@ -34,7 +34,6 @@ from pyanaconda import iutil
 from pyanaconda import safe_dbus
 from pyanaconda.constants import DEFAULT_VC_FONT, DEFAULT_KEYBOARD
 from pyanaconda.flags import can_touch_runtime_system
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
 import gi
 gi.require_version("GLib", "2.0")

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -39,7 +39,6 @@ import blivet.arch
 
 import glob
 from pyanaconda import iutil
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 import os
 import os.path
 import tempfile
@@ -101,9 +100,9 @@ class AnacondaKSScript(KSScript):
 
         (fd, path) = tempfile.mkstemp("", "ks-script-", scriptRoot + "/tmp")
 
-        iutil.eintr_retry_call(os.write, fd, self.script.encode("utf-8"))
-        iutil.eintr_ignore(os.close, fd)
-        iutil.eintr_retry_call(os.chmod, path, 0o700)
+        os.write(fd, self.script.encode("utf-8"))
+        os.close(fd)
+        os.chmod(path, 0o700)
 
         # Always log stdout/stderr from scripts.  Using --log just lets you
         # pick where it goes.  The script will also be logged to program.log

--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -32,7 +32,6 @@ import io
 
 from pyanaconda import constants
 from pyanaconda.iutil import upcase_first_letter, setenv, execWithRedirect
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
 import logging
 log = logging.getLogger("anaconda")

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -31,7 +31,6 @@ from gi.repository import NetworkManager
 
 import shutil
 from pyanaconda import iutil
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 import socket
 import os
 import time

--- a/pyanaconda/ntp.py
+++ b/pyanaconda/ntp.py
@@ -31,7 +31,6 @@ import ntplib
 import socket
 
 from pyanaconda import isys
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.constants import THREAD_SYNC_TIME_BASENAME
 

--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -39,7 +39,6 @@ import functools
 
 from blivet.size import Size
 from pyanaconda.iutil import requests_session
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
 if __name__ == "__main__":
     from pyanaconda import anaconda_log

--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -46,7 +46,6 @@ import sys
 import time
 import threading
 from pyanaconda.iutil import ProxyString, ProxyStringError
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
 log = logging.getLogger("packaging")
 

--- a/pyanaconda/packaging/livepayload.py
+++ b/pyanaconda/packaging/livepayload.py
@@ -35,7 +35,6 @@ from time import sleep
 from threading import Lock
 import requests
 from pyanaconda.iutil import ProxyString, ProxyStringError, lowerASCII
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 import hashlib
 import glob
 import functools
@@ -89,7 +88,7 @@ class LiveImagePayload(ImagePayload):
         # Grab the kernel version list now so it's available after umount
         self._updateKernelVersionList()
 
-        source = iutil.eintr_retry_call(os.statvfs, INSTALL_TREE)
+        source = os.statvfs(INSTALL_TREE)
         self.source_size = source.f_frsize * (source.f_blocks - source.f_bfree)
 
     def unsetup(self):
@@ -115,7 +114,7 @@ class LiveImagePayload(ImagePayload):
         while self.pct < 100:
             dest_size = 0
             for mnt in mountpoints:
-                mnt_stat = iutil.eintr_retry_call(os.statvfs, iutil.getSysroot()+mnt)
+                mnt_stat = os.statvfs(iutil.getSysroot()+mnt)
                 dest_size += mnt_stat.f_frsize * (mnt_stat.f_blocks - mnt_stat.f_bfree)
             if dest_size >= self._adj_size:
                 dest_size -= self._adj_size
@@ -451,7 +450,7 @@ class LiveImageKSPayload(LiveImagePayload):
 
             self._updateKernelVersionList()
 
-            source = iutil.eintr_retry_call(os.statvfs, INSTALL_TREE)
+            source = os.statvfs(INSTALL_TREE)
             self.source_size = source.f_frsize * (source.f_blocks - source.f_bfree)
 
     def install(self):

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -35,8 +35,6 @@ from pyanaconda.storage_utils import try_populate_devicetree
 
 from pykickstart.constants import KS_REBOOT, KS_SHUTDOWN
 
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
-
 import os
 import shutil
 import time

--- a/pyanaconda/simpleconfig.py
+++ b/pyanaconda/simpleconfig.py
@@ -26,8 +26,7 @@ import os
 import shlex
 import string # pylint: disable=deprecated-module
 import tempfile
-from pyanaconda.iutil import upperASCII, eintr_retry_call
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
+from pyanaconda.iutil import upperASCII
 
 _SAFECHARS = frozenset(string.ascii_letters + string.digits + '@%_-+=:,./')
 
@@ -82,7 +81,7 @@ def write_tmpfile(filename, data):
         m = os.stat(filename).st_mode
     else:
         m = 0o0644
-    eintr_retry_call(os.chmod, filename, m)
+    os.chmod(filename, m)
 
     # Move the temporary file over the top of the original
     os.rename(tmpf.name, filename)

--- a/pyanaconda/timezone.py
+++ b/pyanaconda/timezone.py
@@ -30,7 +30,6 @@ import langtable
 from collections import OrderedDict
 
 from pyanaconda import iutil
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 from pyanaconda.constants import THREAD_STORAGE
 from pyanaconda.flags import flags
 from pyanaconda.threads import threadMgr

--- a/pyanaconda/ui/lib/entropy.py
+++ b/pyanaconda/ui/lib/entropy.py
@@ -33,7 +33,6 @@ import math
 
 from pyanaconda.progress import progress_message
 from pyanaconda.constants import MAX_ENTROPY_WAIT
-from pyanaconda.iutil import eintr_retry_call
 from pykickstart.constants import DISPLAY_MODE_GRAPHICAL
 from blivet.util import get_current_entropy
 
@@ -118,7 +117,7 @@ def _tui_wait(msg, desired_entropy):
     # and then just read everything from the input buffer and revert the
     # termios state
     data = "have something"
-    while sys.stdin in eintr_retry_call(select.select, [sys.stdin], [], [], 0)[0] and data:
+    while sys.stdin in select.select([sys.stdin], [], [], 0)[0] and data:
         # just read from stdin and scratch the read data
         data = sys.stdin.read(1)
 

--- a/pyanaconda/ui/lib/space.py
+++ b/pyanaconda/ui/lib/space.py
@@ -103,7 +103,7 @@ class DirInstallSpaceChecker(FileSystemSpaceChecker):
                             in the info bar at the bottom of a Hub.
         """
         self.reset()
-        stat = iutil.eintr_retry_call(os.statvfs, iutil.getSysroot())
+        stat = os.statvfs(iutil.getSysroot())
         free = Size(stat.f_bsize * stat.f_bfree)
         needed = self.payload.spaceRequired
         log.info("fs space: %s  needed: %s", free, needed)

--- a/pyanaconda/users.py
+++ b/pyanaconda/users.py
@@ -27,7 +27,6 @@ from contextlib import contextmanager
 from pyanaconda import iutil
 import pwquality
 from pyanaconda.iutil import strip_accents
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 from pyanaconda.constants import PASSWORD_MIN_LEN
 from pyanaconda.errors import errorHandler, PasswordCryptError, ERROR_RAISE
 from pyanaconda.regexes import GROUPLIST_FANCY_PARSE
@@ -431,7 +430,7 @@ class Users(object):
         sshdir = os.path.join(homedir, ".ssh")
         if not os.path.isdir(sshdir):
             os.mkdir(sshdir, 0o700)
-            iutil.eintr_retry_call(os.chown, sshdir, int(uid), int(gid))
+            os.chown(sshdir, int(uid), int(gid))
 
         authfile = os.path.join(sshdir, "authorized_keys")
         authfile_existed = os.path.exists(authfile)
@@ -440,5 +439,5 @@ class Users(object):
 
         # Only change ownership if we created it
         if not authfile_existed:
-            iutil.eintr_retry_call(os.chown, authfile, int(uid), int(gid))
+            os.chown(authfile, int(uid), int(gid))
             iutil.execWithRedirect("restorecon", ["-r", sshdir])

--- a/pyanaconda/vnc.py
+++ b/pyanaconda/vnc.py
@@ -22,7 +22,6 @@
 import os, sys
 import time
 from pyanaconda import constants, network, product, iutil
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 import socket
 import subprocess
 import dbus
@@ -81,15 +80,15 @@ class VncServer:
 
         r, w = os.pipe()
         password_string = "%s\n" % self.password
-        iutil.eintr_retry_call(os.write, w, password_string.encode("utf-8"))
+        os.write(w, password_string.encode("utf-8"))
 
         with open(self.pw_file, "wb") as pw_file:
             # the -f option makes sure vncpasswd does not ask for the password again
             rc = iutil.execWithRedirect("vncpasswd", ["-f"],
                     stdin=r, stdout=pw_file, binary_output=True, log_output=False)
 
-            iutil.eintr_ignore(os.close, r)
-            iutil.eintr_ignore(os.close, w)
+            os.close(r)
+            os.close(w)
 
         return rc
 
@@ -144,7 +143,7 @@ class VncServer:
 
     def openlogfile(self):
         try:
-            fd = iutil.eintr_retry_call(os.open, self.log_file, os.O_RDWR | os.O_CREAT)
+            fd = os.open(self.log_file, os.O_RDWR | os.O_CREAT)
         except OSError as e:
             sys.stderr.write("error opening %s: %s\n", (self.log_file, e))
             fd = None

--- a/scripts/anaconda-cleanup
+++ b/scripts/anaconda-cleanup
@@ -16,7 +16,6 @@
 """
 import os
 import sys
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
 live_install = "--liveinst" in sys.argv
 image_install = False

--- a/scripts/analog
+++ b/scripts/analog
@@ -26,7 +26,6 @@ import optparse
 import os
 import os.path
 import sys
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
 DEFAULT_PORT = 6080
 DEFAULT_ANALOG_DIR = '.analog'

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -6,9 +6,6 @@
 
 """
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-
 import os
 import sys
 from subprocess import check_output, CalledProcessError

--- a/scripts/instperf
+++ b/scripts/instperf
@@ -3,7 +3,6 @@
 import logging
 from subprocess import Popen, PIPE
 import time
-from pyanaconda.iutil import open   # pylint: disable=redefined-builtin
 
 # grab the top five memory consuming processes, returning them in a string of
 # of the format:

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -20,9 +20,6 @@
 #
 # Author: David Cantrell <dcantrell@redhat.com>
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-
 import logging
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger("bugzilla")

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -21,9 +21,6 @@
 #
 # Author: David Cantrell <dcantrell@redhat.com>
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-
 import os
 import shutil
 import subprocess

--- a/tests/dd_tests/dd_test.py
+++ b/tests/dd_tests/dd_test.py
@@ -1,8 +1,5 @@
 # unit tests for driver disk utilities (utils/dd)
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-
 import os
 import shutil
 import unittest

--- a/tests/dracut_tests/parse-kickstart_test.py
+++ b/tests/dracut_tests/parse-kickstart_test.py
@@ -17,9 +17,6 @@
 #
 # Author(s): Brian C. Lane <bcl@redhat.com>
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-
 import os
 import unittest
 import tempfile

--- a/tests/dracut_tests/test_driver_updates.py
+++ b/tests/dracut_tests/test_driver_updates.py
@@ -1,8 +1,5 @@
 # test_driver_updates.py - unittests for driver_updates.py
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-
 import unittest
 try:
     import unittest.mock as mock

--- a/tests/gettext_tests/gettext_potfiles.py
+++ b/tests/gettext_tests/gettext_potfiles.py
@@ -1,8 +1,5 @@
 #!/usr/bin/python3
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-
 import os, sys, subprocess, tempfile
 
 if "top_srcdir" not in os.environ:

--- a/tests/gui/base.py
+++ b/tests/gui/base.py
@@ -17,10 +17,6 @@
 #
 # Author: Chris Lumens <clumens@redhat.com>
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-# pylint: disable=ignorable-system-call
-
 from blivet.size import MiB
 
 import os

--- a/tests/lib/shutup.py
+++ b/tests/lib/shutup.py
@@ -29,9 +29,6 @@ def shutup():
        for multithreaded applications.
     """
 
-    # Ignore all the warnings about interruptible calls
-    # pylint: disable=ignorable-system-call, interruptible-system-call
-
     # Wrap the whole thing a try-finally to ensure errors don't leak file descriptor
     old_stdout = None
     old_stderr = None

--- a/tests/pyanaconda_tests/iutil_test.py
+++ b/tests/pyanaconda_tests/iutil_test.py
@@ -19,9 +19,6 @@
 # Red Hat Author(s): Vratislav Podzimek <vpodzime@redhat.com>
 #                    Martin Kolman <mkolman@redhat.com>
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-
 from pyanaconda import iutil
 import unittest
 import os

--- a/tests/pyanaconda_tests/ks_version_test.py
+++ b/tests/pyanaconda_tests/ks_version_test.py
@@ -17,9 +17,6 @@
 #
 # Author: Chris Lumens <clumens@redhat.com>
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-
 from mock import Mock
 import unittest
 import os

--- a/tests/pyanaconda_tests/simpleconfig_test.py
+++ b/tests/pyanaconda_tests/simpleconfig_test.py
@@ -18,9 +18,6 @@
 #
 # Red Hat Author(s): Brian C. Lane <bcl@redhat.com>
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-
 from pyanaconda.simpleconfig import SimpleConfigFile
 from pyanaconda.simpleconfig import simple_replace
 from pyanaconda import simpleconfig

--- a/tests/pyanaconda_tests/user_create_test.py
+++ b/tests/pyanaconda_tests/user_create_test.py
@@ -19,9 +19,6 @@
 # Red Hat Author(s): David Shea <dshea@redhat.com>
 #
 
-# Ignore any interruptible calls
-# pylint: disable=interruptible-system-call
-
 from pyanaconda import users
 import unittest
 import tempfile


### PR DESCRIPTION
Python's signal awareness has now advanced to match other high level
languages such as C and no longer does the most annoying possible thing
on EINTR. Remove all the stuff related to that and pretend the whole
thing never happened.

https://github.com/rhinstaller/pocketlint/pull/12