### PR TITLE
Revert "Run cache hack after moving cache to mounted storage (#1287438)"

### DIFF
--- a/pyanaconda/packaging/yumpayload.py
+++ b/pyanaconda/packaging/yumpayload.py
@@ -413,7 +413,6 @@ reposdir=%s
         releasever = self._yum.conf.yumvar['releasever']
         log.debug("setting releasever to previous value of %s", releasever)
         self._resetYum(root=iutil.getSysroot(), keep_cache=True, releasever=releasever, cache_dir=new_cache)
-        self._yumCacheDirHack()
         self.gatherRepoMetadata()
 
         # trigger setup of self._yum.config


### PR DESCRIPTION
This commit was blocking Snapshot 1 creation.

This reverts commit b2aa1a4b50a68f018af99700f3c2fe551192cf40.

*Related: rhbz#1287438*
*Resolves: rhbz#1369698*