### PR TITLE
Add access to the payload from addons (#1288636)

### DIFF
--- a/pyanaconda/addons.py
+++ b/pyanaconda/addons.py
@@ -23,7 +23,10 @@ __all__ = ["AddonSection", "AddonRegistry", "AddonData", "collect_addon_paths"]
 
 import os
 import functools
+import logging
 from pykickstart.sections import Section
+
+log = logging.getLogger("anaconda")
 
 def collect_addon_paths(toplevel_addon_paths, ui_subdir="gui"):
     """This method looks into the directories present
@@ -77,17 +80,27 @@ class AddonRegistry(object):
         return functools.reduce(lambda acc, (id, addon): acc + str(addon),
                                 self.__dict__.iteritems(), "")
 
-    def execute(self, storage, ksdata, instClass, users):
+    def execute(self, storage, ksdata, instClass, users, payload):
         """This method calls execute on all the registered addons."""
         for v in self.__dict__.itervalues():
             if hasattr(v, "execute"):
-                v.execute(storage, ksdata, instClass, users)
+                if v.execute.func_code.co_argcount == 6:
+                    v.execute(storage, ksdata, instClass, users, payload)
+                else:
+                    v.execute(storage, ksdata, instClass, users)
+                    log.warning("Addon %s is using deprecated method signature", v.name)
+                    log.warning("Use execute(storage, ksdata, instClass, users, payload) instead")
 
-    def setup(self, storage, ksdata, instClass):
+    def setup(self, storage, ksdata, instClass, payload):
         """This method calls setup on all the registered addons."""
         for v in self.__dict__.itervalues():
             if hasattr(v, "setup"):
-                v.setup(storage, ksdata, instClass)
+                if v.setup.func_code.co_argcount == 5:
+                    v.setup(storage, ksdata, instClass, payload)
+                else:
+                    v.setup(storage, ksdata, instClass)
+                    log.warning("Addon %s is using deprecated method signature", v.name)
+                    log.warning("Use setup(storage, ksdata, instClass, payload) instead")
 
 
 class AddonData(object):
@@ -114,7 +127,7 @@ class AddonData(object):
     def __str__(self):
         return "%%addon %s %s\n%s%%end\n" % (self.name, self.header_args, self.content)
 
-    def setup(self, storage, ksdata, instClass):
+    def setup(self, storage, ksdata, instClass, payload):
         """Make the changes to the install system.
 
            This method is called before the installation
@@ -122,7 +135,7 @@ class AddonData(object):
            to call it multiple times without breaking the environment."""
         pass
 
-    def execute(self, storage, ksdata, instClass, users):
+    def execute(self, storage, ksdata, instClass, users, payload):
         """Make the changes to the underlying system.
 
            This method is called only once in the post-install

--- a/pyanaconda/install.py
+++ b/pyanaconda/install.py
@@ -101,7 +101,7 @@ def doConfiguration(storage, payload, ksdata, instClass):
         ksdata.sshkey.execute(storage, ksdata, instClass, u)
 
     with progress_report(_("Configuring addons")):
-        ksdata.addons.execute(storage, ksdata, instClass, u)
+        ksdata.addons.execute(storage, ksdata, instClass, u, payload)
 
     with progress_report(_("Generating initramfs")):
         payload.recreateInitrds(force=True)
@@ -165,7 +165,7 @@ def doInstall(storage, payload, ksdata, instClass):
 
     with progress_report(_("Setting up the installation environment")):
         ksdata.firstboot.setup(storage, ksdata, instClass)
-        ksdata.addons.setup(storage, ksdata, instClass)
+        ksdata.addons.setup(storage, ksdata, instClass, payload)
 
     storage.updateKSData()  # this puts custom storage info into ksdata
 


### PR DESCRIPTION
This should add new payload argument to the ``setup()`` and ``execute()`` methods in the ``AddonData`` class without breaking existing API.

Add deprecation warning for old method signature.

*Resolves: rhbz#1288636*

Reported-by: Pat Riehecky ``<riehecky@fnal.gov>``


If you want to  test it. I'm using this https://github.com/jkonecny12/hello-world-anaconda-addon/tree/master-payload-testing for testing.