### PR TITLE
fix typo in systemd service keyword

### DIFF
--- a/data/systemd/anaconda-pre.service
+++ b/data/systemd/anaconda-pre.service
@@ -15,7 +15,7 @@ Wants=systemd-logind.service
 [Service]
 Type=oneshot
 ExecStart=/usr/libexec/anaconda/anaconda-pre-log-gen
-StardardInput=tty
+StandardInput=tty
 StandardOutput=journal+console
 StandardError=journal+console
 TimeoutSec=0


### PR DESCRIPTION
With the typo systemd spams the journal when systemctl is executed,
e.g.:

    Nov 27 15:35:24 example.org systemd[1]: [/usr/lib/systemd/system/anaconda-pre.service:18] Unknown lvalue 'StardardInput' in section 'Service'
    Nov 27 15:35:24 example.org systemd[1]: [/usr/lib/systemd/system/anaconda-pre.service:18] Unknown lvalue 'StardardInput' in section 'Service'
    Nov 27 15:35:24 example.org systemd[1]: [/usr/lib/systemd/system/anaconda-pre.service:18] Unknown lvalue 'StardardInput' in section 'Service'
    Nov 27 15:35:24 example.org systemd[1]: [/usr/lib/systemd/system/anaconda-pre.service:18] Unknown lvalue 'StardardInput' in section 'Service'
    Nov 27 15:35:24 example.org systemd[1]: [/usr/lib/systemd/system/anaconda-pre.service:18] Unknown lvalue 'StardardInput' in section 'Service'
    Nov 27 15:35:24 example.org systemd[1]: [/usr/lib/systemd/system/anaconda-pre.service:18] Unknown lvalue 'StardardInput' in section 'Service'
    Nov 27 15:35:24 example.org systemd[1]: [/usr/lib/systemd/system/anaconda-pre.service:18] Unknown lvalue 'StardardInput' in section 'Service'

(from a Fedora 25 system)