### PR TITLE
Don't acquire the imp's lock (#1644936)

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1346,7 +1346,6 @@ def collect(module_pattern, path, pred):
         module_path = None
 
         try:
-            imp.acquire_lock()
             (fo, module_path, module_flags) = imp.find_module(mod_name, [path])
             module = sys.modules.get(module_pattern % mod_name)
 
@@ -1419,8 +1418,6 @@ def collect(module_pattern, path, pred):
             log.error("Failed to import module %s from path %s in collect: %s", mod_name, module_path, imperr)
             continue
         finally:
-            imp.release_lock()
-
             if mod_info and mod_info[0]:  # pylint: disable=unsubscriptable-object
                 mod_info[0].close()  # pylint: disable=unsubscriptable-object
 


### PR DESCRIPTION
The installer might freeze during the `__import__` call with
the acquired lock. This is only a workaround. We should replace
the library `imp` with the `importlib` library in the future.

Resolves: rhbz#1644936