### PR TITLE
Remove useless arguments from methods of the kickstart commands

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -785,8 +785,8 @@ if __name__ == "__main__":
     from pyanaconda.kickstart import check_kickstart_error
     if ksdata.snapshot.has_snapshot(SNAPSHOT_WHEN_PRE_INSTALL):
         with check_kickstart_error():
-            ksdata.snapshot.pre_setup(anaconda.storage, ksdata)
-            ksdata.snapshot.pre_execute(anaconda.storage, ksdata)
+            ksdata.snapshot.pre_setup(anaconda.storage)
+            ksdata.snapshot.pre_execute(anaconda.storage)
 
     anaconda._intf.setup(ksdata)
     anaconda._intf.run()

--- a/pyanaconda/bootloader/installation.py
+++ b/pyanaconda/bootloader/installation.py
@@ -31,7 +31,7 @@ log = get_module_logger(__name__)
 __all__ = ["write_boot_loader"]
 
 
-def write_boot_loader(storage, payload, ksdata):
+def write_boot_loader(storage, payload):
     """ Write bootloader configuration to disk.
 
         When we get here, the bootloader will already have a default linux
@@ -55,7 +55,7 @@ def write_boot_loader(storage, payload, ksdata):
         if storage.bootloader.skip_bootloader:
             log.info("skipping boot loader install per user request")
             return
-        write_boot_loader_final(storage, payload, ksdata)
+        write_boot_loader_final(storage, payload)
         return
 
     # get a list of installed kernel packages
@@ -101,7 +101,7 @@ def write_boot_loader(storage, payload, ksdata):
                                      label=label, short=short)
         storage.bootloader.add_image(image)
 
-    write_boot_loader_final(storage, payload, ksdata)
+    write_boot_loader_final(storage, payload)
 
 
 def write_sysconfig_kernel(storage, version):
@@ -145,7 +145,7 @@ def write_sysconfig_kernel(storage, version):
     f.close()
 
 
-def write_boot_loader_final(storage, payload, ksdata):
+def write_boot_loader_final(storage, payload):
     """ Do the final write of the bootloader. """
 
     # set up dracut/fips boot args

--- a/pyanaconda/bootloader/installation.py
+++ b/pyanaconda/bootloader/installation.py
@@ -38,29 +38,34 @@ def write_boot_loader(storage, payload):
         image. We only have to add images for the non-default kernels and
         adjust the default to reflect whatever the default variant is.
     """
-    if not storage.bootloader.skip_bootloader:
-        stage1_device = storage.bootloader.stage1_device
-        log.info("boot loader stage1 target device is %s", stage1_device.name)
-        stage2_device = storage.bootloader.stage2_device
-        log.info("boot loader stage2 target device is %s", stage2_device.name)
-
+    # Set up the boot loader.
     storage.bootloader.menu_auto_hide = conf.bootloader.menu_auto_hide
 
     # Bridge storage EFI configuration to bootloader
     if hasattr(storage.bootloader, 'efi_dir'):
         storage.bootloader.efi_dir = conf.bootloader.efi_dir
 
-    # Currently just rpmostreepayload shortcuts the rest of everything below
-    if payload.handlesBootloaderConfiguration:
-        if storage.bootloader.skip_bootloader:
-            log.info("skipping boot loader install per user request")
-            return
-        write_boot_loader_final(storage, payload)
+    # Configure the boot loader.
+    if not payload.handlesBootloaderConfiguration:
+        _configure_boot_loader(storage, payload.kernelVersionList)
+
+    # Should we skip the installation?
+    if storage.bootloader.skip_bootloader:
+        log.info("skipping boot loader install per user request")
         return
+
+    # Install the bootloader.
+    _set_boot_arguments(storage)
+    _install_boot_loader(storage)
+
+
+def _configure_boot_loader(storage, kernel_versions):
+    """Configure the bootloader."""
+    log.debug("Configuring the boot loader.")
 
     # get a list of installed kernel packages
     # add whatever rescue kernels we can find to the end
