### PR TITLE
Ignore errors when trying to activate unsupported swaps

### DIFF
--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -681,6 +681,10 @@ class FSSet(object):
                 try:
                     device.setup()
                     device.format.setup()
+                except (blockdev.SwapOldError, blockdev.SwapSuspendError,
+                        blockdev.SwapUnknownError, blockdev.SwapPagesizeError) as e:
+                    log.error("Failed to activate swap on '%s': %s", device.name, str(e))
+                    break
                 except (StorageError, blockdev.BlockDevError) as e:
                     if error_handler.cb(e) == ERROR_RAISE:
                         raise


### PR DESCRIPTION
Anaconda shouldn't crash when trying to use preexisting swaps
that can't be activated.

Resolves: rhbz#1635253

-----
#1636 for *rhel-devel*
**Do not merge** libblockdev change needs to be merged first.