### PR TITLE
dracut: Add deps for fetch-kickstart-disk

### DIFF
--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -24,6 +24,8 @@ install() {
     # binaries we want in initramfs
     dracut_install eject -o pigz
     dracut_install depmod blkid
+    # Deps for fetch-kickstart-disk
+    dracut_install mount umount cp mkdir rmdir
     inst_binary /usr/libexec/anaconda/dd_list /bin/dd_list
     inst_binary /usr/libexec/anaconda/dd_extract /bin/dd_extract
 


### PR DESCRIPTION
It looks like at some point after RHEL7 `rmdir` dropped out of
the initramfs as nothing else depends on it.  This broke
`fetch-kickstart-disk`.