### PR TITLE
Remove intermediate pot files in po-push

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,6 +80,7 @@ po-pull:
 
 po-push:
 	$(MAKE) -C po $(PACKAGE_NAME).pot-update
+	rm $(srcdir)/po/{main,extra}.pot
 	zanata push $(ZANATA_PUSH_ARGS)
 
 po-all:


### PR DESCRIPTION
Always remove the intermediate pot files (main & extra) before
doing a Zanata push, otherwise the client will push them together
with the anaconda.pot.

This scares translators and makes po-pull 3x longer by trying to
download po files corresponding to the unneeded intermediate pot files.