### PR TITLE
Use the Timezone module in UI

### DIFF
--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -79,7 +79,6 @@ class Flags(object):
         self.singlelang = False
         # enable SE/HMC
         self.hmc = False
-        self.run_boss = False
         # current runtime environments
         self.environs = [ANACONDA_ENVIRON]
         # parse the boot commandline
@@ -91,7 +90,7 @@ class Flags(object):
 
     def read_cmdline(self):
         for f in ("selinux", "debug", "leavebootorder", "testing", "extlinux",
-                  "nombr", "gpt", "noefi", "run_boss"):
+                  "nombr", "gpt", "noefi"):
             self.set_cmdline_bool(f)
 
         if not selinux.is_selinux_enabled():

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -231,7 +231,8 @@ def doInstall(storage, payload, ksdata, instClass):
     # - this used to be before waiting on threads, but I don't think that's needed
     if flags.can_touch_runtime_system("save system time to HW clock"):
         # lets just do this as a top-level task - no
-        save_hwclock = Task("Save system time to HW clock", timezone.save_hw_clock, (ksdata.timezone,))
+
+        save_hwclock = Task("Save system time to HW clock", timezone.save_hw_clock)
         installation_queue.append(save_hwclock)
 
     # setup the installation environment

--- a/pyanaconda/modules/base.py
+++ b/pyanaconda/modules/base.py
@@ -147,6 +147,7 @@ class KickstartModule(BaseModule):
     def kickstarted(self, value):
         self._kickstarted = value
         self.kickstarted_changed.emit()
+        log.debug("Kickstarted is set to %s.", value)
 
     def get_kickstart_handler(self):
         """Return a kickstart handler.
@@ -172,6 +173,7 @@ class KickstartModule(BaseModule):
         :param s: a kickstart string
         :raises: instances of KickstartError
         """
+        log.debug("Reading kickstart...")
         handler = self.get_kickstart_handler()
         parser = self.get_kickstart_parser(handler)
 

--- a/pyanaconda/modules/base_interface.py
+++ b/pyanaconda/modules/base_interface.py
@@ -85,6 +85,13 @@ class KickstartModuleInterface(AdvancedInterfaceTemplate):
         """
         return self.implementation.kickstarted
 
+    def SetKickstarted(self, kickstarted: Bool):
+        """Set the Kickstarted property.
+
+        FIXME: This method should be removed after we move the logic from UI.
+        """
+        self.implementation.kickstarted = kickstarted
+
     @emits_properties_changed
     def ReadKickstart(self, kickstart: Str) -> Dict[Str, Variant]:
         """Read the kickstart string.

--- a/pyanaconda/modules/boss/kickstart_manager.py
+++ b/pyanaconda/modules/boss/kickstart_manager.py
@@ -32,7 +32,8 @@ log = get_module_logger(__name__)
 __all__ = ['KickstartManager', 'SplitKickstartError']
 
 
-class SplitKickstartError(Exception):
+@map_error("{}.SplitKickstartError".format(DBUS_BOSS_ANACONDA_NAME))
+class SplitKickstartError(KickstartError):
     """Error while parsing kickstart for splitting."""
     pass
 

--- a/pyanaconda/modules/timezone/timezone.py
+++ b/pyanaconda/modules/timezone/timezone.py
@@ -57,6 +57,7 @@ class TimezoneModule(KickstartModule):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
+        log.debug("Processing kickstart data...")
         self.set_timezone(data.timezone.timezone)
         self.set_is_utc(data.timezone.isUtc)
         self.set_ntp_enabled(not data.timezone.nontp)
@@ -64,6 +65,7 @@ class TimezoneModule(KickstartModule):
 
     def generate_kickstart(self):
         """Return the kickstart string."""
+        log.debug("Generating kickstart data...")
         data = self.get_kickstart_handler()
         data.timezone.timezone = self.timezone
         data.timezone.isUtc = self.is_utc
@@ -83,6 +85,7 @@ class TimezoneModule(KickstartModule):
         """Set the timezone."""
         self._timezone = timezone
         self.timezone_changed.emit()
+        log.debug("Timezone is set to %s.", timezone)
 
     @property
     def is_utc(self):
@@ -93,6 +96,7 @@ class TimezoneModule(KickstartModule):
         """Set if the hardware clock is set to UTC."""
         self._is_utc = is_utc
         self.is_utc_changed.emit()
