### PR TITLE
Improve test run

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -195,27 +195,21 @@ ci:
 	fi
 
 grab-logs:
+# can't be used after tests automatically because make will end when tests fails
 # clean result dir
 	-rm -rf $(TEST_RESULT_DIR)
 	mkdir -p $(TEST_RESULT_DIR)
 
-	cd $(top_builddir)/tests/ && cp -r --parents ./**/*.log ./*.log* $(TEST_RESULT_DIR) || exit 1
-	-mv $(TEST_RESULT_DIR)/test-suite.log.* $(TEST_RESULT_DIR)/test-suite.log
+	-cd $(top_builddir)/tests/ && cp -r --parents ./**/*.log ./*.log* $(TEST_RESULT_DIR)
+	-cd $(top_builddir)/tests/ && cp -r --parents ./*.log* $(TEST_RESULT_DIR)
 
 run-tests:
 	@mkdir -p $(USER_SITE_PACKAGES)
 	@cp $(abs_builddir)/tests/usercustomize.py $(USER_SITE_PACKAGES)
 	$(MAKE)
 	$(MAKE) TMPDIR=/var/tmp COVERAGE_PROCESS_START=$(abs_builddir)/.coveragerc \
-		TEST_SUITE_LOG=test-suite.log.$$$$ PYTHONUSERBASE=$(USER_SITE_BASE) check
+	    TEST_SUITE_LOG=test-suite.log PYTHONUSERBASE=$(USER_SITE_BASE) check
 	@tail -n 1 tests/gettext_tests/*.log > tests/gettext_tests/gettext_tests.log
-	@sudo $(MAKE) TMPDIR=/var/tmp COVERAGE_PROCESS_START=$(abs_builddir)/.coveragerc \
-		TEST_SUITE_LOG=test-suite.log.$$$$ TESTS=nosetests_root.sh \
-		PYTHONUSERBASE=$(USER_SITE_BASE) check
-	@sudo $(MAKE) TMPDIR=/var/tmp COVERAGE_PROCESS_START=$(abs_builddir)/.coveragerc \
-		TEST_SUITE_LOG=test-suite.log.$$$$ PYTHONUSERBASE=$(USER_SITE_BASE) check
-	@cat tests/test-suite.log.* > tests/test-suite.log
-	@rm -f tests/test-suite.log.*
 	@rm -rf $(USER_SITE_BASE)
 	$(MAKE) coverage-report
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -213,6 +213,16 @@ run-tests:
 	@rm -rf $(USER_SITE_BASE)
 	$(MAKE) coverage-report
 
+tests-nose-only:
+	@mkdir -p $(USER_SITE_PACKAGES)
+	@cp $(abs_builddir)/tests/usercustomize.py $(USER_SITE_PACKAGES)
+	$(MAKE)
+	$(MAKE) -C $(srcdir) TMPDIR=/var/tmp COVERAGE_PROCESS_START=$(abs_builddir)/.coveragerc \
+		TEST_SUITE_LOG=test-suite.log TESTS=nosetests.sh \
+		PYTHONUSERBASE=$(USER_SITE_BASE) check
+	@rm -rf $(USER_SITE_BASE)
+	$(MAKE) coverage-report
+
 test-gui:
 	@rm -f tests/test-suite.log
 	@rm -rf tests/autogui-results-*/

--- a/Makefile.am
+++ b/Makefile.am
@@ -184,22 +184,23 @@ runglade:
 	glade ${GLADE_FILE}
 
 ci:
-# clean result dir
-	-rm -rf $(TEST_RESULT_DIR)
-	mkdir -p $(TEST_RESULT_DIR)
-
-# run tests
 	$(MAKE) run-tests || echo $$? > $(srcdir)/tests/error_occured
+	$(MAKE) grab-logs
 
