### PR TITLE
Spin kickstarts shouldn't be test dependency

### DIFF
--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -14,7 +14,7 @@ from argparse import ArgumentParser
 ANACONDA_SPEC_NAME = "anaconda.spec.in"
 
 TEST_DEPENDENCIES = ["e2fsprogs", "git", "bzip2", "cppcheck", "rpm-ostree", "pykickstart",
-                     "spin-kickstarts", "python3-rpmfluff", "python3-mock", "python3-pocketlint",
+                     "python3-rpmfluff", "python3-mock", "python3-pocketlint",
                      "python3-nose-testconfig", "python3-sphinx_rtd_theme", "python3-lxml",
                      "python3-dogtail", "sudo"]
 


### PR DESCRIPTION
This is not required for tests.