### PR TITLE
Remove the class for kernel arguments from pyanaconda.flags

### DIFF
--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -28,9 +28,8 @@ import struct
 
 from argparse import ArgumentParser, ArgumentError, HelpFormatter, Namespace, Action
 
-from pyanaconda.flags import BootArgs
 from pyanaconda.flags import flags as flags_instance
-
+from pyanaconda.core.kernel import KernelArguments
 from pyanaconda.core.constants import DisplayModes, X_TIMEOUT
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -161,10 +160,10 @@ class AnacondaArgumentParser(ArgumentParser):
         Parse the boot cmdline and create an appropriate Namespace instance
         according to the option definitions set by add_argument.
 
-        boot_cmdline can be given as a string (to be parsed by BootArgs), or a
+        boot_cmdline can be given as a string (to be parsed by KernelArguments), or a
         dict (or any object with .items()) of {bootarg:value} pairs.
 
-        If boot_cmdline is None, the boot_cmdline data will be whatever BootArgs reads
+        If boot_cmdline is None, the boot_cmdline data will be whatever KernelArguments reads
         by default (/proc/cmdline, /run/initramfs/etc/cmdline, /etc/cmdline).
 
         If an option requires a value but the boot arg doesn't provide one,
@@ -179,10 +178,14 @@ class AnacondaArgumentParser(ArgumentParser):
         :rtype: Namespace
         """
         namespace = Namespace()
-        if boot_cmdline is None or isinstance(boot_cmdline, str):
-            bootargs = BootArgs(boot_cmdline)
+
+        if boot_cmdline is None:
+            bootargs = KernelArguments.from_defaults()
+        elif isinstance(boot_cmdline, str):
+            bootargs = KernelArguments.from_string(boot_cmdline)
         else:
             bootargs = boot_cmdline
+
         self.deprecated_bootargs = []
         # go over all options corresponding to current boot cmdline
         # and do any modifications necessary
@@ -216,7 +219,7 @@ class AnacondaArgumentParser(ArgumentParser):
                 continue
             elif option.nargs in ("*", "?", "+"):
                 # store multiple values under one key
-                # parsing of these values to list is done in BootArgs object
+                # parsing of these values to list is done in KernelArguments object
                 if type(val) is list:
                     setattr(namespace, option.dest, val)
                     continue
@@ -366,7 +369,7 @@ def getArgumentParser(version_string, boot_cmdline=None):
     """Return the anaconda argument parser.
 
        :param str version_string: The version string, e.g. 23.19.5.
