### PR TITLE
Support --nohome, --noswap and --noboot options in autopartitioning (#1220866)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -19,7 +19,7 @@ Source0: %{name}-%{version}.tar.bz2
 # match the requires versions of things).
 
 %define gettextver 0.19.8
-%define pykickstartver 2.32-1
+%define pykickstartver 2.33-1
 %define dnfver 2.2.0
 %define partedver 1.8.1
 %define pypartedver 2.5-2

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -127,15 +127,30 @@ class BaseInstallClass(object):
     def customizeDefaultPartitioning(self, storage, data):
         # Customize the default partitioning with kickstart data.
         skipped_mountpoints = set()
+        skipped_fstypes = set()
 
-        # Create a set of mountpoints to remove from autorequests.
-        # Add /home to the set if --nohome is selected.
-        if data.autopart.autopart and data.autopart.nohome:
-            skipped_mountpoints.add("/home")
+        # Create sets of mountpoints and fstypes to remove from autorequests.
+        if data.autopart.autopart:
+            # Remove /home if --nohome is selected.
+            if data.autopart.nohome:
+                skipped_mountpoints.add("/home")
+
+            # Remove /boot if --noboot is selected.
+            if data.autopart.noboot:
+                skipped_mountpoints.add("/boot")
+
+            # Remove swap if --noswap is selected.
+            if data.autopart.noswap:
+                skipped_fstypes.add("swap")
+
+                # Swap will not be recommended by the storage checker.
+                from pyanaconda.storage_utils import storage_checker
+                storage_checker.add_constraint("swap_is_recommended", False)
 
         # Skip mountpoints we want to remove.
         storage.autopart_requests = [req for req in storage.autopart_requests
-                                     if req.mountpoint not in skipped_mountpoints]
+                                     if req.mountpoint not in skipped_mountpoints
+                                     and req.fstype not in skipped_fstypes]
 
     def configure(self, anaconda):
         anaconda.bootloader.timeout = self.bootloaderTimeoutDefault

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -124,12 +124,28 @@ class BaseInstallClass(object):
 
         storage.autopart_requests = autorequests
 
+    def customizeDefaultPartitioning(self, storage, data):
+        # Customize the default partitioning with kickstart data.
+        skipped_mountpoints = set()
+
+        # Create a set of mountpoints to remove from autorequests.
+        # Add /home to the set if --nohome is selected.
+        if data.autopart.autopart and data.autopart.nohome:
+            skipped_mountpoints.add("/home")
+
+        # Skip mountpoints we want to remove.
+        storage.autopart_requests = [req for req in storage.autopart_requests
+                                     if req.mountpoint not in skipped_mountpoints]
+
     def configure(self, anaconda):
         anaconda.bootloader.timeout = self.bootloaderTimeoutDefault
         anaconda.bootloader.boot_args.update(self.bootloaderExtraArgs)
 
         # The default partitioning should be always set.
         self.setDefaultPartitioning(anaconda.storage)
+
+        # Customize the default partitioning with kickstart data.
+        self.customizeDefaultPartitioning(anaconda.storage, anaconda.ksdata)
 
     def setStorageChecker(self, storage_checker):
         # Update constraints and add or remove some checks in

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -254,9 +254,9 @@ class Authconfig(commands.authconfig.FC3_Authconfig):
         except RuntimeError as msg:
             log.error("Error running %s %s: %s", cmd, args, msg)
 
-class AutoPart(commands.autopart.F21_AutoPart):
+class AutoPart(commands.autopart.F26_AutoPart):
     def parse(self, args):
-        retval = commands.autopart.F21_AutoPart.parse(self, args)
+        retval = commands.autopart.F26_AutoPart.parse(self, args)
 
         if self.fstype:
             fmt = blivet.formats.get_format(self.fstype)

--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -326,17 +326,25 @@ def verify_swap(storage, constraints, report_error, report_warning):
         installed = util.total_memory()
         required = Size("%s MiB" % (constraints["min_ram"] + isys.NO_SWAP_EXTRA_RAM))
 
-        if installed < required:
-            report_error(_("You have not specified a swap partition. "
-                           "%(requiredMem)s of memory is required to continue "
-                           "installation without a swap partition, but you only "
-                           "have %(installedMem)s.")
-                         % {"requiredMem": required, "installedMem": installed})
+        if not constraints["swap_is_recommended"]:
+            if installed < required:
+                report_warning(_("You have not specified a swap partition. "
+                                 "%(requiredMem)s of memory is recommended to continue "
+                                 "installation without a swap partition, but you only "
+                                 "have %(installedMem)s.")
+                               % {"requiredMem": required, "installedMem": installed})
         else:
-            report_warning(_("You have not specified a swap partition. "
-                             "Although not strictly required in all cases, "
-                             "it will significantly improve performance "
-                             "for most installations."))
+            if installed < required:
+                report_error(_("You have not specified a swap partition. "
+                               "%(requiredMem)s of memory is required to continue "
+                               "installation without a swap partition, but you only "
+                               "have %(installedMem)s.")
+                             % {"requiredMem": required, "installedMem": installed})
+            else:
+                report_warning(_("You have not specified a swap partition. "
+                                 "Although not strictly required in all cases, "
+                                 "it will significantly improve performance "
+                                 "for most installations."))
 
 
 def verify_swap_uuid(storage, constraints, report_error, report_warning):
@@ -625,6 +633,8 @@ class StorageChecker(object):
         self.add_new_constraint("must_be_on_root", {
             '/bin', '/dev', '/sbin', '/etc', '/lib', '/root', '/mnt', 'lost+found', '/proc'
         })
+
+        self.add_new_constraint("swap_is_recommended", True)
 
     def set_default_checks(self):
         """Set the default checks."""


### PR DESCRIPTION
**Requires a new version of pykickstart!**

Default partitioning can be modified in an install class's method
customizeDefaultPartitioning, where can be applied selections made in
a kickstart file. 
    
The base install class will remove a request for a /home partition,
if --nohome option is selected in a kickstart file. In that case,
the /home partition will not be created.
    
If --noboot option is selected, then no /boot partition will be
created with autopartitioning.
    
If --noswap option is selected, then no swap partition will be
created with autopartitioning. Also the warning about the missing
swap partition will be suppressed in this case.

Resolves: rhbz#1220866