### PR TITLE
F26 dev backport fix payload reset on same repo

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -307,6 +307,19 @@ class Payload(object):
         if repo:
             repo.enabled = False
 
+    def verifyAvailableRepositories(self):
+        """Verify availability of existing repositories.
+
+        This method tests if URL links from active repositories can be reached.
+        It is useful when network settings is changed so that we can verify if repositories
+        are still reachable.
+
+        This method should be overriden.
+        """
+        log.debug("Install method %s is not able to verify availability",
+                  self.__class__.__name__)
+        return False
+
     ###
     ### METHODS FOR WORKING WITH GROUPS
     ###
@@ -815,6 +828,14 @@ class PackagePayload(Payload):
                 log.warning("Could not add %s to groups, not a list.", groupid)
         elif groupid:
             log.warning("Platform group %s not available.", groupid)
+
+    def postSetup(self):
+        """Run specific payload post-configuration tasks on the end of
+        the restartThread call.
+
+        This method could be overriden.
+        """
+        pass
 
     @property
     def kernelPackages(self):
@@ -1418,6 +1439,9 @@ class PayloadManager(object):
             self._setState(self.STATE_ERROR)
             payload.unsetup()
             return
+
+        # run payload specific post configuration tasks
+        payload.postSetup()
 
         self._setState(self.STATE_FINISHED)
 

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -77,11 +77,13 @@ from distutils.version import LooseVersion
 REPO_NOT_SET = False
 MAX_TREEINFO_DOWNLOAD_RETRIES = 6
 
+
 def versionCmp(v1, v2):
-    """ Compare two version number strings. """
+    """Compare two version number strings."""
     firstVersion = LooseVersion(v1)
     secondVersion = LooseVersion(v2)
     return (firstVersion > secondVersion) - (firstVersion < secondVersion)
+
 
 ###
 ### ERROR HANDLING
@@ -89,21 +91,27 @@ def versionCmp(v1, v2):
 class PayloadError(Exception):
     pass
 
+
 class MetadataError(PayloadError):
     pass
 
+
 class NoNetworkError(PayloadError):
     pass
+
 
 # setup
 class PayloadSetupError(PayloadError):
     pass
 
+
 class ImageMissingError(PayloadSetupError):
     pass
 
+
 class ImageDirectoryMountError(PayloadSetupError):
     pass
+
 
 # software selection
 class NoSuchGroup(PayloadError):
@@ -113,23 +121,29 @@ class NoSuchGroup(PayloadError):
         self.adding = adding
         self.required = required
 
+
 class NoSuchPackage(PayloadError):
     def __init__(self, package, required=False):
         PayloadError.__init__(self, package)
         self.package = package
         self.required = required
 
+
 class DependencyError(PayloadError):
     pass
+
 
 # installation
 class PayloadInstallError(PayloadError):
     pass
 
+
 class Payload(object):
-    """ Payload is an abstract class for OS install delivery methods. """
+    """Payload is an abstract class for OS install delivery methods."""
     def __init__(self, data):
-        """ data is a kickstart.AnacondaKSHandler class
+        """Initialize Payload class
+
+        :param data: This param is a kickstart.AnacondaKSHandler class.
         """
         if self.__class__ is Payload:
             raise TypeError("Payload is an abstract class")
@@ -145,31 +159,31 @@ class Payload(object):
         self._session = requests_session()
 
     def setup(self, storage, instClass):
-        """ Do any payload-specific setup. """
+        """Do any payload-specific setup."""
         self.storage = storage
         self.instclass = instClass
         self.verbose_errors = []
 
     def unsetup(self):
-        """ Invalidate a previously setup paylaod. """
+        """Invalidate a previously setup payload."""
         self.storage = None
         self.instclass = None
 
     def preStorage(self):
-        """ Do any payload-specific work necessary before writing the storage
-            configuration.  This method need not be provided by all payloads.
+        """Do any payload-specific work necessary before writing the storage
+        configuration.  This method need not be provided by all payloads.
         """
         pass
 
     def release(self):
