### PR TITLE
Create lvm.conf with thin_* path overrides (#1350296)

### DIFF
--- a/scripts/upd-instroot
+++ b/scripts/upd-instroot
@@ -1127,6 +1127,18 @@ directory = /mnt/sysimage/etc
 directory = /mnt/sysimage/etc
 EOF
 
+echo "Creating lvm.conf"
+cat > $DEST/etc/lvm/lvm.conf <<EOF
+# We need to override the paths to the thin_* executables
+# as they need to be in /usr/sbin due to image build script
+# and loader limitations.
+global {
+thin_check_executable="/usr/sbin/thin_check"
+thin_dump_executable="/usr/sbin/thin_dump"
+thin_repair_executable="/usr/sbin/thin_repair"
+}
+EOF
+
 echo "Creating /etc/skel"
 # libuser needs this when it creates sshpw users
 mkdir -p $DEST/etc/skel


### PR DESCRIPTION
Turns out loader remounts /sbin to /usr/sbin for stage2,
which effectively means we can't put anything to /sbin
through the upd-instroot script.

As LVM tryes to call the the thin_* tools from /sbin this is a problem.

To wor around this create /etc/lvm/lvm.conf file in the image that
overrides paths to the thin_* tools to point to /usr/sbin.

Resolves: rhbz#1350296