### PR TITLE
Enable SE/HMC file access to repo (#1289918)

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -1186,8 +1186,14 @@ if __name__ == "__main__":
             ksdata.method.method = "harddrive"
             device = anaconda.methodstr.split(":", 1)[1]
             ksdata.method.partition = os.path.normpath(device)
+        elif anaconda.methodstr.startswith("hmc"):
+            ksdata.method.method = "hmc"
         else:
             log.error("Unknown method: %s", anaconda.methodstr)
+
+    # Enable SE/HMC if it was selected as an installation source.
+    if ksdata.method.method == "hmc":
+        flags.hmc = True
 
     # Override the selinux state from kickstart if set on the command line
     if flags.selinux != constants.SELINUX_DEFAULT:

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -34,7 +34,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define mehver 0.23-1
 %define nmver 1.0.0-6.git20150107
 %define partedver 1.8.1
-%define pykickstartver 1.99.66.13
+%define pykickstartver 1.99.66.14
 %define pypartedver 2.5-2
 %define pythonpyblockver 0.45
 %define pythonurlgrabberver 3.9.1-5

--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -31,6 +31,7 @@ dist_dracut_SCRIPTS = module-setup.sh \
                       anaconda-ks-sendheaders.sh \
                       anaconda-netroot.sh \
                       anaconda-diskroot \
+                      anaconda-hmcroot \
                       anaconda-copy-ks.sh \
                       anaconda-copy-cmdline.sh \
                       anaconda-copy-dhclient.sh \

--- a/dracut/anaconda-hmcroot
+++ b/dracut/anaconda-hmcroot
@@ -1,0 +1,24 @@
+#!/bin/bash
+# anaconda-hmcroot:
+# Provide access to the root on the USB/DVD drive of the SE/HMC of System z hardware.
+
+command -v info >/dev/null || . /lib/dracut-lib.sh
+command -v anaconda_live_root_dir >/dev/null || . /lib/anaconda-lib.sh
+
+# Debug.
+debug_msg "Trying SE/HMC access with $1."
+
+# Do we already have a root device?
+# Then do not run again.
+[ -e "/dev/root" ] && exit 1
+
+# Do we have SE/HMC file access?
+if /usr/sbin/lshmc ; then
+    info "Anaconda using SE/HMC file access to root."
+    /usr/bin/hmcdrvfs $repodir || warn "Couldn't mount /dev/hmcdrv"
+    anaconda_live_root_dir $repodir
+else
+    debug_msg "No SE/HMC access to files."
+    exit 1
+fi
+

--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -166,6 +166,13 @@ when_any_cdrom_appears() {
       >> $rulesfile
 }
 
+when_any_hmcdrv_appears() {
+    local dev="hmcdrv"
+    local cmd="/sbin/initqueue --settled --onetime --name $dev $*"
+    printf 'KERNEL=="%s", RUN+="%s"\n' "$dev" "$cmd" \
+      >> $rulesfile
+}
+
 plymouth_running() {
     type plymouth >/dev/null 2>&1 && plymouth --ping 2>/dev/null
 }
@@ -270,6 +277,7 @@ run_kickstart() {
     # Figure out whether we need to retry disk/net stuff
     case "$root" in
         anaconda-net:*)   do_net=1 ;;
+        anaconda-hmc)     do_disk=1 ;;
         anaconda-disk:*)  do_disk=1 ;;
         anaconda-auto-cd) do_disk=1 ;;
     esac

--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -19,6 +19,8 @@ done
 
 if [ "$ARCH" != "s390" -a "$ARCH" != "s390x" ]; then
     MODULE_LIST+=" floppy edd iscsi_ibft "
+else
+    MODULE_LIST+=" hmcdrv "
 fi
 
 if [ "$ARCH" = "ppc" ]; then
@@ -30,6 +32,9 @@ MODULE_LIST+=" raid0 raid1 raid5 raid6 raid456 raid10 linear dm-mod dm-zero  \
               sha256 lrw xts "
 
 for m in $MODULE_LIST; do
-    modprobe $m &>/dev/null
+    if modprobe $m ; then
+        debug_msg "$m was loaded"
+    else
+        debug_msg "$m was NOT loaded"
+    fi
 done
-

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -14,6 +14,12 @@ depends() {
     return 0
 }
 
+installkernel() {
+    case "$(uname -m)" in
+        s390*) instmods hmcdrv ;;
+    esac
+}
+
 install() {
     # binaries we want in initramfs
     dracut_install eject -o pigz
@@ -66,5 +72,14 @@ install() {
             *) inst $dep ;;
         esac
     done
+
+    # support for specific architectures
+    case "$(uname -m)" in
+        s390*)
+            inst "/usr/sbin/lshmc"
+            inst "/usr/bin/hmcdrvfs"
+            inst "$moddir/anaconda-hmcroot" "/sbin/anaconda-hmcroot"
+        ;;
+    esac
 }
 

--- a/dracut/parse-anaconda-repo.sh
+++ b/dracut/parse-anaconda-repo.sh
@@ -33,6 +33,12 @@ if [ -n "$repo" ]; then
             set_neednet; root="anaconda-net:$repo" ;;
         hd|cd|cdrom)
             [ -n "$rest" ] && root="anaconda-disk:$rest" ;;
+        hmc)
+            # Set arg to copy the complete image to RAM.
+            # Otherwise, dracut fails with SquashFS errors.
+            echo rd.live.ram=1 >/etc/cmdline.d/99-anaconda-live-ram.conf
+
+            root="anaconda-hmc" ;;
         *)
             warn "Invalid value for 'inst.$arg': $repo" ;;
     esac

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -121,6 +121,10 @@ class HardDrive(commands.harddrive.FC3_HardDrive, DracutArgsMixin):
         else:
             return "inst.repo=hd:%s:%s" % (self.partition, self.dir)
 
