### PR TITLE
Add inst.notmux option

### DIFF
--- a/data/systemd/anaconda-direct.service
+++ b/data/systemd/anaconda-direct.service
@@ -5,6 +5,7 @@ After=instperf.service rsyslog.service systemd-udev-settle.service NetworkManage
 Requires=anaconda.service
 # TODO: use ConditionArchitecture in systemd v210 or later
 ConditionPathIsDirectory=|/sys/hypervisor/s390
+ConditionKernelCommandLine=|inst.notmux
 
 [Service]
 Environment=HOME=/root MALLOC_CHECK_=2 MALLOC_PERTURB_=204 PATH=/usr/bin:/bin:/sbin:/usr GDK_BACKEND=x11 XDG_RUNTIME_DIR=/tmp

--- a/data/systemd/anaconda-tmux@.service
+++ b/data/systemd/anaconda-tmux@.service
@@ -4,6 +4,7 @@ Requires=anaconda.service
 After=anaconda.target anaconda.service
 # TODO: use ConditionArchitecture in systemd v210 or later
 ConditionPathIsDirectory=!/sys/hypervisor/s390
+ConditionKernelCommandLine=!inst.notmux
 
 [Service]
 Type=idle

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -522,6 +522,14 @@ inst.noshell
 
 Do not put a shell on tty2 during install.
 
+.. inst.notmux:
+
+inst.notmux
+^^^^^^^^^^^
+
+Do not use tmux during install. This allows for output to get generated without
+terminal control characters and is really meant for non-interactive uses.
+
 .. inst.syslog:
 
 inst.syslog


### PR DESCRIPTION
Allows a user to execute the anaconda-direct.service rather than
anaconda-tmux.service if they want to. This allows a user to print
output to a console without any terminal control characters.

Fixes #958