### PR TITLE
Fix location of the blivet-gui user help

### DIFF
--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -61,7 +61,7 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
     # title of the spoke (will be displayed on the hub)
     title = CN_("GUI|Spoke", "_BLIVET-GUI PARTITIONING")
 
-    helpFile = "BlivetGuiSpoke.xml"
+    helpFile = "blivet-gui/index.page"
 
     ### methods defined by API ###
     def __init__(self, data, storage, payload, instclass):


### PR DESCRIPTION
blivet-gui help is written in Mallard and yelp refuses to open it if there is no "index.page" file in the directory, so I renamed it to "index.page" and put in a separate directory.

This needs a new version of "anaconda-user-help" package to work, but we can merge this without it (it's broken right now too).