### PR TITLE
Improved driver disk copying (#1269915)

### DIFF
--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -1126,6 +1126,7 @@ class PackagePayload(Payload):
             for line in f:
                 package = line.strip()
                 if package not in self.requiredPackages:
+                    log.info("DD: adding required package: %s", package)
                     self.requiredPackages.append(package)
         log.debug("required packages = %s", self.requiredPackages)
 


### PR DESCRIPTION
Turns out that just changing flags for the cp command won't do
as function needs to support both single file driver disk RPM copy
as well as copying all driver disk RPMs from a given folder.

So let's drop the cp command all together and replace it with Python shutil
based equivalent. As far as I can tell it seams that there should be
no sub-folders in a driver disk RPM repo, so don't copy them
but just log a warning instead.

Also improve the copy-RPM unit tests to cover more scenarios and
add add more logging in the stage2 driver disk package handling code.

Related: rhbz#1269915