### PR TITLE
Support --nohome option in the autopartitioning (#663099)

### DIFF
--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -116,12 +116,28 @@ class BaseInstallClass(object):
 
         storage.autoPartitionRequests = autorequests
 
+    def customizeDefaultPartitioning(self, storage, data):
+        # Customize the default partitioning with kickstart data.
+        skipped_mountpoints = set()
+
+        # Create a set of mountpoints to remove from autorequests.
+        # Add /home to the set if --nohome is selected.
+        if data.autopart.autopart and data.autopart.nohome:
+            skipped_mountpoints.add("/home")
+
+        # Skip mountpoints we want to remove.
+        storage.autoPartitionRequests = [req for req in storage.autoPartitionRequests
+                                         if req.mountpoint not in skipped_mountpoints]
+
     def configure(self, anaconda):
         anaconda.bootloader.timeout = self.bootloaderTimeoutDefault
         anaconda.bootloader.boot_args.update(self.bootloaderExtraArgs)
 
         # The default partitioning should be always set.
         self.setDefaultPartitioning(anaconda.storage)
+
+        # Customize the default partitioning with kickstart data.
+        self.customizeDefaultPartitioning(anaconda.storage, anaconda.ksdata)
 
     def setStorageChecker(self, storage_checker):
         # Update constraints and add or remove some checks in


### PR DESCRIPTION
**Depends on a new version of pykickstart, that is changed here:** https://github.com/rhinstaller/anaconda/pull/985

Default partitioning can be modified in an install class's method
customizeDefaultPartitioning, where can be applied selections made in
a kickstart file. This method can be easily extended for future
--noswap and --noboot options.

The base install class will remove a request for a /home partition,
if --nohome option is selected in a kickstart file. In that case,
the /home partition will not be created.

Subclasses of the base install class can easily ignore this
customization if they override the customizeDefaultPartitioning
method with the pass statement.

Resolves: rhbz#663099