### PR TITLE
BlivetGUI in Anaconda

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -39,6 +39,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libtimezonemapver 0.4.1-2
 %define helpver 22.1-1
 %define libblockdevver 2.1
+%define blivetguiver 2.1.0
 
 BuildRequires: audit-libs-devel
 BuildRequires: gettext >= %{gettextver}
@@ -182,6 +183,7 @@ Requires: NetworkManager-wifi
 Requires: anaconda-user-help >= %{helpver}
 Requires: yelp
 Requires: python3-gobject-base
+Requires: blivet-gui >= %{blivetguiver}
 
 # Needed to compile the gsettings files
 BuildRequires: gsettings-desktop-schemas

--- a/pyanaconda/ui/gui/spokes/blivet_gui.glade
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.glade
@@ -44,6 +44,140 @@
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
+                <child>
+                  <object class="GtkBox" id="BlivetGuiBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">6</property>
+                    <property name="margin_right">6</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkViewport" id="BlivetGuiViewport">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="BottomBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">6</property>
+                    <property name="margin_right">6</property>
+                    <child>
+                      <object class="GtkBox" id="BottomLeftButtonBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkButton" id="summary_button">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="focus_on_click">False</property>
+                            <property name="receives_default">True</property>
+                            <property name="halign">start</property>
+                            <property name="relief">none</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0</property>
+                            <signal name="clicked" handler="on_summary_button_clicked" swapped="no"/>
+                            <child>
+                              <object class="GtkLabel" id="summary_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="use_underline">True</property>
+                                <attributes>
+                                  <attribute name="underline" value="True"/>
+                                  <attribute name="foreground" value="#00000000ffff"/>
+                                </attributes>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="BottomRightButtonBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkButton" id="undoLastActionButton">
+                            <property name="label" translatable="yes" context="GUI|Blivet Gui Partitioning">_Undo last action</property>
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">start</property>
+                            <property name="hexpand">True</property>
+                            <property name="use_underline">True</property>
+                            <signal name="clicked" handler="on_undo_action_button_clicked" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="resetAllButton">
+                            <property name="label" translatable="yes" context="GUI|Blivet Gui Partitioning">_Reset All</property>
+                            <property name="visible">True</property>
+                            <property name="sensitive">False</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">start</property>
+                            <property name="hexpand">True</property>
+                            <property name="use_underline">True</property>
+                            <signal name="clicked" handler="on_reset_button_clicked" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
               </object>
             </child>
           </object>

