### PR TITLE
Improve handling of unsupported filesystems in UI.

### DIFF
--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -37,6 +37,7 @@ from blivet.devicefactory import DEVICE_TYPE_BTRFS
 from blivet.devicefactory import DEVICE_TYPE_MD
 from blivet.devicefactory import DEVICE_TYPE_PARTITION
 from blivet.devicefactory import DEVICE_TYPE_DISK
+from blivet.devicefactory import is_supported_device_type
 
 from pyanaconda.core.i18n import _, N_
 from pyanaconda import isys
@@ -62,6 +63,9 @@ DEVICE_TEXT_MD = N_("RAID")
 DEVICE_TEXT_PARTITION = N_("Standard Partition")
 DEVICE_TEXT_BTRFS = N_("Btrfs")
 DEVICE_TEXT_DISK = N_("Disk")
+
+# Used for info about device with no more supported type (ie btrfs).
+DEVICE_TEXT_UNSUPPORTED = N_("Unsupported")
 
 DEVICE_TEXT_MAP = {DEVICE_TYPE_LVM: DEVICE_TEXT_LVM,
                    DEVICE_TYPE_MD: DEVICE_TEXT_MD,
@@ -938,3 +942,6 @@ def get_supported_filesystems():
             fs_types.append(obj)
 
     return fs_types
+
+def get_supported_autopart_choices():
+    return [c for c in AUTOPART_CHOICES if is_supported_device_type(AUTOPART_DEVICE_TYPES[c[1]])]

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -18,13 +18,12 @@
 # Red Hat, Inc.
 #
 
-from blivet.devicefactory import is_supported_device_type
 
 from pyanaconda.core.i18n import _, C_
 from pyanaconda.product import productName, productVersion
 from pyanaconda.ui.gui.utils import escape_markup, really_hide, really_show
 from pyanaconda.core.constants import DEFAULT_AUTOPART_TYPE
-from pyanaconda.storage_utils import AUTOPART_CHOICES, AUTOPART_DEVICE_TYPES
+from pyanaconda.storage_utils import get_supported_autopart_choices
 
 import gi
 gi.require_version("AnacondaWidgets", "3.3")
@@ -573,9 +572,8 @@ class CreateNewPage(BasePage):
         self._createBox.attach(label, 0, 4, 2, 1)
         label.set_mnemonic_widget(combo)
 
-        autopart_choices = (c for c in AUTOPART_CHOICES if is_supported_device_type(AUTOPART_DEVICE_TYPES[c[1]]))
         default = None
-        for name, code in autopart_choices:
+        for name, code in get_supported_autopart_choices():
             itr = store.append([_(name), code])
             if code == DEFAULT_AUTOPART_TYPE:
                 default = itr

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -28,7 +28,7 @@ from pyanaconda.ui.lib.disks import getDisks, applyDiskSelection, checkDiskSelec
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog, PasswordDialog
-from pyanaconda.storage_utils import AUTOPART_CHOICES, storage_checker, get_supported_filesystems
+from pyanaconda.storage_utils import storage_checker, get_supported_filesystems, get_supported_autopart_choices
 from pyanaconda.format_dasd import DasdFormatting
 
 from blivet.size import Size
@@ -671,7 +671,7 @@ class PartitionSchemeSpoke(NormalTUISpoke):
         if pre_select == AUTOPART_TYPE_DEFAULT:
             pre_select = DEFAULT_AUTOPART_TYPE
 
-        for item in AUTOPART_CHOICES:
+        for item in get_supported_autopart_choices():
             self.part_schemes[item[0]] = item[1]
             if item[1] == pre_select:
                 self._selected_scheme_value = item[1]


### PR DESCRIPTION
UI should not offer filesystems that blivet/libblockdev does not support.

For handling of existing devices just make sure we don't crash, don't offer
modifications (just removing) and present the info about the device type not
being supported in a decent way.

Resolves: rhbz#1533904