### PR TITLE
Fix the processing of the live CD source (#1622248)

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -57,7 +57,7 @@ fi
 # Allow running another command in the place of anaconda, but in this same
 # environment.  This allows storage testing to make use of all the module
 # loading and lvm control in this file, too.
-ANACONDA=${LIVECMD:=anaconda --liveinst --method=livecd://$LIVE_BLOCK}
+ANACONDA="${LIVECMD:=anaconda --liveinst --method=livecd:${LIVE_BLOCK}}"
 
 # load modules that would get loaded by the initramfs (#230945)
 for i in raid0 raid1 raid5 raid6 raid456 raid10 dm-mod dm-zero dm-mirror dm-snapshot dm-multipath dm-round-robin vfat dm-crypt cbc sha256 lrw xts iscsi_tcp iscsi_ibft; do /sbin/modprobe $i 2>/dev/null ; done

--- a/pyanaconda/payload/source/sources.py
+++ b/pyanaconda/payload/source/sources.py
@@ -22,7 +22,7 @@ from enum import Enum
 
 class SourceType(Enum):
     CDROM = "cdrom"
-    HARDDRIVE = "Harddrive"
+    HARDDRIVE = "harddrive"
     NFS = "nfs"
     HTTP = "http"
     HTTPS = "https"
@@ -280,7 +280,7 @@ class LiveSource(BasePayloadSource):
     """Source object for live image sources."""
 
     def __init__(self, partition):
-        super().__init__(SourceType.LIVECD, "livecd")
+        super().__init__(SourceType.LIVECD, "harddrive")
 
         self._partition = partition
 


### PR DESCRIPTION
The installation source for live CD uses the kickstart command
harddrive. There is no kickstart command livecd.

Also, fix the path to the live device in the liveinst script.

Resolves: rhbz#1622248