### PR TITLE
Allow to delete all file systems used by Unknown (#1597199)

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -1973,6 +1973,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         if not self._accordion.is_multiselection:
             if root_name and "_" in root_name:
                 root_name = root_name.replace("_", "__")
+
+            if root_name:
                 checkbox_text = (C_("GUI|Custom Partitioning|Confirm Delete Dialog",
                                     "Delete _all file systems which are only used by %s.")
                                     % root_name)


### PR DESCRIPTION
The confirmation dialog for deleting a mount point didn't show the
checkbox for deleting all related file systems unless there was '_'
in the name of the system.

Resolves: rhbz#1597199