### PR TITLE
Rhel7 branch dont configure hostname with current v2

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -317,8 +317,7 @@ def dracutSetupArgs(networkStorageDevice):
     ifcfg.read()
     return dracutBootArguments(nic,
                                ifcfg,
-                               networkStorageDevice.host_address,
-                               getHostname())
+                               networkStorageDevice.host_address)
 
 def dracutBootArguments(devname, ifcfg, storage_ipaddr, hostname=None):
 

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -169,6 +169,10 @@ def prefix2netmask(prefix):
     netmask = ".".join(str(byte) for byte in _bytes)
     return netmask
 
+
+def current_hostname():
+    return socket.gethostname()
+
 # Try to determine what the hostname should be for this system
 def getHostname():
 
@@ -1269,8 +1273,7 @@ def networkInitialize(ksdata):
         logIfcfgFiles(msg)
 
     if ksdata.network.hostname is None:
-        hostname = getHostname()
-        update_hostname_data(ksdata, hostname)
+        update_hostname_data(ksdata, DEFAULT_HOSTNAME)
 
 def _get_ntp_servers_from_dhcp(ksdata):
     """Check if some NTP servers were returned from DHCP and set them
@@ -1333,9 +1336,6 @@ def wait_for_connecting_NM_thread(ksdata):
     # connection (e.g. auto default dhcp) is activated by NM service
     connected = _wait_for_connecting_NM()
     if connected:
-        if ksdata.network.hostname == DEFAULT_HOSTNAME:
-            hostname = getHostname()
-            update_hostname_data(ksdata, hostname)
         _get_ntp_servers_from_dhcp(ksdata)
     with network_connected_condition:
         global network_connected

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -39,6 +39,7 @@ from pyanaconda.iutil import lowerASCII
 from pyanaconda.bootloader import BootLoaderError
 from pyanaconda.kickstart import refreshAutoSwapSize
 from pyanaconda import isys
+from pyanaconda import network
 
 from blivet import devicefactory
 from blivet.formats import device_formats
@@ -2098,6 +2099,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         if create_new_container:
             # run the vg editor dialog with a default name and disk set
             hostname = self.data.network.hostname
+            if hostname == network.DEFAULT_HOSTNAME:
+                hostname = network.current_hostname()
             name = self._storage_playground.suggestContainerName(hostname=hostname)
             # user_changed_container flips to False if "cancel" picked
             user_changed_container = self.run_container_editor(name=name)
@@ -2397,6 +2400,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
         if default_container_name is None:
             hostname = self.data.network.hostname
+            if hostname == network.DEFAULT_HOSTNAME:
+                hostname = network.current_hostname()
             default_container_name = self._storage_playground.suggestContainerName(hostname=hostname)
 
         log.debug("default container is %s", default_container_name)

--- a/pyanaconda/ui/gui/spokes/network.glade
+++ b/pyanaconda/ui/gui/spokes/network.glade
@@ -2247,6 +2247,31 @@
                             <property name="position">1</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkLabel" id="heading_current_hostname">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="xpad">10</property>
+                            <property name="label" translatable="yes">Current host name:</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_current_hostname">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/pyanaconda/ui/gui/spokes/network.glade
+++ b/pyanaconda/ui/gui/spokes/network.glade
@@ -2248,6 +2248,20 @@
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkButton" id="button_apply_hostname">
+                            <property name="label" translatable="yes">_Apply now</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="use_underline">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkLabel" id="heading_current_hostname">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -2258,7 +2272,7 @@
                           <packing>
                             <property name="expand">True</property>
                             <property name="fill">True</property>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                         <child>
@@ -2269,7 +2283,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
-                            <property name="position">3</property>
+                            <property name="position">4</property>
                           </packing>
                         </child>
                       </object>

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -277,6 +277,7 @@ class NetworkControlBox(GObject.GObject):
     __gsignals__ = {
         "nm-state-changed": (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, []),
         "device-state-changed": (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, [str, int, int, int]),
+        "apply-hostname": (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, []),
     }
 
     supported_device_types = [
@@ -394,6 +395,8 @@ class NetworkControlBox(GObject.GObject):
                                                               self.on_edit_connection)
         self.entry_hostname = self.builder.get_object("entry_hostname")
         self.label_current_hostname = self.builder.get_object("label_current_hostname")
+        self.button_apply_hostname = self.builder.get_object("button_apply_hostname")
+        self.button_apply_hostname.connect("clicked", self.on_apply_hostname)
 
         self.client.connect("notify::%s" % NMClient.CLIENT_STATE,
                             self.on_nm_state_changed)
@@ -686,6 +689,9 @@ class NetworkControlBox(GObject.GObject):
         dev_cfg = model[itr][DEVICES_COLUMN_OBJECT]
         model.remove(itr)
         nm.nm_delete_connection(dev_cfg.con_uuid)
+
+    def on_apply_hostname(self, *args):
+        self.emit("apply-hostname")
 
     def add_device(self, ty):
         log.info("network: adding device of type %s", ty)
@@ -1483,6 +1489,8 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
                                          self.on_nm_state_changed)
         self.network_control_box.connect("device-state-changed",
                                          self.on_device_state_changed)
+        self.network_control_box.connect("apply-hostname",
+                                         self.on_apply_hostname)
 
     def apply(self):
         _update_network_data(self.data, self.network_control_box)
@@ -1498,10 +1506,6 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
             log.debug("network spoke (apply), no changes detected")
 
         self.network_control_box.kill_nmce(msg="leaving network spoke")
-
-    def execute(self):
-        # update system's hostname
-        network.set_hostname(self.data.network.hostname)
 
     @property
     def completed(self):
@@ -1547,6 +1551,19 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
                          NetworkManager.DeviceState.UNAVAILABLE):
             gtk_call_once(self._update_status)
 
+    def on_apply_hostname(self, *args):
+        hostname = self.network_control_box.hostname
+        (valid, error) = network.sanityCheckHostname(hostname)
+        if not valid:
+            self.clear_info()
+            msg = _("Host name is not valid: %s") % error
+            self.set_warning(msg)
+            self.network_control_box.entry_hostname.grab_focus()
+        else:
+            self.clear_info()
+            network.set_hostname(hostname)
+            self._update_hostname()
+
     def _update_status(self):
         hubQ.send_message(self.__class__.__name__, self.status)
 
@@ -1584,6 +1601,8 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
 
         self.network_control_box.connect("nm-state-changed",
                                          self.on_nm_state_changed)
+        self.network_control_box.connect("apply-hostname",
+                                         self.on_apply_hostname)
 
         self._initially_available = self.completed
         log.debug("network standalone spoke (init): completed: %s", self._initially_available)
@@ -1603,10 +1622,6 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
                     fallback=not anaconda_flags.automatedInstall)
 
         self.network_control_box.kill_nmce(msg="leaving standalone network spoke")
-
-    def execute(self):
-        # update system's hostname
-        network.set_hostname(self.data.network.hostname)
 
     @property
     def completed(self):
@@ -1639,6 +1654,19 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
     # Use case: slow dhcp has connected when on spoke
     def on_nm_state_changed(self, *args):
         gtk_call_once(self._update_hostname)
+
+    def on_apply_hostname(self, *args):
+        hostname = self.network_control_box.hostname
+        (valid, error) = network.sanityCheckHostname(hostname)
+        if not valid:
+            self.clear_info()
+            msg = _("Host name is not valid: %s") % error
+            self.set_warning(msg)
+            self.network_control_box.entry_hostname.grab_focus()
+        else:
+            self.clear_info()
+            network.set_hostname(hostname)
+            self._update_hostname()
 
     def _update_hostname(self):
         self.network_control_box.current_hostname = network.current_hostname()

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -144,17 +144,12 @@ class NetworkSpoke(FirstbootSpokeMixIn, EditTUISpoke):
         self._load_new_devices()
         EditTUISpoke.refresh(self, args)
 
-        # on refresh check if we haven't got hostname from NM on activated
-        # connection (dhcp or DNS)
-        if self.hostname_dialog.value == network.DEFAULT_HOSTNAME:
-            hostname = network.getHostname()
-            network.update_hostname_data(self.data, hostname)
-            self.hostname_dialog.value = self.data.network.hostname
-
         summary = self._summary_text()
         self._window += [TextWidget(summary), ""]
         hostname = _("Host name: %s\n") % self.data.network.hostname
         self._window += [TextWidget(hostname), ""]
+        current_hostname = _("Current host name: %s\n") % network.current_hostname()
+        self._window += [TextWidget(current_hostname), ""]
 
         # if we have any errors, display them
         while len(self.errors) > 0:


### PR DESCRIPTION
The change affects the installations where user doesn't configure (static) hostname of target system [1]. In this case we used to set it (in /etc/hostname) to the name we found using getHostname function (ie from dhcp or DNS) in Anaconda [2]. As a result, if installed system was moved to another network environment, or had another transient hostname assigned by network configuration (NM) in general, the transient hostname was not applied. As a workaround users used to write localhost.localdomain in /etc/hostname in %post scripts.

With this pachset we set static hostname of target system only if explicitly configured by user (PATCH 1/4). If it is not, it has default "localhost.localdomain" value (which was already the case when dhcp or dns did not suggest any hostname).

To mitigate this change of behavior:

- Display current environment hostname in network spoke (PATCH 1/4). Formerly the current hostname was showed as value of the "Host name" entry because the ksdata hostname value had been set from it earlier, so it was visible information that could be missed now.

- Try to keep former behaviour of suggesting names for storage containers by offering current hostname in case static hostname was not configured (PATCH 2/4)

- Don't set current environment hostname from target system static hostname (the "Host name" entry) in network spoke's execute() method (eg when leaving the spoke) anymore. Especially don't set it to the default "localhost.localdomain" value which is in "Host name" entry if user does not configure target system hostname. This case was not an issue formerly because the target system hostname was initialized to current hostname of the system (hostname suggested by getHostname) during networking initialization. Setting the environment hostname from the "Host name" entry in execute() was actually added for initial-setup. To keep this functionality I am adding "Apply now" button to the hostname entry [3]. (PATCH 3/4)

- To prevent fallouts from changed behaviour, we keep writing out /etc/hostname even when static hostname is not configured - using value "localhost.localdomain". In this case target system still applies transient hostname (same as if we didn't write /etc/hostname). I bet there is something relying on /etc/hostname existing after installation.

[1] via network --hostname or "Host name" entry of network spoke.
[2] This hostname corresponds to the transient ("transient" as in man hostnamect) hostname of the installer environment set by NetworkManager during installation. To make things a bit more complicated we didn't actually read current system hostname set by NM, but we were using the getHostname function to suggest (and actually configure) the target system hostname.
[3] https://rvykydal.fedorapeople.org/apply_hostname_in_network_spoke_button.webm - note this feature is to be used in initial-setup. I hope it is not disturbing too much in installer case.
