### PR TITLE
Fix local repo files aren't enabled (#1636739)

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -387,7 +387,9 @@ class DNFPayload(payload.PackagePayload):
         #     and use this new one.  The highest profile user of this is livecd
         #     kickstarts.
         if repo.id in self._base.repos:
-            if url or mirrorlist or metalink:
+            if not url and not mirrorlist and not metalink:
+                self._base.repos[repo.id].enable()
+            else:
                 with self._repos_lock:
                     self._base.repos.pop(repo.id)
                     self._base.repos.add(repo)


### PR DESCRIPTION
This is fall of PR:

3496e955f0763ab4016f96ef2af4988796b32005

Line to enable know repositories where accidentally removed.

*Resolves: rhbz#1636739*

*Reported-by: Edgar Hoch <edgar.hoch@ims.uni-stuttgart.de>*