### PR TITLE
Fix only one address is shown in anaconda (#1264400)

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -67,6 +67,9 @@ SECRET_AGENT_IFACE = 'org.freedesktop.NetworkManager.SecretAgent'
 AGENT_MANAGER_IFACE = 'org.freedesktop.NetworkManager.AgentManager'
 AGENT_MANAGER_PATH = "/org/freedesktop/NetworkManager/AgentManager"
 
+IPV4_CONFIG = "IPv4"
+IPV6_CONFIG = "IPv6"
+
 DEVICES_COLUMN_TITLE = 2
 DEVICES_COLUMN_OBJECT = 3
 
@@ -747,9 +750,35 @@ class NetworkControlBox(GObject.GObject):
         else:
             self.add_dev_cfg(DeviceConfiguration(device=device, con=con))
 
-        device.connect("notify::ip4-config", self.on_device_config_changed)
-        device.connect("notify::ip6-config", self.on_device_config_changed)
+        device.connect("notify::ip4-config", self.on_ip_obj_changed, IPV4_CONFIG)
+        device.connect("notify::ip6-config", self.on_ip_obj_changed, IPV6_CONFIG)
         device.connect("state-changed", self.on_device_state_changed)
+
+    def on_ip_obj_changed(self, device, *args):
+        """Callback when ipX-config objects will be changed.
+
+        Register callback on properties (IP address, gateway...) of these ipX-config
+        objects when they are created.
+        """
+        log.debug("%s object changed", args[1])
+        self.on_device_config_changed(device)
+        if args[1] == IPV4_CONFIG:
+            config = device.props.ip4_config
+        else:
+            config = device.props.ip6_config
+
+        if config:
+            # register callback when inner NMIP[4,6]Config object changed
+            config.connect("notify::addresses", self.on_config_changed, device)
+            config.connect("notify::gateway", self.on_config_changed, device)
+            config.connect("notify::nameservers", self.on_config_changed, device)
+
+    def on_config_changed(self, config, *args):
+        """Callback on property change of ipX-config objects.
+
+        Call method which show changed properties (IP, gateway...) to an user.
+        """
+        self.on_device_config_changed(args[1])
 
     def _dev_icon_name(self, dev_cfg):
         icon_name = ""
@@ -1172,6 +1201,22 @@ class NetworkControlBox(GObject.GObject):
         for device in self.client.get_devices():
             _try_disconnect(device, self.on_device_config_changed)
             _try_disconnect(device, self.on_device_state_changed)
+            _try_disconnect(device, self.on_ip_obj_changed)
+            for config in self._get_ip_configs(device):
+                _try_disconnect(config, self.on_config_changed)
+
+    def _get_ip_configs(self, device):
+        out = []
+        try:
+            out.append(self.props.ip4_config)
+        except AttributeError:
+            pass
+        try:
+            out.append(self.props.ip6_config)
+        except AttributeError:
+            pass
+
+        return out
 
 def _try_disconnect(obj, callback):
     try:


### PR DESCRIPTION
Only NMIP[4,6]Config object was connected to signal on change. But when inner objects (Addresses, Nameservers, Gateway) changed it doesn't notify us about this change.
Fix by connecting this inner properties too.

Resolves: *rhbz#1264400*

Reported-by: Marek Hruscak <mhruscak@redhat.com>

Master/F24 version of https://github.com/rhinstaller/anaconda/pull/556 . On master we need to disconnect signals so more code was required here.

(cherry picked from commit b9323749c470ca3ef24bfee82f911a7b85d8f7fe)