### PR TITLE
Don't send intermediate pot files to zanata (gh#791)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,7 @@ uninstall-hook:
 ARCHIVE_TAG   = $(PACKAGE_NAME)-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE)
 
 ZANATA_PULL_ARGS = --transdir $(srcdir)/po/
-ZANATA_PUSH_ARGS = --srcdir $(srcdir)/po/ --push-type source --force
+ZANATA_PUSH_ARGS = --srcfile $(srcdir)/po/anaconda.pot --push-type source --force
 
 RC_RELEASE ?= $(shell date -u +0.1.%Y%m%d%H%M%S)
 MOCKCHROOT ?= fedora-rawhide-$(shell uname -m)


### PR DESCRIPTION
Translators reported that master and f25 branches in zanata
have two pot files, 'main' and 'extra', which never existed
before f25; this caused a sudden drop in translation completion
percentage.

0ee1f56d changed how we make pot files. Now `anaconda.pot` is
generated from two intermediate pot files (main and extra). These
are purely intermediate files, but because `Makefile.am` doesn't
delete them after `anaconda.pot` is done, passing `--srcdir` to
`zanata push` just sends all three `.pot` files to Zanata.

Just using `--srcfile` instead should be sufficient to fix it
(though this is all based on five minutes of reading zanata docs,
please check this). We could also  wipe the intermediate files
once `anaconda.pot` is made, I'm not totally sure whether we
should do that as well (or instead).

Resolves: gh#791