### PR TITLE
Add support for providing results of tasks

### DIFF
--- a/pyanaconda/dbus_addons/baz/baz.py
+++ b/pyanaconda/dbus_addons/baz/baz.py
@@ -20,7 +20,7 @@
 from time import sleep
 
 from pyanaconda.dbus import DBus
-from pyanaconda.dbus_addons.baz.baz_interface import BazInterface
+from pyanaconda.dbus_addons.baz.baz_interface import BazInterface, BazCalculationTaskInterface
 from pyanaconda.modules.common.base import KickstartModule
 from pyanaconda.modules.common.constants.services import BAZ
 from pyanaconda.modules.common.task import Task
@@ -40,6 +40,10 @@ class Baz(KickstartModule):
     def install_with_tasks(self):
         """Return installation tasks."""
         return [self.publish_task(BAZ.namespace, BazTask())]
+
+    def calculate_with_task(self):
+        """Return a calculation task."""
+        return self.publish_task(BAZ.namespace, BazCalculationTask(), BazCalculationTaskInterface)
 
 
 class BazTask(Task):
@@ -62,3 +66,20 @@ class BazTask(Task):
 
         self.report_progress("Finishing...", step_size=1)
         sleep(5)
+
+
+class BazCalculationTask(Task):
+    """The task that calculates something."""
+
+    @property
+    def name(self):
+        return "Calculate something"
+
+    def run(self):
+        result = 0
+
+        for i in range(3):
+            result = result + i
+            sleep(5)
+
+        return result

--- a/pyanaconda/dbus_addons/baz/baz_interface.py
+++ b/pyanaconda/dbus_addons/baz/baz_interface.py
@@ -17,12 +17,26 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.dbus.interface import dbus_interface
+from pyanaconda.dbus.interface import dbus_interface, dbus_class
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.modules.common.constants.services import BAZ
+from pyanaconda.modules.common.task import TaskInterface
 
 
 @dbus_interface(BAZ.interface_name)
 class BazInterface(KickstartModuleInterface):
     """The interface for Baz."""
-    pass
+
+    def CalculateWithTask(self) -> ObjPath:
+        """Get a result with a task."""
+        return self.implementation.calculate_with_task()
+
+
+@dbus_class
+class BazCalculationTaskInterface(TaskInterface):
+    """The interface for the Baz calculation task."""
+
+    @staticmethod
+    def convert_result(value):
+        return get_variant(Int, value)

--- a/pyanaconda/modules/boss/install_manager/installation.py
+++ b/pyanaconda/modules/boss/install_manager/installation.py
@@ -63,13 +63,14 @@ class SystemInstallationTask(AbstractTask):
         """Start the next installation task."""
         self._disconnect_all()
 
-        if not self._subtasks:
-            log.info("Installation is complete.")
+        if self.check_cancel():
+            log.info("Installation is canceled.")
             self._task_stopped_callback()
             return
 
-        if self.check_cancel():
-            log.info("Installation is canceled.")
+        if not self._subtasks:
+            log.info("Installation is complete.")
+            self._task_succeeded_callback()
             self._task_stopped_callback()
             return
 

--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -24,7 +24,7 @@ from pyanaconda.core.event_loop import EventLoop
 from pyanaconda.core.async_utils import run_in_loop
 from pyanaconda.core.timer import Timer
 from pyanaconda.dbus import DBus
-from pyanaconda.modules.common.task import publish_task
+from pyanaconda.modules.common.task import publish_task, TaskInterface
 from pyanaconda.core.signal import Signal
 from pyanaconda.core.kickstart.specification import NoKickstartSpecification, \
     KickstartSpecificationHandler, KickstartSpecificationParser
@@ -62,15 +62,16 @@ class BaseModule(ABC):
         """
         pass
 
-    def publish_task(self, namespace, task, message_bus=DBus):
+    def publish_task(self, namespace, task, interface=TaskInterface, message_bus=DBus):
         """Publish a task.
 
         :param namespace: a DBus namespace
         :param task: an instance of task
+        :param interface: an interface class
         :param message_bus: a message bus
         :return: a DBus path of the published task
         """
-        object_path = publish_task(message_bus, namespace, task)
+        object_path = publish_task(message_bus, namespace, task, interface)
         self._published_tasks[task] = object_path
         return object_path
 

--- a/pyanaconda/modules/common/errors/task.py
+++ b/pyanaconda/modules/common/errors/task.py
@@ -25,3 +25,9 @@ from pyanaconda.modules.common.errors import AnacondaError
 class TaskError(AnacondaError):
     """General exception for task errors."""
     pass
+
+
+@dbus_error("NoResultError", namespace=ANACONDA_NAMESPACE)
+class NoResultError(TaskError):
+    """There is no result of a task."""
+    pass

--- a/pyanaconda/modules/common/task/__init__.py
+++ b/pyanaconda/modules/common/task/__init__.py
@@ -24,16 +24,17 @@ __all__ = ["publish_task", "sync_run_task", "async_run_task", "AbstractTask", "T
            "TaskInterface"]
 
 
-def publish_task(message_bus, namespace, task_instance):
+def publish_task(message_bus, namespace, task, interface=TaskInterface):
     """Publish a task on the given message bus.
 
     :param message_bus: a message bus
     :param namespace: a sequence of names
