### PR TITLE
Allow install classes to set alternate states for firstboot

### DIFF
--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -35,6 +35,8 @@ log = logging.getLogger("anaconda")
 
 from pyanaconda.kickstart import getAvailableDiskSpace
 
+from pykickstart.constants import FIRSTBOOT_DEFAULT
+
 class BaseInstallClass(object):
     # default to not being hidden
     hidden = False
@@ -71,6 +73,9 @@ class BaseInstallClass(object):
 
     # comps environment id to select by default
     defaultPackageEnvironment = None
+
+    # state firstboot should be in unless something special happens
+    firstboot = FIRSTBOOT_DEFAULT
 
     @property
     def l10n_domain(self):

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -717,10 +717,14 @@ class Firewall(commands.firewall.F20_Firewall):
             iutil.execInSysroot(cmd, args)
 
 class Firstboot(commands.firstboot.FC3_Firstboot):
-    def setup(self, *args):
-        # firstboot should be disabled by default after kickstart installations
-        if flags.automatedInstall and not self.seen:
-            self.firstboot = FIRSTBOOT_SKIP
+    def setup(self, ksdata, instClass):
+        if not self.seen:
+            if flags.automatedInstall:
+                # firstboot should be disabled by default after kickstart installations
+                self.firstboot = FIRSTBOOT_SKIP
+            elif instClass.firstboot and not self.firstboot:
+                # if nothing is specified, use the installclass default for firstboot
+                self.firstboot = instClass.firstboot
 
     def execute(self, *args):
         action = iutil.enable_service


### PR DESCRIPTION
In my install class I'd like to be able to say "Just don't run firstboot unless someone actually asked for it".  Currently there isn't an easy way of setting that up.  Interactive installs get it automatically (if unit exists).

I don't want to outright remove it from the release.  This attribute seemed like a viable middle option.