### PR TITLE
Password checking fixes and improvements

### DIFF
--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -5,9 +5,9 @@ firstboot --enable
 
 %anaconda
 # Default password policies
-pwpolicy root --notstrict --minlen=6 --minquality=50 --nochanges --notempty
-pwpolicy user --notstrict --minlen=6 --minquality=50 --nochanges --notempty
-pwpolicy luks --notstrict --minlen=6 --minquality=50 --nochanges --notempty
+pwpolicy root --notstrict --minlen=6 --minquality=1 --nochanges --notempty
+pwpolicy user --notstrict --minlen=6 --minquality=1 --nochanges --emptyok
+pwpolicy luks --notstrict --minlen=6 --minquality=1 --nochanges --notempty
 # NOTE: This applies only to *fully* interactive installations, partial kickstart
 #       installations use defaults specified in pyanaconda/pwpolicy.py.
 #       Automated kickstart installs simply ignore the password policy as the policy

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -69,6 +69,7 @@ pyanaconda/ui/tui/__init__.py
 
 # Graphical interface
 pyanaconda/ui/gui/__init__.py
+pyanaconda/ui/gui/helpers.py
 pyanaconda/ui/gui/hubs/__init__.py
 pyanaconda/ui/gui/hubs/progress.py
 pyanaconda/ui/gui/spokes/custom.py

--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -136,22 +136,35 @@ UNSUPPORTED_HW = 1 << 28
 
 # Password validation
 PASSWORD_MIN_LEN = 6
-PASSWORD_EMPTY_ERROR = N_("The password is empty.")
-PASSWORD_CONFIRM_ERROR_GUI = N_("The passwords do not match.")
-PASSWORD_CONFIRM_ERROR_TUI = N_("The passwords you entered were different.  Please try again.")
-PASSWORD_WEAK = N_("The password you have provided is weak. %s")
-PASSWORD_WEAK_WITH_ERROR = N_("The password you have provided is weak: %s.")
-PASSWORD_WEAK_CONFIRM = N_("You have provided a weak password. Press Done again to use anyway.")
-PASSWORD_WEAK_CONFIRM_WITH_ERROR = N_("You have provided a weak password: %s. Press Done again to use anyway.")
-PASSWORD_ASCII = N_("The password you have provided contains non-ASCII characters. You may not be able to switch between keyboard layouts to login. Press Done to continue.")
+PASSWORD_EMPTY_ERROR = N_("The %(password)s is empty.")  # singular
+PASSWORD_CONFIRM_ERROR_GUI = N_("The %(passwords)s do not match.")  # plural
+PASSWORD_CONFIRM_ERROR_TUI = N_("The %(passwords)s you entered were different.  Please try again.")  # plural
+# The password-too-short constant is used to replace a libpwquality error message,
+# which is why it does not end with a ".", like all the other do.
+PASSWORD_TOO_SHORT = N_("The %(password)s is too short")  # singular
+PASSWORD_WEAK = N_("The %(password)s you have provided is weak.")  # singular
+PASSWORD_WEAK_WITH_ERROR = N_("The %(password)s you have provided is weak: %(error_message)s.")  # singular
+PASSWORD_FINAL_CONFIRM = N_("Press Done again to use anyway.")
+PASSWORD_ASCII = N_("The %(password)s you have provided contains non-ASCII characters. You may not be able to switch between keyboard layouts when typing it.")
+# ^ singular
 PASSWORD_DONE_TWICE = N_("You will have to press Done twice to confirm it.")
+PASSWORD_DONE_TO_CONTINUE = N_("Press Done to continue.")
 
+# password status
 PASSWORD_STATUS_EMPTY = N_("Empty")
 PASSWORD_STATUS_TOO_SHORT = N_("Too short")
 PASSWORD_STATUS_WEAK = N_("Weak")
 PASSWORD_STATUS_FAIR = N_("Fair")
 PASSWORD_STATUS_GOOD = N_("Good")
 PASSWORD_STATUS_STRONG = N_("Strong")
+
+# how should passwords be called in combined strings
+NAME_OF_PASSWORD = N_("password")
+NAME_OF_PASSWORD_PLURAL = N_("passwords")
+
+# how should passphrases be called in combined strings
+NAME_OF_PASSPHRASE = N_("passphrase")
+NAME_OF_PASSPHRASE_PLURAL = N_("passphrases")
 
 # the number of seconds we consider a noticeable freeze of the UI
 NOTICEABLE_FREEZE = 0.1

--- a/pyanaconda/pwpolicy.py
+++ b/pyanaconda/pwpolicy.py
@@ -35,10 +35,10 @@ class F22_PwPolicyData(BaseData):
         BaseData.__init__(self, *args, **kwargs)
         self.name = kwargs.get("name", "")
         self.minlen = kwargs.get("minlen", constants.PASSWORD_MIN_LEN)
-        self.minquality = kwargs.get("minquality", 50)
+        self.minquality = kwargs.get("minquality", 1)
         self.strict = kwargs.get("strict", False)
         self.changesok = kwargs.get("changesok", False)
-        self.emptyok = kwargs.get("emptyok", False)
+        self.emptyok = kwargs.get("emptyok", True)
 
         # The defaults specified above are used only for password input via the UI
         # during a partial kickstart installations.

--- a/pyanaconda/ui/gui/helpers.py
+++ b/pyanaconda/ui/gui/helpers.py
@@ -22,10 +22,16 @@
 # This file contains abstract base classes that are specific to GUI
 # functionality. See also pyanaconda.ui.helpers.
 
+import logging
+log = logging.getLogger("anaconda")
+
 from abc import ABCMeta, abstractproperty, abstractmethod
 from gi.repository import Gtk
 
 from pyanaconda.ui.helpers import InputCheck, InputCheckHandler
+from pyanaconda.i18n import _
+from pyanaconda.users import validatePassword, PasswordCheckRequest
+from pyanaconda import constants
 
 # Inherit abstract methods from InputCheckHandler
 # pylint: disable=abstract-method
@@ -38,6 +44,121 @@ class GUIInputCheckHandler(InputCheckHandler):
 
     __metaclass__ = ABCMeta
 
+    def __init__(self):
+        super(GUIInputCheckHandler, self).__init__()
+        self._policy = None
+        self._input_enabled = True
+
+    @property
+    def policy(self):
+        """Input checking policy.
+
+        :returns: the input checking policy
+        """
+        return self._policy
+
+    @policy.setter
+    def policy(self, input_policy):
+        """Set the input checking policy.
+
+        :param input_policy: the input checking policy
+        """
+        self._policy = input_policy
+
+    @property
+    def input_enabled(self):
+        """Is the input we are checking enabled ?
+
+        For example on the User spoke it is possible to disable the password input field.
+
+        :returns: is the input we are checking enabled
+        :rtype: bool
+        """
+        return self._input_enabled
+
+    @input_enabled.setter
+    def input_enabled(self, value):
+        self._input_enabled = value
+
+    @property
+    def input_kickstarted(self):
+        """Reports if the input was initialized from kickstart.
+
+        :returns: if the input was initialized from kickstart
+        :rtype: bool
+        """
+        return False
+
+    @property
+    def input_username(self):
+        """A username corresponding to the input (if any).
+
+        :returns: username corresponding to the input or None
+        :rtype: str on None
+        """
+        return None
+
+    @property
+    def input(self):
+        """Input to be checked.
+
+        Content of the input field, etc.
+
+        :returns: input to be checked
+        :rtype: str
+        """
+        return None
+
+    @property
+    def input_confirmation(self):
+        """Content of the input confirmation field.
+
+        Note that not all spokes might have a password confirmation field.
+
+        :returns: content of the password confirmation field
+        :rtype: str
+        """
+        pass
+
+    @property
+    def name_of_input(self):
+        """Name of the input to be used called in warnings and error messages.
+
+        For example:
+        "%s contains non-ASCII characters"
+        can be customized to:
+        "Password contains non-ASCII characters"
+        or
+        "Passphrase contains non-ASCII characters"
+
+        :returns: name of the input being checked
+        :rtype: str
+        """
+        return _(constants.NAME_OF_PASSWORD)
+
+    @property
+    def name_of_input_plural(self):
+        """Plural name of the input to be used called in warnings and error messages.
+
+        :returns: plural name of the input being checked
+        :rtype: str
+        """
+        return _(constants.NAME_OF_PASSWORD_PLURAL)
+
+    def set_input_score(self, score):
+        """Set input quality score.
+
+        :param int score: input quality score
+        """
+        pass
+
+    def set_input_status(self, status_message):
+        """Set input quality status message.
+
+        :param str status: input quality status message
+        """
+        pass
+
     def _update_check_status(self, editable, inputcheck):
         inputcheck.update_check_status()
 
