### PR TITLE
Fix the network module specification

### DIFF
--- a/pyanaconda/modules/network/network_kickstart.py
+++ b/pyanaconda/modules/network/network_kickstart.py
@@ -28,6 +28,6 @@ class NetworkKickstartSpecification(KickstartSpecification):
     commands = {
         "network": F27_Network,
     }
-    data = {
+    commands_data = {
         "NetworkData": F27_NetworkData,
     }

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -18,10 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import gi
-
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH
-
 gi.require_version("NM", "1.0")
 
 from gi.repository import NM
@@ -50,7 +46,8 @@ from pyanaconda.core.i18n import _
 from pyanaconda.core.regexes import HOSTNAME_PATTERN_WITHOUT_ANCHORS, IBFT_CONFIGURED_DEVICE_NAME
 from pykickstart.constants import BIND_TO_MAC
 from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_NETWORK_NAME, MODULE_NETWORK_PATH
+from pyanaconda.dbus.constants import MODULE_NETWORK_NAME, MODULE_NETWORK_PATH, \
+    MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH
 
 from pyanaconda.anaconda_loggers import get_module_logger, get_ifcfg_logger
 log = get_module_logger(__name__)

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -352,9 +352,9 @@ def copyUpdatedFiles(tag, updates, cwd, builddir):
         elif gitfile.startswith("data/dbus"):
             # add DBUS service and config files
             if gitfile.endswith(".service"):
-                install_to_dir(gitfile, "usr/share/dbus-1/system-services")
+                install_to_dir(gitfile, "usr/share/dbus-1/services")
             elif gitfile.endswith(".conf"):
-                install_to_dir(gitfile, "etc/dbus-1/system.d")
+                install_to_dir(gitfile, "etc/dbus-1/session.d")
         elif gitfile.find('/') != -1:
             fields = gitfile.split('/')
             subdir = fields[0]


### PR DESCRIPTION
The specification should specify the `commands_data` attribute instead
of `data`, otherwise it fails to parse the network command.