### PR TITLE
Improved driver disk copying (#1269915)

### DIFF
--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -73,6 +73,7 @@ import fnmatch
 # because it breaks sometimes.
 if os.isatty(0):
     import readline # pylint:disable=unused-import
+import shutil
 
 from contextlib import contextmanager
 from logging.handlers import SysLogHandler
@@ -263,7 +264,23 @@ def save_repo(repo, target="/run/install"):
     """copy a repo to the place where the installer will look for it later."""
     newdir = mkdir_seq(os.path.join(target, "DD-"))
     log.debug("save_repo: copying %s to %s", repo, newdir)
-    subprocess.call(["cp", "-arT", repo, newdir])
+    # repo can be two sorts of stuff:
+    # - a path to directory containing rpm files
+    # -> in this case copy it's contents to target
+    # - a path to an RPM file
+    # -> in this case copy the file to destination
+    if os.path.isfile(repo):
+        shutil.copy2(repo, newdir)
+    elif os.path.isdir(repo):
+        for item in os.listdir(repo):
+            item_path = os.path.join(repo, item)
+            if os.path.isfile(item_path):
+                log.debug("copying %s to %s", item_path, newdir)
+                shutil.copy2(item_path, newdir)
+            else:
+                log.warning("DD repo content not a file: %s", item_path)
+    else:
+        log.error("ERROR: DD repository needs to be a file file or a directory: %s", repo)
     return newdir
 
 def extract_drivers(drivers=None, repos=None, outdir="/updates",

--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -1116,6 +1116,7 @@ class PackagePayload(Payload):
             for line in f:
                 package = line.strip()
                 if package not in self.requiredPackages:
+                    log.info("DD: adding required package: %s", package)
                     self.requiredPackages.append(package)
         log.debug("required packages = %s", self.requiredPackages)
 

--- a/tests/dracut_tests/test_driver_updates.py
+++ b/tests/dracut_tests/test_driver_updates.py
@@ -268,15 +268,68 @@ class TestFindRepos(FileTestCaseBase):
 
 
 class TestSaveRepo(FileTestCaseBase):
-    def test_basic(self):
-        """save_repo: copies a directory to /run/install/DD-X"""
+    def test_folder_repo(self):
+        """save_repo: copies directory contents to /run/install/DD-X"""
         makerepo(self.srcdir)
         repo = find_repos(self.srcdir)[0]
-        makefile(repo+'/fake-something.rpm')
+        makefile(repo + '/repodata')
+        makefile(repo + '/fake-something1.rpm')
+        makefile(repo + '/fake-something2.rpm')
+        makefile(repo + '/fake-something3.rpm')
         saved = save_repo(repo, target=self.destdir)
-        self.assertEqual(set(listfiles(saved)), set(["fake-something.rpm"]))
+        expected_files = set(["fake-something1.rpm", "fake-something2.rpm", "fake-something3.rpm", "repodata"])
+        self.assertEqual(set(listfiles(saved)), expected_files)
         self.assertEqual(saved, os.path.join(self.destdir, "DD-1"))
 
+    def test_single_file(self):
+        """save_repo: copies a single file to /run/install/DD-X"""
+        makerepo(self.srcdir)
+        repo = find_repos(self.srcdir)[0]
+        file_path = makefile(repo + '/fake-something1.rpm')
+        makefile(repo + '/fake-something2.rpm')
+        makefile(repo + '/fake-something3.rpm')
+        saved = save_repo(file_path, target=self.destdir)
+        # check that only the single file was copied
+        self.assertEqual(set(listfiles(saved)), set(["fake-something1.rpm"]))
+        self.assertEqual(saved, os.path.join(self.destdir, "DD-1"))
+
+    def test_multiple_repo_folders(self):
+        """save_repo: copies directory contents to multiple /run/install/DD-X folders"""
+        # create multiple repos
+        repo_folder_1 = os.path.join(self.srcdir, "repo1")
+        repo_folder_2 = os.path.join(self.srcdir, "repo2")
+        repo_folder_3 = os.path.join(self.srcdir, "repo3")
+        makerepo(repo_folder_1)
+        makerepo(repo_folder_2)
+        makerepo(repo_folder_3)
+        repo1 = find_repos(repo_folder_1)[0]
+        repo2 = find_repos(repo_folder_2)[0]
+        repo3 = find_repos(repo_folder_3)[0]
+
+        # fill them with fake driver disk RPMs
+        for repo in [repo1, repo2, repo3]:
+            makefile(repo + '/repodata')
+            makefile(repo + '/fake-something1.rpm')
+            makefile(repo + '/fake-something2.rpm')
+            makefile(repo + '/fake-something3.rpm')
+
+        # copy their contents
+        # -> content of each repo should apprently end in a separate /run/install/DD-X folder
+        # -> we will attempt to copy the full content of the first two repos in full
+        #    and just a single RPM from the third repo
+        saved1 = save_repo(repo1, target=self.destdir)
+        saved2 = save_repo(repo2, target=self.destdir)
+        file_path = repo3 + "/fake-something2.rpm"
+        saved3 = save_repo(file_path, target=self.destdir)
+
+        # check that everything was copied correctly
+        full_copy_expected_files = set(["fake-something1.rpm", "fake-something2.rpm", "fake-something3.rpm", "repodata"])
+        self.assertEqual(set(listfiles(saved1)), full_copy_expected_files)
+        self.assertEqual(saved1, os.path.join(self.destdir, "DD-1"))
+        self.assertEqual(set(listfiles(saved2)), full_copy_expected_files)
+        self.assertEqual(saved2, os.path.join(self.destdir, "DD-2"))
+        self.assertEqual(set(listfiles(saved3)), set(["fake-something2.rpm"]))
+        self.assertEqual(saved3, os.path.join(self.destdir, "DD-3"))
 
 from driver_updates import mount, umount, mounted
 class MountTestCase(unittest.TestCase):


### PR DESCRIPTION
Turns out that just changing flags for the cp command won't do
as function needs to support both single file driver disk RPM copy
as well as copying all driver disk RPMs from a given folder.

So let's drop the cp command all together and replace it with Python shutil
based equivalent. As far as I can tell it seams that there should be
no sub-folders in a driver disk RPM repo, so don't copy them
but just log a warning instead.

Also improve the copy-RPM unit tests to cover more scenarios and
add add more logging in the stage2 driver disk package handling code.

Related: rhbz#1269915