--- a/pyanaconda/ui/gui/spokes/blivet_gui.glade
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.glade
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
+<interface>
+  <requires lib="gtk+" version="3.16"/>
+  <requires lib="AnacondaWidgets" version="3.2"/>
+  <object class="AnacondaSpokeWindow" id="blivetGuiSpokeWindow">
+    <property name="can_focus">False</property>
+    <property name="window_name" translatable="yes">BLIVET GUI PARTITIONING</property>
+    <signal name="button-clicked" handler="on_back_clicked" swapped="no"/>
+    <signal name="info-bar-clicked" handler="on_info_bar_clicked" swapped="no"/>
+    <child internal-child="main_box">
+      <object class="GtkBox" id="AnacondaSpokeWindow-main_box1">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+        <child internal-child="nav_box">
+          <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
+            <property name="name">nav-box</property>
+            <property name="can_focus">False</property>
+            <child internal-child="nav_area">
+              <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">
+                <property name="can_focus">False</property>
+                <property name="margin_left">18</property>
+                <property name="margin_right">18</property>
+                <property name="margin_start">18</property>
+                <property name="margin_end">18</property>
+                <property name="margin_top">12</property>
+                <property name="margin_bottom">6</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child internal-child="alignment">
+          <object class="GtkAlignment" id="AnacondaSpokeWindow-alignment1">
+            <property name="can_focus">False</property>
+            <property name="yalign">0</property>
+            <child internal-child="action_area">
+              <object class="GtkBox" id="AnacondaSpokeWindow-action_area1">
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -1,0 +1,294 @@
+#
+# Copyright (C) 2015 - 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vratislav Podzimek <vpodzime@redhat.com>
+#                    Vojtech Trefny <vtrefny@redhat.com>
+#
+
+"""Module with the BlivetGuiSpoke class."""
+
+import gi
+gi.require_version("Gtk", "3.0")
+
+from gi.repository import Gtk
+
+from pyanaconda.ui.gui.spokes import NormalSpoke
+from pyanaconda.ui.helpers import StorageChecker
+from pyanaconda.ui.categories.system import SystemCategory
+from pyanaconda.ui.gui.spokes.lib.summary import ActionSummaryDialog
+from pyanaconda.i18n import _, CN_, C_
+from pyanaconda import isys
+from pyanaconda.bootloader import BootLoaderError
+
+from blivetgui import osinstall
+
+import logging
+log = logging.getLogger("anaconda")
+
+# export only the spoke, no helper functions, classes or constants
+__all__ = ["BlivetGuiSpoke"]
+
+class BlivetGuiSpoke(NormalSpoke, StorageChecker):
+    ### class attributes defined by API ###
+
+    # list all top-level objects from the .glade file that should be exposed
+    # to the spoke or leave empty to extract everything
+    builderObjects = ["blivetGuiSpokeWindow"]
+
+    # the name of the main window widget
+    mainWidgetName = "blivetGuiSpokeWindow"
+
+    # name of the .glade file in the same directory as this source
+    uiFile = "spokes/blivet_gui.glade"
+
+    # category this spoke belongs to
+    category = SystemCategory
+
+    # title of the spoke (will be displayed on the hub)
+    title = CN_("GUI|Spoke", "_BLIVET-GUI PARTITIONING")
+
+    helpFile = "BlivetGuiSpoke.xml"
+
+    ### methods defined by API ###
+    def __init__(self, data, storage, payload, instclass):
+        """
+        :see: pyanaconda.ui.common.Spoke.__init__
+        :param data: data object passed to every spoke to load/store data
+                     from/to it
+        :type data: pykickstart.base.BaseHandler
+        :param storage: object storing storage-related information
+                        (disks, partitioning, bootloader, etc.)
+        :type storage: blivet.Blivet
+        :param payload: object storing packaging-related information
+        :type payload: pyanaconda.packaging.Payload
+        :param instclass: distribution-specific information
+        :type instclass: pyanaconda.installclass.BaseInstallClass
+
+        """
+
+        self._error = None
+        self._back_already_clicked = False
+        self._storage_playground = None
+        self.label_actions = None
+        self.button_reset = None
+        self.button_undo = None
+
+        StorageChecker.__init__(self, min_ram=isys.MIN_GUI_RAM)
+        NormalSpoke.__init__(self, data, storage, payload, instclass)
+
+    def initialize(self):
+        """
+        The initialize method that is called after the instance is created.
+        The difference between __init__ and this method is that this may take
+        a long time and thus could be called in a separated thread.
+
+        :see: pyanaconda.ui.common.UIObject.initialize
+
+        """
+
+        NormalSpoke.initialize(self)
+        self.initialize_start()
+
+        self._storage_playground = None
+
+        self.client = osinstall.BlivetGUIAnacondaClient()
+        box = self.builder.get_object("BlivetGuiViewport")
+        self.label_actions = self.builder.get_object("summary_label")
+        self.button_reset = self.builder.get_object("resetAllButton")
+        self.button_undo = self.builder.get_object("undoLastActionButton")
+
+        self.blivetgui = osinstall.BlivetGUIAnaconda(self.client, self, box)
+
+        self.initialize_done()
+
+    def refresh(self):
+        """
+        The refresh method that is called every time the spoke is displayed.
+        It should update the UI elements according to the contents of
+        self.data.
+
+        :see: pyanaconda.ui.common.UIObject.refresh
+
+        """
+
+        self._back_already_clicked = False
+
+        self._storage_playground = self.storage.copy()
+        self.client.initialize(self._storage_playground)
+        self.blivetgui.initialize()
+
+        # if we re-enter blivet-gui spoke, actions from previous visit were
+        # not removed, we need to update number of blivet-gui actions
+        current_actions = self._storage_playground.devicetree.actions.find()
+        if current_actions:
+            self.blivetgui.set_actions(current_actions)
+
+    def apply(self):
+        """
+        The apply method that is called when the spoke is left. It should
+        update the contents of self.data with values set in the GUI elements.
+
+        """
+
+        pass
+
+    def execute(self):
+        """
+        The excecute method that is called when the spoke is left. It is
+        supposed to do all changes to the runtime environment according to
+        the values set in the GUI elements.
+
+        """
+
+        # nothing to do here
+        pass
+
+    @property
+    def indirect(self):
+        return True
+
+    # This spoke has no status since it's not in a hub
+    @property
+    def status(self):
+        return None
+
+    def clear_errors(self):
+        self._error = None
+        self.clear_info()
+
+    def _do_check(self):
+        self.clear_errors()
+        StorageChecker.errors = []
+        StorageChecker.warnings = []
+
+        # We can't overwrite the main Storage instance because all the other
+        # spokes have references to it that would get invalidated, but we can
+        # achieve the same effect by updating/replacing a few key attributes.
+        self.storage.devicetree._devices = self._storage_playground.devicetree._devices
+        self.storage.devicetree._actions = self._storage_playground.devicetree._actions
+        self.storage.devicetree._hidden = self._storage_playground.devicetree._hidden
+        self.storage.devicetree.names = self._storage_playground.devicetree.names
+        self.storage.roots = self._storage_playground.roots
+
+        # set up bootloader and check the configuration
+        try:
+            self.storage.set_up_bootloader()
+        except BootLoaderError as e:
+            log.error("storage configuration failed: %s", e)
+            StorageChecker.errors = str(e).split("\n")
+            self.data.bootloader.bootDrive = ""
+
+        StorageChecker.checkStorage(self)
+
+        if self.errors:
+            self.set_warning(_("Error checking storage configuration.  <a href=\"\">Click for details</a> or press Done again to continue."))
+        elif self.warnings:
+            self.set_warning(_("Warning checking storage configuration.  <a href=\"\">Click for details</a> or press Done again to continue."))
+
+        # on_info_bar_clicked requires self._error to be set, so set it to the
+        # list of all errors and warnings that storage checking found.
+        self._error = "\n".join(self.errors + self.warnings)
+
+        return self._error == ""
+
+    def activate_action_buttons(self, activate):
+        self.button_undo.set_sensitive(activate)
+        self.button_reset.set_sensitive(activate)
+
+    ### handlers ###
+    def on_info_bar_clicked(self, *args):
+        log.debug("info bar clicked: %s (%s)", self._error, args)
+        if not self._error:
+            return
+
+        dlg = Gtk.MessageDialog(flags=Gtk.DialogFlags.MODAL,
+                                message_type=Gtk.MessageType.ERROR,
+                                buttons=Gtk.ButtonsType.CLOSE,
+                                message_format=str(self._error))
+        dlg.set_decorated(False)
+
+        with self.main_window.enlightbox(dlg):
+            dlg.run()
+            dlg.destroy()
+
+    def on_back_clicked(self, button):
+        # Clear any existing errors
+        self.clear_errors()
+
+        # If back has been clicked on once already and no other changes made on the screen,
+        # run the storage check now.  This handles displaying any errors in the info bar.
+        if not self._back_already_clicked:
+            self._back_already_clicked = True
+
+            # If we hit any errors while saving things above, stop and let the
+            # user think about what they have done
+            if self._error is not None:
+                return
+
+            if not self._do_check():
+                return
+
+        if len(self._storage_playground.devicetree.actions.find()) > 0:
+            dialog = ActionSummaryDialog(self.data)
+            dialog.refresh(self._storage_playground.devicetree.actions.find())
+            with self.main_window.enlightbox(dialog.window):
+                rc = dialog.run()
+
+            if rc != 1:
+                # Cancel.  Stay on the blivet-gui screen.
+                return
+            else:
+                # remove redundant actions and sort them now
+                self._storage_playground.devicetree.actions.prune()
+                self._storage_playground.devicetree.actions.sort()
+
+        NormalSpoke.on_back_clicked(self, button)
+
+    def on_summary_button_clicked(self, _button):
+        self.blivetgui.show_actions()
+
+    def on_undo_action_button_clicked(self, _button):
+        self.blivetgui.actions_undo()
+
+    # This callback is for the button that just resets the UI to anaconda's
+    # current understanding of the disk layout.
+    def on_reset_button_clicked(self, *args):
+        msg = _("Continuing with this action will reset all your partitioning selections "
+                "to their current on-disk state.")
+
+        dlg = Gtk.MessageDialog(flags=Gtk.DialogFlags.MODAL,
+                                message_type=Gtk.MessageType.WARNING,
+                                buttons=Gtk.ButtonsType.NONE,
+                                message_format=msg)
+        dlg.set_decorated(False)
+        dlg.add_buttons(C_("GUI|Custom Partitioning|Reset Dialog", "_Reset selections"), 0,
+                        C_("GUI|Custom Partitioning|Reset Dialog", "_Preserve current selections"), 1)
+        dlg.set_default_response(1)
+
+        with self.main_window.enlightbox(dlg):
+            rc = dlg.run()
+            dlg.destroy()
+
+        if rc == 0:
+            self.refresh()
+            self.blivetgui.reload()
+
+            # XXX: Reset currently preserves actions set in previous runs
+            # of the spoke, so we need to 're-add' these to the ui
+            current_actions = self._storage_playground.devicetree.actions.find()
+            if current_actions:
+                self.blivetgui.set_actions(current_actions)

