### PR TITLE
Check payload is set before accessing its data (#1524785)

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1525,7 +1525,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         log.debug("network: apply ksdata %s", self.data.network)
 
         if self.networking_changed:
-            if self.payload.needsNetwork:
+            if self.payload and self.payload.needsNetwork:
                 if ANACONDA_ENVIRON in anaconda_flags.environs:
                     log.debug("network spoke (apply), network configuration changed - restarting payload thread")
                     from pyanaconda.packaging import payloadMgr


### PR DESCRIPTION
The payload is None when the Network spoke is running in Initial Setup,
so don't access its methods/properties without checking the payload is actually
set to something.

Resolves: rhbz#1524785