### PR TITLE
Temporarily disable translations

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,7 +106,7 @@ rc-release: scratch-bumpver scratch
 	mock -r $(MOCKCHROOT) --buildsrpm  --spec ./$(PACKAGE_NAME).spec --sources . --resultdir $(PWD) || exit 1
 	mock -r $(MOCKCHROOT) --rebuild *src.rpm --resultdir $(PWD) || exit 1
 
-bumpver: po-pull
+bumpver:
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \
 	if [ ! -z "$(IGNORE)" ]; then \
 		opts="$${opts} -i $(IGNORE)" ; \


### PR DESCRIPTION
There is a bug in msgfmt, it corrupts the liveinst.desktop file while
adding translations. Disable them until that gets sorted out.