### PR TITLE
packaging: clear downloaded packages repo cache before using it (#148…

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -893,6 +893,9 @@ class DNFPayload(payload.PackagePayload):
                 log.error("Installation failed: %r", e)
                 _failure_limbo()
 
+        if os.path.exists(self._download_location):
+            log.info("Removing existing package download location: %s", self._download_location)
+            shutil.rmtree(self._download_location)
         pkgs_to_download = self._base.transaction.install_set
         log.info('Downloading packages to %s.', self._download_location)
         progressQ.send_message(_('Downloading packages'))


### PR DESCRIPTION
…0790)

So installer does not crash on reused home having invalid data in the case from
previous interrupted install attemps.