### PR TITLE
Replace deprecated method of DNF

### DIFF
--- a/docs/html/pyanaconda.packaging.html
+++ b/docs/html/pyanaconda.packaging.html
@@ -397,7 +397,7 @@
 <dl class="class">
 <dt id="pyanaconda.packaging.dnfpayload.PayloadRPMDisplay">
 <em class="property">class </em><code class="descclassname">pyanaconda.packaging.dnfpayload.</code><code class="descname">PayloadRPMDisplay</code><span class="sig-paren">(</span><em>queue_instance</em><span class="sig-paren">)</span><a class="headerlink" href="#pyanaconda.packaging.dnfpayload.PayloadRPMDisplay" title="Permalink to this definition">¶</a></dt>
-<dd><p>Bases: <code class="xref py py-class docutils literal"><span class="pre">dnf.callback.LoggingTransactionDisplay</span></code></p>
+<dd><p>Bases: <code class="xref py py-class docutils literal"><span class="pre">dnf.callback.TransactionProgress</span></code></p>
 <dl class="method">
 <dt id="pyanaconda.packaging.dnfpayload.PayloadRPMDisplay.event">
 <code class="descname">event</code><span class="sig-paren">(</span><em>package</em>, <em>action</em>, <em>te_current</em>, <em>te_total</em>, <em>ts_current</em>, <em>ts_total</em><span class="sig-paren">)</span><a class="headerlink" href="#pyanaconda.packaging.dnfpayload.PayloadRPMDisplay.event" title="Permalink to this definition">¶</a></dt>

--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -135,7 +135,7 @@ def _pick_mpoint(df, download_size, install_size):
     return sorted(sufficients.items(), key=operator.itemgetter(1),
                   reverse=True)[0][0]
 
-class PayloadRPMDisplay(dnf.callback.LoggingTransactionDisplay):
+class PayloadRPMDisplay(dnf.callback.TransactionProgress):
     def __init__(self, queue_instance):
         super(PayloadRPMDisplay, self).__init__()
         self._queue = queue_instance


### PR DESCRIPTION
`dnf.callback.LoggingTransactionDisplay is deprecated now. It was considered part of API despite the fact that it has never been documented. Use `dnf.callback.TransactionProgress` instead.