### PR TITLE
Don't display "Alternate Architectures" in product name

### DIFF
--- a/pyanaconda/product.py
+++ b/pyanaconda/product.py
@@ -41,6 +41,8 @@ bugUrl = config.get("Main", "BugURL")
 isFinal = config.getboolean("Main", "IsFinal")
 productArch = config.get("Main", "Arch")
 productName = config.get("Main", "Product")
+if productName.endswith(" Alternate Architectures"):
+    productName = productName[:-len(" Alternate Architectures")]
 productStamp = config.get("Main", "UUID")
 productVersion = config.get("Main", "Version")
 


### PR DESCRIPTION
Temporary fix on anaconda side. This should be resolved in compose tools (or
testing infrastructure) side.

Resolves: rhbz#1488558