### PR TITLE
Single language mode

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -312,6 +312,8 @@ def parseArguments(argv=None, boot_cmdline=None):
     # Language
     ap.add_argument("--keymap", metavar="KEYMAP", help=help_parser.help_text("keymap"))
     ap.add_argument("--lang", metavar="LANG", help=help_parser.help_text("lang"))
+    ap.add_argument("--singlelang", action="store_true", default=False,
+                    help=help_parser.help_text("singlelang"))
 
     # Obvious
     ap.add_argument("--loglevel", metavar="LEVEL", help=help_parser.help_text("loglevel"))
@@ -988,6 +990,7 @@ if __name__ == "__main__":
     flags.selinux = opts.selinux
     flags.eject = opts.eject
     flags.kexec = opts.kexec
+    flags.singlelang = opts.singlelang
 
     # Switch to tty1 on exception in case something goes wrong during X start.
     # This way if, for example, metacity doesn't start, we switch back to a

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -109,6 +109,9 @@ lang
 Language to use for the installation. LANG should be a language code which is valid to be used
 with the lang kickstart command.
 
+singlelang
+Install in single language mode -  no interactive options for language configuration will be available.
+
 loglevel
 Set the minimum level required for messages to be logged on a terminal (log files always
 contain messages of all levels). Values for LEVEL are "debug", "info", "warning", "error",

--- a/docs/boot-options.txt
+++ b/docs/boot-options.txt
@@ -213,6 +213,15 @@ Implies <<inst.text,`inst.text`>>.
 Set the language to be used during installation. The language specified must
 be valid for the `lang` kickstart command.
 
+=== inst.singlelang ===
+Install in single language mode - no interactive options for installation language
+and language support configuration will be available.
+If a language has been specified via the <<inst.lang,`inst.lang`>> boot option
+or the `lang` kickstart command it will be used.
+If no language is specified Anaconda will default to en_US.UTF-8.
+
+*NOTE*: Atomic installations always run in single language mode.
+
 === inst.geoloc ===
 Configure geolocation usage in Anaconda. Geolocation is used to pre-set
 language and time zone.

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -74,6 +74,8 @@ class Flags(object):
         self.nosave_input_ks = False
         self.nosave_output_ks = False
         self.nosave_logs = False
+        # single language options
+        self.singlelang = False
         # parse the boot commandline
         self.cmdline = BootArgs()
         # Lock it down: no more creating new flags!

--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -17,11 +17,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import logging
+log = logging.getLogger("anaconda")
+
 from pyanaconda.installclass import BaseInstallClass
 from pyanaconda.product import productName
 from pyanaconda import network
 from pyanaconda import nm
 from pyanaconda.kickstart import getAvailableDiskSpace
+from pyanaconda.flags import flags
 from blivet.partspec import PartSpec
 from blivet.platform import platform
 from blivet.devicelibs import swap
@@ -72,6 +76,12 @@ class RHELAtomicInstallClass(RHELBaseInstallClass):
     name = "Red Hat Enterprise Linux Atomic Host"
     sortPriority=21000
     hidden = not productName.startswith(("RHEL Atomic Host", "Red Hat Enterprise Linux Atomic"))
