### PR TITLE
Fix Arm EFI package selection and 32 bit status

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1926,7 +1926,8 @@ class ArmEFIGRUB(EFIGRUB):
 
     def __init__(self):
         super().__init__()
-        self._packages64 = ["grub2-efi-arm"]
+        self._packages32 = ["grub2-efi-arm"]
+        self._is_32bit_firmware = True
 
 class MacEFIGRUB(EFIGRUB):
     def __init__(self):


### PR DESCRIPTION
In the initial ArmEFI patches to support ARMv7 there was a copy/paste
error for the package list generation, we also missed setting the platform
as 32 bit.

As a result we're getting i686 grub2/shim:
DEBUG anaconda:anaconda: payload: added package requirement 'grub2-efi-ia32' for bootloader, strong=True
DEBUG anaconda:anaconda: payload: added package requirement 'shim-ia32' for bootloader, strong=True

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>