### PR TITLE
Use LUKS2 by default

### DIFF
--- a/data/product.d/fedora.conf
+++ b/data/product.d/fedora.conf
@@ -9,9 +9,6 @@ default_on_boot = FIRST_WIRED_WITH_LINK
 [Bootloader]
 efi_dir = fedora
 
-[Storage]
-luks_version = luks1
-
 [User Interface]
 default_help_pages =
     FedoraPlaceholder.txt


### PR DESCRIPTION
Switch cryptsetup default metadata format to LUKS2.

Related: rhbz#1668013