### PR TITLE
Fix rescue touched unavailable installclass attr

### DIFF
--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -93,7 +93,8 @@ class Anaconda(object):
             from pyanaconda.installclass import factory
 
             # Get install class by name.
-            if self.ksdata.installclass.seen:
+            # in rescue mode there is no installclass used
+            if hasattr(self.ksdata, "installclass") and self.ksdata.installclass.seen:
                 name = self.ksdata.installclass.name
                 self._instClass = factory.get_install_class_by_name(name)
             # Or just find the best one.


### PR DESCRIPTION
In the rescue mode the `ksdata.installclass` attribute is not available.