### PR TITLE
Fix name of the Zanata Python client package

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,9 @@ ARCHIVE_TAG   = $(PACKAGE_NAME)-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE)
 ZANATA_PULL_ARGS = --transdir $(srcdir)/po/
 ZANATA_PUSH_ARGS = --srcfile $(srcdir)/po/anaconda.pot --push-type source --force
 
+# the Zanata Python client is unfortunately Python 2 only at the moment
+ZANATA_CLIENT_PKG=python2-zanata-client
+
 DIST_NAME ?= $(shell echo "$(GIT_BRANCH)" | sed \
 				-e 's/^f//' \
 				-e 's/master/rawhide/')
@@ -87,7 +90,7 @@ tag:
 	@echo "Tagged as $(ARCHIVE_TAG)"
 
 po-pull:
-	rpm -q zanata-python-client &>/dev/null || ( echo "need to run: dnf install zanata-python-client"; exit 1 )
+	rpm -q $(ZANATA_CLIENT_PKG) &>/dev/null || ( echo "need to run: dnf install $(ZANATA_CLIENT_PKG)"; exit 1 )
 	( cd $(srcdir) && zanata pull $(ZANATA_PULL_ARGS) )
 
 po-push:


### PR DESCRIPTION
The package was renamed to python2-zanata-client in F28.

Also make the zanata client package name to a variable
so it can be easily overridden if needed.