### PR TITLE
Fix librepo logging with new DNF

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -60,7 +60,6 @@ import dnf.transaction
 import libdnf.conf
 import dnf.conf.substitutions
 import rpm
-import librepo
 
 from dnf.const import GROUP_PACKAGE_TYPES
 
@@ -702,7 +701,8 @@ class DNFPayload(payload.PackagePayload):
             conf.install_weak_deps = False
 
         # Setup librepo logging
-        librepo.log_set_file(DNF_LIBREPO_LOG)
+        libdnf.repo.LibrepoLog.removeAllHandlers()
+        libdnf.repo.LibrepoLog.addHandler(DNF_LIBREPO_LOG)
 
         # Increase dnf log level to custom DDEBUG level
         # Do this here to prevent import side-effects in anaconda_logging


### PR DESCRIPTION
Librepo logging was setup by Anaconda using Python3 standard logging mechanism. In DNF 3.5.0 the librepo python bindings are not used anymore so the logging must be set by libdnf library instead.

*Resolves: rhbz#1626609*