### PR TITLE
Allow setting up bridge for fetching isntaller image from kickstart (…

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -392,6 +392,8 @@ def ksnet_to_dracut(args, lineno, net, bootdev=False):
         # NOTE: does dracut actually support wireless? (do we care?)
         log.error("'%s': dracut doesn't support wireless networks",
                       " ".join(args))
+    if net.bridgeslaves:
+        line.append("bridge=%s:%s" % (net.device, net.bridgeslaves))
 
     return " ".join(line)
 

--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -785,7 +785,11 @@ def nm_device_setting_value(name, key1, key2):
     else:
         settings_path = settings_paths[0]
     proxy = _get_proxy(object_path=settings_path, interface_name="org.freedesktop.NetworkManager.Settings.Connection")
-    settings = proxy.GetSettings()
+    try:
+        settings = proxy.GetSettings()
+    except GLib.GError as e:
+        log.debug("nm_device_setting_value: %s", e)
+        raise SettingsNotFoundError(name)
     try:
         value = settings[key1][key2]
     except KeyError:


### PR DESCRIPTION
…#1373360)

Patch by Masahiro Matsuya <mmatsuya@redhat.com>

Resolves: rhbz#1373360

The bridge configuration is limited to what dracut allows with bridge= cmdline
option, ie using dracut default options for the bridge and slaves. Anaconda
will try re-activate the bridge via NM with bridge options from kickstart after
switchroot.