### PR TITLE
Remove dnf from the list of required packages.

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -840,7 +840,6 @@ class DNFPayload(packaging.PackagePayload):
 
     def preInstall(self, packages=None, groups=None):
         super(DNFPayload, self).preInstall(packages, groups)
-        self.requiredPackages += ["dnf"]
         if packages:
             self.requiredPackages += packages
         self.requiredGroups = groups


### PR DESCRIPTION
This being part of the payload is leftover from the days when the
payload type was a choice, and those days are in the past. dnf is part
of @core now, so just let it live there.