### PR TITLE
Password checking improvements

### DIFF
--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -5,7 +5,11 @@ firstboot --enable
 
 %anaconda
 # Default password policies
-pwpolicy root --notstrict --minlen=0 --minquality=1 --nochanges --emptyok
-pwpolicy user --notstrict --minlen=0 --minquality=1 --nochanges --emptyok
-pwpolicy luks --notstrict --minlen=0 --minquality=1 --nochanges --emptyok
+pwpolicy root --notstrict --minlen=6 --minquality=1 --nochanges --emptyok
+pwpolicy user --notstrict --minlen=6 --minquality=1 --nochanges --emptyok
+pwpolicy luks --notstrict --minlen=6 --minquality=1 --nochanges --emptyok
+# NOTE: This applies only to *fully* interactive installations, partial kickstart
+#       installations use defaults specified in pyanaconda/pwpolicy.py.
+#       Automated kickstart installs simply ignore the password policy as the policy
+#       only applies to the UI, not for passwords specified in kickstart.
 %end

--- a/docs/kickstart.rst
+++ b/docs/kickstart.rst
@@ -20,22 +20,22 @@ pwpolicy
     ``name``
         Name of the password entry, currently supported values are: root, user and luks
 
-    ``--minlen`` (8)
+    ``--minlen`` (6)
         Minimum password length. This is passed on to libpwquality.
 
-    ``--minquality`` (50)
+    ``--minquality`` (1)
         Minimum libpwquality to consider good. When using ``--strict`` it will not allow
         passwords with a quality lower than this.
 
-    ``--strict`` (DEFAULT)
+    ``--strict``
         Strict password enforcement. Passwords not meeting the ``--minquality`` level will
         not be allowed.
 
-    ``--notstrict``
+    ``--notstrict`` (**DEFAULT**)
         Passwords not meeting the ``--minquality`` level will be allowed after Done is clicked
         twice.
 
-    ``--emptyok`` (DEFAULT)
+    ``--emptyok`` (**DEFAULT**)
         Allow empty password.
 
     ``--notempty``
@@ -49,11 +49,11 @@ pwpolicy
         Do not allow UI to be used to change the password/user if it has been set in
         the kickstart.
 
-The defaults for these are set in the ``/usr/share/anaconda/interactive-defaults.ks`` file
-provided by Anaconda. If a product, such as Fedora Workstation, wishes to override them
+The defaults for interactive installations are set in the ``/usr/share/anaconda/interactive-defaults.ks``
+file provided by Anaconda. If a product, such as Fedora Workstation, wishes to override them
 then a ``product.img`` needs to be created with a new version of the file included.
 
-When using a kickstart the defaults can be overridded by placing a ``%anaconda`` section into
+When using a kickstart the defaults can be overridded by placing an ``%anaconda`` section into
 the kickstart, like this::
 
     %anaconda

--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -136,7 +136,7 @@ FIRSTBOOT_ENVIRON = "firstboot"
 UNSUPPORTED_HW = 1 << 28
 
 # Password validation
-PASSWORD_MIN_LEN = 8
+PASSWORD_MIN_LEN = 6
 PASSWORD_EMPTY_ERROR = N_("The password is empty.")
 PASSWORD_CONFIRM_ERROR_GUI = N_("The passwords do not match.")
 PASSWORD_CONFIRM_ERROR_TUI = N_("The passwords you entered were different.  Please try again.")

