### PR TITLE
Fix architecutre selection for help content

### DIFF
--- a/pyanaconda/ihelp.py
+++ b/pyanaconda/ihelp.py
@@ -117,7 +117,7 @@ def get_help_path(help_file, instclass):
 
         # the documentation files don't differentiate between 32bit and 64bit x86
         # and just use a "x86" suffix for both
-        if arch.isX86:
+        if arch.isX86():
             architecture = "x86"
         # the arm docks are the same as the x86 docs
         elif arch.isARM() or arch.isAARCH64():


### PR DESCRIPTION
Due to a typo the help content architecture was always set to x86.
Add a missing () to make help content achitecture selection work correctly
on all supported architectures.

Related: rhbz#1260880