### PR TITLE
Configure the installation system

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -506,13 +506,6 @@ if __name__ == "__main__":
 
     anaconda.ksdata = ksdata
 
-    # setup network module mode depending on anaconda runtime environment
-    if not can_touch_runtime_system("setup network module mode"):
-        from pyanaconda.modules.common.constants.services import NETWORK
-        network_proxy = NETWORK.get_proxy()
-        network_proxy.DontTouchRuntimeSystem()
-        log.debug("Network module set up to not touch runtime system")
-
     # setup keyboard layout from the command line option and let
     # it override from kickstart if/when X is initialized
 

--- a/anaconda.py
+++ b/anaconda.py
@@ -284,7 +284,7 @@ if __name__ == "__main__":
     from pyanaconda import startup_utils
 
     # do this early so we can set flags before initializing logging
-    from pyanaconda.flags import flags, can_touch_runtime_system
+    from pyanaconda.flags import flags
     (opts, depr) = parse_arguments(boot_cmdline=flags.cmdline)
 
     from pyanaconda.core.configuration.anaconda import conf
@@ -448,7 +448,7 @@ if __name__ == "__main__":
     # text console with a traceback instead of being left looking at a blank
     # screen. python-meh will replace this excepthook with its own handler
     # once it gets going.
-    if can_touch_runtime_system("early exception handler"):
+    if conf.system.can_switch_tty:
         def _earlyExceptionHandler(ty, value, traceback):
             util.ipmi_report(constants.IPMI_FAILED)
             util.vtActivate(1)
@@ -456,7 +456,7 @@ if __name__ == "__main__":
 
         sys.excepthook = _earlyExceptionHandler
 
-    if can_touch_runtime_system("start audit daemon"):
+    if conf.system.can_audit:
         # auditd will turn into a daemon and exit. Ignore startup errors
         try:
             util.execWithRedirect("/sbin/auditd", [])
@@ -528,7 +528,7 @@ if __name__ == "__main__":
         configured = True
 
     if configured:
-        if can_touch_runtime_system("activate keyboard"):
+        if conf.system.can_activate_keyboard:
             keyboard.activate_keyboard(localization_proxy)
         else:
             # at least make sure we have all the values
@@ -707,7 +707,7 @@ if __name__ == "__main__":
     from pyanaconda.modules.common.constants.services import TIMEZONE
     timezone_proxy = TIMEZONE.get_proxy()
 
