### PR TITLE
Disable test-install in Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -206,7 +206,7 @@ runglade:
 	GLADE_MODULE_SEARCH_PATH=$(builddir)/widgets/src/.libs \
 	glade ${GLADE_FILE}
 
-isolated-ci: test-install
+isolated-ci: rc-release
 # Add our daily build repositories in the mock config file
 	sed -e "s/@DISTRO@/$(DIST_NAME)/" -e "s/@ARCH@/$(ARCH_NAME)/" $(MOCK_CONF_TEMPLATE) > $(MOCK_CONF_OUT)
 	@-rm -f tests/error_occured
@@ -228,7 +228,7 @@ isolated-ci: test-install
 		exit $$status; \
 	fi
 
-ci: test-install
+ci: rc-release
 	$(MAKE) bare-ci
 
 bare-ci:


### PR DESCRIPTION
Purpose of this test is to find out if all dependencies can be resolved on a target Fedora release. However, we don't want to block other tests because there is a missing dependency on Fedora.

This should be run as separate CI job and it should have informative purpose only.