### PR TITLE
Use unformatted DASDs for the partitioning (#1676630)

### DIFF
--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -2314,16 +2314,26 @@ def storage_initialize(storage, ksdata, protected):
        not any(d.protected for d in storage.devices):
         raise UnknownSourceDeviceError(protected)
 
-    # kickstart uses all the disks
-    if flags.automatedInstall:
-        disk_select_proxy = STORAGE.get_proxy(DISK_SELECTION)
-        selected_disks = disk_select_proxy.SelectedDisks
-        ignored_disks = disk_select_proxy.IgnoredDisks
 
-        if not selected_disks:
-            selected_disks = [d.name for d in storage.disks if d.name not in ignored_disks]
-            disk_select_proxy.SetSelectedDisks(selected_disks)
-            log.debug("onlyuse is now: %s", ",".join(selected_disks))
+def select_all_disks_by_default(storage):
+    """Select all disks for the partitioning by default.
+
+    It will select all disks for the partitioning if there are
+    no disks selected. Kickstart uses all the disks by default.
+
+    :param storage: the Blivet's storage object
+    :return: a list of selected disks
+    """
+    disk_select_proxy = STORAGE.get_proxy(DISK_SELECTION)
+    selected_disks = disk_select_proxy.SelectedDisks
+    ignored_disks = disk_select_proxy.IgnoredDisks
+
+    if not selected_disks:
+        selected_disks = [d.name for d in storage.disks if d.name not in ignored_disks]
+        disk_select_proxy.SetSelectedDisks(selected_disks)
+        log.debug("onlyuse is now: %s", ",".join(selected_disks))
+
+    return selected_disks
 
 
 def mount_existing_system(fsset, root_device, read_only=None):

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -74,6 +74,7 @@ from pyanaconda.core.constants import CLEAR_PARTITIONS_NONE, BOOTLOADER_DRIVE_UN
     BOOTLOADER_ENABLED, STORAGE_METADATA_RATIO, AUTOPART_TYPE_DEFAULT
 from pyanaconda.bootloader import BootLoaderError
 from pyanaconda.storage import autopart
+from pyanaconda.storage.osinstall import select_all_disks_by_default
 from pyanaconda.storage_utils import on_disk_storage, nvdimm_update_ksdata_for_used_devices
 from pyanaconda.format_dasd import DasdFormatting
 from pyanaconda.screen_access import sam
@@ -808,6 +809,10 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
 
         # Automatically format DASDs if allowed.
         DasdFormatting.run_automatically(self.storage, self.data, self._show_dasdfmt_report)
+
+        # Update the selected disks.
+        if flags.automatedInstall:
+            self.selected_disks = select_all_disks_by_default(self.storage)
 
         # Continue with initializing.
         hubQ.send_message(self.__class__.__name__, _(constants.PAYLOAD_STATUS_PROBING_STORAGE))

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -47,7 +47,7 @@ from pyanaconda.core.constants import THREAD_STORAGE, THREAD_STORAGE_WATCHER, \
     MOUNT_POINT_REFORMAT, MOUNT_POINT_PATH, MOUNT_POINT_DEVICE, MOUNT_POINT_FORMAT
 from pyanaconda.core.i18n import _, P_, N_, C_
 from pyanaconda.bootloader import BootLoaderError
-from pyanaconda.storage.osinstall import storage_initialize
+from pyanaconda.storage.osinstall import storage_initialize, select_all_disks_by_default
 
 from pykickstart.base import BaseData
 from pykickstart.constants import AUTOPART_TYPE_LVM
@@ -506,6 +506,10 @@ class StorageSpoke(NormalTUISpoke):
 
         # Automatically format DASDs if allowed.
         DasdFormatting.run_automatically(self.storage, self.data)
+
+        # Update the selected disks.
+        if flags.automatedInstall:
+            self.selected_disks = select_all_disks_by_default(self.storage)
 
         # Update disk list.
         self.update_disks()


### PR DESCRIPTION
When an unformatted DASD disk is available during kickstart
installation and it is formatted, it should be selected for
the partitioning by default.

Resolves: rhbz#1676630