### PR TITLE
Enable multiple inst.ks and inst.stage2 urls (#1391724)

### DIFF
--- a/docs/boot-options.txt
+++ b/docs/boot-options.txt
@@ -88,6 +88,9 @@ the space character (' ').
 This specifies the location to fetch only the installer runtime image;
 packages will be ignored. Otherwise the same as <<inst.repo,`inst.repo`>>.
 
+If there are specified multiple locations (only http, https or ftp), they
+will be used sequentially one by one until the image is fetched.
+
 === inst.dd ===
 This specifies the location for driver rpms. May be specified multiple times.
 Locations may be specified using any of the formats allowed for

--- a/docs/boot-options.txt
+++ b/docs/boot-options.txt
@@ -105,6 +105,9 @@ Give the location of a kickstart file to be used to automate the install.
 Locations may be specified using any of the formats allowed for
 <<inst.repo,`inst.repo`>>.
 
+If there are specified multiple locations (only http, https or ftp), they
+will be used sequentially one by one until the kickstart file is fetched.
+
 For any format the `<path>` component defaults to `/ks.cfg` if it is omitted.
 
 For NFS kickstarts, if the `<path>` ends in `/`, `<ip>-kickstart` is added.

--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -220,6 +220,28 @@ online_netdevs() {
     done
 }
 
+# Are all given locations only http, https or ftp urls?
+# Then succeed, otherwise fail.
+are_urls() {
+    local locations="${1}"
+    local location
+
+    # No locations, failure.
+    [ -z "$locations" ] && return 1
+
+    # Check all locations.
+    for location in $locations; do
+        case "${location%%:*}" in
+            http|https|ftp) continue ;;
+            # Another type, failure.
+            *) return 1 ;;
+        esac
+    done
+
+    # Success.
+    return 0
+}
+
 # This is where we actually run the kickstart. Whee!
 # We can't just add udev rules (we'll miss devices that are already active),
 # and we can't just run the scripts manually (we'll miss devices that aren't

--- a/dracut/parse-anaconda-kickstart.sh
+++ b/dracut/parse-anaconda-kickstart.sh
@@ -12,8 +12,23 @@ fi
 # no root? the kickstart will probably tell us what our root device is.
 [ "$kickstart" ] && [ -z "$root" ] && root="anaconda-kickstart"
 
+# Clean.
+rm -f /tmp/ks_urls
+
 case "${kickstart%%:*}" in
     http|https|ftp|nfs|nfs4) # network kickstart? set "neednet"!
+        # Save inst.ks urls to the file /tmp/ks_urls.
+        # If all given inst.ks locations are urls, we will
+        # enable multiple fetching. Otherwise, we will try
+        # only the last location, if it is an url.
+        locations="$(getargs ks= inst.ks=)"
+
+        if are_urls "$locations"; then
+            echo "$locations" > /tmp/ks_urls
+        elif are_urls "$kickstart"; then
+            echo "$kickstart" > /tmp/ks_urls
+        fi
+
         set_neednet
     ;;
     file|path) # "file:<path>" - "path:<path>" is accepted but deprecated

--- a/dracut/parse-anaconda-repo.sh
+++ b/dracut/parse-anaconda-repo.sh
@@ -11,10 +11,25 @@ arg="repo"
 # default to using repo, but if we have stage2=, use that
 [ -n "$stage2" ] && arg="stage2" && repo="$stage2"
 
+# Clean.
+rm -f /tmp/stage2_urls
+
 if [ -n "$repo" ]; then
     splitsep ":" "$repo" repotype rest
     case "$repotype" in
         http|https|ftp|nfs|nfs4|nfsiso)
+            # Save inst.stage2 urls to the file /tmp/stage2_urls.
+            # If all given inst.stage2 locations are urls, we will
+            # enable multiple fetching. Otherwise, we will try only
+            # the last location, if it is an url.
+            locations="$(getargs stage2= inst.stage2=)"
+
+            if are_urls "$locations"; then
+                echo "$locations" > /tmp/stage2_urls
+            elif are_urls "$stage2"; then
+                echo "$stage2" > /tmp/stage2_urls
+            fi
+
             set_neednet; root="anaconda-net:$repo" ;;
         hd|cd|cdrom)
             [ -n "$rest" ] && root="anaconda-disk:$rest" ;;


### PR DESCRIPTION
If there are defined multiple `inst.ks` urls in boot options, we enable to try the urls sequentially one by one untill we successfully fetch the kickstart file. All defined locations must be urls (only http, https or ftp), otherwise we will try only the last location. It works in the same way for `inst.stage2` option.

Resolves: rhbz#1391724