### PR TITLE
Require password confirmation in GUI (#1584064)

### DIFF
--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -101,8 +101,6 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self._empty_check = input_checking.PasswordEmptyCheck()
         # check that the content of the password field & the conformation field are the same
         self._confirm_check = input_checking.PasswordConfirmationCheck()
-        # regards both fields empty as success to let the user escape
-        self._confirm_check.success_if_confirmation_empty = True
         # check password validity, quality and strength
         self._validity_check = input_checking.PasswordValidityCheck()
         # connect UI updates to validity check results

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -303,8 +303,6 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         self._empty_check = input_checking.PasswordEmptyCheck()
         # check that the content of the password field & the conformation field are the same
         self._confirm_check = input_checking.PasswordConfirmationCheck()
-        # regards both fields empty as success to let the user escape
-        self._confirm_check.success_if_confirmation_empty = True
         # check password validity, quality and strength
         self._validity_check = input_checking.PasswordValidityCheck()
         # connect UI updates to validity check results


### PR DESCRIPTION
If a non empty password is entered in the root or user spoke
the content of the confirmation field needs to match it.

Also, the RHEL7 GUI already behaves this way.

We enable this behavior by always enabling the password confirmation
check unconditionally. This can be done as bug 1620135,
which was preventing users from escaping an empty root/user spoke,
has been fixed by disabling all the checks if nothing has
been entered.

Resolves: rhbz#1584064