### PR TITLE
Add initialization-done signal

### DIFF
--- a/pyanaconda/install_tasks.py
+++ b/pyanaconda/install_tasks.py
@@ -19,28 +19,10 @@
 #
 from threading import RLock
 from pyanaconda.isignal import Signal
+from pyanaconda.iutil import synchronized
 import time
-import functools
 import logging
 log = logging.getLogger("anaconda")
-
-def synchronized(wrapped):
-    """A locking decorator for methods.
-
-    The decorator is only intended for methods and the class providing
-    the method also needs to have a Lock/RLock instantiated in self._lock.
-
-    The decorator prevents the wrapped method from being executed until
-    self._lock can be acquired. Once available, it acquires the lock and
-    prevents other decorated methods & other users of self._lock from
-    executing until the wrapped method finishes running.
-    """
-
-    @functools.wraps(wrapped)
-    def _wrapper(self, *args, **kwargs):
-        with self._lock:
-            return wrapped(self, *args, **kwargs)
-    return _wrapper
 
 class BaseTask(object):
     """A base class for Task and TaskQueue.

--- a/pyanaconda/iutil.py
+++ b/pyanaconda/iutil.py
@@ -36,6 +36,7 @@ import sys
 import imp
 import types
 import inspect
+import functools
 
 import requests
 from requests_file import FileAdapter
@@ -1563,3 +1564,22 @@ def item_counter(item_count):
     while index <= item_count:
         yield "%d/%d" % (index, item_count)
         index += 1
+
+def synchronized(wrapped):
+    """A locking decorator for methods.
+
+    The decorator is only intended for methods and the class providing
+    the method also needs to have a Lock/RLock instantiated in self._lock.
+
+    The decorator prevents the wrapped method from being executed until
+    self._lock can be acquired. Once available, it acquires the lock and
+    prevents other decorated methods & other users of self._lock from
+    executing until the wrapped method finishes running.
+    """
+
+    @functools.wraps(wrapped)
+    def _wrapper(self, *args, **kwargs):
+        with self._lock:
+            return wrapped(self, *args, **kwargs)
+    return _wrapper
+

--- a/pyanaconda/lifecycle.py
+++ b/pyanaconda/lifecycle.py
@@ -1,0 +1,162 @@
+# controller.py
+# Anaconda module lifecycle controller.
+#
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from threading import RLock
+from pyanaconda.isignal import Signal
+from pyanaconda.iutil import synchronized
+import logging
+log = logging.getLogger("anaconda")
+
+_controllers = {}
+_controller_categories_map = {}
+
+def get_controller_by_category(category_name):
+    """Return the controller instance that "owns" the corresponding category.
+
+    This is more or less a workaround to the fact that spokes
+    need to know what's their controller, but the controllers
+    are indexed by hub name and spokes don't have a direct reference
+    to the hub they are displayed on.
+
+    Spokes know their category and hubs know what categories the and
+    categories  should not be on two hubs. So we match the spoke category
+    to get the controller corresponding to the spoke.
+
+    :param str category_name: a spoke category name
+    :returns: a Controller instance "owning" the category or None if no matching instance is found
+    :rtype: str or None
+
+    """
+    for controller_name, controller_categories in _controller_categories_map.items():
+        if category_name in controller_categories:
+            return _controllers[controller_name]
+    # no controller has been found for the given spoke based on it's category
+    return None
+
+def get_controller_by_name(controller_name):
+    """Return controller instance by name.
+
+    This function wraps the internal controller dictionary, so that it is not directly exposed.
+
+    The controller names currently correspond to hub class name, eq.:
+    SummaryHub, ProgressHub, etc.
+
+    :param str controller_name: a name of a controller name
+    """
+    return _controllers.get(controller_name)
+
+def add_controller(controller_name, controller_categories):
+    # The controller name is currently based on Hub name
+    # and None indicates that the Hub subclass has not
+    # set the hub_name property to a non-default value.
+    if controller_name is None:
+        log.warning("Controller name is None.")
+    else:
+        log.info("Adding controller: %s", controller_name)
+    controller = Controller()
+    _controllers[controller_name] = controller
+    _controller_categories_map[controller_name] = controller_categories
+    return controller
+
+class Controller(object):
+    """A singleton that track initialization of Anaconda modules."""
+    def __init__(self):
+        self._lock = RLock()
+        self._modules = set()
+        self._all_modules_added = False
+        self.init_done = Signal()
+        self._init_done_triggered = False
+        self._added_module_count = 0
+
+    @synchronized
+    def module_init_start(self, module):
+        """Tell the controller that a module has started initialization.
+
+        :param module: a module which has started initialization
+        """
+        if self._all_modules_added:
+            log.warning("Late module_init_start() from: %s", self)
+        elif module in self._modules:
+            log.warning("Module already marked as initializing: %s", module)
+        else:
+            self._added_module_count += 1
+            self._modules.add(module)
+
+    def all_modules_added(self):
+        """Tell the controller that all expected modules have started initialization.
+
+        Tell the controller that all expected modules have been registered
+        for initialization tracking (or have already been initialized)
+        and no more are expected to be added.
+
+        This is needed so that we don't prematurely trigger the init_done signal
+        when all known modules finish initialization while other modules have not
+        yet been added.
+        """
+        init_done = False
+        with self._lock:
+            log.info("Initialization of all modules (%d) has been started.", self._added_module_count)
+            self._all_modules_added = True
+
+            # if all modules finished initialization before this was added then
+            # trigger the init_done signal at once
+            if not self._modules and not self._init_done_triggered:
+                self._init_done_triggered = True
+                init_done = True
+
+        # we should emit the signal out of the main lock as it doesn't make sense
+        # to hold the controller-state lock once we decide to the trigger init_done signal
+        # (and any callbacks registered on it)
+        if init_done:
+            self._trigger_init_done()
+
+    def module_init_done(self, module):
+        """Tell the controller that a module has finished initialization.
+
+        And if no more modules are being initialized trigger the init_done signal.
+
+        :param module: a module that has finished initialization
+        """
+        init_done = False
+        with self._lock:
+            # prevent the init_done signal from
+            # being triggered more than once
+            if self._init_done_triggered:
+                log.warning("Late module_init_done from module %s.", module)
+            else:
+                if module in self._modules:
+                    log.info("Module initialized: %s", module)
+                    self._modules.discard(module)
+                else:
+                    log.warning("Unknown module reported as initialized: %s", module)
+                # don't trigger the signal if all modules have not yet been added
+                if self._all_modules_added and not self._modules:
+                    init_done = True
+                    self._init_done_triggered = True
+
+        # we should emit the signal out of the main lock as it doesn't make sense
+        # to hold the controller-state lock once we decide to the trigger init_done signal
+        # (and any callbacks registered on it)
+        if init_done:
+            self._trigger_init_done()
+
+    def _trigger_init_done(self):
+        log.info("All modules have been initialized.")
+        self.init_done.emit()

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -25,6 +25,7 @@ from gi.repository import GLib
 from pyanaconda.flags import flags
 from pyanaconda.i18n import _, C_
 from pyanaconda.product import distributionText
+from pyanaconda import lifecycle
 
 from pyanaconda.ui import common
 from pyanaconda.ui.gui import GUIObject
@@ -210,6 +211,13 @@ class Hub(GUIObject, common.Hub):
             # category's title in the wrong place.
             if len(selectors) % 2:
                 row += 1
+
+        # initialization of all expected spokes has been started, so notify the controller
+        hub_controller = lifecycle.get_controller_by_name(self.__class__.__name__)
+        if hub_controller:
+            hub_controller.all_modules_added()
+        else:
+            log.error("Initialization controller for hub %s expected but missing.", self.__class__.__name__)
 
         spokeArea = self.window.get_spoke_area()
         viewport = Gtk.Viewport()

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -287,6 +287,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
     def initialize(self):
         NormalSpoke.initialize(self)
+        self.initialize_start()
         self._grabObjects()
 
         setViewportBackground(self.builder.get_object("availableSpaceViewport"), "#db3279")
@@ -322,6 +323,9 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
                 _fs_types.append(obj.name)
 
         self._fs_types = set(_fs_types)
+
+        # report that the custom spoke has been initialized
+        self.initialize_done()
 
     @property
     def _clearpartDevices(self):

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -430,6 +430,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
     def initialize(self):
         NormalSpoke.initialize(self)
+        self.initialize_start()
         self._daysStore = self.builder.get_object("days")
         self._monthsStore = self.builder.get_object("months")
         self._yearsStore = self.builder.get_object("years")
@@ -537,6 +538,9 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
             threadMgr.wait(constants.THREAD_TIME_INIT)
 
         hubQ.send_ready(self.__class__.__name__, False)
+
+        # report that we are done
+        self.initialize_done()
 
     @property
     def status(self):

--- a/pyanaconda/ui/gui/spokes/filter.py
+++ b/pyanaconda/ui/gui/spokes/filter.py
@@ -522,6 +522,7 @@ class FilterSpoke(NormalSpoke):
 
     def initialize(self):
         NormalSpoke.initialize(self)
+        self.initialize_start()
 
         self.pages = [SearchPage(self.storage, self.builder),
                       MultipathPage(self.storage, self.builder),
@@ -543,6 +544,9 @@ class FilterSpoke(NormalSpoke):
 
         self._store = self.builder.get_object("diskStore")
         self._addDisksButton = self.builder.get_object("addDisksButton")
+
+        # report that we are done
+        self.initialize_done()
 
     def _real_ancestors(self, disk):
         # Return a list of all the ancestors of a disk, but remove the disk

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -323,6 +323,7 @@ class KeyboardSpoke(NormalSpoke):
 
     def initialize(self):
         NormalSpoke.initialize(self)
+        self.initialize_start()
 
         # set X keyboard defaults
         # - this needs to be done early in spoke initialization so that
@@ -383,6 +384,9 @@ class KeyboardSpoke(NormalSpoke):
         self._add_dialog.wait_initialize()
         self._ready = True
         hubQ.send_ready(self.__class__.__name__, False)
+
+        # report that the keyboard spoke initialization has been completed
+        self.initialize_done()
 
     def refresh(self):
         NormalSpoke.refresh(self)

--- a/pyanaconda/ui/gui/spokes/langsupport.py
+++ b/pyanaconda/ui/gui/spokes/langsupport.py
@@ -65,6 +65,7 @@ class LangsupportSpoke(LangLocaleHandler, NormalSpoke):
         self._selected_locales = set()
 
     def initialize(self):
+        self.initialize_start()
         self._languageStore = self.builder.get_object("languageStore")
         self._languageEntry = self.builder.get_object("languageEntry")
         self._languageStoreFilter = self.builder.get_object("languageStoreFilter")
@@ -101,6 +102,9 @@ class LangsupportSpoke(LangLocaleHandler, NormalSpoke):
         highlightedRenderer = self.builder.get_object("highlightedRenderer")
         override_cell_property(highlightedColumn, highlightedRenderer,
                 "icon-name", self._render_lang_highlighted)
+
+        # report that we are done
+        self.initialize_done()
 
     def apply(self):
         # store only additional langsupport locales

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1549,6 +1549,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
     def initialize(self):
         register_secret_agent(self)
         NormalSpoke.initialize(self)
+        self.initialize_start()
         self.network_control_box.initialize()
         if not can_touch_runtime_system("hide hint to use network configuration in DE"):
             self.builder.get_object("network_config_vbox").set_no_show_all(True)
@@ -1559,6 +1560,9 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
         if not self.data.network.seen:
             _update_network_data(self.data, self.network_control_box)
+
+        # report that we are done
+        self.initialize_done()
 
     def refresh(self):
         NormalSpoke.refresh(self)

--- a/pyanaconda/ui/gui/spokes/password.py
+++ b/pyanaconda/ui/gui/spokes/password.py
@@ -55,6 +55,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     def initialize(self):
         NormalSpoke.initialize(self)
+        self.initialize_start()
         # place holders for the text boxes
         self.pw = self.builder.get_object("pw")
         self.confirm = self.builder.get_object("confirmPW")
@@ -98,6 +99,9 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
         # Send ready signal to main event loop
         hubQ.send_ready(self.__class__.__name__, False)
+
+        # report that we are done
+        self.initialize_done()
 
     def refresh(self):
         # Enable the input checks in case they were disabled on the last exit

--- a/pyanaconda/ui/gui/spokes/software.py
+++ b/pyanaconda/ui/gui/spokes/software.py
@@ -321,6 +321,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
 
     def initialize(self):
         NormalSpoke.initialize(self)
+        self.initialize_start()
         threadMgr.add(AnacondaThread(name=constants.THREAD_SOFTWARE_WATCHER,
                       target=self._initialize))
 
@@ -341,6 +342,9 @@ class SoftwareSelectionSpoke(NormalSpoke):
         # we should do dependency solving here.
         if not self._error:
             self._apply()
+
+        # report that software spoke initialization has been completed
+        self.initialize_done()
 
     def _parseEnvironments(self):
         # Set all of the add-on selection states to the default

--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -643,6 +643,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
 
     def initialize(self):
         NormalSpoke.initialize(self)
+        self.initialize_start()
 
         self._grabObjects()
 
@@ -663,8 +664,6 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         self._repoNameWarningBox = self.builder.get_object("repoNameWarningBox")
         self._repoNameWarningLabel = self.builder.get_object("repoNameWarningLabel")
 
-        threadMgr.add(AnacondaThread(name=constants.THREAD_SOURCE_WATCHER, target=self._initialize))
-
         # Register listeners for payload events
         payloadMgr.addListener(payloadMgr.STATE_START, self._payload_refresh)
         payloadMgr.addListener(payloadMgr.STATE_STORAGE, self._probing_storage)
@@ -672,6 +671,10 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         payloadMgr.addListener(payloadMgr.STATE_GROUP_MD, self._downloading_group_md)
         payloadMgr.addListener(payloadMgr.STATE_FINISHED, self._payload_finished)
         payloadMgr.addListener(payloadMgr.STATE_ERROR, self._payload_error)
+
+        # Start the thread last so that we are sure initialize_done() is really called only
+        # after all initialization has been done.
+        threadMgr.add(AnacondaThread(name=constants.THREAD_SOURCE_WATCHER, target=self._initialize))
 
     def _payload_refresh(self):
         hubQ.send_not_ready("SoftwareSelectionSpoke")
@@ -766,6 +769,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         while not self.ready:
             time.sleep(1)
         hubQ.send_ready(self.__class__.__name__, False)
+
+        # report that the source spoke has been initialized
+        self.initialize_done()
 
     def refresh(self):
         NormalSpoke.refresh(self)

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -621,6 +621,7 @@ class StorageSpoke(NormalSpoke, StorageChecker):
 
     def initialize(self):
         NormalSpoke.initialize(self)
+        self.initialize_start()
 
         self.local_disks_box = self.builder.get_object("local_disks_box")
         self.specialized_disks_box = self.builder.get_object("specialized_disks_box")
@@ -701,6 +702,9 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         else:
             self._ready = True
             hubQ.send_ready(self.__class__.__name__, False)
+
+        # report that the storage spoke has been initialized
+        self.initialize_done()
 
     def _update_summary(self):
         """ Update the summary based on the UI. """

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -246,6 +246,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
 
     def initialize(self):
         NormalSpoke.initialize(self)
+        self.initialize_start()
 
         # Create a new UserData object to store this spoke's state
         # as well as the state of the advanced user dialog.
@@ -338,6 +339,9 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         # set the visibility of the password entries
         set_password_visibility(self.pw, False)
         set_password_visibility(self.confirm, False)
+
+        # report that we are done
+        self.initialize_done()
 
     def refresh(self):
         # Enable the input checks in case they were disabled on the last exit

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -106,6 +106,7 @@ class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
         return model[itr][3]
 
     def initialize(self):
+        self.initialize_start()
         self._languageStore = self.builder.get_object("languageStore")
         self._languageStoreFilter = self.builder.get_object("languageStoreFilter")
         self._languageEntry = self.builder.get_object("languageEntry")
@@ -180,6 +181,9 @@ class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
         locale = localization.setup_locale(locales[0], self.data.lang)
         self._set_lang(locale)
         self._select_locale(self.data.lang.lang)
+
+        # report that we are done
+        self.initialize_done()
 
     def _retranslate_one(self, widgetName, context=None):
         widget = self.builder.get_object(widgetName)

--- a/pyanaconda/ui/tui/hubs/__init__.py
+++ b/pyanaconda/ui/tui/hubs/__init__.py
@@ -17,12 +17,16 @@
 # Red Hat, Inc.
 #
 from pyanaconda import ihelp
+from pyanaconda import lifecycle
 from pyanaconda.constants_text import INPUT_PROCESSED, INPUT_DISCARDED
 from pyanaconda.ui.tui import simpleline as tui
 from pyanaconda.ui.tui.tuiobject import TUIObject, HelpScreen
 from pyanaconda.ui import common
 
 from pyanaconda.i18n import _, N_
+
+import logging
+log = logging.getLogger("anaconda")
 
 class TUIHub(TUIObject, common.Hub):
     """Base Hub class implementing the pyanaconda.ui.common.Hub interface.
