### PR TITLE
rhel7-branch: kickstart: support firewall --use-system-defaults

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -34,7 +34,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define mehver 0.23-1
 %define nmver 1.0.0-6.git20150107
 %define partedver 1.8.1
-%define pykickstartver 1.99.66.15
+%define pykickstartver 1.99.66.18
 %define pypartedver 2.5-2
 %define pythonpyblockver 0.45
 %define pythonurlgrabberver 3.9.1-5

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -701,9 +701,9 @@ class Fcoe(commands.fcoe.RHEL7_Fcoe):
 
         return fc
 
-class Firewall(commands.firewall.F28_Firewall):
+class Firewall(commands.firewall.RHEL7_Firewall):
     def __init__(self, *args, **kwargs):
-        commands.firewall.F28_Firewall.__init__(self, *args, **kwargs)
+        commands.firewall.RHEL7_Firewall.__init__(self, *args, **kwargs)
         self.packages = []
 
     def setup(self):

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -701,9 +701,9 @@ class Fcoe(commands.fcoe.RHEL7_Fcoe):
 
         return fc
 
-class Firewall(commands.firewall.F20_Firewall):
+class Firewall(commands.firewall.F28_Firewall):
     def __init__(self, *args, **kwargs):
-        commands.firewall.F20_Firewall.__init__(self, *args, **kwargs)
+        commands.firewall.F28_Firewall.__init__(self, *args, **kwargs)
         self.packages = []
 
     def setup(self):
@@ -712,6 +712,15 @@ class Firewall(commands.firewall.F20_Firewall):
 
     def execute(self, storage, ksdata, instClass):
         args = []
+
+        # If --use-system-defaults was passed then the user wants
+        # whatever was provided by the rpms or ostree to be the
+        # default, do nothing.
+        if self.use_system_defaults:
+            log.info("ks file instructs to use system defaults for "
+                     "firewall, skipping configuration.")
+            return
+
         # enabled is None if neither --enable or --disable is passed
         # default to enabled if nothing has been set.
         if self.enabled == False:


### PR DESCRIPTION
Needed for [1] where we would like to include firewalld
and configure firewalld in Atomic Host (in the ostree) and
have Anaconda leave the delivered "defaults" in place. The
action here is to do nothing if the user specified
--use-system-defaults.

[1] https://pagure.io/atomic-wg/issue/401

(cherry picked from commit cf313116bf1c09c34075e7f06b13cf7f40f078fc)