### PR TITLE
Start only the specified kickstart modules (#1566621)

### DIFF
--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -67,15 +67,22 @@ class Boss(MainModule):
 
     def run(self):
         """Run the boss's loop."""
-        log.debug("Gather the modules.")
-        self._module_manager.add_default_modules()
-        self._module_manager.add_addon_modules()
         log.debug("Schedule publishing.")
         run_in_loop(self.publish)
-        log.debug("Schedule startup of modules.")
-        run_in_loop(self._module_manager.start_modules)
-        log.info("starting mainloop")
+        log.info("Start the main loop.")
         self._loop.run()
+
+    def start_modules(self, service_names, addons_enabled=True):
+        """Start the given kickstart modules."""
+        for service_name in service_names:
+            log.debug("Add module %s.", service_name)
+            self._module_manager.add_module(service_name)
+
+        if addons_enabled:
+            log.debug("Addons are enabled.")
+            self._module_manager.add_addon_modules()
+
+        self._module_manager.start_modules()
 
     def stop(self):
         """Stop all modules and then stop the boss."""

--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -41,6 +41,14 @@ class AnacondaBossInterface(BossInterface):
     Used for synchronization with anaconda during transition.
     """
 
+    def StartModules(self, service_names: List[Str], addons_enabled: Bool):
+        """Start the given kickstart modules.
+
+        :param service_names: a list of service names
+        :param addons_enabled: should we start addons?
+        """
+        self.implementation.start_modules(service_names, addons_enabled)
+
     @property
     def AllModulesAvailable(self) -> Bool:
         """Returns true if all modules are available."""

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -42,7 +42,7 @@ from pyanaconda.screensaver import inhibit_screensaver
 
 from pyanaconda.dbus import DBus
 from pyanaconda.dbus.constants import DBUS_FLAG_NONE
-from pyanaconda.modules.common.constants.services import BOSS
+from pyanaconda.modules.common.constants.services import BOSS, ALL_KICKSTART_MODULES
 
 import blivet
 
@@ -88,10 +88,20 @@ def stop_boss():
     boss_proxy.Quit()
 
 
-def run_boss():
-    """Start Boss service on DBus."""
+def run_boss(kickstart_modules=None, addons_enabled=True):
+    """Start Boss service on DBus.
+
+    :param kickstart_modules: a list of service identifiers
+    :param addons_enabled: should we start the addons?
+    """
+    if kickstart_modules is None:
+        kickstart_modules = ALL_KICKSTART_MODULES
+
     bus_proxy = DBus.get_dbus_proxy()
     bus_proxy.StartServiceByName(BOSS.service_name, DBUS_FLAG_NONE)
+
+    boss_proxy = BOSS.get_proxy()
+    boss_proxy.StartModules([m.service_name for m in kickstart_modules], addons_enabled)
 
 
 def get_anaconda_version_string(build_time_version=False):

--- a/scripts/run_boss_locally.py
+++ b/scripts/run_boss_locally.py
@@ -15,7 +15,7 @@ import argparse
 from gi.repository import Gio
 
 from pyanaconda.dbus import DBusConnection
-from pyanaconda.modules.common.constants.services import  BOSS
+from pyanaconda.modules.common.constants.services import BOSS, ALL_KICKSTART_MODULES
 from pyanaconda.modules.common.errors.kickstart import SplitKickstartError
 
 try:
@@ -50,7 +50,11 @@ EXEC_PATH = 'Exec=/usr/libexec/anaconda/start-module'
 
 def start_anaconda_services():
     print(RED + "starting Boss" + RESET)
-    test_dbus_connection.get_dbus_proxy().StartServiceByName(BOSS.service_name, 0)
+    bus_proxy = test_dbus_connection.get_dbus_proxy()
+    bus_proxy.StartServiceByName(BOSS.service_name, 0)
+
+    boss_proxy = test_dbus_connection.get_proxy(BOSS.service_name, BOSS.object_path)
+    boss_proxy.StartModules([m.service_name for m in ALL_KICKSTART_MODULES], True)
 
 def distribute_kickstart(ks_path):
     tmpfile = tempfile.mktemp(suffix=".run_boss_locally.ks")


### PR DESCRIPTION
We need to be able to specify which kickstart modules should run,
so we can disable some of them in the initial setup.

Related: rhbz#1566621