### PR TITLE
Detect that there is not enough space on a device (#1613232)

### DIFF
--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -156,7 +156,7 @@ class LiveImagePayload(ImagePayload):
             msg = "%s exited with code %d" % (cmd, rc)
             log.info(msg)
 
-        if err or rc == 12:
+        if err or rc == 11:
             exn = PayloadInstallError(err or msg)
             if errorHandler.cb(exn) == ERROR_RAISE:
                 raise exn


### PR DESCRIPTION
In live installations, we ignore all rsync errors except for the ones
that indicate not enough space on a device (see #868755 and #1592520).

The valid return code of rsync is 11 (Error in file I/O) now.

Resolves: rhbz#1613232