### PR TITLE
Fix Anaconda forces payload restart when network (not)change

### DIFF
--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -119,10 +119,9 @@ class PayloadInstallError(PayloadError):
     pass
 
 class Payload(object):
-    """ Payload is an abstract class for OS install delivery methods. """
+    """Payload is an abstract class for OS install delivery methods."""
     def __init__(self, data):
-        """ data is a kickstart.AnacondaKSHandler class
-        """
+        """Data is a kickstart.AnacondaKSHandler class."""
         if self.__class__ is Payload:
             raise TypeError("Payload is an abstract class")
 
@@ -135,35 +134,35 @@ class Payload(object):
         self.txID = None
 
     def setup(self, storage, instClass):
-        """ Do any payload-specific setup. """
+        """Do any payload-specific setup."""
         self.storage = storage
         self.instclass = instClass
 
     def unsetup(self):
-        """ Invalidate a previously setup paylaod. """
+        """Invalidate a previously setup payload."""
         self.storage = None
         self.instclass = None
 
     def preStorage(self):
-        """ Do any payload-specific work necessary before writing the storage
-            configuration.  This method need not be provided by all payloads.
+        """Do any payload-specific work necessary before writing the storage
+        configuration.  This method need not be provided by all payloads.
         """
         pass
 
     def release(self):
-        """ Release any resources in use by this object, but do not do final
-            cleanup.  This is useful for dealing with payload backends that do
-            not get along well with multithreaded programs.
+        """Release any resources in use by this object, but do not do final
+        cleanup.  This is useful for dealing with payload backends that do
+        not get along well with multithreaded programs.
         """
         pass
 
     def reset(self, root=None, releasever=None):
-        """ Reset the instance, not including ksdata. """
+        """Reset the instance, not including ksdata."""
         pass
 
     def prepareMountTargets(self, storage):
         """Run when physical storage is mounted, but other mount points may
-        not exist.  Used by the RPMOSTreePayload subclass. 
+        not exist.  Used by the RPMOSTreePayload subclass.
         """
         pass
 
@@ -178,25 +177,23 @@ class Payload(object):
     ###
     @property
     def addOns(self):
-        """ A list of addon repo identifiers. """
+        """A list of addon repo identifiers."""
         return [r.name for r in self.data.repo.dataList()]
 
     @property
     def baseRepo(self):
-        """
-        Get the identifier of the current base repo. or None
-        """
+        """Get the identifier of the current base repo or None."""
         return None
 
     @property
     def mirrorEnabled(self):
         """Is the closest/fastest mirror option enabled?  This does not make
-           sense for those payloads that do not support this concept.
+        sense for those payloads that do not support this concept.
         """
         return True
 
     def isRepoEnabled(self, repo_id):
-        """ Return True if repo is enabled. """
+        """Return True if repo is enabled."""
         repo = self.getAddOnRepo(repo_id)
         if repo:
             return repo.enabled
@@ -204,7 +201,7 @@ class Payload(object):
             return False
 
     def getAddOnRepo(self, repo_id):
-        """ Return a ksdata Repo instance matching the specified repo id. """
+        """Return a ksdata Repo instance matching the specified repo id."""
         repo = None
         for r in self.data.repo.dataList():
             if r.name == repo_id:
@@ -214,18 +211,18 @@ class Payload(object):
         return repo
 
     def _repoNeedsNetwork(self, repo):
-        """ Returns True if the ksdata repo requires networking. """
+        """Returns True if the ksdata repo requires networking."""
         urls = [repo.baseurl]
         if repo.mirrorlist:
             urls.extend(repo.mirrorlist)
         return self._sourceNeedsNetwork(urls)
 
     def _sourceNeedsNetwork(self, sources):
-        """ Return True if the source requires network.
+        """Return True if the source requires network.
 
-            :param sources: Source paths for testing
-            :type sources: list
-            :returns: True if any source requires network
+        :param sources: Source paths for testing
+        :type sources: list
+        :returns: True if any source requires network
         """
         network_protocols = ["http:", "ftp:", "nfs:", "nfsiso:"]
         for s in sources:
@@ -238,7 +235,7 @@ class Payload(object):
 
     @property
     def needsNetwork(self):
-        """ Test base and additional repositories if they require network. """
+        """Test base and additional repositories if they require network."""
         url = ""
         if self.data.method.method == "nfs":
             # NFS is always on network
@@ -270,7 +267,7 @@ class Payload(object):
         self.data.method.opts = None
 
     def updateBaseRepo(self, fallback=True, root=None, checkmount=True):
-        """ Update the base repository from ksdata.method. """
+        """Update the base repository from ksdata.method."""
         pass
 
     def gatherRepoMetadata(self):
@@ -278,11 +275,11 @@ class Payload(object):
 
     def addRepo(self, newrepo):
         """Add the repo given by the pykickstart Repo object newrepo to the
