### PR TITLE
network: don't show ibft configured devices in UI (#1309661)

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -43,7 +43,7 @@ from pyanaconda import nm
 from pyanaconda import constants
 from pyanaconda.flags import flags, can_touch_runtime_system
 from pyanaconda.i18n import _
-from pyanaconda.regexes import HOSTNAME_PATTERN_WITHOUT_ANCHORS
+from pyanaconda.regexes import HOSTNAME_PATTERN_WITHOUT_ANCHORS, IBFT_CONFIGURED_DEVICE_NAME
 
 import logging
 log = logging.getLogger("anaconda")
@@ -1620,3 +1620,6 @@ def is_using_team_device():
 
 def is_libvirt_device(iface):
     return iface.startswith("virbr")
+
+def is_ibft_configured_device(iface):
+    return IBFT_CONFIGURED_DEVICE_NAME.match(iface)

--- a/pyanaconda/regexes.py
+++ b/pyanaconda/regexes.py
@@ -140,7 +140,6 @@ REPO_NAME_VALID = re.compile(r'^[a-zA-Z0-9_.:-]+$')
 # Product Version string, just the starting numbers like 21 or 21.1
 VERSION_DIGITS = r'([\d.]+)'
 
-
 #Regexes to validate iSCSI Names according to RFC 3720 and RFC 3721
 #The conditions for iSCSI name used in the following regexes are
 #(https://tools.ietf.org/html/rfc3720#section-3.2.6.3.1 , https://tools.ietf.org/html/rfc3721#page-5 and http://standards.ieee.org/regauth/oui/tutorials/EUI64.html):
@@ -161,3 +160,6 @@ ISCSI_IQN_NAME_REGEX = re.compile(r'^iqn\.\d{4}-\d{2}((?<!-)\.(?!-)[a-zA-Z0-9\-]
 #2. For eui format:
 #    a. The format is "eui." followed by an EUI-64 identifier (16 ASCII-encoded hexadecimal digits).
 ISCSI_EUI_NAME_REGEX = re.compile(r'^eui\.[a-fA-F0-9]{16}$')
+
+# Device with this name was configured from ibft (and renamed) by dracut
+IBFT_CONFIGURED_DEVICE_NAME = re.compile(r'^ibft\d+$')

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -400,6 +400,9 @@ class NetworkControlBox(GObject.GObject):
         if network.is_libvirt_device(dev_cfg.get_iface() or ""):
             log.debug("network: GUI, not adding %s", dev_cfg.get_iface())
             return False
+        if network.is_ibft_configured_device(dev_cfg.get_iface() or ""):
+            log.debug("network: GUI, not adding %s configured from iBFT", dev_cfg.get_iface())
+            return False
         if dev_cfg.get_device_type() not in self.supported_device_types:
             log.debug("network: GUI, not adding connection %s of unsupported type", uuid)
             return False
@@ -737,6 +740,9 @@ class NetworkControlBox(GObject.GObject):
         # (can be chopped off to IFNAMSIZ kernel limit)
         if device.get_iface().endswith(('-fcoe', '-fco', '-fc', '-f', '-')):
             return
+        if network.is_ibft_configured_device(device.get_iface() or ""):
+            log.debug("network: not adding connection for device %s configured from iBFT", device.get_iface())
+            return False
 
         # Ignore devices with active read-only connections (created by NM for iBFT VLAN)
         ac = device.get_active_connection()

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -73,6 +73,8 @@ class NetworkSpoke(FirstbootSpokeMixIn, EditTUISpoke):
         for name in devices:
             if name in self.supported_devices:
                 continue
+            if network.is_ibft_configured_device(name):
+                continue
             if nm.nm_device_type_is_ethernet(name):
                 # ignore slaves
                 if nm.nm_device_setting_value(name, "connection", "slave-type"):
@@ -258,6 +260,8 @@ class NetworkSpoke(FirstbootSpokeMixIn, EditTUISpoke):
 
         self.data.network.network = []
         for i, name in enumerate(nm.nm_devices()):
+            if network.is_ibft_configured_device(name):
+                continue
             nd = network.ksdata_from_ifcfg(name)
             if not nd:
                 continue

--- a/tests/regex_tests/ibft_device_name_test.py
+++ b/tests/regex_tests/ibft_device_name_test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+# vim:set fileencoding=utf-8
+#
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
+#
+import unittest
+
+from pyanaconda.regexes import IBFT_CONFIGURED_DEVICE_NAME
+
+def _run_tests(testcase, expression, goodlist, badlist):
+    got_error = False
+    for good in goodlist:
+        try:
+            testcase.assertIsNotNone(expression.match(good))
+        except AssertionError:
+            got_error = True
+            print("Good string %s did not match expression" % good)
+
+    for bad in badlist:
+        try:
+            testcase.assertIsNone(expression.match(bad))
+        except AssertionError:
+            got_error = True
+            print("Bad string %s matched expression" % bad)
+
+    if got_error:
+        testcase.fail()
+
+class IbftDeviceNameTestCase(unittest.TestCase):
+    def netmask_test(self):
+        good_tests = [
+                'ibft0',
+                'ibft1',
+                'ibft11',
+                ]
+
+        bad_tests = [
+                'myibft0',
+                'ibft',
+                'ibftfirst',
+                'ibgt0',
+                ]
+
+        _run_tests(self, IBFT_CONFIGURED_DEVICE_NAME, good_tests, bad_tests)


### PR DESCRIPTION
Port of rhel7-branch patch.

Resolves: rhbz#1309661

In UI we don't show devices having special connection created by NM iBFT plugin
from iBFT. NM is using the connection for the device (when taking it over from
dracut) if it matches device configuration created (also from iBFT) in dracut.
The matching is broken for static configuration, so NM just creates normal
connection for the device (ie not using the connection created by iBFT plugin
based on iBFT table). This does not prevent successful installation but a
device with such configuration is not filtered out for our UI. So take care
also of this case as we don't want to expose (and allow modification of)
configuration from iBFT in UI.

In text mode we also mistakenly used to generate kickstart commands for devices
configured from ibft which is fixed by this patch as well.