### PR TITLE
Improve password checking status and error messages

### DIFF
--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -137,39 +137,57 @@ FIRSTBOOT_ENVIRON = "firstboot"
 # Tainted hardware
 UNSUPPORTED_HW = 1 << 28
 
+# Password type
+class SecretType(Enum):
+    PASSWORD = "password"
+    PASSPHRASE = "passphrase"
+
 # Password validation
-PASSWORD_MIN_LEN = 6
-PASSWORD_EMPTY_ERROR = N_("The %(password_name)s is empty.")  # singular
-PASSWORD_CONFIRM_ERROR_GUI = N_("The %(password_name_plural)s do not match.")  # plural
-PASSWORD_CONFIRM_ERROR_TUI = N_("The %(password_name_plural)s you entered were different. Please try again.")  # plural
-# The password-too-short constant is used to replace a libpwquality error message,
+SECRET_MIN_LEN = 6
+SECRET_EMPTY_ERROR = {
+    SecretType.PASSWORD : N_("The password is empty."),
+    SecretType.PASSPHRASE : N_("The passphrase is empty.")
+}
+SECRET_CONFIRM_ERROR_GUI = {
+    SecretType.PASSWORD : N_("The passwords do not match."),
+    SecretType.PASSPHRASE : N_("The passphrases do not match.")
+}
+SECRET_CONFIRM_ERROR_TUI = {
+    SecretType.PASSWORD : N_("The passwords you entered were different. Please try again."),
+    SecretType.PASSPHRASE : N_("The passphrases you entered were different. Please try again.")
+}
+
+# The secret-too-short constants is used to replace a libpwquality error message,
 # which is why it does not end with a ".", like all the other do.
-PASSWORD_TOO_SHORT = N_("The %(password_name)s is too short")  # singular
-PASSWORD_WEAK = N_("The %(password_name)s you have provided is weak.")  # singular
-PASSWORD_WEAK_WITH_ERROR = N_("The %(password_name)s you have provided is weak: %(error_message)s.")  # singular
-PASSWORD_FINAL_CONFIRM = N_("Press Done again to use anyway.")
-PASSWORD_ASCII = N_("The %(password_name)s you have provided contains non-ASCII characters. You may not be able to switch between keyboard layouts when typing it.")
-# ^ singular
-PASSWORD_DONE_TWICE = N_("You will have to press Done twice to confirm it.")
-PASSWORD_DONE_TO_CONTINUE = N_("Press Done to continue.")
+SECRET_TOO_SHORT = {
+    SecretType.PASSWORD : N_("The password is too short"),
+    SecretType.PASSPHRASE : N_("The passphrase is too short")
+}
+SECRET_WEAK = {
+    SecretType.PASSWORD : N_("The password you have provided is weak."),
+    SecretType.PASSPHRASE : N_("The passphrase you have provided is weak.")
+}
+SECRET_WEAK_WITH_ERROR = {
+    SecretType.PASSWORD : N_("The password you have provided is weak:"),
+    SecretType.PASSPHRASE : N_("The passphrase you have provided is weak:")
+}
+PASSWORD_FINAL_CONFIRM = N_("Press <b>Done</b> again to use the password anyway.")
+SECRET_ASCII = {
+    SecretType.PASSWORD : N_("The password you have provided contains non-ASCII characters. You may not be able to switch between keyboard layouts when typing it."),
+    SecretType.PASSPHRASE : N_("The passphrase you have provided contains non-ASCII characters. You may not be able to switch between keyboard layouts when typing it.")
+}
+PASSWORD_DONE_TWICE = N_("You will have to press <b>Done</b> twice to confirm it.")
+PASSWORD_DONE_TO_CONTINUE = N_("Press <b>Done</b> to continue.")
 
 PASSWORD_SET = N_("Password set.")
 
-class PasswordStatus(Enum):
+class SecretStatus(Enum):
     EMPTY = N_("Empty")
     TOO_SHORT = N_("Too short")
     WEAK = N_("Weak")
     FAIR = N_("Fair")
     GOOD = N_("Good")
     STRONG = N_("Strong")
-
-# how should passwords be called in combined strings
-NAME_OF_PASSWORD = N_("password")
-NAME_OF_PASSWORD_PLURAL = N_("passwords")
-
-# how should passphrases be called in combined strings
-NAME_OF_PASSPHRASE = N_("passphrase")
-NAME_OF_PASSPHRASE_PLURAL = N_("passphrases")
 
 PASSWORD_HIDE = N_("Hide password.")
 PASSWORD_SHOW = N_("Show password.")

--- a/pyanaconda/ui/gui/spokes/lib/passphrase.py
+++ b/pyanaconda/ui/gui/spokes/lib/passphrase.py
@@ -23,7 +23,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 from pyanaconda.ui.gui import GUIObject
-from pyanaconda.i18n import _, N_
+from pyanaconda.i18n import N_
 from pyanaconda.ui.gui.utils import really_hide, really_show, set_password_visibility
 from pyanaconda import input_checking
 from pyanaconda import constants
