### PR TITLE
Do not redraw screen after text YesNo dialog (#1557951)

### DIFF
--- a/pyanaconda/ui/tui/__init__.py
+++ b/pyanaconda/ui/tui/__init__.py
@@ -333,6 +333,5 @@ class TextUserInterface(ui.UserInterface):
 
         question_window = YesNoDialog(message)
         ScreenHandler.push_screen_modal(question_window)
-        question_window.redraw()
 
         return question_window.answer


### PR DESCRIPTION
Anaconda drew screen after YesNoDialog but the usage of YesNoDialog is mostly on places where you don't want to redraw screen or you can even cause crash.

Resolves: rhbz#1557951