### PR TITLE
network: don't crash on devices with zero MAC address (#1334632)

### DIFF
--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -161,7 +161,7 @@ SCREENSHOTS_DIRECTORY = "/tmp/anaconda-screenshots"
 SCREENSHOTS_TARGET_DIRECTORY = "/root/anaconda-screenshots"
 
 # cmdline arguments that append instead of overwrite
-CMDLINE_APPEND = ["modprobe.blacklist"]
+CMDLINE_APPEND = ["modprobe.blacklist", "ifname"]
 
 DEFAULT_AUTOPART_TYPE = AUTOPART_TYPE_LVM
 


### PR DESCRIPTION
Resolves: rhbz#1334632

Make handling of ifname= boot option more robust. In this case don't crash
(regardless of ifname= being used or no) if the device does not have permanent
MAC address.

Also add support for multiple ifname= options

And make one log message meaningful.

Details of infame= handling in anaconda:

When ifname=<DEVNAME>:<MAC> is used we bind DEVNAME to MAC in ifcfg file
when we create the ifcfg file in Anaconda.

We create the ifcfg in Anaconda if it was not created in dracut, ie if the
device was not activated by dracut. (Which means that the ifname= is not
applied by dracut, so this case actually occurs only when we just want to bind
the <MAC> to its <DEVNAME> without renaming it it dracut).  When creating ifcfg
file for <DEVNAME> we check that <MAC> from ifname= corresponds to actual mac
address of the device and if so we bind the <DEVNAME> to the <MAC> by writing
HWADDR value (additionally to DEVICE) into ifcfg file.