### PR TITLE
Branch specific things can now be programable decided by git-find-branch script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ modules.rst
 pyanaconda.*rst
 .coverage
 docs/tests/*.rst
+zanata.xml

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,10 @@ ZANATA_PULL_ARGS = --transdir $(srcdir)/po/
 ZANATA_PUSH_ARGS = --srcfile $(srcdir)/po/anaconda.pot --push-type source --force
 
 RC_RELEASE ?= $(shell date -u +0.1.%Y%m%d%H%M%S)
-MOCKCHROOT ?= fedora-rawhide-$(shell uname -m)
+MOCKCHROOT ?= fedora-$(shell echo "$(GIT_BRANCH)" | sed \
+						-e 's/^f//' \
+						-e 's/\(master\|unstable\)/rawhide/'\
+						)-$(shell uname -m)
 
 COVERAGE ?= coverage3
 USER_SITE_BASE ?= $(abs_top_builddir)/python-site

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,11 +25,11 @@ EXTRA_DIST = COPYING .coveragerc
 # This is needed for make distcheck.
 EXTRA_DIST += $(srcdir)/translation-canary/xgettext_werror.sh
 
-MAINTAINERCLEANFILES = Makefile.in config.guess config.h.in config.sub \
-                       depcomp install-sh ltmain.sh missing ABOUT-NLS \
-                       INSTALL aclocal.m4 configure *.pyc py-compile \
-		       m4/* po/Makefile.in.in po/Rules-quot \
-		       test-driver
+MAINTAINERCLEANFILES =	Makefile.in config.guess config.h.in config.sub \
+						depcomp install-sh ltmain.sh missing ABOUT-NLS \
+						INSTALL aclocal.m4 configure *.pyc zanata.xml.in \
+						py-compile m4/* po/Makefile.in.in po/Rules-quot \
+						test-driver
 
 CLEANFILES = *~
 

--- a/configure.ac
+++ b/configure.ac
@@ -90,6 +90,10 @@ PKG_CHECK_MODULES([PYTHON3], [python3], [
 ANACONDA_PKG_CHECK_MODULES([RPM], [rpm >= 4.10.0])
 ANACONDA_PKG_CHECK_MODULES([LIBARCHIVE], [libarchive >= 3.0.4])
 
+# Find git branch
+s_git_branch="`./scripts/git-find-branch`"
+AC_SUBST(GIT_BRANCH, [$s_git_branch])
+
 # GCC likes to bomb out on some ridiculous warnings.  Add your favorites
 # here.
 SHUT_UP_GCC="-Wno-unused-result"
@@ -110,6 +114,7 @@ AC_CONFIG_SUBDIRS([widgets])
 
 AC_CONFIG_FILES([Makefile
                  anaconda.spec
+                 zanata.xml
                  data/Makefile
                  data/command-stubs/Makefile
                  docs/Makefile

--- a/scripts/git-find-branch
+++ b/scripts/git-find-branch
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+# git-find-branch - We need to have branch specific decision which will be
+#                   based on the main development branches. This script
+#                   will get nearest main branch and return it for others.
+#
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+#
+#
+# There are two ways how find parent branch of this project:
+#
+# 1) When environment variable ANACONDA_TARGET_BRANCH is set, use this
+#    variable as output without any checks. This is for automated tests
+#    mainly.
+# 2) Find all interesting branches for us from Git. Find nearest parent
+#    of checkout branch by comparing nearest commit which is on tested and
+#    checkout branch.
+#
+# Output of this script is name of the nearest base branch without the
+# `-*` suffix.
+#
+#
+# WARNING!
+# This won't work without a merge commit! Git doesn't have any information
+# which branch is the parent without the merge commit, tips of both branches
+# are pointing to the same commit.
+#
+
+
+function compare_commits_by_date() {
+    local time1=$(git show -s --format=%ct $1)
+    local time2=$(git show -s --format=%ct $2)
+
+    if [[ ${time1} -gt ${time2} ]]; then
+        return 1
+    elif [[ ${time1} -lt ${time2} ]]; then
+        return -1
+    else
+        return 0
+    fi
+}
+
+function strip_branch_name {
+    echo ${1%%-*}
+}
+
+# If ANACONDA_TARGET_BRANCH environment variable is set-up use this variable
+# instead
+if [[ "${ANACONDA_TARGET_BRANCH}" != "" ]]; then
+    echo "$(strip_branch_name ${ANACONDA_TARGET_BRANCH})"
+    exit 0
+fi
+
+ACTUAL_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+REMOTE=$(git remote -v | grep "rhinstaller/anaconda.git" | head -n 1 | cut -f 1)
+
+# Find existing Fedora branches
+FED_BRANCHES=$(git branch -a | egrep "${REMOTE}/f[[:digit:]]*-(devel|branch|release)$" | cut -d '/' -f 3)
+# Find existing RHEL branches
+RHEL_BRANCHES=$(git branch -a | egrep "${REMOTE}/rhel[[:digit:]]*-branch$" | cut -d '/' -f 3)
+
+BRANCHES="unstable master ${FED_BRANCHES} ${RHEL_BRANCHES}"
+
+nearest_branch=""
+nearest_br_commit=""
+# Find latest common commit on actual branch and all our branches
+for tested_branch in ${BRANCHES}; do
+    commit="$(git merge-base ${ACTUAL_BRANCH} ${REMOTE}/${tested_branch})"
+    if [[ "${commit}" == "" ]]; then
+        continue
+    elif [[ "${nearest_branch}" == "" ]]; then
+        nearest_branch=${tested_branch}
+        nearest_br_commit="$(git merge-base ${ACTUAL_BRANCH} ${REMOTE}/${tested_branch})"
+    else
+        compare_commits_by_date ${commit} ${nearest_br_commit}
+        if [[ $? -eq 1 ]]; then
+            nearest_branch=${tested_branch}
+            nearest_br_commit="${commit}"
+        fi
+    fi
+done
+
+# Something bad happened
+if [[ "${nearest_branch}" == "" ]]; then
+    echo "Error branch can't be found" >&2
+    exit 1
+fi
+
+echo $(strip_branch_name ${nearest_branch})

--- a/zanata.xml.in
+++ b/zanata.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <config xmlns="http://zanata.org/namespace/config/">
   <url>https://fedora.zanata.org/</url>
-  <project>anaconda</project>
+  <project>@GIT_BRANCH@</project>
   <project-version>master</project-version>
   <project-type>gettext</project-type>
 


### PR DESCRIPTION
Because of our new branching policy all the code from `f**-devel` branch will be in the master branch. This is good for code but it is bad when we need specific things like `zanata` or `mock`. When we change `zanata.xml` on f25-devel the change will propagate to master branch and then we are pushing translation from master to f25 branch on `zanata`. 

New script `git-find-branch` is implemented to help us with this problem. This small script will resolve our actual branch to our main development branches (`f25-devel`, `master`, `unstable`, `rhel7-branch`...) and return the branch name without the `-*` suffix. So `f25-release` and `f25-devel` will be `f25`, this seems easier to me and this behavior can be of course changed in future. The `configure` can then substitute this variable to any file where this is needed.