### PR TITLE
Show the close button in metacity (#1319590)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -178,6 +178,7 @@ Requires: python3-gobject-base
 
 # Needed to compile the gsettings files
 BuildRequires: gsettings-desktop-schemas
+BuildRequires: metacity
 
 %description gui
 This package contains graphical user interface for the Anaconda installer.

--- a/data/window-manager/config/Makefile.am
+++ b/data/window-manager/config/Makefile.am
@@ -22,7 +22,8 @@ schemadir = $(pkgdatadir)/window-manager/glib-2.0/schemas
 # These files need to be compiled by glib-compile-schemas. This is handled
 # in the spec file scriptlets.
 dist_schema_DATA = org.gnome.desktop.wm.keybindings.gschema.override \
-		   org.gnome.desktop.wm.preferences.gschema.override
+		   org.gnome.desktop.wm.preferences.gschema.override \
+		   org.gnome.metacity.gschema.override
 
 # GSettings insists on the override files being in the same directory as the
 # schemas they modify, so pretend that this is the case with symlinks and
@@ -31,6 +32,7 @@ install-data-hook:
 	$(MKDIR_P) $(DESTDIR)$(schemadir)
 	$(LN_S) -f /usr/share/glib-2.0/schemas/org.gnome.desktop.wm.keybindings.gschema.xml $(DESTDIR)$(schemadir)
 	$(LN_S) -f /usr/share/glib-2.0/schemas/org.gnome.desktop.wm.preferences.gschema.xml $(DESTDIR)$(schemadir)
+	$(LN_S) -f /usr/share/glib-2.0/schemas/org.gnome.metacity.gschema.xml $(DESTDIR)$(schemadir)
 	$(LN_S) -f /usr/share/glib-2.0/schemas/org.gnome.desktop.enums.xml $(DESTDIR)$(schemadir)
 	glib-compile-schemas $(DESTDIR)$(schemadir)
 

--- a/data/window-manager/config/org.gnome.desktop.wm.preferences.gschema.override
+++ b/data/window-manager/config/org.gnome.desktop.wm.preferences.gschema.override
@@ -1,6 +1,7 @@
 [org.gnome.desktop.wm.preferences]
-	button-layout=':'
+	button-layout=':close'
 	action-right-click-titlebar='none'
+        action-double-click-titlebar='none'
 	num-workspaces=1
 	theme='Anaconda'
 	mouse-button-modifier=''

--- a/data/window-manager/config/org.gnome.metacity.gschema.override
+++ b/data/window-manager/config/org.gnome.metacity.gschema.override
@@ -1,0 +1,2 @@
+[org.gnome.metacity]
+        edge-tiling=false


### PR DESCRIPTION
This will not affect anaconda windows, since the titlebar is not shown
on anaconda windows.  However, for the two cases where anaconda runs an
external program (yelp and nm-connection-editor), this will display a
close button in the titlebar, allowing the program to actually be
closed.

Thanks to Ray Strode (halfline) for the change.