### PR TITLE
Display progress for the post installation phase

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -20,7 +20,7 @@ Source0: %{name}-%{version}.tar.bz2
 
 %define gettextver 0.19.8
 %define pykickstartver 2.32-1
-%define dnfver 2.0.0
+%define dnfver 2.2.0
 %define partedver 1.8.1
 %define pypartedver 2.5-2
 %define nmver 1.0


### PR DESCRIPTION
Instead of just telling the user that we are "Performing
post installation setup tasks" for many minutes display
detailed progress for the post installation phase.

Both post-scriptlets and installed package verification
are now displayed in the UI as well as logged in packaging.log.

Scriptlets that are run during the installation phase are just logged,
but not displayed in the UI to not needlessly interrupt the flow of
"installing foo-bar 15/345" messages.