### PR TITLE
Add kickstart filter parser

### DIFF
--- a/pyanaconda/kickstart_dispatcher.py
+++ b/pyanaconda/kickstart_dispatcher.py
@@ -1,0 +1,206 @@
+# Anaconda kickstart dispatching for modules
+#
+# Copyright (C) 2017  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from collections import namedtuple
+
+from pykickstart.parser import KickstartParser
+from pykickstart.sections import Section
+
+KickstartCommandOrSection = namedtuple('KickstartCommandOrSection',
+                                       ['content', 'lineno', 'filename'])
+
+
+class FilterSection(Section):
+    """Section for storing section content and header line references.
+
+    Similarly as NullSection defines a section that parser will recognize (ie
+    will not raise an error) and optionally pass itself to a supplied object
+    for storing the section.
+    """
+
+    allLines = True
+
+    def __init__(self, *args, **kwargs):
+        """Create a new FilterSection instance.
+
+        You must pass a sectionOpen parameter (including a leading '%') for the
+        section to make it valid but just ignored. If you want to store the
+        content, supply a filter argument.
+
+        Required kwargs:
+
+        sectionOpen - section name, including '%' starting character
+
+        Optional kwargs:
+        filter - an instance of filter object for storing the section
+                 (KickstartFilterParser) which has to provide add_section(FilterSection)
+                 method
+        """
+        super().__init__(*args, **kwargs)
+        self.sectionOpen = kwargs.get("sectionOpen")
+        self._filter = kwargs.get("filter", None)
+        self.header_lineno = 0
+        self._args = []
+        self._body = []
+
+    def handleHeader(self, lineno, args):
+        self.header_lineno = lineno
+        self._args = args
+
+    def handleLine(self, line):
+        self._body.append(line)
+
+    def __str__(self):
+        body = "".join(self._body)
+        if body:
+            s = "{}\n{}%end\n".format(" ".join(self._args), body)
+        else:
+            s = "{}\n%end\n".format(" ".join(self._args))
+        return s
+
+    def finalize(self):
+        if self._filter is not None:
+            self._filter.add_section(self)
+        self.header_lineno = 0
+        self._args = []
+        self._body = []
+
+
+class FilterKickstartParser(KickstartParser):
+    """Kickstart parser for filtering specific commands and sections.
+
+    Filters specified commands and sections. Does not do any actual command
+    or section parsing (ie command syntax checking).
+    """
+
+    unknown_filename = "<MAIN>"
+
+    def __init__(self, handler, valid_sections=None, missing_include_is_fatal=True):
+        """Initialize the filter.
+
+        :param valid_sections: list of valid kickstart sections
+        :type valid_sections: list(str)
+        :param missing_include_is_fatal: raise error if included file is not found
+        :type missing_include_is_fatal: bool
+        """
+
+        self._valid_sections = valid_sections or []
+        self._accepted_sections = []
+        # calls setupSections
+        super().__init__(handler, missingIncludeIsFatal=missing_include_is_fatal)
+        self._accepted_commands = []
+        self._current_ks_filename = self.unknown_filename
+        self._result = []
+
+    @property
+    def valid_sections(self):
+        """List of valid kickstart sections"""
+        return list(self._valid_sections)
+
+    @valid_sections.setter
+    def valid_sections(self, value):
+        self._valid_sections = value
+
+    def filter(self, filename, commands=None, sections=None):
+        """Filter commands and sections from kickstart given by filename.
+
+        :param filename: name of kickstart file
+        :type filename: str
+        :param commands: list of accepted commands
+        :type commands: list(str)
+        :param sections: list of accepted sections (including % starting character)
+        :type sections: list(str)
+
+        :return: List of objects containing filtered commands and sections.
+                 For command it contains the line, line number and kickstart filename
+                 For section it contains the section, section header line number
+                 and kickstart filename.
+                 The list preservers the order of commands and sections.
+        :rtype: list(KickstartCommandOrSection)
+        """
+        with open(filename, "r") as f:
+            kickstart = f.read()
+        return self.filter_from_string(kickstart, commands=commands, sections=sections,
+                                       filename=filename)
+
+    def filter_from_string(self, kickstart, commands=None, sections=None, filename=None):
+        """Filter commands and sections from kickstart given by string
+
+        :param kickstart: string containing kickstart
+        :type kickstart: str
+        :param commands: list of accepted commands
+        :type commands: list(str)
+        :param sections: list of accepted sections (including % starting character)
+        :type sections: list(str)
+        :param filename: filename to be used as file reference in the result
+        :type filename: str
+
+        :return: List of objects containing filtered commands and sections.
+                 For command it contains the line, line number and kickstart filename
+                 For section it contains the section, section header line number
+                 and kickstart filename.
+                 The list preserves the order of commands and sections.
+        :rtype: list(KickstartCommandOrSection)
+        """
+        self._reset()
+        self._accepted_commands = commands or []
+        self._accepted_sections = sections or []
+        self._current_ks_filename = filename or self.unknown_filename
+        self.readKickstartFromString(kickstart)
+        return self._result
+
+    @staticmethod
+    def kickstart_from_result(result):
+        """Returns kickstart generated from the filtering result."""
+        return "".join(element.content for element in result)
+
+    def add_section(self, section):
+        """Adds the section instance of FilterSection to result."""
+        section = KickstartCommandOrSection(str(section),
+                                            section.header_lineno,
+                                            self._current_ks_filename)
+        self._result.append(section)
+
+    def _reset(self):
+        self._result = []
+        self.setupSections()
+
+    def _handleInclude(self, f):
+        """Overrides parent to keep track of kickstart filename following includes."""
+        parent_file = self._current_ks_filename
+        self._current_ks_filename = f
+        super()._handleInclude(f)
+        self._current_ks_filename = parent_file
+
+    def handleCommand(self, lineno, args):
+        """Overrides parent method to store filtered command."""
+        if args[0] in self._accepted_commands:
+            command = KickstartCommandOrSection(self._line, lineno, self._current_ks_filename)
+            self._result.append(command)
+
+    def setupSections(self):
+        """Overrides parent method to store content of filtered sections."""
+        self._sections = {}
+        for section in self._valid_sections:
+            if section in self._accepted_sections:
+                ksfilter = self
+            else:
+                ksfilter = None
+            self.registerSection(FilterSection(self.handler,
+                                               sectionOpen=section,
+                                               filter=ksfilter))

