### PR TITLE
Backport unified nfs iso patch

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -63,6 +63,12 @@ IMAGE_DIR = MOUNT_DIR + "/image"
 INSTALL_TREE = MOUNT_DIR + "/source"
 BASE_REPO_NAME = "anaconda"
 
+# Get list of repo names witch should be used as base repo
+DEFAULT_REPOS = [productName.split('-')[0].lower(),
+                 "fedora-modular-server",
+                 "rawhide",
+                 "BaseOS"]
+
 ANACONDA_BUS_CONF_FILE = "/usr/share/anaconda/dbus/anaconda-bus.conf"
 ANACONDA_BUS_ADDR_FILE = "/run/anaconda/bus.address"
 

--- a/pyanaconda/image.py
+++ b/pyanaconda/image.py
@@ -17,7 +17,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import os, os.path, stat, tempfile
+import os
+import os.path
+import stat
+import tempfile
 
 from pyanaconda import isys
 from pyanaconda.errors import errorHandler, ERROR_RAISE, InvalidImageSizeError, MissingImageError
@@ -31,9 +34,11 @@ from blivet.errors import FSError
 from productmd.discinfo import DiscInfo
 
 from pyanaconda.anaconda_loggers import get_module_logger
+
 log = get_module_logger(__name__)
 
 _arch = blivet.arch.get_arch()
+
 
 def findFirstIsoImage(path):
     """
@@ -150,6 +155,7 @@ def mountImage(isodir, tree):
         else:
             break
 
+
 # Return the first Device instance containing valid optical install media
 # for this product.
 def opticalInstallMedia(devicetree):
@@ -188,11 +194,14 @@ def opticalInstallMedia(devicetree):
 
     return retval
 
-# Return a generator yielding Device instances that may have HDISO install
-# media somewhere.  Candidate devices are simply any that we can mount.
+
 def potentialHdisoSources(devicetree):
+    """ Return a generator yielding Device instances that may have HDISO install
+        media somewhere. Candidate devices are simply any that we can mount.
+    """
     return (d for d in devicetree.devices
             if d.type == "partition" and d.format.exists and d.format.mountable)
+
 
 def verifyMedia(tree, timestamp=None):
     if os.access("%s/.discinfo" % tree, os.R_OK):

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -1019,11 +1019,6 @@ class ArchivePayload(ImagePayload):
 class PackagePayload(Payload):
     """A PackagePayload installs a set of packages onto the target system."""
 
-    DEFAULT_REPOS = [productName.split('-')[0].lower(),
-                     "fedora-modular-server",
-                     "rawhide",
-                     "BaseOS"]  # pylint: disable=no-member
-
     def __init__(self, data):
         if self.__class__ is PackagePayload:
             raise TypeError("PackagePayload is an abstract class")

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -25,17 +25,13 @@
 
 """
 import os
-import requests
 import shutil
 from glob import glob
 from fnmatch import fnmatch
 import threading
 import re
 import functools
-import time
 from collections import OrderedDict, namedtuple
-
-from productmd.treeinfo import TreeInfo
 
 from blivet.size import Size, ROUND_HALF_UP
 from pyanaconda.core.constants import DRACUT_ISODIR, DRACUT_REPODIR, DD_ALL, DD_FIRMWARE, \
@@ -54,6 +50,7 @@ from pyanaconda.image import opticalInstallMedia, verifyMedia
 from pyanaconda.core.util import ProxyString, ProxyStringError
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core.regexes import VERSION_DIGITS
+from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
 
 from pykickstart.parser import Group
 
@@ -68,8 +65,6 @@ from pyanaconda.product import productName, productVersion
 USER_AGENT = "%s (anaconda)/%s" % (productName, productVersion)
 
 from distutils.version import LooseVersion
-
-MAX_TREEINFO_DOWNLOAD_RETRIES = 6
 
 
 def versionCmp(v1, v2):
@@ -314,7 +309,7 @@ class Payload(object):
         self.instclass = None
         self.txID = None
 
