### PR TITLE
Catch exception when reading from in-memory connection being removed …

### DIFF
--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -757,7 +757,12 @@ def nm_get_all_settings():
     connections = proxy.ListConnections()
     for con in connections:
         proxy = _get_proxy(object_path=con, interface_name="org.freedesktop.NetworkManager.Settings.Connection")
-        settings = proxy.GetSettings()
+        try:
+            settings = proxy.GetSettings()
+        except Exception as e:
+            # The connection may be deleted asynchronously by NM
+            log.debug("nm_get_all_settings: %s", e)
+            continue
         retval.append(settings)
 
     return retval


### PR DESCRIPTION
…(#1439051)

This can happen when a connection is removed by NM between we obtain connection
objects and try to read settings from them.