### PR TITLE
Remove obsolete Group tag & obsolete scriptlets

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -229,7 +229,6 @@ This package contains textual user interface for the Anaconda installer.
 
 %package widgets
 Summary: A set of custom GTK+ widgets for use with anaconda
-Group: System Environment/Libraries
 Requires: python3
 
 %description widgets
@@ -237,7 +236,6 @@ This package contains a set of custom GTK+ widgets used by the anaconda installe
 
 %package widgets-devel
 Summary: Development files for anaconda-widgets
-Group: Development/Libraries
 Requires: glade
 Requires: %{name}-widgets%{?_isa} = %{version}-%{release}
 
@@ -279,12 +277,6 @@ desktop-file-install --dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_d
 
 # If no langs found, keep going
 %find_lang %{name} || :
-
-%post live
-update-desktop-database &> /dev/null || :
-
-%postun live
-update-desktop-database &> /dev/null || :
 
 %ldconfig_scriptlets widgets
 


### PR DESCRIPTION
A couple Fedora-wide spec file cleanup changes we need to backport to
our spec file so they don't get overwritten in next build.

- remove obsolete Group tag

References: https://fedoraproject.org/wiki/Changes/Remove_Group_Tag

- remove obsolete scriptlets

References: https://fedoraproject.org/wiki/Changes/RemoveObsoleteScriptlets

Originally by: Igor Gnatenko <ignatenkobrain@fedoraproject.org>