### PR TITLE
Install grubby-deprecated when using the extlinux bootloader

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -2372,7 +2372,8 @@ class EXTLINUX(BootLoader):
     stage2_device_types = ["partition"]
     stage2_bootable = True
 
-    packages = ["syslinux-extlinux"]
+    # The extlinux bootloader doesn't have BLS support, the old grubby is needed
+    packages = ["syslinux-extlinux", "grubby-deprecated"]
 
     @property
     def config_file(self):


### PR DESCRIPTION
Most bootloaders used in Fedora already have BootLoaderSpec but extlinux
doesn't yet. So when using extlinux the old grubby must to be installed.

Resolves: rhbz#1649778

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>