### PR TITLE
Default locale

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -143,6 +143,9 @@ Requires: python3-coverage >= 4.0-0.12.b3
 # required because of the rescue mode and VNC question
 Requires: anaconda-tui = %{version}-%{release}
 
+# Make sure we get the en locale one way or another
+Requires: (glibc-langpack-en or glibc-all-langpacks)
+
 Obsoletes: anaconda-images <= 10
 Provides: anaconda-images = %{version}-%{release}
 Obsoletes: anaconda-runtime < %{version}-%{release}

--- a/data/systemd/anaconda-tmux@.service
+++ b/data/systemd/anaconda-tmux@.service
@@ -8,7 +8,7 @@ ConditionPathIsDirectory=!/sys/hypervisor/s390
 [Service]
 Type=idle
 WorkingDirectory=/root
-Environment=LANG=C.UTF-8
+Environment=LANG=en_US.UTF-8
 ExecStartPre=/usr/bin/echo -e \033%G
 ExecStart=/usr/bin/tmux -u attach -t anaconda
 StandardInput=tty

--- a/data/systemd/anaconda.service
+++ b/data/systemd/anaconda.service
@@ -5,6 +5,6 @@ Wants=anaconda-noshell.service
 
 [Service]
 Type=forking
-Environment=HOME=/root MALLOC_CHECK_=2 MALLOC_PERTURB_=204 PATH=/usr/bin:/bin:/sbin:/usr/sbin:/mnt/sysimage/bin:/mnt/sysimage/usr/bin:/mnt/sysimage/usr/sbin:/mnt/sysimage/sbin LANG=C.UTF-8 GDK_BACKEND=x11 XDG_RUNTIME_DIR=/tmp GIO_USE_VFS=local
+Environment=HOME=/root MALLOC_CHECK_=2 MALLOC_PERTURB_=204 PATH=/usr/bin:/bin:/sbin:/usr/sbin:/mnt/sysimage/bin:/mnt/sysimage/usr/bin:/mnt/sysimage/usr/sbin:/mnt/sysimage/sbin LANG=en_US.UTF-8 GDK_BACKEND=x11 XDG_RUNTIME_DIR=/tmp GIO_USE_VFS=local
 WorkingDirectory=/root
 ExecStart=/usr/bin/tmux -u -f /usr/share/anaconda/tmux.conf start

--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -61,7 +61,7 @@ INSTALL_TREE = MOUNT_DIR + "/source"
 BASE_REPO_NAME = "anaconda"
 
 # NOTE: this should be LANG_TERRITORY.CODESET, e.g. en_US.UTF-8
-DEFAULT_LANG = "C.UTF-8"
+DEFAULT_LANG = "en_US.UTF-8"
 
 DEFAULT_VC_FONT = "eurlatgr"
 


### PR DESCRIPTION
Don't try to use C.UTF-8 anymore since, at least in the short term, it's too much trouble to deal with, and ensure that en_US.UTF-8 actually has the data for that regardless of how anaconda is installed.