### PR TITLE
Use SimpleConfigFile to get PLATFORM_ID from /etc/os-release

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1410,22 +1410,6 @@ def collect(module_pattern, path, pred):
 
     return retval
 
-def parse_os_release():
-    """Parse the /etc/os-release file and return its contents as a dict.
-
-    :returns: /etc/os-release as a dict
-    :rtype: dict of strings
-    """
-    d = {}
-    if os.path.exists("/etc/os-release"):
-        with open("/etc/os-release") as f:
-            for line in f:
-                k,v = line.rstrip().split("=")
-                d[k] = v.strip('"')
-    else:
-        log.error("/etc/os-release does not exist and thus can't be parsed")
-    return d
-
 def item_counter(item_count):
     """A generator for easy counting of items.
 


### PR DESCRIPTION
SimpleConfigFile looks like a better match for parsing of
/etc/os-release than the primitive custom key value parser.

Also unlike the primitive parser it can handle /etc/os-release files
with blank lines.

Related: rhbz#1613296