### PR TITLE
Set locale to en_US.UTF-8 in every module (#1575415)

### DIFF
--- a/pyanaconda/dbus/launcher.py
+++ b/pyanaconda/dbus/launcher.py
@@ -79,7 +79,7 @@ class DBusLauncher(object):
         self._log_file = open('/tmp/dbus.log', 'a')
         config_file = "--config-file={}".format(os.path.join(ANACONDA_DATA_DIR, "dbus/anaconda-bus.conf"))
         command = [DBusLauncher.DBUS_LAUNCH_BIN, '--print-address', "--syslog", config_file]
-        self._dbus_daemon_process = startProgram(command, stderr=self._log_file)
+        self._dbus_daemon_process = startProgram(command, stderr=self._log_file, reset_lang=False)
 
         if self._dbus_daemon_process.poll() is not None:
             raise IOError("DBus wasn't properly started!")

--- a/pyanaconda/dbus_addons/baz/__main__.py
+++ b/pyanaconda/dbus_addons/baz/__main__.py
@@ -1,7 +1,6 @@
-import logging
-logging.basicConfig(level=logging.DEBUG)
+from pyanaconda.modules.common import init
+init()
 
 from pyanaconda.dbus_addons.baz.baz import Baz
-
 baz = Baz()
 baz.run()

--- a/pyanaconda/modules/boss/__main__.py
+++ b/pyanaconda/modules/boss/__main__.py
@@ -1,10 +1,6 @@
-import logging
-logging.basicConfig(level=logging.DEBUG)
+from pyanaconda.modules.common import init
+init()
 
 from pyanaconda.modules.boss.boss import Boss
-
-# instantiate the Boss class
 boss = Boss()
-# and start it
 boss.run()
-

--- a/pyanaconda/modules/common/__init__.py
+++ b/pyanaconda/modules/common/__init__.py
@@ -27,3 +27,7 @@ def init():
     """
     import logging
     logging.basicConfig(level=logging.DEBUG)
+
+    import locale
+    from pyanaconda.core.constants import DEFAULT_LANG
+    locale.setlocale(locale.LC_ALL, DEFAULT_LANG)

--- a/pyanaconda/modules/common/__init__.py
+++ b/pyanaconda/modules/common/__init__.py
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+__all__ = ["init"]
+
+
+def init():
+    """Do initial configuration of an Anaconda DBus module.
+
+    This method should be imported and called from __main__.py of every
+    Anaconda DBus module before any other import.
+    """
+    import logging
+    logging.basicConfig(level=logging.DEBUG)

--- a/pyanaconda/modules/localization/__main__.py
+++ b/pyanaconda/modules/localization/__main__.py
@@ -1,7 +1,6 @@
-import logging
-logging.basicConfig(level=logging.DEBUG)
+from pyanaconda.modules.common import init
+init()
 
 from pyanaconda.modules.localization.localization import LocalizationModule
-
 localization_module = LocalizationModule()
 localization_module.run()

--- a/pyanaconda/modules/network/__main__.py
+++ b/pyanaconda/modules/network/__main__.py
@@ -1,7 +1,6 @@
-import logging
-logging.basicConfig(level=logging.DEBUG)
+from pyanaconda.modules.common import init
+init()
 
 from pyanaconda.modules.network.network import NetworkModule
-
 network_module = NetworkModule()
 network_module.run()

--- a/pyanaconda/modules/payload/__main__.py
+++ b/pyanaconda/modules/payload/__main__.py
@@ -1,7 +1,6 @@
-import logging
-logging.basicConfig(level=logging.DEBUG)
+from pyanaconda.modules.common import init
+init()
 
 from pyanaconda.modules.payload.payload import PayloadModule
-
 payload_module = PayloadModule()
 payload_module.run()

--- a/pyanaconda/modules/security/__main__.py
+++ b/pyanaconda/modules/security/__main__.py
@@ -1,7 +1,6 @@
-import logging
-logging.basicConfig(level=logging.DEBUG)
+from pyanaconda.modules.common import init
+init()
 
 from pyanaconda.modules.security.security import SecurityModule
-
 security_module = SecurityModule()
 security_module.run()

--- a/pyanaconda/modules/services/__main__.py
+++ b/pyanaconda/modules/services/__main__.py
@@ -1,7 +1,6 @@
-import logging
-logging.basicConfig(level=logging.DEBUG)
+from pyanaconda.modules.common import init
+init()
 
 from pyanaconda.modules.services.services import ServicesModule
-
 services_module = ServicesModule()
 services_module.run()

--- a/pyanaconda/modules/storage/__main__.py
+++ b/pyanaconda/modules/storage/__main__.py
@@ -1,7 +1,6 @@
-import logging
-logging.basicConfig(level=logging.DEBUG)
+from pyanaconda.modules.common import init
+init()
 
 from pyanaconda.modules.storage.storage import StorageModule
-
 storage_module = StorageModule()
 storage_module.run()

--- a/pyanaconda/modules/timezone/__main__.py
+++ b/pyanaconda/modules/timezone/__main__.py
@@ -1,7 +1,6 @@
-import logging
-logging.basicConfig(level=logging.DEBUG)
+from pyanaconda.modules.common import init
+init()
 
 from pyanaconda.modules.timezone.timezone import TimezoneModule
-
 timezone_module = TimezoneModule()
 timezone_module.run()

--- a/pyanaconda/modules/users/__main__.py
+++ b/pyanaconda/modules/users/__main__.py
@@ -1,7 +1,6 @@
-import logging
-logging.basicConfig(level=logging.DEBUG)
+from pyanaconda.modules.common import init
+init()
 
 from pyanaconda.modules.users.users import UsersModule
-
 users_module = UsersModule()
 users_module.run()


### PR DESCRIPTION
We should set locale to en_US.UTF-8 in every Anaconda DBus module,
otherwise the modules might not use the UTF-8 encoding by default.

Resolves: rhbz#1575415
