### PR TITLE
Do not crash on missing multipath device wwn.

### DIFF
--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -240,7 +240,7 @@ class SearchPage(FilterPage):
         elif filterBy == self.SEARCH_TYPE_PORT_TARGET_LUN:
             return self._port_equal(device) and self._target_equal(device) and self._lun_equal(device)
         elif filterBy == self.SEARCH_TYPE_WWID:
-            return self._wwidEntry.get_text() in getattr(device, "wwn", self._long_identifier(device))
+            return self._wwidEntry.get_text() in (getattr(device, "wwn", None) or self._long_identifier(device))
 
     def visible_func(self, model, itr, *args):
         obj = DiskStoreRow(*model[itr])
@@ -278,7 +278,7 @@ class MultipathPage(FilterPage):
             store.append([True, selected, not disk.protected,
                           disk.name, "", disk.model, str(disk.size),
                           disk.vendor, disk.bus, disk.serial,
-                          disk.wwn, "\n".join(paths), "", "",
+                          disk.wwn or "", "\n".join(paths), "", "",
                           "", "", "", "", ""])
             if not disk.vendor in vendors:
                 vendors.append(disk.vendor)
@@ -310,7 +310,7 @@ class MultipathPage(FilterPage):
         elif filterBy == self.SEARCH_TYPE_INTERCONNECT:
             return device.bus == self._icCombo.get_active_text()
         elif filterBy == self.SEARCH_TYPE_WWID:
-            return self._wwidEntry.get_text() in device.wwn
+            return self._wwidEntry.get_text() in (device.wwn or "")
 
     def visible_func(self, model, itr, *args):
         if not flags.mpath:

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -761,7 +761,10 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         # That makes the DO way too wide.
         if isinstance(disk, MultipathDevice):
             desc = disk.wwn
-            description = desc[0:6] + "..." + desc[-8:]
+            if desc:
+                description = desc[0:6] + "..." + desc[-8:]
+            else:
+                description = ""
         elif isinstance(disk, ZFCPDiskDevice):
             # manually mangle the desc of a zFCP device to be multi-line since
             # it's so long it makes the disk selection screen look odd

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -262,7 +262,7 @@ class StorageSpoke(NormalTUISpoke):
         if (isinstance(disk, MultipathDevice) or
                 isinstance(disk, iScsiDiskDevice) or
                 isinstance(disk, FcoeDiskDevice)):
-            if hasattr(disk, "wwn"):
+            if hasattr(disk, "wwn") and disk.wwn:
                 disk_attrs.append(disk.wwn)
         elif isinstance(disk, DASDDevice):
             if hasattr(disk, "busid"):


### PR DESCRIPTION
Blivet sets the wwn attribute value to None if it doesn't find
udev ID_WWN_WITH_EXTENSION value.

Resolves: rhbz#1666242