### PR TITLE
NTP should have better behavior (#1309396)

### DIFF
--- a/pyanaconda/install.py
+++ b/pyanaconda/install.py
@@ -211,6 +211,9 @@ def doInstall(storage, payload, ksdata, instClass):
     ksdata.authconfig.setup()
     ksdata.firewall.setup()
     ksdata.network.setup()
+    # Setup timezone and add chrony as package if timezone was set in KS
+    # and "-chrony" wasn't in packages section and/or --nontp wasn't set.
+    ksdata.timezone.setup(ksdata)
 
     # make name resolution work for rpm scripts in chroot
     if flags.can_touch_runtime_system("copy /etc/resolv.conf to sysroot"):

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -585,7 +585,6 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
         if self._update_datetime_timer_id is not None:
             GLib.source_remove(self._update_datetime_timer_id)
         self._update_datetime_timer_id = None
-        self.data.timezone.setup(self.data)
 
     @property
     def ready(self):


### PR DESCRIPTION
Fix when the ntp servers were in KS then chrony package was installed only with GUI but not in TUI.

Change a behavior of NTP package (chrony) installation and config file creation:

1) When --nontp is in KS then file don't install package and don't create config file.
2) When "-chrony" is in packages section of KS then don't install package but create the config file based on the config file from the installation environment.
3) If nothing used and there are ntp servers then create config file and install NTP package.

The "--nontp" option beats the "-chrony" packages rule.

Resolves: rhbz#1309396
Resolves: rhbz#1260725