@@ -48,6 +169,73 @@ class GUIInputCheckHandler(InputCheckHandler):
         checkRef = InputCheckHandler.add_check(self, input_obj, run_check, data)
         input_obj.connect_after("changed", self._update_check_status, checkRef)
         return checkRef
+
+    # checks
+
+    def check_password_confirm(self, inputcheck):
+        """If the user has entered confirmation data, check whether it matches the password."""
+        # Skip the check if no password is required
+        if (not self.input_enabled) or self.input_kickstarted:
+            result = InputCheck.CHECK_OK
+        elif self.input_confirmation and (self.input != self.input_confirmation):
+            result = _(constants.PASSWORD_CONFIRM_ERROR_GUI) % {"passwords": self.name_of_input_plural}
+        else:
+            result = InputCheck.CHECK_OK
+        return result
+
+    def check_password_strength(self, inputcheck):
+        """Update password check status based on password strength.
+
+           On spokes the password strength check can be waived by pressing "Done" twice.
+           This is controlled through the self.waive_clicks counter.
+           The counter is set in on_back_clicked, which also re-runs this check manually.
+         """
+        pw = self.input
+
+        # Don't run any check if the password is empty - there is a dedicated check for that
+        if not pw:
+            # Also update the score & status if the password is empty,
+            # as it might have been deleted and the previous score and status
+            # would still be shown.
+            self.set_input_score(0)
+            self.set_input_status(_(constants.PASSWORD_STATUS_EMPTY))
+            return InputCheck.CHECK_OK
+
+        # determine password strength
+        request = PasswordCheckRequest(password=pw,
+                                       username=self.input_username,
+                                       minimum_length=self.policy.minlen,
+                                       empty_ok=self.policy.emptyok,
+                                       name_of_password=self.name_of_input)
+
+        result = validatePassword(check_request=request)
+        self.set_input_score(result.password_score)
+        self.set_input_status(result.status_text)
+
+        # Skip the check if no password is required
+        if not self.input_enabled or self.input_kickstarted:
+            return InputCheck.CHECK_OK
+
+        # pylint: disable=no-member
+        if result.password_quality < self.policy.minquality or not result.password_score or not pw:
+            return self.handle_weak_password(result)
+        else:
+            return InputCheck.CHECK_OK
+
+    def handle_weak_password(self, result):
+        if result.length_ok:
+            return _(constants.PASSWORD_WEAK_WITH_ERROR) % {"password": self.name_of_input,
+                                                            "error_message": result.error_message}
+        else:
+            return "%s." % result.error_message
+
+    def check_password_ASCII(self, inputcheck):
+        """Set an error message if the password contains non-ASCII characters."""
+        password = self.get_input(inputcheck.input_obj)
+        if password and any(char not in constants.PW_ASCII_CHARS for char in password):
+            return _(constants.PASSWORD_ASCII) % {"password": self.name_of_input}
+        return InputCheck.CHECK_OK
+
 
 class GUIDialogInputCheckHandler(GUIInputCheckHandler):
     """Provide InputCheckHandler functionality for Gtk dialogs.
@@ -81,6 +269,13 @@ class GUISpokeInputCheckHandler(GUIInputCheckHandler):
 
     __metaclass__ = ABCMeta
 
+    def __init__(self):
+        GUIInputCheckHandler.__init__(self)
+
+        # Store the previous status to avoid setting the info bar to the same
+        # message multiple times
+        self._prev_status = None
+
     def set_status(self, inputcheck):
         """Update the warning with the input validation error from the first
            error message.
@@ -111,7 +306,7 @@ class GUISpokeInputCheckHandler(GUIInputCheckHandler):
         """Check whether the input validation checks allow the spoke to be exited.
 
            Unlike NormalSpoke.on_back_clicked, this function returns a boolean value.
-           Classes implementing this class should run GUISpokeInputCheckHandler.on_back_clicked,
+           Classes implementing this class should run GUISpokePasswordCheckHandler.on_back_clicked,
            and if it succeeded, run NormalSpoke.on_back_clicked.
         """
         failed_check = next(self.failed_checks, None)
@@ -121,3 +316,158 @@ class GUISpokeInputCheckHandler(GUIInputCheckHandler):
             return False
         else:
             return True