-        self._treeinfo = None
+        self._install_tree_metadata = None
 
         self._first_payload_reset = True
 
@@ -349,7 +344,7 @@ class Payload(object):
         """Invalidate a previously setup payload."""
         self.storage = None
         self.instclass = None
-        self._treeinfo = None
+        self._install_tree_metadata = None
 
     def postSetup(self):
         """Run specific payload post-configuration tasks on the end of
@@ -642,8 +637,8 @@ class Payload(object):
     ##
     ## METHODS FOR TREE VERIFICATION
     ##
-    def _refreshTreeInfo(self, url):
-        """Retrieve treeinfo and store it in the self._treeinfo.
+    def _refreshInstallTree(self, url):
+        """Refresh installation tree metadata.
 
         :param url: url of the repo
         :type url: string
@@ -671,74 +666,19 @@ class Payload(object):
                 log.info("Failed to parse proxy for _getTreeInfo %s: %s",
                          proxy_url, e)
 
-        # Retry treeinfo downloads with a progressively longer pause,
-        # so NetworkManager have a chance setup a network and we have
-        # full connectivity before trying to download things. (#1292613)
-        xdelay = util.xprogressive_delay()
-        response = None
-        ret_code = [None, None]
         headers = {"user-agent": USER_AGENT}
-
-        for retry_count in range(0, MAX_TREEINFO_DOWNLOAD_RETRIES + 1):
-            if retry_count > 0:
-                time.sleep(next(xdelay))
-            # Downloading .treeinfo
-            log.info("Trying to download '.treeinfo'")
-            (response, ret_code[0]) = self._download_treeinfo_file(url, ".treeinfo",
-                                                                   headers, proxies, sslverify)
-            if response:
-                break
-            # Downloading treeinfo
-            log.info("Trying to download 'treeinfo'")
-            (response, ret_code[1]) = self._download_treeinfo_file(url, "treeinfo",
-                                                                   headers, proxies, sslverify)
-            if response:
-                break
-
-            # The [.]treeinfo wasn't downloaded. Try it again if [.]treeinfo
-            # is on the server.
-            #
-            # Server returned HTTP 404 code -> no need to try again
-            if (ret_code[0] is not None and ret_code[0] == 404 and ret_code[1] is not None and ret_code[1] == 404):
-                response = None
-                log.error("Got HTTP 404 Error when downloading [.]treeinfo files")
-                break
-            if retry_count < MAX_TREEINFO_DOWNLOAD_RETRIES:
-                # retry
-                log.info("Retrying repo info download for %s, retrying (%d/%d)",
-                         url, retry_count + 1, MAX_TREEINFO_DOWNLOAD_RETRIES)
-            else:
-                # run out of retries
-                err_msg = ("Repo info download for %s failed after %d retries" %
-                           (url, retry_count))
-                log.error(err_msg)
-                self.verbose_errors.append(err_msg)
-                response = None
-
-        if response:
-            # get the treeinfo contents
-            text = response.text
-
-            response.close()
-
-            self._treeinfo = TreeInfo()
-            self._treeinfo.loads(text)
-        else:
-            self._treeinfo = None
-
-    def _download_treeinfo_file(self, url, file_name, headers, proxies, verify):
+        self._install_tree_metadata = InstallTreeMetadata()
         try:
-            result = self._session.get("%s/%s" % (url, file_name), headers=headers,
-                                       proxies=proxies, verify=verify)
-            # Server returned HTTP 4XX or 5XX codes
-            if result.status_code >= 400 and result.status_code < 600:
-                log.info("Server returned %i code", result.status_code)
-                return (None, result.status_code)
-            log.debug("Retrieved '%s' from %s", file_name, url)
-        except requests.exceptions.RequestException as e:
-            log.info("Error downloading '%s': %s", file_name, e)
-            return (None, None)
-        return (result, result.status_code)
+            ret = self._install_tree_metadata.load_url(url, proxies, sslverify, headers)
+        except IOError as e:
+            self._install_tree_metadata = None
+            self.verbose_errors.append(str(e))
+            log.warning("Install tree metadata fetching failed: %s", str(e))
+            return
+
+        if not ret:
+            log.warning("Install tree metadata can't be loaded!")
+            self._install_tree_metadata = None
 
     def _getReleaseVersion(self, url):
         """Return the release version of the tree at the specified URL."""
@@ -749,8 +689,8 @@ class Payload(object):
 
         log.debug("getting release version from tree at %s (%s)", url, version)
 
-        if self._treeinfo:
-            version = self._treeinfo.release.version.lower()
+        if self._install_tree_metadata:
+            version = self._install_tree_metadata.get_release_version()
             log.debug("using treeinfo release version of %s", version)
         else:
             log.debug("using default release version of %s", version)

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -1163,7 +1163,7 @@ class DNFPayload(payload.PackagePayload):
 
         if method.method:
             try:
-                self._refreshTreeInfo(install_tree_url)
+                self._refreshInstallTree(install_tree_url)
                 self._base.conf.releasever = self._getReleaseVersion(install_tree_url)
                 base_repo_url = self._getBaseRepoLocation(install_tree_url)
 
@@ -1270,20 +1270,11 @@ class DNFPayload(payload.PackagePayload):
         * If URL points to repo directly then no .treeinfo file is present. We will just use this
         repo.
         """
