### PR TITLE
Prevent TUI from crashing with a single spoke on a hub

### DIFF
--- a/pyanaconda/ui/tui/hubs/__init__.py
+++ b/pyanaconda/ui/tui/hubs/__init__.py
@@ -150,7 +150,7 @@ class TUIHub(TUIObject, common.Hub):
         prompt = super(TUIHub, self).prompt(args)
 
         if self._spoke_count == 1:
-            prompt.add_option("1", _("to enter the %(spoke_title)s spoke") % list(self._spokes.values())[0].title)
+            prompt.add_option("1", _("to enter the %(spoke_title)s spoke") % {"spoke_title": list(self._spokes.values())[0].title})
 
         if self.has_help:
             prompt.add_help_option()


### PR DESCRIPTION
Prevent the special case code for a single spoke hub in TUI
from crashing due to a string formatting error.