### PR TITLE
Handle empty active attribute for consoles

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -570,7 +570,19 @@ def get_active_console(dev="console"):
     # If there's an 'active' attribute, this is a fake console..
     while os.path.exists("/sys/class/tty/%s/active" % dev):
         # So read the name of the real, primary console out of the file.
-        dev = open("/sys/class/tty/%s/active" % dev).read().split()[-1]
+        console_path = "/sys/class/tty/%s/active" % dev
+        active = open(console_path, "rt").read()
+        if active.split():
+            # the active attribute seems to be pointing to another console
+            dev = active.split()[-1]
+        else:
+            # At least some consoles on PPC have the "active" attribute, but it is empty.
+            # (see rhbz#1569045 for more details)
+            log.warning("%s is empty while console name is expected", console_path)
+            # We can't continue to a next console if active is empty, so set dev to ""
+            # and break the search loop.
+            dev = ""
+            break
     return dev
 
 


### PR DESCRIPTION
Some consoles are not real consoles, but fake/alias consoles
that point to the real console via the "active" attribute.
Apparently it is also possible to have a chain of fake/alias
consoles pointing to each other where only the last one
points to a real console (one that has no active attribute).

But for some reason on some PPC systems there are consoles that
have the active attribute, but it is empty (rhbz#1569045).

If we hit this situation, we can't continue our search for the
real console as we don't know where to go next. So log a warning,
set the console name to "" and stop the search.

This way the code will no longer traceback, but it might
be unable to resolve the correct active as long as the chain
if fake/alias consoles is broken by containing the empty active
attribute.