### PR TITLE
util: Add script to capture logs

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 scriptsdir = $(libexecdir)/$(PACKAGE_NAME)
-dist_scripts_SCRIPTS = upd-updates run-anaconda zramswapon zramswapoff zram-stats anaconda-pre-log-gen
+dist_scripts_SCRIPTS = upd-updates run-anaconda zramswapon zramswapoff zram-stats anaconda-pre-log-gen log-capture
 dist_noinst_SCRIPTS  = upd-kernel makeupdates makebumpver
 
 dist_bin_SCRIPTS = analog anaconda-cleanup instperf anaconda-disable-nm-ibft-plugin

--- a/scripts/log-capture
+++ b/scripts/log-capture
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+date=$(date +%F_%R)
+OUTDIR=/tmp/LogCapture-${date}
+ARCHIVE=${1:/tmp/log-capture.tar.bz2}
+
+_to_log() { local OutputFile=$(tr ' /' '_' <<<"$@"); $@ >${OUTDIR}/${OutputFile}; }
+
+mkdir -p ${OUTDIR}
+cd ${OUTDIR}
+
+if [[ ! -f ks.cfg ]];then
+  echo "No /tmp/ks.cfg present" > ${OUTDIR}/ks.cfg
+fi
+
+_to_log cat /mnt/sysimage/root/anaconda-ks.cfg
+_to_log date
+_to_log dmesg
+_to_log dmidecode
+_to_log lspci -vvnn
+_to_log fdisk -cul
+_to_log ls -lR /dev
+_to_log dmsetup ls --tree
+_to_log lvm pvs
+_to_log lvm vgs
+_to_log lvm lvs
+_to_log cat /proc/mdstat
+_to_log cat /proc/partitions
+_to_log mount
+_to_log df -h
+_to_log cat /proc/meminfo
+_to_log cat /proc/cpuinfo
+_to_log ps axf
+_to_log lsof
+_to_log ip -s li
+_to_log ip a
+_to_log ip r
+
+cp /tmp/*.log ${OUTDIR}
+
+tar cfa ${ARCHIVE} ${OUTDIR}
+
+echo -e "\nFinished gathering data\nUpload ${ARCHIVE} to another system\n"

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -343,7 +343,7 @@ def copyUpdatedFiles(tag, updates, cwd, builddir):
         elif gitfile == "utils/handle-sshpw":
             install_to_dir(gitfile, "usr/sbin")
         elif any(gitfile.endswith(libexec_script) for libexec_script in \
-                 ("zramswapon", "zramswapoff", "zram-stats")):
+                 ("zramswapon", "zramswapoff", "zram-stats", "log-capture")):
             install_to_dir(gitfile, "usr/libexec/anaconda")
         elif gitfile.endswith("AnacondaWidgets.py"):
             import gi


### PR DESCRIPTION
I figured now that we've got `%onerror` shipping an easy script to capture the system state and error logs might come in handy for unifying the troubleshooting.

In theory I'd see the workflow something like:
```
%onerror
/usr/libexec/anaconda/LogCapture /tmp/mylogs.tar
scp /tmp/mylogs.tar hostname:/some/path
%end
```