### PR TITLE
Fix selection of no software environment (#1400045)

### DIFF
--- a/pyanaconda/ui/tui/spokes/software.py
+++ b/pyanaconda/ui/tui/spokes/software.py
@@ -303,6 +303,9 @@ class SoftwareSpoke(NormalTUISpoke):
         self.environment = self._get_environment(self._selection)
         self.addons = self._addons_selection if self.environment is not None else set()
 
+        if not self.environment:
+            return
+
         changed = False
 
         # Not a kickstart with packages, setup the selected environment and addons


### PR DESCRIPTION
In tui, do not apply changes when no environment is selected.

Resolves: rhbz#1400045