### PR TITLE
Modular password checking

### DIFF
--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -5,9 +5,9 @@ firstboot --enable
 
 %anaconda
 # Default password policies
-pwpolicy root --notstrict --minlen=6 --minquality=1 --nochanges --emptyok
+pwpolicy root --notstrict --minlen=6 --minquality=1 --nochanges --notempty
 pwpolicy user --notstrict --minlen=6 --minquality=1 --nochanges --emptyok
-pwpolicy luks --notstrict --minlen=6 --minquality=1 --nochanges --emptyok
+pwpolicy luks --notstrict --minlen=6 --minquality=1 --nochanges --notempty
 # NOTE: This applies only to *fully* interactive installations, partial kickstart
 #       installations use defaults specified in pyanaconda/pwpolicy.py.
 #       Automated kickstart installs simply ignore the password policy as the policy

--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -138,15 +138,19 @@ UNSUPPORTED_HW = 1 << 28
 
 # Password validation
 PASSWORD_MIN_LEN = 6
-PASSWORD_EMPTY_ERROR = N_("The password is empty.")
-PASSWORD_CONFIRM_ERROR_GUI = N_("The passwords do not match.")
-PASSWORD_CONFIRM_ERROR_TUI = N_("The passwords you entered were different.  Please try again.")
-PASSWORD_WEAK = N_("The password you have provided is weak. %s")
-PASSWORD_WEAK_WITH_ERROR = N_("The password you have provided is weak: %s.")
-PASSWORD_WEAK_CONFIRM = N_("You have provided a weak password. Press Done again to use anyway.")
-PASSWORD_WEAK_CONFIRM_WITH_ERROR = N_("You have provided a weak password: %s. Press Done again to use anyway.")
-PASSWORD_ASCII = N_("The password you have provided contains non-ASCII characters. You may not be able to switch between keyboard layouts to login. Press Done to continue.")
+PASSWORD_EMPTY_ERROR = N_("The %(password_name)s is empty.")  # singular
+PASSWORD_CONFIRM_ERROR_GUI = N_("The %(password_name_plural)s do not match.")  # plural
+PASSWORD_CONFIRM_ERROR_TUI = N_("The %(password_name_plural)s you entered were different. Please try again.")  # plural
+# The password-too-short constant is used to replace a libpwquality error message,
+# which is why it does not end with a ".", like all the other do.
+PASSWORD_TOO_SHORT = N_("The %(password_name)s is too short")  # singular
+PASSWORD_WEAK = N_("The %(password_name)s you have provided is weak.")  # singular
+PASSWORD_WEAK_WITH_ERROR = N_("The %(password_name)s you have provided is weak: %(error_message)s.")  # singular
+PASSWORD_FINAL_CONFIRM = N_("Press Done again to use anyway.")
+PASSWORD_ASCII = N_("The %(password_name)s you have provided contains non-ASCII characters. You may not be able to switch between keyboard layouts when typing it.")
+# ^ singular
 PASSWORD_DONE_TWICE = N_("You will have to press Done twice to confirm it.")
+PASSWORD_DONE_TO_CONTINUE = N_("Press Done to continue.")
 
 PASSWORD_SET = N_("Password set.")
 
@@ -157,6 +161,14 @@ class PasswordStatus(Enum):
     FAIR = N_("Fair")
     GOOD = N_("Good")
     STRONG = N_("Strong")
+
+# how should passwords be called in combined strings
+NAME_OF_PASSWORD = N_("password")
+NAME_OF_PASSWORD_PLURAL = N_("passwords")
+
+# how should passphrases be called in combined strings
+NAME_OF_PASSPHRASE = N_("passphrase")
+NAME_OF_PASSPHRASE_PLURAL = N_("passphrases")
 
 PASSWORD_HIDE = N_("Hide password.")
 PASSWORD_SHOW = N_("Show password.")

