### PR TITLE
Some docstring refactoring & typo fixes for the TUI base classes

### DIFF
--- a/pyanaconda/ui/__init__.py
+++ b/pyanaconda/ui/__init__.py
@@ -42,21 +42,21 @@ class UserInterface(object):
     def __init__(self, storage, payload, instclass):
         """Create a new UserInterface instance.
 
-           The arguments this base class accepts defines the API that interfaces
-           have to work with.  A UserInterface does not get free reign over
-           everything in the anaconda class, as that would be a big mess.
-           Instead, a UserInterface may count on the following:
+        The arguments this base class accepts defines the API that interfaces
+        have to work with.  A UserInterface does not get free reign over
+        everything in the anaconda class, as that would be a big mess.
+        Instead, a UserInterface may count on the following:
 
-           storage      -- An instance of storage.Storage.  This is useful for
-                           determining what storage devices are present and how
-                           they are configured.
-           payload      -- An instance of a packaging.Payload subclass.  This
-                           is useful for displaying and selecting packages to
-                           install, and in carrying out the actual installation.
-           instclass    -- An instance of a BaseInstallClass subclass.  This
-                           is useful for determining distribution-specific
-                           installation information like default package
-                           selections and default partitioning.
+        storage      -- An instance of storage.Storage.  This is useful for
+                        determining what storage devices are present and how
+                        they are configured.
+        payload      -- An instance of a packaging.Payload subclass.  This
+                        is useful for displaying and selecting packages to
+                        install, and in carrying out the actual installation.
+        instclass    -- An instance of a BaseInstallClass subclass.  This
+                        is useful for determining distribution-specific
+                        installation information like default package
+                        selections and default partitioning.
         """
         if self.__class__ is UserInterface:
             raise TypeError("UserInterface is an abstract class.")
@@ -78,44 +78,42 @@ class UserInterface(object):
 
     @classmethod
     def update_paths(cls, pathdict):
-        """Receives pathdict and appends it's contents to the current
-           class defined search path dictionary."""
+        """Receives pathdict and appends it's contents to the current class defined search path dictionary."""
         for k, v in pathdict.items():
             cls.paths.setdefault(k, [])
             cls.paths[k].extend(v)
 
     def setup(self, data):
         """Construct all the objects required to implement this interface.
-           This method must be provided by all subclasses.
+
+        This method must be provided by all subclasses.
         """
         raise NotImplementedError
 
     def run(self):