-        """ Release any resources in use by this object, but do not do final
-            cleanup.  This is useful for dealing with payload backends that do
-            not get along well with multithreaded programs.
+        """Release any resources in use by this object, but do not do final
+        cleanup.  This is useful for dealing with payload backends that do
+        not get along well with multithreaded programs.
         """
         pass
 
     def reset(self):
-        """ Reset the instance, not including ksdata. """
+        """Reset the instance, not including ksdata."""
         pass
 
     def prepareMountTargets(self, storage):
@@ -179,15 +193,15 @@ class Payload(object):
         pass
 
     def requiredDeviceSize(self, format_class):
-        """ We need to provide information how big device is required to have successful
-            installation. ``format_class`` should be filesystem format
-            class for the **root** filesystem this class carry information about
-            metadata size.
+        """We need to provide information how big device is required to have successful
+        installation. ``format_class`` should be filesystem format
+        class for the **root** filesystem this class carry information about
+        metadata size.
 
-            :param format_class: Class of the filesystem format.
-            :type format_class: Class which inherits :class:`blivet.formats.fs.FS`
-            :returns: Size of the device with given filesystem format.
-            :rtype: :class:`blivet.size.Size`
+        :param format_class: Class of the filesystem format.
+        :type format_class: Class which inherits :class:`blivet.formats.fs.FS`
+        :returns: Size of the device with given filesystem format.
+        :rtype: :class:`blivet.size.Size`
         """
         device_size = format_class.get_required_size(self.spaceRequired)
         return device_size.round_to_nearest(Size("1 MiB"))
@@ -197,25 +211,23 @@ class Payload(object):
     ###
     @property
     def addOns(self):
-        """ A list of addon repo identifiers. """
+        """A list of addon repo identifiers."""
         return [r.name for r in self.data.repo.dataList()]
 
     @property
     def baseRepo(self):
-        """
-        Get the identifier of the current base repo. or None
-        """
+        """Get the identifier of the current base repo or None."""
         return None
 
     @property
     def mirrorEnabled(self):
         """Is the closest/fastest mirror option enabled?  This does not make
-           sense for those payloads that do not support this concept.
+        sense for those payloads that do not support this concept.
         """
         return True
 
     def isRepoEnabled(self, repo_id):
-        """ Return True if repo is enabled. """
+        """Return True if repo is enabled."""
         repo = self.getAddOnRepo(repo_id)
         if repo:
             return repo.enabled
@@ -223,7 +235,7 @@ class Payload(object):
             return False
 
     def getAddOnRepo(self, repo_id):
-        """ Return a ksdata Repo instance matching the specified repo id. """
+        """Return a ksdata Repo instance matching the specified repo id."""
         repo = None
         for r in self.data.repo.dataList():
             if r.name == repo_id:
@@ -233,18 +245,18 @@ class Payload(object):
         return repo
 
     def _repoNeedsNetwork(self, repo):
-        """ Returns True if the ksdata repo requires networking. """
+        """Returns True if the ksdata repo requires networking."""
         urls = [repo.baseurl]
         if repo.mirrorlist:
             urls.extend(repo.mirrorlist)
         return self._sourceNeedsNetwork(urls)
 
     def _sourceNeedsNetwork(self, sources):
-        """ Return True if the source requires network.
+        """Return True if the source requires network.
 
-            :param sources: Source paths for testing
-            :type sources: list
-            :returns: True if any source requires network
+        :param sources: Source paths for testing
+        :type sources: list
+        :returns: True if any source requires network
         """
         network_protocols = ["http:", "ftp:", "nfs:", "nfsiso:"]
         for s in sources:
@@ -257,6 +269,7 @@ class Payload(object):
 
     @property
     def needsNetwork(self):
+        """Test base and additional repositories if they require network."""
         url = ""
         if self.data.method.method == "nfs":
             # NFS is always on network
@@ -271,7 +284,7 @@ class Payload(object):
                 any(self._repoNeedsNetwork(repo) for repo in self.data.repo.dataList()))
 
     def updateBaseRepo(self, fallback=True, checkmount=True):
-        """ Update the base repository from ksdata.method. """
+        """Update the base repository from ksdata.method."""
         pass
 
     def gatherRepoMetadata(self):
@@ -279,11 +292,11 @@ class Payload(object):
 
     def addRepo(self, newrepo):
         """Add the repo given by the pykickstart Repo object newrepo to the
