### PR TITLE
Use constants in storage checker constraints.

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -624,7 +624,7 @@ if __name__ == "__main__":
         min_ram = isys.MIN_RAM
 
     from pyanaconda.storage_utils import storage_checker
-    storage_checker.add_constraint("min_ram", min_ram)
+    storage_checker.add_constraint(constants.STORAGE_MIN_RAM, min_ram)
     anaconda.instClass.setStorageChecker(storage_checker)
 
     from pyanaconda.anaconda_argparse import name_path_pairs

--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -214,6 +214,14 @@ NTP_SERVER_OK = 0
 NTP_SERVER_NOK = 1
 NTP_SERVER_QUERY = 2
 
+# Storage checker constraints
+STORAGE_MIN_RAM = "min_ram"
+STORAGE_MIN_ROOT = "min_root"
+STORAGE_MIN_PARTITION_SIZES = "min_partition_sizes"
+STORAGE_MUST_BE_ON_LINUXFS = "must_be_on_linuxfs"
+STORAGE_MUST_BE_ON_ROOT = "must_be_on_root"
+STORAGE_SWAP_IS_RECOMMENDED = "swap_is_recommended"
+
 # Display modes
 class DisplayModes(Enum):
     GUI = "GUI"

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -34,7 +34,7 @@ import logging
 log = logging.getLogger("anaconda")
 
 from pyanaconda.kickstart import getAvailableDiskSpace
-
+from pyanaconda.constants import STORAGE_SWAP_IS_RECOMMENDED
 from pykickstart.constants import FIRSTBOOT_DEFAULT
 
 class BaseInstallClass(object):
@@ -145,7 +145,7 @@ class BaseInstallClass(object):
 
                 # Swap will not be recommended by the storage checker.
                 from pyanaconda.storage_utils import storage_checker
-                storage_checker.add_constraint("swap_is_recommended", False)
+                storage_checker.add_constraint(STORAGE_SWAP_IS_RECOMMENDED, False)
 
         # Skip mountpoints we want to remove.
         storage.autopart_requests = [req for req in storage.autopart_requests


### PR DESCRIPTION
Storage checker constraints should be indexed by constants instead
of strings to avoid errors.