### PR TITLE
Remove the selinux flag

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -429,7 +429,6 @@ if __name__ == "__main__":
     flags.debug = opts.debug
     flags.askmethod = opts.askmethod
     flags.mpath = opts.mpath
-    flags.selinux = opts.selinux
     flags.eject = opts.eject
     flags.kexec = opts.kexec
     flags.singlelang = opts.singlelang
@@ -571,9 +570,9 @@ if __name__ == "__main__":
 
     # Override the selinux state from kickstart if set on the command line
     from pyanaconda.modules.common.constants.services import SECURITY
-    if flags.selinux != constants.SELINUX_DEFAULT:
+    if conf.security.selinux != constants.SELINUX_DEFAULT:
         security_proxy = SECURITY.get_proxy()
-        security_proxy.SetSELinux(flags.selinux)
+        security_proxy.SetSELinux(conf.security.selinux)
 
     from pyanaconda import localization
     # Set the language before loading an interface, when it may be too late.

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -69,7 +69,7 @@ enable_closest_mirror = True
 check_supported_locales = False
 
 
-[Services]
+[Security]
 # Enable SELinux usage in the installed system.
 # Valid values:
 #

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -23,7 +23,7 @@ from pyanaconda.core.configuration.bootloader import BootloaderSection
 from pyanaconda.core.configuration.license import LicenseSection
 from pyanaconda.core.configuration.network import NetworkSection
 from pyanaconda.core.configuration.payload import PayloadSection
-from pyanaconda.core.configuration.services import ServicesSection
+from pyanaconda.core.configuration.security import SecuritySection
 from pyanaconda.core.configuration.storage import StorageSection
 from pyanaconda.core.configuration.system import SystemType, SystemSection
 from pyanaconda.core.configuration.target import TargetType, TargetSection
@@ -79,7 +79,7 @@ class AnacondaConfiguration(Configuration):
         self._payload = PayloadSection("Payload", self.get_parser())
         self._bootloader = BootloaderSection("Bootloader", self.get_parser())
         self._storage = StorageSection("Storage", self.get_parser())
-        self._services = ServicesSection("Services", self.get_parser())
+        self._security = SecuritySection("Security", self.get_parser())
         self._ui = UserInterfaceSection("User Interface", self.get_parser())
         self._license = LicenseSection("License", self.get_parser())
 
@@ -119,9 +119,9 @@ class AnacondaConfiguration(Configuration):
         return self._storage
 
     @property
-    def services(self):
-        """The Services section."""
-        return self._services
+    def security(self):
+        """The Security section."""
+        return self._security
 
     @property
     def ui(self):

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -233,6 +233,9 @@ class AnacondaConfiguration(Configuration):
         self.storage._set_option("gpt", opts.gpt)
         self.storage._set_option("multipath_friendly_names", opts.multipath_friendly_names)
 
+        # Set the security flags.
+        self.security._set_option("selinux", opts.selinux)
+
         # Set the type of the installation system.
         if opts.liveinst:
             self.system._set_option("type", SystemType.LIVE_OS.value)

--- a/pyanaconda/core/configuration/security.py
+++ b/pyanaconda/core/configuration/security.py
@@ -20,8 +20,8 @@
 from pyanaconda.core.configuration.base import Section
 
 
-class ServicesSection(Section):
-    """The Services section."""
+class SecuritySection(Section):
+    """The Security section."""
 
     @property
     def selinux(self):

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -16,11 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
-import selinux
-
-from pykickstart.constants import SELINUX_DISABLED
-from pyanaconda.core.constants import SELINUX_DEFAULT, ANACONDA_ENVIRON
+from pyanaconda.core.constants import ANACONDA_ENVIRON
 from pyanaconda.core.kernel import KernelArguments
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -41,12 +37,6 @@ class Flags(object):
         self.usevnc = False
         self.vncquestion = True
         self.mpath = True
-
-        self.selinux = SELINUX_DEFAULT
-
-        if not selinux.is_selinux_enabled():
-            self.selinux = SELINUX_DISABLED
-
         self.debug = False
         self.preexisting_x11 = False
         self.noverifyssl = False

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -1003,7 +1003,7 @@ class PackagePayload(Payload):
             # Use nil if instLangs is empty
             self.rpmMacros.append(('_install_langs', self.data.packages.instLangs or '%{nil}'))
 
-        if flags.selinux:
+        if conf.security.selinux:
             for d in ["/tmp/updates",
                       "/etc/selinux/targeted/contexts/files",
                       "/etc/security/selinux/src/policy",

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -220,7 +220,7 @@ class Rescue(object):
                 log.error("Error enabling swap.")
 
         # turn on selinux also
-        if flags.selinux:
+        if conf.security.selinux:
             # we have to catch the possible exception, because we
             # support read-only mounting
             try:

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -111,7 +111,7 @@ def update_blivet_flags():
     either flipping the original value, or it assigns the flag value
     based on anaconda settings that are passed in.
     """
-    blivet_flags.selinux = flags.selinux
+    blivet_flags.selinux = conf.security.selinux
     blivet_flags.allow_imperfect_devices = flags.rescue_mode
 
     blivet_flags.dmraid = conf.storage.dmraid


### PR DESCRIPTION
The `selinux` option in the Anaconda configuration file should be part
of the `Security` section to keep it consistent with the DBus modules.
So let's rename the `Services` section. Then replace the `selinux` flag
with an option in the Anaconda configuration.