--- a/pyanaconda/ui/gui/spokes/storage.glade
+++ b/pyanaconda/ui/gui/spokes/storage.glade
@@ -798,7 +798,7 @@
                                   <packing>
                                     <property name="left_attach">0</property>
                                     <property name="top_attach">0</property>
-                                    <property name="width">2</property>
+                                    <property name="width">3</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -815,7 +815,7 @@
                                   <packing>
                                     <property name="left_attach">0</property>
                                     <property name="top_attach">3</property>
-                                    <property name="width">2</property>
+                                    <property name="width">3</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -848,6 +848,23 @@
                                   </object>
                                   <packing>
                                     <property name="left_attach">1</property>
+                                    <property name="top_attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkRadioButton" id="blivetguiRadioButton">
+                                    <property name="label" translatable="yes" context="GUI|Storage">_Use blivet-gui.</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="use_underline">True</property>
+                                    <property name="xalign">0</property>
+                                    <property name="draw_indicator">True</property>
+                                    <property name="group">autopartRadioButton</property>
+                                    <signal name="toggled" handler="on_custom_toggled" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">2</property>
                                     <property name="top_attach">1</property>
                                   </packing>
                                 </child>
@@ -899,7 +916,7 @@
                                   <packing>
                                     <property name="left_attach">0</property>
                                     <property name="top_attach">4</property>
