### PR TITLE
Make geolocation with kickstart possible (#1358331)

### DIFF
--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -167,6 +167,10 @@ Configure geolocation usage in Anaconda. Geolocation is used to pre-set language
 The following values for PROVIDER_ID are supported: 0 - disable geolocation, "provider_fedora_geoip"
 - use the Fedora GeoIP API (default) and "provider_hostip" - use the Hostip.info GeoIP API.
 
+geoloc-use-with-ks
+Enable geolocation even during a kickstart installation (both partial and fully automatic).
+Otherwise geolocation is only enabled during a fully interactive installation.
+
 nomount
 Don't automatically mount any installed Linux partitions in rescue mode.
 

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -368,6 +368,14 @@ language and time zone.
 ``inst.geoloc=provider_hostip``
     Use the Hostip.info GeoIP API.
 
+.. inst.geoloc-use-with-ks
+
+inst.geoloc-use-with-ks
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Enable geolocation even during a kickstart installation (both partial and fully automatic).
+Otherwise geolocation is only enabled during a fully interactive installation.
+
 .. inst.keymap:
 
 inst.keymap

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -508,6 +508,8 @@ def getArgumentParser(version_string, boot_cmdline=None):
 
     # Geolocation
     ap.add_argument("--geoloc", metavar="PROVIDER_ID", help=help_parser.help_text("geoloc"))
+    ap.add_argument("--geoloc-use-with-ks", action="store_true", default=False,
+                    help=help_parser.help_text("geoloc-use-with-ks"))
 
     # legacy stuff
     ap.add_argument("--legacygrub", dest="legacygrub", action="store_true",

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -80,6 +80,9 @@ class BaseInstallClass(object):
     # state firstboot should be in unless something special happens
     firstboot = FIRSTBOOT_DEFAULT
 
+    # geolocation
+    use_geolocation_with_kickstart = False
+
     @property
     def l10n_domain(self):
         if self._l10n_domain is None:

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -33,7 +33,6 @@ import os
 from pyanaconda import iutil
 from pyanaconda import product
 from pyanaconda import constants
-from pyanaconda import geoloc
 from pyanaconda import anaconda_logging
 from pyanaconda import network
 from pyanaconda import safe_dbus
@@ -205,23 +204,6 @@ def check_memory(anaconda, options, display_mode=None):
                 stdout_log.warning(reason % reason_args)
                 anaconda.display_mode = constants.DisplayModes.TUI
                 time.sleep(2)
-
-def start_geolocation(provider_id=constants.GEOLOC_DEFAULT_PROVIDER):
-    """Start an asynchronous geolocation attempt.
-
-    The data from geolocation is used to pre-select installation language and timezone.
-
-    :param str provider_id: geolocation provider id
-    """
-    # check if the provider id is valid
-    parsed_id = geoloc.get_provider_id_from_option(provider_id)
-    if parsed_id is None:
-        log.error('geoloc: wrong provider id specified: %s', provider_id)
-    else:
-        provider_id = parsed_id
-    # instantiate the geolocation module and start location data refresh
-    geoloc.init_geolocation(provider_id=provider_id)
-    geoloc.refresh()
 
 def setup_logging_from_options(options):
     """Configure logging according to Anaconda command line/boot options.


### PR DESCRIPTION
Make it possible to use geolocation during a kickstart based
installation. Geolocation is disabled by default during a kickstart
installation to make it more deterministic and independent on geographic
location of the machine.

To enable geolocation during a kickstart installation, use the
inst.geoloc-use-with-ks=1 option (or the --geoloc-use-with-ks=1 option
when running Anaconda as an application from the command line).

There is also an API that install classes can use to enable geolocation
during kickstart installations - the use_geolocation_with_kickstart
attribute.

Resolves: rhbz#1358331