### PR TITLE
Don't connect to signals of the Network Manager DBus objects (#1582233)

### DIFF
--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -43,6 +43,9 @@ supported_device_types = [
     NM.DeviceType.TEAM,
 ]
 
+DEFAULT_PROXY_FLAGS = \
+    Gio.DBusProxyFlags.DO_NOT_CONNECT_SIGNALS | Gio.DBusProxyFlags.DO_NOT_LOAD_PROPERTIES
+
 class UnknownDeviceError(ValueError):
     """Device of specified name was not found by NM"""
     def __str__(self):
@@ -94,7 +97,7 @@ class BondOptionsError(AddConnectionError):
     pass
 
 def _get_proxy(bus_type=Gio.BusType.SYSTEM,
-               proxy_flags=Gio.DBusProxyFlags.NONE,
+               proxy_flags=DEFAULT_PROXY_FLAGS,
                info=None,
                name="org.freedesktop.NetworkManager",
                object_path="/org/freedesktop/NetworkManager",


### PR DESCRIPTION
Every proxy of DBus object provided by the Network Manager connects to
the signals and loads all properties. However, we don't use the signals
and we don't access the cached properties, so it is unnecessary.

It is also a workaround for the bug #1582233, because Anaconda can
freeze when these proxies tries to disconnect from the signals.

Resolves: rhbz#1582233