### PR TITLE
itertools.chain can be iterated only once (#1414391)

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -526,7 +526,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         ui_roots = []
         for root in self._storage_playground.roots:
-            root_devices = chain(root.swaps, root.mounts.values())
+            root_devices = list(chain(root.swaps, root.mounts.values()))
             # Don't make a page if none of the root's devices are left.
             # Also, only include devices in an old page if the format is intact.
             if not any(d for d in root_devices if d in all_devices and d.disks and


### PR DESCRIPTION
If we try to iterate the chain again, it will behave as
an empty iterable. It is better to create and iterate a list.

Resolves: rhbz#1414391