### PR TITLE
Fix the clearpart test with disklabel option

### DIFF
--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -32,7 +32,7 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 DEPENDENCY_SOLVER = "dependency_solver.py"
 
 ANACONDA_MOCK_PATH = "/anaconda"
-NOSE_TESTS_PREFIX = "./pyanaconda_tests/"
+NOSE_TESTS_PREFIX = "./nosetests/pyanaconda_tests/"
 
 
 class MockException(Exception):

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -133,7 +133,8 @@ class StorageInterfaceTestCase(unittest.TestCase):
         """
         self._test_kickstart(ks_in, ks_out)
 
-    def clearpart_disklabel_kickstart_test(self):
+    @patch("pyanaconda.modules.storage.kickstart.DiskLabel")
+    def clearpart_disklabel_kickstart_test(self, disk_label):
         """Test the clearpart command with the disklabel option."""
         ks_in = """
         clearpart --all --disklabel=msdos
@@ -142,7 +143,11 @@ class StorageInterfaceTestCase(unittest.TestCase):
         # Partition clearing information
         clearpart --all --disklabel=msdos
         """
+        disk_label.get_platform_label_types.return_value = ["msdos", "gpt"]
         self._test_kickstart(ks_in, ks_out)
+
+        disk_label.get_platform_label_types.return_value = ["gpt"]
+        self._test_kickstart(ks_in, ks_out, ks_valid=False)
 
     @patch("pyanaconda.modules.storage.kickstart.device_matches")
     def clearpart_list_kickstart_test(self, device_matches):


### PR DESCRIPTION
We should mock the supported disk labels, so we can run our unittests
on different platforms.

The specified nosetests failed to run, because of an invalid path.