### PR TITLE
docs/commit-log.rst: Don't wrap example firstlines

### DIFF
--- a/docs/commit-log.rst
+++ b/docs/commit-log.rst
@@ -12,7 +12,7 @@ following are rules to follow when committing a change to the git repo:
    summary line.  Lastly, the summary lines need to be short.  Ideally
    less than 75 characters, but certainly not longer than 80.
 
-   Here are acceptable first lines for git commit messages:
+   Here are acceptable first lines for git commit messages::
 
        Check partition and filesystem type on upgrade (#123456)
        Fix bootloader configuration setup on ppc64 (#987654)


### PR DESCRIPTION
The list of example commit first lines is given in an indented block. However, the preceding paragraph needs to end with two colons (::) for newlines to be preserved, otherwise the lines are wrapped together in the generated output (see https://rhinstaller.github.io/anaconda/commit-log.html).