### PR TITLE
The encoding should be always set to UTF-8 (#1642857)

### DIFF
--- a/data/systemd/anaconda-direct.service
+++ b/data/systemd/anaconda-direct.service
@@ -8,7 +8,7 @@ ConditionPathIsDirectory=|/sys/hypervisor/s390
 ConditionKernelCommandLine=|inst.notmux
 
 [Service]
-Environment=HOME=/root MALLOC_CHECK_=2 MALLOC_PERTURB_=204 PATH=/usr/bin:/bin:/sbin:/usr GDK_BACKEND=x11 XDG_RUNTIME_DIR=/tmp
+Environment=HOME=/root MALLOC_CHECK_=2 MALLOC_PERTURB_=204 PATH=/usr/bin:/bin:/sbin:/usr GDK_BACKEND=x11 XDG_RUNTIME_DIR=/tmp LANG=en_US.UTF-8
 Type=oneshot
 WorkingDirectory=/root
 ExecStart=/usr/sbin/anaconda

--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -25,8 +25,6 @@ import langtable
 import locale as locale_mod
 import glob
 from collections import namedtuple
-import sys
-import io
 
 from pyanaconda.core import constants, util
 from pyanaconda.core.util import upcase_first_letter, setenv, execWithRedirect
@@ -278,25 +276,6 @@ def setup_locale(locale, localization_proxy=None, text_mode=False):
         locale = constants.DEFAULT_LANG
         setenv("LANG", locale)
         locale_mod.setlocale(locale_mod.LC_ALL, locale)
-
-    # This part is pretty gross:
-    # In python3, sys.stdout and friends are TextIOWrapper objects that translate
-    # betwen str types (in python) and byte types (used to actually read from or
-    # write to the console). These wrappers are configured at startup using the
-    # locale at startup, which means that if anaconda starts with LANG=C or LANG
-    # unset, sys.stdout.encoding will be "ascii". And if the language is then changed,
-    # because anaconda read the kickstart or parsed the command line or whatever,
-    # say, to Czech, text mode will crash because it's going to try to print non-ASCII
-    # characters and sys.stdout doesn't know what to do with them. So, when changing
-    # the locale, create new objects for the standard streams so they are created with
-    # the new locale's encoding.
-
-    # Replacing stdout is about as stable as it looks, and it seems to break when done
-    # after the GUI is started. Only make the switch if the encoding actually changed.
-    if locale_mod.getpreferredencoding() != sys.stdout.encoding:
-        sys.stdin = io.TextIOWrapper(sys.stdin.detach())
-        sys.stdout = io.TextIOWrapper(sys.stdout.detach())
-        sys.stderr = io.TextIOWrapper(sys.stderr.detach())
 
     return locale
 


### PR DESCRIPTION
We shouldn't try to change the encoding of the standard streams
while anaconda is running. Otherwise, logging to these streams
might fail with a traceback. Let's make sure we always start
with the encoding set to UTF-8.

Resolves: rhbz#1642857