### PR TITLE
Add %files for install-env-deps so it actually exists

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -288,7 +288,10 @@ update-desktop-database &> /dev/null || :
 update-desktop-database &> /dev/null || :
 %endif
 
+# main package and install-env-deps are metapackages
 %files
+
+%files install-env-deps
 
 # Allow the lang file to be empty
 %define _empty_manifest_terminate_build 0


### PR DESCRIPTION
The package won't actually be built if it lacks a %files. This
broke Rawhide composes.

Signed-off-by: Adam Williamson <awilliam@redhat.com>