### PR TITLE
Check payload is set before accessing its data (#1524785)

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1557,7 +1557,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         # if installation media or hdd aren't used and settings have changed
         # try if source is available
         if self.networking_changed:
-            if self.payload.needsNetwork:
+            if self.payload and self.payload.needsNetwork:
                 if ANACONDA_ENVIRON in anaconda_flags.environs:
                     log.debug("network spoke (apply), network configuration changed - restarting payload thread")
                     from pyanaconda.payload import payloadMgr


### PR DESCRIPTION
The payload is None when the Network spoke is running in Initial Setup,
so don't access its methods/properties without checking the payload is actually
set to something.

Resolves: rhbz#1524785