### PR TITLE
Configure GRUB and zipl to use the "BootLoaderSpec" boot option configuration format.

### DIFF
--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -269,3 +269,6 @@ timeout in seconds specified as a mandatory value of the option.
 decorated
 Run GUI installer in a decorated window. By default, the window is not decorated, so it doesn't have a title bar,
 resize controls, etc.
+
+noblscfg
+Configure GRUB not to use the "BootLoader Spec" boot option configuration format.

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -634,6 +634,14 @@ the newly installed drive on Power Systems servers and EFI systems. This is
 useful for systems that, for example, should network boot first before falling
 back to a local boot.
 
+.. inst.noblscfg:
+
+inst.noblscfg
+^^^^^^^^^^^^^
+
+Disable the use of the "BootLoader Spec" boot option configuration format with
+GRUB.
+
 
 Storage options
 ---------------

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -510,6 +510,9 @@ def getArgumentParser(version_string, boot_cmdline=None):
     ap.add_argument("--nonibftiscsiboot", action="store_true", default=False,
                     help=help_parser.help_text("nonibftiscsiboot"))
 
+    ap.add_argument("--noblscfg", dest="blscfg", action="store_false", default=True,
+                    help=help_parser.help_text("nobls"))
+
     # Geolocation
     ap.add_argument("--geoloc", metavar="PROVIDER_ID", help=help_parser.help_text("geoloc"))
     ap.add_argument("--geoloc-use-with-ks", action="store_true", default=False,

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -62,6 +62,13 @@ class ZIPLError(Exception):
     pass
 
 
+class FirmwareCompatError(Exception):
+    """ Firmware is incompatible with installation requirements """
+    def __init__(self, reason):
+        Exception.__init__(self)
+        self.reason = reason
+
+
 class ExitError(RuntimeError):
     pass
 
@@ -273,6 +280,16 @@ class ErrorHandler(object):
         self.ui.showError(message)
         return ERROR_RAISE
 
+    def _FirmwareCompatErrorHandler(self, reason):
+        details = str(reason)
+        message = _("Installation was stopped due to an incompatibility with "
+                    "the current version of the system firmware. The exact "
+                    "error message is:\n\n%s\n\n"
+                    "The installer will now terminate.") % details
+
+        self.ui.showError(message)
+        return ERROR_RAISE
+
     def cb(self, exn):
         """This method is the callback that all error handling should pass
            through.  The return value is one of the ERROR_* constants defined
@@ -308,7 +325,8 @@ class ErrorHandler(object):
                 "DependencyError": self._dependencyErrorHandler,
                 "BootLoaderError": self._bootLoaderErrorHandler,
                 "PasswordCryptError": self._passwordCryptErrorHandler,
-                "ZIPLError": self._ziplErrorHandler}
+                "ZIPLError": self._ziplErrorHandler,
+                "FirmwareCompatError": self._FirmwareCompatErrorHandler}
 
         if exn.__class__.__name__ in _map:
             rc = _map[exn.__class__.__name__](exn)

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -62,6 +62,7 @@ class Flags(object):
         self.askmethod = False
         self.eject = True
         self.extlinux = False
+        self.blscfg = True
         self.nombr = False
         self.gpt = False
         self.leavebootorder = False


### PR DESCRIPTION
This pull-request contains two commits from @vathpela that adds a inst.blscfg option to configure the GRUB and zipl bootloaders to use the BootLoaderSpec (BLS) boot option configuration format.

The first commit get rids of the calls to the new-kernel-pkg script since this no longer will be available once grubby is removed from the compose.

The second commit enables the BLS configuration by default. Since this is a new option, a inst.noblscfg is also added to allow anaconda to disable its use.

These changes are part of https://fedoraproject.org/wiki/Changes/BootLoaderSpecByDefault