### PR TITLE
Add comment to /etc/default/grub explaining how cmdline can be set wi…

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1539,10 +1539,18 @@ class GRUB2(GRUB):
         else:
             defaults.write("GRUB_TERMINAL_OUTPUT=\"%s\"\n" % self.terminal_type)
 
+        bls_comment = ("# If GRUB_ENABLE_BLSCFG is enabled, GRUB_CMDLINE_LINUX is only used to set\n"
+                       "# the kernelopts environment variable defined in /boot/grub2/grubenv once.\n"
+                       "# If kernelopts is already set then grub2-mkconfig will ignore the value in\n"
+                       "# GRUB_CMDLINE_LINUX. To edit kernel command line parameters the kernelopts\n"
+                       "# variable needs to be modified using the grub2-editenv tool.\n")
+
         # this is going to cause problems for systems containing multiple
         # linux installations or even multiple boot entries with different
         # boot arguments
         log.info("bootloader.py: used boot args: %s ", self.boot_args)
+        if self.use_bls:
+            defaults.write(bls_comment)
         defaults.write("GRUB_CMDLINE_LINUX=\"%s\"\n" % self.boot_args)
         defaults.write("GRUB_DISABLE_RECOVERY=\"true\"\n")
         #defaults.write("GRUB_THEME=\"/boot/grub2/themes/system/theme.txt\"\n")


### PR DESCRIPTION
…th BLS

On a BLS configuration the menu entries aren't defined in the grub.cfg but
instead defined in BLS snippets in the /boot/loader/entries directory. So
re-generating the grub.cfg with grub2-mkconfig has no effect on the menu
entries or their kernel command line parameters.

That's why modifying GRUB_CMDLINE_LINUX in /etc/default/grub and executing
grub2-mkconfig can't be used anymore to modify the entries kernel cmdline.

This can be confusing for users that are used to those steps to modify the
cmdline, so let's add some comments in /etc/default/grub explaining that's
not supported anymore and how the cmdline can be modified on a BLS setup.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>