### PR TITLE
Make geolocation with kickstart possible (#1358331)

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -343,6 +343,8 @@ def parseArguments(argv=None, boot_cmdline=None):
 
     # Geolocation
     ap.add_argument("--geoloc", metavar="PROVIDER_ID", help=help_parser.help_text("geoloc"))
+    ap.add_argument("--geoloc-use-with-ks", action="store_true", default=False,
+                    help=help_parser.help_text("geoloc-use-with-ks"))
 
     # Kickstart and log saving
     # - use a custom action to convert the values of the nosave option into appropriate flags
@@ -1321,28 +1323,13 @@ if __name__ == "__main__":
     payloadMgr.restartThread(anaconda.storage, ksdata, anaconda.payload, anaconda.instClass,
             fallback=fallback)
 
-    # check if geolocation should be enabled for this type of installation
-    use_geolocation = True
-    if flags.imageInstall or flags.dirInstall or flags.automatedInstall:
-        use_geolocation = False
-    # and also check if it was not disabled by boot option
-    else:
-        # flags.cmdline.getbool is used as it handles values such as
-        # 0, no, off and also nogeoloc as False
-        # and other values or geoloc not being present as True
-        use_geolocation = flags.cmdline.getbool('geoloc', True)
+    # check if geolocation should be enabled for this installation run
+    geoloc.set_geolocation_enabled(options_override=opts.geoloc_use_with_ks,
+                                   install_class_override=anaconda.instClass.use_geolocation_with_kickstart)
 
-    if use_geolocation:
-        provider_id = constants.GEOLOC_DEFAULT_PROVIDER
-        # check if a provider was specified by an option
-        if opts.geoloc is not None:
-            parsed_id = geoloc.get_provider_id_from_option(opts.geoloc)
-            if parsed_id is None:
-                log.error('geoloc: wrong provider id specified: %s', opts.geoloc)
-            else:
-                provider_id = parsed_id
-        # instantiate the geolocation module and start location data refresh
-        geoloc.init_geolocation(provider_id=provider_id)
+    # start geolocation if enabled
+    if geoloc.geolocation_enabled:
+        geoloc.init_geolocation(geoloc_option_value=opts.geoloc)
         geoloc.refresh()
 
     # setup ntp servers and start NTP daemon if not requested otherwise

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -161,6 +161,10 @@ Configure geolocation usage in Anaconda. Geolocation is used to pre-set language
 The following values for PROVIDER_ID are supported: 0 - disable geolocation, "provider_fedora_geoip"
 - use the Fedora GeoIP API (default) and "provider_hostip" - use the Hostip.info GeoIP API.
 
+geoloc-use-with-ks
+Enable geolocation even during a kickstart installation (both partial and fully automatic).
+Otherwise geolocation is only enabled during a fully interactive installation.
+
 nomount
 Don't automatically mount any installed Linux partitions in rescue mode.
 

--- a/docs/boot-options.txt
+++ b/docs/boot-options.txt
@@ -250,6 +250,10 @@ language and time zone.
 
 `inst.geoloc=provider_hostip`:: Use the Hostip.info GeoIP API.
 
+=== inst.geoloc-use-with-ks ===
+Enable geolocation even during a kickstart installation (both partial and fully automatic).
+Otherwise geolocation is only enabled during a fully interactive installation.
+
 === inst.keymap ===
 Set the keyboard layout to use. The layout specified must be valid for use with
 the `keyboard` kickstart command.

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -69,6 +69,9 @@ class BaseInstallClass(object):
     help_placeholder = None
     help_placeholder_with_links = None
 
+    # geolocation
+    use_geolocation_with_kickstart = False
+
     @property
     def l10n_domain(self):
         if self._l10n_domain is None:


### PR DESCRIPTION
Make it possible to use geolocation during a kickstart based
installation. Geolocation is disabled by default during a kickstart
installation to make it more deterministic and independent on geographic
location of the machine.

To enable geolocation during a kickstart installation, use the
inst.geoloc-use-with-ks=1 option (or the --geoloc-use-with-ks=1 option
when running Anaconda as an application from the command line).

There is also an API that install classes can use to enable geolocation
during kickstart installations - the use_geolocation_with_kickstart
attribute.

Resolves: rhbz#1358331