### PR TITLE
NFS DDs installation now works correctly (#1269915)

### DIFF
--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -358,7 +358,7 @@ def _process_driver_rpm(rpm):
     rpm for Anaconda to install on the target system.
     """
     log.info("Examining %s", rpm)
-    new_modules = extract_drivers(repos=[os.path.dirname(rpm)])
+    new_modules = extract_drivers(repos=[rpm])
     if new_modules:
         modules = grab_driver_files()
         load_drivers(modules)
@@ -605,10 +605,10 @@ def main(args):
 
     if mode in ('--disk', '--net'):
         request, dev = args
-        if dev.endswith(".rpm"):
-            process_driver_rpm(dev)
-        else:
+        if dev.endswith(".iso"):
             process_driver_disk(dev)
+        else:
+            process_driver_rpm(dev)
 
     elif mode == '--interactive':
         log.info("starting interactive mode")

--- a/tests/dracut_tests/test_driver_updates.py
+++ b/tests/dracut_tests/test_driver_updates.py
@@ -507,7 +507,7 @@ class ProcessDriverRPMTestCase(unittest.TestCase):
         """process_driver_rpm: extract RPM, grab + load driver"""
         rpm = '/tmp/fake/driver.rpm'
         process_driver_rpm(rpm)
-        self.mocks['extract_drivers'].assert_called_once_with(repos=["/tmp/fake"])
+        self.mocks['extract_drivers'].assert_called_once_with(repos=["/tmp/fake/driver.rpm"])
         self.mocks['grab_driver_files'].assert_called_once_with()
         self.mocks['load_drivers'].assert_called_once_with(self.modlist)
 


### PR DESCRIPTION
Only specified RPM file is now installed when specified by inst.dd and using NFS.
Added a feature that enables to install all RPMs in directory when using NFS.
(e.g. inst.dd=nfs://server/path/directory_with_rpms)

Resolves: rhbz#1269915