### PR TITLE
Change Skylake Spectre_V2 default to Retpolines (#1659626)

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -30,7 +30,7 @@ from parted import PARTITION_BIOS_GRUB
 
 from pyanaconda import iutil
 from blivet.devicelibs import raid
-from pyanaconda.isys import sync
+from pyanaconda.isys import sync, is_skylake
 from pyanaconda.product import productName
 from pyanaconda.flags import flags
 from blivet.errors import StorageError
@@ -825,6 +825,12 @@ class BootLoader(object):
         boot_device = storage.mountpoints.get("/boot")
         if flags.cmdline.get("fips") == "1" and boot_device:
             self.boot_args.add("boot=%s" % self.stage2_device.fstabSpec)
+
+        #
+        # Mitigation to Spectre/Meltdown
+        #
+        if is_skylake():
+            self.boot_args.add("spectre_v2=retpoline")
 
         #
         # dracut

--- a/pyanaconda/isys/__init__.py
+++ b/pyanaconda/isys/__init__.py
@@ -99,6 +99,33 @@ def isLpaeAvailable():
 
     return False
 
+def get_cpu_model():
+    """Get the cpu model number.
+
+    :return: an integer value or None
+    """
+    with open("/proc/cpuinfo", "r") as f:
+        for line in f:
+            name, value = line.split(":")
+
+            if name.strip() == "model":
+                return int(value.strip())
+
+    return None
+
+def is_skylake():
+    """Is it one of the supported Skylake cpu models?
+
+    :return: True or False
+    """
+    return blivet.arch.isX86() and get_cpu_model() in {
+        0x4E,  # INTEL_FAM6_SKYLAKE_MOBILE
+        0x5E,  # INTEL_FAM6_SKYLAKE_DESKTOP
+        0x55,  # INTEL_FAM6_SKYLAKE_X
+        0x8E,  # INTEL_FAM6_KABYLAKE_MOBILE
+        0x9E,  # INTEL_FAM6_KABYLAKE_DESKTOP
+    }
+
 def set_system_time(secs):
     """
     Set system time to time given as a number of seconds since the Epoch.


### PR DESCRIPTION
Set the boot option `spectre_v2` to `retpoline` on Intel Skylake systems.

Resolves: rhbz#1659626