### PR TITLE
Make EFIGRUB._efi_binary a property, not a method

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1846,6 +1846,7 @@ class EFIGRUB(EFIBase, GRUB2):
         if value == '32':
             self._is_32bit_firmware = True
 
+    @property
     def _efi_binary(self):
         if self._is_32bit_firmware:
             return "\\shimia32.efi"


### PR DESCRIPTION
This was previously a class attribute and still is one for the
other classes, and the code that uses it treats it as such. So
for EFIGRUB we need to make it a property. Without this fix,
UEFI installs crash with "TypeError: must be str, not method".

Signed-off-by: Adam Williamson <awilliam@redhat.com>