### PR TITLE
Remove main and extra Zanata pot files on master

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -133,6 +133,7 @@ bumpver: po-pull
 	fi ; \
 	( cd $(srcdir) && scripts/makebumpver $${opts} ) || exit 1 ; \
 	$(MAKE) -C po $(PACKAGE_NAME).pot-update && \
+	rm $(srcdir)/po/{main,extra}.pot
 	zanata push $(ZANATA_PUSH_ARGS)
 
 # Install all packages specified as BuildRequires in the Anaconda specfile


### PR DESCRIPTION
We need to remove main and extra intermediate files which are used to create anaconda.pot file before pushing to Zanata.

This is appending commit to commits

ca9e1063c4e3b30756a4cd496bc66173e109563e
b6b342c39d1a060ea62483b268fa9617cbdd5789

which are fixing the same issue in f25-devel. The f25-devel branch will be merged to master branch but master branch contains one more place to fix this issue now and that is why this commit is here.