### PR TITLE
Initial module enablement and installation support

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -24,7 +24,7 @@ Source0: %{name}-%{version}.tar.bz2
 
 %define blivetguiver 2.1.7-2
 %define dbusver 1.2.3
-%define dnfver 2.2.0
+%define dnfver 3.1.0
 %define dracutver 034-7
 %define fcoeutilsver 1.0.12-3.20100323git
 %define gettextver 0.19.8

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -222,6 +222,29 @@ class ErrorHandler(object):
             else:
                 return ERROR_RAISE
 
+    def _install_specs_missing(self, exn):
+        message = ""
+        if exn.missing_packages:
+            if len(exn.missing_packages) > 1:
+                packages = ", ".join(exn.missing_packages)
+                message = message + _("The following packages are missing:\n%s\n\n") % packages
+            else:
+                message = message + _("The following package is missing:\n%s\n\n") % exn.missing_packages[0]
+
+        if exn.missing_groups_and_modules:
+            if len(exn.missing_groups_and_modules) > 1:
+                groups_modules = ", ".join(exn.missing_groups_and_modules)
+                message = message + _("The following groups or modules are missing:\n%s\n\n") % groups_modules
+            else:
+                message = message + _("The following group or module is missing:\n%s\n\n") % exn.missing_groups_and_modules[0]
+
+        message = message + _("Would you like to ignore this and continue with installation?")
+
+        if self.ui.showYesNoQuestion(message):
+            return ERROR_CONTINUE
+        else:
+            return ERROR_RAISE
+
     def _scriptErrorHandler(self, exn):
         message = _("There was an error running the kickstart script at line "
                     "%(lineno)s.  This is a fatal error and installation will be "
@@ -303,6 +326,7 @@ class ErrorHandler(object):
                 "MissingImageError": self._missingImageHandler,
                 "NoSuchGroup": self._noSuchGroupHandler,
                 "NoSuchPackage": self._noSuchPackageHandler,
+                "InstallSpecsMissing" : self._install_specs_missing,
                 "ScriptError": self._scriptErrorHandler,
                 "PayloadInstallError": self._payloadInstallHandler,
                 "DependencyError": self._dependencyErrorHandler,

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -245,6 +245,22 @@ class ErrorHandler(object):
         else:
             return ERROR_RAISE
 
+    def _no_module_stream_specified(self, exn):
+        message = _("Stream was not specified for a module without a default stream. This is "
+                    "a fatal error and installation will be aborted. The details "
+                    "of this error are:\n\n%(exception)s") % \
+                            {"exception": exn}
+        self.ui.showError(message)
+        return ERROR_RAISE
+
+    def  _multiple_module_streams_specified(self, exn):
+        message = _("Multiple streams have been specified for a single module. This is "
+                    "a fatal error and installation will be aborted. The details "
+                    "of this error are:\n\n%(exception)s") % \
+                            {"exception": exn}
+        self.ui.showError(message)
+        return ERROR_RAISE
+
     def _scriptErrorHandler(self, exn):
         message = _("There was an error running the kickstart script at line "
                     "%(lineno)s.  This is a fatal error and installation will be "
@@ -326,6 +342,8 @@ class ErrorHandler(object):
                 "MissingImageError": self._missingImageHandler,
                 "NoSuchGroup": self._noSuchGroupHandler,
                 "NoSuchPackage": self._noSuchPackageHandler,
+                "NoStreamSpecifiedException": self._no_module_stream_specified,
+                "InstallMoreStreamsException": self._multiple_module_streams_specified,
                 "InstallSpecsMissing" : self._install_specs_missing,
                 "ScriptError": self._scriptErrorHandler,
                 "PayloadInstallError": self._payloadInstallHandler,


### PR DESCRIPTION
Use new DNF API entry points to make it possible to enable install
modules. At the same time we can radically simplify our group exclusion
and environment resolution code by making full use of the new API.

The main change is that instead of incrementally calling "install package"
and "select group" we now gather all the things we want to include
and exclude in the installation transaction and feed it to DNF at once.

In short what this does is:
- makes it possible to install modules, including stream id & profile
- makes it possible to enable modules without installing them
- drops all our group exclusion logic as DNF can now handle that via the new API
- makes it possible to mark environments as installed, meaning we no longer need to resolve environments to groups and that environments are correctly marked as installed on the target system
- overall a nice code cleanup

Possible followup items:
- all in one transaction error handling: tell users all problem with a transaction, not one issue at a time like now
- make it possible to specify all supported package types per group