### PR TITLE
network: use NAME to find ifcfg on s390 with net.ifnames=0 (#1249750)

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -864,6 +864,13 @@ def find_ifcfg_file_of_device(devname, root_path=""):
                 ifcfg_path = find_ifcfg_file([("HWADDR", hwaddr_check)], root_path)
         if not ifcfg_path:
             ifcfg_path = find_ifcfg_file([("DEVICE", devname)], root_path)
+        if not ifcfg_path:
+            if blivet.arch.isS390():
+                # s390 setting generated in dracut with net.ifnames=0
+                # has neither DEVICE nor HWADDR (#1249750)
+                ifcfg_path = find_ifcfg_file([("NAME", devname)], root_path)
+            else:
+                log.warning("network: neither HWADDR nor DEVICE in %s", ifcfg_path)
 
     return ifcfg_path
 


### PR DESCRIPTION
Anaconda creates extra connection because it doesn't recognize ifcfg file
created in dracut because it has neither HWADDR (because it is s390) nor DEVICE
(because we are using kernel names instead of persistent names, net.ifnames=0)
binding info. Assuming dracut's ifcfg file is fine, we probably need to look
for NAME in this case.

Resolves: rhbz#1249750