### PR TITLE
Print an error when the kickstart file is missing (#1297380)

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -1034,6 +1034,11 @@ if __name__ == "__main__":
     # shipped with the installation media.
     ksdata = None
     if opts.ksfile and not opts.liveinst:
+        if not os.path.exists(opts.ksfile):
+            stdoutLog.error("Kickstart file %s is missing.", opts.ksfile)
+            iutil.ipmi_report(constants.IPMI_ABORTED)
+            sys.exit(1)
+
         flags.automatedInstall = True
         flags.eject = False
         ksFiles = [opts.ksfile]


### PR DESCRIPTION
If --kickstart has been passed we should make sure it actually exists.
If we don't the installation tries to continue but gets confused because
automatedInstall has been set.

(cherry picked from commit 8c06aeee7860d262ce8b1dec037d1cfaa670cc11)

Resolves: rhbz#1297380