### PR TITLE
Remove blivet-specific flags from pyanaconda.flags

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -288,6 +288,9 @@ if __name__ == "__main__":
     from pyanaconda.flags import flags, can_touch_runtime_system
     (opts, depr) = parse_arguments(boot_cmdline=flags.cmdline)
 
+    from pyanaconda.core.configuration.anaconda import conf
+    conf.set_from_opts(opts)
+
     if opts.images:
         flags.imageInstall = True
     elif opts.dirinstall:
@@ -434,18 +437,14 @@ if __name__ == "__main__":
     flags.noverifyssl = opts.noverifyssl
     flags.extlinux = opts.extlinux
     flags.nombr = opts.nombr
-    flags.mpathFriendlyNames = opts.mpathfriendlynames
     flags.debug = opts.debug
     flags.askmethod = opts.askmethod
-    flags.dmraid = opts.dmraid
     flags.mpath = opts.mpath
-    flags.ibft = opts.ibft
     flags.nonibftiscsiboot = opts.nonibftiscsiboot
     flags.selinux = opts.selinux
     flags.eject = opts.eject
     flags.kexec = opts.kexec
     flags.singlelang = opts.singlelang
-    flags.gpt = opts.gpt
     flags.leavebootorder = opts.leavebootorder
 
     if opts.liveinst:

--- a/anaconda.py
+++ b/anaconda.py
@@ -432,7 +432,6 @@ if __name__ == "__main__":
     # set flags
     flags.rescue_mode = opts.rescue
     flags.noverifyssl = opts.noverifyssl
-    flags.armPlatform = opts.armPlatform
     flags.extlinux = opts.extlinux
     flags.nombr = opts.nombr
     flags.mpathFriendlyNames = opts.mpathfriendlynames

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -19,9 +19,6 @@ selinux = -1
 
 
 [Storage]
-# The platform id of the ARM processor.
-arm_platform = ""
-
 # Enable dmraid usage during the installation.
 dmraid = True
 

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -41,9 +41,6 @@ rescue
 Start the rescue environment instead of installation.  This option is not supported for
 live installations.
 
-armplatform
-Can be used to specify the ARM platform for the installation by passing the appropriate PLATFORM_ID.
-
 multilib
 Enable dnf's multlib_policy of "all" instead of the default of "best".
 

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -444,7 +444,7 @@ def getArgumentParser(version_string, boot_cmdline=None):
     ap.add_argument("--rescue", dest="rescue", action="store_true", default=False,
                     help=help_parser.help_text("rescue"))
     ap.add_argument("--armplatform", dest="armPlatform", type=str, metavar="PLATFORM_ID",
-                    help=help_parser.help_text("armplatform"))
+                    help="This option is deprecated.")
     ap.add_argument("--multilib", dest="multiLib", action="store_true", default=False,
                     help=help_parser.help_text("multilib"))
 

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -581,8 +581,8 @@ def getArgumentParser(version_string, boot_cmdline=None):
                     help=help_parser.help_text("extlinux"))
     ap.add_argument("--nombr", action="store_true", default=False,
                     help=help_parser.help_text("nombr"))
-    ap.add_argument("--mpathfriendlynames", action="store_true", default=True,
-                    help=help_parser.help_text("mpathfriendlynames"))
+    ap.add_argument("--mpathfriendlynames", dest="multipath_friendly_names", action="store_true",
+                    default=True, help=help_parser.help_text("mpathfriendlynames"))
     ap.add_argument("--kexec", action="store_true", default=False,
                     help=help_parser.help_text("kexec"))
 

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -216,5 +216,23 @@ class AnacondaConfiguration(object):
             if isinstance(obj, AnacondaConfiguration) and isinstance(value, Section):
                 self._validate_members(value)
 
