### PR TITLE
Fixed gtk warnings

### DIFF
--- a/data/anaconda-gtk.css
+++ b/data/anaconda-gtk.css
@@ -184,9 +184,9 @@ AnacondaSpokeSelector:selected:focus {
 @define-color anaconda_internal_element_color #888a85;
 @define-color anaconda_insensitive_borders shade(@anaconda_internal_element_color, 1.37);
 
-AnacondaMountpointSelector:insensitive,
-AnacondaDiskOverview:insensitive,
-AnacondaSpokeSelector:insensitive {
+AnacondaMountpointSelector:disabled,
+AnacondaDiskOverview:disabled,
+AnacondaSpokeSelector:disabled {
     background-color: @anaconda_insensitive_bg_color;
     color: @anaconda_insensitive_fg_color;
     border-color: @anaconda_insensitive_borders;

--- a/data/anaconda-gtk.css
+++ b/data/anaconda-gtk.css
@@ -197,6 +197,6 @@ AnacondaSpokeSelector:disabled {
  * separator up for each column. It looks kind of dumb. Provide a way to not do
  * that.
  */
-GtkTreeView.solid-separator {
+treeview.solid-separator {
     -GtkTreeView-horizontal-separator: 0;
 }

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -412,11 +412,14 @@ class MainWindow(Gtk.Window):
         overlayed_widget.set_from_pixbuf(self._transparent_base.scale_simple(
             overlay_allocation.width, overlay_allocation.height, GdkPixbuf.InterpType.NEAREST))
 
+        # The image's size needs to be recalculated.
+        minimal, requested = overlayed_widget.get_preferred_size()
+
         # Set the allocation for the overlayed image to the full size of the GtkOverlay
         allocation.x = 0
         allocation.y = 0
-        allocation.width = overlay_allocation.width
-        allocation.height = overlay_allocation.height
+        allocation.width = max(minimal.width, min(overlay_allocation.width, requested.width))
+        allocation.height = max(minimal.height, max(overlay_allocation.height, requested.height))
 
         return True
 

--- a/pyanaconda/ui/gui/utils.py
+++ b/pyanaconda/ui/gui/utils.py
@@ -329,7 +329,7 @@ def setViewportBackground(vp, color="@theme_bg_color"):
     """
 
     provider = Gtk.CssProvider()
-    provider.load_from_data("GtkViewport { background-color: %s }" % color)
+    provider.load_from_data("viewport { background: %s }" % color)
     context = vp.get_style_context()
     context.add_provider(provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 

--- a/widgets/src/BaseStandalone.c
+++ b/widgets/src/BaseStandalone.c
@@ -148,6 +148,8 @@ static void anaconda_base_standalone_class_init(AnacondaBaseStandaloneClass *kla
                                                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
 
     g_type_class_add_private(object_class, sizeof(AnacondaBaseStandalonePrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaBaseStandalone");
 }
 
 static void anaconda_base_standalone_init(AnacondaBaseStandalone *win) {

--- a/widgets/src/BaseWindow.c
+++ b/widgets/src/BaseWindow.c
@@ -182,6 +182,7 @@ G_DEFINE_TYPE_WITH_CODE(AnacondaBaseWindow, anaconda_base_window, GTK_TYPE_BIN,
 
 static void anaconda_base_window_class_init(AnacondaBaseWindowClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     object_class->set_property = anaconda_base_window_set_property;
     object_class->get_property = anaconda_base_window_get_property;
@@ -265,6 +266,8 @@ static void anaconda_base_window_class_init(AnacondaBaseWindowClass *klass) {
                                                               G_TYPE_NONE, 0);
 
     g_type_class_add_private(object_class, sizeof(AnacondaBaseWindowPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaBaseWindow");
 }
 
 /**

--- a/widgets/src/DiskOverview.c
+++ b/widgets/src/DiskOverview.c
@@ -135,6 +135,7 @@ static gboolean anaconda_disk_overview_focus_changed(GtkWidget *widget, GdkEvent
 
 static void anaconda_disk_overview_class_init(AnacondaDiskOverviewClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     object_class->set_property = anaconda_disk_overview_set_property;
     object_class->get_property = anaconda_disk_overview_get_property;
@@ -240,6 +241,8 @@ static void anaconda_disk_overview_class_init(AnacondaDiskOverviewClass *klass) 
                                                         G_PARAM_READWRITE));
 
     g_type_class_add_private(object_class, sizeof(AnacondaDiskOverviewPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaDiskOverview");
 }
 
 /**

--- a/widgets/src/DiskOverview.c
+++ b/widgets/src/DiskOverview.c
@@ -321,7 +321,7 @@ static void anaconda_disk_overview_init(AnacondaDiskOverview *widget) {
     g_signal_connect(widget, "focus-out-event", G_CALLBACK(anaconda_disk_overview_focus_changed), NULL);
 
     /* Set "hand" cursor shape when over the selector */
-    widget->priv->cursor = gdk_cursor_new(GDK_HAND2);
+    widget->priv->cursor = gdk_cursor_new_for_display(gdk_display_get_default(), GDK_HAND2);
     g_signal_connect(widget, "realize", G_CALLBACK(anaconda_disk_overview_realize), NULL);
 
     /* Set some properties. */

--- a/widgets/src/HubWindow.c
+++ b/widgets/src/HubWindow.c
@@ -101,8 +101,11 @@ G_DEFINE_TYPE_WITH_CODE(AnacondaHubWindow, anaconda_hub_window, ANACONDA_TYPE_BA
 
 static void anaconda_hub_window_class_init(AnacondaHubWindowClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     g_type_class_add_private(object_class, sizeof(AnacondaHubWindowPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaHubWindow");
 }
 
 /**

--- a/widgets/src/LayoutIndicator.c
+++ b/widgets/src/LayoutIndicator.c
@@ -203,7 +203,7 @@ static void anaconda_layout_indicator_init(AnacondaLayoutIndicator *self) {
                      NULL);
 
     /* layout indicator should have a hand cursor so that looks like clickable widget */
-    self->priv->cursor = gdk_cursor_new(GDK_HAND2);
+    self->priv->cursor = gdk_cursor_new_for_display(gdk_display_get_default(), GDK_HAND2);
     g_signal_connect(self, "realize",
                      G_CALLBACK(anaconda_layout_indicator_realize),
                      NULL);

--- a/widgets/src/LayoutIndicator.c
+++ b/widgets/src/LayoutIndicator.c
@@ -109,6 +109,7 @@ static GdkFilterReturn handle_xevent(GdkXEvent *xev, GdkEvent *event, gpointer e
 
 static void anaconda_layout_indicator_class_init(AnacondaLayoutIndicatorClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     object_class->get_property = anaconda_layout_indicator_get_property;
     object_class->set_property = anaconda_layout_indicator_set_property;
@@ -145,6 +146,8 @@ static void anaconda_layout_indicator_class_init(AnacondaLayoutIndicatorClass *k
                                                       G_PARAM_READWRITE));
 
     g_type_class_add_private(object_class, sizeof(AnacondaLayoutIndicatorPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaLayoutIndicator");
 }
 
 /**

--- a/widgets/src/MountpointSelector.c
+++ b/widgets/src/MountpointSelector.c
@@ -190,7 +190,7 @@ static void anaconda_mountpoint_selector_init(AnacondaMountpointSelector *mountp
     gtk_widget_add_events(GTK_WIDGET(mountpoint), GDK_FOCUS_CHANGE_MASK|GDK_KEY_RELEASE_MASK);
 
     /* Set "hand" cursor shape when over the selector */
-    mountpoint->priv->cursor = gdk_cursor_new(GDK_HAND2);
+    mountpoint->priv->cursor = gdk_cursor_new_for_display(gdk_display_get_default(), GDK_HAND2);
     g_signal_connect(mountpoint, "realize", G_CALLBACK(anaconda_mountpoint_selector_realize), NULL);
 
     /* Create the grid. */

--- a/widgets/src/MountpointSelector.c
+++ b/widgets/src/MountpointSelector.c
@@ -106,6 +106,7 @@ static void anaconda_mountpoint_selector_toggle_background(AnacondaMountpointSel
 
 static void anaconda_mountpoint_selector_class_init(AnacondaMountpointSelectorClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     object_class->set_property = anaconda_mountpoint_selector_set_property;
     object_class->get_property = anaconda_mountpoint_selector_get_property;
@@ -161,6 +162,8 @@ static void anaconda_mountpoint_selector_class_init(AnacondaMountpointSelectorCl
                                                         G_PARAM_READWRITE));
 
     g_type_class_add_private(object_class, sizeof(AnacondaMountpointSelectorPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaMountpointSelector");
 }
 
 /**

--- a/widgets/src/SpokeSelector.c
+++ b/widgets/src/SpokeSelector.c
@@ -103,6 +103,7 @@ static gboolean anaconda_spoke_selector_focus_changed(GtkWidget *widget, GdkEven
 
 static void anaconda_spoke_selector_class_init(AnacondaSpokeSelectorClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     object_class->set_property = anaconda_spoke_selector_set_property;
     object_class->get_property = anaconda_spoke_selector_get_property;
@@ -164,6 +165,8 @@ static void anaconda_spoke_selector_class_init(AnacondaSpokeSelectorClass *klass
                                                         G_PARAM_READWRITE));
 
     g_type_class_add_private(object_class, sizeof(AnacondaSpokeSelectorPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaSpokeSelector");
 }
 
 /**

--- a/widgets/src/SpokeSelector.c
+++ b/widgets/src/SpokeSelector.c
@@ -274,7 +274,7 @@ static void anaconda_spoke_selector_init(AnacondaSpokeSelector *spoke) {
     g_signal_connect(spoke, "focus-out-event", G_CALLBACK(anaconda_spoke_selector_focus_changed), NULL);
 
     /* Set "hand" cursor shape when over the selector */
-    spoke->priv->cursor = gdk_cursor_new(GDK_HAND2);
+    spoke->priv->cursor = gdk_cursor_new_for_display(gdk_display_get_default(), GDK_HAND2);
     g_signal_connect(spoke, "realize", G_CALLBACK(anaconda_spoke_selector_realize), NULL);
 
     /* Create the grid. */

--- a/widgets/src/SpokeSelector.c
+++ b/widgets/src/SpokeSelector.c
@@ -66,7 +66,7 @@
  * </listitem>
  * </itemizedlist>
  * <para>
- * In addition, the :inconsistent pseudo-class can be used to select
+ * In addition, the :indeterminate pseudo-class can be used to select
  * selectors that are in an error state.
  * </para>
  * </refsect2>

--- a/widgets/src/SpokeWindow.c
+++ b/widgets/src/SpokeWindow.c
@@ -74,6 +74,7 @@ static void anaconda_spoke_window_button_clicked(GtkButton *button,
 
 static void anaconda_spoke_window_class_init(AnacondaSpokeWindowClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     klass->button_clicked = NULL;
 
@@ -99,6 +100,8 @@ static void anaconda_spoke_window_class_init(AnacondaSpokeWindowClass *klass) {
                                                          G_TYPE_NONE, 0);
 
     g_type_class_add_private(object_class, sizeof(AnacondaSpokeWindowPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaSpokeWindow");
 }
 
 /**

--- a/widgets/src/StandaloneWindow.c
+++ b/widgets/src/StandaloneWindow.c
@@ -65,6 +65,7 @@ G_DEFINE_TYPE(AnacondaStandaloneWindow, anaconda_standalone_window, ANACONDA_TYP
 
 static void anaconda_standalone_window_class_init(AnacondaStandaloneWindowClass *klass) {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     object_class->get_property = anaconda_standalone_window_get_property;
 
@@ -108,6 +109,8 @@ static void anaconda_standalone_window_class_init(AnacondaStandaloneWindowClass 
                                                         G_PARAM_READABLE));
 
     g_type_class_add_private(object_class, sizeof(AnacondaStandaloneWindowPrivate));
+
+    gtk_widget_class_set_css_name(widget_class, "AnacondaStandaloneWindow");
 }
 
 static void anaconda_standalone_window_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec) {

--- a/widgets/src/resources/SpokeSelector-status.css
+++ b/widgets/src/resources/SpokeSelector-status.css
@@ -4,13 +4,13 @@
 }
 
 /* If the spoke is incomplete, display the text in red */
-AnacondaSpokeSelector:inconsistent #anaconda-spoke-selector-status {
+AnacondaSpokeSelector:indeterminate #anaconda-spoke-selector-status {
     color: #cc1a1a;
 }
 
 /* If the spoke is both incomplete and insensitive, let the insensitive
  * color take precedence
  */
-AnacondaSpokeSelector:insensitive:inconsistent #anaconda-spoke-selector-status {
+AnacondaSpokeSelector:disabled:indeterminate #anaconda-spoke-selector-status {
     color: inherit;
 }


### PR DESCRIPTION
Fixed most of the gtk warnings, the missing upper bar in spokes and some small problems with styles.
The remaining warnings should be caused by other components or they are probably bugs in gtk.

Resolves: rhbz#1433943
Resolves: rhbz#1439766