### PR TITLE
Clear errors when a user updates partitioning settings (#1535781)

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom.py
+++ b/pyanaconda/ui/gui/spokes/custom.py
@@ -2628,6 +2628,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     @timed_action(delay=50, threshold=100)
     def on_update_settings_clicked(self, button):
         """ call _save_right_side, then, perhaps, populate_right_side. """
+        if button:
+            # Clear errors if we are handling a click.
+            self.clear_errors()
+
         self._save_right_side(self._current_selector)
         self._applyButton.set_sensitive(False)
 


### PR DESCRIPTION
In the custom partitioning spoke, we should clear the displayed errors
when a user clicks on the Update Settings button.

Resolves: rhbz#1535781