### PR TITLE
Don't use booleans in Requires

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -144,7 +144,7 @@ Requires: python3-coverage >= 4.0-0.12.b3
 Requires: anaconda-tui = %{version}-%{release}
 
 # Make sure we get the en locale one way or another
-Requires: (glibc-langpack-en or glibc-all-langpacks)
+Requires: glibc-langpack-en
 
 Obsoletes: anaconda-images <= 10
 Provides: anaconda-images = %{version}-%{release}


### PR DESCRIPTION
We're not allowed to use booleans in Requires because dnf-by-default did
not include the tools used to construct a Fedora compose. This means
that boot.iso and other situations will end up with both
glibc-langpack-en and glibc-all-langpacks, but that's apparently the
world we live in now.