### PR TITLE
Master kickstart dispatcher anaconda integration

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -483,7 +483,7 @@ if __name__ == "__main__":
     # If we were given a kickstart file on the command line, parse (but do not
     # execute) that now.  Otherwise, load in defaults from kickstart files
     # shipped with the installation media.
-    ksdata = startup_utils.parse_kickstart(opts, addon_paths)
+    ksdata = startup_utils.parse_kickstart(opts, addon_paths, pass_to_boss=flags.run_boss)
 
     # Pick up any changes from interactive-defaults.ks that would
     # otherwise be covered by the dracut KS parser.

--- a/pyanaconda/dbus/constants.py
+++ b/pyanaconda/dbus/constants.py
@@ -35,6 +35,9 @@ DBUS_BOSS_PATH = auto_object_path(DBUS_BOSS_NAME)
 DBUS_BOSS_INSTALLATION_NAME = "{}.Installation".format(DBUS_BOSS_NAME)
 DBUS_BOSS_INSTALLATION_PATH = auto_object_path(DBUS_BOSS_INSTALLATION_NAME)
 
+# Temporary interface for anaconda
+DBUS_BOSS_ANACONDA_NAME = "{}.Anaconda".format(DBUS_BOSS_NAME)
+
 # Anaconda DBUS modules
 MODULE_FOO_NAME = "{}.Foo".format(DBUS_MODULE_NAMESPACE)
 MODULE_FOO_PATH = auto_object_path(MODULE_FOO_NAME)

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -79,6 +79,7 @@ class Flags(object):
         self.singlelang = False
         # enable SE/HMC
         self.hmc = False
+        self.run_boss = False
         # current runtime environments
         self.environs = [ANACONDA_ENVIRON]
         # parse the boot commandline
@@ -90,7 +91,7 @@ class Flags(object):
 
     def read_cmdline(self):
         for f in ("selinux", "debug", "leavebootorder", "testing", "extlinux",
-                  "nombr", "gpt", "noefi"):
+                  "nombr", "gpt", "noefi", "run_boss"):
             self.set_cmdline_bool(f)
 
         if not selinux.is_selinux_enabled():

--- a/pyanaconda/kickstart_dispatcher/element.py
+++ b/pyanaconda/kickstart_dispatcher/element.py
@@ -78,6 +78,11 @@ class KickstartElement(object):
         """Kickstart file name."""
         return self._filename
 
+    @property
+    def number_of_lines(self):
+        """Returns number of kickstart lines of the element."""
+        return self.content.count('\n')
+
     def is_command(self):
         """The element is a command."""
         return self._type == self.KickstartElementType.COMMAND
@@ -203,6 +208,23 @@ class KickstartElements(object):
 
     def __str__(self):
         return str(self._elements)
+
+    @staticmethod
+    def get_references_from_elements(elements=None):
+        """Returns elements' references to kickstart file.
+
+        :param elements: list of kickstart elements to get references from
+        :type elements: list(KickstartElement)
+
+        :return: list of (lineno, file name) element references indexed by
+                 line in kickstart given by the elements
+        :rtype: list((int, str))
+        """
+        refs = [(0, "")]
+        for element in elements:
+            element_refs = element.number_of_lines * [(element.lineno, element.filename)]
+            refs.extend(element_refs)
+        return refs
 
 
 class TrackedKickstartElements(KickstartElements):

--- a/pyanaconda/kickstart_dispatcher/parser.py
+++ b/pyanaconda/kickstart_dispatcher/parser.py
@@ -16,12 +16,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-__all__ = ["SplitKickstartParser"]
+__all__ = ["SplitKickstartParser", "VALID_SECTIONS_ANACONDA"]
 
 from pykickstart.parser import KickstartParser
 from pykickstart.sections import Section
 from pyanaconda.kickstart_dispatcher.element import TrackedKickstartElements, KickstartElement
 
