### PR TITLE
Enable flexible storage checking on Fedora

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -617,6 +617,15 @@ if __name__ == "__main__":
     if not anaconda.interactive_mode:
         flags.ksprompt = False
 
+    # Set minimal ram size to the storage checker.
+    if anaconda.display_mode == constants.DisplayModes.GUI:
+        min_ram = isys.MIN_GUI_RAM
+    else:
+        min_ram = isys.MIN_RAM
+
+    from pyanaconda.storage_utils import storage_checker
+    storage_checker.add_constraint("min_ram", min_ram)
+
     from pyanaconda.anaconda_argparse import name_path_pairs
 
     image_count = 0

--- a/anaconda.py
+++ b/anaconda.py
@@ -625,6 +625,7 @@ if __name__ == "__main__":
 
     from pyanaconda.storage_utils import storage_checker
     storage_checker.add_constraint("min_ram", min_ram)
+    anaconda.instClass.setStorageChecker(storage_checker)
 
     from pyanaconda.anaconda_argparse import name_path_pairs
 

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -131,6 +131,12 @@ class BaseInstallClass(object):
         # The default partitioning should be always set.
         self.setDefaultPartitioning(anaconda.storage)
 
+    def setStorageChecker(self, storage_checker):
+        # Update constraints and add or remove some checks in
+        # the storage checker to customize the storage sanity
+        # checking.
+        pass
+
     # sets default ONBOOT values and updates ksdata accordingly
     def setNetworkOnbootDefault(self, ksdata):
         pass

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -268,7 +268,7 @@ class AutoPart(commands.autopart.F21_AutoPart):
 
     def execute(self, storage, ksdata, instClass):
         from blivet.autopart import do_autopart
-        from pyanaconda.storage_utils import sanity_check
+        from pyanaconda.storage_utils import storage_checker
 
         if not self.autopart:
             return
@@ -297,9 +297,11 @@ class AutoPart(commands.autopart.F21_AutoPart):
             storage.autopart_type = self.type
 
         do_autopart(storage, ksdata, min_luks_entropy=MIN_CREATE_ENTROPY)
-        errors = sanity_check(storage)
-        if errors:
-            raise PartitioningError("autopart failed:\n" + "\n".join(str(error) for error in errors))
+        report = storage_checker.check(storage)
+        report.log(log)
+
+        if report.failure:
+            raise PartitioningError("autopart failed: \n" + "\n".join(report.all_errors))
 
 class Bootloader(commands.bootloader.F21_Bootloader):
     def __init__(self, *args, **kwargs):

--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -142,122 +142,163 @@ def ui_storage_logger():
     yield
     storage_log.removeFilter(storage_filter)
 
-class SanityException(Exception):
-    pass
 
-class SanityError(SanityException):
-    pass
+def verify_root(storage, constraints, report_error, report_warning):
+    """ Verify the root.
 
-class SanityWarning(SanityException):
-    pass
-
-class LUKSDeviceWithoutKeyError(SanityError):
-    pass
-
-def sanity_check(storage, min_ram=isys.MIN_RAM):
+    :param storage: a storage to check
+    :param constraints: a dictionary of constraints
+    :param report_error: a function for error reporting
+    :param report_warning: a function for warning reporting
     """
