### PR TITLE
Fix a log-related rename mixup

### DIFF
--- a/pyanaconda/anaconda_loggers.py
+++ b/pyanaconda/anaconda_loggers.py
@@ -41,6 +41,9 @@ def get_module_logger(module_name):
         module_name = module_name[11:]
     return logging.getLogger("anaconda.%s" % module_name)
 
+def get_anaconda_root_logger():
+    return logging.getLogger(constants.LOGGER_ANACONDA_ROOT)
+
 def get_main_logger():
     return logging.getLogger(constants.LOGGER_MAIN)
 

--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -228,6 +228,7 @@ class DisplayModes(Enum):
     TUI = "TUI"
 
 # Loggers
+LOGGER_ANACONDA_ROOT = "anaconda"
 LOGGER_MAIN = "anaconda.main"
 LOGGER_STDOUT = "anaconda.stdout"
 LOGGER_STDERR = "anaconda.stdout"

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -80,7 +80,7 @@ from pykickstart.sections import NullSection, PackageSection, PostScriptSection,
 from pykickstart.version import returnClassForVersion
 
 from pyanaconda import anaconda_logging
-from pyanaconda.anaconda_loggers import get_module_logger, get_stdout_logger, get_stderr_logger, get_blivet_logger
+from pyanaconda.anaconda_loggers import get_module_logger, get_stdout_logger, get_stderr_logger, get_blivet_logger, get_anaconda_root_logger
 log = get_module_logger(__name__)
 
 stderrLog = get_stderr_logger()
@@ -1125,7 +1125,9 @@ class Logging(commands.logging.FC6_Logging):
             # not set from the command line
             level = anaconda_logging.logLevelMap[self.level]
             anaconda_logging.logger.loglevel = level
-            anaconda_logging.setHandlersLevel(anaconda_logging, level)
+            # set log level for the "anaconda" root logger
+            anaconda_logging.setHandlersLevel(get_anaconda_root_logger(), level)
+            # set log level for the storage logger
             anaconda_logging.setHandlersLevel(storage_log, level)
 
         if anaconda_logging.logger.remote_syslog is None and len(self.host) > 0:


### PR DESCRIPTION
The first commit adds a getter for the "anaconda" root logger and the second commit fixes the actual mixup.