### PR TITLE
Show or hide the content of the expander (#1441733)

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -145,8 +145,19 @@ class Accordion(Gtk.Box):
         self._expanders = []
 
     def _onExpanded(self, obj, cb=None):
+        # Get the content of the expander.
+        child = obj.get_child()
+
+        if child:
+            # The expander is not expanded yet.
+            is_expanded = not obj.get_expanded()
+            # Show or hide the child.
+            # We need to set this manually because of a gtk bug:
+            # https://bugzilla.gnome.org/show_bug.cgi?id=776937
+            child.set_visible(is_expanded)
+
         if cb:
-            cb(obj.get_child())
+            cb(child)
 
 # A Page is a box that is stored in an Accordion.  It breaks down all the filesystems that
 # comprise a single installed OS into two categories - Data filesystems and System filesystems.


### PR DESCRIPTION
When the expander is expanded or collapsed and we process the
`activate` signal, we should manually show or hide the content
of the expander. Otherwise, the content can be invisible but
still sensitive to user actions.

Resolves: rhbz#1441733