### PR TITLE
Fix the race between StorageCheckHandler and updateCompleteness in ma…

### DIFF
--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -98,8 +98,8 @@ class StorageCheckHandler(object):
         StorageCheckHandler.errors = report.errors
         StorageCheckHandler.warnings = report.warnings
 
-        hubQ.send_ready(self._mainSpokeClass, True)
         report.log(self.log)
+        hubQ.send_ready(self._mainSpokeClass, True)
 
 class SourceSwitchHandler(object):
     """ A class that can be used as a mixin handling


### PR DESCRIPTION
…in hub

This happens approximately in 1 of 100 deployment with next conditions:

- extremely slow storage IO
- kickstart installation with slightly reduced min_partition_size which causes
  appropriate warning

The StorageCheckHandler reports than StorageSpoke is ready, then start
logger for the warning. In separate thread hubQ got HUB_CODE_READY,
but StorageSpoke is not completed because of THREAD_CHECK_STORAGE is not
finished. So, installation stops on main Hub with the warning.