### PR TITLE
Fix syspurpose double quoting

### DIFF
--- a/pyanaconda/modules/subscription/system_purpose.py
+++ b/pyanaconda/modules/subscription/system_purpose.py
@@ -114,21 +114,21 @@ def give_the_system_purpose(sysroot, role, sla, usage, addons):
             # Also as the values can contain white space ween need to make sure the
             # values passed to arguments are all properly quoted.
             if role:
-                args = ["set-role", '"{}"'.format(role)]
+                args = ["set-role", '{}'.format(role)]
                 util.execInSysroot("syspurpose", args)
 
             if sla:
-                args = ["set-sla", '"{}"'.format(sla)]
+                args = ["set-sla", '{}'.format(sla)]
                 util.execInSysroot("syspurpose", args)
 
             if usage:
-                args = ["set-usage", '"{}"'.format(usage)]
+                args = ["set-usage", '{}'.format(usage)]
                 util.execInSysroot("syspurpose", args)
 
             if addons:
-                args = ["add", '"addons"']
+                args = ["add", 'addons']
                 for addon in addons:
-                    args.append('"{}"'.format(addon))
+                    args.append('{}'.format(addon))
                 util.execInSysroot("syspurpose", args)
         else:
             log.error("the syspurpose tool is missing, cannot set system purpose")

--- a/pyanaconda/ui/gui/spokes/system_purpose.glade
+++ b/pyanaconda/ui/gui/spokes/system_purpose.glade
@@ -238,6 +238,9 @@
                         <property name="label" translatable="yes">How will you use this system? All fields are optional, and changes can be made after installation.</property>
                         <property name="wrap">True</property>
                         <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="font-desc" value="Cantarell 12"/>
+                        </attributes>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>


### PR DESCRIPTION
The first commit fixes double quoting in arguments for the syspurpose tool. The second comment is a small tweak for text size in the main description text on the System Purpose spoke.