### PR TITLE
Fix the sanity check verify_gpt_biosboot (#1593446)

### DIFF
--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -309,7 +309,7 @@ def verify_gpt_biosboot(storage, constraints, report_error, report_warning):
         stage1 = storage.bootloader.stage1_device
 
         if arch.is_x86() and not arch.is_efi() and stage1 and stage1.is_disk \
-                and getattr(stage1.format, "labelType", None) == "gpt":
+                and getattr(stage1.format, "label_type", None) == "gpt":
 
             missing = True
             for part in [p for p in storage.partitions if p.disk == stage1]:


### PR DESCRIPTION
Anaconda didn't verify that GPT boot disk on BIOS system has a BIOS
boot partition because of an invalid attribute name.

Resolves: rhbz#1593446