### PR TITLE
Fix password length in the password policy

### DIFF
--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -5,9 +5,9 @@ firstboot --enable
 
 %anaconda
 # Default password policies
-pwpolicy root --notstrict --minlen=8 --minquality=50 --nochanges --notempty
-pwpolicy user --notstrict --minlen=8 --minquality=50 --nochanges --notempty
-pwpolicy luks --notstrict --minlen=8 --minquality=50 --nochanges --notempty
+pwpolicy root --notstrict --minlen=6 --minquality=50 --nochanges --notempty
+pwpolicy user --notstrict --minlen=6 --minquality=50 --nochanges --notempty
+pwpolicy luks --notstrict --minlen=6 --minquality=50 --nochanges --notempty
 # NOTE: This applies only to *fully* interactive installations, partial kickstart
 #       installations use defaults specified in pyanaconda/pwpolicy.py.
 #       Automated kickstart installs simply ignore the password policy as the policy

--- a/pyanaconda/pwpolicy.py
+++ b/pyanaconda/pwpolicy.py
@@ -21,6 +21,8 @@ from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartValueError, formatErrorMsg
 from pykickstart.options import KSOptionParser
 
+from pyanaconda import constants
+
 import warnings
 from pyanaconda.i18n import _
 
@@ -32,7 +34,7 @@ class F22_PwPolicyData(BaseData):
     def __init__(self, *args, **kwargs):
         BaseData.__init__(self, *args, **kwargs)
         self.name = kwargs.get("name", "")
-        self.minlen = kwargs.get("minlen", 8)
+        self.minlen = kwargs.get("minlen", constants.PASSWORD_MIN_LEN)
         self.minquality = kwargs.get("minquality", 50)
         self.strict = kwargs.get("strict", False)
         self.changesok = kwargs.get("changesok", False)


### PR DESCRIPTION
Now that policy-based password length checking works correctly set the
minimal passowrd length in the policy to the value expected by users from
RHEL <=7.2 (6 characters long).

Related: rhbz#1365112
Related: rhbz#1365032