### PR TITLE
Enable DNF depsolver debugging in debug mode

### DIFF
--- a/data/post-scripts/99-copy-logs.ks
+++ b/data/post-scripts/99-copy-logs.ks
@@ -4,6 +4,7 @@
 NOSAVE_INPUT_KS_FILE=/tmp/NOSAVE_INPUT_KS
 NOSAVE_LOGS_FILE=/tmp/NOSAVE_LOGS
 PRE_ANA_LOGS=/tmp/pre-anaconda-logs
+DNF_DEBUG_LOGS=/root/debugdata
 
 if [ -e ${NOSAVE_LOGS_FILE} ]; then
     rm -f ${NOSAVE_LOGS_FILE}
@@ -13,6 +14,8 @@ else
         [ -e /tmp/$log ] && cp /tmp/$log $ANA_INSTALL_PATH/var/log/anaconda/
     done
     [ -e /tmp/pre-anaconda-logs ] && cp -r $PRE_ANA_LOGS $ANA_INSTALL_PATH/var/log/anaconda
+    # copy DNF debug data (if any)
+    [ -e $DNF_DEBUG_LOGS ] && cp -r $DNF_DEBUG_LOGS $ANA_INSTALL_PATH/var/log/anaconda/dnf_debugdata
     cp /tmp/ks-script*.log $ANA_INSTALL_PATH/var/log/anaconda/
     journalctl -b > $ANA_INSTALL_PATH/var/log/anaconda/journal.log
     chmod 0600 $ANA_INSTALL_PATH/var/log/anaconda/*

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -548,6 +548,8 @@ class DNFPayload(payload.PackagePayload):
         conf.cachedir = DNF_CACHE_DIR
         conf.pluginconfpath = DNF_PLUGINCONF_DIR
         conf.logdir = '/tmp/'
+        # enable depsolver debugging if in debug mode
+        self._base.conf.debug_solver = flags.debug
 
         conf.releasever = self._getReleaseVersion(None)
         conf.installroot = util.getSysroot()


### PR DESCRIPTION
If Anaconda runs in debug mode (debug flag passed via
boot options or CLI) enable DNF depsolver debugging.

The result is the /root/debugdata folder, which
contains DNF depsolver debugging data.

Also copy the resulting debug data (if any) to /var/log/anaconda
on the target system. This is basically also a pre-requisite
for using the data for kickstart test debugging.