### PR TITLE
Add 10% for storage metadata to the total required space (#1578395)

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -228,6 +228,9 @@ UNSUPPORTED_FILESYSTEMS = ("btrfs", "ntfs", "tmpfs")
 # Default to these units when reading user input when no units given
 SIZE_UNITS_DEFAULT = "MiB"
 
+# An estimated ratio for metadata size to total disk space.
+STORAGE_METADATA_RATIO = 0.1
+
 # Constants for reporting status to IPMI.  These are from the IPMI spec v2 rev1.1, page 512.
 IPMI_STARTED = 0x7          # installation started
 IPMI_FINISHED = 0x8         # installation finished successfully


### PR DESCRIPTION
In the Install Options dialog, we should add 10% of the disk space for
storage metadata to the total required space. Otherwise, the space
requirements might be confusing.

Resolves: rhbz#1578395