### PR TITLE
Support for installclass command and refactorization

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -19,7 +19,7 @@ Source0: %{name}-%{version}.tar.bz2
 # match the requires versions of things).
 
 %define gettextver 0.19.8
-%define pykickstartver 2.35-1
+%define pykickstartver 2.36-1
 %define dnfver 2.2.0
 %define partedver 1.8.1
 %define pypartedver 2.5-2

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -91,7 +91,14 @@ class Anaconda(object):
     def instClass(self):
         if not self._instClass:
             from pyanaconda.installclass import factory
-            self._instClass = factory.get_best_install_class()
+
+            # Get install class by name.
+            if self.ksdata.installclass.seen:
+                name = self.ksdata.installclass.name
+                self._instClass = factory.get_install_class_by_name(name)
+            # Or just find the best one.
+            else:
+                self._instClass = factory.get_best_install_class()
 
         return self._instClass
 

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -90,8 +90,8 @@ class Anaconda(object):
     @property
     def instClass(self):
         if not self._instClass:
-            from pyanaconda.installclass import DefaultInstall
-            self._instClass = DefaultInstall()
+            from pyanaconda.installclass import factory
+            self._instClass = factory.get_best_install_class()
 
         return self._instClass
 

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -193,6 +193,17 @@ class InstallClassFactory(object):
         self._visible_classes = []
         self._paths = []
 
+    def get_install_class_by_name(self, name):
+        """Return an instance of an install class with a requested name."""
+        for install_class in self.classes:
+            if install_class.name == name:
+                log.info("Using the requested install class %s.",
+                         self._get_class_description(install_class))
+
+                return install_class()
+
+        raise RuntimeError("Unable to find the install class %s.", name)
+
     def get_best_install_class(self):
         """Return the instance of the best found install class."""
         if self.visible_classes:

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -22,23 +22,26 @@
 #
 
 from distutils.sysconfig import get_python_lib
-import os, sys
-import imp
+import os
+import sys
 
 from blivet.partspec import PartSpec
 from blivet.autopart import swap_suggestion
 from blivet.platform import platform
 from blivet.size import Size
 
-from pyanaconda.anaconda_loggers import get_module_logger
-log = get_module_logger(__name__)
-
 from pyanaconda.kickstart import getAvailableDiskSpace
 from pyanaconda.constants import STORAGE_SWAP_IS_RECOMMENDED
 from pykickstart.constants import FIRSTBOOT_DEFAULT
+from pyanaconda.iutil import collect
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
 
 class BaseInstallClass(object):
     # default to not being hidden
+    sortPriority = 0
     hidden = False
     name = "base"
     bootloaderTimeoutDefault = None
@@ -181,114 +184,109 @@ class BaseInstallClass(object):
     def __init__(self):
         pass
 
-allClasses = []
-allClasses_hidden = []
 
-# returns ( className, classObject ) tuples
-def availableClasses(showHidden=False):
-    global allClasses
-    global allClasses_hidden
+class InstallClassFactory(object):
+    """Class used to get an install class instance."""
 