+VALID_SECTIONS_ANACONDA = ["%pre", "%pre-install", "%post", "%onerror", "%traceback",
+                           "%packages", "%addon", "%anaconda"]
 
 class StoreSection(Section):
     """Section for storing section content and header line references.

--- a/pyanaconda/modules/bar/bar.py
+++ b/pyanaconda/modules/bar/bar.py
@@ -35,6 +35,7 @@ class Bar(BaseModuleInterface):
     def __init__(self):
         super().__init__()
         self._task_interfaces = []
+        self._kickstart_commands = ["network", "firewall"]
 
     def _collect_tasks(self):
         return [BarTask()]

--- a/pyanaconda/modules/boss/kickstart_manager.py
+++ b/pyanaconda/modules/boss/kickstart_manager.py
@@ -32,17 +32,18 @@ log = get_module_logger(__name__)
 __all__ = ['KickstartManager', 'SplitKickstartError']
 
 
-@map_error("{}.SplitKickstartError".format(DBUS_BOSS_ANACONDA_NAME))
 class SplitKickstartError(Exception):
-    """Error when parsing kickstart for splitting."""
+    """Error while parsing kickstart for splitting."""
     pass
 
 
-class SplitKickstartUnknownSectionError(SplitKickstartError):
-    """Unknown section was found in kickstart."""
+@map_error("{}.SplitKickstartSectionParsingError".format(DBUS_BOSS_ANACONDA_NAME))
+class SplitKickstartSectionParsingError(SplitKickstartError):
+    """Error while parsing a section in kickstart."""
     pass
 
 
+@map_error("{}.SplitKickstartMissingIncludeError".format(DBUS_BOSS_ANACONDA_NAME))
 class SplitKickstartMissingIncludeError(SplitKickstartError):
     """File included in kickstart was not found."""
     pass
@@ -89,7 +90,7 @@ class KickstartManager(object):
         try:
             result = ksparser.split(path)
         except KickstartParseError as e:
-            raise SplitKickstartUnknownSectionError(e)
+            raise SplitKickstartSectionParsingError(e)
         except KickstartError as e:
             raise SplitKickstartMissingIncludeError(e)
         log.info("split %s: %s", path, result)

--- a/pyanaconda/modules/boss/kickstart_manager.py
+++ b/pyanaconda/modules/boss/kickstart_manager.py
@@ -1,0 +1,136 @@
+#
+# Distributing kickstart to anaconda modules.
+#
+# Copyright (C) 2017  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from pydbus.error import map_error
+
+from pyanaconda.dbus.constants import DBUS_BOSS_ANACONDA_NAME
+
+from pyanaconda.kickstart_dispatcher.parser import SplitKickstartParser, VALID_SECTIONS_ANACONDA
+from pykickstart.version import makeVersion
+from pykickstart.errors import KickstartError, KickstartParseError
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+
+__all__ = ['KickstartManager', 'SplitKickstartError']
+
+
+@map_error("{}.SplitKickstartError".format(DBUS_BOSS_ANACONDA_NAME))
+class SplitKickstartError(Exception):
+    """Error when parsing kickstart for splitting."""
+    pass
+
+
+class SplitKickstartUnknownSectionError(SplitKickstartError):
+    """Unknown section was found in kickstart."""
+    pass
+
+
+class SplitKickstartMissingIncludeError(SplitKickstartError):
+    """File included in kickstart was not found."""
+    pass
+
+
+class KickstartManager(object):
+    """Distributes kickstart to modules and collects it back."""
+
+    def __init__(self):
+        self._kickstart_path = None
+        self._elements = None
+        self._module_observers = []
+
+    @property
+    def module_observers(self):
+        """Get all module observers for kickstart distribution."""
+        return self._module_observers
+
+    @module_observers.setter
+    def module_observers(self, modules):
+        """Set module observers for kickstart distribution.
+
+        :param modules: Module observers list
+        :type modules: list(DBusObjectObserver)
+        """
+        self._module_observers = modules
+
+    @property
+    def elements(self):
+        """Return all elements of split kickstart."""
+        return self._elements
+
+    @property
+    def unprocessed_kickstart(self):
+        """Return kickstart not processed by any module."""
+        return self._elements.get_kickstart_from_elements(self._elements.unprocessed_elements)
+
+    def split(self, path):
+        """Split the kickstart given by path into elements."""
+        self._elements = None
+        self._kickstart_path = path
+        handler = makeVersion()
+        ksparser = SplitKickstartParser(handler, valid_sections=VALID_SECTIONS_ANACONDA)
+        try:
+            result = ksparser.split(path)
+        except KickstartParseError as e:
+            raise SplitKickstartUnknownSectionError(e)
+        except KickstartError as e:
+            raise SplitKickstartMissingIncludeError(e)
+        log.info("split %s: %s", path, result)
+        self._elements = result
+
+    def distribute(self):
+        """Distribute split kickstart to modules synchronously.
+
+        :returns: list of (Line number, Message) errors reported by modules when
+                  distributing kickstart
+        :rtype: list((int, str))
+        """
+        errors = []
+
+        for observer in self._module_observers:
+
+            if not observer.is_service_available:
+                log.warning("distribute kickstart: module %s not available", observer.service_name)
+                continue
+
+            commands = observer.proxy.KickstartCommands()
+            sections = observer.proxy.KickstartSections()
+            addons = observer.proxy.KickstartAddons()
+            log.info("distribute kickstart: %s handles commands %s sections %s addons %s",
+                     observer.service_name, commands, sections, addons)
+
+            elements = self._elements.get_and_process_elements(commands=commands,
+                                                               sections=sections,
+                                                               addons=addons)
+            kickstart = self._elements.get_kickstart_from_elements(elements)
+            log.info("distribute kickstart: %s will get kickstart elements: %s",
+                     observer.service_name, elements)
+
+            error_lineno, error_msg = observer.proxy.ConfigureWithKickstart(kickstart)
+            if error_lineno:
+                line_references = self._elements.get_references_from_elements(elements)
+                kickstart_reference = line_references[error_lineno]
+                errors.append((observer.service_name, kickstart_reference, error_msg))
+
+        return errors
+
+    def collect(self):
+        """Collect kickstarts from configured modules."""
+        pass

--- a/pyanaconda/modules/foo/foo.py
+++ b/pyanaconda/modules/foo/foo.py
@@ -35,6 +35,7 @@ class Foo(BaseModuleInterface):
     def __init__(self):
         super().__init__()
         self._task_interfaces = []
+        self._kickstart_commands = ["timezone"]
 
     def _collect_tasks(self):
         return [FooTask()]

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -436,7 +436,7 @@ def distribute_kickstart_with_boss(kickstart_path):
     log.info("Boss.DistributeKickstart() unprocessed part:\n%s", unprocessed_kickstart)
     return True
 
-def parse_kickstart(options, addon_paths):
+def parse_kickstart(options, addon_paths, pass_to_boss=False):
     """Parse the input kickstart.
 
     If we were given a kickstart file, parse (but do not execute) that now.
