### PR TITLE
Add help placeholders

### DIFF
--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -42,8 +42,9 @@ class RHELBaseInstallClass(BaseInstallClass):
 
     efi_dir = "redhat"
 
-    help_placeholder = "RHEL7Placeholder.html"
-    help_placeholder_with_links = "RHEL7PlaceholderWithLinks.html"
+    help_placeholder = "rhel_help_placeholder.xml"
+    help_placeholder_with_links = "rhel_help_placeholder.xml"
+    help_placeholder_plain_text = "rhel_help_placeholder.txt"
 
     eula_path="/usr/share/redhat-release/EULA"
 


### PR DESCRIPTION
Actual RHEL help content is not yet available, so just always
show a placeholder on RHEL for now.

The placeholders and their use are temporary and will be removed
once correct help content becomes available.