@@ -75,6 +79,14 @@ class TUIHub(TUIObject, common.Hub):
                 self._spoke_count += 1
                 self._keys[self._spoke_count] = spoke
                 self._spokes[spokeClass.__name__] = spoke
+
+        if self._spoke_count:
+            # initialization of all expected spokes has been started, so notify the controller
+            hub_controller = lifecycle.get_controller_by_name(self.__class__.__name__)
+            if hub_controller:
+                hub_controller.all_modules_added()
+            else:
+                log.error("Initialization controller for hub %s expected but missing.", self.__class__.__name__)
 
         # only schedule the hub if it has some spokes
         return self._spoke_count != 0

--- a/pyanaconda/ui/tui/spokes/askvnc.py
+++ b/pyanaconda/ui/tui/spokes/askvnc.py
@@ -47,6 +47,7 @@ class AskVNCSpoke(NormalTUISpoke):
     def __init__(self, app, data, storage=None, payload=None,
                  instclass=None, message=""):
         NormalTUISpoke.__init__(self, app, data, storage, payload, instclass)
+        self.initialize_start()
 
         # The TUI hasn't been initialized with the message handlers yet. Add an
         # exception message handler so that the TUI exits if anything goes wrong
@@ -55,6 +56,7 @@ class AskVNCSpoke(NormalTUISpoke):
         self._message = message
         self._choices = (_(USEVNC), _(USETEXT))
         self._usevnc = False
