### PR TITLE
Initial DNF 3 compatibility fixes

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -602,7 +602,7 @@ class DNFPayload(payload.PackagePayload):
         if transaction is None:
             return Size(0)
 
-        size = sum(tsi.installed.downloadsize for tsi in transaction)
+        size = sum(tsi.pkg.downloadsize for tsi in transaction)
         # reserve extra
         return Size(size) + Size("150 MB")
 
@@ -782,9 +782,9 @@ class DNFPayload(payload.PackagePayload):
         files_nm = 0
         for tsi in transaction:
             # space taken by all files installed by the packages
-            size += tsi.installed.installsize
+            size += tsi.pkg.installsize
             # number of files installed on the system
-            files_nm += len(tsi.installed.files)
+            files_nm += len(tsi.pkg.files)
 
         # append bonus size depending on number of files
         bonus_size = files_nm * BONUS_SIZE_ON_FILE

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -54,7 +54,7 @@ import dnf.logging
 import dnf.exceptions
 import dnf.repo
 import dnf.callback
-import dnf.conf.parser
+import libdnf.conf
 import dnf.conf.substitutions
 import rpm
 import librepo
@@ -325,7 +325,7 @@ class DNFPayload(payload.PackagePayload):
         Currently supports $releasever and $basearch.
         """
         if url:
-            return dnf.conf.parser.substitute(url, self._base.conf.substitutions)
+            return libdnf.conf.ConfigParser.substitute(url, self._base.conf.substitutions)
 
         return None
 

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -54,6 +54,7 @@ import dnf.logging
 import dnf.exceptions
 import dnf.repo
 import dnf.callback
+import dnf.transaction
 import libdnf.conf
 import dnf.conf.substitutions
 import rpm
@@ -176,7 +177,7 @@ class PayloadRPMDisplay(dnf.callback.TransactionProgress):
         # Process DNF actions, communicating with anaconda via the queue
         # A normal installation consists of 'install' messages followed by
         # the 'post' message.
-        if action == self.PKG_INSTALL and ti_done == 0:
+        if action == dnf.transaction.PKG_INSTALL and ti_done == 0:
             # do not report same package twice
             if self._last_ts == ts_done:
                 return
@@ -192,13 +193,13 @@ class PayloadRPMDisplay(dnf.callback.TransactionProgress):
             log_msg = "Installed: %s %s %s" % (nevra, package.buildtime, package.returnIdSum()[1])
             self._queue.put(('log', log_msg))
 
-        elif action == self.TRANS_POST:
+        elif action == dnf.transaction.TRANS_POST:
             self._queue.put(('post', None))
             log_msg = "Post installation setup phase started."
             self._queue.put(('log', log_msg))
             self._postinst_phase = True
 
-        elif action == self.PKG_SCRIPTLET:
+        elif action == dnf.transaction.PKG_SCRIPTLET:
             # Log the exact package nevra, build time and checksum
             nevra = "%s-%s.%s" % (package.name, package.evr, package.arch)
             log_msg = "Configuring (running scriptlet for): %s %s %s" % (nevra, package.buildtime, package.returnIdSum()[1])
@@ -210,7 +211,7 @@ class PayloadRPMDisplay(dnf.callback.TransactionProgress):
                 #self.cnt += 1
                 self._queue.put(('configure', msg))
 
-        elif action == self.PKG_VERIFY:
+        elif action == dnf.transaction.PKG_VERIFY:
             msg = '%s.%s (%d/%d)' % (package.name, package.arch, ts_done, ts_total)
             self._queue.put(('verify', msg))
 


### PR DESCRIPTION
DNF 3 recently landed in Rawhide. With these changes, I can at least complete a default network install, and also do some package selection from the GUI, without anything crashing. The correct packages appear to get installed, and the installed system boots.