### PR TITLE
Remove storage check for too small swap (#1466964)

### DIFF
--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -43,7 +43,6 @@ from pyanaconda import isys
 from pyanaconda.constants import productName, STORAGE_SWAP_IS_RECOMMENDED, STORAGE_MUST_BE_ON_ROOT, \
     STORAGE_MUST_BE_ON_LINUXFS, STORAGE_MIN_PARTITION_SIZES, STORAGE_MIN_ROOT, STORAGE_MIN_RAM
 from pyanaconda.errors import errorHandler, ERROR_RAISE
-from pyanaconda.storage.autopart import swap_suggestion
 from pyanaconda.platform import platform as _platform
 
 from pykickstart.constants import AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_BTRFS
@@ -351,20 +350,6 @@ def verify_swap(storage, constraints, report_error, report_warning):
                                  "Although not strictly required in all cases, "
                                  "it will significantly improve performance "
                                  "for most installations."))
-
-    else:
-        swap_space = sum((device.size for device in swaps), Size(0))
-        disk_space = sum((device.size for device in storage.mountpoints.values()), Size(0))
-        recommended = swap_suggestion(disk_space=disk_space, quiet=True)
-
-        log.debug("Total swap space: %s", swap_space)
-        log.debug("Used disk space: %s", disk_space)
-        log.debug("Recommended swaps space: %s", recommended)
-
-        if swap_space < recommended:
-            report_warning(_("Your swap space is less than %(size)s "
-                             "which is lower than recommended.")
-                           % {"size": recommended})
 
 
 def verify_swap_uuid(storage, constraints, report_error, report_warning):


### PR DESCRIPTION
The size of swap for autopartitioning is computed from the available
disk space. We should be able to repeat this computation to get the
same value for storage checking, so we can compare the actual size
of swap with the recommended one. However, the available disk space
is used for partitioning at that point, so we cannot use it to compute
the recommended size of swap. We could use the total space of
mountable partitions instead of it, but it doesn't work for btrfs and
lvm thinp.

We could also move the check to the custom partitioning spoke. Since
we cannot check swap that was created automatically, we can run the
check only when a new swap is created with Add new mountpoint dialog.
However, that means that the check will not be run when user changes
the size the swap. That can be confusing and users might report this
behavior as a bug.

In conclusion, we are not able to reliably do this check, so it will
be removed.

(reverted commit 00aab8d)

Resolves: rhbz#1466964