### PR TITLE
Fix bad bash '*' expansion when loading kernel modules (#1519220)

### DIFF
--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -9,6 +9,10 @@ KERNEL=$(uname -r)
 
 MODULE_LIST="cramfs squashfs iscsi_tcp "
 
+# if no file matches the glob expand it to the empty string
+# we need this when any ko file cannot be found
+shopt -s nullglob
+
 SCSI_MODULES=/lib/modules/$KERNEL/kernel/drivers/scsi/device_handler/
 for m in $SCSI_MODULES/*.ko; do
     # Shell spew to work around not having basename
@@ -16,6 +20,8 @@ for m in $SCSI_MODULES/*.ko; do
     a="${m##*/}"
     MODULE_LIST+=" ${a%.*}"
 done
+
+shopt -u nullglob
 
 if [ "$ARCH" != "s390" -a "$ARCH" != "s390x" ]; then
     MODULE_LIST+=" floppy edd iscsi_ibft "


### PR DESCRIPTION
The '*' is propagated to the modprobe command and then expanded.
That results in loading mods as 'etc', 'bin', 'lib'...

(cherry-picked from a commit 601a293)

Resolves: rhbz#1519220

Suggested-by: Lukas Nykryn <lnykryn@redhat.com>