### PR TITLE
Use productmd library to parse .treeinfo (#1411673)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -105,6 +105,7 @@ Requires: python3-dbus
 Requires: python3-pwquality
 Requires: python3-systemd
 Requires: python3-pydbus
+Requires: python3-productmd
 
 # pwquality only "recommends" the dictionaries it needs to do anything useful,
 # which is apparently great for containers but unhelpful for the rest of us

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -26,7 +26,6 @@
 """
 import os
 import requests
-import configparser
 import shutil
 from glob import glob
 from fnmatch import fnmatch
@@ -35,6 +34,8 @@ import re
 import functools
 import time
 from collections import OrderedDict, namedtuple
+
+from productmd.treeinfo import TreeInfo
 
 from blivet.size import Size, ROUND_HALF_UP
 
@@ -313,6 +314,8 @@ class Payload(object):
         self.instclass = None
         self.txID = None
 
+        self._treeinfo = None
+
         # A list of verbose error strings from the subclass
         self.verbose_errors = []
 
@@ -331,6 +334,7 @@ class Payload(object):
         """Invalidate a previously setup payload."""
         self.storage = None
         self.instclass = None
+        self._treeinfo = None
 
     def preStorage(self):
         """Do any payload-specific work necessary before writing the storage
@@ -615,20 +619,21 @@ class Payload(object):
     ##
     ## METHODS FOR TREE VERIFICATION
     ##
-    def _getTreeInfo(self, url, proxy_url, sslverify):
-        """Retrieve treeinfo and return the path to the local file.
+    def _refreshTreeInfo(self, url):
+        """Retrieve treeinfo and store it in the self._treeinfo.
 
-        :param baseurl: url of the repo
-        :type baseurl: string
-        :param proxy_url: Optional full proxy URL of or ""
-        :type proxy_url: string
-        :param sslverify: True if SSL certificate should be verified
-        :type sslverify: bool
-        :returns: Path to retrieved .treeinfo file or None
-        :rtype: string or None
+        :param url: url of the repo
+        :type url: string
         """
         if not url:
-            return None
+            return
+
+        if hasattr(self.data.method, "proxy"):
+            proxy_url = self.data.method.proxy
+        else:
+            proxy_url = None
+
+        sslverify = not flags.noverifyssl
 
         log.debug("retrieving treeinfo from %s (proxy: %s ; sslverify: %s)",
                   url, proxy_url, sslverify)
@@ -686,21 +691,17 @@ class Payload(object):
                 log.error(err_msg)
                 self.verbose_errors.append(err_msg)
                 response = None
+
         if response:
             # get the treeinfo contents
             text = response.text
 
-            # close the response
             response.close()
 
-            # write the local treeinfo file
-            with open("/tmp/.treeinfo", "w") as f:
-                f.write(text)
-
-            # and also return the treeinfo contents as a string
-            return text
+            self._treeinfo = TreeInfo()
+            self._treeinfo.loads(text)
         else:
-            return None
+            self._treeinfo = None
 
     def _download_treeinfo_file(self, url, file_name, headers, proxies, verify):
         try:
@@ -725,21 +726,8 @@ class Payload(object):
 
         log.debug("getting release version from tree at %s (%s)", url, version)
 
-        if hasattr(self.data.method, "proxy"):
-            proxy = self.data.method.proxy
-        else:
-            proxy = None
-        treeinfo = self._getTreeInfo(url, proxy, not flags.noverifyssl)
-        if treeinfo:
-            c = configparser.ConfigParser()
-            c.read(treeinfo)
-            try:
-                # Trim off any -Alpha or -Beta
-                version = re.match(VERSION_DIGITS, c.get("general", "version")).group(1)
-            except AttributeError:
-                version = "rawhide"
-            except configparser.Error:
-                pass
+        if self._treeinfo:
+            version = self._treeinfo.release.version.lower()
             log.debug("using treeinfo release version of %s", version)
         else:
             log.debug("using default release version of %s", version)

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -1085,6 +1085,7 @@ class DNFPayload(payload.PackagePayload):
 
         if method.method:
             try:
+                self._refreshTreeInfo(url)
                 self._base.conf.releasever = self._getReleaseVersion(url)
                 log.debug("releasever from %s is %s", url, self._base.conf.releasever)
             except configparser.MissingSectionHeaderError as e:


### PR DESCRIPTION
The python-productmd library is to parse and create treeinfo and other files used to create compose. By using the library we should be always compatible with current treeinfo structure.