### PR TITLE
Don't pass storage to firstboot.setup()

### DIFF
--- a/pyanaconda/install.py
+++ b/pyanaconda/install.py
@@ -191,7 +191,7 @@ def doInstall(storage, payload, ksdata, instClass):
         progress_init(steps)
 
     with progress_report(N_("Setting up the installation environment")):
-        ksdata.firstboot.setup(storage, ksdata, instClass)
+        ksdata.firstboot.setup(ksdata, instClass)
         ksdata.addons.setup(storage, ksdata, instClass, payload)
 
     storage.update_ksdata()  # this puts custom storage info into ksdata


### PR DESCRIPTION
The setup() method of the firstboot command handler
does not need the storage storage and passing it
will only trigger a function signature mismatch.