### PR TITLE
Support for installclass command in RHEL 7.5 (#1412159)

### DIFF
--- a/docs/kickstart.rst
+++ b/docs/kickstart.rst
@@ -50,6 +50,20 @@ pwpolicy <name> [--minlen=LENGTH] [--minquality=QUALITY] [--strict|notstrict] [-
         Do not allow UI to be used to change the password/user if it has been set in
         the kickstart.
 
+
+installclass
+============
+
+installclass --name=<name>
+
+    Require the specified install class to be used for the installation.
+    Otherwise, the best available install class will be used.
+
+    --name
+
+        Name of the required install class.
+
+
 The defaults for interactive installations are set in the /usr/share/anaconda/interactive-defaults.ks
 file provided by Anaconda. If a product, such as Fedora Workstation, wishes to override them
 then a product.img needs to be created with a new version of the file included.

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -96,7 +96,14 @@ class Anaconda(object):
     def instClass(self):
         if not self._instClass:
             from pyanaconda.installclass import factory
-            self._instClass = factory.get_best_install_class()
+
+            # Get install class by name.
+            if self.ksdata.anaconda.installclass.seen:
+                name = self.ksdata.anaconda.installclass.name
+                self._instClass = factory.get_install_class_by_name(name)
+            # Or just find the best one.
+            else:
+                self._instClass = factory.get_best_install_class()
 
         return self._instClass
 

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -95,8 +95,8 @@ class Anaconda(object):
     @property
     def instClass(self):
         if not self._instClass:
-            from pyanaconda.installclass import DefaultInstall
-            self._instClass = DefaultInstall()
+            from pyanaconda.installclass import factory
+            self._instClass = factory.get_best_install_class()
 
         return self._instClass
 

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -173,6 +173,17 @@ class InstallClassFactory(object):
         self._visible_classes = []
         self._paths = []
 
+    def get_install_class_by_name(self, name):
+        """Return an instance of an install class with a requested name."""
+        for install_class in self.classes:
+            if install_class.name == name:
+                log.info("Using the requested install class %s.",
+                         self._get_class_description(install_class))
+
+                return install_class()
+
+        raise RuntimeError("Unable to find the install class %s.", name)
+
     def get_best_install_class(self):
         """Return the instance of the best found install class.
 

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -22,22 +22,25 @@
 #
 
 from distutils.sysconfig import get_python_lib
-import os, sys
-import imputil
+import os
+import sys
 
 from blivet.partspec import PartSpec
 from blivet.devicelibs import swap
 from blivet.platform import platform
 from blivet.size import Size
 
+from pyanaconda.kickstart import getAvailableDiskSpace
+from pyanaconda.constants import DEFAULT_AUTOPART_TYPE
+from pyanaconda.ui.common import collect
+
 import logging
 log = logging.getLogger("anaconda")
 
-from pyanaconda.kickstart import getAvailableDiskSpace
-from pyanaconda.constants import DEFAULT_AUTOPART_TYPE
 
 class BaseInstallClass(object):
     # default to not being hidden
+    sortPriority = 0
     hidden = False
     name = "base"
     bootloaderTimeoutDefault = None
@@ -161,131 +164,115 @@ class BaseInstallClass(object):
     def __init__(self):
         pass
 
-allClasses = []
-allClasses_hidden = []
 
-# returns ( className, classObject ) tuples
-def availableClasses(showHidden=False):
-    global allClasses
-    global allClasses_hidden
+class InstallClassFactory(object):
+    """Class used to get an install class instance."""
 
-    def _ordering(first, second):
-        ((name1, _), priority1) = first
-        ((name2, _), priority2) = second
-
-        if priority1 < priority2:
-            return -1
-        elif priority1 > priority2:
-            return 1
-
-        if name1 < name2:
-            return -1
-        elif name1 > name2:
-            return 1
-
-        return 0
-
-    if not showHidden:
-        if allClasses:
-            return allClasses
-    else:
-        if allClasses_hidden:
-            return allClasses_hidden
-
-    path = []
-
-    env_path = []
-    if "ANACONDA_INSTALL_CLASSES" in os.environ:
-        env_path += os.environ["ANACONDA_INSTALL_CLASSES"].split(":")
-
-    for d in env_path + ["installclasses",
-              "/tmp/updates/pyanaconda/installclasses",
-              "/tmp/product/pyanaconda/installclasses",
-              "%s/pyanaconda/installclasses" % get_python_lib(plat_specific=1) ]:
-        if os.access(d, os.R_OK):
-            path.append(d)
-
-    # append the location of installclasses to the python path so we
-    # can import them
-    sys.path = path + sys.path
-
-    files = []
-    for p in reversed(path):
-        files += os.listdir(p)
-
-    done = {}
-    lst = []
-    for fileName in files:
-        if fileName[0] == '.':
-            continue
-        if len (fileName) < 4:
-            continue
-        if fileName[-3:] != ".py" and fileName[-4:-1] != ".py":
-            continue
-        mainName = fileName.split(".")[0]
-        if mainName in done:
-            continue
-        done[mainName] = 1
-
-        try:
-            found = imputil.imp.find_module(mainName)
-        except ImportError:
-            log.warning ("module import of %s failed: %s", mainName, sys.exc_type)
-            continue
-
-        try:
-            loaded = imputil.imp.load_module(mainName, found[0], found[1], found[2])
-
-            for (_key, obj) in loaded.__dict__.items():
-                # If it's got these two methods, it's an InstallClass.
-                if hasattr(obj, "setDefaultPartitioning") and hasattr(obj, "setPackageSelection"):
-                    sortOrder = getattr(obj, "sortPriority", 0)
-                    if not obj.hidden or showHidden:
-                        lst.append(((obj.name, obj), sortOrder))
-        except (ImportError, AttributeError):
-            log.warning ("module import of %s failed: %s", mainName, sys.exc_type)
-
-    lst.sort(_ordering)
-    for (item, _) in lst:
-        if showHidden:
-            allClasses_hidden += [item]
-        else:
-            allClasses += [item]
-
-    if showHidden:
-        return allClasses_hidden
-    else:
-        return allClasses
-
-def getBaseInstallClass():
-    # figure out what installclass we should base on.
-    allavail = availableClasses(showHidden=True)
-    avail = availableClasses(showHidden=False)
-
-    if len(avail) == 1:
-        (cname, cobject) = avail[0]
-        log.info("using only installclass %s", cname)
-    elif len(allavail) == 1:
-        (cname, cobject) = allavail[0]
-        log.info("using only installclass %s", cname)
-
-    # Use the highest priority install class if more than one found.
-    elif len(avail) > 1:
-        (cname, cobject) = avail.pop()
-        log.info('%s is the highest priority installclass, using it', cname)
-    elif len(allavail) > 1:
-        (cname, cobject) = allavail.pop()
-        log.info('%s is the highest priority installclass, using it', cname)
-
-    # Default to the base installclass if nothing else is found.
-    else:
-        raise RuntimeError("Unable to find an install class to use!!!")
-
-    return cobject
-
-baseclass = getBaseInstallClass()
-
-# we need to be able to differentiate between this and custom
-class DefaultInstall(baseclass):
     def __init__(self):
-        baseclass.__init__(self)
+        self._classes = []
+        self._visible_classes = []
+        self._paths = []
+
+    def get_best_install_class(self):
+        """Return the instance of the best found install class.
+
+        We choose an install class with the highest priority. The priority
+        of an install class is based on its visibility (we prefer visible),
+        its sort priority (we prefer higher number) and its name (in reverse
+        alphabetical order, so Fedora Workstation is preferred before Fedora).
+        """
+        if self.visible_classes:
+            install_class = self.visible_classes[0]
+            log.info("Using a visible install class %s.",
+                     self._get_class_description(install_class))
+
+        elif self.classes:
+            install_class = self.classes[0]
+            log.info("Using a hidden install class %s.",
+                     self._get_class_description(install_class))
+
+        else:
+            raise RuntimeError("Unable to find an install class to use.")
+
+        return install_class()
+
+    @property
+    def paths(self):
+        """Return paths where to look for install classes."""
+        if not self._paths:
+            self._paths = self._get_install_class_paths()
+
+        return self._paths
+
+    @property
+    def classes(self):
+        """Return all available install classes."""
+        if not self._classes:
+            self._classes = self._get_available_classes(self.paths)
+
+        return self._classes
+
+    @property
+    def visible_classes(self):
+        """Return only install classes that are not hidden."""
+        if not self._visible_classes:
+            self._visible_classes = list(filter(self._is_visible_class, self.classes))
+
+        return self._visible_classes
+
+    @staticmethod
+    def _is_visible_class(obj):
+        """Is the class visible?"""
+        return not obj.hidden
+
+    @staticmethod
+    def _is_install_class(obj):
+        """Is the class the install class?"""
+        return issubclass(obj, BaseInstallClass) and obj != BaseInstallClass
+
+    @staticmethod
+    def _get_install_class_key(obj):
+        """Return the install class key for sorting."""
+        return obj.sortPriority, obj.name
+
+    @staticmethod
+    def _get_class_description(install_class):
+        """Return the description of the install class."""
+        return "%s (%s)" % (install_class.name, install_class.__name__)
+
+    def _get_install_class_paths(self):
+        """Return a list of paths to directories with install classes."""
+        path = []
+
+        if "ANACONDA_INSTALL_CLASSES" in os.environ:
+            path += os.environ["ANACONDA_INSTALL_CLASSES"].split(":")
+
+        path += [
+            "installclasses",
+            "/tmp/updates/pyanaconda/installclasses",
+            "/tmp/product/pyanaconda/installclasses",
+            "%s/pyanaconda/installclasses" % get_python_lib(plat_specific=1)
+        ]
+
+        return list(filter(lambda d: os.access(d, os.R_OK), path))
+
+    def _get_available_classes(self, paths):
+        """Return a list of available install classes."""
+        # Append the location of install classes to the python path
+        # so install classes can import and inherit correct classes.
+        sys.path = paths + sys.path
+
+        classes = set()
+        for path in paths:
+            log.debug("Searching %s.", path)
+
+            for install_class in collect("%s", path, self._is_install_class):
+                log.debug("Found %s.", self._get_class_description(install_class))
+                classes.add(install_class)
+
+        # Classes are sorted by their priority and name in the reversed order,
+        # so classes with the highest priority and longer name are preferred.
+        # For example, Fedora Workstation doesn't have higher priority.
+        return sorted(classes, key=self._get_install_class_key, reverse=True)
+
+factory = InstallClassFactory()

--- a/pyanaconda/installclasses/fedora.py
+++ b/pyanaconda/installclasses/fedora.py
@@ -22,6 +22,9 @@ from pyanaconda.product import productName
 from pyanaconda import network
 from pyanaconda import nm
 
+__all__ = ["FedoraBaseInstallClass"]
+
+
 class FedoraBaseInstallClass(BaseInstallClass):
     name = "Fedora"
     sortPriority = 10000

--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -32,6 +32,9 @@ from blivet.platform import platform
 from blivet.devicelibs import swap
 from blivet.size import Size
 
+__all__ = ["RHELBaseInstallClass", "RHELAtomicInstallClass"]
+
+
 class RHELBaseInstallClass(BaseInstallClass):
     name = "Red Hat Enterprise Linux"
     sortPriority = 20000

--- a/pyanaconda/installclasses/rhv.py
+++ b/pyanaconda/installclasses/rhv.py
@@ -27,6 +27,8 @@ from blivet.size import Size
 from pykickstart.constants import AUTOPART_TYPE_LVM_THINP
 from blivet.devicefactory import DEVICE_TYPE_LVM_THINP
 
+__all__ = ["OvirtBaseInstallClass", "RHEVInstallClass"]
+
 
 class OvirtBaseInstallClass(BaseInstallClass):
     name = "oVirt Node Next"

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -79,13 +79,14 @@ from pykickstart.constants import CLEARPART_TYPE_NONE, CLEARPART_TYPE_ALL, \
                                   KS_SCRIPT_POST, KS_SCRIPT_PRE, KS_SCRIPT_TRACEBACK, KS_SCRIPT_PREINSTALL, \
                                   SELINUX_DISABLED, SELINUX_ENFORCING, SELINUX_PERMISSIVE, \
                                   SNAPSHOT_WHEN_POST_INSTALL, SNAPSHOT_WHEN_PRE_INSTALL
-from pykickstart.base import BaseHandler
+from pykickstart.base import BaseHandler, KickstartCommand
 from pykickstart.errors import formatErrorMsg, KickstartError, KickstartValueError
 from pykickstart.parser import KickstartParser
 from pykickstart.parser import Script as KSScript
 from pykickstart.sections import NullSection, PackageSection, PostScriptSection, PreScriptSection, PreInstallScriptSection, \
                                  OnErrorScriptSection, TracebackScriptSection, Section
 from pykickstart.version import returnClassForVersion, RHEL7
+from pykickstart.options import KSOptionParser
 
 import logging
 log = logging.getLogger("anaconda")
@@ -2087,9 +2088,43 @@ class Upgrade(commands.upgrade.F20_Upgrade):
 ### %anaconda Section
 ###
 
+class RHEL7_InstallClass(KickstartCommand):
+    removedKeywords = KickstartCommand.removedKeywords
+    removedAttrs = KickstartCommand.removedAttrs
+
+    def __init__(self, *args, **kwargs):
+        KickstartCommand.__init__(self, *args, **kwargs)
+        self.op = self._getParser()
+        self.name = kwargs.get("name", "")
+
+    def __str__(self):
+        retval = KickstartCommand.__str__(self)
+        if not self.seen:
+            return retval
+
+        retval += "installclass%s\n" % self._getArgsAsStr()
+        return retval
+
+    def _getArgsAsStr(self):
+        retval = ""
+        if self.name:
+            retval += ' --name="%s"' % self.name
+        return retval
+
+    def _getParser(self):
+        op = KSOptionParser()
+        op.add_option("--name", dest="name", required=True, type="string")
+        return op
+
+    def parse(self, args):
+        (opts, _) = self.op.parse_args(args=args, lineno=self.lineno)
+        self._setToSelf(self.op, opts)
+        return self
+
 class AnacondaSectionHandler(BaseHandler):
     """A handler for only the anaconda ection's commands."""
     commandMap = {
+        "installclass": RHEL7_InstallClass,
         "pwpolicy": F22_PwPolicy
     }
 

--- a/pyanaconda/ui/gui/tools/run-spoke.py
+++ b/pyanaconda/ui/gui/tools/run-spoke.py
@@ -29,7 +29,7 @@ ctypes.CDLL("libAnacondaWidgets.so.1", ctypes.RTLD_GLOBAL)
 from pyanaconda import anaconda_log
 anaconda_log.init()
 
-from pyanaconda.installclass import DefaultInstall
+from pyanaconda.installclass import factory
 from blivet import Blivet
 from pyanaconda.threads import initThreading
 from pyanaconda.packaging.yumpayload import YumPayload
@@ -94,7 +94,7 @@ print("Running %s %s from %s" % (spokeText, spokeClass, spokeModule))
 ksdata = makeVersion()
 storage = Blivet(ksdata=ksdata)
 storage.reset()
-instclass = DefaultInstall()
+instclass = factory.get_best_install_class()
 
 payload = YumPayload(ksdata)
 payload.setup(storage, instclass)

--- a/pyanaconda/ui/tui/tools/run-text-spoke.py
+++ b/pyanaconda/ui/tui/tools/run-text-spoke.py
@@ -12,7 +12,7 @@ if len(sys.argv)<2:
 from pyanaconda import anaconda_log
 anaconda_log.init()
 
-from pyanaconda.installclass import DefaultInstall
+from pyanaconda.installclass import factory
 from blivet import Blivet
 from pyanaconda.threads import initThreading
 from pyanaconda.packaging.yumpayload import YumPayload
@@ -81,7 +81,7 @@ print("Running %s %s from %s" % (spokeText, spokeClass, spokeModule))
 ksdata = makeVersion()
 storage = Blivet(ksdata=ksdata)
 storage.reset()
-instclass = DefaultInstall()
+instclass = factory.get_best_install_class()
 app = App("TEST HARNESS", yes_or_no_question = YesNoDialog)
 
 payload = YumPayload(ksdata)

--- a/tests/pyanaconda_tests/installclass_test.py
+++ b/tests/pyanaconda_tests/installclass_test.py
@@ -1,0 +1,209 @@
+#
+# Vendula Poncova <vponcova@redhat.com>
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+import unittest
+from mock import patch
+from pyanaconda.installclass import BaseInstallClass, InstallClassFactory
+from pyanaconda import kickstart
+from pykickstart.errors import KickstartValueError, KickstartParseError
+
+
+class FactoryTest(unittest.TestCase):
+
+    factory_class = None
+    base_class = None
+    collect = None
+
+    def _get_fake_factory(self):
+        """Return the fake factory."""
+        factory = InstallClassFactory()
+        factory._paths = ["/fake/path"]
+        return factory
+
+    def _patch_collect(self, collected):
+        return patch("pyanaconda.installclass.collect", lambda *x: collected)
+
+    def path_test(self):
+        """Test paths to install classes."""
+        # Test the fake factory,
+        factory = self._get_fake_factory()
+        self.assertEqual(factory.paths, ["/fake/path"])
+
+        # Test the real factory.
+        factory = InstallClassFactory()
+        # There should be always at least one path.
+        self.assertTrue(any(filter(lambda p: p.endswith("/pyanaconda/installclasses"), factory.paths)))
+
+    def simple_test(self):
+        """Test the basic factory methods."""
+
+        class NotInstallClass(object):
+            name = "Not Install Class"
+            hidden = False
+            sortPriority = 1
+
+        class InstallClass(BaseInstallClass):
+            name = "Install Class"
+            hidden = True
+            sortPriority = 2
+
+        class ChildInstallClass(InstallClass):
+            name = "Child Install Class"
+            hidden = False
+            sortPriority = 3
+
+        factory = self._get_fake_factory()
+
+        # Test if class is an install class.
+        self.assertEqual(factory._is_install_class(BaseInstallClass), False)
+        self.assertEqual(factory._is_install_class(NotInstallClass), False)
+        self.assertEqual(factory._is_install_class(InstallClass), True)
+        self.assertEqual(factory._is_install_class(ChildInstallClass), True)
+
+        # Test if class is visible.
+        self.assertEqual(factory._is_visible_class(InstallClass), False)
+        self.assertEqual(factory._is_visible_class(ChildInstallClass), True)
+
+        # Test a description.
+        self.assertEqual(factory._get_class_description(InstallClass), "Install Class (InstallClass)")
+
+        # Test a key.
+        self.assertEqual(factory._get_install_class_key(InstallClass), (2, "Install Class"))
+        self.assertEqual(factory._get_install_class_key(ChildInstallClass), (3, "Child Install Class"))
+
+    def collect_test(self):
+        """Test the collecting of the install classes."""
+
+        class InstallClassA(BaseInstallClass):
+            name = "Install Class A"
+            hidden = True
+            sortPriority = 1
+
+        class InstallClassB(BaseInstallClass):
+            name = "Install Class B"
+            sortPriority = 2
+
+        class InstallClassC(BaseInstallClass):
+            name = "Install Class C"
+            sortPriority = 3
+
+        # Test with no available classes.
+        with self._patch_collect([]):
+            factory = self._get_fake_factory()
+            self.assertEqual(factory.classes, [])
+            self.assertEqual(factory.visible_classes, [])
+
+            with self.assertRaises(RuntimeError):
+                factory.get_best_install_class()
+
+            with self.assertRaises(RuntimeError):
+                factory.get_install_class_by_name("Install Class A")
+
+        # Test with one hidden class.
+        with self._patch_collect([InstallClassA]):
+            factory = self._get_fake_factory()
+            self.assertEqual(factory.classes, [InstallClassA])
+            self.assertEqual(factory.visible_classes, [])
+
+            self.assertTrue(isinstance(factory.get_best_install_class(), InstallClassA))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class A"), InstallClassA))
+
+            with self.assertRaises(RuntimeError):
+                factory.get_install_class_by_name("Install Class B")
+
+        with self._patch_collect([InstallClassA, InstallClassB, InstallClassC]):
+            factory = self._get_fake_factory()
+            self.assertEqual(factory.classes, [InstallClassC, InstallClassB, InstallClassA])
+            self.assertEqual(factory.visible_classes, [InstallClassC, InstallClassB])
+
+            self.assertTrue(isinstance(factory.get_best_install_class(), InstallClassC))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class A"), InstallClassA))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class B"), InstallClassB))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class C"), InstallClassC))
+
+            with self.assertRaises(RuntimeError):
+                factory.get_install_class_by_name("Install Class D")
+
+    def sort_test(self):
+        """Test that the install classes are sorted as expected."""
+
+        class InstallClassA1(BaseInstallClass):
+            name = "Install Class A"
+            sortPriority = 1
+
+        class InstallClassA2(BaseInstallClass):
+            name = "Install Class A"
+            sortPriority = 2
+
+        class InstallClassB1(BaseInstallClass):
+            name = "Install Class B 1"
+            sortPriority = 3
+
+        class InstallClassB2(BaseInstallClass):
+            name = "Install Class B 2"
+            sortPriority = 3
+
+        with self._patch_collect([InstallClassA1, InstallClassA2, InstallClassB1, InstallClassB2]):
+            factory = self._get_fake_factory()
+            self.assertEqual(factory.classes, [InstallClassB2, InstallClassB1, InstallClassA2, InstallClassA1])
+
+            self.assertTrue(isinstance(factory.get_best_install_class(), InstallClassB2))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class A"), InstallClassA2))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class B 1"), InstallClassB1))
+            self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class B 2"), InstallClassB2))
+
+
+class RHEL7_Installclass_TestCase(unittest.TestCase):
+
+    def apply_section(self, content):
+        return "\n%anaconda\n" + content + "%end\n"
+
+    def parse(self, s):
+        handler = kickstart.AnacondaKSHandler()
+        parser = kickstart.AnacondaKSParser(handler)
+        parser.readKickstartFromString(self.apply_section(s + "\n"))
+        return handler
+
+    def assert_parse(self, s, expected):
+        self.assertEqual(str(self.parse(s).anaconda), self.apply_section(expected))
+
+    def assert_parse_error(self, s, error):
+        with self.assertRaises(error):
+            self.parse(s)
+
+    def parse_test(self):
+        """Test parsing of the installclass command."""
+        # pass
+        self.assert_parse("installclass --name='An Install Class'",
+                          "installclass --name=\"An Install Class\"\n")
+
+        self.assert_parse("installclass --name=\"An Install Class\"",
+                          "installclass --name=\"An Install Class\"\n")
+
+        # fail
+        self.assert_parse_error("installclass --name", KickstartParseError)
+        self.assert_parse_error("installclass --xyz", KickstartParseError)
+        self.assert_parse_error("installclass --name=\"An Install Class\" --xyz", KickstartParseError)
+        self.assert_parse_error("installclass", KickstartValueError)
+
+    def command_test(self):
+        """Test the installclass command."""
+        handler = self.parse("installclass --name='An Install Class'")
+        self.assertTrue(handler.anaconda.installclass.seen)
+        self.assertEqual(handler.anaconda.installclass.name, "An Install Class")

