### PR TITLE
network: set onboot correctly for vlan on bond device in ks (#1234849)

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -1249,22 +1249,34 @@ def setOnboot(ksdata):
             log.warning("network: set ONBOOT: --device %s does not exist", network_data.device)
             continue
 
-        if network_data.onboot:
-            # We need to handle "no" -> "yes" change by changing ifcfg file instead of the NM connection
-            # so the device does not get autoactivated (BZ #1261864)
-            if not update_onboot_value(devname, network_data.onboot, root_path=""):
-                continue
-        else:
-            try:
-                nm.nm_update_settings_of_device(devname, [['connection', 'autoconnect', network_data.onboot, None]])
-            except (nm.SettingsNotFoundError, nm.UnknownDeviceError) as e:
-                log.debug("setOnboot: %s", e)
-                continue
+        devices_to_update = [devname]
+        master = devname
+        # When defining both bond/team and vlan in one command we need more care
+        # network --onboot yes --device bond0 --bootproto static --bondslaves ens9,ens10
+        # --bondopts mode=active-backup,miimon=100,primary=ens9,fail_over_mac=2
+        # --ip 192.168.111.1 --netmask 255.255.255.0 --gateway 192.168.111.222 --noipv6
+        # --vlanid 222 --no-activate
+        if network_data.vlanid and (network_data.bondslaves or network_data.teamslaves):
+            master = network_data.device
+            devices_to_update.append(master)
 
-        updated_devices.append(devname)
+        for devname in devices_to_update:
+            if network_data.onboot:
+                # We need to handle "no" -> "yes" change by changing ifcfg file instead of the NM connection
+                # so the device does not get autoactivated (BZ #1261864)
+                if not update_onboot_value(devname, network_data.onboot, root_path=""):
+                    continue
+            else:
+                try:
+                    nm.nm_update_settings_of_device(devname, [['connection', 'autoconnect', network_data.onboot, None]])
+                except (nm.SettingsNotFoundError, nm.UnknownDeviceError) as e:
+                    log.debug("setOnboot: %s", e)
+                    continue
+
+            updated_devices.append(devname)
 
         if network_data.bondslaves or network_data.teamslaves:
-            updated_slaves = update_slaves_onboot_value(devname, network_data.onboot)
+            updated_slaves = update_slaves_onboot_value(master, network_data.onboot)
             updated_devices.extend(updated_slaves)
 
     return updated_devices


### PR DESCRIPTION
Related: rhbz#1234849

Port from rhel7-branch.