### PR TITLE
Configure the installation target

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -80,7 +80,7 @@ def exitHandler(rebootData, storage):
     if anaconda.payload:
         anaconda.payload.unsetup()
 
-    if image_count or conf.target.is_directory:
+    if not conf.target.is_hardware:
         anaconda.storage.umount_filesystems(swapoff=False)
         devicetree = anaconda.storage.devicetree
         devicetree.teardown_all()
@@ -96,8 +96,7 @@ def exitHandler(rebootData, storage):
 
     anaconda.dbus_launcher.stop()
 
-    if not conf.target.is_image and not flags.livecdInstall \
-       and not conf.target.is_directory:
+    if conf.target.is_hardware and not flags.livecdInstall:
         from pykickstart.constants import KS_SHUTDOWN, KS_WAIT
 
         if flags.eject or rebootData.eject:
@@ -294,7 +293,7 @@ if __name__ == "__main__":
     # Set up logging as early as possible.
     from pyanaconda import anaconda_logging
     from pyanaconda import anaconda_loggers
-    anaconda_logging.init(write_to_journal=not conf.target.is_image and not conf.target.is_directory)
+    anaconda_logging.init(write_to_journal=conf.target.is_hardware)
     anaconda_logging.logger.setupVirtio(opts.virtiolog)
 
     from pyanaconda import network

--- a/anaconda.py
+++ b/anaconda.py
@@ -96,7 +96,7 @@ def exitHandler(rebootData, storage):
 
     anaconda.dbus_launcher.stop()
 
-    if not flags.imageInstall and not flags.livecdInstall \
+    if not conf.target.is_image and not flags.livecdInstall \
        and not flags.dirInstall:
         from pykickstart.constants import KS_SHUTDOWN, KS_WAIT
 
@@ -291,15 +291,13 @@ if __name__ == "__main__":
     from pyanaconda.core.configuration.anaconda import conf
     conf.set_from_opts(opts)
 
-    if opts.images:
-        flags.imageInstall = True
-    elif opts.dirinstall:
+    if not opts.images and opts.dirinstall:
         flags.dirInstall = True
 
     # Set up logging as early as possible.
     from pyanaconda import anaconda_logging
     from pyanaconda import anaconda_loggers
-    anaconda_logging.init(write_to_journal=not flags.imageInstall and not flags.dirInstall)
+    anaconda_logging.init(write_to_journal=not conf.target.is_image and not flags.dirInstall)
     anaconda_logging.logger.setupVirtio(opts.virtiolog)
 
     from pyanaconda import network
@@ -325,7 +323,7 @@ if __name__ == "__main__":
     # see if we're on s390x and if we've got an ssh connection
     uname = os.uname()
     if uname[4] == 's390x':
-        if 'TMUX' not in os.environ and 'ks' not in flags.cmdline and not flags.imageInstall:
+        if 'TMUX' not in os.environ and 'ks' not in flags.cmdline and not conf.target.is_image:
             startup_utils.prompt_for_ssh()
             sys.exit(0)
 
@@ -685,7 +683,6 @@ if __name__ == "__main__":
             log.info("naming disk image '%s' '%s'", path, name)
             anaconda.storage.disk_images[name] = path
             image_count += 1
-            flags.imageInstall = True
     except ValueError as e:
         stdout_log.error("error specifying image file: %s", e)
         util.ipmi_abort(scripts=ksdata.scripts)

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -21,6 +21,14 @@ kickstart_modules =
      org.fedoraproject.Anaconda.Modules.Services
 
 
+[Installation Target]
+# Type of the installation target.
+type = HARDWARE
+
+# A path to the physical root of the target.
+physical_root = /mnt/sysimage
+
+
 [Services]
 # Enable SELinux usage in the installed system.
 # Valid values:

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -40,6 +40,7 @@ from pyanaconda.nm import nm_device_hwaddress
 from pyanaconda import platform
 from blivet.size import Size
 from pyanaconda.core.i18n import _, N_
+from pyanaconda.core.configuration.anaconda import conf
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -651,7 +652,7 @@ class BootLoader(object):
                 continue
 
             if self.is_valid_stage1_device(device):
-                if flags.imageInstall and device.is_disk:
+                if conf.target.is_image and device.is_disk:
                     # GRUB2 will install to /dev/loop0 but not to
                     # /dev/mapper/<image_name>
                     self.stage1_device = device.parents[0]
@@ -1727,7 +1728,7 @@ class EFIBase(object):
         return "efi/EFI/%s" % (efi_dir,)
 
     def efibootmgr(self, *args, **kwargs):
-        if flags.imageInstall or flags.dirInstall:
+        if conf.target.is_image or flags.dirInstall:
             log.info("Skipping efibootmgr for image/directory install.")
             return ""
 

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1728,7 +1728,7 @@ class EFIBase(object):
         return "efi/EFI/%s" % (efi_dir,)
 
     def efibootmgr(self, *args, **kwargs):
