### PR TITLE
Set correctly the default partitioning.

### DIFF
--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -128,6 +128,9 @@ class BaseInstallClass(object):
         anaconda.bootloader.timeout = self.bootloaderTimeoutDefault
         anaconda.bootloader.boot_args.update(self.bootloaderExtraArgs)
 
+        # The default partitioning should be always set.
+        self.setDefaultPartitioning(anaconda.storage)
+
     # sets default ONBOOT values and updates ksdata accordingly
     def setNetworkOnbootDefault(self, ksdata):
         pass

--- a/pyanaconda/installclasses/centos.py
+++ b/pyanaconda/installclasses/centos.py
@@ -44,7 +44,6 @@ class CentOSBaseInstallClass(BaseInstallClass):
 
     def configure(self, anaconda):
         BaseInstallClass.configure(self, anaconda)
-        BaseInstallClass.setDefaultPartitioning(self, anaconda.storage)
 
     def setNetworkOnbootDefault(self, ksdata):
         if any(nd.onboot for nd in ksdata.network.network if nd.device):

--- a/pyanaconda/installclasses/fedora.py
+++ b/pyanaconda/installclasses/fedora.py
@@ -38,7 +38,6 @@ class FedoraBaseInstallClass(BaseInstallClass):
 
     def configure(self, anaconda):
         BaseInstallClass.configure(self, anaconda)
-        BaseInstallClass.setDefaultPartitioning(self, anaconda.storage)
 
     def setNetworkOnbootDefault(self, ksdata):
         if any(nd.onboot for nd in ksdata.network.network if nd.device):

--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -44,7 +44,6 @@ class RHELBaseInstallClass(BaseInstallClass):
 
     def configure(self, anaconda):
         BaseInstallClass.configure(self, anaconda)
-        BaseInstallClass.setDefaultPartitioning(self, anaconda.storage)
 
     def setNetworkOnbootDefault(self, ksdata):
         if any(nd.onboot for nd in ksdata.network.network if nd.device):

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -280,7 +280,6 @@ class AutoPart(commands.autopart.F21_AutoPart):
 
         # sets up default autopartitioning.  use clearpart separately
         # if you want it
-        instClass.setDefaultPartitioning(storage)
         storage.do_autopart = True
 
         if self.encrypted:


### PR DESCRIPTION
Install classes should call in their configuration methods their own
setDefaultPartitioning methods instead of the BaseInstallClass's one.
Also, it is enough to set the default partitioning once.

Resolves: issue#800