### PR TITLE
Write rootpw command to kickstart (#1557529)

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1835,6 +1835,11 @@ class ReqPart(commands.reqpart.F23_ReqPart):
         autopart.do_reqpart(storage, reqs)
 
 class RootPw(RemovedCommand):
+
+    def __str__(self):
+        user_proxy = USER.get_proxy()
+        return user_proxy.GenerateKickstart()
+
     def execute(self, storage, ksdata, instClass, users):
 
         user_proxy = USER.get_proxy()


### PR DESCRIPTION
During the switch to handle the rootpw command by a kickstart module
the __str__() method of the Kickstart command object has not been
overridden, resulting in the command missing from the output kickstart
Anaconda saves after the installation into /root.

This had the unintended consequence of making Initial Setup lock the
root account during it's run after the installation. Initial Setup
read the kickstart file in /root created by Anaconda and noticed
the rootpw command is missing, which it equaled to root password not
being set. There is logic in place preventing Anaconda/IS from creating
root accounts with empty root password, which triggered and locked
the root account.

So make sure the rootpw command is present in the output kickstart
by adding the overlooked __str__() method override as with all other
kickstart commands handled by DBUS modules.

Resolves: rhbz#1557529