### PR TITLE
Disable BLS config if new-kernel-pkg is installed

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -268,6 +268,8 @@ class BootLoader(object):
         self._update_only = False
         self.skip_bootloader = False
 
+        self.use_bls = flags.blscfg
+
         self.errors = []
         self.warnings = []
 
@@ -1544,7 +1546,12 @@ class GRUB2(GRUB):
         defaults.write("GRUB_CMDLINE_LINUX=\"%s\"\n" % self.boot_args)
         defaults.write("GRUB_DISABLE_RECOVERY=\"true\"\n")
         #defaults.write("GRUB_THEME=\"/boot/grub2/themes/system/theme.txt\"\n")
-        if flags.blscfg:
+
+        if self.use_bls and os.path.exists(util.getSysroot() + "/usr/sbin/new-kernel-pkg"):
+            log.warning("BLS support disabled due new-kernel-pkg being present")
+            self.use_bls = False
+
+        if self.use_bls:
             defaults.write("GRUB_ENABLE_BLSCFG=true\n")
         defaults.close()
 
@@ -2325,7 +2332,7 @@ class ZIPL(BootLoader):
                 args.update(["rootflags=subvol=%s" % image.device.name])
             log.info("bootloader.py: used boot args: %s ", args)
 
-            if flags.blscfg:
+            if self.use_bls:
                 self.update_bls_args(image, args)
             else:
                 self.write_config_image(config, image, args)
@@ -2337,7 +2344,12 @@ class ZIPL(BootLoader):
                   "timeout={}\n"
                   "target=/boot\n")
         config.write(header.format(self.timeout))
-        if not flags.blscfg:
+
+        if self.use_bls and os.path.exists(util.getSysroot() + "/usr/sbin/new-kernel-pkg"):
+            log.warning("BLS support disabled due new-kernel-pkg being present")
+            self.use_bls = False
+
+        if not self.use_bls:
             config.write("default={}\n".format(self.image_label(self.default)))
 
     #


### PR DESCRIPTION
The kernel-install scripts installs kernels and adds BLS snippets in the
/boot/loader/entries directory if new-kernel-pkg isn't present or a BLS
setup was explicility configured (i.e: setting GRUB_ENABLE_BLSCFG=true).

But the kernel package is installed before writing any bootloader config,
so the kernel-install script only rely on the existence of new-kernel-pkg
to choose if a BLS or non-BLS kernel installation will be made.

So if new-kernel-pkg is present and the inst.noblscfg boot option wasn't
used, then kernels will be installed without a BLS snippet but bootloader
config will expect them, leading to an unbootable installed system.

Resolves: rhbz#1654036

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>