### PR TITLE
Use the F25 timezone kickstart command version

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -19,7 +19,7 @@ Source0: %{name}-%{version}.tar.bz2
 # match the requires versions of things).
 
 %define gettextver 0.19.8
-%define pykickstartver 2.30-1
+%define pykickstartver 2.31-1
 %define dnfver 0.6.4
 %define partedver 1.8.1
 %define pypartedver 2.5-2

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1694,9 +1694,9 @@ class SshKey(commands.sshkey.F22_SshKey):
         for usr in self.sshUserList:
             users.setUserSshKey(usr.username, usr.key)
 
-class Timezone(commands.timezone.F23_Timezone):
+class Timezone(commands.timezone.F25_Timezone):
     def __init__(self, *args):
-        commands.timezone.F23_Timezone.__init__(self, *args)
+        commands.timezone.F25_Timezone.__init__(self, *args)
 
         self._added_chrony = False
         self._enabled_chrony = False


### PR DESCRIPTION
The F25 version of the command has been modified to make it possible
to use the --utc flag without requiring a timezone specification to be provided.

This way the hardware clock time format can be set from kickstart while
still requiring the user to select a timezone manually in the UI.

Resolves: rhbz#1312135