### PR TITLE
Actual Anaconda is not compatible with DNF 2.0.0

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -21,6 +21,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define gettextver 0.19.8
 %define pykickstartver 2.31-1
 %define dnfver 0.6.4
+%define dnfmaxver 2.0.0
 %define partedver 1.8.1
 %define pypartedver 2.5-2
 %define nmver 0.9.9.0-10.git20130906
@@ -81,7 +82,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 
 %package core
 Summary: Core of the Anaconda installer
-Requires: python3-dnf >= %{dnfver}
+Requires: python3-dnf >= %{dnfver}, python3-dnf < %{dnfmaxver}
 Requires: python3-blivet >= 1:2.1.2
 Requires: python3-meh >= %{mehver}
 Requires: libreport-anaconda >= 2.0.21-1


### PR DESCRIPTION
Based on comment https://github.com/rhinstaller/anaconda/pull/741#issue-172130581,  I'm marking actual Anaconda as DNF 2.0 incompatible.