@@ -65,8 +65,7 @@ class PassphraseDialog(GUIObject):
                                                        initial_password_confirmation_content = self._confirm_entry.get_text(),
                                                        policy = input_checking.get_policy(self.data, "luks"))
         # configure the checker for passphrase checking
-        self._checker.name_of_password = _(constants.NAME_OF_PASSPHRASE)
-        self._checker.name_of_password_plural = _(constants.NAME_OF_PASSPHRASE_PLURAL)
+        self._checker.secret_type = constants.SecretType.PASSPHRASE
         # connect UI updates to check results
         self._checker.checks_done.connect(self._set_status)
 

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -82,8 +82,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
                 policy = input_checking.get_policy(self.data, "root")
         )
         # configure the checker for password checking
-        self.checker.name_of_password = _(constants.NAME_OF_PASSWORD)
-        self.checker.name_of_password_plural = _(constants.NAME_OF_PASSWORD_PLURAL)
+        self.checker.secret_type = constants.SecretType.PASSWORD
         # remove any placeholder texts if either password or confirmation field changes content from initial state
         self.checker.password.changed_from_initial_state.connect(self.remove_placeholder_texts)
         self.checker.password_confirmation.changed_from_initial_state.connect(self.remove_placeholder_texts)

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -281,9 +281,8 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
                 policy = input_checking.get_policy(self.data, "user")
         )
         # configure the checker for password checking
-        self.checker.name_of_password = _(constants.NAME_OF_PASSWORD)
-        self.checker.name_of_password_plural = _(constants.NAME_OF_PASSWORD_PLURAL)
         self.checker.username = self.username
+        self.checker.secret_type = constants.SecretType.PASSWORD
         # remove any placeholder texts if either password or confirmation field changes content from initial state
         self.checker.password.changed_from_initial_state.connect(self.remove_placeholder_texts)
         self.checker.password_confirmation.changed_from_initial_state.connect(self.remove_placeholder_texts)

--- a/pyanaconda/ui/tui/tuiobject.py
+++ b/pyanaconda/ui/tui/tuiobject.py
@@ -232,9 +232,7 @@ class PasswordDialog(Dialog):
                            " it a second time to continue."))
             return None
         if password != confirm:
-            self._report(_(constants.PASSWORD_CONFIRM_ERROR_TUI) % {
-                "password_name_plural" : _(constants.NAME_OF_PASSWORD_PLURAL)
-            })
+            self._report(_(constants.SECRET_CONFIRM_ERROR_TUI[constants.SecretType.PASSWORD]))
             return None
 
         # If an empty password was provided, unset the value
@@ -263,13 +261,10 @@ class PasswordDialog(Dialog):
                 done_msg = _("\nWould you like to use it anyway?")
 
             if password_check.result.error_message:
-                error_prefix = _(constants.PASSWORD_WEAK_WITH_ERROR) % {
-                    "password_name" : _(constants.NAME_OF_PASSWORD),
-                    "error_message" : password_check.result.error_message
-                }
-                error = "{} {}".format(error_prefix, done_msg)
+                weak_prefix = _(constants.SECRET_WEAK_WITH_ERROR[constants.SecretType.PASSWORD])
+                error = "{} {} {}".format(weak_prefix, password_check.result.error_message, done_msg)
             else:
-                weak_prefix = _(constants.PASSWORD_WEAK) % {"password_name" : _(constants.NAME_OF_PASSWORD)}
+                weak_prefix = _(constants.SECRET_WEAK[constants.SecretType.PASSWORD])
                 error = "{} {}".format(weak_prefix, done_msg)
 
             if not self._policy.strict:

--- a/tests/pyanaconda_tests/password_quality_test.py
+++ b/tests/pyanaconda_tests/password_quality_test.py
@@ -36,7 +36,7 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         self.assertEqual(check.result.password_score, 1)  # empty password is fine with emptyok policy
-        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.EMPTY.value))
+        self.assertEqual(check.result.status_text, _(constants.SecretStatus.EMPTY.value))
         self.assertEqual(check.result.password_quality, 0)
         self.assertIsNotNone(check.result.error_message)
         # empty password should override password-too-short messages
@@ -47,7 +47,7 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         self.assertEqual(check.result.password_score, 1)
-        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.EMPTY.value))
+        self.assertEqual(check.result.status_text, _(constants.SecretStatus.EMPTY.value))
         self.assertEqual(check.result.password_quality, 0)
         self.assertIsNotNone(check.result.error_message)
 
@@ -60,7 +60,7 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         self.assertEqual(check.result.password_score, 1)
-        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.EMPTY.value))
+        self.assertEqual(check.result.status_text, _(constants.SecretStatus.EMPTY.value))
         self.assertEqual(check.result.password_quality, 0)
         self.assertIsNotNone(check.result.error_message)
         # empty_ok with password length
