### PR TITLE
network: handle null wireless AP SSID object (#1262556)

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -527,6 +527,9 @@ class NetworkControlBox(GObject.GObject):
 
     def _find_first_ap_setting(self, device, ap):
         for con in device.filter_connections(self.client.get_connections()):
+            if not con.get_setting_wireless().get_ssid():
+                # non-broadcast AP, we ignore these
+                return
             if con.get_setting_wireless().get_ssid().get_data() == ap.get_ssid().get_data():
                 return con
 
@@ -1080,7 +1083,11 @@ class NetworkControlBox(GObject.GObject):
             value_label.set_label(value_str)
 
     def _add_ap(self, ap, active=False):
-        ssid = ap.get_ssid().get_data()
+        ssid = ap.get_ssid()
+        if not ssid:
+            # get_ssid can return None if AP does not broadcast.
+            return
+        ssid = ssid.get_data()
         if not ssid:
             return
 
@@ -1108,6 +1115,9 @@ class NetworkControlBox(GObject.GObject):
     def _get_strongest_unique_aps(self, access_points):
         strongest_aps = {}
         for ap in access_points:
+            if not ap.get_ssid():
+                # non-broadcasting AP. We don't do anything with these
+                continue
             ssid = ap.get_ssid().get_data()
             if ssid in strongest_aps:
                 if ap.get_strength() > strongest_aps[ssid].get_strength():


### PR DESCRIPTION
With current NetworkManager, per Beniamino Galvani on the bug,
the Ssid for an AccessPoint can be null (if the AP is set not
to broadcast its SSID). Thus we could try and do
None.get_data() and blow up.

The case that definitely caused crashes is _get_strongest_
unique_aps. However it looks to me like _find_first_ap_setting
might also theoretically hit this (I don't think it's terribly
likely, but we might as well be safe).

At present _add_ap is only called after _get_strongest_unique
is done, so in theory we don't need to fix that one, but it's a
pretty generic method so probably safest to fix it too. I'm not
sure we really *need* to check both get_ssid() and get_data();
it may be that once get_ssid() has worked, get_data() always
will too. But I wasn't sure, so I played it safe.

The other cases that I didn't change are all, I think, only ever
going to be used on one of the APs in NM's list after it's been
updated, and we throw out all non-broadcast APs in _add_ap, so
I don't think we need to 'fix' those, we can safely assume that
they'll work.

Resolves: rhbz#1262556