### PR TITLE
rpmostreepayload: detect `/var` and `/var/` (#1626557)

### DIFF
--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -319,7 +319,8 @@ class RPMOSTreePayload(ArchivePayload):
         # to do the default ostree one.
         # https://github.com/ostreedev/ostree/issues/855
         varroot = '/ostree/deploy/' + ostreesetup.osname + '/var'
-        if storage.mountpoints.get("/var") is None:
+        if storage.mountpoints.get("/var") is None \
+           and storage.mountpoints.get("/var/") is None:
             self._setupInternalBindmount(varroot, dest='/var', recurse=False)
         else:
             # Otherwise, bind it


### PR DESCRIPTION
Handle if the user pases `/var/` in their kickstart instead of
`/var`.

Resolves: rhbz#1626557