+        log.debug("UTC is set to %s.", is_utc)
 
     @property
     def ntp_enabled(self):
@@ -103,6 +107,7 @@ class TimezoneModule(KickstartModule):
         """Enable or disable automatic starting of NTP service."""
         self._ntp_enabled = ntp_enabled
         self.ntp_enabled_changed.emit()
+        log.debug("NTP is set to %s.", ntp_enabled)
 
     @property
     def ntp_servers(self):
@@ -113,3 +118,4 @@ class TimezoneModule(KickstartModule):
         """Set NTP servers."""
         self._ntp_servers = list(servers)
         self.ntp_servers_changed.emit()
+        log.debug("NTP servers are set to %s.", servers)

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -42,7 +42,6 @@ from pyanaconda.screensaver import inhibit_screensaver
 
 from pyanaconda.dbus import DBus
 from pyanaconda.dbus.constants import DBUS_BOSS_NAME, DBUS_BOSS_PATH
-from pyanaconda.modules.boss.kickstart_manager import SplitKickstartError
 
 import blivet
 
@@ -410,31 +409,26 @@ def set_installation_method_from_anaconda_options(anaconda, ksdata):
     else:
         log.error("Unknown method: %s", anaconda.methodstr)
 
-def distribute_kickstart_with_boss(kickstart_path):
+
+def wait_for_modules(timeout=10):
+    """Wait for the DBus modules.
+
+    :param timeout: seconds to the timeout
+    :return: True if the modules are ready, otherwise False
+    """
     boss = DBus.get_proxy(DBUS_BOSS_NAME, DBUS_BOSS_PATH)
-    try:
-        boss.SplitKickstart(kickstart_path)
-    except SplitKickstartError as e:
-        log.error("Boss.SplitKickstart(%s) exception: %s", kickstart_path, e)
-        return False
 
-    log.info("Boss.SplitKickstart(%s):\n%s", kickstart_path, boss.UnprocessedKickstart)
-
-    timeout = 10
     while not boss.AllModulesAvailable and timeout > 0:
-        log.info("Waiting %d sec for modules to be started", timeout)
+        log.info("Waiting %d sec for modules to be started.", timeout)
         time.sleep(1)
         timeout = timeout - 1
+
     if not timeout:
-        log.warning("Waiting for modules to be started timed out")
+        log.error("Waiting for modules to be started timed out.")
         return False
 
-    errors = boss.DistributeKickstart()
-    if errors:
-        log.error("Boss.DistributeKickstart() errors: %s", errors)
-    unprocessed_kickstart = boss.UnprocessedKickstart
-    log.info("Boss.DistributeKickstart() unprocessed part:\n%s", unprocessed_kickstart)
     return True
+
 
 def parse_kickstart(options, addon_paths, pass_to_boss=False):
     """Parse the input kickstart.
@@ -474,10 +468,9 @@ def parse_kickstart(options, addon_paths, pass_to_boss=False):
 
         kickstart.preScriptPass(ks)
         log.info("Parsing kickstart: " + ks)
-        ksdata = kickstart.parseKickstart(ks, options.ksstrict)
 
-        if pass_to_boss:
-            distribute_kickstart_with_boss(ks)
+        ksdata = kickstart.parseKickstart(ks, options.ksstrict, pass_to_boss)
+
         # Only load the first defaults file we find.
         break
 

--- a/tests/pyanaconda_tests/ks_version_test.py
+++ b/tests/pyanaconda_tests/ks_version_test.py
@@ -38,6 +38,10 @@ class CommandVersionTestCase(unittest.TestCase):
                 warnings.warn("Skipping the kickstart name {}.".format(name))
                 continue
 
+            # Skip commands that were moved on DBus.
+            if isinstance(children[name](), kickstart.RemovedCommand):
+                continue
+
             print(name, children[name], parents[name])
             self.assertIsInstance(children[name](), parents[name])
 


### PR DESCRIPTION
**We need to create a backup branch before merging.**

Prepare Anaconda for using the DBus modules and replace access to
timezone kickstart data with access to the Timezone kickstart module.

Added logs for the Timezone module and other kickstart modules.

**Known issues:**
* Extra `#version` comment in the final kickstart file.
* Kickstart errors contain wrong line numbers.