### PR TITLE
Improve how storage configuration settings are displayed

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.glade
+++ b/pyanaconda/ui/gui/spokes/storage.glade
@@ -502,11 +502,11 @@
                               <object class="GtkLabel" id="label8">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="margin_left">6</property>
+                                <property name="margin_left">18</property>
                                 <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Device Selection</property>
                                 <attributes>
-                                  <attribute name="font-desc" value="Cantarell 12"/>
+                                  <attribute name="font-desc" value="Cantarell Bold 12"/>
                                   <attribute name="weight" value="bold"/>
                                 </attributes>
                               </object>
@@ -540,6 +540,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="margin_left">18</property>
+                                <property name="margin_top">18</property>
                                 <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Local Standard Disks</property>
                                 <property name="track_visited_links">False</property>
@@ -759,24 +760,6 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkLabel" id="other_options_label">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="margin_left">6</property>
-                                <property name="xalign">0</property>
-                                <property name="label" translatable="yes">Other Storage Options</property>
-                                <attributes>
-                                  <attribute name="font-desc" value="Cantarell 12"/>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">8</property>
-                              </packing>
-                            </child>
-                            <child>
                               <object class="GtkGrid" id="other_options_grid">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -790,8 +773,9 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">Partitioning</property>
+                                    <property name="label" translatable="yes">Storage Configuration</property>
                                     <attributes>
+                                      <attribute name="font-desc" value="Cantarell Bold 12"/>
                                       <attribute name="weight" value="bold"/>
                                     </attributes>
                                   </object>
@@ -820,7 +804,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkRadioButton" id="autopartRadioButton">
-                                    <property name="label" translatable="yes" context="GUI|Storage">A_utomatically configure partitioning.</property>
+                                    <property name="label" translatable="yes" context="GUI|Storage">A_utomatic</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
@@ -836,7 +820,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkRadioButton" id="customRadioButton">
-                                    <property name="label" translatable="yes" context="GUI|Storage">_I will configure partitioning.</property>
+                                    <property name="label" translatable="yes" context="GUI|Storage">_Custom</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
@@ -853,7 +837,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkRadioButton" id="blivetguiRadioButton">
-                                    <property name="label" translatable="yes" context="GUI|Storage">_Use blivet-gui.</property>
+                                    <property name="label" translatable="yes" context="GUI|Storage">A_dvanced Custom (Blivet-GUI)</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
@@ -938,9 +922,6 @@
                                 <child>
                                   <placeholder/>
                                 </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
                                 <child internal-child="accessible">
                                   <object class="AtkObject" id="other_options_grid-atkobject">
                                     <property name="AtkObject::accessible-name" translatable="yes">Storage Options</property>
@@ -950,7 +931,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">9</property>
+                                <property name="position">8</property>
                               </packing>
                             </child>
                             <child>

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -785,7 +785,6 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         self.builder.get_object("summary_button_revealer").set_reveal_child(anySelected)
         self.builder.get_object("local_untouched_label_revealer").set_reveal_child(anySelected)
         self.builder.get_object("special_untouched_label_revealer").set_reveal_child(anySelected)
-        self.builder.get_object("other_options_label").set_sensitive(anySelected)
         self.builder.get_object("other_options_grid").set_sensitive(anySelected)
 
         if len(self.disks) == 0:


### PR DESCRIPTION
Drop the "Other Storage Options" label and change "Partitioning" to
"Storage configuration", which should better describe what this actually
does (LVs, thin LVs, RAID levels, LUKS, etc.).

And as there is now "Storage Configuration" written right above them,
we can shorten the labels on the combo boxes, hopefully making the
configuration method selection more readable:

Storage Configuration
o Automatic o Custom o Advanced Custom (Blivet-GUI)