### PR TITLE
Run zipl again after generating initramfs (#1652727)

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -18,7 +18,7 @@
 # Red Hat, Inc.
 #
 
-from blivet import callbacks
+from blivet import callbacks, arch
 from blivet.devices import BTRFSDevice
 
 from pyanaconda.core.constants import BOOTLOADER_DISABLED
@@ -138,6 +138,11 @@ def doConfiguration(storage, payload, ksdata, instClass):
 
     if flags.flags.livecdInstall and boot_on_btrfs and bootloader_enabled:
         generate_initramfs.append(Task("Write BTRFS bootloader fix", writeBootLoader, (storage, payload, instClass, ksdata)))
+
+    # Invoking zipl should the last thing done on a s390x installation (see #1652727).
+    if arch.is_s390() and not flags.flags.dirInstall and bootloader_enabled:
+        generate_initramfs.append(Task("Rerun zipl", lambda: util.execInSysroot("zipl", [])))
+
     configuration_queue.append(generate_initramfs)
 
     # join a realm (if required)

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -13,10 +13,7 @@ class AnacondaLintConfig(PocketLintConfig):
     def __init__(self):
         PocketLintConfig.__init__(self)
 
-        self.falsePositives = [ FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: GError$"),
-                                FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: S390Error$"),
-                                FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: BlockDevError$"),
-                                FalsePositive(r"^E0712.*: Catching an exception which doesn't inherit from (Base|)Exception: Swap\w*Error$"),
+        self.falsePositives = [
                                 FalsePositive(r"^E1101.*: Instance of 'KickstartSpecificationHandler' has no '.*' member$"),
                                 FalsePositive(r"^E1101.*: Method 'PropertiesChanged' has no 'connect' member$"),
                                 FalsePositive(r"^E1101.*: Instance of 'GError' has no 'message' member"),
@@ -24,6 +21,10 @@ class AnacondaLintConfig(PocketLintConfig):
                                 FalsePositive(r"^E1101.*: HostipGeoIPProvider._refresh: Instance of 'LookupDict' has no 'ok' member"),
                                 FalsePositive(r"^E1101.*: Geocoder._reverse_geocode_nominatim: Instance of 'LookupDict' has no 'ok' member"),
                                 FalsePositive(r"^E1101.*: Instance of 'Namespace' has no '.*' member$"),
+                                FalsePositive(r"^E1101.*: Module 'crypt' has no 'METHOD_MD5' member$"),
+                                FalsePositive(r"^E1101.*: Module 'crypt' has no 'METHOD_SHA256' member$"),
+                                FalsePositive(r"^E1101.*: Module 'crypt' has no 'METHOD_SHA512' member$"),
+                                FalsePositive(r"^W0107.*: Unnecessary pass statement$"),
 
                                 # TODO: BlockDev introspection needs to be added to pylint to handle these
                                 FalsePositive(r"E1101.*: Instance of 'int' has no 'dasd_needs_format' member"),


### PR DESCRIPTION
Anaconda recreates the initrds by calling new-kernel-pkg or dracut.
However, dracut doesn't invoke zipl on s390x, so we have to do it to
fix the bootloader.

Resolves: rhbz#1652727