### PR TITLE
Include Python 3.6 sysconfigdata module in initramfs (#1409177)

### DIFF
--- a/dracut/python-deps
+++ b/dracut/python-deps
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import copy
 import os, sys
+import sysconfig
 from modulefinder import ModuleFinder
 from distutils.sysconfig import get_python_lib, get_config_var, get_makefile_filename, get_config_h_filename
 
@@ -52,6 +53,16 @@ deps = []
 scripts = copy.copy(sys.argv[1:])
 scripts.append(os.path.join(libdir,'site.py'))
 scripts.append(os.path.join(libdir,'sysconfig.py'))
+# platform-specific sysconfigdata module, needed by sysconfig, not
+# detected by ModuleFinder - RHBZ #1409177, Python #29113
+# this will only work and is only needed on Python 3.6+, so hedge it
+try:
+    sysconfmod = os.path.join(libdir, sysconfig._get_sysconfigdata_name() + '.py')
+    if os.path.exists(sysconfmod):
+        scripts.append(sysconfmod)
+except AttributeError:
+    # _get_sysconfigdata_name won't exist on older Pythons
+    pass
 
 while scripts:
     script = scripts.pop()


### PR DESCRIPTION
This should fix kickstart installs with Python 3.6. As explained
in the bug report, Python 3.6 added a platform specific module
containing system config data which the `sysconfig` module needs,
but it imports it with `__import__`, which modulefinder seems
not to be able to cope with. So the module wasn't included in
the installer initramfs, because python-deps uses modulefinder
to calculate the deps of the scripts and misses it.

This adds it as another special case to the file. We have to
use a non-public function to get the module name, unfortunately,
I really can't see any other way to do it.

You can see the relevant code in the `_init_posix` function in
`sysconfig.py`.

Resolves: rhbz#1409177