-    Run a series of tests to verify the storage configuration.
-
-    This function is called at the end of partitioning so that
-    we can make sure you don't have anything silly (like no /,
-    a really small /, etc).
-
-    :param storage: an instance of the :class:`blivet.Blivet` class to check
-    :param min_ram: minimum RAM (in MiB) needed for the installation with swap
-                    space available
-    :rtype: a list of SanityExceptions
-    :return: a list of accumulated errors and warnings
-
-    """
-
-    exns = []
-
-    checkSizes = [('/usr', Size("250 MiB")), ('/tmp', Size("50 MiB")), ('/var', Size("384 MiB")),
-                  ('/home', Size("100 MiB")), ('/boot', Size("200 MiB"))]
-    mustbeonlinuxfs = ['/', '/var', '/tmp', '/usr', '/home', '/usr/share', '/usr/lib']
-    mustbeonroot = ['/bin', '/dev', '/sbin', '/etc', '/lib', '/root', '/mnt', 'lost+found', '/proc']
-
-    filesystems = storage.mountpoints
     root = storage.fsset.root_device
-    swaps = storage.fsset.swap_devices
 
     if root:
-        if root.size < Size("250 MiB"):
-            exns.append(SanityWarning(_("Your root partition is less than 250 "
-                                        "megabytes which is usually too small to "
-                                        "install %s.") % (productName,)))
+        if root.size < constraints["min_root"]:
+            report_warning(_("Your root partition is less than %(size)s "
+                             "which is usually too small to install "
+                             "%(product)s.")
+                           % {'size': constraints["min_root"],
+                              'product': productName})
     else:
-        exns.append(SanityError(_("You have not defined a root partition (/), "
-                                  "which is required for installation of %s "
-                                  "to continue.") % (productName,)))
+        report_error(_("You have not defined a root partition (/), "
+                       "which is required for installation of %s"
+                       " to continue.") % (productName,))
 
-    # Prevent users from installing on s390x with (a) no /boot volume, (b) the
-    # root volume on LVM, and (c) the root volume not restricted to a single
-    # PV
-    # NOTE: There is not really a way for users to create a / volume
-    # restricted to a single PV.  The backend support is there, but there are
-    # no UI hook-ups to drive that functionality, but I do not personally
-    # care.  --dcantrell
+    if storage.root_device and storage.root_device.format.exists:
+        e = storage.must_format(storage.root_device)
+        if e:
+            report_error(e)
+
+
+def verify_s390_constraints(storage, constraints, report_error, report_warning):
+    """ Verify constraints for s390x.
+
+        Prevent users from installing on s390x with (a) no /boot volume, (b) the
+        root volume on LVM, and (c) the root volume not restricted to a single
+        PV
+
+        NOTE: There is not really a way for users to create a / volume
+        restricted to a single PV.  The backend support is there, but there are
+        no UI hook-ups to drive that functionality, but I do not personally
+        care.  --dcantrell
+
+        :param storage: a storage to check
+        :param constraints: a dictionary of constraints
+        :param report_error: a function for error reporting
+        :param report_warning: a function for warning reporting
+    """
+    root = storage.fsset.root_device
+
     if arch.is_s390() and '/boot' not in storage.mountpoints and root:
         if root.type == 'lvmlv' and not root.single_pv:
-            exns.append(SanityError(_("This platform requires /boot on a dedicated "
-                                      "partition or logical volume.  If you do not "
-                                      "want a /boot volume, you must place / on a "
-                                      "dedicated non-LVM partition.")))
+            report_error(_("This platform requires /boot on a dedicated "
+                           "partition or logical volume. If you do not "
+                           "want a /boot volume, you must place / on a "
+                           "dedicated non-LVM partition."))
 
-    # FIXME: put a check here for enough space on the filesystems. maybe?
 
-    for (mount, size) in checkSizes:
+def verify_partition_sizes(storage, constraints, report_error, report_warning):
+    """ Verify the minimal and required partition sizes.
+
+    :param storage: a storage to check
+    :param constraints: a dictionary of constraints
+    :param report_error: a function for error reporting
+    :param report_warning: a function for warning reporting
+    """
+    filesystems = storage.mountpoints
+
+    for (mount, size) in constraints["min_partition_sizes"].items():
         if mount in filesystems and filesystems[mount].size < size:
-            exns.append(SanityWarning(_("Your %(mount)s partition is less than "
-                                        "%(size)s which is lower than recommended "
-                                        "for a normal %(productName)s install.")
-                                      % {'mount': mount, 'size': size, 'productName': productName}))
+            report_warning(_("Your %(mount)s partition is less than "
+                             "%(size)s which is lower than recommended "
+                             "for a normal %(productName)s install.")
+                           % {'mount': mount, 'size': size,
+                              'productName': productName})
 
+
+def verify_partition_format_sizes(storage, constraints, report_error, report_warning):
+    """ Verify that the size of the device is allowed by the format used.
+
+    :param storage: a storage to check
+    :param constraints: a dictionary of constraints
+    :param report_error: a function for error reporting
+    :param report_warning: a function for warning reporting
+    """
     # storage.mountpoints is a property that returns a new dict each time, so
     # iterating over it is thread-safe.
+    filesystems = storage.mountpoints
+
     for (mount, device) in filesystems.items():
         problem = filesystems[mount].check_size()
         if problem < 0:
-            exns.append(SanityError(_("Your %(mount)s partition is too small for %(format)s formatting "
-                                      "(allowable size is %(minSize)s to %(maxSize)s)")
-                        % {"mount": mount, "format": device.format.name,
-                           "minSize": device.min_size, "maxSize": device.max_size}))
+            report_error(_("Your %(mount)s partition is too small for "
+                           "%(format)s formatting (allowable size is "
+                           "%(minSize)s to %(maxSize)s)")
+                         % {"mount": mount, "format": device.format.name,
+                            "minSize": device.min_size, "maxSize": device.max_size})
         elif problem > 0:
-            exns.append(SanityError(_("Your %(mount)s partition is too large for %(format)s formatting "
-                                      "(allowable size is %(minSize)s to %(maxSize)s)")
-                        % {"mount": mount, "format": device.format.name,
-                           "minSize": device.min_size, "maxSize": device.max_size}))
+            report_error(_("Your %(mount)s partition is too large for "
+                           "%(format)s formatting (allowable size is "
+                           "%(minSize)s to %(maxSize)s)")
+                         % {"mount": mount, "format": device.format.name,
+                            "minSize": device.min_size, "maxSize": device.max_size})
 
+
+def verify_bootloader(storage, constraints, report_error, report_warning):
+    """ Verify that the size of the device is allowed by the format used.
+
+    :param storage: a storage to check
+    :param constraints: a dictionary of constraints
+    :param report_error: a function for error reporting
+    :param report_warning: a function for warning reporting
+    """
     if storage.bootloader and not storage.bootloader.skip_bootloader:
         stage1 = storage.bootloader.stage1_device
         if not stage1:
-            exns.append(SanityError(_("No valid boot loader target device found. "
-                                      "See below for details.")))
+            report_error(_("No valid boot loader target device found. "
+                           "See below for details."))
             pe = _platform.stage1_missing_error
             if pe:
-                exns.append(SanityError(_(pe)))
+                report_error(_(pe))
         else:
             storage.bootloader.is_valid_stage1_device(stage1)
-            exns.extend(SanityError(msg) for msg in storage.bootloader.errors)
-            exns.extend(SanityWarning(msg) for msg in storage.bootloader.warnings)
+            for msg in storage.bootloader.errors:
+                report_error(msg)
+
+            for msg in storage.bootloader.warnings:
+                report_warning(msg)
 
         stage2 = storage.bootloader.stage2_device
         if stage1 and not stage2:
-            exns.append(SanityError(_("You have not created a bootable partition.")))
+            report_error(_("You have not created a bootable partition."))
         else:
             storage.bootloader.is_valid_stage2_device(stage2)
-            exns.extend(SanityError(msg) for msg in storage.bootloader.errors)
-            exns.extend(SanityWarning(msg) for msg in storage.bootloader.warnings)
-            if not storage.bootloader.check():
-                exns.extend(SanityError(msg) for msg in storage.bootloader.errors)
+            for msg in storage.bootloader.errors:
+                report_error(msg)
 
-        #
-        # check that GPT boot disk on BIOS system has a BIOS boot partition
-        #
-        if _platform.weight(fstype="biosboot") and \
-           stage1 and stage1.is_disk and \
-           getattr(stage1.format, "labelType", None) == "gpt":
+            for msg in storage.bootloader.warnings:
+                report_warning(msg)
+
+            if not storage.bootloader.check():
+                for msg in storage.bootloader.errors:
+                    report_error(msg)
+
+
+def verify_gpt_biosboot(storage, constraints, report_error, report_warning):
+    """ Verify that GPT boot disk on BIOS system has a BIOS boot partition.
+
+    :param storage: a storage to check
+    :param constraints: a dictionary of constraints
+    :param report_error: a function for error reporting
+    :param report_warning: a function for warning reporting
+    """
+    if storage.bootloader and not storage.bootloader.skip_bootloader:
+        stage1 = storage.bootloader.stage1_device
+
+        if _platform.weight(fstype="biosboot") and stage1 and stage1.is_disk \
+                and getattr(stage1.format, "labelType", None) == "gpt":
+
             missing = True
             for part in [p for p in storage.partitions if p.disk == stage1]:
                 if part.format.type == "biosboot":
@@ -265,77 +306,117 @@ def sanity_check(storage, min_ram=isys.MIN_RAM):
                     break
 
             if missing:
-                exns.append(SanityError(_("Your BIOS-based system needs a special "
-                                          "partition to boot from a GPT disk label. "
-                                          "To continue, please create a 1MiB "
-                                          "'biosboot' type partition.")))
+                report_error(_("Your BIOS-based system needs a special "
+                               "partition to boot from a GPT disk label. "
+                               "To continue, please create a 1MiB "
+                               "'biosboot' type partition."))
+
+
+def verify_swap(storage, constraints, report_error, report_warning):
+    """ Verify the existence of swap.
+
+    :param storage: a storage to check
+    :param constraints: a dictionary of constraints
+    :param report_error: a function for error reporting
+    :param report_warning: a function for warning reporting
+    """
+    swaps = storage.fsset.swap_devices
 
     if not swaps:
         installed = util.total_memory()
-        required = Size("%s MiB" % (min_ram + isys.NO_SWAP_EXTRA_RAM))
+        required = Size("%s MiB" % (constraints["min_ram"] + isys.NO_SWAP_EXTRA_RAM))
 
         if installed < required:
-            exns.append(SanityError(_("You have not specified a swap partition.  "
-                                      "%(requiredMem)s of memory is required to continue installation "
-                                      "without a swap partition, but you only have %(installedMem)s.")
-                        % {"requiredMem": required,
-                           "installedMem": installed}))
+            report_error(_("You have not specified a swap partition. "
+                           "%(requiredMem)s of memory is required to continue "
+                           "installation without a swap partition, but you only "
+                           "have %(installedMem)s.")
+                         % {"requiredMem": required, "installedMem": installed})
         else:
-            exns.append(SanityWarning(_("You have not specified a swap partition.  "
-                                        "Although not strictly required in all cases, "
-                                        "it will significantly improve performance "
-                                        "for most installations.")))
+            report_warning(_("You have not specified a swap partition. "
+                             "Although not strictly required in all cases, "
+                             "it will significantly improve performance "
+                             "for most installations."))
+
+
+def verify_swap_uuid(storage, constraints, report_error, report_warning):
+    """ Verify swap uuid.
+
+    :param storage: a storage to check
+    :param constraints: a dictionary of constraints
+    :param report_error: a function for error reporting
+    :param report_warning: a function for warning reporting
+    """
+    swaps = storage.fsset.swap_devices
     no_uuid = [s for s in swaps if s.format.exists and not s.format.uuid]
+
     if no_uuid:
-        exns.append(SanityWarning(_("At least one of your swap devices does not have "
-                                    "a UUID, which is common in swap space created "
-                                    "using older versions of mkswap. These devices "
-                                    "will be referred to by device path in "
-                                    "/etc/fstab, which is not ideal since device "
-                                    "paths can change under a variety of "
-                                    "circumstances. ")))
+        report_warning(_("At least one of your swap devices does not have "
+                         "a UUID, which is common in swap space created "
+                         "using older versions of mkswap. These devices "
+                         "will be referred to by device path in "
+                         "/etc/fstab, which is not ideal since device "
+                         "paths can change under a variety of "
+                         "circumstances. "))
+
+
+def verify_mountpoints_on_root(storage, constraints, report_error, report_warning):
+    """ Verify mountpoints on the root.
+
+    :param storage: a storage to check
+    :param constraints: a dictionary of constraints
+    :param report_error: a function for error reporting
+    :param report_warning: a function for warning reporting
+    """
+    for mountpoint in storage.mountpoints:
+        if mountpoint in constraints["must_be_on_root"]:
+            report_error(_("This mount point is invalid. The %s directory must "
+                           "be on the / file system.") % mountpoint)
+
+
+def verify_mountpoints_on_linuxfs(storage, constraints, report_error, report_warning):
+    """ Verify mountpoints on linuxfs.
+
+    :param storage: a storage to check
+    :param constraints: a dictionary of constraints
+    :param report_error: a function for error reporting
+    :param report_warning: a function for warning reporting
+    """
+    filesystems = storage.mountpoints
 
     for (mountpoint, dev) in filesystems.items():
-        if mountpoint in mustbeonroot:
-            exns.append(SanityError(_("This mount point is invalid.  The %s directory must "
-                                      "be on the / file system.") % mountpoint))
-
-        if mountpoint in mustbeonlinuxfs and (not dev.format.mountable or not dev.format.linux_native):
-            exns.append(SanityError(_("The mount point %s must be on a linux file system.") % mountpoint))
-
-    if storage.root_device and storage.root_device.format.exists:
-        e = storage.must_format(storage.root_device)
-        if e:
-            exns.append(SanityError(e))
-
-    exns += verify_LUKS_devices_have_key(storage)
-
-    exns += check_mounted_partitions(storage)
-
-    return exns
+        if mountpoint in constraints["must_be_on_linuxfs"] \
+                and (not dev.format.mountable or not dev.format.linux_native):
+            report_error(_("The mount point %s must be on a linux file system.") % mountpoint)
 
 
-def verify_LUKS_devices_have_key(storage):
-    """
-    Verify that all non-existant LUKS devices have some way of obtaining
-    a key.
+def verify_luks_devices_have_key(storage, constraints, report_error, report_warning):
+    """ Verify that all non-existant LUKS devices have some way of obtaining a key.
+
+    :param storage: a storage to check
+    :param constraints: a dictionary of constraints
+    :param report_error: a function for error reporting
+    :param report_warning: a function for warning reporting
 
     Note: LUKS device creation will fail without a key.
-
-    :rtype: generator of str
-    :returns: a generator of error messages, may yield no error messages
-
     """