--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -147,7 +147,13 @@ PASSWORD_WEAK_CONFIRM_WITH_ERROR = N_("You have provided a weak password: %s. Pr
 PASSWORD_ASCII = N_("The password you have provided contains non-ASCII characters. You may not be able to switch between keyboard layouts to login. Press Done to continue.")
 PASSWORD_DONE_TWICE = N_("You will have to press Done twice to confirm it.")
 
-PASSWORD_STRENGTH_DESC = [N_("Empty"), N_("Weak"), N_("Fair"), N_("Good"), N_("Strong")]
+class PasswordStatus(Enum):
+    EMPTY = N_("Empty")
+    TOO_SHORT = N_("Too short")
+    WEAK = N_("Weak")
+    FAIR = N_("Fair")
+    GOOD = N_("Good")
+    STRONG = N_("Strong")
 
 PASSWORD_HIDE = N_("Hide password.")
 PASSWORD_SHOW = N_("Show password.")

--- a/pyanaconda/pwpolicy.py
+++ b/pyanaconda/pwpolicy.py
@@ -32,11 +32,19 @@ class F22_PwPolicyData(BaseData):
     def __init__(self, *args, **kwargs):
         BaseData.__init__(self, *args, **kwargs)
         self.name = kwargs.get("name", "")
-        self.minlen = kwargs.get("minlen", 8)
-        self.minquality = kwargs.get("minquality", 50)
-        self.strict = kwargs.get("strict", True)
+        self.minlen = kwargs.get("minlen", 6)
+        self.minquality = kwargs.get("minquality", 1)
+        self.strict = kwargs.get("strict", False)
         self.changesok = kwargs.get("changesok", False)
         self.emptyok = kwargs.get("emptyok", True)
+
+        # The defaults specified above are used only for password input via the UI
+        # during a partial kickstart installations.
+        # Fully interactive installs (no kickstart is specified by the user)
+        # use the default set by the interactive defaults built-in kickstart file
+        # (data/interactive-defaults.ks).
+        # Automated kickstart installs simply ignore the password policy as the policy
+        # only applies to the UI, not for passwords specified in kickstart.
 
     def __eq__(self, y):
         if not y:

--- a/pyanaconda/ui/gui/spokes/password.py
+++ b/pyanaconda/ui/gui/spokes/password.py
@@ -19,20 +19,14 @@
 
 from pyanaconda.flags import flags
 from pyanaconda.i18n import _, CN_
-from pyanaconda.users import cryptPassword, validatePassword
+from pyanaconda.users import cryptPassword
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
 from pyanaconda.ui.gui.helpers import GUISpokeInputCheckHandler
 from pyanaconda.ui.gui.utils import set_password_visibility
 from pyanaconda.ui.common import FirstbootSpokeMixIn
-from pyanaconda.ui.helpers import InputCheck
 from pyanaconda.ui.communication import hubQ
-
-from pyanaconda.constants import PASSWORD_EMPTY_ERROR, PASSWORD_CONFIRM_ERROR_GUI,\
-        PASSWORD_STRENGTH_DESC, PASSWORD_WEAK, PASSWORD_WEAK_WITH_ERROR,\
-        PASSWORD_WEAK_CONFIRM, PASSWORD_WEAK_CONFIRM_WITH_ERROR, PASSWORD_DONE_TWICE,\
-        PW_ASCII_CHARS, PASSWORD_ASCII
 
 __all__ = ["PasswordSpoke"]
 
@@ -71,27 +65,13 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         # - How strong is the password?
         # - Does the password contain non-ASCII characters?
         # - Is there any data in the confirm box?
-        self.add_check(self.pw, self._checkPasswordEmpty)
-
-        # the password confirmation needs to be checked whenever either of the password
-        # fields change. attach to the confirm field so that errors focus on confirm,
-        # and check changes to the password field in on_password_changed
-        self._confirm_check = self.add_check(self.confirm, self._checkPasswordConfirm)
+        self._confirm_check = self.add_check(self.confirm, self.check_password_confirm)
 
         # Keep a reference for these checks, since they have to be manually run for the
         # click Done twice check.
-        self._pwStrengthCheck = self.add_check(self.pw, self._checkPasswordStrength)
-        self._pwASCIICheck = self.add_check(self.pw, self._checkPasswordASCII)
-
-        self.add_check(self.confirm, self._checkPasswordEmpty)
-
-        # Counters for checks that ask the user to click Done to confirm
-        self._waiveStrengthClicks = 0
-        self._waiveASCIIClicks = 0
-
-        # Password validation data
-        self._pwq_error = None
-        self._pwq_valid = True
+        self._pwEmptyCheck = self.add_check(self.pw, self.check_password_empty)
+        self._pwStrengthCheck = self.add_check(self.pw, self.check_user_password_strength)
+        self._pwASCIICheck = self.add_check(self.pw, self.check_password_ASCII)
 
         self._kickstarted = self.data.rootpw.seen
         if self._kickstarted:
@@ -139,8 +119,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     @property
     def mandatory(self):
-        return not any(user for user in self.data.user.userList
-                            if "wheel" in user.groups)
+        return not any(user for user in self.data.user.userList if "wheel" in user.groups)
 
     def apply(self):
         pw = self.pw.get_text()
@@ -174,61 +153,32 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         return not (self.completed and flags.automatedInstall
                     and self.data.rootpw.seen)
 
-    def _checkPasswordEmpty(self, inputcheck):
-        """Check whether a password has been specified at all."""
+    @property
+    def input(self):
+        return self.pw.get_text()
 
-        # If the password was set by kickstart, skip this check
-        if self._kickstarted and not self.policy.changesok:
-            return InputCheck.CHECK_OK
+    @property
+    def input_confirmation(self):
+        return self.confirm.get_text()
 
-        if not self.get_input(inputcheck.input_obj):
-            if inputcheck.input_obj == self.pw:
-                return _(PASSWORD_EMPTY_ERROR)
-            else:
-                return _(PASSWORD_CONFIRM_ERROR_GUI)
-        else:
-            return InputCheck.CHECK_OK
+    @property
+    def input_kickstarted(self):
+        return self.data.rootpw.seen
 
-    def _checkPasswordConfirm(self, inputcheck):
-        """Check whether the password matches the confirmation data."""
+    @property
+    def input_username(self):
+        return "root"
 
-        pw = self.pw.get_text()
-        confirm = self.confirm.get_text()
+    def set_input_score(self, score):
+        self.pw_bar.set_value(score)
 
-        # Skip the check if no password is required
-        if (not pw and not confirm) and self._kickstarted:
-            result = InputCheck.CHECK_OK
-        elif confirm and (pw != confirm):
-            result = _(PASSWORD_CONFIRM_ERROR_GUI)
-        else:
-            result = InputCheck.CHECK_OK
-
-        return result
-
-    def _updatePwQuality(self, empty, strength):
-        """Update the password quality information.
-        """
-
-        # If the password is empty, clear the strength bar
-        if empty:
-            val = 0
-        elif strength < 50:
-            val = 1
-        elif strength < 75:
-            val = 2
-        elif strength < 90:
-            val = 3
-        else:
-            val = 4
-        text = _(PASSWORD_STRENGTH_DESC[val])
-
-        self.pw_bar.set_value(val)
-        self.pw_label.set_text(text)
+    def set_input_status(self, status_message):
+        self.pw_label.set_text(status_message)
 
     def on_password_changed(self, editable, data=None):
         # Reset the counters used for the "press Done twice" logic
-        self._waiveStrengthClicks = 0
-        self._waiveASCIIClicks = 0
+        self.waive_clicks = 0
+        self.waive_ASCII_clicks = 0
 
         # Update the password/confirm match check on changes to the main password field
         self._confirm_check.update_check_status()
@@ -237,89 +187,22 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         """Called by Gtk callback when the icon of a password entry is clicked."""
         set_password_visibility(entry, not entry.get_visibility())
 
-    def _checkPasswordStrength(self, inputcheck):
-        """Update the error message based on password strength.
-
-           Update the password strength bar and set an error message.
-        """
-
-        pw = self.pw.get_text()
-        confirm = self.confirm.get_text()
-
-        # Skip the check if no password is required
-        if self._kickstarted:
-            return InputCheck.CHECK_OK
-
-        # If the password is empty, clear the strength bar and skip this check
-        if not pw and not confirm:
-            self._updatePwQuality(True, 0)
-            return InputCheck.CHECK_OK
-
-        # determine the password strength
-        valid, pwstrength, error = validatePassword(pw, "root", minlen=self.policy.minlen)
-
-        # set the strength bar
-        self._updatePwQuality(False, pwstrength)
-
-        # If the password failed the validity check, fail this check
-        if not valid and error:
-            return error
-
-        if pwstrength < self.policy.minquality:
-            # If Done has been clicked twice, waive the check
-            if self._waiveStrengthClicks > 1:
-                return InputCheck.CHECK_OK
-            elif self._waiveStrengthClicks == 1:
-                if error:
-                    return _(PASSWORD_WEAK_CONFIRM_WITH_ERROR) % error
-                else:
-                    return _(PASSWORD_WEAK_CONFIRM)
-            else:
-                # non-strict allows done to be clicked twice
-                if self.policy.strict:
-                    done_msg = ""
-                else:
-                    done_msg = _(PASSWORD_DONE_TWICE)
-
-                if error:
-                    return _(PASSWORD_WEAK_WITH_ERROR) % error + " " + done_msg
-                else:
-                    return _(PASSWORD_WEAK) % done_msg
-        else:
-            return InputCheck.CHECK_OK
-
-    def _checkPasswordASCII(self, inputcheck):
-        """Set an error message if the password contains non-ASCII characters.
-
-           Like the password strength check, this check can be bypassed by
-           pressing Done twice.
-        """
-
-        # If Done has been clicked, waive the check
-        if self._waiveASCIIClicks > 0:
-            return InputCheck.CHECK_OK
-
-        password = self.get_input(inputcheck.input_obj)
-        if password and any(char not in PW_ASCII_CHARS for char in password):
-            return _(PASSWORD_ASCII)
-
-        return InputCheck.CHECK_OK
-
     def on_back_clicked(self, button):
         # If the failed check is for password strength or non-ASCII
         # characters, add a click to the counter and check again
         failed_check = next(self.failed_checks_with_message, None)
-        if not self.policy.strict and failed_check == self._pwStrengthCheck:
-            self._waiveStrengthClicks += 1
-            self._pwStrengthCheck.update_check_status()
+        if not self.policy.strict:
+            if failed_check == self._pwStrengthCheck:
+                self.waive_clicks += 1
+                self._pwStrengthCheck.update_check_status()
+            elif failed_check == self._pwEmptyCheck:
+                self.waive_clicks += 1
+                self._pwEmptyCheck.update_check_status()
+            elif failed_check:  # no failed checks -> failed_check == None
+                failed_check.update_check_status()
         elif failed_check == self._pwASCIICheck:
-            self._waiveASCIIClicks += 1
+            self.waive_ASCII_clicks += 1
             self._pwASCIICheck.update_check_status()
-
-        # If neither the password nor the confirm field are set, skip the checks
-        if (not self.pw.get_text()) and (not self.confirm.get_text()):
-            for check in self.checks:
-                check.enabled = False
 
         if GUISpokeInputCheckHandler.on_back_clicked(self, button):
             NormalSpoke.on_back_clicked(self, button)

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -175,20 +175,21 @@ class EditTUIDialog(NormalTUISpoke):
                 self.value = ""
                 return None
 
-            valid, strength, message = validatePassword(pw, user=None, minlen=self.policy.minlen)
+            pw_score, _status_text, pw_quality, error_message = validatePassword(pw, user=None, minlen=self.policy.minlen)
 
-            if not valid:
-                print(message)
+            # if the score is equal to 0 and we have an error message set
+            if not pw_score and error_message:
+                print(error_message)
                 return None
 
-            if strength < self.policy.minquality:
+            if pw_quality < self.policy.minquality:
                 if self.policy.strict:
                     done_msg = ""
                 else:
                     done_msg = _("\nWould you like to use it anyway?")
 
-                if message:
-                    error = _(PASSWORD_WEAK_WITH_ERROR) % message + " " + done_msg
+                if error_message:
+                    error = _(PASSWORD_WEAK_WITH_ERROR) % error_message + " " + done_msg
                 else:
                     error = _(PASSWORD_WEAK) % done_msg
 

--- a/tests/pyanaconda_tests/password_quality_test.py
+++ b/tests/pyanaconda_tests/password_quality_test.py
@@ -1,0 +1,166 @@
+#
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
+
+from pyanaconda.users import validatePassword
+from pyanaconda import constants
+from pyanaconda.i18n import _
+import unittest
+import platform
+
+# libpwquality gives different results when running on RHEL and elsewhere,
+# so we need to skip absolute quality value checking outside of RHEL
+#
+# Ignore the deprecated method warning - we can revisist this when there is actually
+# a replacement for platform.dist available for Fedora as a package.
+# pylint: disable=deprecated-method
+ON_RHEL = platform.dist()[0] == "redhat"
+
+class PasswordQuality(unittest.TestCase):
+    def password_empty_test(self):
+        """Check if quality of an empty password is reported correctly."""
+        score, status, quality, error_message = validatePassword("")
+        self.assertEqual(score, 0)
+        self.assertEqual(status, _(constants.PasswordStatus.EMPTY.value))
+        self.assertEqual(quality, 0)
+        self.assertIsNotNone(error_message)
+        # empty password should override password-too-short messages
+        score, status, quality, error_message = validatePassword("", minlen=10)
+        self.assertEqual(score, 0)
+        self.assertEqual(status, _(constants.PasswordStatus.EMPTY.value))
+        self.assertEqual(quality, 0)
+        self.assertIsNotNone(error_message)
+
+    def password_empty_ok_test(self):
+        """Check if the empty_ok flag works correctly."""
+        score, status, quality, error_message = validatePassword("", empty_ok=True)
+        self.assertEqual(score, 0)
+        self.assertEqual(status, _(constants.PasswordStatus.EMPTY.value))
+        self.assertEqual(quality, 0)
+        self.assertIsNotNone(error_message)
+        # empty_ok with password length
+        score, status, quality, error_message = validatePassword("", minlen=10, empty_ok=True)
+        self.assertEqual(score, 0)
+        self.assertEqual(status, _(constants.PasswordStatus.EMPTY.value))
+        self.assertEqual(quality, 0)
+        self.assertIsNotNone(error_message)
+        # non-empty passwords that are too short should still get a score of 0 & the "too short" message
+        score, status, quality, error_message = validatePassword("123", minlen=10, empty_ok=True)
+        self.assertEqual(score, 0)
+        self.assertEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(quality, 0)
+        self.assertIsNotNone(error_message)
+        # also check a long-enough password, just in case
+        score, status, quality, error_message = validatePassword("1234567891", minlen=10, empty_ok=True)
+        self.assertEqual(score, 1)
+        self.assertEqual(status, _(constants.PasswordStatus.WEAK.value))
+        self.assertEqual(quality, 0)
+        self.assertIsNotNone(error_message)
+
+    def password_length_test(self):
+        """Check if minimal password length is checked properly."""
+        # first check if the default minimal password length is checked correctly
+        # (should be 6 characters at the moment)
+        score, status, _quality, _error_message = validatePassword("123")
+        self.assertEqual(score, 0)
+        self.assertEqual(_(status), _(constants.PasswordStatus.TOO_SHORT.value))
+        score, status, _quality, _error_message = validatePassword("123456")
+        self.assertEqual(score, 1)
+        self.assertEqual(_(status), _(constants.PasswordStatus.WEAK.value))
+
+        # check if setting password length works correctly
+        score, status, _quality, _error_message = validatePassword("12345", minlen=10)
+        self.assertEqual(score, 0)
+        self.assertEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
+        score, status, _quality, _error_message = validatePassword("1234567891", minlen=10)
+        self.assertGreater(score, 0)
+        self.assertNotEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
+
+    def password_quality_test(self):
+        """Check if libpwquality gives reasonable numbers & score is assigned correctly."""
+        # " " should give score 0 (<6 chars) & quality 0
+        score, status, quality, error_message = validatePassword(" ")
+        self.assertEqual(score, 0)
+        self.assertEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(quality, 0)
+        self.assertIsNotNone(error_message)
+
+        # "anaconda" is a dictionary word
+        score, status, quality, error_message = validatePassword("anaconda")
+        self.assertGreater(score, 0)
+        self.assertNotEqual(status, _(constants.PasswordStatus.EMPTY.value))
+        self.assertNotEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(quality, 0)
+        self.assertIsNotNone(error_message)
+
+        # "jelenovipivonelej" is a palindrome
+        score, status, quality, error_message = validatePassword("jelenovipivonelej")
+        self.assertGreater(score, 0)
+        self.assertNotEqual(status, _(constants.PasswordStatus.EMPTY.value))
+        self.assertNotEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(quality, 0)
+        self.assertIsNotNone(error_message)
+
+        # "4naconda-" gives a quality of 27 on RHEL7
+        score, status, quality, error_message = validatePassword("4naconda-")
+        if ON_RHEL:
+            self.assertEqual(score, 1)  # quality < 50
+            self.assertEqual(status, _(constants.PasswordStatus.WEAK.value))
+            self.assertEqual(quality, 27)
+        self.assertIsNone(error_message)
+
+        # "4naconda----" gives a quality of 52 on RHEL7
+        score, status, quality, error_message = validatePassword("4naconda----")
+        if ON_RHEL:
+            self.assertEqual(score, 2)  # quality > 50 & < 75
+            self.assertEqual(status, _(constants.PasswordStatus.FAIR.value))
+            self.assertEqual(quality, 52)
+        self.assertIsNone(error_message)
+
+        # "----4naconda----" gives a quality of 80 on RHEL7
+        score, status, quality, error_message = validatePassword("----4naconda----")
+        if ON_RHEL:
+            self.assertEqual(score, 3)  # quality > 75 & < 90
+            self.assertEqual(status, _(constants.PasswordStatus.GOOD.value))
+            self.assertEqual(quality, 80)
+        self.assertIsNone(error_message)
+
+        # "?----4naconda----?" gives a quality of 100 on RHEL7
+        score, status, quality, error_message = validatePassword("?----4naconda----?")
+        # this should (hopefully) give quality 100 everywhere
+        self.assertEqual(score, 4)  # quality > 90
+        self.assertEqual(status, _(constants.PasswordStatus.STRONG.value))
+        self.assertEqual(quality, 100)
+        self.assertIsNone(error_message)
+
+        # a long enough strong password with minlen set
+        score, status, quality, error_message = validatePassword("?----4naconda----?", minlen=10)
+        # this should (hopefully) give quality 100 everywhere
+        self.assertEqual(score, 4)  # quality > 90
+        self.assertEqual(status, _(constants.PasswordStatus.STRONG.value))
+        self.assertEqual(quality, 100)
+        self.assertIsNone(error_message)
+
+        # minimum password length overrides strong passwords for score and status
+        score, status, quality, error_message = validatePassword("?----4naconda----?", minlen=30)
+        # this should (hopefully) give quality 100 everywhere
+        self.assertEqual(score, 0)  # too short
+        self.assertEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(quality, 100)  # independent on password length
+        self.assertIsNone(error_message)


### PR DESCRIPTION
This patch set cleans up and generally improves password quality checking in Anaconda. While password quality checking sounds simple, it is actually quite complicated due to many states a password can be in, different password entry screens with different expectations and also due to interaction with the password quality policy.

The actual core password checking code has been refactored, as well as the individual password check that have been moved the the GUI helper module and are no longer duplicated in the user and root password spokes. Also the interactive & partial kickstart installations now use the same default policy and there is now also a set of unit tests for the password checking code.

Note: The LUKS passphrase quality checking has not yet been refactored to limit the already significant amount of changes. This will be the target of follow-up PR later on.