### PR TITLE
Include dbus.log when exporting logs

### DIFF
--- a/data/post-scripts/99-copy-logs.ks
+++ b/data/post-scripts/99-copy-logs.ks
@@ -9,7 +9,7 @@ if [ -e ${NOSAVE_LOGS_FILE} ]; then
     rm -f ${NOSAVE_LOGS_FILE}
 else
     mkdir -p $ANA_INSTALL_PATH/var/log/anaconda
-    for log in anaconda.log syslog X.log program.log packaging.log storage.log ifcfg.log lvm.log dnf.librepo.log hawkey.log; do
+    for log in anaconda.log syslog X.log program.log packaging.log storage.log ifcfg.log lvm.log dnf.librepo.log hawkey.log dbus.log; do
         [ -e /tmp/$log ] && cp /tmp/$log $ANA_INSTALL_PATH/var/log/anaconda/
     done
     [ -e /tmp/pre-anaconda-logs ] && cp -r $PRE_ANA_LOGS $ANA_INSTALL_PATH/var/log/anaconda

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -263,7 +263,7 @@ def initExceptionHandling(anaconda):
                  "/tmp/dnf.librepo.log", "/tmp/hawkey.log",
                  "/tmp/lvm.log", util.getSysroot() + "/root/install.log",
                  "/proc/cmdline", "/root/lorax-packages.log",
-                 "/tmp/blivet-gui-utils.log"]
+                 "/tmp/blivet-gui-utils.log", "/tmp/dbus.log"]
 
     if os.path.exists("/tmp/syslog"):
         file_list.extend(["/tmp/syslog"])


### PR DESCRIPTION
Include the new dbus.log when we copy logs to the system
and also in the python-meh log dump, so that is is included
in crash reports.

We don't need to change the log-capture scritp, as it just
includes *.log from /tmp.