### PR TITLE
Select Workstation install class for Workstation live (#1569083)

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -67,6 +67,17 @@ if [ -f /etc/system-release ]; then
     export ANACONDA_PRODUCTVERSION=$( cat /etc/system-release | sed -r -e 's/^.* ([0-9\.]+).*$/\1/' )
 fi
 
+# set PRODUCTVARIANT if this is a Fedora Workstation live image
+# FIXME really, livemedia-creator should include .buildstamp in live
+# images, if it did, we could remove this:
+# https://github.com/weldr/lorax/issues/350
+if [ -f /etc/os-release ]; then
+    variantid=$( grep VARIANT_ID /etc/os-release | tail -1 | cut -d= -f2)
+    if [ "$variantid" = "workstation" ]; then
+        export ANACONDA_PRODUCTVARIANT="Workstation"
+    fi
+fi
+
 if [ $IMAGE_INSTALL = 1 ]; then
     export ANACONDA_PRODUCTVERSION=$(rpmquery -q --qf '%{VERSION}' anaconda | cut -d. -f1)
 fi


### PR DESCRIPTION
The Workstation install class (thus default settings, branding)
is not currently selected for Workstation live image installs,
ever since the install class was moved into anaconda itself.
The most correct fix for this would likely be for lmc to include
.builddstamp in live images, then the existing detection code
should work, but as a quick fix for F28, let's parse the variant
ID out of /etc/os-release.

Signed-off-by: Adam Williamson <awilliam@redhat.com>