### PR TITLE
Better storing logs from build and tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,6 +61,14 @@ COVERAGE ?= coverage3
 USER_SITE_BASE ?= $(abs_top_builddir)/python-site
 USER_SITE_PACKAGES ?= $(shell PYTHONUSERBASE=$(USER_SITE_BASE) $(PYTHON) -m site --user-site)
 
+RESULT_DIR ?= $(srcdir)/result
+BUILD_RESULT_DIR = $(RESULT_DIR)/build
+TEST_RESULT_DIR = $(RESULT_DIR)/tests
+
+SRPM_BUILD_DIR = $(BUILD_RESULT_DIR)/00-srpm-build
+RPM_BUILD_DIR = $(BUILD_RESULT_DIR)/01-rpm-build
+TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
+
 # If translations are present, run tests on the .po files before tarring them
 # up. Use a weird looking loop because shell doesn't have a good way to test
 # for a wildcard
@@ -120,13 +128,14 @@ release-and-tag:
 	$(MAKE) tag
 
 rc-release: scratch-bumpver scratch
-	mock -r $(MOCKCHROOT) --scrub all || exit 1
-	mock -r $(MOCKCHROOT) --buildsrpm  --spec ./$(PACKAGE_NAME).spec --sources . --resultdir $(PWD) || exit 1
-	mock -r $(MOCKCHROOT) --rebuild *src.rpm --resultdir $(PWD) || exit 1
+	-rm -rf $(BUILD_RESULT_DIR)
+	mock -r $(MOCKCHROOT) --clean || exit 1
+	mock -r $(MOCKCHROOT) --buildsrpm  --spec ./$(PACKAGE_NAME).spec --sources . --resultdir $(SRPM_BUILD_DIR) || exit 1
+	mock -r $(MOCKCHROOT) --rebuild $(SRPM_BUILD_DIR)/*src.rpm --resultdir $(RPM_BUILD_DIR) || exit 1
 
 test-install: rc-release
-	mock -r $(MOCKCHROOT) --scrub all || exit 1
-	mock -r $(MOCKCHROOT) --install $(PWD)/anaconda-*$(ARCH_NAME).rpm
+	mock -r $(MOCKCHROOT) --clean || exit 1
+	mock -r $(MOCKCHROOT) --install $(RPM_BUILD_DIR)/anaconda-*$(ARCH_NAME).rpm --resultdir $(TEST_INST_BUILD_DIR)
 
 bumpver: po-pull
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \
@@ -220,7 +229,7 @@ bare-ci:
 		TEST_SUITE_LOG=test-suite.log.$$$$ TESTS=nosetests_root.sh \
 		PYTHONUSERBASE=$(USER_SITE_BASE) check
 	@mkdir -p repo
-	@mv *rpm repo
+	@mv $(RPM_BUILD_DIR)/*rpm repo
 	@createrepo_c -p repo
 	@sudo $(MAKE) TMPDIR=/var/tmp COVERAGE_PROCESS_START=$(abs_builddir)/.coveragerc \
 		TEST_SUITE_LOG=test-suite.log.$$$$ PYTHONUSERBASE=$(USER_SITE_BASE) check
@@ -230,25 +239,25 @@ bare-ci:
 	$(MAKE) coverage-report
 
 isolated-test: setup-test-env
-	mock -r $(MOCKCHROOT) --chroot -- "cd /root/anaconda && $(MAKE) bare-ci" || echo $$? > tests/error_occured
+	mock -r $(MOCKCHROOT) --chroot -- "cd /root/anaconda && $(MAKE) bare-ci" || echo $$? > $(srcdir)/tests/error_occured
 	mock -r $(MOCKCHROOT) --chroot -- "mkdir -p /result && chmod 755 /result" || exit 1
-	mock -r $(MOCKCHROOT) --chroot -- "cp -r /root/anaconda/tests/**/*.log /root/anaconda/tests/*.log* /result/" || exit 1
+	mock -r $(MOCKCHROOT) --chroot -- "cd /root/anaconda/tests && cp -r --parents ./**/*.log ./*.log* /result/" || exit 1
 
-	-rm -rf $(srcdir)/result
-	cp -r "$$(mock -r $(MOCKCHROOT) -p)/result" $(srcdir)
+	-rm -rf $(TEST_RESULT_DIR)
+	mkdir -p $(TEST_RESULT_DIR)
+	cp -r $$(mock -r $(MOCKCHROOT) -p)/result/* $(TEST_RESULT_DIR)/
 # Move builders logs
-	-mv $(srcdir)/*.log $(srcdir)/result/
-	-mv $(srcdir)/result/test-suite.log.* $(srcdir)/result/test-suite.log
-	@if [ -f tests/error_occured ]; then \
+	-mv $(TEST_RESULT_DIR)/test-suite.log.* $(TEST_RESULT_DIR)/test-suite.log
+	@if [ -f $(srcdir)/tests/error_occured ]; then \
 		echo "TEST FAILED"; \
-		status=$$(cat tests/error_occured); \
-		rm tests/error_occured; \
+		status=$$(cat $(srcdir)/tests/error_occured); \
+		rm $(srcdir)/tests/error_occured; \
 		exit $$status; \
 	fi
 
 setup-test-env:
 	@-rm -f tests/error_occured
-	mock -r $(MOCKCHROOT) --scrub all || exit 1
+	mock -r $(MOCKCHROOT) --clean || exit 1
 # Install missing dependencies for running make install-test-requires
 	mock -r $(MOCKCHROOT) -i dnf python3 git || exit 1
 	mock -r $(MOCKCHROOT) --copyin $(srcdir) /root/anaconda || exit 1


### PR DESCRIPTION
After this change when ``./autogen.sh && ./configure && make MOCKCHROOT=anaconda-rawhide-x86_64 isolated-ci`` will be ran the output will be stored in the `result` directory with these files:

```
result
├── build
│   ├── 00-srpm-build
│   │   ├── anaconda-26.2-0.1.20170906131641.fc28.src.rpm
│   │   ├── build.log
│   │   ├── hw_info.log
│   │   ├── root.log
│   │   └── state.log
│   ├── 01-rpm-build
│   │   ├── anaconda-26.2-0.1.20170906131641.fc28.src.rpm
│   │   ├── anaconda-26.2-0.1.20170906131641.fc28.x86_64.rpm
│   │   ├── anaconda-core-26.2-0.1.20170906131641.fc28.x86_64.rpm
│   │   ├── anaconda-core-debuginfo-26.2-0.1.20170906131641.fc28.x86_64.rpm
│   │   ├── anaconda-debuginfo-26.2-0.1.20170906131641.fc28.x86_64.rpm
│   │   ├── anaconda-debugsource-26.2-0.1.20170906131641.fc28.x86_64.rpm
│   │   ├── anaconda-dracut-26.2-0.1.20170906131641.fc28.x86_64.rpm
│   │   ├── anaconda-dracut-debuginfo-26.2-0.1.20170906131641.fc28.x86_64.rpm
│   │   ├── anaconda-gui-26.2-0.1.20170906131641.fc28.x86_64.rpm
│   │   ├── anaconda-tui-26.2-0.1.20170906131641.fc28.x86_64.rpm
│   │   ├── anaconda-widgets-26.2-0.1.20170906131641.fc28.x86_64.rpm
│   │   ├── anaconda-widgets-debuginfo-26.2-0.1.20170906131641.fc28.x86_64.rpm
│   │   ├── anaconda-widgets-devel-26.2-0.1.20170906131641.fc28.x86_64.rpm
│   │   ├── build.log
│   │   ├── hw_info.log
│   │   ├── installed_pkgs.log
│   │   ├── root.log
│   │   └── state.log
│   └── 02-test-install
│       ├── build.log
│       ├── hw_info.log
│       ├── root.log
│       └── state.log
└── tests
    ├── coverage-report.log
    ├── cppcheck
    │   └── runcppcheck.log
    ├── gettext_tests
    │   ├── canary_tests.log
    │   ├── click.py.log
    │   ├── contexts.py.log
    │   ├── gettext_tests.log
    │   └── style_guide.py.log
    ├── glade
    │   └── run_glade_tests.py.log
    ├── nosetests.log
    ├── nosetests_root.log
    ├── pylint
    │   └── runpylint.py.log
    ├── storage
    │   └── run_storage_tests.py.log
    └── test-suite.log

10 directories, 40 files
```

Our CI will store only logs from this directory structure. However, the rpm files can be later used for running KS tests on pull requests.