-           system.  The repo will be automatically enabled and its metadata
-           fetched.
+        system.  The repo will be automatically enabled and its metadata
+        fetched.
 
-           Duplicate repos will not raise an error.  They should just silently
-           take the place of the previous value.
+        Duplicate repos will not raise an error.  They should just silently
+        take the place of the previous value.
         """
         # Add the repo to the ksdata so it'll appear in the output ks file.
         self.data.repo.dataList().append(newrepo)
@@ -327,7 +340,7 @@ class Payload(object):
         return []
 
     def selectedGroups(self):
-        """ Return list of selected group names from kickstart.
+        """Return list of selected group names from kickstart.
 
         NOTE:
         This group names can be mix of group IDs and other valid identifiers.
@@ -339,7 +352,7 @@ class Payload(object):
 
 
     def selectedGroupsIDs(self):
-        """ Return list of IDs for selected groups.
+        """Return list of IDs for selected groups.
 
         Implementation depends on a specific payload class.
         """
@@ -387,28 +400,28 @@ class Payload(object):
     ###
     @property
     def spaceRequired(self):
-        """ The total disk space (Size) required for the current selection. """
+        """The total disk space (Size) required for the current selection."""
         raise NotImplementedError()
 
     @property
     def kernelVersionList(self):
-        """ An iterable of the kernel versions installed by the payload. """
+        """An iterable of the kernel versions installed by the payload."""
         raise NotImplementedError()
 
     ##
     ## METHODS FOR TREE VERIFICATION
     ##
     def _getTreeInfo(self, url, proxy_url, sslverify):
-        """ Retrieve treeinfo and return the path to the local file.
+        """Retrieve treeinfo and return the path to the local file.
 
-            :param baseurl: url of the repo
-            :type baseurl: string
-            :param proxy_url: Optional full proxy URL of or ""
-            :type proxy_url: string
-            :param sslverify: True if SSL certificate should be verified
-            :type sslverify: bool
-            :returns: Path to retrieved .treeinfo file or None
-            :rtype: string or None
+        :param baseurl: url of the repo
+        :type baseurl: string
+        :param proxy_url: Optional full proxy URL of or ""
+        :type proxy_url: string
+        :param sslverify: True if SSL certificate should be verified
+        :type sslverify: bool
+        :returns: Path to retrieved .treeinfo file or None
+        :rtype: string or None
         """
         if not url:
             return None
@@ -500,7 +513,7 @@ class Payload(object):
         return (result, result.status_code)
 
     def _getReleaseVersion(self, url):
-        """ Return the release version of the tree at the specified URL. """
+        """Return the release version of the tree at the specified URL."""
         try:
             version = re.match(VERSION_DIGITS, productVersion).group(1)
         except AttributeError:
@@ -534,7 +547,7 @@ class Payload(object):
     ##
     @staticmethod
     def _setupDevice(device, mountpoint):
-        """ Prepare an install CD/DVD for use as a package source. """
+        """Prepare an install CD/DVD for use as a package source."""
         log.info("setting up device %s and mounting on %s", device.name, mountpoint)
         # Is there a symlink involved?  If so, let's get the actual path.
         # This is to catch /run/install/isodir vs. /mnt/install/isodir, for
@@ -565,7 +578,7 @@ class Payload(object):
 
     @staticmethod
     def _setupNFS(mountpoint, server, path, options):
-        """ Prepare an NFS directory for use as a package source. """
+        """Prepare an NFS directory for use as a package source."""
         log.info("mounting %s:%s:%s on %s", server, path, options, mountpoint)
         if os.path.ismount(mountpoint):
             dev = blivet.util.get_mount_device(mountpoint)
@@ -598,19 +611,19 @@ class Payload(object):
     ### METHODS FOR INSTALLING THE PAYLOAD
     ###
     def preInstall(self, packages=None, groups=None):
-        """ Perform pre-installation tasks. """
+        """Perform pre-installation tasks."""
         iutil.mkdirChain(iutil.getSysroot() + "/root")
 
         self._writeModuleBlacklist()
 
     def install(self):
-        """ Install the payload. """
+        """Install the payload."""
         raise NotImplementedError()
 
     def _writeModuleBlacklist(self):
-        """ Copy modules from modprobe.blacklist=<module> on cmdline to
-            /etc/modprobe.d/anaconda-blacklist.conf so that modules will
-            continue to be blacklisted when the system boots.
+        """Copy modules from modprobe.blacklist=<module> on cmdline to
+        /etc/modprobe.d/anaconda-blacklist.conf so that modules will
+        continue to be blacklisted when the system boots.
         """
         if "modprobe.blacklist" not in flags.cmdline:
             return
