### PR TITLE
network: don't reactivate devices from linuxrc.s390 for early networking (#1329171)

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -813,11 +813,15 @@ static void readNetInfo(struct loaderData_s ** ld) {
 
     if (loaderData->ipv4 && loaderData->netmask) {
         flags |= LOADER_FLAGS_HAVE_CMSCONF;
-    }
-
-    if (loaderData->ipv4 || loaderData->ipv6) {
         anaconda_activated_some_device = 1;
     }
+
+#ifdef ENABLE_IPV6
+    if (loaderData->ipv6info_set) {
+        flags |= LOADER_FLAGS_HAVE_CMSCONF;
+        anaconda_activated_some_device = 1;
+    }
+#endif
 
     free(cfgfile);
     g_strfreev(lines);
@@ -2139,8 +2143,10 @@ int main(int argc, char ** argv) {
         logMessage(INFO, "text mode forced due to serial/virtpconsole");
         flags |= LOADER_FLAGS_TEXT;
     }
-    if (hasGraphicalOverride())
+    if (hasGraphicalOverride()) {
         flags |= LOADER_FLAGS_EARLY_NETWORKING;
+        logMessage(INFO, "early networking required for graphical override");
+    }
     set_fw_search_path(&loaderData, "/lib/firmware/updates:/firmware:/lib/firmware");
     start_fw_loader(&loaderData);
 

--- a/loader/net.c
+++ b/loader/net.c
@@ -2358,8 +2358,9 @@ int chooseNetworkInterface(struct loaderData_s * loaderData) {
  * the network */
 int kickstartNetworkUp(struct loaderData_s * loaderData, iface_t * iface) {
 
-    if ((is_nm_connected() == TRUE) &&
-        (loaderData->netDev != NULL) && (loaderData->netDev_set == 1)) {
+    if (is_nm_connected() == TRUE &&
+         ((loaderData->netDev != NULL && loaderData->netDev_set == 1)
+          || FL_HAVE_CMSCONF(flags))) {
         if (anaconda_activated_some_device) {
             return 0;
         } else {


### PR DESCRIPTION
Resolves: rhbz#1329171

We shouldn't reactivate the devices (activated in s390 init linuxrc.s390) in
loader when trying to bring up early networking on s390.

For ipv6 only configuration the reactivating fails. The bug is hit when
installation (loader) is initiated by ssh -X install@<IP_ADDR> on s390, ie with
X forwarding turned on (-X). In this case loader assumes early networking is
required.

As a conservative fix the patch modifies the condition to leave early
networking setup if network was activated in s390 init (NM is connected
and network configuration from s390 init was found in loader).

The patch is tested.