### PR TITLE
Fix anaconda-pre.service wasn't properly installed (#1255659)

### DIFF
--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -1,6 +1,6 @@
 # systemd/Makefile.am for anaconda
 #
-# Copyright (C) 2011  Red Hat, Inc.
+# Copyright (C) 2011, 2016  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published
@@ -19,15 +19,16 @@ systemddir = $(prefix)/lib/systemd/system
 generatordir = $(prefix)/lib/systemd/system-generators
 
 dist_systemd_DATA = anaconda.service \
-		    anaconda-noshell.service \
-		    anaconda-direct.service \
-		    anaconda.target \
-		    anaconda-tmux@.service \
-		    anaconda-shell@.service \
-		    instperf.service \
-		    anaconda-sshd.service \
-		    anaconda-nm-config.service \
-		    zram.service
+                    anaconda-noshell.service \
+                    anaconda-direct.service \
+                    anaconda.target \
+                    anaconda-tmux@.service \
+                    anaconda-shell@.service \
+                    instperf.service \
+                    anaconda-sshd.service \
+                    anaconda-nm-config.service \
+                    anaconda-pre.service \
+                    zram.service
 
 dist_generator_SCRIPTS = anaconda-generator
 

--- a/data/systemd/anaconda-pre.service
+++ b/data/systemd/anaconda-pre.service
@@ -9,14 +9,12 @@ Wants=rsyslog.service
 Wants=systemd-udev-settle.service
 Wants=NetworkManager.service
 Wants=plymouth-quit.service plymouth-quit-wait.service
-Wants=anaconda-direct.service anaconda.service
-Wants=anaconda-sshd.service
 Wants=zram.service
 Wants=systemd-logind.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/anaconda-pre-log-gen
+ExecStart=/usr/libexec/anaconda/anaconda-pre-log-gen
 StardardInput=tty
 StandardOutput=journal+console
 StandardError=journal+console

--- a/data/systemd/anaconda.target
+++ b/data/systemd/anaconda.target
@@ -10,5 +10,6 @@ Wants=NetworkManager.service
 Wants=plymouth-quit.service plymouth-quit-wait.service
 Wants=anaconda-direct.service anaconda.service
 Wants=anaconda-sshd.service
+Wants=anaconda-pre.service
 Wants=zram.service
 Wants=systemd-logind.service

--- a/scripts/anaconda-pre-log-gen
+++ b/scripts/anaconda-pre-log-gen
@@ -14,7 +14,7 @@ DEBUG_ENABLED=`cat $BOOT_OPTIONS_FILE | egrep -c "\<debug\>|\<inst\.debug\>"`
 
 mkdir ${TARGET_DIRECTORY}
 
-lsblk -a >${TARGET_DIRECTORY}/block_devices.log
-dmesg -a >${TARGET_DIRECTORY}/kernel_ring_buffer.log
+lsblk -a > ${TARGET_DIRECTORY}/block_devices.log
+dmesg > ${TARGET_DIRECTORY}/kernel_ring_buffer.log
 
 lvmdump -d ${TARGET_DIRECTORY}/lvmdump


### PR DESCRIPTION
Service wasn't in the Makefile.

Small improvement on ``Wants`` in a ``anaconda-pre.service``. It should be started before anaconda.service and other anaconda services.

The ``anaconda-pre-log-gen`` was in ``/usr/libexec`` instead of ``/usr/bin``.
The ``dmesg`` command in ``anaconda-pre-log-gen`` doesn't have ``-a`` parameter.

*Related: rhbz#1255659*