### PR TITLE
Fix a typo in python-meh initialization (#1462825)

### DIFF
--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -277,7 +277,7 @@ def initExceptionHandling(anaconda):
                                 "_bootloader.password",
                                 "payload._groups"],
                   localSkipList=["passphrase", "password", "_oldweak", "_password", "try_passphrase"],
-                  file_list=file_list)
+                  fileList=file_list)
 
     conf.register_callback("lsblk_output", lsblk_callback, attchmnt_only=True)
     conf.register_callback("nmcli_dev_list", nmcli_dev_list_callback,


### PR DESCRIPTION
Fix a typo in initialization of the python-meh provided Config class.

A while ago the fileList parameter was renamed to file_list on Anaconda
side due to a small refactoring error. Unfortunately the __init__()
method of the Config class silently accepts *any parameter names whatsoever*,
even if they don't match the parameters it actually accepts.

End result: The additional log files Anaconda specifies are not included
            in the dump as file_list != fileList.

So let's:
- fix parameter name
- add "Make the __init__() method of the python-meh Config class sane"
  to our TODO list