-       :param pyanaconda.flags.BootArgs: The boot command line options
+       :param KernelArguments boot_cmdline: The boot command line options
        :rtype: AnacondaArgumentParser
     """
 
@@ -376,7 +379,7 @@ def getArgumentParser(version_string, boot_cmdline=None):
     # checks the boot arguments for bootarg_prefix+option ('inst.repo').
     # If require_prefix is False, it also accepts the option without the
     # bootarg_prefix ('repo').
-    # See anaconda_optparse.py and BootArgs (in flags.py) for details.
+    # See anaconda_optparse.py and KernelArguments (in flags.py) for details.
     ap = AnacondaArgumentParser(bootarg_prefix="inst.", require_prefix=False)
     help_parser = HelpTextParser(os.path.join(datadir, "anaconda_options.txt"))
 

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -210,6 +210,13 @@ TAR_SUFFIX = (".tar", ".tbz", ".tgz", ".txz", ".tar.bz2", "tar.gz", "tar.xz")
 SCREENSHOTS_DIRECTORY = "/tmp/anaconda-screenshots"
 SCREENSHOTS_TARGET_DIRECTORY = "/root/anaconda-screenshots"
 
+CMDLINE_FILES = [
+    "/proc/cmdline",
+    "/run/install/cmdline",
+    "/run/install/cmdline.d/*.conf",
+    "/etc/cmdline"
+]
+
 # cmdline arguments that append instead of overwrite
 CMDLINE_APPEND = ["modprobe.blacklist", "ifname", "ip"]
 CMDLINE_LIST = ["addrepo"]

--- a/pyanaconda/core/kernel.py
+++ b/pyanaconda/core/kernel.py
@@ -1,0 +1,145 @@
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import shlex
+import glob
+
+from collections import OrderedDict
+from pyanaconda.core.constants import CMDLINE_APPEND, CMDLINE_LIST, CMDLINE_FILES
+
+
+class KernelArguments(OrderedDict):
+    """The kernel arguments.
+
+    Hold boot arguments as an OrderedDict.
+    """
+
+    @classmethod
+    def from_defaults(cls):
+        """Load the default files.
+
+        :return: an instance of KernelArguments
+        """
+        args = cls()
+        args.read(CMDLINE_FILES)
+        return args
+
+    @classmethod
+    def from_string(cls, cmdline):
+        """Load the given cmdline.
+
+        :param cmdline: a string with the kernel cmdline
+        :return: an instance of KernelArguments
+        """
+        args = cls()
+        args.read_string(cmdline)
+        return args
+
+    def read(self, filenames):
+        """Read and parse a file name (or a list of file names).
+
+        Files that can't be read are silently ignored. The names
+        can contain \\*, ?, and character ranges expressed with [].
+
+        :param filenames: a file name or a list of file names
+        :return: a list of successfully read files
+        """
+        readfiles = []
+        if isinstance(filenames, str):
+            filenames = [filenames]
+
+        # Expand any filename globs
+        filenames = [f for g in filenames for f in glob.glob(g)]
+
+        for f in filenames:
+            try:
+                self.read_string(open(f).read())
+                readfiles.append(f)
+            except IOError:
+                continue
+
+        return readfiles
+
+    def read_string(self, cmdline):
+        """Read and parse a string.
+
+        :param cmdline: a string with the kernel command line
+        """
+        cmdline = cmdline.strip()
+        # if the BOOT_IMAGE contains a space, pxelinux will strip one of the
+        # quotes leaving one at the end that shlex doesn't know what to do
+        # with
+        (left, middle, right) = cmdline.rpartition("BOOT_IMAGE=")
+        if right.count('"') % 2:
+            cmdline = left + middle + '"' + right
+
+        # shlex doesn't properly handle \\ (it removes them)
+        # which scrambles the spaces used in labels so use underscores
+        cmdline = cmdline.replace("\\x20", "_")
+
+        lst = shlex.split(cmdline)
+
+        # options might have the inst. prefix (used to differentiate
+        # boot options for the installer from other boot options)
+        inst_prefix = "inst."
+
+        for i in lst:
+            # drop the inst. prefix (if found), so that getbool() works
+            # consistently for both "foo=0" and "inst.foo=0"
+            if i.startswith(inst_prefix):
+                i = i[len(inst_prefix):]
+
+            if "=" in i:
+                (key, val) = i.split("=", 1)
+            else:
+                key = i
+                val = None
+
+            # Some duplicate args create a space separated string
+            if key in CMDLINE_APPEND and self.get(key, None):
+                if val:
+                    self[key] = self[key] + " " + val
+            # Some arguments can contain spaces so adding them in one string is not that helpful
+            elif key in CMDLINE_LIST:
+                if val:
+                    if not self.get(key, None):
+                        self[key] = []
+                    self[key].append(val)
+            else:
+                self[key] = val
+
+    def getbool(self, arg, default=False):
+        """Return the boolean value of the given argument.
+
+        The rules are:
+        - "arg", "arg=val": True
+        - "noarg", "noarg=val", "arg=[0|off|no]": False
+
+        :param arg: a name of the argument
+        :param default: a default value
+        :return: a boolean value of the argument
+        """
+        result = default
+        for a in self:
+            if a == arg:
+                if self[arg] in ("0", "off", "no"):
+                    result = False
+                else:
+                    result = True
+            elif a == 'no' + arg:
+                result = False  # XXX: should noarg=off -> True?
+        return result

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -18,14 +18,12 @@
 #
 
 import selinux
-import shlex
-import glob
-from pyanaconda.core.constants import SELINUX_DEFAULT, CMDLINE_APPEND, CMDLINE_LIST, \
-    ANACONDA_ENVIRON
-from collections import OrderedDict
+from pyanaconda.core.constants import SELINUX_DEFAULT, ANACONDA_ENVIRON
+from pyanaconda.core.kernel import KernelArguments
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
+
 
 # A lot of effort, but it only allows a limited set of flags to be referenced
 class Flags(object):
@@ -83,7 +81,7 @@ class Flags(object):
         # current runtime environments
         self.environs = [ANACONDA_ENVIRON]
         # parse the boot commandline
-        self.cmdline = BootArgs()
+        self.cmdline = KernelArguments.from_defaults()
         # Lock it down: no more creating new flags!
         self.__dict__['_in_init'] = False
         if read_cmdline:
@@ -97,108 +95,6 @@ class Flags(object):
         if not selinux.is_selinux_enabled():
             self.selinux = 0
 
-cmdline_files = ['/proc/cmdline', '/run/install/cmdline',
-                 '/run/install/cmdline.d/*.conf', '/etc/cmdline']
-class BootArgs(OrderedDict):
-    """
-    Hold boot arguments as an OrderedDict.
-    """
-    def __init__(self, cmdline=None, files=None):
-        """
-        Create a BootArgs object.
-        Reads each of the "files", then parses "cmdline" if it was provided.
-        """
-        super().__init__()
-        if files is None:
-            self.read(cmdline_files)
-        elif files:
-            self.read(files)
-        if cmdline:
-            self.readstr(cmdline)
-
-    def read(self, filenames):
-        """
-        Read and parse a filename (or a list of filenames).
-        Files that can't be read are silently ignored.
-        Returns a list of successfully read files.
-        filenames can contain \\*, ?, and character ranges expressed with []
-        """
-
-        readfiles = []
-        if isinstance(filenames, str):
-            filenames = [filenames]
-
-        # Expand any filename globs
-        filenames = [f for g in filenames for f in glob.glob(g)]
-
-        for f in filenames:
-            try:
-                self.readstr(open(f).read())
-                readfiles.append(f)
-            except IOError:
-                continue
-        return readfiles
-
-    def readstr(self, cmdline):
-        cmdline = cmdline.strip()
-        # if the BOOT_IMAGE contains a space, pxelinux will strip one of the
-        # quotes leaving one at the end that shlex doesn't know what to do
-        # with
-        (left, middle, right) = cmdline.rpartition("BOOT_IMAGE=")
-        if right.count('"') % 2:
-            cmdline = left + middle + '"' + right
-
-        # shlex doesn't properly handle \\ (it removes them)
-        # which scrambles the spaces used in labels so use underscores
-        cmdline = cmdline.replace("\\x20", "_")
-
-        lst = shlex.split(cmdline)
-
-        # options might have the inst. prefix (used to differentiate
-        # boot options for the installer from other boot options)
-        inst_prefix = "inst."
-
-        for i in lst:
-            # drop the inst. prefix (if found), so that getbool() works
-            # consistently for both "foo=0" and "inst.foo=0"
-            if i.startswith(inst_prefix):
-                i = i[len(inst_prefix):]
-
-            if "=" in i:
-                (key, val) = i.split("=", 1)
-            else:
-                key = i
-                val = None
-
-            # Some duplicate args create a space separated string
-            if key in CMDLINE_APPEND and self.get(key, None):
-                if val:
-                    self[key] = self[key] + " " + val
-            # Some arguments can contain spaces so adding them in one string is not that helpful
-            elif key in CMDLINE_LIST:
-                if val:
-                    if not self.get(key, None):
-                        self[key] = []
-                    self[key].append(val)
-            else:
-                self[key] = val
-
-    def getbool(self, arg, default=False):
-        """
-        Return the value of the given arg, as a boolean. The rules are:
-        - "arg", "arg=val": True
-        - "noarg", "noarg=val", "arg=[0|off|no]": False
-        """
-        result = default
-        for a in self:
-            if a == arg:
-                if self[arg] in ("0", "off", "no"):
-                    result = False
-                else:
-                    result = True
-            elif a == 'no' + arg:
-                result = False  # XXX: should noarg=off -> True?
-        return result
 
 def can_touch_runtime_system(msg, touch_live=False):
     """
