### PR TITLE
Separate blivet-daily builds in mock config

### DIFF
--- a/utils/mock-blivet-daily.cfg
+++ b/utils/mock-blivet-daily.cfg
@@ -1,0 +1,10 @@
+# Include COPR repository with daily builds of Blivet related projects.
+
+config_opts['yum.conf'] += """
+
+[blivet-daily]
+name=Copr repo for blivet-daily owned by @storage
+baseurl=https://copr-be.cloud.fedoraproject.org/results/@storage/blivet-daily/fedora-$releasever-$basearch/
+enabled=1
+
+"""

--- a/utils/mock-fedora-template.cfg
+++ b/utils/mock-fedora-template.cfg
@@ -2,6 +2,7 @@
 # to base mock file which will be set by @DISTRO@ variable.
 
 include('/etc/mock/fedora-@DISTRO@-@ARCH@.cfg')
+include('./utils/mock-blivet-daily.cfg')
 
 config_opts['nosync'] = True
 
@@ -12,8 +13,4 @@ name=Copr repo for rhinstaller daily builds for Fedora devel
 baseurl=https://copr-be.cloud.fedoraproject.org/results/@rhinstaller/Anaconda-devel/fedora-$releasever-$basearch/
 enabled=1
 
-[blivet-daily]
-name=Copr repo for blivet-daily owned by @storage
-baseurl=https://copr-be.cloud.fedoraproject.org/results/@storage/blivet-daily/fedora-$releasever-$basearch/
-enabled=1
 """

--- a/utils/mock-rawhide-template.cfg
+++ b/utils/mock-rawhide-template.cfg
@@ -2,6 +2,7 @@
 # to base mock file which will be set by @DISTRO@ variable.
 
 include('/etc/mock/fedora-rawhide-@ARCH@.cfg')
+include('./utils/mock-blivet-daily.cfg')
 
 config_opts['nosync'] = True
 
@@ -12,8 +13,4 @@ name=Copr repo for rhinstaller daily builds for Rawhide
 baseurl=https://copr-be.cloud.fedoraproject.org/results/@rhinstaller/Anaconda/fedora-rawhide-$basearch/
 enabled=1
 
-[blivet-daily]
-name=Copr repo for blivet-daily owned by @storage
-baseurl=https://copr-be.cloud.fedoraproject.org/results/@storage/blivet-daily/fedora-$releasever-$basearch/
-enabled=1
 """


### PR DESCRIPTION
It is used from `mock-fedora` and `mock-rawhide` so include it from `mock-blivet` instead of having it hardcoded inside of these configuration files.