### PR TITLE
Remove configurePayload

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -744,8 +744,6 @@ if __name__ == "__main__":
     from pyanaconda import exception
     anaconda.mehConfig = exception.initExceptionHandling(anaconda)
 
-    anaconda.postConfigureInstallClass()
-
     # add additional repositories from the cmdline to kickstart data
     anaconda.add_additional_repositories_to_ksdata()
 

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -407,13 +407,6 @@ class Anaconda(object):
         if addon_paths:
             self._intf.update_paths(addon_paths)
 
-    def postConfigureInstallClass(self):
-        """Do an install class late configuration.
-
-        This will enable to configure payload.
-        """
-        self.instClass.configurePayload(self.payload)
-
     def writeXdriver(self, root=None):
         # this should go away at some point, but until it does, we
         # need to keep it around.

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -109,14 +109,6 @@ class BaseInstallClass(object):
     # Should the installer show a warning about removed support for hardware?
     detect_support_removed = False
 
-    def configurePayload(self, payload):
-        """Configure install class specific payload operations.
-
-        This is called after payload is created.
-        Beware: This method is called before payload is restarted so it is not completely set up.
-        """
-        pass
-
     # sets default ONBOOT values and updates ksdata accordingly
     def setNetworkOnbootDefault(self, ksdata):
         pass

--- a/pyanaconda/installclasses/scientific.py
+++ b/pyanaconda/installclasses/scientific.py
@@ -16,9 +16,7 @@
 #
 
 from pyanaconda.installclasses.rhel import RHELBaseInstallClass
-from pyanaconda.kickstart import RepoData
-from pyanaconda.product import productName, productVersion, productArch
-from pyanaconda.payload import PackagePayload
+from pyanaconda.product import productName
 
 __all__ = ["ScientificBaseInstallClass"]
 
@@ -38,17 +36,3 @@ class ScientificBaseInstallClass(RHELBaseInstallClass):
 
     help_placeholder = "SLPlaceholder.html"
     help_placeholder_with_links = "SLPlaceholder.html"
-
-    def configurePayload(self, payload):  # pylint: disable=line-too-long
-        '''
-            Load SL specific payload repos
-        '''
-        if isinstance(payload, PackagePayload):
-            major_version = productVersion.replace('rolling','').split('.')[0]
-
-            # A number of users like EPEL, seed it disabled
-            payload.addDisabledRepo(RepoData(name='epel', metalink="https://mirrors.fedoraproject.org/metalink?repo=epel-"+major_version+"&arch="+productArch))
-            # ELRepo provides handy hardware drivers, seed it disabled
-            payload.addDisabledRepo(RepoData(name='elrepo', mirrorlist="http://mirrors.elrepo.org/mirrors-elrepo.el"+major_version))
-
-        super().configurePayload(payload)

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -514,16 +514,6 @@ class Payload(object):
         ksrepo.enabled = True
         self.data.repo.dataList().append(ksrepo)
 
-    def addDisabledRepo(self, ksrepo):
-        """Add the repo given by the pykickstart Repo object ksrepo to the
-        system.
-
-        Duplicate repos will not raise an error.  They should just silently
-        take the place of the previous value.
-        """
-        ksrepo.enabled = False
-        self.data.repo.dataList().append(ksrepo)
-
     def removeRepo(self, repo_id):
         repos = self.data.repo.dataList()
         try:

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -435,17 +435,6 @@ class DNFPayload(payload.PackagePayload):
         self._fetch_md(ksrepo.name)
         super().addRepo(ksrepo)
 
-    def addDisabledRepo(self, ksrepo):
-        """Add a disabled repo to dnf and kickstart repo lists.
-
-        :param ksrepo: Kickstart Repository to add
-        :type ksrepo: Kickstart RepoData object.
-        :returns: None
-        """
-        ksrepo.disable()
-        self._add_repo(ksrepo)
-        super().addDisabledRepo(ksrepo)
-
     def _enable_modules(self):
         """Enable modules (if any)."""
         # convert data from kickstart to module specs

--- a/tests/nosetests/pyanaconda_tests/installclass_test.py
+++ b/tests/nosetests/pyanaconda_tests/installclass_test.py
@@ -204,7 +204,6 @@ class Installclass_AttribsTestCase(unittest.TestCase):
         self.assertTrue(hasattr(testclass, 'defaultPackageEnvironment'))
         self.assertTrue(hasattr(testclass, 'setup_on_boot'))
         self.assertTrue(hasattr(testclass, 'use_geolocation_with_kickstart'))
-        self.assertTrue(hasattr(testclass, 'configurePayload'))
 
 
 class F27_Installclass_TestCase(unittest.TestCase):


### PR DESCRIPTION
The method configurePayload was removed from the install classes.
It is used only by the Scientific Linux to add optional repositories.
We will not support this feature in the Anaconda configuration file,
but we are going to find a different way.