### PR TITLE
RTD fixes

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,3 +1,6 @@
+Contribution guidelines
+=======================
+
 How to Contribute to the Anaconda Installer (the short version)
 ----------------------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys, os, shutil
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -32,7 +32,11 @@ if not 'ANACONDA_INSTALL_CLASSES' in os.environ:
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.inheritance_diagram']
+extensions = []
+if not os.environ.get("READTHEDOCS") == "True":
+    extensions.extend(['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.coverage', 'sphinx.ext.inheritance_diagram', 'sphinx.ext.todo'])
+
+shutil.copy2("../CONTRIBUTING.rst", "contributing.rst")
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,22 +12,14 @@ Contents:
    :maxdepth: 1
 
    intro
-   release
    boot-options
    kickstart
+   How to contribute <contributing>
    commit-log
+   release
    driverdisc
    iscsi
    multipath
-   Kickstart Tests <kickstart-tests>
-   modules
+   list-harddrives
+   User interaction config spec <user-interaction-config-file-spec>
    Testing <testing>
-   tests/modules
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-


### PR DESCRIPTION
A couple of fixes to make the documentation look better on Read the Docs:
- add missing rst files to the index
- reorganize the index to move more important items to the top
- make sure the contribution guidelines are included
- add a header to contribution guidelines to make it show correctly on RTD

Also disable API docs generation on RTD - at least for now. It doesn't seem to
work very well at the moment and needs a big heap of dependencies (Pykickstart, Blivet)
not available on RTD to generate. We might be able to make it work in the future
by using an intermediate project to pre-build the API rst files.