### PR TITLE
Fix btrfs metadata raid level kwarg.

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -507,7 +507,7 @@ class BTRFSData(commands.btrfs.F23_BTRFSData):
                 request = storage.new_btrfs(name=name,
                                        subvol=self.subvol,
                                        mountpoint=self.mountpoint,
-                                       meta_data_level=self.metaDataLevel,
+                                       metadata_level=self.metaDataLevel,
                                        data_level=self.dataLevel,
                                        parents=members,
                                        create_options=self.mkfsopts)


### PR DESCRIPTION
Missed when converting to blivet-2.0 API.