### PR TITLE
Fix DD test missing patch for subprocess.check_output

### DIFF
--- a/tests/dracut_tests/test_driver_updates.py
+++ b/tests/dracut_tests/test_driver_updates.py
@@ -497,9 +497,10 @@ class GrabDriverFilesTestCase(FileTestCaseBase):
 
 class LoadDriversTestCase(unittest.TestCase):
     @mock.patch("driver_updates.subprocess.call")
+    @mock.patch("driver_updates.subprocess.check_output")
     @mock.patch("driver_updates.rm_net_intfs_for_unload")
     @mock.patch("driver_updates.list_net_intfs")
-    def test_basic(self, list_net_intfs, rm_net_intfs_for_unload, call):
+    def test_basic(self, list_net_intfs, rm_net_intfs_for_unload, check_output, call):
         """load_drivers: runs depmod and modprobes all named modules"""
         modnames = ['mod1', 'mod2']
         load_drivers({name: [name] for name in modnames})


### PR DESCRIPTION
I'm not sure why this worked before and I don't see any related change in python.

Basically when our testing infrastructure moved to a new Jenkins instance this test started to fail.

So or so there shouldn't be subprocess call to the system in unit-tests. To fix this I'm adding patch for the subprocess.check_output call as it is for other tests here already.

------------------------------

I need to set a bug for this fix and link it before merge. This is more test if the issue is really fixed.