### PR TITLE
Only show the "closest mirror" source option where appropriate

### DIFF
--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -98,6 +98,13 @@ class BaseInstallClass(object):
     # the user at the end of the installation.
     eula_path = None
 
+    # A hint if mirrors are expected to be available for the distribution
+    # installed by the given install class.
+    #
+    # At the moment this just used to show/hide the "closest mirror" option
+    # in the UI.
+    mirrors_available = True
+
     @property
     def l10n_domain(self):
         if self._l10n_domain is None:

--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -47,6 +47,8 @@ class RHELBaseInstallClass(BaseInstallClass):
 
     eula_path="/usr/share/redhat-release/EULA"
 
+    mirrors_available = False
+
     def setNetworkOnbootDefault(self, ksdata):
         if any(nd.onboot for nd in ksdata.network.network if nd.device):
             return

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -324,11 +324,20 @@ class Payload(object):
         # Additional packages required by installer based on used features
         self.requirements = PayloadRequirements()
 
+        # are mirrors available ?
+        # - this is an initial default value that will
+        #   be overridden by value from the current
+        #   install class in the setup() method
+        self._mirrors_available = True
+
     def setup(self, storage, instClass):
         """Do any payload-specific setup."""
         self.storage = storage
         self.instclass = instClass
         self.verbose_errors = []
+        # At the moment we set if mirrors are expected to be
+        # available just based on an current install class.
+        self._mirrors_available = instClass.mirrors_available
 
     def unsetup(self):
         """Invalidate a previously setup payload."""
@@ -387,11 +396,11 @@ class Payload(object):
         return None
 
     @property
-    def mirrorEnabled(self):
+    def mirrors_available(self):
         """Is the closest/fastest mirror option enabled?  This does not make
         sense for those payloads that do not support this concept.
         """
-        return True
+        return self._mirrors_available
 
     @property
     def disabledRepos(self):

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -786,10 +786,6 @@ class DNFPayload(payload.PackagePayload):
         return [g.id for g in groups]
 
     @property
-    def mirrorEnabled(self):
-        return True
-
-    @property
     def repos(self):
         # known repo ids
         with self._repos_lock:

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -768,7 +768,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
 
         # If there's no fallback mirror to use, we should just disable that option
         # in the UI.
-        if not self.payload.mirrorEnabled:
+        if not self.payload.mirrors_available:
             model = self._protocolComboBox.get_model()
             itr = model.get_iter_first()
             while itr and model[itr][self._protocolComboBox.get_id_column()] != PROTOCOL_MIRROR:

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -156,7 +156,8 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
             return
 
         if args == self.SET_NETWORK_INSTALL_MODE:
-            self._container.add(TextWidget(_("Closest mirror")), self._set_network_close_mirror)
+            if self.payload.mirrors_available:
+                self._container.add(TextWidget(_("Closest mirror")), self._set_network_close_mirror)
             self._container.add(TextWidget("http://"), self._set_network_url, SpecifyRepoSpoke.HTTP)
             self._container.add(TextWidget("https://"), self._set_network_url, SpecifyRepoSpoke.HTTPS)
             self._container.add(TextWidget("ftp://"), self._set_network_url, SpecifyRepoSpoke.FTP)


### PR DESCRIPTION
Only show it on distros that actually have public mirrors,
based on install class provided hint.

Also when we are at it cleanup the relevant code a bit,
changing the property name to something more reasonable
and remove the needless override in dnfpayload.

Resolves: rhbz#1608241