### PR TITLE
Restore fix for RHBZ #1323012 (`set_name` not `setName`)

### DIFF
--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -1247,7 +1247,7 @@ class InstallerStorage(Blivet):
                 # Set the boot partition's name on disk labels that support it
                 if dev.parted_partition.disk.supportsFeature(parted.DISK_TYPE_PARTITION_NAME):
                     ped_partition = dev.parted_partition.getPedPartition()
-                    ped_partition.setName(dev.format.name)
+                    ped_partition.set_name(dev.format.name)
                     log.info("Setting label on %s to '%s'", dev, dev.format.name)
 
                 dev.disk.setup()


### PR DESCRIPTION
This was initially fixed in blivet by
https://github.com/rhinstaller/blivet/pull/354 , but the fix
was inadvertently reversed by a refactoring commit that
landed shortly afterwards:
https://github.com/storaged-project/blivet/commit/d3ac10d8
The wrong code was then subsequently moved to anaconda, still
with the wrong method name. So, let's fix it again.

Signed-off-by: Adam Williamson <awilliam@redhat.com>