### PR TITLE
network: use introspection data from libnm instead of libnm-glib

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -23,7 +23,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define dnfver 2.0.0
 %define partedver 1.8.1
 %define pypartedver 2.5-2
-%define nmver 0.9.9.0-10.git20130906
+%define nmver 1.0
 %define dbusver 1.2.3
 %define mehver 0.23-1
 %define firewalldver 0.3.5-1
@@ -120,7 +120,7 @@ Requires: openssh
 Requires: isomd5sum >= %{isomd5sum}
 Requires: createrepo_c
 Requires: NetworkManager >= %{nmver}
-Requires: NetworkManager-glib >= %{nmver}
+Requires: NetworkManager-libnm >= %{nmver}
 Requires: NetworkManager-team
 Requires: dhclient
 Requires: kbd

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -2,7 +2,7 @@
 # network.py - network configuration install data
 #
 # Copyright (C) 2001, 2002, 2003, 2004, 2005, 2006, 2007  Red Hat, Inc.
-#               2008, 2009
+#               2008, 2009, 2017
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,9 +18,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gi
-gi.require_version("NetworkManager", "1.0")
+gi.require_version("NM", "1.0")
 
-from gi.repository import NetworkManager
+from gi.repository import NM
 
 import shutil
 from pyanaconda import iutil
@@ -1467,9 +1467,9 @@ def status_message():
     msg = _("Unknown")
 
     state = nm.nm_state()
-    if state == NetworkManager.State.CONNECTING:
+    if state == NM.State.CONNECTING:
         msg = _("Connecting...")
