### PR TITLE
Fix 'isDisk' property name (#1558906)

### DIFF
--- a/pyanaconda/ui/lib/disks.py
+++ b/pyanaconda/ui/lib/disks.py
@@ -90,7 +90,7 @@ def applyDiskSelection(storage, data, use_names):
     for disk in (d for d in storage.disks if d.name in onlyuse):
         onlyuse.extend(d.name for d in disk.ancestors
                        if d.name not in onlyuse
-                       and d.isDisk)
+                       and d.is_disk)
 
     data.ignoredisk.onlyuse = onlyuse
     data.clearpart.drives = use_names[:]


### PR DESCRIPTION
It's 'is_disk' since Blivet 2.0