### PR TITLE
Move python3-gobject Requires to core

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -104,6 +104,7 @@ Requires: langtable-python3 >= %{langtablever}
 Requires: authconfig
 Requires: firewalld >= %{firewalldver}
 Requires: util-linux >= %{utillinuxver}
+Requires: python3-gobject-base
 Requires: python3-dbus
 Requires: python3-pwquality
 Requires: python3-systemd
@@ -186,7 +187,6 @@ Requires: NetworkManager-wifi
 %endif
 Requires: anaconda-user-help >= %{helpver}
 Requires: yelp
-Requires: python3-gobject-base
 Requires: blivet-gui-runtime >= %{blivetguiver}
 
 # Needed to compile the gsettings files


### PR DESCRIPTION
Only GUI required `python3-gobject` package which is wrong because this package is required for example in `pyanaconda/nm.py` which is used also in TUI.

Moving this package to `core` could prevent future issues.