### PR TITLE
Branching instructions & improvement

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -195,3 +195,129 @@ Once Fedora enters a freeze:
 Once Fedora exits the freeze:
 
 - drop the downstream patches and do merge based releases as before
+
+
+Branching for the next Fedora release
+=====================================
+
+Anaconda uses separate branches for each Fedora release to make parallel Anaconda development for Rawhide and next Fedora possible.
+The branches are named like this:
+
+- f<number>-devel
+- f<number>-release
+
+The ``-devel`` branch is where code changes go and it is periodically merged to the master branch.
+The ``-release`` branch contains release commits and any Fedora version specific hotfixes.
+
+How to branch Anaconda
+----------------------
+
+Create the ``-devel`` branch:
+
+::
+
+    git checkout master
+    git pull
+    git checkout -b f<version>-devel
+
+Create the ``-release`` branch:
+
+::
+
+    git checkout unstable
+    git pull
+    git checkout -b f<version>-release
+
+Push the branches to the origin (``-u`` makes sure to setup tracking) :
+
+::
+
+    git push -u origin f<version>-devel
+    git push -u origin f<version>-release
+
+How to create translation branch for next Fedora in Zanata
+----------------------------------------------------------
+
+The Fedora project uses the fedora.zanata.org translation system, so for each Fedora release we also need
+to create a new translation branch there.
+
+To do this you need to have:
+
+- a FAS account
+- be in the admin group of the Anaconda project on Zanata
+
+1. Go to the Anaconda project on the Fedora Zanata instance: https://fedora.zanata.org/project/view/anaconda
+
+2. Make sure you are logged in.
+
+3. Click on the small arrow next to the ``master`` branch and select ``Copy to new version``
+
+4. On the new page ``version id`` should be ``f<version>`` and make sure ``Copy from previous version`` is ticked
+
+5. Wait till the new branch is created.
+
+How to bump Rawhide Anaconda version
+------------------------------------
+
+- major version becomes major version ``+1``
+- minor version is set to 1
+
+For example, for the F27 branching:
+
+- at the time of branching the Rawhide version was ``27.20``
+- after the bump the version is ``28.1``
+
+
+First checkout the ``unstable`` branch and merge the ``master`` branch into it:
+
+::
+
+    git checkout unstable
+    git merge --no-ff master
+
+Then do the major version bump and verify the output looks correct:
+
+::
+
+    ./scripts/makebumpver --skip-zanata -c --bump-major-version
+
+If everything looks fine (changelog, new major version & the tag) push the changes to the origin:
+
+::
+
+    git push origin unstable --tags
+
+Then continue with the normal Rawhide Anaconda build process.
+
+How to add release version for next Fedora
+------------------------------------------
+
+The current practise is to keep the Rawhide major & minor version from which the
+given Anaconda was branched as-is and add a third version number (the release number
+in the NVR nomenclature) and bump that when releasing a new Anaconda for the
+upcoming Fedora release.
+
+For example, for the F27 branching:
+
+- the last Rawhide Anaconda release was 27.20
+- so the first F27 Anaconda release will be 27.20.1, the next 27.20.2 and so on
+
+First checkout the ``f<version>-release`` branch and merge ``f<version>-devel`` into it:
+
+::
+
+    git checkout f<version>-release
+    git merge --no-ff f<version>-devel
+
+Then add the third (release) version number:
+
+::
+    ./scripts/makebumpver --skip-zanata -c --add-version-number
+
+If everything looks fine (changelog, the version number & tag) push the changes to the origin:
+
+::
+
+    git push origin f<version>-release --tags
+
+Then continue with the normal Upcoming Fedora Anaconda build process.

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -121,6 +121,8 @@ class MakeBumpVer:
                             help="Do not change any files, only run checks.")
         parser.add_argument("-c", "--commit-and-tag", dest="commit_and_tag", action="store_true",
                             help="Create and tag a release commit once bumping the Anaconda version.")
+        parser.add_argument("--bump-major-version", dest="bump_major_version", action="store_true",
+                            help="Bump Anaconda major version and reset minor version to 1.")
 
         # gather all unprocessed command line arguments
         parser.add_argument(nargs=argparse.REMAINDER, dest="unknown_arguments")
@@ -206,9 +208,13 @@ class MakeBumpVer:
         proc = run_program(['git', 'config', field])
         return proc[0].strip('\n')
 
-    def _incrementVersion(self):
+    def _incrementVersion(self, bump_major_version=False):
         fields = self.version.split('.')
