### PR TITLE
Fix NTP server list fetching when running in IS (#1374810)

### DIFF
--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -73,7 +73,7 @@ class TimeSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         if constants.ANACONDA_ENVIRON in flags.environs:
             ntp_servers = self.data.timezone.ntpservers
         elif constants.FIRSTBOOT_ENVIRON in flags.environs:
-            ntp_servers = ntp.get_servers_from_config()
+            ntp_servers = ntp.get_servers_from_config()[1]  # returns a (NPT pools, NTP servers) tupple
         else:
             log.error("tui time spoke: unsupported environment configuration %s,"
                       "can't decide where to get initial NTP servers", flags.environs)


### PR DESCRIPTION
Fix fetching of the NTP server list when the NTP TUI spoke
is running in Initial Setup instead of Anaconda.

Unlike in Anaconda where we get the NTP server list directly
the config file parsing function used when running in Initial Setup
returns a (NTP pools, NTP servers) tuple, so just take the second item,
not the tuple itself.

Resolves: rhbz#1374810