### PR TITLE
send all layouts to localed for keymap conversion (#1333998)

### DIFF
--- a/pyanaconda/keyboard.py
+++ b/pyanaconda/keyboard.py
@@ -138,7 +138,7 @@ def populate_missing_items(keyboard):
         keyboard.vc_keymap = keyboard._keyboard
 
     if keyboard.x_layouts and not keyboard.vc_keymap:
-        keyboard.vc_keymap = localed.convert_layout(keyboard.x_layouts[0])
+        keyboard.vc_keymap = localed.convert_layouts(keyboard.x_layouts)
 
     if not keyboard.vc_keymap:
         keyboard.vc_keymap = DEFAULT_KEYBOARD
@@ -315,7 +315,7 @@ def activate_keyboard(keyboard):
             keyboard.x_layouts.append(keyboard.vc_keymap)
 
     if keyboard.x_layouts:
-        c_keymap = localed.set_and_convert_layout(keyboard.x_layouts[0])
+        c_keymap = localed.set_and_convert_layouts(keyboard.x_layouts)
 
         if not keyboard.vc_keymap:
             keyboard.vc_keymap = c_keymap
@@ -569,7 +569,7 @@ class LocaledWrapper(object):
         except safe_dbus.DBusCallError as e:
             log.error("Failed to set layouts: %s", e)
 
-    def set_and_convert_layout(self, layout_variant):
+    def set_and_convert_layouts(self, layouts_variants):
         """
         Method that sets X11 layout and variant (for later X sessions)
         and returns VConsole keymap that (systemd-localed thinks) matches
@@ -580,11 +580,11 @@ class LocaledWrapper(object):
 
         """
 
-        self.set_layouts([layout_variant], convert=True)
+        self.set_layouts(layouts_variants, convert=True)
 
         return self.keymap
 
-    def convert_layout(self, layout_variant):
+    def convert_layouts(self, layouts_variants):
         """
         Method that returns VConsole keymap that (systemd-localed thinks)
         matches given layout and variant best.
@@ -599,7 +599,7 @@ class LocaledWrapper(object):
         # hack around systemd's lack of functionality -- no function to just
         # convert without changing keyboard configuration
         orig_layouts_variants = self.layouts_variants
-        ret = self.set_and_convert_layout(layout_variant)
+        ret = self.set_and_convert_layouts(layouts_variants)
         self.set_layouts(orig_layouts_variants)
 
         return ret


### PR DESCRIPTION
Resolves: rhbz#1333998

localed's code for deciding what VConsole keymap matches a given
X11 layout/variant config is more likely to work well when we
give it the whole list of X11 layout/variants we have, not just
the first. If you pass it only a single X11 layout/variant, it
will only work if there is an entry in the model map table that
is for *exactly* that layout/variant; for instance, if you pass
it 'ru', it will not consider its entry for 'ru,us' to be a
match. If you pass it a list of layouts, it's actually rather a
lot more likely to find a match - it would consider its 'ru,us'
entry to be a (weak) match for 'ru,foo,bar', for example,
because as a last resort it tries matching just the first part
(up to the first comma) of the layout against the first part of
the table entry, but *only* if you give it multiple layouts.