-        if conf.target.is_image or conf.target.is_directory:
+        if not conf.target.is_hardware:
             log.info("Skipping efibootmgr for image/directory install.")
             return ""
 

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1728,7 +1728,7 @@ class EFIBase(object):
         return "efi/EFI/%s" % (efi_dir,)
 
     def efibootmgr(self, *args, **kwargs):
-        if conf.target.is_image or flags.dirInstall:
+        if conf.target.is_image or conf.target.is_directory:
             log.info("Skipping efibootmgr for image/directory install.")
             return ""
 

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -976,7 +976,7 @@ def detect_unsupported_hardware(install_class):
     """
     warnings = []
 
-    if flags.automatedInstall or flags.dirInstall or conf.target.is_image:
+    if flags.automatedInstall or conf.target.is_directory or conf.target.is_image:
         log.info("Skipping detection of unsupported hardware.")
         return []
 

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -84,9 +84,6 @@ def augmentEnv():
     return env
 
 
-_root_path = "/mnt/sysimage"
-
-
 def getTargetPhysicalRoot():
     """Returns the path to the "physical" storage root, traditionally /mnt/sysimage.
 
@@ -99,19 +96,10 @@ def getTargetPhysicalRoot():
     # target is never mounted anywhere else.  This API call just
     # allows us to have a clean "git grep ROOT_PATH" in other parts of
     # the code.
-    return _root_path
+    return conf.target.physical_root
 
 
-def setTargetPhysicalRoot(path):
-    """Change the physical root path
-
-    :param string path: Path to use instead of /mnt/sysimage/
-    """
-    global _root_path
-    _root_path = path
-
-
-_sysroot = _root_path
+_sysroot = None
 
 
 def getSysroot():
@@ -120,7 +108,10 @@ def getSysroot():
     For ordinary package-based installations, this is the same as the
     target root.
     """
-    return _sysroot
+    if _sysroot:
+        return _sysroot
+
+    return getTargetPhysicalRoot()
 
 
 def setSysroot(path):
@@ -161,7 +152,7 @@ def startProgram(argv, root='/', stdin=None, stdout=subprocess.PIPE, stderr=subp
     # Transparently redirect callers requesting root=_root_path to the
     # configured system root.
     target_root = root
-    if target_root == _root_path:
+    if target_root == getTargetPhysicalRoot():
         target_root = getSysroot()
 
     # Check for and save a preexec_fn argument

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -976,7 +976,7 @@ def detect_unsupported_hardware(install_class):
     """
     warnings = []
 
-    if flags.automatedInstall or conf.target.is_directory or conf.target.is_image:
+    if flags.automatedInstall or not conf.target.is_hardware:
         log.info("Skipping detection of unsupported hardware.")
         return []
 

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -42,6 +42,7 @@ import requests
 from requests_file import FileAdapter
 from requests_ftp import FTPAdapter
 
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.flags import flags
 from pyanaconda.core.process_watchers import WatchProcesses
 from pyanaconda.core.constants import DRACUT_SHUTDOWN_EJECT, TRANSLATIONS_UPDATE_DIR, \
@@ -975,7 +976,7 @@ def detect_unsupported_hardware(install_class):
     """
     warnings = []
 
-    if flags.automatedInstall or flags.dirInstall or flags.imageInstall:
+    if flags.automatedInstall or flags.dirInstall or conf.target.is_image:
         log.info("Skipping detection of unsupported hardware.")
         return []
 

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -53,7 +53,6 @@ class Flags(object):
         self.preexisting_x11 = False
         self.noverifyssl = False
         self.automatedInstall = False
-        self.dirInstall = False
         self.askmethod = False
         self.eject = True
         self.extlinux = False
@@ -101,7 +100,7 @@ def can_touch_runtime_system(msg, touch_live=False):
         log.info("Not doing '%s' in image installation", msg)
         return False
 
-    if flags.dirInstall:
+    if conf.target.is_directory:
         log.info("Not doing '%s' in directory installation", msg)
         return False
 

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -52,7 +52,6 @@ class Flags(object):
         self.debug = False
         self.preexisting_x11 = False
         self.noverifyssl = False
-        self.imageInstall = False
         self.automatedInstall = False
         self.dirInstall = False
         self.askmethod = False
@@ -92,12 +91,13 @@ def can_touch_runtime_system(msg, touch_live=False):
     :rtype: bool
 
     """
+    from pyanaconda.core.configuration.anaconda import conf
 
     if flags.livecdInstall and not touch_live:
         log.info("Not doing '%s' in live installation", msg)
         return False
 
-    if flags.imageInstall:
+    if conf.target.is_image:
         log.info("Not doing '%s' in image installation", msg)
         return False
 

