### PR TITLE
Make the class for removed kickstart commands more strict

### DIFF
--- a/tests/pyanaconda_tests/ks_version_test.py
+++ b/tests/pyanaconda_tests/ks_version_test.py
@@ -36,11 +36,13 @@ class CommandVersionTestCase(unittest.TestCase):
                 warnings.warn("Skipping the kickstart name {}.".format(name))
                 continue
 
+            # Print info about the command for better debugging.
+            print(name, children[name], parents[name])
+
             # Skip commands that were moved on DBus.
             if isinstance(children[name](), kickstart.RemovedCommand):
                 continue
 
-            print(name, children[name], parents[name])
             self.assertIsInstance(children[name](), parents[name])
 
     def commands_test(self):


### PR DESCRIPTION
The `RemovedCommand` class now requires to override its `__str__`
method, so we don't forget to use DBus modules to generate their
part of a kickstart file.

Use the `UselessCommand` class when the command doesn't do anything.