### PR TITLE
Add payload_type attribute to payload classes

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -312,6 +312,7 @@ class Payload(object):
         self.storage = None
         self.instclass = None
         self.txID = None
+        self.payload_type = []
 
         # A list of verbose error strings from the subclass
         self.verbose_errors = []
@@ -955,6 +956,7 @@ class ImagePayload(Payload):
             raise TypeError("ImagePayload is an abstract class")
 
         Payload.__init__(self, data)
+        self.payload_type.append('image')
 
 
 # Inherit abstract methods from ImagePayload
@@ -967,6 +969,7 @@ class ArchivePayload(ImagePayload):
             raise TypeError("ArchivePayload is an abstract class")
 
         ImagePayload.__init__(self, data)
+        self.payload_type.append('archive')
 
 
 class PackagePayload(Payload):
@@ -981,6 +984,7 @@ class PackagePayload(Payload):
         super(PackagePayload, self).__init__(data)
         self.install_device = None
         self._rpm_macros = []
+        self.payload_type.append('package')
 
         # Used to determine which add-ons to display for each environment.
         # The dictionary keys are environment IDs. The dictionary values are two-tuples

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -290,6 +290,7 @@ class DNFPayload(payload.PackagePayload):
     def __init__(self, data):
         payload.PackagePayload.__init__(self, data)
 
+        self.payload_type.append('dnf')
         self._base = None
         self._download_location = None
         self._updates_enabled = True

--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -64,6 +64,7 @@ class LiveImagePayload(ImagePayload):
         self.pct = 0
         self.pct_lock = None
         self.source_size = 1
+        self.payload_type.append('live')
 
         self._kernelVersionList = []
 

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -49,6 +49,7 @@ class RPMOSTreePayload(ArchivePayload):
         super(RPMOSTreePayload, self).__init__(data)
         self._remoteOptions = None
         self._internal_mounts = []
+        self.payload_type.append('rpmostree')
 
     @property
     def handlesBootloaderConfiguration(self):

--- a/pyanaconda/payload/tarpayload.py
+++ b/pyanaconda/payload/tarpayload.py
@@ -50,6 +50,7 @@ class TarPayload(ArchivePayload):
         super(TarPayload, self).__init__(data)
         self.archive = None
         self.image_file = None
+        self.payload_type.append('tar')
 
     def setup(self, storage, instClass):
         super(TarPayload, self).setup(storage, instClass)

--- a/tests/pyanaconda_tests/payload_test.py
+++ b/tests/pyanaconda_tests/payload_test.py
@@ -29,6 +29,10 @@ import shutil
 from pyanaconda.payload.dnfpayload import RepoMDMetaHash
 from pyanaconda.payload import PayloadRequirements, PayloadRequirementsMissingApply
 
+from pyanaconda.payload.dnfpayload import DNFPayload
+from pyanaconda.payload.livepayload import LiveImagePayload
+from pyanaconda.payload.rpmostreepayload import RPMOSTreePayload
+from pyanaconda.payload.tarpayload import TarPayload
 
 class PickLocation(unittest.TestCase):
     def pick_download_location_test(self):
@@ -150,7 +154,28 @@ or it should be. Nah it's just a test!
         os.remove(self._md_file)
         self.assertFalse(r.verify_repoMD())
 
-class  PayloadRequirementsTestCase(unittest.TestCase):
+class PayloadCheckTypeTests(unittest.TestCase):
+    def test_for_dnf_payload_type(self):
+        """Test that the dnf payload_type is defined correctly"""
+        p = DNFPayload(data=None)
+        self.assertIn(p.payload_type, 'dnf')
+
+    def test_for_live_payload_type(self):
+        """Test that the live payload_type is defined correctly"""
+        p = LiveImagePayload(data=None)
+        self.assertIn(p.payload_type, 'live')
+
+    def test_for_rpmostree_payload_type(self):
+        """Test that the rpmostree payload_type is defined correctly"""
+        p = RPMOSTreePayload(data=None)
+        self.assertIn(p.payload_type, 'rpmostree')
+
+    def test_for_tar_payload_type(self):
+        """Test that the tar payload_type is defined correctly"""
+        p = TarPayload(data=None)
+        self.assertIn(p.payload_type, 'tar')
+
+class PayloadRequirementsTestCase(unittest.TestCase):
 
     def requirements_test(self):
         """Check that requirements work correctly."""


### PR DESCRIPTION
For the addons I'm developing, it would be very helpful to have a simple attribute to check the payload type.

What I'm playing with right now only applies to 'dnf' and 'live' payloads.  I didn't find any clean ways to check the install type of the system so this adds attributes and tests.