### PR TITLE
Fix anaconda-live package temporary Requires:

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -127,11 +127,6 @@ Requires: python3-coverage >= 4.0-0.12.b3
 
 # required because of the rescue mode and VNC question
 Requires: anaconda-tui = %{version}-%{release}
-# required during the transition period until
-# anaconda-live is added to the kickstarts used to
-# create live images
-Requires: anaconda-live = %{version}-%{release}
-
 
 # Make sure we get the en locale one way or another
 Requires: glibc-langpack-en
@@ -211,6 +206,11 @@ Requires: anaconda-user-help >= %{helpver}
 Requires: yelp
 Requires: blivet-gui-runtime >= %{blivetguiver}
 Requires: system-logos
+
+# required during the transition period until
+# anaconda-live is added to the kickstarts used to
+# create live images
+Requires: anaconda-live = %{version}-%{release}
 
 # Needed to compile the gsettings files
 BuildRequires: gsettings-desktop-schemas


### PR DESCRIPTION
At the moment there is a temporary Requires: in place so that
the anaconda-live package is always installed when needed.

Eventually this will be removed once the anaconda-live package
is explicitly required in the kickstart files used for live image
generation.

Initially this was simply added to the anaconda-core package,
but this turns out to be incorrect, as it transitively makes
the anaconda-core package depend on anaconda-gui. This not only
pulls in unnecessary dependencies, but also fails the compose on
armv7 where dependencies needed by the Anaconda GUI are not available.

So move the temporary Requires for anaconda-live from anaconda-core
to anaconda-gui, which should fix the issue.