### PR TITLE
Fix accelerator key for blivet-gui partitioning (#1482438)

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.glade
+++ b/pyanaconda/ui/gui/spokes/storage.glade
@@ -828,7 +828,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioButton" id="blivetguiRadioButton">
-                                        <property name="label" translatable="yes" context="GUI|Storage">A_dvanced Custom (Blivet-GUI)</property>
+                                        <property name="label" translatable="yes" context="GUI|Storage">Advanced Custom (_Blivet-GUI)</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>


### PR DESCRIPTION
"D" is already used for "Done" so use "B" instead.