### PR TITLE
Clean up the install classes

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -676,7 +676,6 @@ if __name__ == "__main__":
 
     from pyanaconda.storage_utils import storage_checker
     storage_checker.add_constraint(constants.STORAGE_MIN_RAM, min_ram)
-    anaconda.instClass.setStorageChecker(storage_checker)
 
     from pyanaconda.argument_parsing import name_path_pairs
 

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -138,23 +138,20 @@ class Anaconda(object):
         # Try to find the payload class.  First try the install
         # class.  If it doesn't give us one, fall back to the default.
         if not self._payload:
-            klass = self.instClass.getBackend()
+            from pyanaconda.flags import flags
 
-            if not klass:
-                from pyanaconda.flags import flags
-
-                if self.ksdata.ostreesetup.seen:
-                    from pyanaconda.payload.rpmostreepayload import RPMOSTreePayload
-                    klass = RPMOSTreePayload
-                elif flags.livecdInstall:
-                    from pyanaconda.payload.livepayload import LiveImagePayload
-                    klass = LiveImagePayload
-                elif self.ksdata.method.method == "liveimg":
-                    from pyanaconda.payload.livepayload import LiveImageKSPayload
-                    klass = LiveImageKSPayload
-                else:
-                    from pyanaconda.payload.dnfpayload import DNFPayload
-                    klass = DNFPayload
+            if self.ksdata.ostreesetup.seen:
+                from pyanaconda.payload.rpmostreepayload import RPMOSTreePayload
+                klass = RPMOSTreePayload
+            elif flags.livecdInstall:
+                from pyanaconda.payload.livepayload import LiveImagePayload
+                klass = LiveImagePayload
+            elif self.ksdata.method.method == "liveimg":
+                from pyanaconda.payload.livepayload import LiveImageKSPayload
+                klass = LiveImageKSPayload
+            else:
+                from pyanaconda.payload.dnfpayload import DNFPayload
+                klass = DNFPayload
 
             self._payload = klass(self.ksdata)
 

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -46,7 +46,6 @@ class BaseInstallClass(object):
     hidden = False
     name = "base"
     bootloaderTimeoutDefault = None
-    bootloaderExtraArgs = []
     bootloader_menu_autohide = False
 
     # Anaconda flags several packages to be installed based on the configuration
@@ -186,7 +185,6 @@ class BaseInstallClass(object):
 
     def configure(self, anaconda):
         anaconda.bootloader.timeout = self.bootloaderTimeoutDefault
-        anaconda.bootloader.boot_args.update(self.bootloaderExtraArgs)
 
         # The default partitioning should be always set.
         self.setDefaultPartitioning(anaconda.storage)

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -205,12 +205,6 @@ class BaseInstallClass(object):
         """
         self.setPackageSelection(payload)
 
-    def setStorageChecker(self, storage_checker):
-        # Update constraints and add or remove some checks in
-        # the storage checker to customize the storage sanity
-        # checking.
-        pass
-
     # sets default ONBOOT values and updates ksdata accordingly
     def setNetworkOnbootDefault(self, ksdata):
         pass

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -45,7 +45,6 @@ class BaseInstallClass(object):
     sortPriority = 0
     hidden = False
     name = "base"
-    bootloaderTimeoutDefault = None
     bootloader_menu_autohide = False
 
     # Anaconda flags several packages to be installed based on the configuration
@@ -184,8 +183,6 @@ class BaseInstallClass(object):
                                      and req.fstype not in skipped_fstypes]
 
     def configure(self, anaconda):
-        anaconda.bootloader.timeout = self.bootloaderTimeoutDefault
-
         # The default partitioning should be always set.
         self.setDefaultPartitioning(anaconda.storage)
 

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -127,12 +127,6 @@ class BaseInstallClass(object):
     def setPackageSelection(self, anaconda):
         pass
 
-    def getBackend(self):
-        # The default is to return None here, which means anaconda should
-        # use live or dnf (whichever can be detected).  This method is
-        # provided as a way for other products to specify their own.
-        return None
-
     def setDefaultPartitioning(self, storage):
         autorequests = [PartSpec(mountpoint="/", fstype=storage.default_fstype,
                                  size=Size("1GiB"),

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -124,9 +124,6 @@ class BaseInstallClass(object):
                                self.name)
         return self._l10n_domain
 
-    def setPackageSelection(self, anaconda):
-        pass
-
     def setDefaultPartitioning(self, storage):
         autorequests = [PartSpec(mountpoint="/", fstype=storage.default_fstype,
                                  size=Size("1GiB"),
@@ -203,7 +200,7 @@ class BaseInstallClass(object):
         This is called after payload is created.
         Beware: This method is called before payload is restarted so it is not completely set up.
         """
-        self.setPackageSelection(payload)
+        pass
 
     # sets default ONBOOT values and updates ksdata accordingly
     def setNetworkOnbootDefault(self, ksdata):

--- a/pyanaconda/installclasses/centos.py
+++ b/pyanaconda/installclasses/centos.py
@@ -32,8 +32,6 @@ class CentOSBaseInstallClass(BaseInstallClass):
         hidden = True
     defaultFS = "xfs"
 
-    bootloaderTimeoutDefault = 5
-
     ignoredPackages = ["ntfsprogs"]
 
     installUpdates = False

--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -34,8 +34,6 @@ class RHELBaseInstallClass(BaseInstallClass):
     defaultFS = "xfs"
     default_luks_version = "luks2"
 
-    bootloaderTimeoutDefault = 5
-
     ignoredPackages = ["ntfsprogs"]
 
     installUpdates = False

--- a/tests/nosetests/pyanaconda_tests/installclass_test.py
+++ b/tests/nosetests/pyanaconda_tests/installclass_test.py
@@ -190,7 +190,6 @@ class Installclass_AttribsTestCase(unittest.TestCase):
         self.assertTrue(hasattr(testclass, 'hidden'))
         self.assertTrue(hasattr(testclass, 'name'))
         self.assertTrue(hasattr(testclass, 'bootloaderTimeoutDefault'))
-        self.assertTrue(hasattr(testclass, 'bootloaderExtraArgs'))
         self.assertTrue(hasattr(testclass, 'ignoredPackages'))
         self.assertTrue(hasattr(testclass, 'installUpdates'))
         self.assertTrue(hasattr(testclass, '_l10n_domain'))

--- a/tests/nosetests/pyanaconda_tests/installclass_test.py
+++ b/tests/nosetests/pyanaconda_tests/installclass_test.py
@@ -189,7 +189,6 @@ class Installclass_AttribsTestCase(unittest.TestCase):
         self.assertTrue(hasattr(testclass, 'sortPriority'))
         self.assertTrue(hasattr(testclass, 'hidden'))
         self.assertTrue(hasattr(testclass, 'name'))
-        self.assertTrue(hasattr(testclass, 'bootloaderTimeoutDefault'))
         self.assertTrue(hasattr(testclass, 'ignoredPackages'))
         self.assertTrue(hasattr(testclass, 'installUpdates'))
         self.assertTrue(hasattr(testclass, '_l10n_domain'))


### PR DESCRIPTION
Let's clean up the install classes from methods and attributes that seem to be useless. We can always bring the support back if requested. It will simplify the switch to the configuration files.