@@ -225,5 +121,6 @@ def can_touch_runtime_system(msg, touch_live=False):
         return False
 
     return True
+
 
 flags = Flags()

--- a/tests/nosetests/pyanaconda_tests/argparse_test.py
+++ b/tests/nosetests/pyanaconda_tests/argparse_test.py
@@ -18,9 +18,10 @@
 #
 
 from pyanaconda import argument_parsing
-from pyanaconda.flags import BootArgs
+from pyanaconda.core.kernel import KernelArguments
 from pyanaconda.core.constants import DisplayModes
 import unittest
+
 
 class ArgparseTest(unittest.TestCase):
     def _parseCmdline(self, argv, version="", boot_cmdline=None):
@@ -50,7 +51,8 @@ class ArgparseTest(unittest.TestCase):
         self.assertFalse(opts.noninteractive)
 
         # console=whatever in the boot args defaults to --text
-        opts, _deprecated = self._parseCmdline([], boot_cmdline=BootArgs("console=/dev/ttyS0"))
+        boot_cmdline = KernelArguments.from_string("console=/dev/ttyS0")
+        opts, _deprecated = self._parseCmdline([], boot_cmdline=boot_cmdline)
         self.assertEqual(opts.display_mode, DisplayModes.TUI)
 
     def selinux_test(self):


### PR DESCRIPTION
Move the `BootArgs` class to `pyanaconda.core.kernel` and rename it
to `KernelArguments`. The `__init__` method is simplified and the logic
is replaced with methods `from_defaults` and `from_string`.