### PR TITLE
Enable SE/HMC file access to repo

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -551,6 +551,10 @@ if __name__ == "__main__":
     if anaconda.methodstr and not ksdata.method.seen:
         startup_utils.set_installation_method_from_anaconda_options(anaconda, ksdata)
 
+    # Enable SE/HMC if it was selected as an installation source.
+    if ksdata.method.method == "hmc":
+        flags.hmc = True
+
     # Override the selinux state from kickstart if set on the command line
     if flags.selinux != constants.SELINUX_DEFAULT:
         ksdata.selinux.selinux = flags.selinux

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -37,7 +37,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define mehver 0.23-1
 %define nmver 1.0
 %define partedver 1.8.1
-%define pykickstartver 2.42-1
+%define pykickstartver 2.43-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 0.8-1

--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -29,6 +29,7 @@ dist_dracut_SCRIPTS = module-setup.sh \
                       anaconda-ks-sendheaders.sh \
                       anaconda-netroot.sh \
                       anaconda-diskroot \
+                      anaconda-hmcroot \
                       anaconda-copy-ks.sh \
                       anaconda-copy-cmdline.sh \
                       anaconda-copy-dhclient.sh \

--- a/dracut/anaconda-hmcroot
+++ b/dracut/anaconda-hmcroot
@@ -1,0 +1,24 @@
+#!/bin/bash
+# anaconda-hmcroot:
+# Provide access to the root on the USB/DVD drive of the SE/HMC of System z hardware.
+
+command -v info >/dev/null || . /lib/dracut-lib.sh
+command -v anaconda_live_root_dir >/dev/null || . /lib/anaconda-lib.sh
+
+# Debug.
+debug_msg "Trying SE/HMC access with $1."
+
+# Do we already have a root device?
+# Then do not run again.
+[ -e "/dev/root" ] && exit 1
+
+# Do we have SE/HMC file access?
+if /usr/sbin/lshmc ; then
+    info "Anaconda using SE/HMC file access to root."
+    /usr/bin/hmcdrvfs $repodir || warn "Couldn't mount /dev/hmcdrv"
+    anaconda_live_root_dir $repodir
+else
+    debug_msg "No SE/HMC access to files."
+    exit 1
+fi
+

--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -216,6 +216,13 @@ when_any_cdrom_appears() {
       >> $rulesfile
 }
 
+when_any_hmcdrv_appears() {
+    local dev="hmcdrv"
+    local cmd="/sbin/initqueue --settled --onetime --name $dev $*"
+    printf 'KERNEL=="%s", RUN+="%s"\n' "$dev" "$cmd" \
+      >> $rulesfile
+}
+
 plymouth_running() {
     type plymouth >/dev/null 2>&1 && plymouth --ping 2>/dev/null
 }
@@ -316,6 +323,7 @@ run_kickstart() {
     # Figure out whether we need to retry disk/net stuff
     case "$root" in
         anaconda-net:*)   do_net=1 ;;
+        anaconda-hmc)     do_disk=1 ;;
         anaconda-disk:*)  do_disk=1 ;;
         anaconda-auto-cd) do_disk=1 ;;
     esac

--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -19,6 +19,8 @@ done
 
 if [ "$ARCH" != "s390" -a "$ARCH" != "s390x" ]; then
     MODULE_LIST+=" floppy edd iscsi_ibft "
+else
+    MODULE_LIST+=" hmcdrv "
 fi
 
 if [ "$ARCH" = "ppc" ]; then
@@ -30,6 +32,9 @@ MODULE_LIST+=" raid0 raid1 raid5 raid6 raid456 raid10 linear dm-mod dm-zero  \
               sha256 lrw xts "
 
 for m in $MODULE_LIST; do
-    modprobe $m &>/dev/null
+    if modprobe $m ; then
+        debug_msg "$m was loaded"
+    else
+        debug_msg "$m was NOT loaded"
+    fi
 done
-

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -14,6 +14,12 @@ depends() {
     return 0
 }
 
+installkernel() {
+    case "$(uname -m)" in
+        s390*) instmods hmcdrv ;;
+    esac
+}
+
 install() {
     # binaries we want in initramfs
     dracut_install eject -o pigz
@@ -66,5 +72,14 @@ install() {
             *) inst $dep ;;
         esac
     done
+
+    # support for specific architectures
+    case "$(uname -m)" in
+        s390*)
+            inst "/usr/sbin/lshmc"
+            inst "/usr/bin/hmcdrvfs"
+            inst "$moddir/anaconda-hmcroot" "/sbin/anaconda-hmcroot"
+        ;;
+    esac
 }
 

