### PR TITLE
Trigger the entered signal only the screen is shown (#1443011)

### DIFF
--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -853,7 +853,6 @@ class GraphicalUserInterface(UserInterface):
                     return
 
             self._currentAction.initialize()
-            self._currentAction.entered.emit(self._currentAction)
             self._currentAction.refresh()
 
             self._currentAction.window.set_beta(not self._isFinal)
@@ -895,6 +894,8 @@ class GraphicalUserInterface(UserInterface):
                             STYLE_PROVIDER_PRIORITY_UPDATES)
 
             self.mainWindow.setCurrentAction(self._currentAction)
+            # the window corresponding to the ection should now be visible to the user
+            self._currentAction.entered.emit(self._currentAction)
 
             # Do this at the last possible minute.
             unbusyCursor()
@@ -1026,13 +1027,14 @@ class GraphicalUserInterface(UserInterface):
             return
 
         self._currentAction.exited.emit(self._currentAction)
-        nextAction.entered.emit(nextAction)
 
         nextAction.refresh()
 
         # Do this last.  Setting up curAction could take a while, and we want
         # to leave something on the screen while we work.
         self.mainWindow.setCurrentAction(nextAction)
+        # the new spoke should be now visible, trigger the entered signal
+        nextAction.entered.emit(nextAction)
         self._currentAction = nextAction
         self._actions.pop(0)
 

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -407,9 +407,10 @@ class Hub(GUIObject, common.Hub):
 
         # Enter the spoke
         self._inSpoke = True
-        spoke.entered.emit(spoke)
         spoke.refresh()
         self.main_window.enterSpoke(spoke)
+        # the new spoke should be now visible, trigger the entered signal
+        spoke.entered.emit(spoke)
 
     def spoke_done(self, spoke):
         # Ignore if not in a spoke


### PR DESCRIPTION
Trigger the entered signal only once the screen corresponding to the
given spoke or hub is shown.

This should better correspond to the signal name (we only trigger it once
the screen is visibly entered) and also makes it possible for spokes to set
(and unset) their own custom key bindings.

Also thanks to Vojta Trefny and Vendula Poncova for helping me to figure out the correct method calling order. :)