### PR TITLE
Add timezone module and support for PropertiesChanged

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -166,6 +166,7 @@ AC_CONFIG_FILES([Makefile
                  pyanaconda/modules/boss/install_manager/Makefile
                  pyanaconda/modules/foo/Makefile
                  pyanaconda/modules/foo/tasks/Makefile
+                 pyanaconda/modules/timezone/Makefile
                  data/post-scripts/Makefile
                  data/pixmaps/Makefile
                  tests/Makefile

--- a/data/dbus/org.fedoraproject.Anaconda.Modules.Timezone.conf
+++ b/data/dbus/org.fedoraproject.Anaconda.Modules.Timezone.conf
@@ -1,0 +1,14 @@
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+        <policy user="root">
+                <allow own="org.fedoraproject.Anaconda.Modules.Timezone"/>
+                <allow send_destination="org.fedoraproject.Anaconda.Modules.Timezone"/>
+        </policy>
+        <policy context="default">
+                <deny own="org.fedoraproject.Anaconda.Modules.Timezone"/>
+                <allow send_destination="org.fedoraproject.Anaconda.Modules.Timezone"/>
+        </policy>
+</busconfig>
+

--- a/data/dbus/org.fedoraproject.Anaconda.Modules.Timezone.service
+++ b/data/dbus/org.fedoraproject.Anaconda.Modules.Timezone.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.fedoraproject.Anaconda.Modules.Timezone
+Exec=/usr/libexec/anaconda/start-module pyanaconda.modules.timezone
+User=root

--- a/pyanaconda/dbus/constants.py
+++ b/pyanaconda/dbus/constants.py
@@ -45,20 +45,25 @@ MODULE_FOO_PATH = auto_object_path(MODULE_FOO_NAME)
 MODULE_BAR_NAME = "{}.Bar".format(DBUS_MODULE_NAMESPACE)
 MODULE_BAR_PATH = auto_object_path(MODULE_BAR_NAME)
 
+MODULE_TIMEZONE_NAME = "{}.Timezone".format(DBUS_MODULE_NAMESPACE)
+MODULE_TIMEZONE_PATH = auto_object_path(MODULE_TIMEZONE_NAME)
+
 # Addons (likely for testing purposes only)
 ADDON_BAZ_NAME = "{}.Baz".format(DBUS_ADDON_NAMESPACE)
 ADDON_BAZ_PATH = auto_object_path(ADDON_BAZ_NAME)
 
 # list of all expected Anaconda services
 ANACONDA_SERVICES = [MODULE_FOO_NAME,
-                     MODULE_BAR_NAME]
+                     MODULE_BAR_NAME,
+                     MODULE_TIMEZONE_NAME]
 
 # Task interface name
 DBUS_TASK_NAME = "{}.Task".format(ANACONDA_DBUS_NAMESPACE)
 
 # list of all expected Anaconda DBUS modules
 ANACONDA_MODULES = [(MODULE_FOO_NAME, MODULE_FOO_PATH),
-                    (MODULE_BAR_NAME, MODULE_BAR_PATH)]
+                    (MODULE_BAR_NAME, MODULE_BAR_PATH),
+                    (MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)]
 
 # status codes
 DBUS_START_REPLY_SUCCESS = 1

--- a/pyanaconda/dbus/interface.py
+++ b/pyanaconda/dbus/interface.py
@@ -186,6 +186,35 @@ class DBusSpecification(object):
         node = self._generate_node(cls, interfaces)
         return self.xml_generator.element_to_xml(node)
 
