### PR TITLE
network: bind to device name (not hwaddr) when dumping connections (#…

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -380,6 +380,10 @@ def dumpMissingDefaultIfcfgs():
                 log.debug("network: %s while checking missing ifcfgs, device %s", e, devname)
             continue
         nm.nm_update_settings_of_device(devname, [['connection', 'id', devname, None]])
+        nm.nm_update_settings_of_device(devname, [['connection', 'interface-name', devname, None]])
+        if not _bound_hwaddr_of_device(devname):
+            nm.nm_update_settings_of_device(devname, [['802-3-ethernet', 'mac-address', [], None]])
+
         log.debug("network: dumping ifcfg file for %s from default autoconnection %s", devname, uuid)
         rv.append(devname)
 


### PR DESCRIPTION
…1457215)