### PR TITLE
Use SHA256 instead of MD5 for repoMDHash (#1341280)

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -1185,7 +1185,7 @@ class RepoMDMetaHash(object):
 
     @property
     def repoMD_hash(self):
-        """Return MD5 hash of the repomd.xml file stored."""
+        """Return SHA256 hash of the repomd.xml file stored."""
         return self._repomd_hash
 
     @property
@@ -1205,7 +1205,7 @@ class RepoMDMetaHash(object):
         return new_repomd_hash == self._repomd_hash
 
     def _calculate_hash(self, data):
-        m = hashlib.md5()
+        m = hashlib.sha256()
         m.update(data.encode('ascii', 'backslashreplace'))
         return m.digest()
 

--- a/tests/pyanaconda_tests/payload_test.py
+++ b/tests/pyanaconda_tests/payload_test.py
@@ -124,7 +124,7 @@ or it should be. Nah it's just a test!
 
     def download_file_repomd_test(self):
         """Test if we can download repomd.xml with file:// successfully."""
-        m = hashlib.md5()
+        m = hashlib.sha256()
         m.update(self._content_repomd.encode('ascii', 'backslashreplace'))
         reference_digest = m.digest()
 


### PR DESCRIPTION
MD5 use is not allowed when FIPS mode is enabled. Use SHA256 instead.

Based on: https://github.com/rhinstaller/anaconda/pull/1139