--- a/pyanaconda/geoloc.py
+++ b/pyanaconda/geoloc.py
@@ -180,7 +180,7 @@ class Geolocation(object):
         """
         geolocation_enabled = True
         # don't use geolocation during image and directory installation
-        if conf.target.is_image or flags.dirInstall:
+        if conf.target.is_image or conf.target.is_directory:
             log.info("Geolocation is disabled for image or directory installation.")
             geolocation_enabled = False
         # don't use geolocation during kickstart installation unless explicitly
@@ -218,7 +218,7 @@ class Geolocation(object):
             else:
                 log.info("Geolocation is enabled.")
         else:
-            if conf.target.is_image or flags.dirInstall:
+            if conf.target.is_image or conf.target.is_directory:
                 log.info("Geolocation is disabled for image or directory installation.")
             elif flags.automatedInstall:
                 log.info("Geolocation is disabled due to automated kickstart based installation.")

--- a/pyanaconda/geoloc.py
+++ b/pyanaconda/geoloc.py
@@ -180,7 +180,7 @@ class Geolocation(object):
         """
         geolocation_enabled = True
         # don't use geolocation during image and directory installation
-        if conf.target.is_image or conf.target.is_directory:
+        if not conf.target.is_hardware:
             log.info("Geolocation is disabled for image or directory installation.")
             geolocation_enabled = False
         # don't use geolocation during kickstart installation unless explicitly
@@ -218,7 +218,7 @@ class Geolocation(object):
             else:
                 log.info("Geolocation is enabled.")
         else:
-            if conf.target.is_image or conf.target.is_directory:
+            if not conf.target.is_hardware:
                 log.info("Geolocation is disabled for image or directory installation.")
             elif flags.automatedInstall:
                 log.info("Geolocation is disabled due to automated kickstart based installation.")

--- a/pyanaconda/geoloc.py
+++ b/pyanaconda/geoloc.py
@@ -122,6 +122,7 @@ log = get_module_logger(__name__)
 sensitive_info_log = get_sensitive_info_logger()
 
 from pyanaconda.core import constants
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.threading import AnacondaThread, threadMgr
 from pyanaconda.timezone import get_preferred_timezone, is_valid_timezone
 from pyanaconda.flags import flags
@@ -179,7 +180,7 @@ class Geolocation(object):
         """
         geolocation_enabled = True
         # don't use geolocation during image and directory installation
-        if flags.imageInstall or flags.dirInstall:
+        if conf.target.is_image or flags.dirInstall:
             log.info("Geolocation is disabled for image or directory installation.")
             geolocation_enabled = False
         # don't use geolocation during kickstart installation unless explicitly
@@ -217,7 +218,7 @@ class Geolocation(object):
             else:
                 log.info("Geolocation is enabled.")
         else:
-            if flags.imageInstall or flags.dirInstall:
+            if conf.target.is_image or flags.dirInstall:
                 log.info("Geolocation is disabled for image or directory installation.")
             elif flags.automatedInstall:
                 log.info("Geolocation is disabled due to automated kickstart based installation.")

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -103,8 +103,7 @@ def doConfiguration(storage, payload, ksdata, instClass):
     configuration_queue.append(os_config)
 
     # schedule network configuration (if required)
-    will_write_network = not conf.target.is_image and not conf.target.is_directory
-    if will_write_network:
+    if conf.target.is_hardware:
         network_config = TaskQueue("Network configuration", N_("Writing network configuration"))
         network_config.append(Task("Network configuration",
                                    ksdata.network.execute, (storage, ksdata, instClass)))
@@ -279,7 +278,7 @@ def doInstall(storage, payload, ksdata, instClass):
     early_storage.append(Task("Activate filesystems",
                               task=turn_on_filesystems,
                               task_args=(storage,),
-                              task_kwargs={"mount_only": conf.target.is_directory, "callbacks": callbacks_reg}))
+                              task_kwargs={"callbacks": callbacks_reg}))
 
     early_storage.append(Task("Write early storage", payload.writeStorageEarly))
     installation_queue.append(early_storage)

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -103,7 +103,7 @@ def doConfiguration(storage, payload, ksdata, instClass):
     configuration_queue.append(os_config)
 
     # schedule network configuration (if required)
-    will_write_network = not conf.target.is_image and not flags.flags.dirInstall
+    will_write_network = not conf.target.is_image and not conf.target.is_directory
     if will_write_network:
         network_config = TaskQueue("Network configuration", N_("Writing network configuration"))
         network_config.append(Task("Network configuration",
@@ -177,7 +177,7 @@ def doConfiguration(storage, payload, ksdata, instClass):
     # starts from the generate image or directory contents.
     if conf.target.is_image:
         log.info("Not writing out user interaction config file due to image install mode.")
-    elif flags.flags.dirInstall:
+    elif conf.target.is_directory:
         log.info("Not writing out user interaction config file due to directory install mode.")
     else:
         write_configs.append(Task("Store user interaction config", screen_access.sam.write_out_config_file))
@@ -214,7 +214,7 @@ def doInstall(storage, payload, ksdata, instClass):
     """
     bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
     bootloader_enabled = bootloader_proxy.BootloaderMode != BOOTLOADER_DISABLED
