### PR TITLE
Also capture anaconda-pre logs if they exist

### DIFF
--- a/scripts/log-capture
+++ b/scripts/log-capture
@@ -53,6 +53,10 @@ _to_log ip r
 
 cp /tmp/*.log ${OUTDIR}
 
+if [[ -e /tmp/pre-anaconda-logs/ ]];then
+    cp -r /tmp/pre-anaconda-logs ${OUTDIR}
+fi
+
 tar cfa ${ARCHIVE} ${OUTDIR}
 
 echo -e "\nFinished gathering data\nUpload ${ARCHIVE} to another system\n"


### PR DESCRIPTION
It appears that anaconda also can generate logs in /tmp/pre-anaconda-logs.  Add those to the archive as well.