### PR TITLE
Make sure dracut can make pmem devices from NFIT-based ramdisks.

### DIFF
--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -13,8 +13,11 @@ MODULE_LIST="cramfs squashfs iscsi_tcp "
 # we need this when any ko file cannot be found
 shopt -s nullglob
 
-SCSI_MODULES=/lib/modules/$KERNEL/kernel/drivers/scsi/device_handler/
-for m in $SCSI_MODULES/*.ko; do
+DRIVERDIR=/lib/modules/$KERNEL/kernel/drivers
+SCSI_MODULES=$DRIVERDIR/scsi/device_handler
+NFIT_MODULE=$DRIVERDIR/acpi/nfit/nfit.ko
+NVDIMM_MODULES=$DRIVERDIR/nvdimm
+for m in $SCSI_MODULES/*.ko $NFIT_MODULE $NVDIMM_MODULES/*.ko ; do
     # Shell spew to work around not having basename
     # Trim the paths off the prefix, then the . suffix
     a="${m##*/}"

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -17,6 +17,7 @@ depends() {
 installkernel() {
     case "$(uname -m)" in
         s390*) instmods hmcdrv ;;
+        aarch64|i?86|x86_64) instmods nd_pmem nfit ;;
     esac
 }
 


### PR DESCRIPTION
UEFI 2.7 and ACPI 6.2 support a feature where the firmware sets up a
ramdisk, which it then boots from.  Once the OS is booted, the memory
the ramdisk is in shows up as "reserved", and the firmware marks it in
the ACPI NFIT table as one of four various kinds of ramdisk.

When linux sees this data, if we have the nfit and nd_* nvdimm drivers
available, it creates /dev/pmemM and /dev/pmemMpN devices.

This patch enables anaconda to use that device as its location for e.g.
netinst.iso .

Note: I have not yet tested this.  If someone can help out with creating a netinst.iso image for x86_64, I can test it here on a machine with NFIT ramdisk support in the firmware.