### PR TITLE
Use the KickstartError attributes

### DIFF
--- a/pyanaconda/modules/base_interface.py
+++ b/pyanaconda/modules/base_interface.py
@@ -95,12 +95,10 @@ class KickstartModuleInterface(AdvancedInterfaceTemplate):
         try:
             self.implementation.read_kickstart(kickstart)
         except KickstartError as e:
-            # FIXME: We should return a real line number.
-            # We are waiting for a support from pykickstart.
             return {
                 "success": get_variant(Bool, False),
-                "error_message": get_variant(Str, str(e)),
-                "line_number": get_variant(Int, 1)
+                "error_message": get_variant(Str, str(e.message)),
+                "line_number": get_variant(Int, e.lineno)
             }
 
         return {"success": get_variant(Bool, True)}

--- a/pyanaconda/pwpolicy.py
+++ b/pyanaconda/pwpolicy.py
@@ -18,7 +18,7 @@
 # with the express permission of Red Hat, Inc.
 #
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 from pykickstart.version import F22
 
@@ -140,7 +140,7 @@ class F22_PwPolicy(KickstartCommand):
     def parse(self, args):
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
         if len(extra) != 1:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("policy name required for %s") % "pwpolicy"))
+            raise KickstartParseError(lineno=self.lineno, msg=_("policy name required for %s") % "pwpolicy")
 
         pd = self.handler.PwPolicyData()
         self.set_to_obj(ns, pd)


### PR DESCRIPTION
The kickstart modules are able to return the correct line number and
the original error message about an error in the parsed kickstart
file. It means that we are able to show correct error messages to the
user now.

The function formatErrorMsg from pykickstart is deprecated.

**Depends on:** https://github.com/clumens/pykickstart/pull/212