### PR TITLE
Fix picking mountpoint for package download (#1328151)

### DIFF
--- a/pyanaconda/packaging/dnfpayload.py
+++ b/pyanaconda/packaging/dnfpayload.py
@@ -113,27 +113,47 @@ def _paced(fn):
         return fn(self, *args)
     return paced_fn
 
-def _pick_mpoint(df, download_size, install_size):
+def _pick_mpoint(df, download_size, install_size, download_only):
     def reasonable_mpoint(mpoint):
         return mpoint in DOWNLOAD_MPOINTS
 
     requested = download_size
     requested_root = requested + install_size
     root_mpoint = pyanaconda.iutil.getSysroot()
-    sufficients = {key : val for (key, val) in df.items()
-                   # for root we need to take in count both download and install size
-                   if ((key != root_mpoint and val > requested)
-                   or val > requested_root) and reasonable_mpoint(key)}
     log.debug('Input mount points: %s', df)
     log.debug('Estimated size: download %s & install %s', requested,
               (requested_root - requested))
-    log.info('Sufficient mountpoints found: %s', sufficients)
 
-    if not len(sufficients):
+    # Find sufficient mountpoint to download and install packages.
+    sufficients = {key : val for (key, val) in df.items()
+                   if ((key != root_mpoint and val > requested) or val > requested_root)
+                      and reasonable_mpoint(key)}
+
+    # If no sufficient mountpoints for download and install were found and we are looking
+    # for download mountpoint only, ignore install size and try to find mountpoint just
+    # to download packages. This fallback is required when user skipped space check.
+    if not sufficients and download_only:
+        sufficients = {key : val for (key, val) in df.items()
+                       if val > requested and reasonable_mpoint(key)}
+        if sufficients:
+            log.info('Sufficient mountpoint for download only found: %s', sufficients)
+    elif sufficients:
+        log.info('Sufficient mountpoints found: %s', sufficients)
+
+    if not sufficients:
+        log.debug("No sufficient mountpoints found")
         return None
-    # default to the biggest one:
-    return sorted(sufficients.items(), key=operator.itemgetter(1),
-                  reverse=True)[0][0]
+
+    sorted_mpoints = sorted(sufficients.items(), key=operator.itemgetter(1),
+                            reverse=True)
+
+    # try to pick something else than root mountpoint for downloading
+    if download_only and len(sorted_mpoints) >= 2 and sorted_mpoints[0][0] == root_mpoint:
+        return sorted_mpoints[1][0]
+    else:
+        # default to the biggest one:
+        return sorted_mpoints[0][0]
+
 
 class PayloadRPMDisplay(dnf.callback.TransactionProgress):
     def __init__(self, queue_instance):
@@ -510,11 +530,12 @@ class DNFPayload(packaging.PackagePayload):
         download_size = self._download_space
         install_size = self._spaceRequired()
         df_map = _df_map()
-        mpoint = _pick_mpoint(df_map, download_size, install_size)
+        mpoint = _pick_mpoint(df_map, download_size, install_size, download_only=True)
         if mpoint is None:
             msg = "Not enough disk space to download the packages."
             raise packaging.PayloadError(msg)
 
+        log.info("Mountpoint %s picked as download location", mpoint)
         pkgdir = '%s/%s' % (mpoint, DNF_PACKAGE_CACHE_DIR_SUFFIX)
         with self._repos_lock:
             for repo in self._base.repos.iter_enabled():
@@ -632,7 +653,7 @@ class DNFPayload(packaging.PackagePayload):
             if key.startswith('/') and ((root_mpoint + new_key) not in valid_points):
                 valid_points[root_mpoint + new_key] = val.format.free_space_estimate(val.size)
 
-        m_point = _pick_mpoint(valid_points, download_size, size)
+        m_point = _pick_mpoint(valid_points, download_size, size, download_only=False)
         if not m_point or m_point == root_mpoint:
             # download and install to the same mount point
             size = size + download_size

--- a/tests/pyanaconda_tests/payload_test.py
+++ b/tests/pyanaconda_tests/payload_test.py
@@ -1,0 +1,76 @@
+#
+# Authors: Jiri Konecny <jkonecny@redhat.com>
+#
+## Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from pyanaconda.packaging import dnfpayload
+from blivet.size import Size
+import unittest
+
+class PickLocation(unittest.TestCase):
+    def pick_download_location_test(self):
+        """Take the biggest mountpoint which can be used for download"""
+        df_map = {"/mnt/sysimage/not_used" : Size("20 G"),
+                  "/mnt/sysimage/home"     : Size("2 G"),
+                  "/mnt/sysimage/"         : Size("5 G")}
+        download_size = Size("1.5 G")
+        install_size = Size("1.8 G")
+
+        mpoint = dnfpayload._pick_mpoint(df_map, download_size, install_size, True)
+
+        self.assertEqual(mpoint, "/mnt/sysimage/home")
+
+    def pick_download_root_test(self):
+        """Take the root for download because there are no other available mountpoints
+           even when the root isn't big enough.
+
+           This is required when user skipped the space check.
+        """
+        df_map = {"/mnt/sysimage/not_used" : Size("20 G"),
+                  "/mnt/sysimage/home"     : Size("2 G"),
+                  "/mnt/sysimage"         : Size("5 G")}
+        download_size = Size("2.5 G")
+        install_size = Size("3.0 G")
+
+        mpoint = dnfpayload._pick_mpoint(df_map, download_size, install_size, True)
+
+        self.assertEqual(mpoint, "/mnt/sysimage")
+
+    def pick_install_location_test(self):
+        """Take the root for download and install."""
+        df_map = {"/mnt/sysimage/not_used" : Size("20 G"),
+                  "/mnt/sysimage/home"     : Size("2 G"),
+                  "/mnt/sysimage"         : Size("6 G")}
+        download_size = Size("1.5 G")
+        install_size = Size("3.0 G")
+
+        mpoint = dnfpayload._pick_mpoint(df_map, download_size, install_size, False)
+
+        self.assertEqual(mpoint, "/mnt/sysimage")
+
+    def pick_install_location_error_test(self):
+        """No suitable location is found."""
+        df_map = {"/mnt/sysimage/not_used" : Size("20 G"),
+                  "/mnt/sysimage/home"     : Size("1 G"),
+                  "/mnt/sysimage"         : Size("4 G")}
+        download_size = Size("1.5 G")
+        install_size = Size("3.0 G")
+
+        mpoint = dnfpayload._pick_mpoint(df_map, download_size, install_size, False)
+
+        self.assertEqual(mpoint, None)


### PR DESCRIPTION
Mountpoint where we are downloading packages was picked by the same method as what is used in space check. This method is not working correctly when user skipped space check, it still taking install size in count.

When the first method failed, try again but don't include install size and try to prefer other than root mountpoint for downloading.

*Related: rhbz#1328151*

*Reported-by: Orion Poplawski `<orion@cora.nwra.com>`*