### PR TITLE
Remove the preStorage method in payload

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -268,10 +268,6 @@ def doInstall(storage, payload, ksdata):
     if not manual_part_proxy.Enabled:
         early_storage.append(Task("Insert custom storage to ksdata", storage.update_ksdata))
 
-    # pre-storage tasks
-    # - Is this actually needed ? It does not appear to do anything right now.
-    early_storage.append(Task("Run pre-storage tasks", payload.preStorage))
-
     # callbacks for blivet
     message_clbk = lambda clbk_data: progress_message(clbk_data.msg)
     entropy_wait_clbk = lambda clbk_data: wait_for_entropy(clbk_data.msg,

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -333,12 +333,6 @@ class Payload(object):
         """
         self._first_payload_reset = False
 
-    def preStorage(self):
-        """Do any payload-specific work necessary before writing the storage
-        configuration.  This method need not be provided by all payloads.
-        """
-        pass
-
     def release(self):
         """Release any resources in use by this object, but do not do final
         cleanup.  This is useful for dealing with payload backends that do


### PR DESCRIPTION
Remove the useless method `preStorage` from the payload base class
and the related installation task.