### PR TITLE
Remove redundant help content generation code (#1428787)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -66,11 +66,11 @@ po-empty:
 		exit 1 ; \
 	done
 
-scratch: po-empty get-help
+scratch: po-empty
 	$(MAKE) ARCHIVE_TAG=HEAD dist
 	git checkout -- $(srcdir)/po/$(PACKAGE_NAME).pot
 
-scratch-bumpver: po-empty get-help
+scratch-bumpver: po-empty
 	@opts="-S -n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT) --newrelease $(RC_RELEASE)" ; \
 	if [ ! -z "$(IGNORE)" ]; then \
 		opts="$${opts} -i $(IGNORE)" ; \
@@ -87,7 +87,7 @@ scratch-bumpver: po-empty get-help
 	( cd $(srcdir) && scripts/makebumpver --skip-zanata $${opts} ) || exit 1 ; \
 	$(MAKE) -C po $(PACKAGE_NAME).pot-update
 
-release: get-help
+release:
 	$(MAKE) dist && $(MAKE) tag && git checkout -- $(srcdir)/po/$(PACKAGE_NAME).pot
 
 api:
@@ -197,26 +197,5 @@ runglade:
 	GLADE_CATALOG_SEARCH_PATH=$(srcdir)/widgets/glade \
 	GLADE_MODULE_SEARCH_PATH=$(builddir)/widgets/src/.libs \
 	glade ${GLADE_FILE}
-
-
-# Get content for the Anaconda built-in help system by cloning the
-# installation guide git repository and running the help processing
-# script (it is part of the repository).
-# Once the help content has been generated copy it to our help folder,
-# so that it can be included in the tarball.
-# Skip the git clone if the repository already exists but run git pull
-# to make sure it is up to date. We also clone the repository
-# without history as it si rather big (>400 MB!), which is quite
-# an overkill for <100 kB of help conent. :)
-get-help:
-	if [ ! -d "install-guide" ]; then \
-		if [ -f "installation_guide_repo_url" ]; then \
-			git clone --depth=1 `cat installation_guide_repo_url` ; \
-	    else \
-			git clone --depth=1 $(INSTALLATION_GUIDE_REPO_URL) ; \
-		fi ; \
-	fi ; \
-	( cd install-guide && git pull --rebase && python prepare_anaconda_help_content.py )
-	cp -r install-guide/anaconda_help_content/* $(srcdir)/data/help
 
 ci: rc-release check


### PR DESCRIPTION
Remove redundant help content generation code from the makefile
thart snuck in during the rebase to F21 Anaconda.

It has been apparently running, unnoticed, during each "make release",
not interfering with the help content that is actually used,
which is provided by a separate package (anaconda-user-help).

With fedorahosted going away this peice of code finaly stopped
working, making use aware of its presence, so we can finally retire it.

Resolves: rhbz#1428787