### PR TITLE
Add support for device specification variants (#1200833)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -88,7 +88,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 
 %package core
 Summary: Core of the Anaconda installer
-Requires: python-blivet >= 1:0.61.15.42
+Requires: python-blivet >= 1:0.61.15.52
 Requires: python-meh >= %{mehver}
 Requires: libreport-anaconda >= 2.0.21-1
 Requires: libreport-rhel-anaconda-bugzilla >= 2.1.11-1

--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -22,10 +22,12 @@
 
 import re
 import locale
+import os
 
 from contextlib import contextmanager
 
 from blivet import util
+from blivet import udev
 from blivet.size import Size
 from blivet.errors import StorageError
 from blivet.platform import platform as _platform
@@ -90,6 +92,8 @@ AUTOPART_DEVICE_TYPES = {AUTOPART_TYPE_LVM: DEVICE_TYPE_LVM,
 
 NAMED_DEVICE_TYPES = (DEVICE_TYPE_BTRFS, DEVICE_TYPE_LVM, DEVICE_TYPE_MD, DEVICE_TYPE_LVM_THINP)
 CONTAINER_DEVICE_TYPES = (DEVICE_TYPE_LVM, DEVICE_TYPE_BTRFS, DEVICE_TYPE_LVM_THINP)
+
+udev_device_dict_cache = None
 
 def size_from_input(input_str):
     """Get size from user's input"""
@@ -415,3 +419,114 @@ def filter_unsupported_disklabel_devices(devices):
     """ Return input list minus any devices that exist on an unsupported disklabel. """
     return [d for d in devices
             if not any(not getattr(p, "disklabelSupported", True) for p in d.ancestors)]
+
+def device_name_is_disk(device_name, devicetree=None, refresh_udev_cache=False):
+    """Report if the given device name corresponds to a disk device.
+
+    Check if the device name is a disk device or not. This function uses
+    the provided Blivet devicetree for the checking and Blivet udev module
+    if no devicetree is provided.
+
+    Please note that the udev based check uses an internal cache that is generated
+    when this function is first called in the udev checking mode. This basically
+    means that udev devices added later will not be taken into account.
+    If this is a problem for your usecase then use the refresh_udev_cache option
+    to force a refresh of the udev cache.
+
+    :param str device_name: name of the device to check
+    :param devicetree: device tree to look up devices in (optional)
+    :type devicetree: :class:`blivet.DeviceTree`
+    :param bool refresh_udev_cache: governs if the udev device cache should be refreshed
+    :returns: True if the device name corresponds to a disk, False if not
+    :rtype: bool
+    """
+    if devicetree is None:
+        global udev_device_dict_cache
+        if device_name:
+            if udev_device_dict_cache is None or refresh_udev_cache:
+                # Lazy load the udev dick that contains the {device_name : udev_device,..,}
+                # mappings. The operation could be quite costly due to udev_settle() calls,
+                # so we cache it in this non-elegant way.
+                # An unfortunate side effect of this is that udev devices that show up after
+                # this function is called for the first time will not be taken into account.
+                udev_device_dict_cache = {udev.device_get_name(d): d for d in udev.get_devices()}
+            udev_device = udev_device_dict_cache.get(device_name)
+            return udev_device and udev.device_is_realdisk(udev_device)
+        else:
+            return False
+    else:
+        device = devicetree.getDeviceByName(device_name)
+        return device and device.isDisk
+
+def device_matches(spec, devicetree=None, disks_only=False):
+    """Return names of block devices matching the provided specification.
+
+    :param str spec: a device identifier (name, UUID=<uuid>, &c)
+    :keyword devicetree: device tree to look up devices in (optional)
+    :type devicetree: :class:`blivet.DeviceTree`
+    :param bool disks_only: if only disk devices matching the spec should be returned
+    :returns: names of matching devices
+    :rtype: list of str
+
+    The spec can contain multiple "sub specs" delimited by a |, for example:
+
+    "sd*|hd*|vd*"
+
+    In such case we resolve the specs from left to right and return all
+    unique matches, for example:
+
+    ["sda", "sda1", "sda2", "sdb", "sdb1", "vdb"]
+
+    If disks_only is specified we only return
+    disk devices matching the spec. For the example above
+    the output with disks_only=True would be:
+
+    ["sda", "sdb", "vdb"]
+
+    Also note that parse methods will not have access to a devicetree, while execute
+    methods will. The devicetree is superior in that it can resolve md
+    array names and in that it reflects scheduled device removals, but for
+    normal local disks udev.resolve_devspec should suffice.
+    """
+
+    matches = []
+    # the device specifications might contain multiple "sub specs" separated by a |
+    # - the specs are processed from left to right
+    for single_spec in spec.split("|"):
+        full_spec = single_spec
+        if not full_spec.startswith("/dev/"):
+            full_spec = os.path.normpath("/dev/" + full_spec)
+
+        # the regular case
+        single_spec_matches = udev.resolve_glob(full_spec)
+        for match in single_spec_matches:
+            if match not in matches:
+                # skip non-disk devices in disk-only mode
+                if disks_only and not device_name_is_disk(match):
+                    continue
+                matches.append(match)
+
+        dev_name = None
+        # Use spec here instead of full_spec to preserve the spec and let the
+        # called code decide whether to treat the spec as a path instead of a name.
+        if devicetree is None:
+            # we run the spec through resolve_devspec() here as unlike resolve_glob()
+            # it can also resolve labels and UUIDs
+            dev_name = udev.resolve_devspec(single_spec)
+            if disks_only and dev_name:
+                if not device_name_is_disk(dev_name):
+                    dev_name = None  # not a disk
+        else:
+            # devicetree can also handle labels and UUIDs
+            device = devicetree.resolveDevice(single_spec)
+            if device:
+                dev_name = device.name
+                if disks_only and not device_name_is_disk(dev_name, devicetree=devicetree):
+                    dev_name = None  # not a disk
+
+        # The dev_name variable can be None if the spec is not not found or is not valid,
+        # but we don't want that ending up in the list.
+        if dev_name and dev_name not in matches:
+            matches.append(dev_name)
+
+    return matches


### PR DESCRIPTION
Make it possible to have multiple device specification variants
delimited by | in the device specification string, for example:

"sd*|hd*|vda"

or

"sd*|hd*|vda,/dev/vdc"

The spec variants are processed individually from left to right
and at least one match needs to happen for the | delimited
spec to be considered successfully applied.

Also make sure that callers of the deviceMatches() function
really get disk devices when they expect them, not partitions
or other devices that are not disks.

Resolves: rhbz#1200833