### PR TITLE
makebumpver: Skip 'Merge pull' commits completely.

### DIFF
--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -220,6 +220,7 @@ class MakeBumpVer:
                                 stderr=subprocess.PIPE).communicate()
         lines = filter(lambda x: x.find('l10n: ') != 41 and \
                                  x.find('Merge commit') != 41 and \
+                                 x.find('Merge pull') != 41 and \
                                  x.find('Merge branch') != 41,
                        proc[0].strip('\n').split('\n'))
 


### PR DESCRIPTION
Now that we are merging PRs also on rhel6-branch.

The same we did on rhel7-branch with
https://github.com/rhinstaller/anaconda/commit/87bef96bb79746972d7ee249b685bc343872441b