### PR TITLE
Fix writeStorageLate for live installations (#1334019)

### DIFF
--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -687,8 +687,8 @@ class Payload(object):
         if iutil.getSysroot() != iutil.getTargetPhysicalRoot():
             set_sysroot(iutil.getTargetPhysicalRoot(), iutil.getSysroot())
             self.prepareMountTargets(self.storage)
-            if not flags.dirInstall:
-                self.storage.write()
+        if not flags.dirInstall:
+            self.storage.write()
 
 # Inherit abstract methods from Payload
 # pylint: disable=abstract-method


### PR DESCRIPTION
Ends up this is used by live, so the storage.write() call should be called.