### PR TITLE
Add support for kickstart %onerror scripts (#1412538)

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -1268,7 +1268,7 @@ if __name__ == "__main__":
             flags.imageInstall = True
     except ValueError as e:
         stdoutLog.error("error specifying image file: %s", e)
-        iutil.ipmi_report(constants.IPMI_ABORTED)
+        iutil.ipmi_abort(scripts=ksdata.scripts)
         sys.exit(1)
 
     if image_count:

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -19,7 +19,7 @@ Source0: %{name}-%{version}.tar.bz2
 # match the requires versions of things).
 %define gettextver 0.18.1
 %define intltoolver 0.31.2-3
-%define pykickstartver 1.99.66.9
+%define pykickstartver 1.99.66.11
 %define yumver 3.4.3-91
 %define partedver 1.8.1
 %define pypartedver 2.5-2

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -185,6 +185,7 @@ class AnacondaExceptionHandler(ExceptionHandler):
 
         # run kickstart traceback scripts (if necessary)
         try:
+            iutil.runOnErrorScripts(anaconda.ksdata.scripts)
             kickstart.runTracebackScripts(anaconda.ksdata.scripts)
         # pylint: disable=bare-except
         except:

--- a/pyanaconda/iutil.py
+++ b/pyanaconda/iutil.py
@@ -39,11 +39,11 @@ import random
 import functools
 
 from pyanaconda.flags import flags
-from pyanaconda.constants import DRACUT_SHUTDOWN_EJECT, TRANSLATIONS_UPDATE_DIR, UNSUPPORTED_HW
+from pyanaconda.constants import DRACUT_SHUTDOWN_EJECT, TRANSLATIONS_UPDATE_DIR, UNSUPPORTED_HW, IPMI_ABORTED
 from pyanaconda.constants import SCREENSHOTS_DIRECTORY, SCREENSHOTS_TARGET_DIRECTORY, SALT_CHARS
 from pyanaconda.regexes import URL_PARSE
-
 from pyanaconda.i18n import _
+from pykickstart.constants import KS_SCRIPT_ONERROR
 
 import logging
 log = logging.getLogger("anaconda")
@@ -1173,6 +1173,19 @@ def ipmi_report(event):
     execWithCapture("ipmitool", ["event", "file", path])
 
     os.remove(path)
+
+def ipmi_abort(scripts=None):
+    ipmi_report(IPMI_ABORTED)
+    runOnErrorScripts(scripts)
+
+def runOnErrorScripts(scripts):
+    if not scripts:
+        return
+
+    log.info("Running kickstart %%onerror script(s)")
+    for script in filter(lambda s: s.type == KS_SCRIPT_ONERROR, scripts):
+        script.run("/")
+    log.info("All kickstart %%onerror script(s) have been run")
 
 def get_platform_groupid():
     """ Return a platform group id string

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1,7 +1,7 @@
 #
 # kickstart.py: kickstart install support
 #
-# Copyright (C) 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007
+# Copyright (C) 1999-2016
 # Red Hat, Inc.  All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -72,7 +72,8 @@ from pykickstart.base import BaseHandler
 from pykickstart.errors import formatErrorMsg, KickstartError, KickstartValueError
 from pykickstart.parser import KickstartParser
 from pykickstart.parser import Script as KSScript
-from pykickstart.sections import NullSection, PackageSection, PostScriptSection, PreScriptSection, PreInstallScriptSection, TracebackScriptSection
+from pykickstart.sections import NullSection, PackageSection, PostScriptSection, PreScriptSection, PreInstallScriptSection, \
+                                 OnErrorScriptSection, TracebackScriptSection
 from pykickstart.sections import Section
 from pykickstart.version import returnClassForVersion, RHEL7
 
@@ -2105,6 +2106,7 @@ class AnacondaPreParser(KickstartParser):
         self.registerSection(PreScriptSection(self.handler, dataObj=AnacondaKSScript))
         self.registerSection(NullSection(self.handler, sectionOpen="%pre-install"))
         self.registerSection(NullSection(self.handler, sectionOpen="%post"))
+        self.registerSection(NullSection(self.handler, sectionOpen="%onerror"))
         self.registerSection(NullSection(self.handler, sectionOpen="%traceback"))
         self.registerSection(NullSection(self.handler, sectionOpen="%packages"))
         self.registerSection(NullSection(self.handler, sectionOpen="%addon"))
@@ -2128,6 +2130,7 @@ class AnacondaKSParser(KickstartParser):
         self.registerSection(PreInstallScriptSection(self.handler, dataObj=self.scriptClass))
         self.registerSection(PostScriptSection(self.handler, dataObj=self.scriptClass))
         self.registerSection(TracebackScriptSection(self.handler, dataObj=self.scriptClass))
+        self.registerSection(OnErrorScriptSection(self.handler, dataObj=self.scriptClass))
         self.registerSection(PackageSection(self.handler))
         self.registerSection(AddonSection(self.handler))
         self.registerSection(AnacondaSection(self.handler.anaconda))

--- a/pyanaconda/packaging/rpmostreepayload.py
+++ b/pyanaconda/packaging/rpmostreepayload.py
@@ -23,7 +23,6 @@
 import os
 import sys
 
-from pyanaconda import constants
 from pyanaconda import iutil
 from pyanaconda.i18n import _
 from pyanaconda.progress import progressQ
@@ -168,7 +167,7 @@ class RPMOSTreePayload(ArchivePayload):
             log.error(str(exn))
             if errors.errorHandler.cb(exn) == errors.ERROR_RAISE:
                 progressQ.send_quit(1)
-                iutil.ipmi_report(constants.IPMI_ABORTED)
+                iutil.ipmi_abort(scripts=self.data.scripts)
                 sys.exit(1)
 
         progressQ.send_message(_("Preparing deployment of %s") % (ostreesetup.ref, ))
@@ -203,7 +202,7 @@ class RPMOSTreePayload(ArchivePayload):
             log.error(str(exn))
             if errors.errorHandler.cb(exn) == errors.ERROR_RAISE:
                 progressQ.send_quit(1)
-                iutil.ipmi_report(constants.IPMI_ABORTED)
+                iutil.ipmi_abort(scripts=self.data.scripts)
                 sys.exit(1)
 
         mainctx.pop_thread_default()

--- a/pyanaconda/packaging/yumpayload.py
+++ b/pyanaconda/packaging/yumpayload.py
@@ -40,7 +40,7 @@ import shutil
 import sys
 import time
 import hashlib
-from pyanaconda.iutil import execReadlines
+from pyanaconda.iutil import execReadlines, ipmi_abort
 from pyanaconda.simpleconfig import simple_replace
 from functools import wraps
 from urlgrabber.grabber import URLGrabber, URLGrabError
@@ -66,7 +66,7 @@ except ImportError:
     yum = None
 
 from pyanaconda.constants import BASE_REPO_NAME, DRACUT_ISODIR, INSTALL_TREE, ISO_DIR, MOUNT_DIR, \
-                                 LOGLVL_LOCK, IPMI_ABORTED
+                                 LOGLVL_LOCK
 from pyanaconda.flags import flags
 
 from pyanaconda import iutil
@@ -1560,7 +1560,7 @@ reposdir=%s
             exn = PayloadInstallError(str(e))
             if errorHandler.cb(exn) == ERROR_RAISE:
                 progressQ.send_quit(1)
-                iutil.ipmi_report(IPMI_ABORTED)
+                ipmi_abort(scripts=self.data.scripts)
                 sys.exit(1)
         finally:
             # log the contents of the scriptlet logfile if any
@@ -1580,7 +1580,7 @@ reposdir=%s
             exn = PayloadInstallError("\n".join(install_errors))
             if errorHandler.cb(exn) == ERROR_RAISE:
                 progressQ.send_quit(1)
-                iutil.ipmi_report(IPMI_ABORTED)
+                ipmi_abort(scripts=self.data.scripts)
                 sys.exit(1)
 
     def writeMultiLibConfig(self):

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -26,7 +26,6 @@ from contextlib import contextmanager
 from gi.repository import Gdk, Gtk, AnacondaWidgets, Keybinder, GdkPixbuf, GLib, GObject
 
 from pyanaconda.i18n import _
-from pyanaconda.constants import IPMI_ABORTED
 from pyanaconda import product, iutil, constants
 
 from pyanaconda.ui import UserInterface, common
@@ -986,7 +985,7 @@ class GraphicalUserInterface(UserInterface):
 
         if rc == 1:
             self._currentAction.exit()
-            iutil.ipmi_report(IPMI_ABORTED)
+            iutil.ipmi_abort(scripts=self.data.scripts)
             sys.exit(0)
 
 class GraphicalExceptionHandlingIface(meh.ui.gui.GraphicalIntf):

--- a/pyanaconda/ui/gui/spokes/software.py
+++ b/pyanaconda/ui/gui/spokes/software.py
@@ -566,7 +566,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
 
         if rc == 0:
             # Quit.
-            iutil.ipmi_report(constants.IPMI_ABORTED)
+            iutil.ipmi_abort(scripts=self.data.scripts)
             sys.exit(0)
         elif rc == 1:
             # Send the user to the installation source spoke.

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -1110,7 +1110,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
 
             if rc == 0:
                 # Quit.
-                iutil.ipmi_report(constants.IPMI_ABORTED)
+                iutil.ipmi_abort(scripts=self.data.scripts)
                 sys.exit(0)
 
         elif self.errors:
@@ -1131,8 +1131,8 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
 
             if rc == 0:
                 # Quit.
+                iutil.ipmi_abort(scripts=self.data.scripts)
                 sys.exit(0)
-                iutil.ipmi_report(constants.IPMI_ABORTED)
         elif self.warnings:
             label = _("The following warnings were encountered when checking your storage "
                       "configuration.  These are not fatal, but you may wish to make "

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -35,8 +35,8 @@ from pyanaconda.product import distributionText, isFinal, productName, productVe
 from pyanaconda import flags
 from pyanaconda import geoloc
 from pyanaconda.i18n import _, C_
-from pyanaconda.iutil import is_unsupported_hw, ipmi_report
-from pyanaconda.constants import DEFAULT_LANG, IPMI_ABORTED
+from pyanaconda.iutil import is_unsupported_hw, ipmi_abort
+from pyanaconda.constants import DEFAULT_LANG
 
 import logging
 log = logging.getLogger("anaconda")
@@ -277,7 +277,7 @@ class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
                 rc = dlg.run()
                 dlg.hide()
             if rc != 1:
-                ipmi_report(IPMI_ABORTED)
+                ipmi_abort(scripts=self.data.scripts)
                 sys.exit(0)
 
         if productName.startswith("Red Hat ") and \
@@ -287,7 +287,7 @@ class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
                 rc = dlg.run()
                 dlg.destroy()
             if rc != 1:
-                ipmi_report(IPMI_ABORTED)
+                ipmi_abort(scripts=self.data.scripts)
                 sys.exit(0)
 
         StandaloneSpoke._on_continue_clicked(self, window, user_data)

--- a/pyanaconda/ui/tui/spokes/askvnc.py
+++ b/pyanaconda/ui/tui/spokes/askvnc.py
@@ -27,7 +27,7 @@ from pyanaconda.constants_text import INPUT_PROCESSED
 from pyanaconda.i18n import N_, _
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.ui.tui import exception_msg_handler
-from pyanaconda.iutil import execWithRedirect
+from pyanaconda.iutil import execWithRedirect, ipmi_abort
 import getpass
 import sys
 
@@ -107,6 +107,7 @@ class AskVNCSpoke(NormalTUISpoke):
             d = YesNoDialog(self.app, _(self.app.quit_message))
             self.app.switch_screen_modal(d)
             if d.answer:
+                ipmi_abort(scripts=self.data.scripts)
                 from pyanaconda.flags import can_touch_runtime_system
                 if can_touch_runtime_system("reboot"):
                     execWithRedirect("systemctl", ["--no-wall", "reboot"])

--- a/pyanaconda/vnc.py
+++ b/pyanaconda/vnc.py
@@ -175,7 +175,7 @@ class VncServer:
                 continue
             else:
                 log.critical(err)
-                iutil.ipmi_report(constants.IPMI_ABORTED)
+                iutil.ipmi_abort(scripts=self.anaconda.ksdata.scripts)
                 sys.exit(1)
         self.log.error(P_("Giving up attempting to connect after %d try!\n",
                           "Giving up attempting to connect after %d tries!\n",
@@ -213,7 +213,7 @@ class VncServer:
             self.initialize()
         except (socket.herror, dbus.DBusException, ValueError) as e:
             stdoutLog.critical("Could not initialize the VNC server: %s", e)
-            iutil.ipmi_report(constants.IPMI_ABORTED)
+            iutil.ipmi_abort(scripts=self.anaconda.ksdata.scripts)
             sys.exit(1)
 
         if self.password and (len(self.password) < 6 or len(self.password) > 8):
@@ -239,7 +239,7 @@ class VncServer:
             iutil.startX(xvnccommand, output_redirect=self.openlogfile())
         except OSError:
             stdoutLog.critical("Could not start the VNC server.  Aborting.")
-            iutil.ipmi_report(constants.IPMI_ABORTED)
+            iutil.ipmi_abort(scripts=self.anaconda.ksdata.scripts)
             sys.exit(1)
 
         self.log.info(_("The VNC server is now running."))
@@ -258,7 +258,7 @@ class VncServer:
             self.log.warning(_("\n\nYou chose to execute vnc with a password. \n\n"))
         else:
             self.log.warning(_("\n\nUnknown Error.  Aborting. \n\n"))
-            iutil.ipmi_report(constants.IPMI_ABORTED)
+            iutil.ipmi_abort(scripts=self.anaconda.ksdata.scripts)
             sys.exit(1)
 
         # Lets try to configure the vnc server to whatever the user specified


### PR DESCRIPTION
These run on most error conditions (including when %traceback scripts
would run), but note that they do not run on other kickstart script
failures. That would be strange.

The runOnErrorScripts function is in iutil, not kickstart, because it
gets imported all over the place and this would lead to import cycles.

(cherry picked from commit e470d17)

Resolves: rhbz#1412538