### PR TITLE
Add option to override efi_dir

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1677,7 +1677,10 @@ class GRUB2(GRUB):
 class EFIBase(object):
     @property
     def _config_dir(self):
-        return "efi/EFI/%s" % (self.efi_dir,) # pylint: disable=no-member
+        efi_dir = self.efi_dir
+        if flags.cmdline.get("force_efi_dir") is not None:
+            efi_dir = flags.cmdline.get("force_efi_dir")
+        return "efi/EFI/%s" % (efi_dir,) # pylint: disable=no-member
 
     def efibootmgr(self, *args, **kwargs):
         if flags.imageInstall or flags.dirInstall:
@@ -1788,6 +1791,8 @@ class EFIGRUB1(EFIBase, GRUB):
     def __init__(self):
         super(EFIGRUB1, self).__init__()
         self.efi_dir = 'BOOT'
+        if flags.cmdline.get("force_efi_dir") is not None:
+            self.efi_dir = flags.cmdline.get("force_efi_dir")
 
     #
     # configuration
@@ -2376,7 +2381,10 @@ def writeSysconfigKernel(storage, version, instClass):
     kernel_basename = "vmlinuz-" + version
     kernel_file = "/boot/%s" % kernel_basename
     if not os.path.isfile(iutil.getSysroot() + kernel_file):
-        kernel_file = "/boot/efi/EFI/%s/%s" % (instClass.efi_dir, kernel_basename)
+        efi_dir = instClass.efi_dir
+        if flags.cmdline.get("force_efi_dir") is not None:
+            efi_dir = flags.cmdline.get("force_efi_dir")
+        kernel_file = "/boot/efi/EFI/%s/%s" % (efi_dir, kernel_basename)
         if not os.path.isfile(iutil.getSysroot() + kernel_file):
             log.error("failed to recreate path to default kernel image")
             return

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1799,7 +1799,7 @@ class EFIGRUB1(EFIBase, GRUB):
 
             eg: HD(1,800,64000,faacb4ef-e361-455e-bd97-ca33632550c3)
         """
-        buf = self.efibootmgr("-v", stderr="/dev/tty5", capture=True)
+        buf = self.efibootmgr("-v", capture=True)
         matches = re.search(productName + r'\s+(HD\(.+?\))', buf)
         if matches and matches.groups():
             return matches.group(1)

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1783,6 +1783,12 @@ class EFIGRUB1(EFIBase, GRUB):
     stage2_bootable = False
     stage2_max_end_mb = None
 
+    _efi_binary = "\\grub.efi"
+
+    def __init__(self):
+        super(EFIGRUB1, self).__init__()
+        self.efi_dir = 'BOOT'
+
     #
     # configuration
     #


### PR DESCRIPTION
This is because in CentOS6, the efi_dir is actually 'redhat', not 'centos'.

This is on top of https://github.com/rhinstaller/anaconda/pull/738 and https://github.com/rhinstaller/anaconda/pull/737