### PR TITLE
Make it possible to disable sshd service from running. (#1262707)

### DIFF
--- a/data/systemd/anaconda-sshd.service
+++ b/data/systemd/anaconda-sshd.service
@@ -4,6 +4,8 @@ Before=anaconda.target
 After=syslog.target network.target
 ConditionKernelCommandLine=|sshd
 ConditionKernelCommandLine=|inst.sshd
+ConditionKernelCommandLine=!inst.sshd=0
+ConditionKernelCommandLine=!sshd=0
 # TODO: use ConditionArchitecture in systemd v210 or later
 ConditionPathIsDirectory=|/sys/hypervisor/s390
 


### PR DESCRIPTION
Add a conditional to check whether a user specified inst.sshd=0 in
the anaconda-sshd.service file. If so, this won't start the sshd
service.

Resolves: rhbz#1262707