### PR TITLE
Revert "Show network spoke in the TUI reconfig mode (#1302165)"

### DIFF
--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -26,7 +26,6 @@ from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import EditTUISpoke, OneShotEditTUIDialog
 from pyanaconda.ui.tui.spokes import EditTUISpokeEntry as Entry
 from pyanaconda.ui.tui.simpleline import TextWidget, ColumnWidget
-from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.i18n import N_, _
 from pyanaconda import network
 from pyanaconda import nm
@@ -43,7 +42,7 @@ import re
 __all__ = ["NetworkSpoke"]
 
 
-class NetworkSpoke(FirstbootSpokeMixIn, EditTUISpoke):
+class NetworkSpoke(EditTUISpoke):
     """ Spoke used to configure network settings. """
     title = N_("Network configuration")
     category = SystemCategory


### PR DESCRIPTION
Turns out the Network Spoke has some issues with running in Initial
Setup TUI, so revert this for now.

We will revisit it later once we are reasonably sure Network Spoke
can work correctly in Initial Setup.

This reverts commit f2e0ea93130f821138441938d1a1463040315271.