-           system.  The repo will be automatically enabled and its metadata
-           fetched.
+        system.  The repo will be automatically enabled and its metadata
+        fetched.
 
-           Duplicate repos will not raise an error.  They should just silently
-           take the place of the previous value.
+        Duplicate repos will not raise an error.  They should just silently
+        take the place of the previous value.
         """
         # Add the repo to the ksdata so it'll appear in the output ks file.
         self.data.repo.dataList().append(newrepo)
@@ -371,8 +368,8 @@ class Payload(object):
     def selectPackage(self, pkgid):
         """Mark a package for installation.
 
-           pkgid - The name of a package to be installed.  This could include
-                   a version or architecture component.
+        pkgid - The name of a package to be installed.  This could include
+                a version or architecture component.
         """
         if pkgid in self.data.packages.packageList:
             return
@@ -385,8 +382,8 @@ class Payload(object):
     def deselectPackage(self, pkgid):
         """Mark a package to be excluded from installation.
 
-           pkgid - The name of a package to be excluded.  This could include
-                   a version or architecture component.
+        pkgid - The name of a package to be excluded.  This could include
+                a version or architecture component.
         """
         if pkgid in self.data.packages.excludedList:
             return
@@ -421,7 +418,7 @@ class Payload(object):
     ###
     @property
     def spaceRequired(self):
-        """ The total disk space (Size) required for the current selection. """
+        """The total disk space (Size) required for the current selection."""
         raise NotImplementedError()
 
     @property
@@ -441,16 +438,16 @@ class Payload(object):
     ## METHODS FOR TREE VERIFICATION
     ##
     def _getTreeInfo(self, url, proxy_url, sslverify):
-        """ Retrieve treeinfo and return the path to the local file.
+        """Retrieve treeinfo and return the path to the local file.
 
-            :param baseurl: url of the repo
-            :type baseurl: string
-            :param proxy_url: Optional full proxy URL of or ""
-            :type proxy_url: string
-            :param sslverify: True if SSL certificate should be varified
-            :type sslverify: bool
-            :returns: Path to retrieved .treeinfo file or None
-            :rtype: string or None
+        :param baseurl: url of the repo
+        :type baseurl: string
+        :param proxy_url: Optional full proxy URL of or ""
+        :type proxy_url: string
+        :param sslverify: True if SSL certificate should be varified
+        :type sslverify: bool
+        :returns: Path to retrieved .treeinfo file or None
+        :rtype: string or None
         """
         if not url:
             return None
@@ -532,7 +529,7 @@ class Payload(object):
         return treeinfo
 
     def _getReleaseVersion(self, url):
-        """ Return the release version of the tree at the specified URL. """
+        """Return the release version of the tree at the specified URL."""
         try:
             version = re.match(VERSION_DIGITS, productVersion).group(1)
         except AttributeError:
@@ -564,7 +561,7 @@ class Payload(object):
     ##
     @staticmethod
     def _setupDevice(device, mountpoint):
-        """ Prepare an install CD/DVD for use as a package source. """
+        """Prepare an install CD/DVD for use as a package source."""
         log.info("setting up device %s and mounting on %s", device.name, mountpoint)
         # Is there a symlink involved?  If so, let's get the actual path.
         # This is to catch /run/install/isodir vs. /mnt/install/isodir, for
@@ -595,7 +592,7 @@ class Payload(object):
 
     @staticmethod
     def _setupNFS(mountpoint, server, path, options):
-        """ Prepare an NFS directory for use as a package source. """
+        """Prepare an NFS directory for use as a package source."""
         log.info("mounting %s:%s:%s on %s", server, path, options, mountpoint)
         if os.path.ismount(mountpoint):
             dev = blivet.util.get_mount_device(mountpoint)
@@ -628,19 +625,19 @@ class Payload(object):
     ### METHODS FOR INSTALLING THE PAYLOAD
     ###
     def preInstall(self, packages=None, groups=None):
-        """ Perform pre-installation tasks. """
+        """Perform pre-installation tasks."""
         iutil.mkdirChain(iutil.getSysroot() + "/root")
 
         self._writeModuleBlacklist()
 
     def install(self):
-        """ Install the payload. """
+        """Install the payload."""
         raise NotImplementedError()
 
     def _writeModuleBlacklist(self):
-        """ Copy modules from modprobe.blacklist=<module> on cmdline to
-            /etc/modprobe.d/anaconda-blacklist.conf so that modules will
-            continue to be blacklisted when the system boots.
+        """Copy modules from modprobe.blacklist=<module> on cmdline to
+        /etc/modprobe.d/anaconda-blacklist.conf so that modules will
+        continue to be blacklisted when the system boots.
         """
         if "modprobe.blacklist" not in flags.cmdline:
             return
@@ -674,14 +671,14 @@ class Payload(object):
                 #           prevent boot on some systems
 
     def recreateInitrds(self, force=False):
-        """ Recreate the initrds by calling new-kernel-pkg
+        """Recreate the initrds by calling new-kernel-pkg.
 
-            This needs to be done after all configuration files have been
-            written, since dracut depends on some of them.
+        This needs to be done after all configuration files have been
+        written, since dracut depends on some of them.
 
-            :param force: Always recreate, default is to only do it on first call
-            :type force: bool
-            :returns: None
+        :param force: Always recreate, default is to only do it on first call
+        :type force: bool
+        :returns: None
         """
         if not force and self._createdInitrds:
             return
