### PR TITLE
Remove detach-client from tmux.conf

### DIFF
--- a/data/tmux.conf
+++ b/data/tmux.conf
@@ -17,4 +17,8 @@ new-window -d -n log            "tail -F /tmp/anaconda.log"
 new-window -d -n storage-log    "tail -F /tmp/storage.log"
 new-window -d -n program-log    "tail -F /tmp/program.log"
 
-detach-client -s anaconda
+# The idea here is to detach the client started here via anaconda.service, and
+# then re-attach to it in the tmux service run on the console tty. However,
+# the detach-client directive is now giving us "no current client" for some
+# reason.
+# detach-client -s anaconda


### PR DESCRIPTION
Whatever this was supposed to do, it's not doing it anymore.