### PR TITLE
Support DD rpm loading from local disk device (#1377233)

### DIFF
--- a/docs/driverdisc.rst
+++ b/docs/driverdisc.rst
@@ -19,7 +19,7 @@ Devices which can contain DDs
 -----------------------------
 
 The best place to save your DriverDisc to is USB flash device. We also support
-(or plan to) IDE and SATA block devices with or without partitions, DriverDisc
+IDE and SATA block devices with or without partitions, DriverDisc
 image stored on block device, initrd overlay (see documentation below) and for
 special cases even network retrieval of DriverDisc image.
 


### PR DESCRIPTION
You can now use inst.dd=hd:LABEL=DD:/dd.rpm as kernel boot option.

Changes:
driver-updates-genrules.sh - parse LABEL=DD and similar correctly

driver_updates.py
Optional parameter RPMPATH on --disk param, this parameter is path to the rpm file. If this parameter is present mount device and process the rpm on the mounted device like usual.

*Resolves: rhbz#1377233*