+
+class GUISpokePasswordCheckHandler(GUISpokeInputCheckHandler):
+    """Extend GUISpokeInputCheckHandler with password checking functionality for graphical spokes.
+
+    This class adds methods needed for efficiently check that passwords comply with current
+    passowrd policy in graphical spokes, that can be used by different spokes to avoid code duplication.
+    """
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self):
+        GUISpokeInputCheckHandler.__init__(self)
+        self._password_required = False
+        self._waive_clicks = 0
+        self._waive_ASCII_clicks = 0
+
+    @property
+    def password_required(self):
+        """If password is required to be set for the current screen.
+
+        In general this local on-screen represents stuff like the
+        "require password" tick-box on the user spoke.
+
+        :returns: if password is required for the current screen
+        :rtype: bool
+        """
+        return self._password_required
+
+    @password_required.setter
+    def password_required(self, password_needed):
+        """Set if password is required for the current screen.
+
+        :param bool password_is_required: if pasword needs to be non-empty
+        """
+        self._password_required = password_needed
+
+    @property
+    def waive_clicks(self):
+        """Number of waive clicks the user has done to override an input check.
+
+        :returns: number of waive clicks
+        :rtype: int
+        """
+        return self._waive_clicks
+
+    @waive_clicks.setter
+    def waive_clicks(self, clicks):
+        """Set number of waive clicks.
+
+        :param int clicks: number of waive clicks
+        """
+        self._waive_clicks = clicks
+
+    @property
+    def waive_ASCII_clicks(self):
+        """Number of waive clicks the user has done to override the ASCII input check.
+
+        :returns: number of ASCII check waive clicks
+        :rtype: int
+        """
+        return self._waive_ASCII_clicks
+
+    @waive_ASCII_clicks.setter
+    def waive_ASCII_clicks(self, clicks):
+        """Set number of ASCII check waive clicks.
+
+        :param int clicks: number of ASCII check waive clicks
+        """
+        self._waive_ASCII_clicks = clicks
+
+    def check_password_empty(self, inputcheck):
+        """Check whether a password has been specified at all.
+
+           This check is used for both the password and the confirmation.
+        """
+        # If the password was set by kickstart, skip the check.
+        # pylint: disable=no-member
+        if self.input_kickstarted and not self.policy.changesok:
+            return InputCheck.CHECK_OK
+
+        # Skip the check if no password is required
+        if (not self.input_enabled) or self.input_kickstarted:
+            return InputCheck.CHECK_OK
+        # Also skip the check if the policy says that an empty password is fine
+        # and non-empty password is not required by the screen.
+        # pylint: disable=no-member
+        elif self.policy.emptyok and not self.password_required:
+            return InputCheck.CHECK_OK
+        elif not self.get_input(inputcheck.input_obj):
+            # pylint: disable=no-member
+            if self.policy.strict or self.password_required:
+                return _(constants.PASSWORD_EMPTY_ERROR) % {"password": self.name_of_input}
+            else:
+                if self.waive_clicks > 1:
+                    return InputCheck.CHECK_OK
+                else:
+                    return _(constants.PASSWORD_EMPTY_ERROR) % {"password": self.name_of_input} + " " + _(constants.PASSWORD_DONE_TWICE)
+        else:
+            return InputCheck.CHECK_OK
+
+    def check_password_ASCII(self, inputcheck):
+        """Set an error message if the password contains non-ASCII characters.
+
+           Like the password strength check, this check can be bypassed by
+           pressing Done twice.
+        """
+        password = self.get_input(inputcheck.input_obj)
+        if password and any(char not in constants.PW_ASCII_CHARS for char in password):
+            # If Done has been clicked, waive the check
+            if self.waive_ASCII_clicks > 1:
+                return InputCheck.CHECK_OK
+            elif self.waive_ASCII_clicks == 1:
+                error_message = _(constants.PASSWORD_ASCII) % {"password": self.name_of_input}
+                return "%s %s" % (error_message, _(constants.PASSWORD_FINAL_CONFIRM))
+            else:
+                error_message = _(constants.PASSWORD_ASCII) % {"password": self.name_of_input}
+                return "%s %s" % (error_message, _(constants.PASSWORD_DONE_TWICE))
+
+        return InputCheck.CHECK_OK
+
+    def handle_weak_password(self, result):
+        # If Done has been clicked twice, waive the check
+        if self.waive_clicks > 1:
+            return InputCheck.CHECK_OK
+        elif self.waive_clicks == 1:
+            if result.error_message:
+                if result.length_ok:
+                    main_message = _(constants.PASSWORD_WEAK_WITH_ERROR) % {"password": self.name_of_input,
+                                                                            "error_message": result.error_message}
+                    suffix = _(constants.PASSWORD_FINAL_CONFIRM)
+                    return main_message + " " + suffix
+                else:
+                    return "%s." % result.error_message + " " + _(constants.PASSWORD_FINAL_CONFIRM)
+            else:
+                main_message = _(constants.PASSWORD_WEAK) % {"password": self.name_of_input}
+                return main_message + " " + _(constants.PASSWORD_FINAL_CONFIRM)
+        else:
+            # non-strict allows done to be clicked twice
+            if result.error_message:
+                if result.length_ok:
+                    if self.policy.strict:
+                        combined_error_message = result.error_message
+                    else:
+                        combined_error_message = result.error_message + " " + _(constants.PASSWORD_DONE_TWICE)
+
+                    return _(constants.PASSWORD_WEAK_WITH_ERROR) % {"password": self.name_of_input,
+                                                                    "error_message": combined_error_message}
+                else:
+                    if self.policy.strict:
+                        return "%s." % result.error_message
+                    else:
+                        return "%s." % result.error_message + " " + _(constants.PASSWORD_DONE_TWICE)
+            else:
+                main_message = _(constants.PASSWORD_WEAK) % {"password": self.name_of_input}
+                return main_message + " " + _(constants.PASSWORD_DONE_TWICE)

--- a/pyanaconda/ui/gui/spokes/lib/passphrase.glade
+++ b/pyanaconda/ui/gui/spokes/lib/passphrase.glade
@@ -146,6 +146,7 @@
                 <property name="invisible_char">●</property>
                 <property name="width_chars">32</property>
                 <signal name="activate" handler="on_entry_activated" swapped="no"/>
+                <signal name="changed" handler="on_passphrase_confirmation_changed" swapped="no"/>
               </object>
               <packing>
                 <property name="left_attach">1</property>

--- a/pyanaconda/ui/gui/spokes/password.glade
+++ b/pyanaconda/ui/gui/spokes/password.glade
@@ -80,7 +80,7 @@
                         <property name="can_focus">True</property>
                         <property name="visibility">False</property>
                         <property name="invisible_char">●</property>
-                        <signal name="changed" handler="_updatePwQuality" swapped="no"/>
+                        <signal name="changed" handler="on_password_changed" swapped="no"/>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="pw-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Password</property>
@@ -98,6 +98,7 @@
                         <property name="can_focus">True</property>
                         <property name="visibility">False</property>
                         <property name="invisible_char">●</property>
+                        <signal name="changed" handler="on_password_confirmation_changed" swapped="no"/>
                         <property name="activates_default">True</property>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="confirmPW-atkobject">
@@ -131,7 +132,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="valign">center</property>
-                            <property name="value">2</property>
+                            <property name="value">0</property>
                             <property name="max_value">4</property>
                             <property name="mode">discrete</property>
                           </object>

--- a/pyanaconda/ui/gui/spokes/password.py
+++ b/pyanaconda/ui/gui/spokes/password.py
@@ -22,18 +22,12 @@
 
 from pyanaconda.flags import flags
 from pyanaconda.i18n import _, CN_
-from pyanaconda.users import cryptPassword, validatePassword
+from pyanaconda.users import cryptPassword
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
-from pyanaconda.ui.gui.helpers import GUISpokeInputCheckHandler
+from pyanaconda.ui.gui.helpers import GUISpokePasswordCheckHandler
 from pyanaconda.ui.common import FirstbootSpokeMixIn
-from pyanaconda.ui.helpers import InputCheck
-
-from pyanaconda.constants import PASSWORD_EMPTY_ERROR, PASSWORD_CONFIRM_ERROR_GUI,\
-        PASSWORD_WEAK, PASSWORD_WEAK_WITH_ERROR,\
-        PASSWORD_WEAK_CONFIRM, PASSWORD_WEAK_CONFIRM_WITH_ERROR, PASSWORD_DONE_TWICE,\
-        PW_ASCII_CHARS, PASSWORD_ASCII
 
 import logging
 log = logging.getLogger("anaconda")
@@ -41,7 +35,7 @@ log = logging.getLogger("anaconda")
 __all__ = ["PasswordSpoke"]
 
 
-class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
+class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokePasswordCheckHandler):
     builderObjects = ["passwordWindow"]
 
     mainWidgetName = "passwordWindow"
@@ -56,7 +50,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     def __init__(self, *args):
         NormalSpoke.__init__(self, *args)
-        GUISpokeInputCheckHandler.__init__(self)
+        GUISpokePasswordCheckHandler.__init__(self)
         self._kickstarted = False
 
     def initialize(self):
@@ -71,31 +65,13 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         # - How strong is the password?
         # - Does the password contain non-ASCII characters?
         # - Is there any data in the confirm box?
-        self.add_check(self.pw, self._checkPasswordEmpty)
-
-        # The password confirmation needs to be checked whenever either of the password
-        # fields change. Separate checks are created for each field so that edits on either
-        # will trigger a new check and so that the last edited field will get focus when
-        # Done is clicked. The checks are saved here so that either check can trigger the
-        # other check in order to reset the status on both when either field is changed.
-        # The check_data field is used as a flag to prevent infinite recursion.
-        self._confirm_check = self.add_check(self.confirm, self._checkPasswordConfirm)
-        self._password_check = self.add_check(self.pw, self._checkPasswordConfirm)
+        self._confirm_check = self.add_check(self.confirm, self.check_password_confirm)
 
         # Keep a reference for these checks, since they have to be manually run for the
         # click Done twice check.
