### PR TITLE
For EL rebuilds, users often want EPEL this permits a clean way to add it

### DIFF
--- a/pyanaconda/installclasses/scientific.py
+++ b/pyanaconda/installclasses/scientific.py
@@ -16,7 +16,9 @@
 #
 
 from pyanaconda.installclasses.rhel import RHELBaseInstallClass
-from pyanaconda.product import productName
+from pyanaconda.kickstart import RepoData
+from pyanaconda.product import productName, productVersion, productArch
+from pyanaconda.payload import PackagePayload
 
 __all__ = ["ScientificBaseInstallClass"]
 
@@ -34,10 +36,19 @@ class ScientificBaseInstallClass(RHELBaseInstallClass):
 
     installUpdates = True
 
-    efi_dir = "scientific"
-
     help_placeholder = "SLPlaceholder.html"
     help_placeholder_with_links = "SLPlaceholder.html"
 
-    def __init__(self):
-        RHELBaseInstallClass.__init__(self)
+    def configurePayload(self, payload):  # pylint: disable=line-too-long
+        '''
+            Load SL specific payload repos
+        '''
+        if isinstance(payload, PackagePayload):
+            major_version = productVersion.replace('rolling','').split('.')[0]
+
+            # A number of users like EPEL, seed it disabled
+            payload.addDisabledRepo(RepoData(name='epel', metalink="https://mirrors.fedoraproject.org/metalink?repo=epel-"+major_version+"&arch="+productArch))
+            # ELRepo provides handy hardware drivers, seed it disabled
+            payload.addDisabledRepo(RepoData(name='elrepo', mirrorlist="http://mirrors.elrepo.org/mirrors-elrepo.el"+major_version))
+
+        super().configurePayload(payload)

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1877,6 +1877,13 @@ class RepoData(commands.repo.F27_RepoData):
 
         super().__init__(*args, **kwargs)
 
+    def __str__(self):
+        """Don't output disabled repos"""
+        if self.enabled:
+            return super().__str__()
+        else:
+            return ''
+
 class ReqPart(commands.reqpart.F23_ReqPart):
     def execute(self, storage, ksdata, instClass):
         if not self.reqpart:

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -389,6 +389,26 @@ class Payload(object):
         """
         return True
 
+    @property
+    def disabledRepos(self):
+        """A list of disabled repos."""
+        disabled = []
+        for repo in self.addOns:
+            if not self.isRepoEnabled(repo):
+                disabled.append(repo)
+
+        return disabled
+
+    @property
+    def enabledRepos(self):
+        """A list of enabled repos."""
+        enabled = []
+        for repo in self.addOns:
+            if self.isRepoEnabled(repo):
+                enabled.append(repo)
+
+        return enabled
+
     def isRepoEnabled(self, repo_id):
         """Return True if repo is enabled."""
         repo = self.getAddOnRepo(repo_id)
@@ -469,6 +489,17 @@ class Payload(object):
         take the place of the previous value.
         """
         # Add the repo to the ksdata so it'll appear in the output ks file.
+        ksrepo.enabled = True
+        self.data.repo.dataList().append(ksrepo)
+
+    def addDisabledRepo(self, ksrepo):
+        """Add the repo given by the pykickstart Repo object ksrepo to the
+        system.
+
+        Duplicate repos will not raise an error.  They should just silently
+        take the place of the previous value.
+        """
+        ksrepo.enabled = False
         self.data.repo.dataList().append(ksrepo)
 
     def removeRepo(self, repo_id):

--- a/tests/nosetests/pyanaconda_tests/installclass_test.py
+++ b/tests/nosetests/pyanaconda_tests/installclass_test.py
@@ -206,6 +206,7 @@ class Installclass_AttribsTestCase(unittest.TestCase):
         self.assertTrue(hasattr(testclass, 'defaultPackageEnvironment'))
         self.assertTrue(hasattr(testclass, 'setup_on_boot'))
         self.assertTrue(hasattr(testclass, 'use_geolocation_with_kickstart'))
+        self.assertTrue(hasattr(testclass, 'configurePayload'))
 
 
 class F27_Installclass_TestCase(unittest.TestCase):


### PR DESCRIPTION
Hello,

From the Scientific Linux side, we'd like to add EPEL to the list of disabled additional software repos.

It shouldn't be enabled by default, but it is something a lot of our users utilize.

This code adds a place within the InstallClass were distribution owners can add 3rd party repos they believe their community may desire.

This may also be helpful for pre-seeding the CentOS folks.  They could use this to add some of their most popular SIGs to the list.