--- a/tests/pyanaconda_tests/ks_version_test.py
+++ b/tests/pyanaconda_tests/ks_version_test.py
@@ -16,49 +16,36 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Author: Chris Lumens <clumens@redhat.com>
-from mock import Mock
 import unittest
 import os
+from pyanaconda import kickstart
 
-class BaseTestCase(unittest.TestCase):
-    def setUp(self):
-        import sys
-
-        sys.modules["anaconda_log"] = Mock()
-        sys.modules["block"] = Mock()
-
-        from pyanaconda import kickstart
-        import pykickstart.version
-
-        self.handler = pykickstart.version.makeVersion(kickstart.superclass.version)
-        self._commandMap = kickstart.commandMap
-        self._dataMap = kickstart.dataMap
 
 # Verify that each kickstart command in anaconda uses the correct version of
 # that command as provided by pykickstart.  That is, if there's an FC3 and an
 # F10 version of a command, make sure anaconda >= F10 uses the F10 version.
-class CommandVersionTestCase(BaseTestCase):
+class CommandVersionTestCase(unittest.TestCase):
+
+    def assert_compare_versions(self, children, parents):
+        """Check if children inherit from parents."""
+        for name in children:
+            print(name, children[name], parents[name])
+            self.assertIsInstance(children[name](), parents[name])
+
     def commands_test(self):
         """Test that anaconda uses the right versions of kickstart commands"""
