### PR TITLE
Fix logging of the storage checker report.

### DIFF
--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -488,13 +488,16 @@ class StorageCheckerReport(object):
         :param bool info: should we log the info messages?
         """
         if info:
-            map(logger.debug, self.info)
+            for msg in self.info:
+                logger.debug(msg)
 
         if error:
-            map(logger.error, self.errors)
+            for msg in self.errors:
+                logger.error(msg)
 
         if warning:
-            map(logger.warning, self.warnings)
+            for msg in self.warnings:
+                logger.warning(msg)
 
 
 class StorageChecker(object):


### PR DESCRIPTION
The function map returns an iterator in Python 3. Because of that,
the logging functions are not applied with map and the report does
not log anything.