### PR TITLE
logging: replace SyslogHandler with JournalHandler

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -105,6 +105,7 @@ Requires: firewalld >= %{firewalldver}
 Requires: util-linux >= %{utillinuxver}
 Requires: python3-dbus
 Requires: python3-pwquality
+Requires: python3-systemd
 
 # pwquality only "recommends" the dictionaries it needs to do anything useful,
 # which is apparently great for containers but unhelpful for the rest of us

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -69,7 +69,7 @@ def setup_ifcfg_log():
     logger = get_ifcfg_logger()
     logger.setLevel(logging.DEBUG)
     anaconda_logging.logger.addFileHandler(ifcfgLogFile, logger, logging.DEBUG)
-    anaconda_logging.logger.forwardToSyslog(logger)
+    anaconda_logging.logger.forwardToJournal(logger)
 
     ifcfglog = get_ifcfg_logger()
 


### PR DESCRIPTION
Formerly, we used SyslogHandler logging to /dev/log consumed by systemd-journald.
rsyslog is configured locally for installer environment to pick the messages
from journal via imjournal module and log all messages except for anaconda
messages into /tmp/syslog and tty4.

Let's use JournalHandler logging to systemd-journald natively (via
/run/systemd/journal/socket?) with rsyslog picking the messages from journal in
the same way as before.

This way we can profit from having also records with caller identity key/values
(CODE_LINE, CODE_FILE,...) stored in journal. It is also fixing PRIORITY of
INFO and DEBUG messages which was set incorrectly to 4 (WARNING) before.

Another change is that the SYSLOG_IDENTIFIER is not set to logger name, but to
"anaconda" while the logger name is stored in LOGGER attribute now.