### PR TITLE
Prevent 99-copy-lgs.ks from exiting with a 1

### DIFF
--- a/data/post-scripts/99-copy-logs.ks
+++ b/data/post-scripts/99-copy-logs.ks
@@ -20,8 +20,8 @@ fi
 
 if [ -e ${NOSAVE_INPUT_KS_FILE} ]; then
     rm -f ${NOSAVE_INPUT_KS_FILE}
-else
-    [ -e /run/install/ks.cfg ] && cp /run/install/ks.cfg $ANA_INSTALL_PATH/root/original-ks.cfg
+elif [ -e /run/install/ks.cfg ]; then
+    cp /run/install/ks.cfg $ANA_INSTALL_PATH/root/original-ks.cfg
 fi
 
 %end


### PR DESCRIPTION
Using the previous form would cause the script to exit with a 1 when
/run/install/ks.cfg doesn't exist. Change to using an elif so that it
will return a 0.