### PR TITLE
Add support for the product configuration files

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -321,6 +321,8 @@ update-desktop-database &> /dev/null || :
 %config %{_sysconfdir}/%{name}/*
 %dir %{_sysconfdir}/%{name}/conf.d
 %config %{_sysconfdir}/%{name}/conf.d/*
+%dir %{_sysconfdir}/%{name}/product.d
+%config %{_sysconfdir}/%{name}/product.d/*
 %ifarch %livearches
 %{_bindir}/liveinst
 %{_sbindir}/liveinst

--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,7 @@ AC_CONFIG_FILES([Makefile
                  dracut/Makefile
                  pyanaconda/installclasses/Makefile
                  data/conf.d/Makefile
+                 data/product.d/Makefile
                  data/liveinst/Makefile
                  data/liveinst/console.apps/Makefile
                  data/liveinst/gnome/Makefile

--- a/data/product.d/Makefile.am
+++ b/data/product.d/Makefile.am
@@ -1,6 +1,4 @@
-# data/Makefile.am for anaconda
-#
-# Copyright (C) 2009  Red Hat, Inc.
+# Copyright (C) 2018  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published
@@ -15,18 +13,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = command-stubs liveinst systemd post-scripts pixmaps window-manager dbus conf.d product.d
-
 CLEANFILES = *~
 
-dist_pkgdata_DATA          = interactive-defaults.ks \
-			     tmux.conf \
-			     anaconda-gtk.css
-
-helpdir               = $(datadir)/$(PACKAGE_NAME)
-dist_help_DATA        = anaconda_options.txt
-
-configdir           = $(sysconfdir)/$(PACKAGE_NAME)
-dist_config_DATA    = anaconda.conf
+configdir           = $(sysconfdir)/$(PACKAGE_NAME)/product.d
+dist_config_DATA    = *.conf
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/data/product.d/centos.conf
+++ b/data/product.d/centos.conf
@@ -1,0 +1,7 @@
+# Anaconda configuration file for CentOS Linux.
+
+[Product]
+product_name = CentOS Linux
+
+[Base Product]
+product_name = Red Hat Enterprise Linux

--- a/data/product.d/fedora-atomic-host.conf
+++ b/data/product.d/fedora-atomic-host.conf
@@ -1,0 +1,8 @@
+# Anaconda configuration file for Fedora Atomic Host.
+
+[Product]
+product_name = Fedora
+variant_name = Atomic Host
+
+[Base Product]
+product_name = Fedora

--- a/data/product.d/fedora-server.conf
+++ b/data/product.d/fedora-server.conf
@@ -1,0 +1,8 @@
+# Anaconda configuration file for Fedora Server.
+
+[Product]
+product_name = Fedora
+variant_name = Server
+
+[Base Product]
+product_name = Fedora

--- a/data/product.d/fedora-silverblue.conf
+++ b/data/product.d/fedora-silverblue.conf
@@ -1,0 +1,9 @@
+# Anaconda configuration file for Fedora Silverblue.
+
+[Product]
+product_name = Fedora
+variant_name = Silverblue
+
+[Base Product]
+product_name = Fedora
+variant_name = Workstation

--- a/data/product.d/fedora-workstation.conf
+++ b/data/product.d/fedora-workstation.conf
@@ -1,0 +1,8 @@
+# Anaconda configuration file for Fedora Workstation.
+
+[Product]
+product_name = Fedora
+variant_name = Workstation
+
+[Base Product]
+product_name = Fedora

--- a/data/product.d/fedora.conf
+++ b/data/product.d/fedora.conf
@@ -1,0 +1,4 @@
+# Anaconda configuration file for Fedora.
+
+[Product]
+product_name = Fedora

--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -1,0 +1,4 @@
+# Anaconda configuration file for Red Hat Enterprise Linux.
+
+[Product]
+product_name = Red Hat Enterprise Linux

--- a/data/product.d/scientific-linux.conf
+++ b/data/product.d/scientific-linux.conf
@@ -1,0 +1,7 @@
+# Anaconda configuration file for Scientific Linux.
+
+[Product]
+product_name = Scientific Linux
+
+[Base Product]
+product_name = Red Hat Enterprise Linux

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -319,6 +319,9 @@ class AnacondaConfiguration(object):
 
             config_dir = os.path.join(ANACONDA_CONFIG_DIR, "conf.d")
             for config_path in sorted(os.listdir(config_dir)):
+                if not config_path.endswith(".conf"):
+                    continue
+
                 config.read(os.path.join(config_dir, config_path))
 
         # Validate the configuration.

--- a/pyanaconda/core/configuration/product.py
+++ b/pyanaconda/core/configuration/product.py
@@ -1,0 +1,225 @@
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+#  Author(s):  Vendula Poncova <vponcova@redhat.com>
+#
+import os
+from collections import namedtuple
+
+from pyanaconda.core.constants import ANACONDA_CONFIG_DIR
+from pyanaconda.core.configuration.base import create_parser, read_config, get_option, \
+    ConfigurationError
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+
+__all__ = ["ProductLoader"]
+
+
+ProductKey = namedtuple("Product", ["product_name", "variant_name"])
+ProductKey.__doc__ = "Identification of the product."
+ProductKey.__str__ = lambda key: " ".join(filter(None, key))
+
+
+ProductData = namedtuple("ProductData", ["base_product", "config_path"])
+ProductData.__doc__ = "Data of the product."
+
+
+class ProductLoader(object):
+    """A class for loading information about products from configuration files."""
+
+    @classmethod
+    def from_defaults(cls):
+        """Create a default loader.
+
+        It loads the directory /etc/anaconda/product.d by default.
+
+        :return: an instance of ProductLoader
+        """
+        loader = cls()
+        loader.load_products(os.path.join(ANACONDA_CONFIG_DIR, "product.d"))
+        return loader
+
+    def __init__(self):
+        """Create a new loader."""
+        self._products = {}
+
+    def load_products(self, config_dir):
+        """Load information about products from the given configuration directory.
+
+        Invalid configuration files will be skipped.
+
+        :param config_dir: a path to a directory
+        """
+        for file_name in os.listdir(config_dir):
+            if not file_name.endswith(".conf"):
+                continue
+
+            config_path = os.path.join(config_dir, file_name)
+
+            try:
+                self.load_product(config_path)
+            except ConfigurationError as e:
+                log.error("Skipping an invalid configuration at %s: %s", config_path, e)
+
+    def load_product(self, config_path):
+        """Load information about a product from the given configuration file.
+
+        :param config_path: a path to a configuration file
+        :raises: ConfigurationError if a product cannot be loaded
+        """
+        # Set up the parser.
+        parser = create_parser()
+        self._create_section(parser, "Product")
+        self._create_section(parser, "Base Product")
+
+        # Read the product sections.
+        read_config(parser, config_path)
+        key = self._read_section(parser, "Product")
+        base = self._read_section(parser, "Base Product")
+
+        # Check the product.
+        if not key.product_name:
+            raise ConfigurationError("The product name is not specified.")
+
+        if key in self._products:
+            raise ConfigurationError("The product {} was already loaded.".format(key))
+
+        # Check the base product.
+        if not base.product_name:
+            base = None
+
+        # Add the product.
+        log.info("Found %s at %s.", key, config_path)
+        self._products[key] = ProductData(base, config_path)
+
+    def check_product(self, product_name, variant_name=""):
+        """Check if the specified product is valid.
+
+        :param product_name: a name of the product
+        :param variant_name: a name of the variant
+        :return: True if the product is valid, otherwise False
+        """
+        product_key = ProductKey(product_name, variant_name)
+
+        if product_key not in self._products:
+            log.warning("The product %s doesn't exist.", product_key)
+            return False
+
+        try:
+            self._get_product_bases(product_key)
+        except ConfigurationError as e:
+            log.warning("The product %s is not valid: %s", product_key, e)
+            return False
+
+        return True
+
+    def collect_configurations(self, product_name, variant_name=""):
+        """Collect configuration files of the given product.
+
+        The configuration files should be processed in the given order.
+
+        :param product_name: a name of the product
+        :param variant_name: a name of the variant
+        :return: a list of paths to configuration files
+        """
+        return self._get_product_configs(ProductKey(product_name, variant_name))
+
+    def _create_section(self, parser, section_name):
+        """Create the product section.
+
+        :param parser: a configuration parser
+        :param section_name: a name of a product section
+        """
+        parser.add_section(section_name)
+        parser.set(section_name, "product_name", "")
+        parser.set(section_name, "variant_name", "")
+
+    def _read_section(self, parser, section_name):
+        """Read the product section.
+
+        :param parser: a configuration parser
+        :param section_name: a name of a product section
+        :return: a key of the product
+        """
+        product_name = get_option(parser, section_name, "product_name")
+        variant_name = get_option(parser, section_name, "variant_name")
+        return ProductKey(product_name, variant_name)
+
+    def _get_product_config(self, product_key):
+        """Get the configuration path of the product.
+
+        :param product_key: a key of the product
+        :return: a path to a configuration file
+        """
+        return self._products.get(product_key).config_path
+
+    def _get_product_configs(self, product_key):
+        """Get a list of configuration paths of the product.
+
+        The configuration files should be processed in the given order.
+
+        :param product_key: a key of the product
+        :return: a list of paths to a configuration files
+        """
+        product_keys = reversed(self._get_product_bases(product_key))
+        return [self._get_product_config(key) for key in product_keys]
+
+    def _get_product_base(self, product_key):
+        """Get the base of the product.
+
+        :param product_key: a key of the product
+        :return: a key of the base product
+        """
+        return self._products.get(product_key).base_product
+
+    def _get_product_bases(self, product_key):
+        """Return a list of bases of the given product.
+
+        The products are ordered by the "is based on" relation.
+
+        If the product A is based on the product B and the product B
+        is based on the product C, then the related products of the
+        product A are: A, B, C
+
+        :param product_key: a key of the product
+        :return: a list of keys of the base products
+        :raises: ConfigurationError if the dependencies cannot be resolved
+        """
+        current_key = product_key
+        visited = set()
+        products = []
+
+        while current_key:
+            if current_key not in self._products:
+                raise ConfigurationError(
+                    "Dependencies of the product {} cannot be resolved "
+                    "due to an unknown product {}.".format(product_key, current_key)
+                )
+
+            if current_key in visited:
+                raise ConfigurationError(
+                    "Dependencies of the product {} cannot be resolved "
+                    "due to a conflict with {}.".format(product_key, current_key)
+                )
+
+            visited.add(current_key)
+            products.append(current_key)
+            current_key = self._get_product_base(current_key)
+
+        return products

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -334,6 +334,8 @@ def copyUpdatedFiles(tag, updates, cwd, builddir):
             install_to_dir(gitfile, "etc/anaconda")
         elif gitfile.startswith("data/conf.d"):
             install_to_dir(gitfile, "etc/anaconda/conf.d")
+        elif gitfile.startswith("data/product.d"):
+            install_to_dir(gitfile, "etc/anaconda/product.d")
         elif gitfile == "data/liveinst/liveinst":
             install_to_dir(gitfile, "usr/sbin")
         elif gitfile.startswith("data/pixmaps"):

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -1,0 +1,248 @@
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+import os
+import tempfile
+import unittest
+from textwrap import dedent
+
+from pyanaconda.core.configuration.anaconda import AnacondaConfiguration
+from pyanaconda.core.configuration.base import ConfigurationError
+from pyanaconda.core.configuration.product import ProductLoader
+
+PRODUCT_DIR = os.path.join(os.environ.get("ANACONDA_DATA"), "product.d")
+
+
+class ProductConfigurationTestCase(unittest.TestCase):
+    """Test the default product configurations."""
+
+    def setUp(self):
+        """Set up the default loader."""
+        self._loader = ProductLoader()
+        self._loader.load_products(PRODUCT_DIR)
+
+    def _load_product(self, content):
+        """Load a product configuration with the given content."""
+        with tempfile.NamedTemporaryFile("w") as f:
+            f.write(content)
+            f.flush()
+
+            self._loader.load_product(f.name)
+            return f.name
+
+    def _check_product(self, product_name, variant_name, file_paths):
+        """Check a product."""
+        self.assertTrue(self._loader.check_product(product_name, variant_name))
+
+        config_paths = self._loader.collect_configurations(product_name, variant_name)
+        self.assertEqual(file_paths, config_paths)
+
+    def _check_default_product(self, product_name, variant_name, file_names):
+        """Check a default product."""
+        self._check_product(
+            product_name, variant_name,
+            [os.path.join(PRODUCT_DIR, path) for path in file_names]
+        )
+
+        config = AnacondaConfiguration.from_defaults()
+        paths = self._loader.collect_configurations(product_name, variant_name)
+
+        for path in paths:
+            config.read(path)
+
+        config.validate()
+
+    def fedora_products_test(self):
+        self._check_default_product(
+            "Fedora", "",
+            ["fedora.conf"]
+        )
+        self._check_default_product(
+            "Fedora", "Server",
+            ["fedora.conf", "fedora-server.conf"]
+        )
+        self._check_default_product(
+            "Fedora", "Workstation",
+            ["fedora.conf", "fedora-workstation.conf"]
+        )
+        self._check_default_product(
+            "Fedora", "Atomic Host",
+            ["fedora.conf", "fedora-atomic-host.conf"]
+
+        )
+        self._check_default_product(
+            "Fedora", "Silverblue",
+            ["fedora.conf", "fedora-workstation.conf", "fedora-silverblue.conf"]
+        )
+
+    def rhel_products_test(self):
+        self._check_default_product(
+            "Red Hat Enterprise Linux", "",
+            ["rhel.conf"]
+        )
+        self._check_default_product(
+            "CentOS Linux", "",
+            ["rhel.conf", "centos.conf"]
+        )
+        self._check_default_product(
+            "Scientific Linux", "",
+            ["rhel.conf", "scientific-linux.conf"]
+        )
+
+    def valid_product_test(self):
+        content = dedent("""
+        [Product]
+        product_name = My Product
+        """)
+
+        base_path = self._load_product(content)
+        self._check_product("My Product", "", [base_path])
+
+        content = dedent("""
+        [Product]
+        product_name = My Next Product
+
+        [Base Product]
+        product_name = My Product
+        """)
+
+        path = self._load_product(content)
+        self._check_product("My Next Product", "", [base_path, path])
+
+    def valid_variant_test(self):
+        content = dedent("""
+        [Product]
+        product_name = My Product
+        variant_name = My Variant
+        """)
+
+        base_path = self._load_product(content)
+        self._check_product("My Product", "My Variant", [base_path])
+
+        content = dedent("""
+        [Product]
+        product_name = My Product
+        variant_name = My Next Variant
+
+        [Base Product]
+        product_name = My Product
+        variant_name = My Variant
+        """)
+
+        path = self._load_product(content)
+        self._check_product("My Product", "My Next Variant", [base_path, path])
+
+    def invalid_product_test(self):
+        with self.assertRaises(ConfigurationError):
+            self._load_product("")
+
+        with self.assertRaises(ConfigurationError):
+            self._load_product("[Product]")
+
+        with self.assertRaises(ConfigurationError):
+            self._load_product("[Base Product]")
+
+        content = dedent("""
+        [Product]
+        variant_name = Server
+
+        """)
+
+        with self.assertRaises(ConfigurationError):
+            self._load_product(content)
+
+        content = dedent("""
+        [Base Product]
+        product_name = My Product
+
+        """)
+
+        with self.assertRaises(ConfigurationError):
+            self._load_product(content)
+
+    def invalid_base_product_test(self):
+        content = dedent("""
+        [Product]
+        product_name = My Product
+
+        [Base Product]
+        product_name = Nonexistent Product
+        """)
+        self._load_product(content)
+
+        with self.assertRaises(ConfigurationError):
+            self._loader.collect_configurations("My Product")
+
+        self.assertFalse(self._loader.check_product("My Product"))
+
+    def repeated_base_product_test(self):
+        content = dedent("""
+        [Product]
+        product_name = My Product
+
+        [Base Product]
+        product_name = My Product
+        """)
+        self._load_product(content)
+
+        with self.assertRaises(ConfigurationError):
+            self._loader.collect_configurations("My Product")
+
+        self.assertFalse(self._loader.check_product("My Product"))
+
+    def existing_product_test(self):
+        content = dedent("""
+        [Product]
+        product_name = My Product
+        """)
+
+        self._load_product(content)
+
+        with self.assertRaises(ConfigurationError):
+            self._load_product(content)
+
+    def find_nonexistent_product_test(self):
+        self._loader.check_product("Nonexistent Product")
+        self._loader.check_product("Nonexistent Product", "Nonexistent Variant")
+
+    def ignore_invalid_product_test(self):
+        with tempfile.TemporaryDirectory() as config_dir:
+
+            # A correct product config.
+            with open(os.path.join(config_dir, "1.conf"), "w") as f:
+                f.write(dedent("""
+                [Product]
+                product_name = My Product 1
+                """))
+
+            # An invalid product config.
+            with open(os.path.join(config_dir, "2.conf"), "w") as f:
+                f.write("")
+
+            # A product config with wrong file name.
+            with open(os.path.join(config_dir, "3"), "w") as f:
+                f.write(dedent("""
+                [Product]
+                product_name = My Product 3
+                """))
+
+            self._loader.load_products(config_dir)
+            self.assertTrue(self._loader.check_product("My Product 1"))
+            self.assertFalse(self._loader.check_product("My Product 2"))
+            self.assertFalse(self._loader.check_product("My Product 3"))

--- a/tests/rpm_tests/create_rpm_test.py
+++ b/tests/rpm_tests/create_rpm_test.py
@@ -162,6 +162,27 @@ class InstalledFilesTestCase(RPMTestCase):
 
         self._check_files_in_rpm(src_files, rpm_files)
 
+    def test_product_conf_dir(self):
+        rpm_files = self._get_core_rpm_content()
+        rpm_files = filter(FileFilters.productd_only, rpm_files)
+
+        src_files = self._apply_filters(
+            [
+                FileFilters.src_data_only,
+                FileFilters.productd_only,
+                FileFilters.confs_only,
+            ], self._get_source_files()
+        )
+
+        src_files = self._apply_maps(
+            [
+                ModifyingFilters.remove_data_prefix,
+                lambda x: ModifyingFilters.apply_rpm_prefix("/etc/anaconda", x)
+            ], src_files
+        )
+
+        self._check_files_in_rpm(src_files, rpm_files)
+
     def test_anaconda_service_files(self):
         rpm_files = self._get_core_rpm_content()
 
@@ -325,6 +346,10 @@ class FileFilters(object):
     @staticmethod
     def confd_only(path):
         return "/conf.d/" in path
+
+    @staticmethod
+    def productd_only(path):
+        return "/product.d/" in path
 
     @staticmethod
     def confs_only(path):


### PR DESCRIPTION
There are new configuration files for all supported products at
`/etc/anaconda/product.d`. The configuration files specify only
a product and a base product for now.

The `ProductLoader` is a class for loading products from configuration
files. It provides access to loaded products, resolves dependencies
between products and collects configuration files for the specified
product.