### PR TITLE
Show warnings in datetime and source spokes (#1418604)

### DIFF
--- a/pyanaconda/ui/gui/spokes/source.py
+++ b/pyanaconda/ui/gui/spokes/source.py
@@ -905,8 +905,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         else: # network button could be deativated from last visit
             self._networkButton.set_sensitive(True)
 
-        # Update the URL entry validation now that we're done messing with sensitivites
-        self._updateURLEntryCheck()
+            # Update the URL entry validation now that we're done messing with sensitivities.
+            # It will clear any previous messages.
+            self._updateURLEntryCheck()
 
 
     def _setup_no_updates(self):


### PR DESCRIPTION
When the network time cannot be enabled or disabled, we show a
warning message and reset the switch button to the previous state.
With the reset, the handler is run for the second time and clears
are warning messages, so the user doesn't see the message at all.
Unfortunately, we cannot use handler_block_by_func, because it does
not work, so we need to block the handler manually.

If the network installation source is set, but no network is
configured, we disable the network source settings and set
a warning message. However, updateURLEntryCheck clears all
messages, so it needs to be called only if the network is
configured.

Resolves: rhbz#1418604