### PR TITLE
Clean up the InstallerStorage from the DBus calls

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -49,6 +49,7 @@ from pyanaconda.image import findFirstIsoImage
 from pyanaconda.image import mountImage
 from pyanaconda.image import opticalInstallMedia, verifyMedia, verify_valid_installtree
 from pyanaconda.core.util import ProxyString, ProxyStringError
+from pyanaconda.storage.installation import write_storage_configuration
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core.regexes import VERSION_DIGITS
 from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
@@ -922,7 +923,7 @@ class Payload(object):
         by overriding the unneeded one with a pass.
         """
         if not conf.target.is_directory:
-            self.storage.write()
+            write_storage_configuration(self.storage, util.getSysroot())
 
     def writeStorageLate(self):
         """Some payloads require that the storage configuration be written out
@@ -933,7 +934,7 @@ class Payload(object):
         if util.getSysroot() != util.getTargetPhysicalRoot():
             self.prepareMountTargets(self.storage)
         if not conf.target.is_directory:
-            self.storage.write()
+            write_storage_configuration(self.storage, util.getSysroot())
 
 
 

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -25,12 +25,10 @@ import parted
 
 from pykickstart.constants import AUTOPART_TYPE_LVM
 
-from blivet import arch
 from blivet.blivet import Blivet
 from blivet.storage_log import log_exception_info
 from blivet.devices import PartitionDevice, BTRFSSubVolumeDevice
 from blivet.formats import get_format
-from blivet.iscsi import iscsi
 from blivet.size import Size
 from blivet.devicelibs.crypto import DEFAULT_LUKS_VERSION
 
@@ -45,8 +43,7 @@ from pyanaconda.storage.fsset import FSSet
 from pyanaconda.storage.partitioning import get_full_partitioning_requests
 from pyanaconda.storage.utils import download_escrow_certificate, find_live_backing_device
 from pyanaconda.storage.root import find_existing_installations
-from pyanaconda.modules.common.constants.services import NETWORK, STORAGE
-from pyanaconda.modules.common.constants.objects import ZFCP, FCOE
+from pyanaconda.modules.common.constants.services import NETWORK
 
 import logging
 log = logging.getLogger("anaconda.storage")
@@ -165,24 +162,6 @@ class InstallerStorage(Blivet):
                 dev.disk.format.commit_to_disk()
 
         self.dump_state("final")
-
-    def write(self):
-        sysroot = util.getSysroot()
-        if not os.path.isdir("%s/etc" % sysroot):
-            os.mkdir("%s/etc" % sysroot)
-
-        self.make_mtab()
-        self.fsset.write()
-        iscsi.write(sysroot, self)
-
-        fcoe_proxy = STORAGE.get_proxy(FCOE)
-        fcoe_proxy.WriteConfiguration(sysroot)
-
-        if arch.is_s390():
-            zfcp_proxy = STORAGE.get_proxy(ZFCP)
-            zfcp_proxy.WriteConfiguration(sysroot)
-
-        self.write_dasd_conf(sysroot)
 
     @property
     def bootloader(self):
@@ -736,45 +715,6 @@ class InstallerStorage(Blivet):
 
     def create_swap_file(self, device, size):
         self.fsset.create_swap_file(device, size)
-
-    def write_dasd_conf(self, root):
-        """ Write /etc/dasd.conf to target system for all DASD devices
-            configured during installation.
-        """
-        dasds = [d for d in self.devices if d.type == "dasd"]
-        dasds.sort(key=lambda d: d.name)
-        if not (arch.is_s390() and dasds):
-            return
-
-        with open(os.path.realpath(root + "/etc/dasd.conf"), "w") as f:
-            for dasd in dasds:
-                fields = [dasd.busid] + dasd.get_opts()
-                f.write("%s\n" % " ".join(fields),)
-
-        # check for hyper PAV aliases; they need to get added to dasd.conf as well
-        sysfs = "/sys/bus/ccw/drivers/dasd-eckd"
-
-        # in the case that someone is installing with *only* FBA DASDs,the above
-        # sysfs path will not exist; so check for it and just bail out of here if
-        # that's the case
-        if not os.path.exists(sysfs):
-            return
-
-        # this does catch every DASD, even non-aliases, but we're only going to be
-        # checking for a very specific flag, so there won't be any duplicate entries
-        # in dasd.conf
-        devs = [d for d in os.listdir(sysfs) if d.startswith("0.0")]
-        with open(os.path.realpath(root + "/etc/dasd.conf"), "a") as f:
-            for d in devs:
-                aliasfile = "%s/%s/alias" % (sysfs, d)
-                with open(aliasfile, "r") as falias:
-                    alias = falias.read().strip()
-
-                # if alias == 1, then the device is an alias; otherwise it is a
-                # normal dasd (alias == 0) and we can skip it, since it will have
-                # been added to dasd.conf in the above block of code
-                if alias == "1":
-                    f.write("%s\n" % d)
 
     def make_mtab(self):
         path = "/etc/mtab"

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -46,8 +46,7 @@ from pyanaconda.storage.partitioning import get_full_partitioning_requests
 from pyanaconda.storage.utils import download_escrow_certificate, find_live_backing_device
 from pyanaconda.storage.root import find_existing_installations
 from pyanaconda.modules.common.constants.services import NETWORK, STORAGE
-from pyanaconda.modules.common.constants.objects import DISK_SELECTION, DISK_INITIALIZATION, \
-    ZFCP, FCOE
+from pyanaconda.modules.common.constants.objects import ZFCP, FCOE
 
 import logging
 log = logging.getLogger("anaconda.storage")
