### PR TITLE
Don't create an extra instance of the bootloader

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -704,8 +704,7 @@ if __name__ == "__main__":
         threadMgr.add(AnacondaThread(name=constants.THREAD_TIME_INIT,
                                      target=time_initialize,
                                      args=(timezone_proxy,
-                                           anaconda.storage,
-                                           anaconda.bootloader)))
+                                           anaconda.storage)))
 
     if flags.rescue_mode:
         rescue.start_rescue_mode_ui(anaconda)

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -25,7 +25,6 @@ from tempfile import mkstemp
 import threading
 
 from pyanaconda import addons
-from pyanaconda.bootloader import get_bootloader
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import DisplayModes
 from pyanaconda.core import util, constants
@@ -46,7 +45,6 @@ class Anaconda(object):
     def __init__(self):
         from pyanaconda import desktop
 
-        self._bootloader = None
         self.desktop = desktop.Desktop()
         self.dir = None
         self._display_mode = None
@@ -99,13 +97,6 @@ class Anaconda(object):
             self._dbus_launcher = AnacondaDBusLauncher()
 
         return self._dbus_launcher
-
-    @property
-    def bootloader(self):
-        if not self._bootloader:
-            self._bootloader = get_bootloader()
-
-        return self._bootloader
 
     def _getInterface(self):
         return self._intf

--- a/pyanaconda/timezone.py
+++ b/pyanaconda/timezone.py
@@ -53,7 +53,7 @@ class TimezoneConfigError(Exception):
     """Exception class for timezone configuration related problems"""
     pass
 
-def time_initialize(timezone_proxy, storage, bootloader):
+def time_initialize(timezone_proxy, storage):
     """
     Try to guess if RTC uses UTC time or not, set timezone.isUtc properly and
     set system time from RTC using the UTC guess.
@@ -61,8 +61,6 @@ def time_initialize(timezone_proxy, storage, bootloader):
 
     :param timezone_proxy: DBus proxy of the timezone module
     :param storage: pyanaconda.storage.InstallerStorage instance
-    :param bootloader: bootloader.Bootloader instance
-
     """
 
     if arch.is_s390():
@@ -75,7 +73,7 @@ def time_initialize(timezone_proxy, storage, bootloader):
         ntfs_devs = filter(lambda dev: dev.format.name == "ntfs",
                            storage.devices)
 
-        timezone_proxy.SetIsUTC(not bootloader.has_windows(ntfs_devs))
+        timezone_proxy.SetIsUTC(not storage.bootloader.has_windows(ntfs_devs))
 
     cmd = "hwclock"
     args = ["--hctosys"]

--- a/tests/nosetests/pyanaconda_tests/timezone_test.py
+++ b/tests/nosetests/pyanaconda_tests/timezone_test.py
@@ -68,5 +68,5 @@ class s390HWclock(unittest.TestCase):
     def s390_time_initialize_test(self):
         """Check that time_initialize doesn't call hwclock on s390."""
 
-        timezone.time_initialize(mock.Mock(), mock.Mock(), mock.Mock())
+        timezone.time_initialize(mock.Mock(), mock.Mock())
         self.assertFalse(self.util_mock.execWithRedirect.called)


### PR DESCRIPTION
The Anaconda class doesn't have to create its own instance of
the bootloader. Use storage.bootloader instead.