@@ -703,9 +700,8 @@ class Payload(object):
 
         self._createdInitrds = True
 
-
     def _setDefaultBootTarget(self):
-        """ Set the default systemd target for the system. """
+        """Set the default systemd target for the system."""
         if not os.path.exists(iutil.getSysroot() + "/etc/systemd/system"):
             log.error("systemd is not installed -- can't set default target")
             return
@@ -748,7 +744,7 @@ class Payload(object):
         return args
 
     def postInstall(self):
-        """ Perform post-installation tasks. """
+        """Perform post-installation tasks."""
 
         # set default systemd target
         self._setDefaultBootTarget()
@@ -761,7 +757,7 @@ class Payload(object):
 # Inherit abstract methods from Payload
 # pylint: disable=abstract-method
 class ImagePayload(Payload):
-    """ An ImagePayload installs an OS image to the target system. """
+    """An ImagePayload installs an OS image to the target system."""
 
     def __init__(self, data):
         if self.__class__ is ImagePayload:
@@ -772,7 +768,7 @@ class ImagePayload(Payload):
 # Inherit abstract methods from ImagePayload
 # pylint: disable=abstract-method
 class ArchivePayload(ImagePayload):
-    """ An ArchivePayload unpacks source archives onto the target system. """
+    """An ArchivePayload unpacks source archives onto the target system."""
 
     def __init__(self, data):
         if self.__class__ is ArchivePayload:
@@ -781,7 +777,7 @@ class ArchivePayload(ImagePayload):
         ImagePayload.__init__(self, data)
 
 class PackagePayload(Payload):
-    """ A PackagePayload installs a set of packages onto the target system. """
+    """A PackagePayload installs a set of packages onto the target system."""
 
     DEFAULT_REPOS = [productName.split('-')[0].lower(), "rawhide"]
 
@@ -1110,8 +1106,7 @@ class PackagePayload(Payload):
         raise NotImplementedError()
 
     def addDriverRepos(self):
-        """ Add driver repositories and packages
-        """
+        """Add driver repositories and packages."""
         # Drivers are loaded by anaconda-dracut, their repos are copied
         # into /run/install/DD-X where X is a number starting at 1. The list of
         # packages that were selected is in /run/install/dd_packages
@@ -1212,23 +1207,23 @@ class PackagePayload(Payload):
 class PayloadManager(object):
     """Framework for starting and watching the payload thread.
 
-       This class defines several states, and events can be triggered upon
-       reaching a state. Depending on whether a state has already been reached
-       when a listener is added, the event code may be run in either the
-       calling thread or the payload thread. The event code will block the
-       payload thread regardless, so try not to run anything that takes a long
-       time.
+    This class defines several states, and events can be triggered upon
+    reaching a state. Depending on whether a state has already been reached
+    when a listener is added, the event code may be run in either the
+    calling thread or the payload thread. The event code will block the
+    payload thread regardless, so try not to run anything that takes a long
+    time.
 
-       All states except STATE_ERROR are expected to happen linearly, and adding
-       a listener for a state that has already been reached or passed will
-       immediately trigger that listener. For example, if the payload thread is
-       currently in STATE_GROUP_MD, adding a listener for STATE_NETWORK will
-       immediately run the code being added for STATE_NETWORK.
+    All states except STATE_ERROR are expected to happen linearly, and adding
+    a listener for a state that has already been reached or passed will
+    immediately trigger that listener. For example, if the payload thread is
+    currently in STATE_GROUP_MD, adding a listener for STATE_NETWORK will
+    immediately run the code being added for STATE_NETWORK.
 
-       The payload thread data should be accessed using the payloadMgr object,
-       and the running thread can be accessed using threadMgr with the
-       THREAD_PAYLOAD constant, if you need to wait for it or something. The
-       thread should be started using payloadMgr.restartThread.
+    The payload thread data should be accessed using the payloadMgr object,
+    and the running thread can be accessed using threadMgr with the
+    THREAD_PAYLOAD constant, if you need to wait for it or something. The
+    thread should be started using payloadMgr.restartThread.
     """
 
     STATE_START = 0
@@ -1268,8 +1263,8 @@ class PayloadManager(object):
     def addListener(self, event_id, func):
         """Add a listener for an event.
 
-           :param int event_id: The event to listen for, one of the EVENT_* constants
-           :param function func: An object to call when the event is reached
+        :param int event_id: The event to listen for, one of the EVENT_* constants
+        :param function func: An object to call when the event is reached
         """
 
         # Check that the event_id is valid