@@ -72,7 +72,7 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         self.assertEqual(check.result.password_score, 1)
-        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.EMPTY.value))
+        self.assertEqual(check.result.status_text, _(constants.SecretStatus.EMPTY.value))
         self.assertEqual(check.result.password_quality, 0)
         self.assertIsNotNone(check.result.error_message)
         # non-empty passwords that are too short should still get a score of 0 & the "too short" message
@@ -84,7 +84,7 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         self.assertEqual(check.result.password_score, 0)
-        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
         self.assertEqual(check.result.password_quality, 0)
         self.assertIsNotNone(check.result.error_message)
         # also check a long-enough password, just in case
@@ -96,7 +96,7 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         self.assertEqual(check.result.password_score, 1)
-        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.WEAK.value))
+        self.assertEqual(check.result.status_text, _(constants.SecretStatus.WEAK.value))
         self.assertEqual(check.result.password_quality, 0)
         self.assertIsNotNone(check.result.error_message)
 
@@ -110,7 +110,7 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         self.assertEqual(check.result.password_score, 0)
-        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
 
         # weak but long enough
         request = input_checking.PasswordCheckRequest()
@@ -119,7 +119,7 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         self.assertEqual(check.result.password_score, 1)
-        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.WEAK.value))
+        self.assertEqual(check.result.status_text, _(constants.SecretStatus.WEAK.value))
 
         # check if setting password length works correctly
         request = input_checking.PasswordCheckRequest()
@@ -129,7 +129,7 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         self.assertEqual(check.result.password_score, 0)
-        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
         request.policy.minlen = 10
@@ -137,7 +137,7 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         self.assertGreater(check.result.password_score, 0)
-        self.assertNotEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertNotEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
 
     def password_quality_test(self):
         """Check if libpwquality gives reasonable numbers & score is assigned correctly."""
@@ -148,7 +148,7 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         self.assertEqual(check.result.password_score, 0)
-        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
         self.assertEqual(check.result.password_quality, 0)
         self.assertIsNotNone(check.result.error_message)
 
@@ -159,8 +159,8 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         self.assertGreater(check.result.password_score, 0)
-        self.assertNotEqual(check.result.status_text, _(constants.PasswordStatus.EMPTY.value))
-        self.assertNotEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertNotEqual(check.result.status_text, _(constants.SecretStatus.EMPTY.value))
+        self.assertNotEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
         self.assertEqual(check.result.password_quality, 0)
         self.assertIsNotNone(check.result.error_message)
 
@@ -171,8 +171,8 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         self.assertGreater(check.result.password_score, 0)
-        self.assertNotEqual(check.result.status_text, _(constants.PasswordStatus.EMPTY.value))
-        self.assertNotEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertNotEqual(check.result.status_text, _(constants.SecretStatus.EMPTY.value))
+        self.assertNotEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
         self.assertEqual(check.result.password_quality, 0)
         self.assertIsNotNone(check.result.error_message)
 
@@ -209,7 +209,7 @@ class PasswordQuality(unittest.TestCase):
 
         # this should (hopefully) give quality 100 everywhere
         self.assertEqual(check.result.password_score, 4)  # quality > 90
-        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.STRONG.value))
+        self.assertEqual(check.result.status_text, _(constants.SecretStatus.STRONG.value))
         self.assertEqual(check.result.password_quality, 100)
         self.assertIs(check.result.error_message, "")
 
@@ -222,7 +222,7 @@ class PasswordQuality(unittest.TestCase):
         check.run(request)
         # this should (hopefully) give quality 100 everywhere
         self.assertEqual(check.result.password_score, 4)  # quality > 90
-        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.STRONG.value))
+        self.assertEqual(check.result.status_text, _(constants.SecretStatus.STRONG.value))
         self.assertEqual(check.result.password_quality, 100)
         self.assertIs(check.result.error_message, "")
 
@@ -235,6 +235,6 @@ class PasswordQuality(unittest.TestCase):
         check.run(request)
         # this should (hopefully) give quality 100 everywhere
         self.assertEqual(check.result.password_score, 0)  # too short
-        self.assertEqual(check.result.status_text, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
         self.assertEqual(check.result.password_quality, 0)  # dependent on password length
-        self.assertIs(check.result.error_message, _(constants.PasswordStatus.TOO_SHORT.value))
+        self.assertIs(check.result.error_message, _(constants.SECRET_TOO_SHORT[constants.SecretType.PASSWORD]))


### PR DESCRIPTION
Most importantly have two variants, one for passwords and one for
passphrases. Related to that use "secret" for stuff that can be
password or passphrase (and possibly also something else in the future).

Instead of "password name" a secret-type enum is now used to
differentiate if the secret being checked should be called a
password or a passphrase.

And when we are at it make "Done" bold in the warning messages,
to hopefully improve their readability.