### PR TITLE
Flags shouldn't process the kernel options

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -446,6 +446,7 @@ if __name__ == "__main__":
     flags.eject = opts.eject
     flags.kexec = opts.kexec
     flags.singlelang = opts.singlelang
+    flags.gpt = opts.gpt
 
     if opts.liveinst:
         startup_utils.live_startup(anaconda)

--- a/anaconda.py
+++ b/anaconda.py
@@ -447,6 +447,7 @@ if __name__ == "__main__":
     flags.kexec = opts.kexec
     flags.singlelang = opts.singlelang
     flags.gpt = opts.gpt
+    flags.leavebootorder = opts.leavebootorder
 
     if opts.liveinst:
         startup_utils.live_startup(anaconda)

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -159,6 +159,9 @@ to install to a single path of a multipath is ill-advised, and not supported.
 mpath
 Enable multipath support during the installation (default)
 
+gpt
+Prefer creation of GPT disklabels.
+
 nodmraid
 Disable dmraid usage during the installation.
 

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -513,6 +513,8 @@ def getArgumentParser(version_string, boot_cmdline=None):
                     help=help_parser.help_text("nompath"))
     ap.add_argument("--mpath", action="store_true", help=help_parser.help_text("mpath"))
 
+    ap.add_argument("--gpt", action="store_true", default=False, help=help_parser.help_text("gpt"))
+
     ap.add_argument("--nodmraid", dest="dmraid", action="store_false", default=True,
                     help=help_parser.help_text("nodmraid"))
     ap.add_argument("--dmraid", action="store_true", help=help_parser.help_text("dmraid"))

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -18,6 +18,8 @@
 #
 
 import selinux
+
+from pykickstart.constants import SELINUX_DISABLED
 from pyanaconda.core.constants import SELINUX_DEFAULT, ANACONDA_ENVIRON
 from pyanaconda.core.kernel import KernelArguments
 
@@ -34,14 +36,7 @@ class Flags(object):
         else:
             self.__dict__[attr] = val
 
-    def get(self, attr, val=None):
-        return getattr(self, attr, val)
-
-    def set_cmdline_bool(self, flag):
-        if flag in self.cmdline:
-            setattr(self, flag, self.cmdline.getbool(flag))
-
-    def __init__(self, read_cmdline=True):
+    def __init__(self):
         self.__dict__['_in_init'] = True
         self.livecdInstall = False
         self.ibft = True
@@ -50,7 +45,12 @@ class Flags(object):
         self.vncquestion = True
         self.mpath = True
         self.dmraid = True
+
         self.selinux = SELINUX_DEFAULT
+
+        if not selinux.is_selinux_enabled():
+            self.selinux = SELINUX_DISABLED
+
         self.debug = False
         self.armPlatform = None
         self.preexisting_x11 = False
@@ -68,7 +68,6 @@ class Flags(object):
         # ksprompt is whether or not to prompt for missing ksdata
         self.ksprompt = True
         self.rescue_mode = False
-        self.noefi = False
         self.kexec = False
         # nosave options
         self.nosave_input_ks = False
@@ -84,16 +83,6 @@ class Flags(object):
         self.cmdline = KernelArguments.from_defaults()
         # Lock it down: no more creating new flags!
         self.__dict__['_in_init'] = False
-        if read_cmdline:
-            self.read_cmdline()
-
-    def read_cmdline(self):
-        for f in ("selinux", "debug", "leavebootorder", "testing", "extlinux",
-                  "nombr", "gpt", "noefi"):
-            self.set_cmdline_bool(f)
-
-        if not selinux.is_selinux_enabled():
-            self.selinux = 0
 
 
 def can_touch_runtime_system(msg, touch_live=False):


### PR DESCRIPTION
There is no reason why we should process the kernel options in the
flags, because these flags are later set with the Anaconda options
anyway. The kernel options are handled there.

Also, the flag `noefi` can be removed, because we don't use it and the
flag `leavebootorder` should be set from the Anaconda option.

The option `inst.gpt` should be fully supported now.