### PR TITLE
Change a confusing message for headless systems

### DIFF
--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -277,7 +277,7 @@ def setup_display(anaconda, options, addon_paths=None):
 
     # X on a headless (e.g. s390) system? Nonsense!
     if want_x and anaconda.isHeadless:
-        stdout_log.warning(_("DISPLAY variable not set. Starting text mode."))
+        stdout_log.warning(_("Running on a headless system. Starting text mode."))
         anaconda.display_mode = constants.DisplayModes.TUI
         anaconda.gui_startup_failed = True
         time.sleep(2)


### PR DESCRIPTION
Let's change the confusing message 'DISPLAY variable not set'.

Related: rhbz#1638791