### PR TITLE
Hotfix - disable unsupported hardware detection

### DIFF
--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -54,9 +54,9 @@ class RHELBaseInstallClass(BaseInstallClass):
 
     blivet_gui_supported = False
 
-    detect_unsupported_hardware = True
+    detect_unsupported_hardware = False
 
-    detect_support_removed = True
+    detect_support_removed = False
 
     def setNetworkOnbootDefault(self, ksdata):
         if any(nd.onboot for nd in ksdata.network.network if nd.device):


### PR DESCRIPTION
There are apparently cases where the unsupported hardware
detection algorithm might be a bit too eager, resulting
in unfavourable user experience.

So let's disable unsupported hardware detection for now until the
algorithm is fixed.