### PR TITLE
Use enums in DBus modules

### DIFF
--- a/pyanaconda/modules/security/constants.py
+++ b/pyanaconda/modules/security/constants.py
@@ -1,0 +1,33 @@
+#
+# Private constants for the security module.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from enum import Enum, unique
+
+from pykickstart.constants import SELINUX_DISABLED, SELINUX_ENFORCING, SELINUX_PERMISSIVE
+from pyanaconda.core.constants import SELINUX_DEFAULT
+
+
+@unique
+class SELinuxMode(Enum):
+    """SELinux modes."""
+
+    DEFAULT = SELINUX_DEFAULT
+    DISABLED = SELINUX_DISABLED
+    ENFORCING = SELINUX_ENFORCING
+    PERMISSIVE = SELINUX_PERMISSIVE

--- a/pyanaconda/modules/security/security_interface.py
+++ b/pyanaconda/modules/security/security_interface.py
@@ -23,6 +23,7 @@ from pyanaconda.dbus.property import emits_properties_changed
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.dbus.interface import dbus_interface
+from pyanaconda.modules.security.constants import SELinuxMode
 
 
 @dbus_interface(SECURITY.interface_name)
@@ -48,7 +49,7 @@ class SecurityInterface(KickstartModuleInterface):
 
         :return: a value of the SELinux state
         """
-        return self.implementation.selinux
+        return self.implementation.selinux.value
 
     @emits_properties_changed
     def SetSELinux(self, value: Int):
@@ -58,7 +59,7 @@ class SecurityInterface(KickstartModuleInterface):
 
         :param value: a value of the SELinux state
         """
-        self.implementation.set_selinux(value)
+        self.implementation.set_selinux(SELinuxMode(value))
 
     @property
     def Authselect(self) -> List[Str]:

--- a/pyanaconda/modules/services/constants.py
+++ b/pyanaconda/modules/services/constants.py
@@ -1,0 +1,33 @@
+#
+# Private constants for the services module.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from enum import Enum, unique
+
+from pyanaconda.core.constants import SETUP_ON_BOOT_DEFAULT, SETUP_ON_BOOT_DISABLED,\
+    SETUP_ON_BOOT_ENABLED, SETUP_ON_BOOT_RECONFIG
+
+
+@unique
+class SetupOnBootAction(Enum):
+    """The action for the fist boot setup."""
+
+    DEFAULT = SETUP_ON_BOOT_DEFAULT
+    DISABLED = SETUP_ON_BOOT_DISABLED
+    ENABLED = SETUP_ON_BOOT_ENABLED
+    RECONFIG = SETUP_ON_BOOT_RECONFIG

--- a/pyanaconda/modules/services/services.py
+++ b/pyanaconda/modules/services/services.py
@@ -19,12 +19,12 @@
 #
 from pykickstart.constants import FIRSTBOOT_DEFAULT, FIRSTBOOT_SKIP, FIRSTBOOT_RECONFIG
 
-from pyanaconda.core.constants import TEXT_ONLY_TARGET, GRAPHICAL_TARGET, SETUP_ON_BOOT_DEFAULT, \
-    SETUP_ON_BOOT_ENABLED, SETUP_ON_BOOT_RECONFIG, SETUP_ON_BOOT_DISABLED
+from pyanaconda.core.constants import TEXT_ONLY_TARGET, GRAPHICAL_TARGET
 from pyanaconda.dbus import DBus
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.base import KickstartModule
 from pyanaconda.modules.common.constants.services import SERVICES
+from pyanaconda.modules.services.constants import SetupOnBootAction
 from pyanaconda.modules.services.kickstart import ServicesKickstartSpecification
 from pyanaconda.modules.services.services_interface import ServicesInterface
 
@@ -51,7 +51,7 @@ class ServicesModule(KickstartModule):
         self._default_desktop = ""
 
         self.setup_on_boot_changed = Signal()
-        self._setup_on_boot = SETUP_ON_BOOT_DEFAULT
+        self._setup_on_boot = SetupOnBootAction.DEFAULT
 
     def publish(self):
         """Publish the module."""
@@ -107,10 +107,10 @@ class ServicesModule(KickstartModule):
         :return: a converted value of the action
         """
         mapping = {
-            None: SETUP_ON_BOOT_DEFAULT,
-            FIRSTBOOT_SKIP: SETUP_ON_BOOT_DISABLED,
-            FIRSTBOOT_DEFAULT: SETUP_ON_BOOT_ENABLED,
-            FIRSTBOOT_RECONFIG: SETUP_ON_BOOT_RECONFIG,
+            None: SetupOnBootAction.DEFAULT,
+            FIRSTBOOT_SKIP: SetupOnBootAction.DISABLED,
+            FIRSTBOOT_DEFAULT: SetupOnBootAction.ENABLED,
+            FIRSTBOOT_RECONFIG: SetupOnBootAction.RECONFIG,
         }
 
         if reverse:

--- a/pyanaconda/modules/services/services_interface.py
+++ b/pyanaconda/modules/services/services_interface.py
@@ -22,6 +22,7 @@ from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.modules.common.constants.services import SERVICES
+from pyanaconda.modules.services.constants import SetupOnBootAction
 
 
 @dbus_interface(SERVICES.interface_name)
@@ -108,7 +109,7 @@ class ServicesInterface(KickstartModuleInterface):
     @property
     def SetupOnBoot(self) -> Int:
         """Set up the installed system on the first boot."""
-        return self.implementation.setup_on_boot
+        return self.implementation.setup_on_boot.value
 
     @emits_properties_changed
     def SetSetupOnBoot(self, value: Int):
@@ -125,4 +126,4 @@ class ServicesInterface(KickstartModuleInterface):
 
         :param value: a number of the action
         """
-        self.implementation.set_setup_on_boot(value)
+        self.implementation.set_setup_on_boot(SetupOnBootAction(value))


### PR DESCRIPTION
Use enums for SELinux modes and first boot actions.
We want to use enums inside the modules, so we can
validate the given values with them.