### PR TITLE
Update the pykickstart commands

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -38,7 +38,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.12-1
+%define pykickstartver 3.14-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 1.1-1

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -246,7 +246,7 @@ class DisplayMode(commands.displaymode.F26_DisplayMode, DracutArgsMixin):
 
         return ret
 
-class Bootloader(commands.bootloader.F21_Bootloader, DracutArgsMixin):
+class Bootloader(commands.bootloader.F29_Bootloader, DracutArgsMixin):
     def dracut_args(self, args, lineno, obj):
         if self.extlinux:
             return "extlinux"

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1394,7 +1394,7 @@ class Network(commands.network.F27_Network):
     def execute(self, storage, ksdata, instClass):
         network.write_network_config(storage, ksdata, instClass, util.getSysroot())
 
-class Partition(commands.partition.F23_Partition):
+class Partition(commands.partition.F29_Partition):
     def execute(self, storage, ksdata, instClass):
         for p in self.partitions:
             p.execute(storage, ksdata, instClass)
@@ -1402,7 +1402,7 @@ class Partition(commands.partition.F23_Partition):
         if self.partitions:
             do_partitioning(storage)
 
-class PartitionData(commands.partition.F23_PartData):
+class PartitionData(commands.partition.F29_PartData):
     def execute(self, storage, ksdata, instClass):
         devicetree = storage.devicetree
         kwargs = {}
@@ -2357,14 +2357,6 @@ class Keyboard(RemovedCommand):
         localization_proxy = LOCALIZATION.get_proxy()
         keyboard.write_keyboard_config(localization_proxy, util.getSysroot())
 
-class Upgrade(commands.upgrade.F20_Upgrade):
-    # Upgrade is no longer supported. If an upgrade command was included in
-    # a kickstart, warn the user and exit.
-    def parse(self, args):
-        upgrade_log.error("The upgrade kickstart command is no longer supported. Upgrade functionality is provided through fedup.")
-        sys.stderr.write(_("The upgrade kickstart command is no longer supported. Upgrade functionality is provided through fedup."))
-        util.ipmi_report(IPMI_ABORTED)
-        sys.exit(1)
 
 ###
 ### %anaconda Section
@@ -2504,7 +2496,6 @@ commandMap = {
     "skipx": UselessCommand,
     "snapshot": Snapshot,
     "timezone": Timezone,
-    "upgrade": Upgrade,
     "user": User,
     "volgroup": VolGroup,
     "xconfig": XConfig,

--- a/pyanaconda/modules/storage/kickstart.py
+++ b/pyanaconda/modules/storage/kickstart.py
@@ -19,12 +19,12 @@
 #
 from blivet.formats.disklabel import DiskLabel
 from pykickstart.commands.autopart import F26_AutoPart
-from pykickstart.commands.bootloader import F21_Bootloader
+from pykickstart.commands.bootloader import F29_Bootloader
 from pykickstart.commands.clearpart import F28_ClearPart
-from pykickstart.commands.ignoredisk import F14_IgnoreDisk
+from pykickstart.commands.ignoredisk import F29_IgnoreDisk
 from pykickstart.commands.logvol import F23_LogVol, F23_LogVolData
 from pykickstart.commands.mount import F27_Mount, F27_MountData
-from pykickstart.commands.partition import F23_Partition, F23_PartData
+from pykickstart.commands.partition import F29_Partition, F29_PartData
 from pykickstart.commands.raid import F25_Raid, F25_RaidData
 from pykickstart.commands.reqpart import F23_ReqPart
 from pykickstart.commands.volgroup import F21_VolGroup, F21_VolGroupData
@@ -88,7 +88,7 @@ class ClearPart(F28_ClearPart):
         return retval
 
 
-class IgnoreDisk(F14_IgnoreDisk):
+class IgnoreDisk(F29_IgnoreDisk):
     """The ignoredisk kickstart command."""
 
     def parse(self, args):
@@ -117,13 +117,13 @@ class StorageKickstartSpecification(KickstartSpecification):
     version = F28
     commands = {
         "autopart": F26_AutoPart,
-        "bootloader": F21_Bootloader,
+        "bootloader": F29_Bootloader,
         "clearpart": ClearPart,
         "ignoredisk": IgnoreDisk,
         "logvol": F23_LogVol,
         "mount": F27_Mount,
-        "part": F23_Partition,
-        "partition": F23_Partition,
+        "part": F29_Partition,
+        "partition": F29_Partition,
         "raid": F25_Raid,
         "reqpart": F23_ReqPart,
         "volgroup": F21_VolGroup,
@@ -133,7 +133,7 @@ class StorageKickstartSpecification(KickstartSpecification):
     commands_data = {
         "LogVolData": F23_LogVolData,
         "MountData": F27_MountData,
-        "PartData": F23_PartData,
+        "PartData": F29_PartData,
         "RaidData": F25_RaidData,
         "VolGroupData": F21_VolGroupData,
     }


### PR DESCRIPTION
The bootloader, ignoredisk and partition commands have some options
deprecated in F29. The deprecated command upgrade is removed in F29.

Related: https://github.com/clumens/pykickstart/pull/217
**Depends on: pykickstart-3.13**
