### PR TITLE
Make sure pluginconf.d exists (#1271766)

### DIFF
--- a/data/post-scripts/80-setfilecons.ks
+++ b/data/post-scripts/80-setfilecons.ks
@@ -2,7 +2,7 @@
 
 restorecon -ir /etc/sysconfig/network-scripts /var/lib /etc/lvm \
                /dev /etc/iscsi /var/lib/iscsi /root /var/lock /var/log \
-               /etc/modprobe.d /etc/sysconfig /var/cache/yum
+               /etc/modprobe.d /etc/sysconfig /var/cache/yum /etc/yum
 
 # Also relabel the OSTree variants of the normal mounts (if they exist)
 restorecon -ir /var/roothome /var/home /var/opt /var/srv /var/media /var/mnt

--- a/pyanaconda/packaging/yumpayload.py
+++ b/pyanaconda/packaging/yumpayload.py
@@ -263,6 +263,7 @@ class YumPayload(PackagePayload):
             log.error ("Error setting langpack_locales: %s", msg)
 
     def _copyLangpacksConfigToTarget(self):
+        iutil.mkdirChain(os.path.dirname(iutil.getSysroot()+_yum_target_langpack_conf))
         shutil.copy2(_yum_installer_langpack_conf,
                      iutil.getSysroot()+_yum_target_langpack_conf)
 


### PR DESCRIPTION
If the langpacks package hasn't been included the directory won't exist.
Make sure it does.

Resolves: rhbz#1271766