### PR TITLE
authselect: fix typo in fingerprint case and enable silent last log

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -349,7 +349,7 @@ class Authselect(RemovedCommand):
         if not flags.automatedInstall and self.fingerprint_supported:
             self._run(
                 "/usr/bin/authselect",
-                ["select", "sssd", "with-fingerprint", "--force"],
+                ["select", "sssd", "with-fingerprint", "with-silent-lastlog", "--force"],
                 required=False
             )
 

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -349,7 +349,7 @@ class Authselect(RemovedCommand):
         if not flags.automatedInstall and self.fingerprint_supported:
             self._run(
                 "/usr/bin/authselect",
-                ["select", "sssd", "with-fingerprints", "--force"],
+                ["select", "sssd", "with-fingerprint", "--force"],
                 required=False
             )
 


### PR DESCRIPTION
Parameter "with-fingerprints" does not exist, it spells without 's'
at the end, therefore fingrprint authentication does not work after
this call.

Second patch is related to [1]. Loud pam_lastlog is required for
RHEL but it is not desirable for Fedora, since it delays gdm login
and thus is should be silent by default on Fedora.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1561092