### PR TITLE
Return restorecon utility to Fedora 28 mock

### DIFF
--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -35,7 +35,9 @@ ANACONDA_SPEC_NAME = "anaconda.spec.in"
 TEST_DEPENDENCIES = ["e2fsprogs", "git", "bzip2", "cppcheck", "rpm-ostree", "pykickstart",
                      "python3-rpmfluff", "python3-mock", "python3-pocketlint",
                      "python3-nose-testconfig", "python3-sphinx_rtd_theme", "python3-lxml",
-                     "python3-dogtail"]
+                     "python3-dogtail",
+                     # contains restorecon which was removed in Fedora 28 mock
+                     "policycoreutils"]
 
 
 def _resolve_top_dir():


### PR DESCRIPTION
This broke our tests.