### PR TITLE
dnfpayload: repo in _fetch_md is a dnf repo not ksrepo

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -410,26 +410,26 @@ class DNFPayload(payload.PackagePayload):
 
         log.info("added repo: '%s' - %s", ksrepo.name, url or mirrorlist or metalink)
 
-    def _fetch_md(self, repo):
+    def _fetch_md(self, repo_name):
         """Download repo metadata
 
-        :param repo: name/id of repo to fetch
-        :type repo: str
+        :param repo_name: name/id of repo to fetch
+        :type repo_name: str
         :returns: None
         """
-        ksrepo = self._base.repos[repo]
-        ksrepo.enable()
+        repo = self._base.repos[repo_name]
+        repo.enable()
         try:
             # Load the metadata to verify that the repo is valid
-            ksrepo.load()
+            repo.load()
         except dnf.exceptions.RepoError as e:
-            ksrepo.disable()
-            log.debug("repo: '%s' - %s failed to load repomd", ksrepo.name,
-                      ksrepo.baseurl or ksrepo.mirrorlist or ksrepo.metalink)
+            repo.disable()
+            log.debug("repo: '%s' - %s failed to load repomd", repo.id,
+                     repo.baseurl or repo.mirrorlist or repo.metalink)
             raise MetadataError(e)
 
-        log.info("enabled repo: '%s' - %s and got repomd", ksrepo.name,
-                 ksrepo.baseurl or ksrepo.mirrorlist or ksrepo.metalink)
+        log.info("enabled repo: '%s' - %s and got repomd", repo.id,
+                 repo.baseurl or repo.mirrorlist or repo.metalink)
 
     def add_repo(self, ksrepo):
         """Add an enabled repo to dnf and kickstart repo lists.


### PR DESCRIPTION
In today's Rawhide compose, with DNF 3, the log message logged
by `dnfpayload._fetch_md` - "enabled repo: ..." - was slightly
broken in all the openQA tests that try to use it to verify a
repo was configured correctly. The message is supposed to
include an identifier for the repo ('anaconda', when the repo
in question is the base repo) but in these tests, the identifier
was blank, like this:

"enabled repo: '' - ..."

Looking into it a bit, I noticed that `_fetch_md` calls the repo
object it gets `ksrepo` and uses `ksrepo.name` as the identifier
string, but this is inconsistent with the rest of dnfpayload.
Elsewhere, we consistently use `ksrepo` as a name for instances
of the pykickstart RepoData classes, and `repo` as a name for
DNF Repo class instances. We use `ksrepo.name` as a string id
for RepoData instances, but `repo.id` as a string id for DNF
Repo instances.

The repo object in `_fetch_md` is clearly a DNF Repo class
instance (we get it from `self._base.repos`), but it's called
`ksrepo`, and we use `ksrepo.name` as the string identifier. I
think that *sometimes* DNF repo instances will have a working
`name` attribute but sometimes it'll just be empty, which is
when this bug happens. To be consistent with the rest of this
file and to avoid the bug, we should call the object `repo` and
use the `id` attribute, not the `name` attribute, as the string
identifier.

Signed-off-by: Adam Williamson <awilliam@redhat.com>