--- a/pyanaconda/input_checking.py
+++ b/pyanaconda/input_checking.py
@@ -1,0 +1,827 @@
+#
+# input_checking.py : input & password/passphrase input checking
+#
+# Copyright (C) 2013, 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import pwquality
+
+from pyanaconda.isignal import Signal
+from pyanaconda.i18n import _
+from pyanaconda import constants
+from pyanaconda import users
+from pyanaconda import regexes
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+
+def get_policy(kickstart_data, policy_name):
+    """Get a policy corresponding to the name or default policy.
+
+    If no policy is found for the name the default policy is returned.
+    """
+    policy = kickstart_data.anaconda.pwpolicy.get_policy(policy_name)
+    if not policy:
+        policy = kickstart_data.anaconda.PwPolicyData()
+    return policy
+
+
+class PwqualitySettingsCache(object):
+    """Cache for libpwquality settings used for password validation.
+
+    Libpwquality settings instantiation is probably not exactly cheap
+    and we might need the settings for checking every password (even when
+    it is being typed by the user) so it makes sense to cache the objects
+    for reuse. As there might be multiple active policies for different
+    passwords we need to be able to cache multiple policies based on
+    minimum password length, as we don't input anything else to libpwquality
+    than minimum password length and the password itself.
+    """
+    def __init__(self):
+        self._pwq_settings = {}
+
+    def get_settings_by_minlen(self, minlen):
+        settings = self._pwq_settings.get(minlen)
+        if settings is None:
+            settings = pwquality.PWQSettings()
+            settings.read_config()
+            settings.minlen = minlen
+            self._pwq_settings[minlen] = settings
+        return settings
+
+pwquality_settings_cache = PwqualitySettingsCache()
+
+class PasswordCheckRequest(object):
+    """A wrapper for a password check request.
+
+    This in general means the password to be checked as well as its validation criteria
+    such as minimum length, if it can be empty, etc.
+    """
+
+    def __init__(self):
+        self._password = ""
+        self._password_confirmation = ""
+        self._policy = None
+        self._pwquality_settings = None
+        self._username = "root"
+        self._fullname = ""
+        self._name_of_password = _(constants.NAME_OF_PASSWORD)
+        self._name_of_password_plural = _(constants.NAME_OF_PASSWORD_PLURAL)
+
+    @property
+    def password(self):
+        """Password string to be checked.
+
+        :returns: password string for the check
+        :rtype: str
+        """
+        return self._password
+
+    @password.setter
+    def password(self, new_password):
+        self._password = new_password
+
+    @property
+    def password_confirmation(self):
+        """Content of the password confirmation field.
+
+        :returns: password confirmation string
+        :rtype: str
+        """
+        return self._password_confirmation
+
+    @password_confirmation.setter
+    def password_confirmation(self, new_password_confirmation):
+        self._password_confirmation = new_password_confirmation
+
+    @property
+    def policy(self):
+        """Password quality policy.
+
+        :returns: password quality policy
+        """
+        return self._policy
+
+    @policy.setter
+    def policy(self, new_policy):
+        self._policy = new_policy
+
+    @property
+    def pwquality_settings(self):
+        """Settings for libpwquality (if any).
+
+        :returns: libpwquality settings
+        :rtype: pwquality settings object or None
+        """
+        if not self._pwquality_settings:
+            self._pwquality_settings = pwquality_settings_cache.get_settings_by_minlen(self.policy.minlen)
+        return self._pwquality_settings
+
+    @property
+    def username(self):
+        """The username for which the password is being set.
+
+        If no username is provided, "root" will be used.
+        Use username=None to disable the username check.
+
+        :returns: username corresponding to the password
+        :rtype: str or None
+        """
+        return self._username
+
+    @username.setter
+    def username(self, new_username):
+        self._username = new_username
+
+    @property
+    def fullname(self):
+        """The full name of the user for which the password is being set.
+
+        If no full name is provided, "root" will be used.
+
+        :returns: full user name corresponding to the password
+        :rtype: str or None
+        """
+        return self._fullname
+
+    @fullname.setter
+    def fullname(self, new_fullname):
+        self._fullname = new_fullname
+
+    @property
+    def name_of_password(self):
+        """Specifies how should the password be called in error messages.
+
+        In some cases we are checking a "password", but at other times it
+        might be a "passphrase", etc.
+
+        :returns: name of the password
+        :rtype: str or None
+        """
+        return self._name_of_password
+
+    @name_of_password.setter
+    def name_of_password(self, new_name_of_password):
+        self._name_of_password = new_name_of_password
+
+    @property
+    def name_of_password_plural(self):
+        """Specifies how should the password be called in error messages (plural form).
+
+        In some cases we are checking a "password", but at other times it
+        might be a "passphrase", etc.
+
+        :returns: name of the password
+        :rtype: str or None
+        """
+        return self._name_of_password_plural
+
+    @name_of_password_plural.setter
+    def name_of_password_plural(self, new_name_of_password_plural):
+        self._name_of_password_plural = new_name_of_password_plural
+
+
+class CheckResult(object):
+    """Result of an input check."""
+
+    def __init__(self):
+        self._success = False
+        self._error_message = ""
+        self.error_message_changed = Signal()
+
+    @property
+    def success(self):
+        return self._success
+
+    @success.setter
+    def success(self, value):
+        self._success = value
+
+    @property
+    def error_message(self):
+        """Optional error message describing why the input is not valid.
+
+        :returns: why the input is bad (provided it is bad) or None
+        :rtype: str or None
+        """
+        return self._error_message
+
+    @error_message.setter
+    def error_message(self, new_error_message):
+        self._error_message = new_error_message
+        self.error_message_changed.emit(new_error_message)
+
+
+class PasswordValidityCheckResult(CheckResult):
+    """A wrapper for results for a password check."""
+
+    def __init__(self):
+        super().__init__()
+        self._check_request = None
+        self._password_score = 0
+        self.password_score_changed = Signal()
+        self._status_text = ""
+        self.status_text_changed = Signal()
+        self._password_quality = 0
+        self.password_quality_changed = Signal()
+        self._length_ok = False
+        self.length_ok_changed = Signal()
+
+    @property
+    def check_request(self):
+        """The check request used to generate this check result object.
+
+        Can be used to get the password text and checking parameters
+        for this password check result.
+
+        :returns: the password check request that triggered this password check result
+        :rtype: a PasswordCheckRequest instance
+        """
+        return self._check_request
+
+    @check_request.setter
+    def check_request(self, new_request):
+        self._check_request = new_request
+
+    @property
+    def password_score(self):
+        """A high-level integer score indicating password quality.
+
+        Goes from 0 (invalid password) to 4 (valid & very strong password).
+        Mainly used to drive the password quality indicator in the GUI.
+        """
+        return self._password_score
+
+    @password_score.setter
+    def password_score(self, new_score):
+        self._password_score = new_score
+        self.password_score_changed.emit(new_score)
+
+    @property
+    def status_text(self):
+        """A short overall status message describing the password.
+
+        Generally something like "Good.", "Too short.", "Empty.", etc.
+
+        :rtype: short status message
+        :rtype: str
+        """
+        return self._status_text
+
+    @status_text.setter
+    def status_text(self, new_status_text):
+        self._status_text = new_status_text
+        self.status_text_changed.emit(new_status_text)
+
+    @property
+    def password_quality(self):
+        """More fine grained integer indicator describing password strength.
+
+        This basically exports the quality score assigned by libpwquality to the password,
+        which goes from 0 (unacceptable password) to 100 (strong password).
+
+        Note of caution though about using the password quality value - it is intended
+        mainly for on-line password strength hints, not for long-term stability,
+        even just because password dictionary updates and other peculiarities of password
+        strength judging.
+
+        :returns: password quality value as reported by libpwquality
+        :rtype: int
+        """
+        return self._password_quality
+
+    @password_quality.setter
+    def password_quality(self, value):
+        self._password_quality = value
+        self.password_quality_changed.emit(value)
+
+    @property
+    def length_ok(self):
+        """Reports if the password is long enough.
+
+        :returns: if the password is long enough
+        :rtype: bool
+        """
+        return self._length_ok
+
+    @length_ok.setter
+    def length_ok(self, value):
+        self._length_ok = value
+        self.length_ok_changed.emit(value)
+
+class InputCheck(object):
+    """Input checking base class."""
+
+    def __init__(self):
+        self._result = CheckResult()
+        self._skip = False
+
+    @property
+    def result(self):
+        return self._result
+
+    @property
+    def skip(self):
+        """A flag hinting if this check should be skipped."""
+        return self._skip
+
+    @skip.setter
+    def skip(self, value):
+        # Checks flagged as skipped are
+        # considered successful.
+        # Otherwise old state will linger even if the
+        # check is skipped during checking runs.
+        if value:
+            self.result.error_message = ""
+            self.result.success = True
+        self._skip = value
+
+    def run(self, check_request):
+        """Run the check.
+
+        :param check_request: arbitrary input data to be processed
+
+        Subclasses need to always implement this.
+        """
+        raise NotImplementedError
+
+class RegexpCheck(InputCheck):
+    """A regex based input check."""
+
+    def __init__(self, regexp, error_message):
+        """
+        :param regexp: a regular expression object
+        :param error_message: error message to return if the regexp doesn't match
+        """
+        super().__init__()
+        self._regexp = regexp
+        self._error_message = error_message
+
+    def run(self, check_request):
+        """Check if the provided data matches the regexp.
+
+        :param str check_request: a string to apply the regexp on
+        """
+        if self._regexp.match(check_request):
+            self.result.error_message = ""
+            self.result.success = True
+        else:
+            self.result.error_message = self._error_message
+            self.result.success = False
+
+
+class FunctionCheck(InputCheck):
+    """A function based input check.
+
+    Run a function on a string that returns a two member tuple: (success, error message)
+    """
+
+    def __init__(self, function):
+        """
+        :param function: a function to run on the input
+        """
+        super().__init__()
+        self._function = function
+
+    def run(self, check_request):
+        """Run the function on the provided data.
+
+        :param str check_request: a string to run the function on
+        """
+        success, error_message = self._function(check_request)
+        self.result.error_message = error_message
+        self.result.success = success
+
+
+class PasswordValidityCheck(InputCheck):
+    """Check the validity and quality of a password."""
+
+    def __init__(self):
+        super().__init__()
+        self._result = PasswordValidityCheckResult()
+
+    def run(self, check_request):
+        """Check the validity and quality of a password.
+
+           This is how password quality checking works:
+           - starts with a password and an optional parameters
+           - will report if this password can be used at all (score >0)
+           - will report how strong the password approximately is on a scale of 1-100
+           - if the password is unusable it will be reported why
+
+           This function uses libpwquality to check the password strength.
+           Pwquality will raise a PWQError on a weak password but this function does
+           not pass that forward.
+
+           If the password fails the PWQSettings conditions, the score will be set to 0
+           and the resulting error message will contain the reason why the password is bad.
+
+           :param check_request: a password check request wrapper
+           :type check_request: a PasswordCheckRequest instance
+           :returns: a password check result wrapper
+           :rtype: a PasswordCheckResult instance
+        """
+
+        length_ok = False
+        error_message = ""
+        pw_quality = 0
+        try:
+            # lets run the password through libpwquality
+            pw_quality = check_request.pwquality_settings.check(check_request.password, None, check_request.username)
+        except pwquality.PWQError as e:
+            # Leave valid alone here: the password is weak but can still
+            # be accepted.
+            # PWQError values are built as a tuple of (int, str)
+            error_message = e.args[1]
+
+        if check_request.policy.emptyok:
+            # if we are OK with empty passwords, then empty passwords are also fine length wise
+            length_ok = len(check_request.password) >= check_request.policy.minlen or not check_request.password
+        else:
+            length_ok = len(check_request.password) >= check_request.policy.minlen
+
+        if not check_request.password:
+            if check_request.policy.emptyok:
+                pw_score = 1
+            else:
+                pw_score = 0
+            status_text = _(constants.PasswordStatus.EMPTY.value)
+        elif not length_ok:
+            pw_score = 0
+            status_text = _(constants.PasswordStatus.TOO_SHORT.value)
+            # If the password is too short replace the libpwquality error
+            # message with a generic "password is too short" message.
+            # This is because the error messages returned by libpwquality
+            # for short passwords don't make much sense.
+            error_message = _(constants.PasswordStatus.TOO_SHORT.value) % {"password_name": check_request.name_of_password}
+        elif error_message:
+            pw_score = 1
+            status_text = _(constants.PasswordStatus.WEAK.value)
+        elif pw_quality < 30:
+            pw_score = 2
+            status_text = _(constants.PasswordStatus.FAIR.value)
+        elif pw_quality < 70:
+            pw_score = 3
+            status_text = _(constants.PasswordStatus.GOOD.value)
+        else:
+            pw_score = 4
+            status_text = _(constants.PasswordStatus.STRONG.value)
+
+        # the policy influences the overall success of the check
+        # - score 0 & strict == True -> success = False
+        # - score 0 & strict == False -> success = True
+        success = not error_message
+
+        # set the result now so that the *_changed signals fire only once the check is done
+        self.result.check_request = check_request  # pylint: disable=attribute-defined-outside-init
+        self.result.success = success  # pylint: disable=attribute-defined-outside-init
+        self.result.password_score = pw_score  # pylint: disable=attribute-defined-outside-init
+        self.result.status_text = status_text  # pylint: disable=attribute-defined-outside-init
+        self.result.password_quality = pw_quality  # pylint: disable=attribute-defined-outside-init
+        self.result.error_message = error_message  # pylint: disable=attribute-defined-outside-init
+        self.result.length_ok = length_ok  # pylint: disable=attribute-defined-outside-init
+
+
+class PasswordConfirmationCheck(InputCheck):
+    """Check if the password & password confirmation match."""
+
+    def __init__(self):
+        super().__init__()
+        self._success_if_confirmation_empty = False
+
+    @property
+    def success_if_confirmation_empty(self):
+        """Enables success-if-confirmation-empty mode.
+
+        This property can be used to tell the check to report success if the confirmation filed is empty,
+        which is a paradigm used by Anaconda uses for two things:
+        - to make it possible for users to exit without setting a valid password
+        - to make it possible to exit the spoke if only the password is set
+          but confirmation is empty
+        """
+        return self._success_if_confirmation_empty
+
+    @success_if_confirmation_empty.setter
+    def success_if_confirmation_empty(self, value):
+        self._success_if_confirmation_empty = value
+
+    def run(self, check_request):
+        """If the user has entered confirmation data, check whether it matches the password."""
+        if self.success_if_confirmation_empty and not check_request.password_confirmation:
+            self.result.error_message = ""
+            self.result.success = True
+        elif check_request.password != check_request.password_confirmation:
+            self.result.error_message = _(constants.PASSWORD_CONFIRM_ERROR_GUI) % \
+                                        {"password_name_plural": check_request.name_of_password_plural}
+            self.result.success = False
+        else:
+            self.result.error_message = ""
+            self.result.success = True
+
+
+class PasswordASCIICheck(InputCheck):
+    """Check if the password contains non-ASCII characters.
+
+    Non-ASCII characters might be hard to type in the console and in the LUKS volume unlocking
+    screen, so check if the password contains them so we can warn the user.
+    """
+
+    def run(self, check_request):
+        """Fail if the password contains non-ASCII characters."""
+        has_non_ASCII = any(char not in constants.PW_ASCII_CHARS for char in check_request.password)
+        if check_request.password and has_non_ASCII:
+            self.result.error_message = _(constants.PASSWORD_ASCII) % \
+                                        {"password_name": check_request.name_of_password}
+            self.result.success = False
+        else:
+            self.result.error_message = ""
+            self.result.success = True
+
+
+class PasswordEmptyCheck(InputCheck):
+    """Check if the password is set."""
+
+    def run(self, check_request):
+        """Check whether a password has been specified at all."""
+        if check_request.password:
+            # password set is always success
+            self.result.error_message = ""
+            self.result.success = True
+        else:
+            # otherwise empty password is an error
+            self.result.error_message = _(constants.PASSWORD_EMPTY_ERROR) % \
+                                        {"password_name": check_request.name_of_password}
+            self.result.success = False
+
+
+class UsernameCheck(InputCheck):
+    """Check if the username is valid."""
+
+    def __init__(self):
+        super().__init__()
+        self._success_if_username_empty = False
+
+    @property
+    def success_if_username_empty(self):
+        """Should empty username be considered a success ?"""
+        return self._success_if_username_empty
+
+    @success_if_username_empty.setter
+    def success_if_username_empty(self, value):
+        self._success_if_username_empty = value
+
+    def run(self, check_request):
+        """Check if the username is valid."""
+        # in some cases an empty username is also considered valid,
+        # so that the user can exit the User spoke without filling it in
+        if self.success_if_username_empty and not check_request.username:
+            self.result.error_message = ""
+            self.result.success = True
+        else:
+            success, error_message = users.check_username(check_request.username)
+            self.result.error_message = error_message
+            self.result.success = success
+
+
+class FullnameCheck(InputCheck):
+    """Check if the full user name is valid.
+
+    Most importantly the full user name cannot contain colons.
+    """
+
+    def run(self, check_request):
+        """Check if the full user name is valid."""
+        if regexes.GECOS_VALID.match(check_request.fullname):
+            self.result.error_message = ""
+            self.result.success = True
+        else:
+            self.result.error_message = _("Full name cannot contain colon characters")
+            self.result.success = False
+
+
+class InputField(object):
+    """An input field containing data to be checked.
+
+    The input field can have an initial value that can be
+    monitored for change via signals.
+    """
+
+    def __init__(self, initial_content):
+        self._initial_content = initial_content
+        self._content = initial_content
+        self.changed = Signal()
+        self._initial_change_signal_fired = False
+        self.changed_from_initial_state = Signal()
+
+    @property
+    def content(self):
+        return self._content
+
+    @content.setter
+    def content(self, new_content):
+        old_content = self._content
+        self._content = new_content
+        # check if the input changed from the initial state
+        if old_content != new_content:
+            self.changed.emit()
+            # also fire the changed-from-initial-state signal if required
+            if not self._initial_change_signal_fired and new_content != self._initial_content:
+                self.changed_from_initial_state.emit()
+                self._initial_change_signal_fired = True
+
+
+class PasswordChecker(object):
+    """Run multiple password and input checks in a given order and report the results.
+
+    All added checks (in insertion order) will be run and results returned as error message
+    and success value (True/False). If any check fails success will be False and the
+    error message of the first check to fail will be returned.
+
+    It's also possible to mark individual checks to be skipped by setting their skip property to True.
+    Such check will be skipped during the checking run.
+    """
+
+    def __init__(self, initial_password_content, initial_password_confirmation_content,
+                 policy):
+        self._password = InputField(initial_password_content)
+        self._password_confirmation = InputField(initial_password_confirmation_content)
+        self._checks = []
+        self._success = False
+        self._error_message = ""
+        self._failed_checks = []
+        self._successful_checks = []
+        self._policy = policy
+        self._username = None
+        self._fullname = ""
+        # connect to the password field signals
+        self.password.changed.connect(self.run_checks)
+        self.password_confirmation.changed.connect(self.run_checks)
+
+        # password naming (for use in status/error messages)
+        self._name_of_password = _(constants.NAME_OF_PASSWORD)
+        self._name_of_password_plural = _(constants.NAME_OF_PASSWORD_PLURAL)
+
+        # signals
+        self.checks_done = Signal()
+
+    @property
+    def password(self):
+        """Main password field."""
+        return self._password
+
+    @property
+    def password_confirmation(self):
+        """Password confirmation field."""
+        return self._password_confirmation
+
+    @property
+    def checks(self):
+        return self._checks
+
+    @property
+    def success(self):
+        return self._success
+
+    @property
+    def error_message(self):
+        return self._error_message
+
+    @property
+    def successful_checks(self):
+        """List of successful checks during the last checking run.
+
+        If no checks have succeeded the list will be empty.
+
+        :returns: list of successful checks (if any)
+        :rtype: list
+        """
+        return self._successful_checks
+
+    @property
+    def failed_checks(self):
+        """List of checks failed during the last checking run.
+
+        If no checks have failed the list will be empty.
+
+        :returns: list of failed checks (if any)
+        :rtype: list
+        """
+        return self._failed_checks
+
+    @property
+    def policy(self):
+        return self._policy
+
+    @property
+    def username(self):
+        return self._username
+
+    @username.setter
+    def username(self, new_username):
+        self._username = new_username
+
+    @property
+    def fullname(self):
+        """The full name of the user for which the password is being set.
+
+        If no full name is provided, "root" will be used.
+
+        :returns: full user name corresponding to the password
+        :rtype: str or None
+        """
+        return self._fullname
+
+    @fullname.setter
+    def fullname(self, new_fullname):
+        self._fullname = new_fullname
+
+    # password naming
+    @property
+    def name_of_password(self):
+        """Name of the password to be used called in warnings and error messages.
+
+        For example:
+        "%s contains non-ASCII characters"
+        can be customized to:
+        "Password contains non-ASCII characters"
+        or
+        "Passphrase contains non-ASCII characters"
+
+        :returns: name of the password being checked
+        :rtype: str
+        """
+        return self._name_of_password
+
+    @name_of_password.setter
+    def name_of_password(self, name):
+        self._name_of_password = name
+
+    @property
+    def name_of_password_plural(self):
+        """Plural name of the password to be used called in warnings and error messages.
+
+        :returns: plural name of the password being checked
+        :rtype: str
+        """
+        return self._name_of_password_plural
+
+    @name_of_password_plural.setter
+    def name_of_password_plural(self, name_plural):
+        self._name_of_password_plural = name_plural
+
+    def add_check(self, check_instance):
+        """Add check instance to list of checks."""
+        self._checks.append(check_instance)
+
+    def run_checks(self):
+        # first we need to prepare a check request instance
+        check_request = PasswordCheckRequest()
+        check_request.password = self.password.content
+        check_request.password_confirmation = self.password_confirmation.content
+        check_request.policy = self.policy
+        check_request.username = self.username
+        check_request.fullname = self.fullname
+        check_request.name_of_password = self.name_of_password
+        check_request.name_of_password_plural = self.name_of_password_plural
+
+        # reset the list of failed checks
+        self._failed_checks = []
+
+        error_message = ""
+        for check in self.checks:
+            if not check.skip:
+                check.run(check_request)
+                if check.result.success:
+                    self._successful_checks.append(check)
+                else:
+                    self._failed_checks.append(check)
+
+                if not check.result.success and not self.failed_checks:
+                    # a check failed:
+                    # - remember that & it's error message
+                    # - run other checks as well and ignore their error messages (if any)
+                    # - fail the overall check run (success = False)
+                    error_message = check.result.error_message
+        if self.failed_checks:
+            self._error_message = error_message
+            self._success = False
+        else:
+            self._success = True
+            self._error_message = ""
+        # trigger the success changed signal
+        self.checks_done.emit(self._error_message)

