### PR TITLE
Fix module installation error reporting (#1644635)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -23,7 +23,7 @@ Source0: %{name}-%{version}.tar.bz2
 # match the requires versions of things).
 
 %define dbusver 1.2.3
-%define dnfver 3.5.0
+%define dnfver 3.6.0
 %define dracutver 034-7
 %define fcoeutilsver 1.0.12-3.20100323git
 %define gettextver 0.19.8

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -222,37 +222,17 @@ class ErrorHandler(object):
                 return ERROR_RAISE
 
     def _install_specs_handler(self, exn):
-        missing_packages = exn.no_match_pkg_specs
-        missing_groups_modules = exn.no_match_group_specs
         broken_packages = exn.error_pkg_specs
         broken_groups_modules = exn.error_group_specs
+        module_debsolv_errors = exn.module_debsolv_errors
 
-        message = ""
-
-        # missing packages/groups/modules
-
-        if missing_packages:
-            packages = ", ".join(missing_packages)
-            message = message + _("The following packages are missing:\n%s\n\n") % packages
-
-        if missing_groups_modules:
-            groups_modules = ", ".join(missing_groups_modules)
-            message = message + _("The following groups or modules are missing:\n%s\n\n") % groups_modules
-
-        # broken packages/groups/modules
-
-        if broken_packages:
-            packages = ", ".join(broken_packages)
-            message = message + _("The following packages are broken:\n%s\n\n") % packages
-
-        if broken_groups_modules:
-            groups_modules = ", ".join(broken_groups_modules)
-            message = message + _("The following groups or modules are broken:\n%s\n\n") % groups_modules
+        # We use the nice exception string representation
+        # provided by DNF as the base of our error message.
+        message = "{}\n\n".format(exn)
 
         # if we have at least one broken package, group or module we will abort the installation
-        if broken_packages or broken_groups_modules:
+        if broken_packages or broken_groups_modules or module_debsolv_errors:
             message = message + _("Some packages, groups or modules are broken, the installation will be aborted.")
-
             self.ui.showError(message)
             return ERROR_RAISE
         # "just" missing packages, groups or modules - we give the user an option to continue

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -443,20 +443,27 @@ class DNFPayload(payload.PackagePayload):
         ksrepo.disable()
         self._add_repo(ksrepo)
         super().addDisabledRepo(ksrepo)
+
     def _enable_modules(self):
         """Enable modules (if any)."""
+        # convert data from kickstart to module specs
+        module_specs = []
         for module in self.data.module.dataList():
             # stream definition is optional
             if module.stream:
                 module_spec = "{name}:{stream}".format(name=module.name, stream=module.stream)
             else:
                 module_spec = module.name
-            log.debug("enabling module: %s", module_spec)
-            try:
-                module_base = dnf.module.module_base.ModuleBase(self._base)
-                module_base.enable([module_spec])
-            except dnf.module.exceptions.NoModuleException as e:
-                self._payload_setup_error(e)
+            module_specs.append(module_spec)
+
+        # forward the module specs to enable to DNF
+        log.debug("enabling modules: %s", module_specs)
+        try:
+            module_base = dnf.module.module_base.ModuleBase(self._base)
+            module_base.enable(module_specs)
+        except dnf.exceptions.MarkingErrors as e:
+            log.debug("ModuleBase.enable(): some packages, groups or modules are missing or broken:\n%s", e)
+            self._payload_setup_error(e)
 
     def _apply_selections(self):
         log.debug("applying DNF package/group/module selection")
@@ -556,18 +563,10 @@ class DNFPayload(payload.PackagePayload):
             # install_specs() returns a list of specs that appear to be missing
             self._base.install_specs(install=include_list, exclude=exclude_list)
         except dnf.exceptions.MarkingErrors as e:
-            log.debug("install_specs(): some packages, groups or modules are missing or broken")
-            if e.no_match_pkg_specs:
-                log.debug("install_specs(): missing packages: %s", e.no_match_pkg_specs)
-            if e.no_match_group_specs:
-                log.debug("install_specs(): missing groups or modules: %s", e.no_match_group_specs)
-            if e.error_pkg_specs:
-                log.debug("install_specs(): broken packages: %s", e.error_pkg_specs)
-            if e.error_group_specs:
-                log.debug("install_specs(): broken groups or modules: %s", e.error_group_specs)
-
+            log.debug("install_specs(): some packages, groups or modules are missing or broken:\n%s", e)
             # if no errors were reported and --ignoremissing was used we can continue
-            if not e.error_group_specs and not e.error_pkg_specs and self.data.packages.handleMissing == KS_MISSING_IGNORE:
+            transaction_too_broken = e.error_group_specs or e.error_pkg_specs or e.module_debsolv_errors
+            if not transaction_too_broken and self.data.packages.handleMissing == KS_MISSING_IGNORE:
                 log.info("ignoring missing package/group/module specs due to --ingoremissing flag in kickstart")
             else:
                 self._payload_setup_error(e)


### PR DESCRIPTION
Starting with the 3.6 release DNF now provides much improved
module installation error reporting & includes it in the
string representation of the relevant exception it raises.

So drop our custom error reporting code and just use the
string representation of the DNF exception.

Also adjust the module enable try-block to catch the new exception
and submit all requests for enabling modules at once so we get
a combined error for all broken modules at once.

Backported from commit 1caf765733a1cdcb58e9227047c2468725bdbf13 and
has been in use in Fedora since F29.

Resolves: rhbz#1644635