### PR TITLE
Deselect all addons correctly (#1333505)

### DIFF
--- a/pyanaconda/ui/gui/spokes/software.py
+++ b/pyanaconda/ui/gui/spokes/software.py
@@ -185,10 +185,13 @@ class SoftwareSelectionSpoke(NormalSpoke):
         if not self.environment:
             return
 
+        # NOTE: This block is skipped for kickstart where addons and _origAddons will
+        # both be [], preventing it from wiping out the kickstart's package selection
         addons = self._get_selected_addons()
-        for group in addons:
-            if group not in self.selectedGroups:
-                self.selectedGroups.append(group)
+        if set(addons) != set(self._origAddons):
+            for group in addons:
+                if group not in self.selectedGroups:
+                    self.selectedGroups.append(group)
 
             self._selectFlag = False
             self.payload.data.packages.packageList = []


### PR DESCRIPTION
If depsolve failed with some (or all) addons selected it wasn't cleared
by deselecting all of them because the package and group set were never
cleared.

Add a check to skip this if the addons have not been changed (or never
set, as is the case with kickstart).