### PR TITLE
Always refresh the size of swap before autopartitioning.

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -282,6 +282,7 @@ class AutoPart(commands.autopart.F21_AutoPart):
 
         # sets up default autopartitioning.  use clearpart separately
         # if you want it
+        refreshAutoSwapSize(storage)
         storage.do_autopart = True
 
         if self.encrypted:


### PR DESCRIPTION
This is a fix of the pull request #905 that broke tui
autopartitioning. The call of the method setDefaultPartitioning
should have been replaced with refreshAutoSwapSize.