### PR TITLE
Support fcoe --autovlan option (#1564096)

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -854,7 +854,7 @@ class ClearPart(RemovedCommand):
 
         storage.clear_partitions()
 
-class Fcoe(commands.fcoe.F13_Fcoe):
+class Fcoe(commands.fcoe.F28_Fcoe):
     def parse(self, args):
         fc = super().parse(args)
 

--- a/tests/nosetests/pyanaconda_tests/ks_version_test.py
+++ b/tests/nosetests/pyanaconda_tests/ks_version_test.py
@@ -27,7 +27,6 @@ class CommandVersionTestCase(unittest.TestCase):
 
     # Names of the kickstart commands and data that should be temporarily ignored.
     IGNORED_NAMES = {
-        "fcoe"
     }
 
     def assert_compare_versions(self, children, parents):


### PR DESCRIPTION
This is a backward kickstart compatibility patch, the default behavior is using
autovlan so the option does not have any effect.