### PR TITLE
Move system-logos to anaconda-core (#1529239)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -110,6 +110,7 @@ Requires: python3-dbus
 Requires: python3-pwquality
 Requires: python3-systemd
 Requires: python3-pydbus
+Requires: system-logos
 
 # pwquality only "recommends" the dictionaries it needs to do anything useful,
 # which is apparently great for containers but unhelpful for the rest of us
@@ -173,7 +174,6 @@ Requires: anaconda-core = %{version}-%{release}
 Requires: anaconda-widgets = %{version}-%{release}
 Requires: python3-meh-gui >= %{mehver}
 Requires: adwaita-icon-theme
-Requires: system-logos
 Requires: tigervnc-server-minimal
 Requires: libxklavier >= %{libxklavierver}
 Requires: libgnomekbd


### PR DESCRIPTION
Some of the logo files (in this case syslinux-splash.png) are needed by
non-gui tools like syslinux and grub2. Install them as part of core so
that they are available for anaconda-tui and anaconda-gui.

Related: rhbz#1529239