### PR TITLE
Fix reset payload only on network change (#1364367)

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -626,12 +626,12 @@ class NetworkControlBox(GObject.GObject):
                 uuid, devname, activate_condition = activate # pylint: disable=unpacking-non-sequence
                 if activate_condition():
                     gtk_call_once(self._activate_connection_cb, uuid, devname)
-            if self.spoke:
-                self.spoke.networking_changed = True
             network.logIfcfgFiles("nm-c-e run")
 
     def _activate_connection_cb(self, uuid, devname):
         nm.nm_activate_device_connection(devname, uuid)
+        if self.spoke:
+            self.spoke.networking_changed = True
 
     def on_wireless_enabled(self, *args):
         switch = self.builder.get_object("device_wireless_off_switch")


### PR DESCRIPTION
Reset payload when connection change.
This solve the issue only partially, problem here is that the ``NetworkManager-connection-editor`` will save the connection in other form than it is saved from the ``Dracut``.

So when you click on the save button (without changing anything) for the first time, the payload will be restarted but when you do it more times after, it won't restart the payload thread anymore.

*Resolves: rhbz#1364367*
*Reported-by: Jakub Vavra ``<jvavra@redhat.com>``*