### PR TITLE
Add snapshot feature to Rhel 7

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -1341,6 +1341,12 @@ if __name__ == "__main__":
         if not anaconda.ksdata.timezone.nontp:
             iutil.start_service("chronyd")
 
+    # Create pre-install snapshots
+    from pykickstart.constants import SNAPSHOT_WHEN_PRE_INSTALL
+    if ksdata.snapshot.has_snapshot(SNAPSHOT_WHEN_PRE_INSTALL):
+        ksdata.snapshot.pre_setup(anaconda.storage, ksdata, anaconda.instClass)
+        ksdata.snapshot.pre_execute(anaconda.storage, ksdata, anaconda.instClass)
+
     # FIXME:  This will need to be made cleaner once this file starts to take
     # shape with the new UI code.
     anaconda._intf.setup(ksdata)

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -19,7 +19,7 @@ Source0: %{name}-%{version}.tar.bz2
 # match the requires versions of things).
 %define gettextver 0.18.1
 %define intltoolver 0.31.2-3
-%define pykickstartver 1.99.66.11
+%define pykickstartver 1.99.66.12
 %define yumver 3.4.3-91
 %define partedver 1.8.1
 %define pypartedver 2.5-2
@@ -88,7 +88,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 
 %package core
 Summary: Core of the Anaconda installer
-Requires: python-blivet >= 1:0.61.15.52
+Requires: python-blivet >= 1:0.61.15.60
 Requires: python-meh >= %{mehver}
 Requires: libreport-anaconda >= 2.0.21-1
 Requires: libreport-rhel-anaconda-bugzilla >= 2.1.11-1

--- a/pyanaconda/install.py
+++ b/pyanaconda/install.py
@@ -34,6 +34,7 @@ from pyanaconda.threads import threadMgr
 from pyanaconda.ui.lib.entropy import wait_for_entropy
 from pyanaconda.kexec import setup_kexec
 from pyanaconda.kickstart import runPostScripts, runPreInstallScripts
+from pykickstart.constants import SNAPSHOT_WHEN_POST_INSTALL
 import logging
 import blivet
 log = logging.getLogger("anaconda")
@@ -72,7 +73,7 @@ def doConfiguration(storage, payload, ksdata, instClass):
     if willRunRealmd:
         step_count += 1
 
-    if ksdata.snapshot:
+    if ksdata.snapshot and ksdata.snapshot.has_snapshot(SNAPSHOT_WHEN_POST_INSTALL):
         step_count += 1
 
     progress_init(step_count)
@@ -134,7 +135,7 @@ def doConfiguration(storage, payload, ksdata, instClass):
     # write out the user interaction config file
     screen_access.sam.write_out_config_file()
 
-    if ksdata.snapshot:
+    if ksdata.snapshot and ksdata.snapshot.has_snapshot(SNAPSHOT_WHEN_POST_INSTALL):
         with progress_report(N_("Creating snapshots")):
             ksdata.snapshot.execute(storage, ksdata, instClass)
 

--- a/pyanaconda/install.py
+++ b/pyanaconda/install.py
@@ -28,7 +28,7 @@ from pyanaconda import flags
 from pyanaconda import iutil
 from pyanaconda import timezone
 from pyanaconda import network
-from pyanaconda.i18n import _
+from pyanaconda.i18n import _, N_
 from pyanaconda import screen_access
 from pyanaconda.threads import threadMgr
 from pyanaconda.ui.lib.entropy import wait_for_entropy
@@ -70,6 +70,9 @@ def doConfiguration(storage, payload, ksdata, instClass):
     # increment the counter as the
     # real joining step will be executed
     if willRunRealmd:
+        step_count += 1
+
+    if ksdata.snapshot:
         step_count += 1
 
     progress_init(step_count)
@@ -130,6 +133,10 @@ def doConfiguration(storage, payload, ksdata, instClass):
 
     # write out the user interaction config file
     screen_access.sam.write_out_config_file()
