### PR TITLE
Add support for kickstart snippets in installation image drop directory

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -246,6 +246,10 @@ find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 # Create an empty directory for addons
 mkdir %{buildroot}%{_datadir}/anaconda/addons
 
+# Create an empty directory for kickstart snippets
+mkdir %{buildroot}%{_datadir}/anaconda/kickstarts-prepend.d
+mkdir %{buildroot}%{_datadir}/anaconda/kickstarts-append.d
+
 %ifarch %livearches
 desktop-file-install ---dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_datadir}/applications/liveinst.desktop
 %endif

--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -28,6 +28,8 @@ SELINUX_DEFAULT = -1
 
 # where to look for 3rd party addons
 ADDON_PATHS = ["/usr/share/anaconda/addons"]
+KICKSTART_PREPEND_DROPDIR_PATH = "/usr/share/anaconda/kickstarts-prepend.d"
+KICKSTART_APPEND_DROPDIR_PATH = "/usr/share/anaconda/kickstarts-append.d"
 
 from pykickstart.constants import AUTOPART_TYPE_LVM
 


### PR DESCRIPTION
This allows to have kickstart snippets in installer image drop directory
that would be prepended or appended to user supplied kickstart file (or
interactive-defaults.ks file in case of non-kickstart installation).

The drop directories are:
/usr/share/anaconda/kickstarts-prepend.d
/usr/share/anaconda/kickstarts-append.d

The kickstart snippet files will be concatenated in this order:
1) files from kickstart-prepend.d sorted by name
2) user supplied kickstart or interactive-defaults.ks in case of non-ks install
3) files from kickstart-append.d sorted by name

Use case example: atomic installer specific ostreesetup and (other stuff, like
services) configuration

https://www.redhat.com/archives/anaconda-devel-list/2017-February/msg00000.html

Formerly interactive-defaults.ks was modified with additional atomic-specific
kickstart commands (eg ostreesetup to specify the atomic repo tree) during
atomic installer image build process, which required including the (added)
content of the file in regular kickstart which makes very bad user experience.

Using this new mechanism, atomic could just drop its kickstart snippet into
/usr/share/anaconda/kickstarts-append.d/50-atomic.ks directory and it would be
applied both to kickstart and non-kickstart installations.  The file can be added
to image either right during atomic installer build process as before, but now
also via atomic product.img if it makes sense for the atomic installer image
build process POV.