### PR TITLE
Overwrite network files when using ks liveimg (#1342639)

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -1159,13 +1159,16 @@ def write_sysconfig_network(rootpath, overwrite=False):
     return True
 
 def write_network_config(storage, ksdata, instClass, rootpath):
-    write_hostname(rootpath, ksdata, overwrite=flags.livecdInstall)
+    # overwrite previous settings for LiveCD or liveimg installations
+    overwrite = flags.livecdInstall or ksdata.method.method == "liveimg"
+
+    write_hostname(rootpath, ksdata, overwrite=overwrite)
     set_hostname(ksdata.network.hostname)
-    write_sysconfig_network(rootpath, overwrite=flags.livecdInstall)
+    write_sysconfig_network(rootpath, overwrite=overwrite)
     disableIPV6(rootpath)
     copyIfcfgFiles(rootpath)
     copyDhclientConfFiles(rootpath)
-    copyFileToPath("/etc/resolv.conf", rootpath, overwrite=flags.livecdInstall)
+    copyFileToPath("/etc/resolv.conf", rootpath, overwrite=overwrite)
     instClass.setNetworkOnbootDefault(ksdata)
     autostartFCoEDevices(rootpath, storage, ksdata)
 


### PR DESCRIPTION
A ks liveimg install may have pre-existing network files, overwrite them
on the target the same way we do for live installs. This effects:

/etc/hostname
/etc/resolv.conf
/etc/sysconfig/network

Resolves: rhbz#1342639