### PR TITLE
Drop the temporary anaconda-live dependency

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -207,11 +207,6 @@ Requires: yelp
 Requires: blivet-gui-runtime >= %{blivetguiver}
 Requires: system-logos
 
-# required during the transition period until
-# anaconda-live is added to the kickstarts used to
-# create live images
-Requires: anaconda-live = %{version}-%{release}
-
 # Needed to compile the gsettings files
 BuildRequires: gsettings-desktop-schemas
 BuildRequires: metacity


### PR DESCRIPTION
The PR[0] on Fedora kickstarts has been merged, so we can drop the
temporary dependency on anaconda-live from the anaconda-gui sub-package.

Thanks to this we will no longer pollute boot ISOs and systems where
Initial Setup is installed with files only relevant for a live
installation. :)

[0] https://pagure.io/fedora-kickstarts/pull-request/474