### PR TITLE
Fix adding offload iSCSI devices

### DIFF
--- a/pyanaconda/ui/gui/spokes/filter.py
+++ b/pyanaconda/ui/gui/spokes/filter.py
@@ -177,7 +177,7 @@ class SearchPage(FilterPage):
 
         ports = []
         for disk in disks:
-            if hasattr(disk, "node"):
+            if hasattr(disk, "node") and disk.node is not None:
                 ports.append(str(disk.node.port))
 
         self.setupCombo(self._portCombo, ports)
@@ -337,7 +337,7 @@ class OtherPage(FilterPage):
             paths = [d.name for d in disk.parents]
             selected = disk.name in selectedNames
 
-            if hasattr(disk, "node"):
+            if hasattr(disk, "node") and disk.node is not None:
                 port = str(disk.node.port)
                 lun = str(disk.node.tpgt)
             else:


### PR DESCRIPTION
Offload iscsi devices have `node` set to `None` so we can't use it to get the port and other stuff.