### PR TITLE
Don't setup the hub twice

### DIFF
--- a/pyanaconda/ui/tui/hubs/__init__.py
+++ b/pyanaconda/ui/tui/hubs/__init__.py
@@ -62,6 +62,7 @@ class TUIHub(TUIObject, common.Hub):
         self.input_required = True
 
     def setup(self, args="anaconda"):
+        TUIObject.setup(self, args)
         environment = args
         cats_and_spokes = self._collectCategoriesAndSpokes()
         categories = cats_and_spokes.keys()


### PR DESCRIPTION
We need to make sure, that the simpleline's setup is called as well,
so simpleline will remember that the setup was already done.

Resolves: rhbz#1491333