### PR TITLE
Add support for the RHV branded help content variant (#1378010)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -23,7 +23,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define firewalldver 0.3.5-1
 %define gettextver 0.18.1
 %define gtk3ver 3.22.10
-%define helpver 1:7.3.1-1
+%define helpver 1:7.5.3-1
 %define intltoolver 0.31.2-3
 %define iscsiver 6.2.0.870-3
 %define isomd5sum 1.0.10

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -67,7 +67,7 @@ class BaseInstallClass(object):
     default_autopart_type = DEFAULT_AUTOPART_TYPE
 
     # help
-    help_folder = "/usr/share/anaconda/help"
+    help_folder = "/usr/share/anaconda/help/rhel"
     help_main_page = "Installation_Guide.xml"
     help_placeholder = None
     help_placeholder_with_links = None

--- a/pyanaconda/installclasses/rhv.py
+++ b/pyanaconda/installclasses/rhv.py
@@ -38,6 +38,9 @@ class OvirtBaseInstallClass(BaseInstallClass):
     efi_dir = "centos"
     default_autopart_type = AUTOPART_TYPE_LVM_THINP
 
+    # there is a RHV branded help content variant
+    help_folder = "/usr/share/anaconda/help/rhv"
+
     def configure(self, anaconda):
         BaseInstallClass.configure(self, anaconda)
 


### PR DESCRIPTION
Show the RHV (Red Hat Virtualization) branded help content using the RHV
install class is being used.

The default help content also moved to the rhel subfolder, so also
account for that and bump the required version of the help content
package.

Resolves: rhbz#1378010