### PR TITLE
dracut/parse-kickstart: don't abort on --device=link

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -229,7 +229,6 @@ class DracutNetwork(Network, DracutArgsMixin):
                 net.device = first_device_with_link()
                 if not net.device:
                     log.warning("No device with link found for --device=link")
-                    return
                 else:
                     log.info("Using %s as first device with link found", net.device)
             # tell dracut to bring this device up if it's not already done by user


### PR DESCRIPTION
It never works. parse-anaconda-kickstart.sh generates command line options
and as such is launched from a cmdline hook. That is long before the
network devices could be brought up, or even their drivers are loaded.

Not aborting and generating a device-less "ip=dhcp" option is good enough:
NetworkManager only brings up devices with a carrier anyway.

This is needed to address https://bugzilla.redhat.com/show_bug.cgi?id=1641832