+    devices = (d for d in storage.devices
+               if d.format.type == "luks"
+               and not d.format.exists
+               and not d.format.hasKey)
 
-    for dev in (d for d in storage.devices if d.format.type == "luks" and not d.format.exists and not d.format.has_key):
-        yield LUKSDeviceWithoutKeyError(_("Encryption requested for LUKS device %s but no "
-                                          "encryption key specified for this device.") % (dev.name,))
+    for dev in devices:
+        report_error(_("Encryption requested for LUKS device %s but no "
+                       "encryption key specified for this device.") % (dev.name,))
 
-def check_mounted_partitions(storage):
+
+def verify_mounted_partitions(storage, constraints, report_error, report_warning):
     """ Check the selected disks to make sure all their partitions are unmounted.
 
-        :rtype: generator of str
-        :returns: a generator of error messages, may yield no error messages
+    :param storage: a storage to check
+    :param constraints: a dictionary of constraints
+    :param report_error: a function for error reporting
+    :param report_warning: a function for warning reporting
     """
     for disk in storage.disks:
         if not disk.partitioned:
@@ -344,11 +425,228 @@ def check_mounted_partitions(storage):
         for part in disk.format.partitions:
             part_dev = storage.devicetree.get_device_by_path(part.path)
             if part_dev and part_dev.protected:
-                log.debug("Not checking protected %s for being mounted, assuming live image mount", part.path)
+                log.debug("Not checking protected %s for being mounted, assuming live "
+                          "image mount", part.path)
                 continue
             if part.busy:
