### PR TITLE
Correct deviceLinks to device_links (blivet renamed it)

### DIFF
--- a/pyanaconda/ui/gui/spokes/filter.py
+++ b/pyanaconda/ui/gui/spokes/filter.py
@@ -146,7 +146,7 @@ class FilterPage(object):
         # identifier, but blivet doesn't expose that in any useful way and I don't
         # want to go asking udev.  Instead, we dig around in the deviceLinks and
         # default to the name if we can't figure anything else out.
-        for link in disk.deviceLinks:
+        for link in disk.device_links:
             if "by-path" in link:
                 lastSlash = link.rindex("/")+1
                 return link[lastSlash:]
@@ -380,7 +380,7 @@ class OtherPage(FilterPage):
         elif filterBy == self.SEARCH_TYPE_INTERCONNECT:
             return device.bus == self._icCombo.get_active_text()
         elif filterBy == self.SEARCH_TYPE_ID:
-            for link in device.deviceLinks:
+            for link in device.device_links:
                 if "by-path" in link:
                     return self._idEntry.get_text().strip() in link
 


### PR DESCRIPTION
In 4e8f941b , blivet renamed the `deviceLinks` attribute of
`StorageDevice` and its subclasses to `device_links`. These
uses of it were never updated. The iSCSI one causes anaconda to
crash when logging into an iSCSI target; the other one probably
breaks something as well, but I don't know what.

Needed on master and f25.
