### PR TITLE
Fix mitigation toggling with kickstart

### DIFF
--- a/pyanaconda/ui/gui/spokes/performance.py
+++ b/pyanaconda/ui/gui/spokes/performance.py
@@ -92,6 +92,26 @@ class PerformanceSpoke(NormalSpoke):
                                        no_ibpb=not self._ibpb_switch.get_active())
         self.data.bootloader.appendLine = opts
 
+        # We need to make sure the options are applied here as the execute()
+        # method of the bootloader command might not be called again after user
+        # has exited this spoke.
+
+        # PTI
+        if self._pti_switch.get_active():
+            self.storage.bootloader.boot_args.discard("nopti")
+        else:
+            self.storage.bootloader.boot_args.update(["nopti"])
+        # IBRS
+        if self._ibrs_switch.get_active():
+            self.storage.bootloader.boot_args.discard("noibrs")
+        else:
+            self.storage.bootloader.boot_args.update(["noibrs"])
+        # IBPB
+        if self._ibpb_switch.get_active():
+            self.storage.bootloader.boot_args.discard("noibpb")
+        else:
+            self.storage.bootloader.boot_args.update(["noibpb"])
+
     @property
     def completed(self):
         """Every state of the mitigation options should be valid."""

--- a/pyanaconda/ui/tui/spokes/performance.py
+++ b/pyanaconda/ui/tui/spokes/performance.py
@@ -89,3 +89,23 @@ class PerformanceSpoke(EditTUISpoke):
                                        no_ibrs=not self.args.ibrs,
                                        no_ibpb=not self.args.ibpb)
         self.data.bootloader.appendLine = opts
+
+        # We need to make sure the options are applied here as the execute()
+        # method of the bootloader command might not be called again after user
+        # has exited this spoke.
+
+        # PTI
+        if self.args.pti:
+            self.storage.bootloader.boot_args.discard("nopti")
+        else:
+            self.storage.bootloader.boot_args.update(["nopti"])
+        # IBRS
+        if self.args.ibrs:
+            self.storage.bootloader.boot_args.discard("noibrs")
+        else:
+            self.storage.bootloader.boot_args.update(["noibrs"])
+        # IBPB
+        if self.args.ibpb:
+            self.storage.bootloader.boot_args.discard("noibpb")
+        else:
+            self.storage.bootloader.boot_args.update(["noibpb"])


### PR DESCRIPTION
It turns out that we can't depend for the execute()
method of the bootloader command to be executed
at the start of the installation phase. Whilte it's
called at start of a fully interactive installation,
it's called very early on (at spoke initialization)
during partial kickstart installation and then not
called again.

So instead, make sure the apply the mitigation options
eac time user exists the spoke via the spoke apply() method.

Related: rhbz#1534833