### PR TITLE
Remove ksdata from InstallerStorage

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -690,6 +690,10 @@ if __name__ == "__main__":
             ignored_disks.append(oemdrv_disk)
             disk_select_proxy.SetIgnoredDisks(ignored_disks)
 
+    # Ignore nvdimm devices.
+    from pyanaconda.storage.utils import ignore_nvdimm_blockdevs
+    ignore_nvdimm_blockdevs(ksdata.nvdimm)
+
     from pyanaconda.payload import payloadMgr
     from pyanaconda.timezone import time_initialize
 

--- a/anaconda.py
+++ b/anaconda.py
@@ -699,7 +699,7 @@ if __name__ == "__main__":
 
     if not conf.target.is_directory:
         threadMgr.add(AnacondaThread(name=constants.THREAD_STORAGE, target=initialize_storage,
-                                     args=(anaconda.storage, ksdata, anaconda.protected)))
+                                     args=(anaconda.storage, anaconda.protected)))
 
     from pyanaconda.modules.common.constants.services import TIMEZONE
     timezone_proxy = TIMEZONE.get_proxy()

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -163,7 +163,7 @@ class Anaconda(object):
     def storage(self):
         if not self._storage:
             from pyanaconda.storage.initialization import create_storage
-            self._storage = create_storage(self.ksdata)
+            self._storage = create_storage()
 
         return self._storage
 

--- a/pyanaconda/storage/format_dasd.py
+++ b/pyanaconda/storage/format_dasd.py
@@ -169,7 +169,7 @@ class DasdFormatting(object):
 
         # Update the storage.
         self.report.emit(_("Probing storage"))
-        initialize_storage(storage, data, storage.protected_dev_names)
+        initialize_storage(storage, storage.protected_dev_names)
 
         # Update also the storage snapshot to reflect the changes.
         if on_disk_storage.created:

--- a/pyanaconda/storage/initialization.py
+++ b/pyanaconda/storage/initialization.py
@@ -135,11 +135,10 @@ def update_blivet_flags():
     blivet_flags.allow_imperfect_devices = conf.storage.allow_imperfect_devices
 
 
-def initialize_storage(storage, ksdata, protected):
+def initialize_storage(storage, protected):
     """Perform installer-specific storage initialization.
 
     :param storage: an instance of the Blivet's storage object
-    :param ksdata: an instance of the kickstart data
     :param protected: a list of protected device names
     """
     update_blivet_flags()

--- a/pyanaconda/storage/initialization.py
+++ b/pyanaconda/storage/initialization.py
@@ -58,7 +58,7 @@ def enable_installer_mode():
     udev.device_name_blacklist = [r'^mtd', r'^mmcblk.+boot', r'^mmcblk.+rpmb', r'^zram', '^ndblk']
 
 
-def create_storage(ksdata):
+def create_storage():
     """Create the storage object.
 
     :return: an instance of the Blivet's storage object
@@ -66,7 +66,7 @@ def create_storage(ksdata):
     from pyanaconda.storage.osinstall import InstallerStorage
     import blivet.arch
 
-    storage = InstallerStorage(ksdata=ksdata)
+    storage = InstallerStorage()
     _set_storage_defaults(storage)
 
     if blivet.arch.is_s390():

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -84,11 +84,8 @@ class StorageDiscoveryConfig(object):
 
 class InstallerStorage(Blivet):
     """ Top-level class for managing installer-related storage configuration. """
-    def __init__(self, ksdata=None):
-        """
-            :keyword ksdata: kickstart data store
-            :type ksdata: :class:`pykickstart.Handler`
-        """
+
+    def __init__(self):
         super().__init__()
         self.do_autopart = False
         self.encrypted_autopart = False
@@ -101,7 +98,6 @@ class InstallerStorage(Blivet):
 
         self._default_boot_fstype = None
 
-        self.ksdata = ksdata
         self._bootloader = None
         self.config = StorageDiscoveryConfig()
         self.autopart_type = AUTOPART_TYPE_LVM
@@ -116,23 +112,6 @@ class InstallerStorage(Blivet):
 
         self._autopart_luks_version = None
         self.autopart_pbkdf_args = None
-
-    def copy(self):
-        """Copy the storage.
-
-        Kickstart data are not copied.
-        """
-        # Disable the kickstart data.
-        old_data = self.ksdata
-        self.ksdata = None
-
-        # Create the copy.
-        new_storage = super().copy()
-
-        # Recover the kickstart data.
-        self.ksdata = old_data
-        new_storage.ksdata = old_data
-        return new_storage
 
     def do_it(self, callbacks=None):
         """
@@ -302,7 +281,7 @@ class InstallerStorage(Blivet):
         self.autopart_requests = get_full_partitioning_requests(self, _platform, requests)
 
     def set_up_bootloader(self, early=False):
-        """ Propagate ksdata into BootLoader.
+        """ Set up the boot loader.
 
             :keyword bool early: Set to True to skip stage1_device setup
 
