### PR TITLE
 Fix logging of the DBus modules 

### DIFF
--- a/pyanaconda/anaconda_logging.py
+++ b/pyanaconda/anaconda_logging.py
@@ -86,19 +86,6 @@ def forwardToJournal(logr, log_formatter=None, log_filter=None):
         journal_handler.setFormatter(log_formatter)
     logr.addHandler(journal_handler)
 
-def get_dbus_module_logger(name):
-    """Return logger for a dbus module with correctly setup logging.
-
-    Each DBUS module runs in a separate process, so we need to setup
-    logging for each module separately.
-    """
-    logging.basicConfig(level=logging.DEBUG)
-    dbus_module_logger = logging.getLogger(name)
-    forwardToJournal(dbus_module_logger,
-                     log_filter=AnacondaPrefixFilter(),
-                     log_formatter=logging.Formatter(ANACONDA_SYSLOG_FORMAT))
-    return dbus_module_logger
-
 
 class _AnacondaLogFixer(object):
     """ A mixin for logging.StreamHandler that does not lock during format.

--- a/pyanaconda/dbus/launcher.py
+++ b/pyanaconda/dbus/launcher.py
@@ -69,7 +69,8 @@ def start_dbus_session():
     if is_dbus_session_running():
         return False
 
-    address = execWithCapture(DBUS_LAUNCH_BIN, ["--session", "--print-address", "--fork"],
+    address = execWithCapture(DBUS_LAUNCH_BIN,
+                              ["--session", "--print-address", "--fork", "--syslog"],
                               filter_stderr=True)
 
     if not address:

--- a/pyanaconda/dbus_addons/baz/__main__.py
+++ b/pyanaconda/dbus_addons/baz/__main__.py
@@ -1,3 +1,6 @@
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
 from pyanaconda.dbus_addons.baz.baz import Baz
 
 baz = Baz()

--- a/pyanaconda/dbus_addons/baz/baz.py
+++ b/pyanaconda/dbus_addons/baz/baz.py
@@ -22,8 +22,8 @@ from pyanaconda.dbus.constants import ADDON_BAZ_NAME, ADDON_BAZ_PATH
 from pyanaconda.dbus_addons.baz.baz_interface import BazInterface
 from pyanaconda.modules.base import KickstartModule
 
-from pyanaconda import anaconda_logging
-log = anaconda_logging.get_dbus_module_logger(__name__)
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
 
 
 class Baz(KickstartModule):

--- a/pyanaconda/modules/bar/__main__.py
+++ b/pyanaconda/modules/bar/__main__.py
@@ -1,3 +1,6 @@
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
 from pyanaconda.modules.bar.bar import Bar
 
 bar = Bar()

--- a/pyanaconda/modules/bar/bar.py
+++ b/pyanaconda/modules/bar/bar.py
@@ -26,8 +26,8 @@ from pyanaconda.modules.base import KickstartModule
 from pyanaconda.modules.bar.bar_interface import BarInterface
 from pyanaconda.modules.bar.tasks.bar_task import BarTask
 
-from pyanaconda import anaconda_logging
-log = anaconda_logging.get_dbus_module_logger(__name__)
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
 
 
 class Bar(KickstartModule):

--- a/pyanaconda/modules/base.py
+++ b/pyanaconda/modules/base.py
@@ -29,8 +29,8 @@ from pyanaconda.core.signal import Signal
 from pyanaconda.modules.base_kickstart import NoKickstartSpecification, \
     KickstartSpecificationHandler, KickstartSpecificationParser
 
-from pyanaconda import anaconda_logging
-log = anaconda_logging.get_dbus_module_logger(__name__)
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
 
 
 class BaseModule(ABC):

--- a/pyanaconda/modules/boss/__main__.py
+++ b/pyanaconda/modules/boss/__main__.py
@@ -1,3 +1,6 @@
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
 from pyanaconda.modules.boss.boss import Boss
 
 # instantiate the Boss class

--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -28,8 +28,8 @@ from pyanaconda.modules.boss.install_manager.installation_interface import Insta
 from pyanaconda.modules.boss.install_manager.install_manager import InstallManager
 from pyanaconda.modules.boss.kickstart_manager import KickstartManager
 
-from pyanaconda import anaconda_logging
-log = anaconda_logging.get_dbus_module_logger(__name__)
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
 
 
 class Boss(BaseModule):

--- a/pyanaconda/modules/boss/install_manager/install_manager.py
+++ b/pyanaconda/modules/boss/install_manager/install_manager.py
@@ -21,8 +21,8 @@ from pyanaconda.core.signal import Signal
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.boss.install_manager.installation_interface import InstallationNotRunning
 
-from pyanaconda import anaconda_logging
-log = anaconda_logging.get_dbus_module_logger(__name__)
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
 
 TASK_NAME = 0
 TASK_PATH = 1

--- a/pyanaconda/modules/foo/__main__.py
+++ b/pyanaconda/modules/foo/__main__.py
@@ -1,3 +1,6 @@
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
 from pyanaconda.modules.foo.foo import Foo
 
 foo = Foo()

--- a/pyanaconda/modules/foo/foo.py
+++ b/pyanaconda/modules/foo/foo.py
@@ -23,8 +23,8 @@ from pyanaconda.modules.base import KickstartModule
 from pyanaconda.modules.foo.foo_interface import FooInterface
 from pyanaconda.modules.foo.tasks.foo_task import FooTask
 
-from pyanaconda import anaconda_logging
-log = anaconda_logging.get_dbus_module_logger(__name__)
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
 
 
 class Foo(KickstartModule):

--- a/pyanaconda/modules/network/__main__.py
+++ b/pyanaconda/modules/network/__main__.py
@@ -1,3 +1,6 @@
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
 from pyanaconda.modules.network.network import NetworkModule
 
 network_module = NetworkModule()

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -29,8 +29,9 @@ from pyanaconda.modules.network.network_kickstart import NetworkKickstartSpecifi
 HOSTNAME_SERVICE = "org.freedesktop.hostname1"
 HOSTNAME_PATH = "/org/freedesktop/hostname1"
 
-from pyanaconda import anaconda_logging
-log = anaconda_logging.get_dbus_module_logger(__name__)
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
 
 class NetworkModule(KickstartModule):
     """The Network module."""

--- a/pyanaconda/modules/timezone/__main__.py
+++ b/pyanaconda/modules/timezone/__main__.py
@@ -1,3 +1,6 @@
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
 from pyanaconda.modules.timezone.timezone import TimezoneModule
 
 timezone_module = TimezoneModule()

--- a/pyanaconda/modules/timezone/timezone.py
+++ b/pyanaconda/modules/timezone/timezone.py
@@ -24,8 +24,8 @@ from pyanaconda.modules.base import KickstartModule
 from pyanaconda.modules.timezone.timezone_interface import TimezoneInterface
 from pyanaconda.modules.timezone.timezone_kickstart import TimezoneKickstartSpecification
 
-from pyanaconda import anaconda_logging
-log = anaconda_logging.get_dbus_module_logger(__name__)
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
 
 
 class TimezoneModule(KickstartModule):


### PR DESCRIPTION
Force the message bus to use the system log for messages with the
`--syslog` option. We don't have to set up the loggers for that.

This will not work if the session bus is already running, but we will
move to our own bus anyway.

It doesn't make sense to use special loggers for the DBus modules,
because they import pyanaconda modules that use usual loggers anyway.
If we want to set up logging in DBus modules, we should do that in
the `__main__` files.

We want all levels of logs from the DBus modules for now.