### PR TITLE
Fix needsNetwork() to test only enabled repositories (#1361213)

### DIFF
--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -239,6 +239,7 @@ class Payload(object):
 
     @property
     def needsNetwork(self):
+        """ Test base and additional repositories if they requires network. """
         url = ""
         if self.data.method.method == "nfs":
             # NFS is always on network
@@ -249,8 +250,14 @@ class Payload(object):
             else:
                 url = self.data.url.mirrorlist
 
-        return (self._sourceNeedsNetwork([url]) or
-                any(self._repoNeedsNetwork(repo) for repo in self.data.repo.dataList()))
+        if self._sourceNeedsNetwork([url]):
+            return True
+
+        for repo in self.data.repo.dataList():
+            if repo.enabled and self._repoNeedsNetwork(repo):
+                return True
+
+        return False
 
     def _resetMethod(self):
         self.data.method.method = ""


### PR DESCRIPTION
By testing every repository no groups for installation was loaded even when all enabled repositories were reachable.

Additional repositories which are not reachable are automatically disabled at this moment. This is original/unmodified behavior.

*Resolves: rhbz#1361213*
*Related: rhbz#1358788*