-        self._pwStrengthCheck = self.add_check(self.pw, self._checkPasswordStrength)
-        self._pwASCIICheck = self.add_check(self.pw, self._checkPasswordASCII)
-
-        self.add_check(self.confirm, self._checkPasswordEmpty)
-
-        # Counters for checks that ask the user to click Done to confirm
-        self._waiveStrengthClicks = 0
-        self._waiveASCIIClicks = 0
-
-        # Password validation data
-        self._pw_error_message = None
-        self._pw_score = 0
+        self._pwEmptyCheck = self.add_check(self.pw, self.check_password_empty)
+        self._pwStrengthCheck = self.add_check(self.pw, self.check_password_strength)
+        self._pwASCIICheck = self.add_check(self.pw, self.check_password_ASCII)
 
         self._kickstarted = self.data.rootpw.seen
         if self._kickstarted:
@@ -135,8 +111,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     @property
     def mandatory(self):
-        return not any(user for user in self.data.user.userList
-                            if "wheel" in user.groups)
+        return not any(user for user in self.data.user.userList if "wheel" in user.groups)
 
     def apply(self):
         pw = self.pw.get_text()
@@ -167,147 +142,65 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         return not (self.completed and flags.automatedInstall
                     and self.data.rootpw.seen)
 
-    def _checkPasswordEmpty(self, inputcheck):
-        """Check whether a password has been specified at all."""
+    @property
+    def input(self):
+        return self.pw.get_text()
 
-        # If the password was set by kickstart, skip this check
-        if self._kickstarted and not self.policy.changesok:
-            return InputCheck.CHECK_OK
+    @property
+    def input_confirmation(self):
+        return self.confirm.get_text()
 
-        if not self.get_input(inputcheck.input_obj):
-            if inputcheck.input_obj == self.pw:
-                return _(PASSWORD_EMPTY_ERROR)
-            else:
-                return _(PASSWORD_CONFIRM_ERROR_GUI)
-        else:
-            return InputCheck.CHECK_OK
+    @property
+    def input_kickstarted(self):
+        return self.data.rootpw.seen
 
-    def _checkPasswordConfirm(self, inputcheck):
-        """Check whether the password matches the confirmation data."""
+    @property
+    def input_username(self):
+        return "root"
 
-        pw = self.pw.get_text()
-        confirm = self.confirm.get_text()
+    def set_input_score(self, score):
+        self.pw_bar.set_value(score)
 
-        # Skip the check if no password is required
-        if (not pw and not confirm) and self._kickstarted:
-            result = InputCheck.CHECK_OK
-        elif confirm and (pw != confirm):
-            result = _(PASSWORD_CONFIRM_ERROR_GUI)
-        else:
-            result = InputCheck.CHECK_OK
+    def set_input_status(self, status_message):
+        self.pw_label.set_text(status_message)
 
-        # If the check succeeded, reset the status of the other check object
-        # Disable the current check to prevent a cycle
-        inputcheck.enabled = False
-        if result == InputCheck.CHECK_OK:
-            if inputcheck == self._confirm_check:
-                self._password_check.update_check_status()
-            else:
-                self._confirm_check.update_check_status()
-        inputcheck.enabled = True
+    def on_password_changed(self, editable, data=None):
+        self._password_or_confirmation_changed()
 
-        return result
+    def on_password_confirmation_changed(self, editable, data=None):
+        self._password_or_confirmation_changed()
 
-    def _updatePwQuality(self, editable=None, data=None):
-        """Update the password quality information.
+    def _password_or_confirmation_changed(self):
+        """One of the password input fields changed.
 
