### PR TITLE
Only use <> for markup (#1317297)

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -333,7 +333,7 @@ def check_memory(anaconda, options, display_mode=None):
                          "MB of memory, but you only have %(total_ram)s MB\n.")
 
     reboot_extra = _('\n'
-                     'Press <Enter> to reboot your system.\n')
+                     'Press [Enter] to reboot your system.\n')
     livecd_title = _("Not enough RAM")
     livecd_extra = _(" Try the text mode installer by running:\n\n"
                      "'/usr/bin/liveinst -T'\n\n from a root "
@@ -612,7 +612,7 @@ def prompt_for_ssh():
     if connxinfo:
         stdoutLog.info(_("Please ssh install@%s to begin the install."), connxinfo)
     else:
-        stdoutLog.info(_("Please ssh install@<host> to continue installation."))
+        stdoutLog.info(_("Please ssh install@HOSTNAME to continue installation."))
 
 def cleanPStore():
     """remove files stored in nonvolatile ram created by the pstore subsystem"""

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -431,7 +431,7 @@ class RescueMountSpoke(NormalTUISpoke):
 
     def prompt(self, args=None):
         """ Override the default TUI prompt."""
-        return _("Please press <Enter> to get a shell. ")
+        return _("Please press [Enter] to get a shell. ")
 
     def input(self, args, key):
         """Move along home."""

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -188,7 +188,7 @@ class EditTUIDialog(NormalTUISpoke):
             self.value = cryptPassword(pw)
             return None
         else:
-            return _("Enter a new value for '%s' and press <Enter>\n") % entry.title
+            return _("Enter a new value for '%s' and press [Enter]\n") % entry.title
 
     def input(self, entry, key):
         if entry.aux.match(key):

--- a/pyanaconda/ui/tui/spokes/source.py
+++ b/pyanaconda/ui/tui/spokes/source.py
@@ -285,7 +285,7 @@ class SpecifyNFSRepoSpoke(EditTUISpoke, SourceSwitchHandler):
     category = SoftwareCategory
 
     edit_fields = [
-        Entry(N_("<server>:/<path>"), "server", re.compile(".*$"), True),
+        Entry(N_("SERVER:/PATH"), "server", re.compile(".*$"), True),
         Entry(N_("NFS mount options"), "opts", re.compile(".*$"), True)
     ]
 

--- a/pyanaconda/vnc.py
+++ b/pyanaconda/vnc.py
@@ -199,9 +199,9 @@ class VncServer:
         if self.connxinfo != None:
             self.log.info(_("Please manually connect your vnc client to %s to begin the install."), self.connxinfo)
         else:
-            self.log.info(_("Please manually connect your vnc client to <IP ADDRESS>:%s "
+            self.log.info(_("Please manually connect your vnc client to IP-ADDRESS:%s "
                             "to begin the install. Switch to the shell (Ctrl-B 2) and "
-                            "run 'ip addr' to find the <IP ADDRESS>."), constants.X_DISPLAY_NUMBER)
+                            "run 'ip addr' to find the IP-ADDRESS."), constants.X_DISPLAY_NUMBER)
 
     def startServer(self):
         self.log.info(_("Starting VNC..."))
@@ -251,7 +251,7 @@ class VncServer:
                                 "to the vncviewer is unsuccessful\n\n"))
         elif self.password == "":
             self.log.warning(_("\n\nWARNING!!! VNC server running with NO PASSWORD!\n"
-                                "You can use the vncpassword=<password> boot option\n"
+                                "You can use the vncpassword=PASSWORD boot option\n"
                                 "if you would like to secure the server.\n\n"))
         elif self.password != "":
             self.log.warning(_("\n\nYou chose to execute vnc with a password. \n\n"))

--- a/tests/gettext_tests/style_guide.py
+++ b/tests/gettext_tests/style_guide.py
@@ -32,10 +32,10 @@ bad_strings = {'(?i)bootloader': 'boot loader',
                '(?i)mountpoint': 'mount point',
                'Ok':             'OK',
                # Find instances of "return" that are referring to a keyboard key
-               '(?i)<return>':   '<Enter>',
+               '(?i)<return>':   '[Enter]',
                '(?i)press return': 'press Enter',
                # Make sure "Enter" is capitalized
-               '<enter>':        '<Enter>',
+               '<enter>':        '[Enter]',
                '[Pp]ress enter': 'press Enter'
                }
 
@@ -45,7 +45,8 @@ bad_strings = {'(?i)bootloader': 'boot loader',
 expected_badness = {'pyanaconda/bootloader.py': {'mountpoint': 1},  # format string specifier
                     'pyanaconda/kickstart.py':  {'btrfs': 1},       # quoted filesystem type
                     'pyanaconda/network.py':    {'vlan': 1},        # format string specifier
-                    'pyanaconda/rescue.py':     {'mountpoint': 1}}  # format string specifier
+                    'pyanaconda/rescue.py':     {'mountpoint': 1},  # format string specifier
+                    'anaconda.py':              {'HOSTNAME': 1}}    # ssh to install@HOSTNAME
 
 # Use polib to parse anaconda.pot
 try:


### PR DESCRIPTION
Zanata error checking gets confused when a string looks like markup but
isn't. So convert <Enter> to [Enter] and change several other uses to
UPPER CASE.