### PR TITLE
Disable strict password quality checking for partial kickstart instal…

### DIFF
--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -8,4 +8,8 @@ firstboot --enable
 pwpolicy root --notstrict --minlen=8 --minquality=50 --nochanges --emptyok
 pwpolicy user --notstrict --minlen=8 --minquality=50 --nochanges --emptyok
 pwpolicy luks --notstrict --minlen=8 --minquality=50 --nochanges --notempty
+# NOTE: This applies only to *fully* interactive installations, partial kickstart
+#       installations use defaults specified in pyanaconda/pwpolicy.py.
+#       Automated kickstart installs simply ignore the password policy as the policy
+#       only applies to the UI, not for passwords specified in kickstart.
 %end

--- a/docs/kickstart.rst
+++ b/docs/kickstart.rst
@@ -16,6 +16,8 @@ pwpolicy
 pwpolicy <name> [--minlen=LENGTH] [--minquality=QUALITY] [--strict|notstrict] [--emptyok|notempty] [--changesok|nochanges]
     Set the policy to use for the named password entry.
 
+.. note:: The password policy only applies to password input via the UI, not for passwords specified in kickstart.
+
     name
         Name of the password entry, currently supported values are: root, user and luks
 
@@ -26,11 +28,11 @@ pwpolicy <name> [--minlen=LENGTH] [--minquality=QUALITY] [--strict|notstrict] [-
         Minimum libpwquality to consider good. When using --strict it will not allow
         passwords with a quality lower than this.
 
-    --strict (**DEFAULT**)
+    --strict
         Strict password enforcement. Passwords not meeting the --minquality level will
         not be allowed.
 
-    --notstrict
+    --notstrict (**DEFAULT**)
         Passwords not meeting the --minquality level will be allowed after Done is clicked
         twice.
 
@@ -48,8 +50,8 @@ pwpolicy <name> [--minlen=LENGTH] [--minquality=QUALITY] [--strict|notstrict] [-
         Do not allow UI to be used to change the password/user if it has been set in
         the kickstart.
 
-The defaults for these are set in the /usr/share/anaconda/interactive-defaults.ks file
-provided by Anaconda. If a product, such as Fedora Workstation, wishes to override them
+The defaults for interactive installations are set in the /usr/share/anaconda/interactive-defaults.ks
+file provided by Anaconda. If a product, such as Fedora Workstation, wishes to override them
 then a product.img needs to be created with a new version of the file included.
 
 When using a kickstart the defaults can be overridded by placing a %anaconda section into

--- a/pyanaconda/pwpolicy.py
+++ b/pyanaconda/pwpolicy.py
@@ -34,9 +34,17 @@ class F22_PwPolicyData(BaseData):
         self.name = kwargs.get("name", "")
         self.minlen = kwargs.get("minlen", 8)
         self.minquality = kwargs.get("minquality", 50)
-        self.strict = kwargs.get("strict", True)
+        self.strict = kwargs.get("strict", False)
         self.changesok = kwargs.get("changesok", False)
         self.emptyok = kwargs.get("emptyok", True)
+
+        # The defaults specified above are used only for password input via the UI
+        # during a partial kickstart installations.
+        # Fully interactive installs (no kickstart is specified by the user)
+        # use the default set by the interactive defaults built-in kickstart file
+        # (data/interactive-defaults.ks).
+        # Automated kickstart installs simply ignore the password policy as the policy
+        # only applies to the UI, not for passwords specified in kickstart.
 
     def __eq__(self, y):
         if not y:


### PR DESCRIPTION
…lations

We already disable strict password quality checking in fully interactive
installations (no user provided kickstart), so do the same thing by default
for partial kickstart installations.

Also clarify how the default password policy is set and when it actually applies.

Related: rhbz#1360263