### PR TITLE
Fix _find_by_title method in Accordion

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -610,11 +610,11 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
     ###
     def add_new_selector(self, device):
         """ Add an entry for device to the new install Page. """
-        page = self._accordion._find_by_title(translated_new_install_name()).get_child()
+        page = self._accordion.find_page_by_title(translated_new_install_name())
         devices = [device]
         if not page.members:
             # remove the CreateNewPage and replace it with a regular Page
-            expander = self._accordion._find_by_title(translated_new_install_name())
+            expander = self._accordion.find_page_by_title(translated_new_install_name()).get_parent()
             expander.remove(expander.get_child())
 
             page = Page(translated_new_install_name())
@@ -632,7 +632,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
     def _update_selectors(self):
         """ Update all btrfs selectors' size properties. """
         # we're only updating selectors in the new root. problem?
-        page = self._accordion._find_by_title(translated_new_install_name()).get_child()
+        page = self._accordion.find_page_by_title(translated_new_install_name())
         for selector in page.members:
             update_selector_from_device(selector, selector.device)
 

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -95,10 +95,10 @@ class Accordion(Gtk.Box):
         self._current_selector = None
         self._last_selected = None
 
-    def _find_by_title(self, title):
+    def find_page_by_title(self, title):
         for e in self._expanders:
             if e.get_child().pageTitle == title:
-                return e
+                return e.get_child()
 
         return None
 
@@ -287,26 +287,27 @@ class Accordion(Gtk.Box):
                     return page
 
     def expand_page(self, pageTitle):
-        page = self._find_by_title(pageTitle)
-        if not page:
+        page = self.find_page_by_title(pageTitle)
+        expander = page.get_parent()
+        if not expander:
             raise LookupError()
 
-        if not page.get_expanded():
-            page.emit("activate")
+        if not expander.get_expanded():
+            expander.emit("activate")
 
     def remove_page(self, pageTitle):
         # First, remove the expander from the list of expanders we maintain.
-        target = self._find_by_title(pageTitle)
+        target = self.find_page_by_title(pageTitle)
         if not target:
             return
 
-        self._expanders.remove(target)
+        self._expanders.remove(target.get_parent())
         for s in target.members:
             if s in self._active_selectors:
                 self._active_selectors.remove(s)
 
         # Then, remove it from the box.
-        self.remove(target)
+        self.remove(target.get_parent())
 
     def remove_all_pages(self):
         for e in self._expanders:


### PR DESCRIPTION
It returned expander instead of page which I didn't know also this private method was called in the custom.py.

Fixed usage and renamed from _find_by_title to find_page_by_title. Now it really returns page. Please use .get_parent() method to get expander instead.