### PR TITLE
Clarify a nosave related log message

### DIFF
--- a/pyanaconda/install.py
+++ b/pyanaconda/install.py
@@ -125,7 +125,7 @@ def doConfiguration(storage, payload, ksdata, instClass):
         # don't write the kickstart file to the installed system if this has
         # been disabled by the nosave option
         log.warning("Writing of the output kickstart to installed system has been disabled"
-                    " by the copy_kickstarts option.")
+                    " by the nosave option.")
     else:
         _writeKS(ksdata)
 


### PR DESCRIPTION
It is the nosave option that might prevent the output kickstart
from being written to the installed system.

Related: rhbz#1285519