### PR TITLE
Add support for different message buses

### DIFF
--- a/pyanaconda/dbus/connection.py
+++ b/pyanaconda/dbus/connection.py
@@ -1,0 +1,198 @@
+#
+# Representation of DBus connection.
+#
+# Copyright (C) 2018  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+import os
+from abc import ABC, abstractmethod
+
+import pydbus
+
+from pyanaconda.dbus.constants import DBUS_SESSION_ADDRESS, DBUS_STARTER_ADDRESS
+from pyanaconda.dbus.observer import DBusObjectObserver, DBusCachedObserver
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+__all__ = ["Connection", "DBusConnection", "DBusSystemConnection",
+           "DBusSessionConnection", "DBusDefaultConnection", ]
+
+
+class Connection(ABC):
+    """Abstract class to represent a bus connection.
+
+    It will connect to a bus returned by the get_new_connection method.
+
+    The property connection represents a connection to the bus. You can
+    register a service name with register_service, or publish an object
+    with publish_object and get a proxy of a remote object with get_proxy.
+    """
+
+    def __init__(self):
+        self._connection = None
+        self._service_registrations = []
+        self._object_registrations = []
+
+    @property
+    def connection(self):
+        """Returns a DBus connection."""
+        if not self._connection:
+            self._connection = self.get_new_connection()
+
+        return self._connection
+
+    @abstractmethod
+    def get_new_connection(self):
+        """Get a DBus connection.
+
+        You shouldn't create new connections unless there is a good
+        reason for it. Use DBus.connection instead.
+        """
+        pass
+
+    def register_service(self, service_name):
+        """Register a service on DBus.
+
+        A service can be registered by requesting its name on DBus.
+        This method should be called only after all of the required
+        objects of the service are published on DBus.
+
+        :param service_name: a DBus name of a service
+        """
+        log.debug("Registering a service name %s.", service_name)
+        reg = self.connection.request_name(service_name,
+                                           allow_replacement=True,
+                                           replace=False)
+        self._service_registrations.append(reg)
+
+    def publish_object(self, obj, object_path):
+        """Publish an object on DBus.
+
+        :param obj: an instance of @dbus_interface or @dbus_class
+        :param object_path: a DBus path of an object
+        """
+        log.debug("Publishing an object at %s.", object_path)
+        reg = self.connection.register_object(object_path, obj, None)
+        self._object_registrations.append(reg)
+
+    def get_dbus_proxy(self):
+        """Returns a proxy of DBus.
+
+        :return: a proxy object
+        """
+        return self.connection.dbus
+
+    def get_proxy(self, service_name, object_path):
+        """Returns a proxy of a remote DBus object.
+
+        :param service_name: a DBus name of a service
+        :param object_path: a DBus path an object
+        :return: a proxy object
+        """
+        return self.connection.get(service_name, object_path)
+
+    def get_observer(self, service_name, object_path):
+        """Returns an observer of a remote DBus object.
+
+        :param service_name: a DBus name of a service
+        :param object_path: a DBus path an object
+        :return: an instance of DBusObjectObserver
+        """
+        return DBusObjectObserver(self, service_name, object_path)
+
+    def get_cached_observer(self, service_name, object_path, interface_names):
+        """Returns a cached observer of a remote DBus object.
+
+        :param service_name: a DBus name of a service
+        :param object_path: a DBus path an object
+        :param interface_names: a list of interface names
+        :return: an instance of DBusCachedObserver
+        """
+        return DBusCachedObserver(self, service_name, object_path, interface_names)
+
+    def disconnect(self):
+        """Disconnect from DBus."""
+        log.debug("Disconnecting from the bus.")
+
+        while self._object_registrations:
+            registration = self._object_registrations.pop()
+            registration.unregister()
+
+        while self._service_registrations:
+            registration = self._service_registrations.pop()
+            registration.unown()
+
+        self._connection = None
+
+
+class DBusConnection(Connection):
+    """Representation of a connection for the specified address."""
+
+    def __init__(self, address):
+        """Create a new representation of a connection.
+
+        :param address: a bus address
+        """
+        super().__init__()
+        self._address = address
+
+    @property
+    def address(self):
+        return self._address
+
+    def get_new_connection(self):
+        """Get a connection to a bus at the specified address."""
+        log.info("Connecting to a bus at %s.", self._address)
+        return pydbus.connect(self._address)
+
+
+class DBusSystemConnection(Connection):
+    """Representation of a system bus connection."""
+
+    def get_new_connection(self):
+        """Get a system DBus connection."""
+        log.info("Connecting to the system bus.")
+        return pydbus.SystemBus()
+
+
+class DBusSessionConnection(Connection):
+    """Representation of a session bus connection."""
+
+    def get_new_connection(self):
+        """Get a session DBus connection."""
+        log.info("Connecting to the session bus.")
+        return pydbus.SessionBus()
+
+
+class DBusDefaultConnection(Connection):
+    """Representation of a default bus connection."""
+
+    def get_new_connection(self):
+        """Get a default bus connection.
+
+        Connect to the bus specified by the environmental variable
+        DBUS_STARTER_ADDRESS. If it is not specified, connect to
+        the session bus.
+        """
+        if DBUS_STARTER_ADDRESS in os.environ:
+            bus_address = os.environ.get(DBUS_STARTER_ADDRESS)
+        elif DBUS_SESSION_ADDRESS in os.environ:
+            bus_address = os.environ.get(DBUS_SESSION_ADDRESS)
+        else:
+            raise ConnectionError("Can't find usable bus address!")
+
+        log.info("Connecting to a default bus at %s.", bus_address)
+        return pydbus.connect(bus_address)

