### PR TITLE
Fix crash when software environment is False

### DIFF
--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -148,6 +148,9 @@ class SoftwareSelectionSpoke(NormalSpoke):
         if self.environment is None:
             # None means environment is not set, no need to try translate that to an id
             return None
+        elif self.environment is False:
+            # False means environment is not valid and must be set manually
+            return False
         try:
             return self.payload.environmentId(self.environment)
         except NoSuchGroup:


### PR DESCRIPTION
Software environment is set to False if the environment from kickstart file does not exists. New version of DNF will crash if False is passed.