### PR TITLE
Show the text of completions in the datetime spoke in Fedora

### DIFF
--- a/pyanaconda/ui/gui/spokes/datetime_spoke.glade
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.glade
@@ -22,7 +22,6 @@
   </object>
   <object class="GtkEntryCompletion" id="cityCompletion">
     <property name="model">citiesFilter</property>
-    <property name="text_column">0</property>
     <property name="inline_completion">True</property>
     <signal name="match-selected" handler="on_completion_match_selected" object="cityCombobox" swapped="no"/>
   </object>
@@ -75,7 +74,6 @@
   </object>
   <object class="GtkEntryCompletion" id="regionCompletion">
     <property name="model">regions</property>
-    <property name="text_column">0</property>
     <property name="inline_completion">True</property>
     <signal name="match-selected" handler="on_completion_match_selected" object="regionCombobox" swapped="no"/>
   </object>

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -461,6 +461,15 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
         self._radioButton24h = self.builder.get_object("timeFormatRB")
         self._amPmRevealer = self.builder.get_object("amPmRevealer")
 
+        # Set the entry completions.
+        # The text_column property needs to be set here. If we set
+        # it in the glade file, the completion doesn't show text.
+        region_completion = self.builder.get_object("regionCompletion")
+        region_completion.set_text_column(0)
+
+        city_completion = self.builder.get_object("cityCompletion")
+        city_completion.set_text_column(0)
+
         # create widgets for displaying/configuring date
         day_box, self._dayCombo, day_label = _new_date_field_box(self._daysFilter)
         self._dayCombo.connect("changed", self.on_day_changed)


### PR DESCRIPTION
The text_column property of GtkEntryCompletion shouldn't be set in
a glade file. It should be set in a code with the set_text_column
method instead. Otherwise, the completion doesn't show any text.
This is a documented issue and according to gtk it is not a bug.

(cherry picked from commit e29f169)