### PR TITLE
Adapt to our new daily builds of Anaconda

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,7 @@ MAINTAINERCLEANFILES =	Makefile.in config.guess config.h.in config.sub \
 						py-compile m4/* po/Makefile.in.in po/Rules-quot \
 						test-driver
 
-CLEANFILES = *~ utils/mock-out.cfg
+CLEANFILES = *~ $(MOCK_CONF_OUT)
 
 dist_noinst_DATA      = $(PACKAGE_NAME).spec
 
@@ -52,10 +52,11 @@ DIST_NAME ?= $(shell echo "$(GIT_BRANCH)" | sed \
 				-e 's/^f//' \
 				-e 's/master/rawhide/')
 ARCH_NAME ?= $(shell uname -m)
+DIST_FULL_NAME = $(shell echo "$(DIST_NAME)" | sed -re 's/^[0-9]+/fedora/')
 
 RC_RELEASE ?= $(shell date -u +0.1.%Y%m%d%H%M%S)
 
-MOCK_CONF_TEMPLATE ?= $(srcdir)/utils/mock-template.cfg
+MOCK_CONF_TEMPLATE ?= $(srcdir)/utils/mock-$(DIST_FULL_NAME)-template.cfg
 MOCK_CONF_OUT ?= $(srcdir)/utils/mock-out.cfg
 
 MOCKCHROOT ?= fedora-$(DIST_NAME)-$(ARCH_NAME)

--- a/utils/mock-fedora-template.cfg
+++ b/utils/mock-fedora-template.cfg
@@ -7,9 +7,9 @@ config_opts['nosync'] = True
 
 config_opts['yum.conf'] += """
 
-[vtrefny-rhinstaller]
-name=Copr repo for rhinstaller owned by vtrefny
-baseurl=https://copr-be.cloud.fedoraproject.org/results/vtrefny/rhinstaller/fedora-@DISTRO@-$basearch/
+[rhinstaller-devel]
+name=Copr repo for rhinstaller daily builds for Fedora devel
+baseurl=https://copr-be.cloud.fedoraproject.org/results/@rhinstaller/Anaconda-devel/fedora-$releasever-$basearch/
 enabled=1
 
 [blivet-daily]

--- a/utils/mock-rawhide-template.cfg
+++ b/utils/mock-rawhide-template.cfg
@@ -1,0 +1,19 @@
+# Include COPR repository with daily builds of our main packages
+# to base mock file which will be set by @DISTRO@ variable.
+
+include('/etc/mock/fedora-rawhide-@ARCH@.cfg')
+
+config_opts['nosync'] = True
+
+config_opts['yum.conf'] += """
+
+[rhinstaller]
+name=Copr repo for rhinstaller daily builds for Rawhide
+baseurl=https://copr-be.cloud.fedoraproject.org/results/@rhinstaller/Anaconda/fedora-rawhide-$basearch/
+enabled=1
+
+[blivet-daily]
+name=Copr repo for blivet-daily owned by @storage
+baseurl=https://copr-be.cloud.fedoraproject.org/results/@storage/blivet-daily/fedora-$releasever-$basearch/
+enabled=1
+"""


### PR DESCRIPTION
Our daily builds will be in Anaconda in COPR but they will use a separate repo for Fedora-devel and Fedora-rawhide.

The devel version will always point to the newest Fedora.