### PR TITLE
installclass: fix variant string for Atomic Host (#1640409)

### DIFF
--- a/pyanaconda/installclasses/fedora_atomic_host.py
+++ b/pyanaconda/installclasses/fedora_atomic_host.py
@@ -36,7 +36,7 @@ class AtomicHostInstallClass(FedoraBaseInstallClass):
     sortPriority = FedoraBaseInstallClass.sortPriority + 1
     defaultFS = "xfs"
 
-    if productVariant != "Atomic":
+    if productVariant != "AtomicHost":
         hidden = True
 
     def __init__(self):


### PR DESCRIPTION
We need to fix the variant string for Atomic Host so it can properly be
detected on Atomic Host ISO images.

Resolves: rhbz#1640409