### PR TITLE
Fix the processing of device nodes as driver disks

### DIFF
--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -625,10 +625,17 @@ def main(args):
 
     if mode in ('--disk', '--net'):
         request, dev = args
+
+        # Guess whether this is an ISO or RPM based on the filename.
+        # If neither matches, assume it is a device node and processes as an ISO.
+        # This is relevant for both --disk and --net since --disk could be
+        # pointing to files within the initramfs.
         if dev.endswith(".iso"):
             process_driver_disk(dev)
-        else:
+        elif dev.endswith(".rpm"):
             process_driver_rpm(dev)
+        else:
+            process_driver_disk(dev)
 
     elif mode == '--interactive':
         log.info("starting interactive mode")


### PR DESCRIPTION
Device nodes generally do not end in .iso, so the change to require that
disks end in .iso broke the processing of driver disk devices. Correct
this.

Related: rhbz#1269915