### PR TITLE
Fixed underscore for Jenkins gettext error

### DIFF
--- a/pyanaconda/packaging/yumpayload.py
+++ b/pyanaconda/packaging/yumpayload.py
@@ -1457,7 +1457,7 @@ reposdir=%s
         progress_map = {
             "PROGRESS_PREP"    : _("Preparing transaction from installation source"),
             "PROGRESS_INSTALL" : _("Installing"),
-            "PROGRESS_RETRY"   : _(""),
+            "PROGRESS_RETRY"   : "",
             "PROGRESS_POST"    : _("Performing post-installation setup tasks")
         }
 


### PR DESCRIPTION
Removed underscore on "PROGRESS_RETRY" to prevent errors on Jenkins

Related rhbz#1255094

Signed-off-by: Karel Valek <kvalek@redhat.com>