### PR TITLE
Add inst.addrepo cmdline option

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -739,6 +739,9 @@ if __name__ == "__main__":
 
     anaconda.postConfigureInstallClass()
 
+    # add additional repositories from the cmdline to kickstart data
+    anaconda.add_additional_repositories_to_ksdata()
+
     # Fallback to default for interactive or for a kickstart with no installation method.
     fallback = not (flags.automatedInstall and ksdata.method.method)
     payloadMgr.restartThread(anaconda.storage, ksdata, anaconda.payload, anaconda.instClass, fallback=fallback)

--- a/anaconda.py
+++ b/anaconda.py
@@ -420,7 +420,8 @@ if __name__ == "__main__":
     # add our own additional signal handlers
     signal.signal(signal.SIGHUP, start_debugger)
 
-    anaconda.opts = opts
+    # assign the other anaconda variables from options
+    anaconda.set_from_opts(opts)
 
     # check memory, just the text mode for now:
     startup_utils.check_memory(anaconda, opts, display_mode=constants.DisplayModes.TUI)
@@ -428,20 +429,8 @@ if __name__ == "__main__":
     # Now that we've got command line/boot options, do some extra processing.
     startup_utils.setup_logging_from_options(opts)
 
-    # assign the other anaconda variables from options
-    anaconda.decorated = opts.decorated
-    anaconda.proxy = opts.proxy
-    anaconda.updateSrc = opts.updateSrc
-    anaconda.methodstr = opts.method
-    anaconda.stage2 = opts.stage2
-    flags.rescue_mode = opts.rescue
-
-    if opts.liveinst:
-        startup_utils.live_startup(anaconda)
-    elif "LIVECMD" in os.environ:
-        log.warning("Running via liveinst, but not setting flags.livecdInstall - this is for testing only")
-
     # set flags
+    flags.rescue_mode = opts.rescue
     flags.noverifyssl = opts.noverifyssl
     flags.armPlatform = opts.armPlatform
     flags.extlinux = opts.extlinux
@@ -457,6 +446,11 @@ if __name__ == "__main__":
     flags.eject = opts.eject
     flags.kexec = opts.kexec
     flags.singlelang = opts.singlelang
+
+    if opts.liveinst:
+        startup_utils.live_startup(anaconda)
+    elif "LIVECMD" in os.environ:
+        log.warning("Running via liveinst, but not setting flags.livecdInstall - this is for testing only")
 
     # Switch to tty1 on exception in case something goes wrong during X start.
     # This way if, for example, metacity doesn't start, we switch back to a

--- a/anaconda.py
+++ b/anaconda.py
@@ -219,10 +219,10 @@ def setup_environment():
     # pylint: disable=environment-modify
 
     # Silly GNOME stuff
-    if 'HOME' in os.environ and not "XAUTHORITY" in os.environ:
-        os.environ['XAUTHORITY'] = os.environ['HOME'] + '/.Xauthority'
-    os.environ['HOME'] = '/tmp'
-    os.environ['LC_NUMERIC'] = 'C'
+    if "HOME" in os.environ and not "XAUTHORITY" in os.environ:
+        os.environ["XAUTHORITY"] = os.environ["HOME"] + "/.Xauthority"
+    os.environ["HOME"] = "/tmp"
+    os.environ["LC_NUMERIC"] = "C"
     os.environ["GCONF_GLOBAL_LOCKS"] = "1"
 
     # In theory, this gets rid of our LVM file descriptor warnings
@@ -237,7 +237,7 @@ def setup_environment():
         del os.environ["LD_PRELOAD"]
 
     # Go ahead and set $DISPLAY whether we're going to use X or not
-    if 'DISPLAY' in os.environ:
+    if "DISPLAY" in os.environ:
         flags.preexisting_x11 = True
     else:
         os.environ["DISPLAY"] = ":%s" % constants.X_DISPLAY_NUMBER

--- a/anaconda.py
+++ b/anaconda.py
@@ -437,7 +437,7 @@ if __name__ == "__main__":
     flags.rescue_mode = opts.rescue
 
     if opts.liveinst:
-        startup_utils.live_startup(anaconda, opts)
+        startup_utils.live_startup(anaconda)
     elif "LIVECMD" in os.environ:
         log.warning("Running via liveinst, but not setting flags.livecdInstall - this is for testing only")
 