@@ -644,12 +657,12 @@ class Payload(object):
                 #           prevent boot on some systems
 
     def recreateInitrds(self):
-        """ Recreate the initrds by calling new-kernel-pkg
+        """Recreate the initrds by calling new-kernel-pkg
 
-            This needs to be done after all configuration files have been
-            written, since dracut depends on some of them.
+        This needs to be done after all configuration files have been
+        written, since dracut depends on some of them.
 
-            :returns: None
+        :returns: None
         """
         if not os.path.exists(iutil.getSysroot() + "/usr/sbin/new-kernel-pkg"):
             log.error("new-kernel-pkg does not exist - grubby wasn't installed?  skipping")
@@ -670,8 +683,9 @@ class Payload(object):
                                      "-f", "/boot/initramfs-%s.img" % kernel,
                                     kernel])
 
+
     def _setDefaultBootTarget(self):
-        """ Set the default systemd target for the system. """
+        """Set the default systemd target for the system."""
         if not os.path.exists(iutil.getSysroot() + "/etc/systemd/system"):
             log.error("systemd is not installed -- can't set default target")
             return
@@ -714,7 +728,7 @@ class Payload(object):
         return args
 
     def postInstall(self):
-        """ Perform post-installation tasks. """
+        """Perform post-installation tasks."""
 
         # set default systemd target
         self._setDefaultBootTarget()
@@ -726,18 +740,18 @@ class Payload(object):
 
     def writeStorageEarly(self):
         """Some payloads require that the storage configuration be written out
-           before doing installation.  Right now, this is basically just the
-           dnfpayload.  Payloads should only implement one of these methods
-           by overriding the unneeded one with a pass.
+        before doing installation.  Right now, this is basically just the
+        dnfpayload.  Payloads should only implement one of these methods
+        by overriding the unneeded one with a pass.
         """
         if not flags.dirInstall:
             self.storage.write()
 
     def writeStorageLate(self):
         """Some payloads require that the storage configuration be written out
