### PR TITLE
liveinst changes for Xwayland

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -282,8 +282,9 @@ update-desktop-database &> /dev/null || :
 %{_sbindir}/liveinst
 %config(noreplace) %{_sysconfdir}/pam.d/*
 %config(noreplace) %{_sysconfdir}/security/console.apps/*
-%{_sysconfdir}/X11/xinit/xinitrc.d/*
+%{_libexecdir}/liveinst-setup.sh
 %{_datadir}/applications/*.desktop
+%{_sysconfdir}/xdg/autostart/*.desktop
 %endif
 
 %files gui

--- a/data/liveinst/Makefile.am
+++ b/data/liveinst/Makefile.am
@@ -25,8 +25,10 @@ dist_sbin_SCRIPTS  = liveinst
 desktopdir         = $(datadir)/applications
 desktop_DATA       = liveinst.desktop
 
-xinitdir           = $(sysconfdir)/X11/xinit/xinitrc.d
-dist_xinit_SCRIPTS = zz-liveinst.sh
+dist_libexec_SCRIPTS = liveinst-setup.sh
+
+autostartdir       = $(sysconfdir)/xdg/autostart
+dist_autostart_DATA = liveinst-setup.desktop
 
 install-exec-local:
 	$(MKDIR_P) $(DESTDIR)$(bindir)

--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -186,6 +186,9 @@ if [ -z $LC_ALL ]; then
     export LC_ALL=$LANG
 fi
 
+# Force the X11 backend since sudo and wayland do not mix
+export GDK_BACKEND=x11
+
 if [ -x /usr/bin/udisks ]; then
     /usr/bin/udisks --inhibit -- $ANACONDA $*
 else

--- a/data/liveinst/liveinst-setup.desktop
+++ b/data/liveinst/liveinst-setup.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Liveinst Setup
+TryExec=/usr/sbin/liveinst
+Exec=/usr/libexec/liveinst-setup.sh
+NoDisplay=true
+X-GNOME-AutoRestart=false
+X-GNOME-Autostart-Phase=Initialization
+X-GNOME-Autostart-Notify=false

--- a/data/liveinst/liveinst-setup.sh
+++ b/data/liveinst/liveinst-setup.sh
@@ -10,13 +10,5 @@ fi
 # Also lets us run (with the X11 backend) on Wayland
 [ -x /usr/bin/xhost ] && xhost +si:localuser:root > /dev/null 2>&1
 
-# don't run on geode (olpc)
-if [ `grep -c Geode /proc/cpuinfo` -eq 0 ]; then
-  if [ -b /dev/mapper/live-osimg-min ]; then
-    test -f ${XDG_CONFIG_HOME:-~/.config}/user-dirs.dirs && source ${XDG_CONFIG_HOME:-~/.config}/user-dirs.dirs
-    cp /usr/share/applications/liveinst.desktop "${XDG_DESKTOP_DIR:-$HOME/Desktop}"
-  elif [ -f /.livecd-configured ]; then  # FIXME: old way... this should go away
-    test -f ${XDG_CONFIG_HOME:-~/.config}/user-dirs.dirs && source ${XDG_CONFIG_HOME:-~/.config}/user-dirs.dirs
-    cp /usr/share/applications/liveinst.desktop "${XDG_DESKTOP_DIR:-$HOME/Desktop}"
-  fi
-fi
+test -f ${XDG_CONFIG_HOME:-~/.config}/user-dirs.dirs && source ${XDG_CONFIG_HOME:-~/.config}/user-dirs.dirs
+cp /usr/share/applications/liveinst.desktop "${XDG_DESKTOP_DIR:-$HOME/Desktop}"

--- a/data/liveinst/liveinst-setup.sh
+++ b/data/liveinst/liveinst-setup.sh
@@ -2,6 +2,10 @@
 # Set up a launcher on the desktop for the live installer if we're on
 # a live CD
 
+if [ ! \( -b /dev/mapper/live-base -o /dev/mapper/live-osimg-min \) ]; then
+    exit 0
+fi
+
 # Prevents breakage if the hostname is changed before or during the install
 # Also lets us run (with the X11 backend) on Wayland
 [ -x /usr/bin/xhost ] && xhost +si:localuser:root > /dev/null 2>&1

--- a/data/liveinst/liveinst-setup.sh
+++ b/data/liveinst/liveinst-setup.sh
@@ -3,6 +3,7 @@
 # a live CD
 
 # Prevents breakage if the hostname is changed before or during the install
+# Also lets us run (with the X11 backend) on Wayland
 [ -x /usr/bin/xhost ] && xhost +si:localuser:root > /dev/null 2>&1
 
 # don't run on geode (olpc)


### PR DESCRIPTION
Clean up a couple of aspects of the liveinst xinitrc script, make it run in an xinitrc-less world, and add another environment variable to liveinst.