### PR TITLE
s390x error checking (#1335046)

### DIFF
--- a/pyanaconda/ui/gui/spokes/advstorage/dasd.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/dasd.py
@@ -136,6 +136,11 @@ class DASDDialog(GUIObject):
         except blockdev.S390Error as err:
             self._discoveryError = str(err)
             return
+        except TypeError as err:
+            # this happens when a user doesn't pass any input, so pass a more
+            # informative error str back
+            self._discoveryError = "You must enter values for the device."
+            return
 
     def on_device_entry_activate(self, entry, user_data=None):
         # If the user hit Enter while the start button is displayed, activate

--- a/pyanaconda/ui/gui/spokes/advstorage/zfcp.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/zfcp.py
@@ -148,6 +148,11 @@ class ZFCPDialog(GUIObject):
         except ValueError as e:
             self._discoveryError = str(e)
             return
+        except TypeError as e:
+            # this happens when a user doesn't pass any input, so pass a more
+            # informative error str back
+            self._discoveryError = "You must enter values for the device."
+            return
 
     def on_entry_activated(self, entry, user_data=None):
         # When an entry is activated, press the discover or retry button


### PR DESCRIPTION
These two patches fix tracebacks that would occur in anaconda if you try to manually add zFCP or DASD devices and don't provide any input.