-    elif state == NetworkManager.State.DISCONNECTING:
+    elif state == NM.State.DISCONNECTING:
         msg = _("Disconnecting...")
     else:
         active_devs = [d for d in nm.nm_activated_devices()

--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -1,6 +1,6 @@
 # Network configuration proxy to NetworkManager
 #
-# Copyright (C) 2013  Red Hat, Inc.
+# Copyright (C) 2013,2017  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -20,10 +20,10 @@
 import gi
 gi.require_version("GLib", "2.0")
 gi.require_version("Gio", "2.0")
-gi.require_version("NetworkManager", "1.0")
+gi.require_version("NM", "1.0")
 
 from gi.repository import Gio, GLib
-from gi.repository import NetworkManager
+from gi.repository import NM
 import struct
 import socket
 import logging
@@ -33,13 +33,13 @@ from pyanaconda.constants import DEFAULT_DBUS_TIMEOUT
 from pyanaconda.flags import flags, can_touch_runtime_system
 
 supported_device_types = [
-    NetworkManager.DeviceType.ETHERNET,
-    NetworkManager.DeviceType.WIFI,
-    NetworkManager.DeviceType.INFINIBAND,
-    NetworkManager.DeviceType.BOND,
-    NetworkManager.DeviceType.VLAN,
-    NetworkManager.DeviceType.BRIDGE,
-    NetworkManager.DeviceType.TEAM,
+    NM.DeviceType.ETHERNET,
+    NM.DeviceType.WIFI,
+    NM.DeviceType.INFINIBAND,
+    NM.DeviceType.BOND,
+    NM.DeviceType.VLAN,
+    NM.DeviceType.BRIDGE,
+    NM.DeviceType.TEAM,
 ]
 
 class UnknownDeviceError(ValueError):
@@ -140,7 +140,7 @@ def nm_state():
 
     # If this is an image/dir install assume the network is up
     if not prop and (flags.imageInstall or flags.dirInstall):
-        return NetworkManager.State.CONNECTED_GLOBAL
+        return NM.State.CONNECTED_GLOBAL
     else:
         return prop
 
@@ -154,9 +154,9 @@ def nm_is_connected():
     :return: True if NM is connected, False otherwise.
     :rtype: bool
     """
-    return nm_state() in (NetworkManager.State.CONNECTED_GLOBAL,
-                          NetworkManager.State.CONNECTED_SITE,
-                          NetworkManager.State.CONNECTED_LOCAL)
+    return nm_state() in (NM.State.CONNECTED_GLOBAL,
+                          NM.State.CONNECTED_SITE,
+                          NM.State.CONNECTED_LOCAL)
 
 def nm_is_connecting():
     """Is NetworkManager connecting?
@@ -164,7 +164,7 @@ def nm_is_connecting():
     :return: True if NM is in CONNECTING state, False otherwise.
     :rtype: bool
     """
-    return nm_state() == NetworkManager.State.CONNECTING
+    return nm_state() == NM.State.CONNECTING
 
 def nm_devices():
     """Return names of network devices supported in installer.
@@ -207,7 +207,7 @@ def nm_activated_devices():
             state = _get_property(ac, "State", ".Connection.Active")
         except UnknownMethodGetError:
             continue
-        if state != NetworkManager.ActiveConnectionState.ACTIVATED:
+        if state != NM.ActiveConnectionState.ACTIVATED:
             continue
         devices = _get_property(ac, "Devices", ".Connection.Active")
         for device in devices:
@@ -286,7 +286,7 @@ def nm_device_type_is_wifi(name):
        :raise UnknownDeviceError: if device is not found
        :raise PropertyNotFoundError: if property is not found
     """
-    return nm_device_type(name) == NetworkManager.DeviceType.WIFI
+    return nm_device_type(name) == NM.DeviceType.WIFI
 
 def nm_device_type_is_ethernet(name):
     """Is the type of device ethernet?
@@ -298,7 +298,7 @@ def nm_device_type_is_ethernet(name):
        :raise UnknownDeviceError: if device is not found
        :raise PropertyNotFoundError: if property is not found
     """
-    return nm_device_type(name) == NetworkManager.DeviceType.ETHERNET
+    return nm_device_type(name) == NM.DeviceType.ETHERNET
 
 def nm_device_type_is_infiniband(name):
     """Is the type of device infiniband?
@@ -307,7 +307,7 @@ def nm_device_type_is_infiniband(name):
        UnknownDeviceError if device is not found
        PropertyNotFoundError if type is not found
     """
-    return nm_device_type(name) == NetworkManager.DeviceType.INFINIBAND
+    return nm_device_type(name) == NM.DeviceType.INFINIBAND
 
 def nm_device_type_is_bond(name):
     """Is the type of device bond?
@@ -319,7 +319,7 @@ def nm_device_type_is_bond(name):
        :raise UnknownDeviceError: if device is not found
        :raise PropertyNotFoundError: if property is not found
     """
-    return nm_device_type(name) == NetworkManager.DeviceType.BOND
+    return nm_device_type(name) == NM.DeviceType.BOND
 
 def nm_device_type_is_team(name):
     """Is the type of device team?
@@ -331,7 +331,7 @@ def nm_device_type_is_team(name):
        :raise UnknownDeviceError: if device is not found
        :raise PropertyNotFoundError: if property is not found
     """
-    return nm_device_type(name) == NetworkManager.DeviceType.TEAM
+    return nm_device_type(name) == NM.DeviceType.TEAM
 
 def nm_device_type_is_bridge(name):
     """Is the type of device bridge?
@@ -343,7 +343,7 @@ def nm_device_type_is_bridge(name):
        :raise UnknownDeviceError: if device is not found
        :raise PropertyNotFoundError: if property is not found
     """
-    return nm_device_type(name) == NetworkManager.DeviceType.BRIDGE
+    return nm_device_type(name) == NM.DeviceType.BRIDGE
 
 def nm_device_type_is_vlan(name):
     """Is the type of device vlan?
@@ -355,7 +355,7 @@ def nm_device_type_is_vlan(name):
        :raise UnknownDeviceError: if device is not found
        :raise PropertyNotFoundError: if property is not found
     """
-    return nm_device_type(name) == NetworkManager.DeviceType.VLAN
+    return nm_device_type(name) == NM.DeviceType.VLAN
 
 def nm_device_is_slave(name):
     """Is the device a slave?
@@ -522,7 +522,7 @@ def nm_device_ip_config(name, version=4):
        :raise PropertyNotFoundError: if ip configuration is not found
     """
     state = nm_device_property(name, "State")
-    if state != NetworkManager.DeviceState.ACTIVATED:
+    if state != NM.DeviceState.ACTIVATED:
         return []
 
     if version == 4:
@@ -657,9 +657,9 @@ def _device_settings(name):
        :raise UnknownDeviceError: if device is not found
     """
     devtype = nm_device_type(name)
-    if devtype == NetworkManager.DeviceType.BOND:
+    if devtype == NM.DeviceType.BOND:
         settings = _find_settings(name, 'bond', 'interface-name')
-    elif devtype == NetworkManager.DeviceType.VLAN:
+    elif devtype == NM.DeviceType.VLAN:
         settings = _find_settings(name, 'vlan', 'interface-name')
         if not settings:
             # connections generated by NM from iBFT
@@ -1078,9 +1078,9 @@ def test():
         except UnknownDeviceError as e:
             print("     %s" % e)
             devtype = None
-        if devtype == NetworkManager.DeviceType.ETHERNET:
+        if devtype == NM.DeviceType.ETHERNET:
             print("     type %s" % "ETHERNET")
-        elif devtype == NetworkManager.DeviceType.WIFI:
+        elif devtype == NM.DeviceType.WIFI:
             print("     type %s" % "WIFI")
             wireless_device = devname
 


### PR DESCRIPTION
The installer seems to be one of the few packages that drag in the old
library. Address that.