### PR TITLE
Handling for corrupt or otherwise unsupported disklabels

### DIFF
--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -489,3 +489,8 @@ class StorageSnapshot(object):
 # a snapshot of early storage as we got it from scanning disks without doing any
 # changes
 on_disk_storage = StorageSnapshot()
+
+def filter_unsupported_disklabel_devices(devices):
+    """ Return input list minus any devices that exist on an unsupported disklabel. """
+    return [d for d in devices
+            if not any(not getattr(p, "disklabel_supported", True) for p in d.ancestors)]

--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -352,7 +352,7 @@ def check_mounted_partitions(storage):
         :returns: a generator of error messages, may yield no error messages
     """
     for disk in storage.disks:
-        if not disk.format:
+        if not disk.partitioned:
             continue
 
         for part in disk.format.partitions:

--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -417,17 +417,16 @@ class ResizeDialog(GUIObject):
         """ Remove a device, or if it has protected children, just remove the
             unprotected children.
         """
-        if not any(d for d in self.storage.devices \
-                   if device in d.parents and d.protected):
+        if device.protected:
+            return
+
+        if not any(d.protected for d in device.children):
             # No protected children, remove the device
             self.storage.recursive_remove(device)
         else:
             # Only remove unprotected children
-            unprotected = (d for d in self.storage.devices \
-                           if device in d.parents and not d.protected)
-            for child in unprotected:
-                if child in self.storage.devices:
-                    self.storage.recursive_remove(child)
+            for child in (d for d in device.children if not d.protected):
+                self.storage.recursive_remove(child)
 
     def _scheduleActions(self, model, path, itr, *args):
         obj = PartStoreRow(*model[itr])

--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -134,7 +134,7 @@ class ResizeDialog(GUIObject):
             # First add the disk itself.
             editable = not disk.protected
 
-            if disk.partitioned:
+            if disk.partitioned and disk.format.supported:
                 fstype = ""
                 diskReclaimableSpace = Size(0)
             else:
@@ -152,7 +152,7 @@ class ResizeDialog(GUIObject):
                                                 int(disk.size),
                                                 disk.name])
 
-            if disk.partitioned:
+            if disk.partitioned and disk.format.supported:
                 # Then add all its partitions.
                 for dev in disk.children:
                     if dev.is_extended and disk.format.logical_partitions:
@@ -346,7 +346,7 @@ class ResizeDialog(GUIObject):
         obj = PartStoreRow(*model[itr])
 
         device = self.storage.devicetree.get_device_by_id(obj.id)
-        if device.is_disk and device.partitioned:
+        if device.is_disk and device.partitioned and device.format.supported:
             return False
 
         if obj.action == _(PRESERVE):
@@ -381,7 +381,7 @@ class ResizeDialog(GUIObject):
         # If that row is a disk header, we need to process all the partitions
         # it contains.
         device = self.storage.devicetree.get_device_by_id(selectedRow[DEVICE_ID_COL])
-        if device.is_disk and device.partitioned:
+        if device.is_disk and device.partitioned and device.format.supported:
             partItr = self._diskStore.iter_children(itr)
             while partItr:
                 # Immutable entries are those that we can't do anything to - like


### PR DESCRIPTION
This is the anaconda piece to rhinstaller/blivet#427. The first patch is a touch-up for a recent commit. The next two are little tweaks to use blivet better, and the last one is the main event.