### PR TITLE
Run cache hack after moving cache to mounted storage (#1287438)

### DIFF
--- a/pyanaconda/packaging/yumpayload.py
+++ b/pyanaconda/packaging/yumpayload.py
@@ -413,6 +413,7 @@ reposdir=%s
         releasever = self._yum.conf.yumvar['releasever']
         log.debug("setting releasever to previous value of %s", releasever)
         self._resetYum(root=iutil.getSysroot(), keep_cache=True, releasever=releasever, cache_dir=new_cache)
+        self._yumCacheDirHack()
         self.gatherRepoMetadata()
 
         # trigger setup of self._yum.config


### PR DESCRIPTION
Yum doubles up the /mnt/sysimage on the cache dir if we don't run the
cache hack on it. We DO want it to be under /mnt/sysimage, but not under
/mnt/sysimage/mnt/sysimage/

Without this yum creates the cache at the wrong place, and then when
anaconda-yum runs it uses the right place, leaving a
/mnt/sysimage/mnt/sysimage/var/tmp/yum.cache on the installed system.

Resolves: rhbz#1287438