### PR TITLE
rpmostreepayload: use correct secondary url location

### DIFF
--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -176,7 +176,7 @@ class RPMOSTreePayload(ArchivePayload):
         # The first path here is used by <https://pagure.io/fedora-lorax-templates>
         # and the second by <https://github.com/projectatomic/rpm-ostree-toolbox/>
         if OSTree.check_version(2017, 8):
-            for path in ['/ostree/repo', '/run/install/repo']:
+            for path in ['/ostree/repo', '/run/install/repo/content/repo']:
                 if os.path.isdir(path):
                     pull_opts['localcache-repos'] = GLib.Variant('as', [path])
                     break

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -176,7 +176,7 @@ class RPMOSTreePayload(ArchivePayload):
         # The first path here is used by <https://pagure.io/fedora-lorax-templates>
         # and the second by <https://github.com/projectatomic/rpm-ostree-toolbox/>
         if OSTree.check_version(2017, 8):
-            for path in ['/ostree/repo', '/run/install/repo/content/repo']:
+            for path in ['/ostree/repo', '/install/ostree/repo']:
                 if os.path.isdir(path):
                     pull_opts['localcache-repos'] = GLib.Variant('as', [path])
                     break

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -177,7 +177,7 @@ class RPMOSTreePayload(ArchivePayload):
         # and the second by <https://github.com/projectatomic/rpm-ostree-toolbox/>
         if OSTree.check_version(2017, 8):
             for path in ['/ostree/repo', '/install/ostree/repo']:
-                if os.path.isdir(path):
+                if os.path.isdir(path + '/objects'):
                     pull_opts['localcache-repos'] = GLib.Variant('as', [path])
                     break
 


### PR DESCRIPTION
In f5263d4 we should have been using `/run/install/repo/content/repo`
since that is where we were storing ostree repos on media before
fedora 26. Using the incorrect location of `/run/install/repo/`
means that the install will fail if it is an ostree install and there
is no ostree repo at `/ostree/repo`.