### PR TITLE
Define the default partitioning statically

### DIFF
--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -195,7 +195,7 @@ class Anaconda(object):
             import blivet.arch
 
             self._storage = InstallerStorage(ksdata=self.ksdata)
-            self._set_default_fstype(self._storage)
+            self._set_storage_defaults(self._storage)
 
             if blivet.arch.is_s390():
                 self._load_plugin_s390()
@@ -289,7 +289,7 @@ class Anaconda(object):
             log.warning("Repository name %s is not unique. Only the first repo will be used!",
                         repo.name)
 
-    def _set_default_fstype(self, storage):
+    def _set_storage_defaults(self, storage):
         fstype = None
         boot_fstype = None
 
@@ -317,6 +317,9 @@ class Anaconda(object):
 
         if luks_version:
             storage.set_default_luks_version(luks_version)
+
+        # Set the default partitioning.
+        storage.set_default_partitioning(self.instClass.default_partitioning)
 
     def _load_plugin_s390(self):
         # Make sure s390 plugin is loaded.

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -334,5 +334,3 @@ def setup_display(anaconda, options, addon_paths=None):
 
     # with X running we can initialize the UI interface
     anaconda.initInterface(addon_paths=addon_paths)
-    # and the install class
-    anaconda.instClass.configure(anaconda)

--- a/pyanaconda/installclasses/fedora_atomic_host.py
+++ b/pyanaconda/installclasses/fedora_atomic_host.py
@@ -20,8 +20,8 @@
 import os
 import shutil
 from pyanaconda.installclasses.fedora import FedoraBaseInstallClass
-from pyanaconda.installclasses.fedora_server import FedoraServerInstallClass
 from pyanaconda.product import productVariant
+from pyanaconda.storage.partitioning import SERVER_PARTITIONING
 from pyanaconda.core import util
 
 import logging
@@ -35,6 +35,7 @@ class AtomicHostInstallClass(FedoraBaseInstallClass):
     stylesheet = "/usr/share/anaconda/pixmaps/atomic/fedora-atomic.css"
     sortPriority = FedoraBaseInstallClass.sortPriority + 1
     defaultFS = "xfs"
+    default_partitioning = SERVER_PARTITIONING
 
     if productVariant != "AtomicHost":
         hidden = True
@@ -42,9 +43,6 @@ class AtomicHostInstallClass(FedoraBaseInstallClass):
     def __init__(self):
         self.localemap = {}  # loaded lazily
         super().__init__()
