### PR TITLE
gui: show supported locales on Atomic Host installs

### DIFF
--- a/docs/boot-options.txt
+++ b/docs/boot-options.txt
@@ -240,8 +240,6 @@ If a language has been specified via the <<inst.lang,`inst.lang`>> boot option
 or the `lang` kickstart command it will be used.
 If no language is specified Anaconda will default to en_US.UTF-8.
 
-*NOTE*: Atomic installations always run in single language mode.
-
 === inst.geoloc ===
 Configure geolocation usage in Anaconda. Geolocation is used to pre-set
 language and time zone.

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -133,6 +133,12 @@ class BaseInstallClass(object):
     def setNetworkOnbootDefault(self, ksdata):
         pass
 
+    def filterSupportedLangs(self, ksdata, langs):
+        return langs
+
+    def filterSupportedLocales(self, ksdata, lang, locales):
+        return locales
+
     def __init__(self):
         pass
 

--- a/pyanaconda/ui/gui/spokes/langsupport.py
+++ b/pyanaconda/ui/gui/spokes/langsupport.py
@@ -133,10 +133,16 @@ class LangsupportSpoke(LangLocaleHandler, NormalSpoke):
     def completed(self):
         return True
 
+    def _filter_languages(self, langs):
+        return self.instclass.filterSupportedLangs(self.data, langs)
+
     def _add_language(self, store, native, english, lang):
         native_span = '<span lang="%s">%s</span>' % \
                 (escape_markup(lang), escape_markup(native))
         store.append([native_span, english, lang])
+
+    def _filter_locales(self, lang, locales):
+        return self.instclass.filterSupportedLocales(self.data, lang, locales)
 
     def _add_locale(self, store, native, locale):
         native_span = '<span lang="%s">%s</span>' % \

--- a/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
+++ b/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
@@ -62,7 +62,9 @@ class LangLocaleHandler(object):
                                "pixbuf", self._render_lang_selected)
 
         # fill the list with available translations
-        for lang in localization.get_available_translations():
+        langs = localization.get_available_translations()
+        langs = self._filter_languages(langs)
+        for lang in langs:
             self._add_language(self._languageStore,
                                localization.get_native_name(lang),
                                localization.get_english_name(lang), lang)
@@ -105,7 +107,17 @@ class LangLocaleHandler(object):
         else:
             return None
 
+    def _filter_languages(self, langs):
+        """Override this method with a valid implementation"""
+
+        raise NotImplementedError()
+
     def _add_language(self, store, native, english, lang):
+        """Override this method with a valid implementation"""
+
+        raise NotImplementedError()
+
+    def _filter_locales(self, lang, locales):
         """Override this method with a valid implementation"""
 
         raise NotImplementedError()
@@ -145,6 +157,7 @@ class LangLocaleHandler(object):
 
         self._localeStore.clear()
         locales = localization.get_language_locales(lang)
+        locales = self._filter_locales(lang, locales)
         for locale in locales:
             self._add_locale(self._localeStore,
                              localization.get_native_name(locale),

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -229,11 +229,17 @@ class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
         self._languageEntry.set_text("")
         self._languageStoreFilter.refilter()
 
+    def _filter_languages(self, langs):
+        return self.instclass.filterSupportedLangs(self.data, langs)
+
     def _add_language(self, store, native, english, lang):
         native_span = '<span lang="%s">%s</span>' % \
                 (escape_markup(lang),
                  escape_markup(native))
         store.append([native_span, english, lang, False])
+
+    def _filter_locales(self, lang, locales):
+        return self.instclass.filterSupportedLocales(self.data, lang, locales)
 
     def _add_locale(self, store, native, locale):
         native_span = '<span lang="%s">%s</span>' % \


### PR DESCRIPTION
In RHELAH 7.3.2, we will be adding all the officially supported locales
into the tree (see RHBZ#1186757). This means that users should now be
able to specify their language at install time, rather than defaulting
to en_US (which was done for RHBZ#1235726).

One issue right now is that many locales are presented, i.e. beyond what
is officially supported, which means that the original concerns in
RHBZ#1235726 are still valid. E.g. I shouldn't be able to select
"Asturian" if "ast_ES.utf8" isn't available in the tree.

In the future, we should be limiting the available languages to what the
install payload actually contains.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1186757
Related: https://bugzilla.redhat.com/show_bug.cgi?id=1235726