### PR TITLE
Skip version when processing kernel boot args (#1637112)

### DIFF
--- a/pyanaconda/anaconda_argparse.py
+++ b/pyanaconda/anaconda_argparse.py
@@ -142,6 +142,8 @@ class AnacondaArgumentParser(ArgumentParser):
         :returns: argparse option object or None if no suitable option is found
         :rtype argparse option or None
         """
+        if arg == "version":  # skip option not supported from boot options
+            return None
         if self.bootarg_prefix and arg.startswith(self.bootarg_prefix):
             prefixed_option = True
             arg = arg[len(self.bootarg_prefix):]


### PR DESCRIPTION
Without this patch booting with `version` on kernel boot cmdline will just print anaconda version and quit. This is not expected behavior.

There will be rewrite in Fedora for this code-base, it should fix the root cause of this issue. So there won't be any backport.

*Resolves: rhbz#1637112*