### PR TITLE
Enable /boot on btrfs subvolume with GRUB2

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1417,7 +1417,7 @@ class GRUB2(GRUB):
     stage2_max_end = None
 
     # requirements for boot devices
-    stage2_device_types = ["partition", "mdarray", "lvmlv"]
+    stage2_device_types = ["partition", "mdarray", "lvmlv", "btrfs subvolume"]
     stage2_raid_levels = [raid.RAID0, raid.RAID1, raid.RAID4,
                           raid.RAID5, raid.RAID6, raid.RAID10]
     stage2_raid_metadata = ["0", "0.90", "1.0", "1.2"]


### PR DESCRIPTION
This depends on a version of grubby with btrfs subvolume support. For
example, grubby >= 8.40-10.fc29.