### PR TITLE
Fix a 5 year old typo in the spec file

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -264,7 +264,7 @@ find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 mkdir %{buildroot}%{_datadir}/anaconda/addons
 
 %ifarch %livearches
-desktop-file-install ---dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_datadir}/applications/liveinst.desktop
+desktop-file-install --dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_datadir}/applications/liveinst.desktop
 %endif
 # NOTE: If you see "error: Installed (but unpackaged) file(s) found" that include liveinst files,
 #       check the IS_LIVEINST_ARCH in configure.ac to make sure your architecture is properly defined


### PR DESCRIPTION
This has been in place for ~5 years but only
started failing about a week ago, likely due to
some low level option parsing changes somewhere
down the stack.

Resolves: rhbz#1613488