### PR TITLE
If someone really wants to eject the cdrom, then do it. (#1499792)

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -94,6 +94,10 @@ def exitHandler(rebootData, storage, payload, exitCode=None):
             for cdrom in storage.devicetree.getDevicesByType("cdrom"):
                 if iutil.get_mount_paths(cdrom.path):
                     iutil.dracut_eject(cdrom.path)
+                else:
+                    # it's possible the cdrom is not mounted, e.g. if a user
+                    # boots from DVD, but does not install from it (#1499792)
+                    iutil.dracut_eject(cdrom.path)
 
         if flags.kexec:
             iutil.execWithRedirect("systemctl", ["--no-wall", "kexec"])


### PR DESCRIPTION
If someone boots from DVD but does not install from it, then
/dev/sr0 (or whatever device node is assigned to the cdrom device)
is not mounted. However, users may still wish to eject the DVD once
installation is complete. This ensures that will happen.

Resolves: rhbz#1499792