@@ -1293,17 +1288,17 @@ class PayloadManager(object):
     def restartThread(self, storage, ksdata, payload, instClass, fallback=False, checkmount=True):
         """Start or restart the payload thread.
 
-           This method starts a new thread to restart the payload thread, so
-           this method's return is not blocked by waiting on the previous payload
-           thread. If there is already a payload thread restart pending, this method
-           has no effect.
+        This method starts a new thread to restart the payload thread, so
+        this method's return is not blocked by waiting on the previous payload
+        thread. If there is already a payload thread restart pending, this method
+        has no effect.
 
-           :param blivet.Blivet storage: The blivet storage instance
-           :param kickstart.AnacondaKSHandler ksdata: The kickstart data instance
-           :param packaging.Payload payload: The payload instance
-           :param installclass.BaseInstallClass instClass: The install class instance
-           :param bool fallback: Whether to fall back to the default repo in case of error
-           :param bool checkmount: Whether to check for valid mounted media
+        :param blivet.Blivet storage: The blivet storage instance
+        :param kickstart.AnacondaKSHandler ksdata: The kickstart data instance
+        :param packaging.Payload payload: The payload instance
+        :param installclass.BaseInstallClass instClass: The install class instance
+        :param bool fallback: Whether to fall back to the default repo in case of error
+        :param bool checkmount: Whether to check for valid mounted media
         """
 
         log.debug("Restarting payload thread")

--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -29,8 +29,7 @@
 """
 from __future__ import print_function
 import os, sys
-from urlgrabber.grabber import URLGrabber
-from urlgrabber.grabber import URLGrabError
+from urlgrabber.grabber import URLGrabber, URLGrabError
 import ConfigParser
 import shutil
 from glob import glob
@@ -306,6 +305,19 @@ class Payload(object):
         repo = self.getAddOnRepo(repo_id)
         if repo:
             repo.enabled = False
+
+    def verifyAvailableRepositories(self):
+        """Verify availability of existing repositories.
+
+        This method will test if repositories can be reached by URL from
+        actual repositories. It is useful when network settings is changed
+        so that we can verify if repositories are still reachable.
+
+        This method should be overriden.
+        """
+        log.debug("Install method %s is not able to verify availability",
+                  self.__class__.__name__)
+        return False
 
     ###
     ### METHODS FOR WORKING WITH GROUPS
@@ -829,6 +841,14 @@ class PackagePayload(Payload):
                 log.warning("Could not add %s to groups, not a list.", groupid)
         elif groupid:
             log.warning("Platform group %s not available.", groupid)
+
+    def postSetup(self):
+        """Run specific payload post-configuration tasks on the end of
+        the restartThread call.
+
+        This method could be overriden.
+        """
+        pass
 
     @property
     def kernelPackages(self):
@@ -1381,6 +1401,9 @@ class PayloadManager(object):
             self._setState(self.STATE_ERROR)
             payload.unsetup()
             return
+
+        # run payload specific post configuration tasks
+        payload.postSetup()
 
         self._setState(self.STATE_FINISHED)
 

--- a/pyanaconda/packaging/yumpayload.py
+++ b/pyanaconda/packaging/yumpayload.py
@@ -32,7 +32,6 @@
                   --proxyPassword
                     - drop the use of a file for proxy and ftp auth info
                 - specified via KS as a URL
-
 """
 
 import ConfigParser
@@ -120,8 +119,7 @@ class YumLock(object):
             log.log(LOGLVL_LOCK, "gave up _yum_lock for %s", threading.currentThread().name)
 
 def refresh_base_repo(cond_fn=None):
-    """
-    Function returning decorator for methods that invalidate base repo.
+    """Function returning decorator for methods that invalidate base repo.
     After the method has been run the base repo will be refreshed
 
     :param cond_fn: condition function telling if base repo should be
@@ -131,11 +129,9 @@ def refresh_base_repo(cond_fn=None):
     While the method runs the base_repo is set to None.
     """
     def decorator(method):
-        """
-        Decorator for methods that invalidate base repo cache.
+        """Decorator for methods that invalidate base repo cache.
 
         :param method: decorated method of the YumPayload class
-
         """
         @wraps(method)
         def inner_method(yum_payload, *args, **kwargs):
@@ -159,15 +155,13 @@ _yum_installer_langpack_conf = "/tmp/yum.pluginconf.d/langpacks.conf"
 _yum_target_langpack_conf = "/etc/yum/pluginconf.d/langpacks.conf"
 
 class YumPayload(PackagePayload):
-    """ A YumPayload installs packages onto the target system using yum.
+    """A YumPayload installs packages onto the target system using yum.
 