+    def set_from_opts(self, opts):
+        """Set the configuration from the Anaconda cmdline options.
+
+        This code is too related to the Anaconda cmdline options, so it shouldn't
+        be part of this class. We should find a better, more universal, way to change
+        the Anaconda configuration.
+
+        FIXME: This is a temporary solution.
+
+        :param opts: a namespace of options
+        """
+        self.storage._set_option("dmraid", opts.dmraid)
+        self.storage._set_option("ibft", opts.ibft)
+        self.storage._set_option("gpt", opts.gpt)
+        self.storage._set_option("multipath_friendly_names", opts.multipath_friendly_names)
+
+        self.validate()
+
 
 conf = AnacondaConfiguration.from_defaults()

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -86,11 +86,6 @@ class StorageSection(Section):
     """The Storage section."""
 
     @property
-    def arm_platform(self):
-        """The platform id of the ARM processor."""
-        return self._get_option("arm_platform", str)
-
-    @property
     def dmraid(self):
         """Enable dmraid usage during the installation."""
         return self._get_option("dmraid", bool)

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -39,12 +39,10 @@ class Flags(object):
     def __init__(self):
         self.__dict__['_in_init'] = True
         self.livecdInstall = False
-        self.ibft = True
         self.nonibftiscsiboot = False
         self.usevnc = False
         self.vncquestion = True
         self.mpath = True
-        self.dmraid = True
 
         self.selinux = SELINUX_DEFAULT
 
@@ -61,9 +59,7 @@ class Flags(object):
         self.eject = True
         self.extlinux = False
         self.nombr = False
-        self.gpt = False
         self.leavebootorder = False
-        self.mpathFriendlyNames = True
         # ksprompt is whether or not to prompt for missing ksdata
         self.ksprompt = True
         self.rescue_mode = False

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -52,7 +52,6 @@ class Flags(object):
             self.selinux = SELINUX_DISABLED
 
         self.debug = False
-        self.armPlatform = None
         self.preexisting_x11 = False
         self.noverifyssl = False
         self.imageInstall = False

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -117,7 +117,6 @@ def update_blivet_flags(blivet_flags, anaconda_flags):  # pylint: disable=redefi
     """
     blivet_flags.selinux = anaconda_flags.selinux
 
-    blivet_flags.arm_platform = anaconda_flags.armPlatform
     blivet_flags.gpt = anaconda_flags.gpt
 
     blivet_flags.multipath_friendly_names = anaconda_flags.mpathFriendlyNames

--- a/tests/nosetests/pyanaconda_tests/argparse_test.py
+++ b/tests/nosetests/pyanaconda_tests/argparse_test.py
@@ -18,6 +18,7 @@
 #
 
 from pyanaconda import argument_parsing
+from pyanaconda.core.configuration.anaconda import AnacondaConfiguration
 from pyanaconda.core.kernel import KernelArguments
 from pyanaconda.core.constants import DisplayModes
 import unittest
@@ -87,3 +88,18 @@ class ArgparseTest(unittest.TestCase):
         # with an argument, dirinstall should use that
         opts, _deprecated = self._parseCmdline(['--dirinstall=/what/ever'])
         self.assertEqual(opts.dirinstall, "/what/ever")
+
+    def conf_test(self):
+        conf = AnacondaConfiguration.from_defaults()
+
+        opts, _deprecated = self._parseCmdline([])
+        conf.set_from_opts(opts)
+
+        self.assertEqual(conf.storage.dmraid, True)
+        self.assertEqual(conf.storage.ibft, True)
+
+        opts, _deprecated = self._parseCmdline(['--nodmraid', '--ibft'])
+        conf.set_from_opts(opts)
+
+        self.assertEqual(conf.storage.dmraid, False)
+        self.assertEqual(conf.storage.ibft, True)


### PR DESCRIPTION
We should use the Anaconda config to set up Blivet.

Blivet removed its `arm_platform` flag in [ec978c3](https://github.com/storaged-project/blivet/commit/ec978c3), so Anaconda can
deprecate the `inst.armplatfrom` option, because it is not useful
anymore.