### PR TITLE
Stop using undocumented DNF logging API

### DIFF
--- a/data/post-scripts/99-copy-logs.ks
+++ b/data/post-scripts/99-copy-logs.ks
@@ -8,7 +8,7 @@ if [ -e ${NOSAVE_LOGS_FILE} ]; then
     rm -f ${NOSAVE_LOGS_FILE}
 else
     mkdir -p $ANA_INSTALL_PATH/var/log/anaconda
-    for log in anaconda.log syslog X.log program.log packaging.log storage.log ifcfg.log yum.log dnf.log dnf.rpm.log lvm.log; do
+    for log in anaconda.log syslog X.log program.log packaging.log storage.log ifcfg.log lvm.log dnf.librepo.log hawkey.log; do
         [ -e /tmp/$log ] && cp /tmp/$log $ANA_INSTALL_PATH/var/log/anaconda/
     done
     cp /tmp/ks-script*.log $ANA_INSTALL_PATH/var/log/anaconda/

--- a/pyanaconda/anaconda_log.py
+++ b/pyanaconda/anaconda_log.py
@@ -179,6 +179,13 @@ class AnacondaLog:
                             autoLevel=True)
         self.forwardToSyslog(packaging_logger)
 
+        # Create the dnf logger and link it to packaging
+        dnf_logger = logging.getLogger("dnf")
+        dnf_logger.setLevel(logging.DEBUG)
+        self.addFileHandler(PACKAGING_LOG_FILE, dnf_logger,
+                            minLevel=logging.NOTSET)
+        self.forwardToSyslog(dnf_logger)
+
         # Create the sensitive information logger
         # * the sensitive-info.log file is not copied to the installed
         # system, as it might contain sensitive information that

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -248,8 +248,8 @@ class AnacondaExceptionHandler(ExceptionHandler):
 def initExceptionHandling(anaconda):
     fileList = ["/tmp/anaconda.log", "/tmp/packaging.log",
                 "/tmp/program.log", "/tmp/storage.log", "/tmp/ifcfg.log",
-                "/tmp/dnf.log", "/tmp/dnf.rpm.log", "/tmp/lvm.log",
-                "/tmp/yum.log", iutil.getSysroot() + "/root/install.log",
+                "/tmp/dnf.librepo.log", "/tmp/hawkey.log",
+                "/tmp/lvm.log", iutil.getSysroot() + "/root/install.log",
                 "/proc/cmdline"]
 
     if os.path.exists("/tmp/syslog"):


### PR DESCRIPTION
DNF doesn't want users to access base.logging anymore.

This changes the dnf logging so that the dnf and dnf.rpm loggers go into
packaging.log now. It preserves the dnf.librepo.log file and the
hawkey.log files so that they can be examined after the installation is
complete or crashes.