### PR TITLE
Accept any non-empty password in non-strict mode (#1379323)

### DIFF
--- a/pyanaconda/ui/gui/spokes/password.py
+++ b/pyanaconda/ui/gui/spokes/password.py
@@ -243,7 +243,8 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
         # Check for validity errors
         # pw score == 0 & errors from libpwquality
-        if not self._pw_score and self._pw_error_message:
+        # - ignore if the strict flag in the password policy == False
+        if not self._pw_score and self._pw_error_message and self.policy.strict:
             return self._pw_error_message
 
         # use strength from policy, not bars

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -553,7 +553,8 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
 
         # Check for validity errors
         # pw score == 0 & errors from libpwquality
-        if not self._pw_score and self._pw_error_message:
+        # - ignore if the strict flag in the password policy == False
+        if not self._pw_score and self._pw_error_message and self.policy.strict:
             return self._pw_error_message
 
         # use strength from policy, not bars

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -150,7 +150,8 @@ class EditTUIDialog(NormalTUISpoke):
             pw_score, _status_text, pw_quality, error_message = validatePassword(pw, user=None, minlen=self.policy.minlen)
 
             # if the score is equal to 0 and we have an error message set
-            if not pw_score and error_message:
+            # - ignore if the strict flag in the password policy == False
+            if not pw_score and error_message and self.policy.strict:
                 print(error_message)
                 return None
 


### PR DESCRIPTION
If the strict flag in the password policy is False then Anaconda
should let the user use any non-empty password.

If the password is considered weak and/or too short the user will
be warned but can override the warning and use the password.

Resolves: rhbz#1379323