### PR TITLE
Set platform id for DNF

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1410,6 +1410,21 @@ def collect(module_pattern, path, pred):
 
     return retval
 
+def parse_os_release():
+    """Parse the /etc/os-release file and return its contents as a dict.
+
+    :returns: /etc/os-release as a dict
+    :rtype: dict of strings
+    """
+    d = {}
+    if os.path.exists("/etc/os/release"):
+        with open("/etc/os-release") as f:
+            for line in f:
+                k,v = line.rstrip().split("=")
+                d[k] = v.strip('"')
+    else:
+        log.error("/etc/os-release does not exist and thus can't be parsed")
+    return d
 
 def item_counter(item_count):
     """A generator for easy counting of items.

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -635,6 +635,14 @@ class DNFPayload(payload.PackagePayload):
         conf.logdir = '/tmp/'
         # enable depsolver debugging if in debug mode
         self._base.conf.debug_solver = flags.debug
+        # set the platform id based on the /os/release
+        # present in the installation environment
+        platform_id = util.parse_os_release().get("PLATFORM_ID")
+        if platform_id is None:
+            log.error("platform id not found in os-release")
+        else:
+            log.info("setting DNF platform id to: %s", platform_id)
+            base.conf.module_platform_id = platform_id
 
         conf.releasever = self._getReleaseVersion(None)
         conf.installroot = util.getSysroot()


### PR DESCRIPTION
To correctly install modules DNF needs to know the correct platform id.

On an installed system DNF will get it from /etc/os-release but during
an installation run the target system chroot is empty and there is
no /etc/os-release for DNF to parse.

So parse the /etc/os-release from the installation environment (if any)
and set the DNF platform id based on the PLATFORM_ID key.

Related: rhbz#1613296