### PR TITLE
Use build-time release (#1493952)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -241,7 +241,8 @@ runtime on NFS/HTTP/FTP servers or local disks.
 %setup -q
 
 %build
-%configure
+# use actual build-time release number, not tarball creation time release number
+%configure ANACONDA_RELEASE=%{release}
 %{__make} %{?_smp_mflags}
 
 %install

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,15 @@ m4_define(python_required_version, 3.4)
 AC_PREREQ([2.63])
 AC_INIT([anaconda], [26.1], [anaconda-devel-list@redhat.com])
 
+# make it possible to set build info at build time
+# (patch only builds, modular builds, mass-rebuilds, etc.)
+AC_ARG_VAR(ANACONDA_RELEASE, [Set Anaconda build])
+
+# default release to 1 if not set by option
+AS_IF([test $ANACONDA_RELEASE],
+      [AC_SUBST(PACKAGE_RELEASE, $ANACONDA_RELEASE)],
+      [AC_SUBST(PACKAGE_RELEASE, 1)])
+
 # Disable building static libraries.
 # This needs to be set before initializing automake
 AC_DISABLE_STATIC
@@ -101,7 +110,6 @@ SHUT_UP_GCC="-Wno-unused-result"
 # Add remaining compiler flags we want to use
 CFLAGS="$CFLAGS -Wall -Werror $SHUT_UP_GCC"
 
-AC_SUBST(PACKAGE_RELEASE, [1])
 
 # Perform arch related tests
 AC_CANONICAL_BUILD


### PR DESCRIPTION
As we shown the Anaconda version including the
release we really should use the release as it
exists at the package build time instead of
the release at tarball creation time (which
is generally always 1).

Otherwise we would be lying to users every time
the Anaconda package has been rebuild without
changing the tarball (patch only rebuilds,
mass rebuilds, modular builds, etc.).

So ad a new configure variable that can be used
from the spec file at build time and use it
to set the built-time release version.

NOTE: The release version might not be a number,
but basically an arbitrary string as with
the modular builds.

Resolves: rhbz#1493952