-
-    def setDefaultPartitioning(self, storage):
-        FedoraServerInstallClass.createDefaultPartitioning(storage)
 
     def filterSupportedLangs(self, ksdata, langs):
         self._initialize_localemap(ksdata.ostreesetup.ref,

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -2062,9 +2062,8 @@ class ReqPart(COMMANDS.ReqPart):
             log.debug("Looking for platform-specific boot requirements.")
             bootPartitions = platform.set_platform_boot_partition()
 
-            # blivet doesn't know this - anaconda sets up the default boot fstype
-            # in various places in this file, as well as in setDefaultPartitioning
-            # in the install classes.  We need to duplicate that here.
+            # Blivet doesn't know this - anaconda sets up the default boot fstype
+            # in various places in this file. We need to duplicate that here.
             for part in bootPartitions:
                 if part.mountpoint == "/boot":
                     part.fstype = storage.default_boot_fstype

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -62,6 +62,7 @@ from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _
 from pyanaconda.platform import EFI
 from pyanaconda.platform import platform as _platform
+from pyanaconda.storage.partitioning import get_full_partitioning_requests
 from pyanaconda.modules.common.constants.services import NETWORK, STORAGE
 from pyanaconda.modules.common.constants.objects import DISK_SELECTION, DISK_INITIALIZATION, \
     AUTO_PARTITIONING, ZFCP
@@ -1369,6 +1370,13 @@ class InstallerStorage(Blivet):
 
     def _check_valid_luks_version(self, version):
         get_format("luks", luks_version=version)
+
+    def set_default_partitioning(self, requests):
+        """Set the default partitioning.
+
+        :param requests: a list of partitioning specs
+        """
+        self.autopart_requests = get_full_partitioning_requests(self, _platform, requests)
 
     def set_up_bootloader(self, early=False):
         """ Propagate ksdata into BootLoader.

--- a/pyanaconda/storage/partitioning.py
+++ b/pyanaconda/storage/partitioning.py
@@ -1,0 +1,147 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from blivet.size import Size
+from pyanaconda.core.constants import STORAGE_SWAP_IS_RECOMMENDED
+
+from pyanaconda.modules.common.constants.objects import AUTO_PARTITIONING
+from pyanaconda.modules.common.constants.services import STORAGE
+from pyanaconda.storage.partspec import PartSpec
+
+# Partitioning requirements for servers.
+SERVER_PARTITIONING = [
+    PartSpec(
+        mountpoint="/",
+        size=Size("2GiB"),
+        max_size=Size("15GiB"),
+        grow=True,
+        btr=True,
+        lv=True,
+        thin=True,
+        encrypted=True
+    ),
+    PartSpec(
+        fstype="swap",
+        grow=False,
+        lv=True,
+        encrypted=True
+    )
+]
+
+# Partitioning requirements for workstations.
+WORKSTATION_PARTITIONING = [
+    PartSpec(
+        mountpoint="/",
+        size=Size("1GiB"),
+        max_size=Size("50GiB"),
+        grow=True,
+        btr=True,
+        lv=True,
+        thin=True,
+        encrypted=True),
+    PartSpec(
+        mountpoint="/home",
+        size=Size("500MiB"), grow=True,
+        required_space=Size("50GiB"),
+        btr=True,
+        lv=True,
+        thin=True,
+        encrypted=True),
+    PartSpec(
+        fstype="swap",
+        grow=False,
+        lv=True,
+        encrypted=True
+    )
+]
+
+
+def get_full_partitioning_requests(storage, platform, requests):
+    """Get the full partitioning requests.
+
+    :param storage: the Blivet's storage object
+    :param platform: the current platform object
+    :param requests: a list of partitioning specs
+    :return:
+    """
+    requests = _get_platform_specific_partitioning(platform, requests)
+    requests = _complete_partitioning_requests(storage, requests)
+    requests = _filter_default_partitions(requests)
+    return requests
+
+
+def _get_platform_specific_partitioning(platform, requests):
+    """Get the platform-specific partitioning.
+
+    The requests will be completed with the platform-specific
+    requirements.
+
+    :param platform: the current platform object
+    :param requests: a list of partitioning specs
+    """
+    return platform.set_default_partitioning() + requests
+
+
+def _complete_partitioning_requests(storage, requests):
+    """Complete the partitioning requests.
+
+    :param storage: the Blivet's storage object
+    :param requests: a list of partitioning specs
+    :return:
+    """
+    for request in requests:
+        if request.fstype is None:
+            request.fstype = storage.get_fstype(request.mountpoint)
+
+    return requests
+
+
+def _filter_default_partitions(requests):
+    """Filter default partitions based on the kickstart data.
+
+    :param requests: a list of requests
+    :return: a customized list of requests
+    """
+    auto_part_proxy = STORAGE.get_proxy(AUTO_PARTITIONING)
+    skipped_mountpoints = set()
+    skipped_fstypes = set()
+
+    # Create sets of mountpoints and fstypes to remove from autorequests.
+    if auto_part_proxy.Enabled:
+        # Remove /home if --nohome is selected.
+        if auto_part_proxy.NoHome:
+            skipped_mountpoints.add("/home")
+
+        # Remove /boot if --noboot is selected.
+        if auto_part_proxy.NoBoot:
+            skipped_mountpoints.add("/boot")
+
+        # Remove swap if --noswap is selected.
+        if auto_part_proxy.NoSwap:
+            skipped_fstypes.add("swap")
+
+            # Swap will not be recommended by the storage checker.
+            # TODO: Remove this code from this function.
+            from pyanaconda.storage_utils import storage_checker
+            storage_checker.add_constraint(STORAGE_SWAP_IS_RECOMMENDED, False)
+
+    # Skip mountpoints we want to remove.
+    return [
+        req for req in requests
+        if req.mountpoint not in skipped_mountpoints
+           and req.fstype not in skipped_fstypes
+    ]

--- a/tests/nosetests/pyanaconda_tests/installclass_test.py
+++ b/tests/nosetests/pyanaconda_tests/installclass_test.py
@@ -193,6 +193,7 @@ class Installclass_AttribsTestCase(unittest.TestCase):
         self.assertTrue(hasattr(testclass, 'installUpdates'))
         self.assertTrue(hasattr(testclass, 'efi_dir'))
         self.assertTrue(hasattr(testclass, 'defaultFS'))
+        self.assertTrue(hasattr(testclass, 'default_partitioning'))
         self.assertTrue(hasattr(testclass, 'help_folder'))
         self.assertTrue(hasattr(testclass, 'help_main_page'))
         self.assertTrue(hasattr(testclass, 'help_main_page_plain_text'))

--- a/tests/nosetests/pyanaconda_tests/partitioning_test.py
+++ b/tests/nosetests/pyanaconda_tests/partitioning_test.py
@@ -1,0 +1,78 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+
+from mock import Mock, patch
+
+from pyanaconda.platform import Platform
+from pyanaconda.storage.partspec import PartSpec
+from pyanaconda.storage.partitioning import _get_platform_specific_partitioning, \
+    _complete_partitioning_requests, _filter_default_partitions
+
+
+class PartitioningTestCase(unittest.TestCase):
+
+    def get_platform_specific_partitioning_test(self):
+        requests = _get_platform_specific_partitioning(Platform(), [PartSpec("/")])
+        self.assertEqual(["/boot", "/"], [spec.mountpoint for spec in requests])
+
+    def complete_partitioning_requests_test(self):
+
+        def get_fstype(mountpoint):
+            if mountpoint == "/boot":
+                return "ext4"
+
+            return "xfs"
+
+        storage = Mock()
+        storage.get_fstype = get_fstype
+
+        requests = _complete_partitioning_requests(storage, [PartSpec("/boot"), PartSpec("/")])
+        self.assertEqual(["ext4", "xfs"], [spec.fstype for spec in requests])
+
+    @patch("pyanaconda.dbus.DBus.get_proxy")
+    def filter_all_default_partitioning_test(self, proxy_getter):
+        proxy = Mock()
+        proxy_getter.return_value = proxy
+
+        proxy.NoHome = True
+        proxy.NoBoot = True
+        proxy.NoSwap = True
+
+        requests = _filter_default_partitions(
+            [PartSpec("/boot"), PartSpec("/"), PartSpec("/home"), PartSpec(fstype="swap")]
+        )
+
+        self.assertEqual(["/"], [spec.mountpoint for spec in requests])
+
+    @patch("pyanaconda.dbus.DBus.get_proxy")
+    def filter_none_default_partitioning_test(self, proxy_getter):
+        proxy = Mock()
+        proxy_getter.return_value = proxy
+
+        proxy.NoHome = False
+        proxy.NoBoot = False
+        proxy.NoSwap = False
+
+        requests = _filter_default_partitions(
+            [PartSpec("/boot"), PartSpec("/"), PartSpec("/home"), PartSpec(fstype="swap")]
+        )
+
+        self.assertEqual(
+            ["/boot", "/", "/home", "swap"], [spec.mountpoint or spec.fstype for spec in requests]
+        )


### PR DESCRIPTION
In the install classes, the setDefaultPartitioning method was replaced
with the default_partitioning attribute. The attribute provides a list
of partitioning requirements that will be automatically completed with
platform-specific requirements and user data.

Most of the code was moved to the pyanaconda.storage module.