### PR TITLE
Point at new path for fedora-server.css

### DIFF
--- a/pyanaconda/installclasses/fedora-server.py
+++ b/pyanaconda/installclasses/fedora-server.py
@@ -30,7 +30,7 @@ __all__ = ["FedoraServerInstallClass"]
 
 class FedoraServerInstallClass(FedoraBaseInstallClass):
     name = "Fedora Server"
-    stylesheet = "/usr/share/anaconda/fedora-server.css"
+    stylesheet = "/usr/share/anaconda/pixmaps/server/fedora-server.css"
     defaultFS = "xfs"
     sortPriority = FedoraBaseInstallClass.sortPriority + 1
     if not productName.startswith("Fedora Server"):          # pylint: disable=no-member

--- a/pyanaconda/installclasses/fedora-workstation.py
+++ b/pyanaconda/installclasses/fedora-workstation.py
@@ -1,0 +1,6 @@
+from pyanaconda.installclasses.fedora import FedoraBaseInstallClass
+
+class FedoraWorkstationInstallClass(FedoraBaseInstallClass):
+    name = "Fedora Workstation"
+    stylesheet = "/usr/share/anaconda/pixmaps/workstation/fedora-workstation.css"
+    defaultPackageEnvironment = "workstation-product-environment"

--- a/pyanaconda/installclasses/fedora-workstation.py
+++ b/pyanaconda/installclasses/fedora-workstation.py
@@ -1,6 +1,10 @@
 from pyanaconda.installclasses.fedora import FedoraBaseInstallClass
+from pyanaconda.product import productName
 
 class FedoraWorkstationInstallClass(FedoraBaseInstallClass):
     name = "Fedora Workstation"
     stylesheet = "/usr/share/anaconda/pixmaps/workstation/fedora-workstation.css"
+    sortPriority = FedoraBaseInstallClass.sortPriority + 1
+    if not productName.startswith("Fedora Workstation"):  # pylint: disable=no-member
+        hidden = True
     defaultPackageEnvironment = "workstation-product-environment"


### PR DESCRIPTION
In light of https://pagure.io/fedora-logos/pull-request/2 being merged into Anaconda, we just need to adjust the path that the `fedora-server.py` looks for the CSS file.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>