### PR TITLE
Fix another blivet-2.0 pep8 error

### DIFF
--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -441,7 +441,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
 
             # Make sure anaconda doesn't touch this device.
             part.protected = True
-            self.storage.config.protectedDevSpecs.append(part.name)
+            self.storage.config.protected_dev_specs.append(part.name)
         elif self._mirror_active():
             # this preserves the url for later editing
             self.data.method.method = None


### PR DESCRIPTION
Changed ``protectedDevSpecs`` to pep8 ``protected_dev_specs``.