### PR TITLE
datetime spoke: still pass ksdata to NTPconfigDialog (UIObject)

### DIFF
--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -509,7 +509,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
         if not flags.can_touch_runtime_system("modify system time and date"):
             self._set_date_time_setting_sensitive(False)
 
-        self._config_dialog = NTPconfigDialog(None, self._timezone_module)
+        self._config_dialog = NTPconfigDialog(self.data, self._timezone_module)
         self._config_dialog.initialize()
 
         threadMgr.add(AnacondaThread(name=constants.THREAD_DATE_TIME,


### PR DESCRIPTION
UIObject is using the data for autostep feature.