### PR TITLE
Remove librepo imports from Anaconda (#1626609)

### DIFF
--- a/data/post-scripts/99-copy-logs.ks
+++ b/data/post-scripts/99-copy-logs.ks
@@ -10,7 +10,7 @@ if [ -e ${NOSAVE_LOGS_FILE} ]; then
     rm -f ${NOSAVE_LOGS_FILE}
 else
     mkdir -p $ANA_INSTALL_PATH/var/log/anaconda
-    for log in anaconda.log syslog X.log program.log packaging.log storage.log ifcfg.log lvm.log dnf.librepo.log hawkey.log dbus.log; do
+    for log in anaconda.log syslog X.log program.log packaging.log storage.log ifcfg.log lvm.log hawkey.log dbus.log; do
         [ -e /tmp/$log ] && cp /tmp/$log $ANA_INSTALL_PATH/var/log/anaconda/
     done
     [ -e /tmp/pre-anaconda-logs ] && cp -r $PRE_ANA_LOGS $ANA_INSTALL_PATH/var/log/anaconda

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -262,7 +262,7 @@ class AnacondaExceptionHandler(ExceptionHandler):
 def initExceptionHandling(anaconda):
     file_list = ["/tmp/anaconda.log", "/tmp/packaging.log",
                  "/tmp/program.log", "/tmp/storage.log", "/tmp/ifcfg.log",
-                 "/tmp/dnf.librepo.log", "/tmp/hawkey.log",
+                 "/tmp/hawkey.log",
                  "/tmp/lvm.log", util.getSysroot() + "/root/install.log",
                  "/proc/cmdline", "/root/lorax-packages.log",
                  "/tmp/blivet-gui-utils.log", "/tmp/dbus.log"]

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -60,14 +60,12 @@ import dnf.transaction
 import libdnf.conf
 import dnf.conf.substitutions
 import rpm
-import librepo
 
 from dnf.const import GROUP_PACKAGE_TYPES
 
 DNF_CACHE_DIR = '/tmp/dnf.cache'
 DNF_PLUGINCONF_DIR = '/tmp/dnf.pluginconf'
 DNF_PACKAGE_CACHE_DIR_SUFFIX = 'dnf.package.cache'
-DNF_LIBREPO_LOG = '/tmp/dnf.librepo.log'
 DOWNLOAD_MPOINTS = {'/tmp',
                     '/',
                     '/var/tmp',
@@ -700,9 +698,6 @@ class DNFPayload(payload.PackagePayload):
         # 2. Installs aren't reproducible due to weak deps. failing silently.
         if self.data.packages.excludeWeakdeps:
             conf.install_weak_deps = False
-
-        # Setup librepo logging
-        librepo.log_set_file(DNF_LIBREPO_LOG)
 
         # Increase dnf log level to custom DDEBUG level
         # Do this here to prevent import side-effects in anaconda_logging


### PR DESCRIPTION
Anaconda used the librepo library to redirect logs to a proper place. New DNF 3.4.0/3.5.0 is not using librepo library so there is no need to have this in Anaconda.

Also this library wasn't mentioned in the Anaconda spec file so it nows breaks Anaconda.

*Resolves: rhbz#1626609*