+
+    if ksdata.snapshot:
+        with progress_report(N_("Creating snapshots")):
+            ksdata.snapshot.execute(storage, ksdata, instClass)
 
     progress_complete()
 

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -21,7 +21,7 @@
 from pyanaconda.errors import ScriptError, errorHandler
 from blivet.deviceaction import ActionCreateFormat, ActionDestroyFormat, ActionResizeDevice, ActionResizeFormat
 from blivet.devices import LUKSDevice
-from blivet.devices.lvm import LVMCacheRequest
+from blivet.devices.lvm import LVMCacheRequest, LVMThinLogicalVolumeDevice, LVMThinSnapShotDevice
 from blivet.devicelibs.lvm import getPossiblePhysicalExtents, LVM_PE_SIZE, KNOWN_THPOOL_PROFILES
 from blivet.devicelibs.crypto import MIN_CREATE_ENTROPY
 from blivet.devicelibs import swap as swap_lib
@@ -63,13 +63,12 @@ from pyanaconda.ui.common import collect
 from pyanaconda.addons import AddonSection, AddonData, AddonRegistry, collect_addon_paths
 from pyanaconda.bootloader import GRUB2, get_bootloader
 from pyanaconda.pwpolicy import F22_PwPolicy, F22_PwPolicyData
-from pyanaconda.storage_utils import device_matches
+from pyanaconda.storage_utils import device_matches, try_populate_devicetree
 from pyanaconda import screen_access
-
 from pykickstart.constants import CLEARPART_TYPE_NONE, FIRSTBOOT_SKIP, FIRSTBOOT_RECONFIG, KS_SCRIPT_POST, KS_SCRIPT_PRE, \
                                   KS_SCRIPT_TRACEBACK, KS_SCRIPT_PREINSTALL, SELINUX_DISABLED, SELINUX_ENFORCING, SELINUX_PERMISSIVE
 from pykickstart.base import BaseHandler
-from pykickstart.errors import formatErrorMsg, KickstartError, KickstartValueError
+from pykickstart.errors import formatErrorMsg, KickstartError, KickstartValueError, KickstartParseError
 from pykickstart.parser import KickstartParser
 from pykickstart.parser import Script as KSScript
 from pykickstart.sections import NullSection, PackageSection, PostScriptSection, PreScriptSection, PreInstallScriptSection, \
@@ -1915,6 +1914,68 @@ class SkipX(commands.skipx.FC3_SkipX):
             desktop.runlevel = 3
             desktop.write()
 
+class Snapshot(commands.snapshot.RHEL7_Snapshot):
+    def setup(self, storage, ksdata, instClass):
+        """ Prepare the snapshot.
+
+            This will also do the checking of snapshot validity.
+        """
+        for snap_data in self.dataList():
+            snap_data.setup(storage, ksdata, instClass)
+
+    def execute(self, storage, ksdata, instClass):
+        """ Create ThinLV snapshot.
+
+            Blivet must be reset before creation of the snapshot. This is
+            required because the storage could be changed in post section.
+        """
+        try_populate_devicetree(storage.devicetree)
+        for snap_data in self.dataList():
+            snap_data.execute(storage, ksdata, instClass)
+
+class SnapshotData(commands.snapshot.RHEL7_SnapshotData):
+    def __init__(self, *args, **kwargs):
+        commands.snapshot.RHEL7_SnapshotData.__init__(self, *args, **kwargs)
+        self.thin_snapshot = None
+
+    def setup(self, storage, ksdata, instClass):
+        """ Add ThinLV snapshot to Blivet model but do not create it.
+
+            This will plan snapshot creation on the end of the installation. This way
+            Blivet will do a validity checking for future snapshot.
+        """
+        log.debug("Snapshot name %s setup", self.name)
+        if not self.origin.count('/') == 1:
+            raise KickstartParseError(
+                        formatErrorMsg(self.lineno,
+                                       msg=_("Incorrectly specified origin of the snapshot."
+                                             " Use format \"VolGroup/LV_name\"")))
+        # modify the origin name to the proper DM naming
+        origin = self.origin.replace('-','--').replace('/','-')
+        origin_dev = storage.devicetree.getDeviceByName(origin)
+
+        if not isinstance(origin_dev, LVMThinLogicalVolumeDevice):
+            raise KickstartParseError(
+                        formatErrorMsg(self.lineno,
+                                       msg=(_("Snapshot: origin \"%(origin)s\" of snapshot \"%(name)s\""
+                                              " is not a valid thin LV device.") %
+                                            {"origin": self.origin,
+                                             "name": self.name})))
+
+        self.thin_snapshot = None
+        try:
+            self.thin_snapshot = LVMThinSnapShotDevice(name=self.name,
+                                                       parents=[origin_dev.pool],
+                                                       segType="thin",
+                                                       origin=origin_dev)
+        except ValueError as e:
+            raise KickstartParseError(formatErrorMsg(self.lineno, msg=e))
+
+    def execute(self, storage, ksdata, instClass):
+        """ Execute an action for snapshot creation. """
+        log.debug("Snapshot name %s execute", self.name)
+        self.thin_snapshot.create()
+
 class ZFCP(commands.zfcp.F14_ZFCP):
     def parse(self, args):
         fcp = commands.zfcp.F14_ZFCP.parse(self, args)