-                                    <property name="width">2</property>
+                                    <property name="width">3</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -918,6 +935,12 @@
                                     <property name="width">2</property>
                                   </packing>
                                 </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
                                 <child internal-child="accessible">
                                   <object class="AtkObject" id="other_options_grid-atkobject">
                                     <property name="AtkObject::accessible-name" translatable="yes">Storage Options</property>
@@ -929,6 +952,9 @@
                                 <property name="fill">True</property>
                                 <property name="position">9</property>
                               </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
                             </child>
                           </object>
                         </child>

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -644,8 +644,6 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         if self.encrypted:
             self._encrypted.set_active(True)
 
-        self._customPart.set_active(not self.autopart)
-
         self._update_summary()
 
         self._check_problems()

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -74,6 +74,7 @@ from pyanaconda.i18n import _, C_, CN_, P_
 from pyanaconda import constants, iutil, isys
 from pyanaconda.bootloader import BootLoaderError
 from pyanaconda.storage_utils import on_disk_storage
+from pyanaconda.screen_access import sam
 
 from pykickstart.constants import CLEARPART_TYPE_NONE, AUTOPART_TYPE_LVM
 from pykickstart.errors import KickstartParseError
@@ -303,6 +304,15 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         self._autoPart.connect("toggled", self._method_radio_button_toggled)
         self._customPart.connect("toggled", self._method_radio_button_toggled)
         self._blivetGuiPart.connect("toggled", self._method_radio_button_toggled)
+
+        # hide radio buttons for spokes that have been marked as visited by the
+        # user interaction config file
+        if sam.get_screen_visited("CustomPartitioningSpoke"):
+            self._customPart.set_visible(False)
+            self._customPart.set_no_show_all(True)
+        if sam.get_screen_visited("BlivetGuiSpoke"):
+            self._blivetGuiPart.set_visible(False)
+            self._blivetGuiPart.set_no_show_all(True)
 
         self._last_partitioning_method = self._get_selected_partitioning_method()
 

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -296,6 +296,7 @@ class StorageSpoke(NormalSpoke, StorageChecker):
 
     def _grabObjects(self):
         self._customPart = self.builder.get_object("customRadioButton")
+        self._blivetGuiPart = self.builder.get_object("blivetguiRadioButton")
         self._encrypted = self.builder.get_object("encryptionCheckbox")
         self._reclaim = self.builder.get_object("reclaimCheckbox")
 
@@ -1021,11 +1022,14 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         # 2) user wants to reclaim some more space => run the ResizeDialog
         # 3) we are just asked to do autopart => check free space and see if we need
         #                                        user to do anything more
-        self.autopart = not self._customPart.get_active()
+        self.autopart = not self._customPart.get_active() and not self._blivetGuiPart.get_active()
         disks = [d for d in self.disks if d.name in self.selected_disks]
         dialog = None
         if not self.autopart:
-            self.skipTo = "CustomPartitioningSpoke"
+            if self._customPart.get_active():
+                self.skipTo = "CustomPartitioningSpoke"
+            if self._blivetGuiPart.get_active():
+                self.skipTo = "BlivetGuiSpoke"
         elif self._reclaim.get_active():
             # HINT: change the logic of this 'if' statement if we are asked to
             # support "reclaim before custom partitioning"


### PR DESCRIPTION
Add BlivetGUI to Anaconda. This PR adds new "BlivetGUI spoke" and adds blivet-gui as a third option for partitioning to Storage spoke.

updates.img for testing -- https://vtrefny.fedorapeople.org/img/blivetgui.img (update images are broken in latests rawhide, use [this compose](https://kojipkgs.fedoraproject.org/compose/rawhide/Fedora-Rawhide-20170220.n.2/compose/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-Rawhide-20170220.n.2.iso))
