### PR TITLE
Fix UEFI installation after EFIBase refactor

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1772,7 +1772,7 @@ class EFIBase(object):
         self.add_efi_boot_target()
 
 
-class EFIGRUB1(GRUB, EFIBase):
+class EFIGRUB1(EFIBase, GRUB):
     packages = ["efibootmgr"]
     can_dual_boot = False
 
@@ -1808,7 +1808,7 @@ class EFIGRUB1(GRUB, EFIBase):
                                    self.efi_product_path)
 
 
-class EFIGRUB(GRUB2, EFIBase):
+class EFIGRUB(EFIBase, GRUB2):
     packages = ["grub2-efi", "efibootmgr", "shim"]
     can_dual_boot = False
     stage2_is_valid_stage1 = False


### PR DESCRIPTION
Python class search is left to right and depth first. So it was using
the GRUB/GRUB2 methods before the EFIBase methods.