### PR TITLE
RPM: anaconda-core requires dbus-daemon

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -139,6 +139,10 @@ Requires: anaconda-tui = %{version}-%{release}
 # Make sure we get the en locale one way or another
 Requires: glibc-langpack-en
 
+# anaconda literally runs its own dbus-daemon, so it needs this,
+# even though the distro default is dbus-broker in F30+
+Requires: dbus-daemon
+
 Obsoletes: anaconda-images <= 10
 Provides: anaconda-images = %{version}-%{release}
 Obsoletes: anaconda-runtime < %{version}-%{release}


### PR DESCRIPTION
In Rawhide, the dbus package now requires dbus-broker rather
than dbus-daemon (making dbus-broker the distro default). But
anaconda literally runs its own dbus-daemon. Because this dep
wasn't expressed, composes were failing on live media creation
with anaconda crashing when trying to run the non-existent
dbus-daemon.

Signed-off-by: Adam Williamson <awilliam@redhat.com>