### PR TITLE
dnfpayload: do not try to contact disabled repo (#1470552)

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -1140,8 +1140,7 @@ class DNFPayload(payload.PackagePayload):
         Save repomd hash to test if the repositories can be reached.
         """
         self._repoMD_list = []
-        for repoID in self.repos:
-            repo = self.getRepo(repoID)
+        for repo in self._base.repos.iter_enabled():
             repoMD = RepoMDMetaHash(self, repo)
             repoMD.store_repoMD_hash()
             self._repoMD_list.append(repoMD)


### PR DESCRIPTION
This patch fixes a regression introduced by:

79e66d2a6 Fix Anaconda forces payload restart when network (not)change (#1373449)

When anaconda tries to build the repositories MD5 cache, it mistakenly
iterates over all the repositories it is aware about, ever the disabled ones.

The end result is that it tries to reach the default disabled repositories from
"/etc/anaconda.repos.d/", for example
"https://codecs.fedoraproject.org/openh264/$releasever/$basearch/".

If the user is in a private intranet and the internet is not reachable, this
may lead to very long delays related to long dnf timeouts.

The fix is to only build the MD5 cache for the enabled repositories and leave
the disabled ones alone.

Resolves Fedora bug #1470552 in the RedHat bugzilla.

Signed-off-by: Artem Bityutskiy <artem.bityutskiy@linux.intel.com>