### PR TITLE
Run efibootmgr for only one device in multipath (#1346725)

### DIFF
--- a/booty/bootloaderInfo.py
+++ b/booty/bootloaderInfo.py
@@ -722,7 +722,12 @@ class efiBootloaderInfo(bootloaderInfo):
             rc = iutil.execWithRedirect(argv[0], argv[1:], root = instRoot,
                                         stdout = "/dev/tty5",
                                         stderr = "/dev/tty5")
-            
+            # In multipath device, if it can install into one device, return 0
+            if isinstance(bootdev, MultipathDevice) and rc == 0:
+                msg = "efibootmgr succeeded to register a new boot entry for %s (a parent of multipath device %s)"
+                log.info(msg % (d.path, bootdev.name))
+                return 0
+
         # return last rc, the API doesn't provide anything better than this
         return rc
 


### PR DESCRIPTION
The efibootmgr tool was started for all devices in multipath and if the last device failed then a whole installation will fail.

The issue should be fixed now by stopping the loop on first successful run of efibootmgr tool. This is a multipath, therefore installing bootloader to same device repeatedly is not a good idea.

*Resolves: rhbz#1346725*