### PR TITLE
Spelling fix in Boot Options documentation

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -104,7 +104,7 @@ different ways:
 inst.addrepo
 ^^^^^^^^^^^^
 
-Add additional repository which can be used as another *Instalation Source*
+Add additional repository which can be used as another *Installation Source*
 next to the main repository (see `inst.repo`_). This option can be used multiple
 times during one boot. This can be specified in a few different ways:
 


### PR DESCRIPTION
Was going through the docs and this typo stood out. Feel free to ignore or close if this isn't important enough to fix.

Thanks!