### PR TITLE
rpmostreepayload: Stub out payload methods which use `import rpm`

### DIFF
--- a/pyanaconda/packaging/rpmostreepayload.py
+++ b/pyanaconda/packaging/rpmostreepayload.py
@@ -239,6 +239,17 @@ class RPMOSTreePayload(ArchivePayload):
         # per-machine.
         pass
 
+    def dracutSetupArgs(self):
+        # Override this as it does `import rpm` which can make the
+        # rpmdb incorrectly before we've set up the /var mount point;
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1462979
+        return []
+
+    def _setDefaultBootTarget(self):
+        # Also override this; the boot target is set in the treecompose,
+        # and it also does an `import rpm`
+        pass
+
     def postInstall(self):
         super(RPMOSTreePayload, self).postInstall()
 


### PR DESCRIPTION
I'm not entirely sure what changed from 7.3 to 7.4 to cause this
to start breaking; we're getting an uninitialized rpm database in
`/var/lib/rpm` instead of the default rpmostree version of `/usr/share/rpm`.
This happens because of 2 methods which are doing `import rpm`
inside anaconda *before* we've had a chance to run systemd-tmpfiles and
set up the compatibility link.

Related: rhbz#1462979