### PR TITLE
Add a base class for DBus interfaces

### DIFF
--- a/pyanaconda/dbus/template.py
+++ b/pyanaconda/dbus/template.py
@@ -1,0 +1,101 @@
+#
+# template.py: Templates for DBus objects.
+#
+# Copyright (C) 2017  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from abc import ABC
+
+from pyanaconda.dbus import DBus
+
+__all__ = ["InterfaceTemplate"]
+
+
+class InterfaceTemplate(ABC):
+    """Template for DBus interface.
+
+    This template uses a software design pattern called proxy.
+
+    This class provides a recommended way how to define DBus interfaces
+    and create publishable DBus objects. The class that defines a DBus
+    interface should inherit this class and be decorated with @dbus_class
+    or @dbus_interface decorator. The implementation of this interface will
+    be provided by a separate object called implementation. Therefore the
+    methods of this class should call the methods of the implementation,
+    the signals should be connected to the signals of the implementation
+    and the getters and setters of properties should access the properties
+    of the implementation.
+
+    Example:
+
+    @dbus_interface("org.myproject.InterfaceX")
+    class InterfaceX(InterfaceTemplate):
+        def DoSomething(self) -> Str:
+            return self.implementation.do_something()
+
+    class X(object):
+        def do_something(self):
+            return "Done!"
+
+    x = X()
+    i = InterfaceX(x)
+    i.publish("org/myproject/X/1")
+
+    """
+
+    def __init__(self, implementation):
+        """Create a publishable DBus object.
+
+        :param implementation: an implementation of this interface
+        """
+        self._implementation = implementation
+        self._object_path = None
+        self.connect_signals()
+
+    @property
+    def implementation(self):
+        """Return the implementation of this interface.
+
+        :return: an implementation
+        """
+        return self._implementation
+
+    @property
+    def object_path(self):
+        """Return an DBus object path.
+
+        If this object wasn't published, it returns None.
+
+        :return: a DBus path or None
+        """
+        return self._object_path
+
+    def connect_signals(self):
+        """Interconnect the signals.
+
+        You should connect the emit methods of the interface
+        signals to the signals of the implementation. Every
+        time the implementation emits a signal, this interface
+        reemits the signal on DBus.
+        """
+        pass
+
+    def publish(self, object_path):
+        """Publish the object on DBus.
+
+        :type object_path: a DBus path of the object
+        """
+        DBus.publish_object(self, object_path)
+        self._object_path = object_path

--- a/pyanaconda/modules/bar/bar.py
+++ b/pyanaconda/modules/bar/bar.py
@@ -37,7 +37,7 @@ class Bar(BaseModuleInterface):
         self._task_interfaces = []
 
     def _collect_tasks(self):
-        return [BarTask(MODULE_BAR_NAME)]
+        return [BarTask()]
 
     def publish(self):
         """Publish the module."""
@@ -54,7 +54,7 @@ class Bar(BaseModuleInterface):
         ret = []
 
         for task in self._task_interfaces:
-            ret.append((task.impl_object.name, task.dbus_path))
+            ret.append((task.implementation.name, task.object_path))
 
         return ret
 

--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -27,7 +27,7 @@ from gi.repository import GLib
 
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.modules.base import BaseModule
-from pyanaconda.dbus.constants import DBUS_BOSS_NAME, DBUS_BOSS_PATH
+from pyanaconda.dbus.constants import DBUS_BOSS_NAME, DBUS_BOSS_PATH, DBUS_BOSS_INSTALLATION_PATH
 
 from pyanaconda.modules.boss.module_manager import ModuleManager
 from pyanaconda.modules.boss.install_manager.installation_interface import InstallationInterface
@@ -54,7 +54,7 @@ class Boss(BaseModule):
 
         # start and publish interface
         interface = InstallationInterface(self._install_manager)
-        interface.publish()
+        interface.publish(DBUS_BOSS_INSTALLATION_PATH)
 
     def publish(self):
         """Publish the boss."""

--- a/pyanaconda/modules/boss/install_manager/install_manager.py
+++ b/pyanaconda/modules/boss/install_manager/install_manager.py
@@ -150,7 +150,7 @@ class InstallManager(object):
         s = self._actual_task.ProgressChanged.connect(self._progress_changed)
         self._subscriptions.append(s)
 
-        s = self._actual_task.Started.connect(self._task_started())
+        s = self._actual_task.Started.connect(self._task_started)
         self._subscriptions.append(s)
 
         s = self._actual_task.Stopped.connect(self._task_stopped)

--- a/pyanaconda/modules/boss/install_manager/installation_interface.py
+++ b/pyanaconda/modules/boss/install_manager/installation_interface.py
@@ -24,9 +24,9 @@
 
 from pydbus.error import map_error
 
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import DBUS_BOSS_INSTALLATION_NAME, DBUS_BOSS_INSTALLATION_PATH
+from pyanaconda.dbus.constants import DBUS_BOSS_INSTALLATION_NAME
 from pyanaconda.dbus.interface import dbus_interface, dbus_signal
+from pyanaconda.dbus.template import InterfaceTemplate
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
 
@@ -37,34 +37,22 @@ class InstallationNotRunning(Exception):
 
 
 @dbus_interface(DBUS_BOSS_INSTALLATION_NAME)
-class InstallationInterface(object):
+class InstallationInterface(InterfaceTemplate):
     """Interface for Boss to summarize installation from modules for UIs."""
