### PR TITLE
Move install time dependencies to a metapackage

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -30,7 +30,6 @@ Source0: %{name}-%{version}.tar.bz2
 %define gettextver 0.19.8
 %define gtk3ver 3.22.17
 %define helpver 22.1-1
-%define iscsiver 6.2.0.873-26
 %define isomd5sum 1.0.10
 %define langtablever 0.0.34
 %define libarchivever 3.0.4
@@ -39,7 +38,6 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define partedver 1.8.1
 %define pykickstartver 3.12-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
@@ -92,12 +90,10 @@ Requires: python3-libs
 Requires: python3-dnf >= %{dnfver}
 Requires: python3-blivet >= 1:3.0.0-0.1.b1
 Requires: python3-blockdev >= %{libblockdevver}
-Requires: libblockdev-plugins-all >= %{libblockdevver}
 Requires: python3-meh >= %{mehver}
 Requires: libreport-anaconda >= 2.0.21-1
 Requires: libselinux-python3
 Requires: rpm-python3 >= %{rpmver}
-Requires: parted >= %{partedver}
 Requires: python3-pyparted >= %{pypartedver}
 Requires: python3-requests
 Requires: python3-requests-file
@@ -117,7 +113,6 @@ Requires: python3-pydbus
 Requires: cracklib-dicts
 
 Requires: python3-pytz
-Requires: realmd
 Requires: teamd
 %ifarch %livearches
 Requires: usermode
@@ -125,8 +120,6 @@ Requires: usermode
 %ifarch s390 s390x
 Requires: openssh
 %endif
-Requires: isomd5sum >= %{isomd5sum}
-Requires: createrepo_c
 Requires: NetworkManager >= %{nmver}
 Requires: NetworkManager-libnm >= %{nmver}
 Requires: NetworkManager-team
@@ -134,18 +127,7 @@ Requires: dhclient
 Requires: kbd
 Requires: chrony
 Requires: python3-ntplib
-Requires: rsync
 Requires: systemd
-%ifarch %{ix86} x86_64
-Requires: fcoe-utils >= %{fcoeutilsver}
-%endif
-Requires: python3-iscsi-initiator-utils >= %{iscsiver}
-%ifarch %{ix86} x86_64
-%if ! 0%{?rhel}
-Requires: hfsplus-tools
-%endif
-%endif
-Requires: kexec-tools
 Requires: python3-pid
 Requires: python3-ordered-set >= 2.0.0
 Requires: python3-wrapt
@@ -167,6 +149,36 @@ Obsoletes: booty <= 0.107-1
 %description core
 The anaconda-core package contains the program which was used to install your
 system.
+
+%package install-env-deps
+Summary: Installation environment specific dependencies
+Requires: udisks2-iscsi
+Requires: libblockdev-plugins-all >= %{libblockdevver}
+# active directory/freeipa join support
+Requires: realmd
+Requires: isomd5sum >= %{isomd5sum}
+%ifarch %{ix86} x86_64
+Requires: fcoe-utils >= %{fcoeutilsver}
+%endif
+# likely HFS+ resize support
+%ifarch %{ix86} x86_64
+%if ! 0%{?rhel}
+Requires: hfsplus-tools
+%endif
+%endif
+# kexec support
+Requires: kexec-tools
+Requires: createrepo_c
+# run's on TTY1 in install env
+Requires: tmux
+# install time crash handling
+Requires: gdb
+Requires: rsync
+
+%description install-env-deps
+The anaconda-install-env-deps metapackage lists all installation environment dependencies.
+This makes it possible for packages (such as Initial Setup) to depend on the main Anaconda package without
+pulling in all the install time dependencies as well.
 
 %package gui
 Summary: Graphical user interface for the Anaconda installer


### PR DESCRIPTION
Move dependencies that Anaconda needs only in the installation
environment (live/netinst/DVD) to a metapackage.
This way we can exclude the dependencies when they are not needed
(Initial Setup, dirinstall) while still being able to elegantly
pull them to the install images via Lorax templates and image
kickstarts.

Dependencies moved to anaconda-install-env-deps:
* libblockdev-plugins-all
* realmd - realm join happens at install time only
* isomd5sum - definitely needed at install time only
* createrepo_c - needed for driver disks, install time only
* fcoe-utils - install time fcoe handling
* hfsplus-tools - Mac storage resize support
* kexec-tools - install time kexec support

Dependencies moved from the Lorax template:
* tmux - runs install time status screens
* gdb - install time debugging

Dependencies added:
* udisks2-iscsi - see rhbz#1561047 for details

Dependencies dropped:
* parted - no longer directly called, we use the Python bindings
* python3-iscsi-initiator-utils - no longer used by Anaconda