-        for (commandName, commandObj) in self._commandMap.iteritems():
-            pykickstartClass = self.handler.commands[commandName].__class__
-            self.assertIsInstance(commandObj(), pykickstartClass)
+        anaconda_cmds = kickstart.commandMap
+        pykickstart_cmds = kickstart.superclass.commandMap
+        self.assert_compare_versions(anaconda_cmds, pykickstart_cmds)
 
-# Do the same thing as CommandVersionTestCase, but for data objects.
-class DataVersionTestCase(BaseTestCase):
     def data_test(self):
         """Test that anaconda uses the right versions of kickstart data"""
-        for (dataName, dataObj) in self._dataMap.iteritems():
-            # pykickstart does not expose data objects as a mapping the way
-            # it does command objects.
-            pykickstartClass = eval("self.handler.%s" % dataName)
-            self.assertIsInstance(dataObj(), pykickstartClass)
+        anaconda_data = kickstart.dataMap
+        pykickstart_data = kickstart.superclass.dataMap
+        self.assert_compare_versions(anaconda_data, pykickstart_data)
 
-# Copy the commands tests but with the command map from dracut/parse-kickstart
-class DracutCommandVersionTestCase(CommandVersionTestCase):
-    def setUp(self):
-        CommandVersionTestCase.setUp(self)
-
+    def dracut_commands_test(self):
+        """Test that dracut uses the right versions of kickstart commands"""
         # top_srcdir should have been set by nosetests.sh. If it wasn't, the KeyError
         # will fail the test.
         parse_kickstart_path = os.path.join(os.environ['top_srcdir'], 'dracut', 'parse-kickstart')
