### PR TITLE
Allow changing of empty password option in GUI (#1380277)

### DIFF
--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -292,10 +292,6 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
             # Policy is that a non-empty password is required
             self.usepassword.set_active(True)
 
-        if not self.policy.emptyok:
-            # User isn't allowed to change whether password is required or not
-            self.usepassword.set_sensitive(False)
-
         # Password checks, in order of importance:
         # - if a password is required, is one specified?
         # - if a password is specified and there is data in the confirm box, do they match?


### PR DESCRIPTION
Resolves: rhbz#1380277

We just allow enabling/disabling empty user password in any case in GUI. This would be insufficient wrt to one use case that we might care about:

Defining pwpolicy in kickstart with --nochanges --noempty, eg

%anaconda
pwpolicy user --notstrict --minlen=8 --minquality=50 --nochanges --notempty
%end

without defining a user in kickstart. In this case the expectations might be to create user in GUI but without allowing empty passwords (user shouldn't be allowed to change this in GUI).

To handle this, more thorough patch would be required, something like https://github.com/rvykydal/anaconda/commit/1b8b6e848d1d2307635ec61074d6b8e6d83db5a4.
