### PR TITLE
Fix `shim` and `grub2-efi` to be backwards compatible

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1824,7 +1824,7 @@ class EFIGRUB1(EFIBase, GRUB):
 
 class EFIGRUB(EFIBase, GRUB2):
     _packages32 = [ "grub2-efi-ia32", "shim-ia32" ]
-    _packages64 = [ "grub2-efi-x64", "shim-x64" ]
+    _packages64 = [ "grub2-efi", "shim" ]
     _packages_common = [ "efibootmgr" ]
     can_dual_boot = False
     stage2_is_valid_stage1 = False


### PR DESCRIPTION
`shim` was renamed to `shim-x64` in RHEL 7.4 and Rawhide. Similarly,
`grub2-efi` was renamed to `grub2-efi-x64`. Recently Anaconda started
using these new names, but this breaks backwards compatibility. This PR
moves back to the original names which *is still forward compatible*:

```
$ rpm -q --provides grub2-efi-x64
...
grub2-efi = 1:2.02-0.64.el7.centos
...

$ rpm -q --provides shim-x64
...
shim = 12-1.el7.centos
...
```

Fixes #1202