### PR TITLE
Rhel7 fix create bad dev name ks

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -193,8 +193,9 @@ class Network(commands.network.RHEL7_Network, DracutArgsMixin):
                     return
                 else:
                     log.info("Using %s as first device with link found", net.device)
-            # tell dracut to bring this device up
-            netline = ksnet_to_dracut(args, lineno, net, bootdev=True)
+            # tell dracut to bring this device up if it's not already done by user
+            if not "ip" in proc_cmdline:
+                netline = ksnet_to_dracut(args, lineno, net, bootdev=True)
         else:
             # all subsequent 'network' lines require '--device'
             if not net.device or net.device == "link":

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -63,7 +63,10 @@ def read_cmdline(f):
     for line in lines:
         for arg in line.split():
             k,_,v = arg.partition("=")
-            args[k] = v
+            if k not in args:
+                args[k] = [v]
+            else:
+                args[k].append(v)
     return args
 
 def first_device_with_link():
@@ -310,8 +313,22 @@ def ksnet_to_dracut(args, lineno, net, bootdev=False):
 
     if is_mac(net.device): # this is a MAC - find the interface name
         mac = net.device
+        # we need dev name to create dracut commands
         net.device = find_devname(mac)
         if net.device is None:  # iface not active - pick a name for it
+            try:
+                # find if 'ifname' command isn't already used for this device
+                # if so use user device name
+                for cmd_ifname in proc_cmdline["ifname"]:
+                    cmd_ifname, cmd_mac= cmd_ifname.split(":", 1)
+                    if mac == cmd_mac:
+                        net.device = cmd_ifname
+                        log.info("MAC '%s' is named by user. Use '%s' name." % (mac, cmd_ifname))
+                        break
+            except KeyError:
+                log.debug("ifname= command isn't used generate name ksdev0 for device")
+        # if the device is still None use ksdev0 name
+        if net.device is None:
             net.device = "ksdev0" # we only get called once, so this is OK
             line.append("ifname=%s:%s" % (net.device, mac.lower()))
 
@@ -564,7 +581,9 @@ def write_ifcfg(filename, ifcfg):
 def process_kickstart(ksfile):
     handler = DracutHandler()
     try:
-        handler.ksdevice = proc_cmdline['ksdevice']
+        # if the ksdevice key is present the first item must be there
+        # and it should be only once (ignore the orthers)
+        handler.ksdevice = proc_cmdline['ksdevice'][0]
     except KeyError:
         log.debug("ksdevice argument is not available")
     parser = KickstartParser(handler, missingIncludeIsFatal=False, errorsAreFatal=False)


### PR DESCRIPTION
This patch will do these 2 things:

1. Fixing issue when ifname is used in boot_args. We then can't use ``ksdev0`` as network device name but we should use the ifname one.
2. Fixing behavior with prioritizing network settings in  dracut and stage2.

It should work in this way:

* If there are any ``ip=<iface>:<IP>`` boot arg in Dracut this will be applied in Dracut and kickstart network commands will be applied later when an installation (stage2) starts.
* If there aren't any ``ip=<iface>:<IP>`` boot args in Dracut we will parse kickstart and apply that settings to Dracut.


In short: Dracut will prioritize the network boot args settings over kickstart one but in the stage2 kickstarts will be applied (if --activate is used).

I'm adding diagram with the network work-flow for easier explanation. If there is anything you think it could break please comment. Also comment if you think this behavior is bad.

![Network Dracut diagram](https://jkonecny.fedorapeople.org/redhat/network-settings-priority/network-dracut-stage2_prioritizing.png)

I'm going to finish this diagram with (as best scenario) all network Dracut/Anaconda setups to exactly specify how it should behave for future.
