### PR TITLE
Properly iterate over kickstart locations in a job (#1443485)

### DIFF
--- a/dracut/fetch-kickstart-net.sh
+++ b/dracut/fetch-kickstart-net.sh
@@ -71,13 +71,16 @@ else
     newjob=$hookdir/initqueue/fetch-ks-${netif}.sh
 fi
 
+# We need extra quotation marks to safely iterate over locations in a job.
+quoted_locations="$(for l in $locations; do printf '"%s" ' "$l" ; done)"
+
 # Create a new job.
 cat > $newjob <<__EOT__
 . /lib/url-lib.sh
 . /lib/anaconda-lib.sh
 info "anaconda: kickstart locations are $locations"
 
-for kickstart in $locations; do
+for kickstart in $quoted_locations; do
     info "anaconda: fetching kickstart from \$kickstart"
 
     if fetch_url "\$kickstart" /tmp/ks.cfg; then


### PR DESCRIPTION
The strings over which we iterate should be in quotation marks.
This caused problems with kickstart urls containing an ampersand.

Resolves: rhbz#1443485