### PR TITLE
Set correct pykickstart version

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -36,7 +36,7 @@ import uuid
 import glob
 from pykickstart.parser import KickstartParser, preprocessKickstart
 from pykickstart.sections import NullSection
-from pykickstart.version import returnClassForVersion
+from pykickstart.version import returnClassForVersion, F27
 from pykickstart.errors import KickstartError
 # pylint: disable=wildcard-import,unused-wildcard-import
 from pykickstart.constants import *
@@ -263,7 +263,7 @@ dracutCmds = {
     'text': DisplayMode,
     'bootloader': Bootloader,
 }
-handlerclass = returnClassForVersion()
+handlerclass = returnClassForVersion(F27)
 class DracutHandler(handlerclass):
     def __init__(self):
         handlerclass.__init__(self, commandUpdates=dracutCmds)

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -78,7 +78,7 @@ from pykickstart.parser import KickstartParser
 from pykickstart.parser import Script as KSScript
 from pykickstart.sections import NullSection, PackageSection, PostScriptSection, PreScriptSection, PreInstallScriptSection, \
                                  OnErrorScriptSection, TracebackScriptSection, Section
-from pykickstart.version import returnClassForVersion
+from pykickstart.version import returnClassForVersion, F27
 
 from pyanaconda import anaconda_logging
 from pyanaconda.anaconda_loggers import get_module_logger, get_stdout_logger, get_stderr_logger, get_blivet_logger, get_anaconda_root_logger
@@ -2275,7 +2275,7 @@ dataMap = {
     "VolGroupData": VolGroupData,
 }
 
-superclass = returnClassForVersion()
+superclass = returnClassForVersion(version=F27)
 
 class AnacondaKSHandler(superclass):
     AddonClassType = AddonData


### PR DESCRIPTION
For Fedora devel branch the pykickstart version should be set correctly.

Without this patch tests are failing and Anaconda can work incorrectly when bigger change happen in the `pykickstart` package.