-    if not showHidden:
-        if allClasses:
-            return allClasses
-    else:
-        if allClasses_hidden:
-            return allClasses_hidden
-
-    path = []
-
-    env_path = []
-    if "ANACONDA_INSTALL_CLASSES" in os.environ:
-        env_path += os.environ["ANACONDA_INSTALL_CLASSES"].split(":")
-
-    for d in env_path + ["installclasses",
-              "/tmp/updates/pyanaconda/installclasses",
-              "/tmp/product/pyanaconda/installclasses",
-              "%s/pyanaconda/installclasses" % get_python_lib(plat_specific=1)]:
-        if os.access(d, os.R_OK):
-            path.append(d)
-
-    # append the location of installclasses to the python path so we
-    # can import them
-    sys.path = path + sys.path
-
-    files = []
-    for p in reversed(path):
-        files += os.listdir(p)
-
-    done = {}
-    lst = []
-    for fileName in files:
-        if fileName[0] == '.':
-            continue
-        if len(fileName) < 4:
-            continue
-        if fileName[-3:] != ".py" and fileName[-4:-1] != ".py":
-            continue
-        mainName = fileName.split(".")[0]
-        if mainName in done:
-            continue
-        done[mainName] = 1
-
-        try:
-            found = imp.find_module(mainName)
-        except ImportError:
-            log.warning("module import of %s failed: %s", mainName, sys.exc_info()[0])
-            continue
-
-        try:
-            loaded = imp.load_module(mainName, found[0], found[1], found[2])
-
-            for (_key, obj) in loaded.__dict__.items():
-                # If it's got these two methods, it's an InstallClass.
-                if hasattr(obj, "setDefaultPartitioning") and hasattr(obj, "setPackageSelection"):
-                    sortOrder = getattr(obj, "sortPriority", 0)
-                    if not obj.hidden or showHidden:
-                        lst.append(((obj.name, obj), sortOrder))
-        except (ImportError, AttributeError):
-            log.warning("module import of %s failed: %s", mainName, sys.exc_info()[0])
-
-    # sort by sort order first, then by install class name
-    lst.sort(key=lambda x: (x[1], x[0][0]))
-    for (item, _) in lst:
-        if showHidden:
-            allClasses_hidden += [item]
-        else:
-            allClasses += [item]
-
-    if showHidden:
-        return allClasses_hidden
-    else:
-        return allClasses
-
-def getBaseInstallClass():
-    # figure out what installclass we should base on.
-    allavail = availableClasses(showHidden=True)
-    avail = availableClasses(showHidden=False)
-
-    if len(avail) == 1:
-        (cname, cobject) = avail[0]
-        log.info("using only installclass %s", cname)
-    elif len(allavail) == 1:
-        (cname, cobject) = allavail[0]
-        log.info("using only installclass %s", cname)
-
-    # Use the highest priority install class if more than one found.
-    elif len(avail) > 1:
-        (cname, cobject) = avail.pop()
-        log.info('%s is the highest priority installclass, using it', cname)
-    elif len(allavail) > 1:
-        (cname, cobject) = allavail.pop()
-        log.info('%s is the highest priority installclass, using it', cname)
-    else:
-        raise RuntimeError("Unable to find an install class to use!!!")
-
-    return cobject
-
-baseclass = getBaseInstallClass()
-
-# we need to be able to differentiate between this and custom
-class DefaultInstall(baseclass):
     def __init__(self):
-        baseclass.__init__(self)
+        self._classes = []
+        self._visible_classes = []
+        self._paths = []
+
+    def get_best_install_class(self):
+        """Return the instance of the best found install class."""
+        if self.visible_classes:
+            install_class = self.visible_classes[0]
+            log.info("Using a visible install class %s.",
+                     self._get_class_description(install_class))
+
+        elif self.classes:
+            install_class = self.classes[0]
+            log.info("Using a hidden install class %s.",
+                     self._get_class_description(install_class))
+
+        else:
+            raise RuntimeError("Unable to find an install class to use.")
+
+        return install_class()
+
+    @property
+    def paths(self):
+        """Return paths where to look for install classes."""
+        if not self._paths:
+            self._paths = self._get_install_class_paths()
+
+        return self._paths
+
+    @property
+    def classes(self):
+        """Return all available install classes."""
+        if not self._classes:
+            self._classes = self._get_available_classes(self.paths)
+
+        return self._classes
+
+    @property
+    def visible_classes(self):
+        """Return only install classes that are not hidden."""
+        if not self._visible_classes:
+            self._visible_classes = list(filter(self._is_visible_class, self.classes))
+
+        return self._visible_classes
+
+    @staticmethod
+    def _is_visible_class(obj):
+        """Is the class visible?"""
+        return not obj.hidden
+
+    @staticmethod
+    def _is_install_class(obj):
+        """Is the class the install class?"""
+        return issubclass(obj, BaseInstallClass) and obj != BaseInstallClass
+
+    @staticmethod
+    def _get_install_class_key(obj):
+        """Return the install class key for sorting."""
+        return obj.sortPriority, obj.name
+
+    @staticmethod
+    def _get_class_description(install_class):
+        """Return the description of the install class."""
+        return "%s (%s)" % (install_class.name, install_class.__name__)
+
+    def _get_install_class_paths(self):
+        """Return a list of paths to directories with install classes."""
+        path = []
+
+        if "ANACONDA_INSTALL_CLASSES" in os.environ:
+            path += os.environ["ANACONDA_INSTALL_CLASSES"].split(":")
+
+        path += [
+            "installclasses",
+            "/tmp/updates/pyanaconda/installclasses",
+            "/tmp/product/pyanaconda/installclasses",
+            "%s/pyanaconda/installclasses" % get_python_lib(plat_specific=1)
+        ]
+
+        return list(filter(lambda d: os.access(d, os.R_OK), path))
+
+    def _get_available_classes(self, paths):
+        """Return a list of available install classes."""
+        # Append the location of install classes to the python path
+        # so install classes can import and inherit correct classes.
+        sys.path = paths + sys.path
+
+        classes = set()
+        for path in paths:
+            log.debug("Searching %s.", path)
+
+            for install_class in collect("%s", path, self._is_install_class):
+                log.debug("Found %s.", self._get_class_description(install_class))
+                classes.add(install_class)
+
+        # Classes are sorted by their priority and name in the reversed order,
+        # so classes with the highest priority and longer name are preferred.
+        # For example, Fedora Workstation doesn't have higher priority.
+        return sorted(classes, key=self._get_install_class_key, reverse=True)
+
+factory = InstallClassFactory()

