### PR TITLE
Don't allow unlocking and using of LUKS2 devices (#1608251)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -89,7 +89,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 
 %package core
 Summary: Core of the Anaconda installer
-Requires: python-blivet >= 1:0.61.15.70
+Requires: python-blivet >= 1:0.61.15.71
 Requires: python-meh >= %{mehver}
 Requires: libreport-anaconda >= 2.0.21-1
 Requires: libreport-rhel-anaconda-bugzilla >= 2.1.11-1

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -226,6 +226,9 @@ class RescueMode(NormalTUISpoke):
             if device.format.type != "luks":
                 continue
 
+            if device.format.luks_version != "luks1":
+                continue
+
             skip = False
             unlocked = False
             while not (skip or unlocked):


### PR DESCRIPTION
Users shouldn't be able to unlock or use LUKS2 devices.

* In GUI, users will see a message for uneditable devices.
* In TUI, the installer doesn't unlock any LUKS devices.
* In the rescue mode, it will not be possible to unlock LUKS2 devices.

Resolves: rhbz#1608251
Depends on: https://github.com/storaged-project/blivet/pull/708