### PR TITLE
Preserve the boot option zfcp.allow_lun_scan (#1561662)

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -2148,7 +2148,7 @@ class ZIPL(BootLoader):
             return ["ext4", "ext3", "ext2", "xfs"]
 
     image_label_attr = "short_label"
-    preserve_args = ["cio_ignore", "rd.znet", "rd_ZNET"]
+    preserve_args = ["cio_ignore", "rd.znet", "rd_ZNET", "zfcp.allow_lun_scan"]
 
     def __init__(self):
         super(ZIPL, self).__init__()


### PR DESCRIPTION
The boot option `zfcp.allow_lun_scan` should be preserved in the installed system.

Resolves: rhbz#1561662