### PR TITLE
Use pykickstart 3

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -37,7 +37,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define mehver 0.23-1
 %define nmver 1.0
 %define partedver 1.8.1
-%define pykickstartver 2.44-1
+%define pykickstartver 3.10-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 0.8-1

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -80,7 +80,7 @@ from pykickstart.parser import KickstartParser
 from pykickstart.parser import Script as KSScript
 from pykickstart.sections import NullSection, PackageSection, PostScriptSection, PreScriptSection, PreInstallScriptSection, \
                                  OnErrorScriptSection, TracebackScriptSection, Section
-from pykickstart.version import returnClassForVersion
+from pykickstart.version import returnClassForVersion, F27
 
 from pyanaconda import anaconda_logging
 from pyanaconda.anaconda_loggers import get_module_logger, get_stdout_logger, get_blivet_logger,\
@@ -800,9 +800,9 @@ class Group(commands.group.F12_Group):
             except ValueError as e:
                 group_log.warning(str(e))
 
-class IgnoreDisk(commands.ignoredisk.RHEL6_IgnoreDisk):
+class IgnoreDisk(commands.ignoredisk.F14_IgnoreDisk):
     def parse(self, args):
-        retval = commands.ignoredisk.RHEL6_IgnoreDisk.parse(self, args)
+        retval = commands.ignoredisk.F14_IgnoreDisk.parse(self, args)
 
         # See comment in ClearPart.parse
         drives = []
@@ -1868,7 +1868,7 @@ class Timezone(commands.timezone.F25_Timezone):
                 except ntp.NTPconfigError as ntperr:
                     timezone_log.warning("Failed to save NTP configuration without chrony package: %s", ntperr)
 
-class User(commands.user.F19_User):
+class User(commands.user.F24_User):
     def execute(self, storage, ksdata, instClass, users):
         algo = getPassAlgo(ksdata.authconfig.authconfig)
 
@@ -2165,13 +2165,19 @@ class F27_InstallClass(KickstartCommand):
         return retval
 
     def _getParser(self):
-        op = KSOptionParser()
-        op.add_option("--name", dest="name", required=True, type="string")
+        op = KSOptionParser(prog="installclass", version=F27, description="""
+                            Require the specified install class to be used for
+                            the installation. Otherwise, the best available
+                            install class will be used.""")
+
+        op.add_argument("--name", dest="name", required=True, type=str,
+                        version=F27, help="""
+                        Name of the required install class.""")
         return op
 
     def parse(self, args):
-        (opts, _) = self.op.parse_args(args=args, lineno=self.lineno)
-        self.set_to_self(self.op, opts)
+        ns = self.op.parse_args(args=args, lineno=self.lineno)
+        self.set_to_self(ns)
         return self
 
 class AnacondaSectionHandler(BaseHandler):

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -1191,6 +1191,23 @@ class InstallerStorage(Blivet):
 
         self._short_product_name = shortProductName
 
+    def copy(self):
+        """Copy the storage.
+
+        Kickstart data are not copied.
+        """
+        # Disable the kickstart data.
+        old_data = self.ksdata
+        self.ksdata = None
+
+        # Create the copy.
+        new_storage = super().copy()
+
+        # Recover the kickstart data.
+        self.ksdata = old_data
+        new_storage.ksdata = old_data
+        return new_storage
+
     def do_it(self, callbacks=None):
         """
         Commit queued changes to disk.

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -411,8 +411,17 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             :returns: True if it changed, False if not
             :rtype: bool
         """
-        import copy
-        old_source = copy.deepcopy(self.data.method)
+        # FIXME:
+        # This is an ugly temporary fix, because we cannot use deepcopy since
+        # pykickstart 3. This entire module should be rewritten anyway.
+        old_method = self.data.method.method
+        old_partition = getattr(self.data.method, "partition", None)
+        old_dir = getattr(self.data.method, "dir", None)
+        old_url = getattr(self.data.method, "url", None)
+        old_server = getattr(self.data.method, "server", None)
+        old_opts = getattr(self.data.method, "opts", None)
+        old_mirrorlist = getattr(self.data.method, "mirrorlist", None)
+        old_metalink = getattr(self.data.method, "metalink", None)
 
         if self._autodetectButton.get_active():
             if not self._cdrom:
@@ -420,7 +429,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
 
             self.data.method.method = "cdrom"
             self.payload.install_device = self._cdrom
-            if old_source.method == "cdrom":
+            if old_method == "cdrom":
                 # XXX maybe we should always redo it for cdrom in case they
                 #     switched disks
                 return False
@@ -438,9 +447,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             self.data.method.partition = part.name
             # The / gets stripped off by payload.ISOImage
             self.data.method.dir = "/" + self._currentIsoFile