-    :param task_instance: an instance of a Task
+    :param task: an instance of a Task
+    :param interface: an interface class
     :return: a DBus path of the published task
     """
-    publishable = TaskInterface(task_instance)
-    object_path = TaskInterface.get_object_path(namespace)
+    publishable = interface(task)
+    object_path = interface.get_object_path(namespace)
     message_bus.publish_object(object_path, publishable)
     return object_path
 

--- a/pyanaconda/modules/common/task/result.py
+++ b/pyanaconda/modules/common/task/result.py
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from abc import ABC
+from threading import Lock
+
+from pyanaconda.core.signal import Signal
+from pyanaconda.modules.common.errors.task import NoResultError
+
+__all__ = ['ResultProvider']
+
+
+class ResultProvider(ABC):
+    """Abstract class that allows to provide a result of a task."""
+
+    def __init__(self):
+        super().__init__()
+        self._result_changed_signal = Signal()
+        self.__result_lock = Lock()
+        self.__result = None
+
+    def _set_result(self, result):
+        """Set the result of the task.
+
+        :param result: a result of the task
+        """
+        with self.__result_lock:
+            self.__result = result
+
+    def get_result(self):
+        """Get the result of the task.
+
+        It raises an exception if no result is provided.
+
+        :return: a result of the task
+        :raises: NoResultError if the result is None
+        """
+        with self.__result_lock:
+            if self.__result is None:
+                raise NoResultError("The result is not provided.")
+
+            return self.__result

--- a/pyanaconda/modules/common/task/runnable.py
+++ b/pyanaconda/modules/common/task/runnable.py
@@ -31,6 +31,7 @@ class Runnable(ABC):
         self._started_signal = Signal()
         self._stopped_signal = Signal()
         self._failed_signal = Signal()
+        self._succeeded_signal = Signal()
 
     @property
     def started_signal(self):
@@ -48,6 +49,11 @@ class Runnable(ABC):
         return self._failed_signal
 
     @property
+    def succeeded_signal(self):
+        """Signal emitted when the task succeeds."""
+        return self._succeeded_signal
+
+    @property
     @abstractmethod
     def is_running(self):
         """Is the task running."""
@@ -62,6 +68,7 @@ class Runnable(ABC):
             self._task_started_callback
             self._task_run_callback
             self._task_failed_callback
+            self._task_succeeded_callback
             self._task_stopped_callback
 
         Make sure that you call self._task_started_callback at the
@@ -72,6 +79,9 @@ class Runnable(ABC):
         In a case of failure, call self._task_failed_callback to
         inform that the task has failed. You will still need to
         call also self._task_stopped_callback.
+
+        In a case of success, call self._task_succeeded_callback to
+        inform that the task has succeeded.
 
         Make sure that you always call self._task_stopped_callback
         at the end of the task lifetime to inform that the task is
@@ -93,6 +103,11 @@ class Runnable(ABC):
     def _task_failed_callback(self):
         """Callback for a failed task."""
         self._failed_signal.emit()
+
+    @async_action_nowait
+    def _task_succeeded_callback(self):
+        """Callback for a successful task."""
+        self._succeeded_signal.emit()
 
     @async_action_nowait
     def _task_stopped_callback(self):

--- a/pyanaconda/modules/common/task/task.py
+++ b/pyanaconda/modules/common/task/task.py
@@ -86,6 +86,12 @@ class Task(AbstractTask):
         """Report the first step and run the task."""
         self.report_progress(self.name, step_number=1)
         self.run()
+        self._task_succeeded_callback()
+
+    def _task_succeeded_callback(self):
+        """Don't report the success if the task was canceled."""
+        if not self.check_cancel():
+            super()._task_succeeded_callback()
 
     def _task_failed_with_info_callback(self, *exc_info):
         """Log the error and report the failure."""

--- a/pyanaconda/modules/common/task/task.py
+++ b/pyanaconda/modules/common/task/task.py
@@ -26,6 +26,7 @@ from abc import abstractmethod
 from pyanaconda.core.constants import THREAD_DBUS_TASK
 from pyanaconda.modules.common.task.cancellable import Cancellable
 from pyanaconda.modules.common.task.progress import ProgressReporter
+from pyanaconda.modules.common.task.result import ResultProvider
 from pyanaconda.modules.common.task.runnable import Runnable
 from pyanaconda.threading import threadMgr, AnacondaThread
 
@@ -35,7 +36,7 @@ log = get_module_logger(__name__)
 __all__ = ['AbstractTask', 'Task']
 
 
