### PR TITLE
Don't check for firmware compatibility to enable BootLoaderSpec support

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -35,7 +35,7 @@ from pyanaconda.product import productName
 from pyanaconda.flags import flags, can_touch_runtime_system
 from blivet.fcoe import fcoe
 import pyanaconda.network
-from pyanaconda.errors import errorHandler, ERROR_RAISE, ZIPLError, FirmwareCompatError
+from pyanaconda.errors import errorHandler, ERROR_RAISE, ZIPLError
 from pyanaconda.nm import nm_device_hwaddress
 from pyanaconda import platform
 from blivet.size import Size
@@ -1568,9 +1568,6 @@ class GRUB2(GRUB):
             defaults.write("GRUB_ENABLE_BLSCFG=true\n")
         defaults.close()
 
-    def _test_firmware_compat(self):
-        """ Check that this platform is configured in a compatible way """
-
     def _encrypt_password(self):
         """ Make sure self.encrypted_password is set up properly. """
         if self.encrypted_password:
@@ -1683,9 +1680,6 @@ class GRUB2(GRUB):
         if self.update_only:
             self.update()
             return
-
-        if flags.blscfg:
-            self._test_firmware_compat()
 
         try:
             self.write_device_map()
@@ -2235,24 +2229,6 @@ class IPSeriesGRUB2(GRUB2):
         #       PowerVM / POWER on qemu/kvm
         defaults.write("GRUB_DISABLE_OS_PROBER=true\n")
         defaults.close()
-
-    def _test_firmware_compat(self):
-        """ Check that this platform is configured in a compatible way """
-
-        super()._test_firmware_compat()
-        if not os.access("/sys/firmware/opal", os.F_OK):
-            return
-        try:
-            vstr, vtuple, _ = _get_petitboot_version()
-
-        except FileNotFoundError as err:
-            msg = "Could not get OPAL version: %s" % (err,)
-            errorHandler.cb(FirmwareCompatError(msg))
-
-        if not _version_ge(vtuple, (1, 8, 0)):
-            msg = "Incompatible firmware version %s" % (vstr,)
-            errorHandler.cb(FirmwareCompatError(msg))
-
 
 class MacYaboot(Yaboot):
     prog = "mkofboot"

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -61,14 +61,6 @@ class PasswordCryptError(Exception):
 class ZIPLError(Exception):
     pass
 
-
-class FirmwareCompatError(Exception):
-    """ Firmware is incompatible with installation requirements """
-    def __init__(self, reason):
-        Exception.__init__(self)
-        self.reason = reason
-
-
 class ExitError(RuntimeError):
     pass
 
@@ -338,16 +330,6 @@ class ErrorHandler(object):
         self.ui.showError(message)
         return ERROR_RAISE
 
-    def _FirmwareCompatErrorHandler(self, reason):
-        details = str(reason)
-        message = _("Installation was stopped due to an incompatibility with "
-                    "the current version of the system firmware. The exact "
-                    "error message is:\n\n%s\n\n"
-                    "The installer will now terminate.") % details
-
-        self.ui.showError(message)
-        return ERROR_RAISE
-
     def cb(self, exn):
         """This method is the callback that all error handling should pass
            through.  The return value is one of the ERROR_* constants defined
@@ -386,8 +368,7 @@ class ErrorHandler(object):
                 "DependencyError": self._dependencyErrorHandler,
                 "BootLoaderError": self._bootLoaderErrorHandler,
                 "PasswordCryptError": self._passwordCryptErrorHandler,
-                "ZIPLError": self._ziplErrorHandler,
-                "FirmwareCompatError": self._FirmwareCompatErrorHandler}
+                "ZIPLError": self._ziplErrorHandler}
 
         if exn.__class__.__name__ in _map:
             rc = _map[exn.__class__.__name__](exn)


### PR DESCRIPTION
When Power systems are installed on bare-metal and using the OPAL firmware
interface, the Petitboot bootloader is used to parse the bootloader config
and populate the boot menu entries.

Support for the BootLoaderSpec config files was added in Petitboot 1.8.0,
so this is the minimal version needed to rely on Petitboot to parse them.

But there are machines that have an older firmware version. So instead of
not allowing the installation to finish, enable BLS support and have a way
to generate a grub.cfg file that's supported by any Petitboot version.

Resolves: #1635547

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>