### PR TITLE
RFC: kickstart: only call authselect if explicitly requested

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -344,15 +344,8 @@ class Authselect(RemovedCommand):
     def execute(self, *args):
         security_proxy = SECURITY.get_proxy()
 
-        # Enable fingerprint option by default (#481273).
-        if not flags.automatedInstall and self.fingerprint_supported:
-            self._run(
-                "/usr/bin/authselect",
-                ["select", "sssd", "with-fingerprints", "--force"],
-                required=False
-            )
-
-        # Apply the authselect options from the kickstart file.
+        # Only call authselect if explicitly specified in kickstart.
+        # https://github.com/pbrezina/authselect/issues/48
         if security_proxy.Authselect:
             self._run(
                 "/usr/bin/authselect",


### PR DESCRIPTION
The system image might have a curated version of `nsswitch.conf` that we
don't want to overwrite. Rather than indeterministically calling it
based on whether `fprintd` is in the tree, let's just only call it if it
was explicitly asked for in the kickstart.

See also: https://github.com/pbrezina/authselect/issues/48.