### PR TITLE
Set CSS names on all of the anaconda classes. (#1322036)

### DIFF
--- a/widgets/src/BaseStandalone.c
+++ b/widgets/src/BaseStandalone.c
@@ -152,6 +152,8 @@ static void anaconda_base_standalone_class_init(AnacondaBaseStandaloneClass *kla
                                                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
 
     g_type_class_add_private(object_class, sizeof(AnacondaBaseStandalonePrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaBaseStandalone");
 }
 
 static void anaconda_base_standalone_init(AnacondaBaseStandalone *win) {

--- a/widgets/src/BaseWindow.c
+++ b/widgets/src/BaseWindow.c
@@ -181,6 +181,7 @@ G_DEFINE_TYPE_WITH_CODE(AnacondaBaseWindow, anaconda_base_window, GTK_TYPE_BIN,
 
 static void anaconda_base_window_class_init(AnacondaBaseWindowClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     object_class->set_property = anaconda_base_window_set_property;
     object_class->get_property = anaconda_base_window_get_property;
@@ -264,6 +265,8 @@ static void anaconda_base_window_class_init(AnacondaBaseWindowClass *klass) {
                                                               G_TYPE_NONE, 0);
 
     g_type_class_add_private(object_class, sizeof(AnacondaBaseWindowPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaBaseWindow");
 }
 
 /**

--- a/widgets/src/DiskOverview.c
+++ b/widgets/src/DiskOverview.c
@@ -133,6 +133,7 @@ static gboolean anaconda_disk_overview_focus_changed(GtkWidget *widget, GdkEvent
 
 static void anaconda_disk_overview_class_init(AnacondaDiskOverviewClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     object_class->set_property = anaconda_disk_overview_set_property;
     object_class->get_property = anaconda_disk_overview_get_property;
@@ -238,6 +239,8 @@ static void anaconda_disk_overview_class_init(AnacondaDiskOverviewClass *klass) 
                                                         G_PARAM_READWRITE));
 
     g_type_class_add_private(object_class, sizeof(AnacondaDiskOverviewPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaDiskOverview");
 }
 
 /**

--- a/widgets/src/HubWindow.c
+++ b/widgets/src/HubWindow.c
@@ -100,8 +100,11 @@ G_DEFINE_TYPE_WITH_CODE(AnacondaHubWindow, anaconda_hub_window, ANACONDA_TYPE_BA
 
 static void anaconda_hub_window_class_init(AnacondaHubWindowClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     g_type_class_add_private(object_class, sizeof(AnacondaHubWindowPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaHubWindow");
 }
 
 /**

--- a/widgets/src/LayoutIndicator.c
+++ b/widgets/src/LayoutIndicator.c
@@ -108,6 +108,7 @@ static GdkFilterReturn handle_xevent(GdkXEvent *xev, GdkEvent *event, gpointer e
 
 static void anaconda_layout_indicator_class_init(AnacondaLayoutIndicatorClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     object_class->get_property = anaconda_layout_indicator_get_property;
     object_class->set_property = anaconda_layout_indicator_set_property;
@@ -144,6 +145,8 @@ static void anaconda_layout_indicator_class_init(AnacondaLayoutIndicatorClass *k
                                                       G_PARAM_READWRITE));
 
     g_type_class_add_private(object_class, sizeof(AnacondaLayoutIndicatorPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaLayoutIndicator");
 }
 
 /**

--- a/widgets/src/MountpointSelector.c
+++ b/widgets/src/MountpointSelector.c
@@ -113,6 +113,7 @@ static void anaconda_mountpoint_selector_toggle_background(AnacondaMountpointSel
 
 static void anaconda_mountpoint_selector_class_init(AnacondaMountpointSelectorClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     object_class->set_property = anaconda_mountpoint_selector_set_property;
     object_class->get_property = anaconda_mountpoint_selector_get_property;
@@ -202,6 +203,8 @@ static void anaconda_mountpoint_selector_class_init(AnacondaMountpointSelectorCl
                                           NULL);            // array of types, one for each parameter
 
     g_type_class_add_private(object_class, sizeof(AnacondaMountpointSelectorPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaMountpointSelector");
 }
 
 /**

--- a/widgets/src/SpokeSelector.c
+++ b/widgets/src/SpokeSelector.c
@@ -104,6 +104,7 @@ static gboolean anaconda_spoke_selector_focus_changed(GtkWidget *widget, GdkEven
 
 static void anaconda_spoke_selector_class_init(AnacondaSpokeSelectorClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     object_class->set_property = anaconda_spoke_selector_set_property;
     object_class->get_property = anaconda_spoke_selector_get_property;
@@ -166,6 +167,8 @@ static void anaconda_spoke_selector_class_init(AnacondaSpokeSelectorClass *klass
                                                         G_PARAM_READWRITE));
 
     g_type_class_add_private(object_class, sizeof(AnacondaSpokeSelectorPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaSpokeSelector");
 }
 
 /**

--- a/widgets/src/SpokeWindow.c
+++ b/widgets/src/SpokeWindow.c
@@ -74,6 +74,7 @@ static void anaconda_spoke_window_button_clicked(GtkButton *button,
 
 static void anaconda_spoke_window_class_init(AnacondaSpokeWindowClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     klass->button_clicked = NULL;
 
@@ -99,6 +100,8 @@ static void anaconda_spoke_window_class_init(AnacondaSpokeWindowClass *klass) {
                                                          G_TYPE_NONE, 0);
 
     g_type_class_add_private(object_class, sizeof(AnacondaSpokeWindowPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaSpokeWindow");
 }
 
 /**

--- a/widgets/src/StandaloneWindow.c
+++ b/widgets/src/StandaloneWindow.c
@@ -70,6 +70,7 @@ G_DEFINE_TYPE(AnacondaStandaloneWindow, anaconda_standalone_window, ANACONDA_TYP
 
 static void anaconda_standalone_window_class_init(AnacondaStandaloneWindowClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     object_class->get_property = anaconda_standalone_window_get_property;
 
@@ -113,6 +114,8 @@ static void anaconda_standalone_window_class_init(AnacondaStandaloneWindowClass 
                                                         G_PARAM_READABLE));
 
     g_type_class_add_private(object_class, sizeof(AnacondaStandaloneWindowPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaStandaloneWindow");
 }
 
 static void anaconda_standalone_window_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec) {


### PR DESCRIPTION
Without this, the name usable by CSS selectors ends up being "widget".
Set the CSS name to the type name so that CSS works right again.