### PR TITLE
Show better messages for NoSuchPackage and NoSuchGroup (#1599190)

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -108,12 +108,18 @@ class NoSuchGroup(PayloadError):
         self.adding = adding
         self.required = required
 
+    def __str__(self):
+        return "The group '{}' does not exist".format(self.group)
+
 
 class NoSuchPackage(PayloadError):
     def __init__(self, package, required=False):
         super().__init__(package)
         self.package = package
         self.required = required
+
+    def __str__(self):
+        return "The package '{}' does not exist".format(self.package)
 
 
 class DependencyError(PayloadError):


### PR DESCRIPTION
Exceptions NoSuchPackage and NoSuchGroup should have a better string
representation, otherwise the installer in the cmdline mode shows only
the name of the missing package or group.

This change doesn't affect messages in other modes.

Resolves: rhbz#1599190