### PR TITLE
Fix KS logvol metadata and chunksize parameters (#1572511)

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1222,9 +1222,9 @@ class LogVolData(commands.logvol.F23_LogVolData):
                     else:
                         logvol_log.warning("No matching profile for %s found in LVM configuration", self.profile)
                 if self.metadata_size:
-                    pool_args["metadatasize"] = Size("%d MiB" % self.metadata_size)
+                    pool_args["metadata_size"] = Size("%d MiB" % self.metadata_size)
                 if self.chunk_size:
-                    pool_args["chunksize"] = Size("%d KiB" % self.chunk_size)
+                    pool_args["chunk_size"] = Size("%d KiB" % self.chunk_size)
 
             if self.maxSizeMB:
                 try:


### PR DESCRIPTION
Thanks to our technique how we are passing parameters to blivet and how blivet requires them this was broken for a long time. My theory is that this is broken when blivet renamed everything for PEP-8.

Resolves: rhbz#1572511