### PR TITLE
Do not manually create LUKSDevice when unlocking a LUKS format

### DIFF
--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from blivet.errors import StorageError
-from blivet.devices import LUKSDevice
 
 from pyanaconda.core import util
 from pyanaconda.core.constants import ANACONDA_CLEANUP, THREAD_STORAGE
@@ -313,10 +312,6 @@ class Rescue(object):
         try:
             device.setup()
             device.format.setup()
-            luks_device = LUKSDevice(device.format.map_name,
-                                     parents=[device],
-                                     exists=True)
-            self._storage.devicetree._add_device(luks_device)
 
             # Wait for the device.
             # Otherwise, we could get a message about no Linux partitions.

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -2820,10 +2820,6 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         device.original_format.passphrase = passphrase
         log.info("unlocked %s, now going to populate devicetree...", device.name)
         with ui_storage_logger():
-            luks_dev = LUKSDevice(device.format.map_name,
-                                  parents=[device],
-                                  exists=True)
-            self._storage_playground.devicetree._add_device(luks_dev)
             # save the passphrase for possible reset and to try for other devs
             self._storage_playground.save_passphrase(device)
             # XXX What if the user has changed things using the shell?


### PR DESCRIPTION
`populate` will create the device and add it to devicetree
automatically.
This also solves issues with LUKS 2 devices with integrity where
the LUKS device is not direct child of the partition that is
being unlocked. (So it is not possible to manually create it from
Anaconda and manually set its parents.)