### PR TITLE
Drop T from cp command flags when copying driver disk RPMs (#1269915)

### DIFF
--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -262,7 +262,7 @@ def save_repo(repo, target="/run/install"):
     """copy a repo to the place where the installer will look for it later."""
     newdir = mkdir_seq(os.path.join(target, "DD-"))
     log.debug("save_repo: copying %s to %s", repo, newdir)
-    subprocess.call(["cp", "-arT", repo, newdir])
+    subprocess.call(["cp", "-ar", repo, newdir])
     return newdir
 
 def extract_drivers(drivers=None, repos=None, outdir="/updates",


### PR DESCRIPTION
We are copying the driver disk RPMs to a directory, but cp used the T
flag, which corresponds to:

-T, --no-target-directory
       treat DEST as a normal file

As the destination should always be a directory the T flag doesn't make
sense there. And indeed, if T is removed from the cp flags the driver disk
RPM is copied correctly.

Resolves: rhbz#1269915