### PR TITLE
Fix setting errors and warnings in the StorageCheckHandler (#1453130)

### DIFF
--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -93,8 +93,10 @@ class StorageCheckHandler(object):
         hubQ.send_message(self._mainSpokeClass, _("Checking storage configuration..."))
 
         report = storage_checker.check(self.storage)
-        self.errors = report.errors
-        self.warnings = report.warnings
+        # Storage spoke and custom spoke communicate errors via StorageCheckHandler,
+        # so we need to set errors and warnings class attributes here.
+        StorageCheckHandler.errors = report.errors
+        StorageCheckHandler.warnings = report.warnings
 
         hubQ.send_ready(self._mainSpokeClass, True)
         report.log(self.log)


### PR DESCRIPTION
Storage spoke and custom spoke communicate errors via
StorageCheckHandler, so we need to set errors and warnings
class attributes of the handler. Otherwise, the errors from
the custom spoke are not propagated to the storage spoke.

Resolves: rhbz#1453130