-           This function is called by the ::changed signal handler on the
-           password field.
+        Reset the waive counters and check that both passwords are still the same.
         """
-
-        pwtext = self.pw.get_text()
 
         # Reset the counters used for the "press Done twice" logic
-        self._waiveStrengthClicks = 0
-        self._waiveASCIIClicks = 0
+        self.waive_clicks = 0
+        self.waive_ASCII_clicks = 0
 
-        self._pw_score, status_text, _pw_quality, self._pw_error_message = validatePassword(pwtext,
-                                                                                            "root",
-                                                                                            minlen=self.policy.minlen,
-                                                                                            empty_ok=self.policy.emptyok)
-        self.pw_bar.set_value(self._pw_score)
-        self.pw_label.set_text(status_text)
-
-    def _checkPasswordStrength(self, inputcheck):
-        """Update the error message based on password strength.
-
-           Convert the strength set by _updatePwQuality into an error message.
-        """
-
-        pw = self.pw.get_text()
-        confirm = self.confirm.get_text()
-
-        # Skip the check if no password is required
-        if (not pw and not confirm) and self._kickstarted:
-            return InputCheck.CHECK_OK
-
-        # Check for validity errors
-        # pw score == 0 & errors from libpwquality
-        # - ignore if the strict flag in the password policy == False
-        if not self._pw_score and self._pw_error_message and self.policy.strict:
-            return self._pw_error_message
-
-        # use strength from policy, not bars
-        _pw_score, _status_text, pw_quality, _error_message = validatePassword(pw,
-                                                                               "root",
-                                                                               minlen=self.policy.minlen,
-                                                                               empty_ok=self.policy.emptyok)
-
-        if pw_quality < self.policy.minquality:
-            # If Done has been clicked twice, waive the check
-            if self._waiveStrengthClicks > 1:
-                return InputCheck.CHECK_OK
-            elif self._waiveStrengthClicks == 1:
-                if self._pw_error_message:
-                    return _(PASSWORD_WEAK_CONFIRM_WITH_ERROR) % self._pw_error_message
-                else:
-                    return _(PASSWORD_WEAK_CONFIRM)
-            else:
-                # non-strict allows done to be clicked twice
-                if self.policy.strict:
-                    done_msg = ""
-                else:
-                    done_msg = _(PASSWORD_DONE_TWICE)
-
-                if self._pw_error_message:
-                    return _(PASSWORD_WEAK_WITH_ERROR) % self._pw_error_message + " " + done_msg
-                else:
-                    return _(PASSWORD_WEAK) % done_msg
-        else:
-            return InputCheck.CHECK_OK
-
-    def _checkPasswordASCII(self, inputcheck):
-        """Set an error message if the password contains non-ASCII characters.
-
-           Like the password strength check, this check can be bypassed by
-           pressing Done twice.
-        """
-
-        # If Done has been clicked, waive the check
-        if self._waiveASCIIClicks > 0:
-            return InputCheck.CHECK_OK
-
-        password = self.get_input(inputcheck.input_obj)
-        if password and any(char not in PW_ASCII_CHARS for char in password):
-            return _(PASSWORD_ASCII)
-
-        return InputCheck.CHECK_OK
+        # Update the password/confirm match check on changes to the main password field
+        self._confirm_check.update_check_status()
 
     def on_back_clicked(self, button):
         # If the failed check is for password strength or non-ASCII
         # characters, add a click to the counter and check again
         failed_check = next(self.failed_checks_with_message, None)
-        if not self.policy.strict and failed_check == self._pwStrengthCheck:
-            self._waiveStrengthClicks += 1
-            self._pwStrengthCheck.update_check_status()
-        elif failed_check == self._pwASCIICheck:
-            self._waiveASCIIClicks += 1
+        if not self.policy.strict:
+            if failed_check == self._pwStrengthCheck:
+                self.waive_clicks += 1
+                self._pwStrengthCheck.update_check_status()
+            elif failed_check == self._pwEmptyCheck:
+                self.waive_clicks += 1
+                self._pwEmptyCheck.update_check_status()
+            elif failed_check:  # no failed checks -> failed_check == None
+                failed_check.update_check_status()
+        # A failing ASCII check does not mean the password is weak,
+        # so the waive logic for it should be always available.
+        if failed_check == self._pwASCIICheck:
+            self.waive_ASCII_clicks += 1
             self._pwASCIICheck.update_check_status()
 
-        # If neither the password nor the confirm field are set, skip the checks
-        if (not self.pw.get_text()) and (not self.confirm.get_text()):
-            for check in self.checks:
-                check.enabled = False
-
-        if GUISpokeInputCheckHandler.on_back_clicked(self, button):
+        if GUISpokePasswordCheckHandler.on_back_clicked(self, button):
             NormalSpoke.on_back_clicked(self, button)

--- a/pyanaconda/ui/gui/spokes/user.glade
+++ b/pyanaconda/ui/gui/spokes/user.glade
@@ -166,7 +166,7 @@
                         <property name="can_focus">True</property>
                         <property name="visibility">False</property>
                         <property name="invisible_char">●</property>
-                        <signal name="changed" handler="password_changed" swapped="no"/>
+                        <signal name="changed" handler="on_password_changed" swapped="no"/>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="t_password-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Password</property>
@@ -184,6 +184,7 @@
                         <property name="can_focus">True</property>
                         <property name="visibility">False</property>
                         <property name="invisible_char">●</property>
+                        <signal name="changed" handler="on_password_confirmation_changed" swapped="no"/>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="t_verifypassword-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Confirm Password</property>
@@ -233,7 +234,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="valign">center</property>
-                            <property name="value">2</property>
+                            <property name="value">0</property>
                             <property name="max_value">4</property>
                             <property name="mode">discrete</property>
                           </object>

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -20,23 +20,23 @@
 #                    Chris Lumens <clumens@redhat.com>
 #
 
+import logging
+log = logging.getLogger("anaconda")
+
 import os
 from pyanaconda.flags import flags
 from pyanaconda.i18n import _, CN_
-from pyanaconda.users import cryptPassword, validatePassword, guess_username, check_username
+from pyanaconda.users import cryptPassword, guess_username, check_username
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
 from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.ui.helpers import InputCheck
-from pyanaconda.ui.gui.helpers import GUISpokeInputCheckHandler, GUIDialogInputCheckHandler
+from pyanaconda.ui.gui.helpers import GUISpokePasswordCheckHandler, GUIDialogInputCheckHandler
 
-from pyanaconda.constants import ANACONDA_ENVIRON, FIRSTBOOT_ENVIRON,\
-        PASSWORD_EMPTY_ERROR, PASSWORD_CONFIRM_ERROR_GUI,\
-        PASSWORD_WEAK, PASSWORD_WEAK_WITH_ERROR, PASSWORD_WEAK_CONFIRM,\
-        PASSWORD_WEAK_CONFIRM_WITH_ERROR, PASSWORD_DONE_TWICE,\
-        PW_ASCII_CHARS, PASSWORD_ASCII
+from pyanaconda.constants import ANACONDA_ENVIRON, FIRSTBOOT_ENVIRON
+
 from pyanaconda.regexes import GECOS_VALID, GROUPNAME_VALID, GROUPLIST_FANCY_PARSE
 
 __all__ = ["UserSpoke", "AdvancedUserDialog"]
@@ -199,7 +199,7 @@ class AdvancedUserDialog(GUIObject, GUIDialogInputCheckHandler):
 
         return rc
 
-class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
+class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokePasswordCheckHandler):
     builderObjects = ["userCreationWindow"]
 
     mainWidgetName = "userCreationWindow"
@@ -229,8 +229,11 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
 
     def __init__(self, *args):
         NormalSpoke.__init__(self, *args)
-        GUISpokeInputCheckHandler.__init__(self)
-        self._oldweak = None
+        GUISpokePasswordCheckHandler.__init__(self)
+        # We need to create the _confirm_check variable now,
+        # because a GTK callback, which migh run before initialize(),
+        # might try to access it.
+        self._confirm_check = None
 
     def initialize(self):
         NormalSpoke.initialize(self)
@@ -251,19 +254,22 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         self.usepassword = self.builder.get_object("c_usepassword")
         self.b_advanced = self.builder.get_object("b_advanced")
 
+        # set initial state of the input field
+        self.input_enabled = self.usepassword.get_active()
+
         # Counters for checks that ask the user to click Done to confirm
-        self._waiveStrengthClicks = 0
-        self._waiveASCIIClicks = 0
+        self.waive_clicks = 0
+        self.waive_ASCII_clicks = 0
 
         self.guesser = {
             self.username: True
-            }
+        }
+
+        # set if password is required according to the usepassword combobox
+        self.password_required = self.usepassword.get_active()
 
         # Updated during the password changed event and used by the password
         # field validity checker
-        self._pw_error_message = None
-        self._pw_score = 0
-
         self.pw_bar = self.builder.get_object("password_bar")
         self.pw_label = self.builder.get_object("password_label")
 
@@ -276,6 +282,9 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         self.policy = self.data.anaconda.pwpolicy.get_policy("user")
         if not self.policy:
             self.policy = self.data.anaconda.PwPolicyData()
+
+        # indicate when the password was set by kickstart
+        self._password_kickstarted = self.data.user.seen
 
         # indicate when the password was set by kickstart
         self._user.password_kickstarted = self.data.user.seen
@@ -302,30 +311,38 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         # - if a password is specified and the confirm box is empty or match, how strong is it?
         # - if a strong password is specified, does it contain non-ASCII data?
         # - if a password is required, is there any data in the confirm box?
-        self.add_check(self.pw, self._checkPasswordEmpty)
-
-        # The password confirmation needs to be checked whenever either of the password
-        # fields change. Separate checks are created on each field so that edits on
-        # either will trigger a check and so that the last edited field will get the focus
-        # when Done is clicked. Whichever check is run needs to run the other check in
-        # order to reset the status. The check_data field is used as a flag to prevent
-        # infinite recursion.
-        self._confirm_check = self.add_check(self.confirm, self._checkPasswordConfirm)
-        self._password_check = self.add_check(self.pw, self._checkPasswordConfirm)
+        # the password confirmation needs to be checked whenever either of the password
+        # fields change. attach to the confirm field so that errors focus on confirm,
+        # and check changes to the password field in password_changed
+        self._confirm_check = self.add_check(self.confirm, self.check_password_confirm)
 
         # Keep a reference to these checks, since they have to be manually run for the
         # click Done twice check.
-        self._pwStrengthCheck = self.add_check(self.pw, self._checkPasswordStrength)
-        self._pwASCIICheck = self.add_check(self.pw, self._checkPasswordASCII)
-
-        self.add_check(self.confirm, self._checkPasswordEmpty)
+        self._pwEmptyCheck = self.add_check(self.pw, self.check_password_empty)
+        self._pwStrengthCheck = self.add_check(self.pw, self.check_password_strength)
+        self._pwASCIICheck = self.add_check(self.pw, self.check_password_ASCII)
 
         self.add_check(self.username, self._checkUsername)
 
         self.add_re_check(self.fullname, GECOS_VALID, _("Full name cannot contain colon characters"))
 
-        self._advanced = AdvancedUserDialog(self._user, self._groupDict,
-                                            self.data)
+        # Modify the GUI based on the kickstart and policy information
+        # This needs to happen after the input checks have been created, since
+        # the Gtk signal handlers use the input check variables.
+
+        if self._password_kickstarted:
+            self.usepassword.set_active(True)
+            self.pw.set_placeholder_text(_("The password was set by kickstart."))
+            self.confirm.set_placeholder_text(_("The password was set by kickstart."))
+        elif not self.policy.emptyok:
+            # Policy is that a non-empty password is required
+            self.usepassword.set_active(True)
+
+        if not self.policy.emptyok:
+            # User isn't allowed to change whether password is required or not
+            self.usepassword.set_sensitive(False)
+
+        self._advanced = AdvancedUserDialog(self._user, self._groupDict, self.data)
         self._advanced.initialize()
 
     def refresh(self):
@@ -369,9 +386,9 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
     def apply(self):
         # set the password only if the user enters anything to the text entry
         # this should preserve the kickstart based password
-        if self.usepassword.get_active():
+        if self.input_enabled:
             if self.pw.get_text():
-                self._user.password_kickstarted = False
+                self._password_kickstarted = False
                 self._user.password = cryptPassword(self.pw.get_text())
                 self._user.isCrypted = True
                 self.pw.set_placeholder_text("")
@@ -383,7 +400,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
             self.confirm.set_placeholder_text("")
             self._user.password = ""
             self._user.isCrypted = False
-            self._user.password_kickstarted = False
+            self._password_kickstarted = False
 
         self._user.name = self.username.get_text()
         self._user.gecos = self.fullname.get_text()
@@ -427,38 +444,40 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
     def completed(self):
         return len(self.data.user.userList) > 0
 
-    def _updatePwQuality(self):
-        """This method updates the password indicators according
-        to the password entered by the user.
-        """
-        pwtext = self.pw.get_text()
-        username = self.username.get_text()
-
-        # Reset the counters used for the "press Done twice" logic
-        self._waiveStrengthClicks = 0
-        self._waiveASCIIClicks = 0
-
-        self._pw_score, status_text, _pw_quality, self._pw_error_message = validatePassword(pwtext,
-                                                                                            username,
-                                                                                            minlen=self.policy.minlen,
-                                                                                            empty_ok=self.policy.emptyok)
-        self.pw_bar.set_value(self._pw_score)
-        self.pw_label.set_text(status_text)
-
-    def usepassword_toggled(self, togglebutton = None, data = None):
+    def usepassword_toggled(self, togglebutton=None, data=None):
         """Called by Gtk callback when the "Use password" check
         button is toggled. It will make password entries in/sensitive."""
 
-        self.pw.set_sensitive(self.usepassword.get_active())
-        self.confirm.set_sensitive(self.usepassword.get_active())
+        self.input_enabled = togglebutton.get_active()
+        self.password_required = togglebutton.get_active()
+
+        self.pw.set_sensitive(togglebutton.get_active())
+        self.confirm.set_sensitive(togglebutton.get_active())
 
         # Re-check the password
         self.pw.emit("changed")
         self.confirm.emit("changed")
 
-    def password_changed(self, editable=None, data=None):
-        """Update the password strength level bar"""
-        self._updatePwQuality()
+    def on_password_changed(self, editable, data=None):
+        self._password_or_confirmation_changed()
+
+    def on_password_confirmation_changed(self, editable, data=None):
+        self._password_or_confirmation_changed()
+
+    def _password_or_confirmation_changed(self):
+        """One of the password input fields changed.
+
+        Reset the waive counters and check that both passwords are still the same.
+        """
+
+        # Reset the counters used for the "press Done twice" logic
+        self.waive_clicks = 0
+        self.waive_ASCII_clicks = 0
+
+        # Update the password/confirm match check on changes to the main password field
+        # (but first make sure the check is already setup)
+        if self._confirm_check:
+            self._confirm_check.update_check_status()
 
     def username_changed(self, editable = None, data = None):
         """Called by Gtk callback when the username or hostname
