### PR TITLE
Backport snapshot support from RHEL7

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -717,6 +717,12 @@ if __name__ == "__main__":
         if not anaconda.ksdata.timezone.nontp:
             iutil.start_service("chronyd")
 
+    # Create pre-install snapshots
+    from pykickstart.constants import SNAPSHOT_WHEN_PRE_INSTALL
+    if ksdata.snapshot.has_snapshot(SNAPSHOT_WHEN_PRE_INSTALL):
+        ksdata.snapshot.pre_setup(anaconda.storage, ksdata, anaconda.instClass)
+        ksdata.snapshot.pre_execute(anaconda.storage, ksdata, anaconda.instClass)
+
     anaconda._intf.setup(ksdata)
     anaconda._intf.run()
 

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -19,7 +19,7 @@ Source0: %{name}-%{version}.tar.bz2
 # match the requires versions of things).
 
 %define gettextver 0.19.8
-%define pykickstartver 2.34-1
+%define pykickstartver 2.35-1
 %define dnfver 2.2.0
 %define partedver 1.8.1
 %define pypartedver 2.5-2
@@ -85,7 +85,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 Summary: Core of the Anaconda installer
 Requires: python3-libs
 Requires: python3-dnf >= %{dnfver}
-Requires: python3-blivet >= 1:2.1.7-3
+Requires: python3-blivet >= 1:2.1.9-1
 Requires: python3-blockdev >= %{libblockdevver}
 Requires: libblockdev-plugins-all >= %{libblockdevver}
 Requires: python3-meh >= %{mehver}

--- a/pyanaconda/install.py
+++ b/pyanaconda/install.py
@@ -337,6 +337,12 @@ def doInstall(storage, payload, ksdata, instClass):
     post_install.append(Task("Run post-installation setup tasks", payload.postInstall))
     installation_queue.append(post_install)
 
+    # Create snapshot
+    if ksdata.snapshot:
+        snapshot_creation = TaskQueue("Creating post installation snapshots", N_("Creating snapshots"))
+        snapshot_creation.append(Task("Create post-install snapshots", ksdata.snapshot.execute, (storage, ksdata, instClass)))
+        installation_queue.append(snapshot_creation)
+
     # notify progress tracking about the number of steps
     progress_init(len(installation_queue))
     # log contents of the main task queue

--- a/pyanaconda/install.py
+++ b/pyanaconda/install.py
@@ -35,6 +35,7 @@ from pyanaconda.ui.lib.entropy import wait_for_entropy
 from pyanaconda.kickstart import runPostScripts, runPreInstallScripts
 from pyanaconda.kexec import setup_kexec
 from pyanaconda.install_tasks import Task, TaskQueue
+from pykickstart.constants import SNAPSHOT_WHEN_POST_INSTALL
 import logging
 log = logging.getLogger("anaconda")
 
@@ -338,7 +339,7 @@ def doInstall(storage, payload, ksdata, instClass):
     installation_queue.append(post_install)
 
     # Create snapshot
-    if ksdata.snapshot:
+    if ksdata.snapshot and ksdata.snapshot.has_snapshot(SNAPSHOT_WHEN_POST_INSTALL):
         snapshot_creation = TaskQueue("Creating post installation snapshots", N_("Creating snapshots"))
         snapshot_creation.append(Task("Create post-install snapshots", ksdata.snapshot.execute, (storage, ksdata, instClass)))
         installation_queue.append(snapshot_creation)

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -19,6 +19,7 @@
 #
 
 from pyanaconda.errors import ScriptError, errorHandler
+from pyanaconda.threads import threadMgr
 from blivet.deviceaction import ActionCreateFormat, ActionResizeDevice, ActionResizeFormat
 from blivet.devices import LUKSDevice
 from blivet.devices.lvm import LVMVolumeGroupDevice, LVMCacheRequest, LVMLogicalVolumeDevice
@@ -43,7 +44,7 @@ import os
 import os.path
 import tempfile
 from pyanaconda.flags import flags, can_touch_runtime_system
-from pyanaconda.constants import ADDON_PATHS, IPMI_ABORTED, TEXT_ONLY_TARGET, GRAPHICAL_TARGET
+from pyanaconda.constants import ADDON_PATHS, IPMI_ABORTED, TEXT_ONLY_TARGET, GRAPHICAL_TARGET, THREAD_STORAGE
 import shlex
 import requests
 import sys
@@ -67,8 +68,11 @@ from pyanaconda.bootloader import GRUB2, get_bootloader
 from pyanaconda.pwpolicy import F22_PwPolicy, F22_PwPolicyData
 from pyanaconda.storage_utils import device_matches, try_populate_devicetree
 from pyanaconda import screen_access
