### PR TITLE
Wait for all udev events to finish (#1309348)

### DIFF
--- a/loader/linuxrc.s390
+++ b/loader/linuxrc.s390
@@ -2417,6 +2417,7 @@ function parse_dasd() {
             echo $"Not all specified DASDs could be detected within timeout."
             allgood="no"
         fi
+        udevadm settle
     fi
     while read dasditem; do
         unset range features range lo hi rangegood \


### PR DESCRIPTION
In some cases, a DASD device is not brought online by linuxrc.
Make sure that all udev events are finished before trying to
bring them online.

Resolves: rhbz#1309348