@@ -490,119 +509,27 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
             self.username.set_text(username)
             self.guesser[self.username] = True
 
-    def _checkPasswordEmpty(self, inputcheck):
-        """Check whether a password has been specified at all.
+    @property
+    def input(self):
+        return self.pw.get_text()
 
-           This check is used for both the password and the confirmation.
-        """
+    @property
+    def input_confirmation(self):
+        return self.confirm.get_text()
 
-        # If the password was set by kickstart, skip the strength check
-        if self._user.password_kickstarted and not self.policy.changesok:
-            return InputCheck.CHECK_OK
+    @property
+    def input_kickstarted(self):
+        return self.data.user.seen
 
-        # Skip the check if no password is required
-        if (not self.usepassword.get_active()) or self._user.password_kickstarted:
-            return InputCheck.CHECK_OK
-        elif not self.get_input(inputcheck.input_obj):
-            if inputcheck.input_obj == self.pw:
-                return _(PASSWORD_EMPTY_ERROR)
-            else:
-                return _(PASSWORD_CONFIRM_ERROR_GUI)
-        else:
-            return InputCheck.CHECK_OK
+    @property
+    def input_username(self):
+        return self.username.get_text()
 
-    def _checkPasswordConfirm(self, inputcheck):
-        """If the user has entered confirmation data, check whether it matches the password."""
+    def set_input_score(self, score):
+        self.pw_bar.set_value(score)
 
-        # Skip the check if no password is required
-        if (not self.usepassword.get_active()) or self._user.password_kickstarted:
-            result = InputCheck.CHECK_OK
-        elif self.confirm.get_text() and (self.pw.get_text() != self.confirm.get_text()):
-            result = _(PASSWORD_CONFIRM_ERROR_GUI)
-        else:
-            result = InputCheck.CHECK_OK
-
-        # If the check succeeded, reset the status of the other check object
-        # Disable the current check to prevent a cycle
-        inputcheck.enabled = False
-        if result == InputCheck.CHECK_OK:
-            if inputcheck == self._confirm_check:
-                self._password_check.update_check_status()
-            else:
-                self._confirm_check.update_check_status()
-        inputcheck.enabled = True
-
-        return result
-
-    def _checkPasswordStrength(self, inputcheck):
-        """Update the error message based on password strength.
-
-           The password strength has already been checked in _updatePwQuality, called
-           previously in the signal chain. This method converts the data set from there
-           into an error message.
-
-           The password strength check can be waived by pressing "Done" twice. This
-           is controlled through the self._waiveStrengthClicks counter. The counter
-           is set in on_back_clicked, which also re-runs this check manually.
-         """
-
-        # Skip the check if no password is required
-        if (not self.usepassword.get_active()) or \
-                ((not self.pw.get_text()) and (self._user.password_kickstarted)):
-            return InputCheck.CHECK_OK
-
-        # Check for validity errors
-        # pw score == 0 & errors from libpwquality
-        # - ignore if the strict flag in the password policy == False
-        if not self._pw_score and self._pw_error_message and self.policy.strict:
-            return self._pw_error_message
-
-        # use strength from policy, not bars
-        pw = self.pw.get_text()
-        username = self.username.get_text()
-        _pw_score, _status_text, pw_quality, _error_message = validatePassword(pw,
-                                                                               username,
-                                                                               minlen=self.policy.minlen,
-                                                                               empty_ok=self.policy.emptyok)
-        if pw_quality < self.policy.minquality:
-            # If Done has been clicked twice, waive the check
-            if self._waiveStrengthClicks > 1:
-                return InputCheck.CHECK_OK
-            elif self._waiveStrengthClicks == 1:
-                if self._pw_error_message:
-                    return _(PASSWORD_WEAK_CONFIRM_WITH_ERROR) % self._pw_error_message
-                else:
-                    return _(PASSWORD_WEAK_CONFIRM)
-            else:
-                # non-strict allows done to be clicked twice
-                if self.policy.strict:
-                    done_msg = ""
-                else:
-                    done_msg = _(PASSWORD_DONE_TWICE)
-
-                if self._pw_error_message:
-                    return _(PASSWORD_WEAK_WITH_ERROR) % self._pw_error_message + " " + done_msg
-                else:
-                    return _(PASSWORD_WEAK) % done_msg
-        else:
-            return InputCheck.CHECK_OK
-
-    def _checkPasswordASCII(self, inputcheck):
-        """Set an error message if the password contains non-ASCII characters.
-
-           Like the password strength check, this check can be bypassed by
-           pressing Done twice.
-        """
-
-        # If Done has been clicked, waive the check
-        if self._waiveASCIIClicks > 0:
-            return InputCheck.CHECK_OK
-
-        password = self.get_input(inputcheck.input_obj)
-        if password and any(char not in PW_ASCII_CHARS for char in password):
-            return _(PASSWORD_ASCII)
-
-        return InputCheck.CHECK_OK
+    def set_input_status(self, status_message):
+        self.pw_label.set_text(status_message)
 
     def _checkUsername(self, inputcheck):
         name = self.get_input(inputcheck.input_obj)
