### PR TITLE
Run some configuration when blivet-gui spoke is entered

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -39,7 +39,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libtimezonemapver 0.4.1-2
 %define helpver 22.1-1
 %define libblockdevver 2.1
-%define blivetguiver 2.1.2
+%define blivetguiver 2.1.4
 
 BuildRequires: audit-libs-devel
 BuildRequires: gettext >= %{gettextver}

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -115,6 +115,9 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
 
         self.blivetgui = osinstall.BlivetGUIAnaconda(self.client, self, box)
 
+        # this needs to be done when the spoke is already "realized"
+        self.entered.connect(self.blivetgui.ui_refresh)
+
         self.initialize_done()
 
     def refresh(self):

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -118,6 +118,11 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
         # this needs to be done when the spoke is already "realized"
         self.entered.connect(self.blivetgui.ui_refresh)
 
+        # set up keyboard shurtcuts for blivet-gui (and unset them after
+        # user lefts the spoke)
+        self.entered.connect(self.blivetgui.set_keyboard_shortcuts)
+        self.exited.connect(self.blivetgui.unset_keyboard_shortcuts)
+
         self.initialize_done()
 
     def refresh(self):


### PR DESCRIPTION
This uses changes in https://github.com/rhinstaller/anaconda/pull/1034 to run some "actions" needed by blivet-gui to refresh the UI and setup keyboard shortcuts after user enters the spoke.

Image for testing: https://vtrefny.fedorapeople.org/img/blivetgui.img

This needs to be merged together with https://github.com/rhinstaller/blivet-gui/pull/64