### PR TITLE
Add support for automatic generating of DBus specification.

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -106,6 +106,7 @@ Requires: util-linux >= %{utillinuxver}
 Requires: python3-dbus
 Requires: python3-pwquality
 Requires: python3-systemd
+Requires: python3-pydbus
 
 # pwquality only "recommends" the dictionaries it needs to do anything useful,
 # which is apparently great for containers but unhelpful for the rest of us

--- a/pyanaconda/dbus/interface.py
+++ b/pyanaconda/dbus/interface.py
@@ -1,0 +1,403 @@
+#
+# interface.py:  support for generating XML with interface description
+#
+# Copyright (C) 2017
+# Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author(s):  Vendula Poncova <vponcova@redhat.com>
+#
+# For more info about DBus specification see:
+# https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
+#
+import inspect
+import re
+
+from inspect import Parameter
+from typing import get_type_hints
+from pydbus.generic import signal
+
+from pyanaconda.dbus.typing import get_dbus_type
+from pyanaconda.dbus.xml import XMLGenerator
+
+__all__ = ["dbus_class", "dbus_interface", "dbus_signal"]
+
+
+class dbus_signal(signal):
+    """DBus signal.
+
+    Can be used as:
+        Signal = dbus_signal()
+
+    Or as a method decorator:
+
+        @dbus_signal
+        def Signal(x: Int, y: Double):
+            pass
+
+    Signal is defined by the type hints of a decorated method.
+    This method is accessible as: signal.definition
+
+    If the signal is not defined by a method, it is expected to
+    have no arguments and signal.definition is equal to None.
+    """
+    def __init__(self, method=None):
+        super(dbus_signal, self).__init__()
+        self.definition = method
+
+
+def dbus_interface(interface_name):
+    """DBus interface.
+
+    A new DBus interface can be defined as:
+
+        @dbus_interface
+        class Interface():
+            ...
+
+    The interface will be generated from the given class cls
+    with a name interface_name and added to the DBus XML
+    specification of the class.
+
+    The XML specification is accessible as:
+        Interface.dbus
+    """
+    def decorated(cls):
+        generator = DBusSpecification()
+        cls.dbus = generator.generate_specification(cls, interface_name)
+        return cls
+    return decorated
+
+
+def dbus_class(cls):
+    """DBus class.
+
+    A new DBus class can be defined as:
+
+        @dbus_class
+        class Class(Interface):
+            ...
+
+    DBus class can implement DBus interfaces, but it cannot
+    define a new interface.
+
+    The DBus XML specification will be generated from
+    implemented interfaces (inherited) and it will be
+    accessible as:
+        Class.dbus
+    """
+    # Get the interface decorator without a name.
+    decorated = dbus_interface(None)
+    # Apply the decorator on the given class.
+    return decorated(cls)
+
+
+class DBusSpecificationError(Exception):
+    pass
+
+
+class DBusSpecification(object):
+    """Class for generating DBus XML specification."""
+
+    DIRECTION_IN = "in"
+    DIRECTION_OUT = "out"
+
+    ACCESS_READ = "read"
+    ACCESS_WRITE = "write"
+    ACCESS_READWRITE = "readwrite"
+
+    RETURN_PARAMETER = "return"
+
+    NAME_PATTERN = re.compile(r'[A-Z][A-Za-z0-9]*')
+
+    def __init__(self, xml_generator=XMLGenerator()):
+        self.xml_generator = xml_generator
+
+    def generate_specification(self, cls, interface_name=None):
+        """Generates DBus XML specification for given class.
+
+        If class defines a new interface, it will be added to
+        the specification.
+
+        :param cls: class object to decorate
+        :param str interface_name: name of the interface defined by class
+        :return str: DBus specification in XML
+        """
+        # Collect all interfaces that class inherits.
+        interfaces = self._collect_interfaces(cls)
+
+        # Generate a new interface.
+        if interface_name:
+            interface = self._generate_interface(cls, interfaces, interface_name)
+            interfaces[interface_name] = interface
+
+        # Generate XML specification for the given class.
+        node = self._generate_node(cls, interfaces)
+        return self.xml_generator.element_to_xml(node)
+
+    def _collect_interfaces(self, cls):
+        """Collect interfaces implemented by the class.
+
+        Returns a dictionary that maps interface names
+        to interface elements.
+
+        :param cls: a class object
+        :return: a dictionary of implemented interfaces
+        """
+        interfaces = dict()
+
+        # Visit cls and base classes in reversed order.
+        for member in reversed(inspect.getmro(cls)):
+            # Skip classes with no specification.
+            if not getattr(member, "dbus", None):
+                continue
+
+            # Update found interfaces.
+            node = self.xml_generator.xml_to_element(member.dbus)
+            node_interfaces = self.xml_generator.get_interfaces_from_node(node)
+            interfaces.update(node_interfaces)
+
+        return interfaces
+
+    def _generate_interface(self, cls, interfaces, interface_name):
+        """Generate interface defined by given class.
+
+        :param cls: a class object that defines the interface
+        :param interfaces: a dictionary of implemented interfaces
+        :param interface_name: a name of the new interface
+        :return: an new interface element
+
+        :raises DBusSpecificationError: if a class member cannot be exported
+        """
+        interface = self.xml_generator.get_interface_element(interface_name)
+
+        # Search class members.
+        for member_name, member in inspect.getmembers(cls):
+            # Check it the name is exportable.
+            if not self._is_exportable(member_name):
+                continue
+
+            # Skip names already defined in implemented interfaces.
+            if self._is_defined(interfaces, member_name):
+                continue
+
+            # Generate XML element for exportable member.
+            if self._is_signal(member):
+                element = self._generate_signal(member, member_name)
+            elif self._is_property(member):
+                element = self._generate_property(member, member_name)
+            elif self._is_method(member):
+                element = self._generate_method(member, member_name)
+            else:
+                raise DBusSpecificationError("%s.%s cannot be exported."
+                                             % (cls.__name__, member_name))
+
+            # Add generated element to the interface.
+            self.xml_generator.add_child(interface, element)
+
+        return interface
+
+    def _is_exportable(self, member_name):
+        """Is the name of a class member exportable?
+
+        The name is exportable if it follows the DBus specification.
+        Only CamelCase names are allowed.
+        """
+        return bool(self.NAME_PATTERN.fullmatch(member_name))
+
+    def _is_defined(self, interfaces, member_name):
+        """Is the member name defined in given interfaces?
+
+        :param interfaces: a dictionary of interfaces
+        :param member_name: a name of the class member
+        :return: True if the name is defined, otherwise False
+        """
+        for interface in interfaces.values():
+            for member in interface:
+                # Is it a signal, a property or a method?
+                if not self.xml_generator.is_member(member):
+                    continue
+                # Does it have the same name?
+                if not self.xml_generator.has_name(member, member_name):
+                    continue
+                # The member is already defined.
+                return True
+
+        return False
+
+    def _is_signal(self, member):
+        """Is the class member a DBus signal?"""
+        return isinstance(member, dbus_signal)
+
+    def _generate_signal(self, member, member_name):
+        """Generate signal defined by a class member.
+
+        :param member: a dbus_signal object.
+        :param member_name: a name of the signal
+        :return: a signal element
+
+        raises DBusSpecificationError: if signal has defined return type
+        """
+        element = self.xml_generator.get_signal_element(member_name)
+        method = member.definition
+
+        if not method:
+            return element
+
+        for name, type_hint, direction in self._iterate_parameters(method):
+            # Only input parameters can be defined.
+            if direction == self.DIRECTION_OUT:
+                raise DBusSpecificationError("Signal %s has defined return type." % member_name)
+
+            # All parameters are exported as output parameters (see specification).
+            direction = self.DIRECTION_OUT
+            parameter = self.xml_generator.create_parameter(name, get_dbus_type(type_hint), direction)
+            self.xml_generator.add_child(element, parameter)
+
+        return element
+
+    def _iterate_parameters(self, member):
+        """Iterate over method parameters.
+
+        For every parameter returns its name, a type hint and a direction.
+
+        :param member: a method object
+        :return: an iterator
+
+        raises DBusSpecificationError: if parameters are invalid
+        """
+        # Get type hints for parameters.
+        type_hints = get_type_hints(member)
+
+        # Get method signature.
+        signature = inspect.signature(member)
+
+        # Iterate over method parameters, skip self.
+        for name in list(signature.parameters)[1:]:
+            # Check the kind of the parameter
+            if signature.parameters[name].kind != Parameter.POSITIONAL_OR_KEYWORD:
+                raise DBusSpecificationError("Only positional or keyword arguments are allowed.")
+
+            # Check if the type is defined.
+            if name not in type_hints:
+                raise DBusSpecificationError("Parameter %s doesn't have defined type." % name)
+
+            yield name, type_hints[name], self.DIRECTION_IN
+
+        # Is the return type defined?
+        if signature.return_annotation is signature.empty:
+            return
+
+        # Is the return type other than None?
+        if signature.return_annotation is None:
+            return
+
+        yield self.RETURN_PARAMETER, signature.return_annotation, self.DIRECTION_OUT
+
+    def _is_property(self, member):
+        """Is the class member a DBus property?"""
+        return isinstance(member, property)
+
+    def _generate_property(self, member, member_name):
+        """Generate DBus property defined by class member.
+
+        :param member: a property object
+        :param member_name: a property name
+        :return: a property element
+
+        raises DBusSpecificationError: if the property is invalid
+        """
+        access = None
+        type_hint = None
+
+        try:
+            # Process the setter.
+            if member.fset:
+                [(_, type_hint, _)] = self._iterate_parameters(member.fset)
+                access = self.ACCESS_WRITE
+
+            # Process the getter.
+            if member.fget:
+                [(_, type_hint, _)] = self._iterate_parameters(member.fget)
+                access = self.ACCESS_READ
+
+        except ValueError:
+            raise DBusSpecificationError("Property %s has invalid parameters." % member_name)
+
+        # Property has both.
+        if member.fget and member.fset:
+            access = self.ACCESS_READWRITE
+
+        if access is None:
+            raise DBusSpecificationError("Property %s is not accessible." % member_name)
+
+        return self.xml_generator.create_property(member_name, get_dbus_type(type_hint), access)
+
+    def _is_method(self, member):
+        """Is the class member a DBus method?
+
+        Ignore the difference between instance method and class method.
+
+        For example:
+            class Foo(object):
+                def bar(self, x):
+                    pass
+
+            inspect.isfunction(Foo.bar) # True
+            inspect.isfunction(Foo().bar) # False
+
+            inspect.ismethod(Foo.bar) # False
+            inspect.ismethod(Foo().bar) # True
+
+            _is_method(Foo.bar) # True
+            _is_method(Foo().bar) # True
+        """
+        return inspect.ismethod(member) or inspect.isfunction(member)
+
+    def _generate_method(self, member, member_name):
+        """Generate method defined by given class member.
+
+        :param member: a method object
+        :param member_name: a name of the method
+        :return: a method element
+        """
+        method = self.xml_generator.get_method_element(member_name)
+
+        # Process the parameters.
+        for name, type_hint, direction in self._iterate_parameters(member):
+            # Create the parameter element.
+            parameter = self.xml_generator.create_parameter(name, get_dbus_type(type_hint), direction)
+            # Add the element to the method element.
+            self.xml_generator.add_child(method, parameter)
+
+        return method
+
+    def _generate_node(self, cls, interfaces):
+        """Generate node element that specifies the given class.
+
+        :param cls: a class object
+        :param interfaces: a dictionary of interfaces
+        :return: a node element
+        """
+        node = self.xml_generator.get_node_element()
+
+        # Add comment about specified class.
+        self.xml_generator.add_comment(node, "Specifies %s" % cls.__name__)
+
+        # Add interfaces sorted by their names.
+        for interface_name in sorted(interfaces.keys()):
+            self.xml_generator.add_child(node, interfaces[interface_name])
+
+        return node

