### PR TITLE
Add --skippackages option and null payload

### DIFF
--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -86,6 +86,9 @@ additional kickstart repos (where --noverifyssl can be set per repo).
 liveinst
 Run in live installation mode.
 
+skippackages
+Skip package installation. Only valid with --dirinstall.
+
 resolution
 Run GUI installer in the resolution specified, "1024x768" for example.
 

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -147,6 +147,9 @@ class Anaconda(object):
             elif self.ksdata.method.method == "liveimg":
                 from pyanaconda.payload.livepayload import LiveImageKSPayload
                 klass = LiveImageKSPayload
+            elif self.opts.skippackages:
+                from pyanaconda.payload.nullpayload import NullPayload
+                klass = NullPayload
             else:
                 from pyanaconda.payload.dnfpayload import DNFPayload
                 klass = DNFPayload

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -463,6 +463,8 @@ def getArgumentParser(version_string, boot_cmdline=None):
                     help=help_parser.help_text("noverifyssl"))
     ap.add_argument("--liveinst", action="store_true", default=False,
                     help=help_parser.help_text("liveinst"))
+    ap.add_argument("--skippackages", dest="skippackages", action="store_true", default=False,
+                    help=help_parser.help_text("skippackages"))
 
     # Display
     ap.add_argument("--resolution", dest="runres", default=None, metavar="WIDTHxHEIGHT",

--- a/pyanaconda/payload/nullpayload.py
+++ b/pyanaconda/payload/nullpayload.py
@@ -1,0 +1,38 @@
+# nullpayload.py
+#
+# Copyright (C) 2018  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+from pyanaconda.core import util
+from pyanaconda.payload import Payload, PayloadError, versionCmp
+
+class NullPayload(Payload):
+    """ A NullPayload assumes the target alrady contains a system and does nothing."""
+
+    @property
+    def spaceRequired(self):
+        return 0
+
+    @property
+    def kernelVersionList(self):
+        return []
+
+    def install(self):
+        pass


### PR DESCRIPTION
This option is only valid with --dirinstall. It assumes that all
necesary packages are already installed in the given tree.

This is useful debugging anaconda and when installing packages from
sources that anaconda doesn't have access to.