-    if can_touch_runtime_system("initialize time", touch_live=True):
+    if conf.system.can_initialize_system_clock:
         threadMgr.add(AnacondaThread(name=constants.THREAD_TIME_INIT,
                                      target=time_initialize,
                                      args=(timezone_proxy,
@@ -750,7 +750,7 @@ if __name__ == "__main__":
         geoloc.geoloc.refresh()
 
     # setup ntp servers and start NTP daemon if not requested otherwise
-    if can_touch_runtime_system("start chronyd"):
+    if conf.system.can_set_time_synchronization:
         kickstart_ntpservers = timezone_proxy.NTPServers
 
         if kickstart_ntpservers:

--- a/anaconda.py
+++ b/anaconda.py
@@ -96,7 +96,7 @@ def exitHandler(rebootData, storage):
 
     anaconda.dbus_launcher.stop()
 
-    if conf.target.is_hardware and not flags.livecdInstall:
+    if conf.system.can_reboot:
         from pykickstart.constants import KS_SHUTDOWN, KS_WAIT
 
         if flags.eject or rebootData.eject:
@@ -440,8 +440,6 @@ if __name__ == "__main__":
 
     if opts.liveinst:
         startup_utils.live_startup(anaconda)
-    elif "LIVECMD" in os.environ:
-        log.warning("Running via liveinst, but not setting flags.livecdInstall - this is for testing only")
 
     # Switch to tty1 on exception in case something goes wrong during X start.
     # This way if, for example, metacity doesn't start, we switch back to a

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -21,6 +21,12 @@ kickstart_modules =
      org.fedoraproject.Anaconda.Modules.Services
 
 
+[Installation System]
+# Type of the installation system.
+# FIXME: This is a temporary solution.
+type = UNKNOWN
+
+
 [Installation Target]
 # Type of the installation target.
 type = HARDWARE

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -138,12 +138,10 @@ class Anaconda(object):
         # Try to find the payload class.  First try the install
         # class.  If it doesn't give us one, fall back to the default.
         if not self._payload:
-            from pyanaconda.flags import flags
-
             if self.ksdata.ostreesetup.seen:
                 from pyanaconda.payload.rpmostreepayload import RPMOSTreePayload
                 klass = RPMOSTreePayload
-            elif flags.livecdInstall:
+            elif self.opts.liveinst:
                 from pyanaconda.payload.livepayload import LiveImagePayload
                 klass = LiveImagePayload
             elif self.ksdata.method.method == "liveimg":

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -35,7 +35,7 @@ from blivet.formats.disklabel import DiskLabel
 from pyanaconda.modules.common.constants.objects import FCOE
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.product import productName
-from pyanaconda.flags import flags, can_touch_runtime_system
+from pyanaconda.flags import flags
 import pyanaconda.network
 from pyanaconda.errors import errorHandler, ERROR_RAISE, ZIPLError
 from pyanaconda.nm import nm_device_hwaddress
@@ -2103,7 +2103,7 @@ class IPSeriesYaboot(Yaboot):
         super().install()
 
     def updatePowerPCBootList(self):
-        if not can_touch_runtime_system("updatePowerPCBootList", touch_live=True):
+        if not conf.target.is_hardware:
             return
 
         log.debug("updatePowerPCBootList: self.stage1_device.path = %s", self.stage1_device.path)
@@ -2165,7 +2165,7 @@ class IPSeriesGRUB2(GRUB2):
 
     # This will update the PowerPC's (ppc) bios boot devive order list
     def updateNVRAMBootList(self):
-        if not can_touch_runtime_system("updateNVRAMBootList", touch_live=True):
+        if not conf.target.is_hardware:
             return
 
         log.debug("updateNVRAMBootList: self.stage1_device.path = %s", self.stage1_device.path)

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -202,6 +202,11 @@ class InstallationSystem(Section):
         """Can we read /etc/sysconfig/anaconda?"""
         return self._is_boot_iso or self._is_live_os
 
+    @property
+    def provides_web_browser(self):
+        """Can we redirect users to web pages?"""
+        return self._is_live_os
+
 
 class ServicesSection(Section):
     """The Services section."""

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -105,6 +105,103 @@ class InstallationSystem(Section):
         """Are we running in the unknown OS?"""
         return self._type is SystemType.UNKNOWN
 
+    @property
+    def can_reboot(self):
+        """Can we reboot the system?"""
+        return self._is_boot_iso
+
+    @property
+    def can_switch_tty(self):
+        """Can we change the foreground virtual terminal?"""
+        return self._is_boot_iso
+
+    @property
+    def can_audit(self):
+        """Can we run the audit daemon?"""
+        return self._is_boot_iso
+
+    @property
+    def can_set_hardware_clock(self):
+        """Can we set the Hardware Clock?"""
+        return self._is_boot_iso
+
+    @property
+    def can_initialize_system_clock(self):
+        """Can we initialize the System Clock?
+
+        FIXME: This is a temporary workaround.
+        """
+        return self._is_boot_iso or self._is_live_os
+
+    @property
+    def can_set_system_clock(self):
+        """Can we set the System Clock?"""
+        return self._is_boot_iso
+
+    @property
+    def can_set_time_synchronization(self):
+        """Can we run the NTP daemon?"""
+        return self._is_boot_iso
+
+    @property
+    def can_activate_keyboard(self):
+        """Can we activate the keyboard?
+
+        FIXME: This is a temporary workaround.
+        """
+        return self._is_boot_iso
+
+    @property
+    def can_activate_layouts(self):
+        """Can we activate the layouts?
+
+        FIXME: This is a temporary workaround.
+        """
+        return self._is_boot_iso
+
+    @property
+    def can_configure_keyboard(self):
+        """Can we configure the keyboard?"""
+        return self._is_boot_iso or self._is_live_os
+
+    @property
+    def can_modify_syslog(self):
+        """Can we modify syslog?"""
+        return self._is_boot_iso
+
+    @property
+    def can_change_hostname(self):
+        """Can we change the hostname?"""
+        return self._is_boot_iso
+
+    @property
+    def can_configure_network(self):
+        """Can we configure the network?"""
+        return self._is_boot_iso or self._is_live_os
+
+    @property
+    def can_require_network_connection(self):
+        """Can the system require network connection?
+
+        FIXME: This is a temporary workaround.
+        """
+        return self._is_boot_iso
+
+    @property
+    def provides_system_bus(self):
+        """Can we access the system DBus?"""
+        return self._is_boot_iso or self._is_live_os
+
+    @property
+    def provides_resolver_config(self):
+        """Can we copy /etc/resolv.conf to the target system?"""
+        return self._is_boot_iso
+
+    @property
+    def provides_user_interaction_config(self):
+        """Can we read /etc/sysconfig/anaconda?"""
+        return self._is_boot_iso or self._is_live_os
+
 
 class ServicesSection(Section):
     """The Services section."""

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -33,12 +33,12 @@ from meh import Config
 from meh.dump import ReverseExceptionDump
 from meh.handler import ExceptionHandler
 
-from pyanaconda import flags
 from pyanaconda import kickstart
 from pyanaconda.core import util
 from pyanaconda import startup_utils
 from pyanaconda import product
 from pyanaconda.core.async_utils import run_in_loop
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import THREAD_EXCEPTION_HANDLING_TEST, IPMI_FAILED
 from pyanaconda.errors import NonInteractiveError
 from pyanaconda.core.i18n import _
@@ -231,8 +231,7 @@ class AnacondaExceptionHandler(ExceptionHandler):
         util.ipmi_report(IPMI_FAILED)
 
     def runDebug(self, exc_info):
-        if flags.can_touch_runtime_system("switch console") \
-                and self._intf_tty_num != 1:
+        if conf.system.can_switch_tty and self._intf_tty_num != 1:
             util.vtActivate(1)
 
         os.open("/dev/console", os.O_RDWR)   # reclaim stdin
@@ -254,8 +253,7 @@ class AnacondaExceptionHandler(ExceptionHandler):
         import pdb
         pdb.post_mortem(exc_info.stack)
 
-        if flags.can_touch_runtime_system("switch console") \
-                and self._intf_tty_num != 1:
+        if conf.system.can_switch_tty and self._intf_tty_num != 1:
             util.vtActivate(self._intf_tty_num)
 
 

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -271,7 +271,7 @@ def initExceptionHandling(anaconda):
     if anaconda.opts and anaconda.opts.ksfile:
         file_list.extend([anaconda.opts.ksfile])
 
-    conf = Config(programName="anaconda",
+    config = Config(programName="anaconda",
                   programVersion=startup_utils.get_anaconda_version_string(),
                   programArch=os.uname()[4],
                   attrSkipList=["_intf._actions",
@@ -296,28 +296,28 @@ def initExceptionHandling(anaconda):
                   localSkipList=["passphrase", "password", "_oldweak", "_password", "try_passphrase"],
                   fileList=file_list)
 
-    conf.register_callback("lsblk_output", lsblk_callback, attchmnt_only=False)
-    conf.register_callback("nmcli_dev_list", nmcli_dev_list_callback,
+    config.register_callback("lsblk_output", lsblk_callback, attchmnt_only=False)
+    config.register_callback("nmcli_dev_list", nmcli_dev_list_callback,
                            attchmnt_only=True)
 
     # provide extra information for libreport
-    conf.register_callback("type", lambda: "anaconda", attchmnt_only=True)
-    conf.register_callback("addons", list_addons_callback, attchmnt_only=False)
+    config.register_callback("type", lambda: "anaconda", attchmnt_only=True)
+    config.register_callback("addons", list_addons_callback, attchmnt_only=False)
 
     if "/tmp/syslog" not in file_list:
         # no syslog, grab output from journalctl and put it also to the
         # anaconda-tb file
-        conf.register_callback("journalctl", journalctl_callback, attchmnt_only=False)
+        config.register_callback("journalctl", journalctl_callback, attchmnt_only=False)
 
     if not product.isFinal:
-        conf.register_callback("release_type", lambda: "pre-release", attchmnt_only=True)
+        config.register_callback("release_type", lambda: "pre-release", attchmnt_only=True)
 
-    handler = AnacondaExceptionHandler(conf, anaconda.intf.meh_interface,
+    handler = AnacondaExceptionHandler(config, anaconda.intf.meh_interface,
                                        AnacondaReverseExceptionDump, anaconda.intf.tty_num,
                                        anaconda.gui_initialized, anaconda.interactive_mode)
     handler.install(anaconda)
 
-    return conf
+    return config
 
 
 def lsblk_callback():

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -38,7 +38,6 @@ class Flags(object):
 
     def __init__(self):
         self.__dict__['_in_init'] = True
-        self.livecdInstall = False
         self.nonibftiscsiboot = False
         self.usevnc = False
         self.vncquestion = True

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -79,32 +79,4 @@ class Flags(object):
         self.__dict__['_in_init'] = False
 
 
-def can_touch_runtime_system(msg, touch_live=False):
-    """
-    Guard that should be used before doing actions that modify runtime system.
-
-    :param msg: message to be logged in case that runtime system cannot be touched
-    :type msg: str
-    :param touch_live: whether to allow touching liveCD installation system
-    :type touch_live: bool
-    :rtype: bool
-
-    """
-    from pyanaconda.core.configuration.anaconda import conf
-
-    if flags.livecdInstall and not touch_live:
-        log.info("Not doing '%s' in live installation", msg)
-        return False
-
-    if conf.target.is_image:
-        log.info("Not doing '%s' in image installation", msg)
-        return False
-
-    if conf.target.is_directory:
-        log.info("Not doing '%s' in directory installation", msg)
-        return False
-
-    return True
-
-
 flags = Flags()

--- a/pyanaconda/ihelp.py
+++ b/pyanaconda/ihelp.py
@@ -20,7 +20,7 @@ Anaconda built-in help module
 """
 import os
 
-from pyanaconda.flags import flags
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.localization import find_best_locale_match
 from pyanaconda.core.constants import DEFAULT_LANG
 from pyanaconda.core.util import startProgram
@@ -122,7 +122,7 @@ def get_help_path(help_file, instclass, plain_text=False):
 
     # looks like the installation guide is not available, so just return
     # a placeholder page, which should be always present
-    if flags.livecdInstall:
+    if conf.system.provides_web_browser:
         return _get_best_help_file(instclass.help_folder, placeholder_with_links)
     else:
         return _get_best_help_file(instclass.help_folder, placeholder)

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -274,11 +274,14 @@ def doInstall(storage, payload, ksdata, instClass):
     callbacks_reg = callbacks.create_new_callbacks_register(create_format_pre=message_clbk,
                                                             resize_format_pre=message_clbk,
                                                             wait_for_entropy=entropy_wait_clbk)
-
-    early_storage.append(Task("Activate filesystems",
-                              task=turn_on_filesystems,
-                              task_args=(storage,),
-                              task_kwargs={"callbacks": callbacks_reg}))
+    if conf.target.is_directory:
+        early_storage.append(Task("Mount filesystems",
+                                  task=storage.mount_filesystems))
+    else:
+        early_storage.append(Task("Activate filesystems",
+                                  task=turn_on_filesystems,
+                                  task_args=(storage,),
+                                  task_kwargs={"callbacks": callbacks_reg}))
 
     early_storage.append(Task("Write early storage", payload.writeStorageEarly))
     installation_queue.append(early_storage)

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -28,6 +28,7 @@ from pyanaconda.modules.common.constants.objects import BOOTLOADER, AUTO_PARTITI
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.storage.osinstall import turn_on_filesystems
 from pyanaconda.bootloader import writeBootLoader
+from pyanaconda.payload.livepayload import LiveImagePayload
 from pyanaconda.progress import progress_message, progress_step, progress_complete, progress_init
 from pyanaconda.users import Users
 from pyanaconda import flags
@@ -135,7 +136,7 @@ def doConfiguration(storage, payload, ksdata, instClass):
     bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
     bootloader_enabled = bootloader_proxy.BootloaderMode != BOOTLOADER_DISABLED
 
-    if flags.flags.livecdInstall and boot_on_btrfs and bootloader_enabled:
+    if isinstance(payload, LiveImagePayload) and boot_on_btrfs and bootloader_enabled:
         generate_initramfs.append(Task("Write BTRFS bootloader fix", writeBootLoader, (storage, payload, instClass, ksdata)))
     configuration_queue.append(generate_initramfs)
 

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -240,9 +240,8 @@ def doInstall(storage, payload, ksdata, instClass):
 
     # Save system time to HW clock.
     # - this used to be before waiting on threads, but I don't think that's needed
-    if flags.can_touch_runtime_system("save system time to HW clock"):
+    if conf.system.can_set_hardware_clock:
         # lets just do this as a top-level task - no
-
         save_hwclock = Task("Save system time to HW clock", timezone.save_hw_clock)
         installation_queue.append(save_hwclock)
 
@@ -305,7 +304,7 @@ def doInstall(storage, payload, ksdata, instClass):
     pre_install.append(Task("Setup timezone", ksdata.timezone.setup, (ksdata,)))
 
     # make name resolution work for rpm scripts in chroot
-    if flags.can_touch_runtime_system("copy /etc/resolv.conf to sysroot"):
+    if conf.system.provides_resolver_config:
         # we use a custom Task subclass as the sysroot path has to be resolved
         # only when the task is actually started, not at task creation time
         pre_install.append(WriteResolvConfTask("Copy /resolv.conf to sysroot"))

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -106,7 +106,7 @@ def doConfiguration(storage, payload, ksdata, instClass):
     if conf.target.is_hardware:
         network_config = TaskQueue("Network configuration", N_("Writing network configuration"))
         network_config.append(Task("Network configuration",
-                                   ksdata.network.execute, (storage, ksdata, instClass)))
+                                   ksdata.network.execute, (storage, payload, ksdata, instClass)))
         configuration_queue.append(network_config)
 
     # creating users and groups requires some pre-configuration.

--- a/pyanaconda/keyboard.py
+++ b/pyanaconda/keyboard.py
@@ -28,12 +28,12 @@ import re
 import shutil
 import langtable
 
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.glib import GError, Variant
 from pyanaconda.core import util
 from pyanaconda import safe_dbus
 from pyanaconda import localization
 from pyanaconda.core.constants import DEFAULT_VC_FONT, DEFAULT_KEYBOARD
-from pyanaconda.flags import can_touch_runtime_system
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -375,14 +375,14 @@ def set_x_keyboard_defaults(localization_proxy, xkl_wrapper):
         new_layouts = [DEFAULT_KEYBOARD]
 
     localization_proxy.SetXLayouts(new_layouts)
-    if can_touch_runtime_system("replace runtime X layouts", touch_live=True):
+    if conf.system.can_configure_keyboard:
         xkl_wrapper.replace_layouts(new_layouts)
 
     if len(new_layouts) >= 2 and not localization_proxy.LayoutSwitchOptions:
         # initialize layout switching if needed
         localization_proxy.SetLayoutSwitchOptions(["grp:alt_shift_toggle"])
 
-        if can_touch_runtime_system("init layout switching", touch_live=True):
+        if conf.system.can_configure_keyboard:
             xkl_wrapper.set_switching_options(["grp:alt_shift_toggle"])
             # activate the language-default layout instead of the additional
             # one
@@ -400,7 +400,7 @@ class LocaledWrapper(object):
         try:
             self._connection = safe_dbus.get_new_system_connection()
         except GError as e:
-            if can_touch_runtime_system("raise GLib.GError", touch_live=True):
+            if conf.system.provides_system_bus:
                 raise
 
             log.error("Failed to get safe_dbus connection: %s", e)

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1415,8 +1415,8 @@ class Network(COMMANDS.Network):
         if network.is_using_team_device():
             self.packages = ["teamd"]
 
-    def execute(self, storage, ksdata, instClass):
-        network.write_network_config(storage, ksdata, instClass, util.getSysroot())
+    def execute(self, storage, payload, ksdata, instClass):
+        network.write_network_config(storage, payload, ksdata, instClass, util.getSysroot())
 
 class Nvdimm(COMMANDS.Nvdimm):
     def parse(self, args):

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -50,7 +50,7 @@ from pyanaconda.core.constants import ADDON_PATHS, IPMI_ABORTED, THREAD_STORAGE,
 from pyanaconda.dbus.structure import apply_structure
 from pyanaconda.desktop import Desktop
 from pyanaconda.errors import ScriptError, errorHandler
-from pyanaconda.flags import flags, can_touch_runtime_system
+from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.errors.kickstart import SplitKickstartError
 from pyanaconda.modules.common.constants.services import BOSS, TIMEZONE, LOCALIZATION, SECURITY, \
@@ -2153,8 +2153,7 @@ class Timezone(RemovedCommand):
 
         # do not install and use NTP package
         if not timezone_proxy.NTPEnabled or NTP_PACKAGE in ksdata.packages.excludedList:
-            if util.service_running(NTP_SERVICE) and \
-                    can_touch_runtime_system("stop NTP service"):
+            if util.service_running(NTP_SERVICE) and conf.system.can_set_time_synchronization:
                 ret = util.stop_service(NTP_SERVICE)
                 if ret != 0:
                     timezone_log.error("Failed to stop NTP service")
@@ -2164,8 +2163,7 @@ class Timezone(RemovedCommand):
                 services_proxy.SetDisabledServices(disabled_services)
         # install and use NTP package
         else:
-            if not util.service_running(NTP_SERVICE) and \
-                    can_touch_runtime_system("start NTP service"):
+            if not util.service_running(NTP_SERVICE) and conf.system.can_set_time_synchronization:
                 ret = util.start_service(NTP_SERVICE)
                 if ret != 0:
                     timezone_log.error("Failed to start NTP service")

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -17,7 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.dbus import DBus, SystemBus
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.base import KickstartModule
@@ -47,7 +47,8 @@ class NetworkModule(KickstartModule):
 
         self.current_hostname_changed = Signal()
         self._hostname_service_proxy = None
-        if SystemBus.check_connection():
+
+        if conf.system.provides_system_bus:
             self._hostname_service_proxy = HOSTNAME.get_proxy()
             self._hostname_service_proxy.PropertiesChanged.connect(self._hostname_service_properties_changed)
 

--- a/pyanaconda/modules/network/network_interface.py
+++ b/pyanaconda/modules/network/network_interface.py
@@ -50,18 +50,6 @@ class NetworkInterface(KickstartModuleInterface):
         """
         self.implementation.set_hostname(hostname)
 
-    def DontTouchRuntimeSystem(self):
-        """Prevent the module from touching runtime system.
-
-        This is a temporary module-specific solution.
-        To be used for dirinstall, live install, etc... .
-        For example it prohibits changing current hostname and
-        prevents using hostnamed service.
-
-        To be called as early as possible after module initialization.
-        """
-        self.implementation.can_touch_runtime_system = False
-
     @dbus_signal
     def CurrentHostnameChanged(self, hostname: Str):
         """Signal current hostname change."""

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -42,7 +42,7 @@ from blivet.devices import FcoeDiskDevice
 import blivet.arch
 
 from pyanaconda import nm
-from pyanaconda.flags import flags, can_touch_runtime_system
+from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _
 from pyanaconda.core.regexes import HOSTNAME_PATTERN_WITHOUT_ANCHORS, IBFT_CONFIGURED_DEVICE_NAME
 from pyanaconda.core.configuration.anaconda import conf
@@ -1296,7 +1296,7 @@ def ks_spec_to_device_name(ksspec=""):
 
 # TODO MOD remove, call module when can_touch_runtime_system is resolved
 def set_hostname(hn):
-    if can_touch_runtime_system("set hostname", touch_live=True):
+    if conf.system.can_change_hostname:
         log.info("setting installation environment host name to %s", hn)
         network_proxy = NETWORK.get_proxy()
         network_proxy.SetCurrentHostname(hn)
@@ -1511,7 +1511,7 @@ def apply_kickstart(ksdata):
     return applied_devices
 
 def networkInitialize(ksdata):
-    if not can_touch_runtime_system("networkInitialize", touch_live=True):
+    if not conf.system.can_configure_network:
         return
 
     log.debug("devices found %s", nm.nm_devices())

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -48,6 +48,7 @@ from pyanaconda.core.regexes import HOSTNAME_PATTERN_WITHOUT_ANCHORS, IBFT_CONFI
 from pyanaconda.core.configuration.anaconda import conf
 from pykickstart.constants import BIND_TO_MAC
 from pyanaconda.modules.common.constants.services import NETWORK, TIMEZONE
+from pyanaconda.payload.livepayload import LiveImagePayload
 
 from pyanaconda.anaconda_loggers import get_module_logger, get_ifcfg_logger
 log = get_module_logger(__name__)
@@ -1366,9 +1367,9 @@ def write_sysconfig_network(rootpath, overwrite=False):
         f.write("# Created by anaconda\n")
     return True
 
-def write_network_config(storage, ksdata, instClass, rootpath):
+def write_network_config(storage, payload, ksdata, instClass, rootpath):
     # overwrite previous settings for LiveCD or liveimg installations
-    overwrite = flags.livecdInstall or ksdata.method.method == "liveimg"
+    overwrite = isinstance(payload, LiveImagePayload)
 
     network_proxy = NETWORK.get_proxy()
     hostname = network_proxy.Hostname

--- a/pyanaconda/nm.py
+++ b/pyanaconda/nm.py
@@ -32,7 +32,6 @@ log = get_module_logger(__name__)
 
 from pyanaconda.core.constants import DEFAULT_DBUS_TIMEOUT
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.flags import can_touch_runtime_system
 
 supported_device_types = [
     NM.DeviceType.ETHERNET,
@@ -113,7 +112,7 @@ def _get_proxy(bus_type=Gio.BusType.SYSTEM,
                                                interface_name,
                                                cancellable)
     except GError as e:
-        if can_touch_runtime_system("raise GLib.GError", touch_live=True):
+        if conf.system.provides_system_bus:
             raise
 
         log.error("_get_proxy failed: %s", e)

--- a/pyanaconda/screen_access.py
+++ b/pyanaconda/screen_access.py
@@ -41,7 +41,7 @@ from threading import RLock
 
 from pyanaconda import startup_utils
 from pyanaconda.core import util
-from pyanaconda.flags import can_touch_runtime_system
+from pyanaconda.core.configuration.anaconda import conf
 
 
 class ScreenAccessManager(object):
@@ -68,8 +68,7 @@ class ScreenAccessManager(object):
             # But load the config if a path is specified,
             # so that it is possible to hide spokes in
             # image and directory installation modes.
-            if config_path is None and can_touch_runtime_system(msg="write user interaction config file",
-                                                                touch_live=True):
+            if config_path is None and conf.system.provides_user_interaction_config:
                 config_path = CONFIG_FILE_PATH
             if config_path and os.path.exists(config_path):
                 log.info("parsing existing user interaction config file in %s", config_path)

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -354,8 +354,6 @@ def live_startup(anaconda):
 
     :param anaconda: instance of the Anaconda class
     """
-    flags.livecdInstall = True
-
     try:
         anaconda.dbus_session_connection = safe_dbus.get_new_session_connection()
     except safe_dbus.DBusCallError as e:

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -17,6 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.i18n import _
 
 from pyanaconda.anaconda_loggers import get_stdout_logger, get_storage_logger, get_packaging_logger
@@ -37,7 +38,6 @@ from pyanaconda import network
 from pyanaconda import safe_dbus
 from pyanaconda import kickstart
 from pyanaconda.flags import flags
-from pyanaconda.flags import can_touch_runtime_system
 from pyanaconda.screensaver import inhibit_screensaver
 
 from pyanaconda.payload.source import SourceFactory, PayloadSourceTypeUnrecognized
@@ -243,7 +243,7 @@ def setup_logging_from_options(options):
         packaging_log = get_packaging_logger()
         anaconda_logging.setHandlersLevel(packaging_log, level)
 
-    if can_touch_runtime_system("syslog setup"):
+    if conf.system.can_modify_syslog:
         if options.syslog:
             anaconda_logging.logger.updateRemote(options.syslog)
 

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -2193,10 +2193,12 @@ def turn_on_filesystems(storage, callbacks=None):
 
     """
     if not conf.target.is_directory:
-        if flags.livecdInstall and conf.target.is_hardware and not storage.fsset.active:
+        # FIXME: This is a temporary workaround for live OS.
+        if conf.system._is_live_os and conf.target.is_hardware and not storage.fsset.active:
             # turn off any swaps that we didn't turn on
             # needed for live installs
             blivet_util.run_program(["swapoff", "-a"])
+
         storage.devicetree.teardown_all()
 
         try:
@@ -2308,7 +2310,8 @@ def storage_initialize(storage, ksdata, protected):
         else:
             break
 
-    if protected and not flags.livecdInstall and \
+    # FIXME: This is a temporary workaround for live OS.
+    if protected and not conf.system._is_live_os and \
        not any(d.protected for d in storage.devices):
         raise UnknownSourceDeviceError(protected)
 

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -2192,27 +2192,26 @@ def turn_on_filesystems(storage, callbacks=None):
     :type callbacks: return value of the :func:`blivet.callbacks.create_new_callbacks_register`
 
     """
-    if not conf.target.is_directory:
-        # FIXME: This is a temporary workaround for live OS.
-        if conf.system._is_live_os and conf.target.is_hardware and not storage.fsset.active:
-            # turn off any swaps that we didn't turn on
-            # needed for live installs
-            blivet_util.run_program(["swapoff", "-a"])
+    # FIXME: This is a temporary workaround for live OS.
+    if conf.system._is_live_os and conf.target.is_hardware and not storage.fsset.active:
+        # turn off any swaps that we didn't turn on
+        # needed for live installs
+        blivet_util.run_program(["swapoff", "-a"])
 
-        storage.devicetree.teardown_all()
+    storage.devicetree.teardown_all()
 
-        try:
-            storage.do_it(callbacks)
-        except (FSResizeError, FormatResizeError) as e:
-            if error_handler.cb(e) == ERROR_RAISE:
-                raise
+    try:
+        storage.do_it(callbacks)
+    except (FSResizeError, FormatResizeError) as e:
+        if error_handler.cb(e) == ERROR_RAISE:
+            raise
 
-        storage.turn_on_swap()
+    storage.turn_on_swap()
+
     # FIXME:  For livecd, skip_root needs to be True.
     storage.mount_filesystems()
 
-    if not conf.target.is_directory:
-        write_escrow_packets(storage)
+    write_escrow_packets(storage)
 
 
 def write_escrow_packets(storage):

--- a/pyanaconda/ui/gui/hubs/progress.py
+++ b/pyanaconda/ui/gui/hubs/progress.py
@@ -34,6 +34,7 @@ from pyanaconda.localization import find_best_locale_match
 from pyanaconda.product import productName
 from pyanaconda.flags import flags
 from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import THREAD_INSTALL, THREAD_CONFIGURATION, DEFAULT_LANG, IPMI_FINISHED
 from pykickstart.constants import KS_SHUTDOWN, KS_REBOOT
 
@@ -217,7 +218,7 @@ class ProgressHub(Hub):
     def initialize(self):
         super().initialize()
 
-        if flags.livecdInstall:
+        if not conf.system.can_reboot and conf.target.is_hardware:
             continueText = self.builder.get_object("rebootLabel")
             continueText.set_text(_("%s is now successfully installed on your system and ready "
                                     "for you to use!  When you are ready, reboot your system to start using it!"))

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -38,6 +38,7 @@ from pyanaconda.ui.gui.helpers import GUIDialogInputCheckHandler
 from pyanaconda.ui.helpers import InputCheck
 
 from pyanaconda.core import util, constants
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda import isys
 from pyanaconda import network
 from pyanaconda import ntp
@@ -273,7 +274,7 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
         if rc == 1:
             new_pools, new_servers = self.pools_servers
 
-            if flags.can_touch_runtime_system("save NTP servers configuration"):
+            if conf.system.can_set_time_synchronization:
                 ntp.save_servers_to_config(new_pools, new_servers)
                 util.restart_service(NTP_SERVICE)
 
@@ -506,7 +507,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
         # Set the initial sensitivity of the AM/PM toggle based on the time-type selected
         self._radioButton24h.emit("toggled")
 
-        if not flags.can_touch_runtime_system("modify system time and date"):
+        if not conf.system.can_set_system_clock:
             self._set_date_time_setting_sensitive(False)
 
         self._config_dialog = NTPconfigDialog(self.data, self._timezone_module)
@@ -645,7 +646,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
             self.clear_info()
             gtk_call_once(self._config_dialog.refresh_servers_state)
 
-        if flags.can_touch_runtime_system("get NTP service state"):
+        if conf.system.can_set_time_synchronization:
             ntp_working = has_active_network and util.service_running(NTP_SERVICE)
         else:
             ntp_working = self._timezone_module.proxy.NTPEnabled
@@ -791,7 +792,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
         self._start_updating_timer = None
 
-        if not flags.can_touch_runtime_system("save system time"):
+        if not conf.system.can_set_system_clock:
             return False
 
         month = self._get_combo_selection(self._monthCombo)[0]
@@ -1115,7 +1116,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
     def on_ntp_switched(self, switch, *args):
         if switch.get_active():
             #turned ON
-            if not flags.can_touch_runtime_system("start NTP service"):
+            if not conf.system.can_set_time_synchronization:
                 #cannot touch runtime system, not much to do here
                 return
 
@@ -1144,7 +1145,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
         else:
             #turned OFF
-            if not flags.can_touch_runtime_system("stop NTP service"):
+            if not conf.system.can_set_time_synchronization:
                 #cannot touch runtime system, nothing to do here
                 return
 

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -32,6 +32,7 @@ from pyanaconda.ui.gui.xkl_wrapper import XklWrapper, XklWrapperError
 from pyanaconda import keyboard
 from pyanaconda import flags
 from pyanaconda.core.i18n import _, N_, CN_
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import DEFAULT_KEYBOARD, THREAD_KEYBOARD_INIT, THREAD_ADD_LAYOUTS_INIT
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.core.util import strip_accents, have_word_match
@@ -342,8 +343,7 @@ class KeyboardSpoke(NormalSpoke):
         self._add_dialog = AddLayoutDialog(self.data)
         self._add_dialog.initialize()
 
-        if flags.can_touch_runtime_system("hide runtime keyboard configuration "
-                                          "warning", touch_live=True):
+        if conf.system.can_configure_keyboard:
             self.builder.get_object("warningBox").hide()
 
         # We want to store layouts' names but show layouts as
@@ -363,7 +363,7 @@ class KeyboardSpoke(NormalSpoke):
 
         self._layoutSwitchLabel = self.builder.get_object("layoutSwitchLabel")
 
-        if not flags.can_touch_runtime_system("test X layouts", touch_live=True):
+        if not conf.system.can_configure_keyboard:
             # Disable area for testing layouts as we cannot make
             # it work without modifying runtime system
 
@@ -415,7 +415,7 @@ class KeyboardSpoke(NormalSpoke):
 
     def _addLayout(self, store, name):
         # first try to add the layout
-        if flags.can_touch_runtime_system("add runtime X layout", touch_live=True):
+        if conf.system.can_configure_keyboard:
             self._xkl_wrapper.add_layout(name)
 
         # valid layout, append it to the store
@@ -428,7 +428,7 @@ class KeyboardSpoke(NormalSpoke):
 
         """
 
-        if flags.can_touch_runtime_system("remove runtime X layout", touch_live=True):
+        if conf.system.can_configure_keyboard:
             self._xkl_wrapper.remove_layout(store[itr][0])
         store.remove(itr)
 
@@ -520,7 +520,7 @@ class KeyboardSpoke(NormalSpoke):
             return
 
         store.swap(cur, prev)
-        if flags.can_touch_runtime_system("reorder runtime X layouts", touch_live=True):
+        if conf.system.can_configure_keyboard:
             self._flush_layouts_to_X()
 
         if not store.iter_previous(cur):
@@ -543,7 +543,7 @@ class KeyboardSpoke(NormalSpoke):
             return
 
         store.swap(cur, nxt)
-        if flags.can_touch_runtime_system("reorder runtime X layouts", touch_live=True):
+        if conf.system.can_configure_keyboard:
             self._flush_layouts_to_X()
 
         if activate_default:

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -26,6 +26,7 @@ from gi.repository import Pango, Gdk
 from pyanaconda.modules.common.constants.services import LOCALIZATION
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import CN_
+from pyanaconda.payload.livepayload import LiveImagePayload
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.utils import escape_markup, override_cell_property
 from pyanaconda.ui.categories.localization import LocalizationCategory
@@ -129,7 +130,7 @@ class LangsupportSpoke(LangLocaleHandler, NormalSpoke):
     @property
     def showable(self):
         # don't show the language support spoke on live media and in single language mode
-        return not flags.livecdInstall and not flags.singlelang
+        return not isinstance(self.payload, LiveImagePayload) and not flags.singlelang
 
     @property
     def status(self):

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -27,7 +27,6 @@ gi.require_version("NM", "1.0")
 from gi.repository import Gtk
 from gi.repository import GObject, Pango, Gio, NM
 
-from pyanaconda.flags import can_touch_runtime_system
 from pyanaconda.core.i18n import _, N_, C_, CN_
 from pyanaconda.flags import flags as anaconda_flags
 from pyanaconda.ui.communication import hubQ
@@ -37,6 +36,7 @@ from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.gui.hubs.summary import SummaryHub
 from pyanaconda.ui.gui.utils import gtk_call_once, escape_markup, really_hide, really_show
 from pyanaconda.ui.common import FirstbootSpokeMixIn
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.util import startProgram
 from pyanaconda.core.process_watchers import PidWatcher
 from pyanaconda.core.constants import ANACONDA_ENVIRON
@@ -1507,7 +1507,7 @@ class SecretAgent(dbus.service.Object):
 
 def register_secret_agent(spoke):
 
-    if not can_touch_runtime_system("register anaconda secret agent"):
+    if not conf.system.can_require_network_connection:
         return False
 
     global secret_agent
@@ -1583,7 +1583,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
     @property
     def completed(self):
         # TODO: check also if source requires updates when implemented
-        return (not can_touch_runtime_system("require network connection")
+        return (not conf.system.can_require_network_connection
                 or nm.nm_activated_devices())
 
     @property
@@ -1602,7 +1602,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         NormalSpoke.initialize(self)
         self.initialize_start()
         self.network_control_box.initialize()
-        if not can_touch_runtime_system("hide hint to use network configuration in DE"):
+        if not conf.system.can_require_network_connection:
             self.builder.get_object("network_config_vbox").set_no_show_all(True)
             self.builder.get_object("network_config_vbox").hide()
         else:
@@ -1726,7 +1726,7 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
 
     @property
     def completed(self):
-        return (not can_touch_runtime_system("require network connection")
+        return (not conf.system.can_require_network_connection
                 or nm.nm_activated_devices()
                 or self.data.method.method not in ("url", "nfs"))
 

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -81,6 +81,7 @@ from pyanaconda.screen_access import sam
 from pyanaconda.modules.common.constants.objects import DISK_SELECTION, DISK_INITIALIZATION, \
     BOOTLOADER, AUTO_PARTITIONING
 from pyanaconda.modules.common.constants.services import STORAGE
+from pyanaconda.payload.livepayload import LiveImagePayload
 
 from pykickstart.constants import AUTOPART_TYPE_LVM
 from pykickstart.errors import KickstartParseError
@@ -134,7 +135,7 @@ class InstallOptionsDialogBase(GUIObject):
     def _get_sw_needs_text(self, required_space, sw_space, auto_swap):
         tooltip = _("Please wait... software metadata still loading.")
 
-        if flags.livecdInstall:
+        if isinstance(self.payload, LiveImagePayload):
             sw_text = (_("Your current <b>%(product)s</b> software "
                          "selection requires <b>%(total)s</b> of available "
                          "space, including <b>%(software)s</b> for software and "
@@ -199,7 +200,7 @@ class NeedSpaceDialog(InstallOptionsDialogBase):
         label = self.builder.get_object("need_space_desc_label")
         label.set_markup(label_text)
 
-        if not flags.livecdInstall:
+        if not isinstance(self.payload, LiveImagePayload):
             label.connect("activate-link", self._modify_sw_link_clicked)
 
         self._set_free_space_labels(disk_free, fs_free)
@@ -235,7 +236,7 @@ class NoSpaceDialog(InstallOptionsDialogBase):
         label = self.builder.get_object("no_space_desc_label")
         label.set_markup(label_text)
 
-        if not flags.livecdInstall:
+        if not isinstance(self.payload, LiveImagePayload):
             label.connect("activate-link", self._modify_sw_link_clicked)
 
         self._set_free_space_labels(disk_free, fs_free)

--- a/pyanaconda/ui/gui/xkl_wrapper.py
+++ b/pyanaconda/ui/gui/xkl_wrapper.py
@@ -37,8 +37,8 @@ import threading
 import gettext
 from collections import namedtuple
 
-from pyanaconda import flags
 from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import DEFAULT_KEYBOARD
 from pyanaconda.keyboard import join_layout_variant, parse_layout_variant, KeyboardConfigError, InvalidLayoutVariantSpec
 from pyanaconda.core.async_utils import async_action_wait
@@ -92,7 +92,7 @@ class XklWrapper(object):
         #variants lists to have the same length. Add "" padding to variants.
         #See docstring of the add_layout method for details.
         diff = len(self._rec.layouts) - len(self._rec.variants)
-        if diff > 0 and flags.can_touch_runtime_system("activate layouts"):
+        if diff > 0 and conf.system.can_activate_layouts:
             self._rec.set_variants(self._rec.variants + (diff * [""]))
             if not self._rec.activate(self._engine):
                 # failed to activate layouts given e.g. by a kickstart (may be

--- a/pyanaconda/ui/tui/spokes/askvnc.py
+++ b/pyanaconda/ui/tui/spokes/askvnc.py
@@ -19,12 +19,12 @@
 
 import sys
 
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.core.constants import USEVNC, USETEXT
 from pyanaconda.core.i18n import N_, _, C_
 from pyanaconda.ui.tui import exception_msg_handler
 from pyanaconda.core.util import execWithRedirect, ipmi_abort
-from pyanaconda.flags import can_touch_runtime_system
 
 from simpleline import App
 from simpleline.event_loop.signals import ExceptionSignal
@@ -105,7 +105,7 @@ class AskVNCSpoke(NormalTUISpoke):
                 ScreenHandler.push_screen_modal(d)
                 if d.answer:
                     ipmi_abort(scripts=self.data.scripts)
-                    if can_touch_runtime_system("Quit and Reboot"):
+                    if conf.system.can_reboot:
                         execWithRedirect("systemctl", ["--no-wall", "reboot"])
                     else:
                         sys.exit(1)

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -19,8 +19,9 @@
 
 from pyanaconda import network
 from pyanaconda import nm
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.modules.common.constants.services import NETWORK
-from pyanaconda.flags import can_touch_runtime_system, flags
+from pyanaconda.flags import flags
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog, report_if_failed
@@ -102,7 +103,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
             check if we're installing from CD/DVD, since a network connection
             should not be required in this case.
         """
-        return (not can_touch_runtime_system("require network connection")
+        return (not conf.system.can_require_network_connection
                 or nm.nm_activated_devices())
 
     @property

--- a/tests/nosetests/pyanaconda_tests/argparse_test.py
+++ b/tests/nosetests/pyanaconda_tests/argparse_test.py
@@ -130,3 +130,34 @@ class ArgparseTest(unittest.TestCase):
         self.assertEqual(conf.target.is_image, False)
         self.assertEqual(conf.target.is_directory, True)
         self.assertEqual(conf.target.physical_root, "/what/ever")
+
+    def system_test(self):
+        conf = AnacondaConfiguration.from_defaults()
+
+        opts, _deprecated = self._parseCmdline([])
+        conf.set_from_opts(opts)
+
+        self.assertEqual(conf.system._is_boot_iso, True)
+        self.assertEqual(conf.system._is_live_os, False)
+        self.assertEqual(conf.system._is_unknown, False)
+
+        opts, _deprecated = self._parseCmdline(['--liveinst'])
+        conf.set_from_opts(opts)
+
+        self.assertEqual(conf.system._is_boot_iso, False)
+        self.assertEqual(conf.system._is_live_os, True)
+        self.assertEqual(conf.system._is_unknown, False)
+
+        opts, _deprecated = self._parseCmdline(['--dirinstall=/what/ever'])
+        conf.set_from_opts(opts)
+
+        self.assertEqual(conf.system._is_boot_iso, False)
+        self.assertEqual(conf.system._is_live_os, False)
+        self.assertEqual(conf.system._is_unknown, True)
+
+        opts, _deprecated = self._parseCmdline(['--image=/what/ever.img'])
+        conf.set_from_opts(opts)
+
+        self.assertEqual(conf.system._is_boot_iso, False)
+        self.assertEqual(conf.system._is_live_os, False)
+        self.assertEqual(conf.system._is_unknown, True)


### PR DESCRIPTION
For now, the installation system can be specified in the Anaconda
configuration file. The supported types of the system are BOOT_ISO,
LIVE_OS and UNKNOWN. The type will determine what the installer
is allowed to do with the current system.

This is a temporary solution. The type will be replaced with a list
of rules. The rules will be modified by configuration snippets, that
will be installed by packages specific for each type of the system.