### PR TITLE
Prevent anaconda-core requiring gjs-console

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -1,5 +1,9 @@
 %define livearches %{ix86} x86_64 ppc ppc64 ppc64le
 
+# Avoid anaconda-core requiring gjs-console due to the GNOME welcome
+# screen that's shipped in it
+%global __requires_exclude_from ^%{_datadir}/anaconda/gnome/fedora-welcome.*$
+
 Summary: Graphical system installer
 Name:    anaconda
 Version: @PACKAGE_VERSION@
@@ -346,6 +350,9 @@ update-desktop-database &> /dev/null || :
 - Separate grab-logs from ci target in Makefile (jkonecny)
 - Remove false positive but disable Pylint in makeupdates script (jkonecny)
 - Add copyright to scripts in ./scripts/testing (jkonecny)
+
+* Thu Feb 15 2018 Adam Williamson <awilliam@redhat.com> - 28.20-2
+- Prevent anaconda-core requiring gjs-console (awilliam)
 
 * Fri Feb 09 2018 Martin Kolman <mkolman@redhat.com> - 28.20-1
 - Check the proxy attribute before accessing it (vponcova)


### PR DESCRIPTION
Between 28.18-1 and 28.19-1, anaconda-core suddenly grew a
dependency on /usr/bin/gjs-console. This is ultimately due to
this change:
https://pagure.io/packaging-committee/issue/738
That thingy mungs the shebang in fedora-welcome.js from
/usr/bin/env gjs-console to /usr/bin/gjs-console, which in turn
causes RPM's automatic dependency code to make anaconda-core
depend on /usr/bin/gjs-console .

In a sense this is 'correct', but it's clearly problematic,
because it means we wind up depending on gjs (and gtk3!) in
all sorts of cases where we don't want to. This breaks stuff,
for instance arm minimal disk image composes. Ultimately perhaps
the GNOME welcome screen should be split out from anaconda-core,
but for now this will fix things up.

I have already made this change in dist-git and sent out the
28.20-2 build to Rawhide.

Signed-off-by: Adam Williamson <awilliam@redhat.com>