### PR TITLE
network: create default ifcfg also for missing default NM connection …

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -373,7 +373,13 @@ def dumpMissingDefaultIfcfgs():
         try:
             uuid = nm.nm_device_setting_value(devname, "connection", "uuid")
         except nm.SettingsNotFoundError:
-            log.debug("no ifcfg file for %s", devname)
+            from pyanaconda.kickstart import AnacondaKSHandler
+            handler = AnacondaKSHandler()
+            # pylint: disable=E1101
+            network_data = handler.NetworkData(onboot=False, ipv6="auto")
+            add_connection_for_ksdata(network_data, devname)
+            rv.append(devname)
+            log.debug("network: creating default ifcfg file for %s", devname)
             continue
         except nm.MultipleSettingsFoundError as e:
             if not nm.nm_device_is_slave(devname):


### PR DESCRIPTION
…(#1478141)

In Fedora we create default ifcfg files by dumping default wired connections
created by NM.  NM does not create such connections for InfiniBand devices and
consequently installer crashes in text mode because of missing ifcfg file for
the IB device.

Create default ifcfg also when there is no NM default connection found for a
(in this BZ case InfiniBand) device.

This would be needed also when RHEL (server) policy is applied to the installer
turning creating of default connections by NM off in general. With the patch,
if default NM connection is not found, default ifcfg file is created in the
same way as in rhel7-branch.