+    def generate_properties_mapping(self, specification):
+        """Generates mapping of properties to interfaces.
+
+        The map can be used to detect the interface the property
+        belongs to. We assume that the specification cannot contain
+        interfaces with same property names.
+
+        :param specification: DBus specification in XML
+        :return: a mapping of property names to interface names
+        """
+        node = self.xml_generator.xml_to_element(specification)
+        interfaces = self.xml_generator.get_interfaces_from_node(node)
+
+        mapping = {}
+
+        for interface_name, element in interfaces.items():
+            properties = self.xml_generator.get_properties_from_interface(element)
+
+            for property_name in properties:
+                if property_name in mapping:
+                    msg = "Property {} from {} is already defined in {}.".format(
+                        property_name, interface_name, mapping[property_name]
+                    )
+                    raise DBusSpecificationError(msg)
+
+                mapping[property_name] = interface_name
+
+        return mapping
+
     def _collect_standard_interfaces(self):
         """Collect standard interfaces.
 

--- a/pyanaconda/dbus/property.py
+++ b/pyanaconda/dbus/property.py
@@ -1,0 +1,170 @@
+#
+# Support for DBus properties
+#
+# Copyright (C) 2017
+# Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author(s):  Vendula Poncova <vponcova@redhat.com>
+#
+# For more info about DBus specification see:
+# https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
+#
+from abc import ABC
+from functools import wraps
+
+from pyanaconda.dbus.interface import dbus_signal, DBusSpecification
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
+
+__all__ = ["emits_properties_changed", "PropertiesException", "PropertiesInterface"]
+
+
+def emits_properties_changed(method):
+    """Decorator for emitting properties changes.
+
+    The decorated method has to be a member of a class that
+    inherits PropertiesInterface.
+
+    :param method: a DBus method of a class that inherits PropertiesInterface
+    :return: a wrapper of a DBus method that emits PropertiesChanged
+    """
+    @wraps(method)
+    def wrapper(obj, *args, **kwargs):
+        result = method(obj, *args, **kwargs)
+        obj.flush_changes()
+        return result
+
+    return wrapper
+
+
+class PropertiesException(Exception):
+    """Exception for DBus properties."""
+    pass
+
+
+class PropertiesChanges(object):
+    """Cache for properties changes.
+
+    This class is useful to collect the changed properties
+    and their values, before they are emitted on DBus.
+    """
+
+    def __init__(self, publishable):
+        """Create the cache.
+
+        :param publishable: an object with dbus property
+        """
+        self._property_names = set()
+        self._publishable = publishable
+        self._mapping = self._get_properties_mapping(publishable)
+
+    def _get_properties_mapping(self, publishable):
+        """Returns a properties mapping of an DBus object.
+
+        :param publishable: an object with dbus property
+        :return: a map of properties and their interfaces
+        """
+        specification = getattr(publishable, 'dbus', None)
+
+        if not specification:
+            raise PropertiesException("Object of type {} is not publishable."
+                                      .format(type(publishable).__name__))
+
+        generator = DBusSpecification()
+        return generator.generate_properties_mapping(specification)
+
+    def flush(self):
+        """Flush the cache.
+
+        The content of the cache will be composed to requests
+        and the cache will be cleared.
+
+        The requests can be used to emit the PropertiesChanged
+        signal. The requests are a list of tuples, that contain
+        an interface name and a dictionary of properties changes.
+
+        :return: a list of requests
+        """
+        content = self._property_names
+        self._property_names = set()
+
+        requests = {}
+        for property_name in content:
+            interface_name = self._mapping[property_name]
+            property_value = getattr(self._publishable, property_name)
+
+            requests.setdefault(interface_name, {})
+            requests[interface_name][property_name] = property_value
+
+        return requests.items()
+
+    def check_property(self, property_name):
+        """Check if the property name is valid."""
+        if property_name not in self._mapping:
+            raise PropertiesException("Unknown interface of property {}."
+                                      .format(property_name))
+
+    def update(self, property_name):
+        """Update the cache."""
+        self.check_property(property_name)
+        self._property_names.add(property_name)
+
+
+class PropertiesInterface(ABC):
+    """Standard DBus interface org.freedesktop.DBus.Properties.
+
+    DBus objects don't have to inherit this class, because pydbus provides
+    support for this interface by default. This class only extends this support.
+
+    Report the changed property:
+
+        self.report_changed_property('X')
+
+    Emit all changes when the method is done:
+
+        @emits_properties_changed
+        def SetX(x: Int):
+            self.set_x(x)
+
+    """
+
+    def __init__(self):
+        """Initialize the interface."""
+        self._properties_changes = PropertiesChanges(self)
+
+    @dbus_signal
+    def PropertiesChanged(self, interface: Str, changed: Dict[Str, Variant], invalid: List[Str]):
+        """Standard signal properties changed.
+
+        :param interface: a name of an interface
+        :param changed: a dictionary of changed properties
+        :param invalid: a list of invalidated properties
+        :return:
+        """
+        pass
+
+    def report_changed_property(self, property_name):
+        """Reports changed DBus property.
+
+        :param property_name: a name of a DBus property
+        """
+        self._properties_changes.update(property_name)
+
+    def flush_changes(self):
+        """Flush properties changes."""
+        requests = self._properties_changes.flush()
+
+        for interface, changes in requests:
+            self.PropertiesChanged(interface, changes, [])

--- a/pyanaconda/dbus/xml.py
+++ b/pyanaconda/dbus/xml.py
@@ -77,6 +77,16 @@ class XMLGenerator(object):
         return interfaces
 
     @staticmethod
+    def get_properties_from_interface(interface_element):
+        """Return a dictionary of properties defined in an interface element."""
+        properties = dict()
+
+        for element in interface_element.iterfind("property"):
+            properties[element.attrib["name"]] = element
+
+        return properties
+
+    @staticmethod
     def get_signal_element(name):
         """Create a signal element."""
         return ElementTree.Element("signal", {"name": name})

--- a/pyanaconda/dbus_addons/baz/baz.py
+++ b/pyanaconda/dbus_addons/baz/baz.py
@@ -33,8 +33,3 @@ class Baz(KickstartModule):
         """Publish the module."""
         DBus.publish_object(BazInterface(self), ADDON_BAZ_PATH)
         DBus.register_service(ADDON_BAZ_NAME)
-
-    def ping(self, s):
-        """Return a string."""
-        log.debug(s)
-        return "Baz says hi!"

--- a/pyanaconda/modules/bar/bar.py
+++ b/pyanaconda/modules/bar/bar.py
@@ -41,10 +41,6 @@ class Bar(KickstartModule):
         self.publish_task(BarTask(), MODULE_BAR_PATH)
         DBus.register_service(MODULE_BAR_NAME)
 
-    def ping(self, s):
-        log.debug(s)
-        return "Bar says hi!"
-
     @property
     def kickstart_specification(self):
         return BarKickstartSpecification

--- a/pyanaconda/modules/bar/bar_interface.py
+++ b/pyanaconda/modules/bar/bar_interface.py
@@ -19,6 +19,7 @@
 #
 
 from pyanaconda.dbus.constants import MODULE_BAR_NAME
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.base_interface import KickstartModuleInterface
 from pyanaconda.dbus.interface import dbus_interface
 
@@ -26,4 +27,6 @@ from pyanaconda.dbus.interface import dbus_interface
 @dbus_interface(MODULE_BAR_NAME)
 class BarInterface(KickstartModuleInterface):
     """DBus interface for Bar."""
-    pass
+
+    def SetTimezone(self, timezone: Str):
+        self.implementation.set_timezone(timezone)

--- a/pyanaconda/modules/base.py
+++ b/pyanaconda/modules/base.py
@@ -30,6 +30,7 @@ from abc import ABC
 
 from pyanaconda.dbus import DBus
 from pyanaconda.task import publish_task
+from pyanaconda.isignal import Signal
 from pyanaconda.modules.base_kickstart import get_kickstart_handler, get_kickstart_parser
 from pyanaconda.modules.base_kickstart import NoKickstartSpecification
 
@@ -85,6 +86,22 @@ class KickstartModule(BaseModule):
     def __init__(self):
         super().__init__()
         self._published_tasks = []
+        self._module_properties_changed = Signal()
+
+    @property
+    def module_properties_changed(self):
+        """Signal that module might have changed.
+
+        If someone changes properties of this module
+        on the python level (and not from DBus), he
+        should emit this signal once he is done.
+
+        Example of the callback:
+
+            def callback():
+                pass
+        """
+        return self._module_properties_changed
 
     @property
     def published_tasks(self):

--- a/pyanaconda/modules/base.py
+++ b/pyanaconda/modules/base.py
@@ -140,6 +140,10 @@ class KickstartModule(BaseModule):
         # TODO: We need to add support for addons.
         return list()
 
+    def get_kickstart_data(self):
+        """Get an empty kickstart data."""
+        return get_kickstart_handler(self.kickstart_specification)
+
     def read_kickstart(self, s):
         """Read the given kickstart string.
 

