### PR TITLE
Clean up write_boot_loader

### DIFF
--- a/pyanaconda/bootloader/base.py
+++ b/pyanaconda/bootloader/base.py
@@ -18,9 +18,9 @@
 import collections
 import os
 from glob import glob
-from itertools import chain
 
 import blivet
+from blivet.devices import NetworkStorageDevice
 from blivet.formats.disklabel import DiskLabel
 from blivet.size import Size
 from ordered_set import OrderedSet
@@ -692,32 +692,22 @@ class BootLoader(object):
         elif self.can_update:
             self._update_only = value
 
-    def set_boot_args(self, *args, **kwargs):
-        """ Set up the boot command line.
+    def set_boot_args(self, storage):
+        """Set up the boot command line."""
+        self._set_storage_boot_args(storage)
+        self._preserve_some_boot_args()
+        self._set_graphical_boot_args()
 
-            Keyword Arguments:
-
-                storage - a blivet.Storage instance
-
-            All other arguments are expected to have a dracutSetupArgs()
-            method.
-        """
-        storage = kwargs.pop("storage", None)
+    def _set_storage_boot_args(self, storage):
+        """Set the storage boot args."""
         fcoe_proxy = STORAGE.get_proxy(FCOE)
 
-        #
         # FIPS
-        #
         boot_device = storage.mountpoints.get("/boot")
         if flags.cmdline.get("fips") == "1" and boot_device:
             self.boot_args.add("boot=%s" % self.stage2_device.fstab_spec)
 
-        #
-        # dracut
-        #
-
-        # storage
-        from blivet.devices import NetworkStorageDevice
+        # Storage
         dracut_devices = [storage.root_device]
         if self.stage2_device != storage.root_device:
             dracut_devices.append(self.stage2_device)
@@ -739,6 +729,7 @@ class BootLoader(object):
         netdevs = [d for d in storage.devices \
                    if (getattr(d, "complete", True) and
                        isinstance(d, NetworkStorageDevice))]
+
         rootdev = storage.root_device
         if any(rootdev.depends_on(netdev) for netdev in netdevs):
             dracut_devices = set(dracut_devices)
@@ -777,21 +768,6 @@ class BootLoader(object):
                     self.boot_args.update(setup_args)
                     self.dracut_args.update(setup_args)
 
-        # passed-in objects
-        for cfg_obj in chain(args, kwargs.values()):
-            if hasattr(cfg_obj, "dracutSetupArgs"):
-                setup_args = cfg_obj.dracutSetupArgs()
-                self.boot_args.update(setup_args)
-                self.dracut_args.update(setup_args)
-            elif hasattr(cfg_obj, "dracut_setup_args"):
-                setup_args = cfg_obj.dracut_setup_args()
-                self.boot_args.update(setup_args)
-                self.dracut_args.update(setup_args)
-            else:
-                setup_string = cfg_obj.dracutSetupString()
-                self.boot_args.add(setup_string)
-                self.dracut_args.add(setup_string)
-
         # This is needed for FCoE, bug #743784. The case:
         # We discover LUN on an iface which is part of multipath setup.
         # If the iface is disconnected after discovery anaconda doesn't
@@ -811,10 +787,8 @@ class BootLoader(object):
         if len(glob("/sys/firmware/iscsi_boot*")) > 0:
             self.boot_args.add("rd.iscsi.firmware")
 
-        #
-        # preservation of some of our boot args
-        # FIXME: this is stupid.
-        #
+    def _preserve_some_boot_args(self):
+        """Preserve some of the boot args."""
         for opt in self.global_preserve_args + self.preserve_args:
             if opt not in flags.cmdline:
                 continue
@@ -826,20 +800,27 @@ class BootLoader(object):
 
             self.boot_args.add(new_arg)
 