-           after doing installation.  Right now, this is basically every payload
-           except for dnf.  Payloads should only implement one of these methods
-           by overriding the unneeded one with a pass.
+        after doing installation.  Right now, this is basically every payload
+        except for dnf.  Payloads should only implement one of these methods
+        by overriding the unneeded one with a pass.
         """
         if iutil.getSysroot() != iutil.getTargetPhysicalRoot():
             set_sysroot(iutil.getTargetPhysicalRoot(), iutil.getSysroot())
@@ -745,10 +759,11 @@ class Payload(object):
         if not flags.dirInstall:
             self.storage.write()
 
+
 # Inherit abstract methods from Payload
 # pylint: disable=abstract-method
 class ImagePayload(Payload):
-    """ An ImagePayload installs an OS image to the target system. """
+    """An ImagePayload installs an OS image to the target system."""
 
     def __init__(self, data):
         if self.__class__ is ImagePayload:
@@ -756,10 +771,11 @@ class ImagePayload(Payload):
 
         Payload.__init__(self, data)
 
+
 # Inherit abstract methods from ImagePayload
 # pylint: disable=abstract-method
 class ArchivePayload(ImagePayload):
-    """ An ArchivePayload unpacks source archives onto the target system. """
+    """An ArchivePayload unpacks source archives onto the target system."""
 
     def __init__(self, data):
         if self.__class__ is ArchivePayload:
@@ -767,8 +783,9 @@ class ArchivePayload(ImagePayload):
 
         ImagePayload.__init__(self, data)
 
+
 class PackagePayload(Payload):
-    """ A PackagePayload installs a set of packages onto the target system. """
+    """A PackagePayload installs a set of packages onto the target system."""
 
     DEFAULT_REPOS = [productName.split('-')[0].lower(), "rawhide"]          # pylint: disable=no-member
 
@@ -893,7 +910,7 @@ class PackagePayload(Payload):
         self.reset_install_device()
 
     def reset_install_device(self):
-        """ Unmount the previous base repo and reset the install_device """
+        """Unmount the previous base repo and reset the install_device."""
         # cdrom: install_device.teardown (INSTALL_TREE)
         # hd: umount INSTALL_TREE, install_device.teardown (ISO_DIR)
         # nfs: umount INSTALL_TREE
@@ -1122,8 +1139,7 @@ class PackagePayload(Payload):
         raise NotImplementedError()
 
     def addDriverRepos(self):
-        """ Add driver repositories and packages
-        """
+        """Add driver repositories and packages."""
         # Drivers are loaded by anaconda-dracut, their repos are copied
         # into /run/install/DD-X where X is a number starting at 1. The list of
         # packages that were selected is in /run/install/dd_packages
@@ -1164,7 +1180,7 @@ class PackagePayload(Payload):
 
     @property
     def ISOImage(self):
-        """ The location of a mounted ISO repo, or None. """
+        """The location of a mounted ISO repo, or None."""
         if not self.data.method.method == "harddrive":
             return None
         # This could either be mounted to INSTALL_TREE or on
@@ -1261,29 +1277,30 @@ class PackagePayload(Payload):
         raise NotImplementedError()
 
     def groupId(self, group_name):
-        """ Return group id for translation of groups from a kickstart file."""
+        """Return group id for translation of groups from a kickstart file."""
         raise NotImplementedError()
+
 
 class PayloadManager(object):
     """Framework for starting and watching the payload thread.
 
-       This class defines several states, and events can be triggered upon
-       reaching a state. Depending on whether a state has already been reached
-       when a listener is added, the event code may be run in either the
-       calling thread or the payload thread. The event code will block the
-       payload thread regardless, so try not to run anything that takes a long
-       time.
+    This class defines several states, and events can be triggered upon
+    reaching a state. Depending on whether a state has already been reached
+    when a listener is added, the event code may be run in either the
+    calling thread or the payload thread. The event code will block the
+    payload thread regardless, so try not to run anything that takes a long
+    time.
 
-       All states except STATE_ERROR are expected to happen linearly, and adding
-       a listener for a state that has already been reached or passed will
-       immediately trigger that listener. For example, if the payload thread is
-       currently in STATE_GROUP_MD, adding a listener for STATE_NETWORK will
-       immediately run the code being added for STATE_NETWORK.
+    All states except STATE_ERROR are expected to happen linearly, and adding
+    a listener for a state that has already been reached or passed will
+    immediately trigger that listener. For example, if the payload thread is
+    currently in STATE_GROUP_MD, adding a listener for STATE_NETWORK will
+    immediately run the code being added for STATE_NETWORK.
 
-       The payload thread data should be accessed using the payloadMgr object,
-       and the running thread can be accessed using threadMgr with the
-       THREAD_PAYLOAD constant, if you need to wait for it or something. The
-       thread should be started using payloadMgr.restartThread.
+    The payload thread data should be accessed using the payloadMgr object,
+    and the running thread can be accessed using threadMgr with the
+    THREAD_PAYLOAD constant, if you need to wait for it or something. The
+    thread should be started using payloadMgr.restartThread.
     """
 
     STATE_START = 0
@@ -1323,8 +1340,8 @@ class PayloadManager(object):
     def addListener(self, event_id, func):
         """Add a listener for an event.
 
-           :param int event_id: The event to listen for, one of the EVENT_* constants
-           :param function func: An object to call when the event is reached
+        :param int event_id: The event to listen for, one of the EVENT_* constants
+        :param function func: An object to call when the event is reached
         """
 
         # Check that the event_id is valid
@@ -1348,19 +1365,18 @@ class PayloadManager(object):
     def restartThread(self, storage, ksdata, payload, instClass, fallback=False, checkmount=True):
         """Start or restart the payload thread.
 
