### PR TITLE
network: index team slave connection names starting with 1 (#1401403)

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -513,7 +513,7 @@ def ksnet_to_ifcfg(net, filename=None):
         ifcfg['NAME'] = "Team connection %s" % dev
         ifcfg['TEAM_CONFIG'] = net.teamconfig
 
-        for i, (slave, cfg) in enumerate(net.teamslaves):
+        for i, (slave, cfg) in enumerate(net.teamslaves, 1):
             slave_ifcfg = {
                             'DEVICE': slave,
                             'DEVICETYPE' : "TeamPort",


### PR DESCRIPTION
Resolves: rhbz#1401403

Same as with bond slaves and as NetworkManager naming in general.