--- a/pyanaconda/ui/gui/spokes/__init__.py
+++ b/pyanaconda/ui/gui/spokes/__init__.py
@@ -21,6 +21,9 @@ from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.utils import gtk_call_once
 from pyanaconda import ihelp
 
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
 __all__ = ["StandaloneSpoke", "NormalSpoke"]
 
 # Inherit abstract methods from common.StandaloneSpoke
@@ -62,6 +65,9 @@ class NormalSpoke(GUIObject, common.NormalSpoke):
         # Add a help handler
         self.window.connect_after("help-button-clicked", self._on_help_clicked)
 
+        # warning message
+        self._current_warning_message = ""
+
     def _on_help_clicked(self, window):
         # the help button has been clicked, start the yelp viewer with
         # content for the current spoke
@@ -71,3 +77,21 @@ class NormalSpoke(GUIObject, common.NormalSpoke):
         # Notify the hub that we're finished.
         # The hub will be the current-action of the main window.
         self.main_window.current_action.spoke_done(self)
+
+    def clear_info(self):
+        """Clear the last set warning message and call the ancestors method."""
+        self._current_warning_message = ""
+        super().clear_info()
+
+    def show_warning_message(self, message):
+        """Show error message in the status bar.
+
+        As set_warning() animates the error bar only set new message
+        when it is different from the current one.
+        """
+        if not message:
+            self.clear_info()
+        elif self._current_warning_message != message:
+            self.clear_info()
+            self._current_warning_message = message
+            self.set_warning(message)

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1169,7 +1169,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             self._repoProxyUrlEntry.grab_focus()
             return
         # Otherwise let GUISpokeInputCheckHandler figure out what to focus
