### PR TITLE
Configure GRUB and zipl to use the "BootLoaderSpec" boot option configuration format

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -434,6 +434,7 @@ if __name__ == "__main__":
     flags.noverifyssl = opts.noverifyssl
     flags.armPlatform = opts.armPlatform
     flags.extlinux = opts.extlinux
+    flags.blscfg = opts.blscfg
     flags.nombr = opts.nombr
     flags.mpathFriendlyNames = opts.mpathfriendlynames
     flags.debug = opts.debug

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -275,3 +275,6 @@ timeout in seconds specified as a mandatory value of the option.
 decorated
 Run GUI installer in a decorated window. By default, the window is not decorated, so it doesn't have a title bar,
 resize controls, etc.
+
+noblscfg
+Configure GRUB not to use the "BootLoader Spec" boot option configuration format.

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -673,6 +673,14 @@ the newly installed drive on Power Systems servers and EFI systems. This is
 useful for systems that, for example, should network boot first before falling
 back to a local boot.
 
+.. inst.noblscfg:
+
+inst.noblscfg
+^^^^^^^^^^^^^
+
+Disable the use of the "BootLoader Spec" boot option configuration format with
+GRUB.
+
 
 Storage options
 ---------------

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -520,6 +520,9 @@ def getArgumentParser(version_string, boot_cmdline=None):
     ap.add_argument("--nonibftiscsiboot", action="store_true", default=False,
                     help=help_parser.help_text("nonibftiscsiboot"))
 
