### PR TITLE
Remove setup_on_boot from the install classes

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -759,9 +759,6 @@ if __name__ == "__main__":
         if flags.automatedInstall:
             # Disable by default after kickstart installations.
             services_proxy.SetSetupOnBoot(SETUP_ON_BOOT_DISABLED)
-        else:
-            # Otherwise use the install class's default value.
-            services_proxy.SetSetupOnBoot(anaconda.instClass.setup_on_boot)
 
     # Create pre-install snapshots
     from pykickstart.constants import SNAPSHOT_WHEN_PRE_INSTALL

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -25,7 +25,6 @@ from distutils.sysconfig import get_python_lib
 import os
 import sys
 
-from pyanaconda.core.constants import SETUP_ON_BOOT_DEFAULT
 from pyanaconda.core.util import collect
 from pyanaconda.storage.partitioning import WORKSTATION_PARTITIONING
 from pyanaconda.network import NetworkOnBoot
@@ -77,9 +76,6 @@ class BaseInstallClass(object):
 
     # comps environment id to select by default
     defaultPackageEnvironment = None
-
-    # should we run the initial setup on the first boot?
-    setup_on_boot = SETUP_ON_BOOT_DEFAULT
 
     # EULA path (if any)
     #

--- a/tests/nosetests/pyanaconda_tests/installclass_test.py
+++ b/tests/nosetests/pyanaconda_tests/installclass_test.py
@@ -202,7 +202,6 @@ class Installclass_AttribsTestCase(unittest.TestCase):
         self.assertTrue(hasattr(testclass, 'help_placeholder_plain_text'))
         self.assertTrue(hasattr(testclass, 'stylesheet'))
         self.assertTrue(hasattr(testclass, 'defaultPackageEnvironment'))
-        self.assertTrue(hasattr(testclass, 'setup_on_boot'))
         self.assertTrue(hasattr(testclass, 'network_on_boot'))
 
 


### PR DESCRIPTION
Let's remove the variable setup_on_boot from the install classes,
because it's value doesn't change.