### PR TITLE
except block in py3.5 undefines the variable

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -209,11 +209,11 @@ def do_transaction(base, queue_instance):
         display = PayloadRPMDisplay(queue_instance)
         base.do_transaction(display=display)
         exit_reason = "DNF quit"
-    except BaseException as exit_reason:
+    except BaseException as e:
         log.error('The transaction process has ended abruptly')
-        log.info(exit_reason)
+        log.info(e)
         import traceback
-        exit_reason = str(exit_reason) + traceback.format_exc()
+        exit_reason = str(e) + traceback.format_exc()
     finally:
         queue_instance.put(('quit', str(exit_reason)))
 


### PR DESCRIPTION
try:
    foo = "I tried!"
    raise Exception(foo)
except Exception as foo:
    foo = str(foo) +  " bar"
finally:
    print(foo)

The except block will undefine foo, making finally crash.