### PR TITLE
Documentation enhancements

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -75,9 +75,9 @@ different ways:
 
     You can specify what version of the NFS protocol to use by adding ``nfsvers=X``
     to the `options`.
-    
+
     This accepts not just an installable tree directory in the ``<path>`` element,
-    but you can also specify an ``.iso`` file. That ISO file is then mounted and 
+    but you can also specify an ``.iso`` file. That ISO file is then mounted and
     used as the installation tree. This is often used for simulating a standard
     DVD installation using a remote ``DVD.iso`` image.
 

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -299,7 +299,7 @@ ifname
 inst.dhcpclass
 ^^^^^^^^^^^^^^
 
-Set the DHCP vendor class identifier [#dhcpd]. Defaults to ``anaconda-$(uname -srm)``.
+Set the DHCP vendor class identifier [#dhcpd]_. Defaults to ``anaconda-$(uname -srm)``.
 
 .. [#dhcpd] ISC ``dhcpd`` will see this value as "option vendor-class-identifier".
 


### PR DESCRIPTION
Remove trailing spaces and fix `#dhcpd` anchor name in the `docs/boot-options.rst` file.