-    can_install_bootloader = not flags.flags.dirInstall and bootloader_enabled
+    can_install_bootloader = not conf.target.is_directory and bootloader_enabled
 
     installation_queue = TaskQueue("Installation queue")
     # connect progress reporting
@@ -279,7 +279,7 @@ def doInstall(storage, payload, ksdata, instClass):
     early_storage.append(Task("Activate filesystems",
                               task=turn_on_filesystems,
                               task_args=(storage,),
-                              task_kwargs={"mount_only": flags.flags.dirInstall, "callbacks": callbacks_reg}))
+                              task_kwargs={"mount_only": conf.target.is_directory, "callbacks": callbacks_reg}))
 
     early_storage.append(Task("Write early storage", payload.writeStorageEarly))
     installation_queue.append(early_storage)

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -21,6 +21,7 @@
 from blivet import callbacks
 from blivet.devices import BTRFSDevice
 
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import BOOTLOADER_DISABLED
 from pyanaconda.modules.common.constants.objects import BOOTLOADER, AUTO_PARTITIONING, \
     MANUAL_PARTITIONING
@@ -102,7 +103,7 @@ def doConfiguration(storage, payload, ksdata, instClass):
     configuration_queue.append(os_config)
 
     # schedule network configuration (if required)
-    will_write_network = not flags.flags.imageInstall and not flags.flags.dirInstall
+    will_write_network = not conf.target.is_image and not flags.flags.dirInstall
     if will_write_network:
         network_config = TaskQueue("Network configuration", N_("Writing network configuration"))
         network_config.append(Task("Network configuration",
@@ -174,7 +175,7 @@ def doConfiguration(storage, payload, ksdata, instClass):
     # But make sure it's not written out in the image and directory installation mode,
     # as that might result in spokes being inadvertently hidden when the actual installation
     # starts from the generate image or directory contents.
-    if flags.flags.imageInstall:
+    if conf.target.is_image:
         log.info("Not writing out user interaction config file due to image install mode.")
     elif flags.flags.dirInstall:
         log.info("Not writing out user interaction config file due to directory install mode.")

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -38,6 +38,7 @@ from contextlib import contextmanager
 
 from pyanaconda import keyboard, network, nm, ntp, screen_access, timezone
 from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.kickstart import VERSION, commands as COMMANDS
 from pyanaconda.addons import AddonSection, AddonData, AddonRegistry, collect_addon_paths
 from pyanaconda.bootloader import GRUB2, get_bootloader
@@ -489,7 +490,7 @@ class Bootloader(RemovedCommand):
 
         # Skip bootloader for s390x image installation.
         if blivet.arch.is_s390() \
-                and flags.imageInstall \
+                and conf.target.is_image \
                 and bootloader_proxy.BootloaderMode == BOOTLOADER_ENABLED:
             bootloader_proxy.SetBootloaderMode(BOOTLOADER_SKIPPED)
 

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -44,6 +44,7 @@ from pyanaconda import nm
 from pyanaconda.flags import flags, can_touch_runtime_system
 from pyanaconda.core.i18n import _
 from pyanaconda.core.regexes import HOSTNAME_PATTERN_WITHOUT_ANCHORS, IBFT_CONFIGURED_DEVICE_NAME
+from pyanaconda.core.configuration.anaconda import conf
 from pykickstart.constants import BIND_TO_MAC
 from pyanaconda.modules.common.constants.services import NETWORK, TIMEZONE
 
@@ -1563,7 +1564,7 @@ def _get_ntp_servers_from_dhcp():
 
     # check if some NTP servers were specified from kickstart
     if not timezone_proxy.NTPServers \
-       and not (flags.imageInstall or flags.dirInstall):
+       and not (conf.target.is_image or flags.dirInstall):
         # no NTP servers were specified, add those from DHCP
         timezone_proxy.SetNTPServers(hostnames)
 

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -1563,8 +1563,7 @@ def _get_ntp_servers_from_dhcp():
         hostnames.append(hostname)
 
     # check if some NTP servers were specified from kickstart
-    if not timezone_proxy.NTPServers \
-       and not (conf.target.is_image or conf.target.is_directory):
+    if not timezone_proxy.NTPServers and conf.target.is_hardware:
         # no NTP servers were specified, add those from DHCP
         timezone_proxy.SetNTPServers(hostnames)
 

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -1564,7 +1564,7 @@ def _get_ntp_servers_from_dhcp():
 
     # check if some NTP servers were specified from kickstart
     if not timezone_proxy.NTPServers \
-       and not (conf.target.is_image or flags.dirInstall):
+       and not (conf.target.is_image or conf.target.is_directory):
         # no NTP servers were specified, add those from DHCP
         timezone_proxy.SetNTPServers(hostnames)
 

--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -149,7 +149,7 @@ def nm_state():
     prop = _get_property("/org/freedesktop/NetworkManager", "State")
 
     # If this is an image/dir install assume the network is up
-    if not prop and (conf.target.is_image or conf.target.is_directory):
+    if not prop and not conf.target.is_hardware:
         return NM.State.CONNECTED_GLOBAL
     else:
         return prop

--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -31,6 +31,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 from pyanaconda.core.constants import DEFAULT_DBUS_TIMEOUT
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.flags import flags, can_touch_runtime_system
 
 supported_device_types = [
@@ -148,7 +149,7 @@ def nm_state():
     prop = _get_property("/org/freedesktop/NetworkManager", "State")
 
     # If this is an image/dir install assume the network is up
-    if not prop and (flags.imageInstall or flags.dirInstall):
+    if not prop and (conf.target.is_image or flags.dirInstall):
         return NM.State.CONNECTED_GLOBAL
     else:
         return prop

--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -32,7 +32,7 @@ log = get_module_logger(__name__)
 
 from pyanaconda.core.constants import DEFAULT_DBUS_TIMEOUT
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.flags import flags, can_touch_runtime_system
+from pyanaconda.flags import can_touch_runtime_system
 
 supported_device_types = [
     NM.DeviceType.ETHERNET,
@@ -149,7 +149,7 @@ def nm_state():
     prop = _get_property("/org/freedesktop/NetworkManager", "State")
 
     # If this is an image/dir install assume the network is up
-    if not prop and (conf.target.is_image or flags.dirInstall):
+    if not prop and (conf.target.is_image or conf.target.is_directory):
         return NM.State.CONNECTED_GLOBAL
     else:
         return prop

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -34,6 +34,7 @@ import functools
 from collections import OrderedDict, namedtuple
 
 from blivet.size import Size, ROUND_HALF_UP
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import DRACUT_ISODIR, DRACUT_REPODIR, DD_ALL, DD_FIRMWARE, \
     DD_RPMS, INSTALL_TREE, ISO_DIR, THREAD_STORAGE, THREAD_PAYLOAD, THREAD_PAYLOAD_RESTART, \
     THREAD_WAIT_FOR_CONNECTING_NM, PayloadRequirementType, GRAPHICAL_TARGET, TEXT_ONLY_TARGET
@@ -836,7 +837,7 @@ class Payload(object):
 
         for kernel in self.kernelVersionList:
             log.info("recreating initrd for %s", kernel)
-            if not flags.imageInstall:
+            if not conf.target.is_image:
                 if useDracut:
                     util.execInSysroot("depmod", ["-a", kernel])
                     util.execInSysroot("dracut",

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -928,7 +928,7 @@ class Payload(object):
         dnfpayload.  Payloads should only implement one of these methods
         by overriding the unneeded one with a pass.
         """
-        if not flags.dirInstall:
+        if not conf.target.is_directory:
             self.storage.write()
 
     def writeStorageLate(self):
@@ -939,7 +939,7 @@ class Payload(object):
         """
         if util.getSysroot() != util.getTargetPhysicalRoot():
             self.prepareMountTargets(self.storage)
-        if not flags.dirInstall:
+        if not conf.target.is_directory:
             self.storage.write()
 
 

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -113,7 +113,7 @@ def _df_map():
         structured[key] = Size(int(val) * 1024)
 
     # Add /var/tmp/ if this is a directory or image installation
-    if flags.dirInstall or conf.target.is_image:
+    if conf.target.is_directory or conf.target.is_image:
         var_tmp = os.statvfs("/var/tmp")
         structured["/var/tmp"] = Size(var_tmp.f_frsize * var_tmp.f_bfree)
     return structured

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -27,6 +27,7 @@ from pyanaconda.progress import progressQ, progress_message
 from pyanaconda.core.util import ProxyString, ProxyStringError
 from pyanaconda.core import constants
 from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.modules.common.constants.services import LOCALIZATION
 from pyanaconda.simpleconfig import SimpleConfigFile
 from pyanaconda.kickstart import RepoData
@@ -112,7 +113,7 @@ def _df_map():
         structured[key] = Size(int(val) * 1024)
 
     # Add /var/tmp/ if this is a directory or image installation
-    if flags.dirInstall or flags.imageInstall:
+    if flags.dirInstall or conf.target.is_image:
         var_tmp = os.statvfs("/var/tmp")
         structured["/var/tmp"] = Size(var_tmp.f_frsize * var_tmp.f_bfree)
     return structured
@@ -605,6 +606,7 @@ class DNFPayload(payload.PackagePayload):
             self.txID += 1
         return self.txID
 
+    # pylint: disable=redefined-outer-name
     def _configure_proxy(self):
         """Configure the proxy on the dnf.Base object."""
         conf = self._base.conf

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -113,7 +113,7 @@ def _df_map():
         structured[key] = Size(int(val) * 1024)
 
     # Add /var/tmp/ if this is a directory or image installation
-    if conf.target.is_directory or conf.target.is_image:
+    if not conf.target.is_hardware:
         var_tmp = os.statvfs("/var/tmp")
         structured["/var/tmp"] = Size(var_tmp.f_frsize * var_tmp.f_bfree)
     return structured

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -40,6 +40,7 @@ log = get_module_logger(__name__)
 
 from pyanaconda.payload import ArchivePayload, PayloadInstallError
 from pyanaconda.bootloader import EFIBase
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.glib import format_size_full, create_new_context, Variant, GError
 import pyanaconda.errors as errors
 
@@ -417,7 +418,7 @@ class RPMOSTreePayload(ArchivePayload):
             os.symlink('../loader/grub.cfg', boot_grub2_cfg)
 
         # Skip kernel args setup for dirinstall, there is no bootloader or rootDevice setup.
-        if not flags.dirInstall:
+        if not conf.target.is_directory:
             # OSTree owns the bootloader configuration, so here we give it
             # the argument list we computed from storage, architecture and
             # such.

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -19,6 +19,7 @@
 from blivet.errors import StorageError
 
 from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import ANACONDA_CLEANUP, THREAD_STORAGE
 from pyanaconda.threading import threadMgr
 from pyanaconda.flags import flags
@@ -70,7 +71,7 @@ def makeFStab(instPath=""):
 
 def makeResolvConf(instPath):
     """Make the resolv.conf file in the chroot."""
-    if flags.imageInstall:
+    if conf.target.is_image:
         return
 
     if not os.access("/etc/resolv.conf", os.R_OK):
@@ -156,7 +157,6 @@ class Rescue(object):
         Dependencies:
         - storage module
         - storage initialization thread
-        - global flags: imageInstall
 
         Initialization:
         storage     - storage object
@@ -213,7 +213,7 @@ class Rescue(object):
             return False
 
         # turn on swap
-        if not flags.imageInstall or not self.ro:
+        if not conf.target.is_image or not self.ro:
             try:
                 self._storage.turn_on_swap()
             except StorageError:
@@ -597,7 +597,7 @@ def start_rescue_mode_ui(anaconda):
     scripts = anaconda.ksdata.scripts
     storage = anaconda.storage
     reboot = True
-    if flags.imageInstall:
+    if conf.target.is_image:
         reboot = False
     if flags.automatedInstall and anaconda.ksdata.reboot.action not in [KS_REBOOT, KS_SHUTDOWN]:
         reboot = False

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -868,7 +868,6 @@ class FSSet(object):
 
         return self.crypt_tab.crypttab()
 
-    # pylint: disable=redefined-outer-name
     def mdadm_conf(self):
         """ Return the contents of mdadm.conf. """
         arrays = [d for d in self.devices if isinstance(d, MDRaidArrayDevice)]
@@ -881,18 +880,17 @@ class FSSet(object):
         if not arrays:
             return ""
 
-        # pylint: disable=redefined-outer-name
-        conf = "# mdadm.conf written out by anaconda\n"
-        conf += "MAILADDR root\n"
-        conf += "AUTO +imsm +1.x -all\n"
+        content = "# mdadm.conf written out by anaconda\n"
+        content += "MAILADDR root\n"
+        content += "AUTO +imsm +1.x -all\n"
         devices = list(self.mountpoints.values()) + self.swap_devices
         for array in arrays:
             for device in devices:
                 if device == array or device.depends_on(array):
-                    conf += array.mdadm_conf_entry
+                    content += array.mdadm_conf_entry
                     break
 
-        return conf
+        return content
 
     def fstab(self):
         fmt_str = "%-23s %-23s %-7s %-15s %d %d\n"

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -81,7 +81,7 @@ def enable_installer_mode():
 
     # We don't want image installs writing backups of the *image* metadata
     # into the *host's* /etc/lvm. This can get real messy on build systems.
-    if flags.imageInstall:
+    if conf.target.is_image:
         blivet_flags.lvm_metadata_backup = False
 
     blivet_flags.auto_dev_updates = True
@@ -868,6 +868,7 @@ class FSSet(object):
 
         return self.crypt_tab.crypttab()
 
+    # pylint: disable=redefined-outer-name
     def mdadm_conf(self):
         """ Return the contents of mdadm.conf. """
         arrays = [d for d in self.devices if isinstance(d, MDRaidArrayDevice)]
@@ -1729,7 +1730,7 @@ class InstallerStorage(Blivet):
         else:
             self.ignored_disks.extend(ignored_nvdimm_devs)
 
-        if not flags.imageInstall:
+        if not conf.target.is_image:
             iscsi.startup()
             fcoe.startup()
 
@@ -2004,7 +2005,7 @@ class InstallerStorage(Blivet):
         else:
             template = prefix
 
-        if flags.imageInstall:
+        if conf.target.is_image:
             template = "%s_image" % template
 
         return template
@@ -2191,7 +2192,7 @@ def turn_on_filesystems(storage, mount_only=False, callbacks=None):
 
     """
     if not mount_only:
-        if (flags.livecdInstall and not flags.imageInstall and not storage.fsset.active):
+        if (flags.livecdInstall and not conf.target.is_image and not storage.fsset.active):
             # turn off any swaps that we didn't turn on
             # needed for live installs
             blivet_util.run_program(["swapoff", "-a"])

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -2183,7 +2183,7 @@ def get_containing_device(path, devicetree):
     return devicetree.get_device_by_name(device_name)
 
 
-def turn_on_filesystems(storage, mount_only=False, callbacks=None):
+def turn_on_filesystems(storage, callbacks=None):
     """
     Perform installer-specific activation of storage configuration.
 
@@ -2191,8 +2191,8 @@ def turn_on_filesystems(storage, mount_only=False, callbacks=None):
     :type callbacks: return value of the :func:`blivet.callbacks.create_new_callbacks_register`
 
     """
-    if not mount_only:
-        if (flags.livecdInstall and not conf.target.is_image and not storage.fsset.active):
+    if not conf.target.is_directory:
+        if flags.livecdInstall and conf.target.is_hardware and not storage.fsset.active:
             # turn off any swaps that we didn't turn on
             # needed for live installs
             blivet_util.run_program(["swapoff", "-a"])
@@ -2208,7 +2208,7 @@ def turn_on_filesystems(storage, mount_only=False, callbacks=None):
     # FIXME:  For livecd, skip_root needs to be True.
     storage.mount_filesystems()
 
-    if not mount_only:
+    if not conf.target.is_directory:
         write_escrow_packets(storage)
 
 

--- a/pyanaconda/ui/gui/hubs/summary.py
+++ b/pyanaconda/ui/gui/hubs/summary.py
@@ -19,9 +19,10 @@
 
 from pyanaconda.ui.gui.hubs import Hub
 from pyanaconda.ui.lib.space import FileSystemSpaceChecker, DirInstallSpaceChecker
-from pyanaconda.flags import flags
+from pyanaconda.core.configuration.anaconda import conf
 
 __all__ = ["SummaryHub"]
+
 
 class SummaryHub(Hub):
     """
@@ -57,7 +58,7 @@ class SummaryHub(Hub):
         """
         super().__init__(data, storage, payload, instclass)
 
-        if not flags.dirInstall:
+        if not conf.target.is_directory:
             self._checker = FileSystemSpaceChecker(storage, payload)
         else:
             self._checker = DirInstallSpaceChecker(storage, payload)

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -70,6 +70,7 @@ from pyanaconda.product import productName
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _, C_, CN_, P_
 from pyanaconda.core import util, constants
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import CLEAR_PARTITIONS_NONE, BOOTLOADER_DRIVE_UNSET, \
     BOOTLOADER_ENABLED, STORAGE_METADATA_RATIO, AUTOPART_TYPE_DEFAULT
 from pyanaconda.bootloader import BootLoaderError
@@ -562,7 +563,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
 
     @property
     def showable(self):
-        return not flags.dirInstall
+        return not conf.target.is_directory
 
     @property
     def status(self):

--- a/pyanaconda/ui/lib/disks.py
+++ b/pyanaconda/ui/lib/disks.py
@@ -19,10 +19,10 @@
 
 from blivet.devices import MultipathDevice, iScsiDiskDevice, FcoeDiskDevice
 
-from pyanaconda.flags import flags
 from pyanaconda.core.i18n import P_
 from pyanaconda.modules.common.constants.objects import DISK_SELECTION, DISK_INITIALIZATION
 from pyanaconda.modules.common.constants.services import STORAGE
+from pyanaconda.core.configuration.anaconda import conf
 
 __all__ = ["FakeDiskLabel", "FakeDisk", "getDisks", "isLocalDisk"]
 
@@ -49,7 +49,7 @@ class FakeDisk(object):
 def getDisks(devicetree, fake=False):
     if not fake:
         devices = devicetree.devices
-        if flags.imageInstall:
+        if conf.target.is_image:
             hidden_images = [d for d in devicetree._hidden \
                              if d.name in devicetree.disk_images]
             devices += hidden_images

--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -22,6 +22,7 @@ from pyanaconda.ui.tui.hubs import TUIHub
 from pyanaconda.flags import flags
 from pyanaconda.errors import CmdlineError
 from pyanaconda.core.i18n import N_, _, C_
+from pyanaconda.core.configuration.anaconda import conf
 
 from simpleline import App
 from simpleline.render.screen import InputState
@@ -45,7 +46,7 @@ class SummaryHub(TUIHub):
         super().__init__(data, storage, payload, instclass)
         self.title = N_("Installation")
 
-        if not flags.dirInstall:
+        if not conf.target.is_directory:
             self._checker = FileSystemSpaceChecker(storage, payload)
         else:
             self._checker = DirInstallSpaceChecker(storage, payload)

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -40,6 +40,7 @@ from blivet.formats import get_format
 from pyanaconda.flags import flags
 from pyanaconda.kickstart import doKickstartStorage, resetCustomStorageData
 from pyanaconda.threading import threadMgr, AnacondaThread
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import THREAD_STORAGE, THREAD_STORAGE_WATCHER, \
     DEFAULT_AUTOPART_TYPE, PAYLOAD_STATUS_PROBING_STORAGE, CLEAR_PARTITIONS_ALL, \
     CLEAR_PARTITIONS_LINUX, CLEAR_PARTITIONS_NONE, CLEAR_PARTITIONS_DEFAULT, \
@@ -134,7 +135,7 @@ class StorageSpoke(NormalTUISpoke):
 
     @property
     def showable(self):
-        return not flags.dirInstall
+        return not conf.target.is_directory
 
     @property
     def status(self):

--- a/tests/nosetests/pyanaconda_tests/argparse_test.py
+++ b/tests/nosetests/pyanaconda_tests/argparse_test.py
@@ -89,7 +89,7 @@ class ArgparseTest(unittest.TestCase):
         opts, _deprecated = self._parseCmdline(['--dirinstall=/what/ever'])
         self.assertEqual(opts.dirinstall, "/what/ever")
 
-    def conf_test(self):
+    def storage_test(self):
         conf = AnacondaConfiguration.from_defaults()
 
         opts, _deprecated = self._parseCmdline([])
@@ -103,3 +103,30 @@ class ArgparseTest(unittest.TestCase):
 
         self.assertEqual(conf.storage.dmraid, False)
         self.assertEqual(conf.storage.ibft, True)
+
+    def target_test(self):
+        conf = AnacondaConfiguration.from_defaults()
+
+        opts, _deprecated = self._parseCmdline([])
+        conf.set_from_opts(opts)
+
+        self.assertEqual(conf.target.is_hardware, True)
+        self.assertEqual(conf.target.is_image, False)
+        self.assertEqual(conf.target.is_directory, False)
+        self.assertEqual(conf.target.physical_root, "/mnt/sysimage")
+
+        opts, _deprecated = self._parseCmdline(['--image=/what/ever.img'])
+        conf.set_from_opts(opts)
+
+        self.assertEqual(conf.target.is_hardware, False)
+        self.assertEqual(conf.target.is_image, True)
+        self.assertEqual(conf.target.is_directory, False)
+        self.assertEqual(conf.target.physical_root, "/mnt/sysimage")
+
+        opts, _deprecated = self._parseCmdline(['--dirinstall=/what/ever'])
+        conf.set_from_opts(opts)
+
+        self.assertEqual(conf.target.is_hardware, False)
+        self.assertEqual(conf.target.is_image, False)
+        self.assertEqual(conf.target.is_directory, True)
+        self.assertEqual(conf.target.physical_root, "/what/ever")

--- a/tests/nosetests/pyanaconda_tests/iutil_test.py
+++ b/tests/nosetests/pyanaconda_tests/iutil_test.py
@@ -823,3 +823,15 @@ class MiscTests(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             test_function()
+
+    def sysroot_test(self):
+        self.assertEqual(util.getTargetPhysicalRoot(), "/mnt/sysimage")
+        self.assertEqual(util.getSysroot(), "/mnt/sysimage")
+
+        util.setSysroot("/what/ever")
+        self.assertEqual(util.getTargetPhysicalRoot(), "/mnt/sysimage")
+        self.assertEqual(util.getSysroot(), "/what/ever")
+
+        util.setSysroot(None)
+        self.assertEqual(util.getTargetPhysicalRoot(), "/mnt/sysimage")
+        self.assertEqual(util.getSysroot(), "/mnt/sysimage")


### PR DESCRIPTION
The installation target can be specified in the Anaconda
configuration. The supported types of the target are
`HARDWARE`, `IMAGE` and `DIRECTORY`

Instead of flags, we should use:
`conf.target.is_image`
`conf.target.is_directory`
`conf.target.is_hardware`