### PR TITLE
Remove the testing flag

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -42,7 +42,6 @@ import requests
 from requests_file import FileAdapter
 from requests_ftp import FTPAdapter
 
-from pyanaconda.flags import flags
 from pyanaconda.core.process_watchers import WatchProcesses
 from pyanaconda.core.constants import DRACUT_SHUTDOWN_EJECT, TRANSLATIONS_UPDATE_DIR, \
                                       UNSUPPORTED_HW, IPMI_ABORTED, X_TIMEOUT
@@ -366,11 +365,6 @@ def execWithRedirect(command, argv, stdin=None, stdout=None,
         :param binary_output: whether to treat the output of command as binary data
         :return: The return code of the command
     """
-    if flags.testing:
-        log.info("not running command because we're testing: %s %s",
-                 command, " ".join(argv))
-        return 0
-
     argv = [command] + argv
     return _run_program(argv, stdin=stdin, stdout=stdout, root=root, env_prune=env_prune,
                         log_output=log_output, binary_output=binary_output)[0]
@@ -387,11 +381,6 @@ def execWithCapture(command, argv, stdin=None, root='/', log_output=True, filter
         :param filter_stderr: Whether stderr should be excluded from the returned output
         :return: The output of the command
     """
-    if flags.testing:
-        log.info("not running command because we're testing: %s %s",
-                 command, " ".join(argv))
-        return ""
-
     argv = [command] + argv
     return _run_program(argv, stdin=stdin, root=root, log_output=log_output,
                         filter_stderr=filter_stderr)[1]
@@ -409,11 +398,6 @@ def execWithCaptureBinary(command, argv, stdin=None, root='/', log_output=False,
         :param filter_stderr: Whether stderr should be excluded from the returned output
         :return: The output of the command
     """
-    if flags.testing:
-        log.info("not running command because we're testing: %s %s",
-                 command, " ".join(argv))
-        return ""
-
     argv = [command] + argv
     return _run_program(argv, stdin=stdin, root=root, log_output=log_output,
                         filter_stderr=filter_stderr, binary_output=True)[1]

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -66,7 +66,6 @@ class Flags(object):
         self.nombr = False
         self.gpt = False
         self.leavebootorder = False
-        self.testing = False
         self.mpathFriendlyNames = True
         # ksprompt is whether or not to prompt for missing ksdata
         self.ksprompt = True
@@ -223,10 +222,6 @@ def can_touch_runtime_system(msg, touch_live=False):
 
     if flags.dirInstall:
         log.info("Not doing '%s' in directory installation", msg)
-        return False
-
-    if flags.testing:
-        log.info("Not doing '%s', because we are just testing", msg)
         return False
 
     return True

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -1138,14 +1138,14 @@ class PackagePayload(Payload):
         # hd: umount INSTALL_TREE, install_device.teardown (ISO_DIR)
         # nfs: umount INSTALL_TREE
         # nfsiso: umount INSTALL_TREE, umount ISO_DIR
-        if os.path.ismount(INSTALL_TREE) and not flags.testing:
+        if os.path.ismount(INSTALL_TREE):
             if self.install_device and \
                blivet.util.get_mount_device(INSTALL_TREE) == self.install_device.path:
                 self.install_device.teardown(recursive=True)
             else:
                 blivet.util.umount(INSTALL_TREE)
 
-        if os.path.ismount(ISO_DIR) and not flags.testing:
+        if os.path.ismount(ISO_DIR):
             if self.install_device and \
                blivet.util.get_mount_device(ISO_DIR) == self.install_device.path:
                 self.install_device.teardown(recursive=True)

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -115,7 +115,6 @@ def update_blivet_flags(blivet_flags, anaconda_flags):  # pylint: disable=redefi
     :param anaconda_flags: anaconda flags
     :type anaconda_flags: :class:`pyanaconda.flags.Flags`
     """
-    blivet_flags.testing = anaconda_flags.testing
     blivet_flags.automated_install = anaconda_flags.automatedInstall
     blivet_flags.live_install = anaconda_flags.livecdInstall
     blivet_flags.image_install = anaconda_flags.imageInstall


### PR DESCRIPTION
The Anaconda testing flag can be removed, because we don't use it.
In unit tests, we use mocks and patches instead.