### PR TITLE
Fix gtk warnings in Fedora

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -225,7 +225,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         # Connect partitionsNotebook focus events to scrolling in the parent viewport
         partitionsNotebookViewport = self.builder.get_object("partitionsNotebookViewport")
-        self._partitionsNotebook.set_focus_vadjustment(partitionsNotebookViewport.get_vadjustment())
+        self._partitionsNotebook.set_focus_vadjustment(Gtk.Scrollable.get_vadjustment(partitionsNotebookViewport))
 
         self._pageLabel = self.builder.get_object("pageLabel")
 
@@ -298,8 +298,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._partitionsViewport.add(self._accordion)
 
         # Connect viewport scrolling with accordion focus events
-        self._accordion.set_focus_hadjustment(self._partitionsViewport.get_hadjustment())
-        self._accordion.set_focus_vadjustment(self._partitionsViewport.get_vadjustment())
+        self._accordion.set_focus_hadjustment(Gtk.Scrollable.get_hadjustment(self._partitionsViewport))
+        self._accordion.set_focus_vadjustment(Gtk.Scrollable.get_vadjustment(self._partitionsViewport))
 
         threadMgr.add(AnacondaThread(name=THREAD_CUSTOM_STORAGE_INIT, target=self._initialize))
 

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -388,7 +388,7 @@ class BasePage(Gtk.Box):
         label.set_markup("""<span fgcolor='dark grey' size='large' weight='bold'>%s</span>""" %
                 escape_markup(name))
         label.set_halign(Gtk.Align.START)
-        label.set_margin_left(24)
+        label.set_margin_start(24)
         return label
 
     def mark_selection(self, selector):
@@ -509,7 +509,7 @@ class CreateNewPage(BasePage):
         self._createBox = Gtk.Grid()
         self._createBox.set_row_spacing(6)
         self._createBox.set_column_spacing(6)