@@ -640,11 +567,19 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         # If the failed check is for password strength or non-ASCII
         # characters, add a click to the counter and check again
         failed_check = next(self.failed_checks_with_message, None)
-        if not self.policy.strict and failed_check == self._pwStrengthCheck:
-            self._waiveStrengthClicks += 1
-            self._pwStrengthCheck.update_check_status()
-        elif failed_check == self._pwASCIICheck:
-            self._waiveASCIIClicks += 1
+        if not self.policy.strict:
+            if failed_check == self._pwStrengthCheck:
+                self.waive_clicks += 1
+                self._pwStrengthCheck.update_check_status()
+            elif failed_check == self._pwEmptyCheck:
+                self.waive_clicks += 1
+                self._pwEmptyCheck.update_check_status()
+            elif failed_check:  # no failed checks -> failed_check == None
+                failed_check.update_check_status()
+        # A failing ASCII check does not mean the password is weak,
+        # so the waive logic for it should be always available.
+        if failed_check == self._pwASCIICheck:
+            self.waive_ASCII_clicks += 1
             self._pwASCIICheck.update_check_status()
 
         # If there is no user set, skip the checks
@@ -652,6 +587,6 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
             for check in self.checks:
                 check.enabled = False
 
-        if GUISpokeInputCheckHandler.on_back_clicked(self, button):
+        if GUISpokePasswordCheckHandler.on_back_clicked(self, button):
             NormalSpoke.on_back_clicked(self, button)
 

--- a/tests/pyanaconda_tests/password_quality_test.py
+++ b/tests/pyanaconda_tests/password_quality_test.py
@@ -26,7 +26,7 @@
 # ignore-check: potfiles
 
 
-from pyanaconda.users import validatePassword
+from pyanaconda.users import validatePassword, PasswordCheckRequest
 from pyanaconda import constants
 from pyanaconda.i18n import _
 import unittest
@@ -39,133 +39,125 @@ ON_RHEL = platform.dist()[0] == "redhat"
 class PasswordQuality(unittest.TestCase):
     def password_empty_test(self):
         """Check if quality of an empty password is reported correctly."""
-        score, status, quality, error_message = validatePassword("")
-        self.assertEqual(score, 0)
-        self.assertEqual(status, _(constants.PASSWORD_STATUS_EMPTY))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = PasswordCheckRequest("")
+        result = validatePassword(request)
+        self.assertEqual(result.password_score, 0)
+        self.assertEqual(result.status_text, _(constants.PASSWORD_STATUS_EMPTY))
+        self.assertEqual(result.password_quality, 0)
+        self.assertIsNotNone(result.error_message)
         # empty password should override password-too-short messages
-        score, status, quality, error_message = validatePassword("", minlen=10)
-        self.assertEqual(score, 0)
-        self.assertEqual(status, _(constants.PASSWORD_STATUS_EMPTY))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = PasswordCheckRequest("", minimum_length=10)
+        result = validatePassword(request)
+        self.assertEqual(result.password_score, 0)
+        self.assertEqual(result.status_text, _(constants.PASSWORD_STATUS_EMPTY))
+        self.assertEqual(result.password_quality, 0)
+        self.assertIsNotNone(result.error_message)
 
     def password_empty_ok_test(self):
         """Check if the empty_ok flag works correctly."""
-        score, status, quality, error_message = validatePassword("", empty_ok=True)
-        self.assertEqual(score, 1)
-        self.assertEqual(status, _(constants.PASSWORD_STATUS_WEAK))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = PasswordCheckRequest("", empty_ok=True)
+        result = validatePassword(request)
+        self.assertEqual(result.password_score, 1)
+        self.assertEqual(result.status_text, _(constants.PASSWORD_STATUS_EMPTY))
+        self.assertEqual(result.password_quality, 0)
+        self.assertIsNotNone(result.error_message)
         # empty_ok should override password length
-        score, status, quality, error_message = validatePassword("", minlen=10, empty_ok=True)
-        self.assertEqual(score, 1)
-        self.assertEqual(status, _(constants.PASSWORD_STATUS_WEAK))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = PasswordCheckRequest("", minimum_length=10, empty_ok=True)
+        result = validatePassword(request)
+        self.assertEqual(result.password_score, 1)
+        self.assertEqual(result.status_text, _(constants.PASSWORD_STATUS_EMPTY))
+        self.assertEqual(result.password_quality, 0)
+        self.assertIsNotNone(result.error_message)
         # non-empty passwords that are too short should still get a score of 0 & the "too short" message
-        score, status, quality, error_message = validatePassword("123", minlen=10, empty_ok=True)
-        self.assertEqual(score, 0)
-        self.assertEqual(status, _(constants.PASSWORD_STATUS_TOO_SHORT))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = PasswordCheckRequest("123", minimum_length=10, empty_ok=True)
+        result = validatePassword(request)
+        self.assertEqual(result.password_score, 0)
+        self.assertEqual(result.status_text, _(constants.PASSWORD_STATUS_TOO_SHORT))
+        self.assertEqual(result.password_quality, 0)
+        self.assertIsNotNone(result.error_message)
         # also check a long-enough password, just in case
-        score, status, quality, error_message = validatePassword("1234567891", minlen=10, empty_ok=True)
-        self.assertEqual(score, 1)
-        self.assertEqual(status, _(constants.PASSWORD_STATUS_WEAK))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = PasswordCheckRequest("1234567891", minimum_length=10, empty_ok=True)
+        result = validatePassword(request)
+        self.assertEqual(result.password_score, 1)
+        self.assertEqual(result.status_text, _(constants.PASSWORD_STATUS_WEAK))
+        self.assertEqual(result.password_quality, 0)
+        self.assertIsNotNone(result.error_message)
 
     def password_length_test(self):
         """Check if minimal password length is checked properly."""
         # first check if the default minimal password length is checked correctly
         # (should be 6 characters at the moment)
-        score, status, _quality, _error_message = validatePassword("123")
-        self.assertEqual(score, 0)
-        self.assertEqual(status, _(constants.PASSWORD_STATUS_TOO_SHORT))
-        score, status, _quality, _error_message = validatePassword("123456")
-        self.assertGreater(score, 0)
-        self.assertNotEqual(status, _(constants.PASSWORD_STATUS_EMPTY))
-        self.assertNotEqual(status, _(constants.PASSWORD_STATUS_TOO_SHORT))
+        request = PasswordCheckRequest("123")
+        result = validatePassword(request)
+        self.assertEqual(result.password_score, 0)
+        self.assertEqual(result.status_text, _(constants.PASSWORD_STATUS_TOO_SHORT))
+        request = PasswordCheckRequest("123456")
+        result = validatePassword(request)
+        self.assertGreater(result.password_score, 0)
+        self.assertNotEqual(result.status_text, _(constants.PASSWORD_STATUS_EMPTY))
+        self.assertNotEqual(result.status_text, _(constants.PASSWORD_STATUS_TOO_SHORT))
 
         # check if setting password length works correctly
