### PR TITLE
Check for mounted partitions as part of sanity_check (#1330820)

### DIFF
--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -323,6 +323,8 @@ def sanity_check(storage, min_ram=isys.MIN_RAM):
 
     exns += verify_LUKS_devices_have_key(storage)
 
+    exns += check_mounted_partitions(storage)
+
     return exns
 
 
@@ -343,6 +345,22 @@ def verify_LUKS_devices_have_key(storage):
        not d.format.exists and \
        not d.format.hasKey):
         yield LUKSDeviceWithoutKeyError(_("Encryption requested for LUKS device %s but no encryption key specified for this device.") % (dev.name,))
+
+
+def check_mounted_partitions(storage):
+    """ Check the selected disks to make sure all their partitions are unmounted.
+
+        :rtype: generator of str
+        :returns: a generator of error messages, may yield no error messages
+    """
+    for disk in storage.disks:
+        if not disk.format:
+            continue
+
+        for part in disk.format.partitions:
+            if part.busy:
+                yield SanityError(_("%s is currently mounted and cannot be used for the "
+                                    "installation. Please unmount it and retry.") % part.path)
 
 
 def bound_size(size, device, old_size):


### PR DESCRIPTION
Sometimes partitions end up being mounted, especially during live
installations, so add a check to make sure none of the selected disks
have mounted partitions.