### PR TITLE
use blivet iSCSI singleton directly in storage spoke

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -66,6 +66,7 @@ from blivet.size import Size
 from blivet.devices import MultipathDevice, ZFCPDiskDevice, iScsiDiskDevice
 from blivet.errors import StorageError
 from blivet.platform import platform
+from blivet.iscsi import iscsi
 from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.product import productName
 from pyanaconda.flags import flags
@@ -352,7 +353,7 @@ class StorageSpoke(NormalSpoke, StorageChecker):
                 iscsi_devices.append(d)
 
         if iscsi_devices:
-            self.data.iscsiname.iscsiname = self.storage.iscsi.initiator
+            self.data.iscsiname.iscsiname = iscsi.initiator
             # Remove the old iscsi data information and generate new one
             self.data.iscsi.iscsi = []
             for device in iscsi_devices:
@@ -415,8 +416,8 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         iscsi_data.target = dev_node.name
         iscsi_data.port = dev_node.port
         # Bind interface to target
-        if self.storage.iscsi.ifaces:
-            iscsi_data.iface = self.storage.iscsi.ifaces[dev_node.iface]
+        if iscsi.ifaces:
+            iscsi_data.iface = iscsi.ifaces[dev_node.iface]
 
         auth = dev_node.getAuth()
         if auth:


### PR DESCRIPTION
`Blivet` instances no longer have an `iscsi` attribute which
is the blivet iscsi singleton since 650505fb . Some bits of
anaconda were adjusted to use the singleton directly, but the
storage spoke GUI code was missed.