### PR TITLE
Require "blivet-gui-runtime" instead of "blivet-gui"

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -39,7 +39,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libtimezonemapver 0.4.1-2
 %define helpver 22.1-1
 %define libblockdevver 2.1
-%define blivetguiver 2.1.4
+%define blivetguiver 2.1.5-2
 
 BuildRequires: audit-libs-devel
 BuildRequires: gettext >= %{gettextver}
@@ -184,7 +184,7 @@ Requires: NetworkManager-wifi
 Requires: anaconda-user-help >= %{helpver}
 Requires: yelp
 Requires: python3-gobject-base
-Requires: blivet-gui >= %{blivetguiver}
+Requires: blivet-gui-runtime >= %{blivetguiver}
 
 # Needed to compile the gsettings files
 BuildRequires: gsettings-desktop-schemas


### PR DESCRIPTION
blivet-gui package has been split into two packages and Anaconda
needs the new one.

Related: rhbz#1449752

-------
PR https://github.com/rhinstaller/blivet-gui/pull/75 needs to be merged first and we have to do the update together with a new build of blivet-gui. This is a final blocker for f26 so we can wait after the final freeze.