### PR TITLE
Remove the invalid self argument

### DIFF
--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -400,7 +400,7 @@ class ZPage(FilterPage):
     SEARCH_TYPE_LUN = 'LUN'
 
     def __init__(self, storage, builder):
-        super().__init__(self, storage, builder)
+        super().__init__(storage, builder)
         self.model = self.builder.get_object("zModel")
         self.model.set_visible_func(self.visible_func)
 


### PR DESCRIPTION
When we call super() method, we shouldn't add the self argument.