### PR TITLE
Show a note about EULA where relevant

### DIFF
--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -88,6 +88,16 @@ class BaseInstallClass(object):
     # geolocation
     use_geolocation_with_kickstart = False
 
+    # EULA path (if any)
+    #
+    # If the given distribution has an EULA & feels the need to
+    # tell the user about it fill in this variable by a path
+    # pointing to a file with the EULA on the installed system.
+    #
+    # This is currently used just to show the path to the file to
+    # the user at the end of the installation.
+    eula_path = None
+
     @property
     def l10n_domain(self):
         if self._l10n_domain is None:

--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -45,6 +45,8 @@ class RHELBaseInstallClass(BaseInstallClass):
     help_placeholder = "RHEL7Placeholder.html"
     help_placeholder_with_links = "RHEL7PlaceholderWithLinks.html"
 
+    eula_path="/usr/share/redhat-release/EULA"
+
     def setNetworkOnbootDefault(self, ksdata):
         if any(nd.onboot for nd in ksdata.network.network if nd.device):
             return

--- a/pyanaconda/ui/gui/hubs/progress.py
+++ b/pyanaconda/ui/gui/hubs/progress.py
@@ -143,6 +143,10 @@ class ProgressHub(Hub):
 
         util.ipmi_report(IPMI_FINISHED)
 
+        if self.instclass.eula_path:
+            self.set_warning(_("Use of this product is subject to the license agreement found at %s") % self.instclass.eula_path)
+            self.window.show_all()
+
         # kickstart install, continue automatically if reboot or shutdown selected
         if flags.automatedInstall and self.data.reboot.action in [KS_REBOOT, KS_SHUTDOWN]:
             self.window.emit("continue-clicked")

--- a/pyanaconda/ui/tui/spokes/installation_progress.py
+++ b/pyanaconda/ui/tui/spokes/installation_progress.py
@@ -131,6 +131,14 @@ class ProgressSpoke(StandaloneTUISpoke):
 
         util.ipmi_report(IPMI_FINISHED)
 
+        if self.instclass.eula_path:
+            # Notify user about the EULA (if any).
+            print(_("Installation complete"))
+            print('')
+            print(_("Use of this product is subject to the license agreement found at:"))
+            print(self.instclass.eula_path)
+            print('')
+
         # kickstart install, continue automatically if reboot or shutdown selected
         if flags.automatedInstall and self.data.reboot.action in [KS_REBOOT, KS_SHUTDOWN]:
             # Just pretend like we got input, and our input doesn't care


### PR DESCRIPTION
Show a note about EULA at the end of the installation
in GUI & TUI if the currently active install class
specifies a path to an EULA file.

If no EULA file path is specified, no EULA note will
be shown.