### PR TITLE
Make save button insensitive in LUKS dialog with no input (#1489713)

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/passphrase.py
+++ b/pyanaconda/ui/gui/spokes/lib/passphrase.py
@@ -145,8 +145,10 @@ class PassphraseDialog(GUIObject, GUIInputCheckHandler):
             self._passphrase_warning_image.set_visible(False)
             self._passphrase_warning_label.set_visible(False)
 
-        # The save button should only be sensitive if the match check passes
-        if self._confirm_check.check_status == InputCheck.CHECK_OK and \
+        # The save button should only be sensitive if there is some input and the match check passes
+        if not self.input and not self.input_confirmation:
+            self._save_button.set_sensitive(False)
+        elif self._confirm_check.check_status == InputCheck.CHECK_OK and \
                 (not self.policy.strict or self._strength_check.check_status == InputCheck.CHECK_OK):
             self._save_button.set_sensitive(True)
         else:


### PR DESCRIPTION
Previously the save button would be sensitive in the LUKS passphrase
dialog even if no passphrase and passphrase confirmation has been
filled by the user. This by itself will be detected later and
the installation blocked until the passphrase is fixed.

Still, this is bad UX, so make the save button insensitive if both
the passphrase and passphrase confirmation fields are empty.

Resolves: rhbz#1489713