### PR TITLE
Add support for DNF-2.5.0

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -261,7 +261,8 @@ class DownloadProgress(dnf.callback.DownloadProgress):
         self.downloads[nevra] = done
         self._update()
 
-    def start(self, total_files, total_size):
+    # TODO: Remove pylint disable after DNF-2.5.0 will arrive in Fedora
+    def start(self, total_files, total_size, total_drpms=0): # pylint: disable=arguments-differ
         self.total_files = total_files
         self.total_size = Size(total_size)
 


### PR DESCRIPTION
Callback method `start()` in the `DownloadProgress()` reporting class has the new attribute `total_drpms`.

Without this attribute the installation will crash.