### PR TITLE
Refactor DASD formatting and support detection of LDL DASDs.

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -37,7 +37,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define mehver 0.23-1
 %define nmver 1.0
 %define partedver 1.8.1
-%define pykickstartver 2.40-1
+%define pykickstartver 2.42-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 0.8-1

--- a/pyanaconda/format_dasd.py
+++ b/pyanaconda/format_dasd.py
@@ -1,0 +1,192 @@
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+
+import gi
+gi.require_version("BlockDev", "2.0")
+from gi.repository import BlockDev as blockdev
+
+from blivet import arch
+
+from pyanaconda.flags import flags
+from pyanaconda.ui.lib.disks import getDisks
+from pyanaconda.isignal import Signal
+from pyanaconda.storage_utils import on_disk_storage
+from pyanaconda.i18n import _
+from pyanaconda.storage.osinstall import storage_initialize
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+
+class DasdFormatting(object):
+    """Class for formatting DASDs."""
+
+    def __init__(self):
+        self._dasds = []
+
+        self._can_format_unformatted = True
+        self._can_format_ldl = True
+
+        self._report = Signal()
+        self._report.connect(log.debug)
+
+    @staticmethod
+    def is_supported():
+        """Is DASD formatting supported on this machine?"""
+        return arch.is_s390()
+
+    @property
+    def report(self):
+        """Signal for the progress reporting.
+
+        Emits messages during the formatting.
+        """
+        return self._report
+
+    @property
+    def dasds(self):
+        """List of found DASDs to format."""
+        return self._dasds
+
+    @property
+    def dasds_summary(self):
+        """Returns a string summary of DASDs to format."""
+        return "\n".join(map(self.get_dasd_info, self.dasds))
+
+    def get_dasd_info(self, disk):
+        """Returns a string with description of a DASD."""
+        return "/dev/" + disk.name + " (" + disk.busid + ")"
+
+    def _is_dasd(self, disk):
+        """Is it a DASD disk?"""
+        return disk.type == "dasd"
+
+    def _is_unformatted_dasd(self, disk):
+        """Is it an unformatted DASD?"""
+        return self._is_dasd(disk) and blockdev.s390.dasd_needs_format(disk.busid)
+
+    def _is_ldl_dasd(self, disk):
+        """Is it an LDL DASD?"""
+        return self._is_dasd(disk) and blockdev.s390.dasd_is_ldl(disk.name)
+
+    def _get_unformatted_dasds(self, disks):
+        """Returns a list of unformatted DASDs."""
+        result = []
+
+        if not self._can_format_unformatted:
+            log.debug("We are not allowed to format unformatted DASDs.")
+            return result
+
+        for disk in disks:
+            if self._is_unformatted_dasd(disk):
+                log.debug("Found unformatted DASD: %s", self.get_dasd_info(disk))
+                result.append(disk)
+
+        return result
+
+    def _get_ldl_dasds(self, disks):
+        """Returns a list of LDL DASDs."""
+        result = []
+
+        if not self._can_format_ldl:
+            log.debug("We are not allowed to format LDL DASDs.")
+            return result
+
+        for disk in disks:
+            if self._is_ldl_dasd(disk):
+                log.debug("Found LDL DASD: %s", self.get_dasd_info(disk))
+                result.append(disk)
+
+        return result
+
+    def update_restrictions(self, data):
+        """Read kickstart data to update the restrictions."""
+        self._can_format_unformatted = data.zerombr.zerombr
+        self._can_format_ldl = data.clearpart.cdl
+
+    def search_disks(self, disks):
+        """Search for a list of disks for DASDs to format."""
+        self._dasds = list(set(self._get_unformatted_dasds(disks) + self._get_ldl_dasds(disks)))
+
+    def should_run(self):
+        """Should we run the formatting?"""
+        return bool(self._dasds)
+
+    def do_format(self, disk):
+        """Format a disk."""
+        try:
+            self.report.emit(_("Formatting %s") % self.get_dasd_info(disk))
+            blockdev.s390.dasd_format(disk.name)
+        except blockdev.S390Error as err:
+            self.report.emit(_("Failed formatting %s") % self.get_dasd_info(disk))
+            log.error(err)
+
+    def run(self, storage, data):
+        """Format all found DASDs and update the storage.
+
+        This method could be run in a separate thread.
+        """
+        # Check if we have something to format.
+        if not self._dasds:
+            self.report.emit(_("Nothing to format"))
+            return
+
+        # Format all found DASDs.
+        self.report.emit(_("Formatting DASDs"))
+        for disk in self._dasds:
+            self.do_format(disk)
+
+        # Update the storage.
+        self.report.emit(_("Probing storage"))
+        storage_initialize(storage, data, storage.devicetree.protected_dev_names)
+
+        # Update also the storage snapshot to reflect the changes.
+        if on_disk_storage.created:
+            on_disk_storage.dispose_snapshot()
+        on_disk_storage.create_snapshot(storage)
+
+    @staticmethod
+    def run_automatically(storage, data, callback=None):
+        """Run the DASD formatting automatically.
+
+        This method could be run in a separate thread.
+        """
+        if not flags.automatedInstall:
+            return
+
+        if not DasdFormatting.is_supported():
+            return
+
+        disks = getDisks(storage.devicetree)
+
+        formatting = DasdFormatting()
+        formatting.update_restrictions(data)
+        formatting.search_disks(disks)
+
+        if not formatting.should_run():
+            return
+
+        if callback:
+            formatting.report.connect(callback)
+
+        formatting.run(storage, data)
+
+        if callback:
+            formatting.report.disconnect(callback)

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -632,9 +632,9 @@ class Realm(commands.realm.F19_Realm):
             realm_log.info("Joined realm %s", self.join_realm)
 
 