--- a/dracut/parse-anaconda-repo.sh
+++ b/dracut/parse-anaconda-repo.sh
@@ -33,6 +33,13 @@ if [ -n "$repo" ]; then
         hd|cd|cdrom)
             [ -n "$rest" ] && root="anaconda-disk:$rest"
         ;;
+        hmc)
+            # Set arg to copy the complete image to RAM.
+            # Otherwise, dracut fails with SquashFS errors.
+            echo rd.live.ram=1 >/etc/cmdline.d/99-anaconda-live-ram.conf
+
+            root="anaconda-hmc"
+        ;;
         *)
             warn "Invalid value for 'inst.$arg': $repo"
         ;;

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -126,6 +126,10 @@ class HardDrive(commands.harddrive.FC3_HardDrive, DracutArgsMixin):
         else:
             return "inst.repo=hd:%s:%s" % (self.partition, self.dir)
 
+class Hmc(commands.hmc.F28_Hmc, DracutArgsMixin):
+    def dracut_args(self, args, lineno, obj):
+        return "inst.repo=hmc"
+
 class NFS(commands.nfs.FC6_NFS, DracutArgsMixin):
     def dracut_args(self, args, lineno, obj):
         if self.opts:
@@ -252,6 +256,7 @@ class Bootloader(commands.bootloader.F21_Bootloader, DracutArgsMixin):
 dracutCmds = {
     'cdrom': Cdrom,
     'harddrive': HardDrive,
+    'hmc': Hmc,
     'nfs': NFS,
     'url': URL,
     'updates': Updates,

--- a/dracut/repo-genrules.sh
+++ b/dracut/repo-genrules.sh
@@ -19,4 +19,8 @@ case "$root" in
     # HACK: anaconda demands that CDROMs be mounted at /mnt/install/source
     ln -s repo /run/install/source
   ;;
+  anaconda-hmc)
+    when_any_hmcdrv_appears \
+        anaconda-hmcroot \$env{DEVNAME}
+  ;;
 esac

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -77,6 +77,8 @@ class Flags(object):
         self.nosave_logs = False
         # single language options
         self.singlelang = False
+        # enable SE/HMC
+        self.hmc = False
         # current runtime environments
         self.environs = [ANACONDA_ENVIRON]
         # parse the boot commandline

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -1274,6 +1274,31 @@ class PackagePayload(Payload):
             url = method.url
             mirrorlist = method.mirrorlist
             metalink = method.metalink
+        elif method.method == "hmc":
+            # Check if /dev/hmcdrv is already mounted.
+            if device == "/dev/hmcdrv":
+                log.debug("HMC is already mounted at %s.", DRACUT_REPODIR)
+                url = "file://" + DRACUT_REPODIR
+            else:
+                log.debug("Trying to mount the content of HMC media drive.")
+
+                # Test the SE/HMC file access.
+                if iutil.execWithRedirect("/usr/sbin/lshmc", []):
+                    raise PayloadSetupError("The content of HMC media drive couldn't be accessed.")
+
+                # Test if a path is a mount point.
+                if os.path.ismount(INSTALL_TREE):
+                    log.debug("Don't mount the content of HMC media drive yet.")
+                else:
+                    # Make sure that the directories exists.
+                    iutil.mkdirChain(INSTALL_TREE)
+
+                    # Mount the device.
+                    if iutil.execWithRedirect("/usr/bin/hmcdrvfs", [INSTALL_TREE]):
+                        raise PayloadSetupError("The content of HMC media drive couldn't be mounted.")
+
+                log.debug("We are ready to use the HMC at %s.", INSTALL_TREE)
+                url = "file://" + INSTALL_TREE
         elif method.method == "cdrom" or (checkmount and not method.method):
             # Did dracut leave the DVD or NFS mounted for us?
             device = blivet.util.get_mount_device(DRACUT_REPODIR)

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -388,6 +388,8 @@ def set_installation_method_from_anaconda_options(anaconda, ksdata):
         ksdata.method.method = "harddrive"
         device = anaconda.methodstr.split(":", 1)[1]
         ksdata.method.partition = os.path.normpath(device)
+    elif anaconda.methodstr.startswith("hmc"):
+        ksdata.method.method = "hmc"
     else:
         log.error("Unknown method: %s", anaconda.methodstr)
 