-        self._createBox.set_margin_left(16)
+        self._createBox.set_margin_start(16)
 
         label = Gtk.Label(label=_("You haven't created any mount points for your "
                             "%(product)s %(version)s installation yet.  "
@@ -523,7 +523,8 @@ class CreateNewPage(BasePage):
         self._createNewButton = Gtk.LinkButton(uri="",
                 label=C_("GUI|Custom Partitioning|Autopart Page", "_Click here to create them automatically."))
         label = self._createNewButton.get_children()[0]
-        label.set_alignment(0, 0.5)
+        label.set_xalign(0)
+        label.set_yalign(0.5)
         label.set_hexpand(True)
         label.set_line_wrap(True)
         label.set_use_underline(True)
@@ -571,8 +572,8 @@ class CreateNewPage(BasePage):
             if code == DEFAULT_AUTOPART_TYPE:
                 default = itr
 
-        combo.set_margin_left(18)
-        combo.set_margin_right(18)
+        combo.set_margin_start(18)
+        combo.set_margin_end(18)
         combo.set_hexpand(False)
         combo.set_active_iter(default or store.get_iter_first())
 

--- a/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
+++ b/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
@@ -25,8 +25,9 @@ screens handling languages or locales configuration.
 import gi
 gi.require_version("Gtk", "3.0")
 gi.require_version("Pango", "1.0")
+gi.require_version("GdkPixbuf", "2.0")
 
-from gi.repository import Gtk, Pango
+from gi.repository import Gtk, Pango, GdkPixbuf
 
 from pyanaconda import localization
 from pyanaconda.iutil import strip_accents
@@ -54,11 +55,17 @@ class LangLocaleHandler(object):
         self._localeSelection = None
 
         self._arrow = None
+        self._right_arrow = None
+        self._left_arrow = None
 
     def initialize(self):
-        # Render an arrow for the chosen language
-        self._right_arrow = Gtk.Image.new_from_resource("/org/fedoraproject/anaconda/widgets/right-arrow-icon.png")
-        self._left_arrow = Gtk.Image.new_from_resource("/org/fedoraproject/anaconda/wdigets/left-arrow-icon.png")
+        # Load arrows from resources. Unfortunately, Gtk.Image.new_from_resource does not
+        # work for some reason, so we should use GdkPixbuf.Pixbuf.new_from_resource instead.
+        resource_path = "/org/fedoraproject/anaconda/widgets/"
+        self._right_arrow = GdkPixbuf.Pixbuf.new_from_resource(resource_path + "right-arrow-icon.png")
+        self._left_arrow = GdkPixbuf.Pixbuf.new_from_resource(resource_path + "left-arrow-icon.png")
+
+        # Render an arrow for the chosen language.
         override_cell_property(self._langSelectedColumn, self._langSelectedRenderer,
                                "pixbuf", self._render_lang_selected)
 
@@ -102,7 +109,7 @@ class LangLocaleHandler(object):
             _arrow = self._left_arrow
 
         if sel_itr and lang_store[sel_itr][2] == model[itr][2]:
-            return _arrow.get_pixbuf()
+            return _arrow
         else:
             return None
 

--- a/pyanaconda/ui/gui/spokes/software.py
+++ b/pyanaconda/ui/gui/spokes/software.py
@@ -80,8 +80,8 @@ class SoftwareSelectionSpoke(NormalSpoke):
         # Connect viewport scrolling with listbox focus events
         environmentViewport = self.builder.get_object("environmentViewport")
         addonViewport = self.builder.get_object("addonViewport")
-        self._environmentListBox.set_focus_vadjustment(environmentViewport.get_vadjustment())
-        self._addonListBox.set_focus_vadjustment(addonViewport.get_vadjustment())
+        self._environmentListBox.set_focus_vadjustment(Gtk.Scrollable.get_vadjustment(environmentViewport))
+        self._addonListBox.set_focus_vadjustment(Gtk.Scrollable.get_vadjustment(addonViewport))
 
         # Used to store how the user has interacted with add-ons for the default add-on
         # selection logic. The dictionary keys are group IDs, and the values are selection

--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -639,7 +639,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         # Connect scroll events on the viewport with focus events on the box
         mainViewport = self.builder.get_object("mainViewport")
         mainBox = self.builder.get_object("mainBox")
-        mainBox.set_focus_vadjustment(mainViewport.get_vadjustment())
+        mainBox.set_focus_vadjustment(Gtk.Scrollable.get_vadjustment(mainViewport))
 
     def initialize(self):
         NormalSpoke.initialize(self)

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -336,6 +336,9 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
 
     def _method_radio_button_toggled(self, radio_button):
         """Triggered when one of the partitioning method radio buttons is toggled."""
+        # Run only for an active radio button.
+        if not radio_button.get_active():
+            return
 
         # Hide the encryption checkbox for Blivet GUI storage configuration,
         # as Blivet GUI handles encryption per encrypted device, not globally.

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -37,12 +37,13 @@
 """
 
 import gi
+gi.require_version("Gtk", "3.0")
 gi.require_version("Gdk", "3.0")
 gi.require_version("GLib", "2.0")
 gi.require_version("AnacondaWidgets", "3.3")
 gi.require_version("BlockDev", "2.0")
 
-from gi.repository import Gdk, GLib, AnacondaWidgets
+from gi.repository import Gdk, GLib, AnacondaWidgets, Gtk
 from gi.repository import BlockDev as blockdev
 
 from pyanaconda.ui.communication import hubQ
@@ -697,12 +698,12 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         # See also https://bugzilla.gnome.org/show_bug.cgi?id=744721
         localViewport = self.builder.get_object("localViewport")
         specializedViewport = self.builder.get_object("specializedViewport")
-        self.local_disks_box.set_focus_hadjustment(localViewport.get_hadjustment())
-        self.specialized_disks_box.set_focus_hadjustment(specializedViewport.get_hadjustment())
+        self.local_disks_box.set_focus_hadjustment(Gtk.Scrollable.get_hadjustment(localViewport))
+        self.specialized_disks_box.set_focus_hadjustment(Gtk.Scrollable.get_hadjustment(specializedViewport))
 
         mainViewport = self.builder.get_object("storageViewport")
         mainBox = self.builder.get_object("storageMainBox")
-        mainBox.set_focus_vadjustment(mainViewport.get_vadjustment())
+        mainBox.set_focus_vadjustment(Gtk.Scrollable.get_vadjustment(mainViewport))
 
         threadMgr.add(AnacondaThread(name=constants.THREAD_STORAGE_WATCHER,
                       target=self._initialize))

--- a/widgets/src/BaseWindow.c
+++ b/widgets/src/BaseWindow.c
@@ -359,13 +359,8 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 
     /* Create the name label. */
     win->priv->name_label = gtk_label_new(_(DEFAULT_WINDOW_NAME));
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-    /*
-     * GtkMisc is deprecated, but if you don't set the GtkMisc properties then they
-     * still default to everything being centered. A+ work everyone.
-     */
-    gtk_misc_set_alignment(GTK_MISC(win->priv->name_label), 0, 0);
-G_GNUC_END_IGNORE_DEPRECATIONS
+    gtk_label_set_xalign(GTK_LABEL(win->priv->name_label), 0.0);
+    gtk_label_set_yalign(GTK_LABEL(win->priv->name_label), 0.0);
     gtk_widget_set_hexpand(win->priv->name_label, TRUE);
     gtk_widget_set_name(win->priv->name_label, "anaconda-name-label");
 
@@ -373,18 +368,16 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 
     /* Create the distribution label. */
     win->priv->distro_label = gtk_label_new(_(DEFAULT_DISTRIBUTION));
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-    gtk_misc_set_alignment(GTK_MISC(win->priv->distro_label), 0, 0);
-G_GNUC_END_IGNORE_DEPRECATIONS
+    gtk_label_set_xalign(GTK_LABEL(win->priv->distro_label), 0.0);
+    gtk_label_set_yalign(GTK_LABEL(win->priv->distro_label), 0.0);
     gtk_widget_set_name(win->priv->distro_label, "anaconda-distro-label");
 
     win->priv->orig_distro = g_strdup(DEFAULT_DISTRIBUTION);
 
     /* Create the beta label. */
     win->priv->beta_label = gtk_label_new(_(DEFAULT_BETA));
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-    gtk_misc_set_alignment(GTK_MISC(win->priv->beta_label), 0, 0);
-G_GNUC_END_IGNORE_DEPRECATIONS
+    gtk_label_set_xalign(GTK_LABEL(win->priv->beta_label), 0.0);
+    gtk_label_set_yalign(GTK_LABEL(win->priv->beta_label), 0.0);
     gtk_widget_set_no_show_all(win->priv->beta_label, TRUE);
     gtk_widget_set_name(win->priv->beta_label, "anaconda-beta-label");
 

--- a/widgets/src/LayoutIndicator.c
+++ b/widgets/src/LayoutIndicator.c
@@ -231,9 +231,8 @@ static void anaconda_layout_indicator_init(AnacondaLayoutIndicator *self) {
     gtk_label_set_max_width_chars(self->priv->layout_label, DEFAULT_LABEL_MAX_CHAR_WIDTH);
     gtk_label_set_width_chars(self->priv->layout_label, DEFAULT_LABEL_MAX_CHAR_WIDTH);
     gtk_label_set_ellipsize(self->priv->layout_label, PANGO_ELLIPSIZE_END);
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-    gtk_misc_set_alignment(GTK_MISC(self->priv->layout_label), 0.0, 0.5);
-G_GNUC_END_IGNORE_DEPRECATIONS
+    gtk_label_set_xalign(self->priv->layout_label, 0.0);
+    gtk_label_set_yalign(self->priv->layout_label, 0.5);
     gtk_widget_set_name(GTK_WIDGET(self->priv->layout_label), "anaconda-layout-label");
 
     /* initialize the label with the current layout name */

--- a/widgets/src/MountpointSelector.c
+++ b/widgets/src/MountpointSelector.c
@@ -256,10 +256,8 @@ static void anaconda_mountpoint_selector_init(AnacondaMountpointSelector *mountp
 
     /* Create the name label. */
     mountpoint->priv->name_label = gtk_label_new(_(DEFAULT_NAME));
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-    /* gtk+ did a garbage job of "deprecating" GtkMisc, so keep using it for now */
-    gtk_misc_set_alignment(GTK_MISC(mountpoint->priv->name_label), 0, 0);
-G_GNUC_END_IGNORE_DEPRECATIONS
+    gtk_label_set_xalign(GTK_LABEL(mountpoint->priv->name_label), 0.0);
+    gtk_label_set_yalign(GTK_LABEL(mountpoint->priv->name_label), 0.0);
     gtk_label_set_ellipsize(GTK_LABEL(mountpoint->priv->name_label), PANGO_ELLIPSIZE_MIDDLE);
     gtk_label_set_max_width_chars(GTK_LABEL(mountpoint->priv->name_label), 25);
     gtk_widget_set_hexpand(GTK_WIDGET(mountpoint->priv->name_label), TRUE);
@@ -267,16 +265,14 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 
     /* Create the size label. */
     mountpoint->priv->size_label = gtk_label_new(_(DEFAULT_SIZE));
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-    gtk_misc_set_alignment(GTK_MISC(mountpoint->priv->size_label), 0, 0.5);
-G_GNUC_END_IGNORE_DEPRECATIONS
+    gtk_label_set_xalign(GTK_LABEL(mountpoint->priv->size_label), 0.0);
+    gtk_label_set_yalign(GTK_LABEL(mountpoint->priv->size_label), 0.5);
     gtk_widget_set_name(mountpoint->priv->size_label, "anaconda-mountpoint-size-label");
 
     /* Create the mountpoint label. */
     mountpoint->priv->mountpoint_label = gtk_label_new(DEFAULT_MOUNTPOINT);
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-    gtk_misc_set_alignment(GTK_MISC(mountpoint->priv->mountpoint_label), 0, 0);
-G_GNUC_END_IGNORE_DEPRECATIONS
+    gtk_label_set_xalign(GTK_LABEL(mountpoint->priv->mountpoint_label), 0.0);
+    gtk_label_set_yalign(GTK_LABEL(mountpoint->priv->mountpoint_label), 0.0);
     gtk_widget_set_hexpand(GTK_WIDGET(mountpoint->priv->mountpoint_label), TRUE);
     gtk_widget_set_name(mountpoint->priv->mountpoint_label, "anaconda-mountpoint-label");
 

--- a/widgets/src/SpokeSelector.c
+++ b/widgets/src/SpokeSelector.c
@@ -291,19 +291,16 @@ static void anaconda_spoke_selector_init(AnacondaSpokeSelector *spoke) {
     gtk_label_set_text_with_mnemonic(GTK_LABEL(spoke->priv->title_label), _(DEFAULT_TITLE));
     gtk_label_set_justify(GTK_LABEL(spoke->priv->title_label), GTK_JUSTIFY_LEFT);
     gtk_label_set_mnemonic_widget(GTK_LABEL(spoke->priv->title_label), GTK_WIDGET(spoke));
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-    /* gtk+ did a garbage job of "deprecating" GtkMisc, so keep using it for now */
-    gtk_misc_set_alignment(GTK_MISC(spoke->priv->title_label), 0, 1);
-G_GNUC_END_IGNORE_DEPRECATIONS
+    gtk_label_set_xalign(GTK_LABEL(spoke->priv->title_label), 0.0);
+    gtk_label_set_yalign(GTK_LABEL(spoke->priv->title_label), 1.0);
     gtk_widget_set_hexpand(GTK_WIDGET(spoke->priv->title_label), FALSE);
     gtk_widget_set_name(spoke->priv->title_label, "anaconda-spoke-selector-title");
 
     /* Create the status label. */
     spoke->priv->status_label = gtk_label_new(_(DEFAULT_STATUS));
     gtk_label_set_justify(GTK_LABEL(spoke->priv->status_label), GTK_JUSTIFY_LEFT);
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-    gtk_misc_set_alignment(GTK_MISC(spoke->priv->status_label), 0, 0);
-G_GNUC_END_IGNORE_DEPRECATIONS
+    gtk_label_set_xalign(GTK_LABEL(spoke->priv->status_label), 0.0);
+    gtk_label_set_yalign(GTK_LABEL(spoke->priv->status_label), 0.0);
     gtk_label_set_ellipsize(GTK_LABEL(spoke->priv->status_label), PANGO_ELLIPSIZE_MIDDLE);
     gtk_label_set_max_width_chars(GTK_LABEL(spoke->priv->status_label), 45);
     gtk_widget_set_hexpand(GTK_WIDGET(spoke->priv->status_label), FALSE);


### PR DESCRIPTION
* Replaced deprecated methods.
* Fixed missing arrows in the welcome spoke and the custom spoke.
* Removed some of the ignore deprecation macros in the widgets.