### PR TITLE
Add support for the new 'mount' kickstart command

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -34,7 +34,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define mehver 0.23-1
 %define nmver 1.0.0-6.git20150107
 %define partedver 1.8.1
-%define pykickstartver 1.99.66.14
+%define pykickstartver 1.99.66.15
 %define pypartedver 2.5-2
 %define pythonpyblockver 0.45
 %define pythonurlgrabberver 3.9.1-5

--- a/pyanaconda/install.py
+++ b/pyanaconda/install.py
@@ -185,7 +185,9 @@ def doInstall(storage, payload, ksdata, instClass):
         ksdata.firstboot.setup(storage, ksdata, instClass)
         ksdata.addons.setup(storage, ksdata, instClass, payload)
 
-    storage.updateKSData()  # this puts custom storage info into ksdata
+    # put custom storage info into ksdata, but not if just assigning mount points
+    if not ksdata.mount.dataList():
+        storage.updateKSData()
 
     # Do partitioning.
     payload.preStorage()


### PR DESCRIPTION
It is supposed to set up mount points and optionally new formats
on devices.

(ported commit d3082ac8f8862224cb1e5e8b0dc5c2cb73d267e5 from f27-devel)

Resolves: rhbz#1450922