### PR TITLE
Fix storage spoke completeness checking.

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -412,7 +412,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
     @property
     def completed(self):
         retval = (threadMgr.get(constants.THREAD_EXECUTE_STORAGE) is None and
-                  threadMgr.get(constants.THREAD_CHECK_STORAGE) is None and
+                  not self.checking_storage and
                   self.storage.rootDevice is not None and
                   not self.errors)
         return retval


### PR DESCRIPTION
We should not check completeness based on storage checking thread existence
because the thread itself triggers the completeness checking via ready message
sent to hub queue before finishing. Which is racy.