### PR TITLE
Rhel7 branch dont configure hostname with current

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -173,33 +173,6 @@ def prefix2netmask(prefix):
 def current_hostname():
     return socket.gethostname()
 
-# Try to determine what the hostname should be for this system
-def getHostname():
-
-    hn = None
-
-    # First address (we prefer ipv4) of last device (as it used to be) wins
-    for dev in nm.nm_activated_devices():
-        addrs = (nm.nm_device_ip_addresses(dev, version=4) +
-                 nm.nm_device_ip_addresses(dev, version=6))
-        for ipaddr in addrs:
-            try:
-                hinfo = socket.gethostbyaddr(ipaddr)
-            except socket.herror as e:
-                log.debug("Exception caught trying to get host name of %s: %s", ipaddr, e)
-            else:
-                if len(hinfo) == 3:
-                    hn = hinfo[0]
-                    break
-
-    if not hn or hn in ('(none)', 'localhost', 'localhost.localdomain'):
-        hn = socket.gethostname()
-
-    if not hn or hn in ('(none)', 'localhost', 'localhost.localdomain'):
-        hn = DEFAULT_HOSTNAME
-
-    return hn
-
 def logIfcfgFile(path, message=""):
     content = ""
     if os.access(path, os.R_OK):
@@ -317,8 +290,7 @@ def dracutSetupArgs(networkStorageDevice):
     ifcfg.read()
     return dracutBootArguments(nic,
                                ifcfg,
-                               networkStorageDevice.host_address,
-                               getHostname())
+                               networkStorageDevice.host_address)
 
 def dracutBootArguments(devname, ifcfg, storage_ipaddr, hostname=None):
 

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -169,6 +169,10 @@ def prefix2netmask(prefix):
     netmask = ".".join(str(byte) for byte in _bytes)
     return netmask
 
+
+def current_hostname():
+    return socket.gethostname()
+
 # Try to determine what the hostname should be for this system
 def getHostname():
 
@@ -1269,8 +1273,7 @@ def networkInitialize(ksdata):
         logIfcfgFiles(msg)
 
     if ksdata.network.hostname is None:
-        hostname = getHostname()
-        update_hostname_data(ksdata, hostname)
+        update_hostname_data(ksdata, DEFAULT_HOSTNAME)
 
 def _get_ntp_servers_from_dhcp(ksdata):
     """Check if some NTP servers were returned from DHCP and set them
@@ -1333,9 +1336,6 @@ def wait_for_connecting_NM_thread(ksdata):
     # connection (e.g. auto default dhcp) is activated by NM service
     connected = _wait_for_connecting_NM()
     if connected:
-        if ksdata.network.hostname == DEFAULT_HOSTNAME:
-            hostname = getHostname()
-            update_hostname_data(ksdata, hostname)
         _get_ntp_servers_from_dhcp(ksdata)
     with network_connected_condition:
         global network_connected

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -39,6 +39,7 @@ from pyanaconda.iutil import lowerASCII
 from pyanaconda.bootloader import BootLoaderError
 from pyanaconda.kickstart import refreshAutoSwapSize
 from pyanaconda import isys
+from pyanaconda import network
 
 from blivet import devicefactory
 from blivet.formats import device_formats
@@ -2098,6 +2099,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         if create_new_container:
             # run the vg editor dialog with a default name and disk set
             hostname = self.data.network.hostname
+            if hostname == network.DEFAULT_HOSTNAME:
+                hostname = network.current_hostname()
             name = self._storage_playground.suggestContainerName(hostname=hostname)
             # user_changed_container flips to False if "cancel" picked
             user_changed_container = self.run_container_editor(name=name)
@@ -2397,6 +2400,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
         if default_container_name is None:
             hostname = self.data.network.hostname
+            if hostname == network.DEFAULT_HOSTNAME:
+                hostname = network.current_hostname()
             default_container_name = self._storage_playground.suggestContainerName(hostname=hostname)
 
         log.debug("default container is %s", default_container_name)

--- a/pyanaconda/ui/gui/spokes/network.glade
+++ b/pyanaconda/ui/gui/spokes/network.glade
@@ -2247,6 +2247,31 @@
                             <property name="position">1</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkLabel" id="heading_current_hostname">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="xpad">10</property>
+                            <property name="label" translatable="yes">Current host name:</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_current_hostname">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/pyanaconda/ui/gui/spokes/network.glade
+++ b/pyanaconda/ui/gui/spokes/network.glade
@@ -2248,6 +2248,22 @@
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkCheckButton" id="checkbutton_apply_hostname">
+                            <property name="label" translatable="yes">_Apply now</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkLabel" id="heading_current_hostname">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -2258,7 +2274,7 @@
                           <packing>
                             <property name="expand">True</property>
                             <property name="fill">True</property>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                         <child>
@@ -2269,7 +2285,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
-                            <property name="position">3</property>
+                            <property name="position">4</property>
                           </packing>
                         </child>
                       </object>

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -394,6 +394,7 @@ class NetworkControlBox(GObject.GObject):
                                                               self.on_edit_connection)
         self.entry_hostname = self.builder.get_object("entry_hostname")
         self.label_current_hostname = self.builder.get_object("label_current_hostname")
+        self.checkbutton_apply_hostname = self.builder.get_object("checkbutton_apply_hostname")
 
         self.client.connect("notify::%s" % NMClient.CLIENT_STATE,
                             self.on_nm_state_changed)
@@ -1239,6 +1240,10 @@ class NetworkControlBox(GObject.GObject):
             return
         self.label_current_hostname.set_text(value)
 
+    @property
+    def apply_hostname(self):
+        return self.checkbutton_apply_hostname.get_active()
+
 class SecretAgentDialog(GUIObject):
     builderObjects = ["secret_agent_dialog"]
     mainWidgetName = "secret_agent_dialog"
@@ -1501,7 +1506,8 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
     def execute(self):
         # update system's hostname
-        network.set_hostname(self.data.network.hostname)
+        if self.network_control_box.apply_hostname:
+            network.set_hostname(self.data.network.hostname)
 
     @property
     def completed(self):
@@ -1606,7 +1612,8 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
 
     def execute(self):
         # update system's hostname
-        network.set_hostname(self.data.network.hostname)
+        if self.network_control_box.apply_hostname:
+            network.set_hostname(self.data.network.hostname)
 
     @property
     def completed(self):

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -144,17 +144,12 @@ class NetworkSpoke(FirstbootSpokeMixIn, EditTUISpoke):
         self._load_new_devices()
         EditTUISpoke.refresh(self, args)
 
-        # on refresh check if we haven't got hostname from NM on activated
-        # connection (dhcp or DNS)
-        if self.hostname_dialog.value == network.DEFAULT_HOSTNAME:
-            hostname = network.getHostname()
-            network.update_hostname_data(self.data, hostname)
-            self.hostname_dialog.value = self.data.network.hostname
-
         summary = self._summary_text()
         self._window += [TextWidget(summary), ""]
         hostname = _("Host name: %s\n") % self.data.network.hostname
         self._window += [TextWidget(hostname), ""]
+        current_hostname = _("Current host name: %s\n") % network.current_hostname()
+        self._window += [TextWidget(current_hostname), ""]
 
         # if we have any errors, display them
         while len(self.errors) > 0:


### PR DESCRIPTION
The change affects the installations where user doesn't configure (static) hostname of target system [1]. In this case we used to set it (in /etc/hostname) to the name we found using getHostname function (ie from dhcp or DNS) in Anaconda [2].  As a result, if installed system was moved to another network environment, or had another transient hostname assigned by network configuration (NM) in general, the transient hostname was not applied. As a workaround users used to write localhost.localdomain in /etc/hostname in %post scripts.

With this pachset we set static hostname of target system only if explicitly configured by user (PATCH 1/5). If it is not, it has default "localhost.localdomain" value (which was already the case when dhcp or dns did not suggest any hostname).

To mitigate this change of behavior:

- Display current environment hostname in network spoke (PATCH 1/4). Formerly the current hostname was showed as value of the "Host name" entry because the ksdata hostname value had been set from it earlier, so it was visible information that could be missed now.

- Try to keep former behaviour of suggesting names for storage containers by offering current hostname in case static hostname was not configured (PATCH 2/4)

- Don't set current environment hostname from target system static hostname (the "Host name" entry) in network spoke's execute() method (eg when leaving the spoke) anymore. Especially don't set it to the default "localhost.localdomain" value which is in "Host name" entry if user does not configure target system hostname. This case was not an issue formerly because the target system hostname was initialized to current hostname of the system (hostname suggested by getHostname) during networking initialization. Setting the environment hostname from the "Host name" entry in execute() was actually added for initial-setup. To keep this functionality I am adding "Apply now" checkbox to the hostname entryi [3]. (PATCH 3/4)

- To prevent fallouts from changed behaviour, we keep writing out /etc/hostname even when static hostname is not configured - using value "localhost.localdomain". In this case target system still applies transient hostname (same as if we didn't write /etc/hostname). I bet there is something relying on /etc/hostname existing after installation.

[1] via network --hostname or "Host name" entry of network spoke.
[2] This hostname corresponds to the transient ("transient" as in man hostnamect) hostname of the installer environment set by NetworkManager during installation. To make things a bit more complicated we didn't actually read current system hostname set by NM, but we were using the getHostname function to suggest (and actually configure) the target system hostname.
[3] https://rvykydal.fedorapeople.org/apply_hostname_in_networ_spoke.webm - note this feature is to be used in initial-setup. I hope it is not disturbing too much in installer case.