+        self.initialize_done()
 
     @property
     def indirect(self):

--- a/pyanaconda/ui/tui/spokes/langsupport.py
+++ b/pyanaconda/ui/tui/spokes/langsupport.py
@@ -43,6 +43,7 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     def __init__(self, app, data, storage, payload, instclass):
         NormalTUISpoke.__init__(self, app, data, storage, payload, instclass)
+        self.initialize_start()
 
         self._langs = [localization.get_english_name(lang)
                         for lang in localization.get_available_translations()]
@@ -51,6 +52,7 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         self._locales = dict((lang, localization.get_language_locales(lang))
                                 for lang in self._langs_and_locales.values())
         self._selected = self.data.lang.lang
+        self.initialize_done()
 
     @property
     def completed(self):

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -59,11 +59,13 @@ class NetworkSpoke(FirstbootSpokeMixIn, EditTUISpoke):
         self._apply = False
 
     def initialize(self):
+        self.initialize_start()
         self._load_new_devices()
 
         EditTUISpoke.initialize(self)
         if not self.data.network.seen:
             self._update_network_data()
+        self.initialize_done()
 
     def _load_new_devices(self):
         devices = nm.nm_devices()

--- a/pyanaconda/ui/tui/spokes/password.py
+++ b/pyanaconda/ui/tui/spokes/password.py
@@ -35,7 +35,9 @@ class PasswordSpoke(FirstbootSpokeMixIn, EditTUIDialog):
 
     def __init__(self, app, data, storage, payload, instclass):
         EditTUIDialog.__init__(self, app, data, storage, payload, instclass, "root")