-                yield SanityError(_("%s is currently mounted and cannot be used for the "
-                                    "installation. Please unmount it and retry.") % part.path)
+                report_error(_("%s is currently mounted and cannot be used for the "
+                               "installation. Please unmount it and retry.") % part.path)
+
+
+class StorageCheckerReport(object):
+    """Class for results of the storage checking."""
+
+    def __init__(self):
+        self.info = list()
+        self.errors = list()
+        self.warnings = list()
+
+    @property
+    def all_errors(self):
+        """Return a list of errors and warnings."""
+        return self.errors + self.warnings
+
+    @property
+    def success(self):
+        """Success, if no errors and warnings were reported."""
+        return not self.failure
+
+    @property
+    def failure(self):
+        """Failure, if some errors or warnings were reported."""
+        return bool(self.errors or self.warnings)
+
+    def add_info(self, msg):
+        """ Add an error message.
+
+        :param str msg: an info message
+        """
+        self.info.append(msg)
+
+    def add_error(self, msg):
+        """ Add an error message.
+
+        :param str msg: an error message
+        """
+        self.add_info("Found sanity error: %s" % msg)
+        self.errors.append(msg)
+
+    def add_warning(self, msg):
+        """ Add a warning message.
+
+        :param str msg: a warning message
+        """
+        self.add_info("Found sanity warning: %s" % msg)
+        self.warnings.append(msg)
+
+    def log(self, logger, error=True, warning=True, info=True):
+        """ Log the messages.
+
+        :param logger: an instance of logging.Logger
+        :param bool error: should we log the error messages?
+        :param bool warning: should we log the warning messages?
+        :param bool info: should we log the info messages?
+        """
+        if info:
+            map(logger.debug, self.info)
+
+        if error:
+            map(logger.error, self.errors)
+
+        if warning:
+            map(logger.warning, self.warnings)
+
+
+class StorageChecker(object):
+    """Class for advanced storage checking."""
+
+    def __init__(self):
+        self.checks = list()
+        self.constraints = dict()
+
+    def add_check(self, callback):
+        """ Add a callback for storage checking.
+
+        :param callback: a check for the storage checking
+        :type callback: a function with arguments (storage, constraints,
+        report_error, report_warning), where storage is an instance of the
+        storage to check, constraints is a dictionary of constraints and
+        report_error and report_warning are functions for reporting messages.
+        """
+        self.checks.append(callback)
+
+    def remove_check(self, callback):
+        """ Remove a callback for storage checking.
+
+        :param callback: a check for the storage checking
+        """
+        if callback in self.checks:
+            self.checks.remove(callback)
+
+    def add_new_constraint(self, name, value):
+        """ Add a new constraint for storage checking.
+
+        KeyError will be raised if the constraint already exists.
+
+        :param str name: a name of the new constraint
+        :param value: a value of the constraint
+        """
+        if name in self.constraints:
+            raise KeyError("The constraint %s already exists.", name)
+
+        self.constraints[name] = value
+
+    def add_constraint(self, name, value):
+        """ Add a constraint for storage checking that will override
+        the existing one.
+
+        KeyError will be raised if the constraint does not exist.
+
+        :param str name: a name of the existing constraint
+        :param value: a value of the constraint
+        """
+        if name not in self.constraints:
+            raise KeyError("The constraint %s does not exist.", name)
+
+        self.constraints[name] = value
+
+    def update_constraint(self, name, value):
+        """ Update a constraint for storage checking if the
+        constraint is a dictionary or a set.
+
+        AttributeError will be raised, if the constraint
+        does not have the update method.
+
+        KeyError will be raised, if the constraint does
+        not exists.
+
+        :param str name: a name of the constraint
+        :param value: a value of the constraint (set or dictionary)
+        """
+        self.constraints[name].update(value)
+
+    def check(self, storage, constraints=None, skip=None):
+        """ Run a series of tests to verify the storage configuration.
+
+        This function is called at the end of partitioning so that we can make
+        sure you don't have anything silly (like no /, a really small /, etc).
+
+        :param storage: an instance of the :class:`blivet.Blivet` class to check
+        :param constraints: an dictionary of constraints that will be used by
+               checks or None if we want to use the storage checker's constraints
+        :param skip: a collection of checks we want to skip or None if we don't
+               want to skip any
+        :return an instance of StorageCheckerReport with reported errors and warnings
+        """
+        if constraints is None:
+            constraints = self.constraints
+
+        # Report the constraints.
+        result = StorageCheckerReport()
+        result.add_info("Storage check started with constraints %s."
+                        % constraints)
+
+        # Process checks.
+        for check in self.checks:
+            # Skip this check.
+            if skip and check in skip:
+                result.add_info("Skipped sanity check %s." % check.__name__)
+                continue
+
+            # Run the check.
+            result.add_info("Run sanity check %s." % check.__name__)
+            check(storage, constraints, result.add_error, result.add_warning)
+
+        # Report the result.
+        if result.success:
+            result.add_info("Storage check finished with success.")
+        else:
+            result.add_info("Storage check finished with failure(s).")
+
+        return result
+
+    def set_default_constraints(self):
+        """Set the default constraints needed by default checks."""
+        self.constraints = dict()
+        self.add_new_constraint("min_ram", isys.MIN_RAM)
+        self.add_new_constraint("min_root", Size("250 MiB"))
+        self.add_new_constraint("min_partition_sizes", {
+            '/usr': Size("250 MiB"),
+            '/tmp': Size("50 MiB"),
+            '/var': Size("384 MiB"),
+            '/home': Size("100 MiB"),
+            '/boot': Size("200 MiB")
+        })
+
+        self.add_new_constraint("must_be_on_linuxfs", {
+            '/', '/var', '/tmp', '/usr', '/home', '/usr/share', '/usr/lib'
+        })
+
+        self.add_new_constraint("must_be_on_root", {
+            '/bin', '/dev', '/sbin', '/etc', '/lib', '/root', '/mnt', 'lost+found', '/proc'
+        })
+
+    def set_default_checks(self):
+        """Set the default checks."""
+        self.checks = list()
+        self.add_check(verify_root)
+        self.add_check(verify_s390_constraints)
+        self.add_check(verify_partition_sizes)
+        self.add_check(verify_partition_format_sizes)
+        self.add_check(verify_bootloader)
+        self.add_check(verify_gpt_biosboot)
+        self.add_check(verify_swap)
+        self.add_check(verify_swap_uuid)
+        self.add_check(verify_mountpoints_on_linuxfs)
+        self.add_check(verify_mountpoints_on_root)
+        self.add_check(verify_luks_devices_have_key)
+        self.add_check(verify_mounted_partitions)
+
+
+# Setup the storage checker.
+storage_checker = StorageChecker()
+storage_checker.set_default_constraints()
+storage_checker.set_default_checks()
 
 
 def bound_size(size, device, old_size):

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -27,7 +27,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
-from pyanaconda.ui.helpers import StorageChecker
+from pyanaconda.ui.helpers import StorageCheckHandler
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.gui.spokes.lib.summary import ActionSummaryDialog
 from pyanaconda.i18n import _, CN_, C_
