### PR TITLE
Wait for DBus modules for longer time

### DIFF
--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -410,7 +410,7 @@ def set_installation_method_from_anaconda_options(anaconda, ksdata):
         log.error("Unknown method: %s", anaconda.methodstr)
 
 
-def wait_for_modules(timeout=10):
+def wait_for_modules(timeout=60):
     """Wait for the DBus modules.
 
     :param timeout: seconds to the timeout


### PR DESCRIPTION
Make sure that the DBus modules had enough time to be started, before
anaconda fails, because they are unavailable.