-        elif not GUISpokeInputCheckHandler.on_back_clicked(self, button):
+        elif not self.can_go_back_focus_if_not():
             return
 
         self.clear_info()

--- a/pyanaconda/ui/gui/spokes/root_password.glade
+++ b/pyanaconda/ui/gui/spokes/root_password.glade
@@ -52,7 +52,7 @@
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes" context="GUI|Password">_Root Password:</property>
                         <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">pw</property>
+                        <property name="mnemonic_widget">password_entry</property>
                         <property name="xalign">0</property>
                       </object>
                       <packing>
@@ -66,7 +66,7 @@
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes" context="GUI|Password">_Confirm:</property>
                         <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">confirmPW</property>
+                        <property name="mnemonic_widget">password_confirmation_entry</property>
                         <property name="xalign">0</property>
                       </object>
                       <packing>
@@ -75,7 +75,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkEntry" id="pw">
+                      <object class="GtkEntry" id="password_entry">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="visibility">False</property>
@@ -83,7 +83,7 @@
                         <signal name="changed" handler="on_password_changed" swapped="no"/>
                         <signal name="icon_release" handler="on_password_icon_clicked" swapped="no"/>
                         <child internal-child="accessible">
-                          <object class="AtkObject" id="pw-atkobject">
+                          <object class="AtkObject" id="password_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Password</property>
                           </object>
                         </child>