-        """Run the interface.  This should do little more than just pass
-           through to something else's run method, but is provided here in
-           case more is needed.  This method must be provided by all subclasses.
+        """Run the interface.
+
+        This should do little more than just pass through to something else's run method,
+        but is provided here in case more is needed.  This method must be provided by all subclasses.
         """
         raise NotImplementedError
 
     @property
     def meh_interface(self):
-        """
-        Returns an interface for exception handling (defined by python-meh's
-        AbstractIntf class).
-
-        """
+        """Returns an interface for exception handling (defined by python-meh's AbstractIntf class)."""
         raise NotImplementedError
 
     ###
     ### MESSAGE HANDLING METHODS
     ###
     def showError(self, message):
-        """Display an error dialog with the given message. There is no return
-           value. This method must be implemented by all UserInterface
-           subclasses.
+        """Display an error dialog with the given message.
 
-           In the code, this method should be used sparingly and only for
-           critical errors that anaconda cannot figure out how to recover from.
+        There is no return value. This method must be implemented by all UserInterface
+        subclasses.
+
+        In the code, this method should be used sparingly and only for
+        critical errors that anaconda cannot figure out how to recover from.
         """
         raise NotImplementedError
 
@@ -123,32 +121,31 @@ class UserInterface(object):
         raise NotImplementedError
 
     def showYesNoQuestion(self, message):
-        """Display a dialog with the given message that presents the user a yes
-           or no choice.  This method returns True if the yes choice is selected,
-           and False if the no choice is selected.  From here, anaconda can
-           figure out what to do next.  This method must be implemented by all
-           UserInterface subclasses.
+        """Display a dialog with the given message that presents the user a yes or no choice.
 
-           In the code, this method should be used sparingly and only for those
-           times where anaconda cannot make a reasonable decision.  We don't
-           want to overwhelm the user with choices.
+        This method returns True if the yes choice is selected,
+        and False if the no choice is selected.
+        From here, anaconda can figure out what to do next.
+        This method must be implemented by all UserInterface subclasses.
+
+        In the code, this method should be used sparingly and only for those
+        times where anaconda cannot make a reasonable decision.  We don't
+        want to overwhelm the user with choices.
         """
         raise NotImplementedError
 
     def _collectActionClasses(self, module_pattern_w_path, standalone_class):
-        """Collect all the Hub and Spoke classes which should be enqueued for
-           processing.
+        """Collect all the Hub and Spoke classes which should be enqueued for processing.
 
-           :param module_pattern_w_path: the full name patterns (pyanaconda.ui.gui.spokes.%s)
-                                         and directory paths to modules we are about to import
-           :type module_pattern_w_path: list of (string, string)
+        :param module_pattern_w_path: the full name patterns (pyanaconda.ui.gui.spokes.%s)
+                                      and directory paths to modules we are about to import
+        :type module_pattern_w_path: list of (string, string)
 
-           :param standalone_class: the parent type of Spokes we want to pick up
-           :type standalone_class: common.StandaloneSpoke based types
+        :param standalone_class: the parent type of Spokes we want to pick up
+        :type standalone_class: common.StandaloneSpoke based types
 
-           :return: list of Spoke classes with standalone_class as a parent
-           :rtype: list of Spoke classes
-
+        :return: list of Spoke classes with standalone_class as a parent
+        :rtype: list of Spoke classes
         """
         standalones = []
 
@@ -159,16 +156,15 @@ class UserInterface(object):
         return standalones
 
     def _orderActionClasses(self, spokes, hubs):
-        """Order all the Hub and Spoke classes which should be enqueued for
-           processing according to their pre/post dependencies.
+        """Order all the Hub and Spoke classes which should be enqueued for processing according to their pre/post dependencies.
 
-           :param spokes: the classes we are to about order according
-                          to the hub dependencies
-           :type spokes: list of Spoke instances
+        :param spokes: the classes we are to about order according
+                       to the hub dependencies
+        :type spokes: list of Spoke instances
 
-           :param hubs: the list of Hub classes we check to be in pre/postForHub
-                        attribute of Spokes to pick up
-           :type hubs: common.Hub based types
+        :param hubs: the list of Hub classes we check to be in pre/postForHub
+                     attribute of Spokes to pick up
+        :type hubs: common.Hub based types
         """
 
         actionClasses = []

--- a/pyanaconda/ui/tui/__init__.py
+++ b/pyanaconda/ui/tui/__init__.py
@@ -89,8 +89,6 @@ class TextUserInterface(ui.UserInterface):
                             be translated to allow for change
                             of language.
         :type quitMessage: str
-
-
         """
 
         ui.UserInterface.__init__(self, storage, payload, instclass)
@@ -134,16 +132,17 @@ class TextUserInterface(ui.UserInterface):
         return self._meh_interface
 
     def _list_hubs(self):
-        """returns the list of hubs to use"""
+        """Returns the list of hubs to use."""
         return [SummaryHub]
 
     def _is_standalone(self, spoke):
-        """checks if the passed spoke is standalone"""
+        """Checks if the passed spoke is standalone."""
         return isinstance(spoke, StandaloneSpoke)
 
     def setup(self, data):
         """Construct all the objects required to implement this interface.
-           This method must be provided by all subclasses.
+
+        This method must be provided by all subclasses.
         """
         self._app = tui.App(self.productTitle, yes_or_no_question=YesNoDialog,
                             quit_message=self.quitMessage, queue_instance=hubQ.q)
@@ -165,7 +164,7 @@ class TextUserInterface(ui.UserInterface):
             obj = klass(self._app, data, self.storage, self.payload, self.instclass)
 
             # If we are doing a kickstart install, some standalone spokes
-            # could already be filled out.  In taht case, we do not want
+            # could already be filled out.  In that case, we do not want
             # to display them.
             if self._is_standalone(obj) and obj.completed:
                 del(obj)
@@ -181,9 +180,10 @@ class TextUserInterface(ui.UserInterface):
                 self._app.schedule_screen(obj)
 
     def run(self):
-        """Run the interface.  This should do little more than just pass
-           through to something else's run method, but is provided here in
-           case more is needed.  This method must be provided by all subclasses.
+        """Run the interface.
+
+        This should do little more than just pass through to something else's run method,
+        but is provided here in case more is needed.  This method must be provided by all subclasses.
         """
         return self._app.run()
 
@@ -191,9 +191,7 @@ class TextUserInterface(ui.UserInterface):
     ### MESSAGE HANDLING METHODS
     ###
     def _send_show_message(self, msg_fn, args, ret_queue):
-        """
-        Send message requesting to show some message dialog specified by the
-        message function.
+        """ Send message requesting to show some message dialog specified by the message function.
 
         :param msg_fn: message dialog function requested to be called
         :type msg_fn: a function taking the same number of arguments as is the
@@ -203,21 +201,18 @@ class TextUserInterface(ui.UserInterface):
         :param ret_queue: the queue which the return value of the message dialog
                           function should be put
         :type ret_queue: a queue.Queue instance
-
         """
 
         self._app.queue_instance.put((hubQ.HUB_CODE_SHOW_MESSAGE,
                                      [msg_fn, args, ret_queue]))
 
     def _handle_show_message(self, event, data):
-        """
-        Handler for the HUB_CODE_SHOW_MESSAGE message in the hubQ.
+        """Handler for the HUB_CODE_SHOW_MESSAGE message in the hubQ.
 
         :param event: event data
         :type event: (event_type, message_data)
         :param data: additional data
         :type data: any
-
         """
 
         # event_type, message_data
@@ -227,8 +222,7 @@ class TextUserInterface(ui.UserInterface):
         ret_queue.put(msg_fn(*args))
 
     def _show_message_in_main_thread(self, msg_fn, args):
-        """
-        If running in the main thread, run the message dialog function and
+        """ If running in the main thread, run the message dialog function and
         return its return value. If running in a non-main thread, request the
         message function to be called in the main thread.
 
@@ -237,7 +231,6 @@ class TextUserInterface(ui.UserInterface):
                       length of the args param
         :param args: arguments to be passed to the message dialog function
         :type args: any
-
         """
 
         if threadMgr.in_main_thread():
@@ -254,18 +247,19 @@ class TextUserInterface(ui.UserInterface):
             return ret_queue.get()
 
     def showError(self, message):
-        """Display an error dialog with the given message.  After this dialog
-           is displayed, anaconda will quit.  There is no return value.  This
-           method must be implemented by all UserInterface subclasses.
+        """Display an error dialog with the given message.
 
-           In the code, this method should be used sparingly and only for
-           critical errors that anaconda cannot figure out how to recover from.
+        After this dialog is displayed, anaconda will quit. There is no return value.
+        This method must be implemented by all UserInterface subclasses.
+
+        In the code, this method should be used sparingly and only for
+        critical errors that anaconda cannot figure out how to recover from.
         """
 
         return self._show_message_in_main_thread(self._showError, (message,))
 
     def _showError(self, message):
-        """Internal helper function that MUST BE CALLED FROM THE MAIN THREAD"""
+        """Internal helper function that MUST BE CALLED FROM THE MAIN THREAD."""
 
         if flags.automatedInstall and not flags.ksprompt:
             log.error(message)
@@ -279,27 +273,28 @@ class TextUserInterface(ui.UserInterface):
         return self._show_message_in_main_thread(self._showDetailedError, (message, details))
 
     def _showDetailedError(self, message, details):
-        """Internal helper function that MUST BE CALLED FROM THE MAIN THREAD"""
+        """Internal helper function that MUST BE CALLED FROM THE MAIN THREAD."""
         return self.showError(message + "\n\n" + details)
 
     def showYesNoQuestion(self, message):
-        """Display a dialog with the given message that presents the user a yes
-           or no choice.  This method returns True if the yes choice is selected,
-           and False if the no choice is selected.  From here, anaconda can
-           figure out what to do next.  This method must be implemented by all
-           UserInterface subclasses.
+        """Display a dialog with the given message that presents the user a yes or no choice.
 
-           In the code, this method should be used sparingly and only for those
-           times where anaconda cannot make a reasonable decision.  We don't
-           want to overwhelm the user with choices.
+        This method returns True if the yes choice is selected,
+        and False if the no choice is selected.  From here, anaconda can
+        figure out what to do next.  This method must be implemented by all
+        UserInterface subclasses.
 
-           When cmdline mode is active, the default will be to answer no.
+        In the code, this method should be used sparingly and only for those
+        times where anaconda cannot make a reasonable decision.  We don't
+        want to overwhelm the user with choices.
+
+        When cmdline mode is active, the default will be to answer no.
         """
 
         return self._show_message_in_main_thread(self._showYesNoQuestion, (message,))
 
     def _showYesNoQuestion(self, message):
-        """Internal helper function that MUST BE CALLED FROM THE MAIN THREAD"""
+        """Internal helper function that MUST BE CALLED FROM THE MAIN THREAD."""
 
         if flags.automatedInstall and not flags.ksprompt:
             log.error(message)

--- a/pyanaconda/ui/tui/simpleline/base.py
+++ b/pyanaconda/ui/tui/simpleline/base.py
@@ -38,28 +38,30 @@ def send_exception(queue_instance, ex):
 
 
 class ExitMainLoop(Exception):
-    """This exception ends the outermost mainloop. Used internally when dialogs
-       close."""
+    """This exception ends the outermost mainloop. Used internally when dialogs close."""
     pass
 
 class ExitAllMainLoops(ExitMainLoop):
-    """This exception ends the whole App mainloop structure. App.run() returns
-       False after the exception is processed."""
+    """This exception ends the whole App mainloop structure.
+
+    App.run() returns False after the exception is processed.
+    """
     pass
 
 class App(object):
-    """This is the main class for TUI screen handling. It is responsible for
-       mainloop control and keeping track of the screen stack.
+    """This is the main class for TUI screen handling.
 
-       Screens are organized in stack structure so it is possible to return
-       to caller when dialog or sub-screen closes.
+    It is responsible for mainloop control and keeping track of the screen stack.
 
-       It supports four window transitions:
-       - show new screen replacing the current one (linear progression)
-       - show new screen keeping the current one in stack (hub & spoke)
-       - show new screen and wait for it to end (dialog)
-       - close current window and return to the next one in stack
-       """
+    Screens are organized in stack structure so it is possible to return
+    to caller when dialog or sub-screen closes.
+
+    It supports four window transitions:
+    - show new screen replacing the current one (linear progression)
+    - show new screen keeping the current one in stack (hub & spoke)
+    - show new screen and wait for it to end (dialog)
+    - close current window and return to the next one in stack
+    """
 
     START_MAINLOOP = True
     STOP_MAINLOOP = False
@@ -106,30 +108,30 @@ class App(object):
         self._screens = []
 
     def register_event_handler(self, event, callback, data=None):
-        """This method registers a callback which will be called
-           when message "event" is encountered during process_events.
+        """This method registers a callback which will be called when message "event" is encountered during process_events.
 
-           The callback has to accept two arguments:
-             - the received message in the form of (type, [arguments])
-             - the data registered with the handler
+        The callback has to accept two arguments:
+        - the received message in the form of (type, [arguments])
+        - the data registered with the handler
 
-           :param event: the id of the event we want to react on
-           :type event: number|string
+        :param event: the id of the event we want to react on
+        :type event: number|string
 
-           :param callback: the callback function
-           :type callback: func(event_message, data)
+        :param callback: the callback function
+        :type callback: func(event_message, data)
 
-           :param data: optional data to pass to callback
-           :type data: anything
+        :param data: optional data to pass to callback
+        :type data: anything
         """
         if not event in self._handlers:
             self._handlers[event] = []
         self._handlers[event].append((callback, data))
 
     def _thread_input(self, queue_instance, prompt, hidden):
-        """This method is responsible for interruptible user input. It is expected
-        to be used in a thread started on demand by the App class and returns the
-        input via the communication Queue.
+        """This method is responsible for interruptible user input.
+
+        It is expected to be used in a thread started on demand by the App class
+        and returns the input via the communication Queue.
 
         :param queue_instance: communication queue_instance to be used
         :type queue_instance: queue.Queue instance
@@ -139,7 +141,6 @@ class App(object):
 
         :param hidden: whether typed characters should be echoed or not
         :type hidden: bool
-
         """
 
         if hidden:
@@ -172,7 +173,6 @@ class App(object):
 
         :param args: optional argument to pass to ui's refresh method (can be used to select what item should be displayed or so)
         :type args: anything
-
         """
 
         # (oldscr, oldattr, oldloop)
@@ -184,8 +184,7 @@ class App(object):
         self.redraw()
 
     def switch_screen_with_return(self, ui, args=None):
-        """Schedules a screen to show, but keeps the current one in stack
-           to return to, when the new one is closed.
+        """Schedules a screen to show, but keeps the current one in stack to return to, when the new one is closed.
 
         :param ui: screen to show
         :type ui: UIScreen instance
@@ -200,6 +199,7 @@ class App(object):
 
     def switch_screen_modal(self, ui, args=None):
         """Starts a new screen right away, so the caller can collect data back.
+
         When the new screen is closed, the caller is redisplayed.
 
         This method does not return until the new screen is closed.
@@ -216,8 +216,9 @@ class App(object):
         self._do_redraw()
 
     def schedule_screen(self, ui, args=None):
-        """Add screen to the bottom of the stack. This is mostly usefull
-        at the beginning to prepare the first screen hierarchy to display.
+        """Add screen to the bottom of the stack.
+
+        This is mostly useful at the beginning to prepare the first screen hierarchy to display.
 
         :param ui: screen to show
         :type ui: UIScreen instance
@@ -228,8 +229,9 @@ class App(object):
         self._screens.insert(0, (ui, args, self.NOP))
 
     def close_screen(self, scr=None):
-        """Close the currently displayed screen and exit it's main loop
-        if necessary. Next screen from the stack is then displayed.
+        """Close the currently displayed screen and exit it's main loop if necessary.
+
+        Next screen from the stack is then displayed.
 
         :param scr: if an UIScreen instance is passed it is checked to be the screen we are trying to close.
         :type scr: UIScreen instance
@@ -254,11 +256,12 @@ class App(object):
 
     def _do_redraw(self):
         """Draws the current screen and returns True if user input is requested.
-           If modal screen is requested, starts a new loop and initiates redraw after it ends.
 
-           :return: this method returns True if user input processing is requested
-           :rtype: bool
-           """
+        If modal screen is requested, starts a new loop and initiates redraw after it ends.
+
+        :return: this method returns True if user input processing is requested
+        :rtype: bool
+        """
 
         # there is nothing to display, exit
         if not self._screens:
@@ -298,9 +301,11 @@ class App(object):
         return input_needed
 
     def run(self):
-        """This methods starts the application. Do not use self.mainloop() directly
-        as run() handles all the required exceptions needed to keep nested mainloops
-        working."""
+        """This methods starts the application.
+
+        Do not use self.mainloop() directly as run() handles all the required exceptions
+        needed to keep nested mainloops working.
+        """
 
         try:
             self._mainloop()
@@ -383,14 +388,13 @@ class App(object):
 
     def process_events(self, return_at=None):
         """This method processes incoming async messages and returns
-           when a specific message is encountered or when the queue_instance
-           is empty.
+        when a specific message is encountered or when the queue_instance
+        is empty.
 
-           If return_at message was specified, the received
-           message is returned.
+        If return_at message was specified, the received message is returned.
 
-           If the message does not fit return_at, but handlers are
-           defined then it processes all handlers for this message
+        If the message does not fit return_at, but handlers are
+        defined then it processes all handlers for this message
         """
         while return_at or not self.queue_instance.empty():
             event = self.queue_instance.get()
@@ -407,7 +411,8 @@ class App(object):
 
     def raw_input(self, prompt, hidden=False):
         """This method reads one input from user. Its basic form has only one
-        line, but we might need to override it for more complex apps or testing."""
+        line, but we might need to override it for more complex apps or testing.
+        """
 
         input_thread = AnacondaThread(prefix=constants.THREAD_INPUT_BASENAME,
                                       target=self._thread_input,
@@ -415,10 +420,11 @@ class App(object):
         input_thread.daemon = True
         threadMgr.add(input_thread)
         event = self.process_events(return_at=hubQ.HUB_CODE_INPUT)
-        return event[1][0] # return the user input
+        return event[1][0]  # return the user input
 
     def input(self, args, key):
         """Method called internally to process unhandled input key presses.
+
         Also handles the main quit and close commands.
 
         :param args: optional argument passed from switch_screen calls
@@ -429,7 +435,6 @@ class App(object):
 
         :return: True if key was processed, False if it was not recognized
         :rtype: True|False
-
         """
 
         # delegate the handling to active screen first
@@ -484,8 +489,11 @@ class App(object):
         return self._width
 
 class UIScreen(object):
-    """Base class representing one TUI Screen. Shares some API with anaconda's GUI
-    to make it easy for devs to create similar UI with the familiar API."""
+    """Base class representing one TUI Screen.
+
+    Shares some API with anaconda's GUI to make it easy for devs to create similar UI
+    with the familiar API.
+    """
 
     # title line of the screen
     title = u"Screen.."
@@ -510,14 +518,12 @@ class UIScreen(object):
         self._page = 0
 
     def setup(self, environment):
-        """
-        Do additional setup right before this screen is used.
+        """Do additional setup right before this screen is used.
 
         :param environment: environment (see pyanaconda.constants) the UI is running in
         :type environment: either FIRSTBOOT_ENVIRON or ANACONDA_ENVIRON
         :return: whether this screen should be scheduled or not
         :rtype: bool
-
         """
 
         return True
@@ -537,12 +543,10 @@ class UIScreen(object):
         return True
 
     def _print_long_widget(self, widget):
-        """Prints a long widget (possibly longer than the screen height) with
-           user interaction (when needed).
+        """Prints a long widget (possibly longer than the screen height) with user interaction (when needed).
 
-           :param widget: possibly long widget to print
-           :type widget: Widget instance
-
+        :param widget: possibly long widget to print
+        :type widget: Widget instance
         """
 
         pos = 0
@@ -571,8 +575,7 @@ class UIScreen(object):
                 pos += self._screen_height - 1
 
     def show_all(self):
-        """Prepares all elements of self._window for output and then prints
-        them on the screen."""
+        """Prepares all elements of self._window for output and then prints them on the screen."""
 
         for w in self._window:
             if hasattr(w, "render"):
@@ -640,18 +643,18 @@ class Widget(object):
     def __init__(self, max_width=None, default=None):
         """Initializes base Widgets buffer.
 
-           :param max_width: server as a hint about screen size to write method with default arguments
-           :type max_width: int
+        :param max_width: server as a hint about screen size to write method with default arguments
+        :type max_width: int
 
-           :param default: string containing the default content to fill the buffer with
-           :type default: string
-           """
+        :param default: string containing the default content to fill the buffer with
+        :type default: string
+        """
 
         self._buffer = []
         if default:
             self._buffer = [[c for c in l] for l in default.split("\n")]
         self._max_width = max_width
-        self._cursor = (0, 0) # row, col
+        self._cursor = (0, 0)  # row, col
 
     @property
     def height(self):
@@ -660,8 +663,7 @@ class Widget(object):
 
     @property
     def width(self):
-        """The current width of the internal buffer
-           (id of the first empty column)."""
+        """The current width of the internal buffer (id of the first empty column)."""
         return functools.reduce(lambda acc, l: max(acc, len(l)), self._buffer, 0)
 
     def clear(self):
@@ -677,20 +679,20 @@ class Widget(object):
     def render(self, width):
         """This method has to redraw the widget's self._buffer.
 
-           :param width: the width of buffer requested by the caller
-           :type width: int
+        :param width: the width of buffer requested by the caller
+        :type width: int
 
-           This method will commonly call render of child widgets and then draw and write
-           methods to copy their contents to self._buffer
-           """
+        This method will commonly call render of child widgets and then draw and write
+        methods to copy their contents to self._buffer
+        """
         self.clear()
 
     def get_lines(self):
         """Get lines to write out in order to show this widget.
 
-           :return: lines representing this widget
-           :rtype: list(str)
-           """
+        :return: lines representing this widget
+        :rtype: list(str)
+        """
 
         return [str(u"".join(line)) for line in self._buffer]
 
@@ -716,18 +718,18 @@ class Widget(object):
     def draw(self, w, row=None, col=None, block=False):
         """This method copies w widget's content to this widget's buffer at row, col position.
 
-           :param w: widget to take content from
-           :type w: class Widget
+        :param w: widget to take content from
+        :type w: class Widget
 
-           :param row: row number to start at (default is at the cursor position)
-           :type row: int
+        :param row: row number to start at (default is at the cursor position)
+        :type row: int
 
-           :param col: column number to start at (default is at the cursor position)
-           :type col: int
+        :param col: column number to start at (default is at the cursor position)
+        :type col: int
 
-           :param block: when printing newline, start at column col (True) or at column 0 (False)
-           :type block: boolean
-           """
+        :param block: when printing newline, start at column col (True) or at column 0 (False)
+        :type block: boolean
+        """
 
         # if the starting row is not present, start at the cursor position
         if row is None:
@@ -737,12 +739,12 @@ class Widget(object):
         if col is None:
             col = self._cursor[1]
 
-        # fill up rows to accomodate for w.height
+        # fill up rows to accommodate for w.height
         if self.height < row + w.height:
             for _i in range(row + w.height - self.height):
                 self._buffer.append(list())
 
-        # append columns to accomodate for w.width
+        # append columns to accommodate for w.width
         for l in range(row, row + w.height):
             l_len = len(self._buffer[l])
             w_len = len(w.content[l - row])
@@ -759,24 +761,24 @@ class Widget(object):
     def write(self, text, row=None, col=None, width=None, block=False, wordwrap=False):
         """This method emulates typing machine writing to this widget's buffer.
 
-           :param text: text to type
-           :type text: str
+        :param text: text to type
+        :type text: str
 
-           :param row: row number to start at (default is at the cursor position)
-           :type row: int
+        :param row: row number to start at (default is at the cursor position)
+        :type row: int
 
-           :param col: column number to start at (default is at the cursor position)
-           :type col: int
+        :param col: column number to start at (default is at the cursor position)
+        :type col: int
 
-           :param width: wrap at "col" + "width" column (default is at self._max_width)
-           :type width: int
+        :param width: wrap at "col" + "width" column (default is at self._max_width)
+        :type width: int
 
-           :param block: when printing newline, start at column col (True) or at column 0 (False)
-           :type block: boolean
+        :param block: when printing newline, start at column col (True) or at column 0 (False)
+        :type block: boolean
 
-           :param wordwrap: wrap by words
-           :type wordwrap: boolean
-           """
+        :param wordwrap: wrap by words
+        :type wordwrap: boolean
+        """
         if not text:
             return
 
@@ -830,7 +832,6 @@ class Widget(object):
             # if the line's length is not enough, fill it with spaces
             if y >= len(self._buffer[x]):
                 self._buffer[x] += ((y - len(self._buffer[x]) + 1) * list(u" "))
-
 
             # "type" character
             self._buffer[x][y] = c

--- a/pyanaconda/ui/tui/simpleline/widgets.py
+++ b/pyanaconda/ui/tui/simpleline/widgets.py
@@ -37,8 +37,7 @@ class TextWidget(base.Widget):
         self._text = text
 
     def render(self, width):
-        """Renders the text widget limited to width number of columns
-        (wraps to the next line when the text is longer).
+        """Renders the text widget limited to width number of columns (wraps to the next line when the text is longer).
 
         :param width: maximum width allocated to the string
         :type width: int
@@ -61,8 +60,7 @@ class CenterWidget(base.Widget):
         self._w = w
 
     def render(self, width):
-        """
-        Render the centered widget to internal buffer.
+        """Render the centered widget to internal buffer.
 
         :param width: maximum width the widget should use
         :type width: int
@@ -77,12 +75,12 @@ class ColumnWidget(base.Widget):
     def __init__(self, columns, spacing=0):
         """Create text columns
 
-           :param columns: list containing (column width, [list of widgets to put into this column])
-           :type columns: [(int, [...]), ...]
+        :param columns: list containing (column width, [list of widgets to put into this column])
+        :type columns: [(int, [...]), ...]
 
-           :param spacing: number of spaces to use between columns
-           :type spacing: int
-           """
+        :param spacing: number of spaces to use between columns
+        :type spacing: int
+        """
 
         base.Widget.__init__(self)
         self._spacing = spacing
@@ -100,7 +98,7 @@ class ColumnWidget(base.Widget):
 
         base.Widget.render(self, width)
 
-        # the lefmost empty column
+        # the leftmost empty column
         x = 0
 
         # iterate over tuples (column width, column content)
@@ -150,8 +148,10 @@ class CheckboxWidget(base.Widget):
         self._completed = completed
 
     def render(self, width):
-        """Render the widget to internal buffer. It should be max width
-           characters wide."""
+        """Render the widget to internal buffer.
+
+        It should be max width characters wide.
+        """
         base.Widget.render(self, width)
 
         if self.completed:

--- a/pyanaconda/ui/tui/tuiobject.py
+++ b/pyanaconda/ui/tui/tuiobject.py
@@ -128,7 +128,7 @@ class YesNoDialog(tui.UIScreen):
         self._window.append(u"")
         return True
 
-    def prompt(self, args = None):
+    def prompt(self, args=None):
         return _("Please respond '%(yes)s' or '%(no)s': ") % {
             # TRANSLATORS: 'yes' as positive reply
             "yes": C_('TUI|Spoke Navigation', 'yes'),


### PR DESCRIPTION
Unify the disparate docstring formatting styles in the TUI bases classes
and make them conform to PEP 257 when we are at it. Also fix some typos.