### PR TITLE
Fix a DBus InvalidProperty handling (#1315843)

### DIFF
--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -119,7 +119,8 @@ def _get_property(object_path, prop, interface_name_suffix=""):
     try:
         prop = proxy.Get('(ss)', interface_name, prop)
     except GLib.GError as e:
-        if "org.freedesktop.DBus.Error.AccessDenied" in e.message:
+        if ("org.freedesktop.DBus.Error.AccessDenied" in e.message or
+            "org.freedesktop.DBus.Error.InvalidArgs" in e.message):
             return None
         elif "org.freedesktop.DBus.Error.UnknownMethod" in e.message:
             raise UnknownMethodGetError


### PR DESCRIPTION
Anaconda is crashing now because new InvalidProperty exception from
NetworkManager is now raised.

Resolves: rhbz#1315843

(cherry picked from commit 69a90585c3bb0f924964ff79d120b79ef738b0f4)

This is already in master.
NetworkManager upgraded version in rhel 7.3 so this error is in the rhel now and it's blocking testing of new composes. For this reason I'm going to break 24 hours rule to fix this error ASAP.