### PR TITLE
Bootloader stage2 can't be on btrfs on rhel (#1533904)

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1466,7 +1466,7 @@ class GRUB2(GRUB):
     @property
     def stage2_format_types(self):
         if productName.startswith("Red Hat "):              # pylint: disable=no-member
-            return ["xfs", "ext4", "ext3", "ext2", "btrfs"]
+            return ["xfs", "ext4", "ext3", "ext2"]
         else:
             return ["ext4", "ext3", "ext2", "btrfs", "xfs"]
 


### PR DESCRIPTION
Related: rhbz#1533904