@@ -94,15 +94,16 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkEntry" id="confirmPW">
+                      <object class="GtkEntry" id="password_confirmation_entry">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="visibility">False</property>
                         <property name="invisible_char">●</property>
                         <property name="activates_default">True</property>
+                        <signal name="changed" handler="on_password_confirmation_changed" swapped="no"/>
                         <signal name="icon_release" handler="on_password_icon_clicked" swapped="no"/>
                         <child internal-child="accessible">
-                          <object class="AtkObject" id="confirmPW-atkobject">
+                          <object class="AtkObject" id="password_confirmation_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Confirm Password</property>
                           </object>
                         </child>

--- a/pyanaconda/ui/gui/spokes/user.glade
+++ b/pyanaconda/ui/gui/spokes/user.glade
@@ -61,7 +61,7 @@
                         <property name="xpad">10</property>
                         <property name="label" translatable="yes" context="GUI|User">_Full name</property>
                         <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">t_fullname</property>
+                        <property name="mnemonic_widget">fullname_entry</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -79,7 +79,7 @@
                         <property name="xpad">10</property>
                         <property name="label" translatable="yes" context="GUI|User">_User name</property>
                         <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">t_username</property>
+                        <property name="mnemonic_widget">username_entry</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -90,13 +90,13 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkEntry" id="t_fullname">
+                      <object class="GtkEntry" id="fullname_entry">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="caps_lock_warning">False</property>
-                        <signal name="changed" handler="full_name_changed" swapped="no"/>
+                        <signal name="changed" handler="on_full_name_changed" swapped="no"/>
                         <child internal-child="accessible">
