### PR TITLE
Update the disk summary on Ctrl-A

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -1155,3 +1155,4 @@ class StorageSpoke(NormalSpoke, StorageChecker):
             overview.set_chosen(True)
 
         self._update_disk_list()
+        self._update_summary()


### PR DESCRIPTION
This will perform the UI actions that normally happen when a disk is
selected that were being skipped by the Ctrl-A handler.

Resolves: rhbz#1264958