### PR TITLE
Disable pylint run on bootloader.py

### DIFF
--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -48,7 +48,8 @@ class AnacondaLintConfig(PocketLintConfig):
 
     @property
     def ignoreNames(self):
-        return {"translation-canary"}
+        # FIXME: Remove bootloader.py when python-astroid will be fixed (#1583256)
+        return {"translation-canary", "bootloader.py"}
 
 
 def _get_timelog_path():


### PR DESCRIPTION
Python astroid 2.0.0 raising an exception on bootloader.py and because it doesn't change often we will disable the pylint check completely. 
This file should be enabled again when python-astroid will be fixed.