### PR TITLE
Fix broken kickstart command test

### DIFF
--- a/tests/pyanaconda_tests/ks_version_test.py
+++ b/tests/pyanaconda_tests/ks_version_test.py
@@ -27,6 +27,7 @@ class CommandVersionTestCase(unittest.TestCase):
 
     # Names of the kickstart commands and data that should be temporarily ignored.
     IGNORED_NAMES = {
+        "fcoe"
     }
 
     def assert_compare_versions(self, children, parents):


### PR DESCRIPTION
The test is broken because Anaconda is waiting for pykickstart build
so this commit will fix the test for now. This will be removed once
the Anaconda PR will be merged.