-           This method starts a new thread to restart the payload thread, so
-           this method's return is not blocked by waiting on the previous payload
-           thread. If there is already a payload thread restart pending, this method
-           has no effect.
+        This method starts a new thread to restart the payload thread, so
+        this method's return is not blocked by waiting on the previous payload
+        thread. If there is already a payload thread restart pending, this method
+        has no effect.
 
-           :param blivet.Blivet storage: The blivet storage instance
-           :param kickstart.AnacondaKSHandler ksdata: The kickstart data instance
-           :param payload.Payload payload: The payload instance
-           :param installclass.BaseInstallClass instClass: The install class instance
-           :param bool fallback: Whether to fall back to the default repo in case of error
-           :param bool checkmount: Whether to check for valid mounted media
+        :param blivet.Blivet storage: The blivet storage instance
+        :param kickstart.AnacondaKSHandler ksdata: The kickstart data instance
+        :param payload.Payload payload: The payload instance
+        :param installclass.BaseInstallClass instClass: The install class instance
+        :param bool fallback: Whether to fall back to the default repo in case of error
+        :param bool checkmount: Whether to check for valid mounted media
         """
-
         log.debug("Restarting payload thread")
 
         # If a restart thread is already running, don't start a new one
@@ -1444,6 +1460,7 @@ class PayloadManager(object):
         payload.postSetup()
 
         self._setState(self.STATE_FINISHED)
+
 
 # Initialize the PayloadManager instance
 payloadMgr = PayloadManager()

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -1387,6 +1387,11 @@ class PayloadManager(object):
         threadMgr.add(AnacondaThread(name=THREAD_PAYLOAD_RESTART, target=self._restartThread,
                                      args=(storage, ksdata, payload, instClass, fallback, checkmount)))
 
+    @property
+    def running(self):
+        """Is the payload thread running right now?"""
+        return threadMgr.exists(THREAD_PAYLOAD_RESTART) or threadMgr.exists(THREAD_PAYLOAD)
+
     def _restartThread(self, storage, ksdata, payload, instClass, fallback, checkmount):
         # Wait for the old thread to finish
         threadMgr.wait(THREAD_PAYLOAD)

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -90,6 +90,7 @@ def _failure_limbo():
     while True:
         time.sleep(10000)
 
+
 def _df_map():
     """Return (mountpoint -> size available) mapping."""
     output = pyanaconda.iutil.execWithCapture('df', ['--output=target,avail'])
@@ -110,6 +111,7 @@ def _df_map():
         structured["/var/tmp"] = Size(var_tmp.f_frsize * var_tmp.f_bfree)
     return structured
 
+
 def _paced(fn):
     """Execute `fn` no more often then every 2 seconds."""
     def paced_fn(self, *args):
@@ -119,6 +121,7 @@ def _paced(fn):
         self.last_time = now
         return fn(self, *args)
     return paced_fn
+
 
 def _pick_mpoint(df, download_size, install_size, download_only):
     def reasonable_mpoint(mpoint):
@@ -219,10 +222,11 @@ class PayloadRPMDisplay(dnf.callback.TransactionProgress):
                 self._queue.put(('done', None))
 
     def error(self, message):
-        """ Report an error that occurred during the transaction. Message is a
-            string which describes the error.
+        """Report an error that occurred during the transaction. Message is a
+        string which describes the error.
         """
         self._queue.put(('error', message))
+
 
 class DownloadProgress(dnf.callback.DownloadProgress):
     def __init__(self):
@@ -261,6 +265,7 @@ class DownloadProgress(dnf.callback.DownloadProgress):
         self.total_files = total_files
         self.total_size = Size(total_size)
 
+
 def do_transaction(base, queue_instance):
     # Execute the DNF transaction and catch any errors. An error doesn't
     # always raise a BaseException, so presence of 'quit' without a preceeding
@@ -277,6 +282,7 @@ def do_transaction(base, queue_instance):
     finally:
         base.close()
         queue_instance.put(('quit', str(exit_reason)))
