### PR TITLE
Set the default filesystem type from a kickstart file

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -273,16 +273,8 @@ class AutoPart(commands.autopart.F26_AutoPart):
         if not self.autopart:
             return
 
-        if self.fstype:
-            try:
-                storage.set_default_fstype(self.fstype)
-                storage.set_default_boot_fstype(self.fstype)
-            except ValueError:
-                raise KickstartParseError(formatErrorMsg(self.lineno,
-                                          msg=_("Settings default fstype to %s failed.") % self.fstype))
-
-        # sets up default autopartitioning.  use clearpart separately
-        # if you want it
+        # Sets up default autopartitioning. Use clearpart separately if you want it.
+        # The filesystem type is already set in the storage.
         refreshAutoSwapSize(storage)
         storage.do_autopart = True
 


### PR DESCRIPTION
If the kickstart file specifies the --fstype option in the autopart
command, we should use it to set the default filesystem type. If the
type is not set in a kickstart file, we will use the specified type
from an install class or the default type from blivet.

Also, done a little cleanup in the storage property.