-        # passed-in objects
-        for cfg_obj in chain(args, kwargs.values()):
-            if hasattr(cfg_obj, "dracutSetupArgs"):
-                setup_args = cfg_obj.dracutSetupArgs()
-                self.boot_args.update(setup_args)
-                self.dracut_args.update(setup_args)
-            elif hasattr(cfg_obj, "dracut_setup_args"):
-                setup_args = cfg_obj.dracut_setup_args()
-                self.boot_args.update(setup_args)
-                self.dracut_args.update(setup_args)
-            else:
-                setup_string = cfg_obj.dracutSetupString()
-                self.boot_args.add(setup_string)
-                self.dracut_args.add(setup_string)
+    def _set_graphical_boot_args(self):
+        """Set up the graphical boot."""
+        args = []
+
+        try:
+            import rpm
+        except ImportError:
+            log.info("Failed to import rpm. Cannot set up the graphical boot.")
+        else:
+            util.resetRpmDb()
+            ts = rpm.TransactionSet(util.getSysroot())
+
+            # Only add "rhgb quiet" on non-s390, non-serial installs.
+            if util.isConsoleOnVirtualTerminal() \
+                    and (ts.dbMatch('provides', 'rhgb').count()
+                         or ts.dbMatch('provides', 'plymouth').count()):
+
+                args = ["rhgb", "quiet"]
+
+        self.boot_args.update(args)
+        self.dracut_args.update(args)
 
     #
     # configuration

--- a/pyanaconda/bootloader/installation.py
+++ b/pyanaconda/bootloader/installation.py
@@ -31,7 +31,7 @@ log = get_module_logger(__name__)
 __all__ = ["write_boot_loader"]
 
 
-def write_boot_loader(storage, payload, ksdata):
+def write_boot_loader(storage, payload):
     """ Write bootloader configuration to disk.
 
         When we get here, the bootloader will already have a default linux
@@ -55,7 +55,7 @@ def write_boot_loader(storage, payload, ksdata):
         if storage.bootloader.skip_bootloader:
             log.info("skipping boot loader install per user request")
             return
-        write_boot_loader_final(storage, payload, ksdata)
+        write_boot_loader_final(storage, payload)
         return
 
     # get a list of installed kernel packages
@@ -101,7 +101,7 @@ def write_boot_loader(storage, payload, ksdata):
                                      label=label, short=short)
         storage.bootloader.add_image(image)
 
-    write_boot_loader_final(storage, payload, ksdata)
+    write_boot_loader_final(storage, payload)
 
 
 def write_sysconfig_kernel(storage, version):
@@ -145,7 +145,7 @@ def write_sysconfig_kernel(storage, version):
     f.close()
 
 
-def write_boot_loader_final(storage, payload, ksdata):
+def write_boot_loader_final(storage, payload):
     """ Do the final write of the bootloader. """
 
     # set up dracut/fips boot args

--- a/pyanaconda/bootloader/installation.py
+++ b/pyanaconda/bootloader/installation.py
@@ -38,29 +38,34 @@ def write_boot_loader(storage, payload):
         image. We only have to add images for the non-default kernels and
         adjust the default to reflect whatever the default variant is.
     """
-    if not storage.bootloader.skip_bootloader:
-        stage1_device = storage.bootloader.stage1_device
-        log.info("boot loader stage1 target device is %s", stage1_device.name)
-        stage2_device = storage.bootloader.stage2_device
-        log.info("boot loader stage2 target device is %s", stage2_device.name)
-
+    # Set up the boot loader.
     storage.bootloader.menu_auto_hide = conf.bootloader.menu_auto_hide
 
     # Bridge storage EFI configuration to bootloader
     if hasattr(storage.bootloader, 'efi_dir'):
         storage.bootloader.efi_dir = conf.bootloader.efi_dir
 
-    # Currently just rpmostreepayload shortcuts the rest of everything below
-    if payload.handlesBootloaderConfiguration:
-        if storage.bootloader.skip_bootloader:
-            log.info("skipping boot loader install per user request")
-            return
-        write_boot_loader_final(storage, payload)
+    # Configure the boot loader.
+    if not payload.handlesBootloaderConfiguration:
+        _configure_boot_loader(storage, payload.kernelVersionList)
+
+    # Should we skip the installation?
+    if storage.bootloader.skip_bootloader:
+        log.info("skipping boot loader install per user request")
         return
+
+    # Install the bootloader.
+    _set_boot_arguments(storage)
+    _install_boot_loader(storage)
+
+
+def _configure_boot_loader(storage, kernel_versions):
+    """Configure the bootloader."""
+    log.debug("Configuring the boot loader.")
 
     # get a list of installed kernel packages
     # add whatever rescue kernels we can find to the end
