### PR TITLE
Use Blivet 2.0 for set_default_fstype

### DIFF
--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -173,7 +173,7 @@ class Anaconda(object):
             self._storage = blivet.Blivet(ksdata=self.ksdata)
 
             if self.instClass.defaultFS:
-                self._storage.setDefaultFSType(self.instClass.defaultFS)
+                self._storage.set_default_fstype(self.instClass.defaultFS)
 
             if blivet.arch.is_s390():
                 # want to make sure s390 plugin is loaded


### PR DESCRIPTION
If an InstallClass sets the DefaultFSType variable, this code path
gets executed and crashes anaconda because the method was renamed
in Blivet 2.0.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1329019