### PR TITLE
Save lsblk output to the Anaconda traceback file

### DIFF
--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -298,7 +298,7 @@ def initExceptionHandling(anaconda):
                   localSkipList=["passphrase", "password", "_oldweak", "_password", "try_passphrase"],
                   fileList=file_list)
 
-    conf.register_callback("lsblk_output", lsblk_callback, attchmnt_only=True)
+    conf.register_callback("lsblk_output", lsblk_callback, attchmnt_only=False)
     conf.register_callback("nmcli_dev_list", nmcli_dev_list_callback,
                            attchmnt_only=True)
 


### PR DESCRIPTION
Currently the lsblk output is only attached to the reported bug
but it isn't saved to /tmp or the anaconda-tb file so it is
missing for manually reported bugs.
lsblk output is really useful for storage related bugs, so it
would be nice to have it always.

Resolves: rhbz#1627220