### PR TITLE
Starting from 3.0 DNF expects strings in comps queries

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -912,6 +912,9 @@ class DNFPayload(payload.PackagePayload):
 
     def environmentId(self, environment):
         """Return environment id for the environment specified by id or name."""
+        # the enviroment must be string or else DNF >=3 throws an assert error
+        if not isinstance(environment, str):
+            log.warning("environmentId() called with non-string argument: %s", environment)
         env = self._base.comps.environment_by_pattern(environment)
         if env is None:
             raise payload.NoSuchGroup(environment)

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -145,6 +145,9 @@ class SoftwareSelectionSpoke(NormalSpoke):
         if it is valid and use this property when we need
         the "machine readable" form.
         """
+        if environment is None:
+            # None means environment is not set, no need to try translate that to an id
+            return None
         try:
             return self.payload.environmentId(self.environment)
         except NoSuchGroup:

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -125,6 +125,7 @@ class SoftwareSpoke(NormalTUISpoke):
     def _translate_env_name_to_id(self, environment):
         """ Return the id of the selected environment or None. """
         if environment is None:
+            # None means environment is not set, no need to try translate that to an id
             return None
         try:
             return self.payload.environmentId(environment)


### PR DESCRIPTION
So make sure we only pass strings to the API, otherwise
DNF throws an assert error.

Basically Anaconda uses None internally to indicate the
environment has not been set and we need to prevent this
from leaking to the DNF comps API.