--- a/tests/pyanaconda_tests/kickstart_dispatcher.py
+++ b/tests/pyanaconda_tests/kickstart_dispatcher.py
@@ -1,0 +1,458 @@
+#
+# Radek Vykydal <rvykydal@redhat.com>
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+
+import unittest
+import os
+import shlex
+from contextlib import contextmanager
+
+from pyanaconda.kickstart_dispatcher import KickstartCommandOrSection,  FilterKickstartParser
+from pykickstart.version import returnClassForVersion
+from pykickstart.errors import KickstartParseError, KickstartError
+
+KICKSTART1 = """
+text
+
+%pre
+echo PRE
+%end
+
+url --url=http://download.eng.brq.redhat.com/pub/fedora/development/25/Server/x86_64/os/.
+lang en_US.UTF-8
+keyboard --vckeymap=us --xlayouts='us'
+rootpw --plaintext chrchl
+selinux --enforcing
+firstboot --disable
+authconfig --passalgo=sha512 --enableshadow
+timezone --utc Asia/Tokyo
+
+network --device ens3
+network --device ens4 --activate
+%include {}
+
+%addon pony --fly=True
+%end
+
+bootloader --location=mbr --boot-drive=vda --driveorder=vda
+clearpart --all --drives=vda
+ignoredisk --only-use=vda
+
+firewall --enabled
+
+# Partitioning conflicts with autopart
+#part /boot --fstype=xfs --onpart=vda1
+#part pv.100000 --size=18436 --ondisk=vda
+#volgroup Vol00 --pesize=4096 pv.100000
+#logvol / --fstype=xfs --name=lv_root --vgname=Vol00 --size=15360
+#logvol /home --fstype=xfs --name=lv_home --vgname=Vol00 --size=1024
+#logvol swap --fstype=swap --name=lv_swap --vgname=Vol00 --size=2048
+
+autopart --encrypted --passphrase=chrchl --type=lvm
+
+%addon scorched --planet=Eearth
+%end
+
+%packages --ignoremissing
+@core
+@base
+%end
+
+%post --nochroot --interpreter /usr/bin/bash
+
+echo "POST1"
+%end
+
+%post --nochroot --interpreter /usr/bin/bash
+echo "POST2"
+%end
+""".strip()
+
+
+kickstart_flat=[("ks.test.flat.cfg", KICKSTART1.replace("%include {}", ""))]
+
+# Kickstart with
+# - 2 levels of %include
+# - sections in included kickstart
+INCLUDE_LEVEL_1_FILENAME = "ks.test.include1.cfg"
+INCLUDE_LEVEL_2_FILENAME = "ks.test.include2.cfg"
+kickstart_include=[
+("ks.test.include.cfg", KICKSTART1.format(INCLUDE_LEVEL_1_FILENAME).strip()),
+(INCLUDE_LEVEL_1_FILENAME, """
+network --device=ens51 --activate
+%include {}
+network --device=ens55 --activate
+network --device=ens56 --activate
+repo --name=repo1 --baseurl=http://bla.bla/repo1
+%packages
+@include1
+%end
+""".format(INCLUDE_LEVEL_2_FILENAME).strip()),
+(INCLUDE_LEVEL_2_FILENAME, """
+repo --name=repo1 --baseurl=http://bla.bla/repo1
+network --device=ens541 --activate
+%post --nochroot --interpreter /usr/bin/bash
+echo "POST_include2"
+%end
+""".strip())
+]
+
+kickstart_include_result_kickstart = """
+%pre
+echo PRE
+%end
+network --device ens3
+network --device ens4 --activate
+network --device=ens51 --activate
+network --device=ens541 --activate
+%post --nochroot --interpreter /usr/bin/bash
+echo "POST_include2"
+%end
+network --device=ens55 --activate
+network --device=ens56 --activate
+%packages
+@include1
+%end
+%addon pony --fly=True
+%end
+firewall --enabled
+%addon scorched --planet=Eearth
+%end
+%packages --ignoremissing
+@core
+@base
+%end
+%post --nochroot --interpreter /usr/bin/bash
+
+echo "POST1"
+%end
+%post --nochroot --interpreter /usr/bin/bash
+echo "POST2"
+%end
+""".lstrip()
+
+class FilterKickstartParserTest(unittest.TestCase):
+
+    def setUp(self):
+        self._kickstart_flat = kickstart_flat
+        self._kickstart_include = kickstart_include
+
+    def simple_test(self):
+        """This test should demonstrate usage and output of the filter parser."""
+        ks_content = """
+network --device=ens3 --activate
+firewall --enabled
+%addon pony --fly=True
+%end
+""".lstrip()
+        filename = "ks.test.simple.cfg"
+        valid_sections = ["%pre", "%pre-install", "%post", "%onerror", "%traceback", "%packages", "%addon", "%anaconda"]
+        commands = ["network", "firewall"]
+        sections = ["%addon"]
+
+        handler = returnClassForVersion()
+        ksparser = FilterKickstartParser(handler, valid_sections)
+
+        # Reading kickstart from file
+
+        line1 = KickstartCommandOrSection("network --device=ens3 --activate\n", 1, filename)
+        line2 = KickstartCommandOrSection("firewall --enabled\n", 2, filename)
+        line3 = KickstartCommandOrSection("%addon pony --fly=True\n%end\n", 3, filename)
+        expected_result = [line1, line2, line3]
+
+        with open(filename, "w") as f:
+            f.write(ks_content)
+        result = ksparser.filter(filename, commands, sections)
+        os.remove(filename)
+
+        self.assertEqual(result, expected_result)
+        self.assertEqual(ksparser.kickstart_from_result(result), ks_content)
+
+        # Reading kickstart from string
+
+        filename = ksparser.unknown_filename
+        line1 = KickstartCommandOrSection("network --device=ens3 --activate\n", 1, filename)
+        line2 = KickstartCommandOrSection("firewall --enabled\n", 2, filename)
+        line3 = KickstartCommandOrSection("%addon pony --fly=True\n%end\n", 3, filename)
+        expected_result = [line1, line2, line3]
+
+        result = ksparser.filter_from_string(ks_content, commands, sections)
+
+        self.assertEqual(result, expected_result)
+        self.assertEqual(ksparser.kickstart_from_result(result), ks_content)
+
+    @contextmanager
+    def _prepare_kickstart(self, kickstart_file_specs):
+        file_lines_map = {}
+        for filename, content in kickstart_file_specs:
+            with open(filename, "w") as f:
+                f.write(content)
+            file_lines_map[filename] = content.splitlines(keepends=True)
+        yield file_lines_map
+        for filename, _content in kickstart_file_specs:
+            os.remove(filename)
+
+    def _check_kickstart(self, ksparser, kickstart, commands=None, sections=None):
+        with self._prepare_kickstart(kickstart) as file_lines_map:
+            filename = kickstart[0][0]
+            result = ksparser.filter(filename, commands, sections)
+            self._check_references(result, file_lines_map)
+            self._check_nothing_is_missing(result, kickstart, commands, sections)
+        return result
+
+    def _check_kickstart_from_string(self, ksparser, kickstart, commands=None, sections=None):
+        """Note: works only for kickstart without %include"""
+        filename, content = kickstart[0]
+        file_lines_map = {filename or FilterKickstartParser.unknown_filename: content.splitlines(keepends=True)}
+        result = ksparser.filter_from_string(content, commands, sections, filename)
+        self._check_references(result, file_lines_map)
+        self._check_nothing_is_missing(result, kickstart, commands, sections)
+        return result
+
+    def _check_references(self, result, file_lines_map):
+        """Checks that the line/file references in result are correct.
+
+            Uses shlex (as pykickstart) to parse section headers.
+        """
+        for line_or_section, lineno, filename in result:
+            original_kickstart_line = file_lines_map[filename][lineno-1]
+            if line_or_section.strip()[0] == "%":
+                # section
+                # We keep only references to headers.
+                header = line_or_section.strip().split("\n")[0]
+                # Headers are not stored as source lines but go through shlex
+                # parsing before we can store them in result.
+                self.assertEqual(shlex.split(header), shlex.split(original_kickstart_line))
+            else:
+                # command
+                self.assertEqual(line_or_section, original_kickstart_line)
+
+    def _check_nothing_is_missing(self, result, kickstart, commands, sections):
+        """Checks that all specified lines in kickstart are in the result.
+
+            Uses shlex (as pykickstart) to identify required sections and commands.
+        """
+        # Note: assumes all files are actually included in main kickstart
+        commands = commands or []
+        sections = sections or []
+        ks_count = {}
+        for _filename, content in kickstart:
+            self._count_ks_lines(ks_count, content.splitlines(), commands, sections)
+
+        result_count = {}
+        # Count only first line of content because sections are stored complete
+        self._count_ks_lines(result_count, (element.content.split("\n")[0] for element in result),
+                             commands, sections)
+        self.assertEqual(ks_count, result_count)
+
+    def _count_ks_lines(self, count_dict, lines, commands, sections):
+        for line in lines:
+            args = shlex.split(line)
+            if not args:
+                continue
+            token = args[0]
+            line = " ".join(args)
+            if (token.startswith("%") and token in sections) \
+               or (not token.startswith("%") and token in commands):
+                if line in count_dict:
+                    count_dict[line] = count_dict[line] + 1
+                else:
+                    count_dict[line] = 1
+
+    def filter_test(self):
+        valid_sections = ["%pre", "%pre-install", "%post", "%onerror", "%traceback", "%packages", "%addon", "%anaconda"]
+        handler = returnClassForVersion()
+        ksparser = FilterKickstartParser(handler, valid_sections)
+
+        # Basic test
+        kickstart = self._kickstart_include
+        self._check_kickstart(ksparser,
+                              kickstart = kickstart,
+                              commands = ["network", "firewall"],
+                              sections = ["%packages", "%post", "%pre", "%addon"])
+
+        # Empty commands and sections
+        result = self._check_kickstart(ksparser,
+                                       kickstart = kickstart,
+                                       commands = [],
+                                       sections = [])
+        self.assertEqual(result, [])
+
+        # Passing commands in sections and sections in commands !?
+        result = self._check_kickstart(ksparser,
+                                      kickstart = kickstart,
+                                      commands = ["%packages"],
+                                      sections = ["network"])
+        # The result should be empty
+        self.assertEqual(result, [])
+
+    def kickstart_from_result_test(self):
+        valid_sections = ["%pre", "%pre-install", "%post", "%onerror", "%traceback", "%packages", "%addon", "%anaconda"]
+        handler = returnClassForVersion()
+        ksparser = FilterKickstartParser(handler, valid_sections)
+
+        kickstart = self._kickstart_include
+        result = self._check_kickstart(ksparser,
+                             kickstart = kickstart,
+                             commands = ["network", "firewall"],
+                             sections = ["%packages", "%post", "%pre", "%addon"])
+        self.assertEqual(ksparser.kickstart_from_result(result), kickstart_include_result_kickstart)
+
+    def order_of_arguments_test(self):
+        valid_sections = ["%pre", "%pre-install", "%post", "%onerror", "%traceback", "%packages", "%addon", "%anaconda"]
+        handler = returnClassForVersion()
+        ksparser = FilterKickstartParser(handler, valid_sections)
+        kickstart = self._kickstart_include
+        result1 = self._check_kickstart(ksparser,
+                                       kickstart = kickstart,
+                                       commands = ["network", "firewall"],
+                                       sections = ["%packages", "%post"])
+        result2 = self._check_kickstart(ksparser,
+                                       kickstart = kickstart,
+                                       commands = ["firewall", "network"],
+                                       sections = ["%post", "%packages"])
+        self.assertEqual(result1, result2)
+
+    def filter_from_string_test(self):
+        valid_sections = ["%pre", "%pre-install", "%post", "%onerror", "%traceback", "%packages", "%addon", "%anaconda"]
+        handler = returnClassForVersion()
+        ksparser = FilterKickstartParser(handler, valid_sections)
+        kickstart = self._kickstart_flat
+
+        # Basic test
+        result1 = self._check_kickstart_from_string(ksparser,
+                                         kickstart = kickstart,
+                                         commands = ["network", "firewall"],
+                                         sections = ["%packages", "%post", "%pre", "%addon"])
+        # Reusing ksparser instance works
+        result2 = self._check_kickstart_from_string(ksparser,
+                                         kickstart = kickstart,
+                                         commands = ["lang", "keyboard"],
+                                         sections = ["%pre"])
+        self.assertNotEqual(result1, result2)
+        result3 = self._check_kickstart_from_string(ksparser,
+                                         kickstart = kickstart,
+                                         commands = ["network", "firewall"],
+                                         sections = ["%packages", "%post", "%pre", "%addon"])
+        self.assertEqual(result1, result3)
+
+    def filter_from_string_filename_test(self):
+        valid_sections = ["%pre", "%pre-install", "%post", "%onerror", "%traceback", "%packages", "%addon", "%anaconda"]
+        handler = returnClassForVersion()
+        ksparser = FilterKickstartParser(handler, valid_sections)
+        kickstart = self._kickstart_flat
+
+        commands = ["network", "firewall"]
+        sections = ["%packages", "%post"]
+        filename, content = kickstart[0]
+
+        # Kickstart from string has "<MAIN>" as filename
+        result = ksparser.filter_from_string(content, commands, sections)
+        for element in result:
+            self.assertEqual(element.filename, FilterKickstartParser.unknown_filename)
+        # Or the value supplied by filename optional argument
+        result = ksparser.filter_from_string(content, commands, sections, filename = filename)
+        for element in result:
+            self.assertEqual(element.filename, filename)
+
+    def valid_sections_test(self):
+        valid_sections = ["%pre", "%pre-install", "%post", "%onerror", "%traceback", "%packages", "%addon", "%anaconda"]
+        handler = returnClassForVersion()
+        ksparser = FilterKickstartParser(handler, valid_sections)
+        kickstart = self._kickstart_flat
+
+        returned_valid_sections = ksparser.valid_sections
+        # valid_sections returns new list, not a reference to the internal object
+        returned_valid_sections.append("%test")
+        self.assertNotEqual(returned_valid_sections, ksparser.valid_sections)
+
+        ksparser.valid_sections = ["%packages"]
+        # Invalid section raises exception
+        self.assertRaises(KickstartParseError, self._check_kickstart_from_string, ksparser,
+                                         kickstart = kickstart,
+                                         commands = ["network", "firewall"],
+                                         sections = ["%packages", "%post"])
+        # setting valid sections back to the original, the exception is gone
+        ksparser.valid_sections = valid_sections
+        self._check_kickstart_from_string(ksparser,
+                                         kickstart = kickstart,
+                                         commands = ["network", "firewall"],
+                                         sections = ["%packages", "%post"])
+
+    def invalid_command_test(self):
+        # Invalid command or command option in kickstart does not raise
+        # KickstartParseError because commands and not parsed in the filter.
+        ks_content_invalid_command = """
+network --device=ens3 --activate
+netork --device=ens5 --activate
+network --device=ens7 --activate
+network --devce=ens9 --activate
+""".strip()
+
+        kickstart = [(None, ks_content_invalid_command)]
+        handler = returnClassForVersion()
+        ksparser = FilterKickstartParser(handler)
+        result1 = self._check_kickstart_from_string(ksparser,
+                                       kickstart = kickstart,
+                                       commands = ["network", "firewall"])
+        self.assertEqual(len(result1), 3)
+        # It is even possible to filter unknown commands
+        result1 = self._check_kickstart_from_string(ksparser,
+                                       kickstart = kickstart,
+                                       commands = ["netork"])
+        self.assertEqual(len(result1), 1)
+
+    def conflicting_commands_test(self):
+        # Conflicting commands in kickstart do not raise KickstartParseError
+        # because commands are not parsed in the filter.
+        ks_content_conflicting_commands = """
+# Partitioning conflicts with autopart
+part /boot --fstype=xfs --onpart=vda1
+part pv.100000 --size=18436 --ondisk=vda
+volgroup Vol00 --pesize=4096 pv.100000
+logvol / --fstype=xfs --name=lv_root --vgname=Vol00 --size=15360
+logvol /home --fstype=xfs --name=lv_home --vgname=Vol00 --size=1024
+logvol swap --fstype=swap --name=lv_swap --vgname=Vol00 --size=2048
+
+autopart --encrypted --passphrase=starost --type=lvm
+""".strip()
+        kickstart = [(None, ks_content_conflicting_commands)]
+        handler = returnClassForVersion()
+        ksparser = FilterKickstartParser(handler)
+        result1 = self._check_kickstart_from_string(ksparser,
+                                       kickstart = kickstart,
+                                       commands = ["autopart", "part"])
+        self.assertEqual(len(result1), 3)
+
+    def missing_include_test(self):
+        # Reaction to missing include can be configured in constructor
+        ks_content_missing_include = """
+network --device=ens3
+%include missing_include.cfg
+""".strip()
+        kickstart = [(None, ks_content_missing_include)]
+        handler = returnClassForVersion()
+        # By default raises error
+        ksparser = FilterKickstartParser(handler)
+        self.assertRaises(KickstartError, self._check_kickstart_from_string,
+                          ksparser, kickstart = kickstart, commands = ["network"])
+        # But can be configured not to
+        ksparser = FilterKickstartParser(handler, missing_include_is_fatal=False)
+        self._check_kickstart_from_string(ksparser, kickstart = kickstart, commands = ["network"])
+


### PR DESCRIPTION
Filters kickstart for specific commands and section.
Does not parse commands or section headers during the filtering.