### PR TITLE
hostname: don't set installer env hostname to localhost.localdomain (…

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -1170,7 +1170,8 @@ def write_network_config(storage, ksdata, instClass, rootpath):
     overwrite = flags.livecdInstall or ksdata.method.method == "liveimg"
 
     write_hostname(rootpath, ksdata, overwrite=overwrite)
-    set_hostname(ksdata.network.hostname)
+    if ksdata.network.hostname != DEFAULT_HOSTNAME:
+        set_hostname(ksdata.network.hostname)
     write_sysconfig_network(rootpath, overwrite=overwrite)
     disableIPV6(rootpath)
     copyIfcfgFiles(rootpath)


### PR DESCRIPTION
…#1290858)

Related: rhbz#1290858

Rather keep hostname set by NetworkManager from dhcp or DNS lookup.