--- a/pyanaconda/ui/gui/spokes/installation_source.glade
+++ b/pyanaconda/ui/gui/spokes/installation_source.glade
@@ -613,6 +613,24 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkRadioButton" id="hmcRadioButton">
+                                <property name="label" translatable="yes" context="GUI|Software Source">Installation media via SE/_HMC</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="no_show_all">True</property>
+                                <property name="margin_left">12</property>
+                                <property name="use_underline">True</property>
+                                <property name="xalign">0</property>
+                                <property name="draw_indicator">True</property>
+                                <property name="group">isoRadioButton</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkRadioButton" id="isoRadioButton">
                                 <property name="label" translatable="yes" context="GUI|Software Source">_ISO file:</property>
                                 <property name="can_focus">True</property>
@@ -627,7 +645,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                             <child>
@@ -708,7 +726,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                             <child>
@@ -727,7 +745,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">5</property>
+                                <property name="position">6</property>
                               </packing>
                             </child>
                             <child>
@@ -873,7 +891,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">6</property>
+                                <property name="position">7</property>
                               </packing>
                             </child>
                             <child>
@@ -930,7 +948,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">7</property>
+                                <property name="position">8</property>
                               </packing>
                             </child>
                             <child>
@@ -947,7 +965,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">8</property>
+                                <property name="position">9</property>
                               </packing>
                             </child>
                             <child>
@@ -1286,7 +1304,7 @@
                               <packing>
                                 <property name="expand">True</property>
                                 <property name="fill">True</property>