@@ -476,7 +476,7 @@ def parse_kickstart(options, addon_paths):
         log.info("Parsing kickstart: " + ks)
         ksdata = kickstart.parseKickstart(ks, options.ksstrict)
 
-        if "run_boss" in flags.cmdline:
+        if pass_to_boss:
             distribute_kickstart_with_boss(ks)
         # Only load the first defaults file we find.
         break

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -41,6 +41,10 @@ from pyanaconda.flags import flags
 from pyanaconda.flags import can_touch_runtime_system
 from pyanaconda.screensaver import inhibit_screensaver
 
+from pyanaconda.dbus import DBus
+from pyanaconda.dbus.constants import DBUS_BOSS_NAME, DBUS_BOSS_PATH
+from pyanaconda.modules.boss.kickstart_manager import SplitKickstartError
+
 import blivet
 
 def module_exists(module_path):
@@ -407,6 +411,31 @@ def set_installation_method_from_anaconda_options(anaconda, ksdata):
     else:
         log.error("Unknown method: %s", anaconda.methodstr)
 
+def distribute_kickstart_with_boss(kickstart_path):
+    boss = DBus.get_proxy(DBUS_BOSS_NAME, DBUS_BOSS_PATH)
+    try:
+        boss_kickstart = boss.SplitKickstart(kickstart_path)
+    except SplitKickstartError as e:
+        log.error("Boss.SplitKickstart(%s) exception: %s", kickstart_path, e)
+        return False
+    log.info("Boss.SplitKickstart(%s):\n%s", kickstart_path, boss_kickstart)
+
+    timeout = 10
+    while not boss.AllModulesAvailable() and timeout > 0:
+        log.info("Waiting %d sec for modules to be started", timeout)
+        time.sleep(1)
+        timeout = timeout - 1
+    if not timeout:
+        log.warning("Waiting for modules to be started timed out")
+        return False
+
+    errors = boss.DistributeKickstart()
+    if errors:
+        log.error("Boss.DistributeKickstart() errors: %s", errors)
+    unprocessed_kickstart = boss.UnprocessedKickstart()
+    log.info("Boss.DistributeKickstart() unprocessed part:\n%s", unprocessed_kickstart)
+    return True
+
 def parse_kickstart(options, addon_paths):
     """Parse the input kickstart.
 
@@ -447,6 +476,8 @@ def parse_kickstart(options, addon_paths):
         log.info("Parsing kickstart: " + ks)
         ksdata = kickstart.parseKickstart(ks, options.ksstrict)
 
+        if "run_boss" in flags.cmdline:
+            distribute_kickstart_with_boss(ks)
         # Only load the first defaults file we find.
         break
 

--- a/scripts/run_boss_locally.py
+++ b/scripts/run_boss_locally.py
@@ -11,7 +11,11 @@ import glob
 import pydbus
 import time
 import sys
+import shutil
+import argparse
 from gi.repository import Gio
+
+from pyanaconda.modules.boss.kickstart_manager import SplitKickstartError
 
 try:
     from colorama import Fore, Style
@@ -49,6 +53,28 @@ def start_anaconda_services():
     print(RED + "starting Boss" + RESET)
     test_dbus_connection.dbus.StartServiceByName(DBUS_BOSS_NAME, 0)
 
+def distribute_kickstart(ks_path):
+    tmpfile = tempfile.mktemp(suffix=".run_boss_locally.ks")
+    shutil.copyfile(ks_path, tmpfile)
+    print(RED + "distributing kickstart {}".format(tmpfile) + RESET)
+    boss_object = test_dbus_connection.get(DBUS_BOSS_NAME)
+    try:
+        parsed_kickstart = boss_object.SplitKickstart(tmpfile)
+    except SplitKickstartError as e:
+        print("distribute_kickstart: SplitKickstart() exception: {}".format(e))
+    else:
+        print("distribute_kickstart: SplitKickstart({}):\n{}".format(tmpfile, parsed_kickstart))
+        timeout = 10
+        while not boss_object.AllModulesAvailable() and timeout > 0:
+            print("distribute_kickstart: waiting for modules to start")
+            time.sleep(1)
+            timeout = timeout - 1
+        errors = boss_object.DistributeKickstart()
+        print("distribute_kickstart: DistributeKickstart() errors: {}".format(errors))
+        unprocessed_kickstart = boss_object.UnprocessedKickstart()
+        print("distribute_kickstart: DistributeKickstart() unprocessed:\n{}".format(unprocessed_kickstart))
+    finally:
+        os.unlink(tmpfile)
 
 def stops_anaconda_services():
     print(RED + "stopping Boss" + RESET)
@@ -59,6 +85,12 @@ def stops_anaconda_services():
     print(RED + "waiting a bit for module shutdown to happen" + RESET)
     time.sleep(1)
 
+parser=argparse.ArgumentParser(description="Run Boss DBUS service locally on testing Bus")
+parser.add_argument('-k', '--kickstart', action='store', type=str,
+                    help='distribute kickstart to modules')
+args = parser.parse_args()
+if args.kickstart and not os.path.exists(args.kickstart):
+    print("ERROR: kickstart file {} not found".format(args.kickstart))
 
 print("creating a temporary directory for DBUS service files")
 temp_service_dir = tempfile.TemporaryDirectory(prefix="anaconda_dbus_")
@@ -95,6 +127,9 @@ try:
     print("Connect to the bus address below [press a key to continue]:")
     print("(guid part may be ignored)")
     print(GREEN + test_dbus.get_bus_address() + RESET)
+    if args.kickstart:
+        print()
+        print("Kickstart file {} will be distributed to modules.".format(args.kickstart))
     print()
     print("To control the loop press " + enter_word + " to restart Boss or [" + q_word + "] to Quit session")
     print("###########################################################################")
@@ -105,6 +140,9 @@ try:
 
     while(loop):
         start_anaconda_services()
+
+        if args.kickstart:
+            distribute_kickstart(args.kickstart)
 
         u_input = input()
 

--- a/tests/pyanaconda_tests/kickstart_dispatcher.py
+++ b/tests/pyanaconda_tests/kickstart_dispatcher.py
@@ -342,6 +342,23 @@ echo POST1
                                           ["echo POST1\n"],
                                           12, filename)
 
+        self._expected_element_refs = [
+            (0, ""),
+            (1, filename),
+            (1, filename),
+            (1, filename),
+            (4, filename),
+            (5, filename),
+            (6, filename),
+            (6, filename),
+            (8, filename),
+            (9, filename),
+            (9, filename),
+            (9, filename),
+            (12, filename),
+            (12, filename),
+            (12, filename),
+        ]
 
     def tracked_kickstart_elements_filter_test(self):
         """Test filtering of elements."""
@@ -374,7 +391,6 @@ echo POST1
         self.assertEqual(mixed_elements,
                          [self._element1, self._element2, self._element3, self._element4,
                           self._element7])
-
 
         # nothing required - nothing got
         self.assertEqual(elements.get_elements(), [])
@@ -420,6 +436,19 @@ echo POST1
 
         dumped_ks = elements.get_kickstart_from_elements(elements.all_elements)
         self.assertEqual(dumped_ks, self._expected_ks_content)
+
+    def tracked_kickstart_elements_get_refs_kickstart_test(self):
+        """Test getting of element references."""
+
+        appended_elements = [self._element1, self._element2, self._element3,
+                             self._element4, self._element5, self._element6,
+                             self._element7]
+        elements = TrackedKickstartElements()
+        for element in appended_elements:
+            elements.append(element)
+
+        element_refs = elements.get_references_from_elements(elements.all_elements)
+        self.assertEqual(element_refs, self._expected_element_refs)
 
 
 class SplitKickstartParserTest(unittest.TestCase):

--- a/tests/pyanaconda_tests/kickstart_manager.py
+++ b/tests/pyanaconda_tests/kickstart_manager.py
@@ -1,0 +1,298 @@
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import unittest
+import os
+from contextlib import contextmanager
+
+from pyanaconda.dbus.observer import DBusObjectObserver
+from pyanaconda.modules.boss.kickstart_manager import KickstartManager,\
+    SplitKickstartSectionParsingError, SplitKickstartMissingIncludeError
+
+KICKSTART1 = """
+text
+
+%pre
+echo PRE
+%end
+
+url --url=http://download.eng.brq.redhat.com/pub/fedora/development/25/Server/x86_64/os/.
+lang en_US.UTF-8
+keyboard --vckeymap=us --xlayouts='us'
+rootpw --plaintext chrchl
+selinux --enforcing
+firstboot --disable
+authconfig --passalgo=sha512 --enableshadow
+timezone --utc Asia/Tokyo
+
+network --device ens3
+network --device ens4 --activate
+%include {}
+
+%addon pony --fly=True
+%end
+
+bootloader --location=mbr --boot-drive=vda --driveorder=vda
+clearpart --all --drives=vda
+ignoredisk --only-use=vda
+
+firewall --enabled
+
+# Partitioning conflicts with autopart
+#part /boot --fstype=xfs --onpart=vda1
+#part pv.100000 --size=18436 --ondisk=vda
+#volgroup Vol00 --pesize=4096 pv.100000
+#logvol / --fstype=xfs --name=lv_root --vgname=Vol00 --size=15360
+#logvol /home --fstype=xfs --name=lv_home --vgname=Vol00 --size=1024
+#logvol swap --fstype=swap --name=lv_swap --vgname=Vol00 --size=2048
+
+autopart --encrypted --passphrase=chrchl --type=lvm
+
+%addon scorched --planet=Eearth
+%end
+
+%packages --ignoremissing
+@core
+@PARSE_ERROR
+@base
+%end
+
+%post --nochroot --interpreter /usr/bin/bash
+
+echo "POST1"
+%end
+
+%post --nochroot --interpreter /usr/bin/bash
+echo "POST2"
+%end
+""".strip()
+
+# Kickstart with
+# - 2 levels of %include
+# - sections in included kickstart
+INCLUDE_LEVEL_1_FILENAME = "ks.manager.test.include1.cfg"
+INCLUDE_LEVEL_2_FILENAME = "ks.manager.test.include2.cfg"
+kickstart_include = [
+    ("ks.manager.test.include.cfg", KICKSTART1.format(INCLUDE_LEVEL_1_FILENAME).strip()),
+    (INCLUDE_LEVEL_1_FILENAME, """
+network --device=ens51 --activate
+%include {}
+network --device=ens55 --activate
+network --device=ens56 --activate
+network --hostname=PARSE_ERROR
+repo --name=repo1 --baseurl=http://bla.bla/repo1
+%post
+echo "POST_include1"
+%end
+""".format(INCLUDE_LEVEL_2_FILENAME).strip()),
+    (INCLUDE_LEVEL_2_FILENAME, """
+repo --name=repo1 --baseurl=http://bla.bla/repo1
+network --device=ens541 --activate
+%post --nochroot --interpreter /usr/bin/bash
+echo "POST_include2"
+%end
+""".strip())
+]
+
+# Expected dispatched kickstarts
+
+m1_kickstart = """
+network --device ens3
+network --device ens4 --activate
+network --device=ens51 --activate
+network --device=ens541 --activate
+network --device=ens55 --activate
+network --device=ens56 --activate
+network --hostname=PARSE_ERROR
+firewall --enabled
+""".lstrip()
+
+m2_kickstart = """
+%addon pony --fly=True
+%end
+""".lstrip()
+
+m3_kickstart = """
+%packages --ignoremissing
+@core
+@PARSE_ERROR
+@base
+%end
+""".lstrip()
+
+unprocessed_kickstart = """
+text
+%pre
+echo PRE
+%end
+url --url=http://download.eng.brq.redhat.com/pub/fedora/development/25/Server/x86_64/os/.
+lang en_US.UTF-8
+keyboard --vckeymap=us --xlayouts='us'
+rootpw --plaintext chrchl
+selinux --enforcing
+firstboot --disable
+authconfig --passalgo=sha512 --enableshadow
+timezone --utc Asia/Tokyo
+repo --name=repo1 --baseurl=http://bla.bla/repo1
+%post --nochroot --interpreter /usr/bin/bash
+echo "POST_include2"
+%end
+repo --name=repo1 --baseurl=http://bla.bla/repo1
+%post
+echo "POST_include1"
+%end
+bootloader --location=mbr --boot-drive=vda --driveorder=vda
+clearpart --all --drives=vda
+ignoredisk --only-use=vda
+autopart --encrypted --passphrase=chrchl --type=lvm
+%addon scorched --planet=Eearth
+%end
+%post --nochroot --interpreter /usr/bin/bash
+
+echo "POST1"
+%end
+%post --nochroot --interpreter /usr/bin/bash
+echo "POST2"
+%end
+""".lstrip()
+
+
+class KickstartManagerTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self._kickstart_include = kickstart_include
+        self._m1_kickstart = m1_kickstart
+        self._m2_kickstart = m2_kickstart
+        self._m3_kickstart = m3_kickstart
+        self._unprocessed_kickstart = unprocessed_kickstart
+
+    @contextmanager
+    def _create_ks_files(self, kickstart):
+        """Context with all the kickstart files defined in kickstart list created.
+
+        Yields file name of the main file.
+        """
+        for filename, content in kickstart:
+            with open(filename, "w") as f:
+                f.write(content)
+        yield kickstart[0][0]
+        for filename, _content in kickstart:
+            os.remove(filename)
+
+    def distribute_test(self):
+        manager = KickstartManager()
+        module1 = TestModule(commands=["network", "firewall"])
+        module2 = TestModule(addons=["pony"])
+        module3 = TestModule(sections=["packages"])
+        module4 = TestModule(addons=["scorched"])
+        m1_observer = TestModuleObserver("1", "1", module1)
+        m2_observer = TestModuleObserver("2", "2", module2)
+        m3_observer = TestModuleObserver("3", "3", module3)
+        unavailable_observer = TestModuleObserver("4", "4", module4)
+        unavailable_observer._is_service_available = False
+
+        manager.module_observers = [m1_observer, m2_observer, m3_observer,
+                                    unavailable_observer]
+        with self._create_ks_files(self._kickstart_include) as filename:
+            manager.split(filename)
+        errors = manager.distribute()
+
+        self.assertEqual(module1.kickstart, self._m1_kickstart)
+        self.assertEqual(module2.kickstart, self._m2_kickstart)
+        self.assertEqual(module3.kickstart, self._m3_kickstart)
+        self.assertEqual(module4.kickstart, "")
+        self.assertEqual(manager.unprocessed_kickstart, self._unprocessed_kickstart)
+
+        expected_errors = {("1", 5, 'ks.manager.test.include1.cfg'),
+                           ("3", 42, 'ks.manager.test.include.cfg')}
+        actual_errors = set()
+        for service_name, (lineno, file_name), _msg in errors:
+            actual_errors.add((service_name, lineno, file_name))
+        self.assertEqual(actual_errors, expected_errors)
+
+    def unknown_section_split_test(self):
+        ks_content = """
+network --device=ens3
+%unknown_section
+blah
+%end
+""".strip()
+        manager = KickstartManager()
+        with self._create_ks_files([("ks.mgr.test.unknown_sect.cfg", ks_content)]) as filename:
+            self.assertRaises(SplitKickstartSectionParsingError, manager.split, filename)
+
+    def missing_section_end_split_test(self):
+        ks_content = """
+network --device=ens3
+%packages
+blah
+""".strip()
+        manager = KickstartManager()
+        with self._create_ks_files([("ks.mgr.test.missing_end.cfg", ks_content)]) as filename:
+            self.assertRaises(SplitKickstartSectionParsingError, manager.split, filename)
+
+    def missing_include_split_test(self):
+        ks_content = """
+network --device=ens3
+%include missing_include.cfg
+""".strip()
+        manager = KickstartManager()
+        with self._create_ks_files([("ks.mgr.test.missing_include.cfg", ks_content)]) as filename:
+            self.assertRaises(SplitKickstartMissingIncludeError, manager.split, filename)
+
+
+class TestModuleObserver(DBusObjectObserver):
+
+    def __init__(self, service_name, object_path, test_module):
+        super().__init__(service_name, object_path)
+        self._proxy = test_module
+        self._is_service_available = True
+
+
+class TestModule(object):
+
+    def __init__(self, commands=None, sections=None, addons=None):
+        self.kickstart_commands = commands or []
+        self.kickstart_sections = sections or []
+        self.kickstart_addons = addons or []
+        self.kickstart = ""
+
+    def KickstartSections(self):
+        return self.kickstart_sections
+
+    def KickstartAddons(self):
+        return self.kickstart_addons
+
+    def KickstartCommands(self):
+        return self.kickstart_commands
+
+    def configure_with_kickstart(self, kickstart):
+        """Mock parsing for now.
+
+        Returns parse error if PARSE_ERROR string is found in kickstart.
+        """
+        lineno, msg = (0, "")
+        for lnum, line in enumerate(kickstart.splitlines(), 1):
+            if "PARSE_ERROR" in line:
+                lineno, msg = (lnum, "Mocked parse error: \"PARSE_ERROR\" found")
+                break
+        return (lineno, msg)
+
+    def ConfigureWithKickstart(self, kickstart):
+        self.kickstart = kickstart
+        return self.configure_with_kickstart(kickstart)


### PR DESCRIPTION
Integrate kickstart distpatcher in Anaconda:

- Create Boss interface for early stage of anaconda where there is no event loop so we will call boss methods synchronously or poll the state (modules available).
- Boss (KickstartManager) asks modules for lists of handled elements and gives them partial kickstart (string).
- Mapping between module kickstart and original kickstart lines is handled by Boss (KickstartManager).
- Kickstart parsing in modules is not implemented, there is a dummy implementation returns no-error return value for now and it is possible to trigger parsing error by having PARSE_ERROR string in kickstart (eg "network --hostname=PARSE_ERROR")
- I'll ask Chris if we can modify KickstartParseError to contain lineno attribute. If not, we can be getting it from modified KickstartParser (KickstartParser for modules).
