### PR TITLE
Use unformatted DASDs for the partitioning

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -76,7 +76,8 @@ from pyanaconda.core.constants import CLEAR_PARTITIONS_NONE, BOOTLOADER_DRIVE_UN
     BOOTLOADER_ENABLED, STORAGE_METADATA_RATIO, AUTOPART_TYPE_DEFAULT
 from pyanaconda.bootloader import BootLoaderError
 from pyanaconda.storage import autopart
-from pyanaconda.storage.initialization import update_storage_config, reset_storage
+from pyanaconda.storage.initialization import update_storage_config, reset_storage, \
+    select_all_disks_by_default
 from pyanaconda.storage.snapshot import on_disk_storage
 from pyanaconda.storage.format_dasd import DasdFormatting
 from pyanaconda.screen_access import sam
@@ -808,6 +809,10 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
 
         # Automatically format DASDs if allowed.
         DasdFormatting.run_automatically(self.storage, self.data, self._show_dasdfmt_report)
+
+        # Update the selected disks.
+        if flags.automatedInstall:
+            self.selected_disks = select_all_disks_by_default(self.storage)
 
         # Continue with initializing.
         hubQ.send_message(self.__class__.__name__, _(constants.PAYLOAD_STATUS_PROBING_STORAGE))

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -51,7 +51,7 @@ from pyanaconda.core.constants import THREAD_STORAGE, THREAD_STORAGE_WATCHER, \
 from pyanaconda.core.i18n import _, P_, N_, C_
 from pyanaconda.bootloader import BootLoaderError
 from pyanaconda.storage.initialization import initialize_storage, update_storage_config, \
-    reset_storage
+    reset_storage, select_all_disks_by_default
 
 from pykickstart.base import BaseData
 from pykickstart.constants import AUTOPART_TYPE_LVM
@@ -509,6 +509,10 @@ class StorageSpoke(NormalTUISpoke):
 
         # Automatically format DASDs if allowed.
         DasdFormatting.run_automatically(self.storage, self.data)
+
+        # Update the selected disks.
+        if flags.automatedInstall:
+            self.selected_disks = select_all_disks_by_default(self.storage)
 
         # Update disk list.
         self.update_disks()


### PR DESCRIPTION
When an unformatted DASD disk is available during kickstart
installation and it is formatted, it should be selected for
the partitioning by default.

Related: rhbz#1676630