@@ -42,7 +42,7 @@ log = logging.getLogger("anaconda")
 # export only the spoke, no helper functions, classes or constants
 __all__ = ["BlivetGuiSpoke"]
 
-class BlivetGuiSpoke(NormalSpoke, StorageChecker):
+class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
     ### class attributes defined by API ###
 
     # list all top-level objects from the .glade file that should be exposed
@@ -87,7 +87,7 @@ class BlivetGuiSpoke(NormalSpoke, StorageChecker):
         self.button_reset = None
         self.button_undo = None
 
-        StorageChecker.__init__(self, min_ram=isys.MIN_GUI_RAM)
+        StorageCheckHandler.__init__(self, min_ram=isys.MIN_GUI_RAM)
         NormalSpoke.__init__(self, data, storage, payload, instclass)
 
     def initialize(self):
@@ -161,8 +161,8 @@ class BlivetGuiSpoke(NormalSpoke, StorageChecker):
 
     def _do_check(self):
         self.clear_errors()
-        StorageChecker.errors = []
-        StorageChecker.warnings = []
+        StorageCheckHandler.errors = []
+        StorageCheckHandler.warnings = []
 
         # We can't overwrite the main Storage instance because all the other
         # spokes have references to it that would get invalidated, but we can
@@ -178,10 +178,10 @@ class BlivetGuiSpoke(NormalSpoke, StorageChecker):
             self.storage.set_up_bootloader()
         except BootLoaderError as e:
             log.error("storage configuration failed: %s", e)
-            StorageChecker.errors = str(e).split("\n")
+            StorageCheckHandler.errors = str(e).split("\n")
             self.data.bootloader.bootDrive = ""
 
-        StorageChecker.checkStorage(self)
+        StorageCheckHandler.checkStorage(self)
 
         if self.errors:
             self.set_warning(_("Error checking storage configuration.  <a href=\"\">Click for details</a> or press Done again to continue."))

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -31,7 +31,6 @@ from pyanaconda.ui.helpers import StorageCheckHandler
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.gui.spokes.lib.summary import ActionSummaryDialog
 from pyanaconda.i18n import _, CN_, C_
-from pyanaconda import isys
 from pyanaconda.bootloader import BootLoaderError
 
 from blivetgui import osinstall
@@ -87,7 +86,7 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
         self.button_reset = None
         self.button_undo = None
 
-        StorageCheckHandler.__init__(self, min_ram=isys.MIN_GUI_RAM)
+        StorageCheckHandler.__init__(self)
         NormalSpoke.__init__(self, data, storage, payload, instclass)
 
     def initialize(self):

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -44,7 +44,6 @@ from pyanaconda.constants import SIZE_UNITS_DEFAULT, UNSUPPORTED_FILESYSTEMS
 from pyanaconda.iutil import lowerASCII
 from pyanaconda.bootloader import BootLoaderError
 from pyanaconda.kickstart import refreshAutoSwapSize
-from pyanaconda import isys
 from pyanaconda import network
 
 from blivet import devicefactory
@@ -69,11 +68,11 @@ from blivet.devicelibs import raid, crypto
 from blivet.devices import LUKSDevice, MDRaidArrayDevice, LVMVolumeGroupDevice
 from blivet.platform import platform
 
-from pyanaconda.storage_utils import ui_storage_logger, device_type_from_autopart
+from pyanaconda.storage_utils import ui_storage_logger, device_type_from_autopart, storage_checker, \
+    verify_luks_devices_have_key
 from pyanaconda.storage_utils import DEVICE_TEXT_PARTITION, DEVICE_TEXT_MAP, DEVICE_TEXT_MD
 from pyanaconda.storage_utils import PARTITION_ONLY_FORMAT_TYPES, MOUNTPOINT_DESCRIPTIONS
 from pyanaconda.storage_utils import NAMED_DEVICE_TYPES, CONTAINER_DEVICE_TYPES
-from pyanaconda.storage_utils import SanityError, SanityWarning, LUKSDeviceWithoutKeyError
 from pyanaconda.storage_utils import try_populate_devicetree
 from pyanaconda.storage_utils import filter_unsupported_disklabel_devices
 from pyanaconda import storage_utils
@@ -160,7 +159,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     MIN_SIZE_ENTRY = Size("1 MiB")
 
     def __init__(self, data, storage, payload, instclass):
-        StorageCheckHandler.__init__(self, min_ram=isys.MIN_GUI_RAM)
+        StorageCheckHandler.__init__(self)
         NormalSpoke.__init__(self, data, storage, payload, instclass)
 
         self._back_already_clicked = False
@@ -2444,7 +2443,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     def _do_autopart(self):
         """Helper function for on_create_clicked.
            Assumes a non-final context in which at least some errors
-           discovered by sanity_check are not considered fatal because they
+           discovered by storage checker are not considered fatal because they
            will be dealt with later.
 
            Note: There are never any non-existent devices around when this runs.
@@ -2486,16 +2485,12 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             self._storage_playground.do_autopart = False
             log.debug("finished automatic partitioning")
 
-        exns = storage_utils.sanity_check(self._storage_playground, min_ram=isys.MIN_GUI_RAM)
-        errors = [exn for exn in exns if isinstance(exn, SanityError) and not isinstance(exn, LUKSDeviceWithoutKeyError)]
-        warnings = [exn for exn in exns if isinstance(exn, SanityWarning)]
-        for error in errors:
-            log.error("%s", error)
-        for warning in warnings:
-            log.warning("%s", warning)
+        report = storage_checker.check(self._storage_playground,
+                                       skip=(verify_luks_devices_have_key,))
+        report.log(log)
 
-        if errors:
-            messages = "\n".join(str(error) for error in errors)
+        if report.errors:
+            messages = "\n".join(report.errors)
             log.error("do_autopart failed: %s", messages)
             self._reset_storage()
             self._error = messages

--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -80,7 +80,7 @@ from pyanaconda import storage_utils
 
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.ui.gui.spokes import NormalSpoke
-from pyanaconda.ui.helpers import StorageChecker
+from pyanaconda.ui.helpers import StorageCheckHandler
 from pyanaconda.ui.gui.spokes.lib.cart import SelectedDisksDialog
 from pyanaconda.ui.gui.spokes.lib.passphrase import PassphraseDialog
 from pyanaconda.ui.gui.spokes.lib.accordion import update_selector_from_device, Accordion, Page, CreateNewPage, UnknownPage
@@ -137,7 +137,7 @@ def ui_storage_logged(func):
 
     return decorated
 
-class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
+class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     """
        .. inheritance-diagram:: CustomPartitioningSpoke
           :parts: 3
