### PR TITLE
don't use `systemctl --root` for now (#1369794)

### DIFF
--- a/pyanaconda/iutil.py
+++ b/pyanaconda/iutil.py
@@ -758,10 +758,7 @@ def _run_systemctl(command, service, root="/"):
     """
 
     args = [command, service]
-    if root != "/":
-        args += ["--root", root]
-
-    ret = execWithRedirect("systemctl", args)
+    ret = execWithRedirect("systemctl", args, root=root)
 
     return ret
 


### PR DESCRIPTION
instead just run in a chroot (via execWithRedirect), because
`systemctl --root` will not work for non-systemd services at
present.
