### PR TITLE
Make the anaconda-generator exit early outside of the installation en…

### DIFF
--- a/data/systemd/anaconda-generator
+++ b/data/systemd/anaconda-generator
@@ -1,6 +1,14 @@
 #!/bin/bash
 # anaconda-generator: generate services needed for anaconda operation
 
+# only run in the Anaconda installation environment
+ANACONDA_TARGET="/lib/systemd/system/anaconda.target"
+CURRENT_DEFAULT_TARGET=$(readlink /etc/systemd/system/default.target)
+
+if [ "$ANACONDA_TARGET" != "$CURRENT_DEFAULT_TARGET" ]; then
+    exit 0
+fi
+
 # set up dirs
 systemd_dir=/lib/systemd/system
 target_dir=$systemd_dir/anaconda.target.wants


### PR DESCRIPTION
…vironment (#1289179)

Check if the anaconda-generator is running in the installation
environment by checking where the default.target is pointing.

Proceed normally if it is pointing to the anaconda.target,
exit early if not.

This should get rid of the annoying "anaconda-generator failed with
error code 1" errors in journal when the generator tried to run in
outside of the installation environment.

Resolves: rhbz#1289179