@@ -312,8 +291,8 @@ class InstallerStorage(Blivet):
             not stage1_device 'early' should be set True to prevent
             it from raising BootloaderError
         """
-        if not self.bootloader or not self.ksdata:
-            log.warning("either ksdata or bootloader data missing")
+        if not self.bootloader:
+            log.warning("bootloader data missing")
             return
 
         if self.bootloader.skip_bootloader:

--- a/pyanaconda/storage/utils.py
+++ b/pyanaconda/storage/utils.py
@@ -45,7 +45,8 @@ from pykickstart.errors import KickstartError
 from pyanaconda.core import util
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.errors import errorHandler, ERROR_RAISE
-from pyanaconda.modules.common.constants.services import NETWORK
+from pyanaconda.modules.common.constants.services import NETWORK, STORAGE
+from pyanaconda.modules.common.constants.objects import DISK_SELECTION
 
 from pykickstart.constants import AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_BTRFS
 from pykickstart.constants import AUTOPART_TYPE_LVM, AUTOPART_TYPE_LVM_THINP
@@ -485,6 +486,25 @@ def get_ignored_nvdimm_blockdevs(nvdimm_ksdata):
             ignored_blockdevs.add(ns_info.blockdev)
 
     return ignored_blockdevs
+
+
+def ignore_nvdimm_blockdevs(nvdimm_ksdata):
+    """Add nvdimm devices to be ignored to the ignored disks.
+
+    :param nvdimm_ksdata: nvdimm kickstart data
+    :type nvdimm_ksdata: Nvdimm kickstart command
+    """
+    ignored_nvdimm_devs = get_ignored_nvdimm_blockdevs(nvdimm_ksdata)
+
+    if not ignored_nvdimm_devs:
+        return
+
+    log.debug("Adding NVDIMM devices %s to ignored disks", ",".join(ignored_nvdimm_devs))
+
+    disk_select_proxy = STORAGE.get_proxy(DISK_SELECTION)
+    ignored_disks = disk_select_proxy.IgnoredDisks
+    ignored_disks.extend(ignored_nvdimm_devs)
+    disk_select_proxy.SetIgnoredDisks(ignored_disks)
 
 
 def download_escrow_certificate(url):

--- a/pyanaconda/ui/gui/spokes/lib/refresh.py
+++ b/pyanaconda/ui/gui/spokes/lib/refresh.py
@@ -86,7 +86,7 @@ class RefreshDialog(GUIObject):
 
         # And now to fire up the storage reinitialization.
         threadMgr.add(AnacondaThread(name=constants.THREAD_STORAGE, target=initialize_storage,
-                                     args=(self.storage, self.data, self.storage.protected_dev_names)))
+                                     args=(self.storage, self.storage.protected_dev_names)))
 
         self._elapsed = 0
 

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -634,7 +634,7 @@ class PartTypeSpoke(NormalTUISpoke):
         selected_disks = disk_select_proxy.SelectedDisks
         disk_select_proxy.SetSelectedDisks([])
 
-        initialize_storage(self.storage, self.data, self.storage.protected_dev_names)
+        initialize_storage(self.storage, self.storage.protected_dev_names)
 
         disk_select_proxy.SetSelectedDisks(selected_disks)
         self._manual_part_proxy.SetMountPoints([])
@@ -882,7 +882,7 @@ class MountPointAssignSpoke(NormalTUISpoke):
         disk_select_proxy.SetSelectedDisks([])
 
         print(_("Scanning disks. This may take a moment..."))
-        initialize_storage(self.storage, self.data, self.storage.protected_dev_names)
+        initialize_storage(self.storage, self.storage.protected_dev_names)
 
         disk_select_proxy.SetSelectedDisks(selected_disks)
         self._manual_part_proxy.SetMountPoints([])

--- a/tests/nosetests/pyanaconda_tests/storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/storage_test.py
@@ -8,16 +8,10 @@ from blivet.size import Size
 from pyanaconda.storage.osinstall import InstallerStorage
 from pyanaconda.storage.initialization import initialize_storage
 
-try:
-    from pyanaconda import kickstart
-    pyanaconda_present = True
-except ImportError:
-    pyanaconda_present = False
-
 
 @unittest.skip("not working")
 @unittest.skipUnless(os.geteuid() == 0, "requires root privileges")
-class setupDiskImagesNonZeroSizeTestCase(unittest.TestCase):
+class SetupDiskImagesNonZeroSizeTestCase(unittest.TestCase):
     """
         Test if size of disk images is > 0. Related: rhbz#1252703.
         This test emulates how anaconda configures its storage.
@@ -36,14 +30,12 @@ class setupDiskImagesNonZeroSizeTestCase(unittest.TestCase):
         # at this point the DMLinearDevice has correct size
         self.storage.setup_disk_images()
 
-        # no kickstart available
-        ksdata = kickstart.AnacondaKSHandler([])
         # anaconda calls initialize_storage regardless of whether or not
         # this is an image install. Somewhere along the line this will
         # execute setup_disk_images() once more and the DMLinearDevice created
         # in this second execution has size 0
         with patch('blivet.flags'):
-            initialize_storage(self.storage, ksdata, [])
+            initialize_storage(self.storage, [])
 
     def tearDown(self):
         self.storage.reset()

--- a/tests/storage/cases/__init__.py
+++ b/tests/storage/cases/__init__.py
@@ -135,7 +135,7 @@ class TestCaseComponent(object):
            the storage module.  Subclasses may override this method, but they
            should be sure to call the base method as well.
         """
-        self._storage = InstallerStorage(ksdata=ksdata)
+        self._storage = InstallerStorage()
 
         # blivet only sets up the bootloader in installer_mode.  We don't
         # want installer_mode, though, because that involves running lots
@@ -293,7 +293,7 @@ class ReusingTestCaseComponent(TestCaseComponent):
             self._reusedComponents = reusedComponents
 
     def setupDisks(self, ksdata):
-        self._storage = InstallerStorage(ksdata=ksdata)
+        self._storage = InstallerStorage()
 
         # See comment in super class's method.
         from pyanaconda.bootloader import get_bootloader


### PR DESCRIPTION
Remove the `ksdata` attribute from the `InstallerStorage` class.
The storage object shouldn't keep the kickstart data.