--- a/pyanaconda/dbus/typing.py
+++ b/pyanaconda/dbus/typing.py
@@ -1,0 +1,183 @@
+#
+# typing.py:  specified DBus types and their string representation
+#
+# Copyright (C) 2017
+# Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author(s):  Vendula Poncova <vponcova@redhat.com>
+#
+# For more info about DBus type system see:
+# https://dbus.freedesktop.org/doc/dbus-specification.html#type-system.
+#
+
+from typing import Tuple, Dict, List, NewType, Any, Union, IO
+
+__all__ = ["Bool", "Double", "Str", "Int", "Byte", "Int16", "UInt16",
+           "Int32", "UInt32", "Int64", "UInt64", "File", "ObjPath",
+           "Tuple", "List", "Dict", "Variant"]
+
+# Basic types.
+Bool = bool
+Double = float
+Str = str
+
+# Default integer type: int will be treated as Int32.
+Int = int
+
+# All integer types.
+Byte = NewType('Byte', int)
+Int16 = NewType('Int16', int)
+UInt16 = NewType('UInt16', int)
+Int32 = NewType('Int32', int)
+UInt32 = NewType('UInt32', int)
+Int64 = NewType('Int64', int)
+UInt64 = NewType('UInt64', int)
+
+# Type of a file handler.
+File = IO
+
+# Type of an object path.
+ObjPath = NewType('ObjPath', str)
+
+# Container types.
+# Use Tuple, Dict and List from typing.
+
+# Variant type.
+Variant = Union[
+    Bool,
+    Double,
+    Str,
+    Int,
+    Byte,
+    Int16,
+    UInt16,
+    Int32,
+    UInt32,
+    Int64,
+    UInt64,
+    File,
+    ObjPath,
+    List[Any],
+    Dict[Any, Any],
+    Tuple[Any, ...]
+]
+
+
+def get_dbus_type(type_hint):
+    """Return DBus representation of a type hint.
+
+    :param type_hint: a type hint
+    :return: a string with DBus representation
+    """
+    return DBusType.get_dbus_representation(type_hint)
+
+
+class DBusType(object):
+    """Class for transforming type hints to DBus types."""
+
+    # DBus representation of basic types.
+    _basic_type_mapping = {
+        # Basic types.
+        Bool:       "b",
+        Str:        "s",
+        Double:     "d",
+        # Default integer.
+        Int:        "i",
+        # Integer types.
+        Byte:       "y",
+        Int16:      "n",
+        UInt16:     "q",
+        Int32:      "i",
+        UInt32:     "u",
+        Int64:      "x",
+        UInt64:     "t",
+        # Other basic types.
+        File:       "h",
+        ObjPath:    "o",
+        Variant:    "v"
+    }
+
+    # DBus representation of container types.
+    _container_type_mapping = {
+        Tuple:      "(%s)",
+        List:       "a%s",
+        Dict:       "a{%s}",
+    }
+
+    @staticmethod
+    def get_dbus_representation(type_hint):
+        """Return a DBus representation of the given type hint.
+
+        :param type_hint: a type hint
+        :return str: a DBus representation of the type hint
+
+        :raises ValueError: for unknown types
+        """
+        # Try base types.
+        if DBusType._is_basic_type(type_hint):
+            return DBusType._get_basic_type(type_hint)
+
+        # Try container types.
+        if DBusType._is_container_type(type_hint):
+            return DBusType._get_container_type(type_hint)
+
+        # Or raise an error.
+        raise ValueError("Unknown type: %s" % type_hint)
+
+    @staticmethod
+    def _is_basic_type(type_hint):
+        """Is it a basic type?"""
+        return type_hint in DBusType._basic_type_mapping
+
+    @staticmethod
+    def _get_basic_type(type_hint):
+        """Return a basic type."""
+        return DBusType._basic_type_mapping[type_hint]
+
+    @staticmethod
+    def _is_container_type(type_hint):
+        """Is it a container type?"""
+        # Try to get the "base" type of the container type.
+        origin = getattr(type_hint, "__origin__", None)
+        return origin in DBusType._container_type_mapping
+
+    @staticmethod
+    def _get_container_type(type_hint):
+        """Return a container type."""
+        # Get the "base" type of the container.
+        origin = type_hint.__origin__
+        # Get the arguments of the container.
+        args = type_hint.__args__
+
+        # Check the typing.
+        if origin == Dict:
+            DBusType._check_if_valid_dictionary(type_hint)
+
+        # Generate string.
+        container = DBusType._container_type_mapping[origin]
+        items = [DBusType.get_dbus_representation(arg) for arg in args]
+        return container % "".join(items)
+
+    @staticmethod
+    def _check_if_valid_dictionary(type_hint):
+        """Check the type of a dictionary.
+
+        :raises ValueError: for invalid type
+        """
+        key, _ = type_hint.__args__
+
+        if DBusType._is_container_type(key) or key == Variant:
+            raise ValueError("Dictionary key cannot be of type %s." % key)