--- a/pyanaconda/modules/bar/bar.py
+++ b/pyanaconda/modules/bar/bar.py
@@ -20,7 +20,6 @@
 from pyanaconda.dbus import DBus
 from pyanaconda.dbus.constants import MODULE_BAR_PATH, MODULE_BAR_NAME, MODULE_TIMEZONE_NAME, \
     MODULE_TIMEZONE_PATH
-from pyanaconda.dbus.observer import DBusCachedObserver
 from pyanaconda.modules.bar.bar_kickstart import BarKickstartSpecification
 from pyanaconda.modules.base import KickstartModule
 from pyanaconda.modules.bar.bar_interface import BarInterface
@@ -36,9 +35,9 @@ class Bar(KickstartModule):
     def __init__(self):
         super().__init__()
         self._data = None
-        self._timezone_module = DBusCachedObserver(MODULE_TIMEZONE_NAME,
-                                                   MODULE_TIMEZONE_PATH,
-                                                   [MODULE_TIMEZONE_NAME])
+        self._timezone_module = DBus.get_cached_observer(MODULE_TIMEZONE_NAME,
+                                                         MODULE_TIMEZONE_PATH,
+                                                         [MODULE_TIMEZONE_NAME])
 
     def publish(self):
         """Publish the module."""

--- a/pyanaconda/modules/base.py
+++ b/pyanaconda/modules/base.py
@@ -58,16 +58,9 @@ class BaseModule(ABC):
         """
         pass
 
-    def unpublish(self):
-        """Unpublish DBus objects and unregister a DBus service.
-
-        Everything is unpublished by default.
-        """
-        DBus.unregister_all()
-        DBus.unpublish_all()
-
     def stop(self):
-        self.unpublish()
+        """Stop the module's loop."""
+        DBus.disconnect()
         Timer().timeout_sec(1, self.loop.quit)
 
 

--- a/pyanaconda/modules/boss/module_manager.py
+++ b/pyanaconda/modules/boss/module_manager.py
@@ -21,7 +21,6 @@ from pydbus.auto_names import auto_object_path
 from pyanaconda.dbus import DBus
 from pyanaconda.dbus.constants import ANACONDA_MODULES, DBUS_START_REPLY_SUCCESS, \
     DBUS_ADDON_NAMESPACE, DBUS_FLAG_NONE
