### PR TITLE
Show correct root spoke lock status in reconfig mode (#1507940)

### DIFF
--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -22,7 +22,7 @@ from pyanaconda.core.i18n import _, CN_
 from pyanaconda.users import cryptPassword
 from pyanaconda import input_checking
 from pyanaconda.core import constants
-from pyanaconda.modules.common.constants.services import USER
+from pyanaconda.modules.common.constants.services import USER, SERVICES
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
@@ -60,6 +60,9 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
         self._user_module = USER.get_observer()
         self._user_module.connect()
+
+        self._services_module = SERVICES.get_observer()
+        self._services_module.connect()
 
     def initialize(self):
         NormalSpoke.initialize(self)
@@ -146,10 +149,18 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     @property
     def status(self):
-        if self._user_module.proxy.IsRootPasswordSet:
+        if self._user_module.proxy.IsRootAccountLocked:
+            # check if we are running in Initial Setup reconfig mode
+            reconfig_mode = self._services_module.proxy.SetupOnBoot == constants.SETUP_ON_BOOT_RECONFIG
+            # reconfig mode currently allows re-enabling a locked root account if
+            # user sets a new root password
+            if reconfig_mode:
+                return _("Disabled, set password to enable.")
+            else:
+                return _("Root account is disabled.")
+
+        elif self._user_module.proxy.IsRootPasswordSet:
             return _("Root password is set")
-        elif self._user_module.proxy.IsRootAccountLocked:
-            return _("Root account is disabled")
         else:
             return _("Root password is not set")
 

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -23,7 +23,8 @@ from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import N_, _
-from pyanaconda.modules.common.constants.services import USER
+from pyanaconda.core.constants import SETUP_ON_BOOT_RECONFIG
+from pyanaconda.modules.common.constants.services import USER, SERVICES
 
 from simpleline.render.widgets import TextWidget
 
@@ -48,6 +49,9 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         self._user_module = USER.get_observer()
         self._user_module.connect()
 
+        self._services_module = SERVICES.get_observer()
+        self._services_module.connect()
+
         self.initialize_done()
 
     @property
@@ -65,10 +69,18 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     @property
     def status(self):
-        if self._user_module.proxy.IsRootPasswordSet:
+        if self._user_module.proxy.IsRootAccountLocked:
+            # check if we are running in Initial Setup reconfig mode
+            reconfig_mode = self._services_module.proxy.SetupOnBoot == SETUP_ON_BOOT_RECONFIG
+            # reconfig mode currently allows re-enabling a locked root account if
+            # user sets a new root password
+            if reconfig_mode:
+                return _("Disabled. Set password to enable root account.")
+            else:
+                return _("Root account is disabled.")
+
+        elif self._user_module.proxy.IsRootPasswordSet:
             return _("Password is set.")
-        elif self._user_module.proxy.IsRootAccountLocked:
-            return _("Root account is disabled.")
         else:
             return _("Password is not set.")
 


### PR DESCRIPTION
It is currently possible (and expected on ARM images) to
re-enable a locked root account by setting a new root password
if the root password spoke is running in Initial Setup reconfig mode.

Unfortunately the spoke status in this case just says the password
is set without mentioning that the root account is locked.

So fix the root password spoke status to mention that the root account is locked
but can be re-enabled by setting a new root password.

Resolves: rhbz#1507940