### PR TITLE
Support timeout and retries options in %packages section (#1448459)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -34,7 +34,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define mehver 0.23-1
 %define nmver 1.0.0-6.git20150107
 %define partedver 1.8.1
-%define pykickstartver 1.99.66.13
+%define pykickstartver 1.99.66.14
 %define pypartedver 2.5-2
 %define pythonpyblockver 0.45
 %define pythonurlgrabberver 3.9.1-5

--- a/pyanaconda/packaging/yumpayload.py
+++ b/pyanaconda/packaging/yumpayload.py
@@ -302,6 +302,12 @@ reposdir=%s
         if self.data.packages.multiLib:
             buf += "multilib_policy=all\n"
 
+        if self.data.packages.timeout is not None:
+            buf += "timeout=%s\n" % self.data.packages.timeout
+
+        if self.data.packages.retries is not None:
+            buf += "retries=%s\n" % self.data.packages.retries
+
         if hasattr(self.data.method, "proxy") and self.data.method.proxy:
             try:
                 proxy = ProxyString(self.data.method.proxy)

--- a/scripts/anaconda-yum
+++ b/scripts/anaconda-yum
@@ -134,7 +134,7 @@ def run_yum_transaction(release, arch, yum_conf, install_root, ts_file, script_l
             if retry_count:
                 # retry after waiting a bit
                 time.sleep(next(xdelay))
-                print("PROGRESS_RETRY: Error populating transaction, retrying (%d/%d)"
+                print("PROGRESS_RETRY: Error populating transaction, anaconda is retrying (%d/%d)"
                       % (retry_count, MAX_DOWNLOAD_RETRIES))
             try:
                 # uses dsCallback.transactionPopulation
@@ -144,7 +144,7 @@ def run_yum_transaction(release, arch, yum_conf, install_root, ts_file, script_l
                 continue
         else:
             # else = no break called = no successful attempt
-            print("ERROR: Error populating transaction after %d retries: %s"
+            print("ERROR: Error populating transaction after %d anaconda retries: %s"
                   % (retry_count, e))
             # we don't need to print "QUIT:" there, the finally clause
             # of the toplevel try-block will do that for us


### PR DESCRIPTION
Enable to set yum's timeout and retries with a kickstart file.

Keep in mind, that anaconda does its own retry with a progressive
delay. It is for case of a really unreliable connection. The messages
about retries in anaconda should be more clear now.

Resolves: rhbz#1448459

Depends on: https://github.com/rhinstaller/pykickstart/pull/180