### PR TITLE
Allow users to just assign mount points to block devices

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -37,7 +37,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define mehver 0.23-1
 %define nmver 1.0
 %define partedver 1.8.1
-%define pykickstartver 2.39-1
+%define pykickstartver 2.40-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 0.6-1

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -246,8 +246,9 @@ def doInstall(storage, payload, ksdata, instClass):
     # So let's have two task queues - early storage & late storage.
     early_storage = TaskQueue("Early storage configuration", N_("Configuring storage"))
 
-    # put custom storage info into ksdata
-    early_storage.append(Task("Insert custom storage to ksdata", storage.update_ksdata))
+    # put custom storage info into ksdata, but not if just assigning mount points
+    if not ksdata.mount.dataList():
+        early_storage.append(Task("Insert custom storage to ksdata", storage.update_ksdata))
 
     # pre-storage tasks
     # - Is this actually needed ? It does not appear to do anything right now.

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1152,6 +1152,43 @@ class Logging(commands.logging.FC6_Logging):
                 remote_server = "%s:%s" % (self.host, self.port)
             anaconda_logging.logger.updateRemote(remote_server)
 
+
+class Mount(commands.mount.F27_Mount):
+    def execute(self, storage, ksdata, instClass):
+        storage.do_autopart = False
+
+        for md in self.dataList():
+            md.execute(storage, ksdata, instClass)
+
+class MountData(commands.mount.F27_MountData):
+    def execute(self, storage, ksdata, instClass):
+        dev = storage.devicetree.resolve_device(self.device)
+        if dev is None:
+            raise KickstartParseError(formatErrorMsg(self.lineno,
+                                      msg=_("Unknown or invalid device '%s' specified" % self.device)))
+        if self.reformat:
+            if self.format:
+                fmt = get_format(self.format)
+                if not fmt:
+                    msg = _("Unknown or invalid format '%s' specified for device '%s'" % \
+                            (self.format, self.device))
+                    raise KickstartParseError(formatErrorMsg(self.lineno, msg))
+            else:
+                old_fmt = dev.format
+                if not old_fmt or old_fmt.type is None:
+                    raise KickstartParseError(formatErrorMsg(self.lineno,
+                                              msg=_("No format on device '%s'" % self.device)))
+                fmt = get_format(old_fmt.type)
+            storage.format_device(dev, fmt)
+
+        # only set mount points for mountable formats
+        if dev.format.mountable:
+            dev.format.mountpoint = self.mount_point
+
+        # make sure swaps end up in /etc/fstab
+        if fmt.type == "swap":
+            storage.add_fstab_swap(dev)
+
 class Network(commands.network.F27_Network):
     def __init__(self, *args, **kwargs):
         commands.network.F27_Network.__init__(self, *args, **kwargs)