--- a/pyanaconda/installclasses/centos.py
+++ b/pyanaconda/installclasses/centos.py
@@ -22,6 +22,9 @@ from pyanaconda.product import productName
 from pyanaconda import network
 from pyanaconda import nm
 
+__all__ = ["CentOSBaseInstallClass"]
+
+
 class CentOSBaseInstallClass(BaseInstallClass):
     name = "CentOS Linux"
     sortPriority = 10000

--- a/pyanaconda/installclasses/fedora.py
+++ b/pyanaconda/installclasses/fedora.py
@@ -22,6 +22,9 @@ from pyanaconda.product import productName
 from pyanaconda import network
 from pyanaconda import nm
 
+__all__ = ["FedoraBaseInstallClass"]
+
+
 class FedoraBaseInstallClass(BaseInstallClass):
     name = "Fedora"
     sortPriority = 10000

--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -22,6 +22,9 @@ from pyanaconda.product import productName
 from pyanaconda import network
 from pyanaconda import nm
 
+__all__ = ["RHELBaseInstallClass"]
+
+
 class RHELBaseInstallClass(BaseInstallClass):
     name = "Red Hat Enterprise Linux"
     sortPriority = 10000

--- a/pyanaconda/installclasses/scientific.py
+++ b/pyanaconda/installclasses/scientific.py
@@ -18,6 +18,9 @@
 from pyanaconda.installclasses.rhel import RHELBaseInstallClass
 from pyanaconda.product import productName
 
