### PR TITLE
Remove multiboot support for tboot

### DIFF
--- a/pyanaconda/bootloader/base.py
+++ b/pyanaconda/bootloader/base.py
@@ -146,8 +146,6 @@ class BootLoader(object):
                             "net.ifnames"]
     preserve_args = []
 
-    _trusted_boot = False
-
     def __init__(self):
         super().__init__()
         self.boot_args = Arguments()
@@ -897,14 +895,6 @@ class BootLoader(object):
         self.write_config_images(config)
         config.close()
         self.write_config_post()
-
-    @property
-    def trusted_boot(self):
-        return self._trusted_boot
-
-    @trusted_boot.setter
-    def trusted_boot(self, trusted_boot):
-        self._trusted_boot = trusted_boot
 
     #
     # installation

--- a/pyanaconda/bootloader/image.py
+++ b/pyanaconda/bootloader/image.py
@@ -16,7 +16,7 @@
 # Red Hat, Inc.
 #
 
-__all__ = ["BootLoaderImage", "LinuxBootLoaderImage", "TbootLinuxBootLoaderImage"]
+__all__ = ["BootLoaderImage", "LinuxBootLoaderImage"]
 
 
 class BootLoaderImage(object):
@@ -78,36 +78,3 @@ class LinuxBootLoaderImage(BootLoaderImage):
             filename = "initramfs-%s.img" % self.version
         return filename
 
-
-class TbootLinuxBootLoaderImage(LinuxBootLoaderImage):
-    """Trusted Boot Linux-OS image."""
-
-    def __init__(self, device=None, label=None, short=None, version=None):
-        super().__init__(device=device, label=label, short=short, version=version)
-        self._multiboot = "tboot.gz"
-        self._mbargs = ["logging=vga,serial,memory"]
-        self._args = ["intel_iommu=on"]
-
-    @property
-    def multiboot(self):
-        """Multi boot filename.
-
-        :return: a filename string
-        """
-        return self._multiboot
-
-    @property
-    def mbargs(self):
-        """Multi boot arguments.
-
-        :return: a list os arguments
-        """
-        return self._mbargs
-
-    @property
-    def args(self):
-        """Kernel arguments.
-
-        :return: a list os arguments
-        """
-        return self._args

--- a/pyanaconda/bootloader/installation.py
+++ b/pyanaconda/bootloader/installation.py
@@ -19,7 +19,7 @@ import os
 from glob import glob
 
 from pyanaconda.bootloader.base import BootLoaderError
-from pyanaconda.bootloader.image import LinuxBootLoaderImage, TbootLinuxBootLoaderImage
+from pyanaconda.bootloader.image import LinuxBootLoaderImage
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.errors import errorHandler, ERROR_RAISE
@@ -96,14 +96,9 @@ def write_boot_loader(storage, payload, ksdata):
     for version in kernel_versions:
         label = "%s-%s" % (base_label, version)
         short = "%s-%s" % (base_short_label, version)
-        if storage.bootloader.trusted_boot:
-            image = TbootLinuxBootLoaderImage(device=storage.root_device,
-                                              version=version,
-                                              label=label, short=short)
-        else:
-            image = LinuxBootLoaderImage(device=storage.root_device,
-                                         version=version,
-                                         label=label, short=short)
+        image = LinuxBootLoaderImage(device=storage.root_device,
+                                     version=version,
+                                     label=label, short=short)
         storage.bootloader.add_image(image)
 
     write_boot_loader_final(storage, payload, ksdata)
@@ -147,10 +142,6 @@ def write_sysconfig_kernel(storage, version):
     f.write("\n")
     f.write("# DEFAULTKERNEL specifies the default kernel package type\n")
     f.write("DEFAULTKERNEL=%s\n" % kernel)
-    if storage.bootloader.trusted_boot:
-        f.write("# HYPERVISOR specifies the default multiboot kernel\n")
-        f.write("HYPERVISOR=/boot/tboot.gz\n")
-        f.write("HYPERVISOR_ARGS=logging=vga,serial,memory\n")
     f.close()
 
 


### PR DESCRIPTION
The multiboot support for tboot was added in 2011 by commit 4ac57face30
("add multiboot support for tboot") but it has been unused since commit
e2db119e6cd ("Remove some modules obsoleted by the packaging module.").

The latter removed the code that set the BootLoader class trusted_boot
property if the tboot package was installed, so now it's never enabled.

Also the multiboot support has been removed from the grubby BLS wrapper
and it's not even built into the EFI grub2 binary anymore. Since could
be used by an attacker to bypass the Secure Boot mechanism and execute
unsigned binaries.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>