-from pyanaconda.dbus.observer import DBusObjectObserver
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -40,7 +39,7 @@ class ModuleManager(object):
 
     def add_module(self, service_name, module_path):
         """Add module to manage."""
-        observer = DBusObjectObserver(service_name, module_path)
+        observer = DBus.get_observer(service_name, module_path)
         self._module_observers.append(observer)
 
     def add_default_modules(self):

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -18,8 +18,7 @@
 # Red Hat, Inc.
 #
 
-import pydbus
-from pyanaconda.dbus import DBus
+from pyanaconda.dbus import DBus, SystemBus
 from pyanaconda.dbus.constants import MODULE_NETWORK_NAME, MODULE_NETWORK_PATH
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.base import KickstartModule
@@ -42,7 +41,7 @@ class NetworkModule(KickstartModule):
         self._hostname = "localhost.localdomain"
         self.current_hostname_changed = Signal()
         # TODO fallback solution (no hostnamed) ?
-        self._hostname_service_proxy = pydbus.SystemBus().get(HOSTNAME_SERVICE, HOSTNAME_PATH)
+        self._hostname_service_proxy = SystemBus.get_proxy(HOSTNAME_SERVICE, HOSTNAME_PATH)
         self._hostname_service_proxy.PropertiesChanged.connect(self._hostname_service_properties_changed)
 
     def publish(self):

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -43,8 +43,8 @@ from pyanaconda import network
 from pyanaconda import nm
 from pyanaconda import ntp
 from pyanaconda import flags
+from pyanaconda.dbus import DBus
 from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH
-from pyanaconda.dbus.observer import DBusObjectObserver
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core.i18n import _, CN_
 from pyanaconda.core.async_utils import async_action_wait, async_action_nowait
@@ -434,7 +434,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
         self._shown = False
         self._tz = None
 
