### PR TITLE
Fix local repo files aren't enabled

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -396,7 +396,9 @@ class DNFPayload(payload.PackagePayload):
         #     and use this new one.  The highest profile user of this is livecd
         #     kickstarts.
         if repo.id in self._base.repos:
-            if url or mirrorlist or metalink:
+            if not url and not mirrorlist and not metalink:
+                self._base.repos[repo.id].enable()
+            else:
                 with self._repos_lock:
                     self._base.repos.pop(repo.id)
                     self._base.repos.add(repo)


### PR DESCRIPTION
This is fall of PR:

3496e955f0763ab4016f96ef2af4988796b32005

Line to enable know repositories where accidentally removed.

Resolves: rhbz#1641620

Reported-by: Edgar Hoch <edgar.hoch@ims.uni-stuttgart.de>
(cherry picked from commit e9021fedaa53f13b39df1bbcc8207b83358e54f7)

Backport of: https://github.com/rhinstaller/anaconda/pull/1666