### PR TITLE
Don't mock modules with sys in unit tests

### DIFF
--- a/tests/pyanaconda_tests/ks_version_test.py
+++ b/tests/pyanaconda_tests/ks_version_test.py
@@ -15,20 +15,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from mock import Mock
 import unittest
 import os
+import pykickstart.version
+from pyanaconda import kickstart
+
 
 class BaseTestCase(unittest.TestCase):
     def setUp(self):
-        import sys
-
-        sys.modules["anaconda_logging"] = Mock()
-        sys.modules["block"] = Mock()
-
-        from pyanaconda import kickstart
-        import pykickstart.version
-
         self.handler = pykickstart.version.makeVersion(kickstart.superclass.version)
         self._commandMap = kickstart.commandMap
         self._dataMap = kickstart.dataMap

--- a/tests/pyanaconda_tests/pwpolicy.py
+++ b/tests/pyanaconda_tests/pwpolicy.py
@@ -17,22 +17,11 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from mock import Mock
 import unittest
+from pyanaconda import kickstart
 
-class BaseTestCase(unittest.TestCase):
-    def setUp(self):
-        import sys
 
-        sys.modules["anaconda_logging"] = Mock()
-        sys.modules["block"] = Mock()
-
-        from pyanaconda import kickstart
-        self.kickstart = kickstart
-        self.handler = kickstart.AnacondaKSHandler()
-        self.ksparser = kickstart.AnacondaKSParser(self.handler)
-
-class PwPolicyTestCase(BaseTestCase):
+class PwPolicyTestCase(unittest.TestCase):
     ks = """
 %anaconda
 pwpolicy root --strict --minlen=8 --minquality=50 --nochanges --emptyok
@@ -40,11 +29,16 @@ pwpolicy user --strict --minlen=8 --minquality=50 --nochanges --emptyok
 pwpolicy luks --strict --minlen=8 --minquality=50 --nochanges --emptyok
 %end
 """
+
+    def setUp(self):
+        self.handler = kickstart.AnacondaKSHandler()
+        self.ksparser = kickstart.AnacondaKSParser(self.handler)
+
     def pwpolicy_test(self):
         self.ksparser.readKickstartFromString(self.ks)
 
-        self.assertIsInstance(self.handler, self.kickstart.AnacondaKSHandler)
-        self.assertIsInstance(self.handler.anaconda, self.kickstart.AnacondaSectionHandler)
+        self.assertIsInstance(self.handler, kickstart.AnacondaKSHandler)
+        self.assertIsInstance(self.handler.anaconda, kickstart.AnacondaSectionHandler)
 
         eq_template = "pwpolicy %s --minlen=8 --minquality=50 --strict --nochanges --emptyok\n"
         for name in ["root", "user", "luks"]:

--- a/tests/pyanaconda_tests/storage_checker_test.py
+++ b/tests/pyanaconda_tests/storage_checker_test.py
@@ -20,31 +20,14 @@
 #
 
 import unittest
-from mock import Mock
+from pyanaconda.storage_utils import StorageChecker
 
 
 class StorageCheckerTests(unittest.TestCase):
 
-    def setUp(self):
-        """This madness is supposed to solve the problems with
-         imports in storage_utils that we don't need for testing.
-         """
-        import sys
-
-        sys.modules["blivet"] = Mock()
-        sys.modules["blivet.arch"] = Mock()
-        sys.modules["blivet.size"] = Mock()
-        sys.modules["blivet.errors"] = Mock()
-        sys.modules["blivet.platform"] = Mock()
-        sys.modules["blivet.devicefactory"] = Mock()
-        sys.modules["_isys"] = Mock()
-
-        from pyanaconda.storage_utils import StorageChecker
-        self.checker_type = StorageChecker
-
     def nocheck_test(self):
         """Test a check with no checks."""
-        checker = self.checker_type()
+        checker = StorageChecker()
         report = checker.check(None)
 
         self.assertEqual(report.success, True)
@@ -54,7 +37,7 @@ class StorageCheckerTests(unittest.TestCase):
 
     def simple_error_test(self):
         """Test an simple error report."""
-        checker = self.checker_type()
+        checker = StorageChecker()
 
         def check(storage, constraints, report_error, report_warning):
             report_error("error")
@@ -68,7 +51,7 @@ class StorageCheckerTests(unittest.TestCase):
 
     def simple_warning_test(self):
         """Test an simple warning report."""
-        checker = self.checker_type()
+        checker = StorageChecker()
 
         def check(storage, constraints, report_error, report_warning):
             report_warning("warning")
@@ -81,7 +64,7 @@ class StorageCheckerTests(unittest.TestCase):
 
     def simple_info_test(self):
         """Test simple info messages. """
-        checker = self.checker_type()
+        checker = StorageChecker()
         report = checker.check(None)
         self.assertListEqual(report.info, [
             "Storage check started with constraints {}.",
@@ -90,7 +73,7 @@ class StorageCheckerTests(unittest.TestCase):
 
     def info_test(self):
         """Test info messages. """
-        checker = self.checker_type()
+        checker = StorageChecker()
 
         def error_check(storage, constraints, report_error, report_warning):
             report_error("error")
@@ -119,7 +102,7 @@ class StorageCheckerTests(unittest.TestCase):
 
     def simple_constraints_test(self):
         """Test simple constraint adding."""
-        checker = self.checker_type()
+        checker = StorageChecker()
 
         # Try to add a new constraint with a wrong method.
         self.assertRaises(KeyError, checker.add_constraint, "x", None)
@@ -139,7 +122,7 @@ class StorageCheckerTests(unittest.TestCase):
 
     def check_constraints_test(self):
         """Test constraints checking."""
-        checker = self.checker_type()
+        checker = StorageChecker()
 
         def check(storage, constraints, report_error, report_warning):
             report_warning("%s" % constraints)
@@ -158,7 +141,7 @@ class StorageCheckerTests(unittest.TestCase):
 
     def dictionary_constraints_test(self):
         """Test the dictionary constraints."""
-        checker = self.checker_type()
+        checker = StorageChecker()
 
         checker.add_new_constraint("x", {"a": 1, "b": 2, "c": 3})
         self.assertIn("x", checker.constraints)
@@ -174,7 +157,7 @@ class StorageCheckerTests(unittest.TestCase):
 
     def complicated_test(self):
         """Run a complicated check."""
-        checker = self.checker_type()
+        checker = StorageChecker()
 
         # Set the checks,
         def check_x(storage, constraints, report_error, report_warning):
@@ -247,6 +230,6 @@ class StorageCheckerTests(unittest.TestCase):
 
     def default_settings_test(self):
         """Check the default storage checker."""
-        checker = self.checker_type()
+        checker = StorageChecker()
         checker.set_default_constraints()
         checker.set_default_checks()


### PR DESCRIPTION
We shouldn't change `sys.modules `to mock modules. Use patch instead.
Bad example: `sys.modules["module_name"] = Mock()`