### PR TITLE
Generate resources.h before compiling widgets-common.c

### DIFF
--- a/widgets/src/Makefile.am
+++ b/widgets/src/Makefile.am
@@ -105,6 +105,9 @@ resources.c: $(RESOURCE_XML) $(RESOURCE_DEPS) Makefile
 
 nodist_libAnacondaWidgets_la_SOURCES = resources.c resources.h
 
+# libtool misses this dependency
+widgets-common.c: resources.h
+
 CLEANFILES = resources.c resources.h
 
 MAINTAINERCLEANFILES = gettext.h


### PR DESCRIPTION
Pretty sure something was supposed to figure this out automatically, but oh well