-    kernel_versions = list(payload.kernelVersionList)
+    kernel_versions = list(kernel_versions)
 
     rescue_versions = glob(util.getSysroot() + "/boot/vmlinuz-*-rescue-*")
     rescue_versions += glob(
@@ -86,11 +91,7 @@ def write_boot_loader(storage, payload):
     storage.bootloader.default = default_image
 
     # write out /etc/sysconfig/kernel
-    write_sysconfig_kernel(storage, version)
-
-    if storage.bootloader.skip_bootloader:
-        log.info("skipping boot loader install per user request")
-        return
+    _write_sysconfig_kernel(storage, version)
 
     # now add an image for each of the other kernels
     for version in kernel_versions:
@@ -101,10 +102,11 @@ def write_boot_loader(storage, payload):
                                      label=label, short=short)
         storage.bootloader.add_image(image)
 
-    write_boot_loader_final(storage, payload)
 
+def _write_sysconfig_kernel(storage, version):
+    """Write to /etc/sysconfig/kernel."""
+    log.debug("Writing to /etc/sysconfig/kernel.")
 
-def write_sysconfig_kernel(storage, version):
     # get the name of the default kernel package based on the version
     kernel_basename = "vmlinuz-" + version
     kernel_file = "/boot/%s" % kernel_basename
@@ -145,13 +147,22 @@ def write_sysconfig_kernel(storage, version):
     f.close()
 
 
-def write_boot_loader_final(storage, payload):
-    """ Do the final write of the bootloader. """
+def _set_boot_arguments(storage):
+    """Set up the final boot arguments."""
+    # FIXME: do this from elsewhere?
+    storage.bootloader.set_boot_args(storage)
 
-    # set up dracut/fips boot args
-    # XXX FIXME: do this from elsewhere?
-    storage.bootloader.set_boot_args(storage=storage,
-                                     payload=payload)
+
+def _install_boot_loader(storage):
+    """Do the final write of the boot loader."""
+    log.debug("Installing the boot loader.")
+
+    stage1_device = storage.bootloader.stage1_device
+    log.info("boot loader stage1 target device is %s", stage1_device.name)
+
+    stage2_device = storage.bootloader.stage2_device
+    log.info("boot loader stage2 target device is %s", stage2_device.name)
+
     try:
         storage.bootloader.write()
     except BootLoaderError as e:

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -138,7 +138,7 @@ def doConfiguration(storage, payload, ksdata):
     bootloader_enabled = bootloader_proxy.BootloaderMode != BOOTLOADER_DISABLED
 
     if isinstance(payload, LiveImagePayload) and boot_on_btrfs and bootloader_enabled:
-        generate_initramfs.append(Task("Write BTRFS bootloader fix", write_boot_loader, (storage, payload, ksdata)))
+        generate_initramfs.append(Task("Write BTRFS bootloader fix", write_boot_loader, (storage, payload)))
 
     # Invoking zipl should be the last thing done on a s390x installation (see #1652727).
     if arch.is_s390() and not conf.target.is_directory and bootloader_enabled:
@@ -350,7 +350,7 @@ def doInstall(storage, payload, ksdata):
     # Do bootloader.
     if can_install_bootloader:
         bootloader_install = TaskQueue("Bootloader installation", N_("Installing boot loader"))
-        bootloader_install.append(Task("Install bootloader", write_boot_loader, (storage, payload, ksdata)))
+        bootloader_install.append(Task("Install bootloader", write_boot_loader, (storage, payload)))
         installation_queue.append(bootloader_install)
 
     post_install = TaskQueue("Post-installation setup tasks", (N_("Performing post-installation setup tasks")))

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -93,22 +93,22 @@ def doConfiguration(storage, payload, ksdata):
 
     # schedule the execute methods of ksdata that require an installed system to be present
     os_config = TaskQueue("Installed system configuration", N_("Configuring installed system"))
