### PR TITLE
Increase module startup timeout to 600 seconds

### DIFF
--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -442,7 +442,7 @@ def set_installation_method_from_anaconda_options(anaconda, ksdata):
         log.error("Unknown method: %s", anaconda.methodstr)
 
 
-def wait_for_modules(timeout=60):
+def wait_for_modules(timeout=600):
     """Wait for the DBus modules.
 
     :param timeout: seconds to the timeout


### PR DESCRIPTION
Some recent bug reports seem to indicate the current
60 second timeout for module startup in Anaconda and
30 second timeout in Initial Setup are not enough:

- rhbz#1573538
- rhbz#1572316

While we suspect there might be some outside factors
that make Anaconda startup unnecessary long, let's bump
the timeout to 600 seconds for now, while we investigate
what's going on.

A related Initial Setup will make sure the timeout
value from Anaconda is used so that the 600 second timeout
takes effect there as well.