### PR TITLE
Don't crash if no groups are specified (#1316816)

### DIFF
--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -156,7 +156,8 @@ class AdvancedUserDialog(GUIObject, GUIDialogInputCheckHandler):
         else:
             self._user.gid = None
 
-        self._user.groups = [g.strip() for g in self._tGroups.get_text().split(",")]
+        # ''.split(',') returns [''] instead of [], which is not what we want
+        self._user.groups = [g.strip() for g in self._tGroups.get_text().split(",") if g]
 
     def run(self):
         self.window.show()


### PR DESCRIPTION
If the groups input field in the GUI is empty, set the groups list to an
empty list instead of a list containing an empty string.