### PR TITLE
Bump Blivet version due to systemd-udev dependency

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -83,7 +83,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 %package core
 Summary: Core of the Anaconda installer
 Requires: python3-dnf >= %{dnfver}
-Requires: python3-blivet >= 1:2.1.6-3
+Requires: python3-blivet >= 1:2.1.7-3
 Requires: python3-blockdev >= %{libblockdevver}
 Requires: libblockdev-plugins-all >= %{libblockdevver}
 Requires: python3-meh >= %{mehver}


### PR DESCRIPTION
Bump the required Blivet version so that it correctly pulls-in the
systemd-udev dependency it needs.

This way we can drop the temporary hotfix by Denis Gilmore from the spec file
in Fedora distgit.