### PR TITLE
Turn translations back on.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -104,7 +104,7 @@ rc-release: scratch-bumpver scratch
 	mock -r $(MOCKCHROOT) --buildsrpm  --spec ./$(PACKAGE_NAME).spec --sources . --resultdir $(PWD) || exit 1
 	mock -r $(MOCKCHROOT) --rebuild *src.rpm --resultdir $(PWD) || exit 1
 
-bumpver:
+bumpver: po-pull
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \
 	if [ ! -z "$(IGNORE)" ]; then \
 		opts="$${opts} -i $(IGNORE)" ; \

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -18,8 +18,7 @@ Source0: %{name}-%{version}.tar.bz2
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).
 
-# Also update in AM_GNU_GETTEXT_VERSION in configure.ac
-%define gettextver 0.19.1
+%define gettextver 0.19.8
 %define pykickstartver 2.30-1
 %define dnfver 0.6.4
 %define partedver 1.8.1


### PR DESCRIPTION
gettext 0.19.8 fixes the bug that we were hitting with msgfmt and
desktop files.  This reverts abae279fef8aeb69ba07db4b56c6f10622e939e3.