### PR TITLE
Move the installclass command to the %anaconda section.

### DIFF
--- a/docs/kickstart.rst
+++ b/docs/kickstart.rst
@@ -49,6 +49,20 @@ pwpolicy
         Do not allow UI to be used to change the password/user if it has been set in
         the kickstart.
 
+
+installclass
+------------
+
+``installclass --name=<name>``
+
+    Require the specified install class to be used for the installation.
+    Otherwise, the best available install class will be used.
+
+    ``--name=``
+
+        Name of the required install class.
+
+
 The defaults for interactive installations are set in the ``/usr/share/anaconda/interactive-defaults.ks``
 file provided by Anaconda. If a product, such as Fedora Workstation, wishes to override them
 then a ``product.img`` needs to be created with a new version of the file included.

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -93,8 +93,8 @@ class Anaconda(object):
             from pyanaconda.installclass import factory
 
             # Get install class by name.
-            if self.ksdata.installclass.seen:
-                name = self.ksdata.installclass.name
+            if self.ksdata.anaconda.installclass.seen:
+                name = self.ksdata.anaconda.installclass.name
                 self._instClass = factory.get_install_class_by_name(name)
             # Or just find the best one.
             else:

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -66,7 +66,8 @@ from blivet.partitioning import do_partitioning, grow_lvm
 from blivet.platform import platform
 from blivet.size import Size, KiB
 
-from pykickstart.base import BaseHandler
+from pykickstart.base import BaseHandler, KickstartCommand
+from pykickstart.options import KSOptionParser
 from pykickstart.constants import CLEARPART_TYPE_NONE, CLEARPART_TYPE_ALL, \
                                   FIRSTBOOT_SKIP, FIRSTBOOT_RECONFIG, \
                                   KS_SCRIPT_POST, KS_SCRIPT_PRE, KS_SCRIPT_TRACEBACK, KS_SCRIPT_PREINSTALL, \
@@ -2080,9 +2081,44 @@ class Upgrade(commands.upgrade.F20_Upgrade):
 ### %anaconda Section
 ###
 
+
+class F27_InstallClass(KickstartCommand):
+    removedKeywords = KickstartCommand.removedKeywords
+    removedAttrs = KickstartCommand.removedAttrs
+
+    def __init__(self, *args, **kwargs):
+        KickstartCommand.__init__(self, *args, **kwargs)
+        self.op = self._getParser()
+        self.name = kwargs.get("name", "")
+
+    def __str__(self):
+        retval = KickstartCommand.__str__(self)
+        if not self.seen:
+            return retval
+
+        retval += "installclass%s\n" % self._getArgsAsStr()
+        return retval
+
+    def _getArgsAsStr(self):
+        retval = ""
+        if self.name:
+            retval += ' --name="%s"' % self.name
+        return retval
+
+    def _getParser(self):
+        op = KSOptionParser()
+        op.add_option("--name", dest="name", required=True, type="string")
+        return op
+
+    def parse(self, args):
+        (opts, _) = self.op.parse_args(args=args, lineno=self.lineno)
+        self.set_to_self(self.op, opts)
+        return self
+
 class AnacondaSectionHandler(BaseHandler):
     """A handler for only the anaconda ection's commands."""
     commandMap = {
+        "installclass": F27_InstallClass,
         "pwpolicy": F22_PwPolicy
     }
 


### PR DESCRIPTION
The installclass command is anaconda specific, so it should be
part of the %anaconda section.