### PR TITLE
Make lvdump be more verbose in pre-gen-log script (#1255659)

### DIFF
--- a/scripts/anaconda-pre-log-gen
+++ b/scripts/anaconda-pre-log-gen
@@ -17,4 +17,4 @@ mkdir ${TARGET_DIRECTORY}
 lsblk -a > ${TARGET_DIRECTORY}/block_devices.log
 dmesg > ${TARGET_DIRECTORY}/kernel_ring_buffer.log
 
-lvmdump -d ${TARGET_DIRECTORY}/lvmdump
+lvmdump -u -l -s -d ${TARGET_DIRECTORY}/lvmdump


### PR DESCRIPTION
Add parameters '-l -u -s' to get more output from lvmdump. This script is called before start of Anaconda if inst.debug parameter is active.

-l - Include lvmetad(8) daemon dump if it is running.
-u - Gather  udev  info and context: /etc/udev/udev.conf file.
-s - Gather system info and context.

This PR has dependency on lorax PR: https://github.com/rhinstaller/lorax/pull/182 .