### PR TITLE
Do not enable or disable updates-testing, use setting from repo file …

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -907,12 +907,14 @@ class DNFPayload(payload.PackagePayload):
 
         if self._updates_enabled:
             self.enableRepo("updates")
-            if not constants.isFinal:
-                self.enableRepo("updates-testing")
+# disabled as F29 hotfix for bug 1642089
+#            if not constants.isFinal:
+#                self.enableRepo("updates-testing")
         else:
             self.disableRepo("updates")
-            if not constants.isFinal:
-                self.disableRepo("updates-testing")
+# disabled as F29 hotfix for bug 1642089
+#            if not constants.isFinal:
+#                self.disableRepo("updates-testing")
 
     def disableRepo(self, repo_id):
         try:


### PR DESCRIPTION
…(#1642089)

This is a F29 specific hotfix to drop code from Anaconda that enables or
disables updates-testing based on user input & isFinal flag.

With this change the updates-testing repository will be enabled or
disabled only depending on the "enabled" value in it's repo file.
It will not be possible to enable or disable it from the GUI.

This is a downstream patch for F29 only and a better solution is
expected to be worked out for F30+.

Resolves: rhbz#1642089