### PR TITLE
Add modular server repo to the base repositories (#1506894)

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -980,7 +980,7 @@ class ArchivePayload(ImagePayload):
 class PackagePayload(Payload):
     """A PackagePayload installs a set of packages onto the target system."""
 
-    DEFAULT_REPOS = [productName.split('-')[0].lower(), "rawhide"]          # pylint: disable=no-member
+    DEFAULT_REPOS = [productName.split('-')[0].lower(), "fedora-modular-server", "rawhide"]  # pylint: disable=no-member
 
     def __init__(self, data):
         if self.__class__ is PackagePayload:


### PR DESCRIPTION
The base repo is tested at the end of the installation and if the base repo is not enabled then the payload reset fails. This breaks closest source installation where this check is applied.

The base repo is recognized by name and this name could have the following values:

anaconda
rawhide
first part before "-" sign in the product name

This doesn't work for Fedora-Modular because it is fedora but that can't be used for repo id or there will be repo name collision.

Solved by adding fedora-modular-server to this list too.

Resolves: rhbz#1506894