### PR TITLE
Fix bad sensitivity on boxes in source spoke (#1262833)

### DIFF
--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -792,10 +792,6 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
 
         self._updateURLEntryCheck()
 
-        # Set up the default state of UI elements.
-        self._networkButton.set_sensitive(True)
-        self._networkBox.set_sensitive(True)
-
         if self.data.method.method == "url":
             self._networkButton.set_active(True)
 
@@ -874,6 +870,8 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
 
             self.clear_info()
             self.set_warning(_("You need to configure the network to use a network installation source."))
+        else: # network button could be deativated from last visit
+            self._networkButton.set_sensitive(True)
 
 
     def _setup_no_updates(self):


### PR DESCRIPTION
~~The boxes sensitivity for source types are changed when user clicks on radio button to change type of source.
Fix problem when user enter source spoke -> nothing were clicked and everything is sensitive.~~

**EDIT:**
Remove default sensitivity on Network box. It caused more gtk boxes were sensitive in one time.
Enable network button when we have functional connectivity.

*Reported-by: Pavel Holica <pholica@redhat.com>*

*Resolves: rhbz#1262833*

I don't know why but it doesn't happened on rawhide/f24 so this is rhel7 only.