### PR TITLE
F24 ostree dirinstall

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -76,6 +76,15 @@ def exitHandler(rebootData, storage):
         while True:
             time.sleep(10000)
 
+    if anaconda.dbus_inhibit_id:
+        from pyanaconda.screensaver import uninhibit_screensaver
+        uninhibit_screensaver(anaconda.dbus_session_connection, anaconda.dbus_inhibit_id)
+        anaconda.dbus_inhibit_id = None
+
+    # Unsetup the payload, which most usefully unmounts live images
+    if anaconda.payload:
+        anaconda.payload.unsetup()
+
     if image_count or flags.dirInstall:
         anaconda.storage.umountFilesystems(swapoff=False)
         devicetree = anaconda.storage.devicetree
@@ -85,15 +94,6 @@ def exitHandler(rebootData, storage):
             for loop in dev.parents:
                 loop.controllable = True
             dev.deactivate(recursive=True)
-
-    if anaconda.dbus_inhibit_id:
-        from pyanaconda.screensaver import uninhibit_screensaver
-        uninhibit_screensaver(anaconda.dbus_session_connection, anaconda.dbus_inhibit_id)
-        anaconda.dbus_inhibit_id = None
-
-    # Unsetup the payload, which most usefully unmounts live images
-    if anaconda.payload:
-        anaconda.payload.unsetup()
 
     # Clean up the PID file
     if pidfile:

--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -636,29 +636,11 @@ class Payload(object):
            every payload except for dnf.  Payloads should only implement one of
            these methods by overriding the unneeded one with a pass.
         """
-        if not flags.dirInstall:
-            if iutil.getSysroot() != iutil.getTargetPhysicalRoot():
-                setSysroot(iutil.getTargetPhysicalRoot(), iutil.getSysroot())
-
-                # Now that we have the FS layout in the target, umount
-                # things that were in the legacy sysroot, and put them in
-                # the target root, except for the physical /.  First,
-                # unmount all target filesystems.
-                self.storage.umountFilesystems()
-
-                # Explicitly mount the root on the physical sysroot
-                rootmnt = self.storage.mountpoints.get('/')
-                rootmnt.setup()
-                rootmnt.format.setup(options=rootmnt.format.options, chroot=iutil.getTargetPhysicalRoot())
-
-                self.prepareMountTargets(self.storage)
-
-                # Everything else goes in the target root, including /boot
-                # since the bootloader code will expect to find /boot
-                # inside the chroot.
-                self.storage.mountFilesystems(skipRoot=True)
-
-            self.storage.write()
+        if iutil.getSysroot() != iutil.getTargetPhysicalRoot():
+            setSysroot(iutil.getTargetPhysicalRoot(), iutil.getSysroot())
+            self.prepareMountTargets(self.storage)
+            if not flags.dirInstall:
+                self.storage.write()
 
 # Inherit abstract methods from Payload
 # pylint: disable=abstract-method

--- a/pyanaconda/packaging/rpmostreepayload.py
+++ b/pyanaconda/packaging/rpmostreepayload.py
@@ -22,6 +22,7 @@
 
 import os
 import sys
+from subprocess import CalledProcessError
 
 from pyanaconda import constants
 from pyanaconda import iutil
@@ -269,7 +270,10 @@ class RPMOSTreePayload(ArchivePayload):
         super(RPMOSTreePayload, self).unsetup()
 
         for mount in reversed(self._internal_mounts):
-            umount(mount)
+            try:
+                umount(mount)
+            except CalledProcessError as e:
+                log.debug("unmounting %s failed: %s", str(e))
 
     def recreateInitrds(self):
         # For rpmostree payloads, we're replicating an initramfs from

--- a/pyanaconda/packaging/rpmostreepayload.py
+++ b/pyanaconda/packaging/rpmostreepayload.py
@@ -228,15 +228,21 @@ class RPMOSTreePayload(ArchivePayload):
         mainctx.pop_thread_default()
 
     def prepareMountTargets(self, storage):
+        """ Prepare the ostree root """
         ostreesetup = self.data.ostreesetup
 
         varroot = iutil.getTargetPhysicalRoot() + '/ostree/deploy/' + ostreesetup.osname + '/var'
 
         # Set up bind mounts as if we've booted the target system, so
         # that %post script work inside the target.
-        binds = [(varroot,
-                  iutil.getSysroot() + '/var'),
-                 (iutil.getSysroot() + '/usr', None)]
+        binds = [(varroot, iutil.getSysroot() + '/var'),
+                 (iutil.getSysroot() + '/usr', None),
+                 (iutil.getTargetPhysicalRoot(), iutil.getSysroot() + "/sysroot"),
+                 (iutil.getTargetPhysicalRoot() + "/boot", iutil.getSysroot() + "/boot")]
+
+        # Bind mount the other filesystems from /mnt/sysimage to the ostree root
+        for path in ["/dev", "/dev/pts", "/dev/shm", "/proc", "/run", "/sys", "/sys/fs/selinux"]:
+            binds += [(iutil.getTargetPhysicalRoot()+path, iutil.getSysroot()+path)]
 
         for (src, dest) in binds:
             self._safeExecWithRedirect("mount",
@@ -245,15 +251,6 @@ class RPMOSTreePayload(ArchivePayload):
             if dest is None:
                 self._safeExecWithRedirect("mount",
                                            ["--bind", "-o", "remount,ro", src, src])
-
-        # We previously bind mounted /mnt/sysimage to
-        # /mnt/sysimage/.../sysroot, but this caused issues with mount
-        # path canonicalization.  Instead, directly mount the physical
-        # device at two different paths.
-        dest = iutil.getSysroot() + "/sysroot"
-        self._safeExecWithRedirect("mount",
-                                   [storage.rootDevice.format.device, dest])
-        self._internal_mounts.append(dest)
 
         # Now, ensure that all other potential mount point directories such as
         # (/home) are created.  We run through the full tmpfiles here in order

--- a/pyanaconda/packaging/rpmostreepayload.py
+++ b/pyanaconda/packaging/rpmostreepayload.py
@@ -315,13 +315,15 @@ class RPMOSTreePayload(ArchivePayload):
             os.rename(boot_grub2_cfg, target_grub_cfg)
             os.symlink('../loader/grub.cfg', boot_grub2_cfg)
 
-        # OSTree owns the bootloader configuration, so here we give it
-        # the argument list we computed from storage, architecture and
-        # such.
-        set_kargs_args = ["admin", "instutil", "set-kargs"]
-        set_kargs_args.extend(self.storage.bootloader.boot_args)
-        set_kargs_args.append("root=" + self.storage.rootDevice.fstabSpec)
-        self._safeExecWithRedirect("ostree", set_kargs_args, root=iutil.getSysroot())
+        # Skip kernel args setup for dirinstall, there is no bootloader or rootDevice setup.
+        if not flags.dirInstall:
+            # OSTree owns the bootloader configuration, so here we give it
+            # the argument list we computed from storage, architecture and
+            # such.
+            set_kargs_args = ["admin", "instutil", "set-kargs"]
+            set_kargs_args.extend(self.storage.bootloader.boot_args)
+            set_kargs_args.append("root=" + self.storage.rootDevice.fstabSpec)
+            self._safeExecWithRedirect("ostree", set_kargs_args, root=iutil.getSysroot())
 
     def writeStorageEarly(self):
         pass


### PR DESCRIPTION
These patches allow --dirinstall (and --dirinstall inside a mock) to be used for --make-pxe-live and --make-ostree-live