### PR TITLE
Only show Kernel & performance spoke on x86

### DIFF
--- a/pyanaconda/ui/gui/spokes/performance.py
+++ b/pyanaconda/ui/gui/spokes/performance.py
@@ -19,6 +19,8 @@
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 #
 
+import blivet
+
 from pyanaconda.i18n import _, CN_
 
 from pyanaconda.ui.helpers import find_bootopt_mitigations, set_bootopt_mitigations
@@ -47,6 +49,11 @@ class PerformanceSpoke(NormalSpoke):
 
     title = CN_("GUI|Spoke", "_KERNEL & PERFORMANCE")
     icon = "system-run-symbolic"
+
+    @classmethod
+    def should_run(cls, environment, data):
+        # The Kernel and performance spoke should run just on x86_64 for now.
+        return blivet.arch.isX86()
 
     def __init__(self, *args):
         NormalSpoke.__init__(self, *args)

--- a/pyanaconda/ui/tui/spokes/performance.py
+++ b/pyanaconda/ui/tui/spokes/performance.py
@@ -19,6 +19,7 @@
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 #
 
+import blivet
 
 from pyanaconda import iutil
 
@@ -44,6 +45,11 @@ class PerformanceSpoke(EditTUISpoke):
         Entry("IBRS (Indirect Branch Restricted Speculation)", "ibrs", EditTUISpoke.CHECK, True),
         Entry("IBPB (Indirect Branch Prediction Barriers)", "ibpb", EditTUISpoke.CHECK, True),
         ]
+
+    @classmethod
+    def should_run(cls, environment, data):
+        # The Kernel and performance spoke should run just on x86_64 for now.
+        return blivet.arch.isX86()
 
     def __init__(self, app, data, storage, payload, instclass):
         EditTUISpoke.__init__(self, app, data, storage, payload, instclass)


### PR DESCRIPTION
The kernel and performance spoke provides options to turn
of the following mitigations: KPI, IBRS and IBPB.

Unfortunately it turns out these options are not generally available
on non-x86 RHEL 7 architectures.

So only show the Kernel and performance spoke on x86 and hide it on
all other architectures.

Related: rhbz#1534833