### PR TITLE
Keep symlinks to thin_* tools in /sbin (#1350296)

### DIFF
--- a/scripts/upd-instroot
+++ b/scripts/upd-instroot
@@ -496,6 +496,7 @@ sbin/silo
 sbin/swapoff
 sbin/swapon
 sbin/tune2fs
+sbin/thin_*
 sbin/udev*
 sbin/umount.nfs*
 sbin/vconfig


### PR DESCRIPTION
Keep the symlinks for thin_check and other tools
for thin pool management in /sbin.

Looks like lvcreate and other LVM commands started to expect
the tools (or at least thin_check) to be available in /sbin
and error out if they can't find them there.

Resolves: rhbz#1350296