-    os_config.append(Task("Configure authselect", ksdata.authselect.execute, (storage, ksdata)))
-    os_config.append(Task("Configure SELinux", ksdata.selinux.execute, (storage, ksdata)))
-    os_config.append(Task("Configure first boot tasks", ksdata.firstboot.execute, (storage, ksdata)))
-    os_config.append(Task("Configure services", ksdata.services.execute, (storage, ksdata)))
-    os_config.append(Task("Configure keyboard", ksdata.keyboard.execute, (storage, ksdata)))
-    os_config.append(Task("Configure timezone", ksdata.timezone.execute, (storage, ksdata)))
-    os_config.append(Task("Configure language", ksdata.lang.execute, (storage, ksdata)))
-    os_config.append(Task("Configure firewall", ksdata.firewall.execute, (storage, ksdata)))
-    os_config.append(Task("Configure X", ksdata.xconfig.execute, (storage, ksdata)))
+    os_config.append(Task("Configure authselect", ksdata.authselect.execute))
+    os_config.append(Task("Configure SELinux", ksdata.selinux.execute))
+    os_config.append(Task("Configure first boot tasks", ksdata.firstboot.execute))
+    os_config.append(Task("Configure services", ksdata.services.execute))
+    os_config.append(Task("Configure keyboard", ksdata.keyboard.execute))
+    os_config.append(Task("Configure timezone", ksdata.timezone.execute))
+    os_config.append(Task("Configure language", ksdata.lang.execute))
+    os_config.append(Task("Configure firewall", ksdata.firewall.execute))
+    os_config.append(Task("Configure X", ksdata.xconfig.execute))
     configuration_queue.append(os_config)
 
     # schedule network configuration (if required)
     if conf.system.provides_network_config:
         network_config = TaskQueue("Network configuration", N_("Writing network configuration"))
         network_config.append(Task("Network configuration",
-                                   ksdata.network.execute, (storage, payload, ksdata)))
+                                   ksdata.network.execute, (storage, payload)))
         configuration_queue.append(network_config)
 
     # creating users and groups requires some pre-configuration.
@@ -149,7 +149,7 @@ def doConfiguration(storage, payload, ksdata):
     # join a realm (if required)
     if ksdata.realm.discovered:
         join_realm = TaskQueue("Realm join", N_("Joining realm: %s") % ksdata.realm.discovered)
-        join_realm.append(Task("Join a realm", ksdata.realm.execute, (storage, ksdata)))
+        join_realm.append(Task("Join a realm", ksdata.realm.execute))
         configuration_queue.append(join_realm)
 
     post_scripts = TaskQueue("Post installation scripts", N_("Running post-installation scripts"))
@@ -360,7 +360,7 @@ def doInstall(storage, payload, ksdata):
     # Create snapshot
     if ksdata.snapshot and ksdata.snapshot.has_snapshot(SNAPSHOT_WHEN_POST_INSTALL):
         snapshot_creation = TaskQueue("Creating post installation snapshots", N_("Creating snapshots"))
-        snapshot_creation.append(Task("Create post-install snapshots", ksdata.snapshot.execute, (storage, ksdata)))
+        snapshot_creation.append(Task("Create post-install snapshots", ksdata.snapshot.execute, (storage, )))
         installation_queue.append(snapshot_creation)
 
     # notify progress tracking about the number of steps

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -883,24 +883,6 @@ class Payload(object):
             else:
                 services_proxy.SetDefaultTarget(TEXT_ONLY_TARGET)
 
-    def dracutSetupArgs(self):
-        args = []
-        try:
-            import rpm
-        except ImportError:
-            pass
-        else:
-            util.resetRpmDb()
-            ts = rpm.TransactionSet(util.getSysroot())
-
-            # Only add "rhgb quiet" on non-s390, non-serial installs
-            if util.isConsoleOnVirtualTerminal() and \
-               (ts.dbMatch('provides', 'rhgb').count() or \
-                ts.dbMatch('provides', 'plymouth').count()):
-                args.extend(["rhgb", "quiet"])
-
-        return args
-
     def postInstall(self):
         """Perform post-installation tasks."""
 

--- a/pyanaconda/storage/execution.py
+++ b/pyanaconda/storage/execution.py
@@ -80,7 +80,7 @@ def do_kickstart_storage(storage, data=None, partitioning=None):
 
     # Set up the snapshot here.
     if data is not None:
-        data.snapshot.setup(storage, data)
+        data.snapshot.setup(storage)
 
     # Set up the boot loader.
     storage.set_up_bootloader()


### PR DESCRIPTION
Let's remove useless arguments from the execute and setup methods
of the kickstart commands. The commands for the user configuration
will be updated later.