### PR TITLE
Ignore errors when trying to activate unsupported swaps (#1635252)

### DIFF
--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -676,6 +676,10 @@ class FSSet(object):
                 try:
                     device.setup()
                     device.format.setup()
+                except (blockdev.SwapOldError, blockdev.SwapSuspendError,
+                        blockdev.SwapUnknownError, blockdev.SwapPagesizeError) as e:
+                    log.error("Failed to activate swap on '%s': %s", device.name, str(e))
+                    break
                 except (StorageError, blockdev.BlockDevError) as e:
                     if error_handler.cb(e) == ERROR_RAISE:
                         raise

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -16,6 +16,7 @@ class AnacondaLintConfig(PocketLintConfig):
         self.falsePositives = [ FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: GError$"),
                                 FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: S390Error$"),
                                 FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: BlockDevError$"),
+                                FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: Swap*Error$"),
                                 FalsePositive(r"^E1101.*: Instance of 'KickstartSpecificationHandler' has no '.*' member$"),
                                 FalsePositive(r"^E1101.*: Method 'PropertiesChanged' has no 'connect' member$"),
                                 FalsePositive(r"^E1101.*: Instance of 'GError' has no 'message' member"),


### PR DESCRIPTION
Anaconda shouldn't crash when trying to use preexisting swaps
that can't be activated.

**Do not merge**, https://github.com/storaged-project/libblockdev/pull/405 needs to be merged first.