### PR TITLE
Move code from Blivet

### DIFF
--- a/pyanaconda/platform.py
+++ b/pyanaconda/platform.py
@@ -25,9 +25,9 @@ log = logging.getLogger("anaconda.storage")
 from blivet import arch
 from blivet.devicelibs import raid
 from blivet.formats import get_device_format_class
-from blivet.flags import flags
 from blivet.size import Size
 from pyanaconda.core.i18n import _, N_
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.storage.partspec import PartSpec
 
 
@@ -66,7 +66,7 @@ class Platform(object):
         self.update_from_flags()
 
     def update_from_flags(self):
-        if flags.gpt:
+        if conf.storage.gpt:
             disklabel_class = get_device_format_class("disklabel")
             disklabel_types = disklabel_class.get_platform_label_types()
             if "gpt" not in disklabel_types:

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -1176,6 +1176,16 @@ class InstallerStorage(Blivet):
             :type ksdata: :class:`pykickstart.Handler`
         """
         super().__init__()
+        self.do_autopart = False
+        self.encrypted_autopart = False
+        self.encryption_cipher = None
+        self.escrow_certificates = {}
+
+        self.autopart_escrow_cert = None
+        self.autopart_add_backup_passphrase = False
+        self.autopart_requests = []
+
+        self._default_boot_fstype = None
 
         self.ksdata = ksdata
         self._bootloader = None

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -116,7 +116,6 @@ def update_blivet_flags():
 
     blivet_flags.dmraid = conf.storage.dmraid
     blivet_flags.ibft = conf.storage.ibft
-    blivet_flags.gpt = conf.storage.gpt
     blivet_flags.multipath_friendly_names = conf.storage.multipath_friendly_names
 
 


### PR DESCRIPTION
Anaconda-specific attributes can be moved from the `Blivet` class
in Blivet to the `InstallerStorage` class in Anaconda.

Remove the Blivet's `gpt` flag. Blivet doesn't use this flag, so let's
use our `config` instead.