-
-    def __init__(self, installation_instance):
-        """Create installation interface.
-
-        :param installation_instance: Manager for handling the installation process.
-        """
-        self._instance = installation_instance
-        self.connect_signals()
 
     def connect_signals(self):
         """Connect signals of this interface with the implementation."""
-        self._instance.installation_started.connect(self.InstallationStarted)
-        self._instance.installation_stopped.connect(self.InstallationStopped)
-        self._instance.task_changed_signal.connect(self.TaskChanged)
-        self._instance.progress_changed_signal.connect(self.ProgressChanged)
-        self._instance.progress_changed_float_signal.connect(self.ProgressChangedFloat)
-        self._instance.error_raised_signal.connect(self.ErrorRaised)
-
-    def publish(self):
-        """Publish task on DBus."""
-        DBus.publish_object(self, DBUS_BOSS_INSTALLATION_PATH)
+        self.implementation.installation_started.connect(self.InstallationStarted)
+        self.implementation.installation_stopped.connect(self.InstallationStopped)
+        self.implementation.task_changed_signal.connect(self.TaskChanged)
+        self.implementation.progress_changed_signal.connect(self.ProgressChanged)
+        self.implementation.progress_changed_float_signal.connect(self.ProgressChangedFloat)
+        self.implementation.error_raised_signal.connect(self.ErrorRaised)
 
     @property
     def InstallationRunning(self) -> Bool:
         """Installation is running right now."""
-        return self._instance.installation_running
+        return self.implementation.installation_running
 
     @dbus_signal
     def InstallationStarted(self):
@@ -87,12 +75,12 @@ class InstallationInterface(object):
     @property
     def TaskName(self) -> Str:
         """Name of the actual installation task."""
-        return self._instance.task_name
+        return self.implementation.task_name
 
     @property
     def TaskDescription(self) -> Str:
         """Description of the actual installation task."""
-        return self._instance.task_description
+        return self.implementation.task_description
 
     @dbus_signal
     def ErrorRaised(self, error_description: Str):
@@ -102,7 +90,7 @@ class InstallationInterface(object):
     @property
     def ProgressStepsCount(self) -> Int:
         """Sum of all steps in all Tasks in installation."""
-        return self._instance.progress_steps_count
+        return self.implementation.progress_steps_count
 
     @property
     def Progress(self) -> Tuple[Int, Str]:
@@ -112,7 +100,7 @@ class InstallationInterface(object):
                  step - Number of the step in the whole installation process.
                  description - Description of this step.
         """
-        return self._instance.progress
+        return self.implementation.progress
 
     @property
     def ProgressFloat(self) -> Tuple[Double, Str]:
@@ -122,7 +110,7 @@ class InstallationInterface(object):
                  step - Float number of the step.
                  description - Description of this step.
         """
-        return self._instance.progress_float
+        return self.implementation.progress_float
 
     @dbus_signal
     def ProgressChanged(self, step: Int, description: Str):
@@ -144,7 +132,7 @@ class InstallationInterface(object):
 
     def StartInstallation(self):
         """Start the installation process."""
-        self._instance.start_installation()
+        self.implementation.start_installation()
 
     def Cancel(self):
         """Cancel installation process.
@@ -152,4 +140,4 @@ class InstallationInterface(object):
         Installation will be cancelled as soon as possible. The cancelling process could be blocked
         by active task.
         """
-        self._instance.cancel()
+        self.implementation.cancel()

--- a/pyanaconda/modules/foo/foo.py
+++ b/pyanaconda/modules/foo/foo.py
@@ -37,7 +37,7 @@ class Foo(BaseModuleInterface):
         self._task_interfaces = []
 
     def _collect_tasks(self):
-        return [FooTask(MODULE_FOO_NAME)]
+        return [FooTask()]
 
     def publish(self):
         """Publish the module."""
@@ -54,7 +54,7 @@ class Foo(BaseModuleInterface):
         ret = []
 
         for task in self._task_interfaces:
-            ret.append((task.impl_object.name, task.dbus_path))
+            ret.append((task.implementation.name, task.object_path))
 
         return ret
 

--- a/pyanaconda/task/__init__.py
+++ b/pyanaconda/task/__init__.py
@@ -30,5 +30,5 @@ def publish_task(task_instance: Task, module_dbus_path):
     :type module_dbus_path: str
     """
     interface = TaskInterface(task_instance)
-    interface.publish(module_dbus_path)
+    interface.publish_from_module(module_dbus_path)
     return interface

--- a/pyanaconda/task/task.py
+++ b/pyanaconda/task/task.py
@@ -36,7 +36,7 @@ __all__ = ['Task', 'TaskAlreadyRunningException']
 class Task(ABC):
     """Base class implementing DBus Task interface."""
 
-    def __init__(self, dbus_modul_path):
+    def __init__(self):
         super().__init__()
         self._progress = (0, "")
 

--- a/tests/pyanaconda_tests/tasks_test.py
+++ b/tests/pyanaconda_tests/tasks_test.py
@@ -97,8 +97,7 @@ class TaskTestCase(unittest.TestCase):
 class TestTask(Task):
 
     def __init__(self):
-        # it won't be published to DBus we don't need dbus path
-        super().__init__("")
+        super().__init__()
 
         self._run_condition = Event()
 


### PR DESCRIPTION
The InterfaceTemplate is a recommended base class for defining
a DBus interface, because it enables to separate the implementation
from the definition.

TaskInterface already uses the proxy pattern, so we just need to
modify it a little to use the InterfaceTemplate. Also, the Task class
doesn't need the module path.

InstallationInterface is already using the proxy pattern.

Fixing a connection to a signal in the install manager.
We should connect a callback to a signal.