-    kernel_versions = list(payload.kernelVersionList)
+    kernel_versions = list(kernel_versions)
 
     rescue_versions = glob(util.getSysroot() + "/boot/vmlinuz-*-rescue-*")
     rescue_versions += glob(
@@ -86,11 +91,7 @@ def write_boot_loader(storage, payload):
     storage.bootloader.default = default_image
 
     # write out /etc/sysconfig/kernel
-    write_sysconfig_kernel(storage, version)
-
-    if storage.bootloader.skip_bootloader:
-        log.info("skipping boot loader install per user request")
-        return
+    _write_sysconfig_kernel(storage, version)
 
     # now add an image for each of the other kernels
     for version in kernel_versions:
@@ -101,10 +102,11 @@ def write_boot_loader(storage, payload):
                                      label=label, short=short)
         storage.bootloader.add_image(image)
 
-    write_boot_loader_final(storage, payload)
 
+def _write_sysconfig_kernel(storage, version):
+    """Write to /etc/sysconfig/kernel."""
+    log.debug("Writing to /etc/sysconfig/kernel.")
 
-def write_sysconfig_kernel(storage, version):
     # get the name of the default kernel package based on the version
     kernel_basename = "vmlinuz-" + version
     kernel_file = "/boot/%s" % kernel_basename
@@ -145,13 +147,22 @@ def write_sysconfig_kernel(storage, version):
     f.close()
 
 
-def write_boot_loader_final(storage, payload):
-    """ Do the final write of the bootloader. """
+def _set_boot_arguments(storage):
+    """Set up the final boot arguments."""
+    # FIXME: do this from elsewhere?
+    storage.bootloader.set_boot_args(storage)
 
-    # set up dracut/fips boot args
-    # XXX FIXME: do this from elsewhere?
-    storage.bootloader.set_boot_args(storage=storage,
-                                     payload=payload)
+
+def _install_boot_loader(storage):
+    """Do the final write of the boot loader."""
+    log.debug("Installing the boot loader.")
+
+    stage1_device = storage.bootloader.stage1_device
+    log.info("boot loader stage1 target device is %s", stage1_device.name)
+
+    stage2_device = storage.bootloader.stage2_device
+    log.info("boot loader stage2 target device is %s", stage2_device.name)
+
     try:
         storage.bootloader.write()
     except BootLoaderError as e:

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -138,7 +138,7 @@ def doConfiguration(storage, payload, ksdata):
     bootloader_enabled = bootloader_proxy.BootloaderMode != BOOTLOADER_DISABLED
 
     if isinstance(payload, LiveImagePayload) and boot_on_btrfs and bootloader_enabled:
-        generate_initramfs.append(Task("Write BTRFS bootloader fix", write_boot_loader, (storage, payload, ksdata)))
+        generate_initramfs.append(Task("Write BTRFS bootloader fix", write_boot_loader, (storage, payload)))
 
     # Invoking zipl should be the last thing done on a s390x installation (see #1652727).
     if arch.is_s390() and not conf.target.is_directory and bootloader_enabled:
@@ -350,7 +350,7 @@ def doInstall(storage, payload, ksdata):
     # Do bootloader.
     if can_install_bootloader:
         bootloader_install = TaskQueue("Bootloader installation", N_("Installing boot loader"))
-        bootloader_install.append(Task("Install bootloader", write_boot_loader, (storage, payload, ksdata)))
+        bootloader_install.append(Task("Install bootloader", write_boot_loader, (storage, payload)))
         installation_queue.append(bootloader_install)
 
     post_install = TaskQueue("Post-installation setup tasks", (N_("Performing post-installation setup tasks")))

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -883,24 +883,6 @@ class Payload(object):
             else:
                 services_proxy.SetDefaultTarget(TEXT_ONLY_TARGET)
 
-    def dracutSetupArgs(self):
-        args = []
-        try:
-            import rpm
-        except ImportError:
-            pass
-        else:
-            util.resetRpmDb()
-            ts = rpm.TransactionSet(util.getSysroot())
-
-            # Only add "rhgb quiet" on non-s390, non-serial installs
-            if util.isConsoleOnVirtualTerminal() and \
-               (ts.dbMatch('provides', 'rhgb').count() or \
-                ts.dbMatch('provides', 'plymouth').count()):
-                args.extend(["rhgb", "quiet"])
-
-        return args
-
     def postInstall(self):
         """Perform post-installation tasks."""
 


### PR DESCRIPTION
The method `set_boot_args` in the `Bootloader` class now depends only on
the storage object. The method was split to several smaller methods.

The function `write_boot_loader` was split to several smaller functions
and reorganized, so we can later drop the dependency on the payload
object.