### PR TITLE
Don't offer encrypting for Atomic Host installclass (#1267905)

### DIFF
--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -52,6 +52,9 @@ class BaseInstallClass(object):
     # install the latest updates during installation source selection.
     installUpdates = True
 
+    # Do we want to present the option to encrypt devices?
+    offerEncryption = True
+
     _l10n_domain = None
 
     # The default filesystem type to use.  If None, we will use whatever

--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -77,6 +77,8 @@ class RHELAtomicInstallClass(RHELBaseInstallClass):
     sortPriority=21000
     hidden = not productName.startswith(("RHEL Atomic Host", "Red Hat Enterprise Linux Atomic"))
 
+    offerEncryption = False
+
     def configure(self, anaconda):
         RHELBaseInstallClass.configure(self, anaconda)
         # Atomic installations are always single language (#1235726)

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -293,6 +293,10 @@ class AutoPart(commands.autopart.RHEL7_AutoPart):
         instClass.setDefaultPartitioning(storage)
         storage.doAutoPart = True
 
+        if self.encrypted and not instClass.offerEncryption:
+            raise KickstartValueError(formatErrorMsg(self.lineno,
+                    msg=_("Encrypted filesystems are not supported in this installation.")))
+
         if self.encrypted:
             storage.encryptedAutoPart = True
             storage.encryptionPassphrase = self.passphrase
@@ -1071,6 +1075,10 @@ class LogVolData(commands.logvol.RHEL7_LogVolData):
             if ty == "swap":
                 add_fstab_swap = request
 
+        if self.encrypted and not instClass.offerEncryption:
+            raise KickstartValueError(formatErrorMsg(self.lineno,
+                    msg=_("Encrypted filesystems are not supported in this installation.")))
+
         if self.encrypted:
             if self.passphrase and not storage.encryptionPassphrase:
                 storage.encryptionPassphrase = self.passphrase
@@ -1388,6 +1396,10 @@ class PartitionData(commands.partition.RHEL7_PartData):
             if ty == "swap":
                 add_fstab_swap = request
 
+        if self.encrypted and not instClass.offerEncryption:
+            raise KickstartValueError(formatErrorMsg(self.lineno,
+                    msg=_("Encrypted filesystems are not supported in this installation.")))
+
         if self.encrypted:
             if self.passphrase and not storage.encryptionPassphrase:
                 storage.encryptionPassphrase = self.passphrase
@@ -1577,6 +1589,10 @@ class RaidData(commands.raid.RHEL7_RaidData):
             storage.createDevice(request)
             if ty == "swap":
                 add_fstab_swap = request
+
+        if self.encrypted and not instClass.offerEncryption:
+            raise KickstartValueError(formatErrorMsg(self.lineno,
+                    msg=_("Encrypted filesystems are not supported in this installation.")))
 
         if self.encrypted:
             if self.passphrase and not storage.encryptionPassphrase:

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -278,6 +278,9 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         self._accordion.set_focus_hadjustment(self._partitionsViewport.get_hadjustment())
         self._accordion.set_focus_vadjustment(self._partitionsViewport.get_vadjustment())
 
+        if not self.instclass.offerEncryption:
+            really_hide(self._encryptCheckbox)
+
         threadMgr.add(AnacondaThread(name=THREAD_CUSTOM_STORAGE_INIT, target=self._initialize))
 
     def _initialize(self):
@@ -1990,6 +1993,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                                  name=container_name,
                                  raid_level=self._device_container_raid_level,
                                  encrypted=self._device_container_encrypted,
+                                 offerEncryption=self.instclass.offerEncryption,
                                  size_policy=size_policy,
                                  size=size,
                                  disks=self._clearpartDevices,

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -452,6 +452,8 @@ class ContainerDialog(GUIObject, GUIDialogInputCheckHandler):
         self.encrypted = kwargs.pop("encrypted", False)
         self.exists = kwargs.pop("exists", False)
 
+        offerEncryption = kwargs.pop("offerEncryption", True)
+
         self.size_policy = kwargs.pop("size_policy", SIZE_POLICY_AUTO)
         self.size = kwargs.pop("size", Size(0))
 
@@ -492,7 +494,10 @@ class ContainerDialog(GUIObject, GUIDialogInputCheckHandler):
             itr = model.iter_next(itr)
 
         # XXX how will this be related to the device encryption setting?
-        self._encryptCheckbutton.set_active(self.encrypted)
+        self._encryptCheckbutton.set_active(offerEncryption and self.encrypted)
+
+        if not offerEncryption:
+            really_hide(self._encryptCheckbutton)
 
         # set up the raid level combo
         # XXX how will this be related to the device raid level setting?

--- a/pyanaconda/ui/gui/spokes/storage.glade
+++ b/pyanaconda/ui/gui/spokes/storage.glade
@@ -802,7 +802,7 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkLabel" id="label11">
+                                  <object class="GtkLabel" id="encryptionLabel">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="margin_top">6</property>
@@ -852,7 +852,7 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkBox" id="box1">
+                                  <object class="GtkBox" id="encryptionBox">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="spacing">6</property>

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -53,7 +53,7 @@ from pyanaconda.ui.gui.spokes.lib.resize import ResizeDialog
 from pyanaconda.ui.gui.spokes.lib.dasdfmt import DasdFormatDialog
 from pyanaconda.ui.gui.spokes.lib.refresh import RefreshDialog
 from pyanaconda.ui.categories.system import SystemCategory
-from pyanaconda.ui.gui.utils import escape_markup, gtk_action_nowait, ignoreEscape
+from pyanaconda.ui.gui.utils import escape_markup, gtk_action_nowait, ignoreEscape, really_hide
 from pyanaconda.ui.helpers import StorageChecker
 from pyanaconda.storage_utils import on_disk_storage
 
@@ -601,6 +601,12 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         mainViewport = self.builder.get_object("storageViewport")
         mainBox = self.builder.get_object("storageMainBox")
         mainBox.set_focus_vadjustment(mainViewport.get_vadjustment())
+
+        if not self.instclass.offerEncryption:
+            widget = self.builder.get_object("encryptionBox")
+            label = self.builder.get_object("encryptionLabel")
+            really_hide(widget)
+            really_hide(label)
 
         threadMgr.add(AnacondaThread(name=constants.THREAD_STORAGE_WATCHER,
                       target=self._initialize))


### PR DESCRIPTION
Atomic Host does not include cryptsetup.

Resolves: rhbz#1267905

This is "work in progress" patch by Chris. To me it seems quite complete (ie ACK). I rebased it for top of rhel7-branch and tested with locally built RHELAH 7.3 installer. Also tested that it does not interfere with mainline installer (GUI and kickstart).

The only thing that came up to me is that we might rather want to make the "Encrypt" checkboxes insensitive instead of hiding them, but I don't have strong preference.