### PR TITLE
Require python3-librepo explicitly

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -87,6 +87,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 Summary: Core of the Anaconda installer
 Requires: python3-libs
 Requires: python3-dnf >= %{dnfver}
+Requires: python3-librepo
 Requires: python3-blivet >= 1:3.1.0-1
 Requires: python3-blockdev >= %{libblockdevver}
 Requires: python3-meh >= %{mehver}


### PR DESCRIPTION
Anaconda imports the librepo module at runtime.  Previously this was transitively pulled in via dnf RPM dependencies.  However, as of dnf-3.4.0, dnf no longer requires python3-librepo itself.  This causes anaconda to traceback at runtime as the librepo python module is no longer present.

Add an explicit Requires for the python3-librepo package to fix this.