### PR TITLE
Compare empty confirmation field against input (#1438832)

### DIFF
--- a/pyanaconda/ui/gui/helpers.py
+++ b/pyanaconda/ui/gui/helpers.py
@@ -181,7 +181,7 @@ class GUIInputCheckHandler(InputCheckHandler):
         # Skip the check if no password is required
         if (not self.input_enabled) or self.input_kickstarted:
             result = InputCheck.CHECK_OK
-        elif self.input_confirmation and (self.input != self.input_confirmation):
+        elif self.input != self.input_confirmation:
             result = _(constants.PASSWORD_CONFIRM_ERROR_GUI) % {"passwords": self.name_of_input_plural}
         else:
             result = InputCheck.CHECK_OK


### PR DESCRIPTION
Even if the confirmation filed is empty, it should still be compared
against the input field. This should help reduce typos in passwords and
passphrases and it's also the behavior people are used to from RHEL >=7.2.

Resolves: rhbz#1438832