### PR TITLE
Fix the text completions in the datetime spoke (#1447984)

### DIFF
--- a/pyanaconda/ui/gui/spokes/datetime_spoke.glade
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.glade
@@ -22,7 +22,6 @@
   </object>
   <object class="GtkEntryCompletion" id="cityCompletion">
     <property name="model">citiesFilter</property>
-    <property name="text_column">0</property>
     <property name="inline_completion">True</property>
     <signal name="match-selected" handler="on_completion_match_selected" object="cityCombobox" swapped="no"/>
   </object>
@@ -75,7 +74,6 @@
   </object>
   <object class="GtkEntryCompletion" id="regionCompletion">
     <property name="model">regions</property>
-    <property name="text_column">0</property>
     <property name="inline_completion">True</property>
     <signal name="match-selected" handler="on_completion_match_selected" object="regionCombobox" swapped="no"/>
   </object>

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -988,6 +988,11 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
     def on_city_region_text_entry_activated(self, entry):
         combo = entry.get_parent()
+
+        # Look for the combo box (see the commit message)
+        while not isinstance(combo, Gtk.ComboBox):
+            combo = combo.get_parent()
+
         model = combo.get_model()
         entry_text = entry.get_text().lower()
 

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -438,6 +438,15 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
         self._amPmLabel = self.builder.get_object("amPmLabel")
         self._radioButton24h = self.builder.get_object("timeFormatRB")
 
+        # Set the entry completions.
+        # The text_column property needs to be set here. If we set
+        # it in the glade file, the completion doesn't show text.
+        region_completion = self.builder.get_object("regionCompletion")
+        region_completion.set_text_column(0)
+
+        city_completion = self.builder.get_object("cityCompletion")
+        city_completion.set_text_column(0)
+
         # create widgets for displaying/configuring date
         day_box, self._dayCombo, day_label = _new_date_field_box(self._daysFilter)
         self._dayCombo.connect("changed", self.on_day_changed)


### PR DESCRIPTION
Look higher for the combo box associated with an entry:
* When creating a GtkComboBox with an associated entry,
gtk_bin_get_child on the combo box returns the GtkEntry.
gtk_widget_get_parent on the entry returns a GtkBox.

Show the text of completions in the datetime spoke:
* The text_column property of GtkEntryCompletion shoudn't be set in
a glade file. It should be set in a code with the set_text_column
method instead. Otherwise, the completion doesn't show any text.
This is a documented issue and according to gtk it is not a bug.

Resolves: rhzb#1447984