### PR TITLE
Manually set clock shifts on UI idle (#1251044)

### DIFF
--- a/pyanaconda/isys/__init__.py
+++ b/pyanaconda/isys/__init__.py
@@ -135,10 +135,10 @@ def set_system_date_time(year=None, month=None, day=None, hour=None, minute=None
     minute = minute if minute is not None else now.minute
     second = second if second is not None else now.second
 
-    set_date = datetime.datetime(year, month, day, hour, minute, second, tzinfo=tz)
+    set_date = tz.localize(datetime.datetime(year, month, day, hour, minute, second))
 
     # Calculate the number of seconds between this time and timestamp 0
-    epoch = datetime.datetime.fromtimestamp(0, pytz.UTC)
+    epoch = tz.localize(datetime.datetime.fromtimestamp(0))
     timestamp = (set_date - epoch).total_seconds()
 
     set_system_time(timestamp)


### PR DESCRIPTION
Users reported the clock shifting a few seconds after manually setting
the clock when NTP was not available during installation.

The code was calculating the date to set the system clock by comparing
the GUI text fields to the epoch time. User input was not properly
converted thus the call to set system time was receiving the wrong
values. The GUI would begin updating from the system clock after sitting
idle a few seconds and use this incorrect time.

Resolves: rhbz#1251044
Resolves: rhbz#1293314