### PR TITLE
Master uefi fix2

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -70,6 +70,7 @@ from blivet.errors import NoDisksError
 from blivet.errors import NotEnoughFreeSpaceError
 from blivet.devicelibs import raid, crypto
 from blivet.devices import LUKSDevice, MDRaidArrayDevice, LVMVolumeGroupDevice
+from blivet.platform import platform
 
 from pyanaconda.storage_utils import ui_storage_logger, device_type_from_autopart
 from pyanaconda.storage_utils import DEVICE_TEXT_PARTITION, DEVICE_TEXT_MAP, DEVICE_TEXT_MD
@@ -1932,8 +1933,9 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                     self.on_selector_clicked(None, member)
                     break
 
-    def _show_confirmation_dialog(self, root_name, device):
+    def _show_confirmation_dialog(self, root_name, device, protected_types):
         dialog = ConfirmDeleteDialog(self.data)
+        bootpart = device.format.type in protected_types
         snapshots = (device.direct and not device.isleaf)
         checkbox_text = None
         if not self._accordion.is_multiselection:
@@ -1946,7 +1948,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
             checkbox_text = C_("GUI|Custom Partitioning|Confirm Delete Dialog",
                                "Do _not show this dialog for other selected file systems.")
         dialog.refresh(getattr(device.format, "mountpoint", ""),
-                       device.name, checkbox_text=checkbox_text, snapshots=snapshots)
+                       device.name, checkbox_text=checkbox_text,
+                       snapshots=snapshots, bootpart=bootpart)
         with self.main_window.enlightbox(dialog.window):
             rc = dialog.run()
             option_checked = dialog.option_checked
@@ -1961,6 +1964,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         option_checked = False
         part_removed = False
         is_multiselection = self._accordion.is_multiselection
+        protected_types = platform.bootStage1ConstraintDict["format_types"]
         for selector in self._accordion.selected_items:
             page = self._accordion.page_for_selector(selector)
             device = selector.device
@@ -1974,7 +1978,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
             if root_name == translated_new_install_name():
                 if is_multiselection and not option_checked:
-                    (rc, option_checked) = self._show_confirmation_dialog(root_name, device)
+                    (rc, option_checked) = self._show_confirmation_dialog(root_name, device, protected_types)
 
                     if rc != 1:
                         if option_checked:
@@ -2000,7 +2004,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                 # In multiselection user could confirm once for all next
                 # selections.
                 if not option_checked:
-                    (rc, option_checked) = self._show_confirmation_dialog(root_name, device)
+                    (rc, option_checked) = self._show_confirmation_dialog(root_name, device, protected_types)
 
                     if rc != 1:
                         if option_checked:
@@ -2008,10 +2012,26 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                         continue
 
                 if option_checked and not is_multiselection:
-                    for dev in (s._device for s in page.members):
-                        self._destroy_device(dev)
-                else:
-                    self._destroy_device(device)
+                    otherpgs = (pg for pg in self._accordion.all_pages
+                                if pg is not page)
+                    otherdevs = []
+                    for otherpg in otherpgs:
+                        otherdevs.extend(mem._device.id for mem in otherpg.members)
+                    # we never want to delete known-shared devs here. we also
+                    # exclude 'device' as we'll unconditionally delete it later
+                    for dev in (s._device for s in page.members
+                                if s._device.id not in otherdevs
+                                and s._device.id != device.id):
+                        # we only want to delete boot partitions if they're not
+                        # shared *and* we have no unknown partitions
+                        if (not self.unusedDevices or dev.format.type not in protected_types):
+                            log.debug("deleteall: removed %s", dev.name)
+                            self._destroy_device(dev)
+                        else:
+                            log.debug("deleteall: didn't remove %s", dev.name)
+
+                # We do this even in deleteAll case, see above comment
+                self._destroy_device(device)
 
             part_removed = True
             log.info("ui: removed device %s", device.name)
@@ -2020,6 +2040,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         # refreshing the display will have the effect of making them disappear.
         # It's like they never existed.
         if part_removed:
+            self._storage_playground.roots = findExistingInstallations(self._storage_playground.devicetree)
             self._updateSpaceDisplay()
             self._do_refresh()
 

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -1942,7 +1942,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
             if root_name and "_" in root_name:
                 root_name = root_name.replace("_", "__")
                 checkbox_text = (C_("GUI|Custom Partitioning|Confirm Delete Dialog",
-                                    "Delete _all other file systems in the %s root as well.")
+                                    "Delete _all file systems which are only used by %s.")
                                     % root_name)
         else:
             checkbox_text = C_("GUI|Custom Partitioning|Confirm Delete Dialog",
@@ -2017,11 +2017,11 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                     otherdevs = []
                     for otherpg in otherpgs:
                         otherdevs.extend(mem._device.id for mem in otherpg.members)
-                    # we never want to delete known-shared devs here. we also
-                    # exclude 'device' as we'll unconditionally delete it later
+                    # We never want to delete known-shared devs here.
+                    # The same rule applies for selected device. If it's shared do not
+                    # remove it in other pages when Delete all option is checked.
                     for dev in (s._device for s in page.members
-                                if s._device.id not in otherdevs
-                                and s._device.id != device.id):
+                                if s._device.id not in otherdevs):
                         # we only want to delete boot partitions if they're not
                         # shared *and* we have no unknown partitions
                         if (not self.unusedDevices or dev.format.type not in protected_types):
@@ -2029,9 +2029,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                             self._destroy_device(dev)
                         else:
                             log.debug("deleteall: didn't remove %s", dev.name)
-
-                # We do this even in deleteAll case, see above comment
-                self._destroy_device(device)
+                else:
+                    self._destroy_device(device)
 
             part_removed = True
             log.info("ui: removed device %s", device.name)

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -377,7 +377,7 @@ class ConfirmDeleteDialog(GUIObject):
         self.window.destroy()
 
     # pylint: disable=arguments-differ
-    def refresh(self, mountpoint, device, checkbox_text = "", snapshots=False):
+    def refresh(self, mountpoint, device, checkbox_text = "", snapshots=False, bootpart = False):
         """ Show confirmation dialog with the optional checkbox. If the
             `checkbox_text` for the checkbox is not set then the checkbox
             will not be showed.
@@ -401,7 +401,9 @@ class ConfirmDeleteDialog(GUIObject):
         else:
             txt = device
 
-        if not snapshots:
+        if bootpart:
+            label_text = _("%s may be a system boot partition! Deleting it may break other operating systems. Are you sure you want to delete it?") % txt
+        elif not snapshots:
             label_text = _("Are you sure you want to delete all of the data on %s?") % txt
         else:
             label_text = _("Are you sure you want to delete all of the data on %s, including snapshots and/or subvolumes?") % txt


### PR DESCRIPTION
This is the PR https://github.com/rhinstaller/anaconda/pull/508 but rebased to actual master (there were some conflicts) and with new commit.

When user click on any not-shared partition and check option Delete all it will remove all not-shared partitions from that page. 
If an user did this on shared partition it will remove all not-shared partitions in that page but it will also remove that selected partition (even when it's shared).

To stay consistent use the same rule for the selected partition.

I hope this will be good solution for all of you guys.

*Related: rhbz#1183880*