### PR TITLE
Provides compatibility with DNF-2.0

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -20,7 +20,7 @@ Source0: %{name}-%{version}.tar.bz2
 
 %define gettextver 0.19.8
 %define pykickstartver 2.31-1
-%define dnfver 0.6.4
+%define dnfver 2.0.0
 %define partedver 1.8.1
 %define pypartedver 2.5-2
 %define nmver 0.9.9.0-10.git20130906

--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -527,7 +527,7 @@ class DNFPayload(packaging.PackagePayload):
             types.add('optional')
         exclude = self.data.packages.excludedList
         try:
-            self._base.group_install(grp, types, exclude=exclude)
+            self._base.group_install(grp.id, types, exclude=exclude)
         except dnf.exceptions.MarkingError as e:
             # dnf-1.1.9 raises this error when a package is missing from a group
             raise packaging.NoSuchPackage(str(e), required=True)


### PR DESCRIPTION
We try to help dnf api users to make kompatible theirs product with upcoming dnf-2.0. With this major release there are some api changes in dnf.

It would be also nice to mark anaconda without the patch as dnf-2.0.0 incompatible.