+
 
 class DNFPayload(payload.PackagePayload):
     def __init__(self, data):
@@ -303,14 +309,14 @@ class DNFPayload(payload.PackagePayload):
         self._repoMD_list = []
 
     def _replace_vars(self, url):
-        """ Replace url variables with their values
+        """Replace url variables with their values.
 
-            :param url: url string to do replacement on
-            :type url:  string
-            :returns:   string with variables substituted
-            :rtype:     string or None
+        :param url: url string to do replacement on
+        :type url:  string
+        :returns:   string with variables substituted
+        :rtype:     string or None
 
-            Currently supports $releasever and $basearch
+        Currently supports $releasever and $basearch.
         """
         if url:
             return dnf.conf.parser.substitute(url, self._base.conf.substitutions)
@@ -318,11 +324,11 @@ class DNFPayload(payload.PackagePayload):
         return None
 
     def _add_repo(self, ksrepo):
-        """Add a repo to the dnf repo object
+        """Add a repo to the dnf repo object.
 
-           :param ksrepo: Kickstart Repository to add
-           :type ksrepo: Kickstart RepoData object.
-           :returns: None
+        :param ksrepo: Kickstart Repository to add
+        :type ksrepo: Kickstart RepoData object.
+        :returns: None
         """
         repo = dnf.repo.Repo(ksrepo.name, self._base.conf)
         url = self._replace_vars(ksrepo.baseurl)
@@ -388,11 +394,11 @@ class DNFPayload(payload.PackagePayload):
         log.info("added repo: '%s' - %s", ksrepo.name, url or mirrorlist)
 
     def addRepo(self, ksrepo):
-        """Add a repo to dnf and kickstart repo lists
+        """Add a repo to dnf and kickstart repo lists.
 
-           :param ksrepo: Kickstart Repository to add
-           :type ksrepo: Kickstart RepoData object.
-           :returns: None
+        :param ksrepo: Kickstart Repository to add
+        :type ksrepo: Kickstart RepoData object.
+        :returns: None
         """
         self._add_repo(ksrepo)
         super(DNFPayload, self).addRepo(ksrepo)
@@ -469,7 +475,7 @@ class DNFPayload(payload.PackagePayload):
         return self.txID
 
     def _configure_proxy(self):
-        """ Configure the proxy on the dnf.Base object."""
+        """Configure the proxy on the dnf.Base object."""
         conf = self._base.conf
 
         if hasattr(self.data.method, "proxy") and self.data.method.proxy:
@@ -753,9 +759,9 @@ class DNFPayload(payload.PackagePayload):
                  len(self._base.transaction), self.spaceRequired)
 
     def setUpdatesEnabled(self, state):
-        """ Enable or Disable the repos used to update closest mirror.
+        """Enable or Disable the repos used to update closest mirror.
 
-            :param bool state: True to enable updates, False to disable.
+        :param bool state: True to enable updates, False to disable.
         """
         self._updates_enabled = state
 
@@ -791,7 +797,7 @@ class DNFPayload(payload.PackagePayload):
         return (env.ui_name, env.ui_description)
 
     def environmentId(self, environment):
-        """ Return environment id for the environment specified by id or name."""
+        """Return environment id for the environment specified by id or name."""
         env = self._base.comps.environment_by_pattern(environment)
         if env is None:
             raise payload.NoSuchGroup(environment)
@@ -824,14 +830,14 @@ class DNFPayload(payload.PackagePayload):
         return any(grp for grp in env.option_ids if grp.name == grpid and grp.default)
 
     def groupDescription(self, grpid):
-        """ Return name/description tuple for the group specified by id. """
+        """Return name/description tuple for the group specified by id."""
         grp = self._base.comps.group_by_pattern(grpid)
         if grp is None:
             raise payload.NoSuchGroup(grpid)
         return (grp.ui_name, grp.ui_description)
 
     def groupId(self, group_name):
-        """ Translate group name to group ID.
+        """Translate group name to group ID.
 
         :param group_name: Valid identifier for group specification.
         :returns: Group ID.
