### PR TITLE
kickstart: Drop almost all `timezone` verb -> chrony bridging

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1705,12 +1705,11 @@ class Timezone(commands.timezone.F25_Timezone):
     def __init__(self, *args):
         commands.timezone.F25_Timezone.__init__(self, *args)
 
-        self._added_chrony = False
-        self._enabled_chrony = False
-        self._disabled_chrony = False
-
     def setup(self, ksdata):
-        # do not install and use NTP package
+        # This code *used* to try to manage installation of chrony and
+        # the service enablement state, but no longer does so.
+        # For more information see:
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1331864
         if self.nontp or NTP_PACKAGE in ksdata.packages.excludedList:
             if iutil.service_running(NTP_SERVICE) and \
                     can_touch_runtime_system("stop NTP service"):
@@ -1718,19 +1717,8 @@ class Timezone(commands.timezone.F25_Timezone):
                 if ret != 0:
                     log.error("Failed to stop NTP service")
 
-            if self._added_chrony and NTP_PACKAGE in ksdata.packages.packageList:
-                ksdata.packages.packageList.remove(NTP_PACKAGE)
-                self._added_chrony = False
-
-            # Both un-enable and disable chrony, because sometimes it's installed
-            # off by default (packages) and sometimes not (liveimg).
-            if self._enabled_chrony and NTP_SERVICE in ksdata.services.enabled:
-                ksdata.services.enabled.remove(NTP_SERVICE)
-                self._enabled_chrony = False
-
             if NTP_SERVICE not in ksdata.services.disabled:
                 ksdata.services.disabled.append(NTP_SERVICE)
-                self._disabled_chrony = True
         # install and use NTP package
         else:
             if not iutil.service_running(NTP_SERVICE) and \
@@ -1738,19 +1726,6 @@ class Timezone(commands.timezone.F25_Timezone):
                 ret = iutil.start_service(NTP_SERVICE)
                 if ret != 0:
                     log.error("Failed to start NTP service")
-
-            if not NTP_PACKAGE in ksdata.packages.packageList:
-                ksdata.packages.packageList.append(NTP_PACKAGE)
-                self._added_chrony = True
-
-            if self._disabled_chrony and NTP_SERVICE in ksdata.services.disabled:
-                ksdata.services.disabled.remove(NTP_SERVICE)
-                self._disabled_chrony = False
-
-            if not NTP_SERVICE in ksdata.services.enabled and \
-                    not NTP_SERVICE in ksdata.services.disabled:
-                ksdata.services.enabled.append(NTP_SERVICE)
-                self._enabled_chrony = True
 
     def execute(self, *args):
         # write out timezone configuration


### PR DESCRIPTION
Previously, the `timezone` verb would e.g. automatically install
and enable chrony if `timezone --nontp` wasn't passed.  Since
Atomic Host switched to timesyncd, this caused the installer to
fail.

The other Fedora variants already have chrony installed and enabled,
so this shouldn't affect them.  The only impact I can think of is on
people doing custom kickstart installs, but they can really quite
easily pick/enable their own time service.

The only behavior we do explicitly retain is that if `timezone
--nontp` is specified (or the "disable NTP" box in the UI is checked),
we disable the chrony service.  That's bug 1135768.  I didn't see any
other likely regressions in the commits/bugzillas I found via git
annotate.

Resolves: rhbz#1331864