### PR TITLE
Remove makebumpver dependency from spec file

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -55,9 +55,6 @@ BuildRequires: libgnomekbd-devel
 BuildRequires: libxklavier-devel >= %{libxklavierver}
 BuildRequires: pango-devel
 BuildRequires: python3-kickstart >= %{pykickstartver}
-%if ! 0%{?rhel}
-BuildRequires: python3-bugzilla
-%endif
 BuildRequires: python3-devel
 BuildRequires: python3-nose
 BuildRequires: systemd

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -23,7 +23,9 @@ logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger("bugzilla")
 log.setLevel(logging.INFO)
 
-import bugzilla
+# This is only place where bugzilla library is used. Exclude from dependencies and
+# ignore pylint.
+import bugzilla  # pylint: disable=import-error
 from contextlib import closing
 import datetime
 import argparse


### PR DESCRIPTION
If it is used only in makebumpver there is no need to have it as Anaconda dependency.