### PR TITLE
Add a refresh button to the storage spoke

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.glade
+++ b/pyanaconda/ui/gui/spokes/storage.glade
@@ -950,7 +950,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="margin_right">18</property>
                         <property name="hexpand">True</property>
                         <property name="label" translatable="yes">summary</property>
                         <attributes>
@@ -998,6 +997,45 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRevealer" id="refresh_button_revealer">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="transition_type">crossfade</property>
+                        <property name="reveal_child">True</property>
+                        <child>
+                          <object class="GtkButton" id="refresh_button">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="no_show_all">True</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">False</property>
+                            <property name="relief">none</property>
+                            <property name="use_underline">True</property>
+                            <property name="focus_on_click">False</property>
+                            <property name="xalign">0</property>
+                            <signal name="clicked" handler="on_refresh_clicked" swapped="no"/>
+                            <child>
+                              <object class="GtkLabel" id="label6">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes" context="GUI|Storage">_Refresh...</property>
+                                <property name="use_underline">True</property>
+                                <attributes>
+                                  <attribute name="underline" value="True"/>
+                                  <attribute name="foreground" value="#00000000ffff"/>
+                                </attributes>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">2</property>
                         <property name="top_attach">0</property>
                       </packing>
                     </child>

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -54,6 +54,7 @@ from pyanaconda.ui.gui.spokes.lib.passphrase import PassphraseDialog
 from pyanaconda.ui.gui.spokes.lib.detailederror import DetailedErrorDialog
 from pyanaconda.ui.gui.spokes.lib.resize import ResizeDialog
 from pyanaconda.ui.gui.spokes.lib.dasdfmt import DasdFormatDialog
+from pyanaconda.ui.gui.spokes.lib.refresh import RefreshDialog
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.gui.utils import escape_markup, gtk_action_nowait, ignoreEscape
 from pyanaconda.ui.helpers import StorageChecker
@@ -262,7 +263,7 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         self.encrypted = False
         self.passphrase = ""
         self.selected_disks = self.data.ignoredisk.onlyuse[:]
-        self._last_selected_disks = None
+        self._last_selected_disks = []
         self._back_clicked = False
         self.autopart_missing_passphrase = False
         self.disks_errors = []
@@ -825,11 +826,10 @@ class StorageSpoke(NormalSpoke, StorageChecker):
                 self.storage.devicetree.hide(disk)
 
     def _unhide_disks(self):
-        if self._last_selected_disks:
-            for disk in self.disks:
-                if disk.name not in self.selected_disks and \
-                   disk.name not in self._last_selected_disks:
-                    self.storage.devicetree.unhide(disk)
+        for disk in self.disks:
+            if disk.name not in self.selected_disks and \
+               disk.name not in self._last_selected_disks:
+                self.storage.devicetree.unhide(disk)
 
     def _check_dasd_formats(self):
         rc = DASD_FORMAT_NO_CHANGE
@@ -1148,3 +1148,33 @@ class StorageSpoke(NormalSpoke, StorageChecker):
 
         self._update_disk_list()
         self._update_summary()
+
+    # This callback is for the button that has anaconda go back and rescan the
+    # disks to pick up whatever changes the user made outside our control.
+    def on_refresh_clicked(self, *args):
+        dialog = RefreshDialog(self.data, self.storage)
+        ignoreEscape(dialog.window)
+        with self.main_window.enlightbox(dialog.window):
+            rc = dialog.run()
+            dialog.window.destroy()
+
+        if rc == 1:
+            # User hit OK on the dialog, indicating they stayed on the dialog
+            # until rescanning completed.
+            on_disk_storage.dispose_snapshot()
+            self.refresh()
+            return
+        elif rc != 2:
+            # User either hit cancel on the dialog or closed it via escape, so
+            # there was no rescanning done.
+            # NOTE: rc == 2 means the user clicked on the link that takes them
+            # back to the hub.
+            return
+
+        on_disk_storage.dispose_snapshot()
+
+        # Can't use this spoke's on_back_clicked method as that will try to
+        # save the right hand side, which is no longer valid.  The user must
+        # go back and select their disks all over again since whatever they
+        # did on the shell could have changed what disks are available.
+        NormalSpoke.on_back_clicked(self, None)


### PR DESCRIPTION
This allows users to hot-add disks to a vm without rebooting or having to find the other refresh buttons that exist in the filter spoke and the custom spoke.

The button is in the lower-right corner.

![refresh-disks-rawhide 0](https://cloud.githubusercontent.com/assets/6605451/15755315/22a90e46-28ca-11e6-927a-14bba9b9f861.png)
