### PR TITLE
Fix calling of can_touch_runtime_system function

### DIFF
--- a/pyanaconda/screen_access.py
+++ b/pyanaconda/screen_access.py
@@ -68,7 +68,9 @@ class ScreenAccessManager(object):
             # But load the config if a path is specified,
             # so that it is possible to hide spokes in
             # image and directory installation modes.
-            if config_path is None and can_touch_runtime_system(touch_live=True):
+            if config_path is None and can_touch_runtime_system(
+                                            msg="write user interaction config file",
+                                            touch_live=True):
                 config_path = CONFIG_FILE_PATH
             if config_path and os.path.exists(config_path):
                 log.info("parsing existing user interaction config file in %s", config_path)


### PR DESCRIPTION
The msg parameter is mandatory.