--- a/pyanaconda/modules/base.py
+++ b/pyanaconda/modules/base.py
@@ -74,10 +74,6 @@ class BaseModule(ABC):
         self.unpublish()
         GLib.timeout_add_seconds(1, self.loop.quit)
 
-    def ping(self, s):
-        """Ping the module."""
-        return s
-
 
 class KickstartModule(BaseModule):
     """Base implementation of a kickstart module.

--- a/pyanaconda/modules/base_interface.py
+++ b/pyanaconda/modules/base_interface.py
@@ -20,18 +20,23 @@
 #
 from pykickstart.errors import KickstartError
 
-from pyanaconda.dbus.template import InterfaceTemplate
+from pyanaconda.dbus.property import emits_properties_changed
+from pyanaconda.dbus.template import AdvancedInterfaceTemplate
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.dbus.constants import DBUS_MODULE_NAMESPACE
 
 
 @dbus_interface(DBUS_MODULE_NAMESPACE)
-class KickstartModuleInterface(InterfaceTemplate):
+class KickstartModuleInterface(AdvancedInterfaceTemplate):
     """DBus interface of a kickstart module.
 
     The implementation is provided by the KickstartModule class.
     """
+
+    def connect_signals(self):
+        """Connect the signals."""
+        self.implementation.module_properties_changed.connect(self.flush_changes)
 
     @property
     def AvailableTasks(self) -> List[Tuple[Str, Str]]:
@@ -71,6 +76,7 @@ class KickstartModuleInterface(InterfaceTemplate):
         """
         return self.implementation.kickstart_addon_names
 
