### PR TITLE
Fix bootloader when re-using existing /boot part (#1355795)

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -420,10 +420,10 @@ class Bootloader(commands.bootloader.RHEL7_Bootloader):
                                            msg=(_("Requested boot drive \"%s\" doesn't exist or cannot be used.")
                                                 % self.bootDrive)))
         # Take valid disk from --driveorder
-        elif len(self.driveorder) >= 1:
+        elif len(valid_disks) >= 1:
             log.debug("Bootloader: use '%s' first disk from driveorder as boot drive, dry run %s",
-                      self.driveorder[0], dry_run)
-            self.bootDrive = self.driveorder[0]
+                      valid_disks[0], dry_run)
+            self.bootDrive = valid_disks[0]
         else:
             # Try to find /boot
             #

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -312,6 +312,8 @@ class Bootloader(commands.bootloader.RHEL7_Bootloader):
     def __init__(self, *args, **kwargs):
         commands.bootloader.RHEL7_Bootloader.__init__(self, *args, **kwargs)
         self.location = "mbr"
+        self._useBackup = False
+        self._origBootDrive = None
 
     def parse(self, args):
         commands.bootloader.RHEL7_Bootloader.parse(self, args)
@@ -326,9 +328,29 @@ class Bootloader(commands.bootloader.RHEL7_Bootloader):
 
         return self
 
-    def execute(self, storage, ksdata, instClass):
+    def execute(self, storage, ksdata, instClass, dry_run=False):
+        """ Resolve and execute the bootloader installation.
+
+            :param storage: object storing storage-related information
+                            (disks, partitioning, bootloader, etc.)
+            :type storage: blivet.Blivet
+            :param payload: object storing packaging-related information
+            :type payload: pyanaconda.packaging.Payload
+            :param instclass: distribution-specific information
+            :type instclass: pyanaconda.installclass.BaseInstallClass
+            :param dry_run: flag if this is only dry run before the partitioning
+                            will be resolved
+            :type dry_run: bool
+        """
         if flags.imageInstall and blivet.arch.isS390():
             self.location = "none"
+
+        if dry_run:
+            self._origBootDrive = self.bootDrive
+            self._useBackup = True
+        elif self._useBackup:
+            self.bootDrive = self._origBootDrive
+            self._useBackup = False
 
         if self.location == "none":
             location = None
@@ -373,7 +395,8 @@ class Bootloader(commands.bootloader.RHEL7_Bootloader):
         for drive in self.driveorder[:]:
             matches = device_matches(drive, devicetree=storage.devicetree, disks_only=True)
             if set(matches).isdisjoint(diskSet):
-                log.warning("requested drive %s in boot drive order doesn't exist or cannot be used", drive)
+                log.warning("requested drive %s in boot drive order doesn't exist or cannot be used",
+                            drive)
                 self.driveorder.remove(drive)
             else:
                 valid_disks.extend(matches)
@@ -381,7 +404,7 @@ class Bootloader(commands.bootloader.RHEL7_Bootloader):
         storage.bootloader.disk_order = valid_disks
 
         # When bootloader doesn't have --boot-drive parameter then use this logic as fallback:
-        # 1) If present use first disk from driveorder parameter
+        # 1) If present first valid disk from driveorder parameter
         # 2) If present and usable, use disk where /boot partition is placed
         # 3) Use first disk from Blivet
         if self.bootDrive:
@@ -396,26 +419,39 @@ class Bootloader(commands.bootloader.RHEL7_Bootloader):
                             formatErrorMsg(self.lineno,
                                            msg=(_("Requested boot drive \"%s\" doesn't exist or cannot be used.")
                                                 % self.bootDrive)))
+        # Take valid disk from --driveorder
         elif len(self.driveorder) >= 1:
-            log.debug("Bootloader: use '%s' first disk from driveorder as boot drive",
-                      self.driveorder[0])
+            log.debug("Bootloader: use '%s' first disk from driveorder as boot drive, dry run %s",
+                      self.driveorder[0], dry_run)
             self.bootDrive = self.driveorder[0]
         else:
-            boot_drive = None
             # Try to find /boot
-            for part in ksdata.partition.partitions:
-                if part.mountpoint == "/boot":
-                    device_match = device_matches(part.disk, devicetree=storage.devicetree)
-                    if len(device_match) == 1 and device_match[0] in disk_names:
-                        log.debug("Bootloader: use /boot partition '%s' as boot drive", device_match[0])
-                        boot_drive = device_match[0]
-                    break
-            else: # Nothing was found use first disk from Blivet
-                log.debug("Bootloader: fallback use first disk return from Blivet '%s' as boot drive",
-                          disk_names[0])
-                boot_drive = disk_names[0]
+            #
+            # This method is executed two times. Before and after partitioning.
+            # In the first run, the result is used for other partitioning but
+            # the second will be used.
+            try:
+                boot_dev = storage.mountpoints["/boot"]
+            except KeyError:
+                log.debug("Bootloader: /boot partition is not present, dry run %s", dry_run)
+            else:
+                boot_drive = ""
+                # Find disk ancestor
+                for ancestor in boot_dev.ancestors:
+                    if ancestor.isDisk:
+                        boot_drive = ancestor.name
+                        break
 
-            self.bootDrive = boot_drive
+                if boot_drive and boot_drive in disk_names:
+                    self.bootDrive = boot_drive
+                    log.debug("Bootloader: use /boot partition's disk '%s' as boot drive, dry run %s",
+                              boot_drive, dry_run)
+
+        # Nothing was found use first disk from Blivet
+        if not self.bootDrive:
+            log.debug("Bootloader: fallback use first disk return from Blivet '%s' as boot drive, dry run %s",
+                      disk_names[0], dry_run)
+            self.bootDrive = disk_names[0]
 
         drive = storage.devicetree.resolveDevice(self.bootDrive)
         storage.bootloader.stage1_disk = drive
@@ -2200,7 +2236,7 @@ def doKickstartStorage(storage, ksdata, instClass):
     # snapshot free space now so that we know how much we had available
     storage.createFreeSpaceSnapshot()
 
-    ksdata.bootloader.execute(storage, ksdata, instClass)
+    ksdata.bootloader.execute(storage, ksdata, instClass, dry_run=True)
     ksdata.autopart.execute(storage, ksdata, instClass)
     ksdata.reqpart.execute(storage, ksdata, instClass)
     ksdata.partition.execute(storage, ksdata, instClass)


### PR DESCRIPTION
When existing partition was used then a bootloader saved this partition to other variable which wasn't tested.

Do a more robust fallback and also try to find disk from devicetree instead of KS command. Sorry I had to create ugly hack with ``dry_run`` to achieve this.

*Related: rhbz#1355795*