### PR TITLE
Add base classes for kickstart modules

### DIFF
--- a/pyanaconda/dbus/typing.py
+++ b/pyanaconda/dbus/typing.py
@@ -23,11 +23,12 @@
 # https://dbus.freedesktop.org/doc/dbus-specification.html#type-system.
 #
 
-from typing import Tuple, Dict, List, NewType, Any, Union, IO
+from typing import Tuple, Dict, List, NewType, IO
+from pydbus import Variant
 
 __all__ = ["Bool", "Double", "Str", "Int", "Byte", "Int16", "UInt16",
            "Int32", "UInt32", "Int64", "UInt64", "File", "ObjPath",
-           "Tuple", "List", "Dict", "Variant"]
+           "Tuple", "List", "Dict", "Variant", "get_variant"]
 
 # Basic types.
 Bool = bool
@@ -54,26 +55,7 @@ ObjPath = NewType('ObjPath', str)
 
 # Container types.
 # Use Tuple, Dict and List from typing.
-
-# Variant type.
-Variant = Union[
-    Bool,
-    Double,
-    Str,
-    Int,
-    Byte,
-    Int16,
-    UInt16,
-    Int32,
-    UInt32,
-    Int64,
-    UInt64,
-    File,
-    ObjPath,
-    List[Any],
-    Dict[Any, Any],
-    Tuple[Any, ...]
-]
+# Use Variant from pydbus and get_variant.
 
 
 def get_dbus_type(type_hint):