+    ap.add_argument("--noblscfg", dest="blscfg", action="store_false", default=True,
+                    help=help_parser.help_text("nobls"))
+
     # Geolocation
     ap.add_argument("--geoloc", metavar="PROVIDER_ID", help=help_parser.help_text("geoloc"))
     ap.add_argument("--geoloc-use-with-ks", action="store_true", default=False,

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -24,7 +24,7 @@ import re
 import blivet
 from parted import PARTITION_BIOS_GRUB
 from glob import glob
-from itertools import chain
+from itertools import chain, zip_longest
 import crypt
 from ordered_set import OrderedSet
 
@@ -35,7 +35,7 @@ from pyanaconda.product import productName
 from pyanaconda.flags import flags, can_touch_runtime_system
 from blivet.fcoe import fcoe
 import pyanaconda.network
-from pyanaconda.errors import errorHandler, ERROR_RAISE, ZIPLError
+from pyanaconda.errors import errorHandler, ERROR_RAISE, ZIPLError, FirmwareCompatError
 from pyanaconda.nm import nm_device_hwaddress
 from pyanaconda import platform
 from blivet.size import Size
@@ -97,6 +97,35 @@ def _is_on_ibft(device):
     """Tells whether a given device is ibft disk or not."""
 
     return all(getattr(disk, "ibft", False) for disk in device.disks)
+
+def _get_petitboot_version():
+    """
+    get the version of the petitboot loader that OF expresses as:
+        v1.6.1-pd8c7a0a
+    in the form:
+        ('v1.6.1-pd8c7a0a', (1, 6, 1), 'pd8c7a0a')
+    """
+    path = "/sys/firmware/devicetree/base/ibm,firmware-versions/petitboot"
+    if not os.access(path, os.F_OK):
+        raise FileNotFoundError
+    for line in open(path).readlines():
+        if line.startswith('v'):
+            line = line[1:]
+        (components, digest) = line.split('-')
+        components = [int(x) for x in components.split('.')]
+        return (line, tuple(components), digest)
+
+    return (None, (), None)
+
+def _version_ge(version, goal):
+    """
+    Compare two version tuples and tell you if version is >= goal
+    """
+    for ver0, ver1 in zip_longest(version, goal, fillvalue=0):
+        if ver0 != ver1:
+            return ver0 > ver1
+    return True
+
 
 class BootLoaderError(Exception):
     pass
@@ -1535,7 +1564,12 @@ class GRUB2(GRUB):
         defaults.write("GRUB_CMDLINE_LINUX=\"%s\"\n" % self.boot_args)
         defaults.write("GRUB_DISABLE_RECOVERY=\"true\"\n")
         #defaults.write("GRUB_THEME=\"/boot/grub2/themes/system/theme.txt\"\n")
+        if flags.blscfg:
+            defaults.write("GRUB_ENABLE_BLSCFG=true\n")
         defaults.close()
+
+    def _test_firmware_compat(self):
+        """ Check that this platform is configured in a compatible way """
 
     def _encrypt_password(self):
         """ Make sure self.encrypted_password is set up properly. """
@@ -1649,6 +1683,9 @@ class GRUB2(GRUB):
         if self.update_only:
             self.update()
             return
+
+        if flags.blscfg:
+            self._test_firmware_compat()
 
         try:
             self.write_device_map()
@@ -2199,6 +2236,23 @@ class IPSeriesGRUB2(GRUB2):
         defaults.write("GRUB_DISABLE_OS_PROBER=true\n")
         defaults.close()
 
+    def _test_firmware_compat(self):
+        """ Check that this platform is configured in a compatible way """
+
+        super()._test_firmware_compat()
+        if not os.access("/sys/firmware/opal", os.F_OK):
+            return
+        try:
+            vstr, vtuple, _ = _get_petitboot_version()
+
+        except FileNotFoundError as err:
+            msg = "Could not get OPAL version: %s" % (err,)
+            errorHandler.cb(FirmwareCompatError(msg))
+
+        if not _version_ge(vtuple, (1, 8, 0)):
+            msg = "Incompatible firmware version %s" % (vstr,)
+            errorHandler.cb(FirmwareCompatError(msg))
+
 
 class MacYaboot(Yaboot):
     prog = "mkofboot"
@@ -2250,6 +2304,9 @@ class ZIPL(BootLoader):
         return "/boot"
 
     def write_config_images(self, config):
+        if flags.blscfg:
+            return
+
         for image in self.images:
             if "kdump" in (image.initrd or image.kernel):
                 # no need to create bootloader entries for kdump
@@ -2280,12 +2337,11 @@ class ZIPL(BootLoader):
         header = ("[defaultboot]\n"
                   "defaultauto\n"
                   "prompt=1\n"
-                  "timeout=%(timeout)d\n"
-                  "default=%(default)s\n"
-                  "target=/boot\n"
-                  % {"timeout": self.timeout,
-                     "default": self.image_label(self.default)})
-        config.write(header)
+                  "timeout={}\n"
+                  "target=/boot\n")
+        config.write(header.format(self.timeout))
+        if not flags.blscfg:
+            config.write("default={}\n".format(self.image_label(self.default)))
 
     #
     # installation

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -183,8 +183,7 @@ class TbootLinuxBootLoaderImage(LinuxBootLoaderImage):
     _args = ["intel_iommu=on"]
 
     def __init__(self, device=None, label=None, short=None, version=None):
-        super().__init__(device=device, label=label,
-                                                        short=short, version=version)
+        super().__init__(device=device, label=label, short=short, version=version)
 
     @property
     def multiboot(self):
@@ -827,8 +826,9 @@ class BootLoader(object):
         if usr_device:
             dracut_devices.extend([usr_device])
 
-        netdevs = [d for d in storage.devices if (getattr(d, "complete", True) and
-                   isinstance(d, NetworkStorageDevice))]
+        netdevs = [d for d in storage.devices \
+                   if (getattr(d, "complete", True) and
+                       isinstance(d, NetworkStorageDevice))]
         rootdev = storage.root_device
         if any(rootdev.depends_on(netdev) for netdev in netdevs):
             dracut_devices = set(dracut_devices)
