### PR TITLE
Fix restart payload only when repo needs network (#1358788)

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1497,7 +1497,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         log.debug("network: apply ksdata %s", self.data.network)
 
         if self.networking_changed:
-            if ANACONDA_ENVIRON in anaconda_flags.environs:
+            if ANACONDA_ENVIRON in anaconda_flags.environs and self.payload.needsNetwork:
                 log.debug("network spoke (apply) refresh payload")
                 from pyanaconda.packaging import payloadMgr
                 payloadMgr.restartThread(self.storage, self.data, self.payload, self.instclass,
@@ -1619,7 +1619,8 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
         self._now_available = self.completed
 
         log.debug("network standalone spoke (apply) payload: %s completed: %s", self.payload.baseRepo, self._now_available)
-        if not self.payload.baseRepo and not self._initially_available and self._now_available:
+        if (not self.payload.baseRepo and not self._initially_available
+            and self._now_available and self.payload.needsNetwork):
             from pyanaconda.packaging import payloadMgr
             payloadMgr.restartThread(self.storage, self.data, self.payload, self.instclass,
                     fallback=not anaconda_flags.automatedInstall)


### PR DESCRIPTION
When user change some settings in a network then the payload manager will restart payload thread to test if repositories are still reachable.

Fix use-case when repositories are local so changing of network settings don't require to test repositories.

*Resolves: rhbz#1358788*

*Reported-by: Peter Kotvan ``<pkotvan@redhat.com>``*