### PR TITLE
make anaconda working back again with tmux2.4

### DIFF
--- a/data/tmux.conf
+++ b/data/tmux.conf
@@ -5,10 +5,18 @@ bind -n F1 list-keys
 
 set-option -s exit-unattached off
 set-option -g base-index 1
-set-option -g set-remain-on-exit on
+
+# tmux 2.4 has different name for this option.
+# See https://github.com/rhinstaller/anaconda/pull/1040
+if-shell '[ $(echo "$(tmux -V | cut -d" " -f2) >= 2.4" | bc) -eq 1 ]' \
+    'set-option -g remain-on-exit on' \
+    'set-option -g set-remain-on-exit on'
+
 set-option -g history-limit 10000
 
-new-session -s anaconda -n main "anaconda"
+# The idea here is to detach the client started here via anaconda.service, and
+# then re-attach to it in the tmux service run on the console tty.
+new-session -d -s anaconda -n main "anaconda"
 
 set-option status-right '#[fg=blue]#(echo -n "Switch tab: Alt+Tab | Help: F1 ")'
 
@@ -16,9 +24,3 @@ new-window -d -n shell          "bash --login"
 new-window -d -n log            "tail -F /tmp/anaconda.log"
 new-window -d -n storage-log    "tail -F /tmp/storage.log"
 new-window -d -n program-log    "tail -F /tmp/program.log"
-
-# The idea here is to detach the client started here via anaconda.service, and
-# then re-attach to it in the tmux service run on the console tty. However,
-# the detach-client directive is now giving us "no current client" for some
-# reason.
-# detach-client -s anaconda


### PR DESCRIPTION
Rawhide pulls now tmux-2.4 (https://koji.fedoraproject.org/koji/packageinfo?packageID=9438) which has modified behavior.

See below for more details:

* https://bugzilla.redhat.com/show_bug.cgi?id=1445049
* https://github.com/tmux/tmux/issues/885

![image](https://cloud.githubusercontent.com/assets/508703/25388696/6a604986-29c6-11e7-8360-e19e323340fa.png)


![image](https://cloud.githubusercontent.com/assets/508703/25388666/5b625852-29c6-11e7-9f52-e19632f5f516.png)

![image](https://cloud.githubusercontent.com/assets/508703/25388727/7ff54562-29c6-11e7-8c30-dca1214cfa50.png)