+__all__ = ["ScientificBaseInstallClass"]
+
+
 class ScientificBaseInstallClass(RHELBaseInstallClass):
     '''
         Scientific Linux is a Free RHEL rebuild.

--- a/tests/pyanaconda_tests/installclass_test.py
+++ b/tests/pyanaconda_tests/installclass_test.py
@@ -1,0 +1,174 @@
+#
+# Vendula Poncova <vponcova@redhat.com>
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+
+import unittest
+from mock import patch
+from pyanaconda.installclass import BaseInstallClass, InstallClassFactory
+
+
+class FactoryTest(unittest.TestCase):
+
+    factory_class = None
+    base_class = None
+    collect = None
+
+    def _get_fake_factory(self):
+        """Return the fake factory."""
+        factory = InstallClassFactory()
+        factory._paths = ["/fake/path"]
+        return factory
+
+    def _patch_collect(self, collected):
+        return patch("pyanaconda.installclass.collect", lambda *x: collected)
+
+    def path_test(self):
+        """Test paths to install classes."""
+        # Test the fake factory,
+        factory = self._get_fake_factory()
+        self.assertEqual(factory.paths, ["/fake/path"])
+
+        # Test the real factory.
+        factory = InstallClassFactory()
+        # There should be always at least one path.
+        self.assertTrue(any(filter(lambda p: p.endswith("/pyanaconda/installclasses"), factory.paths)))
+
+    def simple_test(self):
+        """Test the basic factory methods."""
+
+        class NotInstallClass(object):
+            name = "Not Install Class"
+            hidden = False
+            sortPriority = 1
+
+        class InstallClass(BaseInstallClass):
+            name = "Install Class"
+            hidden = True
+            sortPriority = 2
+
+        class ChildInstallClass(InstallClass):
+            name = "Child Install Class"
+            hidden = False
+            sortPriority = 3
+
+        factory = self._get_fake_factory()
+
+        # Test if class is an install class.
+        self.assertEqual(factory._is_install_class(BaseInstallClass), False)
+        self.assertEqual(factory._is_install_class(NotInstallClass), False)
+        self.assertEqual(factory._is_install_class(InstallClass), True)
+        self.assertEqual(factory._is_install_class(ChildInstallClass), True)
+
+        # Test if class is visible.
+        self.assertEqual(factory._is_visible_class(InstallClass), False)
+        self.assertEqual(factory._is_visible_class(ChildInstallClass), True)
+
+        # Test a description.
+        self.assertEqual(factory._get_class_description(InstallClass), "Install Class (InstallClass)")
+
+        # Test a key.
+        self.assertEqual(factory._get_install_class_key(InstallClass), (2, "Install Class"))
+        self.assertEqual(factory._get_install_class_key(ChildInstallClass), (3, "Child Install Class"))
+
+    def collect_test(self):
+        """Test the collecting of the install classes."""
+
+        class InstallClassA(BaseInstallClass):
+            name = "Install Class A"
+            hidden = True
+            sortPriority = 1
+
+        class InstallClassB(BaseInstallClass):
+            name = "Install Class B"
+            hidden = False
+            sortPriority = 2
+
+        class InstallClassC(BaseInstallClass):
+            name = "Install Class C"
+            hidden = False
+            sortPriority = 3
+
+        # Test with no available classes.
+        with self._patch_collect([]):
+            factory = self._get_fake_factory()
+            self.assertEqual(factory.classes, [])
+            self.assertEqual(factory.visible_classes, [])
+
+            with self.assertRaises(RuntimeError):
+                factory.get_best_install_class()
+
+            with self.assertRaises(RuntimeError):
+                factory.get_install_class_by_name("Install Class A")
+
+        # Test with one hidden class.
+        with self._patch_collect([InstallClassA]):
+            factory = self._get_fake_factory()
+            self.assertEqual(factory.classes, [InstallClassA])
+            self.assertEqual(factory.visible_classes, [])
+
+            self.assertTrue(isinstance(factory.get_best_install_class(), InstallClassA))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class A"), InstallClassA))
+
+            with self.assertRaises(RuntimeError):
+                factory.get_install_class_by_name("Install Class B")
+
+        with self._patch_collect([InstallClassA, InstallClassB, InstallClassC]):
+            factory = self._get_fake_factory()
+            self.assertEqual(factory.classes, [InstallClassC, InstallClassB, InstallClassA])
+            self.assertEqual(factory.visible_classes, [InstallClassC, InstallClassB])
+
+            self.assertTrue(isinstance(factory.get_best_install_class(), InstallClassC))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class A"), InstallClassA))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class B"), InstallClassB))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class C"), InstallClassC))
+
+            with self.assertRaises(RuntimeError):
+                factory.get_install_class_by_name("Install Class D")
+
+    def sort_test(self):
+        """Test that the install classes are sorted as expected."""
+
+        class InstallClassA1(BaseInstallClass):
+            name = "Install Class A"
+            hidden = False
+            sortPriority = 1
+
+        class InstallClassA2(BaseInstallClass):
+            name = "Install Class A"
+            hidden = False
+            sortPriority = 2
+
+        class InstallClassB1(BaseInstallClass):
+            name = "Install Class B 1"
+            hidden = False
+            sortPriority = 3
+
+        class InstallClassB2(BaseInstallClass):
+            name = "Install Class B 2"
+            hidden = False
+            sortPriority = 3
+
+        with self._patch_collect([InstallClassA1, InstallClassA2, InstallClassB1, InstallClassB2]):
+            factory = self._get_fake_factory()
+            self.assertEqual(factory.classes, [InstallClassB2, InstallClassB1, InstallClassA2, InstallClassA1])
+
+            self.assertTrue(isinstance(factory.get_best_install_class(), InstallClassB2))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class A"), InstallClassA2))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class B 1"), InstallClassB1))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class B 2"), InstallClassB2))

--- a/tests/storage/cases/__init__.py
+++ b/tests/storage/cases/__init__.py
@@ -26,7 +26,7 @@ blivet_log = logging.getLogger("blivet")
 blivet_log.info(sys.argv[0])
 
 from pyanaconda.bootloader import BootLoaderError
-from pyanaconda.installclass import DefaultInstall
+from pyanaconda.installclass import factory
 from pyanaconda.kickstart import AnacondaKSHandler, AnacondaKSParser, doKickstartStorage
 from pykickstart.errors import KickstartError
 
@@ -198,7 +198,7 @@ class TestCaseComponent(object):
             parser = AnacondaKSParser(AnacondaKSHandler())
             parser.readKickstartFromString(self.ks)
 
-            instClass = DefaultInstall()
+            instClass = factory.get_best_install_class()
 
             self.setupDisks(parser.handler)
 


### PR DESCRIPTION
The install class can be now specified in the kickstart file by its name.

The logic for loading install classes is now hidden in the `InstallClassFactory`. 
The `availableClasses` method was removed, since we can use `collect` from 
`pyanaconda.iutil`. The class `DefaultInstall` was removed as well, because it 
was useless. Added tests for the `InstallClassFactory`.

Modules with install classes should define `__all__`.  Otherwise, when the 
module is loaded, anaconda again discovers also the imported install 
classes (like the base install class).

Depends on https://github.com/rhinstaller/pykickstart/pull/160

