### PR TITLE
network: don't reactivate devices from linuxrc.s390 in loader only fo…

### DIFF
--- a/loader/net.c
+++ b/loader/net.c
@@ -2360,7 +2360,7 @@ int kickstartNetworkUp(struct loaderData_s * loaderData, iface_t * iface) {
 
     if (is_nm_connected() == TRUE &&
          ((loaderData->netDev != NULL && loaderData->netDev_set == 1)
-          || FL_HAVE_CMSCONF(flags))) {
+          || (FL_HAVE_CMSCONF(flags) && loaderData->ipv6info_set))) {
         if (anaconda_activated_some_device) {
             return 0;
         } else {


### PR DESCRIPTION
…r IPv6 (#1421039)

Resolves: rhbz#1421039
Related: rhbz#1329171

In commit dac45625a8e6813876f8ac7e433b10286095915e we stopped reactivating
devices activated during s390 linuxrc in loader because for IPv6 this
reactivation fails [1]. Now  it seems that for IPv4 the reactivation is needed
(at least for the case of this bug). Let's limit preventing the reactivation
only to cases where IPv6 is configured so that we go back to the former
behaviour for IPv4 configuration.

Other option would by to try to fix reactivating of IPv6 but due to the
fragility of the loader code and late stage of the release schedule I'd prefer
to go with IMO the safer before-mentioned approach.

[1] the reactivated device is (incorrectly for this case) configured to try
IPv4 default - dhcp which fails, but there might be more causes of the failure.