### PR TITLE
Check if bridgeslave argument is valid MAC and use it

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -548,6 +548,8 @@ def ksnet_to_ifcfg(net, filename=None):
             ifcfg['BRIDGING_OPTS'] = " ".join(keyvalues)
 
         for i, slave in enumerate(net.bridgeslaves.split(","), 1):
+            if is_mac(slave):
+                slave = find_devname(slave)
             slave_ifcfg = {
                             'TYPE' : "Ethernet",
                             'NAME' : "%s slave %s" % (dev, i),


### PR DESCRIPTION
Allows users to specify bridgeslaves in format --bridgeslaves=<MACADDR>
in the same way it's done for --device to allow automatic bridge configuration

Signed-off-by: Pavel Zhukov pzhukov@redhat.com
