### PR TITLE
Fix packaging log level

### DIFF
--- a/pyanaconda/anaconda_logging.py
+++ b/pyanaconda/anaconda_logging.py
@@ -227,8 +227,7 @@ class AnacondaLog(object):
         packaging_logger.setLevel(logging.DEBUG)
         packaging_logger.propagate = False
         self.addFileHandler(PACKAGING_LOG_FILE, packaging_logger,
-                            minLevel=logging.INFO,
-                            autoLevel=True)
+                            minLevel=logging.DEBUG)
         forwardToJournal(packaging_logger)
 
         # Create the dnf logger and link it to packaging

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -391,7 +391,7 @@ class DNFPayload(payload.PackagePayload):
             with self._repos_lock:
                 self._base.repos.add(repo)
 
-        log.debug("added repo: '%s' - %s", ksrepo.name, url or mirrorlist or metalink)
+        log.info("added repo: '%s' - %s", ksrepo.name, url or mirrorlist or metalink)
 
     def _fetch_md(self, repo):
         """Download repo metadata


### PR DESCRIPTION
The packaging was the only log which has debug level set to INFO. This debug level increased to DEBUG when inst.debug or inst.updates was used.

The reason for this behavior is not valid anymore. The original issue is described here:

https://github.com/rhinstaller/anaconda/commit/0488800dd7f5655caf6fe313c7fac5713b34f00b

Also change message log level to INFO when adding repo.

*Resolves: rhbz#1603178*