### PR TITLE
Replace get_bus with the class DBus 

### DIFF
--- a/pyanaconda/dbus/__init__.py
+++ b/pyanaconda/dbus/__init__.py
@@ -1,21 +1,109 @@
+#
+# Representation of DBus connection.
+#
+# Copyright (C) 2017  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
 import os
 import pydbus
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
-def get_bus():
-    """Get a DBUS bus connection corresponding to the current environment.
+__all__ = ["DBus"]
 
-    During normal usage this function should return connection to the system bus,
-    but during testing/development a custom bus might be used.
-    So just always connect to the bus specified by the DBUS_STARTER_ADDRESS
-    environmental variable.
+
+class DBus(object):
+    """Representation of DBus connection.
+
+    Call DBus.get_connection to get a connection to the DBus. You can
+    register a service with DBus.register_service, or publish an object
+    with DBus.publish_object and get a proxy of a remote DBus object
+    with DBus.get_proxy.
     """
-    bus_address = os.environ.get("DBUS_STARTER_ADDRESS")
-    if bus_address:
-        return pydbus.connect(os.environ["DBUS_STARTER_ADDRESS"])
-    else:
-        log.info("DBUS_STARTER_ADDRESS not defined, using system bus")
+    _connection = None
+
+    @staticmethod
+    def get_connection():
+        """Returns a DBus connection."""
+        if not DBus._connection:
+            DBus._connection = DBus.get_new_connection()
+
+        return DBus._connection
+
+    @staticmethod
+    def get_new_connection():
+        """Get a DBus connection.
+
+        You shouldn't create new connections unless there is a good
+        reason for it. Use DBus.get_connection instead.
+
+        Normally this method should return a connection to the system
+        bus, but during testing/development a custom bus might be used.
+        So just always connect to the bus specified by the environmental
+        variable DBUS_STARTER_ADDRESS.
+        """
+        bus_address = os.environ.get("DBUS_STARTER_ADDRESS")
+
+        if bus_address:
+            log.info("Connecting to DBus at %s.", bus_address)
+            return pydbus.connect(bus_address)
+
+        log.info("Connecting to system DBus.")
         return pydbus.SystemBus()
 
+    @staticmethod
+    def register_service(service_name):
+        """Register a service on DBus.
+
+        A service can be registered by requesting its name on DBus.
+        This method should be called only after all of the required
+        objects of the service are published on DBus.
+
+        :param service_name: a DBus name of a service
+        """
+        log.debug("Registering a service name %s.", service_name)
+        DBus.get_connection().request_name(service_name,
+                                           allow_replacement=True,
+                                           replace=False)
+
+    @staticmethod
+    def publish_object(obj, object_path):
+        """Publish an object on DBus.
+
+        :param obj: an instance of @dbus_interface or @dbus_class
+        :param object_path: a DBus path of an object
+        """
+        log.debug("Publishing an object at %s.", object_path)
+        DBus.get_connection().register_object(object_path, obj, None)
+
+    @staticmethod
+    def get_dbus_proxy():
+        """Returns a proxy of DBus.
+
+        :return: a proxy object
+        """
+        return DBus.get_connection().dbus
+
+    @staticmethod
+    def get_proxy(service_name, object_path):
+        """Returns a proxy of a remote DBus object.
+
+        :param service_name: a DBus name of a service
+        :param object_path: a DBus path an object
+        :return: a proxy object
+        """
+        return DBus.get_connection().get(service_name, object_path)

--- a/pyanaconda/dbus/constants.py
+++ b/pyanaconda/dbus/constants.py
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from pydbus.auto_names import auto_object_path
+
 # main Anaconda DBUS namespace
 ANACONDA_DBUS_NAMESPACE = "org.fedoraproject.Anaconda"
 
@@ -28,16 +30,26 @@ DBUS_ADDON_NAMESPACE = "%s.Addons" % ANACONDA_DBUS_NAMESPACE
 
 # BOSS
 DBUS_BOSS_NAME = "%s.Boss" % ANACONDA_DBUS_NAMESPACE
+DBUS_BOSS_PATH = auto_object_path(DBUS_BOSS_NAME)
 
 # Anaconda DBUS modules
-MODULE_FOO = "%s.Foo" % DBUS_MODULE_NAMESPACE
-MODULE_BAR = "%s.Bar" % DBUS_MODULE_NAMESPACE
+MODULE_FOO_NAME = "%s.Foo" % DBUS_MODULE_NAMESPACE
+MODULE_FOO_PATH = auto_object_path(MODULE_FOO_NAME)
+
+MODULE_BAR_NAME = "%s.Bar" % DBUS_MODULE_NAMESPACE
+MODULE_BAR_PATH = auto_object_path(MODULE_BAR_NAME)
 
 # Addons (likely for testing purposes only)
-ADDON_BAZ = "%s.Baz" % DBUS_ADDON_NAMESPACE
+ADDON_BAZ_NAME = "%s.Baz" % DBUS_ADDON_NAMESPACE
+ADDON_BAZ_PATH = auto_object_path(ADDON_BAZ_NAME)
+
+# list of all expected Anaconda services
+ANACONDA_SERVICES = [MODULE_FOO_NAME,
+                     MODULE_BAR_NAME]
 
 # list of all expected Anaconda DBUS modules
-ANACONDA_MODULES = [MODULE_FOO, MODULE_BAR]
+ANACONDA_MODULES = [MODULE_FOO_PATH,
+                    MODULE_BAR_PATH]
 
 # status codes
 DBUS_START_REPLY_SUCCESS = 1

--- a/pyanaconda/dbus/constants.py
+++ b/pyanaconda/dbus/constants.py
@@ -1,5 +1,5 @@
 #
-# dbus/constants.py: Anaconda DBUS constants
+# Anaconda DBUS constants
 #
 # Copyright (C) 2017  Red Hat, Inc.  All rights reserved.
 #

--- a/pyanaconda/dbus_addons/baz/baz.py
+++ b/pyanaconda/dbus_addons/baz/baz.py
@@ -18,7 +18,7 @@
 # Red Hat, Inc.
 #
 
-from pyanaconda.dbus import dbus_constants
+from pyanaconda.dbus.constants import ADDON_BAZ
 from pyanaconda.modules.base import BaseModule
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
@@ -26,12 +26,13 @@ from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda import anaconda_logging
 log = anaconda_logging.get_dbus_module_logger(__name__)
 
-@dbus_interface(dbus_constants.ADDON_BAZ)
+
+@dbus_interface(ADDON_BAZ)
 class Baz(BaseModule):
 
     def __init__(self):
         super().__init__()
-        self._dbus_name = dbus_constants.ADDON_BAZ
+        self._dbus_name = ADDON_BAZ
 
     def EchoString(self, s: Str) -> Str:
         """Returns whatever is passed to it."""

--- a/pyanaconda/dbus_addons/baz/baz.py
+++ b/pyanaconda/dbus_addons/baz/baz.py
@@ -17,8 +17,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
-from pyanaconda.dbus.constants import ADDON_BAZ
+from pyanaconda.dbus import DBus
+from pyanaconda.dbus.constants import ADDON_BAZ_NAME, ADDON_BAZ_PATH
 from pyanaconda.modules.base import BaseModule
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
@@ -27,12 +27,13 @@ from pyanaconda import anaconda_logging
 log = anaconda_logging.get_dbus_module_logger(__name__)
 
 
-@dbus_interface(ADDON_BAZ)
+@dbus_interface(ADDON_BAZ_NAME)
 class Baz(BaseModule):
 
-    def __init__(self):
-        super().__init__()
-        self._dbus_name = ADDON_BAZ
+    def publish(self):
+        """Publish the module."""
+        DBus.publish_object(self, ADDON_BAZ_PATH)
+        DBus.register_service(ADDON_BAZ_NAME)
 
     def EchoString(self, s: Str) -> Str:
         """Returns whatever is passed to it."""

--- a/pyanaconda/modules/bar/bar.py
+++ b/pyanaconda/modules/bar/bar.py
@@ -18,7 +18,7 @@
 # Red Hat, Inc.
 #
 
-from pyanaconda.dbus import dbus_constants
+from pyanaconda.dbus.constants import MODULE_BAR
 from pyanaconda.modules.base import BaseModule
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
@@ -26,12 +26,13 @@ from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda import anaconda_logging
 log = anaconda_logging.get_dbus_module_logger(__name__)
 
-@dbus_interface(dbus_constants.MODULE_BAR)
+
+@dbus_interface(MODULE_BAR)
 class Bar(BaseModule):
 
     def __init__(self):
         super().__init__()
-        self._dbus_name = dbus_constants.MODULE_BAR
+        self._dbus_name = MODULE_BAR
 
     def EchoString(self, s: Str) -> Str:
         """Returns whatever is passed to it."""

--- a/pyanaconda/modules/bar/bar.py
+++ b/pyanaconda/modules/bar/bar.py
@@ -17,8 +17,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
-from pyanaconda.dbus.constants import MODULE_BAR
+from pyanaconda.dbus import DBus
+from pyanaconda.dbus.constants import MODULE_BAR_PATH, MODULE_BAR_NAME
 from pyanaconda.modules.base import BaseModule
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
@@ -27,12 +27,13 @@ from pyanaconda import anaconda_logging
 log = anaconda_logging.get_dbus_module_logger(__name__)
 
 
-@dbus_interface(MODULE_BAR)
+@dbus_interface(MODULE_BAR_NAME)
 class Bar(BaseModule):
 
-    def __init__(self):
-        super().__init__()
-        self._dbus_name = MODULE_BAR
+    def publish(self):
+        """Publish the module."""
+        DBus.publish_object(self, MODULE_BAR_PATH)
+        DBus.register_service(MODULE_BAR_NAME)
 
     def EchoString(self, s: Str) -> Str:
         """Returns whatever is passed to it."""

--- a/pyanaconda/modules/base.py
+++ b/pyanaconda/modules/base.py
@@ -22,14 +22,15 @@ import gi
 gi.require_version("GLib", "2.0")
 from gi.repository import GLib
 
-from pyanaconda.dbus import dbus_constants
 from pyanaconda.dbus import get_bus
 from pyanaconda.dbus.interface import dbus_interface
+from pyanaconda.dbus.constants import DBUS_MODULE_NAMESPACE
 
 from pyanaconda import anaconda_logging
 log = anaconda_logging.get_dbus_module_logger(__name__)
 
-@dbus_interface(dbus_constants.DBUS_MODULE_NAMESPACE)
+
+@dbus_interface(DBUS_MODULE_NAMESPACE)
 class BaseModule(object):
     """A common base for Anaconda DBUS modules.
 

