### PR TITLE
 Add the boot options inst.stage2.all and inst.ks.all

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -127,6 +127,15 @@ inst.stage2
 This specifies the location to fetch only the installer runtime image;
 packages will be ignored. Otherwise the same as `inst.repo`_.
 
+.. inst.stage2.all:
+
+inst.stage2.all
+^^^^^^^^^^^^^^^
+
+All locations of type http, https or ftp specified with inst.stage2 will
+be used sequentially one by one until the image is fetched. Other locations
+will be ignored.
+
 inst.dd
 ^^^^^^^
 

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -178,6 +178,15 @@ For example:
 * client address: ``192.168.122.100``
 * kickstart file: ``nfs:192.168.122.1:/kickstart/192.168.122.100-kickstart``
 
+.. inst.ks.all:
+
+inst.ks.all
+^^^^^^^^^^^
+
+All locations of type http, https or ftp specified with inst.ks will be used
+sequentially one by one until the kickstart file is fetched. Other locations
+will be ignored.
+
 .. inst.ks.sendmac:
 
 inst.ks.sendmac

--- a/dracut/fetch-kickstart-net.sh
+++ b/dracut/fetch-kickstart-net.sh
@@ -18,27 +18,51 @@ command -v getarg >/dev/null || . /lib/dracut-lib.sh
 . /lib/url-lib.sh
 . /lib/anaconda-lib.sh
 
-if [ "$kickstart" = "nfs:auto" ]; then
-    # construct kickstart URL from dhcp info
-    # server is next_server, or the dhcp server itself if missing
-    . /tmp/net.$netif.dhcpopts
-    server="${new_next_server:-$new_dhcp_server_identifier}"
-    # filename is dhcp 'filename' option, or '/kickstart/' if missing
-    filename="/kickstart/"
-    # read the dhcp lease file and see if we can find 'filename'
-    { while read line; do
-        val="${line#filename }"
-        if [ "$val" != "$line" ]; then
-            eval "filename=$val" # drop quoting and semicolon
-        fi
-      done
-    } < /tmp/net.$netif.lease
-    kickstart="nfs:$server:$filename"
-fi
+# Find locations to the kickstart files.
+locations=""
 
-# NFS kickstart URLs that end in '/' get '$IP_ADDR-kickstart' appended
-case "$kickstart" in
-    nfs*/) kickstart="${kickstart}${new_ip_address}-kickstart" ;;
+case $kickstart in
+    nfs*)
+        # Construct URL for nfs:auto.
+        if [ "$kickstart" = "nfs:auto" ]; then
+            # Construct kickstart URL from dhcp info.
+            # Server is next_server, or the dhcp server itself if missing.
+            . /tmp/net.$netif.dhcpopts
+            server="${new_next_server:-$new_dhcp_server_identifier}"
+            # Filename is dhcp 'filename' option, or '/kickstart/' if missing.
+            filename="/kickstart/"
+            # Read the dhcp lease file and see if we can find 'filename'.
+            { while read line; do
+                val="${line#filename }"
+                if [ "$val" != "$line" ]; then
+                    eval "filename=$val" # Drop quoting and semicolon.
+                fi
+              done
+            } < /tmp/net.$netif.lease
+            kickstart="nfs:$server:$filename"
+        fi
+
+        # URLs that end in '/' get '$IP_ADDR-kickstart' appended.
+        if [[ $kickstart == nfs*/ ]]; then
+            kickstart="${kickstart}${new_ip_address}-kickstart"
+        fi
+
+        # Use the prepared url.
+        locations="$kickstart"
+    ;;
+    http*|ftp*)
+        # Use the location from the variable.
+        locations="$kickstart"
+    ;;
+    urls)
+        # Use the locations from the file.
+        # We will try them one by one until we succeed.
+        locations="$(</tmp/ks_urls)"
+    ;;
+    *)
+        warn "unknown network kickstart URL: $kickstart"
+        return 1
+    ;;
 esac
 
 # If we're doing sendmac, we need to run after anaconda-ks-sendheaders.sh
@@ -48,15 +72,25 @@ else
     newjob=$hookdir/initqueue/fetch-ks-${netif}.sh
 fi
 