@@ -934,7 +940,7 @@ class DNFPayload(payload.PackagePayload):
             log.warning("Can't delete nonexistent download location: %s", self._download_location)
 
     def getRepo(self, repo_id):
-        """ Return the yum repo object. """
+        """Return the yum repo object."""
         return self._base.repos[repo_id]
 
     def isRepoEnabled(self, repo_id):
@@ -1069,11 +1075,11 @@ class DNFPayload(payload.PackagePayload):
                     self.disableRepo(id_)
 
     def _writeDNFRepo(self, repo, repo_path):
-        """ Write a repo object to a DNF repo.conf file
+        """Write a repo object to a DNF repo.conf file.
 
-            :param repo: DNF repository object
-            :param string repo_path: Path to write the repo to
-            :raises: PayloadSetupError if the repo doesn't have a url
+        :param repo: DNF repository object
+        :param string repo_path: Path to write the repo to
+        :raises: PayloadSetupError if the repo doesn't have a url
         """
         with open(repo_path, "w") as f:
             f.write("[%s]\n" % repo.id)
@@ -1132,7 +1138,7 @@ class DNFPayload(payload.PackagePayload):
             self._repoMD_list.append(repoMD)
 
     def postInstall(self):
-        """ Perform post-installation tasks. """
+        """Perform post-installation tasks."""
         # Write selected kickstart repos to target system
         for ks_repo in (ks for ks in (self.getAddOnRepo(r) for r in self.addOns) if ks.install):
             if ks_repo.baseurl.startswith("nfs://"):
@@ -1156,6 +1162,7 @@ class DNFPayload(payload.PackagePayload):
 
     def writeStorageLate(self):
         pass
+
 
 class RepoMDMetaHash(object):
     """Class that holds hash of a repomd.xml file content from a repository.

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1521,11 +1521,14 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
                 log.debug("network spoke (apply) refresh payload")
 
                 from pyanaconda.payload import payloadMgr
-                if not self.payload.verifyAvailableRepositories():
+                if payloadMgr.running:
+                    log.debug("Payload is in the process of restarting, skip the repo availability check.")
+                elif self.payload.verifyAvailableRepositories():
+                    log.debug("Payload isn't restarted, repositories are still available.")
+                else:
+                    log.debug("Repository is not reachable. Restart payload thread.")
                     payloadMgr.restartThread(self.storage, self.data, self.payload, self.instclass,
                                              fallback=not anaconda_flags.automatedInstall)
-                else:
-                    log.debug("Payload isn't restarted, repositories are still available.")
             else:
                 log.debug("network spoke (apply), payload refresh skipped (running outside of installation environment)")
             self.networking_changed = False

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1519,9 +1519,13 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         if self.networking_changed:
             if ANACONDA_ENVIRON in anaconda_flags.environs and self.payload.needsNetwork:
                 log.debug("network spoke (apply) refresh payload")
+
                 from pyanaconda.payload import payloadMgr
-                payloadMgr.restartThread(self.storage, self.data, self.payload, self.instclass,
-                                         fallback=not anaconda_flags.automatedInstall)
+                if not self.payload.verifyAvailableRepositories():
+                    payloadMgr.restartThread(self.storage, self.data, self.payload, self.instclass,
+                                             fallback=not anaconda_flags.automatedInstall)
+                else:
+                    log.debug("Payload isn't restarted, repositories are still available.")
             else:
                 log.debug("network spoke (apply), payload refresh skipped (running outside of installation environment)")
             self.networking_changed = False


### PR DESCRIPTION
Backport of RHEL7 PR: https://github.com/rhinstaller/anaconda/pull/945 with small optimization.

-----------------------------------

This problem is solved by downloading content of `repomd.xml` file and comparing its MD5 hashes with downloaded repomd.xml file from the old repo url.

MD5 hash is used here because it takes less memory and we don't need `repomd.xml` content for anything else.

The `postSetup()` method was added to the payload. This method can be overridden by `Payload` child classes which needs to do additional tasks at the end of the `restartThread` call from the `PayloadManager` class.

Second commit is to make docstrings consistent in `Payload` and `DNFPayload`.