### PR TITLE
Fix crash when new device appear in Welcome screen (#1216926)

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -449,6 +449,12 @@ class NetworkControlBox(GObject.GObject):
         return True
 
     def initialize(self):
+        # There is a signal for newly added devices from NetworkManager but it
+        # is registered after the initialize method.
+        # So if someone adds a new device in the Welcome screen the ifcfg file won't
+        # be created which causes anaconda to crash.
+        log.debug("Dump missing interfaces in NetworkControlBox initialize method")
+        network.dumpMissingDefaultIfcfgs()
         for device in self.client.get_devices():
             self.add_device_to_list(device)
 


### PR DESCRIPTION
Anaconda will crash when user add a new device in the Welcome screen.
This happens because the configuration file for the new device wasn't
created.
Fixed by generating this configuration in NetworkSpoke initialization.

Resolves: rhbz#1216926

Backporting part of the fix PR https://github.com/rhinstaller/anaconda/pull/274 .