-        self._timezone_module = DBusObjectObserver(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
+        self._timezone_module = DBus.get_observer(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
         self._timezone_module.connect()
 
     def initialize(self):

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -45,7 +45,7 @@ from pyanaconda.core import glib
 from pyanaconda import network
 from pyanaconda import nm
 
-from pyanaconda.dbus.observer import DBusObjectObserver
+from pyanaconda.dbus import DBus
 from pyanaconda.dbus.constants import MODULE_NETWORK_NAME, MODULE_NETWORK_PATH
 
 import dbus
@@ -1544,8 +1544,8 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         NormalSpoke.__init__(self, *args, **kwargs)
         self.networking_changed = False
         self.network_control_box = NetworkControlBox(self.builder, nmclient, spoke=self)
-        self._network_module = DBusObjectObserver(MODULE_NETWORK_NAME,
-                                                  MODULE_NETWORK_PATH)
+        self._network_module = DBus.get_observer(MODULE_NETWORK_NAME,
+                                                 MODULE_NETWORK_PATH)
         self._network_module.connect()
         self.network_control_box.hostname = self._network_module.proxy.Hostname
         self.network_control_box.current_hostname = self._network_module.proxy.GetCurrentHostname()
@@ -1689,8 +1689,8 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
         StandaloneSpoke.__init__(self, *args, **kwargs)
         self.network_control_box = NetworkControlBox(self.builder, nmclient, spoke=self)
 
-        self._network_module = DBusObjectObserver(MODULE_NETWORK_NAME,
-                                                  MODULE_NETWORK_PATH)
+        self._network_module = DBus.get_observer(MODULE_NETWORK_NAME,
+                                                 MODULE_NETWORK_PATH)
         self._network_module.connect()
         self.network_control_box.hostname = self._network_module.proxy.Hostname
         self.network_control_box.current_hostname = self._network_module.proxy.GetCurrentHostname()

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -19,7 +19,7 @@
 
 from pyanaconda import network
 from pyanaconda import nm
-from pyanaconda.dbus.observer import DBusObjectObserver
+from pyanaconda.dbus import DBus
 from pyanaconda.dbus.constants import MODULE_NETWORK_NAME, MODULE_NETWORK_PATH
 from pyanaconda.flags import can_touch_runtime_system, flags
 from pyanaconda.ui.categories.system import SystemCategory
@@ -60,8 +60,8 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     def __init__(self, data, storage, payload, instclass):
         NormalTUISpoke.__init__(self, data, storage, payload, instclass)
         self.title = N_("Network configuration")
-        self._network_module = DBusObjectObserver(MODULE_NETWORK_NAME,
-                                                  MODULE_NETWORK_PATH)
+        self._network_module = DBus.get_observer(MODULE_NETWORK_NAME,
+                                                 MODULE_NETWORK_PATH)
         self._network_module.connect()
         self._container = None
         self._value = self._network_module.proxy.Hostname

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -16,8 +16,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.dbus import DBus
 from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH
-from pyanaconda.dbus.observer import DBusObjectObserver
 from pyanaconda.ui.categories.localization import LocalizationCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
@@ -70,7 +70,7 @@ class TimeSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         self._ntp_servers = OrderedDict()
         self._ntp_servers_lock = RLock()
 
-        self._timezone_module = DBusObjectObserver(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
+        self._timezone_module = DBus.get_observer(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
         self._timezone_module.connect()
 
     @property
@@ -298,7 +298,7 @@ class TimeZoneSpoke(NormalTUISpoke):
         self._lower_zones = [z.lower().replace("_", " ") for region in self._timezones for z in self._timezones[region]]
         self._selection = ""
 
-        self._timezone_module = DBusObjectObserver(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
+        self._timezone_module = DBus.get_observer(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
         self._timezone_module.connect()
 
     @property

--- a/tests/pyanaconda_tests/install_manager_test.py
+++ b/tests/pyanaconda_tests/install_manager_test.py
@@ -107,7 +107,7 @@ class InstallManagerTestCase(unittest.TestCase):
 class TestModuleObserver(DBusObjectObserver):
 
     def __init__(self, service_name, object_path, test_module):
-        super().__init__(service_name, object_path)
+        super().__init__(None, service_name, object_path)
         self._proxy = test_module
         self._is_service_available = True
 

--- a/tests/pyanaconda_tests/kickstart_manager.py
+++ b/tests/pyanaconda_tests/kickstart_manager.py
@@ -20,6 +20,8 @@ import unittest
 import os
 from contextlib import contextmanager
 
+from mock import Mock
+
 from pyanaconda.dbus.observer import DBusObjectObserver
 from pyanaconda.modules.boss.kickstart_manager import KickstartManager,\
     SplitKickstartSectionParsingError, SplitKickstartMissingIncludeError
@@ -259,7 +261,7 @@ network --device=ens3
 class TestModuleObserver(DBusObjectObserver):
 
     def __init__(self, service_name, object_path, test_module):
-        super().__init__(service_name, object_path)
+        super().__init__(Mock(), service_name, object_path)
         self._proxy = test_module
         self._is_service_available = True
 


### PR DESCRIPTION
Class Connection is an abstract class that provides a functionality
for working with a bus connection. The connection should be created in
the abstract method get_new_connection. Call methods get_observer and
get_cached_observer to get observers of a remote object.

Classes DBusSystemConnection and DBusSessionConnection define
connections for the system and session buses. DBusConnection define
a connection to a bus at the specific address. DBusDefaultConnection
defines a connection that should be used by all Anaconda modules
to communicate with each other.

Objects DBus, SystemBus and SessionBus provides the connections to
the default, system and session buses.

The class DBusServiceObserver was removed, because it was too complex.