### PR TITLE
Only run when_diskdev_appears for add events.

### DIFF
--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -155,8 +155,8 @@ when_diskdev_appears() {
     local dev="${1#/dev/}" cmd=""; shift
     cmd="/sbin/initqueue --settled --onetime --name $1 $*"
     {
-        printf 'SUBSYSTEM=="block", KERNEL=="%s", RUN+="%s"\n' "$dev" "$cmd"
-        printf 'SUBSYSTEM=="block", SYMLINK=="%s", RUN+="%s"\n' "$dev" "$cmd"
+        printf 'SUBSYSTEM=="block", ACTION=="add", KERNEL=="%s", RUN+="%s"\n' "$dev" "$cmd"
+        printf 'SUBSYSTEM=="block", ACTION=="add", SYMLINK=="%s", RUN+="%s"\n' "$dev" "$cmd"
     } >> $rulesfile
 }
 


### PR DESCRIPTION
This makes when_diskdev_appears behave more like its name: run a command
only when a device appears. Without the ACTION qualifier, the rule also
matches change events, which could cause the command to be run more than
once.

Resolves: rhbz#1260610