@@ -2194,6 +2231,7 @@ commandMap = {
     "lang": Lang,
     "logging": Logging,
     "logvol": LogVol,
+    "mount": Mount,
     "network": Network,
     "part": Partition,
     "partition": Partition,
@@ -2217,6 +2255,7 @@ commandMap = {
 dataMap = {
     "BTRFSData": BTRFSData,
     "LogVolData": LogVolData,
+    "MountData": MountData,
     "PartData": PartitionData,
     "RaidData": RaidData,
     "RepoData": RepoData,
@@ -2474,6 +2513,7 @@ def doKickstartStorage(storage, ksdata, instClass):
     ksdata.volgroup.execute(storage, ksdata, instClass)
     ksdata.logvol.execute(storage, ksdata, instClass)
     ksdata.btrfs.execute(storage, ksdata, instClass)
+    ksdata.mount.execute(storage, ksdata, instClass)
     # setup snapshot here, that means add it to model and do the tests
     # snapshot will be created on the end of the installation
     ksdata.snapshot.setup(storage, ksdata, instClass)

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -2505,8 +2505,6 @@ def resetCustomStorageData(ksdata):
     for command in ["partition", "raid", "volgroup", "logvol", "btrfs"]:
         ksdata.resetCommand(command)
 
-    ksdata.clearpart.type = CLEARPART_TYPE_NONE
-
 def doKickstartStorage(storage, ksdata, instClass):
     """ Setup storage state from the kickstart data """
     ksdata.clearpart.execute(storage, ksdata, instClass)

--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -29,6 +29,8 @@ from blivet import util
 from blivet import udev
 from blivet.size import Size
 from blivet.errors import StorageError
+from blivet.formats import device_formats
+from blivet.formats.fs import FS
 from blivet.platform import platform as _platform
 from blivet.autopart import swap_suggestion
 from blivet.devicefactory import DEVICE_TYPE_LVM
@@ -924,3 +926,17 @@ def device_matches(spec, devicetree=None, disks_only=False):
             matches.append(dev_name)
 
     return matches
+
+def get_supported_filesystems():
+    fs_types = []
+    for cls in device_formats.values():
+        obj = cls()
+
+        # btrfs is always handled by on_device_type_changed
+        supported_fs = (obj.supported and obj.formattable and
+                        (isinstance(obj, FS) or
+                         obj.type in ["biosboot", "prepboot", "swap"]))
+        if supported_fs:
+            fs_types.append(obj)
+
+    return fs_types

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -47,9 +47,7 @@ from pyanaconda.kickstart import refreshAutoSwapSize
 from pyanaconda import network
 
 from blivet import devicefactory
-from blivet.formats import device_formats
 from blivet.formats import get_format
-from blivet.formats.fs import FS
 from blivet.size import Size
 from blivet.devicefactory import DEVICE_TYPE_LVM
 from blivet.devicefactory import DEVICE_TYPE_BTRFS
@@ -69,7 +67,7 @@ from blivet.devices import LUKSDevice, MDRaidArrayDevice, LVMVolumeGroupDevice
 from blivet.platform import platform
 
 from pyanaconda.storage_utils import ui_storage_logger, device_type_from_autopart, storage_checker, \
-    verify_luks_devices_have_key
+    verify_luks_devices_have_key, get_supported_filesystems
 from pyanaconda.storage_utils import DEVICE_TEXT_PARTITION, DEVICE_TEXT_MAP, DEVICE_TEXT_MD
 from pyanaconda.storage_utils import PARTITION_ONLY_FORMAT_TYPES, MOUNTPOINT_DESCRIPTIONS
 from pyanaconda.storage_utils import NAMED_DEVICE_TYPES, CONTAINER_DEVICE_TYPES
@@ -308,19 +306,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
             Restrict the set to ones that we might allow users to select.
         """
-        _fs_types = []
-        for cls in device_formats.values():
-            obj = cls()
-
-            # btrfs is always handled by on_device_type_changed
-            supported_fs = (obj.type not in UNSUPPORTED_FILESYSTEMS and
-                            obj.supported and obj.formattable and
-                            (isinstance(obj, FS) or
-                             obj.type in ["biosboot", "prepboot", "swap"]))
-            if supported_fs:
-                _fs_types.append(obj.name)
-
-        self._fs_types = set(_fs_types)
+        self._fs_types = {fs.name for fs in get_supported_filesystems()} - set(UNSUPPORTED_FILESYSTEMS)
 
         # report that the custom spoke has been initialized
         self.initialize_done()

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -27,7 +27,7 @@ from gi.repository import BlockDev as blockdev
 from pyanaconda.ui.lib.disks import getDisks, applyDiskSelection, checkDiskSelection
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke, EditTUIDialog
-from pyanaconda.storage_utils import AUTOPART_CHOICES, storage_checker
+from pyanaconda.storage_utils import AUTOPART_CHOICES, storage_checker, get_supported_filesystems
 
 from blivet import arch
 from blivet.size import Size
@@ -790,6 +790,7 @@ class SetFormatDialog(EditTUIDialog):
         EditTUIDialog.__init__(self, data, storage, payload, instclass)
         self.title = N_("Configure device format")
         self._mount_data = mount_data
+        self._supported_filesystems = [fmt.type for fmt in get_supported_filesystems()]
 
     @property
     def indirect(self):
@@ -808,12 +809,13 @@ class SetFormatDialog(EditTUIDialog):
             self.value = self._mount_data.format
             return InputState.DISCARDED
         else:
-            fmt = get_format(key)
-            if fmt.type is not None:
+            key = key.lower()
+            if key in self._supported_filesystems:
                 self.value = key
                 return InputState.DISCARDED
             else:
-                print("Invalid format given")
+                print(_("Invalid or unsupported format given"))
+                print(_("Supported formats: %s") % ", ".join(self._supported_filesystems))
                 return InputState.DISCARDED
 
     def apply(self):

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -494,7 +494,8 @@ class PartTypeSpoke(NormalTUISpoke):
             c = CheckboxWidget(title=_(part_type),
                                completed=(not self._do_mount_assign and PARTTYPES[part_type] == self.clearPartType))
             self._container.add(c, self._select_partition_type_callback, part_type)
-        c = CheckboxWidget(title=_("Manually assign mount points"), completed=self._do_mount_assign)
+        c = CheckboxWidget(title=_("Manually assign mount points") + _(" (EXPERIMENTAL)"),
+                           completed=self._do_mount_assign)
         self._container.add(c, self._select_mount_assign)
 
         self.window.add_with_separator(self._container)


### PR DESCRIPTION
This PR adds a new way of storage configuration to the Anaconda installer. It is the most trivial way of storage configuration possible -- just assigning mount points to block devices and optionally reformatting them. Users are allowed and encouraged to do whatever they want with their storage using whichever tools they want eventually just telling the installer which block device to mount where.

There are still certain limitations to keep things consistent, though. In particular, the file system mounted as ``/`` has to be reformatted as part of the installation process and all ``swap`` formats need to be reformatted in order to be used by the newly installed system.

The first three patches are quite well isolated to limit the potential regression surface. The fourth one is invasive, but on the other hand only making things safer and less vulnerable. Without it, the repeated visits of the storage configuration screens are doomed to fail (regardless of the new mount point assignment functionality). It's much safer to just start from scratch if users change their mind about how they want to configure storage.

I plan to implement a few kickstart tests for this new functionality if it gets merged. The goal here is to make this new feature available in Fedora 27 as a new (maybe experimental?) way of storage configuration in text mode.

Note: This requires changes from https://github.com/rhinstaller/pykickstart/pull/178 and a matching bump of the required version of *pykickstart*