### PR TITLE
Fix a typo in anaconda-pre.service (#1421246)

### DIFF
--- a/data/systemd/anaconda-pre.service
+++ b/data/systemd/anaconda-pre.service
@@ -15,7 +15,7 @@ Wants=systemd-logind.service
 [Service]
 Type=oneshot
 ExecStart=/usr/libexec/anaconda/anaconda-pre-log-gen
-StardardInput=tty
+StandardInput=tty
 StandardOutput=journal+console
 StandardError=journal+console
 TimeoutSec=0


### PR DESCRIPTION
Fix a typo in the anaconda-pre.service file.

Resolves: rhbz#1421246