--- a/pyanaconda/dbus/xml.py
+++ b/pyanaconda/dbus/xml.py
@@ -1,0 +1,117 @@
+#
+# xml.py:  support for generating XML with interface description
+#
+# Copyright (C) 2017
+# Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author(s):  Vendula Poncova <vponcova@redhat.com>
+#
+# For more info about DBus specification see:
+# https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
+#
+from xml.etree import ElementTree
+from xml.dom import minidom
+
+
+class XMLGenerator(object):
+    """Class for creating XML and XML elements."""
+
+    @staticmethod
+    def element_to_xml(element):
+        """Return XML of the element."""
+        return ElementTree.tostring(element, method="xml", encoding="unicode")
+
+    @staticmethod
+    def xml_to_element(xml):
+        return ElementTree.fromstring(xml)
+
+    @staticmethod
+    def prettify_xml(xml):
+        """Return pretty printed XML."""
+        # Remove newlines and extra whitespaces,
+        xml_line = "".join([line.strip() for line in xml.splitlines()])
+
+        # Generate pretty xml.
+        return minidom.parseString(xml_line).toprettyxml(indent="  ")
+
+    @staticmethod
+    def add_child(parent_element, child_element):
+        """Append the child element to the parent element."""
+        parent_element.append(child_element)
+
+    @staticmethod
+    def add_comment(element, comment):
+        element.append(ElementTree.Comment(text=comment))
+
+    @staticmethod
+    def get_node_element():
+        """Create a node element called node."""
+        return ElementTree.Element("node")
+
+    @staticmethod
+    def get_interface_element(name):
+        """Create an interface element."""
+        return ElementTree.Element("interface", {"name": name})
+
+    @staticmethod
+    def get_interfaces_from_node(node_element):
+        """Return a dictionary of interfaces defined in a node element."""
+        interfaces = dict()
+
+        for element in node_element.iterfind("interface"):
+            interfaces[element.attrib["name"]] = element
+
+        return interfaces
+
+    @staticmethod
+    def get_signal_element(name):
+        """Create a signal element."""
+        return ElementTree.Element("signal", {"name": name})
+
+    @staticmethod
+    def get_method_element(name):
+        """Create a method element."""
+        return ElementTree.Element("method", {"name": name})
+
+    @staticmethod
+    def create_parameter(name, param_type, direction):
+        """Create a parameter element."""
+        tag = "arg"
+        attr = {
+            "name": name,
+            "type": param_type,
+            "direction": direction
+        }
+        return ElementTree.Element(tag, attr)
+
+    @staticmethod
+    def create_property(name, property_type, access):
+        """Create a property element."""
+        tag = "property"
+        attr = {
+            "name": name,
+            "type": property_type,
+            "access": access
+        }
+        return ElementTree.Element(tag, attr)
+
+    @staticmethod
+    def is_member(member_node):
+        return member_node.tag in ("method", "signal", "property")
+
+    @staticmethod
+    def has_name(node, node_name):
+        return node.attrib.get("name", "") == node_name

