### PR TITLE
Rerun writeBootLoader on Live BTRFS installs

### DIFF
--- a/pyanaconda/install.py
+++ b/pyanaconda/install.py
@@ -102,9 +102,10 @@ def doConfiguration(storage, payload, ksdata, instClass):
     with progress_report(N_("Generating initramfs")):
         payload.recreateInitrds()
 
-    # Work around rhbz#1200539, grubby doesn't handle grub2 missing initrd with /boot on btrfs
-    # So rerun writing the bootloader if this is live and /boot is on btrfs
-    boot_on_btrfs = isinstance(storage.mountpoints.get("/boot", storage.mountpoints.get("/")), BTRFSDevice)
+    # This works around 2 problems, /boot on BTRFS and BTRFS installations where the initrd is
+    # recreated after the first writeBootLoader call. This reruns it after the new initrd has
+    # been created, fixing the kernel root and subvol args and adding the missing initrd entry.
+    boot_on_btrfs = isinstance(storage.mountpoints.get("/"), BTRFSDevice)
     if flags.flags.livecdInstall and boot_on_btrfs \
                                  and (not ksdata.bootloader.disabled and ksdata.bootloader != "none"):
         writeBootLoader(storage, payload, instClass, ksdata)


### PR DESCRIPTION
In order to support installation of live media without an initramfs (to
save space) this reruns writeBootLoader for all live BTRFS
installations. This will also fix the missing initrd line when
/boot is on BTRFS (see rhbz#1200539).

Without this the initial grub2-mkconfig without an initramfs doesn't
build the kernel cmdline correctly. On live installations the initramfs
is always rebuilt, but that happens after the initial call to
writeBootLoader.