-from pykickstart.constants import CLEARPART_TYPE_NONE, FIRSTBOOT_SKIP, FIRSTBOOT_RECONFIG, KS_SCRIPT_POST, KS_SCRIPT_PRE, \
-                                  KS_SCRIPT_TRACEBACK, KS_SCRIPT_PREINSTALL, SELINUX_DISABLED, SELINUX_ENFORCING, SELINUX_PERMISSIVE
+from pykickstart.constants import CLEARPART_TYPE_NONE, CLEARPART_TYPE_ALL, \
+                                  FIRSTBOOT_SKIP, FIRSTBOOT_RECONFIG, \
+                                  KS_SCRIPT_POST, KS_SCRIPT_PRE, KS_SCRIPT_TRACEBACK, KS_SCRIPT_PREINSTALL, \
+                                  SELINUX_DISABLED, SELINUX_ENFORCING, SELINUX_PERMISSIVE, \
+                                  SNAPSHOT_WHEN_POST_INSTALL, SNAPSHOT_WHEN_PRE_INSTALL
 from pykickstart.base import BaseHandler
 from pykickstart.errors import formatErrorMsg, KickstartError, KickstartParseError
 from pykickstart.parser import KickstartParser
@@ -1908,23 +1912,79 @@ class SkipX(commands.skipx.FC3_SkipX):
             desktop.write()
 
 class Snapshot(commands.snapshot.F26_Snapshot):
+    def _post_snapshots(self):
+        return filter(lambda snap: snap.when == SNAPSHOT_WHEN_POST_INSTALL, self.dataList())
+
+    def _pre_snapshots(self):
+        return filter(lambda snap: snap.when == SNAPSHOT_WHEN_PRE_INSTALL, self.dataList())
+
+    def has_snapshot(self, when):
+        """ Is snapshot with this `when` parameter contained in the list of snapshots?
+
+            :param when: `when` parameter from pykickstart which should be test for present.
+            :type when: One of the constants from `pykickstart.constants.SNAPSHOT_*`
+            :returns: True if snapshot with this `when` parameter is present,
+                      False otherwise.
+        """
+        return any(snap.when == when for snap in self.dataList())
+
     def setup(self, storage, ksdata, instClass):
-        """ Prepare the snapshot.
+        """ Prepare post installation snapshots.
 
             This will also do the checking of snapshot validity.
         """
-        for snap_data in self.dataList():
+        for snap_data in self._post_snapshots():
             snap_data.setup(storage, ksdata, instClass)
 
     def execute(self, storage, ksdata, instClass):
-        """ Create ThinLV snapshot.
+        """ Create ThinLV snapshot after post section stops.
 
             Blivet must be reset before creation of the snapshot. This is
             required because the storage could be changed in post section.
         """
-        try_populate_devicetree(storage.devicetree)
-        for snap_data in self.dataList():
-            snap_data.execute(storage, ksdata, instClass)
+        post_snapshots = self._post_snapshots()
+
+        if post_snapshots:
+            try_populate_devicetree(storage.devicetree)
+            for snap_data in post_snapshots:
+                log.debug("Snapshot: creating post-install snapshot %s", snap_data.name)
+                snap_data.execute(storage, ksdata, instClass)
+
+    def pre_setup(self, storage, ksdata, instClass):
+        """ Prepare pre installation snapshots.
+
+            This will also do the checking of snapshot validity.
+        """
+        pre_snapshots = self._pre_snapshots()
+
+        # wait for the storage to load devices
+        if pre_snapshots:
+            threadMgr.wait(THREAD_STORAGE)
+
+        for snap_data in pre_snapshots:
+            snap_data.setup(storage, ksdata, instClass)
+
+    def pre_execute(self, storage, ksdata, instClass):
+        """ Create ThinLV snapshot before installation starts.
+
+            This must be done before user can change anything
+        """
+        pre_snapshots = self._pre_snapshots()
+
+        if pre_snapshots:
+            threadMgr.wait(THREAD_STORAGE)
+
+            if (ksdata.clearpart.devices or ksdata.clearpart.drives or
+                ksdata.clearpart.type == CLEARPART_TYPE_ALL):
+                log.warning("Snapshot: \"clearpart\" command could erase pre-install snapshots!")
+            if ksdata.zerombr.zerombr:
+                log.warning("Snapshot: \"zerombr\" command could erase pre-install snapshots!")
+
+            for snap_data in pre_snapshots:
+                log.debug("Snapshot: creating pre-install snapshot %s", snap_data.name)
+                snap_data.execute(storage, ksdata, instClass)
+
+            try_populate_devicetree(storage.devicetree)
 
 class SnapshotData(commands.snapshot.F26_SnapshotData):
     def __init__(self, *args, **kwargs):
