### PR TITLE
Use the signal handlers to set initial widget sensitivies

### DIFF
--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -800,12 +800,8 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         # We default to the mirror list if available. http otherwise
         if self.payload.mirrorEnabled:
             self._protocolComboBox.set_active_id(PROTOCOL_MIRROR)
-            self._urlEntry.set_sensitive(False)
         else:
             self._protocolComboBox.set_active_id(PROTOCOL_HTTP)
-            self._urlEntry.set_sensitive(True)
-
-        self._updateURLEntryCheck()
 
         if self.data.method.method == "url":
             self._networkButton.set_active(True)
@@ -824,7 +820,6 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
                 self._protocolComboBox.set_active_id(PROTOCOL_HTTP)
                 l = 0
 
-            self._urlEntry.set_sensitive(True)
             self._urlEntry.set_text(proto[l:])
             self._updateURLEntryCheck()
             self._mirrorlistCheckbox.set_active(bool(self.data.method.mirrorlist))
@@ -834,12 +829,10 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             self._protocolComboBox.set_active_id(PROTOCOL_NFS)
 
             self._urlEntry.set_text("%s:%s" % (self.data.method.server, self.data.method.dir))
-            self._urlEntry.set_sensitive(True)
             self._updateURLEntryCheck()
             self.builder.get_object("nfsOptsEntry").set_text(self.data.method.opts or "")
         elif self.data.method.method == "harddrive":
             self._isoButton.set_active(True)
-            self._isoBox.set_sensitive(True)
             self._verifyIsoButton.set_sensitive(True)
 
             if self._currentIsoFile:
@@ -864,20 +857,34 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         # Setup the addon repos
         self._reset_repoStore()
 
+        # Some widgets get enabled/disabled/greyed out depending on
+        # how others are set up.  We can use the signal handlers to handle
+        # that condition here too. Start at the innermost pieces and work
+        # outwards
+
+        # First check the protocol combo in the network box
+        self.on_protocol_changed(self._protocolComboBox)
+
+        # Then simulate changes for the radio buttons, which may override the
+        # sensitivities set for the network box.
+        #
+        # Whichever radio button is selected should have gotten a signal
+        # already, but the ones that are not selected need a signal in order
+        # to disable the related box.
+        self.on_source_toggled(self._autodetectButton, self._autodetectBox)
+        self.on_source_toggled(self._isoButton, self._isoBox)
+        self.on_source_toggled(self._networkButton, self._networkBox)
+
+        # Lastly, if the stage2 image is mounted from an HDISO source, there's
+        # really no way we can tear down that source to allow the user to
+        # change it.  Thus, this entire portion of the spoke should be
+        # insensitive.
         if self.data.method.method == "harddrive" and \
            get_mount_device(constants.DRACUT_ISODIR) == get_mount_device(constants.DRACUT_REPODIR):
-            # If the stage2 image is mounted from an HDISO source, there's really
-            # no way we can tear down that source to allow the user to change it.
-            # Thus, this portion of the spoke should be insensitive.
             for widget in [self._autodetectButton, self._autodetectBox, self._isoButton,
                            self._isoBox, self._networkButton, self._networkBox]:
                 widget.set_sensitive(False)
                 widget.set_tooltip_text(_("The installation source is in use by the installer and cannot be changed."))
-        else:
-            # Then, some widgets get enabled/disabled/greyed out depending on
-            # how others are set up.  We can use the signal handlers to handle
-            # that condition here too.
-            self.on_protocol_changed(self._protocolComboBox)
 
         if not nm.nm_is_connected():
             self._networkButton.set_sensitive(False)
@@ -887,6 +894,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             self.set_warning(_("You need to configure the network to use a network installation source."))
         else: # network button could be deativated from last visit
             self._networkButton.set_sensitive(True)
+
+        # Update the URL entry validation now that we're done messing with sensitivites
+        self._updateURLEntryCheck()
 
 
     def _setup_no_updates(self):


### PR DESCRIPTION
Setting the initial sensitivities in the source spoke is a little
tricky, since the radio buttons determine the sensitivy for each box
corresponding to a method (and the children of that box), but the
protocol combo within one of those boxes also affects sensitivities.
And there's a case where got things wrong: if there is an auto-detected
repo, the auto-detect button would be active, but the network box would
still be sensitive.

Remove a bunch of the manual set_sensitive calls, and add signal handler
calls to refresh() to simulate changes to the protocol combo box as well
as a toggle for each radio button (buttons being disabled needs signals
too).

Resolves: rhbz#1259742