### PR TITLE
Fix pylint errors

### DIFF
--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 # livepayload.py
 # Live media software payload management.
 #

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -26,6 +26,8 @@ class AnacondaLintConfig(PocketLintConfig):
                                 FalsePositive(r"^E1101.*: Module 'crypt' has no 'METHOD_MD5' member$"),
                                 FalsePositive(r"^E1101.*: Module 'crypt' has no 'METHOD_SHA256' member$"),
                                 FalsePositive(r"^E1101.*: Module 'crypt' has no 'METHOD_SHA512' member$"),
+                                FalsePositive(r"^E1120.*: No value for argument 'self' in function call$"),
+                                FalsePositive(r"^E1120.*: No value for argument 'self' in unbound method call$"),
 
                                 # TODO: BlockDev introspection needs to be added to pylint to handle these
                                 FalsePositive(r"E1101.*: Instance of 'int' has no 'dasd_needs_format' member"),


### PR DESCRIPTION
* The livepayload.py doesn't have to be skipped anymore.
* Ignore complaints about calls of functions and methods of libraries
  that are imported via gi.

Related: rhbz#1618633