### PR TITLE
Differentiate upstream and build-time version (#1493952)

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -324,7 +324,7 @@ if __name__ == "__main__":
             startup_utils.prompt_for_ssh()
             sys.exit(0)
 
-    log.info("%s %s", sys.argv[0], startup_utils.get_anaconda_version_string())
+    log.info("%s %s", sys.argv[0], startup_utils.get_anaconda_version_string(build_time_version=True))
     if os.path.exists("/tmp/updates"):
         log.info("Using updates in /tmp/updates/ from %s", opts.updateSrc)
 

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -241,7 +241,8 @@ runtime on NFS/HTTP/FTP servers or local disks.
 %setup -q
 
 %build
-%configure
+# use actual build-time release number, not tarball creation time release number
+%configure ANACONDA_RELEASE=%{release}
 %{__make} %{?_smp_mflags}
 
 %install

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,15 @@ m4_define(python_required_version, 3.4)
 AC_PREREQ([2.63])
 AC_INIT([anaconda], [27.20.4.1], [anaconda-devel-list@redhat.com])
 
+# make it possible to set build info at build time
+# (patch only builds, modular builds, mass-rebuilds, etc.)
+AC_ARG_VAR(ANACONDA_RELEASE, [1])
+
+# default release to 1 if not set by option
+AS_IF([test $ANACONDA_RELEASE],
+      [AC_SUBST(PACKAGE_RELEASE, $ANACONDA_RELEASE)],
+      [AC_SUBST(PACKAGE_RELEASE, 1)])
+
 # Disable building static libraries.
 # This needs to be set before initializing automake
 AC_DISABLE_STATIC
@@ -101,7 +110,6 @@ SHUT_UP_GCC="-Wno-unused-result"
 # Add remaining compiler flags we want to use
 CFLAGS="$CFLAGS -Wall -Werror $SHUT_UP_GCC"
 
-AC_SUBST(PACKAGE_RELEASE, [1])
 
 # Perform arch related tests
 AC_CANONICAL_BUILD

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -77,15 +77,20 @@ def module_exists(module_path):
     except ImportError:
         return False
 
-def get_anaconda_version_string():
+def get_anaconda_version_string(build_time_version=False):
     """Return a string describing current Anaconda version.
     If the current version can't be determined the string
     "unknown" will be returned.
 
+    :param bool build_time_version: return build time version
+
+    Build time version is set at package build time and will
+    in most cases be identified by a build number or other identifier
+    appended to the upstream tarball version.
+
     :returns: string describing Anaconda version
     :rtype: str
     """
-
     # we are importing the version module directly so that we don't drag in any
     # non-necessary stuff; we also need to handle the possibility of the
     # import itself failing
@@ -93,10 +98,19 @@ def get_anaconda_version_string():
         # Ignore pylint not finding the version module, since thanks to automake
         # there's a good chance that version.py is not in the same directory as
         # the rest of pyanaconda.
-        from pyanaconda import version  # pylint: disable=no-name-in-module
-        return version.__version__
+        try:
+            from pyanaconda import version  # pylint: disable=no-name-in-module
+            if build_time_version:
+                return version.__build_time_version__
+            else:
+                return version.__version__
+        except (ImportError, AttributeError):
+            # there is a slight chance version.py might be generated incorrectly
+            # during build, so don't crash in that case
+            return "unknown"
     else:
         return "unknown"
+
 
 def gtk_warning(title, reason):
     """A simple warning dialog for use during early startup of the Anaconda GUI.
@@ -294,7 +308,7 @@ def print_startup_note(options):
 
     :param options: command line/boot options
     """
-    verdesc = "%s for %s %s" % (get_anaconda_version_string(),
+    verdesc = "%s for %s %s" % (get_anaconda_version_string(build_time_version=True),
                                 product.productName, product.productVersion)
     logs_note = " * installation log files are stored in /tmp during the installation"
     shell_and_tmux_note = " * shell is available on TTY2"

--- a/pyanaconda/version.py.in
+++ b/pyanaconda/version.py.in
@@ -1,1 +1,3 @@
-__version__ = "@PACKAGE_VERSION@-@PACKAGE_RELEASE@"
+__version__ = "@PACKAGE_VERSION@"
+__build_time_version__ = "@PACKAGE_VERSION@-@PACKAGE_RELEASE@"
+

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -83,7 +83,7 @@ class MakeBumpVer:
         current_version = values[1]
         current_bug_reporting_mail = values[2]
         # also get the current release number
-        regexp = re.compile(r"PACKAGE_RELEASE, \[(.*)\]")
+        regexp = re.compile(r"ANACONDA_RELEASE, \[(.*)\]")
         self.current_release = re.search(regexp, config_ac).groups()[0]
 
         #argument parsing
@@ -511,8 +511,8 @@ class MakeBumpVer:
                                                 newVersion,
                                                 self.bugreport)
 
-        i = l.index("AC_SUBST(PACKAGE_RELEASE, [%s])\n" % self.current_release)
-        l[i] = "AC_SUBST(PACKAGE_RELEASE, [%s])\n" % self.new_release
+        i = l.index("AC_ARG_VAR(ANACONDA_RELEASE, [%s])\n" % self.current_release)
+        l[i] = "AC_ARG_VAR(ANACONDA_RELEASE, [%s])\n" % self.new_release
 
         f = open(self.configure, 'w')
         f.writelines(l)


### PR DESCRIPTION
There are basically two version Anaconda can have:

- the upstream release version (eq. the version of the tarball)

example: 28.13

- the package version, which is generally a suffix to the upstream
  version and an upstream version can have multiple such suffixes
  due to rebuilds or patch only builds

example: 28.13-1, 28-13.2, 28.13-3, ...

So let's differentiate these two and show them where appropriate:

- show the upstream version for anaconda --version
- show the package version in the installation environment

This should match more closely to user expectations:
- Fedora QA & co. want to know which specific Anaconda patch release
  in used on the installation image during a freeze
- users of Anaconda from the command line mostly just want to
  know the general Anaconda version, many other CLI tools also
  show just the "upstream version" as well

Also handle the case of version.py being incorrectly generated, to
prevent an Anaconda crash in such case.

Resolves: rhbz#1493952