### PR TITLE
Mark post inst tools as disabled only if firstboot --disable is used …

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -752,9 +752,13 @@ class Firstboot(commands.firstboot.FC3_Firstboot):
 
         if self.firstboot == FIRSTBOOT_SKIP:
             action = "disable"
-            # Also tell the screen access manager, so that the fact that post installation tools
-            # should be disabled propagates to the user interaction config file.
-            screen_access.sam.post_install_tools_disabled = True
+
+            if self.seen:
+                # Also tell the screen access manager, so that the fact that post installation tools
+                # should be disabled propagates to the user interaction config file,
+                # But only to this if explicitely requested through the "firstboot --disable/--disabled"
+                # command in kickstart.
+                screen_access.sam.post_install_tools_disabled = True
 
         # enable/disable the Initial Setup service (if its unit is installed)
         if unit_exists:


### PR DESCRIPTION
…(#1448940)

Only set the post_install_tools_disabled flag in the user interaction
config file if the user explicitly requests it via the firstboot
--disable kickstart command.

The main difference from current behavior is that while Anaconda has
been always disabling Initial Setup during a kickstart installation
(unless firstboot --enable) has been used in the kickstart, the same
behavior might not be expected for other post installation setup tools,
such as Gnome Initial Setup, which have been always start
unconditionally up till now.

User that want to make sure no post installation setup tools
(both Initial Setup and Gnome Initial Setup) will run can use
firstboot --disable in kickstart to achieve that.

Resolves: rhbz#1448940