-        fields[-1] = str(int(fields[-1]) + 1)
+        if bump_major_version:  # increment major version
+            fields[0] = str(int(fields[0]) + 1) # bump major version
+            fields[-1] = str(int(1)) # reset minor version to 1
+        else:  # minor version bump
+            fields[-1] = str(int(fields[-1]) + 1)
         new = ".".join(fields)
         return new
 
@@ -641,7 +647,7 @@ class MakeBumpVer:
         if not self.skip_jenkins and not self.check_jenkins():
             log.warning("jenkins test results do not pass; ignoring for now")
 
-        newVersion = self._incrementVersion()
+        newVersion = self._incrementVersion(bump_major_version=self.args.bump_major_version)
         fixedIn = "%s-%s-%s" % (self.name, newVersion, self.new_release)
         rpmlog = self._rpmLog(fixedIn)
 

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -123,6 +123,8 @@ class MakeBumpVer:
                             help="Create and tag a release commit once bumping the Anaconda version.")
         parser.add_argument("--bump-major-version", dest="bump_major_version", action="store_true",
                             help="Bump Anaconda major version and reset minor version to 1.")
+        parser.add_argument("--add-version-number", dest="add_version_number", action="store_true",
+                            help="Add another . separated version number starting at 1. Typically used for branching from Rawhide.")
 
         # gather all unprocessed command line arguments
         parser.add_argument(nargs=argparse.REMAINDER, dest="unknown_arguments")
@@ -130,6 +132,10 @@ class MakeBumpVer:
         self.args = parser.parse_args()
         if self.args.debug:
             log.setLevel(logging.DEBUG)
+
+        if self.args.bump_major_version and self.args.add_version_number:
+            sys.stderr.write("The --bump-major-version and --add-version-number options can't be used at the same time.\n")
+            sys.exit(1)
 
         if self.args.unknown_arguments:
             parser.print_usage()
@@ -208,9 +214,11 @@ class MakeBumpVer:
         proc = run_program(['git', 'config', field])
         return proc[0].strip('\n')
 
-    def _incrementVersion(self, bump_major_version=False):
+    def _incrementVersion(self, bump_major_version=False, add_version_number=False):
         fields = self.version.split('.')
-        if bump_major_version:  # increment major version
+        if add_version_number:  # add another version number to the end
+            fields.append(str(int(1)))
+        elif bump_major_version:  # increment major version
             fields[0] = str(int(fields[0]) + 1) # bump major version
             fields[-1] = str(int(1)) # reset minor version to 1
         else:  # minor version bump
@@ -647,7 +655,8 @@ class MakeBumpVer:
         if not self.skip_jenkins and not self.check_jenkins():
             log.warning("jenkins test results do not pass; ignoring for now")
 
-        newVersion = self._incrementVersion(bump_major_version=self.args.bump_major_version)
+        newVersion = self._incrementVersion(bump_major_version=self.args.bump_major_version,
+                                            add_version_number=self.args.add_version_number)
         fixedIn = "%s-%s-%s" % (self.name, newVersion, self.new_release)
         rpmlog = self._rpmLog(fixedIn)
 

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -40,6 +40,10 @@ DEFAULT_ZANATA_GIT_BRANCH_ALIASES = {
     "unstable": "master",
 }
 
+VERSION_NUMBER_INCREMENT = 1
+DEFAULT_ADDED_VERSION_NUMBER = 1
+DEFAULT_MINOR_VERSION_NUMBER = 1
+
 def run_program(*args):
     """Run a program with universal newlines on"""
     # pylint: disable=no-value-for-parameter
@@ -217,12 +221,12 @@ class MakeBumpVer:
     def _incrementVersion(self, bump_major_version=False, add_version_number=False):
         fields = self.version.split('.')
         if add_version_number:  # add another version number to the end
-            fields.append(str(int(1)))
+            fields.append(str(int(DEFAULT_ADDED_VERSION_NUMBER)))
         elif bump_major_version:  # increment major version
-            fields[0] = str(int(fields[0]) + 1) # bump major version
-            fields[-1] = str(int(1)) # reset minor version to 1
+            fields[0] = str(int(fields[0]) + VERSION_NUMBER_INCREMENT)  # bump major version
+            fields[1] = str(int(DEFAULT_MINOR_VERSION_NUMBER))  # reset minor version to 1
         else:  # minor version bump
-            fields[-1] = str(int(fields[-1]) + 1)
+            fields[-1] = str(int(fields[-1]) + VERSION_NUMBER_INCREMENT)
         new = ".".join(fields)
         return new
 


### PR DESCRIPTION
Add options to `makebumpver` for easy & robust Rawhide & next Fedora Anaconda version bumps and document the whole branching process.