### PR TITLE
Increase EFI System Partition (ESP) size to 200-600 MiB

### DIFF
--- a/pyanaconda/platform.py
+++ b/pyanaconda/platform.py
@@ -156,7 +156,7 @@ class EFI(Platform):
     def set_platform_bootloader_reqs(self):
         ret = super().set_platform_bootloader_reqs()
         ret.append(PartSpec(mountpoint="/boot/efi", fstype="efi",
-                            size=Size("20MiB"), max_size=Size("200MiB"),
+                            size=Size("200MiB"), max_size=Size("600MiB"),
                             grow=True))
         return ret
 
@@ -173,7 +173,7 @@ class MacEFI(EFI):
     def set_platform_bootloader_reqs(self):
         ret = super().set_platform_bootloader_reqs()
         ret.append(PartSpec(mountpoint="/boot/efi", fstype="macefi",
-                            size=Size("20MiB"), max_size=Size("200MiB"),
+                            size=Size("200MiB"), max_size=Size("600MiB"),
                             grow=True))
         return ret
 


### PR DESCRIPTION
Currently the default allocated space for the EFI System Partition (ESP) is
a minimum of 20 MiB and a maximum of 200MiB. This size is more than enough
for storing the EFI binaries needed to boot the machine (shim, grub2, etc).

But the ESP is also used to store firmware updates and we can't predict the
size of the UEFI capsules used for this.

Microsoft mandates OEMs to allocate a minimum of 500MiB, and a Windows boot
loader takes around 25MiB. So some IHVs might assume they can ship firmware
updates of up to ~400MiB. This is unlikely to be common, but it is safer to
have an ESP big enough to not break this assumption in case a vendor has an
UEFI capsule that needs that size, which could cause not getting updates on
some machines.

Also having a bigger ESP is more future proof since it could be used in the
future to store other binaries, in case we want to modernize or boot-loader
stack and increase the ESP usage.

So to prevent people from a future risky repartitioning, let's increase the
ESP size from 20-200 to 200-600 MiB.

Resolves: rhbz#1633640

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>