@@ -160,7 +160,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
     MIN_SIZE_ENTRY = Size("1 MiB")
 
     def __init__(self, data, storage, payload, instclass):
-        StorageChecker.__init__(self, min_ram=isys.MIN_GUI_RAM)
+        StorageCheckHandler.__init__(self, min_ram=isys.MIN_GUI_RAM)
         NormalSpoke.__init__(self, data, storage, payload, instclass)
 
         self._back_already_clicked = False
@@ -1627,8 +1627,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
 
     def _do_check(self):
         self.clear_errors()
-        StorageChecker.errors = []
-        StorageChecker.warnings = []
+        StorageCheckHandler.errors = []
+        StorageCheckHandler.warnings = []
 
         # We can't overwrite the main Storage instance because all the other
         # spokes have references to it that would get invalidated, but we can
@@ -1644,10 +1644,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageChecker):
             self.storage.set_up_bootloader()
         except BootLoaderError as e:
             log.error("storage configuration failed: %s", e)
-            StorageChecker.errors = str(e).split("\n")
+            StorageCheckHandler.errors = str(e).split("\n")
             self.data.bootloader.bootDrive = ""
 
-        StorageChecker.checkStorage(self)
+        StorageCheckHandler.checkStorage(self)
 
         if self.errors:
             self.set_warning(_("Error checking storage configuration.  <a href=\"\">Click for details</a> or press Done again to continue."))

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -71,7 +71,7 @@ from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.product import productName
 from pyanaconda.flags import flags
 from pyanaconda.i18n import _, C_, CN_, P_
-from pyanaconda import constants, iutil, isys
+from pyanaconda import constants, iutil
 from pyanaconda.bootloader import BootLoaderError
 from pyanaconda.storage_utils import on_disk_storage
 from pyanaconda.screen_access import sam
@@ -262,7 +262,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
     title = CN_("GUI|Spoke", "INSTALLATION _DESTINATION")
 
     def __init__(self, *args, **kwargs):
-        StorageCheckHandler.__init__(self, min_ram=isys.MIN_GUI_RAM)
+        StorageCheckHandler.__init__(self)
         NormalSpoke.__init__(self, *args, **kwargs)
         self.applyOnSkip = True
 

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -57,7 +57,7 @@ from pyanaconda.ui.gui.spokes.lib.dasdfmt import DasdFormatDialog
 from pyanaconda.ui.gui.spokes.lib.refresh import RefreshDialog
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.gui.utils import escape_markup, gtk_action_nowait, ignoreEscape
-from pyanaconda.ui.helpers import StorageChecker
+from pyanaconda.ui.helpers import StorageCheckHandler
 
 from pyanaconda.kickstart import doKickstartStorage, refreshAutoSwapSize, resetCustomStorageData
 from blivet import arch
@@ -245,7 +245,7 @@ class NoSpaceDialog(InstallOptionsDialogBase):
 
         self._add_modify_watcher(label)
 
-class StorageSpoke(NormalSpoke, StorageChecker):
+class StorageSpoke(NormalSpoke, StorageCheckHandler):
     """
        .. inheritance-diagram:: StorageSpoke
           :parts: 3
@@ -262,7 +262,7 @@ class StorageSpoke(NormalSpoke, StorageChecker):
     title = CN_("GUI|Spoke", "INSTALLATION _DESTINATION")
 
     def __init__(self, *args, **kwargs):
-        StorageChecker.__init__(self, min_ram=isys.MIN_GUI_RAM)
+        StorageCheckHandler.__init__(self, min_ram=isys.MIN_GUI_RAM)
         NormalSpoke.__init__(self, *args, **kwargs)
         self.applyOnSkip = True
 
@@ -381,7 +381,7 @@ class StorageSpoke(NormalSpoke, StorageChecker):
     @gtk_action_nowait
     def execute(self):
         # Spawn storage execution as a separate thread so there's no big delay
-        # going back from this spoke to the hub while StorageChecker.run runs.
+        # going back from this spoke to the hub while StorageCheckHandler.run runs.
         # Yes, this means there's a thread spawning another thread.  Sorry.
         threadMgr.add(AnacondaThread(name=constants.THREAD_EXECUTE_STORAGE,
                                      target=self._doExecute))
@@ -424,7 +424,7 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         hubQ.send_message(self.__class__.__name__, _("Saving storage configuration..."))
         if flags.automatedInstall and self.data.autopart.encrypted and not self.data.autopart.passphrase:
             self.autopart_missing_passphrase = True
-            StorageChecker.errors = [_("Passphrase for autopart encryption not specified.")]
+            StorageCheckHandler.errors = [_("Passphrase for autopart encryption not specified.")]
             self._ready = True
             hubQ.send_ready(self.__class__.__name__, True)
             return
@@ -433,7 +433,7 @@ class StorageSpoke(NormalSpoke, StorageChecker):
         # ValueError is here because Blivet is returning ValueError from devices/lvm.py
         except (StorageError, KickstartParseError, ValueError) as e:
             log.error("storage configuration failed: %s", e)
-            StorageChecker.errors = str(e).split("\n")
+            StorageCheckHandler.errors = str(e).split("\n")
             hubQ.send_message(self.__class__.__name__, _("Failed to save storage configuration..."))
             self.data.bootloader.bootDrive = ""
             self.data.ignoredisk.drives = []
@@ -445,17 +445,17 @@ class StorageSpoke(NormalSpoke, StorageChecker):
             applyDiskSelection(self.storage, self.data, self.selected_disks)
         except BootLoaderError as e:
             log.error("BootLoader setup failed: %s", e)
-            StorageChecker.errors = str(e).split("\n")
+            StorageCheckHandler.errors = str(e).split("\n")
             hubQ.send_message(self.__class__.__name__, _("Failed to save storage configuration..."))
             self.data.bootloader.bootDrive = ""
         except Exception as e:
             log.error("unexpected storage error: %s", e)
-            StorageChecker.errors = str(e).split("\n")
+            StorageCheckHandler.errors = str(e).split("\n")
             hubQ.send_message(self.__class__.__name__, _("Unexpected storage error"))
             raise e
         else:
             if self.autopart or (flags.automatedInstall and (self.data.autopart.autopart or self.data.partition.seen)):
-                # run() executes StorageChecker.checkStorage in a seperate threat
+                # run() executes StorageCheckHandler.checkStorage in a seperate thread
                 self.run()
         finally:
             resetCustomStorageData(self.data)

--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -60,7 +60,6 @@ from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.i18n import _
 from pyanaconda.payload import payloadMgr
-from pyanaconda import isys
 
 import logging
 import copy
@@ -70,9 +69,8 @@ class StorageCheckHandler(object, metaclass=ABCMeta):
     errors = []
     warnings = []
 
-    def __init__(self, min_ram=isys.MIN_RAM, mainSpokeClass="StorageSpoke"):
+    def __init__(self, mainSpokeClass="StorageSpoke"):
         self._mainSpokeClass = mainSpokeClass
-        self._min_ram = min_ram
 
     @abstractproperty
     def storage(self):
@@ -83,21 +81,19 @@ class StorageCheckHandler(object, metaclass=ABCMeta):
                                      target=self.checkStorage))
 
     def checkStorage(self):
-        from pyanaconda.storage_utils import sanity_check, SanityError, SanityWarning
+        from pyanaconda.storage_utils import storage_checker
 
         threadMgr.wait(constants.THREAD_EXECUTE_STORAGE)
 
         hubQ.send_not_ready(self._mainSpokeClass)
         hubQ.send_message(self._mainSpokeClass, _("Checking storage configuration..."))
-        exns = sanity_check(self.storage, min_ram=self._min_ram)
-        errors = [str(exn) for exn in exns if isinstance(exn, SanityError)]
-        warnings = [str(exn) for exn in exns if isinstance(exn, SanityWarning)]
-        (StorageCheckHandler.errors, StorageCheckHandler.warnings) = (errors, warnings)
+
+        report = storage_checker.check(self.storage)
+        self.errors = report.errors
+        self.warnings = report.warnings
+
         hubQ.send_ready(self._mainSpokeClass, True)
-        for e in StorageCheckHandler.errors:
-            self.log.error(e)
-        for w in StorageCheckHandler.warnings:
-            self.log.warning(w)
+        report.log(self.log)
 
 class SourceSwitchHandler(object, metaclass=ABCMeta):
     """ A class that can be used as a mixin handling