@@ -83,6 +65,23 @@ def get_dbus_type(type_hint):
     :return: a string with DBus representation
     """
     return DBusType.get_dbus_representation(type_hint)
+
+
+def get_variant(type_hint, value):
+    """Return a variant data type.
+
+    The type of a variant is specified with
+    a type hint.
+
+    Example:
+         v1 = get_variant(Bool, True)
+         v2 = get_variant(List[Int], [1,2,3])
+
+    :param type_hint: a type hint
+    :param value: a value of the variant
+    :return: an instance of Variant
+    """
+    return Variant(get_dbus_type(type_hint), value)
 
 
 class DBusType(object):
@@ -135,7 +134,7 @@ class DBusType(object):
             return DBusType._get_container_type(type_hint)
 
         # Or raise an error.
-        raise ValueError("Unknown type: %s" % type_hint)
+        raise TypeError("Unknown type: %s" % type_hint)
 
     @staticmethod
     def _is_basic_type(type_hint):
@@ -180,4 +179,4 @@ class DBusType(object):
         key, _ = type_hint.__args__
 
         if DBusType._is_container_type(key) or key == Variant:
-            raise ValueError("Dictionary key cannot be of type %s." % key)
+            raise TypeError("Dictionary key cannot be of type %s." % key)

--- a/pyanaconda/dbus_addons/baz/baz.py
+++ b/pyanaconda/dbus_addons/baz/baz.py
@@ -1,5 +1,5 @@
-# bar.py
-# Example DBUS module
+# baz.py
+# Example DBUS addon.
 #
 # Copyright (C) 2017 Red Hat, Inc.
 #
@@ -19,23 +19,22 @@
 #
 from pyanaconda.dbus import DBus
 from pyanaconda.dbus.constants import ADDON_BAZ_NAME, ADDON_BAZ_PATH
-from pyanaconda.modules.base import BaseModuleInterface
-from pyanaconda.dbus.interface import dbus_interface
-from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
+from pyanaconda.dbus_addons.baz.baz_interface import BazInterface
+from pyanaconda.modules.base import KickstartModule
 
 from pyanaconda import anaconda_logging
 log = anaconda_logging.get_dbus_module_logger(__name__)
 
 
-@dbus_interface(ADDON_BAZ_NAME)
-class Baz(BaseModuleInterface):
+class Baz(KickstartModule):
+    """The Baz module."""
 
     def publish(self):
         """Publish the module."""
-        DBus.publish_object(self, ADDON_BAZ_PATH)
+        DBus.publish_object(BazInterface(self), ADDON_BAZ_PATH)
         DBus.register_service(ADDON_BAZ_NAME)
 
-    def EchoString(self, s: Str) -> Str:
-        """Returns whatever is passed to it."""
+    def ping(self, s):
+        """Return a string."""
         log.debug(s)
-        return s
+        return "Baz says hi!"

--- a/pyanaconda/dbus_addons/baz/baz_interface.py
+++ b/pyanaconda/dbus_addons/baz/baz_interface.py
@@ -1,5 +1,5 @@
-# foo.py
-# Example DBUS module
+# baz_interface.py
+# Example DBUS addon interface
 #
 # Copyright (C) 2017 Red Hat, Inc.
 #
@@ -17,25 +17,12 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_FOO_PATH, MODULE_FOO_NAME
-from pyanaconda.modules.base import KickstartModule
-from pyanaconda.modules.foo.foo_interface import FooInterface
-from pyanaconda.modules.foo.tasks.foo_task import FooTask
-
-from pyanaconda import anaconda_logging
-log = anaconda_logging.get_dbus_module_logger(__name__)
+from pyanaconda.dbus.constants import ADDON_BAZ_NAME
+from pyanaconda.dbus.interface import dbus_interface
+from pyanaconda.modules.base_interface import KickstartModuleInterface
 
 
-class Foo(KickstartModule):
-    """The Foo module."""
-
-    def publish(self):
-        """Publish the module."""
-        DBus.publish_object(FooInterface(self), MODULE_FOO_PATH)
-        self.publish_task(FooTask(), MODULE_FOO_PATH)
-        DBus.register_service(MODULE_FOO_NAME)
-
-    def ping(self, s):
-        log.debug(s)
-        return "Foo says hi!"
+@dbus_interface(ADDON_BAZ_NAME)
+class BazInterface(KickstartModuleInterface):
+    """The interface for Baz."""
+    pass

--- a/pyanaconda/modules/bar/bar_interface.py
+++ b/pyanaconda/modules/bar/bar_interface.py
@@ -1,5 +1,5 @@
-# foo.py
-# Example DBUS module
+# bar_interface.py
+# Example DBUS interface
 #
 # Copyright (C) 2017 Red Hat, Inc.
 #
@@ -17,25 +17,13 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_FOO_PATH, MODULE_FOO_NAME
-from pyanaconda.modules.base import KickstartModule
-from pyanaconda.modules.foo.foo_interface import FooInterface
-from pyanaconda.modules.foo.tasks.foo_task import FooTask
 
-from pyanaconda import anaconda_logging
-log = anaconda_logging.get_dbus_module_logger(__name__)
+from pyanaconda.dbus.constants import MODULE_BAR_NAME
+from pyanaconda.modules.base_interface import KickstartModuleInterface
+from pyanaconda.dbus.interface import dbus_interface
 
 
-class Foo(KickstartModule):
-    """The Foo module."""
-
-    def publish(self):
-        """Publish the module."""
-        DBus.publish_object(FooInterface(self), MODULE_FOO_PATH)
-        self.publish_task(FooTask(), MODULE_FOO_PATH)
-        DBus.register_service(MODULE_FOO_NAME)
-
-    def ping(self, s):
-        log.debug(s)
-        return "Foo says hi!"
+@dbus_interface(MODULE_BAR_NAME)
+class BarInterface(KickstartModuleInterface):
+    """DBus interface for Bar."""
+    pass

--- a/pyanaconda/modules/bar/bar_kickstart.py
+++ b/pyanaconda/modules/bar/bar_kickstart.py
@@ -1,5 +1,5 @@
-# foo.py
-# Example DBUS module
+#
+# Kickstart specification for bar.
 #
 # Copyright (C) 2017 Red Hat, Inc.
 #
@@ -17,25 +17,29 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_FOO_PATH, MODULE_FOO_NAME
-from pyanaconda.modules.base import KickstartModule
-from pyanaconda.modules.foo.foo_interface import FooInterface
-from pyanaconda.modules.foo.tasks.foo_task import FooTask
+from pykickstart.commands.autopart import F26_AutoPart
+from pykickstart.commands.repo import F27_Repo, F27_RepoData
+from pykickstart.commands.url import F27_Url
+from pykickstart.sections import PackageSection
+from pykickstart.version import F28
 
-from pyanaconda import anaconda_logging
-log = anaconda_logging.get_dbus_module_logger(__name__)
+from pyanaconda.modules.base_kickstart import KickstartSpecification
 
 
-class Foo(KickstartModule):
-    """The Foo module."""
+class BarKickstartSpecification(KickstartSpecification):
 
-    def publish(self):
-        """Publish the module."""
-        DBus.publish_object(FooInterface(self), MODULE_FOO_PATH)
-        self.publish_task(FooTask(), MODULE_FOO_PATH)
-        DBus.register_service(MODULE_FOO_NAME)
+    version = F28
 
-    def ping(self, s):
-        log.debug(s)
-        return "Foo says hi!"
+    commands = {
+        "url": F27_Url,
+        "repo": F27_Repo,
+        "autopart": F26_AutoPart,
+    }
+
+    data = {
+        "RepoData": F27_RepoData,
+    }
+
+    sections = {
+        "packages": PackageSection
+    }

--- a/pyanaconda/modules/base_interface.py
+++ b/pyanaconda/modules/base_interface.py
@@ -1,0 +1,106 @@
+#
+# base_interface.py
+# Base interface for Anaconda modules.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pykickstart.errors import KickstartError
+
+from pyanaconda.dbus.template import InterfaceTemplate
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
+from pyanaconda.dbus.interface import dbus_interface
+from pyanaconda.dbus.constants import DBUS_MODULE_NAMESPACE
+
+
+@dbus_interface(DBUS_MODULE_NAMESPACE)
+class KickstartModuleInterface(InterfaceTemplate):
+    """DBus interface of a kickstart module.
+
+    The implementation is provided by the KickstartModule class.
+    """
+
+    @property
+    def AvailableTasks(self) -> List[Tuple[Str, Str]]:
+        """Return DBus object paths for tasks available for this module.
+
+        :returns: List of tuples (Name, DBus object path) for all Tasks.
+                  See pyanaconda.task.Task for Task API.
+        """
+        result = []
+
+        for task in self.implementation.published_tasks:
+            result.append((task.Name, task.object_path))
+
+        return result
+
+    @property
+    def KickstartCommands(self) -> List[Str]:
+        """Return names of kickstart commands handled by module.
+
+        :returns: List of names of kickstart commands handled by module.
+        """
+        return self.implementation.kickstart_command_names
+
+    @property
+    def KickstartSections(self) -> List[Str]:
+        """Return names of kickstart sections handled by module.
+
+        :returns: List of names of kickstart sections handled by module.
+        """
+        return self.implementation.kickstart_section_names
+
+    @property
+    def KickstartAddons(self) -> List[Str]:
+        """Return names of kickstart addons handled by module.
+
+        :returns: List of names of kickstart addons handled by module.
+        """
+        return self.implementation.kickstart_addon_names
+
+    def ReadKickstart(self, kickstart: Str) -> Dict[Str, Variant]:
+        """Read the kickstart string.
+
+        :param kickstart: a kickstart string
+        :returns: a dictionary with a result
+        """
+        try:
+            self.implementation.read_kickstart(kickstart)
+        except KickstartError as e:
+            # FIXME: We should return a real line number.
+            # We are waiting for a support from pykickstart.
+            return {
+                "success": get_variant(Bool, False),
+                "error_message": get_variant(Str, str(e)),
+                "line_number": get_variant(Int, 1)
+            }
+
+        return {"success": get_variant(Bool, True)}
+
+    def GenerateKickstart(self) -> Str:
+        """Return a kickstart representation of the module
+
+        :return: a kickstart string
+        """
+        return self.implementation.generate_kickstart()
+
+    def Ping(self, s: Str) -> Str:
+        """Ping the module."""
+        return self.implementation.ping(s)
+
+    def Quit(self):
+        """Shut the module down."""
+        self.implementation.stop()

--- a/pyanaconda/modules/base_kickstart.py
+++ b/pyanaconda/modules/base_kickstart.py
@@ -1,0 +1,108 @@
+#
+# Base kickstart objects for Anaconda modules.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pykickstart.base import BaseHandler
+from pykickstart.parser import KickstartParser
+from pykickstart.version import DEVEL
+
+__all__ = ["KickstartSpecification", "NoKickstartSpecification",
+           "get_kickstart_handler", "get_kickstart_parser"]
+
+
+class KickstartSpecification(object):
+    """Specification of kickstart data.
+
+    This specification can be used to get the corresponding
+    handler and parser to parse and handle kickstart data
+    described by this specification.
+
+    You should call get_kickstart_handler to get the kickstart
+    handler for this specification.
+
+    You should call get_kickstart_parser to get the kickstart
+    parser for this specification.
+
+    A specification is defined by these attributes:
+
+    version     - version of a kickstart data
+    commands    - mapping of kickstart command names to
+                  classes that represent them
+    data        - mapping of kickstart data names to
+                  classes that represent them
+    sections    - mapping of kickstart sections names to
+                  classes that represent them
+    """
+
+    version = DEVEL
+    commands = {}
+    data = {}
+    sections = {}
+
+
+class NoKickstartSpecification(KickstartSpecification):
+    """Specification for no kickstart data."""
+    pass
+
+
+class KickstartSpecificationHandler(BaseHandler):
+    """Handler defined by a kickstart specification.
+
+    You should call get_kickstart_handler to get a handler.
+    """
+
+    def __init__(self, *args, version=DEVEL, **kwargs):
+        self.version = version
+        super().__init__(*args, **kwargs)
+
+
+class KickstartSpecificationParser(KickstartParser):
+    """Parser defined by a kickstart specification.
+
+    You should call get_kickstart_parser to get a parser.
+    """
+
+    def setupSection(self):
+        """Do not setup any sections by default."""
+        pass
+
+
+def get_kickstart_handler(specification):
+    """Return a kickstart handler.
+
+    :param specification: a kickstart specification
+    :return: a kickstart handler
+    """
+    return KickstartSpecificationHandler(specification.commands,
+                                         specification.data,
+                                         specification.version)
+
+
+def get_kickstart_parser(handler, specification):
+    """Return a kickstart parser.
+
+    :param handler: a kickstart handler
+    :param specification: a kickstart specification
+    :return: a kickstart parser
+    """
+    parser = KickstartSpecificationParser(handler)
+
+    for section in specification.sections.values():
+        parser.registerSection(section(handler))
+
+    return parser

--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -1,0 +1,74 @@
+# boss_interface.py
+# Anaconda main DBUS module & module manager.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from pyanaconda.dbus.interface import dbus_interface
+from pyanaconda.dbus.constants import DBUS_BOSS_NAME, DBUS_BOSS_ANACONDA_NAME
+from pyanaconda.dbus.template import InterfaceTemplate
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
+
+
+@dbus_interface(DBUS_BOSS_NAME)
+class BossInterface(InterfaceTemplate):
+    """DBus interface for the Boss."""
+
+    def Quit(self):
+        """Stop all modules and then stop the boss."""
+        self.implementation.stop()
+
+
+@dbus_interface(DBUS_BOSS_ANACONDA_NAME)
+class AnacondaBossInterface(BossInterface):
+    """Temporary extension of the boss for anaconda.
+
+    Used for synchronization with anaconda during transition.
+    """
+
+    @property
+    def AllModulesAvailable(self) -> Bool:
+        """Returns true if all modules are available."""
+        return self.implementation.all_modules_available
+
+    @property
+    def UnprocessedKickstart(self) -> Str:
+        """Returns kickstart containing parts that are not handled by any module."""
+        return self.implementation.unprocessed_kickstart
+
+    def SplitKickstart(self, path: Str):
+        """Splits the kickstart for modules.
+
+        :raises SplitKickstartError: if parsing fails
+        """
+        self.implementation.split_kickstart(path)
+
+    def DistributeKickstart(self) -> List[Dict[Str, Variant]]:
+        """Distributes kickstart to modules synchronously.
+
+        Assumes all modules are started.
+
+        :returns: list of kickstart errors
+        """
+        results = self.implementation.distribute_kickstart()
+
+        return [{
+            "module_name": get_variant(Str, result["module_name"]),
+            "file_name": get_variant(Str, result["file_name"]),
+            "line_number": get_variant(Int, result["line_number"]),
+            "error_message": get_variant(Str, result["error_message"])
+        } for result in results]

--- a/pyanaconda/modules/boss/install_manager/install_manager.py
+++ b/pyanaconda/modules/boss/install_manager/install_manager.py
@@ -124,7 +124,7 @@ class InstallManager(object):
                 log.error("Module %s is not available!", observer.service_name)
                 continue
 
-            tasks = observer.proxy.AvailableTasks()
+            tasks = observer.proxy.AvailableTasks
             for task in tasks:
                 log.debug("Getting task %s from module %s", task[TASK_NAME], observer.service_name)
                 task_proxy = DBus.get_proxy(observer.service_name, task[TASK_PATH])

--- a/pyanaconda/modules/boss/kickstart_manager.py
+++ b/pyanaconda/modules/boss/kickstart_manager.py
@@ -111,9 +111,9 @@ class KickstartManager(object):
                 log.warning("distribute kickstart: module %s not available", observer.service_name)
                 continue
 
-            commands = observer.proxy.KickstartCommands()
-            sections = observer.proxy.KickstartSections()
-            addons = observer.proxy.KickstartAddons()
+            commands = observer.proxy.KickstartCommands
+            sections = observer.proxy.KickstartSections
+            addons = observer.proxy.KickstartAddons
             log.info("distribute kickstart: %s handles commands %s sections %s addons %s",
                      observer.service_name, commands, sections, addons)
 
@@ -124,11 +124,17 @@ class KickstartManager(object):
             log.info("distribute kickstart: %s will get kickstart elements: %s",
                      observer.service_name, elements)
 
-            error_lineno, error_msg = observer.proxy.ConfigureWithKickstart(kickstart)
-            if error_lineno:
+            result = observer.proxy.ReadKickstart(kickstart)
+
+            if not result["success"]:
                 line_references = self._elements.get_references_from_elements(elements)
-                kickstart_reference = line_references[error_lineno]
-                errors.append((observer.service_name, kickstart_reference, error_msg))
+                line_number, file_name = line_references[result["line_number"]]
+                result["line_number"] = line_number
+                result["file_name"] = file_name
+                result["module_name"] = observer.service_name
+
+                log.error("distribute kickstart: %s", result)
+                errors.append(result)
 
         return errors
 

--- a/pyanaconda/modules/boss/module_manager.py
+++ b/pyanaconda/modules/boss/module_manager.py
@@ -91,7 +91,7 @@ class ModuleManager(object):
     def _process_module_is_available(self, observer):
         """Process the service_available signal."""
         log.debug("%s is available", observer)
-        observer.proxy.EchoString("Boss says hi!")
+        observer.proxy.Ping("Boss says hi!")
 
     def _process_module_is_unavailable(self, observer):
         """Process the service_unavailable signal."""

--- a/pyanaconda/modules/foo/foo_interface.py
+++ b/pyanaconda/modules/foo/foo_interface.py
@@ -1,5 +1,5 @@
-# foo.py
-# Example DBUS module
+# foo_interface.py
+# Example DBUS module interface
 #
 # Copyright (C) 2017 Red Hat, Inc.
 #
@@ -17,25 +17,13 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_FOO_PATH, MODULE_FOO_NAME
-from pyanaconda.modules.base import KickstartModule
-from pyanaconda.modules.foo.foo_interface import FooInterface
-from pyanaconda.modules.foo.tasks.foo_task import FooTask
 
-from pyanaconda import anaconda_logging
-log = anaconda_logging.get_dbus_module_logger(__name__)
+from pyanaconda.dbus.constants import MODULE_FOO_NAME
+from pyanaconda.modules.base_interface import KickstartModuleInterface
+from pyanaconda.dbus.interface import dbus_interface
 
 
-class Foo(KickstartModule):
-    """The Foo module."""
-
-    def publish(self):
-        """Publish the module."""
-        DBus.publish_object(FooInterface(self), MODULE_FOO_PATH)
-        self.publish_task(FooTask(), MODULE_FOO_PATH)
-        DBus.register_service(MODULE_FOO_NAME)
-
-    def ping(self, s):
-        log.debug(s)
-        return "Foo says hi!"
+@dbus_interface(MODULE_FOO_NAME)
+class FooInterface(KickstartModuleInterface):
+    """DBus interface for Foo."""
+    pass

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -414,14 +414,15 @@ def set_installation_method_from_anaconda_options(anaconda, ksdata):
 def distribute_kickstart_with_boss(kickstart_path):
     boss = DBus.get_proxy(DBUS_BOSS_NAME, DBUS_BOSS_PATH)
     try:
-        boss_kickstart = boss.SplitKickstart(kickstart_path)
+        boss.SplitKickstart(kickstart_path)
     except SplitKickstartError as e:
         log.error("Boss.SplitKickstart(%s) exception: %s", kickstart_path, e)
         return False
-    log.info("Boss.SplitKickstart(%s):\n%s", kickstart_path, boss_kickstart)
+
+    log.info("Boss.SplitKickstart(%s):\n%s", kickstart_path, boss.UnprocessedKickstart)
 
     timeout = 10
-    while not boss.AllModulesAvailable() and timeout > 0:
+    while not boss.AllModulesAvailable and timeout > 0:
         log.info("Waiting %d sec for modules to be started", timeout)
         time.sleep(1)
         timeout = timeout - 1
@@ -432,7 +433,7 @@ def distribute_kickstart_with_boss(kickstart_path):
     errors = boss.DistributeKickstart()
     if errors:
         log.error("Boss.DistributeKickstart() errors: %s", errors)
-    unprocessed_kickstart = boss.UnprocessedKickstart()
+    unprocessed_kickstart = boss.UnprocessedKickstart
     log.info("Boss.DistributeKickstart() unprocessed part:\n%s", unprocessed_kickstart)
     return True
 

--- a/scripts/run_boss_locally.py
+++ b/scripts/run_boss_locally.py
@@ -59,19 +59,20 @@ def distribute_kickstart(ks_path):
     print(RED + "distributing kickstart {}".format(tmpfile) + RESET)
     boss_object = test_dbus_connection.get(DBUS_BOSS_NAME)
     try:
-        parsed_kickstart = boss_object.SplitKickstart(tmpfile)
+        boss_object.SplitKickstart(tmpfile)
     except SplitKickstartError as e:
         print("distribute_kickstart: SplitKickstart() exception: {}".format(e))
     else:
-        print("distribute_kickstart: SplitKickstart({}):\n{}".format(tmpfile, parsed_kickstart))
+        unprocessed_kickstart = boss_object.UnprocessedKickstart
+        print("distribute_kickstart: SplitKickstart({}):\n{}".format(tmpfile, unprocessed_kickstart))
         timeout = 10
-        while not boss_object.AllModulesAvailable() and timeout > 0:
+        while not boss_object.AllModulesAvailable and timeout > 0:
             print("distribute_kickstart: waiting for modules to start")
             time.sleep(1)
             timeout = timeout - 1
         errors = boss_object.DistributeKickstart()
         print("distribute_kickstart: DistributeKickstart() errors: {}".format(errors))
-        unprocessed_kickstart = boss_object.UnprocessedKickstart()
+        unprocessed_kickstart = boss_object.UnprocessedKickstart
         print("distribute_kickstart: DistributeKickstart() unprocessed:\n{}".format(unprocessed_kickstart))
     finally:
         os.unlink(tmpfile)

--- a/tests/pyanaconda_tests/install_manager_test.py
+++ b/tests/pyanaconda_tests/install_manager_test.py
@@ -123,6 +123,7 @@ class TestModule(object):
         """Return instance instead of DBus path."""
         return self._bus_name
 
+    @property
     def AvailableTasks(self):
         return [("TaskName", self._task_instance)]
 


### PR DESCRIPTION
The class that describes the interface of a kickstart module should
inherit the KickstartModuleInterface class and the class that provides
the implementation of the interface should inherit the KickstarModule
class.

Kickstart modules can define KickstartSpecification to be able to
read and write a kickstart string with expected commands and sections.

Also, variants need to be instances of Variant class.