### PR TITLE
Look higher for the combobox associated with an entry (#1333530)

### DIFF
--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -1020,6 +1020,11 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
     def on_city_region_text_entry_activated(self, entry):
         combo = entry.get_parent()
+
+        # It's gotta be up there somewhere, right? right???
+        while not isinstance(combo, Gtk.ComboBox):
+            combo = combo.get_parent()
+
         model = combo.get_model()
         entry_text = entry.get_text().lower()
 


### PR DESCRIPTION
Fun gtk fact: when creating a GtkComboBox with an associated entry,
gtk_bin_get_child() on the combobox returns the GtkEntry.
gtk_widget_get_parent() on the entry returns a GtkBox.