--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -65,7 +65,7 @@ from pyanaconda import isys
 import logging
 import copy
 
-class StorageChecker(object, metaclass=ABCMeta):
+class StorageCheckHandler(object, metaclass=ABCMeta):
     log = logging.getLogger("anaconda")
     errors = []
     warnings = []
@@ -92,11 +92,11 @@ class StorageChecker(object, metaclass=ABCMeta):
         exns = sanity_check(self.storage, min_ram=self._min_ram)
         errors = [str(exn) for exn in exns if isinstance(exn, SanityError)]
         warnings = [str(exn) for exn in exns if isinstance(exn, SanityWarning)]
-        (StorageChecker.errors, StorageChecker.warnings) = (errors, warnings)
+        (StorageCheckHandler.errors, StorageCheckHandler.warnings) = (errors, warnings)
         hubQ.send_ready(self._mainSpokeClass, True)
-        for e in StorageChecker.errors:
+        for e in StorageCheckHandler.errors:
             self.log.error(e)
-        for w in StorageChecker.warnings:
+        for w in StorageCheckHandler.warnings:
             self.log.warning(w)
 
 class SourceSwitchHandler(object, metaclass=ABCMeta):

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -27,7 +27,7 @@ from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.simpleline import TextWidget, CheckboxWidget
 from pyanaconda.ui.tui.tuiobject import YesNoDialog
-from pyanaconda.storage_utils import AUTOPART_CHOICES, sanity_check, SanityError, SanityWarning
+from pyanaconda.storage_utils import AUTOPART_CHOICES, storage_checker
 
 from blivet import arch
 from blivet.size import Size
@@ -405,16 +405,11 @@ class StorageSpoke(NormalTUISpoke):
             self.data.bootloader.bootDrive = ""
         else:
             print(_("Checking storage configuration..."))
-            exns = sanity_check(self.storage)
-            errors = [str(exn) for exn in exns if isinstance(exn, SanityError)]
-            warnings = [str(exn) for exn in exns if isinstance(exn, SanityWarning)]
-            (self.errors, self.warnings) = (errors, warnings)
-            for e in self.errors:
-                log.error(e)
-                print(e)
-            for w in self.warnings:
-                log.warning(w)
-                print(w)
+            report = storage_checker.check(self.storage)
+            print("\n".join(report.all_errors))
+            report.log(log)
+            self.errors = report.errors
+            self.warnings = report.warnings
         finally:
             resetCustomStorageData(self.data)
             self._ready = True