--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,7 @@ AC_CONFIG_FILES([Makefile
                  pyanaconda/dbus/Makefile
                  pyanaconda/isys/Makefile
                  pyanaconda/payload/Makefile
+                 pyanaconda/payload/source/Makefile
                  pyanaconda/storage/Makefile
                  pyanaconda/ui/Makefile
                  pyanaconda/ui/categories/Makefile

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -76,6 +76,12 @@ If only the stage2 option is given without repo, Anaconda will use whatever repo
 system would have enabled by default for installation. For instance, an install of a Fedora release
 will attempt to use the Fedora mirrorlist given by /etc/yum.repos.d/fedora.repo from that release.
 
+addrepo
+This option adds additional repositories to the installation. These repositories are used during
+installation but they are not saved to the installed system. Repository must be specified in the
+'<name>,<url>' format, where name can't contain space and <url> have to be in a supported format.
+Supported formats can be found here: http://rhinstaller.github.io/anaconda/boot-options.html#inst-addrepo
+
 noverifyssl
 Prevents Anaconda from verifying the ssl certificate for all HTTPS connections with an exception of the
 additional kickstart repos (where --noverifyssl can be set per repo).

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -99,6 +99,39 @@ different ways:
     'NN' is the hexidecimal representation of the character (e.g. ``\x20`` for
     the space character (' ').
 
+.. inst.addrepo:
+
+inst.addrepo
+^^^^^^^^^^^^
+
+Add additional repository which can be used as another *Instalation Source*
+next to the main repository (see `inst.repo`_). This option can be used multiple
+times during one boot. This can be specified in a few different ways:
+
+``inst.addrepo=REPO_NAME,[http,https,ftp]://<host>/<path>``
+    Look for the installable tree at the given URL.
+
+``inst.addrepo=REPO_NAME,nfs://<server>:/<path>``
+    Look for the installable tree at the given nfs path. Note that there is a
+    colon after the host. Anaconda passes everything after “nfs:// ” directly
+    to the mount command instead of parsing URLs according to RFC 2224.
+
+``inst.addrepo=REPO_NAME,file://<path>``
+    Look for the installable tree at the given location in the installation
+    environment. Beware, to be able to use this variant the repo needs to
+    be mounted before Anaconda tries to use it (load available software groups).
+    The main usage for this command is having multiple repositories on one
+    bootable ISO and install both the main repo and additional repositories from
+    this ISO. The path to the additional repositories will be then
+    `/run/install/source/REPO_ISO_PATH`. Another solution can be to mount this repo
+    directory in the `%pre` section in the kickstart file.
+    NOTE: The path must be absolute and start with `/` so the final url starts
+    with `file:///...`.
+
+The `REPO_NAME` is name of the repository and it is a required part. The name will be
+used in the installation process. These repositories will be used only during the
+installation but they **will not** be installed to the installed system.
+
 .. inst.noverifyssl:
 
 inst.noverifyssl

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -128,6 +128,12 @@ times during one boot. This can be specified in a few different ways:
     NOTE: The path must be absolute and start with `/` so the final url starts
     with `file:///...`.
 
+``inst.addrepo=REPO_NAME,hd:<device>:<path>``
+    Mount the given `<device>` partition and install from ISO specified by the `<path>`.
+    If the `<path>` is not specified Anaconda will look for the valid installation ISO
+    on the `<device>`. This installation method requires ISO with a valid installable tree.
+    For more detail how to specify `<device>` argument part please see `diskdev`_.
+
 The `REPO_NAME` is name of the repository and it is a required part. The name will be
 used in the installation process. These repositories will be used only during the
 installation but they **will not** be installed to the installed system.

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -56,6 +56,7 @@ class Anaconda(object):
         self.isHeadless = False
         self.ksdata = None
         self.methodstr = None
+        self.additional_repos = None
         self.opts = None
         self._payload = None
         self.proxy = None
@@ -80,6 +81,16 @@ class Anaconda(object):
 
         # Create class for launching our dbus session
         self._dbus_launcher = DBusLauncher()
+
+    def set_from_opts(self, opts):
+        """Load argument to variables from self.opts."""
+        self.opts = opts
+        self.decorated = opts.decorated
+        self.proxy = opts.proxy
+        self.updateSrc = opts.updateSrc
+        self.methodstr = opts.method
+        self.stage2 = opts.stage2
+        self.additional_repos = opts.addRepo
 
     @property
     def bootloader(self):

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -268,6 +268,7 @@ class Anaconda(object):
                 repo.enabled = True
                 repo.partition = source.partition
                 repo.iso_path = source.path
+                repo.baseurl = "file://"
             else:
                 log.error("Source type %s for additional repository %s is not supported!",
                           source.source_type.value, add_repo)

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -168,11 +168,21 @@ class Anaconda(object):
         if self.stage2 and self.stage2.startswith("hd:"):
             specs.append(self.stage2[3:].split(":", 3)[0])
 
+        for additional_repo in self.additional_repos:
+            _name, repo_url = self._get_additional_repo_name(additional_repo)
+            if repo_url.startswith("hd:"):
+                specs.append(repo_url[3:].split(":", 3)[0])
+
         # zRAM swap devices need to be protected
         for zram_dev in glob("/dev/zram*"):
             specs.append(zram_dev)
 
         return specs
+
+    @staticmethod
+    def _get_additional_repo_name(repo):
+        name, rest = repo.split(',', maxsplit=1)
+        return name, rest
 
     @property
     def storage(self):

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -274,7 +274,17 @@ class Anaconda(object):
                           source.source_type.value, add_repo)
                 continue
 
+            self._check_repo_name_uniqueness(repo)
             self.ksdata.repo.dataList().append(repo)
+
+    def _check_repo_name_uniqueness(self, repo):
+        """Log if we are adding repository with already used name
+
+        In automatic kickstart installation this will result in using the first defined repo.
+        """
+        if repo in self.ksdata.repo.dataList():
+            log.warning("Repository name %s is not unique. Only the first repo will be used!",
+                        repo.name)
 
     def _set_default_fstype(self, storage):
         fstype = None

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -264,6 +264,10 @@ class Anaconda(object):
             if source.is_nfs or source.is_http or source.is_https or source.is_ftp \
                     or source.is_file:
                 repo.enabled = True
+            elif source.is_harddrive:
+                repo.enabled = True
+                repo.partition = source.partition
+                repo.iso_path = source.path
             else:
                 log.error("Source type %s for additional repository %s is not supported!",
                           source.source_type.value, add_repo)

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -32,6 +32,7 @@ from pyanaconda.core import util, constants
 from pyanaconda.modules.common.constants.objects import AUTO_PARTITIONING
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.startup_utils import run_boss, stop_boss
+from pyanaconda.payload.source import SourceFactory
 
 from pyanaconda.anaconda_loggers import get_stdout_logger
 stdoutLog = get_stdout_logger()
@@ -162,15 +163,15 @@ class Anaconda(object):
 
         # methodstr and stage2 become strings in ways that pylint can't figure out
         # pylint: disable=unsubscriptable-object
-        if self.methodstr and self.methodstr.startswith("hd:"):
+        if self.methodstr and SourceFactory.is_harddrive(self.methodstr):
             specs.append(self.methodstr[3:].split(":", 3)[0])
 
-        if self.stage2 and self.stage2.startswith("hd:"):
+        if self.stage2 and SourceFactory.is_harddrive(self.stage2):
             specs.append(self.stage2[3:].split(":", 3)[0])
 
         for additional_repo in self.additional_repos:
             _name, repo_url = self._get_additional_repo_name(additional_repo)
-            if repo_url.startswith("hd:"):
+            if SourceFactory.is_harddrive(repo_url):
                 specs.append(repo_url[3:].split(":", 3)[0])
 
         # zRAM swap devices need to be protected

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -446,6 +446,9 @@ def getArgumentParser(version_string, boot_cmdline=None):
                     help=help_parser.help_text("repo"))
     ap.add_argument("--stage2", dest="stage2", default=None, metavar="STAGE2_URL",
                     help=help_parser.help_text("stage2"))
+    ap.add_argument("--addrepo", dest="addRepo", default=[], metavar="NAME,ADDITIONAL_REPO_URL",
+                    nargs='*', action="append",
+                    help=help_parser.help_text("addrepo"))
     ap.add_argument("--noverifyssl", action="store_true", default=False,
                     help=help_parser.help_text("noverifyssl"))
     ap.add_argument("--liveinst", action="store_true", default=False,

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -198,7 +198,7 @@ class AnacondaArgumentParser(ArgumentParser):
                 log.warning("boot option specified without expected number of "
                             "arguments and will be ignored: %s", arg)
                 continue
-            if option.nargs == 0 and option.const is not None:
+            elif option.nargs == 0 and option.const is not None:
                 # nargs == 0 & constr == True -> store_true
                 # (we could also check the class, but it begins with an
                 # underscore, so it would be ugly)
@@ -214,6 +214,13 @@ class AnacondaArgumentParser(ArgumentParser):
                 # we hate you.
 
                 continue
+            elif option.nargs in ("*", "?", "+"):
+                # store multiple values under one key
+                # parsing of these values to list is done in BootArgs object
+                if type(val) is list:
+                    setattr(namespace, option.dest, val)
+                    continue
+
             option(self, namespace, val)
         return namespace
 

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -212,6 +212,7 @@ SCREENSHOTS_TARGET_DIRECTORY = "/root/anaconda-screenshots"
 
 # cmdline arguments that append instead of overwrite
 CMDLINE_APPEND = ["modprobe.blacklist", "ifname", "ip"]
+CMDLINE_LIST = ["addrepo"]
 
 # The default autopart type is lvm.
 # FIXME: Move this constant to the storage module.

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -20,7 +20,8 @@
 import selinux
 import shlex
 import glob
-from pyanaconda.core.constants import SELINUX_DEFAULT, CMDLINE_APPEND, ANACONDA_ENVIRON
+from pyanaconda.core.constants import SELINUX_DEFAULT, CMDLINE_APPEND, CMDLINE_LIST, \
+    ANACONDA_ENVIRON
 from collections import OrderedDict
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -174,6 +175,12 @@ class BootArgs(OrderedDict):
             if key in CMDLINE_APPEND and self.get(key, None):
                 if val:
                     self[key] = self[key] + " " + val
+            # Some arguments can contain spaces so adding them in one string is not that helpful
+            elif key in CMDLINE_LIST:
+                if val:
+                    if not self.get(key, None):
+                        self[key] = []
+                    self[key].append(val)
             else:
                 self[key] = val
 

--- a/pyanaconda/image.py
+++ b/pyanaconda/image.py
@@ -17,14 +17,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from pyanaconda import isys
 import os, os.path, stat, tempfile
 
+from pyanaconda import isys
 from pyanaconda.errors import errorHandler, ERROR_RAISE, InvalidImageSizeError, MissingImageError
 
 import blivet.util
 import blivet.arch
+
 from blivet.errors import FSError
+
+from productmd.discinfo import DiscInfo
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -68,16 +71,15 @@ def findFirstIsoImage(path):
             continue
 
         log.debug("Reading .discinfo")
-        f = open("/mnt/install/cdimage/.discinfo")
-        f.readline()  # skip timestamp
-        f.readline()  # skip release description
-        discArch = f.readline().strip()  # read architecture
-        f.close()
+        disc_info = DiscInfo()
 
-        log.debug("discArch = %s", discArch)
-        if discArch != arch:
+        disc_info.load("/mnt/install/cdimage/.discinfo")
+        disc_arch = disc_info.arch
+
+        log.debug("discArch = %s", disc_arch)
+        if disc_arch != arch:
             log.warning("findFirstIsoImage: architectures mismatch: %s, %s",
-                        discArch, arch)
+                        disc_arch, arch)
             blivet.util.umount("/mnt/install/cdimage")
             continue
 

--- a/pyanaconda/image.py
+++ b/pyanaconda/image.py
@@ -73,8 +73,12 @@ def findFirstIsoImage(path):
         log.debug("Reading .discinfo")
         disc_info = DiscInfo()
 
-        disc_info.load("/mnt/install/cdimage/.discinfo")
-        disc_arch = disc_info.arch
+        try:
+            disc_info.load("/mnt/install/cdimage/.discinfo")
+            disc_arch = disc_info.arch
+        except Exception as ex:  # pylint: disable=broad-except
+            log.warning(".discinfo file can't be loaded: %s", ex)
+            continue
 
         log.debug("discArch = %s", disc_arch)
         if disc_arch != arch:

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1992,6 +1992,9 @@ class RaidData(COMMANDS.RaidData):
             storage.add_fstab_swap(add_fstab_swap)
 
 class RepoData(COMMANDS.RepoData):
+
+    __mount_counter = 0
+
     def __init__(self, *args, **kwargs):
         """ Add enabled kwarg
 
@@ -2003,6 +2006,8 @@ class RepoData(COMMANDS.RepoData):
         self.treeinfo_origin = kwargs.pop("treeinfo_origin", False)
         self.partition = kwargs.pop("partition", None)
         self.iso_path = kwargs.pop("iso_path", None)
+
+        self.mount_dir_suffix = kwargs.pop("mount_dir_suffix", None)
 
         super().__init__(*args, **kwargs)
 
@@ -2016,7 +2021,22 @@ class RepoData(COMMANDS.RepoData):
                    enabled=other.enabled,
                    treeinfo_origin=other.treeinfo_origin,
                    partition=other.partition,
-                   iso_path=other.iso_path)
+                   iso_path=other.iso_path,
+                   mount_dir_suffix=other.mount_dir_suffix)
+
+    def generate_mount_dir(self):
+        """Generate persistent mount directory suffix
+
+        This is valid only for HD repositories
+        """
+        if self.is_harddrive_based() and self.mount_dir_suffix is None:
+            self.mount_dir_suffix = "addition_" + self._generate_mount_dir_suffix()
+
+    @classmethod
+    def _generate_mount_dir_suffix(cls):
+        suffix = str(cls.__mount_counter)
+        cls.__mount_counter += 1
+        return suffix
 
     def __str__(self):
         """Don't output disabled repos"""

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -2001,6 +2001,8 @@ class RepoData(COMMANDS.RepoData):
         self.enabled = kwargs.pop("enabled", True)
         self.repo_id = kwargs.pop("repo_id", None)
         self.treeinfo_origin = kwargs.pop("treeinfo_origin", False)
+        self.partition = kwargs.pop("partition", None)
+        self.iso_path = kwargs.pop("iso_path", None)
 
         super().__init__(*args, **kwargs)
 
@@ -2010,6 +2012,9 @@ class RepoData(COMMANDS.RepoData):
             return super().__str__()
         else:
             return ''
+
+    def is_harddrive_based(self):
+        return self.partition is not None
 
 class ReqPart(COMMANDS.ReqPart):
     def execute(self, storage, ksdata, instClass):

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -2006,6 +2006,18 @@ class RepoData(COMMANDS.RepoData):
 
         super().__init__(*args, **kwargs)
 
+    @classmethod
+    def create_copy(cls, other):
+        return cls(name=other.name,
+                   baseurl=other.baseurl,
+                   mirrorlist=other.mirrorlist,
+                   metalink=other.metalink,
+                   proxy=other.proxy,
+                   enabled=other.enabled,
+                   treeinfo_origin=other.treeinfo_origin,
+                   partition=other.partition,
+                   iso_path=other.iso_path)
+
     def __str__(self):
         """Don't output disabled repos"""
         if self.enabled:

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -1424,6 +1424,20 @@ class PackagePayload(Payload):
 
         return url
 
+    def _setup_harddrive_addon_repo(self, storage, ksrepo):
+        isodevice = storage.devicetree.resolve_device(ksrepo.partition)
+        if not isodevice:
+            raise PayloadSetupError("device for HDISO addon repo install %s does not exist" %
+                                    ksrepo.partition)
+
+        device_mount_dir = ISO_DIR + "-" + ksrepo.name
+        install_root_dir = INSTALL_TREE + "-" + ksrepo.name
+
+        self._find_and_mount_iso(isodevice, device_mount_dir, ksrepo.iso_path, install_root_dir)
+        url = "file://" + install_root_dir
+
+        return url
+
     ###
     ### METHODS FOR WORKING WITH REPOSITORIES
     ###

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -1458,8 +1458,10 @@ class PackagePayload(Payload):
             raise PayloadSetupError("device for HDISO addon repo install %s does not exist" %
                                     ksrepo.partition)
 
-        device_mount_dir = ISO_DIR + "-" + ksrepo.name
-        install_root_dir = INSTALL_TREE + "-" + ksrepo.name
+        ksrepo.generate_mount_dir()
+
+        device_mount_dir = ISO_DIR + "-" + ksrepo.mount_dir_suffix
+        install_root_dir = INSTALL_TREE + "-" + ksrepo.mount_dir_suffix
 
         self._find_and_mount_iso(isodevice, device_mount_dir, ksrepo.iso_path, install_root_dir)
         url = "file://" + install_root_dir

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -1166,43 +1166,54 @@ class PackagePayload(Payload):
     def _setupMedia(self, device):
         method = self.data.method
         if method.method == "harddrive":
-            self._setupDevice(device, mountpoint=ISO_DIR)
-
-            # check for ISO images in the newly mounted dir
-            path = ISO_DIR
-            if method.dir:
-                path = os.path.normpath("%s/%s" % (path, method.dir))
-
-            # XXX it would be nice to streamline this when we're just setting
-            #     things back up after storage activation instead of having to
-            #     pretend we don't already know which ISO image we're going to
-            #     use
-            image = findFirstIsoImage(path)
-            if not image:
-                device.teardown(recursive=True)
-                raise PayloadSetupError("failed to find valid iso image")
-
-            if path.endswith(".iso"):
-                path = os.path.dirname(path)
-
-            # this could already be set up the first time through
-            if not os.path.ismount(INSTALL_TREE):
-                # mount the ISO on a loop
-                image = os.path.normpath("%s/%s" % (path, image))
-                mountImage(image, INSTALL_TREE)
-
-            if not method.dir.endswith(".iso"):
-                method.dir = os.path.normpath("%s/%s" % (method.dir,
-                                                         os.path.basename(image)))
-                while method.dir.startswith("/"):
-                    # riduculous
-                    method.dir = method.dir[1:]
+            method.dir = self._find_and_mount_iso(device, ISO_DIR, method.dir, INSTALL_TREE)
         # Check to see if the device is already mounted, in which case
         # we don't need to mount it again
         elif method.method == "cdrom" and blivet.util.get_mount_paths(device.path):
             return
         else:
             device.format.setup(mountpoint=INSTALL_TREE)
+
+    def _find_and_mount_iso(self, device, device_mount_dir, iso_path, iso_mount_dir):
+        """Find and mount installation source from ISO on device.
+
+        Return changed path to the iso to save looking for iso in the future call.
+        """
+        self._setupDevice(device, mountpoint=device_mount_dir)
+
+        # check for ISO images in the newly mounted dir
+        path = device_mount_dir
+        if iso_path:
+            path = os.path.normpath("%s/%s" % (path, iso_path))
+
+        # XXX it would be nice to streamline this when we're just setting
+        #     things back up after storage activation instead of having to
+        #     pretend we don't already know which ISO image we're going to
+        #     use
+        image = findFirstIsoImage(path)
+        if not image:
+            device.teardown(recursive=True)
+            raise PayloadSetupError("failed to find valid iso image")
+
+        if path.endswith(".iso"):
+            path = os.path.dirname(path)
+
+        # this could already be set up the first time through
+        if not os.path.ismount(iso_mount_dir):
+            # mount the ISO on a loop
+            image = os.path.normpath("%s/%s" % (path, image))
+            mountImage(image, iso_mount_dir)
+
+        if not iso_path.endswith(".iso"):
+            result_path = os.path.normpath("%s/%s" % (iso_path,
+                                                      os.path.basename(image)))
+            while result_path.startswith("/"):
+                # riduculous
+                result_path = result_path[1:]
+
+            return result_path
+
+        return iso_path
 
     def _setupInstallDevice(self, storage, checkmount):
         # XXX FIXME: does this need to handle whatever was set up by dracut?

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -1218,6 +1218,10 @@ class DNFPayload(payload.PackagePayload):
 
         for repo in self.addOns:
             ksrepo = self.getAddOnRepo(repo)
+
+            if ksrepo.is_harddrive_based():
+                ksrepo.baseurl = self._setup_harddrive_addon_repo(self.storage, ksrepo)
+
             log.debug("repo %s: mirrorlist %s, baseurl %s, metalink %s",
                       ksrepo.name, ksrepo.mirrorlist, ksrepo.baseurl, ksrepo.metalink)
             # one of these must be set to create new repo

--- a/pyanaconda/payload/source/Makefile.am
+++ b/pyanaconda/payload/source/Makefile.am
@@ -1,6 +1,6 @@
-# payload/Makefile.am for anaconda
+# payload/source/Makefile.am for anaconda
 #
-# Copyright (C) 2012  Red Hat, Inc.
+# Copyright (C) 2018  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published
@@ -15,10 +15,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = source
 
 pkgpyexecdir = $(pyexecdir)/py$(PACKAGE_NAME)
-payloaddir = $(pkgpyexecdir)/payload
+payloaddir = $(pkgpyexecdir)/payload/source
 payload_PYTHON = $(srcdir)/*.py
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/pyanaconda/payload/source/__init__.py
+++ b/pyanaconda/payload/source/__init__.py
@@ -1,0 +1,22 @@
+# Anaconda payload source module.
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from pyanaconda.payload.source.factory import SourceFactory, PayloadSourceTypeUnrecognized
+
+__all__ = ["SourceFactory", "PayloadSourceTypeUnrecognized"]

--- a/pyanaconda/payload/source/factory.py
+++ b/pyanaconda/payload/source/factory.py
@@ -1,0 +1,118 @@
+# Factory to parse source from different sources and give source objects back.
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.core.util import parseNfsUrl
+from pyanaconda.payload.source.sources import CDRomSource, HDDSource, NFSSource, HTTPSource, \
+    HTTPSSource, FTPSource, FileSource, LiveSource, HMCSource
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+
+class PayloadSourceTypeUnrecognized(Exception):
+    pass
+
+
+class SourceFactory(object):
+
+    @classmethod
+    def parse_repo_cmdline_string(cls, cmdline):
+        """Parse cmdline string to source class."""
+        if cls.is_cdrom(cmdline):
+            return CDRomSource()
+        elif cls.is_nfs(cmdline):
+            nfs_options, server, path = parseNfsUrl(cmdline)
+            return NFSSource(server, path, nfs_options)
+        elif cls.is_harddrive(cmdline):
+            url = cmdline.split(":", 1)[1]
+            url_parts = url.split(":")
+            device = url_parts[0]
+            path = ""
+            if len(url_parts) == 2:
+                path = url_parts[1]
+            elif len(url_parts) == 3:
+                path = url_parts[2]
+
+            return HDDSource(device, path)
+        elif cls.is_http(cmdline):
+            # installation source specified by bootoption
+            # overrides source set from kickstart;
+            # the kickstart might have specified a mirror list,
+            # so we need to clear it here if plain url source is provided
+            # by a bootoption, because having both url & mirror list
+            # set at once is not supported and breaks dnf in
+            # unpredictable ways
+            return HTTPSource(cmdline)
+        elif cls.is_https(cmdline):
+            return HTTPSSource(cmdline)
+        elif cls.is_ftp(cmdline):
+            return FTPSource(cmdline)
+        elif cls.is_file(cmdline):
+            return FileSource(cmdline)
+        elif cls.is_livecd(cmdline):
+            device = cmdline.split(":", 1)[1]
+            return LiveSource(device)
+        elif cls.is_hmc(cmdline):
+            return HMCSource()
+        else:
+            raise PayloadSourceTypeUnrecognized("Can't find source type for {}".format(cmdline))
+
+    @staticmethod
+    def is_cdrom(cmdline):
+        """Is this cmdline parameter cdrom based payload source?"""
+        return cmdline.startswith("cdrom")
+
+    @staticmethod
+    def is_harddrive(cmdline):
+        """Is this cmdline parameter hdd based payload source?"""
+        return cmdline.startswith("hd:")
+
+    @staticmethod
+    def is_nfs(cmdline):
+        """Is this cmdline parameter nfs based payload source?"""
+        return cmdline.startswith("nfs:")
+
+    @staticmethod
+    def is_http(cmdline):
+        """Is this cmdline parameter http based payload source?"""
+        return cmdline.startswith("http:")
+
+    @staticmethod
+    def is_https(cmdline):
+        """Is this cmdline parameter https based payload source?"""
+        return cmdline.startswith("https:")
+
+    @staticmethod
+    def is_ftp(cmdline):
+        """Is this cmdline parameter ftp based payload source?"""
+        return cmdline.startswith("ftp:")
+
+    @staticmethod
+    def is_file(cmdline):
+        """Is this cmdline parameter local file based payload source?"""
+        return cmdline.startswith("file:")
+
+    @staticmethod
+    def is_livecd(cmdline):
+        """Is this cmdline parameter live image based payload source?"""
+        return cmdline.startswith("livecd")
+
+    @staticmethod
+    def is_hmc(cmdline):
+        """Is this cmdline parameter HMC based payload source?"""
+        return cmdline.startswith("hmc")

--- a/pyanaconda/payload/source/sources.py
+++ b/pyanaconda/payload/source/sources.py
@@ -1,0 +1,303 @@
+# Sources used in payloads.
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from enum import Enum
+
+
+class SourceType(Enum):
+    CDROM = "cdrom"
+    HARDDRIVE = "Harddrive"
+    NFS = "nfs"
+    HTTP = "http"
+    HTTPS = "https"
+    FTP = "ftp"
+    FILE = "file"
+    LIVECD = "livecd"
+    HMC = "hmc"
+    UNKNOWN = "unknown"
+
+
+class BasePayloadSource(object):
+    """Base object for payload source.
+
+    Implements common methods for payload source.
+    """
+    def __init__(self, source_type: SourceType, method_type: str):
+        super().__init__()
+
+        self._source_type = source_type
+        self._method_type = method_type
+
+    @property
+    def source_type(self) -> SourceType:
+        """Get source type.
+
+        :rtype: SourceType enum.
+        """
+        return self._source_type
+
+    @property
+    def method_type(self) -> str:
+        """Get method type string
+
+        :rtype: str
+        """
+        return self._method_type
+
+    @property
+    def is_cdrom(self):
+        """Is this cdrom source?
+
+        :rtype: bool
+        """
+        return self._source_type == SourceType.CDROM
+
+    @property
+    def is_harddrive(self):
+        """Is this hard drive source?
+
+        :rtype bool
+        """
+        return self._source_type == SourceType.HARDDRIVE
+
+    @property
+    def is_nfs(self):
+        """Is this nfs source?
+
+        :rtype bool
+        """
+        return self._source_type == SourceType.NFS
+
+    @property
+    def is_http(self):
+        """Is this http source?
+
+        :rtype bool
+        """
+        return self._source_type == SourceType.HTTP
+
+    @property
+    def is_https(self):
+        """Is this https source?
+
+        :rtype bool
+        """
+        return self._source_type == SourceType.HTTPS
+
+    @property
+    def is_ftp(self):
+        """Is this ftp source?
+
+        :rtype bool
+        """
+        return self._source_type == SourceType.FTP
+
+    @property
+    def is_file(self):
+        """Is this file:// based source?
+
+        :rtype bool
+        """
+        return self._source_type == SourceType.FILE
+
+    @property
+    def is_livecd(self):
+        """Is this livecd source?
+
+        :rtype bool
+        """
+        return self._source_type == SourceType.LIVECD
+
+    @property
+    def is_hmc(self):
+        """Is this hmc source?
+
+        :rtype bool
+        """
+        return self._source_type == SourceType.HMC
+
+
+class CDRomSource(BasePayloadSource):
+    """Source object for CDrom sources."""
+
+    def __init__(self):
+        super().__init__(SourceType.CDROM, "cdrom")
+
+
+class NFSSource(BasePayloadSource):
+    """Source object for NFS sources."""
+
+    def __init__(self, server, path, opts):
+        super().__init__(SourceType.NFS, "nfs")
+        self._server = server
+        self._path = path
+        self._opts = opts
+
+    @property
+    def server(self):
+        """Get server.
+
+        :rtype: str
+        """
+        return self._server
+
+    @property
+    def path(self):
+        """Get server path.
+
+        :rtype: str
+        """
+        return self._path
+
+    @property
+    def options(self):
+        """Get nfs mount options.
+
+        :rtype: str
+        """
+        return self._opts
+
+
+class HDDSource(BasePayloadSource):
+    """Source object for hard drive source."""
+
+    def __init__(self, partition, path):
+        super().__init__(SourceType.HARDDRIVE, "harddrive")
+
+        self._partition = partition
+        self._path = path
+
+    @property
+    def partition(self):
+        """Partition with the source.
+
+        :rtype: str
+        """
+        return self._partition
+
+    @property
+    def path(self):
+        """Path to a source on the partition.
+
+        :rtype: str
+        """
+        return self._path
+
+
+class URLBasedSource(BasePayloadSource):
+    """Base class for URL based sources."""
+
+    def __init__(self, source_type, url, mirrorlist=False, metalink=False):
+        super().__init__(source_type, "url")
+
+        if mirrorlist and metalink:
+            raise KeyError("Can't have one link both mirrorlist and metalink!")
+
+        self._url = url
+        self._mirrorlist = mirrorlist
+        self._metalink = metalink
+
+    @property
+    def url(self):
+        """Get url link.
+
+        :rtype: str
+        """
+        return self._url
+
+    @property
+    def is_mirrorlist(self):
+        """Is mirrorlist url?
+
+        :rtype: bool
+        """
+        return self._mirrorlist
+
+    @property
+    def is_metalink(self):
+        """Is metalink url?
+
+        :rtype: bool
+        """
+        return self._metalink
+
+
+class HTTPSource(URLBasedSource):
+    """Source object for HTTP sources."""
+
+    def __init__(self, url, mirrorlist=False, metalink=False):
+        super().__init__(SourceType.HTTP, url, mirrorlist, metalink)
+
+
+class HTTPSSource(URLBasedSource):
+    """Source object for HTTPS sources."""
+
+    def __init__(self, url, mirrorlist=False, metalink=False):
+        super().__init__(SourceType.HTTPS, url, mirrorlist, metalink)
+
+
+class FTPSource(URLBasedSource):
+    """Source object for FTP sources."""
+
+    def __init__(self, url, mirrorlist=False, metalink=False):
+        super().__init__(SourceType.FTP, url, mirrorlist, metalink)
+
+
+class FileSource(BasePayloadSource):
+    """Source object for file:// based sources."""
+
+    def __init__(self, path):
+        super().__init__(SourceType.FILE, "url")
+
+        self._path = path
+
+    @property
+    def path(self):
+        """Path to the file source.
+
+        :rtype: str
+        """
+        return self._path
+
+
+class LiveSource(BasePayloadSource):
+    """Source object for live image sources."""
+
+    def __init__(self, partition):
+        super().__init__(SourceType.LIVECD, "livecd")
+
+        self._partition = partition
+
+    @property
+    def partition(self):
+        """Partition with live image.
+
+        :rtype: str
+        """
+        return self._partition
+
+
+class HMCSource(BasePayloadSource):
+    """Source object for HMC sources.
+
+    S390 cdrom like device.
+    """
+
+    def __init__(self):
+        super().__init__(SourceType.HMC, "hmc")

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -373,11 +373,10 @@ def print_startup_note(options):
         print(separate_attachements_note)
 
 
-def live_startup(anaconda, options):
+def live_startup(anaconda):
     """Live environment startup tasks.
 
     :param anaconda: instance of the Anaconda class
-    :param options: command line/boot options
     """
     flags.livecdInstall = True
 

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1405,15 +1405,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             log.debug("Setting up repos: %s", repos)
             for name in repos:
                 repo = self.payload.getAddOnRepo(name)
-                ks_repo = self.data.RepoData(name=repo.name,
-                                             baseurl=repo.baseurl,
-                                             mirrorlist=repo.mirrorlist,
-                                             metalink=repo.metalink,
-                                             proxy=repo.proxy,
-                                             enabled=repo.enabled,
-                                             treeinfo_origin=repo.treeinfo_origin,
-                                             partition=repo.partition,
-                                             iso_path=repo.iso_path)
+                ks_repo = self.data.RepoData.create_copy(repo)
                 # Track the original name, user may change .name
                 ks_repo.orig_name = name
                 # Add addon repository id for identification

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1411,7 +1411,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
                                              metalink=repo.metalink,
                                              proxy=repo.proxy,
                                              enabled=repo.enabled,
-                                             treeinfo_origin=repo.treeinfo_origin)
+                                             treeinfo_origin=repo.treeinfo_origin,
+                                             partition=repo.partition,
+                                             iso_path=repo.iso_path)
                 # Track the original name, user may change .name
                 ks_repo.orig_name = name
                 # Add addon repository id for identification

--- a/tests/nosetests/pyanaconda_tests/payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/payload_test.py
@@ -1,7 +1,5 @@
 #
-# Authors: Jiri Konecny <jkonecny@redhat.com>
-#
-## Copyright (C) 2017  Red Hat, Inc.
+# Copyright (C) 2018  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -16,6 +14,8 @@
 # source code or documentation are not subject to the GNU General Public
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
+#
+# Authors: Jiri Konecny <jkonecny@redhat.com>
 #
 
 from pyanaconda.payload import dnfpayload
@@ -150,7 +150,8 @@ or it should be. Nah it's just a test!
         os.remove(self._md_file)
         self.assertFalse(r.verify_repoMD())
 
-class  PayloadRequirementsTestCase(unittest.TestCase):
+
+class PayloadRequirementsTestCase(unittest.TestCase):
 
     def requirements_test(self):
         """Check that requirements work correctly."""


### PR DESCRIPTION
Add support for the `inst.addrepo` command line option.

This option supports:
* http, https, ftp
* nfs in the `repo` kickstart command variant
* file:// -- new solution for loading local installation tree structures

This will basically read the new `inst.addrepo` and pass it to the installation kickstart data. That data are then processed as usual. This boot option can be used multiple times so you can use it to specify multiple additional repositories.

The `file://` solution is brand new and it is used to load installation tree from the installation environment. It is working even when specified by the `repo` kickstart command so the output kickstart file works as expected.

*Resolves: rhbz#1595415*