### PR TITLE
Revert back to running DNF in a subprocess

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -37,7 +37,6 @@ import configparser
 import collections
 import itertools
 import multiprocessing
-import multiprocessing.dummy
 import operator
 import hashlib
 import shutil
@@ -1020,7 +1019,7 @@ class DNFPayload(payload.PackagePayload):
         progress_message(pre_msg)
 
         queue_instance = multiprocessing.Queue()
-        process = multiprocessing.dummy.Process(target=do_transaction,
+        process = multiprocessing.Process(target=do_transaction,
                                           args=(self._base, queue_instance))
         process.start()
         (token, msg) = queue_instance.get()


### PR DESCRIPTION
When working on the modula installation support via the install_specs()
API we hit a weird issue with DNF crashing on a "foregin key error"
when accessing one of its sqlite databases.

When looking into it with the DNF developers we found out the issue
goes away when we just run the DNF transaction in a dummy process
instead of a real one. That seemed to work fine and there were no
apparent regressions at that time so we went with the workaround.

Looks like we might have been wrong - bug 1614511 strongly hints
on chroot being used by rpm od DNF during package installation trasaction
is causing GTK to crash by basically swapping the root filesystem under
it.

A similar issue back with yum was the main reason for isolating
the yum payload into a separate process. So switch back to the previous
behavior where the DNF trasaction runs in a separate sub-process to
shield the main Anaconda process from rpm/DNF chroot shenanigans.

Resolves: rhbz#1614511
Related: rhbz#1613296