### PR TITLE
Add efi_dir to the BaseInstallClass (#1412391)

### DIFF
--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -59,6 +59,9 @@ class BaseInstallClass(object):
 
     _l10n_domain = None
 
+    # EFI directory.
+    efi_dir = "default"
+
     # The default filesystem type to use.  If None, we will use whatever
     # Blivet uses by default.
     defaultFS = None

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -213,12 +213,6 @@ class InstallClassFactory(object):
             install_class = self.visible_classes[0]
             log.info("Using a visible install class %s.",
                      self._get_class_description(install_class))
-
-        elif self.classes:
-            install_class = self.classes[0]
-            log.info("Using a hidden install class %s.",
-                     self._get_class_description(install_class))
-
         else:
             raise RuntimeError("Unable to find an install class to use.")
 

--- a/pyanaconda/installclasses/default.py
+++ b/pyanaconda/installclasses/default.py
@@ -1,0 +1,31 @@
+#
+# default.py
+#
+# Copyright (C) 2017  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from pyanaconda.installclasses.fedora import FedoraBaseInstallClass
+
+__all__ = ["DefaultInstallClass"]
+
+
+class DefaultInstallClass(FedoraBaseInstallClass):
+    """This install class will be used by default.
+
+    In case, that anaconda cannot use any other install class,
+    this one will be used, so the installation will not fail.
+    """
+    sortPriority = 0
+    hidden = False

--- a/tests/pyanaconda_tests/installclass_test.py
+++ b/tests/pyanaconda_tests/installclass_test.py
@@ -124,7 +124,9 @@ class FactoryTest(unittest.TestCase):
             self.assertEqual(factory.classes, [InstallClassA])
             self.assertEqual(factory.visible_classes, [])
 
-            self.assertTrue(isinstance(factory.get_best_install_class(), InstallClassA))
+            with self.assertRaises(RuntimeError):
+                factory.get_best_install_class()
+
             self.assertTrue(isinstance(factory.get_install_class_by_name("Install Class A"), InstallClassA))
 
             with self.assertRaises(RuntimeError):


### PR DESCRIPTION
Attribute efi_dir should be defined in BaseInstallClass as well.

Also, it doesn't make sense to use hidden install classes. If we cannot
use a visible install class, we should raise an exception.

Resolves: rhbz#1412391