### PR TITLE
Show a warning for unformatted /var

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -300,6 +300,8 @@ STORAGE_MIN_ROOT = "min_root"
 STORAGE_MIN_PARTITION_SIZES = "min_partition_sizes"
 STORAGE_MUST_BE_ON_LINUXFS = "must_be_on_linuxfs"
 STORAGE_MUST_BE_ON_ROOT = "must_be_on_root"
+STORAGE_REFORMAT_WHITELIST = "reformat_whitelist"
+STORAGE_REFORMAT_BLACKLIST = "reformat_blacklist"
 STORAGE_SWAP_IS_RECOMMENDED = "swap_is_recommended"
 STORAGE_LUKS2_MIN_RAM = "luks2_min_ram"
 

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -2011,34 +2011,6 @@ class InstallerStorage(Blivet):
 
         return template
 
-    def format_by_default(self, device):
-        """Return whether the device should be reformatted by default."""
-        formatlist = ['/boot', '/var', '/tmp', '/usr']
-        exceptlist = ['/home', '/usr/local', '/opt', '/var/www']
-
-        if not device.format.linux_native:
-            return False
-
-        if device.format.mountable:
-            if not device.format.mountpoint:
-                return False
-
-            if device.format.mountpoint == "/" or \
-               device.format.mountpoint in formatlist:
-                return True
-
-            for p in formatlist:
-                if device.format.mountpoint.startswith(p):
-                    for q in exceptlist:
-                        if device.format.mountpoint.startswith(q):
-                            return False
-                    return True
-        elif device.format.type == "swap":
-            return True
-
-        # be safe for anything else and default to off
-        return False
-
     def turn_on_swap(self):
         self.fsset.turn_on_swap(root_path=util.getSysroot())
 

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -2039,16 +2039,6 @@ class InstallerStorage(Blivet):
         # be safe for anything else and default to off
         return False
 
-    def must_format(self, device):
-        """ Return a string explaining why the device must be reformatted.
-
-            Return None if the device need not be reformatted.
-        """
-        if device.format.mountable and device.format.mountpoint == "/":
-            return _("You must create a new file system on the root device.")
-
-        return None
-
     def turn_on_swap(self):
         self.fsset.turn_on_swap(root_path=util.getSysroot())
 

--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -49,7 +49,7 @@ from pyanaconda import isys
 from pyanaconda.core.constants import productName, STORAGE_SWAP_IS_RECOMMENDED, \
     STORAGE_MUST_BE_ON_ROOT, STORAGE_MUST_BE_ON_LINUXFS, \
     STORAGE_MIN_PARTITION_SIZES, STORAGE_MIN_ROOT, \
-    STORAGE_MIN_RAM, STORAGE_LUKS2_MIN_RAM
+    STORAGE_MIN_RAM, STORAGE_LUKS2_MIN_RAM, STORAGE_REFORMAT_BLACKLIST, STORAGE_REFORMAT_WHITELIST
 from pyanaconda.errors import errorHandler, ERROR_RAISE
 from pyanaconda.platform import platform as _platform
 
@@ -220,6 +220,27 @@ def verify_s390_constraints(storage, constraints, report_error, report_warning):
             report_error(_("The LDL DASD disk {name} ({busid}) cannot be used "
                            "for the installation. Please format it.")
                          .format(name="/dev/" + disk.name, busid=disk.busid))
+
+
+def verify_partition_formatting(storage, constraints, report_error, report_warning):
+    """ Verify partitions that should be reformatted by default.
+
+    :param storage: a storage to check
+    :param constraints: a dictionary of constraints
+    :param report_error: a function for error reporting
+    :param report_warning: a function for warning reporting
+    """
+    mountpoints = [
+        mount for mount, device in storage.mountpoints.items()
+        if device.format.exists
+        and device.format.linux_native
+        and not any(filter(mount.startswith, constraints[STORAGE_REFORMAT_BLACKLIST]))
+        and any(filter(mount.startswith, constraints[STORAGE_REFORMAT_WHITELIST]))
+    ]
+
+    for mount in mountpoints:
+        report_warning(_("It is recommended to create a new file system on your "
+                         "%(mount)s partition.") % {'mount': mount})
 
 
 def verify_partition_sizes(storage, constraints, report_error, report_warning):
@@ -682,6 +703,14 @@ class StorageChecker(object):
             '/bin', '/dev', '/sbin', '/etc', '/lib', '/root', '/mnt', 'lost+found', '/proc'
         })
 
+        self.add_new_constraint(STORAGE_REFORMAT_WHITELIST, {
+            '/boot', '/var', '/tmp', '/usr'
+        })
+
+        self.add_new_constraint(STORAGE_REFORMAT_BLACKLIST, {
+            '/home', '/usr/local', '/opt', '/var/www'
+        })
+
         self.add_new_constraint(STORAGE_SWAP_IS_RECOMMENDED, True)
         self.add_new_constraint(STORAGE_LUKS2_MIN_RAM, Size("128 MiB"))
 
@@ -690,6 +719,7 @@ class StorageChecker(object):
         self.checks = list()
         self.add_check(verify_root)
         self.add_check(verify_s390_constraints)
+        self.add_check(verify_partition_formatting)
         self.add_check(verify_partition_sizes)
         self.add_check(verify_partition_format_sizes)
         self.add_check(verify_bootloader)

--- a/pyanaconda/storage_utils.py
+++ b/pyanaconda/storage_utils.py
@@ -183,10 +183,8 @@ def verify_root(storage, constraints, report_error, report_warning):
                        "which is required for installation of %s"
                        " to continue.") % (productName,))
 
-    if storage.root_device and storage.root_device.format.exists:
-        e = storage.must_format(storage.root_device)
-        if e:
-            report_error(e)
+    if root and root.format.exists and root.format.mountable and root.format.mountpoint == "/":
+        report_error(_("You must create a new file system on the root device."))
 
 
 def verify_s390_constraints(storage, constraints, report_error, report_warning):


### PR DESCRIPTION
Let's move code from the method `must_format` to the storage checker,
where it belongs. Then we can remove this method.

Let's move code from the method `format_by_default` to the storage
checker, where it belongs. Then we can remove this method.

The installer will show a warning if the checker detects a partition
that should be reformatted, for example `/var`.

Resolves: rhbz#1575131