### PR TITLE
Add a new configuration option allow_imperfect_devices

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -104,6 +104,9 @@ gpt = False
 # Tell multipathd to use user friendly names when naming devices during the installation.
 multipath_friendly_names = True
 
+# Do you want to allow imperfect devices (for example, degraded mdraid array devices)?
+allow_imperfect_devices = False
+
 # Default file system type. Use whatever Blivet uses by default.
 file_system_type =
 

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -233,6 +233,10 @@ class AnacondaConfiguration(Configuration):
         self.storage._set_option("gpt", opts.gpt)
         self.storage._set_option("multipath_friendly_names", opts.multipath_friendly_names)
 
+        # Set up the rescue mode.
+        if opts.rescue:
+            self.storage._set_option("allow_imperfect_devices", True)
+
         # Set the security flags.
         self.security._set_option("selinux", opts.selinux)
 

--- a/pyanaconda/core/configuration/storage.py
+++ b/pyanaconda/core/configuration/storage.py
@@ -56,6 +56,15 @@ class StorageSection(Section):
         return self._get_option("multipath_friendly_names", bool)
 
     @property
+    def allow_imperfect_devices(self):
+        """Do you want to allow imperfect devices?
+
+        Imperfect devices are for example degraded mdraid arrays.
+        This option should be enabled only in the rescue mode.
+        """
+        return self._get_option("allow_imperfect_devices", bool)
+
+    @property
     def file_system_type(self):
         """Default file system type.
 

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -112,12 +112,11 @@ def update_blivet_flags():
     based on anaconda settings that are passed in.
     """
     blivet_flags.selinux = conf.security.selinux
-    blivet_flags.allow_imperfect_devices = flags.rescue_mode
-
     blivet_flags.dmraid = conf.storage.dmraid
     blivet_flags.ibft = conf.storage.ibft
     blivet_flags.gpt = conf.storage.gpt
     blivet_flags.multipath_friendly_names = conf.storage.multipath_friendly_names
+    blivet_flags.allow_imperfect_devices = conf.storage.allow_imperfect_devices
 
 
 def release_from_redhat_release(fn):


### PR DESCRIPTION
Add a new configuration option allow_imperfect_devices, so we can use
it to set up blivet's flags for the rescue mode.