+        self.initialize_start()
         self._password = None
+        self.initialize_done()
 
     @property
     def completed(self):

--- a/pyanaconda/ui/tui/spokes/progress.py
+++ b/pyanaconda/ui/tui/spokes/progress.py
@@ -43,8 +43,10 @@ class ProgressSpoke(StandaloneTUISpoke):
     priority = 0
 
     def __init__(self, app, ksdata, storage, payload, instclass):
+        self.initialize_start()
         StandaloneTUISpoke.__init__(self, app, ksdata, storage, payload, instclass)
         self._stepped = False
+        self.initialize_done()
 
     @property
     def completed(self):

--- a/pyanaconda/ui/tui/spokes/software.py
+++ b/pyanaconda/ui/tui/spokes/software.py
@@ -67,6 +67,7 @@ class SoftwareSpoke(NormalTUISpoke):
     def initialize(self):
         # Start a thread to wait for the payload and run the first, automatic
         # dependency check
+        self.initialize_start()
         super(SoftwareSpoke, self).initialize()
         threadMgr.add(AnacondaThread(name=THREAD_SOFTWARE_WATCHER,
             target=self._initialize))
@@ -89,6 +90,14 @@ class SoftwareSpoke(NormalTUISpoke):
 
         # Apply the initial selection
         self._apply()