-        if self._treeinfo:
-            variants = self._treeinfo.variants
-
-            for variant in variants:
-                if variant in constants.DEFAULT_REPOS:
-                    variant_obj = variants[variant]
-                    log.info("Found base repository in treeinfo file.")
-                    if variant_obj.paths.repository == ".":
-                        log.debug("Treeinfo points base repository to installation tree root.")
-                        base_repo_url = install_tree_url
-                    else:
-                        base_repo_url = install_tree_url + "/" + variant_obj.paths.repository
-                        log.debug("Treeinfo points base repository to %s.", base_repo_url)
-                    return base_repo_url
+        if self._install_tree_metadata:
+            repo_md = self._install_tree_metadata.get_base_repo_metadata()
+            if repo_md:
+                log.debug("Treeinfo points base repository to %s.", repo_md.path)
+                return repo_md.path
 
         log.debug("No base repository found in treeinfo file. Using installation tree root.")
         return install_tree_url
@@ -1295,9 +1286,7 @@ class DNFPayload(payload.PackagePayload):
         :param base_repo_url: Base repository url. This is not saved anywhere when the function
         is called. It will be add to the existing urls if not None.
         """
-        if self._treeinfo:
-            variants = self._treeinfo.variants
-
+        if self._install_tree_metadata:
             existing_urls = []
 
             if base_repo_url is not None:
@@ -1306,15 +1295,10 @@ class DNFPayload(payload.PackagePayload):
             for ksrepo in self.data.repo.dataList():
                 existing_urls.append(ksrepo.baseurl)
 
-            for variant in variants:
-                variant_obj = variants[variant]
-                variant_url = install_tree_url
-
-                if not variant_obj.paths.repository == ".":
-                    variant_url = install_tree_url + "/" + variant_obj.paths.repository
-
-                if variant_url not in existing_urls:
-                    repo = RepoData(name=variant, baseurl=variant_url, install=False, enabled=True)
+            for repo_md in self._install_tree_metadata.get_metadata_repos():
+                if repo_md.path not in existing_urls:
+                    repo = RepoData(name=repo_md.name, baseurl=repo_md.path,
+                                    install=False, enabled=True)
                     repo.treeinfo_origin = True
                     self.data.repo.dataList().append(repo)
 

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -796,7 +796,7 @@ class DNFPayload(payload.PackagePayload):
     @property
     def baseRepo(self):
         # is any locking needed here?
-        repo_names = [constants.BASE_REPO_NAME] + self.DEFAULT_REPOS
+        repo_names = [constants.BASE_REPO_NAME] + constants.DEFAULT_REPOS
         with self._repos_lock:
             for repo in self._base.repos.iter_enabled():
                 if repo.id in repo_names:
@@ -1274,7 +1274,7 @@ class DNFPayload(payload.PackagePayload):
             variants = self._treeinfo.variants
 
             for variant in variants:
-                if variant in self.DEFAULT_REPOS:
+                if variant in constants.DEFAULT_REPOS:
                     variant_obj = variants[variant]
                     log.info("Found base repository in treeinfo file.")
                     if variant_obj.paths.repository == ".":

--- a/pyanaconda/payload/install_tree_metadata.py
+++ b/pyanaconda/payload/install_tree_metadata.py
@@ -1,0 +1,206 @@
+# Gather and provides metadata about installation tree.
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import time
+import requests
+
+from productmd.treeinfo import TreeInfo
+from pyanaconda.core import util, constants
+
+from pyanaconda.anaconda_loggers import get_packaging_logger
+log = get_packaging_logger()
+
+MAX_TREEINFO_DOWNLOAD_RETRIES = 6
+
+
+class InstallTreeMetadata(object):
+
+    def __init__(self):
+        self._tree_info = TreeInfo()
+        self._meta_repos = []
+
+    def load_text(self, text):
+        """Loads .treeinfo content."""
+        self._tree_info.loads(text)
+
+    def load_file(self, path):
+        """Loads installation tree metadata from root path."""
+        self._clear()
+        self._tree_info.load(path)
+
+    def load_url(self, url, proxies, sslverify, headers):
+        """Load URL link.
+
+        This can be also to local file.
+
+        Parameters here are passed to requests object so make them compatible with requests.
+
+        :param url: URL poiting to the installation tree.
+        :param proxies: Proxy used for the request.
+        :param sslverify: sslverify object which will be used in request.
+        :param headers: Additional headers of the request.
+        :returns: True if the install tree repo metadata was successfully loaded. False otherwise.
+
+        :raise: IOError is thrown in case of immediate failure.
+        """
+        # Retry treeinfo downloads with a progressively longer pause,
+        # so NetworkManager have a chance setup a network and we have
+        # full connectivity before trying to download things. (#1292613)
+        xdelay = util.xprogressive_delay()
+        response = None
+        ret_code = [None, None]
+        session = util.requests_session()
+
+        self._clear()
+
+        for retry_count in range(0, MAX_TREEINFO_DOWNLOAD_RETRIES + 1):
+            if retry_count > 0:
+                time.sleep(next(xdelay))
+            # Downloading .treeinfo
+            log.info("Trying to download '.treeinfo'")
+            (response, ret_code[0]) = self._download_treeinfo_file(session, url, ".treeinfo",
+                                                                   headers, proxies, sslverify)
+            if response:
+                break
+            # Downloading treeinfo
+            log.info("Trying to download 'treeinfo'")
+            (response, ret_code[1]) = self._download_treeinfo_file(session, url, "treeinfo",
+                                                                   headers, proxies, sslverify)
+            if response:
+                break
+
+            # The [.]treeinfo wasn't downloaded. Try it again if [.]treeinfo
+            # is on the server.
+            #
+            # Server returned HTTP 404 code -> no need to try again
+            if (ret_code[0] is not None and ret_code[0] == 404
+                    and ret_code[1] is not None and ret_code[1] == 404):
+                response = None
+                log.error("Got HTTP 404 Error when downloading [.]treeinfo files")
+                break
+            if retry_count < MAX_TREEINFO_DOWNLOAD_RETRIES:
+                # retry
+                log.info("Retrying repo info download for %s, retrying (%d/%d)",
+                         url, retry_count + 1, MAX_TREEINFO_DOWNLOAD_RETRIES)
+            else:
+                # run out of retries
+                err_msg = ("Repo info download for %s failed after %d retries" %
+                           (url, retry_count))
+                log.error(err_msg)
+                raise IOError("Can't get .treeinfo file from the url {}".format(url))
+
+        if response:
+            # get the treeinfo contents
+            text = response.text
+
+            response.close()
+
+            self.load_text(text)
+            return True
+
+        return False
+
+    @staticmethod
+    def _download_treeinfo_file(session, url, file_name, headers, proxies, verify):
+        try:
+            result = session.get("%s/%s" % (url, file_name), headers=headers,
+                                 proxies=proxies, verify=verify)
+            # Server returned HTTP 4XX or 5XX codes
+            if 400 <= result.status_code < 600:
+                log.info("Server returned %i code", result.status_code)
+                return None, result.status_code
+            log.debug("Retrieved '%s' from %s", file_name, url)
+        except requests.exceptions.RequestException as e:
+            log.info("Error downloading '%s': %s", file_name, e)
+            return (None, None)
+        return result, result.status_code
+
+    def _clear(self):
+        """Clear metadata repositories."""
+        self._tree_info = TreeInfo()
+        self._meta_repos = []
+
+    def get_release_version(self):
+        """Get release version from the repository.
+
+        :returns: Version as lowercase string.
+        :raises: ValueError if version is not present.
+        """
+        version = self._tree_info.release.version
+
+        if not version:
+            raise ValueError("Can't read release version from the .treeinfo file! "
+                             "Is the .treeinfo file corrupted?")
+
+        return version.lower()
+
+    def get_repos_metadata(self):
+        """Get all repository metadata objects."""
+        if not self._meta_repos:
+            self._read_variants()
+
+        return self._meta_repos
+
+    def get_repo_metadata_by_name(self, name):
+        """Get repository metadata object with given name.
+
+        :param name: Name of the variant to return.
+        :rtype name: VariantRepo object or None.
+        """
+        for variant in self.get_repos_metadata():
+            if name == variant.name:
+                return variant
+
+        return None
+
+    def get_base_repo_metadata(self, additional_names):
+        """Get repo metadata about base repository."""
+        repos = additional_names + constants.DEFAULT_REPOS
+
+        for repo_md in self.get_repos_metadata():
+            if repo_md.name in repos:
+                return repo_md
+
+        return None
+
+    def _read_variants(self):
+        for variant_name in self._tree_info.variants:
+            variant_object = self._tree_info.variants[variant_name]
+            self._meta_repos.append(RepoMetadata(variant_name, variant_object))
+
+
+class RepoMetadata(object):
+    """Metadata repo object contains metadata about repository."""
+
+    def __init__(self, name, obj):
+        """Do not instantiate this class directly.
+        Use InstallTreeMetadata to instantiate this class.
+        """
+        self._name = name
+        self._obj = obj
+
+    @property
+    def name(self):
+        """Get name of this repository."""
+        return self._name
+
+    @property
+    def path(self):
+        """Get relative repository root path."""
+        return self._obj.paths.repository

--- a/pyanaconda/payload/install_tree_metadata.py
+++ b/pyanaconda/payload/install_tree_metadata.py
@@ -230,3 +230,11 @@ class RepoMetadata(object):
             return self._root_path
         else:
             return os.path.join(self._root_path, self.relative_path)
+
+    def is_valid(self):
+        """Quick check if the repo is a valid repository.
+
+        This is only check if the repository is invalid. If success it doesn't mean it is valid.
+
+        :returns: True if repository is not invalid, False otherwise."""
+        return os.access(os.path.join(self.path, "repodata"), os.R_OK)

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1169,8 +1169,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         if not REPO_NAME_VALID.match(repo_name):
             return _("Invalid repository name")
 
-        cnames = [constants.BASE_REPO_NAME] + \
-                 self.payload.DEFAULT_REPOS + \
+        cnames = [constants.BASE_REPO_NAME] + constants.DEFAULT_REPOS + \
                  [r for r in self.payload.repos if r not in self.payload.addOns]
         if repo_name in cnames:
             return _("Repository name conflicts with internal repository name.")


### PR DESCRIPTION
Add InstallTreeMetadata to abstract work with TreeInfo object from productmd library.

Use this class to check if at least one repodata folder is present on the installation media.

Backport of https://github.com/rhinstaller/anaconda/pull/1659.