### PR TITLE
Don't allow /boot on LVM (#1641986)

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1468,7 +1468,7 @@ class GRUB2(GRUB):
     stage2_max_end = None
 
     # requirements for boot devices
-    stage2_device_types = ["partition", "mdarray", "lvmlv"]
+    stage2_device_types = ["partition", "mdarray"]
     stage2_raid_levels = [raid.RAID0, raid.RAID1, raid.RAID4,
                           raid.RAID5, raid.RAID6, raid.RAID10]
     stage2_raid_metadata = ["0", "0.90", "1.0", "1.2"]


### PR DESCRIPTION
While /boot on LVM can work in some (limited) cases, it is not in any
way a supported configuration, in RHEL or upstream.

Resolves: rhbz#1641986