### PR TITLE
Use system Python when running Anaconda

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/libexec/system-python
 #
 # anaconda: The Red Hat Linux Installation program
 #

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -83,6 +83,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 
 %package core
 Summary: Core of the Anaconda installer
+Requires: python3-libs
 Requires: python3-dnf >= %{dnfver}
 Requires: python3-blivet >= 1:2.1.7-3
 Requires: python3-blockdev >= %{libblockdevver}


### PR DESCRIPTION
Change the shebang in the main Anaconda script to use system Python.
This should result in get_python_lib() returning the correct path to
site packages even once the Python side change (bug 1426435) is reapplied.