### PR TITLE
Only quit GTK mainloop on GUI quit request (#1643111)

### DIFF
--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -1032,7 +1032,7 @@ class GraphicalUserInterface(UserInterface):
         if rc == 1:
             self._currentAction.exited.emit(self._currentAction)
             util.ipmi_abort(scripts=self.data.scripts)
-            sys.exit(0)
+            Gtk.main_quit()
 
 class GraphicalExceptionHandlingIface(meh.ui.gui.GraphicalIntf):
     """


### PR DESCRIPTION
If the user selects the quit action from GUI only quit the GTK mainloop
instead of killing the whole process by calling exit(0).

Initial Setup starts the GUI mainloop and then expects it to always to quit,
so that it can run various post-configuration actions, such as rebooting
the machine on RHEL if EULA has not been accepted.

This change should not influence "normal" non-IS Anaconda runs,
as in such case ending the mainloop should be equivalent to killing
the process.

Resolves: rhbz#1643111