### PR TITLE
Stop kickstart when space check fails (#1320436)

### DIFF
--- a/pyanaconda/packaging/yumpayload.py
+++ b/pyanaconda/packaging/yumpayload.py
@@ -1332,6 +1332,10 @@ reposdir=%s
         self.selectRequiredPackages()
 
     def checkSoftwareSelection(self):
+        if not self.baseRepo:
+            log.warn("Skipping checkSoftwareSelect, no base repo setup.")
+            return
+
         log.info("checking software selection")
         self.txID = time.time()
 

--- a/pyanaconda/ui/gui/spokes/software.py
+++ b/pyanaconda/ui/gui/spokes/software.py
@@ -159,10 +159,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
         hubQ.send_message(self.__class__.__name__, payloadMgr.error)
 
     def _apply(self):
-        if not self.environment:
-            return
-
-        if not (flags.automatedInstall and self.data.packages.seen):
+        if self.environment and not (flags.automatedInstall and self.data.packages.seen):
             addons = self._get_selected_addons()
             for group in addons:
                 if group not in self.selectedGroups:

--- a/pyanaconda/ui/tui/spokes/software.py
+++ b/pyanaconda/ui/tui/spokes/software.py
@@ -198,6 +198,14 @@ class SoftwareSpoke(NormalTUISpoke):
 
         self._origEnv = self.environment
 
+    def execute(self):
+        """ Called when kickstarting and all spokes are ready.
+
+            This makes sure that the required size estimate is correct for kickstart.
+        """
+        print(_("Checking software selection"))
+        self.checkSoftwareSelection()
+
     def checkSoftwareSelection(self):
         """ Depsolving """
         try:


### PR DESCRIPTION
Text mode kickstart behavior was inconsistent, it would allow an
installation to continue even though the space check failed. Every other
install method stops, letting the user add more space before continuing.

Resolves: rhbz#1320436