### PR TITLE
Make lvdump be more verbose in pre-gen-log script (#1255659)

### DIFF
--- a/scripts/anaconda-pre-log-gen
+++ b/scripts/anaconda-pre-log-gen
@@ -17,4 +17,4 @@ mkdir ${TARGET_DIRECTORY}
 lsblk -a > ${TARGET_DIRECTORY}/block_devices.log
 dmesg > ${TARGET_DIRECTORY}/kernel_ring_buffer.log
 
-lvmdump -d ${TARGET_DIRECTORY}/lvmdump
+lvmdump -u -l -s -d ${TARGET_DIRECTORY}/lvmdump


### PR DESCRIPTION
Add parameters '-l -u -s' to get more output from lvmdump.

This patch depends on this change in Lorax https://github.com/rhinstaller/lorax/pull/181 .

*Related: rhbz#1255659*