+    @emits_properties_changed
     def ReadKickstart(self, kickstart: Str) -> Dict[Str, Variant]:
         """Read the kickstart string.
 

--- a/pyanaconda/modules/base_interface.py
+++ b/pyanaconda/modules/base_interface.py
@@ -97,10 +97,6 @@ class KickstartModuleInterface(InterfaceTemplate):
         """
         return self.implementation.generate_kickstart()
 
-    def Ping(self, s: Str) -> Str:
-        """Ping the module."""
-        return self.implementation.ping(s)
-
     def Quit(self):
         """Shut the module down."""
         self.implementation.stop()

--- a/pyanaconda/modules/boss/module_manager.py
+++ b/pyanaconda/modules/boss/module_manager.py
@@ -91,7 +91,7 @@ class ModuleManager(object):
     def _process_module_is_available(self, observer):
         """Process the service_available signal."""
         log.debug("%s is available", observer)
-        observer.proxy.Ping("Boss says hi!")
+        observer.proxy.Ping()
 
     def _process_module_is_unavailable(self, observer):
         """Process the service_unavailable signal."""

--- a/pyanaconda/modules/foo/foo.py
+++ b/pyanaconda/modules/foo/foo.py
@@ -35,7 +35,3 @@ class Foo(KickstartModule):
         DBus.publish_object(FooInterface(self), MODULE_FOO_PATH)
         self.publish_task(FooTask(), MODULE_FOO_PATH)
         DBus.register_service(MODULE_FOO_NAME)
-
-    def ping(self, s):
-        log.debug(s)
-        return "Foo says hi!"

--- a/pyanaconda/modules/timezone/Makefile.am
+++ b/pyanaconda/modules/timezone/Makefile.am
@@ -1,6 +1,6 @@
-# modules/Makefile.am for anaconda
+# modules/timezone/Makefile.am for anaconda
 #
-# Copyright (C) 2017  Red Hat, Inc.
+# Copyright (C) 2018  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published
@@ -15,10 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = boss bar foo timezone
-
 pkgpyexecdir = $(pyexecdir)/py$(PACKAGE_NAME)
