### PR TITLE
Correctly propagate --ipv6gateway to ifcfg files(#1170845)

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -453,13 +453,13 @@ def ksnet_to_ifcfg(net, filename=None):
         if net.ipv6 == 'dhcp':
             ifcfg['DHCPV6C'] = "yes"
             ifcfg['IPV6_AUTOCONF'] = "no"
-            if net.ipv6gateway:
-                ifcfg['IPV6_DEFAULTGW'] = net.ipv6gateway
         elif net.ipv6 == 'auto':
             ifcfg['IPV6_AUTOCONF'] = "yes" # NOTE: redundant (this is the default)
         elif ':' in net.ipv6:
             ifcfg['IPV6ADDR'] = net.ipv6
             ifcfg['IPV6_AUTOCONF'] = "no"
+            if net.ipv6gateway:
+                ifcfg['IPV6_DEFAULTGW'] = net.ipv6gateway
 
     # misc stuff
     if net.mtu:

--- a/tests/dracut_tests/parse-kickstart_test.py
+++ b/tests/dracut_tests/parse-kickstart_test.py
@@ -253,7 +253,7 @@ network --device br0 --activate --bootproto dhcp --bridgeslaves=eth0 --bridgeopt
 
     def network_ipv6_only_test(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
-            ks_file.write("""network --noipv4 --hostname=blah.test.com --ipv6=1:2:3:4:5:6:7:8 --device lo --nameserver=1:1:1:1::,2:2:2:2::""")
+            ks_file.write("""network --noipv4 --hostname=blah.test.com --ipv6=1:2:3:4:5:6:7:8 --ipv6gateway=2001:beaf:cafe::1 --device lo --nameserver=1:1:1:1::,2:2:2:2::""")
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
@@ -266,8 +266,9 @@ network --device br0 --activate --bootproto dhcp --bridgeslaves=eth0 --bridgeopt
             self.assertEqual(ifcfg_lines[4], 'IPV6ADDR="1:2:3:4:5:6:7:8"\n', ifcfg_lines)
             self.assertEqual(ifcfg_lines[5], 'IPV6INIT="yes"\n', ifcfg_lines)
             self.assertEqual(ifcfg_lines[6], 'IPV6_AUTOCONF="no"\n', ifcfg_lines)
-            self.assertEqual(ifcfg_lines[7], 'ONBOOT="yes"\n', ifcfg_lines)
-            self.assertTrue(ifcfg_lines[8].startswith("UUID="), ifcfg_lines)
+            self.assertEqual(ifcfg_lines[7], 'IPV6_DEFAULTGW="2001:beaf:cafe::1"\n', ifcfg_lines)
+            self.assertEqual(ifcfg_lines[8], 'ONBOOT="yes"\n', ifcfg_lines)
+            self.assertTrue(ifcfg_lines[9].startswith("UUID="), ifcfg_lines)
 
     def network_vlanid_test(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:


### PR DESCRIPTION
Original patch by Masahiro Matsuya.

Resolves: rhbz#1170845

Backport from rhel7-branch,
https://github.com/rhinstaller/anaconda/issues/948