### PR TITLE
Fix a bad usage of execWithRedirect (#1270319)

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -558,11 +558,11 @@ class Realm(commands.realm.F19_Realm):
             # no explicit password arg using implicit --no-password
             pw_args = ["--no-password"]
 
-        argv = ["realm", "join", "--install", iutil.getSysroot(), "--verbose"] + \
+        argv = ["join", "--install", iutil.getSysroot(), "--verbose"] + \
                pw_args + self.join_args
         rc = -1
         try:
-            rc = iutil.execWithRedirect("realm", argv)[0]
+            rc = iutil.execWithRedirect("realm", argv)
         except OSError:
             pass
 


### PR DESCRIPTION
execWithRedirect returns an int, not a tuple, and the argv used to
execute realm still had the command as argv[0], which is no longer
needed.

(cherry picked from commit 08a55ebeb6ce6fa9e66332bb9f34d0d69ea80ecc)

Resolves: rhbz#1270319