### PR TITLE
Rhel dev cleanup obsolete ar mv7 bits

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1933,6 +1933,14 @@ class Aarch64EFIGRUB(EFIGRUB):
         super().__init__()
         self._packages64 = ["grub2-efi-aa64", "shim-aa64"]
 
+class ArmEFIGRUB(EFIGRUB):
+    _serial_consoles = ["ttyAMA", "ttyS"]
+    _efi_binary = "\\grubarm.efi"
+
+    def __init__(self):
+        super().__init__()
+        self._packages64 = ["grub2-efi-arm"]
+
 class MacEFIGRUB(EFIGRUB):
     def __init__(self):
         super().__init__()
@@ -2490,6 +2498,7 @@ bootloader_by_platform = {
     platform.S390: ZIPL,
     platform.Aarch64EFI: Aarch64EFIGRUB,
     platform.ARM: EXTLINUX,
+    platform.ArmEFI: ArmEFIGRUB,
 }
 
 if flags.cmdline.get("legacygrub") == "1":

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -2490,7 +2490,6 @@ bootloader_by_platform = {
     platform.S390: ZIPL,
     platform.Aarch64EFI: Aarch64EFIGRUB,
     platform.ARM: EXTLINUX,
-    platform.omapARM: EXTLINUX,
 }
 
 if flags.cmdline.get("legacygrub") == "1":

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -53,7 +53,6 @@ from pyanaconda.core.i18n import _, N_
 
 from pyanaconda.core import util
 from pyanaconda import isys
-from pyanaconda.platform import platform
 from pyanaconda.image import findFirstIsoImage
 from pyanaconda.image import mountImage
 from pyanaconda.image import opticalInstallMedia, verifyMedia
@@ -1110,11 +1109,8 @@ class PackagePayload(Payload):
         if blivet.arch.is_x86(32) and isys.isPaeAvailable():
             kernels.insert(0, "kernel-PAE")
 
-        # most ARM systems use platform-specific kernels
+        # ARM systems use either the standard Multiplatform or LPAE platform
         if blivet.arch.is_arm():
-            if platform.arm_machine is not None:
-                kernels = ["kernel-%s" % platform.arm_machine]
-
             if isys.isLpaeAvailable():
                 kernels.insert(0, "kernel-lpae")
 

--- a/pyanaconda/platform.py
+++ b/pyanaconda/platform.py
@@ -182,6 +182,10 @@ class Aarch64EFI(EFI):
     _non_linux_format_types = ["vfat", "ntfs"]
 
 
+class ArmEFI(EFI):
+    _non_linux_format_types = ["vfat", "ntfs"]
+
+
 class PPC(Platform):
     _ppc_machine = arch.get_ppc_machine()
     _boot_stage1_device_types = ["partition"]
@@ -275,6 +279,8 @@ def get_platform():
             return MacEFI()
         elif arch.is_aarch64():
             return Aarch64EFI()
+        elif arch.is_arm():
+            return ArmEFI()
         else:
             return EFI()
     elif arch.is_x86():

--- a/pyanaconda/platform.py
+++ b/pyanaconda/platform.py
@@ -244,7 +244,6 @@ class S390(Platform):
 
 
 class ARM(Platform):
-    _arm_machine = None
     _boot_stage1_device_types = ["disk"]
     _boot_mbr_description = N_("Master Boot Record")
     _boot_descriptions = {"disk": _boot_mbr_description,
@@ -252,12 +251,6 @@ class ARM(Platform):
 
     _boot_stage1_missing_error = N_("You must include at least one MBR-formatted "
                                     "disk as an install target.")
-
-    @property
-    def arm_machine(self):
-        if not self._arm_machine:
-            self._arm_machine = arch.get_arm_machine()
-        return self._arm_machine
 
 
 def get_platform():
@@ -287,7 +280,6 @@ def get_platform():
     elif arch.is_x86():
         return X86()
     elif arch.is_arm():
-        arm_machine = arch.get_arm_machine()
         return ARM()
     else:
         raise SystemError("Could not determine system architecture.")

--- a/pyanaconda/platform.py
+++ b/pyanaconda/platform.py
@@ -260,29 +260,6 @@ class ARM(Platform):
         return self._arm_machine
 
 
-class omapARM(ARM):
-    _boot_stage1_format_types = ["vfat"]
-    _boot_stage1_device_types = ["partition"]
-    _boot_stage1_mountpoints = ["/boot/uboot"]
-    _boot_uboot_description = N_("U-Boot Partition")
-    _boot_descriptions = {"partition": _boot_uboot_description}
-    _boot_stage1_missing_error = N_("You must include a U-Boot Partition on a "
-                                    "FAT-formatted disk, mounted at /boot/uboot.")
-
-    def set_platform_bootloader_reqs(self):
-        """Return the ARM-OMAP platform-specific partitioning information."""
-        ret = [PartSpec(mountpoint="/boot/uboot", fstype="vfat",
-                        size=Size("20MiB"), max_size=Size("200MiB"),
-                        grow=True)]
-        return ret
-
-    def set_default_partitioning(self):
-        ret = ARM.set_default_partitioning(self)
-        ret.append(PartSpec(mountpoint="/", fstype="ext4",
-                            size=Size("2GiB"), max_size=Size("3GiB")))
-        return ret
-
-
 def get_platform():
     """Check the architecture of the system and return an instance of a
        Platform subclass to match.  If the architecture could not be determined,
@@ -311,10 +288,7 @@ def get_platform():
         return X86()
     elif arch.is_arm():
         arm_machine = arch.get_arm_machine()
-        if arm_machine == "omap":
-            return omapARM()
-        else:
-            return ARM()
+        return ARM()
     else:
         raise SystemError("Could not determine system architecture.")
 


### PR DESCRIPTION
Backport of https://github.com/rhinstaller/anaconda/pull/1572 .

This is required otherwise we are using removed API of blivet.