+# Create a new job.
 cat > $newjob <<__EOT__
 . /lib/url-lib.sh
 . /lib/anaconda-lib.sh
-info "anaconda fetching kickstart from $kickstart"
-if fetch_url "$kickstart" /tmp/ks.cfg; then
-    parse_kickstart /tmp/ks.cfg
-    run_kickstart
-else
-    warn "failed to fetch kickstart from $kickstart"
-fi
+locations="$locations"
+
+info "anaconda: kickstart locations are: \$locations"
+
+for kickstart in \$locations; do
+    info "anaconda: fetching kickstart from \$kickstart"
+
+    if fetch_url "\$kickstart" /tmp/ks.cfg; then
+        info "anaconda: successfully fetched kickstart from \$kickstart"
+        parse_kickstart /tmp/ks.cfg
+        run_kickstart
+        break
+    else
+        warn "anaconda: failed to fetch kickstart from \$kickstart"
+    fi
+done
 rm \$job # remove self from initqueue
 __EOT__

--- a/dracut/kickstart-genrules.sh
+++ b/dracut/kickstart-genrules.sh
@@ -4,7 +4,7 @@
 . /lib/anaconda-lib.sh
 
 case "${kickstart%%:*}" in
-    http|https|ftp|nfs)
+    http|https|ftp|nfs|urls)
         # handled by fetch-kickstart-net in the online hook
         wait_for_kickstart
     ;;

--- a/dracut/parse-anaconda-kickstart.sh
+++ b/dracut/parse-anaconda-kickstart.sh
@@ -12,8 +12,19 @@ fi
 # no root? the kickstart will probably tell us what our root device is.
 [ "$kickstart" ] && [ -z "$root" ] && root="anaconda-kickstart"
 
+# Clear the file for multiple ks urls.
+rm -f /tmp/ks_urls
+
+# Is the option for multiple ks urls enabled?
+getargbool 0 inst.ks.all && kickstart="urls"
+
 case "${kickstart%%:*}" in
     http|https|ftp|nfs|nfs4) # network kickstart? set "neednet"!
+        set_neednet
+    ;;
+    urls) # multiple network kickstarts?
+        locations="$(getargs ks= inst.ks=)"
+        get_urls "$locations" >/tmp/ks_urls
         set_neednet
     ;;
     file|path) # "file:<path>" - "path:<path>" is accepted but deprecated

--- a/dracut/parse-anaconda-repo.sh
+++ b/dracut/parse-anaconda-repo.sh
@@ -11,15 +11,31 @@ arg="repo"
 # default to using repo, but if we have stage2=, use that
 [ -n "$stage2" ] && arg="stage2" && repo="$stage2"
 
+# Clear the file for multiple stage2 urls.
+rm -f /tmp/stage2_urls
+
+# Is the option for multiple stage2 urls enabled?
+getargbool 0 inst.stage2.all && repo="urls"
+
 if [ -n "$repo" ]; then
     splitsep ":" "$repo" repotype rest
     case "$repotype" in
         http|https|ftp|nfs|nfs4|nfsiso)
-            set_neednet; root="anaconda-net:$repo" ;;
+            root="anaconda-net:$repo"
+            set_neednet
+        ;;
+        urls)
+            root="anaconda-net:urls"
+            locations="$(getargs stage2= inst.stage2=)"
+            get_urls "$locations" >/tmp/stage2_urls
+            set_neednet
+        ;;
         hd|cd|cdrom)
-            [ -n "$rest" ] && root="anaconda-disk:$rest" ;;
+            [ -n "$rest" ] && root="anaconda-disk:$rest"
+        ;;
         *)
-            warn "Invalid value for 'inst.$arg': $repo" ;;
+            warn "Invalid value for 'inst.$arg': $repo"
+        ;;
     esac
 fi
 


### PR DESCRIPTION
Anaconda will try to fetch stage2 from all defined locations that
are http, https or ftp if the boot option inst.stage2.all is set.
Other types of locations will be ignored.

(cherry-picked from a commit 6aba174)

Anaconda will try to fetch a kickstart file from all defined locations
that are http, https or ftp if the boot option inst.ks.all is set.
Other types of locations will be ignored.

(cherry-picked from a commit 98a1f0f)