### PR TITLE
Translate press-c-to-continue correctly in TUI (#1364539)

### DIFF
--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -300,7 +300,8 @@ class RootSpoke(NormalTUISpoke):
         try:
             keyid = int(key) - 1
         except ValueError:
-            if key.lower() == "c":
+            # TRANSLATORS: 'c' to continue
+            if key.lower() == C_('TUI|Spoke Navigation', 'c'):
                 self.apply()
                 self.close()
                 return INPUT_PROCESSED

--- a/pyanaconda/ui/tui/spokes/software.py
+++ b/pyanaconda/ui/tui/spokes/software.py
@@ -188,8 +188,8 @@ class SoftwareSpoke(NormalTUISpoke):
             keyid = int(key) - 1
         except ValueError:
             # TRANSLATORS: 'c' to continue
-            if key.lower() == C_("TUI|Spoke Navigation", "c") and \
-                    0 <= self._selection < len(self.payload.environments):
+            continue_requested = key.lower() == C_('TUI|Spoke Navigation', 'c')
+            if continue_requested and 0 <= self._selection < len(self.payload.environments):
                 self.apply()
                 self.close()
                 return INPUT_PROCESSED

--- a/pyanaconda/ui/tui/spokes/source.py
+++ b/pyanaconda/ui/tui/spokes/source.py
@@ -24,7 +24,7 @@ from pyanaconda.ui.tui.spokes import EditTUISpokeEntry as Entry
 from pyanaconda.ui.tui.simpleline import TextWidget, ColumnWidget
 from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.packaging import PackagePayload, payloadMgr
-from pyanaconda.i18n import N_, _
+from pyanaconda.i18n import N_, _, C_
 from pyanaconda.image import opticalInstallMedia, potentialHdisoSources
 from pyanaconda.iutil import DataHolder
 
@@ -450,7 +450,8 @@ class SelectISOSpoke(NormalTUISpoke, SourceSwitchHandler):
         return True
 
     def input(self, args, key):
-        if key == "c":
+        # TRANSLATORS: 'c' to continue
+        if key.lower() == C_('TUI|Spoke Navigation', 'c'):
             self.apply()
             self.close()
             return key

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -39,7 +39,7 @@ from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.constants import THREAD_STORAGE, THREAD_STORAGE_WATCHER, THREAD_DASDFMT, DEFAULT_AUTOPART_TYPE
 from pyanaconda.constants import PAYLOAD_STATUS_PROBING_STORAGE
 from pyanaconda.constants_text import INPUT_PROCESSED
-from pyanaconda.i18n import _, P_, N_
+from pyanaconda.i18n import _, P_, N_, C_
 from pyanaconda.bootloader import BootLoaderError
 
 from pykickstart.constants import CLEARPART_TYPE_ALL, CLEARPART_TYPE_LINUX, CLEARPART_TYPE_NONE, AUTOPART_TYPE_LVM
@@ -275,7 +275,8 @@ class StorageSpoke(NormalTUISpoke):
                 self._update_disk_list(self.disks[keyid])
             return INPUT_PROCESSED
         except (ValueError, IndexError):
-            if key.lower() == "c":
+            # TRANSLATORS: 'c' to continue
+            if key.lower() == C_('TUI|Spoke Navigation', 'c'):
                 if self.selected_disks:
                     # check selected disks to see if we have any unformatted DASDs
                     # if we're on s390x, since they need to be formatted before we
@@ -497,7 +498,8 @@ class AutoPartSpoke(NormalTUISpoke):
         try:
             keyid = int(key) - 1
         except ValueError:
-            if key.lower() == "c":
+            # TRANSLATORS: 'c' to continue
+            if key.lower() == C_('TUI|Spoke Navigation', 'c'):
                 newspoke = PartitionSchemeSpoke(self.app, self.data, self.storage,
                                                 self.payload, self.instclass)
                 self.app.switch_screen_modal(newspoke)
@@ -548,7 +550,8 @@ class PartitionSchemeSpoke(NormalTUISpoke):
         try:
             keyid = int(key) - 1
         except ValueError:
-            if key.lower() == "c":
+            # TRANSLATORS: 'c' to continue
+            if key.lower() == C_('TUI|Spoke Navigation', 'c'):
                 self.apply()
                 self.close()
                 return INPUT_PROCESSED


### PR DESCRIPTION
The press-c-to-continue shortcut has been partially translated
on some screens in the TUI. It has been translated in the prompt,
but a plan "c" character was still expected, regardless on what has been
shown to the user.

In some cases (such as in the storage configuration spoke) the user
could be instructed to press "p" for "Pokračovat" (in Czech language
installation), but TUI would expect "c" to be pressed.

This has been fixed and TUI should now always ask for the same
character it tells the user to input.

Resolves: rhbz#1364539