### PR TITLE
Fixes in tui software selection

### DIFF
--- a/pyanaconda/packaging/yumpayload.py
+++ b/pyanaconda/packaging/yumpayload.py
@@ -441,18 +441,27 @@ reposdir=%s
         """Release package sacks and close their connections to the database."""
         with _yum_lock:
             # Check if the meta package sack was created.
-            if self._yum._pkgSack is not None:
+            if self._yum._pkgSack is None:
+                return
 
+            try:
                 # Drop cached data in every sack.
                 self._yum.pkgSack.dropCachedData()
 
                 # Close every sack.
                 for sack in self._yum.pkgSack.sacks.values():
-                    sack.close()
-                    del sack
+                    try:
+                        sack.close()
+                        del sack
+                    except RepoError as error:
+                        log.warn("The payload sack could not be closed: %s", error)
 
                 # Close the meta sack.
                 del self._yum.pkgSack
+
+            except RepoError as error:
+                # Do not propagate the repo exceptions.
+                log.warn("The payload could not be released: %s", error)
 
     def deleteYumTS(self):
         with _yum_lock:
@@ -1398,6 +1407,9 @@ reposdir=%s
             else:
                 for msg in msgs:
                     log.warning(msg)
+
+                # Release the package sacks.
+                self.release()
 
                 raise DependencyError(msgs)
 

--- a/pyanaconda/ui/tui/spokes/software.py
+++ b/pyanaconda/ui/tui/spokes/software.py
@@ -236,9 +236,11 @@ class SoftwareSpoke(NormalTUISpoke):
         """ Depsolving """
         try:
             self.payload.checkSoftwareSelection()
-        except DependencyError:
+        except DependencyError as e:
+            self.errors = [str(e)]
             self._tx_id = None
         else:
+            self.errors = []
             self._tx_id = self.payload.txID
 
     @property


### PR DESCRIPTION
Some small fixes in the tui software selection spoke and the yum payload:

* If the software selection is defined by a kickstart file, we should remember it and use it until a new software selection is made. Resolves: rhbz#1371229
* The software spoke should not be initialized in the `status` method, but in the `initialize` method.
* If the `checkSoftwareSelection` finds a dependency error, we should report an error instead of showing the source changed message. Resolves: rhbz#979307
* Payload should be released also in a case that a dependency error is found.
* Release can raise an exception if we try to release resources from different threads. That should not happen and we should fix these cases. However, we don't want the installer to fail because of that either. Therefore, all exceptions from release will be catched and logged only.