-        User-defined (aka: addon) repos exist both in ksdata and in yum. They
-        are the only repos in ksdata.repo. The repos we find in the yum config
-        only exist in yum. Lastly, the base repo exists in yum and in
-        ksdata.method.
+    User-defined (aka: addon) repos exist both in ksdata and in yum. They
+    are the only repos in ksdata.repo. The repos we find in the yum config
+    only exist in yum. Lastly, the base repo exists in yum and in
+    ksdata.method.
     """
-
-
     def __init__(self, data):
         if rpm is None or yum is None:
             raise PayloadError("unsupported payload type")
@@ -189,7 +183,7 @@ class YumPayload(PackagePayload):
         self.reset()
 
     def reset(self, root=None, releasever=None):
-        """ Reset this instance to its initial (unconfigured) state. """
+        """Reset this instance to its initial (unconfigured) state."""
 
         super(YumPayload, self).reset()
         # This value comes from a default install of the x86_64 Fedora 18.  It
@@ -224,11 +218,11 @@ class YumPayload(PackagePayload):
         self._repoMD_list = []
 
     def _resetYum(self, root=None, keep_cache=False, releasever=None, cache_dir=_yum_cache_dir):
-        """ Delete and recreate the payload's YumBase instance.
+        """Delete and recreate the payload's YumBase instance.
 
-            Setup _yum.preconf -- DO NOT TOUCH IT OUTSIDE THIS METHOD
-            NOTE:  This is enforced by tests/pylint/preconf.py.  If the name
-            of this method changes, change it there too.
+        Setup _yum.preconf -- DO NOT TOUCH IT OUTSIDE THIS METHOD
+        NOTE:  This is enforced by tests/pylint/preconf.py.  If the name
+        of this method changes, change it there too.
         """
         if root is None:
             root = self._root_dir
@@ -286,7 +280,7 @@ class YumPayload(PackagePayload):
                      iutil.getSysroot()+_yum_target_langpack_conf)
 
     def _writeYumConfig(self, cache_dir=_yum_cache_dir):
-        """ Write out anaconda's main yum configuration file. """
+        """Write out anaconda's main yum configuration file."""
         buf = """
 [main]
 cachedir=%s
@@ -336,11 +330,11 @@ reposdir=%s
             self._yum.conf.cachedir = self._yum.conf.cachedir[len(root):]
 
     def _writeYumRepo(self, repo, repo_path):
-        """ Write a repo object to a yum repo.conf file
+        """Write a repo object to a yum repo.conf file
 
-            :param repo: Yum repository object
-            :param string repo_path: Path to write the repo to
-            :raises: PayloadSetupError if the repo doesn't have a url
+        :param repo: Yum repository object
+        :param string repo_path: Path to write the repo to
+        :raises: PayloadSetupError if the repo doesn't have a url
         """
         with open(repo_path, "w") as f:
             f.write("[%s]\n" % repo.id)
@@ -398,13 +392,13 @@ reposdir=%s
                 f.write("enablegroups=0\n")
 
     def _writeInstallConfig(self):
-        """ Write out the yum config that will be used to install packages.
+        """Write out the yum config that will be used to install packages.
 
-            Write out repo config files for all enabled repos, then
-            create a new YumBase instance with the new filesystem tree as its
-            install root.
+        Write out repo config files for all enabled repos, then
+        create a new YumBase instance with the new filesystem tree as its
+        install root.
 
-            This needs to be called from inside a yum_lock
+        This needs to be called from inside a yum_lock.
         """
         self._repos_dir = "/tmp/yum.repos.d"
         if not os.path.isdir(self._repos_dir):
@@ -483,17 +477,17 @@ reposdir=%s
 
     @property
     def baseRepo(self):
-        """ Return the current base repo id
-            :returns: repo id or None
+        """Return the current base repo id.
 
-            Methods that change (or could change) the base_repo
-            need to be decorated with @refresh_base_repo
+        :returns: repo id or None
+
+        NOTE: Methods that change (or could change) the base_repo
+              need to be decorated with @refresh_base_repo.
         """
         return self._base_repo
 
     def _refreshBaseRepo(self):
-        """ Examine the enabled repos and update _base_repo
-        """
+        """Examine the enabled repos and update _base_repo."""
         with _yum_lock:
             for repo_name in BASE_REPO_NAMES:
                 if repo_name in self.repos and \
@@ -518,14 +512,14 @@ reposdir=%s
                 return False
 
     def getRepo(self, repo_id):
-        """ Return the yum repo object. """
+        """Return the yum repo object."""
         with _yum_lock:
             repo = self._yum.repos.getRepo(repo_id)
 
         return repo
 
     def isRepoEnabled(self, repo_id):
-        """ Return True if repo is enabled. """
+        """Return True if repo is enabled."""
         try:
             return self.getRepo(repo_id).enabled
         except RepoError:
@@ -541,16 +535,16 @@ reposdir=%s
 
     @refresh_base_repo()
     def updateBaseRepo(self, fallback=True, root=None, checkmount=True):
-        """ Update the base repo based on self.data.method.
+        """Update the base repo based on self.data.method.
 
-            - Tear down any previous base repo devices, symlinks, &c.
-            - Reset the YumBase instance.
-            - Try to convert the new method to a base repo.
-            - If that fails, we'll use whatever repos yum finds in the config.
-            - Set up addon repos.
-            - Filter out repos that don't make sense to have around.
-            - Get metadata for all enabled repos, disabling those for which the
-              retrieval fails.
+        - Tear down any previous base repo devices, symlinks, &c.
+        - Reset the YumBase instance.
+        - Try to convert the new method to a base repo.
+        - If that fails, we'll use whatever repos yum finds in the config.
+        - Set up addon repos.
+        - Filter out repos that don't make sense to have around.
+        - Get metadata for all enabled repos, disabling those for which the
+          retrieval fails.
         """
         log.info("configuring base repo")
 
@@ -728,7 +722,7 @@ reposdir=%s
 
     @refresh_base_repo()
     def _configureAddOnRepo(self, repo):
-        """ Configure a single ksdata repo. """
+        """Configure a single ksdata repo."""
         url = repo.baseurl
         if url and url.startswith("nfs://"):
             # Let the assignment throw ValueError for bad NFS urls from kickstart
@@ -777,17 +771,17 @@ reposdir=%s
             self.data.repo.dataList().append(ks_repo)
 
     def _getAddons(self, baseurl, proxy_url, sslverify):
-        """ Check the baseurl or mirrorlist for a repository, see if it has any
-            valid addon repos and if so, return a list of (repo name, repo URL).
+        """Check the baseurl or mirrorlist for a repository, see if it has any
+        valid addon repos and if so, return a list of (repo name, repo URL).
 
-            :param baseurl: url of the repo
-            :type baseurl: string
-            :param proxy_url: Full URL of optional proxy or ""
-            :type proxy_url: string
-            :param sslverify: True if SSL certificate should be varified
-            :type sslverify: bool
-            :returns: list of tuples of addons (id, name, url)
-            :rtype: list of tuples
+        :param baseurl: url of the repo
+        :type baseurl: string
+        :param proxy_url: Full URL of optional proxy or ""
+        :type proxy_url: string
+        :param sslverify: True if SSL certificate should be varified
+        :type sslverify: bool
+        :returns: list of tuples of addons (id, name, url)
+        :rtype: list of tuples
         """
         retval = []
 
@@ -823,7 +817,7 @@ reposdir=%s
         return retval
 
     def _getRepoMetadata(self, yumrepo):
-        """ Retrieve repo metadata if we don't already have it. """
+        """Retrieve repo metadata if we don't already have it."""
         # And try to grab its metadata.  We do this here so it can be done
         # on a per-repo basis, so we can then get some finer grained error
         # handling and recovery.
@@ -845,14 +839,14 @@ reposdir=%s
                 log.error("failed to get groups for repo %s", yumrepo.id)
 
     def _replaceVars(self, url):
-        """ Replace url variables with their values
+        """Replace url variables with their values.
 
-            :param url: url string to do replacement on
-            :type url:  string
-            :returns:   string with variables substituted
-            :rtype:     string or None
+        :param url: url string to do replacement on
+        :type url:  string
+        :returns:   string with variables substituted
+        :rtype:     string or None
 
