### PR TITLE
Enable hibernation only on x86 (#1554345)

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -794,9 +794,9 @@ class BootLoader(object):
         swap_devices = storage.fsset.swap_devices
         dracut_devices.extend(swap_devices)
 
-        # Add resume= option to enable hibernation.
+        # Add resume= option to enable hibernation on x86.
         # Choose the largest swap device for that.
-        if swap_devices:
+        if blivet.arch.is_x86() and swap_devices:
             resume_device = max(swap_devices, key=lambda x: x.size)
             self.boot_args.add("resume=%s" % resume_device.fstab_spec)
 


### PR DESCRIPTION
Hibernation is not supported on some architectures,
so anaconda will add the resume option only on x86.

Resolves: rhbz#1554345