### PR TITLE
Make sure fips is correctly enabled on target system (#1619568)

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -915,6 +915,15 @@ class Payload(object):
                                        ["--mkinitrd", "--dracut", "--depmod",
                                         "--update", kernel])
 
+                # if the installation is running in fips mode then make sure
+                # fips is also correctly enabled in the installed system
+                if flags.cmdline.get("fips") == "1":
+                    # We use the --no-bootcfg option as we don't want fips-mode-setup to
+                    # modify the bootloader configuration.
+                    # Anaconda already does everything needed & it would require gruby to
+                    # be available on the system.
+                    util.execInSysroot("fips-mode-setup", ["--enable", "--no-bootcfg"])
+
             else:
                 # hostonly is not sensible for disk image installations
                 # using /dev/disk/by-uuid/ is necessary due to disk image naming

--- a/pyanaconda/platform.py
+++ b/pyanaconda/platform.py
@@ -93,8 +93,6 @@ class Platform(object):
     @property
     def packages(self):
         _packages = self._packages
-        if flags.boot_cmdline.get('fips', None) == '1':
-            _packages.append('dracut-fips')
         return _packages
 
     def set_platform_bootloader_reqs(self):


### PR DESCRIPTION
If installation is running in fips mode (fips=1 on boot command line)
Anaconda needs to make sure that also the target system is correctly
configured
for fips.

To achieve this we must call the fips-mode-setup tool after dracut finishes
initrd regeneration.

Also we can drop the optional requirement for the dracut-fips package,
which is no long needed or even available.

Resolves: rhbz#1619568