@@ -1602,7 +1602,8 @@ class GRUB2(GRUB):
         # set boot_success so that the menu is hidden on the boot after install
         if self.menu_auto_hide:
             rc = util.execInSysroot("grub2-editenv",
-                            ["-", "set", "menu_auto_hide=1", "boot_success=1"])
+                                    ["-", "set", "menu_auto_hide=1",
+                                     "boot_success=1"])
             if rc:
                 log.error("failed to set menu_auto_hide=1")
 

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -62,6 +62,13 @@ class ZIPLError(Exception):
     pass
 
 
+class FirmwareCompatError(Exception):
+    """ Firmware is incompatible with installation requirements """
+    def __init__(self, reason):
+        Exception.__init__(self)
+        self.reason = reason
+
+
 class ExitError(RuntimeError):
     pass
 
@@ -331,6 +338,16 @@ class ErrorHandler(object):
         self.ui.showError(message)
         return ERROR_RAISE
 
+    def _FirmwareCompatErrorHandler(self, reason):
+        details = str(reason)
+        message = _("Installation was stopped due to an incompatibility with "
+                    "the current version of the system firmware. The exact "
+                    "error message is:\n\n%s\n\n"
+                    "The installer will now terminate.") % details
+
+        self.ui.showError(message)
+        return ERROR_RAISE
+
     def cb(self, exn):
         """This method is the callback that all error handling should pass
            through.  The return value is one of the ERROR_* constants defined
@@ -369,7 +386,8 @@ class ErrorHandler(object):
                 "DependencyError": self._dependencyErrorHandler,
                 "BootLoaderError": self._bootLoaderErrorHandler,
                 "PasswordCryptError": self._passwordCryptErrorHandler,
-                "ZIPLError": self._ziplErrorHandler}
+                "ZIPLError": self._ziplErrorHandler,
+                "FirmwareCompatError": self._FirmwareCompatErrorHandler}
 
         if exn.__class__.__name__ in _map:
             rc = _map[exn.__class__.__name__](exn)

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -63,6 +63,7 @@ class Flags(object):
         self.askmethod = False
         self.eject = True
         self.extlinux = False
+        self.blscfg = True
         self.nombr = False
         self.gpt = False
         self.leavebootorder = False

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -887,23 +887,34 @@ class Payload(object):
 
 
     def recreateInitrds(self):
-        """Recreate the initrds by calling new-kernel-pkg
+        """Recreate the initrds by calling new-kernel-pkg or dracut
 
         This needs to be done after all configuration files have been
         written, since dracut depends on some of them.
 
         :returns: None
         """
-        if not os.path.exists(util.getSysroot() + "/usr/sbin/new-kernel-pkg"):
-            log.error("new-kernel-pkg does not exist - grubby wasn't installed?  skipping")
-            return
+        if os.path.exists(util.getSysroot() + "/usr/sbin/new-kernel-pkg"):
+            useDracut = False
+        else:
+            log.warning("new-kernel-pkg does not exist - grubby wasn't installed?  using dracut instead.")
+            useDracut = True
 
         for kernel in self.kernelVersionList:
             log.info("recreating initrd for %s", kernel)
             if not flags.imageInstall:
-                util.execInSysroot("new-kernel-pkg",
-                                   ["--mkinitrd", "--dracut",
-                                    "--depmod", "--update", kernel])
+                if useDracut:
+                    util.execInSysroot("depmod", ["-a", kernel])
+                    util.execInSysroot("dracut",
+                                       ["-H", "--persistent-policy", "by-uuid",
+                                        "-f",
+                                        "/boot/initramfs-%s.img" % kernel,
+                                        kernel])
+                else:
+                    util.execInSysroot("new-kernel-pkg",
+                                       ["--mkinitrd", "--dracut", "--depmod",
+                                        "--update", kernel])
+
             else:
                 # hostonly is not sensible for disk image installations
                 # using /dev/disk/by-uuid/ is necessary due to disk image naming


### PR DESCRIPTION
This PR is basically the same than PR #1545, that contains @vathpela patches to add BootLoaderSpec support to Anaconda.

The only differences are that it's based on top of the `rhel-devel` branch, and adds a `Resolves: rhbz#1615442` to the commit message as asked by @poncovka.
