### PR TITLE
kickstart: use F27_Firewall, not F28_Firewall

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -707,9 +707,9 @@ class Fcoe(commands.fcoe.F13_Fcoe):
 
         return fc
 
-class Firewall(commands.firewall.F28_Firewall):
+class Firewall(commands.firewall.F27_Firewall):
     def __init__(self, *args, **kwargs):
-        commands.firewall.F28_Firewall.__init__(self, *args, **kwargs)
+        commands.firewall.F27_Firewall.__init__(self, *args, **kwargs)
         self.packages = []
 
     def setup(self):


### PR DESCRIPTION
clumens made it F27 when he backported the patch
from the pykickstart pykickstart2 PR [1]  to the f27 
package [2].

[1] https://github.com/rhinstaller/pykickstart/pull/204
[2] https://src.fedoraproject.org/rpms/pykickstart/c/efdb64965ec11dc8c16c38006c2db81bda6430a5?branch=f27