### PR TITLE
Fix wrong attribute of AnacondaYumRepo (#1395076)

### DIFF
--- a/yuminstall.py
+++ b/yuminstall.py
@@ -2109,7 +2109,7 @@ debuglevel=6
                 repo.mirrorlist = []
                 repo.cost = None
 
-            line = "repo --name=\"%s\" " % (repo.name or repo.repoid)
+            line = "repo --name=\"%s\" " % (repo.name or repo.id)
 
             if repo.baseurl:
                 line += " --baseurl=%s" % repo.anacondaBaseURLs[0]


### PR DESCRIPTION
The name of the attribute is id, not repoid.

Resolves: rhbz#1395076