### PR TITLE
Set liveimg min_size to be x3 the real size

### DIFF
--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -294,7 +294,7 @@ class LiveImageKSPayload(LiveImagePayload):
         if not os.path.exists(self.data.method.url[7:]):
             return "file does not exist: %s" % self.data.method.url
 
-        self._min_size = os.stat(self.data.method.url[7:])[stat.ST_SIZE] * 3
+        self._min_size = os.stat(self.data.method.url[7:]).st_blocks * 512 * 3
         return None
 
     def setup(self, storage, instClass):


### PR DESCRIPTION
When using liveimg to install from a fairly large sparse file, the
minimum required size for the partition is huge, even if the content of
the payload is very small