--- a/tests/pyanaconda_tests/dbus_interface_test.py
+++ b/tests/pyanaconda_tests/dbus_interface_test.py
@@ -1,0 +1,604 @@
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+
+import unittest
+
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
+from pyanaconda.dbus.xml import XMLGenerator
+from pyanaconda.dbus.interface import DBusSpecification, DBusSpecificationError, dbus_interface, dbus_class, dbus_signal
+
+
+class InterfaceGeneratorTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.generator = DBusSpecification()
+        self.maxDiff = None
+
+    def _compare(self, cls, expected_xml):
+        """Compare cls specification with the given xml."""
+        generated_xml = cls.dbus  # pylint: disable=no-member
+        self.assertMultiLineEqual(XMLGenerator.prettify_xml(generated_xml),
+                                  XMLGenerator.prettify_xml(expected_xml))
+
+    def exportable_test(self):
+        """Test if the given name should be exported."""
+        self.assertTrue(self.generator._is_exportable("Name"))
+        self.assertTrue(self.generator._is_exportable("ValidName"))
+        self.assertTrue(self.generator._is_exportable("ValidName123"))
+        self.assertTrue(self.generator._is_exportable("Valid123Name456"))
+        self.assertTrue(self.generator._is_exportable("VALIDNAME123"))
+
+        self.assertFalse(self.generator._is_exportable("name"))
+        self.assertFalse(self.generator._is_exportable("_Name"))
+        self.assertFalse(self.generator._is_exportable("__Name"))
+        self.assertFalse(self.generator._is_exportable("invalid_name"))
+        self.assertFalse(self.generator._is_exportable("invalid_name_123"))
+        self.assertFalse(self.generator._is_exportable("Invalid_Name"))
+        self.assertFalse(self.generator._is_exportable("invalidname"))
+        self.assertFalse(self.generator._is_exportable("invalid123"))
+        self.assertFalse(self.generator._is_exportable("invalidName"))
+        self.assertFalse(self.generator._is_exportable("123InvalidName"))
+
+    def is_method_test(self):
+        """Test if methods are DBus methods."""
+
+        class IsMethodClass(object):
+
+            def Test1(self, a: Int):
+                pass
+
+            Test2 = None
+
+            @property
+            def Test3(self):
+                return None
+
+            @dbus_signal
+            def Test4(self):
+                pass
+
+        self.assertTrue(self.generator._is_method(IsMethodClass.Test1))
+        self.assertFalse(self.generator._is_method(IsMethodClass.Test2))
+        self.assertFalse(self.generator._is_method(IsMethodClass.Test3))
+        self.assertFalse(self.generator._is_method(IsMethodClass.Test4))
+
+    def invalid_method_test(self):
+        """Test invalid methods."""
+
+        class InvalidMethodClass(object):
+
+            def Test1(self, a):
+                pass
+
+            def Test2(self, a=None):
+                pass
+
+            def Test3(self, a, b):
+                pass
+
+            def Test4(self, a: Int, b: Str, c):
+                pass
+
+            def Test5(self, a: Int, b: Str, c) -> Int:
+                pass
+
+            def Test6(self, *arg):
+                pass
+
+            def Test7(self, **kwargs):
+                pass
+
+            def Test8(self, a, b, *, c, d=None):
+                pass
+
+        methods = [
+            InvalidMethodClass.Test1,
+            InvalidMethodClass.Test2,
+            InvalidMethodClass.Test3,
+            InvalidMethodClass.Test4,
+            InvalidMethodClass.Test5,
+            InvalidMethodClass.Test6,
+            InvalidMethodClass.Test7,
+            InvalidMethodClass.Test8,
+        ]
+
+        for method in methods:
+            with self.assertRaises(DBusSpecificationError):
+                self.generator._generate_method(method, method.__name__)
+
+    def method_test(self):
+        """Test interface with a method."""
+
+        @dbus_interface("Interface")
+        class MethodClass(object):
+
+            def Method1(self):
+                pass
+
+            def Method2(self, x:Int):
+                pass
+
+            def Method3(self) -> Int:
+                pass
+
+            def Method4(self, x: List[Double], y: File) -> Tuple[Int, Bool]:
+                return 0, True
+
+        expected_xml = '''
+        <node>
+            <!--Specifies MethodClass-->
+            <interface name="Interface">
+                <method name="Method1"/>
+                <method name="Method2">
+                    <arg direction="in" name="x" type="i"/>
+                </method>
+                <method name="Method3">
+                    <arg direction="out" name="return" type="i"/>
+                </method>
+                <method name="Method4">
+                    <arg direction="in" name="x" type="ad"/>
+                    <arg direction="in" name="y" type="h"/>
+                    <arg direction="out" name="return" type="(ib)"/>
+                </method>
+            </interface>
+        </node>
+        '''
+
+        self._compare(MethodClass, expected_xml)
+
+    def is_property_test(self):
+        """Test property detection."""
+
+        class IsPropertyClass(object):
+
+            @property
+            def Property1(self) -> Int:
+                return 1
+
+            def _get_property2(self):
+                return 2
+
+            Property2 = property(fget=_get_property2)
+
+            def Property3(self) -> Int:
+                return 3
+
+            @dbus_signal
+            def Property4(self):
+                pass
+
+        self.assertTrue(self.generator._is_property(IsPropertyClass.Property1))
+        self.assertTrue(self.generator._is_property(IsPropertyClass.Property2))
+        self.assertFalse(self.generator._is_property(IsPropertyClass.Property3))
+        self.assertFalse(self.generator._is_property(IsPropertyClass.Property4))
+
+    def property_test(self):
+        """Test the interface with a property."""
+
+        @dbus_interface("Interface")
+        class ReadWritePropertyClass(object):
+
+            def __init__(self):
+                self._property = 0
+
+            @property
+            def Property(self) -> Int:
+                return self._property
+
+            @Property.setter
+            def Property(self, value: Int):
+                self._property = value
+
+        expected_xml = '''
+        <node>
+            <!--Specifies ReadWritePropertyClass-->
+            <interface name="Interface">
+                <property name="Property" type="i" access="readwrite" />
+            </interface>
+        </node>
+        '''
+
+        self._compare(ReadWritePropertyClass, expected_xml)
+
+    def invalid_property_test(self):
+        """Test the interface with an invalid property."""
+
+        class InvalidPropertyClass(object):
+
+            InvalidProperty = property()
+
+            @property
+            def NoHintProperty(self):
+                return 1
+
+        with self.assertRaises(DBusSpecificationError):
+            self.generator._generate_property(InvalidPropertyClass.InvalidProperty, "InvalidProperty")
+
+        with self.assertRaises(DBusSpecificationError):
+            self.generator._generate_property(InvalidPropertyClass.NoHintProperty, "NoHintProperty")
+
+    def property_readonly_test(self):
+        """Test readonly property."""
+
+        @dbus_interface("Interface")
+        class ReadonlyPropertyClass(object):
+
+            def __init__(self):
+                self._property = 0
+
+            @property
+            def Property(self) -> Int:
+                return self._property
+
+        expected_xml = '''
+        <node>
+            <!--Specifies ReadonlyPropertyClass-->
+            <interface name="Interface">
+                <property name="Property" type="i" access="read" />
+            </interface>
+        </node>
+        '''
+
+        self._compare(ReadonlyPropertyClass, expected_xml)
+
+    def property_writeonly_test(self):
+        """Test writeonly property."""
+
+        @dbus_interface("Interface")
+        class WriteonlyPropertyClass(object):
+
+            def __init__(self):
+                self._property = 0
+
+            def set_property(self, x: Int):
+                self._property = x
+
+            Property = property(fset=set_property)
+
+        expected_xml = '''
+        <node>
+            <!--Specifies WriteonlyPropertyClass-->
+            <interface name="Interface">
+                <property name="Property" type="i" access="write" />
+            </interface>
+        </node>
+        '''
+
+        self._compare(WriteonlyPropertyClass, expected_xml)
+
+    def is_signal_test(self):
+        """Test signal detection."""
+
+        class IsSignalClass(object):
+
+            @dbus_signal
+            def Signal1(self):
+                pass
+
+            @dbus_signal
+            def Signal2(self, x:Int, y:Double):
+                pass
+
+            Signal3 = dbus_signal()
+
+            def Signal4(self):
+                pass
+
+            @property
+            def Signal5(self):
+                return None
+
+            Signal6 = None
+
+        self.assertTrue(self.generator._is_signal(IsSignalClass.Signal1))
+        self.assertTrue(self.generator._is_signal(IsSignalClass.Signal2))
+        self.assertTrue(self.generator._is_signal(IsSignalClass.Signal3))
+        self.assertFalse(self.generator._is_signal(IsSignalClass.Signal4))
+        self.assertFalse(self.generator._is_signal(IsSignalClass.Signal5))
+        self.assertFalse(self.generator._is_signal(IsSignalClass.Signal6))
+
+    def simple_signal_test(self):
+        """Test interface with a simple signal."""
+
+        @dbus_interface("Interface")
+        class SimpleSignalClass(object):
+            SimpleSignal = dbus_signal()
+
+        expected_xml = '''
+        <node>
+            <!--Specifies SimpleSignalClass-->
+            <interface name="Interface">
+                <signal name="SimpleSignal"/>
+            </interface>
+        </node>
+        '''
+
+        self._compare(SimpleSignalClass, expected_xml)
+
+    def signal_test(self):
+        """Test interface with signals."""
+
+        @dbus_interface("Interface")
+        class SignalClass(object):
+
+            @dbus_signal
+            def SomethingHappened(self):
+                """Signal that something happened."""
+                pass
+
+            @dbus_signal
+            def SignalSomething(self, x: Int, y: Str):
+                """
+                Signal that something happened.
+
+                :param x: Parameter x.
+                :param y: Parameter y
+                """
+                pass
+
+            def _emit_signals(self):
+                self.SomethingHappened.emit()  # pylint: disable=no-member
+                self.SignalSomething.emit(0, "Something!")  # pylint: disable=no-member
+
+        expected_xml = '''
+        <node>
+            <!--Specifies SignalClass-->
+            <interface name="Interface">
+                <signal name="SignalSomething">
+                    <arg direction="out" name="x" type="i"/>
+                    <arg direction="out" name="y" type="s"/>
+                </signal>
+                <signal name="SomethingHappened"/>
+            </interface>
+        </node>
+        '''
+
+        self._compare(SignalClass, expected_xml)
+
+    def invalid_signal_test(self):
+        """Test interface with an invalid signal."""
+
+        class InvalidSignalClass(object):
+
+            @dbus_signal
+            def Signal1(self, x):
+                pass
+
+            @dbus_signal
+            def Signal2(self) -> Int:
+                return 1
+
+        with self.assertRaises(DBusSpecificationError):
+            self.generator._generate_signal(InvalidSignalClass.Signal1, "Signal1")
+
+        with self.assertRaises(DBusSpecificationError):
+            self.generator._generate_signal(InvalidSignalClass.Signal2, "Signal2")
+
+    def override_method_test(self):
+        """Test interface with overridden methods."""
+
+        @dbus_interface("A")
+        class AClass(object):
+
+            def MethodA1(self, x: Int) -> Double:
+                return x + 1.0
+
+            def MethodA2(self) -> Bool:
+                return False
+
+            def MethodA3(self, x: List[Int]):
+                pass
+
+        class BClass(AClass):
+
+            def MethodA1(self, x: Int) -> Double:
+                return x + 2.0
+
+            def MethodB1(self) -> Str:
+                return ""
+
+        @dbus_interface("C")
+        class CClass(object):
+
+            def MethodC1(self) -> Tuple[Int, Int]:
+                return 1, 2
+
+            def MethodC2(self, x: Double):
+                pass
+
+        @dbus_interface("D")
+        class DClass(BClass, CClass):
+
+            def MethodD1(self) -> Tuple[Int, Str]:
+                return 0, ""
+
+            def MethodA3(self, x: List[Int]):
+                pass
+
+            def MethodC2(self, x: Double):
+                pass
+
+        expected_xml = '''
+        <node>
+            <!--Specifies DClass-->
+            <interface name="A">
+                <method name="MethodA1">
+                    <arg direction="in" name="x" type="i"/>
+                    <arg direction="out" name="return" type="d"/>
+                </method>
+                <method name="MethodA2">
+                    <arg direction="out" name="return" type="b"/>
+                </method>
+                <method name="MethodA3">
+                    <arg direction="in" name="x" type="ai"/>
+                </method>
+            </interface>
+            <interface name="C">
+                <method name="MethodC1">
+                    <arg direction="out" name="return" type="(ii)"/>
+                </method>
+                <method name="MethodC2">
+                    <arg direction="in" name="x" type="d"/>
+                </method>
+            </interface>
+            <interface name="D">
+                <method name="MethodB1">
+                    <arg direction="out" name="return" type="s"/>
+                </method>
+                <method name="MethodD1">
+                    <arg direction="out" name="return" type="(is)"/>
+                </method>
+            </interface>
+        </node>
+        '''
+
+        self._compare(DClass, expected_xml)
+
+    def complex_test(self):
+        """Test complex example."""
+
+        @dbus_interface("ComplexA")
+        class ComplexClassA(object):
+
+            def __init__(self):
+                self.a = 1
+
+            @dbus_signal
+            def SignalA(self, x: Int):
+                pass
+
+            @property
+            def PropertyA(self) -> Double:
+                return self.a + 2.5
+
+            def MethodA(self) -> Int:
+                return self.a
+
+            def _methodA(self):
+                return None
+
+        expected_xml = '''
+        <node>
+            <!--Specifies ComplexClassA-->
+            <interface name="ComplexA">
+                <method name="MethodA">
+                    <arg direction="out" name="return" type="i"/>
+                </method>
+                <property access="read" name="PropertyA" type="d"/>
+                <signal name="SignalA">
+                   <arg direction="out" name="x" type="i"/>
+                </signal>
+            </interface>
+        </node>
+        '''
+
+        self._compare(ComplexClassA, expected_xml)
+
+        @dbus_interface("ComplexB")
+        class ComplexClassB(ComplexClassA):
+
+            def __init__(self):
+                super().__init__()
+                self.b = 2.0
+
+            @dbus_signal
+            def SignalB(self, x: Bool, y: Double, z: Tuple[Int, Int]):
+                pass
+
+            @property
+            def PropertyB(self) -> Double:
+                return self.b
+
+            def MethodA(self) -> Int:
+                return int(self.b)
+
+            def MethodB(self, a: Str, b: List[Double], c: Int) -> Int:
+                return int(self.b)
+
+            def _methodB(self, x: Bool):
+                pass
+
+        expected_xml = '''
+        <node>
+            <!--Specifies ComplexClassB-->
+           <interface name="ComplexA">
+                <method name="MethodA">
+                    <arg direction="out" name="return" type="i"/>
+                </method>
+                <property access="read" name="PropertyA" type="d"/>
+                <signal name="SignalA">
+                   <arg direction="out" name="x" type="i"/>
+                </signal>
+            </interface>
+            <interface name="ComplexB">
+                <method name="MethodB">
+                    <arg direction="in" name="a" type="s"/>
+                    <arg direction="in" name="b" type="ad"/>
+                    <arg direction="in" name="c" type="i"/>
+                    <arg direction="out" name="return" type="i"/>
+                </method>
+                <property access="read" name="PropertyB" type="d"/>
+                <signal name="SignalB">
+                    <arg direction="out" name="x" type="b"/>
+                    <arg direction="out" name="y" type="d"/>
+                    <arg direction="out" name="z" type="(ii)"/>
+                </signal>
+            </interface>
+        </node>
+        '''
+
+        self._compare(ComplexClassB, expected_xml)
+
+        @dbus_class
+        class ComplexClassC(ComplexClassB):
+
+            def MethodB(self, a: Str, b: List[Double], c: Int) -> Int:
+                return 1
+
+        expected_xml = '''
+        <node>
+            <!--Specifies ComplexClassC-->
+           <interface name="ComplexA">
+                <method name="MethodA">
+                    <arg direction="out" name="return" type="i"/>
+                </method>
+                <property access="read" name="PropertyA" type="d"/>
+                <signal name="SignalA">
+                   <arg direction="out" name="x" type="i"/>
+                </signal>
+            </interface>
+            <interface name="ComplexB">
+                <method name="MethodB">
+                    <arg direction="in" name="a" type="s"/>
+                    <arg direction="in" name="b" type="ad"/>
+                    <arg direction="in" name="c" type="i"/>
+                    <arg direction="out" name="return" type="i"/>
+                </method>
+                <property access="read" name="PropertyB" type="d"/>
+                <signal name="SignalB">
+                    <arg direction="out" name="x" type="b"/>
+                    <arg direction="out" name="y" type="d"/>
+                    <arg direction="out" name="z" type="(ii)"/>
+                </signal>
+            </interface>
+        </node>
+        '''
+
+        self._compare(ComplexClassC, expected_xml)

