### PR TITLE
Work around logging's crummy lock behavior.

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -142,6 +142,7 @@ Requires: kexec-tools
 %endif
 Requires: python3-pid
 Requires: python3-ordered-set >= 2.0.0
+Requires: python3-wrapt
 
 Requires: python3-coverage >= 4.0-0.12.b3
 


### PR DESCRIPTION
The log handlers in Python's logging module use mutexes to guard against
multiple threads writing to the same log at the same time. However, it
does not hold this lock only during the write operation. It holds the
lock during Handler.handle(), which includes formatting the log record.
The problem with that is that the format operation has to stringify all
of those objects that we passed to the log function, and if any of those
objects happen to have locks of their own to ensure data consistency,
like blivet objects do, then things can go south in a hurry.

See also https://bugs.python.org/issue24645

Override this locking behavior in our Handler subclasses so that the
lock is held at a less stupid point in this process.