### PR TITLE
Fix requires in dependency solver

### DIFF
--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -82,7 +82,7 @@ def parse_args():
 
 def runtime_dependencies(spec_content):
     """Find all Requires from spec file."""
-    packages = re.findall(r"(?<!BuildRequires: )(?<=Requires: ) *[^ \n]*", spec_content)
+    packages = re.findall(r"\n *Requires: *([^ \n]*)", spec_content)
     result = set()
 
     for pkg in packages:
@@ -95,7 +95,7 @@ def runtime_dependencies(spec_content):
 
 def build_dependencies(spec_content, is_s390):
     """Find all BuildRequires from spec file."""
-    packages = re.findall(r"(?<=BuildRequires: ) *[^ \n]*", spec_content)
+    packages = re.findall(r"\n *BuildRequires: *([^ \n]*)", spec_content)
     result = set()
 
     for pkg in packages:


### PR DESCRIPTION
Dependency solver took Requires: from anywhere in the spec file and now it is part of the comments. Fix this behavior.