### PR TITLE
Ensure LDL DASDs formatted in text ks. (#1259437)

### DIFF
--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -327,7 +327,7 @@ class StorageSpoke(NormalTUISpoke):
                 unformatted += make_unformatted_dasd_list([d.name for d in getDisks(self.storage.devicetree)])
             if self.data.clearpart.cdl:
                 # LDL DASDs
-                ldl += [d for d in self.storage.devicetree.dasd if is_ldl_dasd(d.name)]
+                ldl += [d.name for d in self.storage.devicetree.dasd if is_ldl_dasd(d.name)]
             # combine into one nice list
             to_format = list(set(unformatted + ldl))
         else:


### PR DESCRIPTION
Similar to 9840fd7, this patch makes sure to create a list of LDL
DASD names, not a list of LDL DASD device objects, since the dev
name must be passed to format_dasd.

Resolves: rhbz#1259437