### PR TITLE
Now possible to use DUD from http (#1261024)

### DIFF
--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -129,6 +129,15 @@ getargbool 0 vnc inst.vnc && warn "anaconda requiring network for vnc" && set_ne
 
 # Driver Update Disk
 warn_renamed_arg "dd" "inst.dd"
+# Net may be needed 
+if dd=$(getarg dd inst.dd); then
+    if [ -n "$dd" ]; then
+        case $dd in
+            http*|ftp*|nfs*)
+                set_neednet
+        esac
+    fi
+fi
 
 # re-read the commandline args
 unset CMDLINE


### PR DESCRIPTION
Fixed bug in driver update disk logic when using inst.dd=http:/... did not activated network.
This bug manifested itself when no other parameter activated network.

Fixed by adding logic to ask for network activation when needed.

Resolves: rhbz#1261024