### PR TITLE
Delete file systems used only by a given installation (#1453097)

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -355,7 +355,7 @@ class ConfirmDeleteDialog(GUIObject):
             rootName = rootName.replace("_", "__")
         self._removeAll.set_label(
                 C_("GUI|Custom Partitioning|Confirm Delete Dialog",
-                    "Delete _all other file systems in the %s root as well.")
+                    "Delete _all file systems which are only used by %s.")
                 % rootName)
         self._removeAll.set_sensitive(rootName is not None)
 


### PR DESCRIPTION
If user chooses to delete all file systems which are only used by
a given installation, we will skip the file systems that are shared
between more installations.

Before that we offered to delete all systems including those
used by other installed operating systems. That could be confusing
and result in data loss. The new behaviour is closer to Fedora's.

Resolves: rhbz#1453097