### PR TITLE
Make sure that fetch_url is defined.

### DIFF
--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -2,6 +2,7 @@
 
 command -v unpack_img >/dev/null || . /lib/img-lib.sh
 command -v getarg >/dev/null || . /lib/dracut-lib.sh
+command -v fetch_url >/dev/null || . /lib/url-lib.sh
 
 # config_get SECTION KEY < FILE
 # read an .ini-style config file, find the KEY in the given SECTION, and return


### PR DESCRIPTION
In some cases, anaconda couldn't fetch the stage2 because of
the unknown command fetch_url. It happened on s390x.