### PR TITLE
Fix the status of the StorageSpoke for dasd formatting (#1274596)

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -456,10 +456,10 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         """ A short string describing the current status of storage setup. """
         msg = _("No disks selected")
 
-        if flags.automatedInstall and not self.storage.root_device:
-            msg = _("Kickstart insufficient")
-        elif threadMgr.get(constants.THREAD_DASDFMT):
+        if threadMgr.get(constants.THREAD_DASDFMT):
             msg = _("Formatting DASDs")
+        elif flags.automatedInstall and not self.storage.root_device:
+            msg = _("Kickstart insufficient")
         elif self.data.ignoredisk.onlyuse:
             msg = P_(("%d disk selected"),
                      ("%d disks selected"),


### PR DESCRIPTION
Show the status message about dasd formatting instead of the
insufficient kickstart file.

Resolves: rhbz#1274596