### PR TITLE
Use `time.tzset()` to apply timezone changes when we can

### DIFF
--- a/pyanaconda/isys/__init__.py
+++ b/pyanaconda/isys/__init__.py
@@ -118,6 +118,8 @@ def set_system_date_time(year=None, month=None, day=None, hour=None, minute=None
     if not tz:
         tz = pytz.UTC
 
+    time.tzset()
+
     # get the right values
     now = datetime.datetime.now(tz)
     year = year if year is not None else now.year

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -53,6 +53,7 @@ from pyanaconda.threads import threadMgr, AnacondaThread
 import datetime
 import re
 import threading
+import time
 import locale as locale_mod
 import functools
 
@@ -611,6 +612,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
         if is_valid_timezone(self.data.timezone.timezone):
             self._tzmap.set_timezone(self.data.timezone.timezone)
+            time.tzset()
 
         self._update_datetime()
 
@@ -992,9 +994,11 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
                 offset = -float(city[3:])
 
             self._tzmap.set_selected_offset(offset)
+            time.tzset()
         else:
             # we don't want the timezone-changed signal to be emitted
             self._tzmap.set_timezone(timezone)
+            time.tzset()
 
         # update "old" values
         self._old_city = city


### PR DESCRIPTION
Threading makes this tricky, but this should at least apply any
'new' timezone whenever it gets changed to the datetime spoke
thread and the main thread. As I discovered in RHBZ #1433560,
Python's behaviour seems to have changed between 3.5 and 3.6
such that changes made to the 'TZ' environment variable don't
affect Python's "current" timezone (as used by things like the
datetime module) until `time.tzset()` is called.

This and #1035 would each fix RHBZ #1433560 without the other being applied. But they are also compatible and I think applying both would make sense. #1035 makes `set_system_date_time` work even if Python's idea of the 'current' timezone is not the same as the timezone the function is called with. This PR tries to update Python's idea of the current timezone when it's changed in anaconda (at least as well as we can, I think threading makes this more complex). This has consequences beyond `set_system_date_time` - the one I've noticed is that the timestamps on anaconda log files are in whatever Python currently considers the 'local time' to be, but there may be other impacts also.