### PR TITLE
Don't make safe to observe services on buses that don't run

### DIFF
--- a/pyanaconda/dbus/observer.py
+++ b/pyanaconda/dbus/observer.py
@@ -124,8 +124,7 @@ class DBusObserver(object):
         The observer is not connected to the service until it
         emits the service_available signal.
         """
-        if self._message_bus.check_connection():
-            self._watch()
+        self._watch()
 
     def disconnect(self):
         """Disconnect from the service.
@@ -133,8 +132,7 @@ class DBusObserver(object):
         Disconnect from the service if it is connected and stop
         watching its availability.
         """
-        if self._message_bus.check_connection():
-            self._unwatch()
+        self._unwatch()
 
         if self.is_service_available:
             self._disable_service()


### PR DESCRIPTION
Methods `connect_once_available` and `disconnect` should fail if
the connection to the message bus cannot be set up. We don't need
to support the previous behaviour anymore.

This reverts the commit d4e2ed9.