### PR TITLE
Replace setNetworkOnbootDefault

### DIFF
--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -28,6 +28,7 @@ import sys
 from pyanaconda.core.constants import SETUP_ON_BOOT_DEFAULT
 from pyanaconda.core.util import collect
 from pyanaconda.storage.partitioning import WORKSTATION_PARTITIONING
+from pyanaconda.network import NetworkOnBoot
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -109,9 +110,8 @@ class BaseInstallClass(object):
     # Should the installer show a warning about removed support for hardware?
     detect_support_removed = False
 
-    # sets default ONBOOT values and updates ksdata accordingly
-    def setNetworkOnbootDefault(self, ksdata):
-        pass
+    # The default network on boot.
+    network_on_boot = NetworkOnBoot.NONE
 
     def filterSupportedLangs(self, ksdata, langs):
         return langs

--- a/pyanaconda/installclasses/centos.py
+++ b/pyanaconda/installclasses/centos.py
@@ -18,9 +18,8 @@
 #
 
 from pyanaconda.installclass import BaseInstallClass
+from pyanaconda.network import NetworkOnBoot
 from pyanaconda.product import productName
-from pyanaconda import network
-from pyanaconda import nm
 
 __all__ = ["CentOSBaseInstallClass"]
 
@@ -43,15 +42,4 @@ class CentOSBaseInstallClass(BaseInstallClass):
 
     blivet_gui_supported = False
 
-    def setNetworkOnbootDefault(self, ksdata):
-        if any(nd.onboot for nd in ksdata.network.network if nd.device):
-            return
-        # choose the device used during installation
-        # (ie for majority of cases the one having the default route)
-        dev = network.default_route_device() or network.default_route_device(family="inet6")
-        if not dev:
-            return
-        # ignore wireless (its ifcfgs would need to be handled differently)
-        if nm.nm_device_type_is_wifi(dev):
-            return
-        network.update_onboot_value(dev, True, ksdata=ksdata)
+    network_on_boot = NetworkOnBoot.DEFAULT_ROUTE_DEVICE

--- a/pyanaconda/installclasses/fedora.py
+++ b/pyanaconda/installclasses/fedora.py
@@ -18,9 +18,8 @@
 #
 
 from pyanaconda.installclass import BaseInstallClass
+from pyanaconda.network import NetworkOnBoot
 from pyanaconda.product import productName
-from pyanaconda import network
-from pyanaconda import nm
 
 __all__ = ["FedoraBaseInstallClass"]
 
@@ -39,17 +38,4 @@ class FedoraBaseInstallClass(BaseInstallClass):
 
     default_luks_version = "luks1"
 
-    def setNetworkOnbootDefault(self, ksdata):
-        if any(nd.onboot for nd in ksdata.network.network if nd.device):
-            return
-        # choose first wired device having link
-        for dev in nm.nm_devices():
-            if nm.nm_device_type_is_wifi(dev):
-                continue
-            try:
-                link_up = nm.nm_device_carrier(dev)
-            except (nm.UnknownDeviceError, nm.PropertyNotFoundError):
-                continue
-            if link_up:
-                network.update_onboot_value(dev, True, ksdata=ksdata)
-                break
+    network_on_boot = NetworkOnBoot.FIRST_WIRED_WITH_LINK

--- a/pyanaconda/installclasses/rhel.py
+++ b/pyanaconda/installclasses/rhel.py
@@ -18,9 +18,8 @@
 #
 
 from pyanaconda.installclass import BaseInstallClass
+from pyanaconda.network import NetworkOnBoot
 from pyanaconda.product import productName
-from pyanaconda import network
-from pyanaconda import nm
 
 __all__ = ["RHELBaseInstallClass"]
 
@@ -54,15 +53,4 @@ class RHELBaseInstallClass(BaseInstallClass):
 
     detect_support_removed = True
 
-    def setNetworkOnbootDefault(self, ksdata):
-        if any(nd.onboot for nd in ksdata.network.network if nd.device):
-            return
-        # choose the device used during installation
-        # (ie for majority of cases the one having the default route)
-        dev = network.default_route_device() or network.default_route_device(family="inet6")
-        if not dev:
-            return
-        # ignore wireless (its ifcfgs would need to be handled differently)
-        if nm.nm_device_type_is_wifi(dev):
-            return
-        network.update_onboot_value(dev, True, ksdata=ksdata)
+    network_on_boot = NetworkOnBoot.DEFAULT_ROUTE_DEVICE

--- a/tests/nosetests/pyanaconda_tests/installclass_test.py
+++ b/tests/nosetests/pyanaconda_tests/installclass_test.py
@@ -203,6 +203,7 @@ class Installclass_AttribsTestCase(unittest.TestCase):
         self.assertTrue(hasattr(testclass, 'stylesheet'))
         self.assertTrue(hasattr(testclass, 'defaultPackageEnvironment'))
         self.assertTrue(hasattr(testclass, 'setup_on_boot'))
+        self.assertTrue(hasattr(testclass, 'network_on_boot'))
         self.assertTrue(hasattr(testclass, 'use_geolocation_with_kickstart'))
 
 


### PR DESCRIPTION
The method setNetworkOnbootDefault was removed from the install classes
and replaced with the attribute network_on_boot. The logic from the
install classes was moved to pyanaconda.network.