### PR TITLE
Add a button to refresh the disk list.

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.glade
+++ b/pyanaconda/ui/gui/spokes/storage.glade
@@ -950,7 +950,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="margin_right">18</property>
                         <property name="hexpand">True</property>
                         <property name="label" translatable="yes">summary</property>
                         <attributes>
@@ -998,6 +997,45 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRevealer" id="refresh_button_revealer">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="transition_type">crossfade</property>
+                        <property name="reveal_child">True</property>
+                        <child>
+                          <object class="GtkButton" id="refresh_button">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="no_show_all">True</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">False</property>
+                            <property name="relief">none</property>
+                            <property name="use_underline">True</property>
+                            <property name="focus_on_click">False</property>
+                            <property name="xalign">0</property>
+                            <signal name="clicked" handler="on_refresh_clicked" swapped="no"/>
+                            <child>
+                              <object class="GtkLabel" id="label6">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes" context="GUI|Storage">_Refresh...</property>
+                                <property name="use_underline">True</property>
+                                <attributes>
+                                  <attribute name="underline" value="True"/>
+                                  <attribute name="foreground" value="#00000000ffff"/>
+                                </attributes>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">2</property>
                         <property name="top_attach">0</property>
                       </packing>
                     </child>


### PR DESCRIPTION
(cherry picked from commit 1ea511667713fbe860ec34901d560840bdee7e5e)

Resolves: rhbz#1191305

This is the `rhel7-branch` version of #656. The button is in the lower right corner and it runs the same dialog as the one in the custom spoke:

![refresh-disks-el7-0](https://cloud.githubusercontent.com/assets/6605451/15757371/3cd7a148-28d3-11e6-868e-8edb375a858b.png)
![refresh-disks-el7-1](https://cloud.githubusercontent.com/assets/6605451/15757372/3cd7c100-28d3-11e6-8985-6c6e8a5478ea.png)