+class Hmc(commands.hmc.RHEL7_Hmc, DracutArgsMixin):
+    def dracut_args(self, args, lineno, obj):
+        return "inst.repo=hmc"
+
 class NFS(commands.nfs.FC6_NFS, DracutArgsMixin):
     def dracut_args(self, args, lineno, obj):
         if self.opts:
@@ -240,6 +244,7 @@ class Bootloader(commands.bootloader.RHEL7_Bootloader, DracutArgsMixin):
 dracutCmds = {
     'cdrom': Cdrom,
     'harddrive': HardDrive,
+    'hmc': Hmc,
     'nfs': NFS,
     'url': URL,
     'updates': Updates,

--- a/dracut/repo-genrules.sh
+++ b/dracut/repo-genrules.sh
@@ -19,4 +19,8 @@ case "$root" in
     # HACK: anaconda demands that CDROMs be mounted at /mnt/install/source
     ln -s repo /run/install/source
   ;;
+  anaconda-hmc)
+    when_any_hmcdrv_appears \
+        anaconda-hmcroot \$env{DEVNAME}
+  ;;
 esac

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -76,6 +76,8 @@ class Flags(object):
         self.nosave_logs = False
         # single language options
         self.singlelang = False
+        # enable SE/HMC
+        self.hmc = False
         # current runtime environments
         self.environs = [ANACONDA_ENVIRON]
         # parse the boot commandline

--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -1080,6 +1080,32 @@ class PackagePayload(Payload):
             url = method.url
             mirrorlist = method.mirrorlist
             sslverify = not (method.noverifyssl or flags.noverifyssl)
+        elif method.method == "hmc":
+            # Check if /dev/hmcdrv is already mounted.
+            if device == "/dev/hmcdrv":
+                log.debug("HMC is already mounted at %s.", DRACUT_REPODIR)
+                url = "file://" + DRACUT_REPODIR
+            else:
+                log.debug("Trying to mount the content of HMC media drive.")
+
+                # Test the SE/HMC file access.
+                if iutil.execWithRedirect("/usr/sbin/lshmc", []):
+                    raise PayloadSetupError("The content of HMC media drive couldn't be accessed.")
+
+                # Test if a path is a mount point.
+                if os.path.ismount(INSTALL_TREE):
+                    log.debug("Don't mount the content of HMC media drive yet.")
+                else:
+                    # Make sure that the directories exists.
+                    iutil.mkdirChain(INSTALL_TREE)
+
+                    # Mount the device.
+                    if iutil.execWithRedirect("/usr/bin/hmcdrvfs", [INSTALL_TREE]):
+                        raise PayloadSetupError("The content of HMC media drive couldn't be mounted.")
+
+                log.debug("We are ready to use the HMC at %s.", INSTALL_TREE)
+                url = "file://" + INSTALL_TREE
+
         elif method.method == "cdrom" or (checkmount and not method.method):
             # Did dracut leave the DVD or NFS mounted for us?
             device = blivet.util.get_mount_device(DRACUT_REPODIR)

--- a/pyanaconda/ui/gui/spokes/source.glade
+++ b/pyanaconda/ui/gui/spokes/source.glade
@@ -614,6 +614,24 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkRadioButton" id="hmcRadioButton">
+                                <property name="label" translatable="yes" context="GUI|Software Source">Installation media via SE/_HMC</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="no_show_all">True</property>
+                                <property name="margin_left">12</property>
+                                <property name="use_underline">True</property>
+                                <property name="xalign">0</property>
+                                <property name="draw_indicator">True</property>
+                                <property name="group">isoRadioButton</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkRadioButton" id="isoRadioButton">
                                 <property name="label" translatable="yes" context="GUI|Software Source">_ISO file:</property>
                                 <property name="can_focus">True</property>
@@ -628,7 +646,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                             <child>
@@ -710,7 +728,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                             <child>
@@ -729,7 +747,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">5</property>
+                                <property name="position">6</property>
                               </packing>
                             </child>
                             <child>
@@ -868,7 +886,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">6</property>
+                                <property name="position">7</property>
                               </packing>
                             </child>
                             <child>
@@ -925,7 +943,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">7</property>
+                                <property name="position">8</property>
                               </packing>
                             </child>
                             <child>
@@ -943,7 +961,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">8</property>
+                                <property name="position">9</property>
                               </packing>
                             </child>
                             <child>
@@ -1277,7 +1295,7 @@
                               <packing>
                                 <property name="expand">True</property>
                                 <property name="fill">True</property>
-                                <property name="position">9</property>
+                                <property name="position">10</property>
                               </packing>
                             </child>
                           </object>

--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -209,6 +209,13 @@ class SourceSwitchHandler(object):
 
         self.data.method.method = "cdrom"
 
+    def set_source_hmc(self):
+        """ Switch to install source via HMC """
+        # clean any old HDD ISO sources
+        self._clean_hdd_iso()
+
+        self.data.method.method = "hmc"
+
     def set_source_closest_mirror(self):
         """ Switch to the closest mirror install source """
         # clean any old HDD ISO sources


### PR DESCRIPTION
Provide access to files on the USB/DVD drive of the SE/HMC of System
z hardware with a boot option: inst.repo=hmc

Resolves: rhbz#1289918

Depends on: https://github.com/rhinstaller/pykickstart/pull/179
Depends on: https://github.com/rhinstaller/lorax/pull/251