-class ClearPart(commands.clearpart.F21_ClearPart):
+class ClearPart(commands.clearpart.F28_ClearPart):
     def parse(self, args):
-        retval = commands.clearpart.F21_ClearPart.parse(self, args)
+        retval = commands.clearpart.F28_ClearPart.parse(self, args)
 
         if self.type is None:
             self.type = CLEARPART_TYPE_NONE

--- a/pyanaconda/ui/gui/spokes/lib/dasdfmt.glade
+++ b/pyanaconda/ui/gui/spokes/lib/dasdfmt.glade
@@ -67,7 +67,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">start</property>
-                <property name="label" translatable="yes">The following unformatted DASDs have been detected on your system. You can choose to format them now with dasdfmt or cancel to leave them unformatted. Unformatted DASDs cannot be used during installation.</property>
+                <property name="label" translatable="yes">The following unformatted or LDL DASDs have been detected on your system. You can choose to format them now with dasdfmt or cancel to leave them unformatted. Unformatted DASDs cannot be used during installation.</property>
                 <property name="wrap">True</property>
                 <attributes>
                   <attribute name="font-desc" value="Cantarell 12"/>
@@ -96,7 +96,7 @@
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
+            <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
@@ -108,7 +108,7 @@
             <property name="label">List unformatted DASDs here.</property>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
@@ -182,6 +182,7 @@
                   <object class="GtkSpinner" id="spinner4">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="halign">end</property>
                     <property name="active">True</property>
                   </object>
                   <packing>
@@ -193,6 +194,7 @@
                   <object class="GtkLabel" id="formatLabel">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="halign">start</property>
                     <property name="label">Current DASD being formatted.</property>
                   </object>
                   <packing>
@@ -204,8 +206,7 @@
                   <object class="GtkLabel" id="returnToHubLabel1">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="label" translatable="yes">You may &lt;a href=""&gt;go back to the main menu&lt;/a&gt; to complete other
-installation options while formatting completes.</property>
+                    <property name="label" translatable="yes">This may take a moment. You may &lt;a href=""&gt;go back to the main menu&lt;/a&gt; to complete other installation options while formatting completes.</property>
                     <property name="use_markup">True</property>
                     <property name="wrap">True</property>
                     <property name="track_visited_links">False</property>

--- a/pyanaconda/ui/lib/disks.py
+++ b/pyanaconda/ui/lib/disks.py
@@ -77,6 +77,9 @@ def getDisks(devicetree, fake=False):
     # Remove duplicate names from the list.
     return sorted(set(disks), key=lambda d: d.name)
 
