### PR TITLE
Bootloader menu auto hide support (now based on  modularization-devel)

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -212,6 +212,7 @@ class BootLoader(object):
     config_file_mode = 0o600
     can_dual_boot = False
     can_update = False
+    menu_auto_hide = False
     image_label_attr = "label"
 
     encryption_support = False
@@ -1614,6 +1615,14 @@ class GRUB2(GRUB):
             if rc:
                 log.error("failed to set default menu entry to %s", productName)
 
+        # set menu_auto_hide grubenv variable if we should enable menu_auto_hide
+        # set boot_success so that the menu is hidden on the boot after install
+        if self.menu_auto_hide:
+            rc = util.execInSysroot("grub2-editenv",
+                            ["-", "set", "menu_auto_hide=1", "boot_success=1"])
+            if rc:
+                log.error("failed to set menu_auto_hide=1")
+
         # now tell grub2 to generate the main configuration file
         rc = util.execInSysroot("grub2-mkconfig",
                                 ["-o", self.config_file])
@@ -2526,6 +2535,8 @@ def writeBootLoader(storage, payload, instClass, ksdata):
         log.info("boot loader stage1 target device is %s", stage1_device.name)
         stage2_device = storage.bootloader.stage2_device
         log.info("boot loader stage2 target device is %s", stage2_device.name)
+
+    storage.bootloader.menu_auto_hide = instClass.bootloader_menu_autohide
 
     # Bridge storage EFI configuration to bootloader
     if hasattr(storage.bootloader, 'efi_dir'):

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -47,6 +47,7 @@ class BaseInstallClass(object):
     name = "base"
     bootloaderTimeoutDefault = None
     bootloaderExtraArgs = []
+    bootloader_menu_autohide = False
 
     # Anaconda flags several packages to be installed based on the configuration
     # of the system -- things like fs utilities, bootloader, &c. This is a list

--- a/pyanaconda/installclasses/fedora_workstation.py
+++ b/pyanaconda/installclasses/fedora_workstation.py
@@ -26,6 +26,7 @@ class FedoraWorkstationInstallClass(FedoraBaseInstallClass):
     stylesheet = "/usr/share/anaconda/pixmaps/workstation/fedora-workstation.css"
     sortPriority = FedoraBaseInstallClass.sortPriority + 1
     defaultPackageEnvironment = "workstation-product-environment"
+    bootloader_menu_autohide = True
 
     if productVariant != "Workstation":
         hidden = True


### PR DESCRIPTION
These 2 commits implement:

1. Tracking for which installclasses the bootloader should (auto) hide its bootmenu by defaults; and
2. Actually enabling the menu_auto_hide feature for GRUB2 when the installclass indicates it should be enabled.

Together these implement the anaconda part of:
https://fedoraproject.org/wiki/Changes/HiddenGrubMenu