### PR TITLE
Remove unused argument and code.

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -1209,14 +1209,11 @@ class PackagePayload(Payload):
     def environmentDescription(self, environmentid):
         raise NotImplementedError()
 
-    def selectEnvironment(self, environmentid, excluded=None):
+    def selectEnvironment(self, environmentid):
         if environmentid not in self.environments:
             raise NoSuchGroup(environmentid)
 
         self.data.packages.environment = environmentid
-
-        if excluded is None:
-            excluded = []
 
     def environmentGroups(self, environmentid, optional=True):
         raise NotImplementedError()


### PR DESCRIPTION
Maybe it is not so simple, should we keep the optional kwarg? I didn't find any place using the kwarg, so perhaps it is only some refactoring fallout. I hope it is not used by some addon or installclass out of our git repo.