### PR TITLE
Fix import from a renamed module (#1462538)

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -19,7 +19,7 @@
 #
 
 from pyanaconda.errors import ScriptError, errorHandler
-from pyanaconda.threads import threadMgr
+from pyanaconda.threading import threadMgr
 from blivet.deviceaction import ActionCreateFormat, ActionResizeDevice, ActionResizeFormat
 from blivet.devices import LUKSDevice
 from blivet.devices.lvm import LVMVolumeGroupDevice, LVMCacheRequest, LVMLogicalVolumeDevice


### PR DESCRIPTION
Module pyanaconda.threads has been renamed to pyanaconda.threading.

Resolves: rhbz#1462538