### PR TITLE
Fix tests by renaming packaging to payload

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -635,7 +635,7 @@ if __name__ == "__main__":
         anaconda.storage.setup_disk_images()
 
     from blivet.osinstall import storage_initialize
-    from pyanaconda.packaging import payloadMgr
+    from pyanaconda.payload import payloadMgr
     from pyanaconda.timezone import time_initialize
 
     if not flags.dirInstall:

--- a/configure.ac
+++ b/configure.ac
@@ -133,7 +133,7 @@ AC_CONFIG_FILES([Makefile
                  pyanaconda/Makefile
                  pyanaconda/version.py
                  pyanaconda/isys/Makefile
-                 pyanaconda/packaging/Makefile
+                 pyanaconda/payload/Makefile
                  pyanaconda/ui/Makefile
                  pyanaconda/ui/categories/Makefile
                  pyanaconda/ui/lib/Makefile

--- a/pyanaconda/Makefile.am
+++ b/pyanaconda/Makefile.am
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = installclasses isys ui packaging
+SUBDIRS = installclasses isys ui payload
 
 MAINTAINERCLEANFILES = Makefile.in
 

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -107,7 +107,7 @@ class Anaconda(object):
 
     @property
     def payload(self):
-        # Try to find the packaging payload class.  First try the install
+        # Try to find the payload class.  First try the install
         # class.  If it doesn't give us one, fall back to the default.
         if not self._payload:
             klass = self.instClass.getBackend()
@@ -116,16 +116,16 @@ class Anaconda(object):
                 from pyanaconda.flags import flags
 
                 if self.ksdata.ostreesetup.seen:
-                    from pyanaconda.packaging.rpmostreepayload import RPMOSTreePayload
+                    from pyanaconda.payload.rpmostreepayload import RPMOSTreePayload
                     klass = RPMOSTreePayload
                 elif flags.livecdInstall:
-                    from pyanaconda.packaging.livepayload import LiveImagePayload
+                    from pyanaconda.payload.livepayload import LiveImagePayload
                     klass = LiveImagePayload
                 elif self.ksdata.method.method == "liveimg":
-                    from pyanaconda.packaging.livepayload import LiveImageKSPayload
+                    from pyanaconda.payload.livepayload import LiveImageKSPayload
                     klass = LiveImageKSPayload
                 else:
-                    from pyanaconda.packaging.dnfpayload import DNFPayload
+                    from pyanaconda.payload.dnfpayload import DNFPayload
                     klass = DNFPayload
 
             self._payload = klass(self.ksdata)

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -35,7 +35,7 @@ from pyanaconda.flags import flags, can_touch_runtime_system
 from blivet.fcoe import fcoe
 import pyanaconda.network
 from pyanaconda.errors import errorHandler, ERROR_RAISE, ZIPLError
-from pyanaconda.packaging.rpmostreepayload import RPMOSTreePayload
+from pyanaconda.payload.rpmostreepayload import RPMOSTreePayload
 from pyanaconda.nm import nm_device_hwaddress
 from blivet import platform
 from blivet.size import Size

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -326,8 +326,8 @@ class Bootloader(commands.bootloader.F21_Bootloader):
             :param storage: object storing storage-related information
                             (disks, partitioning, bootloader, etc.)
             :type storage: blivet.Blivet
-            :param payload: object storing packaging-related information
-            :type payload: pyanaconda.packaging.Payload
+            :param payload: object storing payload-related information
+            :type payload: pyanaconda.payload.Payload
             :param instclass: distribution-specific information
             :type instclass: pyanaconda.installclass.BaseInstallClass
             :param dry_run: flag if this is only dry run before the partitioning

--- a/pyanaconda/payload/Makefile.am
+++ b/pyanaconda/payload/Makefile.am
@@ -1,4 +1,4 @@
-# packaging/Makefile.am for anaconda
+# payload/Makefile.am for anaconda
 #
 # Copyright (C) 2012  Red Hat, Inc.
 #
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 pkgpyexecdir = $(pyexecdir)/py$(PACKAGE_NAME)
-packagingdir = $(pkgpyexecdir)/packaging
-packaging_PYTHON = $(srcdir)/*.py
+payloaddir = $(pkgpyexecdir)/payload
+payload_PYTHON = $(srcdir)/*.py
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -693,19 +693,19 @@ class Payload(object):
         self._copyDriverDiskFiles()
 
     def writeStorageEarly(self):
-        """Some packaging payloads require that the storage configuration be
-           written out before doing installation.  Right now, this is basically
-           just the dnfpayload.  Payloads should only implement one of these
-           methods by overriding the unneeded one with a pass.
+        """Some payloads require that the storage configuration be written out
+           before doing installation.  Right now, this is basically just the
+           dnfpayload.  Payloads should only implement one of these methods
+           by overriding the unneeded one with a pass.
         """
         if not flags.dirInstall:
             self.storage.write()
 
     def writeStorageLate(self):
-        """Some packaging payloads require that the storage configuration be
-           written out after doing installation.  Right now, this is basically
-           every payload except for dnf.  Payloads should only implement one of
-           these methods by overriding the unneeded one with a pass.
+        """Some payloads require that the storage configuration be written out
+           after doing installation.  Right now, this is basically every payload
+           except for dnf.  Payloads should only implement one of these methods
+           by overriding the unneeded one with a pass.
         """
         if iutil.getSysroot() != iutil.getTargetPhysicalRoot():
             set_sysroot(iutil.getTargetPhysicalRoot(), iutil.getSysroot())
@@ -1293,7 +1293,7 @@ class PayloadManager(object):
 
            :param blivet.Blivet storage: The blivet storage instance
            :param kickstart.AnacondaKSHandler ksdata: The kickstart data instance
-           :param packaging.Payload payload: The payload instance
+           :param payload.Payload payload: The payload instance
            :param installclass.BaseInstallClass instClass: The install class instance
            :param bool fallback: Whether to fall back to the default repo in case of error
            :param bool checkmount: Whether to check for valid mounted media

--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -37,7 +37,7 @@ import hashlib
 import glob
 import functools
 
-from pyanaconda.packaging import ImagePayload, PayloadSetupError, PayloadInstallError
+from pyanaconda.payload import ImagePayload, PayloadSetupError, PayloadInstallError
 
 from pyanaconda.constants import INSTALL_TREE, THREAD_LIVE_PROGRESS
 from pyanaconda.constants import IMAGE_DIR, TAR_SUFFIX
@@ -53,7 +53,7 @@ from blivet.size import Size
 import blivet.util
 from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.i18n import _
-from pyanaconda.packaging import versionCmp
+from pyanaconda.payload import versionCmp
 
 class LiveImagePayload(ImagePayload):
     """ A LivePayload copies the source image onto the target system. """

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -40,7 +40,7 @@ from blivet.util import umount
 import logging
 log = logging.getLogger("anaconda")
 
-from pyanaconda.packaging import ArchivePayload, PayloadInstallError
+from pyanaconda.payload import ArchivePayload, PayloadInstallError
 import pyanaconda.errors as errors
 
 class RPMOSTreePayload(ArchivePayload):

--- a/pyanaconda/payload/tarpayload.py
+++ b/pyanaconda/payload/tarpayload.py
@@ -34,7 +34,7 @@ except ImportError:
     log.error("import of tarfile failed")
     tarfile = None
 
-from pyanaconda.packaging import ArchivePayload, PayloadError, versionCmp
+from pyanaconda.payload import ArchivePayload, PayloadError, versionCmp
 from pyanaconda import iutil
 
 # TarPayload is not yet fully implemented

--- a/pyanaconda/ui/__init__.py
+++ b/pyanaconda/ui/__init__.py
@@ -50,7 +50,7 @@ class UserInterface(object):
         storage      -- An instance of storage.Storage.  This is useful for
                         determining what storage devices are present and how
                         they are configured.
-        payload      -- An instance of a packaging.Payload subclass.  This
+        payload      -- An instance of a payload.Payload subclass.  This
                         is useful for displaying and selecting packages to
                         install, and in carrying out the actual installation.
         instclass    -- An instance of a BaseInstallClass subclass.  This

--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -202,7 +202,7 @@ class Spoke(object, metaclass=ABCMeta):
            storage      -- An instance of storage.Storage.  This is useful for
                            determining what storage devices are present and how
                            they are configured.
-           payload      -- An instance of a packaging.Payload subclass.  This
+           payload      -- An instance of a payload.Payload subclass.  This
                            is useful for displaying and selecting packages to
                            install, and in carrying out the actual installation.
            instclass    -- An instance of a BaseInstallClass subclass.  This
@@ -545,7 +545,7 @@ class Hub(object, metaclass=ABCMeta):
            storage      -- An instance of storage.Storage.  This is useful for
                            determining what storage devices are present and how
                            they are configured.
-           payload      -- An instance of a packaging.Payload subclass.  This
+           payload      -- An instance of a payload.Payload subclass.  This
                            is useful for displaying and selecting packages to
                            install, and in carrying out the actual installation.
            instclass    -- An instance of a BaseInstallClass subclass.  This

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -77,7 +77,7 @@ class Hub(GUIObject, common.Hub):
            storage      -- An instance of storage.Storage.  This is useful for
                            determining what storage devices are present and how
                            they are configured.
-           payload      -- An instance of a packaging.Payload subclass.  This
+           payload      -- An instance of a payload.Payload subclass.  This
                            is useful for displaying and selecting packages to
                            install, and in carrying out the actual installation.
            instclass    -- An instance of a BaseInstallClass subclass.  This

--- a/pyanaconda/ui/gui/hubs/summary.py
+++ b/pyanaconda/ui/gui/hubs/summary.py
@@ -47,7 +47,7 @@ class SummaryHub(Hub):
            storage      -- An instance of storage.Storage.  This is useful for
                            determining what storage devices are present and how
                            they are configured.
-           payload      -- An instance of a packaging.Payload subclass.  This
+           payload      -- An instance of a payload.Payload subclass.  This
                            is useful for displaying and selecting packages to
                            install, and in carrying out the actual installation.
            instclass    -- An instance of a BaseInstallClass subclass.  This

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -73,8 +73,8 @@ class BlivetGuiSpoke(NormalSpoke, StorageChecker):
         :param storage: object storing storage-related information
                         (disks, partitioning, bootloader, etc.)
         :type storage: blivet.Blivet
-        :param payload: object storing packaging-related information
-        :type payload: pyanaconda.packaging.Payload
+        :param payload: object storing payload-related information
+        :type payload: pyanaconda.payload.Payload
         :param instclass: distribution-specific information
         :type instclass: pyanaconda.installclass.BaseInstallClass
 

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1519,7 +1519,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         if self.networking_changed:
             if ANACONDA_ENVIRON in anaconda_flags.environs and self.payload.needsNetwork:
                 log.debug("network spoke (apply) refresh payload")
-                from pyanaconda.packaging import payloadMgr
+                from pyanaconda.payload import payloadMgr
                 payloadMgr.restartThread(self.storage, self.data, self.payload, self.instclass,
                                          fallback=not anaconda_flags.automatedInstall)
             else:
@@ -1657,7 +1657,7 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
         log.debug("network standalone spoke (apply) payload: %s completed: %s", self.payload.baseRepo, self._now_available)
         if (not self.payload.baseRepo and not self._initially_available
             and self._now_available and self.payload.needsNetwork):
-            from pyanaconda.packaging import payloadMgr
+            from pyanaconda.payload import payloadMgr
             payloadMgr.restartThread(self.storage, self.data, self.payload, self.instclass,
                     fallback=not anaconda_flags.automatedInstall)
 

--- a/pyanaconda/ui/gui/spokes/software.py
+++ b/pyanaconda/ui/gui/spokes/software.py
@@ -25,7 +25,7 @@ from gi.repository import Gtk, Pango
 
 from pyanaconda.flags import flags
 from pyanaconda.i18n import _, C_, CN_
-from pyanaconda.packaging import PackagePayload, payloadMgr, NoSuchGroup
+from pyanaconda.payload import PackagePayload, payloadMgr, NoSuchGroup
 from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda import constants, iutil
 
@@ -211,7 +211,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
         self._apply()
 
     def checkSoftwareSelection(self):
-        from pyanaconda.packaging import DependencyError
+        from pyanaconda.payload import DependencyError
         hubQ.send_message(self.__class__.__name__, _("Checking software dependencies..."))
         try:
             self.payload.checkSoftwareSelection()

--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -46,7 +46,7 @@ from pyanaconda.ui.gui.utils import blockedHandler, fire_gtk_action, find_first_
 from pyanaconda.iutil import ProxyString, ProxyStringError, cmp_obj_attrs
 from pyanaconda.ui.gui.utils import gtk_call_once, really_hide, really_show, fancy_set_sensitive
 from pyanaconda.threads import threadMgr, AnacondaThread
-from pyanaconda.packaging import PackagePayload, payloadMgr
+from pyanaconda.payload import PackagePayload, payloadMgr
 from pyanaconda.regexes import REPO_NAME_VALID, URL_PARSE, HOSTNAME_PATTERN_WITHOUT_ANCHORS
 from pyanaconda import constants
 from pyanaconda import nm
@@ -1228,7 +1228,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         self._updateURLEntryCheck()
 
     def _update_payload_repos(self):
-        """ Change the packaging repos to match the new edits
+        """ Change the payload repos to match the new edits
 
             This will add new repos to the addon repo list, remove
             ones that were removed and update any changes made to

--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -59,7 +59,7 @@ from pyanaconda import constants
 from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.i18n import _
-from pyanaconda.packaging import payloadMgr
+from pyanaconda.payload import payloadMgr
 from pyanaconda import isys
 
 import logging

--- a/pyanaconda/ui/lib/space.py
+++ b/pyanaconda/ui/lib/space.py
@@ -40,7 +40,7 @@ class FileSystemSpaceChecker(object):
 
            Attributes:
 
-           payload  -- An instance of a packaging.Payload subclass.
+           payload  -- An instance of a payload.Payload subclass.
            storage  -- An instance of storage.Storage.
         """
         self.payload = payload

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -253,7 +253,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, EditTUISpoke):
         if self._apply:
             self._apply = False
             if ANACONDA_ENVIRON in flags.environs:
-                from pyanaconda.packaging import payloadMgr
+                from pyanaconda.payload import payloadMgr
                 payloadMgr.restartThread(self.storage, self.data, self.payload,
                                          self.instclass, checkmount=False)
 

--- a/pyanaconda/ui/tui/spokes/software.py
+++ b/pyanaconda/ui/tui/spokes/software.py
@@ -22,7 +22,7 @@ from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.simpleline import TextWidget, ColumnWidget, CheckboxWidget
 from pyanaconda.threads import threadMgr, AnacondaThread
-from pyanaconda.packaging import DependencyError, PackagePayload, payloadMgr, NoSuchGroup
+from pyanaconda.payload import DependencyError, PackagePayload, payloadMgr, NoSuchGroup
 from pyanaconda.i18n import N_, _, C_
 
 from pyanaconda.constants import THREAD_PAYLOAD

--- a/pyanaconda/ui/tui/spokes/source.py
+++ b/pyanaconda/ui/tui/spokes/source.py
@@ -23,7 +23,7 @@ from pyanaconda.ui.tui.spokes import EditTUISpoke, NormalTUISpoke
 from pyanaconda.ui.tui.spokes import EditTUISpokeEntry as Entry
 from pyanaconda.ui.tui.simpleline import TextWidget, ColumnWidget
 from pyanaconda.threads import threadMgr, AnacondaThread
-from pyanaconda.packaging import PackagePayload, payloadMgr
+from pyanaconda.payload import PackagePayload, payloadMgr
 from pyanaconda.i18n import N_, _, C_
 from pyanaconda.image import opticalInstallMedia, potentialHdisoSources
 from pyanaconda.iutil import DataHolder

--- a/tests/pyanaconda_tests/payload_test.py
+++ b/tests/pyanaconda_tests/payload_test.py
@@ -18,7 +18,7 @@
 # Red Hat, Inc.
 #
 
-from pyanaconda.packaging import dnfpayload
+from pyanaconda.payload import dnfpayload
 from blivet.size import Size
 import unittest
 


### PR DESCRIPTION
`Pylint` and `nosetests` are failing now because `python3-setuptools` have a new dependency which is called 'packaging'. So when our tests set the `PYTHONPATH` to `pyanaconda` directory then we will replace the python3 standard `packaging` module.

Renaming from `pyanaconda/packaging` to `pyanaconda/payload` should fix this issue.