### PR TITLE
gui: show supported locales on Atomic Host installs

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -351,9 +351,6 @@ If a language has been specified via the `inst.lang`_ boot option
 or the `lang` kickstart command it will be used.
 If no language is specified Anaconda will default to en_US.UTF-8.
 
-.. NOTE::
-         Atomic installations always run in single language mode.
-
 .. inst.geoloc:
 
 inst.geoloc

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -172,6 +172,12 @@ class BaseInstallClass(object):
     def setNetworkOnbootDefault(self, ksdata):
         pass
 
+    def filterSupportedLangs(self, ksdata, langs):
+        return langs
+
+    def filterSupportedLocales(self, ksdata, lang, locales):
+        return locales
+
     def __init__(self):
         pass
 

--- a/pyanaconda/ui/gui/spokes/langsupport.py
+++ b/pyanaconda/ui/gui/spokes/langsupport.py
@@ -139,10 +139,16 @@ class LangsupportSpoke(LangLocaleHandler, NormalSpoke):
     def completed(self):
         return True
 
+    def _filter_languages(self, langs):
+        return self.instclass.filterSupportedLangs(self.data, langs)
+
     def _add_language(self, store, native, english, lang):
         native_span = '<span lang="%s">%s</span>' % \
                 (escape_markup(lang), escape_markup(native))
         store.append([native_span, english, lang])
+
+    def _filter_locales(self, lang, locales):
+        return self.instclass.filterSupportedLocales(self.data, lang, locales)
 
     def _add_locale(self, store, native, locale):
         native_span = '<span lang="%s">%s</span>' % \

--- a/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
+++ b/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
@@ -70,7 +70,9 @@ class LangLocaleHandler(object):
                                "pixbuf", self._render_lang_selected)
 
         # fill the list with available translations
-        for lang in localization.get_available_translations():
+        langs = localization.get_available_translations()
+        langs = self._filter_languages(langs)
+        for lang in langs:
             self._add_language(self._languageStore,
                                localization.get_native_name(lang),
                                localization.get_english_name(lang), lang)
@@ -113,7 +115,17 @@ class LangLocaleHandler(object):
         else:
             return None
 
+    def _filter_languages(self, langs):
+        """Override this method with a valid implementation"""
+
+        raise NotImplementedError()
+
     def _add_language(self, store, native, english, lang):
+        """Override this method with a valid implementation"""
+
+        raise NotImplementedError()
+
+    def _filter_locales(self, lang, locales):
         """Override this method with a valid implementation"""
 
         raise NotImplementedError()
@@ -153,6 +165,7 @@ class LangLocaleHandler(object):
 
         self._localeStore.clear()
         locales = localization.get_language_locales(lang)
+        locales = self._filter_locales(lang, locales)
         for locale in locales:
             self._add_locale(self._localeStore,
                              localization.get_native_name(locale),

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -247,11 +247,17 @@ class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
         self._languageEntry.set_text("")
         self._languageStoreFilter.refilter()
 
+    def _filter_languages(self, langs):
+        return self.instclass.filterSupportedLangs(self.data, langs)
+
     def _add_language(self, store, native, english, lang):
         native_span = '<span lang="%s">%s</span>' % \
                 (escape_markup(lang),
                  escape_markup(native))
         store.append([native_span, english, lang, False])
+
+    def _filter_locales(self, lang, locales):
+        return self.instclass.filterSupportedLocales(self.data, lang, locales)
 
     def _add_locale(self, store, native, locale):
         native_span = '<span lang="%s">%s</span>' % \


### PR DESCRIPTION
Fedora Atomic Host has never shipped with all supported locales. It
originally shipped with only `en_US`, though that was changed afterwards
to cover at least the same locales as RHEL7[1]. However, we would still
show all the locales in the installer GUI.

This patch adds support for allowing installclasses to filter locales
that should be shown based on the actual content carried in the ISO. The
Atomic installclass can then make use of this. This is essentially the
same patch as the one for rhel7-branch[2], but split out since the
Atomic installclass is not here.

[1] https://pagure.io/fedora-atomic/c/5a5edddc9a6b943e6fe902defad177009c43867a
[2] https://github.com/rhinstaller/anaconda/pull/871

Related: https://pagure.io/atomic-wg/issue/282