+
+        # Wait for the software selection thread that might be started by _apply().
+        # We are already running in a thread, so it should not needlessly block anything
+        # and only like this we can be sure we are really initialized.
+        threadMgr.wait(THREAD_CHECK_SOFTWARE)
+
+        # report that the software spoke has been initialized
+        self.initialize_done()
 
     def _payload_start(self):
         # Source is changing, invalidate the software selection and clear the

--- a/pyanaconda/ui/tui/spokes/source.py
+++ b/pyanaconda/ui/tui/spokes/source.py
@@ -72,6 +72,7 @@ class SourceSpoke(EditTUISpoke, SourceSwitchHandler):
 
     def initialize(self):
         EditTUISpoke.initialize(self)
+        self.initialize_start()
 
         threadMgr.add(AnacondaThread(name=THREAD_SOURCE_WATCHER,
                                      target=self._initialize))
@@ -90,6 +91,9 @@ class SourceSpoke(EditTUISpoke, SourceSwitchHandler):
             self._cdrom = opticalInstallMedia(self.storage.devicetree)
 
         self._ready = True
+
+        # report that the source spoke has been initialized
+        self.initialize_done()
 
     def _payload_error(self):
         self._error = True

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -421,6 +421,7 @@ class StorageSpoke(NormalTUISpoke):
 
     def initialize(self):
         NormalTUISpoke.initialize(self)
