### PR TITLE
Specify unit for reserved space in VG (#1260887)

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1889,7 +1889,7 @@ class VolGroupData(commands.volgroup.RHEL7_VolGroupData):
 
             storage.createDevice(request)
             if self.reserved_space:
-                request.reserved_space = self.reserved_space
+                request.reserved_space = Size("%dMiB" % self.reserved_space)
             elif self.reserved_percent:
                 request.reserved_percent = self.reserved_percent
 


### PR DESCRIPTION
The kickstart documentation says the number passed as
'--reserved-space' is in MiB. However, blivet's
LVMVolumeGroupObject's reserved_space expects the value to be a
'Size' instance so we need to make sure the unit is actually made
effective.