-        score, status, _quality, _error_message = validatePassword("12345", minlen=10)
-        self.assertEqual(score, 0)
-        self.assertEqual(status, _(constants.PASSWORD_STATUS_TOO_SHORT))
-        score, status, _quality, _error_message = validatePassword("1234567891", minlen=10)
-        self.assertGreater(score, 0)
-        self.assertNotEqual(status, _(constants.PASSWORD_STATUS_TOO_SHORT))
+        request = PasswordCheckRequest("12345", minimum_length=10)
+        result = validatePassword(request)
+        self.assertEqual(result.password_score, 0)
+        self.assertEqual(result.status_text, _(constants.PASSWORD_STATUS_TOO_SHORT))
+        request = PasswordCheckRequest("1234567891", minimum_length=10)
+        result = validatePassword(request)
+        self.assertGreater(result.password_score, 0)
+        self.assertNotEqual(result.status_text, _(constants.PASSWORD_STATUS_TOO_SHORT))
 
     def password_quality_test(self):
         """Check if libpwquality gives reasonable numbers & score is assigned correctly."""
         # " " should give score 0 (<6 chars) & quality 0
-        score, status, quality, error_message = validatePassword(" ")
-        self.assertEqual(score, 0)
-        self.assertEqual(status, _(constants.PASSWORD_STATUS_TOO_SHORT))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = PasswordCheckRequest(" ")
+        result = validatePassword(request)
+        self.assertEqual(result.password_score, 0)
+        self.assertEqual(result.status_text, _(constants.PASSWORD_STATUS_TOO_SHORT))
+        self.assertEqual(result.password_quality, 0)
+        self.assertIsNotNone(result.error_message)
 
         # "anaconda" is a dictionary word
-        score, status, quality, error_message = validatePassword("anaconda")
-        self.assertGreater(score, 0)
-        self.assertNotEqual(status, _(constants.PASSWORD_STATUS_EMPTY))
-        self.assertNotEqual(status, _(constants.PASSWORD_STATUS_TOO_SHORT))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = PasswordCheckRequest("anaconda")
+        result = validatePassword(request)
+        self.assertGreater(result.password_score, 0)
+        self.assertNotEqual(result.status_text, _(constants.PASSWORD_STATUS_EMPTY))
+        self.assertNotEqual(result.status_text, _(constants.PASSWORD_STATUS_TOO_SHORT))
+        self.assertEqual(result.password_quality, 0)
+        self.assertIsNotNone(result.error_message)
 
         # "jelenovipivonelej" is a palindrome
-        score, status, quality, error_message = validatePassword("jelenovipivonelej")
-        self.assertGreater(score, 0)
-        self.assertNotEqual(status, _(constants.PASSWORD_STATUS_EMPTY))
-        self.assertNotEqual(status, _(constants.PASSWORD_STATUS_TOO_SHORT))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = PasswordCheckRequest("jelenovipivonelej")
+        result = validatePassword(request)
+        self.assertGreater(result.password_score, 0)
+        self.assertNotEqual(result.status_text, _(constants.PASSWORD_STATUS_EMPTY))
+        self.assertNotEqual(result.status_text, _(constants.PASSWORD_STATUS_TOO_SHORT))
+        self.assertEqual(result.password_quality, 0)
+        self.assertIsNotNone(result.error_message)
 
-        # "4naconda-" gives a quality of 27 on RHEL7
-        score, status, quality, error_message = validatePassword("4naconda-")
+        # "4naconda-" gives reasonable quality (76) on RHEL7
+        request = PasswordCheckRequest("4naconda-")
+        result = validatePassword(request)
         if ON_RHEL:
-            self.assertEqual(score, 1)  # quality < 50
-            self.assertEqual(status, _(constants.PASSWORD_STATUS_WEAK))
-            self.assertEqual(quality, 27)
-        self.assertIsNone(error_message)
-
-        # "4naconda----" gives a quality of 52 on RHEL7
-        score, status, quality, error_message = validatePassword("4naconda----")
-        if ON_RHEL:
-            self.assertEqual(score, 2)  # quality > 50 & < 75
-            self.assertEqual(status, _(constants.PASSWORD_STATUS_FAIR))
-            self.assertEqual(quality, 52)
-        self.assertIsNone(error_message)
-
-        # "----4naconda----" gives a quality of 81 on RHEL7
-        score, status, quality, error_message = validatePassword("----4naconda----")
-        if ON_RHEL:
-            self.assertEqual(score, 3)  # quality > 75 & < 90
-            self.assertEqual(status, _(constants.PASSWORD_STATUS_GOOD))
-            self.assertEqual(quality, 81)
-        self.assertIsNone(error_message)
+            self.assertEqual(result.password_score, 4)
+            self.assertEqual(result.status_text, _(constants.PASSWORD_STATUS_STRONG))
+            self.assertEqual(result.password_quality, 76)
+        self.assertIsNone(result.error_message)
 
         # "?----4naconda----?" gives a quality of 100 on RHEL7
-        score, status, quality, error_message = validatePassword("?----4naconda----?")
+        request = PasswordCheckRequest("?----4naconda----?")
+        result = validatePassword(request)
         # this should (hopefully) give quality 100 everywhere
-        self.assertEqual(score, 4)  # quality > 90
-        self.assertEqual(status, _(constants.PASSWORD_STATUS_STRONG))
-        self.assertEqual(quality, 100)
-        self.assertIsNone(error_message)
+        self.assertEqual(result.password_score, 4)
+        self.assertEqual(result.status_text, _(constants.PASSWORD_STATUS_STRONG))
+        self.assertEqual(result.password_quality, 100)
+        self.assertIsNone(result.error_message)
 
         # a long enough strong password with minlen set
-        score, status, quality, error_message = validatePassword("?----4naconda----?", minlen=10)
+        request = PasswordCheckRequest("?----4naconda----??!!", minimum_length=10)
+        result = validatePassword(request)
         # this should (hopefully) give quality 100 everywhere
-        self.assertEqual(score, 4)  # quality > 90
-        self.assertEqual(status, _(constants.PASSWORD_STATUS_STRONG))
-        self.assertEqual(quality, 100)
-        self.assertIsNone(error_message)
-
-        # minimum password length overrides strong passwords for score and status
-        score, status, quality, error_message = validatePassword("?----4naconda----?", minlen=30)
-        # this should (hopefully) give quality 100 everywhere
-        self.assertEqual(score, 0)  # too short
-        self.assertEqual(status, _(constants.PASSWORD_STATUS_TOO_SHORT))
-        self.assertEqual(quality, 100)  # independent on password length
-        self.assertIsNone(error_message)
+        self.assertEqual(result.password_score, 4)
+        self.assertEqual(result.status_text, _(constants.PASSWORD_STATUS_STRONG))
+        self.assertEqual(result.password_quality, 100)
+        self.assertIsNone(result.error_message)


### PR DESCRIPTION
This is a preliminary version of the password checking improvements - but the PR is rather big & changing quite a lot of stuff so I think it's good to make it available for review sooner rather then later.

In short what this pull request does:
- first commit setts a more sane default password policy
- the second commit refactors the password checking code, decreasing code duplication and hopefully making to code clearer and more easy to maintain
    - it also fixes a ton of small password checking issues if the maze that is the overall policy based password checking code

Looking forward to any feedback - thanks in advance!

Known issues - the following is a list of known issues with the PR. I plan to keep it up to date as issues are found & fixed, eventually ironing them all out so that the PR can be pushed:
- password status is not updated when whole password is selected and deleted - **FIXED**
- password policy does not properly affect LUKS passphrase entry - **FIXED**
- press-done-twice logic shows incorrect messages for empty password - **FIXED**
- the "create a user without password" checkbox is always inactive  & grayed out - **FIXED**
- non-ASCII passwords can't be used even if done is clicked repeatedly - **FIXED**
- password confirmation not applied if only the password and not the confirmation field change - **FIXED**
- [the RHEL7 docs](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html) will have to be changed to reflect the new saner password policy defaults
