### PR TITLE
Fix network spoke being incorrectly marked as mandatory (#1374864)

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1537,7 +1537,9 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
     @property
     def mandatory(self):
-        return self.data.method.method in ("url", "nfs")
+        # the network spoke should be mandatory only if it is running
+        # during the installation and if the installation source requires network
+        return ANACONDA_ENVIRON in anaconda_flags.environs and self.payload.needsNetwork
 
     @property
     def status(self):

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -92,10 +92,9 @@ class NetworkSpoke(FirstbootSpokeMixIn, EditTUISpoke):
 
     @property
     def mandatory(self):
-        """ This spoke should only be necessary if we're using an installation
-            source that requires a network connection.
-        """
-        return self.data.method.method in ("url", "nfs")
+        # the network spoke should be mandatory only if it is running
+        # during the installation and if the installation source requires network
+        return ANACONDA_ENVIRON in flags.environs and self.payload.needsNetwork
 
     @property
     def status(self):


### PR DESCRIPTION
The network spoke should only be marked mandatory during an installation
from network sources.

So only mark it as mandatory when it runs in Anaconda & the installation
source indicates that it needs network.

Also use a modern way of checking if the installation source needs
network when we are at it.

Resolves: rhbz#1374864