### PR TITLE
Fix all cd-rom devices are ejected after the installation

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -94,10 +94,6 @@ def exitHandler(rebootData, storage, payload, exitCode=None):
             for cdrom in storage.devicetree.getDevicesByType("cdrom"):
                 if iutil.get_mount_paths(cdrom.path):
                     iutil.dracut_eject(cdrom.path)
-                else:
-                    # it's possible the cdrom is not mounted, e.g. if a user
-                    # boots from DVD, but does not install from it (#1499792)
-                    iutil.dracut_eject(cdrom.path)
 
         if flags.kexec:
             iutil.execWithRedirect("systemctl", ["--no-wall", "kexec"])


### PR DESCRIPTION
This reverts commit 720115d61e9e2c2ebc9afb4a10f2b591ad0dc1d7.

It looks like that this change is not required and it causing troubles that every CD-ROM is always ejected.

Resolves: rhbz#1618408