### PR TITLE
Schedule the kickstart custom partitioning in the Storage module

### DIFF
--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -51,6 +51,11 @@ MANUAL_PARTITIONING = DBusObjectIdentifier(
     basename="Manual"
 )
 
+CUSTOM_PARTITIONING = DBusObjectIdentifier(
+    namespace=PARTITIONING_NAMESPACE,
+    basename="Custom"
+)
+
 FCOE = DBusObjectIdentifier(
     namespace=STORAGE_NAMESPACE,
     basename="FCoE"

--- a/pyanaconda/modules/common/errors/storage.py
+++ b/pyanaconda/modules/common/errors/storage.py
@@ -27,6 +27,12 @@ class UnavailableStorageError(AnacondaError):
     pass
 
 
+@dbus_error("UnavailableDataError", namespace=STORAGE_NAMESPACE)
+class UnavailableDataError(AnacondaError):
+    """The data are not available."""
+    pass
+
+
 @dbus_error("InvalidStorageError", namespace=STORAGE_NAMESPACE)
 class InvalidStorageError(AnacondaError):
     """The storage model is not valid."""

--- a/pyanaconda/modules/storage/kickstart.py
+++ b/pyanaconda/modules/storage/kickstart.py
@@ -167,6 +167,7 @@ class StorageKickstartSpecification(KickstartSpecification):
     commands = {
         "autopart": AutoPart,
         "bootloader": COMMANDS.Bootloader,
+        "btrfs": COMMANDS.BTRFS,
         "clearpart": ClearPart,
         "fcoe": Fcoe,
         "ignoredisk": IgnoreDisk,
@@ -182,6 +183,7 @@ class StorageKickstartSpecification(KickstartSpecification):
     }
 
     commands_data = {
+        "BTRFSData": COMMANDS.BTRFSData,
         "FcoeData": COMMANDS.FcoeData,
         "LogVolData": COMMANDS.LogVolData,
         "MountData": COMMANDS.MountData,

--- a/pyanaconda/modules/storage/partitioning/__init__.py
+++ b/pyanaconda/modules/storage/partitioning/__init__.py
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 from pyanaconda.modules.storage.partitioning.automatic import AutoPartitioningModule
+from pyanaconda.modules.storage.partitioning.custom import CustomPartitioningModule
 from pyanaconda.modules.storage.partitioning.manual import ManualPartitioningModule
 
-__all__ = ["AutoPartitioningModule", "ManualPartitioningModule"]
+
+__all__ = ["AutoPartitioningModule", "ManualPartitioningModule", "CustomPartitioningModule"]

--- a/pyanaconda/modules/storage/partitioning/custom.py
+++ b/pyanaconda/modules/storage/partitioning/custom.py
@@ -1,0 +1,79 @@
+#
+# Custom partitioning module.
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.dbus import DBus
+from pyanaconda.modules.common.constants.objects import CUSTOM_PARTITIONING
+from pyanaconda.modules.common.errors.storage import UnavailableDataError
+from pyanaconda.modules.storage.partitioning.base import PartitioningModule
+from pyanaconda.modules.storage.partitioning.base_interface import PartitioningInterface
+from pyanaconda.modules.storage.partitioning.configure import StorageConfigureTask
+from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
+from pyanaconda.storage.execution import CustomPartitioningExecutor
+
+log = get_module_logger(__name__)
+
+
+class CustomPartitioningModule(PartitioningModule):
+    """The custom partitioning module."""
+
+    def __init__(self):
+        """Initialize the module."""
+        super().__init__()
+        self._data = None
+
+    @property
+    def data(self):
+        """The partitioning data.
+
+        :return: an instance of kickstart data
+        """
+        if self._data is None:
+            raise UnavailableDataError()
+
+        return self._data
+
+    def publish(self):
+        """Publish the module."""
+        DBus.publish_object(CUSTOM_PARTITIONING.object_path, PartitioningInterface(self))
+
+    def process_kickstart(self, data):
+        """Process the kickstart data."""
+        # FIXME: Don't keep everything.
+        self._data = data
+
+        # FIXME: Remove this ugly hack.
+        self._data.onPart = {}
+
+    def setup_kickstart(self, data):
+        """Setup the kickstart data."""
+        # TODO: Provide the kickstart data.
+        pass
+
+    def configure_with_task(self):
+        """Schedule the partitioning actions."""
+        task = StorageConfigureTask(self.storage, CustomPartitioningExecutor(self.data))
+        path = self.publish_task(CUSTOM_PARTITIONING.namespace, task)
+        return path
+
+    def validate_with_task(self):
+        """Validate the scheduled partitions."""
+        task = StorageValidateTask(self.storage)
+        path = self.publish_task(CUSTOM_PARTITIONING.namespace, task)
+        return path

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -30,7 +30,7 @@ from pyanaconda.modules.storage.disk_selection import DiskSelectionModule
 from pyanaconda.modules.storage.fcoe import FCOEModule
 from pyanaconda.modules.storage.kickstart import StorageKickstartSpecification
 from pyanaconda.modules.storage.partitioning import AutoPartitioningModule, \
-    ManualPartitioningModule
+    ManualPartitioningModule, CustomPartitioningModule
 from pyanaconda.modules.storage.reset import StorageResetTask
 from pyanaconda.modules.storage.storage_interface import StorageInterface
 from pyanaconda.modules.storage.zfcp import ZFCPModule
@@ -70,6 +70,9 @@ class StorageModule(KickstartModule):
         self._manual_part_module = ManualPartitioningModule()
         self._add_module(self._manual_part_module)
 
+        self._custom_part_module = CustomPartitioningModule()
+        self._add_module(self._custom_part_module)
+
         self._fcoe_module = FCOEModule()
         self._add_module(self._fcoe_module)
 
@@ -86,6 +89,7 @@ class StorageModule(KickstartModule):
         # Connect signals.
         self.storage_changed.connect(self._auto_part_module.on_storage_reset)
         self.storage_changed.connect(self._manual_part_module.on_storage_reset)
+        self.storage_changed.connect(self._custom_part_module.on_storage_reset)
 
     def _add_module(self, storage_module):
         """Add a base kickstart module."""

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -100,6 +100,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
             [
                 'autopart',
                 'bootloader',
+                'btrfs',
                 'clearpart',
                 'fcoe',
                 'ignoredisk',


### PR DESCRIPTION
Let's remove the data argument form the execute methods and set it
only in the `__init__` method of the custom partitioning executor.
Also introduce a base class for the partitioning executors.

Create a storage module for custom partitioning defined by kickstart.