### PR TITLE
Add the /EFI directory to the boot.iso (#1188876)

### DIFF
--- a/scripts/mk-images
+++ b/scripts/mk-images
@@ -1280,7 +1280,7 @@ elif [ ${BUILDARCH} = ppc64 ]; then
     # ... and similar for ppc64
     source $TOPDIR/mk-images.ppc
 elif [ ${BUILDARCH} = "x86_64" ]; then
-    export UEFI_BOOT_ISO="no"
+    export UEFI_BOOT_ISO="yes"
     source $TOPDIR/mk-images.x86
     source $TOPDIR/mk-images.efi
 elif [ ${BUILDARCH} = "i386" ]; then


### PR DESCRIPTION
The boot.iso should be able to boot on UEFI systems, currently they have
the UEFI boot image but are missing the contents of the /EFI directory.

Resolves: rhbz#1188876