+        self.initialize_start()
 
         threadMgr.add(AnacondaThread(name=THREAD_STORAGE_WATCHER,
                                      target=self._initialize))
@@ -444,6 +445,9 @@ class StorageSpoke(NormalTUISpoke):
 
         self._update_summary()
         self._ready = True
+
+        # report that the storage spoke has been initialized
+        self.initialize_done()
 
 class AutoPartSpoke(NormalTUISpoke):
     """ Autopartitioning options are presented here.

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -64,6 +64,7 @@ class TimeSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         return False
 
     def initialize(self):
+        self.initialize_start()
         # We get the initial NTP servers (if any):
         # - from kickstart when running inside of Anaconda
         #   during the installation
@@ -86,6 +87,10 @@ class TimeSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
             # check if the newly added NTP servers work fine
             self._check_ntp_servers_async(self._ntp_servers.keys())
+
+        # we assume that the NTP spoke is initialized enough even if some NTP
+        # server check threads might still be running
+        self.initialize_done()
 
     def _check_ntp_servers_async(self, servers):
         """Asynchronously check if given NTP servers appear to be working.

--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -69,6 +69,7 @@ class UserSpoke(FirstbootSpokeMixIn, EditTUISpoke):
     def __init__(self, app, data, storage, payload, instclass):
         FirstbootSpokeMixIn.__init__(self)
         EditTUISpoke.__init__(self, app, data, storage, payload, instclass, "user")
