### PR TITLE
rpmostreepayload: Handle /var as a user-specified mountpoint

### DIFF
--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -233,10 +233,13 @@ class RPMOSTreePayload(ArchivePayload):
 
         # Set up bind mounts as if we've booted the target system, so
         # that %post script work inside the target.
-        binds = [(varroot, iutil.getSysroot() + '/var'),
-                 (iutil.getSysroot() + '/usr', None),
+        binds = [(iutil.getSysroot() + '/usr', None),
                  (iutil.getTargetPhysicalRoot(), iutil.getSysroot() + "/sysroot"),
                  (iutil.getTargetPhysicalRoot() + "/boot", iutil.getSysroot() + "/boot")]
+
+        # https://github.com/ostreedev/ostree/issues/855
+        if storage.mountpoints.get("/var") is None:
+            binds.append((varroot, iutil.getSysroot() + '/var'))
 
         # Bind mount filesystems from /mnt/sysimage to the ostree root; perhaps
         # in the future consider `mount --move` to make the output of `findmnt`


### PR DESCRIPTION
See: https://github.com/ostreedev/ostree/issues/855

Basically, if `/var` is in the user specified mounts, don't override
it with the "default ostree" `var`.

This allows people to easily keep all of their local state (apart from `/etc`)
in a single partition with potentially different quotas etc.