### PR TITLE
Make it possible to change root password set in kickstart

### DIFF
--- a/pyanaconda/ui/gui/spokes/password.py
+++ b/pyanaconda/ui/gui/spokes/password.py
@@ -143,8 +143,10 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokePasswordCheckHandl
 
     @property
     def sensitive(self):
+        # The spoke cannot be entered if root password was set in the kickstart
+        # and the root password policy doesn't allow changes.
         return not (self.completed and flags.automatedInstall
-                    and self.data.rootpw.seen)
+                    and self.data.rootpw.seen and not self.policy.changesok)
 
     @property
     def input(self):


### PR DESCRIPTION
Make it possible to change root password set in kickstart if the current password policy allows it (--changesok).

The first patch makes it possible to enter the root password spoke when root password is set in kickstart and and password policy for the root password contains the --changesok flag.

The second and third patch fix various UI issues that otherwise show up when entering the root password spoke while a root password is set in kickstart.