### PR TITLE
Fix TUI ErrorDialog processing (#1337427)

### DIFF
--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -52,6 +52,8 @@ class SummaryHub(TUIHub):
             sys.stdout.flush()
             spokes = self._keys.values()
             while not all(spoke.ready for spoke in spokes):
+                # Catch any asyncronous events (like storage crashing)
+                self._app.process_events()
                 sys.stdout.write('.')
                 sys.stdout.flush()
                 time.sleep(1)

--- a/pyanaconda/ui/tui/tuiobject.py
+++ b/pyanaconda/ui/tui/tuiobject.py
@@ -18,11 +18,11 @@
 #
 # Red Hat Author(s): Martin Sivak <msivak@redhat.com>
 #
-
+import sys
+from pyanaconda import iutil, constants
 from pyanaconda.i18n import N_, _, C_
 from pyanaconda.ui import common
 from pyanaconda.ui.tui import simpleline as tui
-from pyanaconda.constants_text import INPUT_PROCESSED
 
 class ErrorDialog(tui.UIScreen):
     """Dialog screen for reporting errors to user."""
@@ -51,9 +51,12 @@ class ErrorDialog(tui.UIScreen):
         return _("Press enter to exit.")
 
     def input(self, args, key):
-        """This dialog is closed by any input."""
-        self.close()
-        return INPUT_PROCESSED
+        """This dialog is closed by any input.
+
+        And causes the program to quit.
+        """
+        iutil.ipmi_report(constants.IPMI_ABORTED)
+        sys.exit(1)
 
 class PasswordDialog(tui.UIScreen):
     """Dialog screen for password input."""


### PR DESCRIPTION
There were a couple problems here. First was that the kickstart spoke
ready loop didn't process any events, so the dialog would never be
shown.

Second is that the dialog should do what it says and actually exit when
you hit enter.

The exit is placed in the input handler because we want to make sure
there is no further processing done. If the screen is allowed to close
and return to the mainloop you end up catching the traceback that
triggered this in other places, and falling into python-meh handling of
the error you wanted to use a nice dialog for.