### PR TITLE
network: avoid registering GTypes from multiple threads (#1366271)

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -48,6 +48,8 @@ from pyanaconda.i18n import _
 from pyanaconda.regexes import HOSTNAME_PATTERN_WITHOUT_ANCHORS
 
 from gi.repository import NetworkManager
+# Register the types so that the use in threads is safe
+NetworkManager.State # pylint: disable=pointless-statement
 
 import logging
 log = logging.getLogger("anaconda")

--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -20,7 +20,14 @@
 #
 
 from gi.repository import Gio, GLib
+
 from gi.repository import NetworkManager
+# Register the types so that the use in threads is safe
+NetworkManager.ActiveConnectionState # pylint: disable=pointless-statement
+NetworkManager.DeviceState # pylint: disable=pointless-statement
+NetworkManager.DeviceType # pylint: disable=pointless-statement
+NetworkManager.State # pylint: disable=pointless-statement
+
 import IPy
 import struct
 import socket


### PR DESCRIPTION
An attempt to derefrence an GEnum value causes a lazy registering of
GType which is not thread-safe. It is however done from the
wait_for_connecting_NM_thread() thread.

Let's just create the types that are potentially used from the
wait_for_connecting_NM_thread() thread in advance.

Resolves: rhbz#1366271