-# grab logs
-	cd $(top_builddir)/tests/ && cp -r --parents ./**/*.log ./*.log* $(TEST_RESULT_DIR) || exit 1
-	-mv $(TEST_RESULT_DIR)/test-suite.log.* $(TEST_RESULT_DIR)/test-suite.log
 	@if [ -f $(srcdir)/tests/error_occured ]; then \
 		echo "TEST FAILED"; \
 		status=$$(cat $(srcdir)/tests/error_occured); \
 		rm $(srcdir)/tests/error_occured; \
 		exit $$status; \
 	fi
+
+grab-logs:
+# clean result dir
+	-rm -rf $(TEST_RESULT_DIR)
+	mkdir -p $(TEST_RESULT_DIR)
+
+	cd $(top_builddir)/tests/ && cp -r --parents ./**/*.log ./*.log* $(TEST_RESULT_DIR) || exit 1
+	-mv $(TEST_RESULT_DIR)/test-suite.log.* $(TEST_RESULT_DIR)/test-suite.log
 
 run-tests:
 	@mkdir -p $(USER_SITE_PACKAGES)

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -846,6 +846,10 @@ def get_rpm_from_Koji_thread(package, fedora_number, arch,
     """
     # just to be sure, create a separate session for each query,
     # as the individual lookups will run in different threads
+
+    # koji library is imported only here not in Anaconda but pylint is ran for all script files
+    # if we don't want to add BuildRequires than we need to disable pylint here
+    # pylint: disable=import-error
     import koji
     kojiclient = koji.ClientSession('http://koji.fedoraproject.org/kojihub', {})
     version = package.version

--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -56,7 +56,8 @@ def _read_spec_file():
 
 
 def parse_args():
-    parser = ArgumentParser(description="Resolve Anaconda all dependencies.")
+    parser = ArgumentParser(description="Resolve Anaconda all dependencies.",
+                            epilog="Without any options the '-b -r -t' options will be used.")
     parser.add_argument('-b', '--build', action='store_true',  dest="build",
                         help="resolve build dependencies")
     parser.add_argument('-r', '--runtime', action='store_true', dest='runtime',

--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -1,5 +1,24 @@
 #!/bin/python3
 #
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+#
+#
 # Resolve dependencies from spec file.
 #
 # Return a list of packages required for build, runtime, tests or combination of those.

--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -35,7 +35,7 @@ ANACONDA_SPEC_NAME = "anaconda.spec.in"
 TEST_DEPENDENCIES = ["e2fsprogs", "git", "bzip2", "cppcheck", "rpm-ostree", "pykickstart",
                      "python3-rpmfluff", "python3-mock", "python3-pocketlint",
                      "python3-nose-testconfig", "python3-sphinx_rtd_theme", "python3-lxml",
-                     "python3-dogtail", "sudo"]
+                     "python3-dogtail"]
 
 
 def _resolve_top_dir():

--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -1,5 +1,24 @@
 #!/bin/python3
 #
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+#
+#
 # Setup mock testing environment for Anaconda.
 #
 

--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -32,6 +32,7 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 DEPENDENCY_SOLVER = "dependency_solver.py"
 
 ANACONDA_MOCK_PATH = "/anaconda"
+NOSE_TESTS_PREFIX = "./pyanaconda_tests/"
 
 
 class MockException(Exception):
@@ -66,6 +67,19 @@ def _resolve_top_dir():
     # go up two dirs to get top path
     top_dir = os.path.split(script_dir)[0]
     return os.path.split(top_dir)[0]
+
+
+def _replace_prefix_paths(paths, prefix):
+    result = []
+
+    for p in paths:
+        if os.path.exists(p):
+            basename = os.path.basename(p)
+            result.append(os.path.join(prefix + basename))
+        else:
+            result.append(p)
+
+    return result
 
 
 def _check_dir_exists(path):
@@ -146,13 +160,29 @@ One of these commands must be used. These commands can be combined.
                        help="""
                        run anaconda tests in a mock
                        """)
+    group.add_argument('--run-nosetests', '-n', action='store', nargs='*',
+                       metavar='tests/pyanaconda_tests/test.py',
+                       dest='nose_targets',
+                       help="""
+                       run anaconda nosetests;
+                       you can specify which tests will run by giving paths to tests files
+                       from anaconda root dir as additional parameters
+                       """)
     group.add_argument('--copy', '-c', action='store_true', dest='copy',
                        help="""
                        keep existing mock and only replace Anaconda folder in it;
                        this will not re-init mock chroot
                        """)
 
-    return parser.parse_args()
+    namespace = parser.parse_args()
+    check_args(namespace)
+
+    return namespace
+
+
+def check_args(namespace):
+    if namespace.run_tests and namespace.nose_targets is not None:
+        raise AttributeError("You can't combine `--run-tests` and `--run-nosetests` commands!")
 
 
 def get_required_packages():
@@ -222,20 +252,54 @@ def install_packages_to_mock(mock_command, packages):
     _check_subprocess(cmd, "Can't install packages to mock.")
 
 
-def run_tests(mock_command):
+def prepare_anaconda(mock_command):
     cmd = _prepare_command(mock_command)
 
     cmd = _run_cmd_in_chroot(cmd)
     cmd.append('cd {} && ./autogen.sh && ./configure'.format(ANACONDA_MOCK_PATH))
 
-    _check_subprocess(cmd, "Can't run tests in a mock.")
+    _check_subprocess(cmd, "Can't prepare anaconda in a mock.")
+
+
+def run_tests(mock_command):
+    prepare_anaconda(mock_command)
 
     cmd = _prepare_command(mock_command)
 
     cmd = _run_cmd_in_chroot(cmd)
     cmd.append('cd {} && make ci'.format(ANACONDA_MOCK_PATH))
 
-    _call_subprocess(cmd)
+    result = _call_subprocess(cmd)
+
+    return result.returncode == 0
+
+
+def run_nosetests(mock_command, specified_test_files):
+    prepare_anaconda(mock_command)
+
+    cmd = _prepare_command(mock_command)
+
+    specified_test_files = _replace_prefix_paths(specified_test_files, NOSE_TESTS_PREFIX)
+    additional_args = " ".join(specified_test_files)
+
+    cmd = _run_cmd_in_chroot(cmd)
+    cmd.append('cd {} && make tests-nose-only NOSE_TESTS_ARGS="{}"'.format(ANACONDA_MOCK_PATH,
+                                                                           additional_args))
+
+    result = _call_subprocess(cmd)
+
+    move_logs_in_mock(mock_command)
+
+    return result.returncode == 0
+
+
+def move_logs_in_mock(mock_command):
+    cmd = _prepare_command(mock_command)
+    cmd = _run_cmd_in_chroot(cmd)
+
+    cmd.append('cd {} && make grab-logs'.format(ANACONDA_MOCK_PATH))
+
+    _check_subprocess(cmd, "Can't move logs to result folder inside of mock.")
 
 
 def init_mock(mock_command):
@@ -256,6 +320,7 @@ if __name__ == "__main__":
 
     mock_cmd = create_mock_command(ns.mock_config, ns.uniqueext)
     mock_init_run = False
+    success = True
 
     if not any([ns.init, ns.copy, ns.run_tests, ns.install]):
         print("You need to specify one of the main commands!", file=sys.stderr)
@@ -279,7 +344,13 @@ if __name__ == "__main__":
         copy_anaconda_to_mock(mock_cmd)
 
     if ns.run_tests:
-        run_tests(mock_cmd)
+        success = run_tests(mock_cmd)
+    elif ns.nose_targets is not None:
+        success = run_nosetests(mock_cmd, ns.nose_targets)
 
     if ns.result_folder:
         copy_result(mock_cmd, ns.result_folder)
+
+    if not success:
+        print("\nTESTS FAILED!\n")
+        sys.exit(1)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -38,6 +38,8 @@ EXTRA_DIST = README.rst usercustomize.py
 EXTRA_DIST += $(top_srcdir)/translation-canary/translation_canary/*.py \
 	      $(top_srcdir)/translation-canary/translation_canary/*/*.py
 
