### PR TITLE
UI support for configuring certain mitigations (#1534833)

### DIFF
--- a/pyanaconda/ui/gui/spokes/performance.glade
+++ b/pyanaconda/ui/gui/spokes/performance.glade
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.2 -->
+<interface>
+  <requires lib="gtk+" version="3.6"/>
+  <requires lib="AnacondaWidgets" version="1.0"/>
+  <object class="AnacondaSpokeWindow" id="performanceWindow">
+    <property name="can_focus">False</property>
+    <property name="window_name" translatable="yes">KERNEL &amp; PERFORMANCE</property>
+    <signal name="button-clicked" handler="on_back_clicked" swapped="no"/>
+    <child internal-child="main_box">
+      <object class="GtkBox" id="AnacondaSpokeWindow-main_box1">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+        <child internal-child="nav_box">
+          <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
+            <property name="can_focus">False</property>
+            <child internal-child="nav_area">
+              <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">
+                <property name="can_focus">False</property>
+                <property name="margin_left">6</property>
+                <property name="margin_right">6</property>
+                <property name="margin_top">6</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child internal-child="alignment">
+          <object class="GtkAlignment" id="AnacondaSpokeWindow-alignment1">
+            <property name="can_focus">False</property>
+            <property name="xscale">0</property>
+            <property name="yscale">0.5</property>
+            <property name="top_padding">16</property>
+            <child internal-child="action_area">
+              <object class="GtkBox" id="AnacondaSpokeWindow-action_area1">
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkGrid" id="perfgrid">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="row_spacing">10</property>
+                    <property name="column_spacing">24</property>
+                    <child>
+                      <object class="GtkBox" id="vbox_pti">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">start</property>
+                        <property name="hexpand">True</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">3</property>
+                        <child>
+                          <object class="GtkLabel" id="label_pti">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_top">12</property>
+                            <property name="label">PTI</property>
+                            <property name="ellipsize">end</property>
+                            <property name="xalign">0</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                              <attribute name="scale" value="1.2"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_wired_status">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label">Page Table Isolation</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkAlignment" id="alignment_pti_switch">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
+                        <child>
+                          <object class="GtkSwitch" id="switch_pti">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <property name="active">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="vbox_pti1">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">start</property>
+                        <property name="hexpand">True</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">3</property>
+                        <child>
+                          <object class="GtkLabel" id="label_pti1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_top">12</property>
+                            <property name="label">IBRS</property>
+                            <property name="ellipsize">end</property>
+                            <property name="xalign">0</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                              <attribute name="scale" value="1.2"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_wired_status1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label">Indirect Branch Restricted Speculation</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="vbox_pti2">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">start</property>
+                        <property name="hexpand">True</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">3</property>
+                        <child>
+                          <object class="GtkLabel" id="label_pti2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_top">12</property>
+                            <property name="label">IBPB</property>
+                            <property name="ellipsize">end</property>
+                            <property name="xalign">0</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                              <attribute name="scale" value="1.2"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_wired_status2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label">Indirect Branch Prediction Barriers</property>
+                            <property name="xalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkAlignment" id="alignment_ibrs_switch">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
+                        <child>
+                          <object class="GtkSwitch" id="switch_ibrs">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">start</property>
+                            <property name="active">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkAlignment" id="alignment_ibpb">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
+                        <child>
+                          <object class="GtkSwitch" id="switch_ibpb">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="halign">end</property>
+                            <property name="valign">start</property>
+                            <property name="active">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_pti3">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label">Mitigations</property>
+                        <property name="ellipsize">end</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                          <attribute name="scale" value="1.2"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child internal-child="accessible">
+      <object class="AtkObject" id="performanceWindow-atkobject">
+        <property name="AtkObject::accessible-name" translatable="yes">ROOT PASSWORD</property>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/pyanaconda/ui/gui/spokes/performance.py
+++ b/pyanaconda/ui/gui/spokes/performance.py
@@ -1,0 +1,103 @@
+# performance spoke class
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
+
+from pyanaconda.flags import flags
+from pyanaconda.i18n import _, CN_
+
+from pyanaconda.ui.helpers import find_bootopt_mitigations, set_bootopt_mitigations
+from pyanaconda.ui.gui.spokes import NormalSpoke
+from pyanaconda.ui.categories.system import SystemCategory
+
+import logging
+log = logging.getLogger("anaconda")
+
+__all__ = ["PerformanceSpoke"]
+
+
+class PerformanceSpoke(NormalSpoke):
+    """ The Kernel & Performance spoke provides tunables for
+    certain security mitigations, that are kernel based and
+    might incur a performance penalty.
+    """
+
+    builderObjects = ["performanceWindow"]
+
+    mainWidgetName = "performanceWindow"
+    uiFile = "spokes/performance.glade"
+    helpFile = "PerformanceSpoke.xml"
+
+    category = SystemCategory
+
+    title = CN_("GUI|Spoke", "_KERNEL & PERFORMANCE")
+    icon = "system-run-symbolic"
+
+    def __init__(self, *args):
+        NormalSpoke.__init__(self, *args)
+        self._pti_switch = self.builder.get_object("switch_pti")
+        self._ibrs_switch = self.builder.get_object("switch_ibrs")
+        self._ibpb_switch = self.builder.get_object("switch_ibpb")
+
+    def initialize(self):
+        NormalSpoke.initialize(self)
+        self.initialize_start()
+
+        # some mitigations might be disabled in the input kickstart
+        disabled_mitigations = find_bootopt_mitigations(self.data.bootloader.appendLine)
+
+        # set the switches accordingly
+        self._pti_switch.set_active(not disabled_mitigations.no_pti)
+        self._ibrs_switch.set_active(not disabled_mitigations.no_ibrs)
+        self._ibpb_switch.set_active(not disabled_mitigations.no_ibpb)
+
+        # report that we are done
+        self.initialize_done()
+
+    @property
+    def status(self):
+        # set based on mitigations being turned ON/OFF
+        all_enabled = all([self._pti_switch.get_active(),
+                           self._ibrs_switch.get_active(),
+                           self._ibpb_switch.get_active()])
+        if all_enabled:
+            return _("All mitigations enabled")
+        else:
+            return _("Some mitigations disabled")
+
+    @property
+    def mandatory(self):
+        return False
+
+    def apply(self):
+        # set boot options accordingly
+        opts = set_bootopt_mitigations(opts=self.data.bootloader.appendLine,
+                                       no_pti=not self._pti_switch.get_active(),
+                                       no_ibrs=not self._ibrs_switch.get_active(),
+                                       no_ibpb=not self._ibpb_switch.get_active())
+        self.data.bootloader.appendLine = opts
+
+    @property
+    def completed(self):
+        """Every state of the mitigation options should be valid."""
+        return True
+
+    @property
+    def sensitive(self):
+        return True

--- a/pyanaconda/ui/tui/spokes/performance.py
+++ b/pyanaconda/ui/tui/spokes/performance.py
@@ -1,0 +1,92 @@
+# Performance text spoke
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
+
+
+from pyanaconda import iutil
+
+from pyanaconda.flags import flags
+from pyanaconda.i18n import N_, _
+
+from pyanaconda.ui.helpers import find_bootopt_mitigations, set_bootopt_mitigations
+from pyanaconda.ui.categories.system import SystemCategory
+from pyanaconda.ui.tui.spokes import EditTUISpoke
+from pyanaconda.ui.tui.spokes import EditTUISpokeEntry as Entry
+
+__all__ = ["PerformanceSpoke"]
+
+class PerformanceSpoke(EditTUISpoke):
+    """ The Kernel & performance spoke provides tunables for
+    certain security mitigations, that are kernel based and
+    might incur a performance penalty.
+    """
+    title = N_("Kernel & performance")
+    category = SystemCategory
+
+    edit_fields = [
+        Entry("PTI (Page Table Isolation)", "pti", EditTUISpoke.CHECK, True),
+        Entry("IBRS (Indirect Branch Restricted Speculation)", "ibrs", EditTUISpoke.CHECK, True),
+        Entry("IBPB (Indirect Branch Prediction Barriers)", "ibpb", EditTUISpoke.CHECK, True),
+        ]
+
+    def __init__(self, app, data, storage, payload, instclass):
+        EditTUISpoke.__init__(self, app, data, storage, payload, instclass)
+        self.initialize_start()
+
+        self.args = iutil.DataHolder(pti=True, ibrs=True, ibpb=True)
+
+        # some mitigations might be disabled in the input kickstart
+        disabled_mitigations = find_bootopt_mitigations(self.data.bootloader.appendLine)
+
+        # set the TUI checkboxes accordingly
+        self.args.pti = not disabled_mitigations.no_pti
+        self.args.ibrs = not disabled_mitigations.no_ibrs
+        self.args.ibpb = not disabled_mitigations.no_ibpb
+
+        self.initialize_done()
+
+    @property
+    def completed(self):
+        """Every state of the mitigation options should be valid."""
+        return True
+
+    @property
+    def mandatory(self):
+        return False
+
+    @property
+    def status(self):
+        # set based on mitigations being turned ON/OFF
+        all_enabled = all([self.args.pti, self.args.ibrs, self.args.ibpb])
+        if all_enabled:
+            return _("All mitigations enabled.")
+        else:
+            return _("Some mitigations disabled.")
+
+    def input(self, args, key):
+        return EditTUISpoke.input(self, args, key)
+
+    def apply(self):
+        # set boot options accordingly
+        opts = set_bootopt_mitigations(opts=self.data.bootloader.appendLine,
+                                       no_pti=not self.args.pti,
+                                       no_ibrs=not self.args.ibrs,
+                                       no_ibpb=not self.args.ibpb)
+        self.data.bootloader.appendLine = opts

--- a/tests/pyanaconda_tests/ui_helpers_test.py
+++ b/tests/pyanaconda_tests/ui_helpers_test.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+
+import unittest
+import os
+
+from pyanaconda.ui.helpers import find_bootopt_mitigations, set_bootopt_mitigations
+
+class BootoptMitigationsTests(unittest.TestCase):
+    def find_bootopt_mitigations_test(self):
+        """Check that options for disabling mitigations are detected correctly."""
+
+        # empty string
+        result = find_bootopt_mitigations("")
+        self.assertFalse(result.no_pti)
+        self.assertFalse(result.no_ibrs)
+        self.assertFalse(result.no_ibpb)
+
+        # single mitigation and random other options
+        result = find_bootopt_mitigations("foo nopti bar")
+        self.assertTrue(result.no_pti)
+        self.assertFalse(result.no_ibrs)
+        self.assertFalse(result.no_ibpb)
+
+        # all mitigations set and random other options
+        result = find_bootopt_mitigations("foo nopti bar noibrs noibpb baz")
+        self.assertTrue(result.no_pti)
+        self.assertTrue(result.no_ibrs)
+        self.assertTrue(result.no_ibpb)
+
+    def set_bootopt_mitigations_test(self):
+        """Check that options for disabling mitigations are set correctly."""
+
+        # not disabling any mitigations should not remove or add any options
+        opts = set_bootopt_mitigations("", no_pti=False, no_ibrs=False, no_ibpb=False)
+        self.assertIs(opts, "")
+        opts = set(set_bootopt_mitigations("foo bar", no_pti=False, no_ibrs=False, no_ibpb=False).split(" "))
+        self.assertIn("foo", opts)
+        self.assertIn("bar", opts)
+        self.assertNotIn("nopti", opts)
+        self.assertNotIn("noibrs", opts)
+        self.assertNotIn("noibpb", opts)
+
+        # enable disabled mitigation
+        opts = set(set_bootopt_mitigations("foo nopti bar", no_pti=False, no_ibrs=False, no_ibpb=False).split(" "))
+        self.assertIn("foo", opts)
+        self.assertIn("bar", opts)
+        self.assertNotIn("nopti", opts)
+        self.assertNotIn("noibrs", opts)
+        self.assertNotIn("noibpb", opts)
+
+        # disable already disabled mitigation
+        opts = set(set_bootopt_mitigations("foo noibrs bar", no_pti=False, no_ibrs=True, no_ibpb=False).split(" "))
+        self.assertIn("foo", opts)
+        self.assertIn("bar", opts)
+        self.assertIn("noibrs", opts)
+        self.assertNotIn("nopti", opts)
+        self.assertNotIn("noibpb", opts)
+
+        # enable one disabled mitigation and disable two others
+        opts = set(set_bootopt_mitigations("foo nopti bar", no_pti=False, no_ibrs=True, no_ibpb=True).split(" "))
+        self.assertIn("foo", opts)
+        self.assertIn("bar", opts)
+        self.assertIn("noibrs", opts)
+        self.assertIn("noibpb", opts)
+        self.assertNotIn("nopti", opts)


### PR DESCRIPTION
Add the "KERNEL & PERFORMANCE" spoke to GUI and TUI, which makes
it possible to turn off certain security mitigations.

Mitigations that can currently be turned off:

- PTI
- IBRS
- IBPB

The mechanism is similar to (and compatible with) using the
--append option of the bootloader kickstart command.

If a mitigation is turned off via bootloader --append
(for example with "bootloader --append 'nopti') this
will be reflected in the UI. And turning mitigation on and
off will be reflected in the output kickstart.

Resolves: rhbz#1534833