### PR TITLE
Change the pop-up text with the pre-release warning (#1542998)

### DIFF
--- a/pyanaconda/ui/gui/spokes/welcome.glade
+++ b/pyanaconda/ui/gui/spokes/welcome.glade
@@ -20,7 +20,7 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="quitButton">
-                <property name="label" translatable="yes" context="GUI|Welcome|Beta Warn Dialog">_Get me out of here!</property>
+                <property name="label" translatable="yes" context="GUI|Welcome|Beta Warn Dialog">I want to _exit.</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -34,7 +34,7 @@
             </child>
             <child>
               <object class="GtkButton" id="continueButton">
-                <property name="label" translatable="yes" context="GUI|Welcome|Beta Warn Dialog">_I accept my fate.</property>
+                <property name="label" translatable="yes" context="GUI|Welcome|Beta Warn Dialog">I want to _proceed.</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -94,7 +94,11 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="valign">start</property>
-                <property name="label" translatable="yes">You wake up inside an OS installer in Timbuktu, and it's six months in the future.  But, there are bugs.  Bugs everywhere.  Bugs you must live with.  This OS of the future isn't a stable OS you can rely on.  It's for testing purposes only.</property>
+                <property name="label" translatable="yes">Notice: This is pre-released software that is intended for development and testing purposes only.  Do *not* use this software for any critical work or for production environments.
+
+By clicking "I want to proceed", you understand and accept the risks associated with pre-released software, that you intend to use this for testing and development purposes only and are willing to report any bugs or issues in order to enhance this work.
+
+If you do not understand or accept the risks, then please exit this program by selecting "I want to exit" which will reboot your system.</property>
                 <property name="wrap">True</property>
                 <attributes>
                   <attribute name="font-desc" value="Cantarell 12"/>


### PR DESCRIPTION
We should use the RHEL version of the pop-up text.

(cherry-picked from commits c02b585 and e033e50)

Resolves: rhbz#1542998