+NOSE_TESTS_ARGS ?= ""
+
 # Test scripts need to be listed both here and in TESTS
 dist_check_SCRIPTS = $(srcdir)/glade/*.py \
 		     $(srcdir)/lib/*.py \

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -32,11 +32,6 @@ In case the *ci* target fails there is also a *coverage-report* target
 which can be used to combine the multiple `.coverage` files into one and
 produce a human readable report.
 
-.. NOTE::
-
-    Your regular user account also needs to execute `sudo' because some tests
-    require root privileges!
-
 Testing Inside Mock
 -------------------
 

--- a/tests/nosetests.sh
+++ b/tests/nosetests.sh
@@ -6,9 +6,9 @@ if [ -z "$top_srcdir" ]; then
     . ${top_srcdir}/tests/testenv.sh
 fi
 
-# If no tests were selected, select all of them
-if [ $# -eq 0 ]; then
+# If no tests were selected by user or makefile, select all of them
+if [ $# -eq 0 ] && [ -z $NOSE_TESTS_ARGS ]; then
     set -- "${top_srcdir}"/tests/*_tests
 fi
 
-exec nosetests-3 -v --exclude=logpicker -a \!acceptance,\!slow "$@"
+exec nosetests-3 -v --exclude=logpicker -a \!acceptance,\!slow $NOSE_TESTS_ARGS "$@"

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -16,8 +16,6 @@ class AnacondaLintConfig(PocketLintConfig):
                                 # TODO: Should be fixed with https://github.com/PyCQA/astroid/pull/433
                                 FalsePositive(r"^E1129.*: Context manager 'lock' doesn't implement __enter__ and __exit__.$"),
 
-                                # XXX: This is temporary until koji has python3 versions.
-                                FalsePositive(r"^E0401.*: Unable to import 'koji'$"),
                                 FalsePositive(r"^E1101.*: Instance of 'GError' has no 'message' member"),
                                 FalsePositive(r"^E1101.*: FedoraGeoIPProvider._refresh: Instance of 'LookupDict' has no 'ok' member"),
                                 FalsePositive(r"^E1101.*: HostipGeoIPProvider._refresh: Instance of 'LookupDict' has no 'ok' member"),

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -1,8 +1,13 @@
 #!/usr/bin/python3
 
 import sys
+import time
 
+from os import path
 from pocketlint import FalsePositive, PocketLintConfig, PocketLinter
+
+TIME_LOG = "pylint-time.log"
+
 
 class AnacondaLintConfig(PocketLintConfig):
     def __init__(self):
@@ -44,8 +49,28 @@ class AnacondaLintConfig(PocketLintConfig):
     def ignoreNames(self):
         return {"translation-canary"}
 
+
+def _get_timelog_path():
+    log_dir = path.dirname(path.realpath(__file__))
+    return "{}/{}".format(log_dir, TIME_LOG)
+
+
+def save_start_time():
+    lt = time.localtime()
+    with open(_get_timelog_path(), 'at') as f:
+        f.write("Start - {}:{}:{}\n".format(lt.tm_hour, lt.tm_min, lt.tm_sec))
+
+
+def save_end_time():
+    lt = time.localtime()
+    with open(_get_timelog_path(), 'at') as f:
+        f.write("End - {}:{}:{}\n".format(lt.tm_hour, lt.tm_min, lt.tm_sec))
+
+
 if __name__ == "__main__":
     conf = AnacondaLintConfig()
     linter = PocketLinter(conf)
+    save_start_time()
     rc = linter.run()
+    save_end_time()
     sys.exit(rc)


### PR DESCRIPTION
* do not run test under root (all tests were ran as user and then again as sudo)
* add run only nosetests to makefile 
* add run only nosetests to setup-mock-test-env script
* move gui only dependencies to a special category

This will remove `sudo` and `python3-dogtail` from default test dependencies and tests are now almost twice as fast :speedboat:  .