### PR TITLE
Move the glade adaptor to a separate plugin

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -338,6 +338,7 @@ update-desktop-database &> /dev/null || :
 
 %files widgets-devel
 %{_libdir}/libAnacondaWidgets.so
+%{_libdir}/glade/modules/libAnacondaWidgets.so
 %{_includedir}/*
 %{_datadir}/glade/catalogs/AnacondaWidgets.xml
 %{_datadir}/gtk-doc

--- a/tests/cppcheck/runcppcheck.sh
+++ b/tests/cppcheck/runcppcheck.sh
@@ -32,6 +32,8 @@ cppcheck_output="$(echo "$filelist" |
         --enable=warning,unusedFunction \
         --suppress=unusedFunction:*/widgets/src/* \
         --suppress=unusedFunction:widgets/src/* \
+        --suppress=unusedFunction:*/widgets/glade/* \
+        --suppress=unusedFunction:widgets/glade/* \
         2>&1 )"
 
 if [ -n "$cppcheck_output" ]; then

--- a/widgets/glade/Makefile.am
+++ b/widgets/glade/Makefile.am
@@ -20,4 +20,16 @@
 gladedir	= $(datadir)/glade/catalogs
 dist_glade_DATA	= AnacondaWidgets.xml
 
+glade_moduledir = $(libdir)/glade/modules
+glade_module_LTLIBRARIES = libAnacondaWidgets.la
+
+# Create a glade plugin containing the adaptor file that links
+# to the regular libAnacondaWidgets
+libAnacondaWidgets_la_SOURCES = glade-adaptor.c
+libAnacondaWidgets_la_CFLAGS  = $(GLADEUI_CFLAGS) \
+				-I$(top_srcdir)/src
+libAnacondaWidgets_la_LDFLAGS = -module -avoid-version
+libAnacondaWidgets_la_LIBADD  = $(GLADEUI_LIBS) \
+				$(top_builddir)/src/libAnacondaWidgets.la
+
 MAINTAINERCLEANFILES = Makefile.in

--- a/widgets/glade/glade-adaptor.c
+++ b/widgets/glade/glade-adaptor.c
@@ -30,9 +30,9 @@
 
 #include <gtk/gtk.h>
 
-#include "BaseWindow.h"
-#include "HubWindow.h"
-#include "SpokeWindow.h"
+#include <BaseWindow.h>
+#include <HubWindow.h>
+#include <SpokeWindow.h>
 
 void anaconda_standalone_window_post_create(GladeWidgetAdaptor *adaptor,
                                             GObject *object, GladeCreateReason reason) {

--- a/widgets/src/Makefile.am
+++ b/widgets/src/Makefile.am
@@ -56,12 +56,11 @@ WIDGETSDATA = '"$(datadir)/anaconda"'
 noinst_HEADERS = gettext.h intl.h
 
 lib_LTLIBRARIES = libAnacondaWidgets.la
-libAnacondaWidgets_la_CFLAGS = $(GTK_CFLAGS) $(GLADEUI_CFLAGS) $(LIBXKLAVIER_CFLAGS) -Wall -g\
+libAnacondaWidgets_la_CFLAGS = $(GTK_CFLAGS) $(LIBXKLAVIER_CFLAGS) -Wall -g\
 			       -DWIDGETS_DATADIR=$(WIDGETSDATA)
-libAnacondaWidgets_la_LIBADD = $(GTK_LIBS) $(GLADEUI_LIBS) $(LIBXKLAVIER_LIBS)
+libAnacondaWidgets_la_LIBADD = $(GTK_LIBS) $(LIBXKLAVIER_LIBS)
 libAnacondaWidgets_la_LDFLAGS = $(LTLIBINTL) -version-info 4:0:0
-libAnacondaWidgets_la_SOURCES = $(SOURCES) $(HDRS) \
-	  glade-adaptor.c
+libAnacondaWidgets_la_SOURCES = $(SOURCES) $(HDRS)
 
 lib_includedir=$(includedir)/AnacondaWidgets
 lib_include_HEADERS = $(HDRS)


### PR DESCRIPTION
The glade adaptor is only needed when running the glade UI, so it
doesn't need to be in the main widgets library. Move glade-adaptor.c to
a plugin in the widgets-devel package.