### PR TITLE
Remove l10n_domain from the install classes

### DIFF
--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -57,8 +57,6 @@ class BaseInstallClass(object):
     # install the latest updates during installation source selection.
     installUpdates = True
 
-    _l10n_domain = None
-
     # EFI directory.
     efi_dir = "default"
 
@@ -114,13 +112,6 @@ class BaseInstallClass(object):
 
     # Should the installer show a warning about removed support for hardware?
     detect_support_removed = False
-
-    @property
-    def l10n_domain(self):
-        if self._l10n_domain is None:
-            raise RuntimeError("Localization domain for '%s' not set." %
-                               self.name)
-        return self._l10n_domain
 
     def setDefaultPartitioning(self, storage):
         autorequests = [PartSpec(mountpoint="/", fstype=storage.default_fstype,

--- a/pyanaconda/installclasses/centos.py
+++ b/pyanaconda/installclasses/centos.py
@@ -36,8 +36,6 @@ class CentOSBaseInstallClass(BaseInstallClass):
 
     installUpdates = False
 
-    _l10n_domain = "comps"
-
     efi_dir = "centos"
 
     help_placeholder = "CentOSPlaceholder.html"

--- a/pyanaconda/installclasses/fedora.py
+++ b/pyanaconda/installclasses/fedora.py
@@ -31,8 +31,6 @@ class FedoraBaseInstallClass(BaseInstallClass):
     if not productName.startswith("Fedora"):          # pylint: disable=no-member
         hidden = True
 
-    _l10n_domain = "anaconda"
-
     efi_dir = "fedora"
 
     help_placeholder = "FedoraPlaceholder.html"

--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -38,8 +38,6 @@ class RHELBaseInstallClass(BaseInstallClass):
 
     installUpdates = False
 
-    _l10n_domain = "comps"
-
     efi_dir = "redhat"
 
     help_placeholder = "rhel_help_placeholder.xml"

--- a/tests/nosetests/pyanaconda_tests/installclass_test.py
+++ b/tests/nosetests/pyanaconda_tests/installclass_test.py
@@ -191,7 +191,6 @@ class Installclass_AttribsTestCase(unittest.TestCase):
         self.assertTrue(hasattr(testclass, 'name'))
         self.assertTrue(hasattr(testclass, 'ignoredPackages'))
         self.assertTrue(hasattr(testclass, 'installUpdates'))
-        self.assertTrue(hasattr(testclass, '_l10n_domain'))
         self.assertTrue(hasattr(testclass, 'efi_dir'))
         self.assertTrue(hasattr(testclass, 'defaultFS'))
         self.assertTrue(hasattr(testclass, 'help_folder'))


### PR DESCRIPTION
Remove the property l10n_domain from the install classes, because
it is not used anywhere.