### PR TITLE
Fix traceback when payload have None as url (#1371494)

### DIFF
--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -230,7 +230,7 @@ class Payload(object):
         """
         network_protocols = ["http:", "ftp:", "nfs:", "nfsiso:"]
         for s in sources:
-            if any(s.startswith(p) for p in network_protocols):
+            if s and any(s.startswith(p) for p in network_protocols):
                 log.debug("Source %s needs network for installation", s)
                 return True
 


### PR DESCRIPTION
It's regression from commit 136961544060bd3891af981bbae5bc969117d08a

*Resolves: rhbz#1371494*