### PR TITLE
aarch64 now has kexec-tools

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -134,9 +134,7 @@ Requires: python3-iscsi-initiator-utils >= %{iscsiver}
 Requires: hfsplus-tools
 %endif
 %endif
-%ifnarch aarch64
 Requires: kexec-tools
-%endif
 Requires: python3-pid
 Requires: python3-ordered-set >= 2.0.0
 Requires: python3-wrapt


### PR DESCRIPTION
Now aarch64 has support for kexec an associated tools support we can drop the
architecture conditional.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>