### PR TITLE
It allows to always mark one env_group as installed

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -345,8 +345,8 @@ class DNFPayload(packaging.PackagePayload):
             log.info("skipping core group due to %%packages --nocore; system may not be complete")
         else:
             try:
-                self._select_group('core', required=True)
-                log.info("selected group: core")
+                self._select_group('minimal-environment', required=True)
+                log.info("selected group: minimal-environment")
             except packaging.NoSuchGroup as e:
                 self._miss(e)
 


### PR DESCRIPTION
It prevents if user install other env_group and later on try to remove it that
dnf will not try to remove 'core' group that will be required by
minimall-install group.

It will not install any additional packages, only it mark istead of only core
group installed, additional env_group minimal_install that has only one
mandatory group - core.