### PR TITLE
Don't write user interaction config for image & directory install (#1…

### DIFF
--- a/pyanaconda/install.py
+++ b/pyanaconda/install.py
@@ -130,8 +130,17 @@ def doConfiguration(storage, payload, ksdata, instClass):
     else:
         _writeKS(ksdata)
 
-    # write out the user interaction config file
-    screen_access.sam.write_out_config_file()
+    # Write out the user interaction config file.
+    #
+    # But make sure it's not written out in the image and directory installation mode,
+    # as that might result in spokes being inadvertedly hidden when the actual installation
+    # startes from the generate image or directory contents.
+    if flags.flags.imageInstall:
+        log.info("Not writing out user interaction config file due to image install mode.")
+    elif flags.flags.dirInstall:
+        log.info("Not writing out user interaction config file due to directory install mode.")
+    else:
+        screen_access.sam.write_out_config_file()
 
     progress_complete()
 


### PR DESCRIPTION
…379106)

Don't write out the user interaction config file for image and directory
installation modules.

In these modes Anaconda actually prepares the installation image,
so storing the config file could result in spokes being hidden
during the actual installation.

For example if the storage spokes was visited during an interactive
image or directory installation, it would not be shown during the
actual installation run from the generated image/directory,
as it would be considered already visited.