### PR TITLE
Drop the inst.noblscfg option (#1658980)

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -434,7 +434,6 @@ if __name__ == "__main__":
     flags.noverifyssl = opts.noverifyssl
     flags.armPlatform = opts.armPlatform
     flags.extlinux = opts.extlinux
-    flags.blscfg = opts.blscfg
     flags.nombr = opts.nombr
     flags.mpathFriendlyNames = opts.mpathfriendlynames
     flags.debug = opts.debug

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -275,6 +275,3 @@ timeout in seconds specified as a mandatory value of the option.
 decorated
 Run GUI installer in a decorated window. By default, the window is not decorated, so it doesn't have a title bar,
 resize controls, etc.
-
-noblscfg
-Configure GRUB not to use the "BootLoader Spec" boot option configuration format.

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -673,15 +673,6 @@ the newly installed drive on Power Systems servers and EFI systems. This is
 useful for systems that, for example, should network boot first before falling
 back to a local boot.
 
-.. inst.noblscfg:
-
-inst.noblscfg
-^^^^^^^^^^^^^
-
-Disable the use of the "BootLoader Spec" boot option configuration format with
-GRUB.
-
-
 Storage options
 ---------------
 

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -517,9 +517,6 @@ def getArgumentParser(version_string, boot_cmdline=None):
     ap.add_argument("--nonibftiscsiboot", action="store_true", default=False,
                     help=help_parser.help_text("nonibftiscsiboot"))
 
-    ap.add_argument("--noblscfg", dest="blscfg", action="store_false", default=True,
-                    help=help_parser.help_text("nobls"))
-
     # Geolocation
     ap.add_argument("--geoloc", metavar="PROVIDER_ID", help=help_parser.help_text("geoloc"))
     ap.add_argument("--geoloc-use-with-ks", action="store_true", default=False,

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1564,8 +1564,7 @@ class GRUB2(GRUB):
         defaults.write("GRUB_CMDLINE_LINUX=\"%s\"\n" % self.boot_args)
         defaults.write("GRUB_DISABLE_RECOVERY=\"true\"\n")
         #defaults.write("GRUB_THEME=\"/boot/grub2/themes/system/theme.txt\"\n")
-        if flags.blscfg:
-            defaults.write("GRUB_ENABLE_BLSCFG=true\n")
+        defaults.write("GRUB_ENABLE_BLSCFG=true\n")
         defaults.close()
 
     def _encrypt_password(self):
@@ -2345,10 +2344,7 @@ class ZIPL(BootLoader):
                 args.update(["rootflags=subvol=%s" % image.device.name])
             log.info("bootloader.py: used boot args: %s ", args)
 
-            if flags.blscfg:
-                self.update_bls_args(image, args)
-            else:
-                self.write_config_image(config, image, args)
+            self.update_bls_args(image, args)
 
     def write_config_header(self, config):
         header = ("[defaultboot]\n"
@@ -2357,8 +2353,6 @@ class ZIPL(BootLoader):
                   "timeout={}\n"
                   "target=/boot\n")
         config.write(header.format(self.timeout))
-        if not flags.blscfg:
-            config.write("default={}\n".format(self.image_label(self.default)))
 
     #
     # installation

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -63,7 +63,6 @@ class Flags(object):
         self.askmethod = False
         self.eject = True
         self.extlinux = False
-        self.blscfg = True
         self.nombr = False
         self.gpt = False
         self.leavebootorder = False


### PR DESCRIPTION
This option was added to allow installing a system configured without BLS
support. But the option is misleading because even when the bootloader is
configured without BLS, the grubby-deprecated package must be installed
in order to install new kernels and add entries in the bootloader config.

However, that is not supported on RHEL. So the inst.noblscfg option
doesn't really serve a purpose at this point and can just be dropped.

(cherry picked from d87eb1e)

Resolves: rhbz#1658980