### PR TITLE
Log payloadError so we know why installation failed.

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -722,6 +722,7 @@ class DNFPayload(packaging.PackagePayload):
             self._download_location = self._pick_download_location()
         except packaging.PayloadError as e:
             if errors.errorHandler.cb(e) == errors.ERROR_RAISE:
+                log.error("Installation failed: %r", e)
                 _failure_limbo()
 
         pkgs_to_download = self._base.transaction.install_set
@@ -734,6 +735,7 @@ class DNFPayload(packaging.PackagePayload):
             msg = 'Failed to download the following packages: %s' % str(e)
             exc = packaging.PayloadInstallError(msg)
             if errors.errorHandler.cb(exc) == errors.ERROR_RAISE:
+                log.error("Installation failed: %r", exc)
                 _failure_limbo()
 
         log.info('Downloading packages finished.')


### PR DESCRIPTION
Otherwise it just quits and all we have to go by is this in the logs:
Sufficient mountpoints found: {}