### PR TITLE
Fix the 'non-ASCII characters in password' checks (#1413813)

### DIFF
--- a/pyanaconda/ui/gui/spokes/password.py
+++ b/pyanaconda/ui/gui/spokes/password.py
@@ -202,11 +202,11 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
             elif failed_check == self._pwEmptyCheck:
                 self.waive_clicks += 1
                 self._pwEmptyCheck.update_check_status()
+            elif failed_check == self._pwASCIICheck:
+                self.waive_ASCII_clicks += 1
+                self._pwASCIICheck.update_check_status()
             elif failed_check:  # no failed checks -> failed_check == None
                 failed_check.update_check_status()
-        elif failed_check == self._pwASCIICheck:
-            self.waive_ASCII_clicks += 1
-            self._pwASCIICheck.update_check_status()
 
         if GUISpokeInputCheckHandler.on_back_clicked(self, button):
             NormalSpoke.on_back_clicked(self, button)

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -544,11 +544,11 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
             elif failed_check == self._pwEmptyCheck:
                 self.waive_clicks += 1
                 self._pwEmptyCheck.update_check_status()
+            elif failed_check == self._pwASCIICheck:
+                self.waive_ASCII_clicks += 1
+                self._pwASCIICheck.update_check_status()
             elif failed_check:  # no failed checks -> failed_check == None
                 failed_check.update_check_status()
-        elif failed_check == self._pwASCIICheck:
-            self.waive_ASCII_clicks += 1
-            self._pwASCIICheck.update_check_status()
 
         # If there is no user set, skip the checks
         if not self.username.get_text():


### PR DESCRIPTION
Currently, you can never successfully click through the 'non-
ASCII characters in password' warning. This is because the
`elif failed_check == self._pwASCIICheck:` blocks are wrongly
indented - they go with `if not self.policy.strict`, so they
would *only* kick in if the 'strict' policy was active. They
should be indented one additional level so they go with all
the *other* `if failed_check` conditionals. It also seems
logical to move them above the `elif failed_check:` catch-all.