-class AbstractTask(Runnable, Cancellable, ProgressReporter):
+class AbstractTask(Runnable, Cancellable, ProgressReporter, ResultProvider):
     """Abstract class for running a long-term task."""
 
     @property
@@ -85,7 +86,7 @@ class Task(AbstractTask):
     def _task_run_callback(self):
         """Report the first step and run the task."""
         self.report_progress(self.name, step_number=1)
-        self.run()
+        self._set_result(self.run())
         self._task_succeeded_callback()
 
     def _task_succeeded_callback(self):
@@ -109,8 +110,13 @@ class Task(AbstractTask):
 
         Call self.check_cancel to check if the task should be canceled
         and terminate the task immediately if it returns True.
+
+        Return a result of the task or None if the task doesn't provide
+        a result.
+
+        :return: a result of the task
         """
-        pass
+        return None
 
     def finish(self):
         """Finish the task run.

--- a/pyanaconda/modules/common/task/task_interface.py
+++ b/pyanaconda/modules/common/task/task_interface.py
@@ -57,6 +57,7 @@ class TaskInterface(InterfaceTemplate):
         self.implementation.started_signal.connect(self.Started)
         self.implementation.stopped_signal.connect(self.Stopped)
         self.implementation.failed_signal.connect(self.Failed)
+        self.implementation.succeeded_signal.connect(self.Succeeded)
 
     @property
     def Name(self) -> Str:
@@ -104,6 +105,11 @@ class TaskInterface(InterfaceTemplate):
     @dbus_signal
     def Failed(self):
         """Signal when this task fails."""
+        pass
+
+    @dbus_signal
+    def Succeeded(self):
+        """Signal when this task succeeds."""
         pass
 
     def Start(self):

--- a/pyanaconda/modules/common/task/task_interface.py
+++ b/pyanaconda/modules/common/task/task_interface.py
@@ -25,6 +25,7 @@ from pyanaconda.dbus.namespace import get_dbus_path
 from pyanaconda.modules.common.constants.interfaces import TASK
 from pyanaconda.dbus.template import InterfaceTemplate
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
+from pyanaconda.modules.common.errors.task import NoResultError
 
 __all__ = ['TaskInterface']
 
@@ -123,6 +124,27 @@ class TaskInterface(InterfaceTemplate):
     def Finish(self):
         """Finish the task after it stopped.
 
-        This method will return an error if the task failed.
+        This method will raise an error if the task has failed.
         """
         self.implementation.finish()
+
+    @staticmethod
+    def convert_result(value) -> Variant:
+        """Convert the value of the result.
+
+        Convert the value into a variant.
+
+        :param value: a value of the result
+        :return: a variant with the value
+        :raises: NoResultError by default
+        """
+        raise NoResultError("The result is not publishable.")
+
+    def GetResult(self) -> Variant:
+        """Get the result of the task if any.
+
+        :return: a variant with the result
+        :raises: NoResultError by default
+        """
+        result = self.implementation.get_result()
+        return self.convert_result(result)

--- a/tests/nosetests/pyanaconda_tests/module_tasks_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_tasks_test.py
@@ -139,6 +139,30 @@ class TaskInterfaceTestCase(unittest.TestCase):
         message_bus.publish_object.called_once()
         message_bus.reset_mock()
 
+    @dbus_class
+    class SimpleTaskInterface(TaskInterface):
+        pass
+
+    def publish_with_interface_test(self):
+        """Test task publishing with a specified interface."""
+        TaskInterface._task_counter = 1
+        message_bus = Mock()
+
+        object_path = publish_task(
+            message_bus=message_bus,
+            namespace=("A", "B", "C"),
+            task=self.SimpleTask(),
+            interface=self.SimpleTaskInterface
+        )
+
+        self.assertEqual("/A/B/C/Tasks/1", object_path)
+        message_bus.publish_object.called_once()
+
+        publishable = message_bus.publish_object.call_args[0][1]
+        self.assertIsInstance(publishable, self.SimpleTaskInterface)
+
+        message_bus.reset_mock()
+
     def simple_progress_reporting_test(self):
         """Test simple progress reporting."""
         self._set_up_task(self.SimpleTask())


### PR DESCRIPTION
The `Succeeded` signal is emitted only if a task has succeeded. It
means that no errors were raised during the run of the task and
the task wasn't canceled.

The `GetResult` method returns a result of a task. It will raise the
`NoResultError` exception if the task doesn't provide a result or the
result is not publishable on DBus. A task doesn't provide a result if
it has failed.

If you want to provide a result of a task, return the result in the
run method of the task and create a new class that will override the
`convert_result` method of the `TaskInterface` class. Publish the
task with this interface class.

For example:

```
  @dbus_class
  class MyTaskInterface(TaskInterface):

    @staticmethod
    def convert_result(value):
      return get_variant(Int, value)
```