@@ -2031,6 +2092,7 @@ commandMap = {
         "services": Services,
         "sshkey": SshKey,
         "skipx": SkipX,
+        "snapshot": Snapshot,
         "timezone": Timezone,
         "upgrade": Upgrade,
         "user": User,
@@ -2045,6 +2107,7 @@ dataMap = {
         "PartData": PartitionData,
         "RaidData": RaidData,
         "RepoData": RepoData,
+        "SnapshotData": SnapshotData,
         "VolGroupData": VolGroupData,
 }
 
@@ -2262,6 +2325,9 @@ def doKickstartStorage(storage, ksdata, instClass):
     ksdata.volgroup.execute(storage, ksdata, instClass)
     ksdata.logvol.execute(storage, ksdata, instClass)
     ksdata.btrfs.execute(storage, ksdata, instClass)
+    # setup snapshot here, that means add it to model and do the tests
+    # snapshot will be created on the end of the installation
+    ksdata.snapshot.setup(storage, ksdata, instClass)
     # also calls ksdata.bootloader.execute
     storage.setUpBootLoader()
 

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -27,6 +27,7 @@ from blivet.devicelibs.lvm import getPossiblePhysicalExtents, LVM_PE_SIZE, KNOWN
 from blivet.devicelibs.crypto import MIN_CREATE_ENTROPY
 from blivet.devicelibs import swap as swap_lib
 from blivet.formats import getFormat
+from blivet.formats.fs import XFS
 from blivet.partitioning import doPartitioning
 from blivet.partitioning import growLVM
 from blivet.errors import PartitioningError
@@ -1956,6 +1957,9 @@ class Snapshot(commands.snapshot.RHEL7_Snapshot):
             for snap_data in post_snapshots:
                 log.debug("Snapshot: creating post-install snapshot %s", snap_data.name)
                 snap_data.execute(storage, ksdata, instClass)
+                if isinstance(snap_data.thin_snapshot.format, XFS):
+                    log.debug("Generating new UUID for XFS snapshot")
+                    snap_data.thin_snapshot.format.regenerate_uuid()
 
     def pre_setup(self, storage, ksdata, instClass):
         """ Prepare pre installation snapshots.


### PR DESCRIPTION
This feature adding possibility to create snapshot for thin pool LVM devices. It is possible to create snapshot before and after the installation by using `--when` parameter which is mandatory.

Adding snapshot KS command:

``snapshot <origin_vg/origin_lv> --name=<snapshot_name> --when=<pre-install | post-install>``

*Resolves: rhbz#1113207*

This PR depends on: https://github.com/rhinstaller/pykickstart/pull/152 and https://github.com/rhinstaller/blivet/pull/563 .

This will be backported to Rawhide later.