### PR TITLE
Add system purpose support

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -37,7 +37,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.16-1
+%define pykickstartver 3.16.2-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 1.1-1
@@ -105,6 +105,7 @@ Requires: python3-pwquality
 Requires: python3-systemd
 Requires: python3-pydbus
 Requires: python3-productmd
+Requires: python3-syspurpose
 
 # pwquality only "recommends" the dictionaries it needs to do anything useful,
 # which is apparently great for containers but unhelpful for the rest of us

--- a/configure.ac
+++ b/configure.ac
@@ -175,6 +175,7 @@ AC_CONFIG_FILES([Makefile
                  pyanaconda/modules/localization/Makefile
                  pyanaconda/modules/users/Makefile
                  pyanaconda/modules/users/user/Makefile
+                 pyanaconda/modules/subscription/Makefile
                  pyanaconda/modules/payload/Makefile
                  pyanaconda/modules/storage/Makefile
                  pyanaconda/modules/storage/bootloader/Makefile

--- a/data/dbus/org.fedoraproject.Anaconda.Modules.Subscription.conf
+++ b/data/dbus/org.fedoraproject.Anaconda.Modules.Subscription.conf
@@ -1,0 +1,14 @@
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+        <policy user="root">
+                <allow own="org.fedoraproject.Anaconda.Modules.Subscription"/>
+                <allow send_destination="org.fedoraproject.Anaconda.Modules.Subscription"/>
+        </policy>
+        <policy context="default">
+                <deny own="org.fedoraproject.Anaconda.Modules.Subscription"/>
+                <allow send_destination="org.fedoraproject.Anaconda.Modules.Subscription"/>
+        </policy>
+</busconfig>
+

--- a/data/dbus/org.fedoraproject.Anaconda.Modules.Subscription.service
+++ b/data/dbus/org.fedoraproject.Anaconda.Modules.Subscription.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.fedoraproject.Anaconda.Modules.Subscription
+Exec=/usr/libexec/anaconda/start-module pyanaconda.modules.subscription
+User=root

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -74,6 +74,7 @@ from pykickstart.commands.skipx import FC3_SkipX as SkipX
 from pykickstart.commands.snapshot import F26_Snapshot as Snapshot
 from pykickstart.commands.sshpw import F24_SshPw as SshPw
 from pykickstart.commands.sshkey import F22_SshKey as SshKey
+from pykickstart.commands.syspurpose import RHEL8_Syspurpose as Syspurpose
 from pykickstart.commands.timezone import F25_Timezone as Timezone
 from pykickstart.commands.updates import F7_Updates as Updates
 from pykickstart.commands.url import F27_Url as Url

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -24,7 +24,7 @@ from blivet.devices import BTRFSDevice
 from pyanaconda.core.constants import BOOTLOADER_DISABLED
 from pyanaconda.modules.common.constants.objects import BOOTLOADER, AUTO_PARTITIONING, \
     MANUAL_PARTITIONING
-from pyanaconda.modules.common.constants.services import STORAGE
+from pyanaconda.modules.common.constants.services import STORAGE, SUBSCRIPTION
 from pyanaconda.storage.osinstall import turn_on_filesystems
 from pyanaconda.bootloader import writeBootLoader
 from pyanaconda.progress import progress_message, progress_step, progress_complete, progress_init
@@ -99,6 +99,7 @@ def doConfiguration(storage, payload, ksdata, instClass):
     os_config.append(Task("Configure language", ksdata.lang.execute, (storage, ksdata, instClass)))
     os_config.append(Task("Configure firewall", ksdata.firewall.execute, (storage, ksdata, instClass)))
     os_config.append(Task("Configure X", ksdata.xconfig.execute, (storage, ksdata, instClass)))
+    os_config.append(Task("Configure system purpose", ksdata.syspurpose.execute, (storage, ksdata, instClass)))
     configuration_queue.append(os_config)
 
     # schedule network configuration (if required)
@@ -327,6 +328,13 @@ def doInstall(storage, payload, ksdata, instClass):
         payload.requirements.add_groups(payload.languageGroups(), reason="language groups")
         payload.requirements.add_packages(payload.langpacks(), reason="langpacks", strong=False)
         payload.preInstall()
+
+        # check if we need the syspurpose package needed for system purpose support
+        subscription_proxy = SUBSCRIPTION.get_proxy()
+        if subscription_proxy.IsSystemPurposeSet:
+            # at least one value has been set, so we need the utility being installed in the target system
+            # chroot so we can call it
+            payload.requirements.add_packages(["python3-syspurpose"], reason="system purpose", strong=False)
 
     pre_install.append(Task("Find additional packages & run preInstall()", run_pre_install))
     installation_queue.append(pre_install)

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -53,7 +53,7 @@ from pyanaconda.flags import flags, can_touch_runtime_system
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.errors.kickstart import SplitKickstartError
 from pyanaconda.modules.common.constants.services import BOSS, TIMEZONE, LOCALIZATION, SECURITY, \
-    USERS, SERVICES, STORAGE, NETWORK
+    USERS, SERVICES, STORAGE, SUBSCRIPTION, NETWORK
 from pyanaconda.modules.common.constants.objects import DISK_INITIALIZATION, BOOTLOADER, FIREWALL, \
     AUTO_PARTITIONING, MANUAL_PARTITIONING
 from pyanaconda.modules.common.task import sync_run_task
@@ -961,6 +961,17 @@ class Lang(RemovedCommand):
         localization_proxy = LOCALIZATION.get_proxy()
         task_path = localization_proxy.InstallLanguageWithTask(util.getSysroot())
         task_proxy = LOCALIZATION.get_proxy(task_path)
+        sync_run_task(task_proxy)
+
+class Syspurpose(RemovedCommand):
+    def __str__(self):
+        subscription_proxy = SUBSCRIPTION.get_proxy()
+        return subscription_proxy.GenerateKickstart()
+
+    def execute(self, *args, **kwargs):
+        subscription_proxy = SUBSCRIPTION.get_proxy()
+        task_path = subscription_proxy.SetSystemPurposeWithTask(util.getSysroot())
+        task_proxy = SUBSCRIPTION.get_proxy(task_path)
         sync_run_task(task_proxy)
 
 # no overrides needed here
@@ -2557,6 +2568,7 @@ commandMap = {
     "selinux": SELinux,
     "services": Services,
     "sshkey": SshKey,
+    "syspurpose": Syspurpose,
     "skipx": UselessCommand,
     "snapshot": Snapshot,
     "timezone": Timezone,

--- a/pyanaconda/modules/common/constants/namespaces.py
+++ b/pyanaconda/modules/common/constants/namespaces.py
@@ -61,6 +61,11 @@ USERS_NAMESPACE = (
     "Users"
 )
 
+SUBSCRIPTION_NAMESPACE = (
+    *MODULES_NAMESPACE,
+    "Subscription"
+)
+
 PAYLOAD_NAMESPACE = (
     *MODULES_NAMESPACE,
     "Payload"

--- a/pyanaconda/modules/common/constants/services.py
+++ b/pyanaconda/modules/common/constants/services.py
@@ -20,7 +20,7 @@ from pyanaconda.dbus import SystemBus
 from pyanaconda.dbus.identifier import DBusServiceIdentifier
 from pyanaconda.modules.common.constants.namespaces import BOSS_NAMESPACE, TIMEZONE_NAMESPACE, \
     NETWORK_NAMESPACE, LOCALIZATION_NAMESPACE, SECURITY_NAMESPACE, USERS_NAMESPACE, BAZ_NAMESPACE, \
-    PAYLOAD_NAMESPACE, STORAGE_NAMESPACE, SERVICES_NAMESPACE
+    PAYLOAD_NAMESPACE, STORAGE_NAMESPACE, SERVICES_NAMESPACE, SUBSCRIPTION_NAMESPACE
 
 # Anaconda services.
 
@@ -50,6 +50,10 @@ SECURITY = DBusServiceIdentifier(
 
 USERS = DBusServiceIdentifier(
     namespace=USERS_NAMESPACE
+)
+
+SUBSCRIPTION = DBusServiceIdentifier(
+    namespace=SUBSCRIPTION_NAMESPACE
 )
 
 PAYLOAD = DBusServiceIdentifier(
@@ -85,4 +89,5 @@ ALL_KICKSTART_MODULES = [
     PAYLOAD,
     STORAGE,
     SERVICES,
+    SUBSCRIPTION,
 ]

--- a/pyanaconda/modules/subscription/Makefile.am
+++ b/pyanaconda/modules/subscription/Makefile.am
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pkgpyexecdir = $(pyexecdir)/py$(PACKAGE_NAME)
+subscriptiondir = $(pkgpyexecdir)/modules/subscription
+subscription_PYTHON = $(srcdir)/*.py
+
+MAINTAINERCLEANFILES = Makefile.in

--- a/pyanaconda/modules/subscription/__main__.py
+++ b/pyanaconda/modules/subscription/__main__.py
@@ -1,0 +1,6 @@
+from pyanaconda.modules.common import init
+init()
+
+from pyanaconda.modules.subscription.subscription import SubscriptionModule
+subscription_module = SubscriptionModule()
+subscription_module.run()

--- a/pyanaconda/modules/subscription/installation.py
+++ b/pyanaconda/modules/subscription/installation.py
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import os
+
+from pyanaconda.modules.common.task import Task
+from pyanaconda.modules.subscription import system_purpose
+
+class SystemPurposeConfigurationTask(Task):
+    """Installation task for setting system purpose."""
+
+    def __init__(self, sysroot, role, sla, usage, addons):
+        """Create a new task.
+
+        :param sysroot: a path to the root of the installed system
+        :param lang: a value for LANG locale variable
+        """
+        super().__init__()
+        self._sysroot = sysroot
+        self._role = role
+        self._sla = sla
+        self._usage = usage
+        self._addons = addons
+
+    @property
+    def name(self):
+        return "Set system purpose"
+
+    def run(self):
+        system_purpose.give_the_system_purpose(self._sysroot,
+                                                 self._role,
+                                                 self._sla,
+                                                 self._usage,
+                                                 self._addons)

--- a/pyanaconda/modules/subscription/kickstart.py
+++ b/pyanaconda/modules/subscription/kickstart.py
@@ -1,0 +1,30 @@
+#
+# Kickstart handler for subscription module.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.core.kickstart.version import VERSION
+from pyanaconda.core.kickstart.commands import Syspurpose
+from pyanaconda.core.kickstart import KickstartSpecification
+
+
+class SubscriptionKickstartSpecification(KickstartSpecification):
+
+    version = VERSION
+    commands = {
+        "syspurpose": Syspurpose,
+    }

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -1,0 +1,246 @@
+#
+# Kickstart module for subscription handling.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.dbus import DBus
+from pyanaconda.core.signal import Signal
+from pyanaconda.modules.common.base import KickstartModule
+from pyanaconda.modules.common.constants.services import SUBSCRIPTION
+from pyanaconda.modules.subscription.subscription_interface import SubscriptionInterface
+from pyanaconda.modules.subscription.kickstart import SubscriptionKickstartSpecification
+from pyanaconda.modules.subscription.installation import SystemPurposeConfigurationTask
+from pyanaconda.modules.subscription import system_purpose
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+
+class SubscriptionModule(KickstartModule):
+    """The Subscription module."""
+
+    def __init__(self):
+        super().__init__()
+        self._valid_roles = {}
+        self.role_changed = Signal()
+        self._role = ""
+
+        self._valid_slas = {}
+        self.sla_changed = Signal()
+        self._sla = ""
+
+        self._valid_usage_types = {}
+        self.usage_changed = Signal()
+        self._usage = ""
+
+        self.addons_changed = Signal()
+        self._addons = []
+
+        self.is_system_purpose_set_changed = Signal()
+        self.role_changed.connect(self.is_system_purpose_set_changed.emit)
+        self.sla_changed.connect(self.is_system_purpose_set_changed.emit)
+        self.usage_changed.connect(self.is_system_purpose_set_changed.emit)
+        self.addons_changed.connect(self.is_system_purpose_set_changed.emit)
+
+        self._load_valid_values()
+
+    def _load_valid_values(self):
+        """Load lists of valid roles, SLAs and usage types.
+
+        About role/sla/validity:
+        - an older installation image might have older list of valid fields,
+          missing fields that have become valid after the image has been released
+        - fields that have been valid in the past might be dropped in the future
+        - there is no list of valid addons
+
+        Due to this we need to take into account that the listing might not always be
+        comprehensive and that we need to allow what might on a first glance look like
+        invalid values to be written to the target system.
+        """
+        roles, slas, usage_types = system_purpose.get_valid_fields()
+        self._valid_roles = roles
+        self._valid_slas = slas
+        self._valid_usage_types = usage_types
+
+    def publish(self):
+        """Publish the module."""
+        DBus.publish_object(SUBSCRIPTION.object_path, SubscriptionInterface(self))
+        DBus.register_service(SUBSCRIPTION.service_name)
+
+    @property
+    def kickstart_specification(self):
+        """Return the kickstart specification."""
+        return SubscriptionKickstartSpecification
+
+    def process_kickstart(self, data):
+        """Process the kickstart data."""
+        log.debug("Processing kickstart data...")
+        # Try if any of the values in kickstart match a valid field.
+        # If it does, write the valid field value instead of the value from kickstart.
+        #
+        # This way a value in kickstart that has a different case and/or trailing white space
+        # can still be used to preselect a value in a UI instead of being marked as a custom
+        # user specified value.
+        self._process_role(data)
+        self._process_sla(data)
+        self._process_usage(data)
+
+        # we don't have any list of valid addons and addons are not shown in the UI,
+        # so we just forward the values from kickstart
+        if data.syspurpose.addons:
+            self.set_addons(data.syspurpose.addons)
+
+    def _process_role(self, data):
+        if data.syspurpose.role:
+            role_match = system_purpose.match_field(data.syspurpose.role, self.valid_roles)
+        else:
+            role_match = None
+
+        if role_match:
+            log.info("role value %s from kickstart matched to know valid field %s", data.syspurpose.role, role_match)
+            self.set_role(role_match)
+        elif data.syspurpose.role:
+            log.info("using custom role value from kickstart: %s", data.syspurpose.role)
+            self.set_role(data.syspurpose.role)
+
+    def _process_sla(self, data):
+        if data.syspurpose.sla:
+            sla_match = system_purpose.match_field(data.syspurpose.sla, self.valid_slas)
+        else:
+            sla_match = None
+
+        if sla_match:
+            log.info("SLA value %s from kickstart matched to know valid field %s", data.syspurpose.sla, sla_match)
+            self.set_sla(sla_match)
+        elif data.syspurpose.sla:
+            log.info("using custom SLA value from kickstart: %s", data.syspurpose.sla)
+            self.set_sla(data.syspurpose.sla)
+
+    def _process_usage(self, data):
+        if data.syspurpose.usage:
+            usage_match = system_purpose.match_field(data.syspurpose.usage, self._valid_usage_types)
+        else:
+            usage_match = None
+
+        if usage_match:
+            log.info("usage value %s from kickstart matched to know valid field %s", data.syspurpose.usage, usage_match)
+            self.set_usage(usage_match)
+        elif data.syspurpose.usage:
+            log.info("using custom usage value from kickstart: %s", data.syspurpose.usage)
+            self.set_usage(data.syspurpose.usage)
+
+    def generate_kickstart(self):
+        """Return the kickstart string."""
+        log.debug("Generating kickstart data...")
+        data = self.get_kickstart_handler()
+        data.syspurpose.role = self.role
+        data.syspurpose.sla = self.sla
+        data.syspurpose.usage = self.usage
+        data.syspurpose.addons = self.addons
+        return str(data)
+
+    @property
+    def valid_roles(self):
+        """Return a list of valid roles.
+
+        :return: list of valid roles
+        :rtype: list of strings
+        """
+        return self._valid_roles
+
+    @property
+    def role(self):
+        """Return the intended role (if any)."""
+        return self._role
+
+    def set_role(self, role):
+        """Set the role."""
+        self._role = role
+        self.role_changed.emit()
+        log.debug("Role is set to %s.", role)
+
+    @property
+    def valid_slas(self):
+        """Return a list of valid SLAs.
+
+        :return: list of valid SLAs
+        :rtype: list of strings
+        """
+        return self._valid_slas
+
+    @property
+    def sla(self):
+        """Return the intended SLA (if any)."""
+        return self._sla
+
+    def set_sla(self, sla):
+        """Set the SLA."""
+        self._sla = sla
+        self.sla_changed.emit()
+        log.debug("SLA is set to %s.", sla)
+
+    @property
+    def valid_usage_types(self):
+        """Return a list of valid usage types.
+
+        :return: list of valid usage types
+        :rtype: list of strings
+        """
+        return self._valid_usage_types
+
+    @property
+    def usage(self):
+        """Return the intended usage (if any)."""
+        return self._usage
+
+    def set_usage(self, usage):
+        """Set the intended usage."""
+        self._usage = usage
+        self.usage_changed.emit()
+        log.debug("Usage is set to %s.", usage)
+
+    @property
+    def addons(self):
+        """Return list of additional layered products or features (if any)."""
+        return self._addons
+
+    def set_addons(self, addons):
+        """Set the intended layered products or features."""
+        self._addons = addons
+        self.addons_changed.emit()
+        log.debug("Addons set to %s.", addons)
+
+    @property
+    def is_system_purpose_set(self):
+        """Report if system purpose will be set.
+
+        This basically means at least one of role, SLA, usage or addons
+        has a user-set non-default value.
+        """
+        return any((self.role, self.sla, self.usage, self.addons))
+
+    def set_system_purpose_with_task(self, sysroot):
+        """Set system purpose for the installed system with an installation task.
+
+        FIXME: This is just a temporary method.
+
+        :param sysroot: a path to the root of the installed system
+        :return: a DBus path of an installation task
+        """
+        task = SystemPurposeConfigurationTask(sysroot, self.role, self.sla, self.usage, self.addons)
+        path = self.publish_task(SUBSCRIPTION.namespace, task)
+        return path

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -1,0 +1,141 @@
+#
+# DBus interface for the subscription module.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.modules.common.constants.services import SUBSCRIPTION
+from pyanaconda.dbus.property import emits_properties_changed
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
+from pyanaconda.modules.common.base import KickstartModuleInterface
+from pyanaconda.dbus.interface import dbus_interface
+
+
+@dbus_interface(SUBSCRIPTION.interface_name)
+class SubscriptionInterface(KickstartModuleInterface):
+    """DBus interface for Subscription module."""
+
+    def connect_signals(self):
+        super().connect_signals()
+        self.watch_property("Role", self.implementation.role_changed)
+        self.watch_property("SLA", self.implementation.sla_changed)
+        self.watch_property("Usage", self.implementation.usage_changed)
+        self.watch_property("Addons", self.implementation.addons_changed)
+
+        # the SystemPurposeWillBeSet property depends on the value of
+        # all other system purpose properties
+        self.watch_property("IsSystemPurposeSet", self.implementation.is_system_purpose_set_changed)
+
+    @property
+    def ValidRoles(self) -> List[Str]:
+        """Return all valid roles."""
+        return self.implementation.valid_roles
+
+    @property
+    def Role(self) -> Str:
+        """Role for system subscription purposes."""
+        return self.implementation.role
+
+    @emits_properties_changed
+    def SetRole(self, role: Str):
+        """Set the intended role.
+
+        Sets the role intent for subscription purposes.
+
+        This setting is optional.
+
+        :param str role: a role string
+        """
+        self.implementation.set_role(role)
+
+    @property
+    def ValidSLAs(self) -> List[Str]:
+        """Return all valid SLAs."""
+        return self.implementation.valid_slas
+
+    @property
+    def SLA(self) -> Str:
+        """SLA for system subscription purposes."""
+        return self.implementation.sla
+
+    @emits_properties_changed
+    def SetSLA(self, sla: Str):
+        """Set the intended SLA.
+
+        Sets the SLA intent for subscription purposes.
+
+        This setting is optional.
+
+        :param str sla: a SLA string
+        """
+        self.implementation.set_sla(sla)
+
+    @property
+    def ValidUsageTypes(self) -> List[Str]:
+        """List all valid usage types."""
+        return self.implementation.valid_usage_types
+
+    @property
+    def Usage(self) -> Str:
+        """Usage for system subscription purposes."""
+        return self.implementation.usage
+
+    @emits_properties_changed
+    def SetUsage(self, usage: Str):
+        """Set the intended usage.
+
+        Sets the usage intent for subscription purposes.
+
+        This setting is optional.
+
+        :param str usage: a usage string
+        """
+        self.implementation.set_usage(usage)
+
+    @property
+    def Addons(self) -> List[Str]:
+        """Addons for system subscription purposes."""
+        return self.implementation.addons
+
+    @emits_properties_changed
+    def SetAddons(self, addons: List[Str]):
+        """Set the intended addons (additional layered products and features).
+
+        This setting is optional.
+
+        :param addons: a list of strings, one per layered product/feature
+        :type addons: list of strings
+        """
+        self.implementation.set_addons(addons)
+
+    @property
+    def IsSystemPurposeSet(self) -> Bool:
+        """Report if at least one system purpose value is set.
+
+        This is basically a shortcut so that the DBUS API users don't
+        have to query Role, Sla, Usage & Addons every time they want
+        to check if at least one system purpose value is set.
+        """
+        return self.implementation.is_system_purpose_set
+
+    def SetSystemPurposeWithTask(self, sysroot: Str) -> ObjPath:
+        """Set system purpose for the installed system with an installation task.
+
+        FIXME: This is just a temporary method.
+
+        :return: a DBus path of an installation task
+        """
+        return self.implementation.set_system_purpose_with_task(sysroot)

--- a/pyanaconda/modules/subscription/system_purpose.py
+++ b/pyanaconda/modules/subscription/system_purpose.py
@@ -1,0 +1,136 @@
+#
+# System purpose module.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import os
+import json
+
+from pyanaconda.core import util
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+VALID_FIELDS_FILE_PATH = "/etc/rhsm/syspurpose/valid_fields.json"
+
+def get_valid_fields(valid_fields_file_path=VALID_FIELDS_FILE_PATH):
+    """Get valid role, sla and usage fields for system purpose use.
+
+    If no valid fields are provided, the fields file is not found or can not be
+    parsed then all three lists will be empty.
+
+    :param str valid_fields_file_path: path to a JSON file holding the valid field listings
+
+    :return: role, sla and usage type lists
+    :rtype: [roles], [slas], [usages]
+    """
+    valid_roles = []
+    valid_slas = []
+    valid_usage_types = []
+    if os.path.exists(valid_fields_file_path):
+        try:
+            with open(valid_fields_file_path, "rt") as f:
+                valid_fields_json = json.load(f)
+                valid_roles = valid_fields_json.get("role", [])
+                valid_slas = valid_fields_json.get("service_level_agreement", [])
+                valid_usage_types = valid_fields_json.get("usage", [])
+        except (IOError, json.JSONDecodeError):
+            log.exception("parsing of syspurpose valid fields file at %s failed", valid_fields_file_path)
+    else:
+        log.warning("system purpose valid fields file not found at %s", valid_fields_file_path)
+    return valid_roles, valid_slas, valid_usage_types
+
+
+def normalize_field(raw_field):
+    """Normalize a field for matching.
+
+    Fields specified in free form by users can have different case or trailing white space,
+    while still technically being a match on a valid field.
+
+    So convert the field to lower case and strip any trailing white space and return the result.
+
+    :param str raw_field: raw not normalized field
+    :return: normalized field suitable for matching
+    :rtype: str
+    """
+    return raw_field.strip().lower()
+
+
+def match_field(raw_field, valid_fields):
+    """Try to match the field on an item in a list of fields.
+
+    If a match is found return the first matching item from the list.
+
+    :param raw_field str: field to match
+    :param list valid_fields: list of valid fields to match against
+    """
+    matching_valid_field = None
+    normalized_field = normalize_field(raw_field)
+
+    for valid_field in valid_fields:
+        if normalized_field == normalize_field(valid_field):
+            # looks like the fields match, no need to search
+            # any further
+            matching_valid_field = valid_field
+            break
+
+    return matching_valid_field
+
+def give_the_system_purpose(sysroot, role, sla, usage, addons):
+    """Set system purpose for the installed system by calling the syspurpose tool.
+
+    The tool is called in the installed system chroot, so this method can be only
+    called once the system rootfs content is in place.
+
+    :param role: role of the system
+    :type role: str or None
+    :param sla: Service Level Agreement for the system
+    :type sla: str or None
+    :param usage: intended usage of the system
+    :type usage: str or None
+    :param list addons: any additional layered products or features
+    """
+    if role or sla or usage or addons:
+        syspurpose_sysroot_path = os.path.join(sysroot, "usr/sbin/syspurpose")
+        if os.path.exists(syspurpose_sysroot_path):
+            # The syspurpose utility can only set one value at a time,
+            # so we might need to call it multiple times to set all the
+            # requested values.
+            #
+            # Also as the values can contain white space ween need to make sure the
+            # values passed to arguments are all properly quoted.
+            if role:
+                args = ["set-role", '"{}"'.format(role)]
+                util.execInSysroot("syspurpose", args)
+
+            if sla:
+                args = ["set-sla", '"{}"'.format(sla)]
+                util.execInSysroot("syspurpose", args)
+
+            if usage:
+                args = ["set-usage", '"{}"'.format(usage)]
+                util.execInSysroot("syspurpose", args)
+
+            if addons:
+                args = ["add", '"addons"']
+                for addon in addons:
+                    args.append('"{}"'.format(addon))
+                util.execInSysroot("syspurpose", args)
+        else:
+            log.error("the syspurpose tool is missing, cannot set system purpose")
+    else:
+        log.warning("not calling syspurpose as no fields have been provided")

--- a/pyanaconda/ui/gui/spokes/system_purpose.glade
+++ b/pyanaconda/ui/gui/spokes/system_purpose.glade
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <requires lib="AnacondaWidgets" version="1.0"/>
+  <object class="AnacondaSpokeWindow" id="system_purpose_window">
+    <property name="can_focus">False</property>
+    <property name="window_name" translatable="yes">SYSTEM PURPOSE</property>
+    <signal name="button-clicked" handler="on_back_clicked" swapped="no"/>
+    <child internal-child="main_box">
+      <object class="GtkBox" id="AnacondaSpokeWindow-main_box1">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+        <child internal-child="nav_box">
+          <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
+            <property name="can_focus">False</property>
+            <child internal-child="nav_area">
+              <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">
+                <property name="can_focus">False</property>
+                <property name="margin_left">6</property>
+                <property name="margin_right">6</property>
+                <property name="margin_top">6</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child internal-child="alignment">
+          <object class="GtkAlignment" id="AnacondaSpokeWindow-alignment1">
+            <property name="can_focus">False</property>
+            <property name="yalign">0</property>
+            <property name="top_padding">12</property>
+            <property name="bottom_padding">48</property>
+            <property name="left_padding">48</property>
+            <property name="right_padding">48</property>
+            <child internal-child="action_area">
+              <object class="GtkBox" id="AnacondaSpokeWindow-action_area1">
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkGrid" id="main_grid">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkGrid" id="content_grid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="column_spacing">48</property>
+                        <property name="column_homogeneous">True</property>
+                        <child>
+                          <object class="GtkGrid" id="right_grid">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="vexpand">True</property>
+                            <child>
+                              <object class="GtkScrolledWindow" id="sla_scrolled_window">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="hexpand">True</property>
+                                <property name="vexpand">True</property>
+                                <property name="hscrollbar_policy">never</property>
+                                <property name="shadow_type">in</property>
+                                <child>
+                                  <object class="GtkViewport" id="sla_viewport">
+                                    <property name="width_request">250</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <child>
+                                      <object class="GtkListBox" id="sla_list_box">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="hexpand">True</property>
+                                        <signal name="row-activated" handler="on_row_activated" swapped="no"/>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="sla_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="margin_bottom">6</property>
+                                <property name="hexpand">True</property>
+                                <property name="ypad">8</property>
+                                <property name="label" translatable="yes">Red Hat Service Level Agreement</property>
+                                <property name="xalign">0</property>
+                                <attributes>
+                                  <attribute name="font-desc" value="Cantarell 12"/>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="usage_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="margin_top">8</property>
+                                <property name="margin_bottom">6</property>
+                                <property name="hexpand">True</property>
+                                <property name="ypad">8</property>
+                                <property name="label" translatable="yes">Usage</property>
+                                <property name="xalign">0</property>
+                                <attributes>
+                                  <attribute name="font-desc" value="Cantarell 12"/>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkScrolledWindow" id="usage_scrolled_window">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="hexpand">True</property>
+                                <property name="vexpand">True</property>
+                                <property name="hscrollbar_policy">never</property>
+                                <property name="shadow_type">in</property>
+                                <child>
+                                  <object class="GtkViewport" id="usage_viewport">
+                                    <property name="width_request">250</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <child>
+                                      <object class="GtkListBox" id="usage_list_box">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="hexpand">True</property>
+                                        <signal name="row-activated" handler="on_row_activated" swapped="no"/>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">3</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkGrid">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkLabel" id="role_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="margin_bottom">6</property>
+                                <property name="hexpand">True</property>
+                                <property name="ypad">8</property>
+                                <property name="label" translatable="yes">Role</property>
+                                <property name="xalign">0</property>
+                                <attributes>
+                                  <attribute name="font-desc" value="Cantarell 12"/>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkScrolledWindow" id="role_scrolled_window">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="events">GDK_STRUCTURE_MASK | GDK_SCROLL_MASK</property>
+                                <property name="hexpand">True</property>
+                                <property name="vexpand">True</property>
+                                <property name="hscrollbar_policy">never</property>
+                                <property name="shadow_type">in</property>
+                                <child>
+                                  <object class="GtkViewport" id="role_viewport">
+                                    <property name="width_request">250</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <child>
+                                      <object class="GtkListBox" id="role_list_box">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="vexpand">True</property>
+                                        <signal name="row-activated" handler="on_row_activated" swapped="no"/>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="explanation_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="hexpand">True</property>
+                        <property name="ypad">16</property>
+                        <property name="label" translatable="yes">How will you use this system? All fields are optional, and changes can be made after installation.</property>
+                        <property name="use_markup">True</property>
+                        <property name="wrap">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child internal-child="accessible">
+      <object class="AtkObject" id="system_purpose_window-atkobject">
+        <property name="AtkObject::accessible-name" translatable="yes">SYSTEM PURPOSE</property>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/pyanaconda/ui/gui/spokes/system_purpose.py
+++ b/pyanaconda/ui/gui/spokes/system_purpose.py
@@ -1,0 +1,262 @@
+# system purpose spoke class
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import gi
+gi.require_version("Gtk", "3.0")
+gi.require_version("Pango", "1.0")
+
+from gi.repository import Gtk, Pango
+
+from pyanaconda.flags import flags
+from pyanaconda.core.i18n import _, CN_
+from pyanaconda.core import constants
+from pyanaconda.modules.common.constants.services import SUBSCRIPTION
+
+from pyanaconda.ui.gui.spokes import NormalSpoke
+from pyanaconda.ui.gui.utils import escape_markup
+from pyanaconda.ui.categories.system import SystemCategory
+from pyanaconda.ui.communication import hubQ
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+__all__ = ["SystemPurposeSpoke"]
+
+
+class SystemPurposeSpoke(NormalSpoke):
+    """
+       .. inheritance-diagram:: SystemPurposeSpoke
+          :parts: 3
+    """
+    builderObjects = ["system_purpose_window"]
+
+    mainWidgetName = "system_purpose_window"
+    uiFile = "spokes/system_purpose.glade"
+    helpFile = "SystemPurposeSpoke.xml"
+
+    category = SystemCategory
+
+    icon = "dialog-question-symbolic"
+    title = CN_("GUI|Spoke", "_System Purpose")
+
+    def __init__(self, *args):
+        NormalSpoke.__init__(self, *args)
+
+        # connect to the subscription DBUS module API
+        self._subscription_module = SUBSCRIPTION.get_observer()
+        self._subscription_module.connect()
+
+        # record if the spoke has been visited by the user at least once
+        self._spoke_visited = False
+
+        # Add three invisible radio buttons so that we can show list boxes
+        # with no radio buttons ticked
+        self._fakeRoleButton = Gtk.RadioButton(group=None)
+        self._fakeRoleButton.set_active(True)
+        self._fakeSLAButton = Gtk.RadioButton(group=None)
+        self._fakeSLAButton.set_active(True)
+        self._fakeUsageButton = Gtk.RadioButton(group=None)
+        self._fakeUsageButton.set_active(True)
+
+    def initialize(self):
+        NormalSpoke.initialize(self)
+        self.initialize_start()
+        # get object references from the builders
+        self._role_list_box = self.builder.get_object("role_list_box")
+        self._sla_list_box = self.builder.get_object("sla_list_box")
+        self._usage_list_box = self.builder.get_object("usage_list_box")
+
+        # Connect viewport scrolling with listbox focus events
+        role_viewport = self.builder.get_object("role_viewport")
+        sla_viewport = self.builder.get_object("sla_viewport")
+        usage_viewport = self.builder.get_object("usage_viewport")
+        self._role_list_box.set_focus_vadjustment(Gtk.Scrollable.get_vadjustment(role_viewport))
+        self._sla_list_box.set_focus_vadjustment(Gtk.Scrollable.get_vadjustment(sla_viewport))
+        self._usage_list_box.set_focus_vadjustment(Gtk.Scrollable.get_vadjustment(usage_viewport))
+
+        # set list view states state based on valid system purpose fields and values from kickstart (if any)
+
+        # role
+        self._fill_listbox(self._role_list_box,
+                           self._fakeRoleButton,
+                           self.on_role_toggled,
+                           self._subscription_module.proxy.Role,
+                           self._subscription_module.proxy.ValidRoles)
+        # SLA
+        self._fill_listbox(self._sla_list_box,
+                           self._fakeSLAButton,
+                           self.on_sla_toggled,
+                           self._subscription_module.proxy.SLA,
+                           self._subscription_module.proxy.ValidSLAs)
+        # usage
+        self._fill_listbox(self._usage_list_box,
+                           self._fakeUsageButton,
+                           self.on_usage_toggled,
+                           self._subscription_module.proxy.Usage,
+                           self._subscription_module.proxy.ValidUsageTypes)
+
+        # Send ready signal to main event loop
+        hubQ.send_ready(self.__class__.__name__, False)
+
+        # report that we are done
+        self.initialize_done()
+
+    def _fill_listbox(self, listbox, radio_button_group, clicked_callback, user_provided_value, valid_values):
+        """Fill the given list box with data based on current value & valid values.
+
+        Please note that it is possible that the list box will be empty if no
+        list of valid values are available and the user has not supplied any value
+        via kickstart or the DBUS API.
+
+        :param listbox: the listbox to fill
+        :param radio_button_group: radio button group for the list box
+        :param callable clicked_callback: called when a radio button in the list box is clicked
+        :param user_provided_value: the value provided by the user (if any)
+        :type user_provided_value: str or None
+        :param list valid_values: list of known valid values
+        """
+        preselected_value_list = self._handle_user_provided_value(user_provided_value,
+                                                                  valid_values)
+
+        for value, display_string, preselected in preselected_value_list:
+            radio_button = Gtk.RadioButton(group=radio_button_group)
+            radio_button.set_active(preselected)
+            self._add_row(listbox, value, display_string, radio_button, clicked_callback)
+
+    def _add_row(self, listbox, original_value, name, button, clicked_callback):
+        """Add a row to a listbox on the system purpose screen."""
+        row = Gtk.ListBoxRow()
+        # attach custom original value to the row
+        # - that way we can access the original value corresponding to
+        #   the display value when the row is clicked
+        row.original_value = original_value
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+
+        button.set_valign(Gtk.Align.CENTER)
+        button.set_margin_start(6)
+        button.connect("toggled", clicked_callback, row)
+        box.add(button)
+
+        label = Gtk.Label(label='<span size="large">{}</span>'.format(escape_markup(name)),
+                          use_markup=True, wrap=True, wrap_mode=Pango.WrapMode.WORD_CHAR,
+                          hexpand=True, xalign=0, yalign=0.5)
+        label.set_margin_top(8)
+        label.set_margin_bottom(8)
+        box.add(label)
+
+        row.add(box)
+        listbox.insert(row, -1)
+
+    def _handle_user_provided_value(self, user_provided_value, valid_values):
+        """Handle user provided value (if any) based on list of valid values.
+
+        There are three possible outcomes:
+        - the value matches one of the valid values, so we preselect the valid value
+        - the value does not match a valid value, so we append a custom value
+          to the list and preselect it
+        - the user provided value is not available (empty string), no matching will be done
+          and no value will be preselected
+
+        :param str user_provided_value: a value provided by user
+        :param list valid_values: a list of valid values
+        :returns: list of values with one value preselected
+        :rtype: list of (str, str, bool) tuples in (<value>, <display string>, <is_preselected>) format
+        """
+        preselected_value_list = []
+        value_matched = False
+        for valid_value in valid_values:
+            preselect = False
+            if user_provided_value and not value_matched:
+                if user_provided_value == valid_value:
+                    preselect = True
+                    value_matched = True
+            preselected_value_list.append((valid_value, valid_value, preselect))
+        # check if the user provided value matched a valid value
+        if user_provided_value and not value_matched:
+            # user provided value did not match any valid value,
+            # add it as a custom value to the list and preselect it
+            other_value_string = _("Other ({})").format(user_provided_value)
+            preselected_value_list.append((user_provided_value, other_value_string, True))
+        return preselected_value_list
+
+    # Signal handlers
+    def on_row_activated(self, listbox, row):
+        """Activated if any row is clicked.
+
+        Make sure to activate the corresponding radio button on the row that was clicked.
+        """
+        box = row.get_children()[0]
+        button = box.get_children()[0]
+        button.set_active(True)
+
+    def on_role_toggled(self, radio, row):
+        # If the radio button toggled to inactive, don't reactivate the row
+        if radio.get_active():
+            self._subscription_module.proxy.SetRole(row.original_value)
+            row.activate()
+
+    def on_sla_toggled(self, radio, row):
+        # If the radio button toggled to inactive, don't reactivate the row
+        if radio.get_active():
+            self._subscription_module.proxy.SetSLA(row.original_value)
+            row.activate()
+
+    def on_usage_toggled(self, radio, row):
+        # If the radio button toggled to inactive, don't reactivate the row
+        if radio.get_active():
+            self._subscription_module.proxy.SetUsage(row.original_value)
+            row.activate()
+
+    def refresh(self):
+        # we can now consider the spoke as visited
+        self._spoke_visited = True
+
+    @property
+    def system_purpose_set(self):
+        """Was something in the spoke set via kickstart or by the user ?"""
+        return self._subscription_module.proxy.IsSystemPurposeSet
+
+    @property
+    def status(self):
+        if self.system_purpose_set:
+            return _("System purpose has been set.")
+        else:
+            if self._spoke_visited:
+                # visited but nothing selected
+                return _("No purpose declared.")
+            else:
+                # not yet visited & nothing in kickstart
+                return _("None selected.")
+
+    @property
+    def mandatory(self):
+        return False
+
+    def apply(self):
+        # Send ready signal to main event loop
+        hubQ.send_ready(self.__class__.__name__, False)
+
+    @property
+    def completed(self):
+        # the system purpose spoke is not mandatory & even default values are considered valid
+        return True
+
+    @property
+    def sensitive(self):
+        # the system purpose spoke should be always accessible
+        return True

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
@@ -1,0 +1,166 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
+import unittest
+from unittest.mock import Mock, patch
+
+from pyanaconda.modules.common.constants.services import SUBSCRIPTION
+from pyanaconda.modules.subscription.subscription import SubscriptionInterface, SubscriptionModule
+from tests.nosetests.pyanaconda_tests import check_kickstart_interface, check_dbus_property
+
+
+class SubscriptionInterfaceTestCase(unittest.TestCase):
+    """Test DBus interface for the subscription module."""
+
+    def setUp(self):
+        """Set up the subscription module."""
+        self.subscription_module = SubscriptionModule()
+        self.subscription_interface = SubscriptionInterface(self.subscription_module)
+
+        # Connect to the properties changed signal.
+        self.callback = Mock()
+        self.subscription_interface.PropertiesChanged.connect(self.callback)
+
+    def kickstart_properties_test(self):
+        """Test kickstart properties."""
+        self.assertEqual(self.subscription_interface.KickstartCommands, ["syspurpose"])
+        self.assertEqual(self.subscription_interface.KickstartSections, [])
+        self.assertEqual(self.subscription_interface.KickstartAddons, [])
+        self.callback.assert_not_called()
+
+    def default_property_values_test(self):
+        """Test the default subscription module values are as expected."""
+        self.assertEqual(self.subscription_interface.Role, None)
+        self.assertEqual(self.subscription_interface.SLA, None)
+        self.assertEqual(self.subscription_interface.Usage, None)
+        self.assertEqual(self.subscription_interface.Addons, [])
+        # check the lists of valid values look reasonably sane:
+        # - they are either an empty list
+        # - or they contain a non zero amount of items
+        valid_roles = self.subscription_interface.ValidRoles
+        valid_slas = self.subscription_interface.ValidSLAs
+        valid_usage_types = self.subscription_interface.ValidUsageTypes
+        self.assertTrue(len(valid_roles) > 0 or valid_roles == [])
+        self.assertTrue(len(valid_slas) > 0 or valid_slas == [])
+        self.assertTrue(len(valid_usage_types) > 0 or valid_usage_types == [])
+
+    def set_role_test(self):
+        """Test if setting role from DBUS works correctly."""
+        self.subscription_interface.SetRole("FOO ROLE")
+        self.assertEqual(self.subscription_interface.Role, "FOO ROLE")
+        self.callback.assert_called_once_with(SUBSCRIPTION.interface_name, {'Role': 'FOO ROLE'}, [])
+
+    def set_sla_test(self):
+        """Test if setting SLA from DBUS works correctly."""
+        self.subscription_interface.SetSLA("BAR SLA")
+        self.assertEqual(self.subscription_interface.SLA, "BAR SLA")
+        self.callback.assert_called_once_with(SUBSCRIPTION.interface_name, {'SLA': 'BAR SLA'}, [])
+
+    def set_usage_test(self):
+        """Test if setting usage from DBUS works correctly."""
+        self.subscription_interface.SetUsage("BAZ USAGE")
+        self.callback.assert_called_once_with(SUBSCRIPTION.interface_name, {'Usage': 'BAZ USAGE'}, [])
+        self.assertEqual(self.subscription_interface.Usage, "BAZ USAGE")
+
+    def set_addons_test(self):
+        """Test if setting addons from DBUS works correctly."""
+        self.subscription_interface.SetAddons(["foo product", "bar feature"])
+        self.callback.assert_called_once_with(SUBSCRIPTION.interface_name, {'Addons': ["foo product", "bar feature"]}, [])
+        self.assertEqual(self.subscription_interface.Addons, ["foo product", "bar feature"])
+
+    def ks_set_role_test(self):
+        """Test if setting role from kickstart works correctly."""
+        self.subscription_interface.ReadKickstart('syspurpose --role="ROLE FOO"')
+        self.assertEqual(self.subscription_interface.Role, 'ROLE FOO')
+
+    def ks_set_sla_test(self):
+        """Test if setting SLA from kickstart works correctly."""
+        self.subscription_interface.ReadKickstart('syspurpose --sla="SLA BAR"')
+        self.assertEqual(self.subscription_interface.SLA, 'SLA BAR')
+
+    def ks_set_usage_test(self):
+        """Test if setting usage from kickstart works correctly."""
+        self.subscription_interface.ReadKickstart('syspurpose --usage="USAGE BAZ"')
+        self.assertEqual(self.subscription_interface.Usage, 'USAGE BAZ')
+
+    def ks_set_addons_test(self):
+        """Test if setting addons from kickstart works correctly."""
+        self.subscription_interface.ReadKickstart('syspurpose --addon="Foo Product" --addon="Bar Feature"')
+        self.assertEqual(self.subscription_interface.Addons, ["Foo Product", "Bar Feature"])
+
+    def ks_set_all_test(self):
+        """Test if setting all options from kickstart works correctly."""
+        self.subscription_interface.ReadKickstart('syspurpose --role="FOO" --sla="BAR" --usage="BAZ" --addon="Foo Product" --addon="Bar Feature"')
+        self.assertEqual(self.subscription_interface.Role, 'FOO')
+        self.assertEqual(self.subscription_interface.SLA, 'BAR')
+        self.assertEqual(self.subscription_interface.Usage, 'BAZ')
+        self.assertEqual(self.subscription_interface.Addons, ["Foo Product", "Bar Feature"])
+
+    def ks_set_nothing_test(self):
+        """Test what happens if just the syspurpose command is used."""
+        self.subscription_interface.ReadKickstart('syspurpose')
+        self.assertEqual(self.subscription_interface.Role, None)
+        self.assertEqual(self.subscription_interface.SLA, None)
+        self.assertEqual(self.subscription_interface.Usage, None)
+        self.assertEqual(self.subscription_interface.Addons, [])
+
+    def _test_kickstart(self, ks_in, ks_out):
+        check_kickstart_interface(self, self.subscription_interface, ks_in, ks_out)
+
+    def ks_out_no_kickstart_test(self):
+        """Test with no kickstart."""
+        ks_in = None
+        ks_out = ""
+        self._test_kickstart(ks_in, ks_out)
+
+    def ks_out_command_only_test(self):
+        """Test with only syspurpose command being used."""
+        ks_in = "syspurpose"
+        ks_out = ""
+        self._test_kickstart(ks_in, ks_out)
+
+    def ks_out_set_role_test(self):
+        """Check kickstart with role being used."""
+        ks_in = 'syspurpose --role="FOO ROLE"'
+        ks_out = '# Intended system purpose\nsyspurpose --role="FOO ROLE"'
+        self._test_kickstart(ks_in, ks_out)
+
+    def ks_out_set_sla_test(self):
+        """Check kickstart with SLA being used."""
+        ks_in = 'syspurpose --sla="FOO SLA"'
+        ks_out = '# Intended system purpose\nsyspurpose --sla="FOO SLA"'
+        self._test_kickstart(ks_in, ks_out)
+
+    def ks_out_set_usage_test(self):
+        """Check kickstart with usage being used."""
+        ks_in = 'syspurpose --usage="FOO USAGE"'
+        ks_out = '# Intended system purpose\nsyspurpose --usage="FOO USAGE"'
+        self._test_kickstart(ks_in, ks_out)
+
+    def ks_out_set_addons_test(self):
+        """Check kickstart with addons being used."""
+        ks_in = 'syspurpose --addon="Foo Product" --addon="Bar Feature"'
+        ks_out = '# Intended system purpose\nsyspurpose --addon="Foo Product" --addon="Bar Feature"'
+        self._test_kickstart(ks_in, ks_out)
+
+    def ks_out_set_all_usage_test(self):
+        """Check kickstart with all options being used."""
+        ks_in = 'syspurpose --role="FOO" --sla="BAR" --usage="BAZ" --addon="Foo Product" --addon="Bar Feature"'
+        ks_out = '# Intended system purpose\nsyspurpose --role="FOO" --sla="BAR" --usage="BAZ" --addon="Foo Product" --addon="Bar Feature"'
+        self._test_kickstart(ks_in, ks_out)

--- a/tests/nosetests/pyanaconda_tests/system_purpose_test.py
+++ b/tests/nosetests/pyanaconda_tests/system_purpose_test.py
@@ -1,0 +1,91 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+
+import unittest
+import tempfile
+import os
+
+from pyanaconda.modules.subscription import system_purpose
+
+VALID_FIELDS_FILE_NAME = "valid_fields.json"
+VALID_FIELDS_JSON = """
+{
+    "role": [
+      "AAA Desktop",
+      "BBB Server",
+      "CCC workstation",
+      "DDD super hypernode"
+    ],
+    "service_level_agreement": [
+      "Hyper",
+      "Super",
+      "Reasonable Effort"
+    ],
+    "usage": [
+      "Safe",
+      "Cookie Factory",
+      "Apocalypse Recovery"
+    ]
+}"""
+
+class SystemPurposeTests(unittest.TestCase):
+
+    def get_valid_fields_test(self):
+        """Test parsing of the valid_fields.json file."""
+        # try to open file that does not exist
+        with tempfile.TemporaryDirectory() as tempdir_path:
+            no_file_path = os.path.join(tempdir_path, VALID_FIELDS_FILE_NAME)
+            # the result should be three empty lists
+            role, sla, usage = system_purpose.get_valid_fields(valid_fields_file_path=no_file_path)
+            self.assertListEqual([role, sla, usage], [[],[],[]])
+
+        # try to parse a valid valid fields file
+        with tempfile.NamedTemporaryFile(mode="w+t") as valid_fields_json:
+            valid_fields_json.write(VALID_FIELDS_JSON)
+            valid_fields_json.flush()
+            role, sla, usage = system_purpose.get_valid_fields(valid_fields_file_path=valid_fields_json.name)
+            self.assertListEqual(role, ["AAA Desktop", "BBB Server", "CCC workstation", "DDD super hypernode"])
+            self.assertListEqual(sla, ["Hyper", "Super", "Reasonable Effort"])
+            self.assertListEqual(usage, ["Safe", "Cookie Factory", "Apocalypse Recovery"])
+
+    def normalize_field_test(self):
+        """Test system purpose field normalization."""
+        self.assertEqual(system_purpose.normalize_field("aaa"), "aaa")
+        self.assertEqual(system_purpose.normalize_field("AAA"), "aaa")
+        self.assertEqual(system_purpose.normalize_field(" AAA "), "aaa")
+        self.assertEqual(system_purpose.normalize_field(" AAA BBB "), "aaa bbb")
+        self.assertEqual(system_purpose.normalize_field(" AbC deF "), "abc def")
+
+    def match_field_test(self):
+        """Test system purpose field matching works as expected."""
+        # should not match
+        self.assertIsNone(system_purpose.match_field("A", ["B"]))
+        self.assertIsNone(system_purpose.match_field("A-B", ["A B"]))
+        self.assertIsNone(system_purpose.match_field("A_B", ["A B"]))
+        self.assertIsNone(system_purpose.match_field("A_B", ["A-B"]))
+        # should match
+        self.assertEqual(system_purpose.match_field("a", ["a"]), "a")
+        self.assertEqual(system_purpose.match_field("A", ["a"]), "a")
+        self.assertEqual(system_purpose.match_field("a", ["A"]), "A")
+        self.assertEqual(system_purpose.match_field(" a ", ["A"]), "A")
+        self.assertEqual(system_purpose.match_field("a", [" A "]), " A ")
+        self.assertEqual(system_purpose.match_field("a B cd ", ["A b CD"]), "A b CD")
+        # match from multiple options
+        self.assertEqual(system_purpose.match_field("A", ["B", "c", "def", "A"]), "A")
+        self.assertEqual(system_purpose.match_field("A", ["B", "c", "def", "A", "z", "A"]), "A")
+        self.assertEqual(system_purpose.match_field("a", ["A", "A"]), "A")
+        self.assertEqual(system_purpose.match_field("foo BAR", ["foo Bar", "foo ar"]), "foo Bar")


### PR DESCRIPTION
The system purpose functionality is used to give hints to other tools about the
intended usage of the system.

Anaconda plays adds support for setting system purpose values via
kickstart & GUI and forwards them to the syspurpose tool which is
called inside the installed system chroot after the package installation
and configuration phase has been finished.

Also as with other kickstart/spoke combos in Anaconda, the values
in kickstart should reflect in the GUI if possible and kickstart
can thus be used to pre-select system purpose values in the GUI
if needed.

If a value from kickstart does not match to any of the valid values,
it will still be forwarded to the syspurpose tool and shown as
Other (<value>) in the GUI.

The system purpose support in Anaconda is considered fully optional,
so an installation can be completed without setting any system purpose
values in kickstart or GUI. In the same way Anaconda can tolerate
missing list of valid system purpose values and even no syspurpose utility
being available on the installed system.

Resolves: rhbz#1612060