### PR TITLE
Don't show time and date controls in live installations (#1510425)

### DIFF
--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -508,7 +508,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
         self._radioButton24h.emit("toggled")
 
         if not conf.system.can_set_system_clock:
-            self._set_date_time_setting_sensitive(False)
+            self._hide_date_time_setting()
 
         self._config_dialog = NTPconfigDialog(self.data, self._timezone_module)
         self._config_dialog.initialize()
@@ -1100,6 +1100,12 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
             self._amPmRevealer.set_reveal_child(True)
 
         self._hoursLabel.set_text("%0.2d" % new_hours)
+
+    def _hide_date_time_setting(self):
+        #contains all date/time setting widgets
+        footer_alignment = self.builder.get_object("footerAlignment")
+        footer_alignment.set_no_show_all(True)
+        footer_alignment.hide()
 
     def _set_date_time_setting_sensitive(self, sensitive):
         #contains all date/time setting widgets


### PR DESCRIPTION
The time and date controls are used to set the System Clock on the
current system. This is not allowed in live installations, so we can
hide these controls there.

Resolves: rhbz#1510425