### PR TITLE
Authconfig is replaced with authselect (#1542968)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -27,7 +27,6 @@ Source0: %{name}-%{version}.tar.bz2
 %define dnfver 2.2.0
 %define dracutver 034-7
 %define fcoeutilsver 1.0.12-3.20100323git
-%define firewalldver 0.3.5-1
 %define gettextver 0.19.8
 %define gtk3ver 3.22.17
 %define helpver 22.1-1
@@ -106,9 +105,6 @@ Requires: python3-requests-ftp
 Requires: python3-kickstart >= %{pykickstartver}
 Requires: langtable-data >= %{langtablever}
 Requires: langtable-python3 >= %{langtablever}
-Requires: authselect
-Requires: authselect-compat
-Requires: firewalld >= %{firewalldver}
 Requires: util-linux >= %{utillinuxver}
 Requires: python3-gobject-base
 Requires: python3-dbus

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -106,7 +106,8 @@ Requires: python3-requests-ftp
 Requires: python3-kickstart >= %{pykickstartver}
 Requires: langtable-data >= %{langtablever}
 Requires: langtable-python3 >= %{langtablever}
-Requires: authconfig
+Requires: authselect
+Requires: authselect-compat
 Requires: firewalld >= %{firewalldver}
 Requires: util-linux >= %{utillinuxver}
 Requires: python3-gobject-base

--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -1,6 +1,5 @@
 # Kickstart defaults file for an interative install.
 # This is not loaded if a kickstart file is provided on the command line.
-auth --enableshadow --passalgo=sha512
 firstboot --enable
 
 %anaconda

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -82,7 +82,7 @@ def doConfiguration(storage, payload, ksdata, instClass):
 
     # schedule the execute methods of ksdata that require an installed system to be present
     os_config = TaskQueue("Installed system configuration", N_("Configuring installed system"))
-    os_config.append(Task("Configure authconfig", ksdata.authconfig.execute, (storage, ksdata, instClass)))
+    os_config.append(Task("Configure authselect", ksdata.authselect.execute, (storage, ksdata, instClass)))
     os_config.append(Task("Configure SELinux", ksdata.selinux.execute, (storage, ksdata, instClass)))
     os_config.append(Task("Configure first boot tasks", ksdata.firstboot.execute, (storage, ksdata, instClass)))
     os_config.append(Task("Configure services", ksdata.services.execute, (storage, ksdata, instClass)))
@@ -289,7 +289,7 @@ def doInstall(storage, payload, ksdata, instClass):
 
     # Check for other possibly needed additional packages.
     pre_install = TaskQueue("Pre install tasks", N_("Running pre-installation tasks"))
-    pre_install.append(Task("Setup authconfig", ksdata.authconfig.setup))
+    pre_install.append(Task("Setup authselect", ksdata.authselect.setup))
     pre_install.append(Task("Setup firewall", ksdata.firewall.setup))
     pre_install.append(Task("Setup network", ksdata.network.setup))
     # Setup timezone and add chrony as package if timezone was set in KS
@@ -309,7 +309,7 @@ def doInstall(storage, payload, ksdata, instClass):
         # to finish setting up the system.
         payload.requirements.add_packages(storage.packages, reason="storage")
         payload.requirements.add_packages(ksdata.realm.packages, reason="realm")
-        payload.requirements.add_packages(ksdata.authconfig.packages, reason="authconfig")
+        payload.requirements.add_packages(ksdata.authselect.packages, reason="authselect")
         payload.requirements.add_packages(ksdata.firewall.packages, reason="firewall")
         payload.requirements.add_packages(ksdata.network.packages, reason="network")
         payload.requirements.add_packages(ksdata.timezone.packages, reason="ntp", strong=False)

--- a/pyanaconda/users.py
+++ b/pyanaconda/users.py
@@ -33,18 +33,6 @@ import re
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
-def getPassAlgo(authconfigStr):
-    """ Reads the auth string and returns a string indicating our desired
-        password encoding algorithm.
-    """
-    if authconfigStr.find("--enablemd5") != -1 or authconfigStr.find("--passalgo=md5") != -1:
-        return 'md5'
-    elif authconfigStr.find("--passalgo=sha256") != -1:
-        return 'sha256'
-    elif authconfigStr.find("--passalgo=sha512") != -1:
-        return 'sha512'
-    else:
-        return None
 
 def cryptPassword(password, algo=None):
     salts = {'md5': crypt.METHOD_MD5,

--- a/tests/pyanaconda_tests/kickstart_dispatcher.py
+++ b/tests/pyanaconda_tests/kickstart_dispatcher.py
@@ -44,7 +44,6 @@ keyboard --vckeymap=us --xlayouts='us'
 rootpw --plaintext chrchl
 selinux --enforcing
 firstboot --disable
-authconfig --passalgo=sha512 --enableshadow
 timezone --utc Asia/Tokyo
 
 network --device ens3
@@ -129,7 +128,6 @@ keyboard --vckeymap=us --xlayouts='us'
 rootpw --plaintext chrchl
 selinux --enforcing
 firstboot --disable
-authconfig --passalgo=sha512 --enableshadow
 timezone --utc Asia/Tokyo
 network --device ens3
 network --device ens4 --activate

--- a/tests/pyanaconda_tests/kickstart_manager.py
+++ b/tests/pyanaconda_tests/kickstart_manager.py
@@ -37,7 +37,6 @@ keyboard --vckeymap=us --xlayouts='us'
 rootpw --plaintext chrchl
 selinux --enforcing
 firstboot --disable
-authconfig --passalgo=sha512 --enableshadow
 timezone --utc Asia/Tokyo
 
 network --device ens3
@@ -146,7 +145,6 @@ keyboard --vckeymap=us --xlayouts='us'
 rootpw --plaintext chrchl
 selinux --enforcing
 firstboot --disable
-authconfig --passalgo=sha512 --enableshadow
 timezone --utc Asia/Tokyo
 repo --name=repo1 --baseurl=http://bla.bla/repo1
 %post --nochroot --interpreter /usr/bin/bash

--- a/tests/pyanaconda_tests/ks_version_test.py
+++ b/tests/pyanaconda_tests/ks_version_test.py
@@ -27,8 +27,6 @@ class CommandVersionTestCase(unittest.TestCase):
 
     # Names of the kickstart commands and data that should be temporarily ignored.
     IGNORED_NAMES = {
-        "auth",
-        "authconfig",
     }
 
     def assert_compare_versions(self, children, parents):


### PR DESCRIPTION
Authconfig is deprecated, so anaconda will run authselect instead.
If a kickstart file specifies the authconfig command, anaconda will
run authconfig-compat with given authconfig arguments for the backward
compatibility.

The --passalgo and --enableshadow options are not supported by
authselect.

Resolves: rhbz#1542968

**Depends on:** 
https://github.com/pbrezina/authselect/pull/36
https://github.com/pbrezina/authselect/issues/30
https://github.com/clumens/pykickstart/pull/209