### PR TITLE
Remove spurious echo call from tmux service file

### DIFF
--- a/data/systemd/anaconda-tmux@.service
+++ b/data/systemd/anaconda-tmux@.service
@@ -10,7 +10,6 @@ ConditionKernelCommandLine=!inst.notmux
 Type=idle
 WorkingDirectory=/root
 Environment=LANG=en_US.UTF-8
-ExecStartPre=/usr/bin/echo -e \033%G
 ExecStart=/usr/bin/tmux -u attach -t anaconda
 StandardInput=tty
 StandardOutput=tty


### PR DESCRIPTION
Resolves: rhbz#1554243

Port of commit
b29bdff2e041ec4f354c3334d8aa15ea8366a17

Looks like systemd 236 does not like the escape sequence in the
call, which most likely tries to ring the terminal bell (!).

We have no evidence of this ever working & dropping the line makes
Tmux work again, so just drop the line - at least for now.