--- a/tests/pyanaconda_tests/dbus_typing_test.py
+++ b/tests/pyanaconda_tests/dbus_typing_test.py
@@ -1,0 +1,176 @@
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+
+import unittest
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
+from pyanaconda.dbus.typing import get_dbus_type
+
+import gi
+gi.require_version("GLib", "2.0")
+from gi.repository import GLib
+
+
+class DBusTypingTests(unittest.TestCase):
+
+    def _compare(self, type_hint, expected_string):
+        """Compare generated and expected types."""
+        dbus_type = get_dbus_type(type_hint)
+        self.assertEqual(dbus_type, expected_string)
+        self.assertTrue(GLib.VariantType.string_is_valid(dbus_type))
+
+    def unknown_test(self):
+        """Test the unknown type."""
+
+        class UnknownType:
+            pass
+
+        with self.assertRaises(ValueError):
+            get_dbus_type(UnknownType)
+
+        with self.assertRaises(ValueError):
+            get_dbus_type(List[UnknownType])
+
+        with self.assertRaises(ValueError):
+            get_dbus_type(Tuple[Int, Str, UnknownType])
+
+        with self.assertRaises(ValueError):
+            get_dbus_type(Dict[Int, UnknownType])
+
+    def invalid_test(self):
+        """Test the invalid types."""
+        with self.assertRaises(ValueError):
+            get_dbus_type(Dict[List[Bool], Bool])
+
+        with self.assertRaises(ValueError):
+            get_dbus_type(Dict[Variant, Int])
+
+        with self.assertRaises(ValueError):
+            get_dbus_type(Tuple[Int, Double, Dict[Tuple[Int, Int], Bool]])
+
+    def simple_test(self):
+        """Test simple types."""
+        self._compare(int, "i")
+        self._compare(bool, "b")
+        self._compare(float, "d")
+        self._compare(str, "s")
+
+    def basic_test(self):
+        """Test basic types."""
+        self._compare(Int, "i")
+        self._compare(Bool, "b")
+        self._compare(Double, "d")
+        self._compare(Str, "s")
+        self._compare(ObjPath, "o")
+        self._compare(File, "h")
+        self._compare(Variant, "v")
+
+    def int_test(self):
+        """Test integer types."""
+        self._compare(Byte, "y")
+        self._compare(Int16, "n")
+        self._compare(UInt16, "q")
+        self._compare(Int32, "i")
+        self._compare(UInt32, "u")
+        self._compare(Int64, "x")
+        self._compare(UInt64, "t")
+
+    def container_test(self):
+        """Test container types."""
+        self._compare(Tuple[Bool], "(b)")
+        self._compare(Tuple[Int, Str], "(is)")
+        self._compare(Tuple[File, Variant, Double], "(hvd)")
+
+        self._compare(List[Int], "ai")
+        self._compare(List[Bool], "ab")
+        self._compare(List[File], "ah")
+        self._compare(List[ObjPath], "ao")
+
+        self._compare(Dict[Str, Int], "a{si}")
+        self._compare(Dict[Int, Bool], "a{ib}")
+
+    def alias_test(self):
+        """Test type aliases."""
+        AliasType = List[Double]
+        self._compare(Dict[Str, AliasType], "a{sad}")
+
+    def depth_test(self):
+        """Test difficult type structures."""
+        self._compare(Tuple[Int, Tuple[Str, Str]], "(i(ss))")
+        self._compare(Tuple[Tuple[Tuple[Int]]], "(((i)))")
+        self._compare(Tuple[Bool, Tuple[Tuple[Int], Str]], "(b((i)s))")
+
+        self._compare(List[List[List[Int]]], "aaai")
+        self._compare(List[Tuple[Dict[Str, Int]]], "a(a{si})")
+        self._compare(List[Dict[Str, Tuple[File, Variant]]], "aa{s(hv)}")
+
+        self._compare(Dict[Str, List[Bool]], "a{sab}")
+        self._compare(Dict[Str, Tuple[Int, Int, Double]], "a{s(iid)}")
+        self._compare(Dict[Str, Tuple[Int, Int, Dict[Int, Str]]], "a{s(iia{is})}")
+
+    @unittest.skip("Requires mypy to be setup.")
+    def mypy_test(self):
+        """Test types with mypy."""
+        from mypy import api  # pylint: disable=import-error
+        out, err, res = api.run(["-c", mypy_script])
+        self.assertEqual(res, 0, msg=out + err)
+
+mypy_script = """
+from pyanaconda.dbus.typing import *
+
+a = True        # type: Bool
+b = 1.0         # type: Double
+c = ""          # type: Str
+
+d = 1           # type: Int
+e = Byte(1)     # type: Byte
+f = Int16(1)    # type: Int16
+g = UInt16(1)   # type: UInt16
+h = Int32(1)    # type: Int32
+i = UInt32(1)   # type: UInt32
+j = Int64(1)    # type: Int64
+k = UInt64(1)   # type: UInt64
+
+l = open("/tmp/123")  # type: File
+m = ObjPath("/com/mycompany/c5yo817y0c1y1c5b")  # type: ObjPath
+
+n = (1, "a")    # type: Tuple[Int, Str]
+o = {1: "a"}    # type: Dict[Int, Str]
+p = [1, 2, 3]   # type: List[Int]
+
+va = True        # type: Variant
+vb = 1.0         # type: Variant
+vc = ""          # type: Variant
+
+vd = 1           # type: Variant
+ve = Byte(1)     # type: Variant
+vf = Int16(1)    # type: Variant
+vg = UInt16(1)   # type: Variant
+vh = Int32(1)    # type: Variant
+vi = UInt32(1)   # type: Variant
+vj = Int64(1)    # type: Variant
+vk = UInt64(1)   # type: Variant
+
+vl = open("/tmp/123")  # type: Variant
+vm = ObjPath("/com/mycompany/c5yo817y0c1y1c5b")  # type: Variant
+
+vn = (1, "a")    # type: Variant
+vo = {1: "a"}    # type: Variant
+vp = [1, 2, 3]   # type: Variant
+"""

