### PR TITLE
Use Platform Python in installation environment

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/libexec/platform-python
 #
 # anaconda: The Red Hat Linux Installation program
 #

--- a/data/command-stubs/list-harddrives-stub
+++ b/data/command-stubs/list-harddrives-stub
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/libexec/platform-python
 #
 # scan system for harddrives and output device name/size
 #

--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/libexec/platform-python
 #
 # Copyright (C) 2015 by Red Hat, Inc.  All rights reserved.
 #

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/libexec/platform-python
 #vim: set fileencoding=utf8
 # parse-kickstart - read a kickstart file and emit equivalent dracut boot args
 #

--- a/dracut/python-deps
+++ b/dracut/python-deps
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/libexec/platform-python
 # python-deps - find the dependencies of a given python script.
 #
 # Copyright (C) 2012-2015 by Red Hat, Inc.  All rights reserved.

--- a/scripts/anaconda-cleanup
+++ b/scripts/anaconda-cleanup
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/libexec/platform-python
 """
     always:
         - unmount everything under /mnt/sysimage

--- a/scripts/instperf
+++ b/scripts/instperf
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/libexec/platform-python
 
 import logging
 from subprocess import Popen, PIPE

--- a/scripts/start-module
+++ b/scripts/start-module
@@ -8,4 +8,4 @@ if [ -d "/run/install" ]; then
   export PYTHONPATH=/run/install/updates:/run/install/product:/tmp/updates:/tmp/product
 fi
 
-python3 -m $1
+/usr/libexec/platform-python -m $1

--- a/utils/handle-sshpw
+++ b/utils/handle-sshpw
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/libexec/platform-python
 #
 # handle-sshpw:  Code processing sshpw lines in kickstart files for the
 #                install environment.


### PR DESCRIPTION
Anaconda should explicitly use Platform Python when running
in the installation environment, which is expected to be Platform Python
only. Even though a shebang rewriter should be in place in the
buildsystem, this still needs to be done explicitly to make updates
images work and due to calling the Python binary directly when starting
DBUS modules.

Maintenance and build scripts are still expected to run in
an environment where a "normal" Python will be available so
no changes are needed.