### PR TITLE
Use context manager to check KickstartError

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -719,9 +719,11 @@ if __name__ == "__main__":
 
     # Create pre-install snapshots
     from pykickstart.constants import SNAPSHOT_WHEN_PRE_INSTALL
+    from pyanaconda.kickstart import check_kickstart_error
     if ksdata.snapshot.has_snapshot(SNAPSHOT_WHEN_PRE_INSTALL):
-        ksdata.snapshot.pre_setup(anaconda.storage, ksdata, anaconda.instClass)
-        ksdata.snapshot.pre_execute(anaconda.storage, ksdata, anaconda.instClass)
+        with check_kickstart_error():
+            ksdata.snapshot.pre_setup(anaconda.storage, ksdata, anaconda.instClass)
+            ksdata.snapshot.pre_execute(anaconda.storage, ksdata, anaconda.instClass)
 
     anaconda._intf.setup(ksdata)
     anaconda._intf.run()

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -46,6 +46,7 @@ import os.path
 import tempfile
 from pyanaconda.flags import flags, can_touch_runtime_system
 from pyanaconda.constants import ADDON_PATHS, IPMI_ABORTED, TEXT_ONLY_TARGET, GRAPHICAL_TARGET, THREAD_STORAGE
+from contextlib import contextmanager
 import shlex
 import requests
 import sys
@@ -89,6 +90,17 @@ stderrLog = logging.getLogger("anaconda.stderr")
 storage_log = logging.getLogger("blivet")
 stdoutLog = logging.getLogger("anaconda.stdout")
 from pyanaconda import anaconda_log
+
+@contextmanager
+def check_kickstart_error():
+    try:
+        yield
+    except KickstartError as e:
+        # We do not have an interface here yet, so we cannot use our error
+        # handling callback.
+        print(e)
+        iutil.ipmi_report(IPMI_ABORTED)
+        sys.exit(1)
 
 class AnacondaKSScript(KSScript):
     """ Execute a kickstart script
@@ -2266,14 +2278,8 @@ def preScriptPass(f):
     # generates an included file that has commands for later.
     ksparser = AnacondaPreParser(AnacondaKSHandler())
 
-    try:
+    with check_kickstart_error():
         ksparser.readKickstart(f)
-    except KickstartError as e:
-        # We do not have an interface here yet, so we cannot use our error
-        # handling callback.
-        print(e)
-        iutil.ipmi_report(IPMI_ABORTED)
-        sys.exit(1)
 
     # run %pre scripts
     runPreScripts(ksparser.handler.scripts)


### PR DESCRIPTION
Code for the checking if KickstartError raised were copied in the code. Use context manager to avoid copying.

*Resolves: rhbz#1463118*

*Reported-by: Peter Kotvan <pkotvan@redhat.com>*
(cherry picked from commit fa68680d0c13fb3edec2e942c587bea49f8b78da)