### PR TITLE
Provide comprehensive log messages about the display mode (#1534474)

### DIFF
--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -229,6 +229,15 @@ class Anaconda(object):
         return (self._display_mode == DisplayModes.TUI
                 and not self._interactive_mode)
 
+    def log_display_mode(self):
+        if not self.display_mode:
+            log.error("Display mode is not set!")
+            return
+
+        log.info("Display mode is set to '%s %s'.",
+                 constants.INTERACTIVE_MODE_NAME[self.interactive_mode],
+                 constants.DISPLAY_MODE_NAME[self.display_mode])
+
     def _set_default_fstype(self, storage):
         fstype = None
         boot_fstype = None

--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -228,6 +228,17 @@ class DisplayModes(Enum):
     GUI = "GUI"
     TUI = "TUI"
 
+
+DISPLAY_MODE_NAME = {
+    DisplayModes.GUI: "graphical mode",
+    DisplayModes.TUI: "text mode"
+}
+
+INTERACTIVE_MODE_NAME = {
+    True: "interactive",
+    False: "noninteractive"
+}
+
 # Loggers
 LOGGER_ANACONDA_ROOT = "anaconda"
 LOGGER_MAIN = "anaconda.main"

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -293,14 +293,7 @@ def setup_display(anaconda, options, addon_paths=None):
             # user has explicitly specified text mode
             flags.vncquestion = False
 
-    display_mode_name = anaconda.display_mode.value
-    if display_mode_name:
-        log.info("Display mode = %s", anaconda.display_mode)
-    elif anaconda.display_mode:
-        log.error("Unknown display mode: %s", anaconda.display_mode)
-    else:
-        log.error("Display mode not set!")
-
+    anaconda.log_display_mode()
     startup_utils.check_memory(anaconda, options)
 
     # check_memory may have changed the display mode


### PR DESCRIPTION
Log message for the cmdline installation:
`Display mode is set to 'noninteractive text mode'.`

Log message for the interactive graphical installation:
`Display mode is set to 'interactive graphical mode'.`

Resolves: rhbz#1534474