### PR TITLE
Enable Custom GRUB2 Password Utility (#985962)

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1399,6 +1399,7 @@ class GRUB2(GRUB):
     packages = ["grub2"]
     _config_file = "grub.cfg"
     _config_dir = "grub2"
+    _passwd_file = "user.cfg"
     defaults_file = "/etc/default/grub"
     terminal_type = "console"
     stage2_max_end = None
@@ -1529,17 +1530,12 @@ class GRUB2(GRUB):
         if not self.password and not self.encrypted_password:
             return
 
-        users_file = iutil.getSysroot() + "/etc/grub.d/01_users"
+        users_file = "%s%s/%s" % (iutil.getSysroot(), self.config_dir, self._passwd_file)
         header = iutil.open_with_perm(users_file, "w", 0o700)
-        header.write("#!/bin/sh -e\n\n")
-        header.write("cat << \"EOF\"\n")
         # XXX FIXME: document somewhere that the username is "root"
-        header.write("set superusers=\"root\"\n")
-        header.write("export superusers\n")
         self._encrypt_password()
-        password_line = "password_pbkdf2 root " + self.encrypted_password
+        password_line = "GRUB2_PASSWORD=" + self.encrypted_password
         header.write("%s\n" % password_line)
-        header.write("EOF\n")
         header.close()
 
     def write_config(self):


### PR DESCRIPTION
Changes the output of the GRUB2 password selection to output
the encrypted and hashed password to a file in /boot/grub2.

Code change depends on the commit in GRUB2 that adds the
friendly GRUB2 password change utility.

Resolves: rhbz#985962
