### PR TITLE
NTP should have better behavior (#1309396)

### DIFF
--- a/pyanaconda/install.py
+++ b/pyanaconda/install.py
@@ -204,6 +204,9 @@ def doInstall(storage, payload, ksdata, instClass):
     # Check for additional packages
     ksdata.authconfig.setup()
     ksdata.firewall.setup()
+    # Setup timezone and add chrony as package if timezone was set in KS
+    # and "-chrony" wasn't in packages section and/or --nontp wasn't set.
+    ksdata.timezone.setup(ksdata)
 
     # anaconda requires storage packages in order to make sure the target
     # system is bootable and configurable, and some other packages in order

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1610,7 +1610,8 @@ class Timezone(commands.timezone.F18_Timezone):
         self._disabled_chrony = False
 
     def setup(self, ksdata):
-        if self.nontp:
+        # do not install and use NTP package
+        if self.nontp or NTP_PACKAGE in ksdata.packages.excludedList:
             if iutil.service_running(NTP_SERVICE) and \
                     can_touch_runtime_system("stop NTP service"):
                 ret = iutil.stop_service(NTP_SERVICE)
@@ -1630,7 +1631,7 @@ class Timezone(commands.timezone.F18_Timezone):
             if NTP_SERVICE not in ksdata.services.disabled:
                 ksdata.services.disabled.append(NTP_SERVICE)
                 self._disabled_chrony = True
-
+        # install and use NTP package
         else:
             if not iutil.service_running(NTP_SERVICE) and \
                     can_touch_runtime_system("start NTP service"):
@@ -1662,23 +1663,35 @@ class Timezone(commands.timezone.F18_Timezone):
         timezone.write_timezone_config(self, iutil.getSysroot())
 
         # write out NTP configuration (if set)
-        if self.ntpservers:
+        if not self.nontp and self.ntpservers:
             chronyd_out_path = os.path.normpath(iutil.getSysroot() + ntp.CHRONY_CONFIG_FILE)
             ntpd_out_path = os.path.normpath(iutil.getSysroot() + ntp.NTP_CONFIG_FILE)
-            try:
-                ntp.save_servers_to_config(self.ntpservers,
-                                           conf_file_path=ntp.CHRONY_CONFIG_FILE,
-                                           out_file_path=chronyd_out_path)
-            except ntp.NTPconfigError as ntperr:
-                log.warning("Failed to save NTP configuration for chrony: %s", ntperr)
+            if os.path.exists(chronyd_out_path):
+                log.debug("Modifying installed chrony configuration")
+                try:
+                    ntp.save_servers_to_config(self.ntpservers, conf_file_path=chronyd_out_path)
+                except ntp.NTPconfigError as ntperr:
+                    log.warning("Failed to save NTP configuration for chrony: %s", ntperr)
+            else:
+                log.debug("Creating chrony configuration based on the "
+                          "configuration from installation environment")
+                try:
+                    ntp.save_servers_to_config(self.ntpservers,
+                                               conf_file_path=ntp.CHRONY_CONFIG_FILE,
+                                               out_file_path=chronyd_out_path)
+                except ntp.NTPconfigError as ntperr:
+                    log.warning("Failed to save NTP configuration without chrony package: %s", ntperr)
 
-            try:
-                ntp.save_servers_to_config(self.ntpservers,
-                                           conf_file_path=ntp.NTP_CONFIG_FILE,
-                                           out_file_path=ntpd_out_path)
-            except ntp.NTPconfigError as ntperr:
-                log.warning("Failed to save NTP configuration for ntpd: %s", ntperr)
-
+            if os.path.exists(ntpd_out_path):
+                log.debug("Modifying installed ntpd configuration")
+                try:
+                    ntp.save_servers_to_config(self.ntpservers, conf_file_path=ntpd_out_path)
+                except ntp.NTPconfigError as ntperr:
+                    log.warning("Failed to save NTP configuration for ntpd: %s", ntperr)
+            # This is special customer request when the ntp is installed so there is no point
+            # in creating conf file from NTP from installation environment.
+            else:
+                log.debug("ntpd configuration isn't created because the package wasn't installed")
 
 class User(commands.user.F19_User):
     def execute(self, storage, ksdata, instClass, users):

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -554,7 +554,6 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
         if self._update_datetime_timer_id is not None:
             GLib.source_remove(self._update_datetime_timer_id)
         self._update_datetime_timer_id = None
-        self.data.timezone.setup(self.data)
 
     @property
     def ready(self):


### PR DESCRIPTION
Fix when the ntp servers were in KS then chrony package was
installed only with GUI but not in TUI.

Change a behavior of NTP package chrony installation and
config file creation:

1) When --nontp is in KS file then don't install ntp package and don't
create config file.
2) When "-chrony" is in packages section of KS then don't
install package but create the config files based on the config file
from the installation environment.
3) If nothing used and there are ntp servers then create config file and
install chrony package.

The "--nontp" option beats the "-chrony" packages rule.

Based on commit db800dc1bcb62cb8f811adae09a5b07c4f71ea5f but in RHEL
there is ntpd too. Which is handled as before this patch so we creating
the configuration files for ntp if ntp package is installed and --nontp
is not used.

Resolves: rhbz#1309396
Resolves: rhbz#1260725

*Based on PR https://github.com/rhinstaller/anaconda/pull/517 which is already in master now*