### PR TITLE
Check before removing repo specific caches (#1369698)

### DIFF
--- a/pyanaconda/packaging/yumpayload.py
+++ b/pyanaconda/packaging/yumpayload.py
@@ -1577,7 +1577,8 @@ reposdir=%s
             # remove cache dirs of install-specific repos
             for repo in self._yum.repos.listEnabled():
                 if repo.name == BASE_REPO_NAME or repo.id.startswith("anaconda-"):
-                    shutil.rmtree(repo.cachedir)
+                    if os.path.isdir(repo.cachedir):
+                        shutil.rmtree(repo.cachedir)
 
         self._removeTxSaveFile()
 


### PR DESCRIPTION
If the top level cache directory has already been removed these will not
exist and trying to remove them will cause a traceback.

Resolves: rhbz#1369698