-modulesdir = $(pkgpyexecdir)/modules
-modules_PYTHON = $(srcdir)/*.py
+timezonedir = $(pkgpyexecdir)/modules/timezone
+timezone_PYTHON = $(srcdir)/*.py
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/pyanaconda/modules/timezone/__main__.py
+++ b/pyanaconda/modules/timezone/__main__.py
@@ -1,0 +1,4 @@
+from pyanaconda.modules.timezone.timezone import TimezoneModule
+
+timezone_module = TimezoneModule()
+timezone_module.run()

--- a/pyanaconda/modules/timezone/timezone.py
+++ b/pyanaconda/modules/timezone/timezone.py
@@ -1,0 +1,115 @@
+#
+# Kickstart module for date and time settings.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.dbus import DBus
+from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH
+from pyanaconda.isignal import Signal
+from pyanaconda.modules.base import KickstartModule
+from pyanaconda.modules.timezone.timezone_interface import TimezoneInterface
+from pyanaconda.modules.timezone.timezone_kickstart import TimezoneKickstartSpecification
+
+from pyanaconda import anaconda_logging
+log = anaconda_logging.get_dbus_module_logger(__name__)
+
+
+class TimezoneModule(KickstartModule):
+    """The Timezone module."""
+
+    def __init__(self):
+        super().__init__()
+        self.timezone_changed = Signal()
+        self._timezone = "America/New_York"
+
+        self.is_utc_changed = Signal()
+        self._is_utc = False
+
+        self.ntp_enabled_changed = Signal()
+        self._ntp_enabled = True
+
+        self.ntp_servers_changed = Signal()
+        self._ntp_servers = []
+
+    def publish(self):
+        """Publish the module."""
+        DBus.publish_object(TimezoneInterface(self), MODULE_TIMEZONE_PATH)
+        DBus.register_service(MODULE_TIMEZONE_NAME)
+
+    @property
+    def kickstart_specification(self):
+        """Return the kickstart specification."""
+        return TimezoneKickstartSpecification
+
+    def process_kickstart(self, data):
+        """Process the kickstart data."""
+        self.set_timezone(data.timezone.timezone)
+        self.set_utc(data.timezone.isUtc)
+        self.set_ntp_enabled(not data.timezone.nontp)
+        self.set_ntp_servers(data.timezone.ntpservers)
+
+    def generate_kickstart(self):
+        """Return the kickstart string."""
+        data = self.get_kickstart_data()
+        data.timezone.timezone = self.timezone
+        data.timezone.isUtc = self.is_utc
+        data.timezone.nontp = not self.ntp_enabled
+
+        if self.ntp_enabled:
+            data.timezone.ntpservers = list(self.ntp_servers)
+
+        return str(data)
+
+    @property
+    def timezone(self):
+        """Return the timezone."""
+        return self._timezone
+
+    def set_timezone(self, timezone):
+        """Set the timezone."""
+        self._timezone = timezone
+        self.timezone_changed.emit()
+
+    @property
+    def is_utc(self):
+        """Is the hardware clock set to UTC?"""
+        return self._is_utc
+
+    def set_utc(self, is_utc):
+        """Set if the hardware clock is set to UTC."""
+        self._is_utc = is_utc
+        self.is_utc_changed.emit()
+
+    @property
+    def ntp_enabled(self):
+        """Enable automatic starting of NTP service."""
+        return self._ntp_enabled
+
+    def set_ntp_enabled(self, ntp_enabled):
+        """Enable or disable automatic starting of NTP service."""
+        self._ntp_enabled = ntp_enabled
+        self.ntp_enabled_changed.emit()
+
+    @property
+    def ntp_servers(self):
+        """Return a list of NTP servers."""
+        return self._ntp_servers
+
+    def set_ntp_servers(self, servers):
+        """Set NTP servers."""
+        self._ntp_servers = list(servers)
+        self.ntp_servers_changed.emit()

--- a/pyanaconda/modules/timezone/timezone_interface.py
+++ b/pyanaconda/modules/timezone/timezone_interface.py
@@ -1,0 +1,109 @@
+#
+# DBus interface for the timezone module.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME
+from pyanaconda.dbus.property import emits_properties_changed
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
+from pyanaconda.modules.base_interface import KickstartModuleInterface
+from pyanaconda.dbus.interface import dbus_interface
+
+
+@dbus_interface(MODULE_TIMEZONE_NAME)
+class TimezoneInterface(KickstartModuleInterface):
+    """DBus interface for Timezone module."""
+
+    def connect_signals(self):
+        super().connect_signals()
+        self.implementation.timezone_changed.connect(self.changed("Timezone"))
+        self.implementation.is_utc_changed.connect(self.changed("IsUTC"))
+        self.implementation.ntp_enabled_changed.connect(self.changed("NTPEnabled"))
+        self.implementation.ntp_servers_changed.connect(self.changed("NTPServers"))
+
+    @property
+    def Timezone(self) -> Str:
+        """Timezone the system will use."""
+        return self.implementation.timezone
+
+    @emits_properties_changed
+    def SetTimezone(self, timezone: Str):
+        """Set the timezone.
+
+        Sets the system time zone to timezone. To view a list of
+        available time zones, use the timedatectl list-timezones
+        command.
+
+        Example: Europe/Prague
+
+        :param timezone: a string with a timezone
+        """
+        self.implementation.set_timezone(timezone)
+
+    @property
+    def IsUTC(self) -> Bool:
+        """Is the hardware clock set to UTC?
+
+        The system assumes that the hardware clock is set to UTC
+        (Greenwich Mean) time, if true.
+
+        :return: True, if the hardware clock set to UTC, otherwise False
+        """
+        return self.implementation.is_utc
+
+    @emits_properties_changed
+    def SetUTC(self, is_utc: Bool):
+        """Set if the hardware clock set to UTC or not.
+
+        :param is_utc: Is the hardware clock set to UTC?
+        """
+        self.implementation.set_utc(is_utc)
+
+    @property
+    def NTPEnabled(self) -> Bool:
+        """Is automatic starting of NTP service enabled?
+
+        :return: True, if the service is enabled, otherwise false.
+        """
+        return self.implementation.ntp_enabled
+
+    @emits_properties_changed
+    def SetNTPEnabled(self, ntp_enabled: Bool):
+        """Enable or disable automatic starting of NTP service.
+
+        :param ntp_enabled: should be NTP service enabled?
+        """
+        self.implementation.set_ntp_enabled(ntp_enabled)
+
+    @property
+    def NTPServers(self) -> List[Str]:
+        """A list of NTP servers.
+
+        :return: a list of servers
+        """
+        return self.implementation.ntp_servers
+
+    @emits_properties_changed
+    def SetNTPServers(self, servers: List[Str]):
+        """Set the NTP servers.
+
+        Example: [ntp.cesnet.cz]
+
+        :param servers: a list of servers
+        """
+        self.implementation.set_ntp_servers(servers)

--- a/pyanaconda/modules/timezone/timezone_kickstart.py
+++ b/pyanaconda/modules/timezone/timezone_kickstart.py
@@ -1,0 +1,30 @@
+#
+# Kickstart handler for date and time settings.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pykickstart.commands.timezone import F25_Timezone
+from pykickstart.version import F28
+from pyanaconda.modules.base_kickstart import KickstartSpecification
+
+
+class TimezoneKickstartSpecification(KickstartSpecification):
+
+    version = F28
+    commands = {
+        "timezone": F25_Timezone,
+    }

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -11,6 +11,7 @@ class AnacondaLintConfig(PocketLintConfig):
         self.falsePositives = [ FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: GError$"),
                                 FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: S390Error$"),
                                 FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: BlockDevError$"),
+                                FalsePositive(r"^E1101.*: Instance of 'KickstartSpecificationHandler' has no '.*' member$"),
 
                                 # TODO: Should be fixed with https://github.com/PyCQA/astroid/pull/433
                                 FalsePositive(r"^E1129.*: Context manager 'lock' doesn't implement __enter__ and __exit__.$"),


### PR DESCRIPTION
**Add an object observer with cached properties**

Class `DBusCachedObserver` is an extension of `DBusObjectObserver` that allows to cache properties of the remote object. The observer is connected to the `PropertiesChanged` signal of the remote object and
updates its cache every time the signal is emitted. Then it emits its own signal `cached_properties_changed`. Only properties of specified interfaces will be cached.

**Recognize members of standard interfaces**

Members of standard interfaces shouldn't be added to the DBus specification of an interface, because they are already declared by default.

We should get rid of our `Ping` method and use the standard one from `org.freedesktop.DBus.Peer`, because it causes errors. 

**Collect properties changes before emit**

Class `PropertiesInterface` provides tools for collecting properties changes and emitting them at once at the end of the DBus method call. The changes are collected in an instance of `PropertiesChanges` and emitted by methods decorated with `@emits_properties_changed`. The interface name of properties is extracted from the DBus specification.

Class `AdvancedInterfaceTemplate` implements `PropertiesInterface`, so it provides support for collecting and emitting properties changes. Class `KickstartModuleInterface` now inherits the new template.

**Add timezone module**

Added a new kickstart module for timezone. The module is able to handle the kickstart data, but the rest of the logic will be moved later.

Added code that tests new features in one of our temporary modules.

TODO: Add tests.