### PR TITLE
Fix jumping boxes in root password spoke

### DIFF
--- a/pyanaconda/ui/gui/spokes/root_password.glade
+++ b/pyanaconda/ui/gui/spokes/root_password.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.19.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.6"/>
   <requires lib="AnacondaWidgets" version="1.0"/>
@@ -81,7 +81,7 @@
                         <property name="visibility">False</property>
                         <property name="invisible_char">●</property>
                         <signal name="changed" handler="on_password_changed" swapped="no"/>
-                        <signal name="icon_release" handler="on_password_icon_clicked" swapped="no"/>
+                        <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="password_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Password</property>
@@ -101,7 +101,7 @@
                         <property name="invisible_char">●</property>
                         <property name="activates_default">True</property>
                         <signal name="changed" handler="on_password_confirmation_changed" swapped="no"/>
-                        <signal name="icon_release" handler="on_password_icon_clicked" swapped="no"/>
+                        <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="password_confirmation_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Confirm Password</property>
@@ -117,6 +117,7 @@
                       <object class="GtkBox" id="box2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkLevelBar" id="password_bar">

--- a/pyanaconda/ui/gui/spokes/user.glade
+++ b/pyanaconda/ui/gui/spokes/user.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.6"/>
   <requires lib="AnacondaWidgets" version="1.0"/>
@@ -57,11 +57,11 @@
                       <object class="GtkLabel" id="label1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">1</property>
                         <property name="xpad">10</property>
                         <property name="label" translatable="yes" context="GUI|User">_Full name</property>
                         <property name="use_underline">True</property>
                         <property name="mnemonic_widget">fullname_entry</property>
+                        <property name="xalign">1</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -75,11 +75,11 @@
                       <object class="GtkLabel" id="label2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">1</property>
                         <property name="xpad">10</property>
                         <property name="label" translatable="yes" context="GUI|User">_User name</property>
                         <property name="use_underline">True</property>
                         <property name="mnemonic_widget">username_entry</property>
+                        <property name="xalign">1</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -127,11 +127,11 @@
                       <object class="GtkLabel" id="label3">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">1</property>
                         <property name="xpad">10</property>
                         <property name="label" translatable="yes" context="GUI|User">_Password</property>
                         <property name="use_underline">True</property>
                         <property name="mnemonic_widget">password_entry</property>
+                        <property name="xalign">1</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -145,11 +145,11 @@
                       <object class="GtkLabel" id="label4">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">1</property>
                         <property name="xpad">10</property>
                         <property name="label" translatable="yes" context="GUI|User">_Confirm password</property>
                         <property name="use_underline">True</property>
                         <property name="mnemonic_widget">password_confirmation_entry</property>
+                        <property name="xalign">1</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
@@ -166,7 +166,7 @@
                         <property name="visibility">False</property>
                         <property name="invisible_char">●</property>
                         <signal name="changed" handler="on_password_changed" swapped="no"/>
-                        <signal name="icon_release" handler="on_password_icon_clicked" swapped="no"/>
+                        <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="password_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Password</property>
@@ -185,7 +185,7 @@
                         <property name="visibility">False</property>
                         <property name="invisible_char">●</property>
                         <signal name="changed" handler="on_password_confirmation_changed" swapped="no"/>
-                        <signal name="icon_release" handler="on_password_icon_clicked" swapped="no"/>
+                        <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="password_confirmation_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Confirm Password</property>
@@ -201,9 +201,9 @@
                       <object class="GtkLabel" id="label6">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">&lt;b&gt;Tip:&lt;/b&gt; Keep your user name shorter than 32 characters and do not use spaces.</property>
                         <property name="use_markup">True</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -231,6 +231,7 @@
                       <object class="GtkBox" id="box2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
                         <child>
                           <object class="GtkLevelBar" id="password_bar">
                             <property name="visible">True</property>


### PR DESCRIPTION
When text telling how strong the password is changed the length of the box will change which will also change edit boxes where user types password. The result was that these boxes were "jumping" based on the strength of the password typed in.

How it works now:
![incorrect_final](https://user-images.githubusercontent.com/1643889/51193330-e978d400-18e8-11e9-9706-e70bccc08dea.png)

How it works with this PR:
![correct_final](https://user-images.githubusercontent.com/1643889/51193357-f5fd2c80-18e8-11e9-8223-fea7f7594924.png)
