### PR TITLE
Drop xorg-x11-server-Xorg check from graphical target detection (#158…

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -894,7 +894,6 @@ class Payload(object):
 
             # XXX one day this might need to account for anaconda's display mode
             if ts.dbMatch("provides", 'service(graphical-login)').count() and \
-               ts.dbMatch('provides', 'xorg-x11-server-Xorg').count() and \
                not flags.usevnc:
                 # We only manipulate the ksdata.  The symlink is made later
                 # during the config write out.


### PR DESCRIPTION
…3958)

While this package will still likely continue to be installed on Wayland systems
due to xwayland, it should be enough that we check for a package that
provides "service(graphical-login)" to correctly detect if a graphical
system target should be used instead of multi-user.

This might fix some edge cases where users install x server for
on a system without the intent to ever log into the system
graphically (no package providing "service(graphical-login)" is
installed). Previously such users could erroneously get graphical
target set.

Resolves: rhbz#1583958