+        self.initialize_start()
         if self.data.user.userList:
             self.args = self.data.user.userList[0]
             self.args._create = True
@@ -83,6 +84,8 @@ class UserSpoke(FirstbootSpokeMixIn, EditTUISpoke):
         self.args._password = ""
 
         self.errors = []
+
+        self.initialize_done()
 
     def refresh(self, args=None):
         self.args._admin = "wheel" in self.args.groups

--- a/pyanaconda/ui/tui/spokes/warnings_spoke.py
+++ b/pyanaconda/ui/tui/spokes/warnings_spoke.py
@@ -42,6 +42,7 @@ class WarningsSpoke(StandaloneTUISpoke):
 
     def __init__(self, *args, **kwargs):
         StandaloneTUISpoke.__init__(self, *args, **kwargs)
+        self.initialize_start()
 
         self._message = _("This hardware (or a combination thereof) is not "
                           "supported by Red Hat.  For more information on "
@@ -52,6 +53,8 @@ class WarningsSpoke(StandaloneTUISpoke):
         self._unsupported = productName.startswith("Red Hat ") and \
                             is_unsupported_hw() and \
                             not self.data.unsupportedhardware.unsupported_hardware
+
+        self.initialize_done()
 
     @property
     def completed(self):

--- a/tests/pyanaconda_tests/controller_test.py
+++ b/tests/pyanaconda_tests/controller_test.py
@@ -1,0 +1,126 @@
+#
+# Martin Kolman <mkolman@redhat.com>
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+
+import unittest
+
+from pyanaconda.lifecycle import Controller
+
+class TestModule(object):
+    def __init__(self):
+        self._test = 1
+
+
+class InstallTasksTestCase(unittest.TestCase):
+    def setUp(self):
+        self._test_variable1 = 0
+
+    def _increment_var1(self):
+        self._test_variable1 += 1
+
+    def controller_test(self):
+        """Check that the module initialization controller works correctly."""
+        module1 = TestModule()
+        module2 = TestModule()
+        module3 = TestModule()
+
+        ctrl = Controller()
+
+        ctrl.init_done.connect(self._increment_var1)
+
+        # mark the modules as being initialized
+        ctrl.module_init_start(module1)
+        ctrl.module_init_start(module2)
+        ctrl.module_init_start(module3)
+
+        # tell the controller that all expected modules have been added
+        ctrl.all_modules_added()
+
+        # report modules initialization as being finished
+        # - order should not matter
+        ctrl.module_init_done(module2)
+        ctrl.module_init_done(module3)
+        ctrl.module_init_done(module1)
+
+        # When the last of the expected modules reports
+        # initialization as done the init_done signal of the
+        # controller should be triggered. So check that
+        # it really happened.
+        self.assertEqual(self._test_variable1, 1)
+
+    def controller_robustness_test(self):
+        """Check of controller handles various edge cases."""
+        module1 = TestModule()
+        module2 = TestModule()
+        module3 = TestModule()
+        module4 = TestModule()
+        module5 = TestModule()
+        module6 = TestModule()
+        module7 = TestModule()
+        module8 = TestModule()
+        module9 = TestModule()
+
+        ctrl = Controller()
+
+        ctrl.init_done.connect(self._increment_var1)
+
+        # add some modules and set them as initialized right away
+        # - this should basically cancel itself out as
+        # - the init_done signal will not be triggered as all_modules_added()
+        #   has not yet been called
+        ctrl.module_init_start(module4)
+        ctrl.module_init_start(module5)
+        ctrl.module_init_done(module5)
+        ctrl.module_init_done(module4)
+        # check that the init_done has not yet been triggered
+        self.assertEqual(self._test_variable1, 0)
+
+        # mark the modules as being initialized
+        ctrl.module_init_start(module1)
+        ctrl.module_init_start(module2)
+        ctrl.module_init_start(module3)
+
+        # tell the controller that all expected modules have been added
+        ctrl.all_modules_added()
+
+        # attempts to add & set modules as initialized after all_modules_added() is called
+        # should be also ignored
+        ctrl.module_init_start(module6)
+        ctrl.module_init_start(module7)
+        ctrl.module_init_done(module6)
+
+        # check that the init_done has not yet been triggered
+        self.assertEqual(self._test_variable1, 0)
+
+        # report modules initialization as being finished
+        # - order should not matter
+        ctrl.module_init_done(module2)
+        ctrl.module_init_done(module3)
+        ctrl.module_init_done(module1)
+
+        # attempts to add & set modules as initialized after the init_done signal
+        # has been triggered should be ignored as well
+        ctrl.module_init_start(module8)
+        ctrl.module_init_start(module9)
+        ctrl.module_init_done(module7)  # from attempt
+        ctrl.module_init_done(module9)
+        ctrl.module_init_done(module8)
+
+        # check that the init_done signal has been triggered only once
+        self.assertEqual(self._test_variable1, 1)

--- a/tests/pyanaconda_tests/installation_tasks.py
+++ b/tests/pyanaconda_tests/installation_tasks.py
@@ -20,11 +20,8 @@
 
 import unittest
 
-from threading import Lock
-
 from pyanaconda.install_tasks import Task
 from pyanaconda.install_tasks import TaskQueue
-from pyanaconda.install_tasks import synchronized
 
 class InstallTasksTestCase(unittest.TestCase):
 
@@ -372,43 +369,3 @@ class InstallTasksTestCase(unittest.TestCase):
         self.assertEqual(self._test_variable1, 3)
         self.assertEqual(self._test_variable2, 2)
         self.assertEqual(self._test_variable3, 1)
-
-    def synchronized_decorator_test(self):
-        """Check that the @synchronized decorator works correctly."""
-
-        # The @synchronized decorator work on methods of classes
-        # that provide self._lock with Lock or RLock instance.
-        class LockableClass(object):
-            def __init__(self):
-                self._lock = Lock()
-
-            def test_method(self):
-                lock_state = self._lock.locked()
-                return lock_state
-
-            @synchronized
-            def sync_test_method(self):
-                lock_state = self._lock.locked()
-                return lock_state
-
-        lockable = LockableClass()
-        self.assertFalse(lockable.test_method())
-        self.assertTrue(lockable.sync_test_method())
-
-        # The @synchronized decorator does not work on classes without self._lock.
-        class NotLockableClass(object):
-            @synchronized
-            def sync_test_method(self):
-                return "Hello world!"
-
-        not_lockable = NotLockableClass()
-        with self.assertRaises(AttributeError):
-            not_lockable.sync_test_method()
-
-        # It also does not work on functions.
-        @synchronized
-        def test_function():
-            return "Hello world!"
-
-        with self.assertRaises(TypeError):
-            test_function()


### PR DESCRIPTION
This pull request has been motivated by the current method of checking that all spokes have been initialized - joining all running threads - not being very robust.

The new method uses an initialization controller that track spoke initialization and triggers a signal (called init_done) once all spokes have been initialized on a given hub.

Due to the architecture of our GUI and TUI interface there are some parts of the PR I'm not really sure about, such as:
- accessing the controller from spokes
  - the controller is per-hub
  - but in our architecture spokes don't directly know on which hub they are running
  - to work around this spoke category matching is used to first find the hub on which the spoke is running and then then its controller

- initialize_start() needs to be always called when spoke initialization starts
  - this might look superfluous as it hub might as well just call that when running the initialize method
  - but that way any third party addon adding a spoke unaware of the initialization controller would prevent the init_done signal from being triggered by not calling initialize_done()
  - this is of course a trade-off - "unaware" addons won't block the init_done signal but we might consider initialization as done even if an "unaware" addon is still being initialized

- initialization in TUI
  - some spokes in TUI don't override the initialize() method
  - initialization (if any) seems to be done in __init__() in sich cases
  - initialize_start()/initialize_done() might look a little weird in such a case