### PR TITLE
fix multiple inst.dd=<path> args (rhbz#1268792)

### DIFF
--- a/dracut/driver-updates-genrules.sh
+++ b/dracut/driver-updates-genrules.sh
@@ -26,7 +26,7 @@ for dd in $DD_OEMDRV $DD_DISK; do
     # ..is this actually a disk image that already exists inside initramfs?
     if [ -f $dd ]; then
         # if so, no need to wait for udev - add it to initqueue now
-        initqueue --onetime --unique --name dd_initrd \
+        initqueue --onetime --name dd_initrd \
             driver-updates --disk $dd $dd
     else
         # otherwise, tell udev to do driver-updates when the device appears


### PR DESCRIPTION
Using `--unique` here with means that each job with the same `--name`
will overwrite the previous one, which means that if you do:

    inst.dd=/dud/dd1.iso inst.dd=/dud/dd2.iso

...then the latter overwrites the former and we only end up loading one
driver disk.

Removing `--unique` means that both jobs will be added, as expected.

Note that this *also* means that you'll get two jobs if you add the same
path twice, like so:

    inst.dd=/dud/dd1.iso inst.dd=/dud/dd1.iso

but processing the same DUD twice should be harmless, so that's fine.

Resolves: rhbz#1268792