### PR TITLE
Don't set Anaconda-specific flags in Blivet

### DIFF
--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -79,7 +79,7 @@ def enable_installer_mode():
 
     # We don't want image installs writing backups of the *image* metadata
     # into the *host's* /etc/lvm. This can get real messy on build systems.
-    if blivet_flags.image_install:
+    if flags.imageInstall:
         blivet_flags.lvm_metadata_backup = False
 
     blivet_flags.auto_dev_updates = True
@@ -115,10 +115,6 @@ def update_blivet_flags(blivet_flags, anaconda_flags):  # pylint: disable=redefi
     :param anaconda_flags: anaconda flags
     :type anaconda_flags: :class:`pyanaconda.flags.Flags`
     """
-    blivet_flags.automated_install = anaconda_flags.automatedInstall
-    blivet_flags.live_install = anaconda_flags.livecdInstall
-    blivet_flags.image_install = anaconda_flags.imageInstall
-
     blivet_flags.selinux = anaconda_flags.selinux
 
     blivet_flags.arm_platform = anaconda_flags.armPlatform

--- a/tests/nosetests/pyanaconda_tests/storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/storage_test.py
@@ -3,7 +3,6 @@ import unittest
 from unittest.mock import patch
 
 from blivet import util
-from blivet.flags import flags
 from blivet.size import Size
 
 from pyanaconda.storage.osinstall import InstallerStorage, storage_initialize
@@ -35,8 +34,6 @@ class setupDiskImagesNonZeroSizeTestCase(unittest.TestCase):
         # at this point the DMLinearDevice has correct size
         self.storage.setup_disk_images()
 
-        # emulates setting the anaconda flags which later update
-        flags.image_install = True
         # no kickstart available
         ksdata = kickstart.AnacondaKSHandler([])
         # anaconda calls storage_initialize regardless of whether or not
@@ -52,8 +49,6 @@ class setupDiskImagesNonZeroSizeTestCase(unittest.TestCase):
         for fn in self.storage.disk_images.values():
             if os.path.exists(fn):
                 os.unlink(fn)
-
-        flags.image_install = False
 
     def runTest(self):
         disk = self.storage.disks[0]


### PR DESCRIPTION
The Anaconda-specific flags are going to be removed in Blivet, because
they are not used or useful anymore.

See: https://github.com/storaged-project/blivet/pull/723