### PR TITLE
Use /usr/bin/python3 shebang once again

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -1,4 +1,4 @@
-#!/usr/libexec/system-python
+#!/usr/bin/python3
 #
 # anaconda: The Red Hat Linux Installation program
 #


### PR DESCRIPTION
This revert changes from b23760dcac91fcc77cc629d3e87757a8b4b6aae0

System Python was removed,
see https://fedoraproject.org/wiki/Changes/Platform_Python_Stack

Currently, /usr/libexec/system-python is just a symbolic link to /usr/bin/python3