-                          <object class="AtkObject" id="t_fullname-atkobject">
+                          <object class="AtkObject" id="fullname_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Full Name</property>
                           </object>
                         </child>
@@ -107,13 +107,13 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkEntry" id="t_username">
+                      <object class="GtkEntry" id="username_entry">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <signal name="changed" handler="username_changed" swapped="no"/>
+                        <signal name="changed" handler="on_username_changed" swapped="no"/>
                         <signal name="changed" handler="on_username_set_by_user" swapped="no"/>
                         <child internal-child="accessible">
-                          <object class="AtkObject" id="t_username-atkobject">
+                          <object class="AtkObject" id="username_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">User Name</property>
                           </object>
                         </child>
@@ -131,7 +131,7 @@
                         <property name="xpad">10</property>
                         <property name="label" translatable="yes" context="GUI|User">_Password</property>
                         <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">t_password</property>
+                        <property name="mnemonic_widget">password_entry</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -149,7 +149,7 @@
                         <property name="xpad">10</property>
                         <property name="label" translatable="yes" context="GUI|User">_Confirm password</property>
                         <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">t_verifypassword</property>
+                        <property name="mnemonic_widget">password_confirmation_entry</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -160,15 +160,15 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkEntry" id="t_password">
+                      <object class="GtkEntry" id="password_entry">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="visibility">False</property>
                         <property name="invisible_char">●</property>
-                        <signal name="changed" handler="password_changed" swapped="no"/>
+                        <signal name="changed" handler="on_password_changed" swapped="no"/>
                         <signal name="icon_release" handler="on_password_icon_clicked" swapped="no"/>
                         <child internal-child="accessible">
-                          <object class="AtkObject" id="t_password-atkobject">
+                          <object class="AtkObject" id="password_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Password</property>
                           </object>
                         </child>
@@ -179,14 +179,15 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkEntry" id="t_verifypassword">
+                      <object class="GtkEntry" id="password_confirmation_entry">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="visibility">False</property>
                         <property name="invisible_char">●</property>
+                        <signal name="changed" handler="on_password_confirmation_changed" swapped="no"/>
                         <signal name="icon_release" handler="on_password_icon_clicked" swapped="no"/>
                         <child internal-child="accessible">
-                          <object class="AtkObject" id="t_verifypassword-atkobject">
+                          <object class="AtkObject" id="password_confirmation_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Confirm Password</property>
                           </object>
                         </child>
@@ -210,7 +211,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkCheckButton" id="c_usepassword">
+                      <object class="GtkCheckButton" id="password_required_checkbox">
                         <property name="label" translatable="yes" context="GUI|User">_Require a password to use this account</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -219,7 +220,7 @@
                         <property name="xalign">0</property>
                         <property name="active">True</property>
                         <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="usepassword_toggled" swapped="no"/>
+                        <signal name="toggled" handler="password_required_toggled" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -268,7 +269,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkCheckButton" id="c_admin">
+                      <object class="GtkCheckButton" id="admin_checkbox">
                         <property name="label" translatable="yes" context="GUI|User">_Make this user administrator</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