--- a/pyanaconda/modules/base.py
+++ b/pyanaconda/modules/base.py
@@ -22,7 +22,6 @@ import gi
 gi.require_version("GLib", "2.0")
 from gi.repository import GLib
 
-from pyanaconda.dbus import get_bus
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.dbus.constants import DBUS_MODULE_NAMESPACE
 
@@ -40,22 +39,22 @@ class BaseModule(object):
 
     def __init__(self):
         self._loop = GLib.MainLoop()
-        self._bus = get_bus()
-        self._dbus_name = None
 
     def run(self):
-        # schedule publishing once loop is running
-        GLib.idle_add(self.publish_module)
-        # start mainloop
-        log.debug("starting module mainloop: %s", self._dbus_name)
+        """Run the module's loop."""
+        log.debug("Schedule publishing.")
+        GLib.idle_add(self.publish)
+        log.debug("Start the loop.")
         self._loop.run()
 
-    def publish_module(self):
-        """Publish the module on DBUS and start its main loop."""
-        self._bus.publish(self._dbus_name, self)
-        log.debug("module %s has been published", self._dbus_name)
+    def publish(self):
+        """Publish DBus objects and register a DBus service.
+
+        Nothing is published by default.
+        """
+        pass
 
     def Quit(self):
         """Shut the module down."""
