### PR TITLE
timezone: for kickstart allow also timezones not offered by GUI (#145…

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1765,7 +1765,11 @@ class Timezone(commands.timezone.RHEL7_Timezone):
 
     def execute(self, *args):
         # write out timezone configuration
-        if not timezone.is_valid_timezone(self.timezone):
+        if timezone.is_valid_timezone(self.timezone):
+            if not timezone.is_valid_ui_timezone(self.timezone):
+                log.warning("Timezone specification %s set in kickstart is "\
+                            "not offered by installer GUI.", self.timezone)
+        else:
             # this should never happen, but for pity's sake
             log.warning("Timezone %s set in kickstart is not valid, falling "\
                         "back to default (America/New_York).", self.timezone)

--- a/pyanaconda/timezone.py
+++ b/pyanaconda/timezone.py
@@ -202,9 +202,9 @@ def get_all_regions_and_timezones():
     result["Etc"] = set(ETC_ZONES)
     return result
 
-def is_valid_timezone(timezone):
+def is_valid_ui_timezone(timezone):
     """
-    Check if a given string is an existing timezone.
+    Check if a given string is a timezone specification offered by GUI.
 
     :type timezone: str
     :rtype: bool
@@ -214,6 +214,23 @@ def is_valid_timezone(timezone):
     etc_zones = ["Etc/" + zone for zone in ETC_ZONES]
 
     return timezone in pytz.common_timezones + etc_zones
+
+def is_valid_timezone(timezone):
+    """
+    Check if a given string is a valid timezone specification.
+
+    This includes also deprecated/backward timezones linked to other timezones
+    in tz database (eg Japan -> Asia/Tokyo). Both the tzdata package (installed
+    system) and TimezoneMap widget (installer GUI) should support them and be
+    able link them to the correct timezone specification using the data from
+    "backward" file.
+
+    :type timezone: str
+    :rtype: bool
+
+    """
+
+    return is_valid_ui_timezone(timezone) or timezone in pytz.all_timezones
 
 def get_timezone(timezone):
     """

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -40,7 +40,7 @@ from pyanaconda.ui.gui.helpers import GUIDialogInputCheckHandler
 from pyanaconda.ui.helpers import InputCheck
 
 from pyanaconda.i18n import _, CN_
-from pyanaconda.timezone import NTP_SERVICE, get_all_regions_and_timezones, get_timezone, is_valid_timezone
+from pyanaconda.timezone import NTP_SERVICE, get_all_regions_and_timezones, get_timezone, is_valid_timezone, is_valid_ui_timezone
 from pyanaconda.localization import get_xlated_timezone, resolve_date_format
 from pyanaconda import iutil
 from pyanaconda import isys
@@ -511,8 +511,13 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
             self.add_to_store_xlated(self._citiesStore, city, xlated)
 
         self._update_datetime_timer_id = None
-        if is_valid_timezone(self.data.timezone.timezone):
+        if is_valid_ui_timezone(self.data.timezone.timezone):
             self._set_timezone(self.data.timezone.timezone)
+        elif is_valid_timezone(self.data.timezone.timezone):
+            log.warning("Timezone specification %s is not offered by installer GUI.",
+                        self.data.timezone.timezone)
+            # Try to get the correct linked timezone via TimezoneMap selection
+            self._tzmap.set_timezone(self.data.timezone.timezone)
         elif not flags.flags.automatedInstall:
             log.warning("%s is not a valid timezone, falling back to default (%s)",
                         self.data.timezone.timezone, DEFAULT_TZ)


### PR DESCRIPTION
…2873)

Resolves: rhbz#1452873

For example Japan, which is linked to Asia/Tokyo in Olson tz database,
and we offer only Asia/Tokyo in GUI.