### PR TITLE
Switch to the adwaita icon theme.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -146,7 +146,7 @@ install-requires:
 
 # Install all packages required for running the tests
 install-test-requires: install-buildrequires install-requires
-		dnf install bzip2 cppcheck gnome-icon-theme gnome-icon-theme-symbolic \
+		dnf install bzip2 cppcheck \
 		    lorax mock parallel rpm-ostree virt-install pykickstart spin-kickstarts  \
 		    python3-rpmfluff python3-mock python3-pocketlint python3-nose-testconfig \
 		    python3-sphinx_rtd_theme libvirt-python3 python3-lxml python3-dogtail

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -834,7 +834,6 @@ class GraphicalUserInterface(UserInterface):
             # Set some program-wide settings.
             settings = Gtk.Settings.get_default()
             settings.set_property("gtk-font-name", "Cantarell")
-            settings.set_property("gtk-icon-theme-name", "gnome")
 
             # Apply the application stylesheet
             css_path = os.environ.get("ANACONDA_DATA", "/usr/share/anaconda")

--- a/tests/glade/run_glade_tests.py
+++ b/tests/glade/run_glade_tests.py
@@ -9,8 +9,8 @@ from gladecheck import GladePlugin
 
 # Check for prerequisites
 # used in check_icons.py via tests/lib/iconcheck.py
-if os.system("rpm -q gnome-icon-theme gnome-icon-theme-symbolic >/dev/null 2>&1") != 0:
-    print("gnome-icon-theme and gnome-icon-theme-symbolic must be installed")
+if os.system("rpm -q adwaita-icon-theme >/dev/null 2>&1") != 0:
+    print("adwaita-icon-theme must be installed")
     sys.exit(99)
 
 # If no test scripts were specified on the command line, select check_*.py

--- a/tests/lib/iconcheck.py
+++ b/tests/lib/iconcheck.py
@@ -20,11 +20,10 @@
 
 import os
 
-ICON_PATH = "/usr/share/icons/gnome"
+ICON_PATH = "/usr/share/icons/Adwaita"
 ICON_EXTS = ("png", "jpg", "svg")
 
-# This method depends on gnome-icon-theme being installed. gnome-icon-theme-legacy
-# may be installed, but the icons in it will not be considered.
+# This method depends on adwaita-icon-theme being installed.
 def icon_exists(icon_name):
     for dirpath, _dirs, files in os.walk(ICON_PATH):
         for icon in (icon_name + "." + ext for ext in ICON_EXTS):


### PR DESCRIPTION
adwaita-icon-theme and gnome-icon-theme merged a while back, so we can
use the default icon theme settings now and still get the same icons
that GNOME uses. Also, the gnome-icon-theme packages in Fedora are no
longer updated, so this way we keep up with any changes.