### PR TITLE
Really fix with tmux 2.4 (version comparison was busted)

### DIFF
--- a/data/tmux.conf
+++ b/data/tmux.conf
@@ -8,7 +8,9 @@ set-option -g base-index 1
 
 # tmux 2.4 has different name for this option.
 # See https://github.com/rhinstaller/anaconda/pull/1040
-if-shell '[ $(echo "$(tmux -V | cut -d" " -f2) >= 2.4" | bc) -eq 1 ]' \
+# This checks if the current tmux version (from tmux -V) >= 2.4, using
+# sort -V to do a version-y comparison (and -r to reverse it)
+if-shell '[ $(printf "$(tmux -V | cut -d" " -f2)\n2.4" | sort -Vr | head -n1) == $(tmux -V | cut -d" " -f2) ]' \
     'set-option -g remain-on-exit on' \
     'set-option -g set-remain-on-exit on'
 


### PR DESCRIPTION
The attempt in 6752b131 to conditionalize the tmux config on
tmux version didn't work right, for two reasons: bc isn't in
the installer environment, and bc doesn't do the right kind of
comparison anyway (we want to compare following versioning
conventions, bc does a floating point number comparison). This
ought to do it properly, I hope.