+def getDisksByNames(disks, names):
+    return [d for d in disks if d.name in names]
+
 def isLocalDisk(disk):
     return (not isinstance(disk, MultipathDevice)
             and not isinstance(disk, iScsiDiskDevice)

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -17,20 +17,15 @@
 # Red Hat, Inc.
 #
 
-import gi
-gi.require_version("BlockDev", "2.0")
-
 from collections import OrderedDict
 
-from gi.repository import BlockDev as blockdev
-
-from pyanaconda.ui.lib.disks import getDisks, applyDiskSelection, checkDiskSelection
+from pyanaconda.ui.lib.disks import getDisks, applyDiskSelection, checkDiskSelection, getDisksByNames
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog
 from pyanaconda.storage_utils import AUTOPART_CHOICES, storage_checker, get_supported_filesystems
+from pyanaconda.format_dasd import DasdFormatting
 
-from blivet import arch
 from blivet.size import Size
 from blivet.errors import StorageError
 from blivet.devices import DASDDevice, FcoeDiskDevice, iScsiDiskDevice, MultipathDevice, ZFCPDiskDevice
@@ -94,16 +89,6 @@ class StorageSpoke(NormalTUISpoke):
         self.disks = []
         self.errors = []
         self.warnings = []
-
-        if self.data.zerombr.zerombr and arch.is_s390():
-            # if zerombr is specified in a ks file and there are unformatted
-            # dasds, automatically format them. pass in storage.devicetree here
-            # instead of storage.disks since media_present is checked on disks;
-            # a dasd needing dasdfmt will fail this media check though
-            to_format = [d for d in getDisks(self.storage.devicetree)
-                         if d.type == "dasd" and blockdev.s390.dasd_needs_format(d.busid)]
-            if to_format:
-                self.run_dasdfmt(to_format)
 
         if not flags.automatedInstall:
             # default to using autopart for interactive installs
@@ -208,7 +193,7 @@ class StorageSpoke(NormalTUISpoke):
         if not any(d in self.storage.disks for d in self.disks):
             # something happened to self.storage (probably reset), need to
             # reinitialize the list of disks
-            self._initialize(reinit=True)
+            self.update_disks()
 
         # synchronize our local data store with the global ksdata
         # Commment out because there is no way to select a disk right
@@ -289,15 +274,25 @@ class StorageSpoke(NormalTUISpoke):
             # TRANSLATORS: 'c' to continue
             if key.lower() == C_('TUI|Spoke Navigation', 'c'):
                 if self.selected_disks:
-                    # check selected disks to see if we have any unformatted DASDs
-                    # if we're on s390x, since they need to be formatted before we
-                    # can use them.
-                    if arch.is_s390():
-                        _disks = [d for d in self.disks if d.name in self.selected_disks]
-                        to_format = [d for d in _disks if d.type == "dasd" and
-                                     blockdev.s390.dasd_needs_format(d.busid)]
-                        if to_format:
-                            self.run_dasdfmt(to_format)
+                    # Is DASD formatting supported?
+                    if DasdFormatting.is_supported():
+                        # Wait for storage.
+                        threadMgr.wait(THREAD_STORAGE)
+
+                        # Get selected disks.
+                        disks = getDisksByNames(self.disks, self.selected_disks)
+
+                        # Check if some of the disks should be formatted.
+                        dasd_formatting = DasdFormatting()
+                        dasd_formatting.search_disks(disks)
+
+                        if dasd_formatting.should_run():
+                            # We want to apply current selection before running dasdfmt to
+                            # prevent this information from being lost afterward
+                            applyDiskSelection(self.storage, self.data, self.selected_disks)
+
+                            # Run the dialog.
+                            self.run_dasdfmt_dialog(dasd_formatting)
                             self.redraw()
                             return InputState.PROCESSED
 
@@ -323,42 +318,37 @@ class StorageSpoke(NormalTUISpoke):
             else:
                 return super(StorageSpoke, self).input(args, key)
 
-    def run_dasdfmt(self, to_format):
-        """
-        This generates the list of DASDs requiring dasdfmt and runs dasdfmt
-        against them.
-        """
-        # if the storage thread is running, wait on it to complete before taking
-        # any further actions on devices; most likely to occur if user has
-        # zerombr in their ks file
-        threadMgr.wait(THREAD_STORAGE)
+    def run_dasdfmt_dialog(self, dasd_formatting):
+        """Do DASD formatting if user agrees."""
+        # Prepare text of the dialog.
+        text = ""
+        text += _("The following unformatted or LDL DASDs have been "
+                  "detected on your system. You can choose to format them "
+                  "now with dasdfmt or cancel to leave them unformatted. "
+                  "Unformatted DASDs cannot be used during installation.\n\n")
 
-        # ask user to verify they want to format if zerombr not in ks file
-        if not self.data.zerombr.zerombr:
-            # prepare our msg strings; copied directly from dasdfmt.glade
-            summary = _("The following unformatted DASDs have been detected on your system. You can choose to format them now with dasdfmt or cancel to leave them unformatted. Unformatted DASDs cannot be used during installation.\n\n")
+        text += dasd_formatting.dasds_summary + "\n\n"
 
-            warntext = _("Warning: All storage changes made using the installer will be lost when you choose to format.\n\nProceed to run dasdfmt?\n")
+        text += _("Warning: All storage changes made using the installer will "
+                  "be lost when you choose to format.\n\nProceed to run dasdfmt?\n")
 
-            displaytext = summary + "\n".join("/dev/" + d.name for d in to_format) + "\n" + warntext
+        # Run the dialog.
+        question_window = YesNoDialog(text)
+        ScreenHandler.push_screen_modal(question_window)
+        if not question_window.answer:
+            return None
 
-            # now show actual prompt; note -- in cmdline mode, auto-answer for
-            # this is 'no', so unformatted DASDs will remain so unless zerombr
-            # is added to the ks file
-            question_window = YesNoDialog(displaytext)
-            ScreenHandler.push_screen_modal(question_window)
-            if not question_window.answer:
-                # no? well fine then, back to the storage spoke with you;
-                return None
+        print(_("This may take a moment."), flush=True)
 
-        for disk in to_format:
-            try:
-                print(_("Formatting /dev/%s. This may take a moment.") % disk.name)
-                blockdev.s390.dasd_format(disk.name)
-            except blockdev.S390Error as err:
-                # Log errors if formatting fails, but don't halt the installer
-                log.error(str(err))
-                continue
+        # Do the DASD formatting.
+        dasd_formatting.report.connect(self._show_dasdfmt_report)
+        dasd_formatting.run(self.storage, self.data)
+        dasd_formatting.report.disconnect(self._show_dasdfmt_report)
+
+        self.update_disks()
+
+    def _show_dasdfmt_report(self, msg):
+        print(msg, flush=True)
 
     def apply(self):
         self.autopart = self.data.autopart.autopart
@@ -433,12 +423,27 @@ class StorageSpoke(NormalTUISpoke):
         self.selected_disks = self.data.ignoredisk.onlyuse[:]
         # Probably need something here to track which disks are selected?
 
-    def _initialize(self, reinit=False):
+    def _initialize(self):
         """
         Secondary initialize so wait for the storage thread to complete before
         populating our disk list
         """
+        # Wait for storage.
+        threadMgr.wait(THREAD_STORAGE)
 
+        # Automatically format DASDs if allowed.
+        DasdFormatting.run_automatically(self.storage, self.data)
+
+        # Update disk list.
+        self.update_disks()
+
+        # Storage is ready.
+        self._ready = True
+
+        # Report that the storage spoke has been initialized.
+        self.initialize_done()
+
+    def update_disks(self):
         threadMgr.wait(THREAD_STORAGE)
 
         self.disks = sorted(getDisks(self.storage.devicetree),
@@ -446,15 +451,6 @@ class StorageSpoke(NormalTUISpoke):
         # if only one disk is available, go ahead and mark it as selected
         if len(self.disks) == 1:
             self._update_disk_list(self.disks[0])
-
-        self._update_summary()
-
-        if not reinit:
-            self._ready = True
-
-            # report that the storage spoke has been initialized
-            self.initialize_done()
-
 
 class PartTypeSpoke(NormalTUISpoke):
     """ Partitioning options are presented here.

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -30,6 +30,7 @@ class AnacondaLintConfig(PocketLintConfig):
                                 FalsePositive(r"E1101.*: Instance of 'int' has no 'zfcp_sanitize_lun_input' member"),
                                 FalsePositive(r"E1101.*: Instance of 'int' has no 'name_from_node' member"),
                                 FalsePositive(r"E1101.*: Instance of 'int' has no 'generate_backup_passphrase' member"),
+                                FalsePositive(r"E1101.*: Instance of 'int' has no 'dasd_is_ldl' member"),
                               ]
 
     @property


### PR DESCRIPTION
The code for DASD formatting was moved to the class DasdFormatting in
the pyanaconda.format_dasd module. Automatic formatting can be run
with run_automatically, otherwise UI has to do the steps manually.
This way the logic is separated from the UI and it is the same for
TUI and GUI. And it will be easier to move the code on DBus.

Also, formatting of LDL DASDs is now supported as well. Disks with the
LDL format will be automatically formatted with the clearpart --cdl
option. Otherwise, user can choose to format them if he selects them
in a spoke.

Based on commits:
a4a2e86, 7e28f03, aab9b91, 356e89c, d83e06d, 4ffe0de, 1e0f384