### PR TITLE
Prohibit network configuration on Live OS.

### DIFF
--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -177,7 +177,7 @@ class InstallationSystem(Section):
     @property
     def can_configure_network(self):
         """Can we configure the network?"""
-        return self._is_boot_iso or self._is_live_os
+        return self._is_boot_iso
 
     @property
     def can_require_network_connection(self):


### PR DESCRIPTION
As network spoke is not used on Live OS (and only hostname setting part
would be displayed if it was) the only actual change here will be that
networkInitialize is not called on Live OS. Which, most importantly means:

1) Ifcfg files won't be ensured to be existing for each device supported by
installer.  This should be OK as usually default autoconnections created by NM
are just dumped into ifcfg file and in general we want to move to the state
where we don't create ifcfg file if the device was not explicitly configured
(and let NM do it's default job).

2) Also kickstart network configuration won't be applied which is probably OK,
We don't seem to be able or want to support kickstart network configuration
on Live OS.