+
+    def configure(self, anaconda):
+        RHELBaseInstallClass.configure(self, anaconda)
+        # Atomic installations are always single language (#1235726)
+        log.info("Automatically enabling single language mode for %s installation." % self.name)
+        flags.singlelang = True
 
     def setDefaultPartitioning(self, storage):
         autorequests = [PartSpec(mountpoint="/", fstype=storage.defaultFSType,

--- a/pyanaconda/keyboard.py
+++ b/pyanaconda/keyboard.py
@@ -29,9 +29,11 @@ mutually converting X layouts and VConsole keymaps.
 import os
 import re
 import shutil
+import langtable
 
 from pyanaconda import iutil
 from pyanaconda import safe_dbus
+from pyanaconda import localization
 from pyanaconda.constants import DEFAULT_VC_FONT, DEFAULT_KEYBOARD
 from pyanaconda.flags import can_touch_runtime_system
 
@@ -320,6 +322,55 @@ def activate_keyboard(keyboard):
 
         # write out keyboard configuration for the X session
         write_keyboard_config(keyboard, root="/", convert=False)
+
+def set_x_keyboard_defaults(ksdata, xkl_wrapper):
+    """
+    Set default keyboard settings (layouts, layout switching).
+
+    :param ksdata: kickstart instance
+    :type ksdata: object instance
+    :param xkl_wrapper: XklWrapper instance
+    :type xkl_wrapper: object instance
+    :raise InvalidLocaleSpec: if an invalid locale is given (see
+                              localization.LANGCODE_RE)
+    """
+    locale = ksdata.lang.lang
+
+    # remove all X layouts that are not valid X layouts (unsupported)
+    for layout in ksdata.keyboard.x_layouts:
+        if not xkl_wrapper.is_valid_layout(layout):
+            ksdata.keyboard.x_layouts.remove(layout)
+
+    if ksdata.keyboard.x_layouts:
+        # do not add layouts if there are any specified in the kickstart
+        # (the x_layouts list comes from kickstart)
+        return
+
+    layouts = localization.get_locale_keyboards(locale)
+    if layouts:
+        # take the first locale (with highest rank) from the list and
+        # store it normalized
+        new_layouts = [normalize_layout_variant(layouts[0])]
+        if not langtable.supports_ascii(layouts[0]):
+            # does not support typing ASCII chars, append the default layout
+            new_layouts.append(DEFAULT_KEYBOARD)
+    else:
+        log.error("Failed to get layout for chosen locale '%s'", locale)
+        new_layouts = [DEFAULT_KEYBOARD]
+
+    ksdata.keyboard.x_layouts = new_layouts
+    if can_touch_runtime_system("replace runtime X layouts", touch_live=True):
+        xkl_wrapper.replace_layouts(new_layouts)
+
+    if len(new_layouts) >= 2 and not ksdata.keyboard.switch_options:
+        # initialize layout switching if needed
+        ksdata.keyboard.switch_options = ["grp:alt_shift_toggle"]
+
+        if can_touch_runtime_system("init layout switching", touch_live=True):
+            xkl_wrapper.set_switching_options(["grp:alt_shift_toggle"])
+            # activate the language-default layout instead of the additional
+            # one
+            xkl_wrapper.activate_default_layout()
 
 class LocaledWrapperError(KeyboardConfigError):
     """Exception class for reporting Localed-related problems"""

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -322,6 +322,12 @@ class KeyboardSpoke(NormalSpoke):
 
     def initialize(self):
         NormalSpoke.initialize(self)
+
+        # set X keyboard defaults
+        # - this needs to be done early in spoke initialization so that
+        #   the spoke status does not show outdated keyboard selection
+        keyboard.set_x_keyboard_defaults(self.data, self._xkl_wrapper)
+
         self._add_dialog = AddLayoutDialog(self.data)
         self._add_dialog.initialize()
 

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -328,6 +328,10 @@ class KeyboardSpoke(NormalSpoke):
         #   the spoke status does not show outdated keyboard selection
         keyboard.set_x_keyboard_defaults(self.data, self._xkl_wrapper)
 
+        # make sure the x_layouts list has at least one keyboard layout
+        if not self.data.keyboard.x_layouts:
+            self.data.keyboard.x_layouts.append(DEFAULT_KEYBOARD)
+
         self._add_dialog = AddLayoutDialog(self.data)
         self._add_dialog.initialize()
 

--- a/pyanaconda/ui/gui/spokes/langsupport.py
+++ b/pyanaconda/ui/gui/spokes/langsupport.py
@@ -113,7 +113,8 @@ class LangsupportSpoke(LangLocaleHandler, NormalSpoke):
 
     @property
     def showable(self):
-        return not flags.livecdInstall
+        # don't show the language support spoke on live media and in single language mode
+        return not flags.livecdInstall and not flags.singlelang
 
     @property
     def status(self):

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -86,6 +86,12 @@ class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
 
     @property
     def completed(self):
+        # Skip the welcome screen if we are in single language mode
+        # If language has not been set the default language (en_US)
+        # will be used for the installation and for the installed system.
+        if flags.flags.singlelang:
+            return True
+
         if flags.flags.automatedInstall and self.data.lang.seen:
             return self.data.lang.lang and self.data.lang.lang != ""
         else:

--- a/pyanaconda/ui/tui/spokes/langsupport.py
+++ b/pyanaconda/ui/tui/spokes/langsupport.py
@@ -23,6 +23,7 @@ from pyanaconda.ui.categories.localization import LocalizationCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.simpleline import TextWidget, ColumnWidget
 from pyanaconda.ui.common import FirstbootSpokeMixIn
+from pyanaconda.flags import flags
 from pyanaconda import localization
 from pyanaconda.i18n import N_, _, C_
 
@@ -56,6 +57,11 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     @property
     def mandatory(self):
         return False
+
+    @property
+    def showable(self):
+        # don't show the language support spoke in single language mode
+        return not flags.singlelang
 
     @property
     def status(self):


### PR DESCRIPTION
This pull request adds a single language mode to Anaconda - in this mode no interactive language configuration is possible during the installation. Language can still be set via the _inst.lang_ boot option or the _lang_ kickstart command, but can't be changed during the installation. If no language is set aanconda will use the default language (en_US).

Single language mode can be enabled by the _inst.singlelang_ boot option and is enabled by default for all Atomic installations.