@@ -76,4 +63,6 @@ class DracutCommandVersionTestCase(CommandVersionTestCase):
             parse_module = imp.load_module('parse_kickstart', parse_temp.file,
                     parse_temp.name, ('', 'r', imp.PY_COMPILED))
 
-        self._commandMap = parse_module.dracutCmds
+        dracut_commands = parse_module.dracutCmds
+        pykickstart_commands = kickstart.superclass.commandMap
+        self.assert_compare_versions(dracut_commands, pykickstart_commands)

--- a/tests/storage/cases/__init__.py
+++ b/tests/storage/cases/__init__.py
@@ -27,7 +27,7 @@ blivet.util.set_up_logging()
 blivet_log = logging.getLogger("blivet")
 blivet_log.info(sys.argv[0])
 
-from pyanaconda.installclass import DefaultInstall
+from pyanaconda.installclass import factory
 from pyanaconda.kickstart import AnacondaKSHandler, AnacondaKSParser, doKickstartStorage
 from pykickstart.errors import KickstartError
 
@@ -205,7 +205,7 @@ class TestCaseComponent(object):
             parser = AnacondaKSParser(AnacondaKSHandler())
             parser.readKickstartFromString(self.ks)
 
-            instClass = DefaultInstall()
+            instClass = factory.get_best_install_class()
 
             doKickstartStorage(self._blivet, parser.handler, instClass)
             self._blivet.updateKSData()


### PR DESCRIPTION
The install class can be now specified in the kickstart file by its name 
with the `installclass` command in the `%anaconda` section.

Backported from: https://github.com/rhinstaller/anaconda/pull/1120
Resolves: rhbz#1412159