### PR TITLE
fstab: include a note about systemctl daemon-reload

### DIFF
--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -906,8 +906,11 @@ class FSSet(object):
 # /etc/fstab
 # Created by anaconda on %s
 #
-# Accessible filesystems, by reference, are maintained under '/dev/disk'
-# See man pages fstab(5), findfs(8), mount(8) and/or blkid(8) for more info
+# Accessible filesystems, by reference, are maintained under '/dev/disk/'.
+# See man pages fstab(5), findfs(8), mount(8) and/or blkid(8) for more info.
+#
+# After editing this file, run 'systemctl daemon-reload' to update systemd
+# units generated from this file.
 #
 """ % time.asctime()
 


### PR DESCRIPTION
People occasionally have issues where they change their fstab, but
systemd doesn't know about this. This can be particularly annoying
when a line is removed, but systemd is holding on to the unit for the
removed mount point.