@@ -1937,28 +1997,29 @@ class SnapshotData(commands.snapshot.F26_SnapshotData):
             This will plan snapshot creation on the end of the installation. This way
             Blivet will do a validity checking for future snapshot.
         """
-        log.debug("Snapshot name %s setup", self.name)
         if not self.origin.count('/') == 1:
-            raise KickstartParseError(
-                        formatErrorMsg(self.lineno,
-                                       msg=_("Incorrectly specified origin of the snapshot."
-                                             " Use format \"VolGroup/LV-name\"")))
-        # modify the origin name to the proper DM naming
-        origin = self.origin.replace('-','--').replace('/','-')
+            msg = _("Incorrectly specified origin of the snapshot. Use format \"VolGroup/LV-name\"")
+            raise KickstartParseError(formatErrorMsg(self.lineno, msg=msg))
+
+        # modify origin and snapshot name to the proper DM naming
+        snap_name = self.name.replace('-', '--')
+        origin = self.origin.replace('-', '--').replace('/', '-')
         origin_dev = storage.devicetree.get_device_by_name(origin)
+        log.debug("Snapshot: name %s has origin %s", self.name, origin_dev)
 
         if origin_dev is None:
-            raise KickstartParseError(
-                        formatErrorMsg(self.lineno,
-                                       msg=_("Snapshot: origin \"%s\" doesn't exists!") % self.origin))
+            msg = _("Snapshot: origin \"%s\" doesn't exists!") % self.origin
+            raise KickstartParseError(formatErrorMsg(self.lineno, msg=msg))
 
         if not origin_dev.is_thin_lv:
-            raise KickstartParseError(
-                        formatErrorMsg(self.lineno,
-                                       msg=(_("Snapshot: origin \"%(origin)s\" of snapshot \"%(name)s\""
-                                              " is not a valid thin LV device.") %
-                                            {"origin": self.origin,
-                                             "name": self.name})))
+            msg = (_("Snapshot: origin \"%(origin)s\" of snapshot \"%(name)s\""
+                     " is not a valid thin LV device.") % {"origin": self.origin,
+                                                           "name": self.name})
+            raise KickstartParseError(formatErrorMsg(self.lineno, msg=msg))
+
+        if storage.devicetree.get_device_by_name("%s-%s" % (origin_dev.vg.name, snap_name)):
+            msg = _("Snapshot %s already exists.") % self.name
+            raise KickstartParseError(formatErrorMsg(self.lineno, msg=msg))
 
         self.thin_snapshot = None
         try:
@@ -1971,7 +2032,6 @@ class SnapshotData(commands.snapshot.F26_SnapshotData):
 
     def execute(self, storage, ksdata, instClass):
         """ Execute an action for snapshot creation. """
-        log.debug("Snapshot name %s execute", self.name)
         self.thin_snapshot.create()
 
 class ZFCP(commands.zfcp.F14_ZFCP):

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -26,6 +26,7 @@ from blivet.devices.lvm import LVMVolumeGroupDevice, LVMCacheRequest, LVMLogical
 from blivet.devicelibs.lvm import LVM_PE_SIZE, KNOWN_THPOOL_PROFILES
 from blivet.devicelibs.crypto import MIN_CREATE_ENTROPY
 from blivet.formats import get_format
+from blivet.formats.fs import XFS
 from blivet.partitioning import do_partitioning
 from blivet.partitioning import grow_lvm
 from blivet.errors import PartitioningError, StorageError, BTRFSValueError
@@ -2033,6 +2034,9 @@ class SnapshotData(commands.snapshot.F26_SnapshotData):
     def execute(self, storage, ksdata, instClass):
         """ Execute an action for snapshot creation. """
         self.thin_snapshot.create()
+        if isinstance(self.thin_snapshot.format, XFS):
+            log.debug("Generating new UUID for XFS snapshot")
+            self.thin_snapshot.format.reset_uuid()
 
 class ZFCP(commands.zfcp.F14_ZFCP):
     def parse(self, args):


### PR DESCRIPTION
Backport snapshot feature from RHEL(https://github.com/rhinstaller/anaconda/pull/1002) to F26 and master.

This also fix issue which is on RHEL when UUID wasn't changed for pre install snapshots. This will be fixed in RHEL7 later.

The PR https://github.com/rhinstaller/blivet/pull/586 needs to be merged before this one. 