@@ -70,16 +69,6 @@ class StorageDiscoveryConfig(object):
         # Whether clear_partitions removes scheduled/non-existent devices and
         # disklabels depends on this flag.
         self.clear_non_existent = False
-
-    def update(self, *args, **kwargs):
-        """Update configuration."""
-        disk_init_proxy = STORAGE.get_proxy(DISK_INITIALIZATION)
-
-        self.clear_part_type = disk_init_proxy.InitializationMode
-        self.clear_part_disks = disk_init_proxy.DrivesToClear
-        self.clear_part_devices = disk_init_proxy.DevicesToClear
-        self.initialize_disks = disk_init_proxy.InitializeLabelsEnabled
-        self.zero_mbr = disk_init_proxy.FormatUnrecognizedEnabled
 
 
 class InstallerStorage(Blivet):
@@ -480,22 +469,6 @@ class InstallerStorage(Blivet):
         for device in self.devices:
             if device.format.type == "luks" and device.format.exists:
                 self.save_passphrase(device)
-
-        self.config.update()
-
-        disk_select_proxy = STORAGE.get_proxy(DISK_SELECTION)
-        self.ignored_disks = disk_select_proxy.IgnoredDisks
-        self.exclusive_disks = disk_select_proxy.SelectedDisks
-
-        if not conf.target.is_image:
-            iscsi.startup()
-
-            fcoe_proxy = STORAGE.get_proxy(FCOE)
-            fcoe_proxy.ReloadModule()
-
-            if arch.is_s390():
-                zfcp_proxy = STORAGE.get_proxy(ZFCP)
-                zfcp_proxy.ReloadModule()
 
         super().reset(cleanup_only=cleanup_only)
 

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -76,6 +76,7 @@ from pyanaconda.core.constants import CLEAR_PARTITIONS_NONE, BOOTLOADER_DRIVE_UN
     BOOTLOADER_ENABLED, STORAGE_METADATA_RATIO, AUTOPART_TYPE_DEFAULT
 from pyanaconda.bootloader import BootLoaderError
 from pyanaconda.storage import autopart
+from pyanaconda.storage.initialization import update_storage_config, reset_storage
 from pyanaconda.storage.utils import nvdimm_update_ksdata_for_used_devices
 from pyanaconda.storage.snapshot import on_disk_storage
 from pyanaconda.storage.format_dasd import DasdFormatting
@@ -84,7 +85,6 @@ from pyanaconda.modules.common.constants.objects import DISK_SELECTION, DISK_INI
     BOOTLOADER, AUTO_PARTITIONING
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.payload.livepayload import LiveImagePayload
-
 from pykickstart.constants import AUTOPART_TYPE_LVM
 from pykickstart.errors import KickstartParseError
 
@@ -412,7 +412,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             self.clearPartType = CLEAR_PARTITIONS_NONE
             self._disk_init_observer.proxy.SetInitializationMode(CLEAR_PARTITIONS_NONE)
 
-        self.storage.config.update()
+        update_storage_config(self.storage.config)
         self.storage.autopart_type = self._auto_part_observer.proxy.Type
         self.storage.encrypted_autopart = self._auto_part_observer.proxy.Encrypted
         self.storage.encryption_passphrase = self._auto_part_observer.proxy.Passphrase
@@ -501,7 +501,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             self._disk_select_observer.proxy.SetSelectedDisks([])
 
             # The reset also calls self.storage.config.update().
-            self.storage.reset()
+            reset_storage(self.storage)
 
             # Now set data back to the user's specified config.
             self.disks = getDisks(self.storage.devicetree)

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -50,7 +50,8 @@ from pyanaconda.core.constants import THREAD_STORAGE, THREAD_STORAGE_WATCHER, \
     MOUNT_POINT_REFORMAT, MOUNT_POINT_PATH, MOUNT_POINT_DEVICE, MOUNT_POINT_FORMAT
 from pyanaconda.core.i18n import _, P_, N_, C_
 from pyanaconda.bootloader import BootLoaderError
-from pyanaconda.storage.initialization import initialize_storage
+from pyanaconda.storage.initialization import initialize_storage, update_storage_config, \
+    reset_storage
 
 from pykickstart.base import BaseData
 from pykickstart.constants import AUTOPART_TYPE_LVM
@@ -440,7 +441,7 @@ class StorageSpoke(NormalTUISpoke):
             self._bootloader_observer.proxy.SetDrive(BOOTLOADER_DRIVE_UNSET)
             self.storage.bootloader.reset()
 
-        self.storage.config.update()
+        update_storage_config(self.storage.config)
 
         # If autopart is selected we want to remove whatever has been
         # created/scheduled to make room for autopart.
@@ -464,7 +465,7 @@ class StorageSpoke(NormalTUISpoke):
             self.storage.autopart_type = self._auto_part_observer.proxy.Type
 
             # The reset also calls self.storage.config.update().
-            self.storage.reset()
+            reset_storage(self.storage.reset)
 
             # Now set data back to the user's specified config.
             applyDiskSelection(self.storage, self.data, self.selected_disks)


### PR DESCRIPTION
Configure the storage and reload the additional storage modules before
we call the `reset` method of the `InstallerStorage` class. Let's move the
code to the `reset_storage` function.

Let's create a new function `write_storage_configuration` from the
`write` method of the `InstallerStorage` class, so we can later create
an installation task from it.