### PR TITLE
Run zipl again after generating initramfs (#1652727)

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -18,7 +18,7 @@
 # Red Hat, Inc.
 #
 
-from blivet import callbacks
+from blivet import callbacks, arch
 from blivet.devices import BTRFSDevice
 
 from pyanaconda.core.configuration.anaconda import conf
@@ -138,6 +138,11 @@ def doConfiguration(storage, payload, ksdata, instClass):
 
     if isinstance(payload, LiveImagePayload) and boot_on_btrfs and bootloader_enabled:
         generate_initramfs.append(Task("Write BTRFS bootloader fix", writeBootLoader, (storage, payload, instClass, ksdata)))
+
+    # Invoking zipl should be the last thing done on a s390x installation (see #1652727).
+    if arch.is_s390() and not conf.target.is_directory and bootloader_enabled:
+        generate_initramfs.append(Task("Rerun zipl", lambda: util.execInSysroot("zipl", [])))
+
     configuration_queue.append(generate_initramfs)
 
     # join a realm (if required)


### PR DESCRIPTION
Anaconda recreates the initrds by calling new-kernel-pkg or dracut.
However, dracut doesn't invoke zipl on s390x, so we have to do it to
fix the bootloader.

(cherry picked from db4e6bb)

Resolves: rhbz#1652727