### PR TITLE
Fix catch TUI not main thread exceptions

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -40,7 +40,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define pykickstartver 2.36-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
-%define simplelinever 0.4-1
+%define simplelinever 0.5-1
 %define utillinuxver 2.15.1
 
 BuildRequires: audit-libs-devel

--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -61,7 +61,7 @@ class SummaryHub(TUIHub):
             sys.stdout.flush()
             spokes = self._spokes.values()
             while not all(spoke.ready for spoke in spokes):
-                # Catch any asyncronous events (like storage crashing)
+                # Catch any asynchronous events (like storage crashing)
                 loop = App.get_event_loop()
                 loop.process_signals()
                 sys.stdout.write('.')


### PR DESCRIPTION
Exception which are not in a main thread was passed to the `hubQ` which is not used anymore in Simpleline. To resolve this issue, exceptions are now enqueued as `ExceptionSignal`.

This must be merged after https://github.com/rhinstaller/python-simpleline/pull/39