### PR TITLE
DNF 3.5 compatibility

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -24,7 +24,7 @@ Source0: %{name}-%{version}.tar.bz2
 
 %define blivetguiver 2.1.7-2
 %define dbusver 1.2.3
-%define dnfver 3.2.0
+%define dnfver 3.5.0
 %define dracutver 034-7
 %define fcoeutilsver 1.0.12-3.20100323git
 %define gettextver 0.19.8


### PR DESCRIPTION
DNF 3.5 changes some of it's package & module installation interfaces
and we need to adjust Anaconda accordingly:

- the module-enable method was moved from Base to a separate module
- the install_specs() method now raises exceptions instead of returning
  a value if something is wrong
- the exception contains separate list of for missing missing or broken
  packages, groups or modules

Related: rhbz#1613296