### PR TITLE
Add option to set kernel.hung_task_timeout_secs option

### DIFF
--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -35,6 +35,7 @@ dist_dracut_SCRIPTS = module-setup.sh \
                       anaconda-copy-dhclient.sh \
                       anaconda-copy-s390ccwconf.sh \
                       anaconda-ifcfg.sh \
+                      anaconda-set-kernel-hung-timeout.sh \
                       fetch-kickstart-net.sh \
                       fetch-kickstart-disk \
                       fetch-updates-disk \

--- a/dracut/anaconda-set-kernel-hung-timeout.sh
+++ b/dracut/anaconda-set-kernel-hung-timeout.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# anaconda-set-kernel-hung-timeout.sh - set kernel hung timeout value
+# Used for VM guests in kickstart tests (#1633549)
+
+hung_timeout=$(getarg inst.kernel.hung_task_timeout_secs=)
+
+if [ -n "$hung_timeout" ]; then
+    echo ${hung_timeout} > /proc/sys/kernel/hung_task_timeout_secs
+fi

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -45,6 +45,7 @@ install() {
     inst_hook pre-pivot 50 "$moddir/anaconda-copy-cmdline.sh"
     inst_hook pre-pivot 50 "$moddir/anaconda-copy-s390ccwconf.sh"
     inst_hook pre-pivot 90 "$moddir/anaconda-copy-dhclient.sh"
+    inst_hook pre-pivot 95 "$moddir/anaconda-set-kernel-hung-timeout.sh"
     inst_hook pre-pivot 99 "$moddir/save-initramfs.sh"
     inst_hook pre-shutdown 50 "$moddir/anaconda-pre-shutdown.sh"
     # kickstart parsing, WOOOO


### PR DESCRIPTION
Adds installer boot option

inst.kernel.hung_task_timeout_secs

which sets

kernel.hung_task_timoeut_secs sysctl option

Used for VM guests in kickstart tests.

Resolves: rhbz#1633549