### PR TITLE
Update access to blivet fcoe singleton. (#1440134)

### DIFF
--- a/pyanaconda/ui/gui/spokes/advstorage/fcoe.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/fcoe.py
@@ -17,6 +17,8 @@
 # Red Hat, Inc.
 #
 
+from blivet.fcoe import fcoe
+
 from pyanaconda import constants
 from pyanaconda.threads import threadMgr, AnacondaThread
 from pyanaconda.ui.gui import GUIObject
@@ -41,7 +43,7 @@ class FCoEDialog(GUIObject):
         self._addError = None
 
         self.storage = storage
-        self.fcoe = self.storage.fcoe()
+        self.fcoe = fcoe
         self._update_devicetree = False
 
         self._addButton = self.builder.get_object("addButton")
@@ -85,7 +87,7 @@ class FCoEDialog(GUIObject):
 
     def _add(self):
         try:
-            self._addError = self.fcoe.addSan(self.nic, self.use_dcb, self.use_auto_vlan)
+            self._addError = self.fcoe.add_san(self.nic, self.use_dcb, self.use_auto_vlan)
         except (IOError, OSError) as e:
             self._addError = str(e)
 


### PR DESCRIPTION
The fcoe singleton is no longer stored as an attribute of the `Blivet` object. I should have fixed this when I made the change in blivet (for 2.0 or 2.1 IIRC). Let me know if this is the wrong target branch, of course.