### PR TITLE
Use the configuration file in DBus modules

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -94,7 +94,7 @@ def exitHandler(rebootData, storage):
     if pidfile:
         pidfile.close()
 
-    anaconda.cleanup_dbus_session()
+    anaconda.dbus_launcher.stop()
 
     if not flags.imageInstall and not flags.livecdInstall \
        and not flags.dirInstall:
@@ -478,17 +478,17 @@ if __name__ == "__main__":
     log.info("Default encoding = %s ", sys.getdefaultencoding())
 
     # start dbus session (if not already running) and run boss in it
-    anaconda.run_boss_with_dbus()
-
-    # Collect all addon paths
-    addon_paths = collect_addon_paths(constants.ADDON_PATHS)
-
-    # Make sure that all DBus modules are ready.
-    if not startup_utils.wait_for_modules():
-        stdout_log.error("Anaconda DBus modules failed to start on time.")
+    try:
+        anaconda.dbus_launcher.start()
+    except TimeoutError as e:
+        stdout_log.error(str(e))
+        anaconda.dbus_launcher.stop()
         util.ipmi_report(constants.IPMI_ABORTED)
         time.sleep(10)
         sys.exit(1)
+
+    # Collect all addon paths
+    addon_paths = collect_addon_paths(constants.ADDON_PATHS)
 
     # If we were given a kickstart file on the command line, parse (but do not
     # execute) that now.  Otherwise, load in defaults from kickstart files

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -315,6 +315,8 @@ update-desktop-database &> /dev/null || :
 %{_bindir}/anaconda-cleanup
 %dir %{_sysconfdir}/%{name}
 %config %{_sysconfdir}/%{name}/*
+%dir %{_sysconfdir}/%{name}/conf.d
+%config %{_sysconfdir}/%{name}/conf.d/*
 %ifarch %livearches
 %{_bindir}/liveinst
 %{_sbindir}/liveinst

--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,7 @@ AC_CONFIG_FILES([Makefile
                  docs/Makefile
                  dracut/Makefile
                  pyanaconda/installclasses/Makefile
+                 data/conf.d/Makefile
                  data/liveinst/Makefile
                  data/liveinst/console.apps/Makefile
                  data/liveinst/gnome/Makefile

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -6,6 +6,20 @@
 # Run Anaconda in the debugging mode.
 debug = False
 
+# Enable Anaconda addons.
+addons_enabled = True
+
+# List of enabled Anaconda DBus modules.
+kickstart_modules =
+     org.fedoraproject.Anaconda.Modules.Timezone
+     org.fedoraproject.Anaconda.Modules.Network
+     org.fedoraproject.Anaconda.Modules.Localization
+     org.fedoraproject.Anaconda.Modules.Security
+     org.fedoraproject.Anaconda.Modules.Users
+     org.fedoraproject.Anaconda.Modules.Payload
+     org.fedoraproject.Anaconda.Modules.Storage
+     org.fedoraproject.Anaconda.Modules.Services
+
 
 [Services]
 # Enable SELinux usage in the installed system.

--- a/data/conf.d/00-do-nothing.conf
+++ b/data/conf.d/00-do-nothing.conf
@@ -1,0 +1,1 @@
+# This is a temporary config file for testing.

--- a/data/conf.d/01-still-do-nothing.conf
+++ b/data/conf.d/01-still-do-nothing.conf
@@ -1,0 +1,1 @@
+# This is another temporary config file for testing.

--- a/data/conf.d/Makefile.am
+++ b/data/conf.d/Makefile.am
@@ -1,6 +1,4 @@
-# data/Makefile.am for anaconda
-#
-# Copyright (C) 2009  Red Hat, Inc.
+# Copyright (C) 2018  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published
@@ -15,18 +13,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = command-stubs liveinst systemd post-scripts pixmaps window-manager dbus conf.d
-
 CLEANFILES = *~
 
-dist_pkgdata_DATA          = interactive-defaults.ks \
-			     tmux.conf \
-			     anaconda-gtk.css
-
-helpdir               = $(datadir)/$(PACKAGE_NAME)
-dist_help_DATA        = anaconda_options.txt
-
-configdir           = $(sysconfdir)/$(PACKAGE_NAME)
-dist_config_DATA    = anaconda.conf
+configdir           = $(sysconfdir)/$(PACKAGE_NAME)/conf.d
+dist_config_DATA    = *.conf
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -60,6 +60,16 @@ class AnacondaSection(Section):
         """Run Anaconda in the debugging mode."""
         return self._get_option("debug", bool)
 
+    @property
+    def addons_enabled(self):
+        """Enable Anaconda addons."""
+        return self._get_option("addons_enabled", bool)
+
+    @property
+    def kickstart_modules(self):
+        """List of enabled kickstart modules."""
+        return self._get_option("kickstart_modules").split()
+
 
 class ServicesSection(Section):
     """The Services section."""

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -141,12 +141,17 @@ class AnacondaConfiguration(object):
 
         # Read the temporary configuration file.
         config_path = os.environ.get("ANACONDA_CONFIG_TMP", ANACONDA_CONFIG_TMP)
+        if config_path and os.path.exists(config_path):
+            config.read(config_path)
 
         # Or use the defaults if it doesn't exist.
-        if not config_path or not os.path.exists(config_path):
+        else:
             config_path = os.path.join(ANACONDA_CONFIG_DIR, "anaconda.conf")
+            config.read(config_path)
 
-        config.read(config_path)
+            config_dir = os.path.join(ANACONDA_CONFIG_DIR, "conf.d")
+            for config_path in sorted(os.listdir(config_dir)):
+                config.read(os.path.join(config_dir, config_path))
 
         # Validate the configuration.
         config.validate()

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -59,7 +59,10 @@ ISO_DIR = MOUNT_DIR + "/isodir"
 IMAGE_DIR = MOUNT_DIR + "/image"
 INSTALL_TREE = MOUNT_DIR + "/source"
 BASE_REPO_NAME = "anaconda"
+
+ANACONDA_BUS_CONF_FILE = "/usr/share/anaconda/dbus/anaconda-bus.conf"
 ANACONDA_BUS_ADDR_FILE = "/run/anaconda/bus.address"
+
 ANACONDA_DATA_DIR = "/usr/share/anaconda"
 ANACONDA_CONFIG_DIR = "/etc/anaconda/"
 ANACONDA_CONFIG_TMP = "/run/anaconda/anaconda.conf"

--- a/pyanaconda/dbus/launcher.py
+++ b/pyanaconda/dbus/launcher.py
@@ -25,91 +25,109 @@
 #
 
 import os
+import time
 from subprocess import TimeoutExpired
 
-from pyanaconda.dbus.constants import DBUS_ANACONDA_SESSION_ADDRESS
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.util import startProgram
-from pyanaconda.core.constants import ANACONDA_BUS_ADDR_FILE, ANACONDA_DATA_DIR
-from pyanaconda.anaconda_loggers import get_anaconda_root_logger
+from pyanaconda.core.constants import ANACONDA_BUS_ADDR_FILE, ANACONDA_CONFIG_TMP,\
+    ANACONDA_BUS_CONF_FILE
+from pyanaconda.dbus import DBus
+from pyanaconda.dbus.constants import DBUS_ANACONDA_SESSION_ADDRESS, DBUS_FLAG_NONE
+from pyanaconda.modules.common.constants.services import BOSS
 
+from pyanaconda.anaconda_loggers import get_anaconda_root_logger
 log = get_anaconda_root_logger()
 
-__all__ = ["DBusLauncher"]
+__all__ = ["AnacondaDBusLauncher"]
 
 
-class DBusLauncher(object):
+class AnacondaDBusLauncher(object):
+    """Class for launching the Anaconda DBus modules."""
 
     DBUS_LAUNCH_BIN = "dbus-daemon"
-    TERMINATE_WAITING_TIME = 20
 
     def __init__(self):
         self._dbus_daemon_process = None
         self._log_file = None
+        self._bus_address = None
 
-    @classmethod
-    def is_dbus_session_running(cls):
-        """Check if dbus session is running.
+    @property
+    def bus_address(self):
+        """The address of the Anaconda DBus session."""
+        return self._bus_address
 
-        :returns: True if DBus is running, False otherwise
+    def start(self, timeout=600):
+        """Start DBus modules.
+
+        Start the DBus session, the boss and the kickstart modules.
+
+        :param timeout: seconds to the launcher timeout
+        :raises TimeoutError if the launcher times out
         """
-        if os.environ.get(DBUS_ANACONDA_SESSION_ADDRESS):
-            return True
+        self._write_temporary_config()
 
-        return False
+        self._start_dbus_session()
+        self._set_environment()
+        self._write_bus_address()
 
-    @classmethod
-    def get_anaconda_dbus_address(cls):
-        """Return name of the dbus session where Anaconda lives.
+        self._start_boss()
+        self._start_modules()
+        self._wait_for_modules(timeout)
 
-        :returns: dbus session name
-        :rtype: str
+    def stop(self, timeout=20):
+        """Stop the DBus modules.
+
+        Stop the DBus session, the boss and the kickstart modules.
+
+        :param timeout: seconds to the launcher timeout
         """
-        bus_addr_file = ANACONDA_BUS_ADDR_FILE
-        if os.path.exists(bus_addr_file):
-            with open(bus_addr_file, 'rt') as f:
-                return f.readline().rstrip('\n')
-        else:
-            return ""
+        self._stop_boss_and_modules()
 
-    def start_dbus_session(self):
-        """Start dbus session if not running already.
+        self._stop_dbus_session(timeout)
+        self._remove_bus_address_file()
 
-        :returns: True if session was started, False otherwise
-        """
+        self._remove_temporary_config()
+
+    def _write_temporary_config(self):
+        """Create the temporary config file."""
+        dirname = os.path.dirname(ANACONDA_CONFIG_TMP)
+
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+
+        log.info("Writing a temporary configuration loaded from: %s", conf.get_sources())
+        conf.write(ANACONDA_CONFIG_TMP)
+
+    def _remove_temporary_config(self):
+        """Remove the temporary config file."""
+        if os.path.exists(ANACONDA_CONFIG_TMP):
+            os.unlink(ANACONDA_CONFIG_TMP)
+
+    def _start_dbus_session(self):
+        """Start dbus session if not running already."""
+        command = [
+            self.DBUS_LAUNCH_BIN,
+            '--print-address',
+            "--syslog",
+            "--config-file={}".format(ANACONDA_BUS_CONF_FILE)
+        ]
+
         self._log_file = open('/tmp/dbus.log', 'a')
-        config_file = "--config-file={}".format(os.path.join(ANACONDA_DATA_DIR, "dbus/anaconda-bus.conf"))
-        command = [DBusLauncher.DBUS_LAUNCH_BIN, '--print-address', "--syslog", config_file]
         self._dbus_daemon_process = startProgram(command, stderr=self._log_file, reset_lang=False)
 
         if self._dbus_daemon_process.poll() is not None:
             raise IOError("DBus wasn't properly started!")
 
-        address = self._dbus_daemon_process.stdout.readline().decode('utf-8')
+        address = self._dbus_daemon_process.stdout.readline().decode('utf-8').strip()
 
         if not address:
             raise IOError("Unable to start DBus session!")
 
-        # pylint: disable=environment-modify
-        os.environ[DBUS_ANACONDA_SESSION_ADDRESS] = address.rstrip('\n')
-        return True
+        self._bus_address = address
 
-    def write_bus_address(self):
-        address = os.environ[DBUS_ANACONDA_SESSION_ADDRESS]
-        file_name = ANACONDA_BUS_ADDR_FILE
-        run_dir = os.path.dirname(file_name)
-
-        if not os.path.exists(run_dir):
-            os.mkdir(run_dir)
-
-        with open(file_name, 'wt') as f:
-            f.write(address)
-
-    def stop(self):
+    def _stop_dbus_session(self, timeout):
         """Stop DBus service and clean bus address file."""
-        f = ANACONDA_BUS_ADDR_FILE
-        if os.path.exists(f):
-            os.unlink(f)
-
         if self._log_file:
             self._log_file.close()
 
@@ -119,7 +137,7 @@ class DBusLauncher(object):
         self._dbus_daemon_process.terminate()
 
         try:
-            self._dbus_daemon_process.wait(DBusLauncher.TERMINATE_WAITING_TIME)
+            self._dbus_daemon_process.wait(timeout)
         except TimeoutExpired:
             log.error("DBus daemon wasn't terminated kill it now")
             self._dbus_daemon_process.kill()
@@ -130,3 +148,53 @@ class DBusLauncher(object):
             log.error("DBus daemon can't be killed!")
         elif ret_code != 0:
             log.error("DBus daemon exited with error %s", ret_code)
+
+    def _set_environment(self):
+        """Set the environment variables."""
+        # pylint: disable=environment-modify
+        os.environ[DBUS_ANACONDA_SESSION_ADDRESS] = self._bus_address
+
+    def _write_bus_address(self):
+        """Write the bus address to a file."""
+        file_name = ANACONDA_BUS_ADDR_FILE
+        run_dir = os.path.dirname(file_name)
+
+        if not os.path.exists(run_dir):
+            os.mkdir(run_dir)
+
+        with open(file_name, 'wt') as f:
+            f.write(self._bus_address)
+
+    def _remove_bus_address_file(self):
+        """Remove the file with the bus address."""
+        f = ANACONDA_BUS_ADDR_FILE
+        if os.path.exists(f):
+            os.unlink(f)
+
+    def _start_boss(self):
+        """Start the boss."""
+        bus_proxy = DBus.get_dbus_proxy()
+        bus_proxy.StartServiceByName(BOSS.service_name, DBUS_FLAG_NONE)
+
+    def _start_modules(self):
+        """Start the kickstart modules."""
+        boss_proxy = BOSS.get_proxy()
+        boss_proxy.StartModules()
+
+    def _wait_for_modules(self, timeout):
+        """Wait for the modules to start."""
+        boss = BOSS.get_proxy()
+
+        while not boss.AllModulesAvailable and timeout > 0:
+            log.info("Waiting %d sec for modules to be started.", timeout)
+            time.sleep(1)
+            timeout = timeout - 1
+
+        if not timeout:
+            log.error("Waiting for modules to be started timed out.")
+            raise TimeoutError("Anaconda DBus modules failed to start on time.")
+
+    def _stop_boss_and_modules(self):
+        """Stop the boss and the kickstart modules."""
+        boss_proxy = BOSS.get_proxy()
+        boss_proxy.Quit()

--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -19,6 +19,7 @@
 #
 
 from pyanaconda.core.async_utils import run_in_loop
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.boss.boss_interface import AnacondaBossInterface
 from pyanaconda.modules.boss.module_manager import ModuleManager
@@ -70,13 +71,13 @@ class Boss(MainModule):
         log.info("Start the main loop.")
         self._loop.run()
 
-    def start_modules(self, service_names, addons_enabled=True):
+    def start_modules(self):
         """Start the given kickstart modules."""
-        for service_name in service_names:
+        for service_name in conf.anaconda.kickstart_modules:
             log.debug("Add module %s.", service_name)
             self._module_manager.add_module(service_name)
 
-        if addons_enabled:
+        if conf.anaconda.addons_enabled:
             log.debug("Addons are enabled.")
             self._module_manager.add_addon_modules()
 

--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -48,13 +48,9 @@ class AnacondaBossInterface(BossInterface):
     Used for synchronization with anaconda during transition.
     """
 
-    def StartModules(self, service_names: List[Str], addons_enabled: Bool):
-        """Start the given kickstart modules.
-
-        :param service_names: a list of service names
-        :param addons_enabled: should we start addons?
-        """
-        self.implementation.start_modules(service_names, addons_enabled)
+    def StartModules(self):
+        """Start the kickstart modules."""
+        self.implementation.start_modules()
 
     @property
     def AllModulesAvailable(self) -> Bool:

--- a/pyanaconda/modules/common/__init__.py
+++ b/pyanaconda/modules/common/__init__.py
@@ -31,3 +31,8 @@ def init():
     import locale
     from pyanaconda.core.constants import DEFAULT_LANG
     locale.setlocale(locale.LC_ALL, DEFAULT_LANG)
+
+    from pyanaconda.core.configuration.anaconda import conf
+    from pyanaconda.anaconda_loggers import get_module_logger
+    log = get_module_logger(__name__)
+    log.debug("The configuration is loaded from: %s", conf.get_sources())

--- a/pyanaconda/modules/common/constants/services.py
+++ b/pyanaconda/modules/common/constants/services.py
@@ -73,16 +73,3 @@ HOSTNAME = DBusServiceIdentifier(
     interface_version=1,
     message_bus=SystemBus
 )
-
-# Other constants.
-
-ALL_KICKSTART_MODULES = [
-    TIMEZONE,
-    NETWORK,
-    LOCALIZATION,
-    SECURITY,
-    USERS,
-    PAYLOAD,
-    STORAGE,
-    SERVICES,
-]

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -40,9 +40,6 @@ from pyanaconda.flags import flags
 from pyanaconda.flags import can_touch_runtime_system
 from pyanaconda.screensaver import inhibit_screensaver
 
-from pyanaconda.dbus import DBus
-from pyanaconda.dbus.constants import DBUS_FLAG_NONE
-from pyanaconda.modules.common.constants.services import BOSS
 from pyanaconda.payload.source import SourceFactory, PayloadSourceTypeUnrecognized
 
 import blivet
@@ -81,21 +78,6 @@ def module_exists(module_path):
         return True
     except ImportError:
         return False
-
-
-def stop_boss():
-    """Stop boss by calling Quit() on DBus."""
-    boss_proxy = BOSS.get_proxy()
-    boss_proxy.Quit()
-
-
-def run_boss():
-    """Start Boss service on DBus."""
-    bus_proxy = DBus.get_dbus_proxy()
-    bus_proxy.StartServiceByName(BOSS.service_name, DBUS_FLAG_NONE)
-
-    boss_proxy = BOSS.get_proxy()
-    boss_proxy.StartModules()
 
 
 def get_anaconda_version_string(build_time_version=False):
@@ -417,26 +399,6 @@ def set_installation_method_from_anaconda_options(anaconda, ksdata):
         ksdata.method.metalink = None
     elif source.is_livecd:
         ksdata.method.partition = source.partition
-
-
-def wait_for_modules(timeout=600):
-    """Wait for the DBus modules.
-
-    :param timeout: seconds to the timeout
-    :return: True if the modules are ready, otherwise False
-    """
-    boss = BOSS.get_proxy()
-
-    while not boss.AllModulesAvailable and timeout > 0:
-        log.info("Waiting %d sec for modules to be started.", timeout)
-        time.sleep(1)
-        timeout = timeout - 1
-
-    if not timeout:
-        log.error("Waiting for modules to be started timed out.")
-        return False
-
-    return True
 
 
 def parse_kickstart(options, addon_paths, pass_to_boss=False):

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -42,7 +42,7 @@ from pyanaconda.screensaver import inhibit_screensaver
 
 from pyanaconda.dbus import DBus
 from pyanaconda.dbus.constants import DBUS_FLAG_NONE
-from pyanaconda.modules.common.constants.services import BOSS, ALL_KICKSTART_MODULES
+from pyanaconda.modules.common.constants.services import BOSS
 from pyanaconda.payload.source import SourceFactory, PayloadSourceTypeUnrecognized
 
 import blivet
@@ -89,20 +89,13 @@ def stop_boss():
     boss_proxy.Quit()
 
 
-def run_boss(kickstart_modules=None, addons_enabled=True):
-    """Start Boss service on DBus.
-
-    :param kickstart_modules: a list of service identifiers
-    :param addons_enabled: should we start the addons?
-    """
-    if kickstart_modules is None:
-        kickstart_modules = ALL_KICKSTART_MODULES
-
+def run_boss():
+    """Start Boss service on DBus."""
     bus_proxy = DBus.get_dbus_proxy()
     bus_proxy.StartServiceByName(BOSS.service_name, DBUS_FLAG_NONE)
 
     boss_proxy = BOSS.get_proxy()
-    boss_proxy.StartModules([m.service_name for m in kickstart_modules], addons_enabled)
+    boss_proxy.StartModules()
 
 
 def get_anaconda_version_string(build_time_version=False):

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -332,6 +332,8 @@ def copyUpdatedFiles(tag, updates, cwd, builddir):
             install_to_dir(gitfile, "usr/share/anaconda")
         elif gitfile == "data/anaconda.conf":
             install_to_dir(gitfile, "etc/anaconda")
+        elif gitfile.startswith("data/conf.d"):
+            install_to_dir(gitfile, "etc/anaconda/conf.d")
         elif gitfile == "data/liveinst/liveinst":
             install_to_dir(gitfile, "usr/sbin")
         elif gitfile.startswith("data/pixmaps"):

--- a/scripts/run_boss_locally.py
+++ b/scripts/run_boss_locally.py
@@ -15,7 +15,7 @@ import argparse
 from gi.repository import Gio
 
 from pyanaconda.dbus import DBusConnection
-from pyanaconda.modules.common.constants.services import BOSS, ALL_KICKSTART_MODULES
+from pyanaconda.modules.common.constants.services import BOSS
 from pyanaconda.modules.common.errors.kickstart import SplitKickstartError
 
 try:
@@ -54,7 +54,7 @@ def start_anaconda_services():
     bus_proxy.StartServiceByName(BOSS.service_name, 0)
 
     boss_proxy = test_dbus_connection.get_proxy(BOSS.service_name, BOSS.object_path)
-    boss_proxy.StartModules([m.service_name for m in ALL_KICKSTART_MODULES], True)
+    boss_proxy.StartModules()
 
 def distribute_kickstart(ks_path):
     tmpfile = tempfile.mktemp(suffix=".run_boss_locally.ks")

--- a/tests/nosetests/pyanaconda_tests/configuration_test.py
+++ b/tests/nosetests/pyanaconda_tests/configuration_test.py
@@ -25,6 +25,7 @@ from textwrap import dedent
 from pyanaconda.core.configuration.anaconda import AnacondaConfiguration
 from pyanaconda.core.configuration.base import create_parser, read_config, write_config, \
     get_option, set_option, ConfigurationError, ConfigurationDataError, ConfigurationFileError
+from pyanaconda.modules.common.constants import services
 
 
 class ConfigurationTestCase(unittest.TestCase):
@@ -222,3 +223,20 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
             conf.write(f.name)
             f.flush()
             self.assertTrue(f.read(), "The file shouldn't be empty.")
+
+    def kickstart_modules_test(self):
+        conf = AnacondaConfiguration.from_defaults()
+
+        self.assertEqual(
+            set(conf.anaconda.kickstart_modules),
+            set(service.service_name for service in (
+                services.TIMEZONE,
+                services.NETWORK,
+                services.LOCALIZATION,
+                services.SECURITY,
+                services.USERS,
+                services.PAYLOAD,
+                services.STORAGE,
+                services.SERVICES
+            ))
+        )

--- a/tests/rpm_tests/create_rpm_test.py
+++ b/tests/rpm_tests/create_rpm_test.py
@@ -37,7 +37,6 @@ class InstallRPMTestCase(RPMTestCase):
 class InstalledFilesTestCase(RPMTestCase):
     """Test if files in anaconda directory are correctly placed in the rpm files."""
 
-    ANACONDA_CONF = "anaconda.conf"
     ANACONDA_BUS_CONF = "anaconda-bus.conf"
     ANACONDA_GENERATOR = "anaconda-generator"
 
@@ -139,16 +138,18 @@ class InstalledFilesTestCase(RPMTestCase):
         self._check_files_in_rpm(src_files, rpm_files)
 
     def test_anaconda_conf_file(self):
-        rpm_files = self._get_core_rpm_content()
+        self.assertIn("data/anaconda.conf", self._get_source_files())
+        self.assertIn("/etc/anaconda/anaconda.conf", self._get_core_rpm_content())
 
-        rpm_files = filter(lambda f: FileFilters.specific_file_only(self.ANACONDA_CONF, f),
-                           rpm_files)
+    def test_anaconda_conf_dir(self):
+        rpm_files = self._get_core_rpm_content()
+        rpm_files = filter(FileFilters.confd_only, rpm_files)
 
         src_files = self._apply_filters(
             [
                 FileFilters.src_data_only,
+                FileFilters.confd_only,
                 FileFilters.confs_only,
-                lambda f: FileFilters.specific_file_only(self.ANACONDA_CONF, f)
             ], self._get_source_files()
         )
 
@@ -320,6 +321,10 @@ class FileFilters(object):
     @staticmethod
     def src_dbus_only(path):
         return "data/dbus" in path
+
+    @staticmethod
+    def confd_only(path):
+        return "/conf.d/" in path
 
     @staticmethod
     def confs_only(path):


### PR DESCRIPTION
The Anaconda DBus launcher is able to set up and clean up everything
related to the DBus modules. It will create a temporary configuration
file, start a DBus session, set up the environment, start the boss
and kickstart modules and wait for the modules to start. It raises
TimeoutError if the modules don't start on time.

The list of enabled kickstart modules is provided by the configuration file
now.