### PR TITLE
Add anaconda-install-env-deps as dependency of the anaconda package

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -80,6 +80,7 @@ BuildRequires: libxml2
 Requires: anaconda-core = %{version}-%{release}
 Requires: anaconda-gui = %{version}-%{release}
 Requires: anaconda-tui = %{version}-%{release}
+Requires: anaconda-install-env-deps = %{version}-%{release}
 
 %description
 The anaconda package is a metapackage for the Anaconda installer.


### PR DESCRIPTION
This way anyone installing just the "anaconda" package should still get
all the install time dependencies as before (seems to be the case at
least with Pungi).

And at the same time. Initial Setup should be fine, as it depends only
on "anaconda-tui" or "anaconda-gui", which both depend on "anaconda-core",
but not in any way on the "anaconda" package itself.