### PR TITLE
Validate dasd and zfcp user input (#1335092)

### DIFF
--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -109,9 +109,11 @@ THREAD_GEOLOCATION_REFRESH = "AnaGeolocationRefreshThread"
 THREAD_DATE_TIME = "AnaDateTimeThread"
 THREAD_TIME_INIT = "AnaTimeInitThread"
 THREAD_DASDFMT = "AnaDasdfmtThread"
+THREAD_DASD_DISCOVER = "AnaDasdDiscoverThread"
 THREAD_KEYBOARD_INIT = "AnaKeyboardThread"
 THREAD_ADD_LAYOUTS_INIT = "AnaAddLayoutsInitThread"
 THREAD_NTP_SERVER_CHECK = "AnaNTPserver"
+THREAD_ZFCP_DISCOVER = "AnaZfcpDiscoverThread"
 
 # Geolocation constants
 

--- a/pyanaconda/regexes.py
+++ b/pyanaconda/regexes.py
@@ -163,3 +163,23 @@ ISCSI_EUI_NAME_REGEX = re.compile(r'^eui\.[a-fA-F0-9]{16}$')
 
 # Device with this name was configured from ibft (and renamed) by dracut
 IBFT_CONFIGURED_DEVICE_NAME = re.compile(r'^ibft\d+$')
+
+# Regex to validate a DASD device number (full or partial).
+#
+# A DASD number has the format n.n.hhhh, where n is any decimal
+# digit and h any hexadecimal digit, e.g., 0.0.abcd, 0.0.002A.
+#
+# The partial form of the DASD number is missing hexadecimal digits,
+# e.g., 0.0.b, or missing a bus number, e.g., 0012. The minimal
+# partial number contains a single digit. For example a.
+DASD_DEVICE_NUMBER = re.compile(r'^(?:[0-9]\.[0-9]\.|\.|)[0-9A-Fa-f]{1,4}$')
+
+# Regex to validate the Logical Unit Number (LUN).
+# The LUN is a 16 digit hexadecimal value padded with zeroes to the right,
+# for example 0x4010403300000000.
+ZFCP_LUN_NUMBER = re.compile(r'^(?:0x|)[0-9A-Fa-f]{1,16}$')
+
+# Regex to validate the Worldwide Port Name (WWPN).
+# The WWPN is a 16 digit hexadecimal number prefixed with 0x,
+# for example 0x5005076303000104.
+ZFCP_WWPN_NUMBER = re.compile(r'^(?:0x|)[0-9A-Fa-f]{16}$')

--- a/pyanaconda/ui/gui/spokes/filter.py
+++ b/pyanaconda/ui/gui/spokes/filter.py
@@ -685,11 +685,7 @@ class FilterSpoke(NormalSpoke):
 
         with self.main_window.enlightbox(dialog.window):
             dialog.refresh()
-            rc = dialog.run()
-
-        if rc == 1:
-            self.skipTo = "StorageSpoke"
-            self.on_back_clicked(rc)
+            dialog.run()
 
         # We now need to refresh so any new disks picked up by adding advanced
         # storage are displayed in the UI.

--- a/tests/regex_tests/dasd_name_test.py
+++ b/tests/regex_tests/dasd_name_test.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+#
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+import unittest
+
+from regexcheck import regex_match
+from pyanaconda.regexes import DASD_DEVICE_NUMBER
+
+
+class DASDNameRegexTestCase(unittest.TestCase):
+
+    def device_name_test(self):
+        good_tests = [
+                '0.0.0000',
+                '0.0.abcd',
+                '0.0.ABCD',
+                '1.2.3456',
+                '1.2.000a',
+                '1.2.00a',
+                '1.2.0a',
+                '1.2.a',
+                '.000a',
+                '.00a',
+                '.0a',
+                '.a',
+                '000a',
+                '00a',
+                '0a',
+                'a',
+                ]
+
+        bad_tests = [
+                'totalnonsens',
+                'a.a.0000',
+                '0.0.gggg',
+                '0.000a',
+                '0.0.',
+                '01.01.abcd',
+                '0.0.abcde',
+                '',
+                ]
+
+        if not regex_match(DASD_DEVICE_NUMBER, good_tests, bad_tests):
+            self.fail()

--- a/tests/regex_tests/zfcp_name_test.py
+++ b/tests/regex_tests/zfcp_name_test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+#
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+import unittest
+
+from regexcheck import regex_match
+from pyanaconda.regexes import ZFCP_LUN_NUMBER, ZFCP_WWPN_NUMBER
+
+
+class ZFCPNameRegexTestCase(unittest.TestCase):
+
+    def lun_name_test(self):
+        good_tests = [
+                '0x0000000000000000',
+                '0x0123456789abcdef',
+                '0x0123456789ABCDEF',
+                '0x01234567',
+                '0x0123',
+                '0x0',
+                '0000000000000000',
+                '0123456789abcdef',
+                '0123456789ABCDEF',
+                '01234567',
+                '0123',
+                '0',
+                ]
+
+        bad_tests = [
+                'totalnonsens',
+                '0x00000000000000000',
+                '0xabcdefg',
+                '1x0',
+                '0y0',
+                '',
+                ]
+
+        if not regex_match(ZFCP_LUN_NUMBER, good_tests, bad_tests):
+            self.fail()
+
+    def wwpn_name_test(self):
+        good_tests = [
+            '0x0000000000000000',
+            '0x0123456789abcdef',
+            '0x0123456789ABCDEF',
+            '0000000000000000',
+            '0123456789abcdef',
+            '0123456789ABCDEF',
+        ]
+
+        bad_tests = [
+            'totalnonsens',
+            '0x00000000000000000',
+            '0x000000000000000g',
+            '0y0000000000000000',
+            '0x000000000000000',
+            '00000000000000000',
+            '000000000000000g',
+            '000000000000000',
+            '0x0123456789abcde',
+            '0x0123456789ABCDE',
+            '0123456789abcde',
+            '0123456789ABCDE',
+            '0',
+            '',
+        ]
+
+        if not regex_match(ZFCP_WWPN_NUMBER, good_tests, bad_tests):
+            self.fail()
+


### PR DESCRIPTION
In gui, the user input for dasd and zfcp devices should be validated
before it is sanitized and the discovery is run. Otherwise, the
blockdev.s390.sanitize_* functions could cause the out of memory
error.

Also, the gui dialogs for dasd and zfcp were polished a little and
their behaviour made a little more consistent.

Resolves: rhbz#1335092