-            if (old_source.method == "harddrive" and
-                self.storage.devicetree.resolve_device(old_source.partition) == part and
-                old_source.dir in [self._currentIsoFile, "/" + self._currentIsoFile]):
+            if (old_method == "harddrive" and
+                self.storage.devicetree.resolve_device(old_partition) == part and
+                old_dir in [self._currentIsoFile, "/" + self._currentIsoFile]):
                 return False
 
             # Make sure anaconda doesn't touch this device.
@@ -450,7 +459,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             # this preserves the url for later editing
             self.data.method.method = None
             self.data.method.proxy = self._proxyUrl
-            if not old_source.method and self.payload.baseRepo and \
+            if not old_method and self.payload.baseRepo and \
                not self._proxyChange and not self._updatesChange:
                 return False
         elif self._ftp_active():
@@ -466,8 +475,8 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             # revisited.
             if not url.startswith("ftp://"):
                 url = "ftp://" + url
-            if old_source.method == "url" and not self._proxyChange and \
-                    old_source.url == url:
+            if old_method == "url" and not self._proxyChange and \
+                    old_url == url:
                 return False
             self.data.method.method = "url"
             self.data.method.proxy = self._proxyUrl
@@ -491,8 +500,8 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
                 url = "https://" + url
 
             url_type = self._urlTypeComboBox.get_active_id()
-            if old_source.method == "url" and not self._proxyChange and \
-                not self._url_changed(url, url_type, old_source):
+            if old_method == "url" and not self._proxyChange and \
+                not self._url_changed(url, url_type, old_url, old_mirrorlist, old_metalink):
                 return False
 
             self.data.method.method = "url"
@@ -521,25 +530,25 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
 
             self.data.method.opts = self.builder.get_object("nfsOptsEntry").get_text() or ""
 
-            if (old_source.method == "nfs" and
-                old_source.server == self.data.method.server and
-                old_source.dir == self.data.method.dir and
-                old_source.opts == self.data.method.opts):
+            if (old_method == "nfs" and
+                old_server == self.data.method.server and
+                old_dir == self.data.method.dir and
+                old_opts == self.data.method.opts):
                 return False
 
         # If the user moved from an HDISO method to some other, we need to
         # clear the protected bit on that device.
-        if old_source.method == "harddrive" and old_source.partition:
+        if old_method == "harddrive" and old_partition:
             if not self._isoButton.get_active():
                 # Only clear this if iso isn't selected
                 self._currentIsoFile = None
                 self._isoChooserButton.set_label(self._origIsoChooserButton)
                 self._isoChooserButton.set_use_underline(True)
 
-            if old_source.partition in self.storage.config.protected_dev_specs:
-                self.storage.config.protected_dev_specs.remove(old_source.partition)
+            if old_partition in self.storage.config.protected_dev_specs:
+                self.storage.config.protected_dev_specs.remove(old_partition)
 
-            dev = self.storage.devicetree.get_device_by_name(old_source.partition)
+            dev = self.storage.devicetree.get_device_by_name(old_partition)
             if dev:
                 dev.protected = False
 
@@ -548,13 +557,13 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
 
         return True
 
-    def _url_changed(self, url, url_type, old_method):
+    def _url_changed(self, url, url_type, old_url, old_mirrorlist, old_metalink):
         if url_type == URL_TYPE_URL:
-            return url != old_method.url
+            return url != old_url
         elif url_type == URL_TYPE_MIRRORLIST:
-            return url != old_method.mirrorlist
+            return url != old_mirrorlist
         else:
-            return url != old_method.metalink
+            return url != old_metalink
 
     @property
     def changed(self):

--- a/tests/pyanaconda_tests/installclass_test.py
+++ b/tests/pyanaconda_tests/installclass_test.py
@@ -22,7 +22,7 @@ import unittest
 from mock import patch
 from pyanaconda.installclass import BaseInstallClass, InstallClassFactory
 from pyanaconda import kickstart
-from pykickstart.errors import KickstartParseError, KickstartValueError
+from pykickstart.errors import KickstartParseError
 
 
 class FactoryTest(unittest.TestCase):
@@ -206,7 +206,7 @@ class F27_Installclass_TestCase(unittest.TestCase):
                           "installclass --name=\"An Install Class\"\n")
 
         # fail
-        self.assert_parse_error("installclass", KickstartValueError)
+        self.assert_parse_error("installclass", KickstartParseError)
         self.assert_parse_error("installclass --name", KickstartParseError)
         self.assert_parse_error("installclass --xyz", KickstartParseError)
         self.assert_parse_error("installclass --name=\"An Install Class\" --xyz", KickstartParseError)


### PR DESCRIPTION
**DO NOT MERGE**
Adapt anaconda's commands to pykickstart 3.

We cannot do deepcopy of the method command since pykickstart 3,
because it tries to do deepcopy of patterns. However, we shouldn't
do it anyway and the code where we used it should be rewritten.

TODO: Run the kickstart tests.

NOTE: The kdump addon fails when it tries to parse its section in
a kickstart file. However, when it is not specified, the installer is fine.

**Requires: pykickstart-3**