### PR TITLE
Fixed the default behaviour of the autopartitioning (#1380767)

### DIFF
--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -115,6 +115,9 @@ class BaseInstallClass(object):
         anaconda.bootloader.timeout = self.bootloaderTimeoutDefault
         anaconda.bootloader.boot_args.update(self.bootloaderExtraArgs)
 
+        # The default partitioning should be always set.
+        self.setDefaultPartitioning(anaconda.storage)
+
     # sets default ONBOOT values and updates ksdata accordingly
     def setNetworkOnbootDefault(self, ksdata):
         pass

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -34,6 +34,7 @@ import logging
 log = logging.getLogger("anaconda")
 
 from pyanaconda.kickstart import getAvailableDiskSpace
+from pyanaconda.constants import DEFAULT_AUTOPART_TYPE
 
 class BaseInstallClass(object):
     # default to not being hidden
@@ -57,6 +58,10 @@ class BaseInstallClass(object):
     # The default filesystem type to use.  If None, we will use whatever
     # Blivet uses by default.
     defaultFS = None
+
+    # The default partitioning scheme to use for autopartitioning.
+    # It has to be always set.
+    default_autopart_type = DEFAULT_AUTOPART_TYPE
 
     # help
     help_folder = "/usr/share/anaconda/help"

--- a/pyanaconda/installclasses/fedora.py
+++ b/pyanaconda/installclasses/fedora.py
@@ -37,7 +37,6 @@ class FedoraBaseInstallClass(BaseInstallClass):
 
     def configure(self, anaconda):
         BaseInstallClass.configure(self, anaconda)
-        BaseInstallClass.setDefaultPartitioning(self, anaconda.storage)
 
     def setNetworkOnbootDefault(self, ksdata):
         if any(nd.onboot for nd in ksdata.network.network if nd.device):

--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -53,7 +53,6 @@ class RHELBaseInstallClass(BaseInstallClass):
 
     def configure(self, anaconda):
         BaseInstallClass.configure(self, anaconda)
-        self.setDefaultPartitioning(anaconda.storage)
 
     def setNetworkOnbootDefault(self, ksdata):
         if any(nd.onboot for nd in ksdata.network.network if nd.device):

--- a/pyanaconda/installclasses/rhv.py
+++ b/pyanaconda/installclasses/rhv.py
@@ -24,6 +24,7 @@ from blivet.partspec import PartSpec
 from blivet.platform import platform
 from blivet.devicelibs import swap
 from blivet.size import Size
+from pykickstart.constants import AUTOPART_TYPE_LVM_THINP
 
 
 class OvirtBaseInstallClass(BaseInstallClass):
@@ -32,6 +33,7 @@ class OvirtBaseInstallClass(BaseInstallClass):
     hidden = not productName.startswith("oVirt")
 
     efi_dir = "centos"
+    default_autopart_type = AUTOPART_TYPE_LVM_THINP
 
     def configure(self, anaconda):
         BaseInstallClass.configure(self, anaconda)

--- a/pyanaconda/iutil.py
+++ b/pyanaconda/iutil.py
@@ -1242,3 +1242,7 @@ def touch(file_path):
     # even when the path points to dirrectory
     if not os.path.exists(file_path):
         os.mknod(file_path)
+
+def firstNotNone(iterable):
+    """Return the first item that is not None."""
+    return next((item for item in iterable if item is not None), None)

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -290,7 +290,7 @@ class AutoPart(commands.autopart.RHEL7_AutoPart):
 
         # sets up default autopartitioning.  use clearpart separately
         # if you want it
-        instClass.setDefaultPartitioning(storage)
+        refreshAutoSwapSize(storage)
         storage.doAutoPart = True
 
         if self.encrypted:

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -35,7 +35,7 @@ from pyanaconda.i18n import _, N_, CP_
 from pyanaconda.product import productName, productVersion, translated_new_install_name
 from pyanaconda.threads import AnacondaThread, threadMgr
 from pyanaconda.constants import THREAD_EXECUTE_STORAGE, THREAD_STORAGE, THREAD_CUSTOM_STORAGE_INIT
-from pyanaconda.iutil import lowerASCII
+from pyanaconda.iutil import lowerASCII, firstNotNone
 from pyanaconda.bootloader import BootLoaderError
 from pyanaconda.kickstart import refreshAutoSwapSize
 from pyanaconda import isys
@@ -153,6 +153,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         self._hidden_disks = []
         self._fs_types = []             # list of supported fstypes
         self._free_space = Size(0)
+        self._default_autopart_type = None
 
         self._device_size_text = None
         self._device_disks = []
@@ -273,6 +274,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
         # Unfortunately, we have to narrow them down a little bit more because
         # this list will include things like PVs and RAID members.
         self._fsStore.clear()
+
+        # Set the default partitioning scheme.
+        self._default_autopart_type = firstNotNone((self.data.autopart.type,
+                                                    self.instclass.default_autopart_type))
 
         # Connect viewport scrolling with accordion focus events
         self._accordion.set_focus_hadjustment(self._partitionsViewport.get_hadjustment())
@@ -501,6 +506,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
             page = CreateNewPage(translated_new_install_name(),
                                  self.on_create_clicked,
                                  self._change_autopart_type,
+                                 self._default_autopart_type,
                                  partitionsToReuse=bool(ui_roots) or bool(unused_devices))
             self._accordion.addPage(page, cb=self.on_page_clicked)
 

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -24,7 +24,6 @@
 from pyanaconda.i18n import _
 from pyanaconda.product import productName, productVersion
 from pyanaconda.ui.gui.utils import escape_markup, really_hide, really_show
-from pyanaconda.constants import DEFAULT_AUTOPART_TYPE
 from pyanaconda.storage_utils import AUTOPART_CHOICES
 
 from gi.repository.AnacondaWidgets import MountpointSelector
@@ -263,7 +262,7 @@ class UnknownPage(Page):
 # of this class will be packed into the Accordion first and then when the new installation
 # is created, it will be removed and replaced with a Page for it.
 class CreateNewPage(Page):
-    def __init__(self, title, createClickedCB, autopartTypeChangedCB, partitionsToReuse=True):
+    def __init__(self, title, createClickedCB, autopartTypeChangedCB, defaultAutopartType, partitionsToReuse=True):
         # pylint: disable=super-init-not-called,non-parent-init-called
         Gtk.Box.__init__(self, orientation=Gtk.Orientation.VERTICAL, spacing=6)
         self.members = []
@@ -329,7 +328,7 @@ class CreateNewPage(Page):
 
         for item in (AUTOPART_CHOICES):
             itr = store.append([_(item[0]), item[1]])
-            if item[1] == DEFAULT_AUTOPART_TYPE:
+            if item[1] == defaultAutopartType:
                 default = itr
 
         combo.set_margin_left(18)

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -50,7 +50,7 @@ from collections import OrderedDict
 import logging
 log = logging.getLogger("anaconda")
 
-__all__ = ["StorageSpoke", "AutoPartSpoke"]
+__all__ = ["StorageSpoke"]
 
 CLEARALL = N_("Use All Space")
 CLEARLINUX = N_("Replace Existing Linux system(s)")

--- a/tests/pyanaconda_tests/iutil_test.py
+++ b/tests/pyanaconda_tests/iutil_test.py
@@ -752,6 +752,18 @@ class MiscTests(unittest.TestCase):
         for d, r in dirs:
             self.assertEquals(iutil.parent_dir(d), r)
 
+    def first_not_none_test(self):
+        self.assertEquals(iutil.firstNotNone([]), None)
+        self.assertEquals(iutil.firstNotNone([None, None, None]), None)
+
+        self.assertEquals(iutil.firstNotNone([1, None, None]), 1)
+        self.assertEquals(iutil.firstNotNone([None, 2, None]), 2)
+        self.assertEquals(iutil.firstNotNone([None, None, 3]), 3)
+
+        self.assertEquals(iutil.firstNotNone([0, None, None]), 0)
+        self.assertEquals(iutil.firstNotNone([1, 2, 3]), 1)
+        self.assertEquals(iutil.firstNotNone([None, 2, 3]), 2)
+
 class EncryptPasswordTests(unittest.TestCase):
     def encrypt_password_test(self):
         """ Test the encrypt_password function"""


### PR DESCRIPTION
Always set the default partitioning
* The default partitioning of the install class should be always set.

Enable to define the autopart type in an install class
* The default partitioning scheme can be defined in an install class.
  If the kickstart file defines the scheme, it will be used instead.
    
Resolves: rhbz#1380767