### PR TITLE
Set the default filesystem type from a kickstart file (#1449099)

### DIFF
--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -165,11 +165,24 @@ class Anaconda(object):
         if not self._storage:
             import blivet
             self._storage = blivet.Blivet(ksdata=self.ksdata)
-
-            if self.instClass.defaultFS:
-                self._storage.setDefaultFSType(self.instClass.defaultFS)
+            self._setDefaultFSType(self._storage)
 
         return self._storage
+
+    def _setDefaultFSType(self, storage):
+        fstype = None
+
+        # Get the default fstype from a kickstart file.
+        if self.ksdata.autopart.autopart and self.ksdata.autopart.fstype:
+            fstype = self.ksdata.autopart.fstype
+        # Or from an install class.
+        elif self.instClass.defaultFS:
+            fstype = self.instClass.defaultFS
+
+        # Set the default fstype.
+        if fstype:
+            storage.setDefaultFSType(fstype)
+            storage.setDefaultBootFSType(fstype)
 
     def dumpState(self):
         from meh import ExceptionInfo

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -286,16 +286,8 @@ class AutoPart(commands.autopart.RHEL7_AutoPart):
         if not self.autopart:
             return
 
-        if self.fstype:
-            try:
-                storage.setDefaultFSType(self.fstype)
-                storage.setDefaultBootFSType(self.fstype)
-            except ValueError:
-                raise KickstartValueError(formatErrorMsg(self.lineno,
-                        msg=_("Settings default fstype to %s failed.") % self.fstype))
-
-        # sets up default autopartitioning.  use clearpart separately
-        # if you want it
+        # Sets up default autopartitioning. Use clearpart separately if you want it.
+        # The filesystem type is already set in the storage.
         refreshAutoSwapSize(storage)
         storage.doAutoPart = True
 


### PR DESCRIPTION
If the kickstart file specifies the --fstype option in the autopart
command, we should use it to set the default filesystem type. If the
type is not set in a kickstart file, we will use the specified type
from an install class or the default type from blivet.

Resolves: rhbz#1449099