### PR TITLE
Use the default LUKS version for auto partitioning (#1624680)

### DIFF
--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -1199,7 +1199,7 @@ class InstallerStorage(Blivet):
         self._short_product_name = shortProductName
         self._default_luks_version = DEFAULT_LUKS_VERSION
 
-        self.autopart_luks_version = None
+        self._autopart_luks_version = None
         self.autopart_pbkdf_args = None
 
     def copy(self):
@@ -1358,6 +1358,21 @@ class InstallerStorage(Blivet):
         log.debug("trying to set new default luks version to '%s'", version)
         self._check_valid_luks_version(version)
         self._default_luks_version = version
+
+    @property
+    def autopart_luks_version(self):
+        """The autopart LUKS version."""
+        return self._autopart_luks_version or self._default_luks_version
+
+    @autopart_luks_version.setter
+    def autopart_luks_version(self, version):
+        """Set the autopart LUKS version.
+
+        :param version: a string with LUKS version
+        :raises: ValueError on invalid input
+        """
+        self._check_valid_luks_version(version)
+        self._autopart_luks_version = version
 
     def _check_valid_luks_version(self, version):
         get_format("luks", luks_version=version)


### PR DESCRIPTION
If the LUKS version for auto partitioning is not set, use the
default LUKS version instead.

Resolves: rhbz#1624680