### PR TITLE
Change the install test URL.

### DIFF
--- a/tests/install/run_install_test.sh
+++ b/tests/install/run_install_test.sh
@@ -57,7 +57,7 @@ EOF
 # out here.
 if [[ "$(uname -m)" == "x86_64" ]]; then
     cat <<EOF >> ${tmpdir}/yum.conf
-baseurl=http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/\$basearch/os/
+baseurl=http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/\$basearch/os/
 EOF
 else
     cat <<EOF >> ${tmpdir}/yum.conf


### PR DESCRIPTION
Everything moved because that is what Fedora does best.

The fedora-secondary URL will probably change at some point, but it
hasn't yet.