--- a/tests/pyanaconda_tests/dbus_xml_test.py
+++ b/tests/pyanaconda_tests/dbus_xml_test.py
@@ -1,0 +1,74 @@
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+
+import unittest
+from pyanaconda.dbus.interface import XMLGenerator
+
+
+class XMLGeneratorTestCase(unittest.TestCase):
+
+    def _compare(self, element, xml):
+        self.assertEqual(XMLGenerator.element_to_xml(element), xml)
+
+    def node_test(self):
+        """Test the node element."""
+        self._compare(XMLGenerator.get_node_element(), '<node />')
+
+    def interface_test(self):
+        """Test the interface element."""
+        self._compare(
+            XMLGenerator.get_interface_element("InterfaceName"),
+            '<interface name="InterfaceName" />'
+        )
+
+    def parameter_test(self):
+        """Test the parameter element."""
+        self._compare(
+            XMLGenerator.create_parameter("ParameterName",
+                                          "ParameterType",
+                                          "ParameterDirection"),
+            '<arg '
+            'direction="ParameterDirection" '
+            'name="ParameterName" '
+            'type="ParameterType" />')
+
+    def property_test(self):
+        """Test the property element."""
+        self._compare(
+            XMLGenerator.create_property("PropertyName",
+                                         "PropertyType",
+                                         "PropertyAccess"),
+            '<property '
+            'access="PropertyAccess" '
+            'name="PropertyName" '
+            'type="PropertyType" />'
+        )
+
+    def method_test(self):
+        """Test the method element."""
+        element = XMLGenerator.get_method_element("MethodName")
+        xml = '<method name="MethodName" />'
+        self._compare(element, xml)
+
+    def signal_test(self):
+        """Test the signal element."""
+        element = XMLGenerator.get_signal_element("SignalName")
+        xml = '<signal name="SignalName" />'
+        self._compare(element, xml)


### PR DESCRIPTION
With provided generators dbus_signal, dbus_interface and dbus_class,
it is possible to define a DBus interface with a Python class and
provide a DBus specification of a Python class. Types are derived
from type hints using types from pyanaconda.dbus.typing. Only class
members with CamelCase names are considered to be members of the DBus
interface.

It is supported the inheritance of DBus interfaces. Generated DBus
specification will contain all interfaces of the class ancestors.
If the class defines a new DBus interface, then class members with
names already defined in inherited interfaces are not considered to
be members of the new DBus interface.

Example of a class that defines a new DBus interface with a method,
a signal and a property. Instances of this class can be also exported
to DBus.

```
@dbus_interface("Interface")
class NewInterface(object):

  def Method(self, x: Int) -> List[Int]
    return [x]

  @dbus_signal
  def Signal(self, y: Double)
    pass

  @property
  def Property(self) -> Bool:
    return False
```

Example of a class that doesn't define a new DBus interface, but
instances can be exported to DBus.
```

@dbus_class
class ExportableClass(NewInterface):
  pass
```

It is required DBus library pydbus.