### PR TITLE
Use the RHEL 7 timezone kickstart command version

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1658,7 +1658,7 @@ class SshKey(commands.sshkey.F22_SshKey):
         for usr in self.sshUserList:
             users.setUserSshKey(usr.username, usr.key)
 
-class Timezone(commands.timezone.F18_Timezone):
+class Timezone(commands.timezone.RHEL7_Timezone):
     def __init__(self, *args):
         commands.timezone.F18_Timezone.__init__(self, *args)
 


### PR DESCRIPTION
The RHEL 7 version of the command has been modified to make it possible
to use the --utc flag without requiring a timezone specification to be provided.

This way the hardware clock time format can be set from kickstart while
still requiring the user to select a timezone manually in the UI.

Resolves: rhbz#1312135