### PR TITLE
Use wwn attr instead of removed wwid. (#1565693)

### DIFF
--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -240,7 +240,7 @@ class SearchPage(FilterPage):
         elif filterBy == self.SEARCH_TYPE_PORT_TARGET_LUN:
             return self._port_equal(device) and self._target_equal(device) and self._lun_equal(device)
         elif filterBy == self.SEARCH_TYPE_WWID:
-            return self._wwidEntry.get_text() in getattr(device, "wwid", self._long_identifier(device))
+            return self._wwidEntry.get_text() in getattr(device, "wwn", self._long_identifier(device))
 
     def visible_func(self, model, itr, *args):
         obj = DiskStoreRow(*model[itr])
@@ -278,7 +278,7 @@ class MultipathPage(FilterPage):
             store.append([True, selected, not disk.protected,
                           disk.name, "", disk.model, str(disk.size),
                           disk.vendor, disk.bus, disk.serial,
-                          disk.wwid, "\n".join(paths), "", "",
+                          disk.wwn, "\n".join(paths), "", "",
                           "", "", "", "", ""])
             if not disk.vendor in vendors:
                 vendors.append(disk.vendor)
@@ -310,7 +310,7 @@ class MultipathPage(FilterPage):
         elif filterBy == self.SEARCH_TYPE_INTERCONNECT:
             return device.bus == self._icCombo.get_active_text()
         elif filterBy == self.SEARCH_TYPE_WWID:
-            return self._wwidEntry.get_text() in device.wwid
+            return self._wwidEntry.get_text() in device.wwn
 
     def visible_func(self, model, itr, *args):
         if not flags.mpath:

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -742,7 +742,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         # We don't want to display the whole huge WWID for a multipath device.
         # That makes the DO way too wide.
         if isinstance(disk, MultipathDevice):
-            desc = disk.wwid.split(":")
+            desc = disk.wwn.split(":")
             description = ":".join(desc[0:3]) + "..." + ":".join(desc[-4:])
         elif isinstance(disk, ZFCPDiskDevice):
             # manually mangle the desc of a zFCP device to be multi-line since

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -259,8 +259,8 @@ class StorageSpoke(NormalTUISpoke):
         if (isinstance(disk, MultipathDevice) or
                 isinstance(disk, iScsiDiskDevice) or
                 isinstance(disk, FcoeDiskDevice)):
-            if hasattr(disk, "wwid"):
-                disk_attrs.append(disk.wwid)
+            if hasattr(disk, "wwn"):
+                disk_attrs.append(disk.wwn)
         elif isinstance(disk, DASDDevice):
             if hasattr(disk, "busid"):
                 disk_attrs.append(disk.busid)


### PR DESCRIPTION
The 'wwid' attribute was removed in blivet-3.1.0. Now all disk-like
devices have a 'wwn' attribute that gets its value from udev's ID_WWN
property.