### PR TITLE
Set kernel watchdog timeout to avoid lockups on some systems (#1643717)

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -844,6 +844,10 @@ class BootLoader(object):
         swap_devices = storage.fsset.swap_devices
         dracut_devices.extend(swap_devices)
 
+        # rhbz#1643717 hotfix: set kernel watchdog timeout to work around kernel
+        #                      lookup issues with systems that have many LUNs
+        self.boot_args.add("watchdog_thresh=30")
+
         # Add resume= option to enable hibernation on x86.
         # Choose the largest swap device for that.
         if blivet.arch.is_x86() and swap_devices:


### PR DESCRIPTION
On some systems with many attached LUNs (100+) kernel lookups can happen
unless the kernel watchdog timeout via the watchdog_thresh boot option
is set. So set the boot option unconditionally when writing bootloader
configuration.

Note that this will only influence the installed system once it is first
booted, not the installation environment itself.

Related: rhbz#1643717