### PR TITLE
don't install kernel-PAE on x86_64 (#1313957)

### DIFF
--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -751,7 +751,7 @@ class PackagePayload(Payload):
 
         kernels = ["kernel"]
 
-        if isys.isPaeAvailable():
+        if blivet.arch.isX86(32) and isys.isPaeAvailable():
             kernels.insert(0, "kernel-PAE")
 
         # most ARM systems use platform-specific kernels


### PR DESCRIPTION
PAE is *available* on x86_64 systems, but we do not want to
install kernel-PAE on them even if it is in the repo for some
reason.

An alternative to this is to rename `isPaeAvailable()` to
`isPaeWanted()` and have it return False on x86_64, but I guess
that's technically an interface change, and this is also easy.