### PR TITLE
Use signals for Spoke & Hub entry/exit callbacks

### DIFF
--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -853,7 +853,7 @@ class GraphicalUserInterface(UserInterface):
                     return
 
             self._currentAction.initialize()
-            self._currentAction.entry()
+            self._currentAction.entered.emit(self._currentAction)
             self._currentAction.refresh()
 
             self._currentAction.window.set_beta(not self._isFinal)
@@ -1025,8 +1025,8 @@ class GraphicalUserInterface(UserInterface):
             self._on_continue_clicked(nextAction)
             return
 
-        self._currentAction.exit()
-        nextAction.entry()
+        self._currentAction.exited.emit(self._currentAction)
+        nextAction.entered.emit(nextAction)
 
         nextAction.refresh()
 
@@ -1051,7 +1051,7 @@ class GraphicalUserInterface(UserInterface):
             dialog.window.destroy()
 
         if rc == 1:
-            self._currentAction.exit()
+            self._currentAction.exited.emit(self._currentAction)
             iutil.ipmi_abort(scripts=self.data.scripts)
             sys.exit(0)
 

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -399,7 +399,7 @@ class Hub(GUIObject, common.Hub):
 
         # Enter the spoke
         self._inSpoke = True
-        spoke.entry()
+        spoke.entered.emit(spoke)
         spoke.refresh()
         self.main_window.enterSpoke(spoke)
 
@@ -422,7 +422,7 @@ class Hub(GUIObject, common.Hub):
             spoke.execute()
             spoke.visitedSinceApplied = False
 
-        spoke.exit()
+        spoke.exited.emit(spoke)
 
         self._inSpoke = False
 

--- a/pyanaconda/ui/tui/simpleline/base.py
+++ b/pyanaconda/ui/tui/simpleline/base.py
@@ -518,11 +518,11 @@ class App(object):
             # for that
 
             # "close" the previous screen (if any)
-            if App._current_screen and hasattr(App._current_screen, "exit"):
-                App._current_screen.exit()
+            if App._current_screen and hasattr(App._current_screen, "exited"):
+                App._current_screen.exited.emit(App._current_screen)
             # "enter" the new screen (if any)
-            if new_screen and hasattr(new_screen, "entry"):
-                new_screen.entry()
+            if new_screen and hasattr(new_screen, "entered"):
+                new_screen.entered.emit(new_screen)
 
         App._current_screen = new_screen
 


### PR DESCRIPTION
Replace the custom callback calling implementation for the Spoke/Hub
entry/exit events by using the Signal class.

Like this we can remove quite a few lines of code while providing
improved functionality (entry/exit callbacks can now be added & removed at
runtime if needed, etc.).