### PR TITLE
iSCSI: adjust to change in how blivet passes auth info

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -419,14 +419,12 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         if iscsi.ifaces:
             iscsi_data.iface = iscsi.ifaces[dev_node.iface]
 
-        auth = dev_node.getAuth()
-        if auth:
-            if auth.username and auth.password:
-                iscsi_data.user = auth.username
-                iscsi_data.password = auth.password
-            if auth.reverse_username and auth.reverse_password:
-                iscsi_data.user_in = auth.reverse_username
-                iscsi_data.password_in = auth.reverse_password
+        if dev_node.username and dev_node.password:
+            iscsi_data.user = dev_node.username
+            iscsi_data.password = dev_node.password
+        if dev_node.r_username and dev_node.r_password:
+            iscsi_data.user_in = dev_node.r_username
+            iscsi_data.password_in = dev_node.r_password
         return iscsi_data
 
     @property


### PR DESCRIPTION
When blivet switched from using libiscsi to storaged, the node
attribute of an `iScsiDiskDevice` changed from being a libiscsi
`PyIscsiNode` instance to a blivet `NodeInfo` namedtuple, but
both blivet and anaconda continued trying to call the `getAuth`
method of the node - which `NodeInfo` doesn't have - to find
the authentication info for the node. I've sent a blivet PR
to store this information in the `NodeInfo` namedtuple instead:
https://github.com/rhinstaller/blivet/pull/518 . This patch
adjusts anaconda to use it.

Note: this assumes that the `self.iscsi.log_into_node()` call in `pyanaconda/ui/gui/spokes/advstorage/iscsi.py` will happen before this code gets hit; I think it should, but if that's not the case, it won't work right.
