### PR TITLE
Fix disable additional repositories

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -391,6 +391,9 @@ class DNFPayload(payload.PackagePayload):
             with self._repos_lock:
                 self._base.repos.add(repo)
 
+        if not ksrepo.enabled:
+            self.disableRepo(repo.id)
+
         log.info("added repo: '%s' - %s", ksrepo.name, url or mirrorlist or metalink)
 
     def _fetch_md(self, repo):


### PR DESCRIPTION
I really wonder how is it possible but it looks like we didn't disabled DNF repositories if they were disabled in KS data.

Thanks to this we always used all the additional repositories even when user disabled them in the UI.