### PR TITLE
80-setfilecons: Add a few paths (/var/run, /var/spool)

### DIFF
--- a/data/post-scripts/80-setfilecons.ks
+++ b/data/post-scripts/80-setfilecons.ks
@@ -1,10 +1,18 @@
 %post
+# We need to handle SELinux relabeling for a few reasons:
+# - %post scripts that write files into places in /etc, but don't do
+#   labeling correctly
+# - Anaconda code that does the same (e.g. moving our log files into
+#   /var/log/anaconda)
+# - ostree payloads, where all of the labeling of /var is the installer's
+#   responsibility (see https://github.com/ostreedev/ostree/pull/872 )
 
 restorecon -ir /etc/sysconfig/network-scripts /var/lib /etc/lvm \
                /dev /etc/iscsi /var/lib/iscsi /root /var/lock /var/log \
-               /etc/modprobe.d /etc/sysconfig /var/cache/yum
+               /etc/modprobe.d /etc/sysconfig /var/cache/yum \
+               /var/spool
 
-# Also relabel the OSTree variants of the normal mounts (if they exist)
+# Also relabel the OSTree variants of the traditional mounts if present
 restorecon -ir /var/roothome /var/home /var/opt /var/srv /var/media /var/mnt
 
 restorecon -i /etc/rpm/macros /etc/dasd.conf /etc/zfcp.conf /lib64 /usr/lib64 \
@@ -12,7 +20,8 @@ restorecon -i /etc/rpm/macros /etc/dasd.conf /etc/zfcp.conf /lib64 /usr/lib64 \
               /etc/modprobe.conf* /var/log/*tmp /etc/crypttab \
               /etc/mdadm.conf /etc/sysconfig/network /root/install.log* \
               /etc/*shadow* /etc/group* /etc/passwd* /etc/dhcp/dhclient-*.conf \
-              /etc/localtime /etc/hostname /root/install.log*
+              /etc/localtime /etc/hostname /root/install.log* \
+              /var/run
 
 if [ -e /etc/zipl.conf ]; then
     restorecon -i /etc/zipl.conf


### PR DESCRIPTION
First, add a comment to the top of the file with my understanding of the purpose
of this file. According to `git annotate`, this code was originally intended
to handle relabeling for files that anaconda itself created.  (A better
fix would be to create files with the right label in the first place, but
that's a whole other topic)

Since then though, I think we've ended up doing ad-hoc relabeling for
things that users/admins do in `%post`.  It's really easy to have
the same problem with shell scripts there, although modern SELinux
does have automatic filename transitions which simplifies some cases.

However, the way OSTree is defined, it's categorically the installer's
job to label `/var`.  See <https://github.com/ostreedev/ostree/pull/872>.
I'd like to apply that PR; from a default FAH install, we just need to
fix the labels for `/var/run` and `/var/spool`.  So add those to the list.

It's tempting to change this code to do something like:
`if <is ostree>; then restorecon -r /var; fi` or so, but let's go
with the conservative fix for now.