### PR TITLE
Don't try to do payload reset in Initial Setup

### DIFF
--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -20,7 +20,7 @@
 import selinux
 import shlex
 import glob
-from pyanaconda.constants import SELINUX_DEFAULT, CMDLINE_APPEND
+from pyanaconda.constants import SELINUX_DEFAULT, CMDLINE_APPEND, ANACONDA_ENVIRON
 from collections import OrderedDict
 
 import logging
@@ -76,6 +76,8 @@ class Flags(object):
         self.nosave_logs = False
         # single language options
         self.singlelang = False
+        # current runtime environments
+        self.environs = [ANACONDA_ENVIRON]
         # parse the boot commandline
         self.cmdline = BootArgs()
         # Lock it down: no more creating new flags!

--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -495,9 +495,6 @@ class Hub(object):
         self.paths = {}
         self._spokes = {}
 
-        # spokes for which environments this hub should collect?
-        self._environs = [ANACONDA_ENVIRON]
-
     @abstractproperty
     def data(self):
         pass

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -114,7 +114,7 @@ class Hub(GUIObject, common.Hub):
             selectors = []
             for spokeClass in sorted(cats_and_spokes[c], key=lambda s: s.title):
                 # Check if this spoke is to be shown in the supported environments
-                if not any(spokeClass.should_run(environ, self.data) for environ in self._environs):
+                if not any(spokeClass.should_run(environ, self.data) for environ in flags.environs):
                     continue
 
                 # Create the new spoke and populate its UI with whatever data.

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1497,10 +1497,13 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         log.debug("network: apply ksdata %s", self.data.network)
 
         if self.networking_changed:
-            log.debug("network spoke (apply) refresh payload")
-            from pyanaconda.packaging import payloadMgr
-            payloadMgr.restartThread(self.storage, self.data, self.payload, self.instclass,
-                                     fallback=not anaconda_flags.automatedInstall)
+            if ANACONDA_ENVIRON in anaconda_flags.environs:
+                log.debug("network spoke (apply) refresh payload")
+                from pyanaconda.packaging import payloadMgr
+                payloadMgr.restartThread(self.storage, self.data, self.payload, self.instclass,
+                                         fallback=not anaconda_flags.automatedInstall)
+            else:
+                log.debug("network spoke (apply), payload refresh skipped (running outside of installation environment)")
             self.networking_changed = False
         else:
             log.debug("network spoke (apply), no changes detected")

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -21,7 +21,7 @@
 #
 
 
-from pyanaconda.flags import can_touch_runtime_system
+from pyanaconda.flags import can_touch_runtime_system, flags
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import EditTUISpoke, OneShotEditTUIDialog
 from pyanaconda.ui.tui.spokes import EditTUISpokeEntry as Entry
@@ -33,6 +33,7 @@ from pyanaconda import nm
 
 from pyanaconda.regexes import IPV4_PATTERN_WITHOUT_ANCHORS, IPV4_NETMASK_WITHOUT_ANCHORS
 from pyanaconda.constants_text import INPUT_PROCESSED
+from pyanaconda.constants import ANACONDA_ENVIRON
 
 import logging
 log = logging.getLogger("anaconda")
@@ -244,9 +245,10 @@ class NetworkSpoke(FirstbootSpokeMixIn, EditTUISpoke):
 
         if self._apply:
             self._apply = False
-            from pyanaconda.packaging import payloadMgr
-            payloadMgr.restartThread(self.storage, self.data, self.payload,
-                                     self.instclass, checkmount=False)
+            if ANACONDA_ENVIRON in flags.environs:
+                from pyanaconda.packaging import payloadMgr
+                payloadMgr.restartThread(self.storage, self.data, self.payload,
+                                         self.instclass, checkmount=False)
 
     def _update_network_data(self):
         hostname = self.data.network.hostname


### PR DESCRIPTION
At the moment the network spoke tries to trigger a payload reset when network settings are changed even if running inside of Initial Setup. This is of course wrong, as there is no payload instance in Initial Setup, which can trigger a lot of various issues (crashes, weird log messages, etc.).

The first patch adds the environs flag so that spokes can easily check the environment at runtime. It also gets rid of the old _environs hub property.

The second patch then uses the environs flag to only trigger the payload reset when the network spoke is run from inside of Anaconda. 