### PR TITLE
Check to see if DD repo is already in addOn list (#1268357)

### DIFF
--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -1026,10 +1026,12 @@ class PackagePayload(Payload):
                 log.info("Running createrepo on %s", repo)
                 iutil.execWithRedirect("createrepo", [repo])
 
-            ks_repo = self.data.RepoData(name="DD-%d" % dir_num,
-                                         baseurl="file://"+repo,
-                                         enabled=True)
-            self.addRepo(ks_repo)
+            repo_name = "DD-%d" % dir_num
+            if repo_name not in self.addOns:
+                ks_repo = self.data.RepoData(name=repo_name,
+                                             baseurl="file://"+repo,
+                                             enabled=True)
+                self.addRepo(ks_repo)
 
         # Add packages
         if not os.path.exists("/run/install/dd_packages"):


### PR DESCRIPTION
When the repodata was re-downloaded it would add the DD repos again
without checking to see if they were already there.

Resolves: rhbz#1268357