### PR TITLE
Use the default levelbar offset values.

### DIFF
--- a/data/anaconda-gtk.css
+++ b/data/anaconda-gtk.css
@@ -14,8 +14,6 @@
 @define-color anaconda_level_bar_medium     orange;
 @define-color anaconda_level_bar_high       green;
 
-/* The .fill part works around https://bugzilla.gnome.org/show_bug.cgi?id=761416 */
-levelbar.discrete trough block.filled.full,
 levelbar.discrete trough block.filled.low {
     border-color: darker(@anaconda_level_bar_low);
     background: @anaconda_level_bar_low;
@@ -26,6 +24,7 @@ levelbar.discrete trough block.filled.medium {
     background: @anaconda_level_bar_medium;
 }
 
+levelbar.discrete trough block.filled.full,
 levelbar.discrete trough block.filled.high {
     border-color: darker(@anaconda_level_bar_high);
     background: @anaconda_level_bar_high;

--- a/pyanaconda/ui/gui/spokes/lib/passphrase.py
+++ b/pyanaconda/ui/gui/spokes/lib/passphrase.py
@@ -62,6 +62,7 @@ class PassphraseDialog(GUIObject, GUIInputCheckHandler):
         self._strength_bar.add_offset_value("low", 2)
         self._strength_bar.add_offset_value("medium", 3)
         self._strength_bar.add_offset_value("high", 4)
+        self._strength_bar.add_offset_value("full", 4)
 
         # Configure the password policy, if available. Otherwise use defaults.
         self.policy = self.data.anaconda.pwpolicy.get_policy("luks")

--- a/pyanaconda/ui/gui/spokes/password.py
+++ b/pyanaconda/ui/gui/spokes/password.py
@@ -106,6 +106,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self.pw_bar.add_offset_value("low", 2)
         self.pw_bar.add_offset_value("medium", 3)
         self.pw_bar.add_offset_value("high", 4)
+        self.pw_bar.add_offset_value("full", 4)
 
         # Configure the password policy, if available. Otherwise use defaults.
         self.policy = self.data.anaconda.pwpolicy.get_policy("root")

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -277,6 +277,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         self.pw_bar.add_offset_value("low", 2)
         self.pw_bar.add_offset_value("medium", 3)
         self.pw_bar.add_offset_value("high", 4)
+        self.pw_bar.add_offset_value("full", 4)
 
         # Configure the password policy, if available. Otherwise use defaults.
         self.policy = self.data.anaconda.pwpolicy.get_policy("user")


### PR DESCRIPTION
The effect is the same as the previous CSS rule, but now we're working
with instead of around.