### PR TITLE
Remove workaround for bd_s390_dasd_online

### DIFF
--- a/pyanaconda/modules/storage/dasd/discover.py
+++ b/pyanaconda/modules/storage/dasd/discover.py
@@ -60,11 +60,6 @@ class DASDDiscoverTask(Task):
         """Discover the device."""
         # pylint: disable=try-except-raise
         try:
-            online = blockdev.s390.dasd_online(self._device_number)
+            blockdev.s390.dasd_online(self._device_number)
         except blockdev.S390Error as e:
             raise StorageDiscoveryError(str(e))
-
-        if not online:
-            raise StorageDiscoveryError(
-                "The device could not be switched online. It may not exist."
-            )


### PR DESCRIPTION
When the bd_s390_dasd_online function from s390.c was called and the
device with the given number did not exist, the function returned
false without a message (an exception in Python).

This seems to be working now, so we can remove the workaround.