### PR TITLE
network: respect --activate value for bridge from kickstart (#1416687)

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -560,7 +560,7 @@ def ksnet_to_ifcfg(net, filename=None):
                             'TYPE' : "Ethernet",
                             'NAME' : "%s slave %s" % (dev, i),
                             'UUID' : str(uuid.uuid4()),
-                            'ONBOOT' : "yes",
+                            'ONBOOT' : "yes" if net.activate else "no",
                             'BRIDGE' : dev,
                             'HWADDR' : readsysfile("/sys/class/net/%s/address" % slave),
                           }


### PR DESCRIPTION
Resolves: rhbz#1416687

We need to set correct ONBOOT value (which is "no" if we don't want to activate
the device in stage 2) for NM also for the slave.

Depends on
https://github.com/rhinstaller/anaconda/pull/938/commits/4458d7c7a2171a8b97aa895c8a3f332179a76554