### PR TITLE
Use the file system type provided by Blivet by default (#1663585)

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -101,8 +101,8 @@ gpt = False
 # Tell multipathd to use user friendly names when naming devices during the installation.
 multipath_friendly_names = True
 
-# Default file system type.
-file_system_type = xfs
+# Default file system type. Use whatever Blivet uses by default.
+file_system_type =
 
 # Default partitioning.
 # Valid values:

--- a/data/product.d/fedora-atomic-host.conf
+++ b/data/product.d/fedora-atomic-host.conf
@@ -12,6 +12,7 @@ product_name = Fedora
 check_supported_locales = True
 
 [Storage]
+file_system_type = xfs
 default_partitioning = SERVER
 
 [User Interface]

--- a/data/product.d/fedora-server.conf
+++ b/data/product.d/fedora-server.conf
@@ -11,6 +11,7 @@ product_name = Fedora
 default_environment = server-product-environment
 
 [Storage]
+file_system_type = xfs
 default_partitioning = SERVER
 
 [User Interface]

--- a/data/product.d/fedora-workstation.conf
+++ b/data/product.d/fedora-workstation.conf
@@ -13,9 +13,5 @@ default_environment = workstation-product-environment
 [Bootloader]
 menu_auto_hide = True
 
-[Storage]
-# Use whatever Blivet uses by default.
-file_system_type =
-
 [User Interface]
 custom_stylesheet = /usr/share/anaconda/pixmaps/workstation/fedora-workstation.css

--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -19,6 +19,9 @@ enable_closest_mirror = False
 [Bootloader]
 efi_dir = redhat
 
+[Storage]
+file_system_type = xfs
+
 [User Interface]
 default_help_pages =
     rhel_help_placeholder.txt


### PR DESCRIPTION
We should use the file system type provided by Blivet by default.
The default file system type was changed to `xfs` in a commit eadde80,
because most of the products use this option. However, it broke
the `livemedia-creator`, so let's change it back.

Resolves: rhbz#1663585