-        log.debug("module quiting: %s", self._dbus_name)
+        log.debug("Schedule quitting.")
         GLib.timeout_add_seconds(1, self._loop.quit)

--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -22,21 +22,22 @@ import gi
 gi.require_version("GLib", "2.0")
 from gi.repository import GLib
 
-from pyanaconda.dbus import dbus_constants
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.modules.base import BaseModule
+from pyanaconda.dbus.constants import DBUS_BOSS_NAME
 
 from pyanaconda.modules.boss.module_manager import ModuleManager  # pylint: disable=relative-beyond-top-level
 
 from pyanaconda import anaconda_logging
 log = anaconda_logging.get_dbus_module_logger(__name__)
 
-@dbus_interface(dbus_constants.DBUS_BOSS_NAME)
+
+@dbus_interface(DBUS_BOSS_NAME)
 class Boss(BaseModule):
 
     def __init__(self, module_manager=None):
         super().__init__()
-        self._dbus_name = dbus_constants.DBUS_BOSS_NAME
+        self._dbus_name = DBUS_BOSS_NAME
         if module_manager is None:
             self._module_manager = ModuleManager()
 

--- a/pyanaconda/modules/boss/module_manager.py
+++ b/pyanaconda/modules/boss/module_manager.py
@@ -17,9 +17,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from pyanaconda.dbus import dbus_constants, get_bus
+from pyanaconda.dbus import get_bus
 
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.dbus.constants import ANACONDA_MODULES, DBUS_START_REPLY_SUCCESS, \
+    DBUS_ADDON_NAMESPACE
+
 log = get_module_logger(__name__)
 
 
@@ -38,7 +41,7 @@ class ModuleManager(object):
     @property
     def expected_module_services(self):
         expected_modules = []
-        expected_modules.extend(dbus_constants.ANACONDA_MODULES)
+        expected_modules.extend(ANACONDA_MODULES)
         expected_modules.extend(self.addon_module_services)
         return expected_modules
 
@@ -57,7 +60,7 @@ class ModuleManager(object):
             log.debug("%s error: %s", service, error)
             self._failed_module_services.append(service)
         elif returned:
-            if returned == dbus_constants.DBUS_START_REPLY_SUCCESS:
+            if returned == DBUS_START_REPLY_SUCCESS:
                 log.debug("%s started successfully, returned: %s)", service, returned)
                 self._started_module_services.append(service)
             else:
@@ -84,7 +87,7 @@ class ModuleManager(object):
         self._addon_module_services = []
         names = self._bus.dbus.ListActivatableNames()
         for name in names:
-            if name.startswith(dbus_constants.DBUS_ADDON_NAMESPACE):
+            if name.startswith(DBUS_ADDON_NAMESPACE):
                 self._addon_module_services.append(name)
 
 

--- a/pyanaconda/modules/foo/foo.py
+++ b/pyanaconda/modules/foo/foo.py
@@ -17,7 +17,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.dbus.constants import MODULE_FOO
+from pyanaconda.dbus import DBus
+from pyanaconda.dbus.constants import MODULE_FOO_PATH, MODULE_FOO_NAME
 from pyanaconda.modules.base import BaseModule
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
@@ -26,12 +27,13 @@ from pyanaconda import anaconda_logging
 log = anaconda_logging.get_dbus_module_logger(__name__)
 
 
-@dbus_interface(MODULE_FOO)
+@dbus_interface(MODULE_FOO_NAME)
 class Foo(BaseModule):
 
-    def __init__(self):
-        super().__init__()
-        self._dbus_name = MODULE_FOO
+    def publish(self):
+        """Publish the module."""
+        DBus.publish_object(self, MODULE_FOO_PATH)
+        DBus.register_service(MODULE_FOO_NAME)
 
     def EchoString(self, s: Str) -> Str:
         """Returns whatever is passed to it."""

--- a/pyanaconda/modules/foo/foo.py
+++ b/pyanaconda/modules/foo/foo.py
@@ -17,8 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
-from pyanaconda.dbus import dbus_constants
+from pyanaconda.dbus.constants import MODULE_FOO
 from pyanaconda.modules.base import BaseModule
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
@@ -26,12 +25,13 @@ from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda import anaconda_logging
 log = anaconda_logging.get_dbus_module_logger(__name__)
 
-@dbus_interface(dbus_constants.MODULE_FOO)
+
+@dbus_interface(MODULE_FOO)
 class Foo(BaseModule):
 
     def __init__(self):
         super().__init__()
-        self._dbus_name = dbus_constants.MODULE_FOO
+        self._dbus_name = MODULE_FOO
 
     def EchoString(self, s: Str) -> Str:
         """Returns whatever is passed to it."""

--- a/scripts/run_boss_locally.py
+++ b/scripts/run_boss_locally.py
@@ -7,7 +7,7 @@ import pydbus
 import time
 from gi.repository import Gio
 
-from pyanaconda.dbus import dbus_constants
+from pyanaconda.dbus.constants import DBUS_BOSS_NAME
 
 os.putenv("PYTHONPATH", os.path.abspath(".."))  # pylint: disable=environment-modify
 
@@ -46,13 +46,13 @@ try:
     test_dbus_connection = pydbus.connect(test_dbus.get_bus_address())
 
     print("starting Boss")
-    test_dbus_connection.dbus.StartServiceByName(dbus_constants.DBUS_BOSS_NAME, 0)
+    test_dbus_connection.dbus.StartServiceByName(DBUS_BOSS_NAME, 0)
 
     input("press any key to stop Boss and cleanup")
 
     print("stopping Boss")
 
-    boss_object = test_dbus_connection.get(dbus_constants.DBUS_BOSS_NAME)
+    boss_object = test_dbus_connection.get(DBUS_BOSS_NAME)
     boss_object.Quit()
 
     print("waiting a bit for module shutdown to happen")

--- a/scripts/run_boss_locally.py
+++ b/scripts/run_boss_locally.py
@@ -9,7 +9,9 @@ from gi.repository import Gio
 
 from pyanaconda.dbus.constants import DBUS_BOSS_NAME
 
-os.putenv("PYTHONPATH", os.path.abspath(".."))  # pylint: disable=environment-modify
+paths = os.environ.get("PYTHONPATH", "").split(":")
+paths.insert(0, os.path.abspath(".."))
+os.putenv("PYTHONPATH", ":".join(paths))  # pylint: disable=environment-modify
 
 MODULES_DIR = os.path.abspath("../pyanaconda/modules")
 DBUS_SERVICES_DIR = "../data/dbus/"


### PR DESCRIPTION
We should call static methods of DBus class instead of get_bus. The
class DBus keeps one instance of the DBus connection that is created
on demand. It also provides methods for easy publishing and creating
proxies.

We should never keep our own instances of the DBus connection unless
we have a very good reason for it.

The module pyanaconda.dbus.dbus_constants was renamed
to pyanaconda.dbus.constants.

The PYTHONPATH should be only modified in run_boss_locally, not
replaced, so we can change it and add our local repositories.