### PR TITLE
Replace DBus constants for names and paths

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -518,9 +518,8 @@ if __name__ == "__main__":
     # setup keyboard layout from the command line option and let
     # it override from kickstart if/when X is initialized
 
-    from pyanaconda.dbus import DBus
-    from pyanaconda.dbus.constants import MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH
-    localization_proxy = DBus.get_proxy(MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH)
+    from pyanaconda.modules.common.constants.services import LOCALIZATION
+    localization_proxy = LOCALIZATION.get_proxy()
 
     configured = any((localization_proxy.Keyboard,
                       localization_proxy.VirtualConsoleKeymap,
@@ -585,6 +584,9 @@ if __name__ == "__main__":
 
     from pyanaconda import localization
     # Set the language before loading an interface, when it may be too late.
+
+    from pyanaconda.modules.common.constants.services import LOCALIZATION
+    localization_proxy = LOCALIZATION.get_proxy()
 
     # If the language was set on the command line, copy that to kickstart
     if opts.lang:
@@ -691,8 +693,8 @@ if __name__ == "__main__":
         threadMgr.add(AnacondaThread(name=constants.THREAD_STORAGE, target=storage_initialize,
                                      args=(anaconda.storage, ksdata, anaconda.protected)))
 
-    from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH
-    timezone_proxy = DBus.get_proxy(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
+    from pyanaconda.modules.common.constants.services import TIMEZONE
+    timezone_proxy = TIMEZONE.get_proxy()
 
     if can_touch_runtime_system("initialize time", touch_live=True):
         threadMgr.add(AnacondaThread(name=constants.THREAD_TIME_INIT,

--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,7 @@ AC_CONFIG_FILES([Makefile
                  pyanaconda/modules/common/base/Makefile
                  pyanaconda/modules/common/task/Makefile
                  pyanaconda/modules/common/errors/Makefile
+                 pyanaconda/modules/common/constants/Makefile
                  pyanaconda/modules/bar/Makefile
                  pyanaconda/modules/bar/tasks/Makefile
                  pyanaconda/modules/boss/Makefile

--- a/pyanaconda/dbus/connection.py
+++ b/pyanaconda/dbus/connection.py
@@ -89,11 +89,11 @@ class Connection(ABC):
                                            replace=False)
         self._service_registrations.append(reg)
 
-    def publish_object(self, obj, object_path):
+    def publish_object(self, object_path, obj):
         """Publish an object on DBus.
 
-        :param obj: an instance of @dbus_interface or @dbus_class
         :param object_path: a DBus path of an object
+        :param obj: an instance of @dbus_interface or @dbus_class
         """
         log.debug("Publishing an object at %s.", object_path)
         reg = self.connection.register_object(object_path, obj, None)

--- a/pyanaconda/dbus/constants.py
+++ b/pyanaconda/dbus/constants.py
@@ -1,5 +1,5 @@
 #
-# Anaconda DBUS constants
+# DBus constants.
 #
 # Copyright (C) 2017  Red Hat, Inc.  All rights reserved.
 #
@@ -17,70 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from pydbus.auto_names import auto_object_path
-
-# main Anaconda DBUS namespace
-ANACONDA_DBUS_NAMESPACE = "org.fedoraproject.Anaconda"
-
-# DBUS namespace for modules
-DBUS_MODULE_NAMESPACE = "{}.Modules".format(ANACONDA_DBUS_NAMESPACE)
-
-# DBUS namespace for addons
-DBUS_ADDON_NAMESPACE = "{}.Addons".format(ANACONDA_DBUS_NAMESPACE)
-
-# BOSS
-DBUS_BOSS_NAME = "{}.Boss".format(ANACONDA_DBUS_NAMESPACE)
-DBUS_BOSS_PATH = auto_object_path(DBUS_BOSS_NAME)
-
-DBUS_BOSS_INSTALLATION_NAME = "{}.Installation".format(DBUS_BOSS_NAME)
-DBUS_BOSS_INSTALLATION_PATH = auto_object_path(DBUS_BOSS_INSTALLATION_NAME)
-
-# Temporary interface for anaconda
-DBUS_BOSS_ANACONDA_NAME = "{}.Anaconda".format(DBUS_BOSS_NAME)
-
-# Anaconda DBUS modules
-MODULE_FOO_NAME = "{}.Foo".format(DBUS_MODULE_NAMESPACE)
-MODULE_FOO_PATH = auto_object_path(MODULE_FOO_NAME)
-
-MODULE_BAR_NAME = "{}.Bar".format(DBUS_MODULE_NAMESPACE)
-MODULE_BAR_PATH = auto_object_path(MODULE_BAR_NAME)
-
-MODULE_TIMEZONE_NAME = "{}.Timezone".format(DBUS_MODULE_NAMESPACE)
-MODULE_TIMEZONE_PATH = auto_object_path(MODULE_TIMEZONE_NAME)
-
-MODULE_NETWORK_NAME = "{}.Network".format(DBUS_MODULE_NAMESPACE)
-MODULE_NETWORK_PATH = auto_object_path(MODULE_NETWORK_NAME)
-
-MODULE_LOCALIZATION_NAME = "{}.Localization".format(DBUS_MODULE_NAMESPACE)
-MODULE_LOCALIZATION_PATH = auto_object_path(MODULE_LOCALIZATION_NAME)
-
-MODULE_SECURITY_NAME = "{}.Security".format(DBUS_MODULE_NAMESPACE)
-MODULE_SECURITY_PATH = auto_object_path(MODULE_SECURITY_NAME)
-
-MODULE_USER_NAME = "{}.User".format(DBUS_MODULE_NAMESPACE)
-MODULE_USER_PATH = auto_object_path(MODULE_USER_NAME)
-
-# Addons (likely for testing purposes only)
-ADDON_BAZ_NAME = "{}.Baz".format(DBUS_ADDON_NAMESPACE)
-ADDON_BAZ_PATH = auto_object_path(ADDON_BAZ_NAME)
-
-# list of all expected Anaconda services
-ANACONDA_SERVICES = [MODULE_FOO_NAME,
-                     MODULE_BAR_NAME,
-                     MODULE_TIMEZONE_NAME]
-
-# Task interface name
-DBUS_TASK_NAME = "{}.Task".format(ANACONDA_DBUS_NAMESPACE)
-
-# list of all expected Anaconda DBUS modules
-ANACONDA_MODULES = [(MODULE_FOO_NAME, MODULE_FOO_PATH),
-                    (MODULE_BAR_NAME, MODULE_BAR_PATH),
-                    (MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH),
-                    (MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH),
-                    (MODULE_NETWORK_NAME, MODULE_NETWORK_PATH),
-                    (MODULE_SECURITY_NAME, MODULE_SECURITY_PATH),
-                    (MODULE_USER_NAME, MODULE_USER_PATH)]
-
 # status codes
 DBUS_START_REPLY_SUCCESS = 1
 
@@ -90,12 +26,3 @@ DBUS_FLAG_NONE = 0
 # system environment variable holding dbus session address
 DBUS_ANACONDA_SESSION_ADDRESS = "DBUS_ANACONDA_SESSION_BUS_ADDRESS"
 DBUS_STARTER_ADDRESS = "DBUS_STARTER_ADDRESS"
-
-# NOTE: There is no DBUS_START_REPLY_FAILURE or something similar,
-#       as there is a separate field for error reporting.
-#       For more information see the DBUS docs:
-#       https://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-start-service-by-name
-
-
-
-

--- a/pyanaconda/dbus/error.py
+++ b/pyanaconda/dbus/error.py
@@ -1,0 +1,45 @@
+#
+# DBus errors.
+#
+# Copyright (C) 2018  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from pydbus.error import map_error, map_by_default
+from pyanaconda.dbus.namespace import get_dbus_name
+
+__all__ = ['dbus_error', 'dbus_error_by_default']
+
+
+def dbus_error(error_name, namespace):
+    """Define decorated class as a DBus error.
+
+    The decorated exception class will be mapped to a DBus error.
+
+    :param error_name: a DBus name of the error
+    :param namespace: a sequence of strings
+    :return: a decorator
+    """
+    return map_error(get_dbus_name(*namespace, error_name))
+
+
+def dbus_error_by_default(cls):
+    """Define a default DBus error.
+
+    The decorated exception class will be mapped to all unknown DBus errors.
+
+    :param cls: an exception class
+    :return: a decorated class
+    """
+    return map_by_default(cls)

--- a/pyanaconda/dbus/identifier.py
+++ b/pyanaconda/dbus/identifier.py
@@ -1,0 +1,176 @@
+#
+# Identification of DBus objects, interfaces and services.
+#
+# Copyright (C) 2018  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from pyanaconda.dbus import DBus
+from pyanaconda.dbus.namespace import get_dbus_path, get_dbus_name
+
+__all__ = ['DBusInterfaceIdentifier', 'DBusObjectIdentifier', 'DBusServiceIdentifier']
+
+
+class DBusBaseIdentifier(object):
+    """A base identifier."""
+
+    def __init__(self, namespace, basename=None):
+        """Create an identifier.
+
+        :param namespace: a sequence of strings
+        :param basename: a string with the base name or None
+        """
+        if basename:
+            namespace = (*namespace, basename)
+
+        self._namespace = namespace
+        self._name = get_dbus_name(*namespace)
+        self._path = get_dbus_path(*namespace)
+
+    @property
+    def namespace(self):
+        """DBus namespace of this object."""
+        return self._namespace
+
+    def __str__(self):
+        """Return the string representation."""
+        return self._name
+
+
+class DBusInterfaceIdentifier(DBusBaseIdentifier):
+    """Identifier of a DBus interface."""
+
+    def __init__(self, namespace, basename=None, interface_version=None):
+        """Describe a DBus interface.
+
+        :param namespace: a sequence of strings
+        :param basename: a string with the base name or None
+        :param interface_version: a version of the interface
+        """
+        super().__init__(namespace, basename=basename)
+        self._interface_version = interface_version
+
+    def _version_to_string(self, version):
+        """Convert version to a string.
+
+        :param version: a number or None
+        :return: a string
+        """
+        if version is None:
+            return ""
+
+        return str(version)
+
+    @property
+    def interface_name(self):
+        """Full name of the DBus interface."""
+        return self._name + self._version_to_string(self._interface_version)
+
+    def __str__(self):
+        """Return the string representation."""
+        return self.interface_name
+
+
+class DBusObjectIdentifier(DBusInterfaceIdentifier):
+    """Identifier of a DBus object."""
+
+    def __init__(self, namespace, basename=None, interface_version=None, object_version=None):
+        """Describe a DBus object.
+
+        :param namespace: a sequence of strings
+        :param basename: a string with the base name or None
+        :param interface_version: a version of the DBus interface
+        :param object_version: a version of the DBus object
+        """
+        super().__init__(namespace, basename=basename, interface_version=interface_version)
+        self._object_version = object_version
+
+    @property
+    def object_path(self):
+        """Full path of the DBus object."""
+        return self._path + self._version_to_string(self._object_version)
+
+    def __str__(self):
+        """Return the string representation."""
+        return self.object_path
+
+
+class DBusServiceIdentifier(DBusObjectIdentifier):
+    """Identifier of a DBus service."""
+
+    def __init__(self, namespace, basename=None, interface_version=None, object_version=None,
+                 service_version=None, message_bus=DBus):
+        """Describe a DBus service.
+
+        :param namespace: a sequence of strings
+        :param basename: a string with the base name or None
+        :param interface_version: a version of the DBus interface
+        :param object_version: a version of the DBus object
+        :param service_version: a version of the DBus service
+        :param message_bus: a message bus
+        """
+        super().__init__(namespace, basename=basename,
+                         interface_version=interface_version,
+                         object_version=object_version)
+
+        self._service_version = service_version
+        self._message_bus = message_bus
+
+    @property
+    def service_name(self):
+        """Full name of a DBus service."""
+        return self._name + self._version_to_string(self._service_version)
+
+    def __str__(self):
+        """Return the string representation."""
+        return self.service_name
+
+    def get_proxy(self, object_path=None):
+        """Returns a proxy of the DBus object.
+
+        :param object_path: a DBus path an object or None
+        :return: a proxy object
+        """
+        if object_path is None:
+            object_path = self.object_path
+
+        return self._message_bus.get_proxy(self.service_name, object_path)
+
+    def get_observer(self, object_path=None):
+        """Returns an observer of the DBus object.
+
+        :param object_path: a DBus path of an object or None
+        :return: an observer object
+        """
+        if object_path is None:
+            object_path = self.object_path
+
+        return self._message_bus.get_observer(self.service_name, object_path)
+
+    def get_cached_observer(self, object_path=None, interface_names=None):
+        """Returns a cached observer of the DBus object.
+
+        :param object_path: a DBus path of an object or None
+        :param interface_names: a list of interface names or None
+        :return: an observer object
+        """
+        if object_path is None:
+            object_path = self.object_path
+
+            if interface_names is None:
+                interface_names = [self.interface_name]
+
+        return self._message_bus.get_cached_observer(
+            self.service_name, object_path, interface_names
+        )

--- a/pyanaconda/dbus/namespace.py
+++ b/pyanaconda/dbus/namespace.py
@@ -1,0 +1,47 @@
+#
+# DBus names and paths.
+#
+# Copyright (C) 2018  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+__all__ = ['get_dbus_name', 'get_dbus_path', 'get_namespace_from_name']
+
+
+def get_dbus_name(*namespace):
+    """Create a DBus name from the given names.
+
+    :param namespace: a sequence of names
+    :return: a DBus name
+    """
+    return ".".join(namespace)
+
+
+def get_dbus_path(*namespace):
+    """Create a DBus path from the given names.
+
+    :param namespace: a sequence of names
+    :return: a DBus path
+    """
+    return "/" + "/".join(namespace)
+
+
+def get_namespace_from_name(name):
+    """Return a namespace of the DBus name.
+
+    :param name: a DBus name
+    :return: a sequence of names
+    """
+    return tuple(name.split("."))

--- a/pyanaconda/dbus/template.py
+++ b/pyanaconda/dbus/template.py
@@ -98,7 +98,7 @@ class InterfaceTemplate(ABC):
 
         :type object_path: a DBus path of the object
         """
-        DBus.publish_object(self, object_path)
+        DBus.publish_object(object_path, self)
         self._object_path = object_path
 
 

--- a/pyanaconda/dbus/template.py
+++ b/pyanaconda/dbus/template.py
@@ -18,7 +18,6 @@
 #
 from abc import ABC
 
-from pyanaconda.dbus import DBus
 from pyanaconda.dbus.property import PropertiesInterface
 
 __all__ = ["InterfaceTemplate", "AdvancedInterfaceTemplate"]
@@ -41,7 +40,7 @@ class InterfaceTemplate(ABC):
 
     Example:
 
-    @dbus_interface("org.myproject.InterfaceX")
+    @dbus_interface("org.myproject.X")
     class InterfaceX(InterfaceTemplate):
         def DoSomething(self) -> Str:
             return self.implementation.do_something()
@@ -52,8 +51,8 @@ class InterfaceTemplate(ABC):
 
     x = X()
     i = InterfaceX(x)
-    i.publish("org/myproject/X/1")
 
+    DBus.publish_object("/org/myproject/X", i)
     """
 
     def __init__(self, implementation):
@@ -62,7 +61,6 @@ class InterfaceTemplate(ABC):
         :param implementation: an implementation of this interface
         """
         self._implementation = implementation
-        self._object_path = None
         self.connect_signals()
 
     @property
@@ -73,16 +71,6 @@ class InterfaceTemplate(ABC):
         """
         return self._implementation
 
-    @property
-    def object_path(self):
-        """Return an DBus object path.
-
-        If this object wasn't published, it returns None.
-
-        :return: a DBus path or None
-        """
-        return self._object_path
-
     def connect_signals(self):
         """Interconnect the signals.
 
@@ -92,14 +80,6 @@ class InterfaceTemplate(ABC):
         reemits the signal on DBus.
         """
         pass
-
-    def publish(self, object_path):
-        """Publish the object on DBus.
-
-        :type object_path: a DBus path of the object
-        """
-        DBus.publish_object(object_path, self)
-        self._object_path = object_path
 
 
 class AdvancedInterfaceTemplate(InterfaceTemplate, PropertiesInterface):

--- a/pyanaconda/dbus_addons/baz/baz.py
+++ b/pyanaconda/dbus_addons/baz/baz.py
@@ -18,9 +18,9 @@
 # Red Hat, Inc.
 #
 from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import ADDON_BAZ_NAME, ADDON_BAZ_PATH
 from pyanaconda.dbus_addons.baz.baz_interface import BazInterface
 from pyanaconda.modules.common.base import KickstartModule
+from pyanaconda.modules.common.constants.services import BAZ
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -31,5 +31,5 @@ class Baz(KickstartModule):
 
     def publish(self):
         """Publish the module."""
-        DBus.publish_object(BazInterface(self), ADDON_BAZ_PATH)
-        DBus.register_service(ADDON_BAZ_NAME)
+        DBus.publish_object(BAZ.object_path, BazInterface(self))
+        DBus.register_service(BAZ.service_name)

--- a/pyanaconda/dbus_addons/baz/baz_interface.py
+++ b/pyanaconda/dbus_addons/baz/baz_interface.py
@@ -17,12 +17,12 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.dbus.constants import ADDON_BAZ_NAME
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.modules.common.base import KickstartModuleInterface
+from pyanaconda.modules.common.constants.services import BAZ
 
 
-@dbus_interface(ADDON_BAZ_NAME)
+@dbus_interface(BAZ.interface_name)
 class BazInterface(KickstartModuleInterface):
     """The interface for Baz."""
     pass

--- a/pyanaconda/keyboard.py
+++ b/pyanaconda/keyboard.py
@@ -348,7 +348,6 @@ def set_x_keyboard_defaults(localization_proxy, xkl_wrapper):
     :raise InvalidLocaleSpec: if an invalid locale is given (see
                               localization.LANGCODE_RE)
     """
-
     x_layouts = localization_proxy.XLayouts
     # remove all X layouts that are not valid X layouts (unsupported)
     valid_layouts = []

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -43,15 +43,13 @@ from pyanaconda.addons import AddonSection, AddonData, AddonRegistry, collect_ad
 from pyanaconda.bootloader import GRUB2, get_bootloader
 from pyanaconda.core.constants import ADDON_PATHS, IPMI_ABORTED, TEXT_ONLY_TARGET, \
     GRAPHICAL_TARGET, THREAD_STORAGE, SELINUX_DEFAULT, REALM_NAME, REALM_DISCOVER, REALM_JOIN
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH, DBUS_BOSS_NAME, \
-    DBUS_BOSS_PATH, MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH, MODULE_SECURITY_NAME, \
-    MODULE_SECURITY_PATH, MODULE_USER_NAME, MODULE_USER_PATH
 from pyanaconda.desktop import Desktop
 from pyanaconda.errors import ScriptError, errorHandler
 from pyanaconda.flags import flags, can_touch_runtime_system
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.errors.kickstart import SplitKickstartError
+from pyanaconda.modules.common.constants.services import BOSS, TIMEZONE, LOCALIZATION, SECURITY, \
+    USER
 from pyanaconda.platform import platform
 from pyanaconda.pwpolicy import F22_PwPolicy, F22_PwPolicyData
 from pyanaconda.simpleconfig import SimpleConfigFile
@@ -312,7 +310,7 @@ class Authselect(RemovedCommand):
                 os.path.exists(util.getSysroot() + "/lib/security/pam_fprintd.so"))
 
     def setup(self):
-        security_proxy = DBus.get_proxy(MODULE_SECURITY_NAME, MODULE_SECURITY_PATH)
+        security_proxy = SECURITY.get_proxy()
 
         if security_proxy.Authselect or not flags.automatedInstall:
             self.packages += ["authselect"]
@@ -321,7 +319,7 @@ class Authselect(RemovedCommand):
             self.packages += ["authselect-compat"]
 
     def execute(self, *args):
-        security_proxy = DBus.get_proxy(MODULE_SECURITY_NAME, MODULE_SECURITY_PATH)
+        security_proxy = SECURITY.get_proxy()
 
         # Enable fingerprint option by default (#481273).
         if not flags.automatedInstall and self.fingerprint_supported:
@@ -649,7 +647,7 @@ class Realm(RemovedCommand):
         return ""
 
     def setup(self):
-        security_proxy = DBus.get_proxy(MODULE_SECURITY_NAME, MODULE_SECURITY_PATH)
+        security_proxy = SECURITY.get_proxy()
         realm = security_proxy.Realm
 
         if not realm[REALM_NAME]:
@@ -686,7 +684,7 @@ class Realm(RemovedCommand):
         if not self.discovered:
             return
 
-        security_proxy = DBus.get_proxy(MODULE_SECURITY_NAME, MODULE_SECURITY_PATH)
+        security_proxy = SECURITY.get_proxy()
         realm = security_proxy.Realm
 
         for arg in realm[REALM_JOIN]:
@@ -943,10 +941,11 @@ class IscsiName(commands.iscsiname.FC6_IscsiName):
 
 class Lang(RemovedCommand):
     def __str__(self):
-        localization_proxy = DBus.get_proxy(MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH)
+        localization_proxy = LOCALIZATION.get_proxy()
         return localization_proxy.GenerateKickstart()
+
     def execute(self, *args, **kwargs):
-        localization_proxy = DBus.get_proxy(MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH)
+        localization_proxy = LOCALIZATION.get_proxy()
         lang = localization_proxy.Language
         localization.write_language_configuration(lang, util.getSysroot())
 
@@ -1836,7 +1835,7 @@ class ReqPart(commands.reqpart.F23_ReqPart):
 class RootPw(RemovedCommand):
     def execute(self, storage, ksdata, instClass, users):
 
-        user_proxy = DBus.get_proxy(MODULE_USER_NAME, MODULE_USER_PATH)
+        user_proxy = USER.get_proxy()
 
         if flags.automatedInstall and not user_proxy.IsRootPasswordSet and not user_proxy.IsRootpwKickstarted:
             # Lock the root password if during an installation with kickstart
@@ -1864,11 +1863,11 @@ class SELinux(RemovedCommand):
     }
 
     def __str__(self):
-        security_proxy = DBus.get_proxy(MODULE_SECURITY_NAME, MODULE_SECURITY_PATH)
+        security_proxy = SECURITY.get_proxy()
         return security_proxy.GenerateKickstart()
 
     def execute(self, *args):
-        security_proxy = DBus.get_proxy(MODULE_SECURITY_NAME, MODULE_SECURITY_PATH)
+        security_proxy = SECURITY.get_proxy()
         selinux = security_proxy.SELinux
 
         if selinux == SELINUX_DEFAULT:
@@ -1907,11 +1906,11 @@ class Timezone(RemovedCommand):
         self.packages = []
 
     def __str__(self):
-        timezone_proxy = DBus.get_proxy(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
+        timezone_proxy = TIMEZONE.get_proxy()
         return timezone_proxy.GenerateKickstart()
 
     def setup(self, ksdata):
-        timezone_proxy = DBus.get_proxy(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
+        timezone_proxy = TIMEZONE.get_proxy()
 
         # do not install and use NTP package
         if not timezone_proxy.NTPEnabled or NTP_PACKAGE in ksdata.packages.excludedList:
@@ -1939,7 +1938,7 @@ class Timezone(RemovedCommand):
 
     def execute(self, *args):
         # get the DBus proxies
-        timezone_proxy = DBus.get_proxy(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
+        timezone_proxy = TIMEZONE.get_proxy()
 
         # write out timezone configuration
         kickstart_timezone = timezone_proxy.Timezone
@@ -2232,7 +2231,7 @@ class ZFCP(commands.zfcp.F14_ZFCP):
 
 class Keyboard(RemovedCommand):
     def execute(self, *args):
-        localization_proxy = DBus.get_proxy(MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH)
+        localization_proxy = LOCALIZATION.get_proxy()
         keyboard.write_keyboard_config(localization_proxy, util.getSysroot())
 
 class Upgrade(commands.upgrade.F20_Upgrade):
@@ -2540,7 +2539,7 @@ def parseKickstart(f, strict_mode=False, pass_to_boss=False):
 
             # Parse the kickstart file in DBus modules.
             if pass_to_boss:
-                boss = DBus.get_proxy(DBUS_BOSS_NAME, DBUS_BOSS_PATH)
+                boss = BOSS.get_proxy()
 
                 boss.SplitKickstart(f)
                 errors = boss.DistributeKickstart()

--- a/pyanaconda/modules/bar/bar.py
+++ b/pyanaconda/modules/bar/bar.py
@@ -22,7 +22,6 @@ from pyanaconda.modules.bar.bar_interface import BarInterface
 from pyanaconda.modules.bar.kickstart import BarKickstartSpecification
 from pyanaconda.modules.bar.tasks.bar_task import BarTask
 from pyanaconda.modules.common.base import KickstartModule
-from pyanaconda.modules.common.constants.namespaces import BAR_NAMESPACE
 from pyanaconda.modules.common.constants.services import BAR, TIMEZONE
 
 from pyanaconda.anaconda_loggers import get_module_logger

--- a/pyanaconda/modules/bar/bar.py
+++ b/pyanaconda/modules/bar/bar.py
@@ -18,12 +18,12 @@
 # Red Hat, Inc.
 #
 from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_BAR_PATH, MODULE_BAR_NAME, MODULE_TIMEZONE_NAME, \
-    MODULE_TIMEZONE_PATH
-from pyanaconda.modules.bar.kickstart import BarKickstartSpecification
-from pyanaconda.modules.common.base import KickstartModule
 from pyanaconda.modules.bar.bar_interface import BarInterface
+from pyanaconda.modules.bar.kickstart import BarKickstartSpecification
 from pyanaconda.modules.bar.tasks.bar_task import BarTask
+from pyanaconda.modules.common.base import KickstartModule
+from pyanaconda.modules.common.constants.namespaces import BAR_NAMESPACE
+from pyanaconda.modules.common.constants.services import BAR, TIMEZONE
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -35,16 +35,14 @@ class Bar(KickstartModule):
     def __init__(self):
         super().__init__()
         self._data = None
-        self._timezone_module = DBus.get_cached_observer(MODULE_TIMEZONE_NAME,
-                                                         MODULE_TIMEZONE_PATH,
-                                                         [MODULE_TIMEZONE_NAME])
+        self._timezone_module = TIMEZONE.get_cached_observer()
 
     def publish(self):
         """Publish the module."""
         # Publish bar.
-        DBus.publish_object(BarInterface(self), MODULE_BAR_PATH)
-        self.publish_task(BarTask(), MODULE_BAR_PATH)
-        DBus.register_service(MODULE_BAR_NAME)
+        DBus.publish_object(BAR.object_path, BarInterface(self))
+        self.publish_task(BAR.namespace, BarTask())
+        DBus.register_service(BAR.service_name)
 
         # Start to watch the timezone module.
         self._timezone_module.cached_properties_changed.connect(self._timezone_callback)

--- a/pyanaconda/modules/bar/bar_interface.py
+++ b/pyanaconda/modules/bar/bar_interface.py
@@ -17,14 +17,13 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
-from pyanaconda.dbus.constants import MODULE_BAR_NAME
+from pyanaconda.modules.common.constants.services import BAR
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.dbus.interface import dbus_interface
 
 
-@dbus_interface(MODULE_BAR_NAME)
+@dbus_interface(BAR.interface_name)
 class BarInterface(KickstartModuleInterface):
     """DBus interface for Bar."""
 

--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -21,11 +21,12 @@
 from pyanaconda.core.async_utils import run_in_loop
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.boss.boss_interface import AnacondaBossInterface
-from pyanaconda.modules.common.base import BaseModule
-from pyanaconda.dbus.constants import DBUS_BOSS_NAME, DBUS_BOSS_PATH, DBUS_BOSS_INSTALLATION_PATH
 from pyanaconda.modules.boss.module_manager import ModuleManager
 from pyanaconda.modules.boss.install_manager import InstallManager, InstallationInterface
 from pyanaconda.modules.boss.kickstart_manager import KickstartManager
+from pyanaconda.modules.common.base import BaseModule
+from pyanaconda.modules.common.constants.objects import BOSS_INSTALLATION
+from pyanaconda.modules.common.constants.services import BOSS
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -58,10 +59,11 @@ class Boss(BaseModule):
 
     def publish(self):
         """Publish the boss."""
-        DBus.publish_object(AnacondaBossInterface(self), DBUS_BOSS_PATH)
-        DBus.publish_object(InstallationInterface(self._install_manager),
-                            DBUS_BOSS_INSTALLATION_PATH)
-        DBus.register_service(DBUS_BOSS_NAME)
+        DBus.publish_object(BOSS.object_path,
+                            AnacondaBossInterface(self))
+        DBus.publish_object(BOSS_INSTALLATION.object_path,
+                            InstallationInterface(self._install_manager))
+        DBus.register_service(BOSS.service_name)
 
     def run(self):
         """Run the boss's loop."""

--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -19,12 +19,13 @@
 #
 
 from pyanaconda.dbus.interface import dbus_interface
-from pyanaconda.dbus.constants import DBUS_BOSS_NAME, DBUS_BOSS_ANACONDA_NAME
+from pyanaconda.modules.common.constants.interfaces import BOSS_ANACONDA
+from pyanaconda.modules.common.constants.services import BOSS
 from pyanaconda.dbus.template import InterfaceTemplate
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
 
-@dbus_interface(DBUS_BOSS_NAME)
+@dbus_interface(BOSS.interface_name)
 class BossInterface(InterfaceTemplate):
     """DBus interface for the Boss."""
 
@@ -33,7 +34,7 @@ class BossInterface(InterfaceTemplate):
         self.implementation.stop()
 
 
-@dbus_interface(DBUS_BOSS_ANACONDA_NAME)
+@dbus_interface(BOSS_ANACONDA.interface_name)
 class AnacondaBossInterface(BossInterface):
     """Temporary extension of the boss for anaconda.
 

--- a/pyanaconda/modules/boss/install_manager/install_interface.py
+++ b/pyanaconda/modules/boss/install_manager/install_interface.py
@@ -21,14 +21,13 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
-from pyanaconda.dbus.constants import DBUS_BOSS_INSTALLATION_NAME
 from pyanaconda.dbus.interface import dbus_interface, dbus_signal
+from pyanaconda.modules.common.constants.objects import BOSS_INSTALLATION
 from pyanaconda.dbus.template import InterfaceTemplate
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
 
-@dbus_interface(DBUS_BOSS_INSTALLATION_NAME)
+@dbus_interface(BOSS_INSTALLATION.interface_name)
 class InstallationInterface(InterfaceTemplate):
     """Interface for Boss to summarize installation from modules for UIs."""
 

--- a/pyanaconda/modules/boss/install_manager/install_manager.py
+++ b/pyanaconda/modules/boss/install_manager/install_manager.py
@@ -124,10 +124,12 @@ class InstallManager(object):
                 log.error("Module %s is not available!", observer.service_name)
                 continue
 
-            tasks = observer.proxy.AvailableTasks
-            for task in tasks:
-                log.debug("Getting task %s from module %s", task[TASK_NAME], observer.service_name)
-                task_proxy = DBus.get_proxy(observer.service_name, task[TASK_PATH])
+            service_name = observer.service_name
+            task_paths = observer.proxy.AvailableTasks
+
+            for object_path in task_paths:
+                log.debug("Getting task %s from module %s", object_path, service_name)
+                task_proxy = DBus.get_proxy(service_name, object_path)
                 self._tasks.add(task_proxy)
 
     def _sum_steps_count(self):

--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -99,9 +99,9 @@ class KickstartModule(BaseModule):
         """Returns a list of published tasks."""
         return self._published_tasks
 
-    def publish_task(self, implementation, module_path):
+    def publish_task(self, dbus_path, task):
         """Publish a task."""
-        published = publish_task(implementation, module_path)
+        published = publish_task(dbus_path, task)
         self._published_tasks.append(published)
 
     @property

--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -73,7 +73,7 @@ class KickstartModule(BaseModule):
 
     def __init__(self):
         super().__init__()
-        self._published_tasks = []
+        self._published_tasks = {}
         self._module_properties_changed = Signal()
 
         self.kickstarted_changed = Signal()
@@ -96,13 +96,13 @@ class KickstartModule(BaseModule):
 
     @property
     def published_tasks(self):
-        """Returns a list of published tasks."""
+        """Returns a dictionary of published tasks."""
         return self._published_tasks
 
-    def publish_task(self, dbus_path, task):
+    def publish_task(self, namespace, task, message_bus=DBus):
         """Publish a task."""
-        published = publish_task(dbus_path, task)
-        self._published_tasks.append(published)
+        object_path = publish_task(message_bus, namespace, task)
+        self.published_tasks[task] = object_path
 
     @property
     def kickstart_specification(self):

--- a/pyanaconda/modules/common/base/base_interface.py
+++ b/pyanaconda/modules/common/base/base_interface.py
@@ -20,14 +20,14 @@
 #
 from pykickstart.errors import KickstartError
 
+from pyanaconda.modules.common.constants.interfaces import KICKSTART_MODULE
 from pyanaconda.dbus.property import emits_properties_changed
 from pyanaconda.dbus.template import AdvancedInterfaceTemplate
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.dbus.interface import dbus_interface
-from pyanaconda.dbus.constants import DBUS_MODULE_NAMESPACE
 
 
-@dbus_interface(DBUS_MODULE_NAMESPACE)
+@dbus_interface(KICKSTART_MODULE.interface_name)
 class KickstartModuleInterface(AdvancedInterfaceTemplate):
     """DBus interface of a kickstart module.
 

--- a/pyanaconda/modules/common/base/base_interface.py
+++ b/pyanaconda/modules/common/base/base_interface.py
@@ -40,18 +40,12 @@ class KickstartModuleInterface(AdvancedInterfaceTemplate):
         self.implementation.kickstarted_changed.connect(self.changed("Kickstarted"))
 
     @property
-    def AvailableTasks(self) -> List[Tuple[Str, Str]]:
+    def AvailableTasks(self) -> List[ObjPath]:
         """Return DBus object paths for tasks available for this module.
 
-        :returns: List of tuples (Name, DBus object path) for all Tasks.
-                  See pyanaconda.task.Task for Task API.
+        :returns: List of object paths for all available tasks.
         """
-        result = []
-
-        for task in self.implementation.published_tasks:
-            result.append((task.Name, task.object_path))
-
-        return result
+        return list(self.implementation.published_tasks.values())
 
     @property
     def KickstartCommands(self) -> List[Str]:

--- a/pyanaconda/modules/common/constants/Makefile.am
+++ b/pyanaconda/modules/common/constants/Makefile.am
@@ -14,10 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = base task errors constants
-
 pkgpyexecdir = $(pyexecdir)/py$(PACKAGE_NAME)
-modules_commondir = $(pkgpyexecdir)/modules/common
-modules_common_PYTHON = $(srcdir)/*.py
+modules_constantsdir = $(pkgpyexecdir)/modules/common/constants
+modules_constants_PYTHON = $(srcdir)/*.py
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/pyanaconda/modules/common/constants/interfaces.py
+++ b/pyanaconda/modules/common/constants/interfaces.py
@@ -1,0 +1,36 @@
+#
+# Known DBus interfaces.
+#
+# Copyright (C) 2018  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from pyanaconda.dbus.identifier import DBusInterfaceIdentifier
+from pyanaconda.modules.common.constants.namespaces import ANACONDA_NAMESPACE, BOSS_NAMESPACE, \
+    MODULES_NAMESPACE
+
+
+KICKSTART_MODULE = DBusInterfaceIdentifier(
+    namespace=MODULES_NAMESPACE
+)
+
+BOSS_ANACONDA = DBusInterfaceIdentifier(
+    namespace=BOSS_NAMESPACE,
+    basename="Anaconda"
+)
+
+TASK = DBusInterfaceIdentifier(
+    namespace=ANACONDA_NAMESPACE,
+    basename="Task"
+)

--- a/pyanaconda/modules/common/constants/namespaces.py
+++ b/pyanaconda/modules/common/constants/namespaces.py
@@ -1,0 +1,77 @@
+#
+# DBus namespaces, where a namespace is just a tuple of strings.
+#
+# Copyright (C) 2018  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANACONDA_NAMESPACE = (
+    "org", "fedoraproject", "Anaconda"
+)
+
+MODULES_NAMESPACE = (
+    *ANACONDA_NAMESPACE,
+    "Modules"
+)
+
+ADDONS_NAMESPACE = (
+    *ANACONDA_NAMESPACE,
+    "Addons"
+)
+
+BOSS_NAMESPACE = (
+    *ANACONDA_NAMESPACE,
+    "Boss"
+)
+
+FOO_NAMESPACE = (
+    *MODULES_NAMESPACE,
+    "Foo"
+)
+
+BAR_NAMESPACE = (
+    *MODULES_NAMESPACE,
+    "Bar"
+)
+
+TIMEZONE_NAMESPACE = (
+    *MODULES_NAMESPACE,
+    "Timezone"
+)
+
+NETWORK_NAMESPACE = (
+    *MODULES_NAMESPACE,
+    "Network",
+)
+
+LOCALIZATION_NAMESPACE = (
+    *MODULES_NAMESPACE,
+    "Localization",
+)
+
+SECURITY_NAMESPACE = (
+    *MODULES_NAMESPACE,
+    "Security"
+)
+
+USER_NAMESPACE = (
+    *MODULES_NAMESPACE,
+    "User"
+)
+
+BAZ_NAMESPACE = (
+    *ADDONS_NAMESPACE,
+    "Baz"
+)

--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -1,0 +1,25 @@
+#
+# Known DBus objects.
+#
+# Copyright (C) 2018  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from pyanaconda.dbus.identifier import DBusObjectIdentifier
+from pyanaconda.modules.common.constants.namespaces import BOSS_NAMESPACE
+
+BOSS_INSTALLATION = DBusObjectIdentifier(
+    namespace=BOSS_NAMESPACE,
+    basename="Installation"
+)

--- a/pyanaconda/modules/common/constants/services.py
+++ b/pyanaconda/modules/common/constants/services.py
@@ -1,0 +1,83 @@
+#
+# Known DBus services.
+#
+# Copyright (C) 2018  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from pyanaconda.dbus import SystemBus
+from pyanaconda.dbus.identifier import DBusServiceIdentifier
+from pyanaconda.modules.common.constants.namespaces import BOSS_NAMESPACE, FOO_NAMESPACE, \
+    BAR_NAMESPACE, BAZ_NAMESPACE, TIMEZONE_NAMESPACE, NETWORK_NAMESPACE, LOCALIZATION_NAMESPACE, \
+    SECURITY_NAMESPACE, USER_NAMESPACE
+
+# Anaconda services.
+
+BOSS = DBusServiceIdentifier(
+    namespace=BOSS_NAMESPACE
+)
+
+FOO = DBusServiceIdentifier(
+    namespace=FOO_NAMESPACE
+)
+
+BAR = DBusServiceIdentifier(
+    namespace=BAR_NAMESPACE
+)
+
+BAZ = DBusServiceIdentifier(
+    namespace=BAZ_NAMESPACE
+)
+
+TIMEZONE = DBusServiceIdentifier(
+    namespace=TIMEZONE_NAMESPACE
+)
+
+NETWORK = DBusServiceIdentifier(
+    namespace=NETWORK_NAMESPACE
+)
+
+LOCALIZATION = DBusServiceIdentifier(
+    namespace=LOCALIZATION_NAMESPACE
+)
+
+SECURITY = DBusServiceIdentifier(
+    namespace=SECURITY_NAMESPACE
+)
+
+USER = DBusServiceIdentifier(
+    namespace=USER_NAMESPACE
+)
+
+# System services.
+
+HOSTNAME = DBusServiceIdentifier(
+    namespace=("org", "freedesktop", "hostname"),
+    service_version=1,
+    object_version=1,
+    interface_version=1,
+    message_bus=SystemBus
+)
+
+# Other constants.
+
+ALL_KICKSTART_MODULES = [
+    FOO,
+    BAR,
+    TIMEZONE,
+    NETWORK,
+    LOCALIZATION,
+    SECURITY,
+    USER
+]

--- a/pyanaconda/modules/common/errors/__init__.py
+++ b/pyanaconda/modules/common/errors/__init__.py
@@ -16,23 +16,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from pydbus.error import map_error, map_by_default
 from pykickstart.errors import KickstartError
+from pyanaconda.dbus.error import dbus_error_by_default, dbus_error
+from pyanaconda.modules.common.constants.namespaces import ANACONDA_NAMESPACE
 
-from pyanaconda.dbus.constants import ANACONDA_DBUS_NAMESPACE
 
-
-@map_by_default
+@dbus_error_by_default
 class DBusError(Exception):
     """A default DBus error."""
     pass
 
 
-@map_error("{}.Error".format(ANACONDA_DBUS_NAMESPACE))
+@dbus_error("Error", namespace=ANACONDA_NAMESPACE)
 class AnacondaError(Exception):
     """A default Anaconda error."""
     pass
 
 
 # Define mapping for existing exceptions.
-map_error("{}.KickstartError".format(ANACONDA_DBUS_NAMESPACE))(KickstartError)
+dbus_error("KickstartError", namespace=ANACONDA_NAMESPACE)(KickstartError)

--- a/pyanaconda/modules/common/errors/installation.py
+++ b/pyanaconda/modules/common/errors/installation.py
@@ -16,18 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from pydbus.error import map_error
+from pyanaconda.dbus.error import dbus_error
+from pyanaconda.modules.common.constants.namespaces import ANACONDA_NAMESPACE
 from pyanaconda.modules.common.errors import AnacondaError
-from pyanaconda.dbus.constants import DBUS_BOSS_INSTALLATION_NAME
 
 
-@map_error("{}.InstallationError".format(DBUS_BOSS_INSTALLATION_NAME))
+@dbus_error("InstallationError", namespace=ANACONDA_NAMESPACE)
 class InstallationError(AnacondaError):
     """General exception for the installation errors."""
     pass
 
 
-@map_error("{}.InstallationNotRunning".format(DBUS_BOSS_INSTALLATION_NAME))
+@dbus_error("InstallationNotRunning", namespace=ANACONDA_NAMESPACE)
 class InstallationNotRunning(InstallationError):
     """Exception will be raised when action requires running installation."""
     pass

--- a/pyanaconda/modules/common/errors/kickstart.py
+++ b/pyanaconda/modules/common/errors/kickstart.py
@@ -16,25 +16,24 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from pydbus.error import map_error
-
+from pyanaconda.dbus.error import dbus_error
+from pyanaconda.modules.common.constants.namespaces import BOSS_NAMESPACE
 from pyanaconda.modules.common.errors import AnacondaError
-from pyanaconda.dbus.constants import DBUS_BOSS_ANACONDA_NAME
 
 
-@map_error("{}.SplitKickstartError".format(DBUS_BOSS_ANACONDA_NAME))
+@dbus_error("SplitKickstartError", namespace=BOSS_NAMESPACE)
 class SplitKickstartError(AnacondaError):
     """Error while parsing kickstart for splitting."""
     pass
 
 
-@map_error("{}.SplitKickstartSectionParsingError".format(DBUS_BOSS_ANACONDA_NAME))
+@dbus_error("SplitKickstartSectionParsingError", namespace=BOSS_NAMESPACE)
 class SplitKickstartSectionParsingError(SplitKickstartError):
     """Error while parsing a section in kickstart."""
     pass
 
 
-@map_error("{}.SplitKickstartMissingIncludeError".format(DBUS_BOSS_ANACONDA_NAME))
+@dbus_error("SplitKickstartMissingIncludeError", namespace=BOSS_NAMESPACE)
 class SplitKickstartMissingIncludeError(SplitKickstartError):
     """File included in kickstart was not found."""
     pass

--- a/pyanaconda/modules/common/errors/task.py
+++ b/pyanaconda/modules/common/errors/task.py
@@ -16,18 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from pydbus.error import map_error
-from pyanaconda.dbus.constants import DBUS_TASK_NAME
+from pyanaconda.dbus.error import dbus_error
+from pyanaconda.modules.common.constants.namespaces import ANACONDA_NAMESPACE
 from pyanaconda.modules.common.errors import AnacondaError
 
 
-@map_error("{}.TaskError".format(DBUS_TASK_NAME))
+@dbus_error("TaskError", namespace=ANACONDA_NAMESPACE)
 class TaskError(AnacondaError):
     """General exception for task errors."""
     pass
 
 
-@map_error("{}.TaskAlreadyRunningError".format(DBUS_TASK_NAME))
+@dbus_error("TaskAlreadyRunningError", namespace=ANACONDA_NAMESPACE)
 class TaskAlreadyRunningError(TaskError):
     """Exception will be raised when starting task which is already running."""
     pass

--- a/pyanaconda/modules/common/task/__init__.py
+++ b/pyanaconda/modules/common/task/__init__.py
@@ -21,13 +21,12 @@ from pyanaconda.modules.common.task.task_interface import TaskInterface
 __all__ = ["publish_task", "Task", "TaskInterface"]
 
 
-def publish_task(task_instance: Task, module_dbus_path):
+def publish_task(dbus_path, task_instance: Task):
     """Publish Task to the DBus.
 
+    :param str dbus_path: prefix of the DBus object path
     :param task_instance: Instance of a Task.
-    :param module_dbus_path: DBus object path of a module.
-    :type module_dbus_path: str
     """
     interface = TaskInterface(task_instance)
-    interface.publish_from_module(module_dbus_path)
+    interface.publish_from_module(dbus_path)
     return interface

--- a/pyanaconda/modules/common/task/__init__.py
+++ b/pyanaconda/modules/common/task/__init__.py
@@ -21,12 +21,15 @@ from pyanaconda.modules.common.task.task_interface import TaskInterface
 __all__ = ["publish_task", "Task", "TaskInterface"]
 
 
-def publish_task(dbus_path, task_instance: Task):
-    """Publish Task to the DBus.
+def publish_task(message_bus, namespace, task_instance):
+    """Publish a task on the given message bus.
 
-    :param str dbus_path: prefix of the DBus object path
-    :param task_instance: Instance of a Task.
+    :param message_bus: a message bus
+    :param namespace: a sequence of names
+    :param task_instance: an instance of a Task
+    :return: a DBus path of the published task
     """
-    interface = TaskInterface(task_instance)
-    interface.publish_from_module(dbus_path)
-    return interface
+    publishable = TaskInterface(task_instance)
+    object_path = TaskInterface.get_object_path(namespace)
+    message_bus.publish_object(object_path, publishable)
+    return object_path

--- a/pyanaconda/modules/common/task/task_interface.py
+++ b/pyanaconda/modules/common/task/task_interface.py
@@ -21,14 +21,14 @@
 # Red Hat, Inc.
 #
 from pyanaconda.dbus.interface import dbus_interface, dbus_signal
-from pyanaconda.dbus.constants import DBUS_TASK_NAME
+from pyanaconda.modules.common.constants.interfaces import TASK
 from pyanaconda.dbus.template import InterfaceTemplate
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
 __all__ = ['TaskInterface']
 
 
-@dbus_interface(DBUS_TASK_NAME)
+@dbus_interface(TASK.interface_name)
 class TaskInterface(InterfaceTemplate):
     """Base class for implementing Task.
 

--- a/pyanaconda/modules/common/task/task_interface.py
+++ b/pyanaconda/modules/common/task/task_interface.py
@@ -21,6 +21,7 @@
 # Red Hat, Inc.
 #
 from pyanaconda.dbus.interface import dbus_interface, dbus_signal
+from pyanaconda.dbus.namespace import get_dbus_path
 from pyanaconda.modules.common.constants.interfaces import TASK
 from pyanaconda.dbus.template import InterfaceTemplate
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
@@ -37,16 +38,18 @@ class TaskInterface(InterfaceTemplate):
 
     _task_counter = 1
 
-    def __init__(self, implementation):
-        """Create Task interface for DBus.
+    @staticmethod
+    def get_object_path(namespace):
+        """Get the unique object path in the given namespace.
 
-        :param implementation: Instance of the pyanaconda.task.task.Task class.
+        This method is not thread safe for now.
+
+        :param namespace: a sequence of names
+        :return: a DBus path of a task
         """
-        # this number will be part of the object path on DBus
-        self._task_number = TaskInterface._task_counter
+        task_number = TaskInterface._task_counter
         TaskInterface._task_counter += 1
-
-        super().__init__(implementation)
+        return get_dbus_path(*namespace, "Tasks", str(task_number))
 
     def connect_signals(self):
         """Connect signals to the implementation."""
@@ -54,17 +57,6 @@ class TaskInterface(InterfaceTemplate):
         self.implementation.error_raised_signal.connect(self.ErrorRaised)
         self.implementation.started_signal.connect(self.Started)
         self.implementation.stopped_signal.connect(self.Stopped)
-
-    def publish_from_module(self, module_path):
-        """Publish task on DBus using the module path.
-
-        Every new created interface instance will get new number used as a last part of the
-        DBus object path to avoid conflict.
-
-        :param module_path: DBus object path to the module.
-        :type module_path: str
-        """
-        self.publish("{}/Tasks/{}".format(module_path, self._task_number))
 
     @property
     def Name(self) -> Str:

--- a/pyanaconda/modules/foo/foo.py
+++ b/pyanaconda/modules/foo/foo.py
@@ -18,8 +18,8 @@
 # Red Hat, Inc.
 #
 from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_FOO_PATH, MODULE_FOO_NAME
 from pyanaconda.modules.common.base import KickstartModule
+from pyanaconda.modules.common.constants.services import FOO
 from pyanaconda.modules.foo.foo_interface import FooInterface
 from pyanaconda.modules.foo.tasks.foo_task import FooTask
 
@@ -32,6 +32,6 @@ class Foo(KickstartModule):
 
     def publish(self):
         """Publish the module."""
-        DBus.publish_object(FooInterface(self), MODULE_FOO_PATH)
-        self.publish_task(FooTask(), MODULE_FOO_PATH)
-        DBus.register_service(MODULE_FOO_NAME)
+        DBus.publish_object(FOO.object_path, FooInterface(self))
+        self.publish_task(FOO.namespace, FooTask())
+        DBus.register_service(FOO.service_name)

--- a/pyanaconda/modules/foo/foo_interface.py
+++ b/pyanaconda/modules/foo/foo_interface.py
@@ -17,13 +17,12 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
-from pyanaconda.dbus.constants import MODULE_FOO_NAME
 from pyanaconda.modules.common.base import KickstartModuleInterface
+from pyanaconda.modules.common.constants.services import FOO
 from pyanaconda.dbus.interface import dbus_interface
 
 
-@dbus_interface(MODULE_FOO_NAME)
+@dbus_interface(FOO.interface_name)
 class FooInterface(KickstartModuleInterface):
     """DBus interface for Foo."""
     pass

--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -18,9 +18,9 @@
 # Red Hat, Inc.
 #
 from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.base import KickstartModule
+from pyanaconda.modules.common.constants.services import LOCALIZATION
 from pyanaconda.modules.localization.localization_interface import LocalizationInterface
 from pyanaconda.modules.localization.kickstart import LocalizationKickstartSpecification
 
@@ -56,8 +56,8 @@ class LocalizationModule(KickstartModule):
 
     def publish(self):
         """Publish the module."""
-        DBus.publish_object(LocalizationInterface(self), MODULE_LOCALIZATION_PATH)
-        DBus.register_service(MODULE_LOCALIZATION_NAME)
+        DBus.publish_object(LOCALIZATION.object_path, LocalizationInterface(self))
+        DBus.register_service(LOCALIZATION.service_name)
 
     @property
     def kickstart_specification(self):

--- a/pyanaconda/modules/localization/localization_interface.py
+++ b/pyanaconda/modules/localization/localization_interface.py
@@ -18,14 +18,14 @@
 # Red Hat, Inc.
 #
 
-from pyanaconda.dbus.constants import MODULE_LOCALIZATION_NAME
+from pyanaconda.modules.common.constants.services import LOCALIZATION
 from pyanaconda.dbus.property import emits_properties_changed
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.dbus.interface import dbus_interface
 
 
-@dbus_interface(MODULE_LOCALIZATION_NAME)
+@dbus_interface(LOCALIZATION.interface_name)
 class LocalizationInterface(KickstartModuleInterface):
     """DBus interface for Localization module."""
 

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -18,16 +18,12 @@
 # Red Hat, Inc.
 #
 
-from pyanaconda.dbus import DBus, SystemBus
-from pyanaconda.dbus.constants import MODULE_NETWORK_NAME, MODULE_NETWORK_PATH
+from pyanaconda.dbus import DBus
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.base import KickstartModule
+from pyanaconda.modules.common.constants.services import NETWORK, HOSTNAME
 from pyanaconda.modules.network.network_interface import NetworkInterface
 from pyanaconda.modules.network.kickstart import NetworkKickstartSpecification
-
-HOSTNAME_SERVICE = "org.freedesktop.hostname1"
-HOSTNAME_PATH = "/org/freedesktop/hostname1"
-HOSTNAME_INTERFACE = "org.freedesktop.hostname1"
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -46,8 +42,7 @@ class NetworkModule(KickstartModule):
 
     def _get_hostname_service_observer(self):
         """Get an observer of the hostname service."""
-        service = SystemBus.get_cached_observer(
-            HOSTNAME_SERVICE, HOSTNAME_PATH, [HOSTNAME_INTERFACE])
+        service = HOSTNAME.get_cached_observer()
 
         service.cached_properties_changed.connect(
             self._hostname_service_properties_changed)
@@ -57,8 +52,8 @@ class NetworkModule(KickstartModule):
 
     def publish(self):
         """Publish the module."""
-        DBus.publish_object(NetworkInterface(self), MODULE_NETWORK_PATH)
-        DBus.register_service(MODULE_NETWORK_NAME)
+        DBus.publish_object(NETWORK.object_path, NetworkInterface(self))
+        DBus.register_service(NETWORK.service_name)
 
     @property
     def kickstart_specification(self):

--- a/pyanaconda/modules/network/network_interface.py
+++ b/pyanaconda/modules/network/network_interface.py
@@ -18,14 +18,14 @@
 # Red Hat, Inc.
 #
 
-from pyanaconda.dbus.constants import MODULE_NETWORK_NAME
+from pyanaconda.modules.common.constants.services import NETWORK
 from pyanaconda.dbus.property import emits_properties_changed
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.dbus.interface import dbus_interface, dbus_signal
 
 
-@dbus_interface(MODULE_NETWORK_NAME)
+@dbus_interface(NETWORK.interface_name)
 class NetworkInterface(KickstartModuleInterface):
     """DBus interface for Network module."""
 

--- a/pyanaconda/modules/security/security.py
+++ b/pyanaconda/modules/security/security.py
@@ -21,9 +21,9 @@ import shlex
 
 from pyanaconda.core.constants import SELINUX_DEFAULT, REALM_NAME, REALM_DISCOVER, REALM_JOIN
 from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_SECURITY_NAME, MODULE_SECURITY_PATH
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.base import KickstartModule
+from pyanaconda.modules.common.constants.services import SECURITY
 from pyanaconda.modules.security.kickstart import SecurityKickstartSpecification
 from pyanaconda.modules.security.security_interface import SecurityInterface
 
@@ -55,8 +55,8 @@ class SecurityModule(KickstartModule):
 
     def publish(self):
         """Publish the module."""
-        DBus.publish_object(SecurityInterface(self), MODULE_SECURITY_PATH)
-        DBus.register_service(MODULE_SECURITY_NAME)
+        DBus.publish_object(SECURITY.object_path, SecurityInterface(self))
+        DBus.register_service(SECURITY.service_name)
 
     @property
     def kickstart_specification(self):

--- a/pyanaconda/modules/security/security_interface.py
+++ b/pyanaconda/modules/security/security_interface.py
@@ -18,14 +18,14 @@
 # Red Hat, Inc.
 #
 from pyanaconda.core.constants import REALM_NAME, REALM_DISCOVER, REALM_JOIN
-from pyanaconda.dbus.constants import MODULE_SECURITY_NAME
+from pyanaconda.modules.common.constants.services import SECURITY
 from pyanaconda.dbus.property import emits_properties_changed
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.dbus.interface import dbus_interface
 
 
-@dbus_interface(MODULE_SECURITY_NAME)
+@dbus_interface(SECURITY.interface_name)
 class SecurityInterface(KickstartModuleInterface):
     """DBus interface for the security module."""
 

--- a/pyanaconda/modules/timezone/timezone.py
+++ b/pyanaconda/modules/timezone/timezone.py
@@ -18,9 +18,9 @@
 # Red Hat, Inc.
 #
 from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.base import KickstartModule
+from pyanaconda.modules.common.constants.services import TIMEZONE
 from pyanaconda.modules.timezone.timezone_interface import TimezoneInterface
 from pyanaconda.modules.timezone.kickstart import TimezoneKickstartSpecification
 
@@ -47,8 +47,8 @@ class TimezoneModule(KickstartModule):
 
     def publish(self):
         """Publish the module."""
-        DBus.publish_object(TimezoneInterface(self), MODULE_TIMEZONE_PATH)
-        DBus.register_service(MODULE_TIMEZONE_NAME)
+        DBus.publish_object(TIMEZONE.object_path, TimezoneInterface(self))
+        DBus.register_service(TIMEZONE.service_name)
 
     @property
     def kickstart_specification(self):

--- a/pyanaconda/modules/timezone/timezone_interface.py
+++ b/pyanaconda/modules/timezone/timezone_interface.py
@@ -17,15 +17,14 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
-from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME
+from pyanaconda.modules.common.constants.services import TIMEZONE
 from pyanaconda.dbus.property import emits_properties_changed
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.dbus.interface import dbus_interface
 
 
-@dbus_interface(MODULE_TIMEZONE_NAME)
+@dbus_interface(TIMEZONE.interface_name)
 class TimezoneInterface(KickstartModuleInterface):
     """DBus interface for Timezone module."""
 

--- a/pyanaconda/modules/user/user.py
+++ b/pyanaconda/modules/user/user.py
@@ -18,9 +18,9 @@
 # Red Hat, Inc.
 #
 from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_USER_NAME, MODULE_USER_PATH
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.base import KickstartModule
+from pyanaconda.modules.common.constants.services import USER
 from pyanaconda.modules.user.user_interface import UserInterface
 from pyanaconda.modules.user.kickstart import UserKickstartSpecification
 
@@ -46,8 +46,8 @@ class UserModule(KickstartModule):
 
     def publish(self):
         """Publish the module."""
-        DBus.publish_object(UserInterface(self), MODULE_USER_PATH)
-        DBus.register_service(MODULE_USER_NAME)
+        DBus.publish_object(USER.object_path, UserInterface(self))
+        DBus.register_service(USER.service_name)
 
     @property
     def kickstart_specification(self):

--- a/pyanaconda/modules/user/user_interface.py
+++ b/pyanaconda/modules/user/user_interface.py
@@ -18,7 +18,6 @@
 # Red Hat, Inc.
 #
 
-from pyanaconda.dbus.constants import MODULE_USER_NAME
 from pyanaconda.modules.common.constants.services import USER
 from pyanaconda.dbus.property import emits_properties_changed
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import

--- a/pyanaconda/modules/user/user_interface.py
+++ b/pyanaconda/modules/user/user_interface.py
@@ -19,13 +19,14 @@
 #
 
 from pyanaconda.dbus.constants import MODULE_USER_NAME
+from pyanaconda.modules.common.constants.services import USER
 from pyanaconda.dbus.property import emits_properties_changed
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.dbus.interface import dbus_interface
 
 
-@dbus_interface(MODULE_USER_NAME)
+@dbus_interface(USER.interface_name)
 class UserInterface(KickstartModuleInterface):
     """DBus interface for User module."""
 

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -45,9 +45,7 @@ from pyanaconda.flags import flags, can_touch_runtime_system
 from pyanaconda.core.i18n import _
 from pyanaconda.core.regexes import HOSTNAME_PATTERN_WITHOUT_ANCHORS, IBFT_CONFIGURED_DEVICE_NAME
 from pykickstart.constants import BIND_TO_MAC
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_NETWORK_NAME, MODULE_NETWORK_PATH, \
-    MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH
+from pyanaconda.modules.common.constants.services import NETWORK, TIMEZONE
 
 from pyanaconda.anaconda_loggers import get_module_logger, get_ifcfg_logger
 log = get_module_logger(__name__)
@@ -1291,7 +1289,7 @@ def ks_spec_to_device_name(ksspec=""):
 def set_hostname(hn):
     if can_touch_runtime_system("set hostname", touch_live=True):
         log.info("setting installation environment host name to %s", hn)
-        network_proxy = DBus.get_proxy(MODULE_NETWORK_NAME, MODULE_NETWORK_PATH)
+        network_proxy = NETWORK.get_proxy()
         network_proxy.SetCurrentHostname(hn)
 
 def write_hostname(rootpath, hostname, overwrite=False):
@@ -1363,7 +1361,7 @@ def write_network_config(storage, ksdata, instClass, rootpath):
     # overwrite previous settings for LiveCD or liveimg installations
     overwrite = flags.livecdInstall or ksdata.method.method == "liveimg"
 
-    network_proxy = DBus.get_proxy(MODULE_NETWORK_NAME, MODULE_NETWORK_PATH)
+    network_proxy = NETWORK.get_proxy()
     hostname = network_proxy.Hostname
     write_hostname(rootpath, hostname, overwrite=overwrite)
     if hostname != DEFAULT_HOSTNAME:
@@ -1386,7 +1384,7 @@ def update_hostname_data(ksdata, hostname):
     if not hostname_found:
         nd = hostname_ksdata(hostname)
         ksdata.network.network.append(nd)
-    network_proxy = DBus.get_proxy(MODULE_NETWORK_NAME, MODULE_NETWORK_PATH)
+    network_proxy = NETWORK.get_proxy()
     network_proxy.SetHostname(hostname)
 
 def get_device_name(network_data):
@@ -1540,7 +1538,7 @@ def networkInitialize(ksdata):
         logIfcfgFiles(msg)
 
     # initialize ksdata hostname
-    network_proxy = DBus.get_proxy(MODULE_NETWORK_NAME, MODULE_NETWORK_PATH)
+    network_proxy = NETWORK.get_proxy()
     if network_proxy.Hostname == DEFAULT_HOSTNAME:
         bootopts_hostname = hostname_from_cmdline(flags.cmdline)
         if bootopts_hostname:
@@ -1549,7 +1547,7 @@ def networkInitialize(ksdata):
 def _get_ntp_servers_from_dhcp():
     """Check if some NTP servers were returned from DHCP and set them
     to ksdata (if not NTP servers were specified in the kickstart)"""
-    timezone_proxy = DBus.get_proxy(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
+    timezone_proxy = TIMEZONE.get_proxy()
     ntp_servers = nm.nm_ntp_servers_from_dhcp()
     log.info("got %d NTP servers from DHCP", len(ntp_servers))
     hostnames = []

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -19,9 +19,6 @@
 #
 import os
 
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH
-
 from blivet.size import Size
 from pykickstart.constants import GROUP_ALL, GROUP_DEFAULT, KS_MISSING_IGNORE
 from pyanaconda.flags import flags
@@ -30,6 +27,7 @@ from pyanaconda.progress import progressQ, progress_message
 from pyanaconda.core.util import ProxyString, ProxyStringError
 from pyanaconda.core import constants
 from pyanaconda.core import util
+from pyanaconda.modules.common.constants.services import LOCALIZATION
 
 import pyanaconda.errors as errors
 import pyanaconda.localization
@@ -672,7 +670,7 @@ class DNFPayload(payload.PackagePayload):
 
         langpacks = []
         # add base langpacks into transaction
-        localization_proxy = DBus.get_proxy(MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH)
+        localization_proxy = LOCALIZATION.get_proxy()
         for lang in [localization_proxy.Language] + localization_proxy.LanguageSupport:
             loc = pyanaconda.localization.find_best_locale_match(lang, alangs)
             if not loc:
@@ -1005,7 +1003,7 @@ class DNFPayload(payload.PackagePayload):
         return True
 
     def languageGroups(self):
-        localization_proxy = DBus.get_proxy(MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH)
+        localization_proxy = LOCALIZATION.get_proxy()
         locales = [localization_proxy.Language] + localization_proxy.LanguageSupport
         match_fn = pyanaconda.localization.langcode_matches_locale
         gids = set()

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -41,7 +41,8 @@ from pyanaconda.flags import can_touch_runtime_system
 from pyanaconda.screensaver import inhibit_screensaver
 
 from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import DBUS_BOSS_NAME, DBUS_BOSS_PATH, DBUS_FLAG_NONE
+from pyanaconda.dbus.constants import DBUS_FLAG_NONE
+from pyanaconda.modules.common.constants.services import BOSS
 
 import blivet
 
@@ -83,14 +84,14 @@ def module_exists(module_path):
 
 def stop_boss():
     """Stop boss by calling Quit() on DBus."""
-    boss_proxy = DBus.get_proxy(DBUS_BOSS_NAME, DBUS_BOSS_PATH)
+    boss_proxy = BOSS.get_proxy()
     boss_proxy.Quit()
 
 
 def run_boss():
     """Start Boss service on DBus."""
     bus_proxy = DBus.get_dbus_proxy()
-    bus_proxy.StartServiceByName(DBUS_BOSS_NAME, DBUS_FLAG_NONE)
+    bus_proxy.StartServiceByName(BOSS.service_name, DBUS_FLAG_NONE)
 
 
 def get_anaconda_version_string(build_time_version=False):
@@ -437,7 +438,7 @@ def wait_for_modules(timeout=60):
     :param timeout: seconds to the timeout
     :return: True if the modules are ready, otherwise False
     """
-    boss = DBus.get_proxy(DBUS_BOSS_NAME, DBUS_BOSS_PATH)
+    boss = BOSS.get_proxy()
 
     while not boss.AllModulesAvailable and timeout > 0:
         log.info("Waiting %d sec for modules to be started.", timeout)

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -57,9 +57,7 @@ from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _
 from pyanaconda.platform import EFI
 from pyanaconda.platform import platform as _platform
-
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_NETWORK_NAME, MODULE_NETWORK_PATH
+from pyanaconda.modules.common.constants.services import NETWORK
 
 import logging
 log = logging.getLogger("anaconda.storage")
@@ -1893,9 +1891,8 @@ class InstallerStorage(Blivet):
     def _get_hostname(self):
         """Return a hostname."""
         ignored_hostnames = {None, "", 'localhost', 'localhost.localdomain'}
-        hostname = None
 
-        network_proxy = DBus.get_proxy(MODULE_NETWORK_NAME, MODULE_NETWORK_PATH)
+        network_proxy = NETWORK.get_proxy()
         hostname = network_proxy.Hostname
 
         if hostname in ignored_hostnames:

--- a/pyanaconda/timezone.py
+++ b/pyanaconda/timezone.py
@@ -29,9 +29,8 @@ from collections import OrderedDict
 
 from pyanaconda.core import util
 from pyanaconda.core.constants import THREAD_STORAGE
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH
 from pyanaconda.flags import flags
+from pyanaconda.modules.common.constants.services import TIMEZONE
 from pyanaconda.threading import threadMgr
 from blivet import arch
 
@@ -152,7 +151,7 @@ def save_hw_clock(timezone_proxy=None):
         return
 
     if not timezone_proxy:
-        timezone_proxy = DBus.get_proxy(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
+        timezone_proxy = TIMEZONE.get_proxy()
 
     cmd = "hwclock"
     args = ["--systohc"]

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -43,8 +43,7 @@ from pyanaconda import network
 from pyanaconda import nm
 from pyanaconda import ntp
 from pyanaconda import flags
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH
+from pyanaconda.modules.common.constants.services import TIMEZONE
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core.i18n import _, CN_
 from pyanaconda.core.async_utils import async_action_wait, async_action_nowait
@@ -434,7 +433,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
         self._shown = False
         self._tz = None
 
-        self._timezone_module = DBus.get_observer(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
+        self._timezone_module = TIMEZONE.get_observer()
         self._timezone_module.connect()
 
     def initialize(self):

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -31,12 +31,11 @@ from pyanaconda.ui.gui.utils import override_cell_property
 from pyanaconda.ui.gui.xkl_wrapper import XklWrapper, XklWrapperError
 from pyanaconda import keyboard
 from pyanaconda import flags
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH
 from pyanaconda.core.i18n import _, N_, CN_
 from pyanaconda.core.constants import DEFAULT_KEYBOARD, THREAD_KEYBOARD_INIT, THREAD_ADD_LAYOUTS_INIT
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.core.util import strip_accents, have_word_match
+from pyanaconda.modules.common.constants.services import LOCALIZATION
 from pyanaconda.threading import threadMgr, AnacondaThread
 
 import locale as locale_mod
@@ -288,7 +287,7 @@ class KeyboardSpoke(NormalSpoke):
         self._removeButton = self.builder.get_object("removeLayoutButton")
         self._previewButton = self.builder.get_object("previewButton")
 
-        self._l12_module = DBus.get_observer(MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH)
+        self._l12_module = LOCALIZATION.get_observer()
         self._l12_module.connect()
         self._seen = self._l12_module.proxy.KeyboardKickstarted
 

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -23,8 +23,7 @@ gi.require_version("Gdk", "3.0")
 
 from gi.repository import Pango, Gdk
 
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH
+from pyanaconda.modules.common.constants.services import LOCALIZATION
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import CN_
 from pyanaconda.ui.gui.spokes import NormalSpoke
@@ -66,7 +65,7 @@ class LangsupportSpoke(LangLocaleHandler, NormalSpoke):
         LangLocaleHandler.__init__(self)
         self._selected_locales = set()
 
-        self._l12_module = DBus.get_observer(MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH)
+        self._l12_module = LOCALIZATION.get_observer()
         self._l12_module.connect()
 
     def initialize(self):

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -41,12 +41,10 @@ from pyanaconda.core.util import startProgram
 from pyanaconda.core.process_watchers import PidWatcher
 from pyanaconda.core.constants import ANACONDA_ENVIRON
 from pyanaconda.core import glib
+from pyanaconda.modules.common.constants.services import NETWORK
 
 from pyanaconda import network
 from pyanaconda import nm
-
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_NETWORK_NAME, MODULE_NETWORK_PATH
 
 import dbus
 import dbus.service
@@ -1544,8 +1542,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         NormalSpoke.__init__(self, *args, **kwargs)
         self.networking_changed = False
         self.network_control_box = NetworkControlBox(self.builder, nmclient, spoke=self)
-        self._network_module = DBus.get_observer(MODULE_NETWORK_NAME,
-                                                 MODULE_NETWORK_PATH)
+        self._network_module = NETWORK.get_observer()
         self._network_module.connect()
         self.network_control_box.hostname = self._network_module.proxy.Hostname
         self.network_control_box.current_hostname = self._network_module.proxy.GetCurrentHostname()
@@ -1689,8 +1686,7 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
         StandaloneSpoke.__init__(self, *args, **kwargs)
         self.network_control_box = NetworkControlBox(self.builder, nmclient, spoke=self)
 
-        self._network_module = DBus.get_observer(MODULE_NETWORK_NAME,
-                                                 MODULE_NETWORK_PATH)
+        self._network_module = NETWORK.get_observer()
         self._network_module.connect()
         self.network_control_box.hostname = self._network_module.proxy.Hostname
         self.network_control_box.current_hostname = self._network_module.proxy.GetCurrentHostname()

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -22,8 +22,7 @@ from pyanaconda.core.i18n import _, CN_
 from pyanaconda.users import cryptPassword
 from pyanaconda import input_checking
 from pyanaconda.core import constants
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_USER_NAME, MODULE_USER_PATH
+from pyanaconda.modules.common.constants.services import USER
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
@@ -59,7 +58,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         NormalSpoke.__init__(self, *args)
         GUISpokeInputCheckHandler.__init__(self)
 
-        self._user_module = DBus.get_observer(MODULE_USER_NAME, MODULE_USER_PATH)
+        self._user_module = USER.get_observer()
         self._user_module.connect()
 
     def initialize(self):

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -24,8 +24,7 @@ from pyanaconda.core.i18n import _, CN_
 from pyanaconda.users import cryptPassword, guess_username, check_groupname
 from pyanaconda import input_checking
 from pyanaconda.core import constants
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_USER_NAME, MODULE_USER_PATH
+from pyanaconda.modules.common.constants.services import USER
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui import GUIObject
@@ -243,7 +242,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         NormalSpoke.__init__(self, *args)
         GUISpokeInputCheckHandler.__init__(self)
 
-        self._user_module = DBus.get_observer(MODULE_USER_NAME, MODULE_USER_PATH)
+        self._user_module = USER.get_observer()
         self._user_module.connect()
 
     def initialize(self):

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -22,11 +22,6 @@ import re
 import os
 
 import gi
-
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH
-from pyanaconda.dbus.constants import MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH
-
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
@@ -43,6 +38,7 @@ from pyanaconda import geoloc
 from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.util import is_unsupported_hw, ipmi_abort
 from pyanaconda.core.constants import DEFAULT_LANG, WINDOW_TITLE_TEXT
+from pyanaconda.modules.common.constants.services import TIMEZONE, LOCALIZATION
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -69,7 +65,7 @@ class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
         LangLocaleHandler.__init__(self)
         self._origStrings = {}
 
-        self._l12_module = DBus.get_observer(MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH)
+        self._l12_module = LOCALIZATION.get_observer()
         self._l12_module.connect()
 
     def apply(self):
@@ -87,7 +83,7 @@ class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
         if flags.flags.automatedInstall and not geoloc.geoloc.enabled:
             return
 
-        timezone_proxy = DBus.get_proxy(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
+        timezone_proxy = TIMEZONE.get_proxy()
         loc_timezones = localization.get_locale_timezones(self._l12_module.proxy.Language)
         if geoloc.geoloc.result.timezone:
             # (the geolocation module makes sure that the returned timezone is

--- a/pyanaconda/ui/tui/spokes/language_support.py
+++ b/pyanaconda/ui/tui/spokes/language_support.py
@@ -17,8 +17,7 @@
 # Red Hat, Inc.
 #
 
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH
+from pyanaconda.modules.common.constants.services import LOCALIZATION
 from pyanaconda.ui.categories.localization import LocalizationCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
@@ -60,7 +59,7 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         self._locales = dict((lang, localization.get_language_locales(lang))
                              for lang in self._langs_and_locales.values())
 
-        self._l12_module = DBus.get_observer(MODULE_LOCALIZATION_NAME, MODULE_LOCALIZATION_PATH)
+        self._l12_module = LOCALIZATION.get_observer()
         self._l12_module.connect()
 
         self._selected = self._l12_module.proxy.Language

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -19,8 +19,7 @@
 
 from pyanaconda import network
 from pyanaconda import nm
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_NETWORK_NAME, MODULE_NETWORK_PATH
+from pyanaconda.modules.common.constants.services import NETWORK
 from pyanaconda.flags import can_touch_runtime_system, flags
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
@@ -60,8 +59,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     def __init__(self, data, storage, payload, instclass):
         NormalTUISpoke.__init__(self, data, storage, payload, instclass)
         self.title = N_("Network configuration")
-        self._network_module = DBus.get_observer(MODULE_NETWORK_NAME,
-                                                 MODULE_NETWORK_PATH)
+        self._network_module = NETWORK.get_observer()
         self._network_module.connect()
         self._container = None
         self._value = self._network_module.proxy.Hostname

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -23,8 +23,7 @@ from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import N_, _
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_USER_NAME, MODULE_USER_PATH
+from pyanaconda.modules.common.constants.services import USER
 
 from simpleline.render.widgets import TextWidget
 
@@ -46,7 +45,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         self._policy = self.data.anaconda.pwpolicy.get_policy("root", fallback_to_default=True)
         self._password = None
 
-        self._user_module = DBus.get_observer(MODULE_USER_NAME, MODULE_USER_PATH)
+        self._user_module = USER.get_observer()
         self._user_module.connect()
 
         self.initialize_done()

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -16,8 +16,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH
+from pyanaconda.modules.common.constants.services import TIMEZONE
 from pyanaconda.ui.categories.localization import LocalizationCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
@@ -70,7 +69,7 @@ class TimeSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         self._ntp_servers = OrderedDict()
         self._ntp_servers_lock = RLock()
 
-        self._timezone_module = DBus.get_observer(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
+        self._timezone_module = TIMEZONE.get_observer()
         self._timezone_module.connect()
 
     @property
@@ -298,7 +297,7 @@ class TimeZoneSpoke(NormalTUISpoke):
         self._lower_zones = [z.lower().replace("_", " ") for region in self._timezones for z in self._timezones[region]]
         self._selection = ""
 
-        self._timezone_module = DBus.get_observer(MODULE_TIMEZONE_NAME, MODULE_TIMEZONE_PATH)
+        self._timezone_module = TIMEZONE.get_observer()
         self._timezone_module.connect()
 
     @property

--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -23,8 +23,7 @@ from pyanaconda.core.constants import ANACONDA_ENVIRON, FIRSTBOOT_ENVIRON, PASSW
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.core.regexes import GECOS_VALID
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import MODULE_USER_NAME, MODULE_USER_PATH
+from pyanaconda.modules.common.constants.services import USER
 
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
 from pyanaconda.ui.common import FirstbootSpokeMixIn
@@ -90,7 +89,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
         self.errors = []
 
-        self._user_module = DBus.get_observer(MODULE_USER_NAME, MODULE_USER_PATH)
+        self._user_module = USER.get_observer()
         self._user_module.connect()
 
         self.initialize_done()

--- a/scripts/run_boss_locally.py
+++ b/scripts/run_boss_locally.py
@@ -15,7 +15,7 @@ import argparse
 from gi.repository import Gio
 
 from pyanaconda.dbus import DBusConnection
-from pyanaconda.dbus.constants import DBUS_BOSS_NAME, DBUS_BOSS_PATH
+from pyanaconda.modules.common.constants.services import  BOSS
 from pyanaconda.modules.common.errors.kickstart import SplitKickstartError
 
 try:
@@ -50,13 +50,13 @@ EXEC_PATH = 'Exec=/usr/libexec/anaconda/start-module'
 
 def start_anaconda_services():
     print(RED + "starting Boss" + RESET)
-    test_dbus_connection.get_dbus_proxy().StartServiceByName(DBUS_BOSS_NAME, 0)
+    test_dbus_connection.get_dbus_proxy().StartServiceByName(BOSS.service_name, 0)
 
 def distribute_kickstart(ks_path):
     tmpfile = tempfile.mktemp(suffix=".run_boss_locally.ks")
     shutil.copyfile(ks_path, tmpfile)
     print(RED + "distributing kickstart {}".format(tmpfile) + RESET)
-    boss_object = test_dbus_connection.get_proxy(DBUS_BOSS_NAME, DBUS_BOSS_PATH)
+    boss_object = test_dbus_connection.get_proxy(BOSS.service_name, BOSS.object_path)
     try:
         boss_object.SplitKickstart(tmpfile)
     except SplitKickstartError as e:
@@ -79,7 +79,7 @@ def distribute_kickstart(ks_path):
 def stops_anaconda_services():
     print(RED + "stopping Boss" + RESET)
 
-    boss_object = test_dbus_connection.get_proxy(DBUS_BOSS_NAME, DBUS_BOSS_PATH)
+    boss_object = test_dbus_connection.get_proxy(BOSS.service_name, BOSS.object_path)
     boss_object.Quit()
 
     print(RED + "waiting a bit for module shutdown to happen" + RESET)

--- a/tests/pyanaconda_tests/__init__.py
+++ b/tests/pyanaconda_tests/__init__.py
@@ -24,7 +24,7 @@ from gi.repository import GLib
 
 from textwrap import dedent
 from mock import Mock
-from pyanaconda.dbus.constants import DBUS_MODULE_NAMESPACE
+from pyanaconda.modules.common.constants.interfaces import KICKSTART_MODULE
 
 
 class run_in_glib(object):
@@ -82,7 +82,7 @@ def check_kickstart_interface(test, interface, ks_in, ks_out):
 
     # Test the properties changed callback.
     if ks_in is not None:
-        callback.assert_any_call(DBUS_MODULE_NAMESPACE, {'Kickstarted': True}, [])
+        callback.assert_any_call(KICKSTART_MODULE.interface_name, {'Kickstarted': True}, [])
     else:
         test.assertEqual(interface.Kickstarted, False)
         callback.assert_not_called()

--- a/tests/pyanaconda_tests/dbus_identifier.py
+++ b/tests/pyanaconda_tests/dbus_identifier.py
@@ -1,0 +1,227 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+import unittest
+from mock import Mock
+
+from pyanaconda.dbus.identifier import DBusInterfaceIdentifier, DBusObjectIdentifier, \
+    DBusServiceIdentifier, DBusBaseIdentifier
+
+
+class DBusIdentifierTestCase(unittest.TestCase):
+    """Test DBus identifiers."""
+
+    def assert_namespace(self, obj, namespace):
+        """Check the DBus namespace object."""
+        self.assertEqual(obj.namespace, namespace)
+
+    def assert_interface(self, obj, interface_name):
+        """Check the DBus interface object."""
+        self.assertEqual(obj.interface_name, interface_name)
+
+    def identifier_test(self):
+        """Test the DBus identifier object."""
+        identifier = DBusBaseIdentifier(
+            namespace=("a", "b", "c")
+        )
+        self.assert_namespace(identifier, ("a", "b", "c"))
+
+        identifier = DBusBaseIdentifier(
+            basename="d",
+            namespace=("a", "b", "c")
+        )
+        self.assert_namespace(identifier, ("a", "b", "c", "d"))
+
+    def interface_test(self):
+        """Test the DBus interface object."""
+        interface = DBusInterfaceIdentifier(
+            namespace=("a", "b", "c")
+        )
+        self.assert_namespace(interface, ("a", "b", "c"))
+        self.assert_interface(interface, "a.b.c")
+
+        interface = DBusInterfaceIdentifier(
+            namespace=("a", "b", "c"),
+            interface_version=1
+        )
+        self.assert_namespace(interface, ("a", "b", "c"))
+        self.assert_interface(interface, "a.b.c1")
+
+        interface = DBusInterfaceIdentifier(
+            basename="d",
+            namespace=("a", "b", "c"),
+            interface_version=1
+        )
+        self.assert_namespace(interface, ("a", "b", "c", "d"))
+        self.assert_interface(interface, "a.b.c.d1")
+
+    def assert_object(self, obj, object_path):
+        """Check the DBus object."""
+        self.assertEqual(obj.object_path, object_path)
+
+    def object_test(self):
+        """Test the DBus object."""
+        obj = DBusObjectIdentifier(
+            namespace=("a", "b", "c")
+        )
+        self.assert_namespace(obj, ("a", "b", "c"))
+        self.assert_interface(obj, "a.b.c")
+        self.assert_object(obj, "/a/b/c")
+
+        obj = DBusObjectIdentifier(
+            namespace=("a", "b", "c"),
+            object_version=2,
+            interface_version=4
+        )
+        self.assert_namespace(obj, ("a", "b", "c"))
+        self.assert_interface(obj, "a.b.c4")
+        self.assert_object(obj, "/a/b/c2")
+
+        obj = DBusObjectIdentifier(
+            basename="d",
+            namespace=("a", "b", "c"),
+            object_version=2,
+            interface_version=4
+        )
+        self.assert_namespace(obj, ("a", "b", "c", "d"))
+        self.assert_interface(obj, "a.b.c.d4")
+        self.assert_object(obj, "/a/b/c/d2")
+
+    def assert_service(self, obj, service_name):
+        """Check the DBus service object."""
+        self.assertEqual(obj.service_name, service_name)
+
+    def service_test(self):
+        """Test the DBus service object."""
+        service = DBusServiceIdentifier(
+            namespace=("a", "b", "c")
+        )
+        self.assert_namespace(service, ("a", "b", "c"))
+        self.assert_interface(service, "a.b.c")
+        self.assert_object(service, "/a/b/c")
+        self.assert_service(service, "a.b.c")
+
+        service = DBusServiceIdentifier(
+            namespace=("a", "b", "c"),
+            service_version=3,
+            interface_version=5,
+            object_version=7
+        )
+        self.assert_namespace(service, ("a", "b", "c"))
+        self.assert_interface(service, "a.b.c5")
+        self.assert_object(service, "/a/b/c7")
+        self.assert_service(service, "a.b.c3")
+
+        service = DBusServiceIdentifier(
+            basename="d",
+            namespace=("a", "b", "c"),
+            service_version=3,
+            interface_version=5,
+            object_version=7
+        )
+        self.assert_namespace(service, ("a", "b", "c", "d"))
+        self.assert_interface(service, "a.b.c.d5")
+        self.assert_object(service, "/a/b/c/d7")
+        self.assert_service(service, "a.b.c.d3")
+
+
+class DBusServiceIdentifierTestCase(unittest.TestCase):
+    """Test DBus service identifiers."""
+
+    def get_proxy_test(self):
+        """Test getting a proxy."""
+        bus = Mock()
+        namespace = ("a", "b", "c")
+
+        service = DBusServiceIdentifier(
+            namespace=namespace,
+            message_bus=bus
+        )
+
+        obj = DBusObjectIdentifier(
+            basename="object",
+            namespace=namespace
+        )
+
+        service.get_proxy()
+        bus.get_proxy.assert_called_with("a.b.c", "/a/b/c")
+        bus.reset_mock()
+
+        service.get_proxy(obj.object_path)
+        bus.get_proxy.assert_called_with("a.b.c", "/a/b/c/object")
+        bus.reset_mock()
+
+    def get_observer_test(self):
+        """Test getting an observer."""
+        bus = Mock()
+        namespace = ("a", "b", "c")
+
+        service = DBusServiceIdentifier(
+            namespace=namespace,
+            message_bus=bus
+        )
+
+        obj = DBusObjectIdentifier(
+            basename="d",
+            namespace=namespace
+        )
+
+        service.get_observer()
+        bus.get_observer.assert_called_with("a.b.c", "/a/b/c")
+        bus.reset_mock()
+
+        service.get_observer(obj.object_path)
+        bus.get_observer.assert_called_with("a.b.c", "/a/b/c/d")
+        bus.reset_mock()
+
+    def get_cached_observer_test(self):
+        """Test getting a cached observer."""
+        bus = Mock()
+        namespace = ("a", "b", "c")
+
+        service = DBusServiceIdentifier(
+            namespace=namespace,
+            message_bus=bus
+        )
+
+        obj = DBusObjectIdentifier(
+            basename="object",
+            namespace=namespace
+        )
+
+        interface = DBusInterfaceIdentifier(
+            basename="interface",
+            namespace=namespace
+        )
+
+        service.get_cached_observer()
+        bus.get_cached_observer.assert_called_with("a.b.c", "/a/b/c", ["a.b.c"])
+        bus.reset_mock()
+
+        service.get_cached_observer(obj.object_path)
+        bus.get_cached_observer.assert_called_with("a.b.c", "/a/b/c/object", None)
+        bus.reset_mock()
+
+        service.get_cached_observer(interface_names=[interface.interface_name])
+        bus.get_cached_observer.assert_called_with("a.b.c", "/a/b/c", ["a.b.c.interface"])
+        bus.reset_mock()
+
+        service.get_cached_observer(obj.object_path, interface_names=[interface.interface_name])
+        bus.get_cached_observer.assert_called_with("a.b.c", "/a/b/c/object", ["a.b.c.interface"])
+        bus.reset_mock()

--- a/tests/pyanaconda_tests/dbus_namespace.py
+++ b/tests/pyanaconda_tests/dbus_namespace.py
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+import unittest
+from pyanaconda.dbus.namespace import get_dbus_name, get_dbus_path, get_namespace_from_name
+
+
+class DBusNamespaceTestCase(unittest.TestCase):
+
+    def dbus_name_test(self):
+        """Test DBus path."""
+        self.assertEqual(get_dbus_name(), "")
+        self.assertEqual(get_dbus_name("a"), "a")
+        self.assertEqual(get_dbus_name("a", "b"), "a.b")
+        self.assertEqual(get_dbus_name("a", "b", "c"), "a.b.c")
+        self.assertEqual(get_dbus_name("org", "freedesktop", "DBus"), "org.freedesktop.DBus")
+
+    def dbus_path_test(self):
+        """Test DBus path."""
+        self.assertEqual(get_dbus_path(), "/")
+        self.assertEqual(get_dbus_path("a"), "/a")
+        self.assertEqual(get_dbus_path("a", "b"), "/a/b")
+        self.assertEqual(get_dbus_path("a", "b", "c"), "/a/b/c")
+        self.assertEqual(get_dbus_path("org", "freedesktop", "DBus"), "/org/freedesktop/DBus")
+
+    def namespace_test(self):
+        """Test namespaces."""
+        self.assertEqual(get_namespace_from_name("a"), ("a",))
+        self.assertEqual(get_namespace_from_name("a.b"), ("a", "b"))
+        self.assertEqual(get_namespace_from_name("a.b.c"), ("a", "b", "c"))
+        self.assertEqual(get_namespace_from_name("org.freedesktop.DBus"), ("org", "freedesktop", "DBus"))

--- a/tests/pyanaconda_tests/install_manager_test.py
+++ b/tests/pyanaconda_tests/install_manager_test.py
@@ -125,7 +125,7 @@ class TestModule(object):
 
     @property
     def AvailableTasks(self):
-        return [("TaskName", self._task_instance)]
+        return [self._task_instance]
 
 
 class TestTask(object):

--- a/tests/pyanaconda_tests/module_localization_test.py
+++ b/tests/pyanaconda_tests/module_localization_test.py
@@ -21,7 +21,7 @@ import unittest
 from textwrap import dedent
 from mock import Mock
 
-from pyanaconda.dbus.constants import MODULE_LOCALIZATION_NAME
+from pyanaconda.modules.common.constants.services import LOCALIZATION
 from pyanaconda.modules.localization.localization import LocalizationModule
 from pyanaconda.modules.localization.localization_interface import LocalizationInterface
 from tests.pyanaconda_tests import check_kickstart_interface
@@ -51,37 +51,37 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
         """Test the Language property."""
         self.localization_interface.SetLanguage("cs_CZ.UTF-8")
         self.assertEqual(self.localization_interface.Language, "cs_CZ.UTF-8")
-        self.callback.assert_called_once_with(MODULE_LOCALIZATION_NAME, {'Language': 'cs_CZ.UTF-8'}, [])
+        self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'Language': 'cs_CZ.UTF-8'}, [])
 
     def language_support_property_test(self):
         """Test the LanguageSupport property."""
         self.localization_interface.SetLanguageSupport(["fr_FR"])
         self.assertEqual(self.localization_interface.LanguageSupport, ["fr_FR"])
-        self.callback.assert_called_once_with(MODULE_LOCALIZATION_NAME, {'LanguageSupport': ["fr_FR"]}, [])
+        self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'LanguageSupport': ["fr_FR"]}, [])
 
     def keyboard_property_test(self):
         """Test the Keyboard property."""
         self.localization_interface.SetKeyboard("cz")
         self.assertEqual(self.localization_interface.Keyboard, "cz")
-        self.callback.assert_called_once_with(MODULE_LOCALIZATION_NAME, {'Keyboard': 'cz'}, [])
+        self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'Keyboard': 'cz'}, [])
 
     def vc_keymap_property_test(self):
         """Test the VirtualConsoleKeymap property."""
         self.localization_interface.SetVirtualConsoleKeymap("cz")
         self.assertEqual(self.localization_interface.VirtualConsoleKeymap, "cz")
-        self.callback.assert_called_once_with(MODULE_LOCALIZATION_NAME, {'VirtualConsoleKeymap': 'cz'}, [])
+        self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'VirtualConsoleKeymap': 'cz'}, [])
 
     def x_layouts_property_test(self):
         """Test the XLayouts property."""
         self.localization_interface.SetXLayouts(["en", "cz(querty)"])
         self.assertEqual(self.localization_interface.XLayouts, ["en", "cz(querty)"])
-        self.callback.assert_called_once_with(MODULE_LOCALIZATION_NAME, {'XLayouts': ["en", "cz(querty)"]}, [])
+        self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'XLayouts': ["en", "cz(querty)"]}, [])
 
     def switch_options_property_test(self):
         """Test the LayoutSwitchOptions property."""
         self.localization_interface.SetLayoutSwitchOptions(["grp:alt_shift_toggle"])
         self.assertEqual(self.localization_interface.LayoutSwitchOptions, ["grp:alt_shift_toggle"])
-        self.callback.assert_called_once_with(MODULE_LOCALIZATION_NAME, {'LayoutSwitchOptions': ["grp:alt_shift_toggle"]}, [])
+        self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'LayoutSwitchOptions': ["grp:alt_shift_toggle"]}, [])
 
     def keyboard_seen_test(self):
         """Test the KeyboardKickstarted property."""

--- a/tests/pyanaconda_tests/module_security_test.py
+++ b/tests/pyanaconda_tests/module_security_test.py
@@ -22,7 +22,7 @@ from mock import Mock
 from pykickstart.constants import SELINUX_ENFORCING
 
 from pyanaconda.core.constants import REALM_NAME, REALM_DISCOVER, REALM_JOIN
-from pyanaconda.dbus.constants import MODULE_SECURITY_NAME
+from pyanaconda.modules.common.constants.services import SECURITY
 from pyanaconda.dbus.typing import get_variant, Str, List
 from pyanaconda.modules.security.security import SecurityModule
 from pyanaconda.modules.security.security_interface import SecurityInterface
@@ -54,19 +54,19 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         """Test the selinux property."""
         self.security_interface.SetSELinux(SELINUX_ENFORCING)
         self.assertEqual(self.security_interface.SELinux, SELINUX_ENFORCING)
-        self.callback.assert_called_once_with(MODULE_SECURITY_NAME, {'SELinux': SELINUX_ENFORCING}, [])
+        self.callback.assert_called_once_with(SECURITY.interface_name, {'SELinux': SELINUX_ENFORCING}, [])
 
     def authselect_property_test(self):
         """Test the authselect property."""
         self.security_interface.SetAuthselect(["sssd", "with-mkhomedir"])
         self.assertEqual(self.security_interface.Authselect, ["sssd", "with-mkhomedir"])
-        self.callback.assert_called_once_with(MODULE_SECURITY_NAME, {'Authselect': ["sssd", "with-mkhomedir"]}, [])
+        self.callback.assert_called_once_with(SECURITY.interface_name, {'Authselect': ["sssd", "with-mkhomedir"]}, [])
 
     def authconfig_property_test(self):
         """Test the authconfig property."""
         self.security_interface.SetAuthconfig(["--passalgo=sha512", "--useshadow"])
         self.assertEqual(self.security_interface.Authconfig, ["--passalgo=sha512", "--useshadow"])
-        self.callback.assert_called_once_with(MODULE_SECURITY_NAME, {'Authconfig': ["--passalgo=sha512", "--useshadow"]}, [])
+        self.callback.assert_called_once_with(SECURITY.interface_name, {'Authconfig': ["--passalgo=sha512", "--useshadow"]}, [])
 
     def realm_property_test(self):
         """Test the realm property."""
@@ -84,7 +84,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
 
         self.security_interface.SetRealm(realm_in)
         self.assertEqual(realm_out, self.security_interface.Realm)
-        self.callback.assert_called_once_with(MODULE_SECURITY_NAME, {'Realm': realm_out}, [])
+        self.callback.assert_called_once_with(SECURITY.interface_name, {'Realm': realm_out}, [])
 
     def _test_kickstart(self, ks_in, ks_out):
         check_kickstart_interface(self, self.security_interface, ks_in, ks_out)

--- a/tests/pyanaconda_tests/module_timezone_test.py
+++ b/tests/pyanaconda_tests/module_timezone_test.py
@@ -20,7 +20,7 @@
 import unittest
 from mock import Mock
 
-from pyanaconda.dbus.constants import MODULE_TIMEZONE_NAME
+from pyanaconda.modules.common.constants.services import TIMEZONE
 from pyanaconda.modules.timezone.timezone import TimezoneModule
 from pyanaconda.modules.timezone.timezone_interface import TimezoneInterface
 from tests.pyanaconda_tests import check_kickstart_interface
@@ -50,25 +50,25 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         """Test the Timezone property."""
         self.timezone_interface.SetTimezone("Europe/Prague")
         self.assertEqual(self.timezone_interface.Timezone, "Europe/Prague")
-        self.callback.assert_called_once_with(MODULE_TIMEZONE_NAME, {'Timezone': 'Europe/Prague'}, [])
+        self.callback.assert_called_once_with(TIMEZONE.interface_name, {'Timezone': 'Europe/Prague'}, [])
 
     def utc_property_test(self):
         """Test the IsUtc property."""
         self.timezone_interface.SetIsUTC(True)
         self.assertEqual(self.timezone_interface.IsUTC, True)
-        self.callback.assert_called_once_with(MODULE_TIMEZONE_NAME, {'IsUTC': True}, [])
+        self.callback.assert_called_once_with(TIMEZONE.interface_name, {'IsUTC': True}, [])
 
     def ntp_property_test(self):
         """Test the NTPEnabled property."""
         self.timezone_interface.SetNTPEnabled(False)
         self.assertEqual(self.timezone_interface.NTPEnabled, False)
-        self.callback.assert_called_once_with(MODULE_TIMEZONE_NAME, {'NTPEnabled': False}, [])
+        self.callback.assert_called_once_with(TIMEZONE.interface_name, {'NTPEnabled': False}, [])
 
     def ntp_servers_property_test(self):
         """Test the NTPServers property."""
         self.timezone_interface.SetNTPServers(["ntp.cesnet.cz"])
         self.assertEqual(self.timezone_interface.NTPServers, ["ntp.cesnet.cz"])
-        self.callback.assert_called_once_with(MODULE_TIMEZONE_NAME, {'NTPServers': ["ntp.cesnet.cz"]}, [])
+        self.callback.assert_called_once_with(TIMEZONE.interface_name, {'NTPServers': ["ntp.cesnet.cz"]}, [])
 
     def _test_kickstart(self, ks_in, ks_out):
         check_kickstart_interface(self, self.timezone_interface, ks_in, ks_out)


### PR DESCRIPTION
DBus objects, interfaces and services can be described with namespaces
and identifiers. They provide shorcuts to proxies and observers.

DBus errors should be defined with the dbus_error decorator that
requires the error name and the error namespace. Default DBus
error can be defined with dbus_error_by_default.