### PR TITLE
Remove btrfs support from UI.

### DIFF
--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -39,6 +39,7 @@ from blivet.devicefactory import DEVICE_TYPE_BTRFS
 from blivet.devicefactory import DEVICE_TYPE_MD
 from blivet.devicefactory import DEVICE_TYPE_PARTITION
 from blivet.devicefactory import DEVICE_TYPE_DISK
+from blivet.devicefactory import is_supported_device_type
 
 from pyanaconda.i18n import _, N_
 from pyanaconda import isys
@@ -61,6 +62,9 @@ DEVICE_TEXT_MD = N_("RAID")
 DEVICE_TEXT_PARTITION = N_("Standard Partition")
 DEVICE_TEXT_BTRFS = N_("Btrfs")
 DEVICE_TEXT_DISK = N_("Disk")
+
+# Used for info about device with no more supported type (ie btrfs).
+DEVICE_TEXT_UNSUPPORTED = N_("Unsupported")
 
 DEVICE_TEXT_MAP = {DEVICE_TYPE_LVM: DEVICE_TEXT_LVM,
                    DEVICE_TYPE_MD: DEVICE_TEXT_MD,
@@ -940,3 +944,6 @@ def get_supported_filesystems():
             fs_types.append(obj)
 
     return fs_types
+
+def get_supported_autopart_choices():
+    return [c for c in AUTOPART_CHOICES if is_supported_device_type(AUTOPART_DEVICE_TYPES[c[1]])]

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -68,7 +68,8 @@ from blivet.platform import platform
 
 from pyanaconda.storage_utils import ui_storage_logger, device_type_from_autopart, storage_checker, \
     verify_luks_devices_have_key, get_supported_filesystems
-from pyanaconda.storage_utils import DEVICE_TEXT_PARTITION, DEVICE_TEXT_MAP, DEVICE_TEXT_MD
+from pyanaconda.storage_utils import DEVICE_TEXT_PARTITION, DEVICE_TEXT_MAP, DEVICE_TEXT_MD, \
+    DEVICE_TEXT_UNSUPPORTED
 from pyanaconda.storage_utils import PARTITION_ONLY_FORMAT_TYPES, MOUNTPOINT_DESCRIPTIONS
 from pyanaconda.storage_utils import NAMED_DEVICE_TYPES, CONTAINER_DEVICE_TYPES
 from pyanaconda.storage_utils import try_populate_devicetree
@@ -115,6 +116,8 @@ DEVICE_CONFIGURATION_ERROR_MSG = N_("Device reconfiguration failed. <a href=\"\"
                                     "details.</a>")
 UNRECOVERABLE_ERROR_MSG = N_("Storage configuration reset due to unrecoverable "
                              "error. <a href=\"\">Click for details.</a>")
+
+DEVICE_TYPE_CONST_UNSUPPORTED = "DEVICE_TYPE_UNSUPPORTED"
 
 def dev_type_from_const(dev_type_const):
     """ Return integer corresponding to name for device type defined as
@@ -671,6 +674,15 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     def _add_device_type(self, dev_type_const):
         self._typeStore.append([_(DEVICE_TEXT_MAP[dev_type_from_const(dev_type_const)]),
                                 dev_type_const])
+
+    def _set_device_type(self, dev_type_const):
+        itr = self._typeStore.get_iter_first()
+        while itr:
+            if dev_type_from_const(self._typeStore[itr][1]) == dev_type_const:
+                self._typeCombo.set_active_iter(itr)
+                return True
+            itr = self._typeStore.iter_next(itr)
+        return False
 
     def _validate_mountpoint(self, mountpoint, device, device_type, new_fs_type,
                             reformat, encrypted, raid_level):
@@ -1421,7 +1433,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         if use_dev.is_disk:
             should_appear.add("DEVICE_TYPE_DISK")
 
-        should_appear = set(dt for dt in should_appear if is_supported_device_type(dev_type_from_const(dt)))
+        should_appear_supported = set(dt for dt in should_appear
+                                      if is_supported_device_type(dev_type_from_const(dt)))
 
         # go through the store and remove things that shouldn't be included
         # store.remove() updates or invalidates the passed iterator
@@ -1429,15 +1442,15 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         valid = True
         while itr and valid:
             dev_type_const = self._typeStore[itr][1]
-            if dev_type_const not in should_appear:
+            if dev_type_const not in should_appear_supported:
                 valid = self._typeStore.remove(itr)
-            elif dev_type_const in should_appear:
+            else:
                 # already seen, shouldn't be added to the list again
-                should_appear.remove(dev_type_const)
+                should_appear_supported.remove(dev_type_const)
                 itr = self._typeStore.iter_next(itr)
 
         # add missing device types
-        for dev_type_const in should_appear:
+        for dev_type_const in should_appear_supported:
             self._add_device_type(dev_type_const)
 
         device_type = devicefactory.get_device_type(device)
@@ -1458,15 +1471,17 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
             self._device_name_dict[_type] = name
 
-        itr = self._typeStore.get_iter_first()
-        while itr:
-            if dev_type_from_const(self._typeStore[itr][1]) == device_type:
+        if not self._set_device_type(device_type):
+            unsupported = device_type in (dev_type_from_const(dc) for dc
+                                          in should_appear - should_appear_supported)
+            if unsupported:
+                # For existing unsupported device add the information in the UI
+                log.debug("Existing device with unsupported type %s found", DEVICE_TEXT_MAP[device_type])
+                itr = self._typeStore.append([_(DEVICE_TEXT_UNSUPPORTED), DEVICE_TYPE_CONST_UNSUPPORTED])
                 self._typeCombo.set_active_iter(itr)
-                break
-            itr = self._typeStore.iter_next(itr)
-        else:
-            msg = "Didn't find device type %s in device type combobox" % device_type
-            raise KeyError(msg)
+            else:
+                msg = "Didn't find device type %s in device type combobox" % device_type
+                raise KeyError(msg)
 
         return device_type
 

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -18,13 +18,11 @@
 # Red Hat, Inc.
 #
 
-from blivet.devicefactory import is_supported_device_type
-
 from pyanaconda.i18n import _, C_
 from pyanaconda.product import productName, productVersion
 from pyanaconda.ui.gui.utils import escape_markup, really_hide, really_show
 from pyanaconda.constants import DEFAULT_AUTOPART_TYPE
-from pyanaconda.storage_utils import AUTOPART_CHOICES, AUTOPART_DEVICE_TYPES
+from pyanaconda.storage_utils import get_supported_autopart_choices
 
 import gi
 gi.require_version("AnacondaWidgets", "3.3")
@@ -573,9 +571,8 @@ class CreateNewPage(BasePage):
         self._createBox.attach(label, 0, 4, 2, 1)
         label.set_mnemonic_widget(combo)
 
-        autopart_choices = (c for c in AUTOPART_CHOICES if is_supported_device_type(AUTOPART_DEVICE_TYPES[c[1]]))
         default = None
-        for name, code in autopart_choices:
+        for name, code in get_supported_autopart_choices():
             itr = store.append([_(name), code])
             if code == DEFAULT_AUTOPART_TYPE:
                 default = itr

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -27,7 +27,7 @@ from gi.repository import BlockDev as blockdev
 from pyanaconda.ui.lib.disks import getDisks, applyDiskSelection, checkDiskSelection
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke, EditTUIDialog
-from pyanaconda.storage_utils import AUTOPART_CHOICES, storage_checker, get_supported_filesystems
+from pyanaconda.storage_utils import storage_checker, get_supported_filesystems, get_supported_autopart_choices
 
 from blivet import arch
 from blivet.size import Size
@@ -587,7 +587,7 @@ class PartitionSchemeSpoke(NormalTUISpoke):
         self._container = None
         self.part_schemes = OrderedDict()
         pre_select = self.data.autopart.type or DEFAULT_AUTOPART_TYPE
-        for item in AUTOPART_CHOICES:
+        for item in get_supported_autopart_choices():
             self.part_schemes[item[0]] = item[1]
             if item[1] == pre_select:
                 self._selected_scheme_value = item[1]


### PR DESCRIPTION
UI should stop offer btrfs when blivet/libblockdev (based on system) stops
supporting it (blivet.devicefactory.is_supported_device_type).

For handling existing btrfs devices just make sure we don't crash, don't offer
modifications (just removing) and present the info about the device type not
being supported in a decent way.