-            Currently supports $releasever and $basearch
+        Currently supports $releasever and $basearch.
         """
         if not url:
             return url
@@ -864,7 +858,7 @@ reposdir=%s
         return url
 
     def _addYumRepo(self, name, baseurl, mirrorlist=None, proxyurl=None, **kwargs):
-        """ Add a yum repo to the YumBase instance. """
+        """Add a yum repo to the YumBase instance."""
         needsAdding = True
 
         # First, delete any pre-existing repo with the same name.
@@ -924,7 +918,7 @@ reposdir=%s
 
     @refresh_base_repo(lambda s, r_id: r_id.name in BASE_REPO_NAMES)
     def addRepo(self, newrepo):
-        """ Add a ksdata repo. """
+        """Add a ksdata repo."""
         log.debug("adding new repo %s", newrepo.name)
         self._addYumRepo(newrepo.name, newrepo.baseurl, newrepo.mirrorlist, newrepo.proxy)   # FIXME: handle MetadataError
         super(YumPayload, self).addRepo(newrepo)
@@ -938,7 +932,7 @@ reposdir=%s
 
     @refresh_base_repo(lambda s, r_id: r_id in BASE_REPO_NAMES)
     def removeRepo(self, repo_id):
-        """ Remove a repo as specified by id. """
+        """Remove a repo as specified by id."""
         log.debug("removing repo %s", repo_id)
 
         # if this is an NFS repo, we'll want to unmount the NFS mount after
@@ -961,7 +955,7 @@ reposdir=%s
 
     @refresh_base_repo(lambda s, r_id: r_id in BASE_REPO_NAMES)
     def enableRepo(self, repo_id):
-        """ Enable a repo as specified by id. """
+        """Enable a repo as specified by id."""
         log.debug("enabling repo %s", repo_id)
         if repo_id in self.repos:
             with _yum_lock:
@@ -970,7 +964,7 @@ reposdir=%s
 
     @refresh_base_repo(lambda s, r_id: r_id in BASE_REPO_NAMES)
     def disableRepo(self, repo_id):
-        """ Disable a repo as specified by id. """
+        """Disable a repo as specified by id."""
         log.debug("disabling repo %s", repo_id)
         if repo_id in self.repos:
             with _yum_lock:
@@ -985,7 +979,7 @@ reposdir=%s
     ###
     @property
     def environments(self):
-        """ List of environment ids. """
+        """List of environment ids."""
         environments = []
         yum_groups = self._yumGroups
         if yum_groups:
@@ -1038,7 +1032,7 @@ reposdir=%s
         return False
 
     def environmentDescription(self, environmentid):
-        """ Return name/description tuple for the environment specified by id. """
+        """Return name/description tuple for the environment specified by id."""
         groups = self._yumGroups
         if not groups:
             return (environmentid, environmentid)
@@ -1052,7 +1046,7 @@ reposdir=%s
             return (environment.ui_name, environment.ui_description)
 
     def environmentId(self, environment):
-        """ Return environment id for the environment specified by id or name."""
+        """Return environment id for the environment specified by id or name."""
         groups = self._yumGroups
         if not groups:
             return environment
@@ -1110,7 +1104,7 @@ reposdir=%s
     ###
     @property
     def _yumGroups(self):
-        """ yum.comps.Comps instance. """
+        """yum.comps.Comps instance."""
         if not self._setup:
             return []
 
@@ -1126,7 +1120,7 @@ reposdir=%s
 
     @property
     def groups(self):
-        """ List of group ids. """
+        """List of group ids."""
         groups = []
         yum_groups = self._yumGroups
         if yum_groups:
@@ -1153,7 +1147,7 @@ reposdir=%s
         return list(lang_groups)
 
     def groupDescription(self, groupid):
-        """ Return name/description tuple for the group specified by id. """
+        """Return name/description tuple for the group specified by id."""
         groups = self._yumGroups
         if not groups:
             return (groupid, groupid)
@@ -1238,8 +1232,8 @@ reposdir=%s
     def _selectYumPackage(self, pkgid, required=False):
         """Mark a package for installation.
 
-           pkgid - The name of a package to be installed.  This could include
-                   a version or architecture component.
+        pkgid - The name of a package to be installed.  This could include
+                a version or architecture component.
         """
         log.debug("select package %s", pkgid)
         with _yum_lock:
@@ -1251,8 +1245,8 @@ reposdir=%s
     def _deselectYumPackage(self, pkgid):
         """Mark a package to be excluded from installation.
 
-           pkgid - The name of a package to be excluded.  This could include
-                   a version or architecture component.
+        pkgid - The name of a package to be excluded.  This could include
+                a version or architecture component.
         """
         log.debug("deselect package %s", pkgid)
         with _yum_lock:
@@ -1263,7 +1257,7 @@ reposdir=%s
     ###
     @property
     def spaceRequired(self):
-        """ The total disk space (Size) required for the current selection. """
+        """The total disk space (Size) required for the current selection."""
         return self._space_required
 
     def calculateSpaceNeeds(self):
@@ -1313,9 +1307,9 @@ reposdir=%s
                 time.sleep(100000)
 
     def _applyYumSelections(self):
-        """ Apply the selections in ksdata to yum.
+        """Apply the selections in ksdata to yum.
 
-            This follows the same ordering/pattern as kickstart.py.
+        This follows the same ordering/pattern as kickstart.py.
         """
         if self.data.packages.nocore:
             log.info("skipping core group due to %%packages --nocore; system may not be complete")
@@ -1447,7 +1441,7 @@ reposdir=%s
             self._handleMissing(e)
 
     def preInstall(self, packages=None, groups=None):
-        """ Perform pre-installation tasks. """
+        """Perform pre-installation tasks."""
         super(YumPayload, self).preInstall(packages, groups)
         progressQ.send_message(_("Starting package installation process"))
 
@@ -1473,15 +1467,14 @@ reposdir=%s
                 while True:
                     time.sleep(100000)
 
-
     def install(self):
-        """ Install the payload.
+        """Install the payload.
 
-            This writes out the yum transaction and then uses a Process thread
-            to execute it in a totally separate process.
+        This writes out the yum transaction and then uses a Process thread
+        to execute it in a totally separate process.
 
