### PR TITLE
network: fix static ipv6 config with static gateway (#1177984)

### DIFF
--- a/scripts/mk-images
+++ b/scripts/mk-images
@@ -806,7 +806,7 @@ makeinitrd() {
         instbin $IMGPATH /usr/bin/find $MBD_DIR /sbin/find
 
         # required for linuxrc.s390 (and other commands)
-        for cmd in ping ping6 cat head tr wc echo printf cut mknod ; do
+        for cmd in cat head tr wc echo printf cut mknod ; do
             instbin $IMGPATH /usr/bin/$cmd $MBD_DIR /sbin/$cmd
         done
         instbin $IMGPATH /usr/sbin/cmsfscat $MBD_DIR /sbin/cmsfscat
@@ -1080,6 +1080,7 @@ EOF
     instbin $IMGPATH /usr/bin/uname $MBD_DIR /sbin/uname
     instbin $IMGPATH /sbin/killall5 $MBD_DIR /sbin/killall5
     instbin $IMGPATH /usr/bin/ping $MBD_DIR /sbin/ping
+    instbin $IMGPATH /usr/bin/ping6 $MBD_DIR /sbin/ping6
     ln -sf killall5 $MBD_DIR/sbin/pidof
 
     # Indirect dependencies

--- a/scripts/upd-instroot
+++ b/scripts/upd-instroot
@@ -345,6 +345,7 @@ bin/mount
 bin/mv
 bin/ntfs-3g
 bin/ping
+bin/ping6
 bin/ps
 bin/pwd
 bin/rm
@@ -783,7 +784,6 @@ bin/find
 bin/gzip
 bin/ls
 bin/mknod
-bin/ping6
 bin/ps
 bin/sort
 bin/tar


### PR DESCRIPTION
Resolves: rhbz#1177984

NM requires ping6 for establishing static ipv6 address. If missing, the first
http request to destination routed via user supplied gateway fails because it
has link-local source address.

NOTE: We remove also ping from s390-specific installer initrd tools as it is
now included on all platforms.