### PR TITLE
Drop the inst.noblscfg option

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -426,7 +426,6 @@ if __name__ == "__main__":
     flags.rescue_mode = opts.rescue
     flags.noverifyssl = opts.noverifyssl
     flags.extlinux = opts.extlinux
-    flags.blscfg = opts.blscfg
     flags.nombr = opts.nombr
     flags.debug = opts.debug
     flags.askmethod = opts.askmethod

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -279,6 +279,3 @@ timeout in seconds specified as a mandatory value of the option.
 decorated
 Run GUI installer in a decorated window. By default, the window is not decorated, so it doesn't have a title bar,
 resize controls, etc.
-
-noblscfg
-Configure GRUB not to use the "BootLoader Spec" boot option configuration format.

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -673,15 +673,6 @@ the newly installed drive on Power Systems servers and EFI systems. This is
 useful for systems that, for example, should network boot first before falling
 back to a local boot.
 
-.. inst.noblscfg:
-
-inst.noblscfg
-^^^^^^^^^^^^^
-
-Disable the use of the "BootLoader Spec" boot option configuration format with
-GRUB.
-
-
 Storage options
 ---------------
 

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -527,9 +527,6 @@ def getArgumentParser(version_string, boot_cmdline=None):
     ap.add_argument("--nonibftiscsiboot", action="store_true", default=False,
                     help=help_parser.help_text("nonibftiscsiboot"))
 
-    ap.add_argument("--noblscfg", dest="blscfg", action="store_false", default=True,
-                    help=help_parser.help_text("nobls"))
-
     # Geolocation
     ap.add_argument("--geoloc", metavar="PROVIDER_ID", help=help_parser.help_text("geoloc"))
     ap.add_argument("--geoloc-use-with-ks", action="store_true", default=False,

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -268,7 +268,7 @@ class BootLoader(object):
         self._update_only = False
         self.skip_bootloader = False
 
-        self.use_bls = flags.blscfg
+        self.use_bls = True
 
         self.errors = []
         self.warnings = []

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -55,7 +55,6 @@ class Flags(object):
         self.askmethod = False
         self.eject = True
         self.extlinux = False
-        self.blscfg = True
         self.nombr = False
         self.leavebootorder = False
         # ksprompt is whether or not to prompt for missing ksdata

--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -48,7 +48,6 @@ from pyanaconda.anaconda_loggers import get_packaging_logger
 log = get_packaging_logger()
 
 from pyanaconda.errors import errorHandler, ERROR_RAISE
-from pyanaconda.flags import flags
 from pyanaconda.progress import progressQ
 from blivet.size import Size
 import blivet.util
@@ -202,7 +201,7 @@ class LiveImagePayload(ImagePayload):
             util.execInSysroot("systemd-machine-id-setup", [])
 
         for kernel in self.kernelVersionList:
-            if flags.blscfg:
+            if not os.path.exists(util.getSysroot() + "/usr/sbin/new-kernel-pkg"):
                 log.info("Regenerating BLS info for %s", kernel)
                 util.execInSysroot("kernel-install", ["add", kernel, "/lib/modules/{0}/vmlinuz".format(kernel)])
 


### PR DESCRIPTION
This option was added to allow installing a system configured without BLS
support. But the option is misleading because even when the bootloader is
configured without BLS, the grubby-deprecated package must be installed
in order to install new kernels and add entries in the bootloader config.

The kernel-install scripts already use the existence of the new-kernel-pkg
to decide if a BLS snippet will be added or not when a kernel is installed
and also is used to configure a bootloader with BLS support or not.

So the inst.noblscfg option doesn't really serve a purpose at this point
and can just be dropped. Instead, a user can choose to avoid configuring
the system with BLS by installing the grubby-deprecated package.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>