### PR TITLE
Fix generated zanata.xml from https unstable branch

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,7 +51,7 @@ ZANATA_PUSH_ARGS = --srcfile $(srcdir)/po/anaconda.pot --push-type source --forc
 RC_RELEASE ?= $(shell date -u +0.1.%Y%m%d%H%M%S)
 MOCKCHROOT ?= fedora-$(shell echo "$(GIT_BRANCH)" | sed \
 						-e 's/^f//' \
-						-e 's/\(master\|unstable\)/rawhide/'\
+						-e 's/master/rawhide/'\
 						)-$(shell uname -m)
 
 COVERAGE ?= coverage3

--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,7 @@ ANACONDA_PKG_CHECK_MODULES([RPM], [rpm >= 4.10.0])
 ANACONDA_PKG_CHECK_MODULES([LIBARCHIVE], [libarchive >= 3.0.4])
 
 # Find git branch
-s_git_branch="`./scripts/git-find-branch`"
+s_git_branch="`./scripts/git-find-branch | sed 's/unstable/master/'`"
 AC_SUBST(GIT_BRANCH, [$s_git_branch])
 
 # GCC likes to bomb out on some ridiculous warnings.  Add your favorites

--- a/scripts/git-find-branch
+++ b/scripts/git-find-branch
@@ -67,7 +67,7 @@ if [[ "${ANACONDA_TARGET_BRANCH}" != "" ]]; then
 fi
 
 ACTUAL_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-REMOTE=$(git remote -v | grep "rhinstaller/anaconda.git" | head -n 1 | cut -f 1)
+REMOTE=$(git remote -v | grep "rhinstaller/anaconda" | head -n 1 | cut -f 1)
 
 # Find existing Fedora branches
 FED_BRANCHES=$(git branch -a | egrep "${REMOTE}/f[[:digit:]]*-(devel|branch|release)$" | cut -d '/' -f 3)


### PR DESCRIPTION
Protocol https doesn't end with `.git` suffix.

We need to have master instead of unstable here.