### PR TITLE
Split the Anaconda configuration handler to more files

### DIFF
--- a/pyanaconda/core/configuration/services.py
+++ b/pyanaconda/core/configuration/services.py
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+#  Author(s):  Vendula Poncova <vponcova@redhat.com>
+#
+from pyanaconda.core.configuration.base import Section
+
+
+class ServicesSection(Section):
+    """The Services section."""
+
+    @property
+    def selinux(self):
+        """Enable SELinux usage in the installed system.
+
+        Valid values:
+
+         -1  The value is not set.
+          0  SELinux is disabled (permissive).
+          1  SELinux is enabled (enforcing).
+        """
+        value = self._get_option("selinux", int)
+
+        if value not in (-1, 0, 1):
+            raise ValueError("Invalid value: {}".format(value))
+
+        return value

--- a/pyanaconda/core/configuration/storage.py
+++ b/pyanaconda/core/configuration/storage.py
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+#  Author(s):  Vendula Poncova <vponcova@redhat.com>
+#
+from pyanaconda.core.configuration.base import Section
+
+
+class StorageSection(Section):
+    """The Storage section."""
+
+    @property
+    def dmraid(self):
+        """Enable dmraid usage during the installation."""
+        return self._get_option("dmraid", bool)
+
+    @property
+    def ibft(self):
+        """Enable iBFT usage during the installation."""
+        return self._get_option("ibft", bool)
+
+    @property
+    def gpt(self):
+        """Do you prefer creation of GPT disk labels?"""
+        return self._get_option("gpt", bool)
+
+    @property
+    def multipath_friendly_names(self):
+        """Use user friendly names for multipath devices.
+
+        Tell multipathd to use user friendly names when naming devices
+        during the installation.
+        """
+        return self._get_option("multipath_friendly_names", bool)

--- a/pyanaconda/core/configuration/system.py
+++ b/pyanaconda/core/configuration/system.py
@@ -1,0 +1,159 @@
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+#  Author(s):  Vendula Poncova <vponcova@redhat.com>
+#
+from enum import Enum
+from pyanaconda.core.configuration.base import Section
+
+
+class SystemType(Enum):
+    """The type of the installation system."""
+    BOOT_ISO = "BOOT_ISO"
+    LIVE_OS = "LIVE_OS"
+    UNKNOWN = "UNKNOWN"
+
+
+class SystemSection(Section):
+    """The Installation System section."""
+
+    @property
+    def _type(self):
+        """Type of the installation system.
+
+        FIXME: This is a temporary solution.
+        """
+        return self._get_option("type", SystemType)
+
+    @property
+    def _is_boot_iso(self):
+        """Are we running in the boot.iso?"""
+        return self._type is SystemType.BOOT_ISO
+
+    @property
+    def _is_live_os(self):
+        """Are we running in the live OS?"""
+        return self._type is SystemType.LIVE_OS
+
+    @property
+    def _is_unknown(self):
+        """Are we running in the unknown OS?"""
+        return self._type is SystemType.UNKNOWN
+
+    @property
+    def can_reboot(self):
+        """Can we reboot the system?"""
+        return self._is_boot_iso
+
+    @property
+    def can_switch_tty(self):
+        """Can we change the foreground virtual terminal?"""
+        return self._is_boot_iso
+
+    @property
+    def can_audit(self):
+        """Can we run the audit daemon?"""
+        return self._is_boot_iso
+
+    @property
+    def can_set_hardware_clock(self):
+        """Can we set the Hardware Clock?"""
+        return self._is_boot_iso
+
+    @property
+    def can_initialize_system_clock(self):
+        """Can we initialize the System Clock?
+
+        FIXME: This is a temporary workaround.
+        """
+        return self._is_boot_iso or self._is_live_os
+
+    @property
+    def can_set_system_clock(self):
+        """Can we set the System Clock?"""
+        return self._is_boot_iso
+
+    @property
+    def can_set_time_synchronization(self):
+        """Can we run the NTP daemon?"""
+        return self._is_boot_iso
+
+    @property
+    def can_activate_keyboard(self):
+        """Can we activate the keyboard?
+
+        FIXME: This is a temporary workaround.
+        """
+        return self._is_boot_iso
+
+    @property
+    def can_activate_layouts(self):
+        """Can we activate the layouts?
+
+        FIXME: This is a temporary workaround.
+        """
+        return self._is_boot_iso
+
+    @property
+    def can_configure_keyboard(self):
+        """Can we configure the keyboard?"""
+        return self._is_boot_iso or self._is_live_os
+
+    @property
+    def can_modify_syslog(self):
+        """Can we modify syslog?"""
+        return self._is_boot_iso
+
+    @property
+    def can_change_hostname(self):
+        """Can we change the hostname?"""
+        return self._is_boot_iso
+
+    @property
+    def can_configure_network(self):
+        """Can we configure the network?"""
+        return self._is_boot_iso
+
+    @property
+    def provides_network_config(self):
+        """Can we copy network configuration to the target system?
+
+        We can do it only if the current system configuration is created by
+        anaconda (or installation process in general, as on Live OS) and
+        therefore can be copied to the target system.
+        """
+        return self._is_boot_iso or self._is_live_os
+
+    @property
+    def provides_system_bus(self):
+        """Can we access the system DBus?"""
+        return self._is_boot_iso or self._is_live_os
+
+    @property
+    def provides_resolver_config(self):
+        """Can we copy /etc/resolv.conf to the target system?"""
+        return self._is_boot_iso
+
+    @property
+    def provides_user_interaction_config(self):
+        """Can we read /etc/sysconfig/anaconda?"""
+        return self._is_boot_iso or self._is_live_os
+
+    @property
+    def provides_web_browser(self):
+        """Can we redirect users to web pages?"""
+        return self._is_live_os

--- a/pyanaconda/core/configuration/target.py
+++ b/pyanaconda/core/configuration/target.py
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+#  Author(s):  Vendula Poncova <vponcova@redhat.com>
+#
+from enum import Enum
+
+from pyanaconda.core.configuration.base import Section
+
+
+class TargetType(Enum):
+    """Type of the installation target."""
+    HARDWARE = "HARDWARE"
+    IMAGE = "IMAGE"
+    DIRECTORY = "DIRECTORY"
+
+
+class TargetSection(Section):
+    """The Installation Target section."""
+
+    @property
+    def type(self):
+        """Type of the installation target."""
+        return self._get_option("type", TargetType)
+
+    @property
+    def physical_root(self):
+        """A path to the physical root of the target."""
+        return self._get_option("physical_root")
+
+    @property
+    def is_hardware(self):
+        """Are we installing on hardware?"""
+        return self.type is TargetType.HARDWARE
+
+    @property
+    def is_image(self):
+        """Are we installing on an image?"""
+        return self.type is TargetType.IMAGE
+
+    @property
+    def is_directory(self):
+        """Are we installing to a directory?"""
+        return self.type is TargetType.DIRECTORY


### PR DESCRIPTION
The file that defines the Anaconda configuration handler should be
split to several smaller files, because it started to be too large.