### PR TITLE
Fix the use of CSS psuedo-classes in the widgets.

### DIFF
--- a/widgets/src/MountpointSelector.c
+++ b/widgets/src/MountpointSelector.c
@@ -371,11 +371,20 @@ static void anaconda_mountpoint_selector_set_property(GObject *object, guint pro
 }
 
 static void anaconda_mountpoint_selector_toggle_background(AnacondaMountpointSelector *widget) {
+    /* Copy state flag changes to the child labels so they can be used in CSS selectors */
     if (widget->priv->chosen) {
         gtk_widget_set_state_flags(GTK_WIDGET(widget), GTK_STATE_FLAG_SELECTED, FALSE);
+        gtk_widget_set_state_flags(widget->priv->arrow, GTK_STATE_FLAG_SELECTED, FALSE);
+        gtk_widget_set_state_flags(widget->priv->name_label, GTK_STATE_FLAG_SELECTED, FALSE);
+        gtk_widget_set_state_flags(widget->priv->size_label, GTK_STATE_FLAG_SELECTED, FALSE);
+        gtk_widget_set_state_flags(widget->priv->mountpoint_label, GTK_STATE_FLAG_SELECTED, FALSE);
     }
     else {
         gtk_widget_unset_state_flags(GTK_WIDGET(widget), GTK_STATE_FLAG_SELECTED);
+        gtk_widget_unset_state_flags(widget->priv->arrow, GTK_STATE_FLAG_SELECTED);
+        gtk_widget_unset_state_flags(widget->priv->name_label, GTK_STATE_FLAG_SELECTED);
+        gtk_widget_unset_state_flags(widget->priv->size_label, GTK_STATE_FLAG_SELECTED);
+        gtk_widget_unset_state_flags(widget->priv->mountpoint_label, GTK_STATE_FLAG_SELECTED);
     }
 }
 

--- a/widgets/src/SpokeSelector.c
+++ b/widgets/src/SpokeSelector.c
@@ -67,8 +67,10 @@
  *
  *   The status of the spoke
  *
- * In addition, the :inconsistent pseudo-class can be used to select
- * selectors that are in an error state.
+ * In addition, the :indeterminate pseudo-class can be used to select
+ * selectors that are in an error state. The :indeterminate pseudo-class is
+ * also set on the anaconda-spoke-selector-title and
+ * anaconda-spoke-selector-status labels.
  */
 
 enum {
@@ -420,18 +422,19 @@ gboolean anaconda_spoke_selector_get_incomplete(AnacondaSpokeSelector *spoke) {
  * Since: 1.0
  */
 void anaconda_spoke_selector_set_incomplete(AnacondaSpokeSelector *spoke, gboolean is_incomplete) {
-    GtkStateFlags flags = gtk_widget_get_state_flags(GTK_WIDGET(spoke));
-
     /*
      * If the spoke is incomplete, set the "inconsistent" state to indicate that it
-     * needs attention
+     * needs attention. Copy the flag to the child labels to make style stuff work.
      */
     if (is_incomplete) {
-        flags |= GTK_STATE_FLAG_INCONSISTENT;
+        gtk_widget_set_state_flags(GTK_WIDGET(spoke), GTK_STATE_FLAG_INCONSISTENT, FALSE);
+        gtk_widget_set_state_flags(spoke->priv->status_label, GTK_STATE_FLAG_INCONSISTENT, FALSE);
+        gtk_widget_set_state_flags(spoke->priv->title_label, GTK_STATE_FLAG_INCONSISTENT, FALSE);
     } else {
-        flags &= ~GTK_STATE_FLAG_INCONSISTENT;
+        gtk_widget_unset_state_flags(GTK_WIDGET(spoke), GTK_STATE_FLAG_INCONSISTENT);
+        gtk_widget_unset_state_flags(spoke->priv->status_label, GTK_STATE_FLAG_INCONSISTENT);
+        gtk_widget_unset_state_flags(spoke->priv->title_label, GTK_STATE_FLAG_INCONSISTENT);
     }
-    gtk_widget_set_state_flags(GTK_WIDGET(spoke), flags, TRUE);
 
     /* Update the icon we are displaying, complete with any warning emblem. */
     set_icon(spoke, spoke->priv->icon_name);

--- a/widgets/src/resources/MountpointSelector-mountpoint.css
+++ b/widgets/src/resources/MountpointSelector-mountpoint.css
@@ -8,6 +8,6 @@
     font-weight: bold;
 }
 
-AnacondaMountpointSelector:selected #anaconda-mountpoint-label {
+#anaconda-mountpoint-label:selected {
     color: black;
 }

--- a/widgets/src/resources/SpokeSelector-status.css
+++ b/widgets/src/resources/SpokeSelector-status.css
@@ -4,13 +4,13 @@
 }
 
 /* If the spoke is incomplete, display the text in red */
-AnacondaSpokeSelector:inconsistent #anaconda-spoke-selector-status {
+#anaconda-spoke-selector-status:indeterminate {
     color: #cc1a1a;
 }
 
 /* If the spoke is both incomplete and insensitive, let the insensitive
  * color take precedence
  */
-AnacondaSpokeSelector:insensitive:inconsistent #anaconda-spoke-selector-status {
+#anaconda-spoke-selector-status:disabled:indeterminate {
     color: inherit;
 }


### PR DESCRIPTION
The selectors that depend on state flags set in container classes
stopped working, probably because a more-specific selector in the
default theme overrode them. Propagate state flag changes to the leaf
widgets so that the state-sensitive selectors work again and so that
this can't happen again.

Also switch to the new pseudo-class names that match the CSS
psuedo-class names (but no longer match the names of the state flags
that drive them), which gets rid of all of those deprecation warnings.