### PR TITLE
Enhance git-find-branch script

### DIFF
--- a/scripts/git-find-branch
+++ b/scripts/git-find-branch
@@ -84,6 +84,19 @@ elif [[ -z "${ACTUAL_BRANCH}" ]]; then
     exit 2
 fi
 
+# Try to find if we are on one of the main branches right now
+for tested_branch in ${BRANCHES}; do
+    if [ "$ACTUAL_BRANCH" == "$tested_branch" ]; then
+        actual_br_commit="$(git show --pretty=format:%H)"
+        tested_br_commit="$(git show --pretty=format:%H $tested_branch)"
+        # Test if the branches point to the same commit
+        if [ "$actual_br_commit" == "$tested_br_commit" ]; then
+            echo $(strip_branch_name "$ACTUAL_BRANCH")
+            exit 0
+        fi
+    fi
+done
+
 nearest_branch=""
 nearest_br_commit=""
 # Find latest common commit on actual branch and all our branches


### PR DESCRIPTION
The `git-find-branch` script worked badly if we were on a main branch (eg. `f26-devel`) and this branch was pointing to the same place as `master` branch (or some other branch with higher priority).

This is fixed now by adding quick test which is testing branch name. If this name is the same as some main branch it will do another check to test if they are pointing to the same commit.

This solution is also quicker when you are on a main branch directly or for CI.

NOTE:
You can still break this by changing name of your branch or creating new one from the base which doesn't have any new commit.