### PR TITLE
We should not have pyanaconda submodules on PYTHONPATH

### DIFF
--- a/tests/testenv.sh
+++ b/tests/testenv.sh
@@ -9,9 +9,9 @@ fi
 : "${top_builddir:=$top_srcdir}"
 
 if [ -z "$PYTHONPATH" ]; then
-    PYTHONPATH="${top_builddir}/pyanaconda/isys/.libs:${top_srcdir}/pyanaconda:${top_srcdir}:${top_srcdir}/tests/lib:${top_srcdir}/dracut"
+    PYTHONPATH="${top_builddir}/pyanaconda/isys/.libs:${top_srcdir}:${top_srcdir}/tests/lib:${top_srcdir}/dracut"
 else
-    PYTHONPATH="${PYTHONPATH}:${top_builddir}/pyanaconda/isys/.libs:${top_srcdir}/pyanaconda:${top_srcdir}:${top_srcdir}/tests/lib:${top_srcdir}/dracut"
+    PYTHONPATH="${PYTHONPATH}:${top_builddir}/pyanaconda/isys/.libs:${top_srcdir}:${top_srcdir}/tests/lib:${top_srcdir}/dracut"
 fi
 
 if [ -z "$LD_LIBRARY_PATH" ]; then


### PR DESCRIPTION
If we add a path to the pyanaconda directory on PYTHONPATH, then
names of pyanaconda submodules can collide with names of other
modules. Therefore, we should avoid that.

Note: Tested with pyanaconda.unittest module and the tests passed.