### PR TITLE
Use SHA256 instead of MD5 for repoMDHash (#1341280)

### DIFF
--- a/pyanaconda/packaging/yumpayload.py
+++ b/pyanaconda/packaging/yumpayload.py
@@ -1683,7 +1683,7 @@ class RepoMDMetaHash(object):
 
     @property
     def repoMDHash(self):
-        """Return MD5 hash of the repomd.xml file stored."""
+        """Return SHA256 hash of the repomd.xml file stored."""
         return self._repomd_hash
 
     @property
@@ -1703,7 +1703,7 @@ class RepoMDMetaHash(object):
         return new_repomd_hash == self._repomd_hash
 
     def _calculateHash(self, data):
-        m = hashlib.md5()
+        m = hashlib.sha256()
         m.update(data)
         return m.digest()
 

--- a/tests/pyanaconda_tests/payload_test.py
+++ b/tests/pyanaconda_tests/payload_test.py
@@ -67,7 +67,7 @@ or it should be. Nah it's just a test!
 
     def download_file_repomd_test(self):
         """Test if we can download repomd.xml with file:// successfully."""
-        m = hashlib.md5()
+        m = hashlib.sha256()
         m.update(self._content_repomd)
         reference_digest = m.digest()
 


### PR DESCRIPTION
MD5 use is not allowed when FIPS mode is enabled. Use SHA256 instead.

Related: rhbz#1341280