### PR TITLE
Use the KickstartHandler class

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -37,7 +37,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define mehver 0.23-1
 %define nmver 1.0
 %define partedver 1.8.1
-%define pykickstartver 3.10-1
+%define pykickstartver 3.12-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 0.8-1

--- a/pyanaconda/modules/bar/bar_kickstart.py
+++ b/pyanaconda/modules/bar/bar_kickstart.py
@@ -18,6 +18,7 @@
 # Red Hat, Inc.
 #
 from pykickstart.commands.user import F19_User, F19_UserData
+from pykickstart.parser import Packages
 from pykickstart.sections import PackageSection
 from pykickstart.version import F28
 
@@ -32,10 +33,14 @@ class BarKickstartSpecification(KickstartSpecification):
         "user": F19_User,
     }
 
-    data = {
+    commands_data = {
         "UserData": F19_UserData,
     }
 
     sections = {
         "packages": PackageSection
+    }
+
+    sections_data = {
+        "packages": Packages
     }

--- a/pyanaconda/modules/base.py
+++ b/pyanaconda/modules/base.py
@@ -26,8 +26,8 @@ from pyanaconda.core.timer import Timer
 from pyanaconda.dbus import DBus
 from pyanaconda.task import publish_task
 from pyanaconda.core.signal import Signal
-from pyanaconda.modules.base_kickstart import get_kickstart_handler, get_kickstart_parser
-from pyanaconda.modules.base_kickstart import NoKickstartSpecification
+from pyanaconda.modules.base_kickstart import NoKickstartSpecification, \
+    KickstartSpecificationHandler, KickstartSpecificationParser
 
 from pyanaconda import anaconda_logging
 log = anaconda_logging.get_dbus_module_logger(__name__)
@@ -148,9 +148,20 @@ class KickstartModule(BaseModule):
         self._kickstarted = value
         self.kickstarted_changed.emit()
 
-    def get_kickstart_data(self):
-        """Get an empty kickstart data."""
-        return get_kickstart_handler(self.kickstart_specification)
+    def get_kickstart_handler(self):
+        """Return a kickstart handler.
+
+        :return: a kickstart handler
+        """
+        return KickstartSpecificationHandler(self.kickstart_specification)
+
+    def get_kickstart_parser(self, handler):
+        """Return a kickstart parser.
+
+        :param handler: a kickstart handler
+        :return: a kickstart parser
+        """
+        return KickstartSpecificationParser(handler, self.kickstart_specification)
 
     def read_kickstart(self, s):
         """Read the given kickstart string.
@@ -161,9 +172,8 @@ class KickstartModule(BaseModule):
         :param s: a kickstart string
         :raises: instances of KickstartError
         """
-        spec = self.kickstart_specification
-        handler = get_kickstart_handler(spec)
-        parser = get_kickstart_parser(handler, spec)
+        handler = self.get_kickstart_handler()
+        parser = self.get_kickstart_parser(handler)
 
         parser.readKickstartFromString(s)
         self.process_kickstart(handler)

--- a/pyanaconda/modules/timezone/timezone.py
+++ b/pyanaconda/modules/timezone/timezone.py
@@ -64,7 +64,7 @@ class TimezoneModule(KickstartModule):
 
     def generate_kickstart(self):
         """Return the kickstart string."""
-        data = self.get_kickstart_data()
+        data = self.get_kickstart_handler()
         data.timezone.timezone = self.timezone
         data.timezone.isUtc = self.is_utc
         data.timezone.nontp = not self.ntp_enabled

--- a/tests/pyanaconda_tests/module_timezone_test.py
+++ b/tests/pyanaconda_tests/module_timezone_test.py
@@ -90,7 +90,6 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         timezone Europe/Prague
         """
         ks_out = """
-        #version=DEVEL
         # System timezone
         timezone Europe/Prague
         """
@@ -102,7 +101,6 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         timezone --utc --nontp Europe/Prague
         """
         ks_out = """
-        #version=DEVEL
         # System timezone
         timezone Europe/Prague --isUtc --nontp
         """
@@ -114,7 +112,6 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         timezone --ntpservers ntp.cesnet.cz Europe/Prague
         """
         ks_out = """
-        #version=DEVEL
         # System timezone
         timezone Europe/Prague --ntpservers=ntp.cesnet.cz
         """


### PR DESCRIPTION
We can use the empty kickstart handler provided by pykickstart now.
this should fix the problem with extra `#version` comments in the final
kickstart file.

Since the kickstart handler doesn't hold any sections data by default,
they can be specified in the `sections_data` attribute of the
kickstart specification.

Kickstart modules can also provide their own kickstart handler and
parser if necessary.

**Depends on:** https://github.com/clumens/pykickstart/pull/211