### PR TITLE
 Use observers to access the hostname service

### DIFF
--- a/pyanaconda/dbus/connection.py
+++ b/pyanaconda/dbus/connection.py
@@ -63,6 +63,17 @@ class Connection(ABC):
         """
         pass
 
+    def check_connection(self):
+        """Check if the connection is set up.
+
+        :return: True if the connection is set up otherwise False
+        """
+        try:
+            return self.connection is not None
+        except Exception as e:  # pylint: disable=broad-except
+            log.error("Connection failed to be created:\n%s", e)
+            return False
+
     def register_service(self, service_name):
         """Register a service on DBus.
 

--- a/pyanaconda/dbus/observer.py
+++ b/pyanaconda/dbus/observer.py
@@ -124,7 +124,8 @@ class DBusObserver(object):
         The observer is not connected to the service until it
         emits the service_available signal.
         """
-        self._watch()
+        if self._message_bus.check_connection():
+            self._watch()
 
     def disconnect(self):
         """Disconnect from the service.
@@ -132,7 +133,8 @@ class DBusObserver(object):
         Disconnect from the service if it is connected and stop
         watching its availability.
         """
-        self._unwatch()
+        if self._message_bus.check_connection():
+            self._unwatch()
 
         if self.is_service_available:
             self._disable_service()


### PR DESCRIPTION
On some systems, the system services and the system bus don't have
to run. We should set up observers to access the hostname service
and call connect_once_available to make sure that the system bus
is checked before we try to connect to it.

