### PR TITLE
network tui: fix changing ipv4 config from static to dhcp (#1432886)

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -417,6 +417,7 @@ def _get_ip_setting_values_from_ksdata(networkdata):
         method4 = "auto"
     values.append(["ipv4", "method", method4, "s"])
 
+    addresses4 = []
     if method4 == "manual":
         addr4 = nm.nm_ipv4_to_dbus_int(networkdata.ip)
         if networkdata.gateway:
@@ -424,7 +425,9 @@ def _get_ip_setting_values_from_ksdata(networkdata):
         else:
             gateway4 = 0  # will be ignored by NetworkManager
         prefix4 = netmask2prefix(networkdata.netmask)
-        values.append(["ipv4", "addresses", [[addr4, prefix4, gateway4]], "aau"])
+        addresses4 = [[addr4, prefix4, gateway4]]
+
+    values.append(["ipv4", "addresses", addresses4, "aau"])
 
     # ipv6 settings
     if networkdata.noipv6:
@@ -440,6 +443,7 @@ def _get_ip_setting_values_from_ksdata(networkdata):
             method6 = "manual"
     values.append(["ipv6", "method", method6, "s"])
 
+    addresses6 = []
     if method6 == "manual":
         addr6, _slash, prefix6 = networkdata.ipv6.partition("/")
         if prefix6:
@@ -451,7 +455,8 @@ def _get_ip_setting_values_from_ksdata(networkdata):
             gateway6 = nm.nm_ipv6_to_dbus_ay(networkdata.ipv6gateway)
         else:
             gateway6 = [0] * 16
-        values.append(["ipv6", "addresses", [(addr6, prefix6, gateway6)], "a(ayuay)"])
+        addresses6 = [(addr6, prefix6, gateway6)]
+    values.append(["ipv6", "addresses", addresses6, "a(ayuay)"])
 
     # nameservers
     nss4 = []

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -231,6 +231,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, EditTUISpoke):
 
             network.update_settings_with_ksdata(devname, ndata)
             network.update_onboot_value(devname, ndata.onboot, ksdata=None, root_path="")
+            network.logIfcfgFiles("settings of %s updated in tui" % devname)
 
             if ndata._apply:
                 self._apply = True
@@ -300,13 +301,11 @@ def check_ipv6_address(value):
     return (network.check_ip_address(value, version=6), None)
 
 def check_nameservers(value):
-    addresses = [str.strip(i) for i in value.split(",")]
-    if not addresses:
-        return (False, None)
-
-    for ip in addresses:
-        if not network.check_ip_address(ip):
-            return (False, None)
+    if value.strip():
+        addresses = [str.strip(i) for i in value.split(",")]
+        for ip in addresses:
+            if not network.check_ip_address(ip):
+                return (False, None)
     return (True, None)
 
 class ConfigureNetworkSpoke(EditTUISpoke):


### PR DESCRIPTION
- Clear static ip settings when changing the configuration
  (also for ipv6).
- Log the change.
- Allow removing of nameserver setting (empty string).

Resolves: rhbz#1432886