### PR TITLE
Bump Pykickstart version

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -19,7 +19,7 @@ Source0: %{name}-%{version}.tar.bz2
 # match the requires versions of things).
 
 %define gettextver 0.19.8
-%define pykickstartver 2.33-1
+%define pykickstartver 2.34-1
 %define dnfver 2.2.0
 %define partedver 1.8.1
 %define pypartedver 2.5-2


### PR DESCRIPTION
We now need Pykickstart >= 2.34-1 for the F26_AutoPart
command, which is needed by the new --nohome, --noboot and --noswap
options of the autopart command.