### PR TITLE
Relax blivet dependency to >= 2.1.6-3

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -83,7 +83,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 %package core
 Summary: Core of the Anaconda installer
 Requires: python3-dnf >= %{dnfver}, python3-dnf < %{dnfmaxver}
-Requires: python3-blivet >= 1:2.1.7
+Requires: python3-blivet >= 1:2.1.6-3
 Requires: python3-meh >= %{mehver}
 Requires: libreport-anaconda >= 2.0.21-1
 Requires: libselinux-python3


### PR DESCRIPTION
dlehman did a 2.1.6-3 build of blivet with the iSCSI fixes, not
a 2.1.7 build, so we need to relax this dep or anaconda cannot
be installed.