### PR TITLE
Warn about broken keyboard layout switching in VNC (#1274228)

### DIFF
--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -423,7 +423,12 @@ class KeyboardSpoke(NormalSpoke):
         store.remove(itr)
 
     def _refresh_switching_info(self):
-        if self.data.keyboard.switch_options:
+        if flags.flags.usevnc:
+            self._layoutSwitchLabel.set_text(_("Keyboard layouts are not "
+                                               "supported when using VNC.\n"
+                                               "However the settings will be used "
+                                               "after the installation."))
+        elif self.data.keyboard.switch_options:
             first_option = self.data.keyboard.switch_options[0]
             desc = self._xkl_wrapper.get_switch_opt_description(first_option)
 


### PR DESCRIPTION
Keyboard layout switching doesn't work in VNC. VNC is using its own layout system. Overall the keyboard setting in VNC looks like it is ignored.
This commit replaces the message how to switch layout ("Alt+Shift"...) for VNC with message that shows warning to a user that keyboard settings isn't used for VNC, but will be applied after the installation.

*Resolves: rhbz#1274228*