### PR TITLE
Set default entry to the BLS id instead of the entry index

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -1616,15 +1616,16 @@ class GRUB2(GRUB):
 
         # make sure the default entry is the OS we are installing
         if self.default is not None:
-            # find the index of the default image
-            try:
-                default_index = self.images.index(self.default)
-            except ValueError:
-                # pylint: disable=no-member
-                log.warning("Failed to find default image (%s), defaulting to 0", self.default.label)
-                default_index = 0
+            machine_id_path = util.getSysroot() + "/etc/machine-id"
+            if not os.access(machine_id_path, os.R_OK):
+                log.error("failed to read machine-id, default entry not set")
+                return
 
-            rc = util.execInSysroot("grub2-set-default", [str(default_index)])
+            with open(machine_id_path, "r") as fd:
+                machine_id = fd.readline().strip()
+
+            default_entry = "%s-%s" % (machine_id, self.default.version)
+            rc = util.execInSysroot("grub2-set-default", [default_entry])
             if rc:
                 log.error("failed to set default menu entry to %s", productName)
 


### PR DESCRIPTION
The GRUB default boot entry is set to the default's entry index. This made
sense on a non-BLS configuration because the entries where defined in the
GRUB config file, so they had a strict definition order.

But that's not the case on a BLS configuration, users can add or remove an
entry by just dropping or removing files from the /boot/loader/entries dir.

That means the default won't necessary be the installed kernel, but rather
the BLS that's first in the sorted list of BLS snippets.

So instead the default entry shold be explicit and be set to the BLS id of
the default kernel (the machine ID followed by a dash and kernel version).

That is also what is used when a new kernel is installed, so the initial
grubenv should be consistent.

Resolves: rhbz#1671047

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>