-                                <property name="position">9</property>
+                                <property name="position">10</property>
                               </packing>
                             </child>
                           </object>

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -413,7 +413,6 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             :rtype: bool
         """
         import copy
-
         old_source = copy.deepcopy(self.data.method)
 
         if self._autodetectButton.get_active():
@@ -426,6 +425,8 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
                 # XXX maybe we should always redo it for cdrom in case they
                 #     switched disks
                 return False
+        elif self._hmcButton.get_active():
+            self.data.method.method = "hmc"
         elif self._isoButton.get_active():
             # If the user didn't select a partition (not sure how that would
             # happen) or didn't choose a directory (more likely), then return
@@ -599,6 +600,8 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             return _("NFS server %s") % self.data.method.server
         elif self.data.method.method == "cdrom":
             return _("Local media")
+        elif self.data.method.method == "hmc":
+            return _("Local media via SE/HMC")
         elif self.data.method.method == "harddrive":
             if not self._currentIsoFile:
                 return _("Error setting up ISO file")
@@ -613,6 +616,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         self._autodetectBox = self.builder.get_object("autodetectBox")
         self._autodetectDeviceLabel = self.builder.get_object("autodetectDeviceLabel")
         self._autodetectLabel = self.builder.get_object("autodetectLabel")
+        self._hmcButton = self.builder.get_object("hmcRadioButton")
         self._isoButton = self.builder.get_object("isoRadioButton")
         self._isoBox = self.builder.get_object("isoBox")
         self._networkButton = self.builder.get_object("networkRadioButton")
@@ -681,6 +685,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         # want to let me pass in user data.
         # See also: https://bugzilla.gnome.org/show_bug.cgi?id=727919
         self._autodetectButton.connect("toggled", self.on_source_toggled, self._autodetectBox)
+        self._hmcButton.connect("toggled", self.on_source_toggled, None)
         self._isoButton.connect("toggled", self.on_source_toggled, self._isoBox)
         self._networkButton.connect("toggled", self.on_source_toggled, self._networkBox)
         self._networkButton.connect("toggled", self._updateURLEntryCheck)
@@ -750,8 +755,6 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
     def _initialize(self):
         threadMgr.wait(constants.THREAD_PAYLOAD)
 
-        added = False
-
         # If there's no fallback mirror to use, we should just disable that option
         # in the UI.
         if not self.payload.mirrorEnabled:
@@ -775,16 +778,18 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         if self._cdrom:
             fire_gtk_action(self._autodetectDeviceLabel.set_text, _("Device: %s") % self._cdrom.name)
             fire_gtk_action(self._autodetectLabel.set_text, _("Label: %s") % (getattr(self._cdrom.format, "label", "") or ""))
-            added = True
+
+            # These UI elements default to not being showable.  If optical install
+            # media were found, mark them to be shown.
+            gtk_call_once(self._autodetectBox.set_no_show_all, False)
+            gtk_call_once(self._autodetectButton.set_no_show_all, False)
 
         if self.data.method.method == "harddrive":
             self._currentIsoFile = self.payload.ISOImage
 
-        # These UI elements default to not being showable.  If optical install
-        # media were found, mark them to be shown.
-        if added:
-            gtk_call_once(self._autodetectBox.set_no_show_all, False)
-            gtk_call_once(self._autodetectButton.set_no_show_all, False)
+        # Enable the SE/HMC option.
+        if flags.hmc:
+            gtk_call_once(self._hmcButton.set_no_show_all, False)
 
         # Add the mirror manager URL in as the default for HTTP and HTTPS.
         # We'll override this later in the refresh() method, if they've already
@@ -891,6 +896,8 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             else:
                 self._isoChooserButton.set_label("")
             self._isoChooserButton.set_use_underline(False)
+        elif self.data.method.method == "hmc":
+            self._hmcButton.set_active(True)
         else:
             # No method was given in advance, so now we need to make a sensible
             # guess.  Go with autodetected media if that was provided, and then
@@ -923,6 +930,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         # already, but the ones that are not selected need a signal in order
         # to disable the related box.
         self.on_source_toggled(self._autodetectButton, self._autodetectBox)
+        self.on_source_toggled(self._hmcButton, None)
         self.on_source_toggled(self._isoButton, self._isoBox)
         self.on_source_toggled(self._networkButton, self._networkBox)
 
@@ -933,7 +941,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         if self.data.method.method == "harddrive" and \
            get_mount_device(constants.DRACUT_ISODIR) == get_mount_device(constants.DRACUT_REPODIR):
             for widget in [self._autodetectButton, self._autodetectBox, self._isoButton,
-                           self._isoBox, self._networkButton, self._networkBox]:
+                           self._isoBox, self._networkButton, self._networkBox, self._hmcButton]:
                 widget.set_sensitive(False)
                 widget.set_tooltip_text(_("The installation source is in use by the installer and cannot be changed."))
 
@@ -1137,7 +1145,10 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         # the newly enabled button as well as the previously enabled (now
         # disabled) button.
         enabled = button.get_active()
-        relatedBox.set_sensitive(enabled)
+
+        if relatedBox:
+            relatedBox.set_sensitive(enabled)
+
         self._setup_no_updates()
 
     def on_back_clicked(self, button):

--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -206,6 +206,13 @@ class SourceSwitchHandler(object, metaclass=ABCMeta):
 
         self.data.method.method = "cdrom"
 
+    def set_source_hmc(self):
+        """ Switch to install source via HMC """
+        # clean any old HDD ISO sources
+        self._clean_hdd_iso()
+
+        self.data.method.method = "hmc"
+
     def set_source_closest_mirror(self):
         """ Switch to the closest mirror install source """
         # clean any old HDD ISO sources

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -68,6 +68,7 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
         self._ready = False
         self._error = False
         self._cdrom = None
+        self._hmc = False
 
     def initialize(self):
         NormalTUISpoke.initialize(self)
@@ -89,6 +90,10 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
         elif not flags.automatedInstall:
             self._cdrom = opticalInstallMedia(self.storage.devicetree)
 
+        # Enable the SE/HMC option.
+        if flags.hmc:
+            self._hmc = True
+
         self._ready = True
 
         # report that the source spoke has been initialized
@@ -106,6 +111,8 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
             return _("NFS server %s") % method.server
         elif method.method == "cdrom":
             return _("Local media")
+        elif method.method == "hmc":
+            return _("Local media via SE/HMC")
         elif method.method == "harddrive":
             if not method.dir:
                 return _("Error setting up software source")
@@ -160,6 +167,9 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
             self._container.add(TextWidget(_("local ISO file")), self._set_iso_install_source)
             self._container.add(TextWidget(_("Network")), self._set_network_install_source)
 
+            if self._hmc:
+                self._container.add(TextWidget(_("SE/HMC")), self._set_hmc_install_source)
+
         self.window.add_with_separator(self._container)
 
     # Set installation source callbacks
@@ -167,6 +177,11 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
     def _set_cd_install_source(self, data):
         self.set_source_cdrom()
         self.payload.install_device = self._cdrom
+        self.apply()
+        self.close()
+
+    def _set_hmc_install_source(self, data):
+        self.set_source_hmc()
         self.apply()
         self.close()
 
@@ -205,7 +220,6 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
 
     def input(self, args, key):
         """ Handle the input; this decides the repo source. """
-
         if not self._container.process_user_input(key):
             return super(SourceSpoke, self).input(args, key)
 


### PR DESCRIPTION
Provide access to files on the USB/DVD drive of the SE/HMC of System
z hardware with a boot option: inst.repo=hmc

(cherry-picked from a commit 0a07eba)

**Depends on:** https://github.com/rhinstaller/pykickstart/pull/198
**Depends on:** https://github.com/rhinstaller/lorax/pull/284