@@ -288,7 +289,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
-                          <object class="GtkButton" id="b_advanced">
+                          <object class="GtkButton" id="advanced_button">
                             <property name="label" translatable="yes" context="GUI|User">_Advanced...</property>
                             <property name="visible">True</property>
                             <property name="sensitive">False</property>

--- a/tests/pyanaconda_tests/password_quality_test.py
+++ b/tests/pyanaconda_tests/password_quality_test.py
@@ -18,149 +18,223 @@
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 #
 
-from pyanaconda.users import validatePassword
+from pyanaconda import input_checking
+from pyanaconda.pwpolicy import F22_PwPolicyData
 from pyanaconda import constants
 from pyanaconda.i18n import _
 import unittest
-import platform
 
-# libpwquality gives different results when running on RHEL and elsewhere,
-# so we need to skip absolute quality value checking outside of RHEL
-#
-# Ignore the deprecated method warning - we can revisist this when there is actually
-# a replacement for platform.dist available for Fedora as a package.
-# pylint: disable=deprecated-method
-ON_RHEL = platform.dist()[0] == "redhat"
+def get_policy():
+    return F22_PwPolicyData()
 
 class PasswordQuality(unittest.TestCase):
     def password_empty_test(self):
         """Check if quality of an empty password is reported correctly."""
-        score, status, quality, error_message = validatePassword("")
-        self.assertEqual(score, 0)
-        self.assertEqual(status, _(constants.PasswordStatus.EMPTY.value))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.password = ""
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertEqual(check.result.password_score, 1)  # empty password is fine with emptyok policy
+        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.EMPTY.value))
+        self.assertEqual(check.result.password_quality, 0)
+        self.assertIsNotNone(check.result.error_message)
         # empty password should override password-too-short messages
-        score, status, quality, error_message = validatePassword("", minlen=10)
-        self.assertEqual(score, 0)
-        self.assertEqual(status, _(constants.PasswordStatus.EMPTY.value))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.policy.minlen = 10
+        request.password = ""
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertEqual(check.result.password_score, 1)
+        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.EMPTY.value))
+        self.assertEqual(check.result.password_quality, 0)
+        self.assertIsNotNone(check.result.error_message)
 
     def password_empty_ok_test(self):
         """Check if the empty_ok flag works correctly."""
-        score, status, quality, error_message = validatePassword("", empty_ok=True)
-        self.assertEqual(score, 0)
-        self.assertEqual(status, _(constants.PasswordStatus.EMPTY.value))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.policy.emptyok = True
+        request.password = ""
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertEqual(check.result.password_score, 1)
+        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.EMPTY.value))
+        self.assertEqual(check.result.password_quality, 0)
+        self.assertIsNotNone(check.result.error_message)
         # empty_ok with password length
-        score, status, quality, error_message = validatePassword("", minlen=10, empty_ok=True)
-        self.assertEqual(score, 0)
-        self.assertEqual(status, _(constants.PasswordStatus.EMPTY.value))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.policy.emptyok = True
+        request.policy.minlen = 10
+        request.password = ""
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertEqual(check.result.password_score, 1)
+        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.EMPTY.value))
+        self.assertEqual(check.result.password_quality, 0)
+        self.assertIsNotNone(check.result.error_message)
         # non-empty passwords that are too short should still get a score of 0 & the "too short" message
-        score, status, quality, error_message = validatePassword("123", minlen=10, empty_ok=True)
-        self.assertEqual(score, 0)
-        self.assertEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.policy.emptyok = True
+        request.policy.minlen = 10
+        request.password = "123"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertEqual(check.result.password_score, 0)
+        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(check.result.password_quality, 0)
+        self.assertIsNotNone(check.result.error_message)
         # also check a long-enough password, just in case
-        score, status, quality, error_message = validatePassword("1234567891", minlen=10, empty_ok=True)
-        self.assertEqual(score, 1)
-        self.assertEqual(status, _(constants.PasswordStatus.WEAK.value))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.policy.emptyok = True
+        request.policy.minlen = 10
+        request.password = "1234567891"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertEqual(check.result.password_score, 1)
+        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.WEAK.value))
+        self.assertEqual(check.result.password_quality, 0)
+        self.assertIsNotNone(check.result.error_message)
 
     def password_length_test(self):
         """Check if minimal password length is checked properly."""
         # first check if the default minimal password length is checked correctly
         # (should be 6 characters at the moment)
-        score, status, _quality, _error_message = validatePassword("123")
-        self.assertEqual(score, 0)
-        self.assertEqual(_(status), _(constants.PasswordStatus.TOO_SHORT.value))
-        score, status, _quality, _error_message = validatePassword("123456")
-        self.assertEqual(score, 1)
-        self.assertEqual(_(status), _(constants.PasswordStatus.WEAK.value))
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.password = "123"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertEqual(check.result.password_score, 0)
+        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+
+        # weak but long enough
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.password = "123456"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertEqual(check.result.password_score, 1)
+        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.WEAK.value))
 
         # check if setting password length works correctly
-        score, status, _quality, _error_message = validatePassword("12345", minlen=10)
-        self.assertEqual(score, 0)
-        self.assertEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
-        score, status, _quality, _error_message = validatePassword("1234567891", minlen=10)
-        self.assertGreater(score, 0)
-        self.assertNotEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.policy.minlen = 10
+        request.password = "12345"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertEqual(check.result.password_score, 0)
+        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.policy.minlen = 10
+        request.password = "1234567891"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertGreater(check.result.password_score, 0)
+        self.assertNotEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
 
     def password_quality_test(self):
         """Check if libpwquality gives reasonable numbers & score is assigned correctly."""
         # " " should give score 0 (<6 chars) & quality 0
