### PR TITLE
Add new checks for user names (#1491006)

### DIFF
--- a/pyanaconda/regexes.py
+++ b/pyanaconda/regexes.py
@@ -30,20 +30,17 @@ GECOS_VALID = re.compile(r'^[^:]*$')
 # the portable filesystem character set (ASCII alnum plus dot, underscore,
 # and hyphen), with the additional restriction that names not start with a
 # hyphen. The Red Hat modification to shadow-utils starts with these rules
-# and additionally allows a final $, because Samba.
+# and additionally allows a final $, because Samba. It doesn't allow fully
+# numeric names or just "." or "..".
 #
 # shadow-utils also defines length limits for names: 32 for group names,
 # and UT_NAMESIZE for user names (which is defined as 32 bits/utmp.h). This
 # expression captures all of that: the initial character, followed by either
 # up to 30 portable characters and a dollar sign or up to 31 portable characters,
-# both for a maximum total of 32. The empty string is not allowed. "root" is not
-# allowed.
+# both for a maximum total of 32. The empty string is not allowed.
 
-# a base expression without anchors, helpful for building other expressions
-# If the string is the right length to match "root", use a lookback expression
-# to make sure it isn't.
 PORTABLE_FS_CHARS = r'a-zA-Z0-9._-'
-_USERNAME_BASE = r'[a-zA-Z0-9._](([' + PORTABLE_FS_CHARS + r']{0,2})|([' + PORTABLE_FS_CHARS + r']{3}(?<!root))|([' + PORTABLE_FS_CHARS + r']{4,31})|([' + PORTABLE_FS_CHARS + r']{,30}\$))'
+_USERNAME_BASE = r'[a-zA-Z0-9._][' + PORTABLE_FS_CHARS + r']{0,30}([' + PORTABLE_FS_CHARS + r']|\$)?'
 
 USERNAME_VALID = re.compile(r'^' + _USERNAME_BASE + '$')
 GROUPNAME_VALID = USERNAME_VALID

--- a/pyanaconda/users.py
+++ b/pyanaconda/users.py
@@ -148,23 +148,36 @@ def validatePassword(pw, user="root", settings=None, minlen=None, empty_ok=False
     return pw_score, status_text, pw_quality, error_message
 
 def check_username(name):
+    # Check reserved names.
     if name in os.listdir("/") + ["root", "home", "daemon", "system"]:
         return (False, _("User name is reserved for system: %s") % name)
 
+    # Check shadow-utils rules.
     if name.startswith("-"):
-        return (False, _("User name cannot start with '-' character"))
+        return (False, _("User name cannot start with '-' character."))
+
+    if name in [".", ".."]:
+        return (False, _("User name '%s' is not allowed.") % name)
+
+    if name.isdigit():
+        return (False, _("Fully numeric user name is not allowed."))
 
     # Final '$' allowed for Samba
+    if name == "$":
+        return (False, _("User name '$' is not allowed."))
+
     if name.endswith("$"):
         sname = name[:-1]
     else:
         sname = name
+
     match = re.search(r'[^' + PORTABLE_FS_CHARS + r']', sname)
+
     if match:
         return (False, _("User name cannot contain character: '%s'") % match.group())
 
     if len(name) > 32:
-        return (False, _("User name must be shorter than 33 characters"))
+        return (False, _("User name must be shorter than 33 characters."))
 
     # Check also with THE regexp to be sure
     if not USERNAME_VALID.match(name):

--- a/tests/pyanaconda_tests/user_test.py
+++ b/tests/pyanaconda_tests/user_test.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+
+import unittest
+from pyanaconda.users import check_username
+
+
+class UserNameTests(unittest.TestCase):
+
+    def _assert_username(self, name, expected_validity):
+        valid, message = check_username(name)
+        self.assertEqual(valid, expected_validity, message)
+        self.assertEqual(not valid, message is not None)
+
+    def reserved_names_test(self):
+        """Test the reserved names."""
+        self._assert_username("root", False)
+        self._assert_username("home", False)
+        self._assert_username("system", False)
+
+        self._assert_username("foo", True)
+
+    def hyphen_test(self):
+        """Test names with a hyphen."""
+        self._assert_username("-foo", False)
+        self._assert_username("-f", False)
+        self._assert_username("-", False)
+
+        self._assert_username("f-", True)
+        self._assert_username("foo-", True)
+
+    def dots_test(self):
+        """Test dots."""
+        self._assert_username(".", False)
+        self._assert_username("..", False)
+
+        self._assert_username("...", True)
+
+    def numbers_test(self):
+        """Test numbers in names."""
+        self._assert_username("1", False)
+        self._assert_username("12", False)
+        self._assert_username("123", False)
+
+        self._assert_username("1a", True)
+        self._assert_username("12a", True)
+        self._assert_username("123a", True)
+
+    def dolar_test(self):
+        """Test a dolar in names."""
+        self._assert_username("$", False)
+        self._assert_username("$f", False)
+        self._assert_username("f$oo", False)
+
+        self._assert_username("f$", True)
+        self._assert_username("foo$", True)
+
+    def chars_test(self):
+        """Test invalid characters."""
+        self._assert_username("?", False)
+        self._assert_username("f?", False)
+        self._assert_username("foo?", False)
+
+        self._assert_username("fo.o", True)
+        self._assert_username("fo_o", True)
+        self._assert_username("fo-o", True)
+        self._assert_username("fo9o", True)
+
+    def length_test(self):
+        """Test the length of names."""
+        self._assert_username("f" * 33, False)
+
+        self._assert_username("f" * 32, True)
+        self._assert_username("f" * 1, True)

--- a/tests/regex_tests/username_test.py
+++ b/tests/regex_tests/username_test.py
@@ -70,7 +70,6 @@ class UsernameRegexTestCase(unittest.TestCase):
                 'gggggggggggggggggggggggggburdell$',
                 ' gburdell',
                 ':gburdell',
-                'root',
                 '$',
                 '-'
                 ]


### PR DESCRIPTION
* User names cannot be fully numerical.
* User names '.' and '..' are forbidden.
* The regex was simplified since 'root' is checked in check_username
  and it is not possible to check all forbidden cases with one regex
  anymore.
* Add message for the user name '$'.
* Add tests for check_username.

The changes reflect the policy of the current patched shadow-utils.

Resolves: rhbz#1491006