### PR TITLE
Fix SL install class to use right efi dir

### DIFF
--- a/pyanaconda/installclasses/scientific.py
+++ b/pyanaconda/installclasses/scientific.py
@@ -34,7 +34,7 @@ class ScientificBaseInstallClass(RHELBaseInstallClass):
 
     installUpdates = True
 
-    efi_dir = "sl"
+    efi_dir = "scientific"
 
     help_placeholder = "SLPlaceholder.html"
     help_placeholder_with_links = "SLPlaceholder.html"


### PR DESCRIPTION
Turns out when I initially committed the efi dir, I did it wrong.  This is the correct EFI dir for Scientific Linux.