### PR TITLE
Use sshd-keygen.target instead of hardcoded sshd-keygen script

### DIFF
--- a/data/systemd/anaconda-sshd.service
+++ b/data/systemd/anaconda-sshd.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=OpenSSH server daemon
 Before=anaconda.target
-After=syslog.target network.target
+After=syslog.target network.target sshd-keygen.target
+Wants=sshd-keygen.target
 ConditionKernelCommandLine=|sshd
 ConditionKernelCommandLine=|inst.sshd
 # TODO: use ConditionArchitecture in systemd v210 or later
@@ -9,7 +10,6 @@ ConditionPathIsDirectory=|/sys/hypervisor/s390
 
 [Service]
 EnvironmentFile=/etc/sysconfig/sshd
-ExecStartPre=/usr/sbin/sshd-keygen
 ExecStartPre=/usr/sbin/handle-sshpw
 ExecStart=/usr/sbin/sshd -D $OPTIONS -f /etc/ssh/sshd_config.anaconda
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
For Fedora 25 (resolving [rhbz#1331753](https://bugzilla.redhat.com/show_bug.cgi?id=1331753), we are [removing legacy `sshd-keygen` script](https://fedoraproject.org/wiki/Changes/Remove_slogin_and_sshd-keygen) and moving to systemd instantiated services (under the umbrella of `sshd-keygen.target`).

I didn't test this on s390, but it is the same we have in [Fedora `sshd.service`](http://pkgs.fedoraproject.org/cgit/rpms/openssh.git/tree/sshd.service#n4).