### PR TITLE
Language attributes

### DIFF
--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -25,6 +25,10 @@ import re
 import langtable
 import os
 
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
 from pyanaconda.ui.gui.hubs.summary import SummaryHub
 from pyanaconda.ui.gui.spokes import StandaloneSpoke
 from pyanaconda.ui.gui.utils import setup_gtk_direction, escape_markup, gtk_action_wait
@@ -280,8 +284,11 @@ class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
         #   so make sure the object is actually what we think it is
         # - ignoring this run is OK as the initial title is
         #   already translated to the initial language
-        if hasattr(self.main_window, "set_title"):
+        if isinstance(self.main_window, Gtk.Window):
             self.main_window.set_title(_(WINDOW_TITLE_TEXT))
+
+            # Correct the language attributes for labels
+            self.main_window.reapply_language()
 
     def refresh(self):
         self._select_locale(self.data.lang.lang)

--- a/widgets/doc/AnacondaWidgets-docs.xml
+++ b/widgets/doc/AnacondaWidgets-docs.xml
@@ -42,6 +42,11 @@
         <xi:include href="xml/LayoutIndicator.xml" />
     </chapter>
 
+    <chapter id="utility">
+        <title>Utility Functions</title>
+        <xi:include href="xml/widgets-common.xml" />
+    </chapter>
+
     <chapter id="hierarchy">
         <title>Object Hierarchy</title>
         <xi:include href="xml/tree_index.sgml" />
@@ -61,6 +66,10 @@
 
     <index id="api-index-3.1" role="3.1">
 	<title>Index of new symbols in 3.1</title>
+    </index>
+
+    <index id="api-index-3.4" role="3.4">
+	<title>Index of new symbols in 3.4</title>
     </index>
 
     <xi:include href="xml/annotation-glossary.xml">

--- a/widgets/src/Makefile.am
+++ b/widgets/src/Makefile.am
@@ -31,7 +31,8 @@ GISOURCES = BaseWindow.c \
 	 SpokeWindow.c \
 	 StandaloneWindow.c \
 	 LayoutIndicator.c \
-	 BaseStandalone.c
+	 BaseStandalone.c \
+	 widgets-common.c
 
 GIHDRS = BaseWindow.h \
 	 DiskOverview.h \
@@ -41,11 +42,12 @@ GIHDRS = BaseWindow.h \
 	 SpokeWindow.h \
 	 StandaloneWindow.h \
 	 LayoutIndicator.h \
-	 BaseStandalone.h
+	 BaseStandalone.h \
+	 widgets-common.h
 
-NONGISOURCES = widgets-common.c
+NONGISOURCES =
 
-NONGIHDRS = widgets-common.h
+NONGIHDRS =
 
 SOURCES = $(GISOURCES) $(NONGISOURCES)
 

--- a/widgets/src/widgets-common.c
+++ b/widgets/src/widgets-common.c
@@ -24,6 +24,7 @@
 #include "widgets-common.h"
 
 #include <gtk/gtk.h>
+#include <pango/pango.h>
 
 /**
  * anaconda_widget_apply_stylesheet:
@@ -65,4 +66,49 @@ void anaconda_widget_apply_stylesheet(GtkWidget *widget, const gchar *name)
     style_context = gtk_widget_get_style_context(widget);
     gtk_style_context_add_provider(style_context, GTK_STYLE_PROVIDER(style_provider),
             GTK_STYLE_PROVIDER_PRIORITY_APPLICATION - 1);
+}
+
+/**
+ * anaconda_apply_language:
+ * @label: (transfer none): The widget to which to apply the language
+ * @language: The language to apply to the widget
+ *
+ * Apply a Pango language attribute to a label.
+ *
+ * For some formatting decisions, in particular the font choice, the language
+ * of the text being rendered needs to be known. This is especially the case
+ * for the Chinese, Japanese and Korean translations, since Unicode uses a
+ * single codepoint for the CJK characters across languages, even when the
+ * particular language may render the character very differently. For example,
+ * U+76F4 (直) shows up a good bit in the translations, it is rendered differently
+ * in Chinese and Japanese, and it is considered unreadable between the two.
+ *
+ * This function applies a #PangoAttrLanguage attribute to the label so that
+ * the underlying renderer can do the right thing.
+ *
+ * Since: 3.4
+ */
+void anaconda_apply_language(GtkLabel *label, const gchar *language) {
+    PangoLanguage *pango_language;
+    PangoAttribute *attr;
+    PangoAttrList *attrlist;
+    gboolean attrlist_unref = FALSE;
+
+    pango_language = pango_language_from_string(language);
+    attr = pango_attr_language_new(pango_language);
+
+    /* If the label already has an attribute list, modify it, otherwise create a new one. */
+    attrlist = gtk_label_get_attributes(label);
+    if (!attrlist) {
+        attrlist = pango_attr_list_new();
+        attrlist_unref = TRUE;
+    }
+
+    pango_attr_list_change(attrlist, attr);
+    gtk_label_set_attributes(label, attrlist);
+
+    /* Drop the local attrlist reference if there is one */
+    if (attrlist_unref) {
+        pango_attr_list_unref(attrlist);
+    }
 }

--- a/widgets/src/widgets-common.h
+++ b/widgets/src/widgets-common.h
@@ -22,9 +22,14 @@
 
 #include <gtk/gtk.h>
 
+G_BEGIN_DECLS
+
 #define ANACONDA_RESOURCE_PATH  "/org/fedoraproject/anaconda/widgets/"
 
 G_GNUC_INTERNAL void anaconda_widget_apply_stylesheet(GtkWidget *widget, const gchar *name);
 
+void anaconda_apply_language(GtkLabel *label, const gchar *language);
+
+G_END_DECLS
 
 #endif


### PR DESCRIPTION
In certain cases, Pango needs to know what language to render text in. The default language cannot be changed once the application has started, so work around that by explicitly setting language attributes on all labels instead.