-            It monitors the status of the install and logs debug info, updates
-            the progress meter and cleans up when it is done.
+        It monitors the status of the install and logs debug info, updates
+        the progress meter and cleans up when it is done.
         """
         progress_map = {
             "PROGRESS_PREP"    : _("Preparing transaction from installation source"),
@@ -1596,7 +1589,7 @@ reposdir=%s
             log.error("failed to write out yum.conf: %s", e)
 
     def postInstall(self):
-        """ Perform post-installation tasks. """
+        """Perform post-installation tasks."""
         with _yum_lock:
             # clean up repo tmpdirs
             self._yum.cleanPackages()
@@ -1640,7 +1633,7 @@ reposdir=%s
 
 class RepoMDMetaHash(object):
     """Class that holds hash of a repomd.xml file content from a repository.
-    This class can test availability of this repository by comparing hashes.
+    This class is used to test availability of this repository by comparing hashes.
     """
     def __init__(self, payload, repo):
         self._repoId = repo.id

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1506,8 +1506,11 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
             if ANACONDA_ENVIRON in anaconda_flags.environs and self.payload.needsNetwork:
                 log.debug("network spoke (apply) refresh payload")
                 from pyanaconda.packaging import payloadMgr
-                payloadMgr.restartThread(self.storage, self.data, self.payload, self.instclass,
-                                         fallback=not anaconda_flags.automatedInstall)
+                if not self.payload.verifyAvailableRepositories():
+                    payloadMgr.restartThread(self.storage, self.data, self.payload, self.instclass,
+                                             fallback=not anaconda_flags.automatedInstall)
+                else:
+                    log.debug("Payload isn't restarted, repositories are still available.")
             else:
                 log.debug("network spoke (apply), payload refresh skipped (running outside of installation environment)")
             self.networking_changed = False

--- a/tests/pyanaconda_tests/payload_test.py
+++ b/tests/pyanaconda_tests/payload_test.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+#
+
+import unittest
+import tempfile
+import os
+import hashlib
+import shutil
+
+from pyanaconda.packaging.yumpayload import RepoMDMetaHash
+
+class DummyRepo(object):
+
+    def __init__(self):
+        self.id = "anaconda"
+        self.urls = []
+
+class DummyPayload(object):
+    def __init__(self):
+        class DummyMethod(object):
+            def __init__(self):
+                self.method = None
+
+        class DummyData(object):
+            def __init__(self):
+                self.method = DummyMethod()
+
+        self.data = DummyData()
+
+class YumPayloadMDCheckTests(unittest.TestCase):
+
+    def setUp(self):
+        self._content_repomd = """
+Content of the repomd.xml file
+
+or it should be. Nah it's just a test!
+"""
+        self._temp_dir = tempfile.mkdtemp(suffix="pyanaconda_tests")
+        os.makedirs(os.path.join(self._temp_dir, "repodata"))
+        self._md_file = os.path.join(self._temp_dir, "repodata", "repomd.xml")
+        with open(self._md_file, 'w') as f:
+            f.write(self._content_repomd)
+        self._dummyRepo = DummyRepo()
+        self._dummyRepo.urls = ["file://" + self._temp_dir]
+
+    def tearDown(self):
+        # remove the testing directory
+        shutil.rmtree(self._temp_dir)
+
+    def download_file_repomd_test(self):
+        """Test if we can download repomd.xml with file:// successfully."""
+        m = hashlib.md5()
+        m.update(self._content_repomd)
+        reference_digest = m.digest()
+
+        r = RepoMDMetaHash(DummyPayload(), self._dummyRepo)
+        r.storeRepoMDHash()
+
+        self.assertEqual(r.repoMDHash, reference_digest)
+
+    def verify_repo_test(self):
+        """Test verification method."""
+        r = RepoMDMetaHash(DummyPayload(), self._dummyRepo)
+        r.storeRepoMDHash()
+
+        # test if repomd comparision works properly
+        self.assertTrue(r.verifyRepoMD())
+
+        # test if repomd change will be detected
+        with open(self._md_file, 'a') as f:
+            f.write("This should not be here!")
+        self.assertFalse(r.verifyRepoMD())
+
+        # test correct behavior when the repo file won't be available
+        os.remove(self._md_file)
+        self.assertFalse(r.verifyRepoMD())
+


### PR DESCRIPTION
This problem is solved by downloading content of `repomd.xml` file and comparing its MD5 hashes with downloaded `repomd.xml` file from the old repo url.
    
MD5 hash is used here because it takes less memory and we don't need `repomd.xml` content for anything else.
    
The `postSetup()` method was added to the payload. This method can be overridden by `Payload` child classes which needs to do additional tasks on the end of the `restartThread` call from the `PayloadManager` class.
    
*Resolves: rhbz#1373449*
*Resolves: rhbz#1358778*

Second commit is to make docstrings consistent in `Payload` and `YumPayload`.


I want to backport this to Rawhide later.