### PR TITLE
Catch DNF MarkingError during group installation (#1337731)

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -511,7 +511,10 @@ class DNFPayload(packaging.PackagePayload):
             types.add('optional')
         exclude = self.data.packages.excludedList
         try:
-            self._base.group_install(grp, types, exclude=exclude)
+            # Setting strict=False means that missing packages in the group will be ignored
+            # this is necessary because comps has no way to express arch-specific packages
+            # eg. s390-tools in @anaconda-tools doesn't exist on x86_64
+            self._base.group_install(grp, types, exclude=exclude, strict=False)
         except dnf.exceptions.MarkingError as e:
             # dnf-1.1.9 raises this error when a package is missing from a group
             raise packaging.NoSuchPackage(str(e), required=True)

--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -512,6 +512,9 @@ class DNFPayload(packaging.PackagePayload):
         exclude = self.data.packages.excludedList
         try:
             self._base.group_install(grp, types, exclude=exclude)
+        except dnf.exceptions.MarkingError as e:
+            # dnf-1.1.9 raises this error when a package is missing from a group
+            raise packaging.NoSuchPackage(str(e), required=True)
         except dnf.exceptions.CompsError as e:
             # DNF raises this when it is already selected
             log.debug(e)


### PR DESCRIPTION
dnf-1.1.9 has started raising an error when packages in a group are
missing. This catches the error, displays a dialog and exits the
installation.