### PR TITLE
Replace deprecated dracut options for booting with ibft.

### DIFF
--- a/data/systemd/anaconda-nm-config.service
+++ b/data/systemd/anaconda-nm-config.service
@@ -1,5 +1,6 @@
 [Unit]
 ConditionKernelCommandLine=!ip=ibft
+ConditionKernelCommandLine=!rd.iscsi.ibft
 Description=Anaconda NetworkManager configuration
 Before=NetworkManager.service
 

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -909,10 +909,10 @@ class BootLoader(object):
                 continue
             self.boot_args.add("ifname=%s:%s" % (nic, hwaddr.lower()))
 
-        # Add iscsi_firmware to trigger dracut running iscsistart
+        # Add rd.iscsi.firmware to trigger dracut running iscsistart
         # See rhbz#1099603 and rhbz#1185792
         if len(glob("/sys/firmware/iscsi_boot*")) > 0:
-            self.boot_args.add("iscsi_firmware")
+            self.boot_args.add("rd.iscsi.firmware")
 
         #
         # preservation of some of our boot args

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -413,7 +413,7 @@ def dracutBootArguments(devname, ifcfg, storage_ipaddr, hostname=None):
     netargs = set()
 
     if ifcfg.get('BOOTPROTO') == 'ibft':
-        netargs.add("ip=ibft")
+        netargs.add("rd.iscsi.ibft")
     elif storage_ipaddr:
         if hostname is None:
             hostname = ""

--- a/tests/nosetests/pyanaconda_tests/network_test.py
+++ b/tests/nosetests/pyanaconda_tests/network_test.py
@@ -352,13 +352,13 @@ class NetworkIfcfgTests(unittest.TestCase):
         ifcfg = self.ifcfg_mock({"BOOTPROTO": "ibft"})
         self.assertEqual(
                 network.dracutBootArguments("em1", ifcfg, ""),
-                set(["ip=ibft"]))
+                set(["rd.iscsi.ibft"]))
 
         ifcfg = self.ifcfg_mock({"BOOTPROTO": "ibft",
                                  "HWADDR": "00:00:00:00:00:00"})
         self.assertEqual(
                 network.dracutBootArguments("em1", ifcfg, ""),
-                set(["ip=ibft"]))
+                set(["rd.iscsi.ibft"]))
 
         ifcfg = self.ifcfg_mock({"BOOTPROTO": "dhcp"})
         self.assertEqual(


### PR DESCRIPTION
Generate correct options for installed system (part of the change happens
in blivet).

Accept rd.iscsi.ibft as installer option. Deprecated ip=ibft will keep working
until dracut removes it. When this happens, we can still use
parse-anaconda-options dracut script to translate it to the rd.iscsi.ibft
for some transitional timeframe.

Enabling NM ibft module via the patched service will still accept ip=ibft.

Resolves: rhbz#1566052