### PR TITLE
Translate press-c-to-continue correctly in TUI (#1364539)

### DIFF
--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -26,7 +26,7 @@ from pyanaconda import iutil
 from pyanaconda.constants import ANACONDA_CLEANUP
 from pyanaconda.constants_text import INPUT_PROCESSED
 from pyanaconda.flags import flags
-from pyanaconda.i18n import _, N_
+from pyanaconda.i18n import _, N_, C_
 from pyanaconda.kickstart import runPostScripts
 from pyanaconda.ui.tui.simpleline import TextWidget, ColumnWidget, CheckboxWidget
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
@@ -298,7 +298,8 @@ class RootSpoke(NormalTUISpoke):
         try:
             keyid = int(key) - 1
         except ValueError:
-            if key.lower() == "c":
+            # TRANSLATORS: 'c' to continue
+            if key.lower() == C_('TUI|Spoke Navigation', 'c'):
                 self.apply()
                 self.close()
                 return INPUT_PROCESSED

--- a/pyanaconda/ui/tui/spokes/software.py
+++ b/pyanaconda/ui/tui/spokes/software.py
@@ -25,7 +25,7 @@ from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.simpleline import TextWidget, ColumnWidget, CheckboxWidget
 from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.packaging import DependencyError, PackagePayload
-from pyanaconda.i18n import N_, _
+from pyanaconda.i18n import N_, _, C_
 
 from pyanaconda.constants import THREAD_PAYLOAD
 from pyanaconda.constants import THREAD_CHECK_SOFTWARE
@@ -150,7 +150,9 @@ class SoftwareSpoke(NormalTUISpoke):
         try:
             keyid = int(key) - 1
         except ValueError:
-            if key.lower() == "c" and 0 <= self._selection < len(self.payload.environments):
+            # TRANSLATORS: 'c' to continue
+            continue_requested = key.lower() == C_('TUI|Spoke Navigation', 'c')
+            if continue_requested and 0 <= self._selection < len(self.payload.environments):
                 self.apply()
                 self.close()
                 return INPUT_PROCESSED

--- a/pyanaconda/ui/tui/spokes/source.py
+++ b/pyanaconda/ui/tui/spokes/source.py
@@ -26,7 +26,7 @@ from pyanaconda.ui.tui.spokes import EditTUISpokeEntry as Entry
 from pyanaconda.ui.tui.simpleline import TextWidget, ColumnWidget
 from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.packaging import PackagePayload, payloadMgr
-from pyanaconda.i18n import N_, _
+from pyanaconda.i18n import N_, _, C_
 from pyanaconda.image import opticalInstallMedia, potentialHdisoSources
 from pyanaconda.iutil import DataHolder
 
@@ -457,7 +457,8 @@ class SelectISOSpoke(NormalTUISpoke, SourceSwitchHandler):
         return True
 
     def input(self, args, key):
-        if key == "c":
+        # TRANSLATORS: 'c' to continue
+        if key.lower() == C_('TUI|Spoke Navigation', 'c'):
             self.apply()
             self.close()
             return key

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -39,7 +39,7 @@ from pyanaconda.kickstart import doKickstartStorage, resetCustomStorageData
 from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.constants import THREAD_STORAGE, THREAD_STORAGE_WATCHER, THREAD_DASDFMT, DEFAULT_AUTOPART_TYPE
 from pyanaconda.constants_text import INPUT_PROCESSED
-from pyanaconda.i18n import _, P_, N_
+from pyanaconda.i18n import _, P_, N_, C_
 from pyanaconda.bootloader import BootLoaderError
 
 from pykickstart.constants import CLEARPART_TYPE_ALL, CLEARPART_TYPE_LINUX, CLEARPART_TYPE_NONE, AUTOPART_TYPE_LVM
@@ -266,7 +266,8 @@ class StorageSpoke(NormalTUISpoke):
                 self._update_disk_list(self.disks[keyid])
             return INPUT_PROCESSED
         except (ValueError, IndexError):
-            if key.lower() == "c":
+            # TRANSLATORS: 'c' to continue
+            if key.lower() == C_('TUI|Spoke Navigation', 'c'):
                 if self.selected_disks:
                     # check selected disks to see if we have any unformatted or
                     # LDL DASDs if we're on s390x, since they need to be
@@ -518,7 +519,8 @@ class AutoPartSpoke(NormalTUISpoke):
         try:
             keyid = int(key) - 1
         except ValueError:
-            if key.lower() == "c":
+            # TRANSLATORS: 'c' to continue
+            if key.lower() == C_('TUI|Spoke Navigation', 'c'):
                 newspoke = PartitionSchemeSpoke(self.app, self.data, self.storage,
                                                 self.payload, self.instclass)
                 self.app.switch_screen_modal(newspoke)
@@ -569,7 +571,8 @@ class PartitionSchemeSpoke(NormalTUISpoke):
         try:
             keyid = int(key) - 1
         except ValueError:
-            if key.lower() == "c":
+            # TRANSLATORS: 'c' to continue
+            if key.lower() == C_('TUI|Spoke Navigation', 'c'):
                 self.apply()
                 self.close()
                 return INPUT_PROCESSED


### PR DESCRIPTION
The press-c-to-continue shortcut has been partially translated
on some screens in the TUI. It has been translated in the prompt,
but a plan "c" character was still expected, regardless on what has been
shown to the user.

In some cases (such as in the storage configuration spoke) the user
could be instructed to press "p" for "Pokračovat" (in Czech language
installation), but TUI would expect "c" to be pressed.

This has been fixed and TUI should now always ask for the same
character it tells the user to input.

Resolves: rhbz#1364539