-        score, status, quality, error_message = validatePassword(" ")
-        self.assertEqual(score, 0)
-        self.assertEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.password = " "
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertEqual(check.result.password_score, 0)
+        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(check.result.password_quality, 0)
+        self.assertIsNotNone(check.result.error_message)
 
         # "anaconda" is a dictionary word
-        score, status, quality, error_message = validatePassword("anaconda")
-        self.assertGreater(score, 0)
-        self.assertNotEqual(status, _(constants.PasswordStatus.EMPTY.value))
-        self.assertNotEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.password = "anaconda"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertGreater(check.result.password_score, 0)
+        self.assertNotEqual(check.result.status_text, _(constants.PasswordStatus.EMPTY.value))
+        self.assertNotEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(check.result.password_quality, 0)
+        self.assertIsNotNone(check.result.error_message)
 
         # "jelenovipivonelej" is a palindrome
-        score, status, quality, error_message = validatePassword("jelenovipivonelej")
-        self.assertGreater(score, 0)
-        self.assertNotEqual(status, _(constants.PasswordStatus.EMPTY.value))
-        self.assertNotEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
-        self.assertEqual(quality, 0)
-        self.assertIsNotNone(error_message)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.password = "jelenovipivonelej"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertGreater(check.result.password_score, 0)
+        self.assertNotEqual(check.result.status_text, _(constants.PasswordStatus.EMPTY.value))
+        self.assertNotEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(check.result.password_quality, 0)
+        self.assertIsNotNone(check.result.error_message)
 
         # "4naconda-" gives a quality of 27 on RHEL7
-        score, status, quality, error_message = validatePassword("4naconda-")
-        if ON_RHEL:
-            self.assertEqual(score, 1)  # quality < 50
-            self.assertEqual(status, _(constants.PasswordStatus.WEAK.value))
-            self.assertEqual(quality, 27)
-        self.assertIsNone(error_message)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.password = "4naconda-"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertIs(check.result.error_message, "")
 
         # "4naconda----" gives a quality of 52 on RHEL7
-        score, status, quality, error_message = validatePassword("4naconda----")
-        if ON_RHEL:
-            self.assertEqual(score, 2)  # quality > 50 & < 75
-            self.assertEqual(status, _(constants.PasswordStatus.FAIR.value))
-            self.assertEqual(quality, 52)
-        self.assertIsNone(error_message)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.password = "4naconda----"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertIs(check.result.error_message, "")
 
         # "----4naconda----" gives a quality of 80 on RHEL7
-        score, status, quality, error_message = validatePassword("----4naconda----")
-        if ON_RHEL:
-            self.assertEqual(score, 3)  # quality > 75 & < 90
-            self.assertEqual(status, _(constants.PasswordStatus.GOOD.value))
-            self.assertEqual(quality, 80)
-        self.assertIsNone(error_message)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.password = "----4naconda----"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+        self.assertIs(check.result.error_message, "")
 
         # "?----4naconda----?" gives a quality of 100 on RHEL7
-        score, status, quality, error_message = validatePassword("?----4naconda----?")
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.password = "?----4naconda----?"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
+
         # this should (hopefully) give quality 100 everywhere
-        self.assertEqual(score, 4)  # quality > 90
-        self.assertEqual(status, _(constants.PasswordStatus.STRONG.value))
-        self.assertEqual(quality, 100)
-        self.assertIsNone(error_message)
+        self.assertEqual(check.result.password_score, 4)  # quality > 90
+        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.STRONG.value))
+        self.assertEqual(check.result.password_quality, 100)
+        self.assertIs(check.result.error_message, "")
 
         # a long enough strong password with minlen set
-        score, status, quality, error_message = validatePassword("?----4naconda----?", minlen=10)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.policy.minlen = 10
+        request.password = "!?----4naconda----?!"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
         # this should (hopefully) give quality 100 everywhere
-        self.assertEqual(score, 4)  # quality > 90
-        self.assertEqual(status, _(constants.PasswordStatus.STRONG.value))
-        self.assertEqual(quality, 100)
-        self.assertIsNone(error_message)
+        self.assertEqual(check.result.password_score, 4)  # quality > 90
+        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.STRONG.value))
+        self.assertEqual(check.result.password_quality, 100)
+        self.assertIs(check.result.error_message, "")
 
         # minimum password length overrides strong passwords for score and status
-        score, status, quality, error_message = validatePassword("?----4naconda----?", minlen=30)
+        request = input_checking.PasswordCheckRequest()
+        request.policy = get_policy()
+        request.policy.minlen = 30
+        request.password = "?----4naconda----?"
+        check = input_checking.PasswordValidityCheck()
+        check.run(request)
         # this should (hopefully) give quality 100 everywhere
-        self.assertEqual(score, 0)  # too short
-        self.assertEqual(status, _(constants.PasswordStatus.TOO_SHORT.value))
-        self.assertEqual(quality, 100)  # independent on password length
-        self.assertIsNone(error_message)
+        self.assertEqual(check.result.password_score, 0)  # too short
+        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(check.result.password_quality, 0)  # dependent on password length
+        self.assertIs(check.result.error_message, _(constants.PasswordStatus.TOO_SHORT.value))


### PR DESCRIPTION
This pull request adds the UI independent `input_checking` module and converts the passphrase, root password spoke and user spoke to use it. This should make the whole password checking machinery more robust, less buggy and should also be easier to test.

There is also a cleanup and deduplication of the the passphrase dialog, root password spoke and user spoke source code.

And other than that:
- includes fixes from RHEL 7.4
- more sane default password checking policy in interactive defaults
- better warning messages & more sane click-done-twice logic
- we don't say password in the passphrase dialog anymore
- empty passphrase is no longer accepted in the LUKS dialog

**TODO:** 
- add unit tests covering the new code