--- a/tests/pyanaconda_tests/storage_checker_test.py
+++ b/tests/pyanaconda_tests/storage_checker_test.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+
+import unittest
+from mock import Mock
+
+
+class StorageCheckerTests(unittest.TestCase):
+
+    def setUp(self):
+        """This madness is supposed to solve the problems with
+         imports in storage_utils that we don't need for testing.
+         """
+        import sys
+
+        sys.modules["blivet"] = Mock()
+        sys.modules["blivet.arch"] = Mock()
+        sys.modules["blivet.size"] = Mock()
+        sys.modules["blivet.errors"] = Mock()
+        sys.modules["blivet.platform"] = Mock()
+        sys.modules["blivet.devicefactory"] = Mock()
+        sys.modules["_isys"] = Mock()
+
+        from pyanaconda.storage_utils import StorageChecker
+        self.checker_type = StorageChecker
+
+    def nocheck_test(self):
+        """Test a check with no checks."""
+        checker = self.checker_type()
+        report = checker.check(None)
+
+        self.assertEqual(report.success, True)
+        self.assertEqual(report.failure, False)
+        self.assertListEqual(report.errors, [])
+        self.assertListEqual(report.warnings, [])
+
+    def simple_error_test(self):
+        """Test an simple error report."""
+        checker = self.checker_type()
+
+        def check(storage, constraints, report_error, report_warning):
+            report_error("error")
+
+        checker.add_check(check)
+        report = checker.check(None)
+
+        self.assertEqual(report.success, False)
+        self.assertListEqual(report.errors, ["error"])
+        self.assertListEqual(report.warnings, [])
+
+    def simple_warning_test(self):
+        """Test an simple warning report."""
+        checker = self.checker_type()
+
+        def check(storage, constraints, report_error, report_warning):
+            report_warning("warning")
+
+        checker.add_check(check)
+        report = checker.check(None)
+        self.assertEqual(report.success, False)
+        self.assertListEqual(report.errors, [])
+        self.assertListEqual(report.warnings, ["warning"])
+
+    def simple_info_test(self):
+        """Test simple info messages. """
+        checker = self.checker_type()
+        report = checker.check(None)
+        self.assertListEqual(report.info, [
+            "Storage check started with constraints {}.",
+            "Storage check finished with success."
+        ])
+
+    def info_test(self):
+        """Test info messages. """
+        checker = self.checker_type()
+
+        def error_check(storage, constraints, report_error, report_warning):
+            report_error("error")
+
+        def warning_check(storage, constraints, report_error, report_warning):
+            report_warning("warning")
+
+        def skipped_check(storage, constraints, report_error, report_warning):
+            report_warning("skipped")
+
+        checker.add_new_constraint("x", None)
+        checker.add_check(error_check)
+        checker.add_check(warning_check)
+        checker.add_check(skipped_check)
+
+        report = checker.check(None, skip=(skipped_check,))
+        self.assertListEqual(report.info, [
+            "Storage check started with constraints {'x': None}.",
+            "Run sanity check error_check.",
+            "Found sanity error: error",
+            "Run sanity check warning_check.",
+            "Found sanity warning: warning",
+            "Skipped sanity check skipped_check.",
+            "Storage check finished with failure(s)."
+        ])
+
+    def simple_constraints_test(self):
+        """Test simple constraint adding."""
+        checker = self.checker_type()
+
+        # Try to add a new constraint with a wrong method.
+        self.assertRaises(KeyError, checker.add_constraint, "x", None)
+
+        # Try to add a new constraint two times.
+        checker.add_new_constraint("x", None)
+        self.assertRaises(KeyError, checker.add_new_constraint, "x", None)
+
+        # Try to update a constraint with a wrong method.
+        checker.add_constraint("x", 1)
+        self.assertRaises(AttributeError, checker.update_constraint, "x", None)
+
+        # Update a constraint.
+        checker.add_constraint("x", {"a": 1, "b": 2})
+        checker.update_constraint("x", {"c": 3})
+        self.assertEqual(checker.constraints["x"], {"a": 1, "b": 2, "c": 3})
+
+    def check_constraints_test(self):
+        """Test constraints checking."""
+        checker = self.checker_type()
+
+        def check(storage, constraints, report_error, report_warning):
+            report_warning("%s" % constraints)
+
+        checker.add_check(check)
+        report = checker.check(None)
+        self.assertListEqual(report.warnings, ["{}"])
+
+        checker.add_new_constraint("x", 1)
+        report = checker.check(None)
+        self.assertListEqual(report.warnings, ["{'x': 1}"])
+
+        checker.add_constraint("x", 0)
+        report = checker.check(None)
+        self.assertListEqual(report.warnings, ["{'x': 0}"])
+
+    def dictionary_constraints_test(self):
+        """Test the dictionary constraints."""
+        checker = self.checker_type()
+
+        checker.add_new_constraint("x", {"a": 1, "b": 2, "c": 3})
+        self.assertIn("x", checker.constraints)
+        self.assertEqual(checker.constraints["x"], {"a": 1, "b": 2, "c": 3})
+
+        checker.update_constraint("x", {"a": None, "d": 4})
+        self.assertIn("x", checker.constraints)
+        self.assertEqual(checker.constraints["x"], {"a": None, "b": 2, "c": 3, "d": 4})
+
+        checker.add_constraint("x", {"e": 4, "f": 5})
+        self.assertIn("x", checker.constraints)
+        self.assertEqual(checker.constraints["x"], {"e": 4, "f": 5})
+
+    def complicated_test(self):
+        """Run a complicated check."""
+        checker = self.checker_type()
+
+        # Set the checks,
+        def check_x(storage, constraints, report_error, report_warning):
+            if constraints["x"] != 1:
+                report_error("x is not equal to 1")
+
+        def check_y(storage, constraints, report_error, report_warning):
+            if constraints["y"] != 2:
+                report_error("y is not equal to 2")
+
+        def check_z(storage, constraints, report_error, report_warning):
+            if constraints["z"] != 3:
+                report_error("z is not equal to 3")
+
+        checker.add_check(check_x)
+        checker.add_check(check_y)
+        checker.add_check(check_z)
+
+        # Set the constraints.
+        checker.add_new_constraint("x", 1)
+        checker.add_new_constraint("y", 2)
+        checker.add_new_constraint("z", 3)
+
+        # Run the checker. OK
+        report = checker.check(None)
+        self.assertEqual(report.success, True)
+        self.assertListEqual(report.errors, [])
+        self.assertListEqual(report.warnings, [])
+
+        # Set constraints to different values.
+        checker.add_constraint("x", 0)
+        checker.add_constraint("y", 1)
+        checker.add_constraint("z", 2)
+
+        # Run the checker. FAIL
+        report = checker.check(None)
+        self.assertEqual(report.success, False)
+        self.assertListEqual(report.errors, [
+            "x is not equal to 1",
+            "y is not equal to 2",
+            "z is not equal to 3"
+        ])
+        self.assertListEqual(report.warnings, [])
+
+        # Run the checker. Test SKIP.
+        report = checker.check(None, skip=(check_y,))
+        self.assertEqual(report.success, False)
+        self.assertListEqual(report.errors, [
+            "x is not equal to 1",
+            "z is not equal to 3"
+        ])
+        self.assertListEqual(report.warnings, [])
+
+        # Run the checker. Test CONSTRAINTS.
+        constraints = {"x": 1, "y": 2, "z": 3}
+        report = checker.check(None, constraints=constraints)
+        self.assertEqual(report.success, True)
+        self.assertListEqual(report.errors, [])
+        self.assertListEqual(report.warnings, [])
+
+        # Remove checks.
+        checker.remove_check(check_x)
+        checker.remove_check(check_y)
+        checker.remove_check(check_z)
+
+        report = checker.check(None)
+        self.assertEqual(report.success, True)
+        self.assertListEqual(report.errors, [])
+        self.assertListEqual(report.warnings, [])
+
+    def default_settings_test(self):
+        """Check the default storage checker."""
+        checker = self.checker_type()
+        checker.set_default_constraints()
+        checker.set_default_checks()


### PR DESCRIPTION
Cherry picked from https://github.com/rhinstaller/anaconda/pull/972.

* `StorageChecker` was renamed to a more specific name `StorageCheckHandler`, so we can define a class `StorageChecker `for actual storage checking.

* The function `sanity_check` was replaced with many small functions for storage checking that can be registered with `storage_checker` and called with defined constraints. This enables us to make the
    storage checking more flexible, since we can dynamically register new checks, change the constraints or just skip some checks.

* Enabled install classes to customize the storage checking, so they can modify the storage checker and customize it to their needs.

* `SanityError` and `SanityWarning` exceptions were removed, because they were never raised and we only used them to distinguish between errors and warnings. That is not necessary now.