### PR TITLE
Hotfix for missing storage in payload class (#1271657)

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -585,6 +585,10 @@ class DNFPayload(packaging.PackagePayload):
     @property
     def spaceRequired(self):
         size = self._spaceRequired()
+        if not self.storage:
+            log.warning("Payload doesn't have storage")
+            return size
+
         download_size = self._download_space
         valid_points = _df_map()
         root_mpoint = pyanaconda.iutil.getSysroot()


### PR DESCRIPTION
The problem here is that payload is setting up storage when
PayloadManager run a thread but the user could do steps which
will call the spaceRequired() method sooner.

Now the behavior is the same as it was with the old spaceRequired
method for the variant when storage is not set.

Resolves: rhbz#1271657

*This is more general (hot)fix for the bugs "NoneType has no mountpoint"*