### PR TITLE
Payload cleanup

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -700,7 +700,7 @@ if __name__ == "__main__":
     disk_select_proxy = STORAGE.get_proxy(DISK_SELECTION)
     disk_select_proxy.SetProtectedDevices(protected_devices)
 
-    from pyanaconda.payload import payloadMgr
+    from pyanaconda.payload.manager import payloadMgr
     from pyanaconda.timezone import time_initialize
 
     if not conf.target.is_directory:

--- a/anaconda.py
+++ b/anaconda.py
@@ -741,7 +741,7 @@ if __name__ == "__main__":
 
     # Fallback to default for interactive or for a kickstart with no installation method.
     fallback = not (flags.automatedInstall and ksdata.method.method)
-    payloadMgr.restartThread(anaconda.storage, ksdata, anaconda.payload, fallback=fallback)
+    payloadMgr.restart_thread(anaconda.storage, ksdata, anaconda.payload, fallback=fallback)
 
     # initialize the geolocation singleton
     geoloc.init_geolocation(geoloc_option=opts.geoloc, options_override=opts.geoloc_use_with_ks)

--- a/pyanaconda/bootloader/installation.py
+++ b/pyanaconda/bootloader/installation.py
@@ -41,11 +41,11 @@ def write_boot_loader(storage, payload):
     adjust the default to reflect whatever the default variant is.
     """
     # Configure the boot loader.
-    if not payload.handlesBootloaderConfiguration:
+    if not payload.handles_bootloader_configuration:
         configure_boot_loader(
             sysroot=util.getSysroot(),
             storage=storage,
-            kernel_versions=payload.kernelVersionList
+            kernel_versions=payload.kernel_version_list
         )
 
     # Install the boot loader.

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -127,7 +127,7 @@ def doConfiguration(storage, payload, ksdata):
 
     # Initramfs generation
     generate_initramfs = TaskQueue("Initramfs generation", N_("Generating initramfs"))
-    generate_initramfs.append(Task("Generate initramfs", payload.recreateInitrds))
+    generate_initramfs.append(Task("Generate initramfs", payload.recreate_initrds))
 
     # This works around 2 problems, /boot on BTRFS and BTRFS installations where the initrd is
     # recreated after the first writeBootLoader call. This reruns it after the new initrd has
@@ -321,7 +321,7 @@ def doInstall(storage, payload, ksdata):
         pre_install.append(WriteResolvConfTask("Copy /resolv.conf to sysroot"))
 
     def run_pre_install():
-        """This means to gather what additional packages (if any) are needed & executing payload.preInstall()."""
+        """This means to gather what additional packages (if any) are needed & executing payload.pre_install()."""
         # anaconda requires storage packages in order to make sure the target
         # system is bootable and configurable, and some other packages in order
         # to finish setting up the system.
@@ -334,11 +334,11 @@ def doInstall(storage, payload, ksdata):
 
         if can_install_bootloader:
             payload.requirements.add_packages(storage.bootloader.packages, reason="bootloader")
-        payload.requirements.add_groups(payload.languageGroups(), reason="language groups")
+        payload.requirements.add_groups(payload.language_groups(), reason="language groups")
         payload.requirements.add_packages(payload.langpacks(), reason="langpacks", strong=False)
-        payload.preInstall()
+        payload.pre_install()
 
-    pre_install.append(Task("Find additional packages & run preInstall()", run_pre_install))
+    pre_install.append(Task("Find additional packages & run pre_install()", run_pre_install))
     installation_queue.append(pre_install)
 
     payload_install = TaskQueue("Payload installation", N_("Installing."))
@@ -349,7 +349,7 @@ def doInstall(storage, payload, ksdata):
     if not payload.needs_storage_configuration:
         late_storage = TaskQueue("Late storage configuration", N_("Configuring storage"))
         late_storage.append(Task("Prepare mount targets",
-                                 task=payload.prepareMountTargets,
+                                 task=payload.prepare_mount_targets,
                                  task_args=(storage, )))
 
         if not conf.target.is_directory:
@@ -366,7 +366,7 @@ def doInstall(storage, payload, ksdata):
         installation_queue.append(bootloader_install)
 
     post_install = TaskQueue("Post-installation setup tasks", (N_("Performing post-installation setup tasks")))
-    post_install.append(Task("Run post-installation setup tasks", payload.postInstall))
+    post_install.append(Task("Run post-installation setup tasks", payload.post_install))
     installation_queue.append(post_install)
 
     # Create snapshot

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -20,7 +20,6 @@ import os
 import shutil
 import re
 import functools
-from distutils.version import LooseVersion
 from glob import glob
 from fnmatch import fnmatch
 from abc import ABCMeta
@@ -40,6 +39,7 @@ from pyanaconda.image import opticalInstallMedia, verifyMedia, verify_valid_inst
 from pyanaconda.core.util import ProxyString, ProxyStringError
 from pyanaconda.core.regexes import VERSION_DIGITS
 from pyanaconda.payload.errors import PayloadError, PayloadSetupError, NoSuchGroup
+from pyanaconda.payload.utils import version_cmp
 from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
 from pyanaconda.payload.requirement import PayloadRequirements
 from pyanaconda.product import productName, productVersion
@@ -55,13 +55,6 @@ from pyanaconda.anaconda_loggers import get_module_logger
 
 log = get_module_logger(__name__)
 USER_AGENT = "%s (anaconda)/%s" % (productName, productVersion)
-
-
-def versionCmp(v1, v2):
-    """Compare two version number strings."""
-    firstVersion = LooseVersion(v1)
-    secondVersion = LooseVersion(v2)
-    return (firstVersion > secondVersion) - (firstVersion < secondVersion)
 
 
 class Payload(metaclass=ABCMeta):
@@ -768,7 +761,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
                          if fnmatch(f, "/boot/vmlinuz-*") or
                          fnmatch(f, "/boot/efi/EFI/%s/vmlinuz-*" % conf.bootloader.efi_dir)))
 
-        return sorted(files, key=functools.cmp_to_key(versionCmp))
+        return sorted(files, key=functools.cmp_to_key(version_cmp))
 
     @property
     def rpmMacros(self):

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -96,7 +96,7 @@ class Payload(metaclass=ABCMeta):
 
     def post_setup(self):
         """Run specific payload post-configuration tasks on the end of
-        the restartThread call.
+        the restart_thread call.
 
         This method could be overriden.
         """

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -686,18 +686,6 @@ class Payload(object):
             log.info("Some of the requirements were not applied.")
 
 
-# Inherit abstract methods from Payload
-# pylint: disable=abstract-method
-class ImagePayload(Payload):
-    """An ImagePayload installs an OS image to the target system."""
-
-    def __init__(self, data):
-        if self.__class__ is ImagePayload:
-            raise TypeError("ImagePayload is an abstract class")
-
-        super().__init__(data)
-
-
 class PackagePayload(Payload):
     """A PackagePayload installs a set of packages onto the target system."""
 

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -18,11 +18,12 @@
 #
 import os
 import shutil
-from glob import glob
-from fnmatch import fnmatch
 import re
 import functools
 from distutils.version import LooseVersion
+from glob import glob
+from fnmatch import fnmatch
+from abc import ABCMeta
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import DRACUT_ISODIR, DRACUT_REPODIR, DD_ALL, DD_FIRMWARE, \
@@ -63,16 +64,13 @@ def versionCmp(v1, v2):
     return (firstVersion > secondVersion) - (firstVersion < secondVersion)
 
 
-class Payload(object):
+class Payload(metaclass=ABCMeta):
     """Payload is an abstract class for OS install delivery methods."""
     def __init__(self, data):
         """Initialize Payload class
 
         :param data: This param is a kickstart.AnacondaKSHandler class.
         """
-        if self.__class__ is Payload:
-            raise TypeError("Payload is an abstract class")
-
         self.data = data
         self.storage = None
         self.txID = None
@@ -682,13 +680,10 @@ class Payload(object):
             log.info("Some of the requirements were not applied.")
 
 
-class PackagePayload(Payload):
+class PackagePayload(Payload, metaclass=ABCMeta):
     """A PackagePayload installs a set of packages onto the target system."""
 
     def __init__(self, data):
-        if self.__class__ is PackagePayload:
-            raise TypeError("PackagePayload is an abstract class")
-
         super().__init__(data)
         self.install_device = None
         self._rpm_macros = []

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -43,6 +43,7 @@ from pyanaconda.image import opticalInstallMedia, verifyMedia, verify_valid_inst
 from pyanaconda.core.util import ProxyString, ProxyStringError
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core.regexes import VERSION_DIGITS
+from pyanaconda.payload.errors import PayloadError, PayloadSetupError, NoSuchGroup
 from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
 from pyanaconda.product import productName, productVersion
 
@@ -64,43 +65,6 @@ def versionCmp(v1, v2):
     firstVersion = LooseVersion(v1)
     secondVersion = LooseVersion(v2)
     return (firstVersion > secondVersion) - (firstVersion < secondVersion)
-
-
-###
-# ERROR HANDLING
-###
-class PayloadError(Exception):
-    pass
-
-
-class MetadataError(PayloadError):
-    pass
-
-
-# setup
-class PayloadSetupError(PayloadError):
-    pass
-
-
-# software selection
-class NoSuchGroup(PayloadError):
-    def __init__(self, group, adding=True, required=False):
-        super().__init__(group)
-        self.group = group
-        self.adding = adding
-        self.required = required
-
-    def __str__(self):
-        return "The group '{}' does not exist".format(self.group)
-
-
-class DependencyError(PayloadError):
-    pass
-
-
-# installation
-class PayloadInstallError(PayloadError):
-    pass
 
 
 PayloadRequirementReason = namedtuple('PayloadRequirementReason', ['reason', 'strong'])

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -66,7 +66,7 @@ class Payload(metaclass=ABCMeta):
         """
         self.data = data
         self.storage = None
-        self.txID = None
+        self.tx_id = None
 
         self._install_tree_metadata = None
 
@@ -94,7 +94,7 @@ class Payload(metaclass=ABCMeta):
         self.storage = None
         self._install_tree_metadata = None
 
-    def postSetup(self):
+    def post_setup(self):
         """Run specific payload post-configuration tasks on the end of
         the restartThread call.
 
@@ -113,13 +113,13 @@ class Payload(metaclass=ABCMeta):
         """Reset the instance, not including ksdata."""
         pass
 
-    def prepareMountTargets(self, storage):
+    def prepare_mount_targets(self, storage):
         """Run when physical storage is mounted, but other mount points may
         not exist.  Used by the RPMOSTreePayload subclass.
         """
         pass
 
-    def requiredDeviceSize(self, format_class):
+    def required_device_size(self, format_class):
         """We need to provide information how big device is required to have successful
         installation. ``format_class`` should be filesystem format
         class for the **root** filesystem this class carry information about
@@ -130,19 +130,19 @@ class Payload(metaclass=ABCMeta):
         :returns: Size of the device with given filesystem format.
         :rtype: :class:`blivet.size.Size`
         """
-        device_size = format_class.get_required_size(self.spaceRequired)
+        device_size = format_class.get_required_size(self.space_required)
         return device_size.round_to_nearest(Size("1 MiB"), ROUND_HALF_UP)
 
     ###
     # METHODS FOR WORKING WITH REPOSITORIES
     ###
     @property
-    def addOns(self):
+    def addons(self):
         """A list of addon repo identifiers."""
         return [r.name for r in self.data.repo.dataList()]
 
     @property
-    def baseRepo(self):
+    def base_repo(self):
         """Get the identifier of the current base repo or None."""
         return None
 
@@ -154,34 +154,34 @@ class Payload(metaclass=ABCMeta):
         return conf.payload.enable_closest_mirror
 
     @property
-    def disabledRepos(self):
+    def disabled_repos(self):
         """A list of disabled repos."""
         disabled = []
-        for repo in self.addOns:
-            if not self.isRepoEnabled(repo):
+        for repo in self.addons:
+            if not self.is_repo_enabled(repo):
                 disabled.append(repo)
 
         return disabled
 
     @property
-    def enabledRepos(self):
+    def enabled_repos(self):
         """A list of enabled repos."""
         enabled = []
-        for repo in self.addOns:
-            if self.isRepoEnabled(repo):
+        for repo in self.addons:
+            if self.is_repo_enabled(repo):
                 enabled.append(repo)
 
         return enabled
 
-    def isRepoEnabled(self, repo_id):
+    def is_repo_enabled(self, repo_id):
         """Return True if repo is enabled."""
-        repo = self.getAddOnRepo(repo_id)
+        repo = self.get_addon_repo(repo_id)
         if repo:
             return repo.enabled
         else:
             return False
 
-    def getAddOnRepo(self, repo_id):
+    def get_addon_repo(self, repo_id):
         """Return a ksdata Repo instance matching the specified repo id."""
         repo = None
         for r in self.data.repo.dataList():
@@ -191,16 +191,16 @@ class Payload(metaclass=ABCMeta):
 
         return repo
 
-    def _repoNeedsNetwork(self, repo):
+    def _repo_needs_network(self, repo):
         """Returns True if the ksdata repo requires networking."""
         urls = [repo.baseurl]
         if repo.mirrorlist:
             urls.extend(repo.mirrorlist)
         elif repo.metalink:
             urls.extend(repo.metalink)
-        return self._sourceNeedsNetwork(urls)
+        return self._source_needs_network(urls)
 
-    def _sourceNeedsNetwork(self, sources):
+    def _source_needs_network(self, sources):
         """Return True if the source requires network.
 
         :param sources: Source paths for testing
@@ -217,7 +217,7 @@ class Payload(metaclass=ABCMeta):
         return False
 
     @property
-    def needsNetwork(self):
+    def needs_network(self):
         """Test base and additional repositories if they require network."""
         url = ""
         if self.data.method.method is None:
@@ -234,17 +234,17 @@ class Payload(metaclass=ABCMeta):
             elif self.data.url.metalink:
                 url = self.data.url.metalink
 
-        return (self._sourceNeedsNetwork([url]) or
-                any(self._repoNeedsNetwork(repo) for repo in self.data.repo.dataList()))
+        return (self._source_needs_network([url]) or
+                any(self._repo_needs_network(repo) for repo in self.data.repo.dataList()))
 
-    def updateBaseRepo(self, fallback=True, checkmount=True):
+    def update_base_repo(self, fallback=True, checkmount=True):
         """Update the base repository from ksdata.method."""
         pass
 
-    def gatherRepoMetadata(self):
+    def gather_repo_metadata(self):
         pass
 
-    def addRepo(self, ksrepo):
+    def add_repo(self, ksrepo):
         """Add the repo given by the pykickstart Repo object ksrepo to the
         system.  The repo will be automatically enabled and its metadata
         fetched.
@@ -256,7 +256,7 @@ class Payload(metaclass=ABCMeta):
         ksrepo.enabled = True
         self.data.repo.dataList().append(ksrepo)
 
-    def removeRepo(self, repo_id):
+    def remove_repo(self, repo_id):
         repos = self.data.repo.dataList()
         try:
             idx = [repo.name for repo in repos].index(repo_id)
@@ -265,17 +265,17 @@ class Payload(metaclass=ABCMeta):
         else:
             repos.pop(idx)
 
-    def enableRepo(self, repo_id):
-        repo = self.getAddOnRepo(repo_id)
+    def enable_repo(self, repo_id):
+        repo = self.get_addon_repo(repo_id)
         if repo:
             repo.enabled = True
 
-    def disableRepo(self, repo_id):
-        repo = self.getAddOnRepo(repo_id)
+    def disable_repo(self, repo_id):
+        repo = self.get_addon_repo(repo_id)
         if repo:
             repo.enabled = False
 
-    def verifyAvailableRepositories(self):
+    def verify_available_repositories(self):
         """Verify availability of existing repositories.
 
         This method tests if URL links from active repositories can be reached.
@@ -306,34 +306,34 @@ class Payload(metaclass=ABCMeta):
         """
         return True
 
-    def languageGroups(self):
+    def language_groups(self):
         return []
 
     def langpacks(self):
         return []
 
-    def selectedGroups(self):
+    def selected_groups(self):
         """Return list of selected group names from kickstart.
 
         NOTE:
         This group names can be mix of group IDs and other valid identifiers.
-        If you want group IDs use `selectedGroupsIDs` instead.
+        If you want group IDs use `selected_groups_IDs` instead.
 
         :return: list of group names in a format specified by a kickstart file.
         """
         return [grp.name for grp in self.data.packages.groupList]
 
-    def selectedGroupsIDs(self):
+    def selected_groups_IDs(self):
         """Return list of IDs for selected groups.
 
         Implementation depends on a specific payload class.
         """
-        return self.selectedGroups()
+        return self.selected_groups()
 
-    def groupSelected(self, groupid):
+    def group_selected(self, groupid):
         return Group(groupid) in self.data.packages.groupList
 
-    def selectGroup(self, groupid, default=True, optional=False):
+    def select_group(self, groupid, default=True, optional=False):
         if optional:
             include = GROUP_ALL
         elif default:
@@ -356,7 +356,7 @@ class Payload(metaclass=ABCMeta):
 
         self.data.packages.groupList.append(grp)
 
-    def deselectGroup(self, groupid):
+    def deselect_group(self, groupid):
         grp = Group(groupid)
 
         if grp in self.data.packages.excludedGroupList:
@@ -371,19 +371,19 @@ class Payload(metaclass=ABCMeta):
     # METHODS FOR QUERYING STATE
     ###
     @property
-    def spaceRequired(self):
+    def space_required(self):
         """The total disk space (Size) required for the current selection."""
         raise NotImplementedError()
 
     @property
-    def kernelVersionList(self):
+    def kernel_version_list(self):
         """An iterable of the kernel versions installed by the payload."""
         raise NotImplementedError()
 
     ###
     # METHODS FOR TREE VERIFICATION
     ###
-    def _refreshInstallTree(self, url):
+    def _refresh_install_tree(self, url):
         """Refresh installation tree metadata.
 
         :param url: url of the repo
@@ -397,18 +397,18 @@ class Payload(metaclass=ABCMeta):
         else:
             proxy_url = None
 
-        # sslverify can be:
+        # ssl_verify can be:
         #   - the path to a cert file
         #   - True, to use the system's certificates
         #   - False, to not verify
-        sslverify = getattr(self.data.method, "sslcacert", not flags.noverifyssl)
+        ssl_verify = getattr(self.data.method, "sslcacert", not flags.noverifyssl)
 
-        sslclientcert = getattr(self.data.method, "sslclientcert", None)
-        sslclientkey = getattr(self.data.method, "sslclientkey", None)
-        sslcert = (sslclientcert, sslclientkey) if sslclientcert else None
+        ssl_client_cert = getattr(self.data.method, "ssl_client_cert", None)
+        ssl_client_key = getattr(self.data.method, "ssl_client_key", None)
+        ssl_cert = (ssl_client_cert, ssl_client_key) if ssl_client_cert else None
 
-        log.debug("retrieving treeinfo from %s (proxy: %s ; sslverify: %s)",
-                  url, proxy_url, sslverify)
+        log.debug("retrieving treeinfo from %s (proxy: %s ; ssl_verify: %s)",
+                  url, proxy_url, ssl_verify)
 
         proxies = {}
         if proxy_url:
@@ -423,7 +423,7 @@ class Payload(metaclass=ABCMeta):
         headers = {"user-agent": USER_AGENT}
         self._install_tree_metadata = InstallTreeMetadata()
         try:
-            ret = self._install_tree_metadata.load_url(url, proxies, sslverify, sslcert, headers)
+            ret = self._install_tree_metadata.load_url(url, proxies, ssl_verify, ssl_cert, headers)
         except IOError as e:
             self._install_tree_metadata = None
             self.verbose_errors.append(str(e))
@@ -434,7 +434,7 @@ class Payload(metaclass=ABCMeta):
             log.warning("Install tree metadata can't be loaded!")
             self._install_tree_metadata = None
 
-    def _getReleaseVersion(self, url):
+    def _get_release_version(self, url):
         """Return the release version of the tree at the specified URL."""
         try:
             version = re.match(VERSION_DIGITS, productVersion).group(1)
@@ -455,16 +455,16 @@ class Payload(metaclass=ABCMeta):
     # METHODS FOR MEDIA MANAGEMENT (XXX should these go in another module?)
     ###
     @staticmethod
-    def _setupDevice(device, mountpoint):
+    def _setup_device(device, mountpoint):
         """Prepare an install CD/DVD for use as a package source."""
         log.info("setting up device %s and mounting on %s", device.name, mountpoint)
         # Is there a symlink involved?  If so, let's get the actual path.
         # This is to catch /run/install/isodir vs. /mnt/install/isodir, for
         # instance.
-        realMountpoint = os.path.realpath(mountpoint)
+        real_mountpoint = os.path.realpath(mountpoint)
 
-        if os.path.ismount(realMountpoint):
-            mdev = blivet.util.get_mount_device(realMountpoint)
+        if os.path.ismount(real_mountpoint):
+            mdev = blivet.util.get_mount_device(real_mountpoint)
             if mdev:
                 log.warning("%s is already mounted on %s", mdev, mountpoint)
 
@@ -472,7 +472,7 @@ class Payload(metaclass=ABCMeta):
                 return
             else:
                 try:
-                    blivet.util.umount(realMountpoint)
+                    blivet.util.umount(real_mountpoint)
                 except OSError as e:
                     log.error(str(e))
                     log.info("umount failed -- mounting on top of it")
@@ -486,7 +486,7 @@ class Payload(metaclass=ABCMeta):
             raise PayloadSetupError(str(e))
 
     @staticmethod
-    def _setupNFS(mountpoint, server, path, options):
+    def _setup_NFS(mountpoint, server, path, options):
         """Prepare an NFS directory for use as a package source."""
         log.info("mounting %s:%s:%s on %s", server, path, options, mountpoint)
         if os.path.ismount(mountpoint):
@@ -519,17 +519,17 @@ class Payload(metaclass=ABCMeta):
     ###
     # METHODS FOR INSTALLING THE PAYLOAD
     ###
-    def preInstall(self):
+    def pre_install(self):
         """Perform pre-installation tasks."""
         util.mkdirChain(util.getSysroot() + "/root")
 
-        self._writeModuleBlacklist()
+        self._write_module_blacklist()
 
     def install(self):
         """Install the payload."""
         raise NotImplementedError()
 
-    def _writeModuleBlacklist(self):
+    def _write_module_blacklist(self):
         """Copy modules from modprobe.blacklist=<module> on cmdline to
         /etc/modprobe.d/anaconda-blacklist.conf so that modules will
         continue to be blacklisted when the system boots.
@@ -543,7 +543,7 @@ class Payload(metaclass=ABCMeta):
             for module in flags.cmdline["modprobe.blacklist"].split():
                 f.write("blacklist %s\n" % module)
 
-    def _copyDriverDiskFiles(self):
+    def _copy_driver_disk_files(self):
         # Multiple driver disks may be loaded, so we need to glob for all
         # the firmware files in the common DD firmware directory
         for f in glob(DD_FIRMWARE + "/*"):
@@ -575,13 +575,13 @@ class Payload(metaclass=ABCMeta):
         return False
 
     @property
-    def handlesBootloaderConfiguration(self):
+    def handles_bootloader_configuration(self):
         """Whether this payload backend writes the bootloader configuration itself; if
         False (the default), the generic bootloader configuration code will be used.
         """
         return False
 
-    def recreateInitrds(self):
+    def recreate_initrds(self):
         """Recreate the initrds by calling new-kernel-pkg or dracut
 
         This needs to be done after all configuration files have been
@@ -590,16 +590,16 @@ class Payload(metaclass=ABCMeta):
         :returns: None
         """
         if os.path.exists(util.getSysroot() + "/usr/sbin/new-kernel-pkg"):
-            useDracut = False
+            use_dracut = False
         else:
             log.warning("new-kernel-pkg does not exist - grubby wasn't installed? "
                         " using dracut instead.")
-            useDracut = True
+            use_dracut = True
 
-        for kernel in self.kernelVersionList:
+        for kernel in self.kernel_version_list:
             log.info("recreating initrd for %s", kernel)
             if not conf.target.is_image:
-                if useDracut:
+                if use_dracut:
                     util.execInSysroot("depmod", ["-a", kernel])
                     util.execInSysroot("dracut",
                                        ["-H", "--persistent-policy", "by-uuid",
@@ -629,7 +629,7 @@ class Payload(metaclass=ABCMeta):
                                     "-f", "/boot/initramfs-%s.img" % kernel,
                                     kernel])
 
-    def _setDefaultBootTarget(self):
+    def _set_default_boot_target(self):
         """Set the default systemd target for the system."""
         if not os.path.exists(util.getSysroot() + "/etc/systemd/system"):
             log.error("systemd is not installed -- can't set default target")
@@ -657,16 +657,16 @@ class Payload(metaclass=ABCMeta):
             else:
                 services_proxy.SetDefaultTarget(TEXT_ONLY_TARGET)
 
-    def postInstall(self):
+    def post_install(self):
         """Perform post-installation tasks."""
 
         # set default systemd target
-        self._setDefaultBootTarget()
+        self._set_default_boot_target()
 
         # write out static config (storage, modprobe, keyboard, ??)
         #   kickstart should handle this before we get here
 
-        self._copyDriverDiskFiles()
+        self._copy_driver_disk_files()
 
         log.info("Installation requirements: %s", self.requirements)
         if not self.requirements.applied:
@@ -686,23 +686,23 @@ class PackagePayload(Payload, metaclass=ABCMeta):
         # consisting of lists of add-on group IDs. The first list is the add-ons specific
         # to the environment, and the second list is the other add-ons possible for the
         # environment.
-        self._environmentAddons = {}
+        self._environment_addons = {}
 
-    def preInstall(self):
-        super().preInstall()
+    def pre_install(self):
+        super().pre_install()
 
         # Set rpm-specific options
 
         # nofsync speeds things up at the risk of rpmdb data loss in a crash.
         # But if we crash mid-install you're boned anyway, so who cares?
-        self.rpmMacros.append(('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}'))
+        self.rpm_macros.append(('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}'))
 
         if self.data.packages.excludeDocs:
-            self.rpmMacros.append(('_excludedocs', '1'))
+            self.rpm_macros.append(('_excludedocs', '1'))
 
         if self.data.packages.instLangs is not None:
             # Use nil if instLangs is empty
-            self.rpmMacros.append(('_install_langs', self.data.packages.instLangs or '%{nil}'))
+            self.rpm_macros.append(('_install_langs', self.data.packages.instLangs or '%{nil}'))
 
         if conf.security.selinux:
             for d in ["/tmp/updates",
@@ -711,10 +711,10 @@ class PackagePayload(Payload, metaclass=ABCMeta):
                       "/etc/security/selinux"]:
                 f = d + "/file_contexts"
                 if os.access(f, os.R_OK):
-                    self.rpmMacros.append(('__file_context_path', f))
+                    self.rpm_macros.append(('__file_context_path', f))
                     break
         else:
-            self.rpmMacros.append(('__file_context_path', '%{nil}'))
+            self.rpm_macros.append(('__file_context_path', '%{nil}'))
 
         # Add platform specific group
         groupid = util.get_platform_groupid()
@@ -724,7 +724,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
             log.warning("Platform group %s not available.", groupid)
 
     @property
-    def kernelPackages(self):
+    def kernel_packages(self):
         if "kernel" in self.data.packages.excludedList:
             return []
 
@@ -741,7 +741,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
         return kernels
 
     @property
-    def kernelVersionList(self):
+    def kernel_version_list(self):
         # Find all installed rpms that provide 'kernel'
 
         # If a PackagePayload is in use, rpm needs to be available
@@ -764,12 +764,12 @@ class PackagePayload(Payload, metaclass=ABCMeta):
         return sorted(files, key=functools.cmp_to_key(version_cmp))
 
     @property
-    def rpmMacros(self):
+    def rpm_macros(self):
         """A list of (name, value) pairs to define as macros in the rpm transaction."""
         return self._rpm_macros
 
-    @rpmMacros.setter
-    def rpmMacros(self, value):
+    @rpm_macros.setter
+    def rpm_macros(self, value):
         self._rpm_macros = value
 
     def reset(self):
@@ -831,7 +831,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
             else:
                 blivet.util.umount(mount_point)
 
-    def _setupMedia(self, device):
+    def _setup_media(self, device):
         method = self.data.method
         if method.method == "harddrive":
             try:
@@ -857,7 +857,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
 
         Return changed path to the iso to save looking for iso in the future call.
         """
-        self._setupDevice(device, mountpoint=device_mount_dir)
+        self._setup_device(device, mountpoint=device_mount_dir)
 
         # check for ISO images in the newly mounted dir
         path = device_mount_dir
@@ -894,14 +894,14 @@ class PackagePayload(Payload, metaclass=ABCMeta):
         return iso_path
 
     def _setup_install_tree(self, device, install_tree_path, device_mount_dir):
-        self._setupDevice(device, mountpoint=device_mount_dir)
+        self._setup_device(device, mountpoint=device_mount_dir)
         path = os.path.normpath("%s/%s" % (device_mount_dir, install_tree_path))
 
         if not verify_valid_installtree(path):
             device.teardown(recursive=True)
             raise PayloadSetupError("failed to find valid installation tree")
 
-    def _setupInstallDevice(self, storage, checkmount):
+    def _setup_install_device(self, storage, checkmount):
         # XXX FIXME: does this need to handle whatever was set up by dracut?
         method = self.data.method
         url = None
@@ -933,32 +933,32 @@ class PackagePayload(Payload, metaclass=ABCMeta):
 
     def _setup_harddrive_device(self, storage, method, isodev, device):
         url = None
-        needmount = False
+        need_mount = False
 
         if method.biospart:
             log.warning("biospart support is not implemented")
-            devspec = method.biospart
+            dev_spec = method.biospart
         else:
-            devspec = method.partition
-            needmount = True
+            dev_spec = method.partition
+            need_mount = True
             # See if we used this method for stage2, thus dracut left it
             if isodev and method.partition and \
                method.partition in isodev and \
                DRACUT_ISODIR in device:
                 # Everything should be setup
                 url = "file://" + DRACUT_REPODIR
-                needmount = False
+                need_mount = False
                 # We don't setup an install_device here
                 # because we can't tear it down
 
-        isodevice = storage.devicetree.resolve_device(devspec)
-        if needmount:
-            if not isodevice:
-                raise PayloadSetupError("device for HDISO install %s does not exist" % devspec)
+        iso_device = storage.devicetree.resolve_device(dev_spec)
+        if need_mount:
+            if not iso_device:
+                raise PayloadSetupError("device for HDISO install %s does not exist" % dev_spec)
 
-            self._setupMedia(isodevice)
+            self._setup_media(iso_device)
             url = "file://" + INSTALL_TREE
-            self.install_device = isodevice
+            self.install_device = iso_device
 
         return url
 
@@ -985,32 +985,32 @@ class PackagePayload(Payload, metaclass=ABCMeta):
                 url = "file://" + DRACUT_REPODIR
         else:
             # see if the nfs dir is mounted
-            needmount = True
+            need_mount = True
             if device:
                 _options, host, path = util.parseNfsUrl('nfs:%s' % device)
                 if method.server and method.server == host and \
                    method.dir and method.dir == path:
-                    needmount = False
+                    need_mount = False
                     path = DRACUT_REPODIR
             elif isodev:
                 # isodev with no device can happen when options on an existing
                 # nfs mount have changed. It is already mounted, but on INSTALL_TREE
-                # which is the same as DRACUT_ISODIR, making it hard for _setupNFS
+                # which is the same as DRACUT_ISODIR, making it hard for _setup_NFS
                 # to detect that it is already mounted.
                 _options, host, path = util.parseNfsUrl('nfs:%s' % isodev)
                 if path and path in isodev:
-                    needmount = False
+                    need_mount = False
                     path = DRACUT_ISODIR
 
-            if needmount:
+            if need_mount:
                 # Mount the NFS share on INSTALL_TREE. If it ends up
                 # being nfsiso we will move the mountpoint to ISO_DIR.
                 if method.dir.endswith(".iso"):
-                    nfsdir = os.path.dirname(method.dir)
+                    nfs_dir = os.path.dirname(method.dir)
                 else:
-                    nfsdir = method.dir
-                self._setupNFS(INSTALL_TREE, method.server, nfsdir,
-                               method.opts)
+                    nfs_dir = method.dir
+                self._setup_NFS(INSTALL_TREE, method.server, nfs_dir,
+                                method.opts)
                 path = INSTALL_TREE
 
             # check for ISO images in the newly mounted dir
@@ -1106,7 +1106,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
             if self.install_device:
                 if not method.method:
                     method.method = "cdrom"
-                self._setupMedia(self.install_device)
+                self._setup_media(self.install_device)
                 url = "file://" + INSTALL_TREE
             elif method.method == "cdrom":
                 raise PayloadSetupError("no usable optical media found")
@@ -1114,8 +1114,8 @@ class PackagePayload(Payload, metaclass=ABCMeta):
         return url
 
     def _setup_harddrive_addon_repo(self, storage, ksrepo):
-        isodevice = storage.devicetree.resolve_device(ksrepo.partition)
-        if not isodevice:
+        iso_device = storage.devicetree.resolve_device(ksrepo.partition)
+        if not iso_device:
             raise PayloadSetupError("device for HDISO addon repo install %s does not exist" %
                                     ksrepo.partition)
 
@@ -1124,7 +1124,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
         device_mount_dir = ISO_DIR + "-" + ksrepo.mount_dir_suffix
         install_root_dir = INSTALL_TREE + "-" + ksrepo.mount_dir_suffix
 
-        self._find_and_mount_iso(isodevice, device_mount_dir, ksrepo.iso_path, install_root_dir)
+        self._find_and_mount_iso(iso_device, device_mount_dir, ksrepo.iso_path, install_root_dir)
         url = "file://" + install_root_dir
 
         return url
@@ -1137,7 +1137,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
         """A list of repo identifiers, not objects themselves."""
         raise NotImplementedError()
 
-    def addDriverRepos(self):
+    def add_driver_repos(self):
         """Add driver repositories and packages."""
         # Drivers are loaded by anaconda-dracut, their repos are copied
         # into /run/install/DD-X where X is a number starting at 1. The list of
@@ -1160,11 +1160,11 @@ class PackagePayload(Payload, metaclass=ABCMeta):
                 util.execWithRedirect("createrepo_c", [repo])
 
             repo_name = "DD-%d" % dir_num
-            if repo_name not in self.addOns:
+            if repo_name not in self.addons:
                 ks_repo = self.data.RepoData(name=repo_name,
                                              baseurl="file://" + repo,
                                              enabled=True)
-                self.addRepo(ks_repo)
+                self.add_repo(ks_repo)
 
         # Add packages
         if not os.path.exists("/run/install/dd_packages"):
@@ -1175,7 +1175,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
                 self.requirements.add_packages([package], reason="driver disk")
 
     @property
-    def ISOImage(self):
+    def ISO_image(self):
         """The location of a mounted ISO repo, or None."""
         if not self.data.method.method == "harddrive":
             return None
@@ -1196,42 +1196,42 @@ class PackagePayload(Payload, metaclass=ABCMeta):
     def environments(self):
         raise NotImplementedError()
 
-    def environmentHasOption(self, environmentid, grpid):
+    def environment_has_option(self, environment_id, grpid):
         raise NotImplementedError()
 
-    def environmentOptionIsDefault(self, environmentid, grpid):
+    def environment_option_is_default(self, environment_id, grpid):
         raise NotImplementedError()
 
-    def environmentDescription(self, environmentid):
+    def environment_description(self, environment_id):
         raise NotImplementedError()
 
-    def selectEnvironment(self, environmentid):
-        if environmentid not in self.environments:
-            raise NoSuchGroup(environmentid)
+    def select_environment(self, environment_id):
+        if environment_id not in self.environments:
+            raise NoSuchGroup(environment_id)
 
-        self.data.packages.environment = environmentid
+        self.data.packages.environment = environment_id
 
     @property
-    def environmentAddons(self):
-        return self._environmentAddons
+    def environment_addons(self):
+        return self._environment_addons
 
-    def _isGroupVisible(self, grpid):
+    def _is_group_visible(self, grpid):
         raise NotImplementedError()
 
-    def _refreshEnvironmentAddons(self):
-        log.info("Refreshing environmentAddons")
-        self._environmentAddons = {}
+    def _refresh_environment_addons(self):
+        log.info("Refreshing environment_addons")
+        self._environment_addons = {}
 
         for environment in self.environments:
-            self._environmentAddons[environment] = ([], [])
+            self._environment_addons[environment] = ([], [])
 
             # Determine which groups are specific to this environment and which other groups
             # are available in this environment.
             for grp in self.groups:
-                if self.environmentHasOption(environment, grp):
-                    self._environmentAddons[environment][0].append(grp)
-                elif self._isGroupVisible(grp):
-                    self._environmentAddons[environment][1].append(grp)
+                if self.environment_has_option(environment, grp):
+                    self._environment_addons[environment][0].append(grp)
+                elif self._is_group_visible(grp):
+                    self._environment_addons[environment][1].append(grp)
 
     ###
     # METHODS FOR WORKING WITH GROUPS
@@ -1240,7 +1240,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
     def groups(self):
         raise NotImplementedError()
 
-    def selectedGroupsIDs(self):
+    def selected_groups_IDs(self):
         """ Return list of selected group IDs.
 
         :return: List of selected group IDs.
@@ -1249,8 +1249,8 @@ class PackagePayload(Payload, metaclass=ABCMeta):
         # pylint: disable=try-except-raise
         try:
             ret = []
-            for grp in self.selectedGroups():
-                ret.append(self.groupId(grp))
+            for grp in self.selected_groups():
+                ret.append(self.group_id(grp))
             return ret
         # Translation feature is not implemented for this payload.
         except NotImplementedError:
@@ -1259,9 +1259,9 @@ class PackagePayload(Payload, metaclass=ABCMeta):
         except PayloadError as ex:
             raise PayloadError("Can't translate group names to group ID - {}".format(ex))
 
-    def groupDescription(self, grpid):
+    def group_description(self, grpid):
         raise NotImplementedError()
 
-    def groupId(self, group_name):
+    def group_id(self, group_name):
         """Return group id for translation of groups from a kickstart file."""
         raise NotImplementedError()

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -43,7 +43,8 @@ from pyanaconda.image import opticalInstallMedia, verifyMedia, verify_valid_inst
 from pyanaconda.core.util import ProxyString, ProxyStringError
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core.regexes import VERSION_DIGITS
-from pyanaconda.payload.errors import PayloadError, PayloadSetupError, NoSuchGroup
+from pyanaconda.payload.errors import PayloadError, PayloadSetupError, NoSuchGroup, \
+    PayloadRequirementsMissingApply
 from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
 from pyanaconda.product import productName, productVersion
 
@@ -110,10 +111,6 @@ class PayloadRequirement(object):
 
     def __repr__(self):
         return 'PayloadRequirement(id=%s, reasons=%s)' % (self.id, self._reasons)
-
-
-class PayloadRequirementsMissingApply(Exception):
-    pass
 
 
 class PayloadRequirements(object):

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -1473,9 +1473,6 @@ class PackagePayload(Payload):
     def _isGroupVisible(self, grpid):
         raise NotImplementedError()
 
-    def _groupHasInstallableMembers(self, grpid):
-        raise NotImplementedError()
-
     def _refreshEnvironmentAddons(self):
         log.info("Refreshing environmentAddons")
         self._environmentAddons = {}
@@ -1486,9 +1483,7 @@ class PackagePayload(Payload):
             # Determine which groups are specific to this environment and which other groups
             # are available in this environment.
             for grp in self.groups:
-                if not self._groupHasInstallableMembers(grp):
-                    continue
-                elif self.environmentHasOption(environment, grp):
+                if self.environmentHasOption(environment, grp):
                     self._environmentAddons[environment][0].append(grp)
                 elif self._isGroupVisible(grp):
                     self._environmentAddons[environment][1].append(grp)

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -20,19 +20,16 @@ import os
 import shutil
 from glob import glob
 from fnmatch import fnmatch
-import threading
 import re
 import functools
 from distutils.version import LooseVersion
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import DRACUT_ISODIR, DRACUT_REPODIR, DD_ALL, DD_FIRMWARE, \
-    DD_RPMS, INSTALL_TREE, ISO_DIR, THREAD_STORAGE, THREAD_PAYLOAD, THREAD_PAYLOAD_RESTART, \
-    THREAD_WAIT_FOR_CONNECTING_NM, GRAPHICAL_TARGET, TEXT_ONLY_TARGET
+    DD_RPMS, INSTALL_TREE, ISO_DIR, GRAPHICAL_TARGET, TEXT_ONLY_TARGET
 from pyanaconda.modules.common.constants.services import SERVICES
 from pykickstart.constants import GROUP_ALL, GROUP_DEFAULT, GROUP_REQUIRED
 from pyanaconda.flags import flags
-from pyanaconda.core.i18n import _, N_
 
 from pyanaconda.core import util
 from pyanaconda import isys
@@ -40,7 +37,6 @@ from pyanaconda.image import findFirstIsoImage
 from pyanaconda.image import mountImage
 from pyanaconda.image import opticalInstallMedia, verifyMedia, verify_valid_installtree
 from pyanaconda.core.util import ProxyString, ProxyStringError
-from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core.regexes import VERSION_DIGITS
 from pyanaconda.payload.errors import PayloadError, PayloadSetupError, NoSuchGroup
 from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
@@ -1281,207 +1277,3 @@ class PackagePayload(Payload):
     def groupId(self, group_name):
         """Return group id for translation of groups from a kickstart file."""
         raise NotImplementedError()
-
-
-class PayloadManager(object):
-    """Framework for starting and watching the payload thread.
-
-    This class defines several states, and events can be triggered upon
-    reaching a state. Depending on whether a state has already been reached
-    when a listener is added, the event code may be run in either the
-    calling thread or the payload thread. The event code will block the
-    payload thread regardless, so try not to run anything that takes a long
-    time.
-
-    All states except STATE_ERROR are expected to happen linearly, and adding
-    a listener for a state that has already been reached or passed will
-    immediately trigger that listener. For example, if the payload thread is
-    currently in STATE_GROUP_MD, adding a listener for STATE_NETWORK will
-    immediately run the code being added for STATE_NETWORK.
-
-    The payload thread data should be accessed using the payloadMgr object,
-    and the running thread can be accessed using threadMgr with the
-    THREAD_PAYLOAD constant, if you need to wait for it or something. The
-    thread should be started using payloadMgr.restartThread.
-    """
-
-    STATE_START = 0
-    # Waiting on storage
-    STATE_STORAGE = 1
-    # Waiting on network
-    STATE_NETWORK = 2
-    # Verify repository availability
-    STATE_TEST_AVAILABILITY = 3
-    # Downloading package metadata
-    STATE_PACKAGE_MD = 4
-    # Downloading group metadata
-    STATE_GROUP_MD = 5
-    # All done
-    STATE_FINISHED = 6
-
-    # Error
-    STATE_ERROR = -1
-
-    # Error strings
-    ERROR_SETUP = N_("Failed to set up installation source")
-    ERROR_MD = N_("Error downloading package metadata")
-
-    def __init__(self):
-        self._event_lock = threading.Lock()
-        self._event_listeners = {}
-        self._thread_state = self.STATE_START
-        self._error = None
-
-        # Initialize a list for each event state
-        for event_id in range(self.STATE_ERROR, self.STATE_FINISHED + 1):
-            self._event_listeners[event_id] = []
-
-    @property
-    def error(self):
-        return _(self._error)
-
-    def addListener(self, event_id, func):
-        """Add a listener for an event.
-
-        :param int event_id: The event to listen for, one of the EVENT_* constants
-        :param function func: An object to call when the event is reached
-        """
-
-        # Check that the event_id is valid
-        assert isinstance(event_id, int)
-        assert event_id <= self.STATE_FINISHED
-        assert event_id >= self.STATE_ERROR
-
-        # Add the listener inside the lock in case we need to run immediately,
-        # to make sure the listener isn't triggered twice
-        with self._event_lock:
-            self._event_listeners[event_id].append(func)
-
-            # If an error event was requested, run it if currently in an error state
-            if event_id == self.STATE_ERROR:
-                if event_id == self._thread_state:
-                    func()
-            # Otherwise, run if the requested event has already occurred
-            elif event_id <= self._thread_state:
-                func()
-
-    def restartThread(self, storage, ksdata, payload,
-                      fallback=False, checkmount=True, onlyOnChange=False):
-        """Start or restart the payload thread.
-
-        This method starts a new thread to restart the payload thread, so
-        this method's return is not blocked by waiting on the previous payload
-        thread. If there is already a payload thread restart pending, this method
-        has no effect.
-
-        :param pyanaconda.storage.InstallerStorage storage: The blivet storage instance
-        :param kickstart.AnacondaKSHandler ksdata: The kickstart data instance
-        :param payload.Payload payload: The payload instance
-        :param bool fallback: Whether to fall back to the default repo in case of error
-        :param bool checkmount: Whether to check for valid mounted media
-        :param bool onlyOnChange: Restart thread only if existing repositories changed.
-                                  This won't restart thread even when a new repository was added!!
-        """
-        log.debug("Restarting payload thread")
-
-        # If a restart thread is already running, don't start a new one
-        if threadMgr.get(THREAD_PAYLOAD_RESTART):
-            return
-
-        thread_args = (storage, ksdata, payload, fallback, checkmount, onlyOnChange)
-        # Launch a new thread so that this method can return immediately
-        threadMgr.add(AnacondaThread(name=THREAD_PAYLOAD_RESTART, target=self._restartThread,
-                                     args=thread_args))
-
-    @property
-    def running(self):
-        """Is the payload thread running right now?"""
-        return threadMgr.exists(THREAD_PAYLOAD_RESTART) or threadMgr.exists(THREAD_PAYLOAD)
-
-    def _restartThread(self, storage, ksdata, payload, fallback, checkmount, onlyOnChange):
-        # Wait for the old thread to finish
-        threadMgr.wait(THREAD_PAYLOAD)
-
-        thread_args = (storage, ksdata, payload, fallback, checkmount, onlyOnChange)
-        # Start a new payload thread
-        threadMgr.add(AnacondaThread(name=THREAD_PAYLOAD, target=self._runThread,
-                                     args=thread_args))
-
-    def _setState(self, event_id):
-        # Update the current state
-        log.debug("Updating payload thread state: %d", event_id)
-        with self._event_lock:
-            # Update the state within the lock to avoid a race with listeners
-            # currently being added
-            self._thread_state = event_id
-
-            # Run any listeners for the new state
-            for func in self._event_listeners[event_id]:
-                func()
-
-    def _runThread(self, storage, ksdata, payload, fallback, checkmount, onlyOnChange):
-        # This is the thread entry
-        # Set the initial state
-        self._error = None
-        self._setState(self.STATE_START)
-
-        # Wait for storage
-        self._setState(self.STATE_STORAGE)
-        threadMgr.wait(THREAD_STORAGE)
-
-        # Wait for network
-        self._setState(self.STATE_NETWORK)
-        # FIXME: condition for cases where we don't want network
-        # (set and use payload.needsNetwork ?)
-        threadMgr.wait(THREAD_WAIT_FOR_CONNECTING_NM)
-
-        payload.setup(storage)
-
-        # If this is a non-package Payload, we're done
-        if not isinstance(payload, PackagePayload):
-            self._setState(self.STATE_FINISHED)
-            return
-
-        # Test if any repository changed from the last update
-        if onlyOnChange:
-            log.debug("Testing repositories availability")
-            self._setState(self.STATE_TEST_AVAILABILITY)
-            if payload.verifyAvailableRepositories():
-                log.debug("Payload isn't restarted, repositories are still available.")
-                self._setState(self.STATE_FINISHED)
-                return
-
-        # Keep setting up package-based repositories
-        # Download package metadata
-        self._setState(self.STATE_PACKAGE_MD)
-        try:
-            payload.updateBaseRepo(fallback=fallback, checkmount=checkmount)
-            payload.addDriverRepos()
-        except (OSError, PayloadError) as e:
-            log.error("PayloadError: %s", e)
-            self._error = self.ERROR_SETUP
-            self._setState(self.STATE_ERROR)
-            payload.unsetup()
-            return
-
-        # Gather the group data
-        self._setState(self.STATE_GROUP_MD)
-        payload.gatherRepoMetadata()
-        payload.release()
-
-        # Check if that failed
-        if not payload.baseRepo:
-            log.error("No base repo configured")
-            self._error = self.ERROR_MD
-            self._setState(self.STATE_ERROR)
-            payload.unsetup()
-            return
-
-        # run payload specific post configuration tasks
-        payload.postSetup()
-
-        self._setState(self.STATE_FINISHED)
-
-
-# Initialize the PayloadManager instance
-payloadMgr = PayloadManager()

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -881,7 +881,7 @@ class DNFPayload(payload.PackagePayload):
             raise NoSuchGroup(grpid)
         return grp.visible
 
-    def checkSoftwareSelection(self):
+    def check_software_selection(self):
         log.info("checking software selection")
         self._bump_tx_id()
         self._base.reset(goal=True)
@@ -901,7 +901,7 @@ class DNFPayload(payload.PackagePayload):
         log.info("%d packages selected totalling %s",
                  len(self._base.transaction), self.space_required)
 
-    def setUpdatesEnabled(self, state):
+    def set_updates_enabled(self, state):
         """Enable or Disable the repos used to update closest mirror.
 
         :param bool state: True to enable updates, False to disable.
@@ -939,11 +939,11 @@ class DNFPayload(payload.PackagePayload):
             raise NoSuchGroup(environment_id)
         return (env.ui_name, env.ui_description)
 
-    def environmentId(self, environment):
+    def environment_id(self, environment):
         """Return environment id for the environment specified by id or name."""
         # the enviroment must be string or else DNF >=3 throws an assert error
         if not isinstance(environment, str):
-            log.warning("environmentId() called with non-string argument: %s", environment)
+            log.warning("environment_id() called with non-string argument: %s", environment)
         env = self._base.comps.environment_by_pattern(environment)
         if env is None:
             raise NoSuchGroup(environment)
@@ -1002,7 +1002,7 @@ class DNFPayload(payload.PackagePayload):
         if self.install_device:
             self._setup_media(self.install_device)
         try:
-            self.checkSoftwareSelection()
+            self.check_software_selection()
             self._download_location = self._pick_download_location()
         except PayloadError as e:
             if errors.errorHandler.cb(e) == errors.ERROR_RAISE:
@@ -1077,7 +1077,7 @@ class DNFPayload(payload.PackagePayload):
             # we don't have to care about clearing the download location ourselves.
             log.warning("Can't delete nonexistent download location: %s", self._download_location)
 
-    def getRepo(self, repo_id):
+    def get_repo(self, repo_id):
         """Return the yum repo object."""
         return self._base.repos[repo_id]
 
@@ -1122,7 +1122,8 @@ class DNFPayload(payload.PackagePayload):
     def update_base_repo(self, fallback=True, checkmount=True):
         log.info('configuring base repo')
         self.reset()
-        install_tree_url, mirrorlist, metalink = self._setup_install_device(self.storage, checkmount)
+        install_tree_url, mirrorlist, metalink = self._setup_install_device(self.storage,
+                                                                            checkmount)
 
         # Fallback to installation root
         base_repo_url = install_tree_url
@@ -1138,7 +1139,7 @@ class DNFPayload(payload.PackagePayload):
         self._base.read_all_repos()
 
         # If setup updates/updates-testing
-        self.setUpdatesEnabled(self._updates_enabled)
+        self.set_updates_enabled(self._updates_enabled)
 
         # Repos on disk are always enabled. When reloaded their state needs to
         # be synchronized with the user selection.
@@ -1157,7 +1158,7 @@ class DNFPayload(payload.PackagePayload):
             try:
                 self._refresh_install_tree(install_tree_url)
                 self._base.conf.releasever = self._get_release_version(install_tree_url)
-                base_repo_url = self._getBaseRepoLocation(install_tree_url)
+                base_repo_url = self._get_base_repo_location(install_tree_url)
 
                 if self.first_payload_reset:
                     self._add_treeinfo_repositories(install_tree_url, base_repo_url)
@@ -1241,7 +1242,7 @@ class DNFPayload(payload.PackagePayload):
                 if repo in enabled_repos:
                     self._fetch_md(repo)
 
-    def _getBaseRepoLocation(self, install_tree_url):
+    def _get_base_repo_location(self, install_tree_url):
         """Try to find base repository from the treeinfo file.
 
         The URL can be installation tree root or a subfolder in the installation root.
@@ -1300,7 +1301,7 @@ class DNFPayload(payload.PackagePayload):
 
         return install_tree_url
 
-    def _writeDNFRepo(self, repo, repo_path):
+    def _write_dnf_repo(self, repo, repo_path):
         """Write a repo object to a DNF repo.conf file.
 
         :param repo: DNF repository object
@@ -1378,7 +1379,7 @@ class DNFPayload(payload.PackagePayload):
                 continue
 
             try:
-                repo = self.getRepo(ks_repo.name)
+                repo = self.get_repo(ks_repo.name)
                 if not repo:
                     continue
             except (dnf.exceptions.RepoError, KeyError):
@@ -1386,7 +1387,7 @@ class DNFPayload(payload.PackagePayload):
             repo_path = util.getSysroot() + YUM_REPOS_DIR + "%s.repo" % repo.id
             try:
                 log.info("Writing %s.repo to target system.", repo.id)
-                self._writeDNFRepo(repo, repo_path)
+                self._write_dnf_repo(repo, repo_path)
             except PayloadSetupError as e:
                 log.error(e)
 

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -879,9 +879,6 @@ class DNFPayload(payload.PackagePayload):
             raise payload.NoSuchGroup(grpid)
         return grp.visible
 
-    def _groupHasInstallableMembers(self, grpid):
-        return True
-
     def checkSoftwareSelection(self):
         log.info("checking software selection")
         self._bump_tx_id()

--- a/pyanaconda/payload/errors.py
+++ b/pyanaconda/payload/errors.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+
+class PayloadError(Exception):
+    pass
+
+
+class MetadataError(PayloadError):
+    pass
+
+
+# setup
+class PayloadSetupError(PayloadError):
+    pass
+
+
+# software selection
+class NoSuchGroup(PayloadError):
+    def __init__(self, group, adding=True, required=False):
+        super().__init__(group)
+        self.group = group
+        self.adding = adding
+        self.required = required
+
+    def __str__(self):
+        return "The group '{}' does not exist".format(self.group)
+
+
+class DependencyError(PayloadError):
+    pass
+
+
+# installation
+class PayloadInstallError(PayloadError):
+    pass

--- a/pyanaconda/payload/errors.py
+++ b/pyanaconda/payload/errors.py
@@ -49,3 +49,7 @@ class DependencyError(PayloadError):
 # installation
 class PayloadInstallError(PayloadError):
     pass
+
+
+class PayloadRequirementsMissingApply(Exception):
+    pass

--- a/pyanaconda/payload/install_tree_metadata.py
+++ b/pyanaconda/payload/install_tree_metadata.py
@@ -87,13 +87,15 @@ class InstallTreeMetadata(object):
             # Downloading .treeinfo
             log.info("Trying to download '.treeinfo'")
             (response, ret_code[0]) = self._download_treeinfo_file(session, url, ".treeinfo",
-                                                                   headers, proxies, sslverify, sslcert)
+                                                                   headers, proxies,
+                                                                   sslverify, sslcert)
             if response:
                 break
             # Downloading treeinfo
             log.info("Trying to download 'treeinfo'")
             (response, ret_code[1]) = self._download_treeinfo_file(session, url, "treeinfo",
-                                                                   headers, proxies, sslverify, sslcert)
+                                                                   headers, proxies,
+                                                                   sslverify, sslcert)
             if response:
                 break
 

--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -39,7 +39,7 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.util import ProxyString, ProxyStringError
 from pyanaconda.core import util
 from pyanaconda.core.i18n import _
-from pyanaconda.payload import ImagePayload, versionCmp
+from pyanaconda.payload import Payload, versionCmp
 from pyanaconda.payload.errors import PayloadSetupError, PayloadInstallError
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.errors import errorHandler, ERROR_RAISE
@@ -55,7 +55,7 @@ from pyanaconda.anaconda_loggers import get_packaging_logger
 log = get_packaging_logger()
 
 
-class LiveImagePayload(ImagePayload):
+class LiveImagePayload(Payload):
     """ A LivePayload copies the source image onto the target system. """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -327,7 +327,7 @@ class LiveImageKSPayload(LiveImagePayload):
         """ Check the availability and size of the image.
         """
         # This is on purpose, we don't want to call LiveImagePayload's setup method.
-        ImagePayload.setup(self, storage)
+        super().setup(self, storage)
 
         if self.data.method.url.startswith("file://"):
             error = self._setup_file_image()
@@ -343,7 +343,7 @@ class LiveImageKSPayload(LiveImagePayload):
 
     def unsetup(self):
         # Skip LiveImagePayload's unsetup method
-        ImagePayload.unsetup(self)
+        super().unsetup(self)
 
     def _preInstall_url_image(self):
         """ Download the image using Requests with progress reporting"""

--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -86,7 +86,7 @@ class LiveImagePayload(Payload):
             raise PayloadInstallError("Failed to mount the install tree")
 
         # Grab the kernel version list now so it's available after umount
-        self._updateKernelVersionList()
+        self._update_kernel_version_list()
 
         source = os.statvfs(INSTALL_TREE)
         self.source_size = source.f_frsize * (source.f_blocks - source.f_bfree)
@@ -171,14 +171,14 @@ class LiveImagePayload(Payload):
 
         # Live needs to create the rescue image before bootloader is written
         if os.path.exists(util.getSysroot() + "/usr/sbin/new-kernel-pkg"):
-            useNKP = True
+            use_nkp = True
         else:
             log.warning("new-kernel-pkg does not exist - grubby wasn't installed?")
-            useNKP = False
+            use_nkp = False
 
         for kernel in self.kernel_version_list:
             log.info("Generating rescue image for %s", kernel)
-            if useNKP:
+            if use_nkp:
                 util.execInSysroot("new-kernel-pkg",
                                    ["--rpmposttrans", kernel])
             else:
@@ -214,7 +214,7 @@ class LiveImagePayload(Payload):
     def space_required(self):
         return Size(util.getDirSize("/") * 1024)
 
-    def _updateKernelVersionList(self):
+    def _update_kernel_version_list(self):
         files = glob.glob(INSTALL_TREE + "/boot/vmlinuz-*")
         files.extend(glob.glob(INSTALL_TREE + "/boot/efi/EFI/%s/vmlinuz-*" %
                                conf.bootloader.efi_dir))
@@ -346,7 +346,7 @@ class LiveImageKSPayload(LiveImagePayload):
         # Skip LiveImagePayload's unsetup method
         super().unsetup(self)
 
-    def _preInstall_url_image(self):
+    def _pre_install_url_image(self):
         """ Download the image using Requests with progress reporting"""
 
         error = None
@@ -402,7 +402,7 @@ class LiveImageKSPayload(LiveImagePayload):
         if self.data.method.url.startswith("file://"):
             self.image_path = self.data.method.url[7:]
         else:
-            error = self._preInstall_url_image()
+            error = self._pre_install_url_image()
 
         if error:
             exn = PayloadInstallError(str(error))
@@ -446,7 +446,7 @@ class LiveImageKSPayload(LiveImagePayload):
 
         # Nothing more to mount
         if not os.path.exists(INSTALL_TREE + "/LiveOS"):
-            self._updateKernelVersionList()
+            self._update_kernel_version_list()
             return
 
         # Mount the first .img in the directory on INSTALL_TREE
@@ -474,7 +474,7 @@ class LiveImageKSPayload(LiveImagePayload):
                 if errorHandler.cb(exn) == ERROR_RAISE:
                     raise exn
 
-            self._updateKernelVersionList()
+            self._update_kernel_version_list()
 
             source = os.statvfs(INSTALL_TREE)
             self.source_size = source.f_frsize * (source.f_blocks - source.f_bfree)

--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -39,8 +39,8 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.util import ProxyString, ProxyStringError
 from pyanaconda.core import util
 from pyanaconda.core.i18n import _
-from pyanaconda.payload import ImagePayload, PayloadSetupError, PayloadInstallError
-from pyanaconda.payload import versionCmp
+from pyanaconda.payload import ImagePayload, versionCmp
+from pyanaconda.payload.errors import PayloadSetupError, PayloadInstallError
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.errors import errorHandler, ERROR_RAISE
 from pyanaconda.progress import progressQ

--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -39,7 +39,8 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.util import ProxyString, ProxyStringError
 from pyanaconda.core import util
 from pyanaconda.core.i18n import _
-from pyanaconda.payload import Payload, versionCmp
+from pyanaconda.payload import Payload
+from pyanaconda.payload.utils import version_cmp
 from pyanaconda.payload.errors import PayloadSetupError, PayloadInstallError
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.errors import errorHandler, ERROR_RAISE
@@ -220,7 +221,7 @@ class LiveImagePayload(Payload):
 
         self._kernelVersionList = sorted((f.split("/")[-1][8:] for f in files
                                          if os.path.isfile(f) and "-rescue-" not in f),
-                                         key=functools.cmp_to_key(versionCmp))
+                                         key=functools.cmp_to_key(version_cmp))
 
     @property
     def kernelVersionList(self):
@@ -566,4 +567,4 @@ class LiveImageKSPayload(LiveImagePayload):
 
             # Strip out vmlinuz- from the names
             return sorted((n.split("/")[-1][8:] for n in names if "boot/vmlinuz-" in n),
-                          key=functools.cmp_to_key(versionCmp))
+                          key=functools.cmp_to_key(version_cmp))

--- a/pyanaconda/payload/manager.py
+++ b/pyanaconda/payload/manager.py
@@ -1,0 +1,238 @@
+# Class for management payload threading.
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import threading
+
+from pyanaconda.core.constants import THREAD_STORAGE, THREAD_PAYLOAD, THREAD_PAYLOAD_RESTART, \
+    THREAD_WAIT_FOR_CONNECTING_NM
+from pyanaconda.core.i18n import _, N_
+from pyanaconda.threading import threadMgr, AnacondaThread
+from pyanaconda.payload import PackagePayload
+from pyanaconda.payload.errors import PayloadError
+
+from pyanaconda.anaconda_loggers import get_module_logger
+
+log = get_module_logger(__name__)
+
+
+__all__ = ["payloadMgr"]
+
+
+class PayloadManager(object):
+    """Framework for starting and watching the payload thread.
+
+    This class defines several states, and events can be triggered upon
+    reaching a state. Depending on whether a state has already been reached
+    when a listener is added, the event code may be run in either the
+    calling thread or the payload thread. The event code will block the
+    payload thread regardless, so try not to run anything that takes a long
+    time.
+
+    All states except STATE_ERROR are expected to happen linearly, and adding
+    a listener for a state that has already been reached or passed will
+    immediately trigger that listener. For example, if the payload thread is
+    currently in STATE_GROUP_MD, adding a listener for STATE_NETWORK will
+    immediately run the code being added for STATE_NETWORK.
+
+    The payload thread data should be accessed using the payloadMgr object,
+    and the running thread can be accessed using threadMgr with the
+    THREAD_PAYLOAD constant, if you need to wait for it or something. The
+    thread should be started using payloadMgr.restartThread.
+    """
+
+    STATE_START = 0
+    # Waiting on storage
+    STATE_STORAGE = 1
+    # Waiting on network
+    STATE_NETWORK = 2
+    # Verify repository availability
+    STATE_TEST_AVAILABILITY = 3
+    # Downloading package metadata
+    STATE_PACKAGE_MD = 4
+    # Downloading group metadata
+    STATE_GROUP_MD = 5
+    # All done
+    STATE_FINISHED = 6
+
+    # Error
+    STATE_ERROR = -1
+
+    # Error strings
+    ERROR_SETUP = N_("Failed to set up installation source")
+    ERROR_MD = N_("Error downloading package metadata")
+
+    def __init__(self):
+        self._event_lock = threading.Lock()
+        self._event_listeners = {}
+        self._thread_state = self.STATE_START
+        self._error = None
+
+        # Initialize a list for each event state
+        for event_id in range(self.STATE_ERROR, self.STATE_FINISHED + 1):
+            self._event_listeners[event_id] = []
+
+    @property
+    def error(self):
+        return _(self._error)
+
+    def addListener(self, event_id, func):
+        """Add a listener for an event.
+
+        :param int event_id: The event to listen for, one of the EVENT_* constants
+        :param function func: An object to call when the event is reached
+        """
+
+        # Check that the event_id is valid
+        assert isinstance(event_id, int)
+        assert event_id <= self.STATE_FINISHED
+        assert event_id >= self.STATE_ERROR
+
+        # Add the listener inside the lock in case we need to run immediately,
+        # to make sure the listener isn't triggered twice
+        with self._event_lock:
+            self._event_listeners[event_id].append(func)
+
+            # If an error event was requested, run it if currently in an error state
+            if event_id == self.STATE_ERROR:
+                if event_id == self._thread_state:
+                    func()
+            # Otherwise, run if the requested event has already occurred
+            elif event_id <= self._thread_state:
+                func()
+
+    def restartThread(self, storage, ksdata, payload,
+                      fallback=False, checkmount=True, onlyOnChange=False):
+        """Start or restart the payload thread.
+
+        This method starts a new thread to restart the payload thread, so
+        this method's return is not blocked by waiting on the previous payload
+        thread. If there is already a payload thread restart pending, this method
+        has no effect.
+
+        :param pyanaconda.storage.InstallerStorage storage: The blivet storage instance
+        :param kickstart.AnacondaKSHandler ksdata: The kickstart data instance
+        :param payload.Payload payload: The payload instance
+        :param bool fallback: Whether to fall back to the default repo in case of error
+        :param bool checkmount: Whether to check for valid mounted media
+        :param bool onlyOnChange: Restart thread only if existing repositories changed.
+                                  This won't restart thread even when a new repository was added!!
+        """
+        log.debug("Restarting payload thread")
+
+        # If a restart thread is already running, don't start a new one
+        if threadMgr.get(THREAD_PAYLOAD_RESTART):
+            return
+
+        thread_args = (storage, ksdata, payload, fallback, checkmount, onlyOnChange)
+        # Launch a new thread so that this method can return immediately
+        threadMgr.add(AnacondaThread(name=THREAD_PAYLOAD_RESTART, target=self._restartThread,
+                                     args=thread_args))
+
+    @property
+    def running(self):
+        """Is the payload thread running right now?"""
+        return threadMgr.exists(THREAD_PAYLOAD_RESTART) or threadMgr.exists(THREAD_PAYLOAD)
+
+    def _restartThread(self, storage, ksdata, payload, fallback, checkmount, onlyOnChange):
+        # Wait for the old thread to finish
+        threadMgr.wait(THREAD_PAYLOAD)
+
+        thread_args = (storage, ksdata, payload, fallback, checkmount, onlyOnChange)
+        # Start a new payload thread
+        threadMgr.add(AnacondaThread(name=THREAD_PAYLOAD, target=self._runThread,
+                                     args=thread_args))
+
+    def _setState(self, event_id):
+        # Update the current state
+        log.debug("Updating payload thread state: %d", event_id)
+        with self._event_lock:
+            # Update the state within the lock to avoid a race with listeners
+            # currently being added
+            self._thread_state = event_id
+
+            # Run any listeners for the new state
+            for func in self._event_listeners[event_id]:
+                func()
+
+    def _runThread(self, storage, ksdata, payload, fallback, checkmount, onlyOnChange):
+        # This is the thread entry
+        # Set the initial state
+        self._error = None
+        self._setState(self.STATE_START)
+
+        # Wait for storage
+        self._setState(self.STATE_STORAGE)
+        threadMgr.wait(THREAD_STORAGE)
+
+        # Wait for network
+        self._setState(self.STATE_NETWORK)
+        # FIXME: condition for cases where we don't want network
+        # (set and use payload.needsNetwork ?)
+        threadMgr.wait(THREAD_WAIT_FOR_CONNECTING_NM)
+
+        payload.setup(storage)
+
+        # If this is a non-package Payload, we're done
+        if not isinstance(payload, PackagePayload):
+            self._setState(self.STATE_FINISHED)
+            return
+
+        # Test if any repository changed from the last update
+        if onlyOnChange:
+            log.debug("Testing repositories availability")
+            self._setState(self.STATE_TEST_AVAILABILITY)
+            if payload.verifyAvailableRepositories():
+                log.debug("Payload isn't restarted, repositories are still available.")
+                self._setState(self.STATE_FINISHED)
+                return
+
+        # Keep setting up package-based repositories
+        # Download package metadata
+        self._setState(self.STATE_PACKAGE_MD)
+        try:
+            payload.updateBaseRepo(fallback=fallback, checkmount=checkmount)
+            payload.addDriverRepos()
+        except (OSError, PayloadError) as e:
+            log.error("PayloadError: %s", e)
+            self._error = self.ERROR_SETUP
+            self._setState(self.STATE_ERROR)
+            payload.unsetup()
+            return
+
+        # Gather the group data
+        self._setState(self.STATE_GROUP_MD)
+        payload.gatherRepoMetadata()
+        payload.release()
+
+        # Check if that failed
+        if not payload.baseRepo:
+            log.error("No base repo configured")
+            self._error = self.ERROR_MD
+            self._setState(self.STATE_ERROR)
+            payload.unsetup()
+            return
+
+        # run payload specific post configuration tasks
+        payload.postSetup()
+
+        self._setState(self.STATE_FINISHED)
+
+
+# Initialize the PayloadManager instance
+payloadMgr = PayloadManager()

--- a/pyanaconda/payload/manager.py
+++ b/pyanaconda/payload/manager.py
@@ -179,7 +179,7 @@ class PayloadManager(object):
         # Wait for network
         self._setState(PayloadState.WAITING_NETWORK)
         # FIXME: condition for cases where we don't want network
-        # (set and use payload.needsNetwork ?)
+        # (set and use payload.needs_network ?)
         threadMgr.wait(THREAD_WAIT_FOR_CONNECTING_NM)
 
         payload.setup(storage)
@@ -193,7 +193,7 @@ class PayloadManager(object):
         if onlyOnChange:
             log.debug("Testing repositories availability")
             self._setState(PayloadState.VERIFYING_AVAILABILITY)
-            if payload.verifyAvailableRepositories():
+            if payload.verify_available_repositories():
                 log.debug("Payload isn't restarted, repositories are still available.")
                 self._setState(PayloadState.FINISHED)
                 return
@@ -202,8 +202,8 @@ class PayloadManager(object):
         # Download package metadata
         self._setState(PayloadState.DOWNLOADING_PKG_METADATA)
         try:
-            payload.updateBaseRepo(fallback=fallback, checkmount=checkmount)
-            payload.addDriverRepos()
+            payload.update_base_repo(fallback=fallback, checkmount=checkmount)
+            payload.add_driver_repos()
         except (OSError, PayloadError) as e:
             log.error("PayloadError: %s", e)
             self._error = self.ERROR_SETUP
@@ -213,11 +213,11 @@ class PayloadManager(object):
 
         # Gather the group data
         self._setState(PayloadState.DOWNLOADING_GROUP_METADATA)
-        payload.gatherRepoMetadata()
+        payload.gather_repo_metadata()
         payload.release()
 
         # Check if that failed
-        if not payload.baseRepo:
+        if not payload.base_repo:
             log.error("No base repo configured")
             self._error = self.ERROR_MD
             self._setState(PayloadState.ERROR)
@@ -225,7 +225,7 @@ class PayloadManager(object):
             return
 
         # run payload specific post configuration tasks
-        payload.postSetup()
+        payload.post_setup()
 
         self._setState(PayloadState.FINISHED)
 

--- a/pyanaconda/payload/requirement.py
+++ b/pyanaconda/payload/requirement.py
@@ -1,0 +1,202 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from collections import OrderedDict, namedtuple
+from pyanaconda.core.constants import PayloadRequirementType
+from pyanaconda.payload.errors import PayloadRequirementsMissingApply
+
+from pyanaconda.anaconda_loggers import get_module_logger
+
+log = get_module_logger(__name__)
+
+PayloadRequirementReason = namedtuple('PayloadRequirementReason', ['reason', 'strong'])
+
+
+__all__ = ["PayloadRequirements", "PayloadRequirement"]
+
+
+class PayloadRequirement(object):
+    """An object to store a payload requirement with info about its reasons.
+
+    For each requirement multiple reasons together with their strength
+    can be stored in this object using the add_reason method.
+    A reason should be just a string with description (ie for tracking purposes).
+    Strength is a boolean flag that can be used to indicate whether missing the
+    requirement should be considered fatal. Strength of the requirement is
+    given by strength of all its reasons.
+    """
+    def __init__(self, req_id, reasons=None):
+        self._id = req_id
+        self._reasons = reasons or []
+
+    @property
+    def id(self):
+        """Identifier of the requirement (eg a package name)"""
+        return self._id
+
+    @property
+    def reasons(self):
+        """List of reasons for the requirement"""
+        return [reason for reason, strong in self._reasons]
+
+    @property
+    def strong(self):
+        """Strength of the requirement (ie should it be considered fatal?)"""
+        return any(strong for reason, strong in self._reasons)
+
+    def add_reason(self, reason, strong=False):
+        """Adds a reason to the requirement with optional strength of the reason"""
+        self._reasons.append(PayloadRequirementReason(reason, strong))
+
+    def __str__(self):
+        return "PayloadRequirement(id=%s, reasons=%s, strong=%s)" % (self.id,
+                                                                     self.reasons,
+                                                                     self.strong)
+
+    def __repr__(self):
+        return 'PayloadRequirement(id=%s, reasons=%s)' % (self.id, self._reasons)
+
+
+class PayloadRequirements(object):
+    """A container for payload requirements imposed by installed functionality.
+
+    Stores names of packages and groups required by used installer features,
+    together with descriptions of reasons why the object is required and if the
+    requirement is strong. Not satisfying strong requirement would be fatal for
+    installation.
+    """
+
+    def __init__(self):
+        self._apply_called_for_all_requirements = True
+        self._apply_cb = None
+        self._reqs = {}
+        for req_type in PayloadRequirementType:
+            self._reqs[req_type] = OrderedDict()
+
+    def add_packages(self, package_names, reason, strong=True):
+        """Add packages required for the reason.
+
+        If a package is already required, the new reason will be
+        added and the strength of the requirement will be updated.
+
+        :param package_names: names of packages to be added
+        :type package_names: list of str
+        :param reason: description of reason for adding the packages
+        :type reason: str
+        :param strong: is the requirement strong (ie is not satisfying it fatal?)
+        :type strong: bool
+        """
+        self._add(PayloadRequirementType.package, package_names, reason, strong)
+
+    def add_groups(self, group_ids, reason, strong=True):
+        """Add groups required for the reason.
+
+        If a group is already required, the new reason will be
+        added and the strength of the requirement will be updated.
+
+        :param group_ids: ids of groups to be added
+        :type group_ids: list of str
+        :param reason: descripiton of reason for adding the groups
+        :type reason: str
+        :param strong: is the requirement strong
+        :type strong: bool
+        """
+        self._add(PayloadRequirementType.group, group_ids, reason, strong)
+
+    def _add(self, req_type, ids, reason, strong):
+        if not ids:
+            log.debug("no %s requirement added for %s", req_type.value, reason)
+        reqs = self._reqs[req_type]
+        for r_id in ids:
+            if r_id not in reqs:
+                reqs[r_id] = PayloadRequirement(r_id)
+            reqs[r_id].add_reason(reason, strong)
+            self._apply_called_for_all_requirements = False
+            log.debug("added %s requirement '%s' for %s, strong=%s",
+                      req_type.value, r_id, reason, strong)
+
+    @property
+    def packages(self):
+        """List of package requirements.
+
+        return: list of package requirements
+        rtype: list of PayloadRequirement
+        """
+        return list(self._reqs[PayloadRequirementType.package].values())
+
+    @property
+    def groups(self):
+        """List of group requirements.
+
+        return: list of group requirements
+        rtype: list of PayloadRequirement
+        """
+        return list(self._reqs[PayloadRequirementType.group].values())
+
+    def set_apply_callback(self, callback):
+        """Set the callback for applying requirements.
+
+        The callback will be called by apply() method.
+        param callback: callback function to be called by apply() method
+        type callback: a function taking one argument (requirements object)
+        """
+        self._apply_cb = callback
+
+    def apply(self):
+        """Apply requirements using callback function.
+
+        Calls the callback supplied via set_apply_callback() method. If no
+        callback was set, an axception is raised.
+
+        return: return value of the callback
+        rtype: type of the callback return value
+        raise PayloadRequirementsMissingApply: if there is no callback set
+
+        """
+        if self._apply_cb:
+            self._apply_called_for_all_requirements = True
+            rv = self._apply_cb(self)
+            log.debug("apply with result %s called on requirements %s", rv, self)
+            return rv
+        else:
+            raise PayloadRequirementsMissingApply
+
+    @property
+    def applied(self):
+        """Was all requirements applied?
+
+        return: Was apply called for all current requirements?
+        rtype: bool
+        """
+        return self.empty or self._apply_called_for_all_requirements
+
+    @property
+    def empty(self):
+        """Are requirements empty?
+
+        return: True if there are no requirements, else False
+        rtype: bool
+        """
+        return not any(self._reqs.values())
+
+    def __str__(self):
+        r = []
+        for req_type in PayloadRequirementType:
+            for rid, req in self._reqs[req_type].items():
+                r.append((req_type.value, rid, req))
+        return str(r)

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -55,21 +55,21 @@ class RPMOSTreePayload(Payload):
         self._locale_map = None
 
     @property
-    def handlesBootloaderConfiguration(self):
+    def handles_bootloader_configuration(self):
         return True
 
     @property
-    def kernelVersionList(self):
+    def kernel_version_list(self):
         # OSTree handles bootloader configuration
         return []
 
     @property
-    def spaceRequired(self):
+    def space_required(self):
         # We don't have this data with OSTree at the moment
         return Size("500 MB")
 
     @property
-    def needsNetwork(self):
+    def needs_network(self):
         """Test ostree repository if it requires network."""
         return not (self.data.ostreesetup.url and self.data.ostreesetup.url.startswith("file://"))
 
@@ -331,7 +331,7 @@ class RPMOSTreePayload(Payload):
                                        [bindopt, src, dest])
         self._internal_mounts.append(src if bind_ro else dest)
 
-    def prepareMountTargets(self, storage):
+    def prepare_mount_targets(self, storage):
         """ Prepare the ostree root """
         ostreesetup = self.data.ostreesetup
 
@@ -401,14 +401,14 @@ class RPMOSTreePayload(Payload):
             except CalledProcessError as e:
                 log.debug("unmounting %s failed: %s", mount, str(e))
 
-    def recreateInitrds(self):
+    def recreate_initrds(self):
         # For rpmostree payloads, we're replicating an initramfs from
         # a compose server, and should never be regenerating them
         # per-machine.
         pass
 
-    def postInstall(self):
-        super().postInstall()
+    def post_install(self):
+        super().post_install()
 
         gi.require_version("OSTree", "1.0")
         from gi.repository import OSTree

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -28,7 +28,8 @@ from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _
 from pyanaconda.localization import get_locale_map_from_ostree, strip_codeset_and_modifier
 from pyanaconda.progress import progressQ
-from pyanaconda.payload import ArchivePayload, PayloadInstallError
+from pyanaconda.payload import ArchivePayload
+from pyanaconda.payload.errors import PayloadInstallError
 from pyanaconda.bootloader.efi import EFIBase
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.glib import format_size_full, create_new_context, Variant, GError

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -99,7 +99,7 @@ class RPMOSTreePayload(Payload):
         locale = strip_codeset_and_modifier(locale)
         return locale in locale_map.get(language, [])
 
-    def _safeExecWithRedirect(self, cmd, argv, **kwargs):
+    def _safe_exec_with_redirect(self, cmd, argv, **kwargs):
         """Like util.execWithRedirect, but treat errors as fatal"""
         rc = util.execWithRedirect(cmd, argv, **kwargs)
         if rc != 0:
@@ -107,7 +107,7 @@ class RPMOSTreePayload(Payload):
             if errors.errorHandler.cb(exn) == errors.ERROR_RAISE:
                 raise exn
 
-    def _pullProgressCb(self, asyncProgress):
+    def _pull_progress_cb(self, asyncProgress):
         status = asyncProgress.get_status()
         outstanding_fetches = asyncProgress.get_uint('outstanding-fetches')
         if status:
@@ -131,7 +131,7 @@ class RPMOSTreePayload(Payload):
         else:
             progressQ.send_message(_("Writing objects"))
 
-    def _copyBootloaderData(self):
+    def _copy_bootloader_data(self):
         # Copy bootloader data files from the deployment
         # checkout to the target root.  See
         # https://bugzilla.gnome.org/show_bug.cgi?id=726757 This
@@ -165,10 +165,11 @@ class RPMOSTreePayload(Payload):
                     for subname in os.listdir(srcpath):
                         sub_srcpath = os.path.join(srcpath, subname)
                         sub_destpath = os.path.join(destpath, subname)
-                        self._safeExecWithRedirect('cp', ['-r', '-p', sub_srcpath, sub_destpath])
+                        self._safe_exec_with_redirect('cp',
+                                                      ['-r', '-p', sub_srcpath, sub_destpath])
             else:
                 log.info("Copying bootloader data: %s", fname)
-                self._safeExecWithRedirect('cp', ['-r', '-p', srcpath, destpath])
+                self._safe_exec_with_redirect('cp', ['-r', '-p', srcpath, destpath])
 
             # Unfortunate hack, see https://github.com/rhinstaller/anaconda/issues/1188
             efi_grubenv_link = physboot + '/grub2/grubenv'
@@ -187,9 +188,9 @@ class RPMOSTreePayload(Payload):
         log.info("executing ostreesetup=%r", ostreesetup)
 
         # Initialize the filesystem - this will create the repo as well
-        self._safeExecWithRedirect("ostree",
-                                   ["admin", "--sysroot=" + util.getTargetPhysicalRoot(),
-                                    "init-fs", util.getTargetPhysicalRoot()])
+        self._safe_exec_with_redirect("ostree",
+                                      ["admin", "--sysroot=" + util.getTargetPhysicalRoot(),
+                                       "init-fs", util.getTargetPhysicalRoot()])
 
         # Here, we use the physical root as sysroot, because we haven't
         # yet made a deployment.
@@ -220,7 +221,7 @@ class RPMOSTreePayload(Payload):
                                {"branchName": ref, "source": ostreesetup.remote})
 
         progress = OSTree.AsyncProgress.new()
-        progress.connect('changed', self._pullProgressCb)
+        progress.connect('changed', self._pull_progress_cb)
 
         pull_opts = {'refs': Variant('as', [ref])}
         # If we're doing a kickstart, we can at least use the content as a reference:
@@ -256,9 +257,9 @@ class RPMOSTreePayload(Payload):
         # complex.
         repo.remote_delete(self.data.ostreesetup.remote, None)
 
-        self._safeExecWithRedirect("ostree",
-                                   ["admin", "--sysroot=" + util.getTargetPhysicalRoot(),
-                                    "os-init", ostreesetup.osname])
+        self._safe_exec_with_redirect("ostree",
+                                      ["admin", "--sysroot=" + util.getTargetPhysicalRoot(),
+                                       "os-init", ostreesetup.osname])
 
         admin_deploy_args = ["admin", "--sysroot=" + util.getTargetPhysicalRoot(),
                              "deploy", "--os=" + ostreesetup.osname]
@@ -267,7 +268,7 @@ class RPMOSTreePayload(Payload):
 
         log.info("ostree admin deploy starting")
         progressQ.send_message(_("Deployment starting: %s") % (ref, ))
-        self._safeExecWithRedirect("ostree", admin_deploy_args)
+        self._safe_exec_with_redirect("ostree", admin_deploy_args)
         log.info("ostree admin deploy complete")
         progressQ.send_message(_("Deployment complete: %s") % (ref, ))
 
@@ -280,7 +281,7 @@ class RPMOSTreePayload(Payload):
         util.setSysroot(deployment_path.get_path())
 
         try:
-            self._copyBootloaderData()
+            self._copy_bootloader_data()
         except (OSError, RuntimeError) as e:
             exn = PayloadInstallError("Failed to copy bootloader data: %s" % e)
             log.error(str(exn))
@@ -291,10 +292,10 @@ class RPMOSTreePayload(Payload):
 
         mainctx.pop_thread_default()
 
-    def _setupInternalBindmount(self, src, dest=None,
-                                src_physical=True,
-                                bind_ro=False,
-                                recurse=True):
+    def _setup_internal_bindmount(self, src, dest=None,
+                                  src_physical=True,
+                                  bind_ro=False,
+                                  recurse=True):
         """Internal API for setting up bind mounts between the physical root and
            sysroot, also ensures we track them in self._internal_mounts so we can
            cleanly unmount them.
@@ -316,10 +317,10 @@ class RPMOSTreePayload(Payload):
         # Canonicalize dest to the full path
         dest = util.getSysroot() + dest
         if bind_ro:
-            self._safeExecWithRedirect("mount",
-                                       ["--bind", src, src])
-            self._safeExecWithRedirect("mount",
-                                       ["--bind", "-o", "remount,ro", src, src])
+            self._safe_exec_with_redirect("mount",
+                                          ["--bind", src, src])
+            self._safe_exec_with_redirect("mount",
+                                          ["--bind", "-o", "remount,ro", src, src])
         else:
             # Recurse for non-ro binds so we pick up sub-mounts
             # like /sys/firmware/efi/efivars.
@@ -327,8 +328,8 @@ class RPMOSTreePayload(Payload):
                 bindopt = '--rbind'
             else:
                 bindopt = '--bind'
-            self._safeExecWithRedirect("mount",
-                                       [bindopt, src, dest])
+            self._safe_exec_with_redirect("mount",
+                                          [bindopt, src, dest])
         self._internal_mounts.append(src if bind_ro else dest)
 
     def prepare_mount_targets(self, storage):
@@ -341,23 +342,23 @@ class RPMOSTreePayload(Payload):
         # bind mounts.
 
         # Make /usr readonly like ostree does at runtime normally
-        self._setupInternalBindmount('/usr', bind_ro=True, src_physical=False)
+        self._setup_internal_bindmount('/usr', bind_ro=True, src_physical=False)
 
         # Explicitly do API mounts; some of these may be tracked by blivet, but
         # we'll skip them below.
         api_mounts = ["/dev", "/proc", "/run", "/sys"]
         for path in api_mounts:
-            self._setupInternalBindmount(path)
+            self._setup_internal_bindmount(path)
 
         # Handle /var; if the admin didn't specify a mount for /var, we need
         # to do the default ostree one.
         # https://github.com/ostreedev/ostree/issues/855
-        varroot = '/ostree/deploy/' + ostreesetup.osname + '/var'
+        var_root = '/ostree/deploy/' + ostreesetup.osname + '/var'
         if storage.mountpoints.get("/var") is None:
-            self._setupInternalBindmount(varroot, dest='/var', recurse=False)
+            self._setup_internal_bindmount(var_root, dest='/var', recurse=False)
         else:
             # Otherwise, bind it
-            self._setupInternalBindmount('/var', recurse=False)
+            self._setup_internal_bindmount('/var', recurse=False)
 
         # Now that we have /var, start filling in any directories that may be
         # required later there. We explicitly make /var/lib, since
@@ -374,9 +375,9 @@ class RPMOSTreePayload(Payload):
         # target.
         for varsubdir in ('home', 'roothome', 'lib/rpm', 'opt', 'srv',
                           'usrlocal', 'mnt', 'media', 'spool', 'spool/mail'):
-            self._safeExecWithRedirect("systemd-tmpfiles",
-                                       ["--create", "--boot", "--root=" + util.getSysroot(),
-                                        "--prefix=/var/" + varsubdir])
+            self._safe_exec_with_redirect("systemd-tmpfiles",
+                                          ["--create", "--boot", "--root=" + util.getSysroot(),
+                                           "--prefix=/var/" + varsubdir])
 
         # Handle mounts like /boot (except avoid /boot/efi; we just need the
         # toplevel), and any admin-specified points like /home (really
@@ -387,10 +388,10 @@ class RPMOSTreePayload(Payload):
         for mount in sorted(storage.mountpoints, key=len):
             if mount in ('/', '/var') or mount in api_mounts:
                 continue
-            self._setupInternalBindmount(mount, recurse=False)
+            self._setup_internal_bindmount(mount, recurse=False)
 
         # And finally, do a nonrecursive bind for the sysroot
-        self._setupInternalBindmount("/", dest="/sysroot", recurse=False)
+        self._setup_internal_bindmount("/", dest="/sysroot", recurse=False)
 
     def unsetup(self):
         super().unsetup()
@@ -454,4 +455,4 @@ class RPMOSTreePayload(Payload):
             set_kargs_args = ["admin", "instutil", "set-kargs"]
             set_kargs_args.extend(self.storage.bootloader.boot_args)
             set_kargs_args.append("root=" + self.storage.root_device.fstab_spec)
-            self._safeExecWithRedirect("ostree", set_kargs_args, root=util.getSysroot())
+            self._safe_exec_with_redirect("ostree", set_kargs_args, root=util.getSysroot())

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -22,31 +22,31 @@ import os
 import sys
 from subprocess import CalledProcessError
 
+import pyanaconda.errors as errors
 from pyanaconda.core import util
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _
 from pyanaconda.localization import get_locale_map_from_ostree, strip_codeset_and_modifier
 from pyanaconda.progress import progressQ
-
-import gi
-gi.require_version("Gio", "2.0")
-
-from gi.repository import Gio
-
-from blivet.size import Size
-from blivet.util import umount
-
-from pyanaconda.anaconda_loggers import get_module_logger
-log = get_module_logger(__name__)
-
 from pyanaconda.payload import ArchivePayload, PayloadInstallError
 from pyanaconda.bootloader.efi import EFIBase
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.glib import format_size_full, create_new_context, Variant, GError
-import pyanaconda.errors as errors
+
+from blivet.size import Size
+from blivet.util import umount
+
+import gi
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
 
 class RPMOSTreePayload(ArchivePayload):
-    """ A RPMOSTreePayload deploys a tree (possibly with layered packages) onto the target system. """
+    """ A RPMOSTreePayload deploys a tree (possibly with layered packages)
+    onto the target system."""
     def __init__(self, data):
         super().__init__(data)
         self._remoteOptions = None
@@ -188,7 +188,7 @@ class RPMOSTreePayload(ArchivePayload):
         # Initialize the filesystem - this will create the repo as well
         self._safeExecWithRedirect("ostree",
                                    ["admin", "--sysroot=" + util.getTargetPhysicalRoot(),
-                                   "init-fs", util.getTargetPhysicalRoot()])
+                                    "init-fs", util.getTargetPhysicalRoot()])
 
         # Here, we use the physical root as sysroot, because we haven't
         # yet made a deployment.
@@ -215,7 +215,7 @@ class RPMOSTreePayload(ArchivePayload):
         # Variable substitute the ref: https://pagure.io/atomic-wg/issue/299
         ref = RpmOstree.varsubst_basearch(ostreesetup.ref)
 
-        progressQ.send_message(_("Starting pull of %(branchName)s from %(source)s") % \
+        progressQ.send_message(_("Starting pull of %(branchName)s from %(source)s") %
                                {"branchName": ref, "source": ostreesetup.remote})
 
         progress = OSTree.AsyncProgress.new()
@@ -257,7 +257,7 @@ class RPMOSTreePayload(ArchivePayload):
 
         self._safeExecWithRedirect("ostree",
                                    ["admin", "--sysroot=" + util.getTargetPhysicalRoot(),
-                                   "os-init", ostreesetup.osname])
+                                    "os-init", ostreesetup.osname])
 
         admin_deploy_args = ["admin", "--sysroot=" + util.getTargetPhysicalRoot(),
                              "deploy", "--os=" + ostreesetup.osname]

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -28,7 +28,7 @@ from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _
 from pyanaconda.localization import get_locale_map_from_ostree, strip_codeset_and_modifier
 from pyanaconda.progress import progressQ
-from pyanaconda.payload import ArchivePayload
+from pyanaconda.payload import Payload
 from pyanaconda.payload.errors import PayloadInstallError
 from pyanaconda.bootloader.efi import EFIBase
 from pyanaconda.core.configuration.anaconda import conf
@@ -45,7 +45,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class RPMOSTreePayload(ArchivePayload):
+class RPMOSTreePayload(Payload):
     """ A RPMOSTreePayload deploys a tree (possibly with layered packages)
     onto the target system."""
     def __init__(self, data):

--- a/pyanaconda/payload/source/sources.py
+++ b/pyanaconda/payload/source/sources.py
@@ -30,7 +30,6 @@ class SourceType(Enum):
     FILE = "file"
     LIVECD = "livecd"
     HMC = "hmc"
-    UNKNOWN = "unknown"
 
 
 class BasePayloadSource(object):

--- a/pyanaconda/payload/utils.py
+++ b/pyanaconda/payload/utils.py
@@ -1,0 +1,27 @@
+# Small utilities used in the payload by multiple places.
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from distutils.version import LooseVersion
+
+
+def version_cmp(v1, v2):
+    """Compare two version number strings."""
+    firstVersion = LooseVersion(v1)
+    secondVersion = LooseVersion(v2)
+    return (firstVersion > secondVersion) - (firstVersion < secondVersion)

--- a/pyanaconda/payload/utils.py
+++ b/pyanaconda/payload/utils.py
@@ -22,6 +22,6 @@ from distutils.version import LooseVersion
 
 def version_cmp(v1, v2):
     """Compare two version number strings."""
-    firstVersion = LooseVersion(v1)
-    secondVersion = LooseVersion(v2)
-    return (firstVersion > secondVersion) - (firstVersion < secondVersion)
+    first_version = LooseVersion(v1)
+    second_version = LooseVersion(v2)
+    return (first_version > second_version) - (first_version < second_version)

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -48,7 +48,7 @@ from pyanaconda.ui.gui.utils import blockedHandler, fire_gtk_action, find_first_
 from pyanaconda.ui.gui.utils import gtk_call_once, really_hide, really_show, fancy_set_sensitive
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload import PackagePayload
-from pyanaconda.payload.manager import payloadMgr
+from pyanaconda.payload.manager import payloadMgr, PayloadState
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.regexes import REPO_NAME_VALID, URL_PARSE, HOSTNAME_PATTERN_WITHOUT_ANCHORS
 from pyanaconda.modules.common.constants.services import NETWORK
@@ -767,12 +767,12 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             really_hide(self._updatesBox)
 
         # Register listeners for payload events
-        payloadMgr.addListener(payloadMgr.STATE_START, self._payload_refresh)
-        payloadMgr.addListener(payloadMgr.STATE_STORAGE, self._probing_storage)
-        payloadMgr.addListener(payloadMgr.STATE_PACKAGE_MD, self._downloading_package_md)
-        payloadMgr.addListener(payloadMgr.STATE_GROUP_MD, self._downloading_group_md)
-        payloadMgr.addListener(payloadMgr.STATE_FINISHED, self._payload_finished)
-        payloadMgr.addListener(payloadMgr.STATE_ERROR, self._payload_error)
+        payloadMgr.addListener(PayloadState.STARTED, self._payload_refresh)
+        payloadMgr.addListener(PayloadState.WAITING_STORAGE, self._probing_storage)
+        payloadMgr.addListener(PayloadState.DOWNLOADING_PKG_METADATA, self._downloading_package_md)
+        payloadMgr.addListener(PayloadState.DOWNLOADING_GROUP_METADATA, self._downloading_group_md)
+        payloadMgr.addListener(PayloadState.FINISHED, self._payload_finished)
+        payloadMgr.addListener(PayloadState.ERROR, self._payload_error)
 
         # Start the thread last so that we are sure initialize_done() is really called only
         # after all initialization has been done.

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -415,7 +415,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         if flags.askmethod:
             flags.askmethod = False
 
-        payloadMgr.restartThread(self.storage, self.data, self.payload, checkmount=False)
+        payloadMgr.restart_thread(self.storage, self.data, self.payload, checkmount=False)
         self.clear_info()
 
     def _method_changed(self):
@@ -767,12 +767,12 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             really_hide(self._updatesBox)
 
         # Register listeners for payload events
-        payloadMgr.addListener(PayloadState.STARTED, self._payload_refresh)
-        payloadMgr.addListener(PayloadState.WAITING_STORAGE, self._probing_storage)
-        payloadMgr.addListener(PayloadState.DOWNLOADING_PKG_METADATA, self._downloading_package_md)
-        payloadMgr.addListener(PayloadState.DOWNLOADING_GROUP_METADATA, self._downloading_group_md)
-        payloadMgr.addListener(PayloadState.FINISHED, self._payload_finished)
-        payloadMgr.addListener(PayloadState.ERROR, self._payload_error)
+        payloadMgr.add_listener(PayloadState.STARTED, self._payload_refresh)
+        payloadMgr.add_listener(PayloadState.WAITING_STORAGE, self._probing_storage)
+        payloadMgr.add_listener(PayloadState.DOWNLOADING_PKG_METADATA, self._downloading_package_md)
+        payloadMgr.add_listener(PayloadState.DOWNLOADING_GROUP_METADATA, self._downloading_group_md)
+        payloadMgr.add_listener(PayloadState.FINISHED, self._payload_finished)
+        payloadMgr.add_listener(PayloadState.ERROR, self._payload_error)
 
         # Start the thread last so that we are sure initialize_done() is really called only
         # after all initialization has been done.

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1612,9 +1612,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             Before final release this will also toggle the updates-testing repo
         """
         if self._noUpdatesCheckbox.get_active():
-            self.payload.setUpdatesEnabled(False)
+            self.payload.set_updates_enabled(False)
         else:
-            self.payload.setUpdatesEnabled(True)
+            self.payload.set_updates_enabled(True)
 
         # Refresh the metadata using the new set of repos
         self._updatesChange = True

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -47,7 +47,8 @@ from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.gui.utils import blockedHandler, fire_gtk_action, find_first_child
 from pyanaconda.ui.gui.utils import gtk_call_once, really_hide, really_show, fancy_set_sensitive
 from pyanaconda.threading import threadMgr, AnacondaThread
-from pyanaconda.payload import PackagePayload, payloadMgr
+from pyanaconda.payload import PackagePayload
+from pyanaconda.payload.manager import payloadMgr
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.regexes import REPO_NAME_VALID, URL_PARSE, HOSTNAME_PATTERN_WITHOUT_ANCHORS
 from pyanaconda.modules.common.constants.services import NETWORK

--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -81,7 +81,7 @@ class ResizeDialog(GUIObject):
 
         self._required_label = self.builder.get_object("requiredSpaceLabel")
         markup = _("Installation requires a total of <b>%s</b> for system data.")
-        required_dev_size = self.payload.requiredDeviceSize(FS.biggest_overhead_FS())
+        required_dev_size = self.payload.required_device_size(FS.biggest_overhead_FS())
         self._required_label.set_markup(markup % escape_markup(str(required_dev_size)))
 
         self._reclaimDescLabel = self.builder.get_object("reclaimDescLabel")
@@ -312,7 +312,7 @@ class ResizeDialog(GUIObject):
             self._deleteButton.set_sensitive(False)
 
     def _update_reclaim_button(self, got):
-        required_dev_size = self.payload.requiredDeviceSize(FS.biggest_overhead_FS())
+        required_dev_size = self.payload.required_device_size(FS.biggest_overhead_FS())
         self._resizeButton.set_sensitive(got+self._initialFreeSpace >= required_dev_size)
 
     # pylint: disable=arguments-differ

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1452,7 +1452,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         # if installation media or hdd aren't used and settings have changed
         # try if source is available
         if self.networking_changed:
-            if self.payload and self.payload.needsNetwork:
+            if self.payload and self.payload.needs_network:
                 if ANACONDA_ENVIRON in anaconda_flags.environs:
                     log.debug("network spoke (apply), network configuration changed - restarting payload thread")
                     from pyanaconda.payload.manager import payloadMgr
@@ -1479,7 +1479,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
     def mandatory(self):
         # the network spoke should be mandatory only if it is running
         # during the installation and if the installation source requires network
-        return ANACONDA_ENVIRON in anaconda_flags.environs and self.payload.needsNetwork
+        return ANACONDA_ENVIRON in anaconda_flags.environs and self.payload.needs_network
 
     @property
     def status(self):
@@ -1605,9 +1605,9 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
 
         self._now_available = self.completed
 
-        log.debug("network standalone spoke (apply) payload: %s completed: %s", self.payload.baseRepo, self._now_available)
-        if (not self.payload.baseRepo and not self._initially_available
-            and self._now_available and self.payload.needsNetwork):
+        log.debug("network standalone spoke (apply) payload: %s completed: %s", self.payload.base_repo, self._now_available)
+        if (not self.payload.base_repo and not self._initially_available
+            and self._now_available and self.payload.needs_network):
             from pyanaconda.payload.manager import payloadMgr
             payloadMgr.restartThread(self.storage, self.data, self.payload,
                     fallback=not anaconda_flags.automatedInstall)

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1455,7 +1455,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
             if self.payload and self.payload.needsNetwork:
                 if ANACONDA_ENVIRON in anaconda_flags.environs:
                     log.debug("network spoke (apply), network configuration changed - restarting payload thread")
-                    from pyanaconda.payload import payloadMgr
+                    from pyanaconda.payload.manager import payloadMgr
                     payloadMgr.restartThread(self.storage, self.data, self.payload,
                                              fallback=not anaconda_flags.automatedInstall, onlyOnChange=True)
                 else:
@@ -1608,7 +1608,7 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
         log.debug("network standalone spoke (apply) payload: %s completed: %s", self.payload.baseRepo, self._now_available)
         if (not self.payload.baseRepo and not self._initially_available
             and self._now_available and self.payload.needsNetwork):
-            from pyanaconda.payload import payloadMgr
+            from pyanaconda.payload.manager import payloadMgr
             payloadMgr.restartThread(self.storage, self.data, self.payload,
                     fallback=not anaconda_flags.automatedInstall)
 

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1456,7 +1456,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
                 if ANACONDA_ENVIRON in anaconda_flags.environs:
                     log.debug("network spoke (apply), network configuration changed - restarting payload thread")
                     from pyanaconda.payload.manager import payloadMgr
-                    payloadMgr.restartThread(self.storage, self.data, self.payload,
+                    payloadMgr.restart_thread(self.storage, self.data, self.payload,
                                              fallback=not anaconda_flags.automatedInstall, onlyOnChange=True)
                 else:
                     log.debug("network spoke (apply), network configuration changed - "
@@ -1609,7 +1609,7 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
         if (not self.payload.base_repo and not self._initially_available
             and self._now_available and self.payload.needs_network):
             from pyanaconda.payload.manager import payloadMgr
-            payloadMgr.restartThread(self.storage, self.data, self.payload,
+            payloadMgr.restart_thread(self.storage, self.data, self.payload,
                     fallback=not anaconda_flags.automatedInstall)
 
         self.network_control_box.kill_nmce(msg="leaving standalone network spoke")

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -26,7 +26,8 @@ from gi.repository import Gtk, Pango
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _, C_, CN_
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.payload import PackagePayload, payloadMgr, NoSuchGroup, PayloadError
+from pyanaconda.payload import PackagePayload, payloadMgr
+from pyanaconda.payload.errors import NoSuchGroup, PayloadError, DependencyError
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core import util, constants
 
@@ -218,7 +219,6 @@ class SoftwareSelectionSpoke(NormalSpoke):
         self._apply()
 
     def checkSoftwareSelection(self):
-        from pyanaconda.payload import DependencyError
         hubQ.send_message(self.__class__.__name__, _("Checking software dependencies..."))
         try:
             self.payload.checkSoftwareSelection()

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -27,7 +27,7 @@ from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _, C_, CN_
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.payload import PackagePayload
-from pyanaconda.payload.manager import payloadMgr
+from pyanaconda.payload.manager import payloadMgr, PayloadState
 from pyanaconda.payload.errors import NoSuchGroup, PayloadError, DependencyError
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core import util, constants
@@ -105,10 +105,10 @@ class SoftwareSelectionSpoke(NormalSpoke):
         self._error = False
 
         # Register event listeners to update our status on payload events
-        payloadMgr.addListener(payloadMgr.STATE_PACKAGE_MD, self._downloading_package_md)
-        payloadMgr.addListener(payloadMgr.STATE_GROUP_MD, self._downloading_group_md)
-        payloadMgr.addListener(payloadMgr.STATE_FINISHED, self._payload_finished)
-        payloadMgr.addListener(payloadMgr.STATE_ERROR, self._payload_error)
+        payloadMgr.addListener(PayloadState.DOWNLOADING_PKG_METADATA, self._downloading_package_md)
+        payloadMgr.addListener(PayloadState.DOWNLOADING_GROUP_METADATA, self._downloading_group_md)
+        payloadMgr.addListener(PayloadState.FINISHED, self._payload_finished)
+        payloadMgr.addListener(PayloadState.ERROR, self._payload_error)
 
         # Add an invisible radio button so that we can show the environment
         # list with no radio buttons ticked

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -155,7 +155,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
             # False means environment is not valid and must be set manually
             return False
         try:
-            return self.payload.environmentId(self.environment)
+            return self.payload.environment_id(self.environment)
         except NoSuchGroup:
             return None
 
@@ -222,7 +222,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
     def checkSoftwareSelection(self):
         hubQ.send_message(self.__class__.__name__, _("Checking software dependencies..."))
         try:
-            self.payload.checkSoftwareSelection()
+            self.payload.check_software_selection()
         except DependencyError as e:
             self._errorMsgs = str(e)
             hubQ.send_message(self.__class__.__name__, _("Error checking software dependencies"))

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -105,10 +105,10 @@ class SoftwareSelectionSpoke(NormalSpoke):
         self._error = False
 
         # Register event listeners to update our status on payload events
-        payloadMgr.addListener(PayloadState.DOWNLOADING_PKG_METADATA, self._downloading_package_md)
-        payloadMgr.addListener(PayloadState.DOWNLOADING_GROUP_METADATA, self._downloading_group_md)
-        payloadMgr.addListener(PayloadState.FINISHED, self._payload_finished)
-        payloadMgr.addListener(PayloadState.ERROR, self._payload_error)
+        payloadMgr.add_listener(PayloadState.DOWNLOADING_PKG_METADATA, self._downloading_package_md)
+        payloadMgr.add_listener(PayloadState.DOWNLOADING_GROUP_METADATA, self._downloading_group_md)
+        payloadMgr.add_listener(PayloadState.FINISHED, self._payload_finished)
+        payloadMgr.add_listener(PayloadState.ERROR, self._payload_error)
 
         # Add an invisible radio button so that we can show the environment
         # list with no radio buttons ticked

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -201,11 +201,11 @@ class SoftwareSelectionSpoke(NormalSpoke):
             self._selectFlag = False
             self.payload.data.packages.packageList = []
             self.payload.data.packages.groupList = []
-            self.payload.selectEnvironment(self.environment)
+            self.payload.select_environment(self.environment)
             log.debug("Environment selected for installation: %s", self.environment)
             log.debug("Groups selected for installation: %s", addons)
             for group in addons:
-                self.payload.selectGroup(group)
+                self.payload.select_group(group)
 
             # And then save these values so we can check next time.
             self._origAddons = addons
@@ -229,7 +229,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
             self._tx_id = None
         else:
             self._errorMsgs = None
-            self._tx_id = self.payload.txID
+            self._tx_id = self.payload.tx_id
         finally:
             hubQ.send_ready(self.__class__.__name__, False)
             hubQ.send_ready("SourceSpoke", False)
@@ -285,7 +285,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
         return bool(not threadMgr.get(constants.THREAD_SOFTWARE_WATCHER) and
                     not threadMgr.get(constants.THREAD_PAYLOAD) and
                     not threadMgr.get(constants.THREAD_CHECK_SOFTWARE) and
-                    self.payload.baseRepo is not None)
+                    self.payload.base_repo is not None)
 
     @property
     def showable(self):
@@ -325,7 +325,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
                 # source is switched to one where the selected environment is no longer valid
                 return _("Selected environment is not valid")
 
-        return self.payload.environmentDescription(self.environment)[0]
+        return self.payload.environment_description(self.environment)[0]
 
     def initialize(self):
         super().initialize()
@@ -337,8 +337,8 @@ class SoftwareSelectionSpoke(NormalSpoke):
         threadMgr.wait(constants.THREAD_PAYLOAD)
         # Select groups which should be selected by kickstart
         try:
-            for group in self.payload.selectedGroupsIDs():
-                if self.environment and self.payload.environmentOptionIsDefault(self.environment, group):
+            for group in self.payload.selected_groups_IDs():
+                if self.environment and self.payload.environment_option_is_default(self.environment, group):
                     self._addonStates[group] = self._ADDON_DEFAULT
                 else:
                     self._addonStates[group] = self._ADDON_SELECTED
@@ -405,7 +405,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
 
         # create rows for all valid environments
         for environmentid in self.payload.environments:
-            (name, desc) = self.payload.environmentDescription(environmentid)
+            (name, desc) = self.payload.environment_description(environmentid)
 
             # use the invisible radio button as a group for all environment
             # radio buttons
@@ -435,7 +435,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
         self._addonListBox.show_all()
 
     def _addAddon(self, grp):
-        (name, desc) = self.payload.groupDescription(grp)
+        (name, desc) = self.payload.group_description(grp)
 
         if grp in self._addonStates:
             # If the add-on was previously selected by the user, select it
@@ -446,9 +446,9 @@ class SoftwareSelectionSpoke(NormalSpoke):
                 selected = False
             # Otherwise, use the default state
             else:
-                selected = self.payload.environmentOptionIsDefault(self.environmentid, grp)
+                selected = self.payload.environment_option_is_default(self.environmentid, grp)
         else:
-            selected = self.payload.environmentOptionIsDefault(self.environmentid, grp)
+            selected = self.payload.environment_option_is_default(self.environmentid, grp)
 
         check = Gtk.CheckButton()
         check.set_active(selected)
@@ -457,11 +457,11 @@ class SoftwareSelectionSpoke(NormalSpoke):
     @property
     def _addSep(self):
         """ Whether the addon list contains a separator. """
-        return len(self.payload.environmentAddons[self.environmentid][0]) > 0 and \
-            len(self.payload.environmentAddons[self.environmentid][1]) > 0
+        return len(self.payload.environment_addons[self.environmentid][0]) > 0 and \
+            len(self.payload.environment_addons[self.environmentid][1]) > 0
 
     def refreshAddons(self):
-        if self.environment and (self.environmentid in self.payload.environmentAddons):
+        if self.environment and (self.environmentid in self.payload.environment_addons):
             self._clear_listbox(self._addonListBox)
 
             # We have two lists:  One of addons specific to this environment,
@@ -474,7 +474,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
             # state will be used. Otherwise, the add-on will be selected if it is a default
             # for this environment.
 
-            for grp in self.payload.environmentAddons[self.environmentid][0]:
+            for grp in self.payload.environment_addons[self.environmentid][0]:
                 self._addAddon(grp)
 
             # This marks a separator in the view - only add it if there's both environment
@@ -482,7 +482,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
             if self._addSep:
                 self._addonListBox.insert(Gtk.Separator(), -1)
 
-            for grp in self.payload.environmentAddons[self.environmentid][1]:
+            for grp in self.payload.environment_addons[self.environmentid][1]:
                 self._addAddon(grp)
 
         self._selectFlag = True
@@ -493,11 +493,11 @@ class SoftwareSelectionSpoke(NormalSpoke):
             self.clear_info()
 
     def _allAddons(self):
-        if self.environmentid in self.payload.environmentAddons:
-            addons = copy.copy(self.payload.environmentAddons[self.environmentid][0])
+        if self.environmentid in self.payload.environment_addons:
+            addons = copy.copy(self.payload.environment_addons[self.environmentid][0])
             if self._addSep:
                 addons.append('')
-            addons += self.payload.environmentAddons[self.environmentid][1]
+            addons += self.payload.environment_addons[self.environmentid][1]
         else:
             addons = []
         return addons
@@ -521,12 +521,12 @@ class SoftwareSelectionSpoke(NormalSpoke):
     def _mark_addon_selection(self, grpid, selected):
         # Mark selection or return its state to the default state
         if selected:
-            if self.payload.environmentOptionIsDefault(self.environment, grpid):
+            if self.payload.environment_option_is_default(self.environment, grpid):
                 self._addonStates[grpid] = self._ADDON_DEFAULT
             else:
                 self._addonStates[grpid] = self._ADDON_SELECTED
         else:
-            if not self.payload.environmentOptionIsDefault(self.environment, grpid):
+            if not self.payload.environment_option_is_default(self.environment, grpid):
                 self._addonStates[grpid] = self._ADDON_DEFAULT
             else:
                 self._addonStates[grpid] = self._ADDON_DESELECTED
@@ -538,7 +538,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
 
     @property
     def txid_valid(self):
-        return self._tx_id == self.payload.txID
+        return self._tx_id == self.payload.tx_id
 
     # Signal handlers
     def on_radio_button_toggled(self, radio, row):

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -26,7 +26,8 @@ from gi.repository import Gtk, Pango
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _, C_, CN_
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.payload import PackagePayload, payloadMgr
+from pyanaconda.payload import PackagePayload
+from pyanaconda.payload.manager import payloadMgr
 from pyanaconda.payload.errors import NoSuchGroup, PayloadError, DependencyError
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core import util, constants

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -164,7 +164,7 @@ class InstallOptionsDialogBase(GUIObject):
         return (not threadMgr.get(constants.THREAD_PAYLOAD) and
                 not threadMgr.get(constants.THREAD_SOFTWARE_WATCHER) and
                 not threadMgr.get(constants.THREAD_CHECK_SOFTWARE) and
-                self.payload.baseRepo is not None)
+                self.payload.base_repo is not None)
 
     def _check_for_storage_thread(self, button):
         if self._software_is_ready():
@@ -998,7 +998,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             fs_free = sum(f[1] for f in free_space.values())
 
         disks_size = sum((d.size for d in disks), Size(0))
-        sw_space = self.payload.spaceRequired
+        sw_space = self.payload.space_required
         auto_swap = sum((r.size for r in self.storage.autopart_requests
                                 if r.fstype == "swap"), Size(0))
         if self.autopart and auto_swap == Size(0):

--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -59,7 +59,7 @@ from pyanaconda.core import constants
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.core.i18n import _
-from pyanaconda.payload import payloadMgr
+from pyanaconda.payload.manager import payloadMgr
 from pyanaconda.anaconda_loggers import get_module_logger
 
 import copy

--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -130,7 +130,7 @@ class SourceSwitchHandler(object, metaclass=ABCMeta):
         """
         self._clean_hdd_iso()
         self.data.method.method = None
-        payloadMgr.restartThread(self.storage, self.data, self.payload, checkmount=False)   # pylint: disable=no-member
+        payloadMgr.restart_thread(self.storage, self.data, self.payload, checkmount=False)   # pylint: disable=no-member
         threadMgr.wait(constants.THREAD_PAYLOAD_RESTART)
         threadMgr.wait(constants.THREAD_PAYLOAD)
 

--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -171,7 +171,7 @@ class SourceSwitchHandler(object, metaclass=ABCMeta):
 
         self.data.method.method = "harddrive"
         self.data.method.partition = partition
-        # the / gets stripped off by payload.ISOImage
+        # the / gets stripped off by payload.ISO_image
         self.data.method.dir = "/" + iso_path
 
         # as we already made the device protected when

--- a/pyanaconda/ui/lib/space.py
+++ b/pyanaconda/ui/lib/space.py
@@ -52,7 +52,7 @@ class FileSystemSpaceChecker(object):
 
     def _calculate_needed_space(self):
         """Calculate the needed space."""
-        return self.payload.spaceRequired
+        return self.payload.space_required
 
     def check(self):
         """Check configured storage against software selections.  When this
@@ -77,7 +77,7 @@ class FileSystemSpaceChecker(object):
             message = _("Not enough space in file systems for the current software selection.")
         else:
             result = False
-            required = self.payload.requiredDeviceSize(self.storage.root_device.format)
+            required = self.payload.required_device_size(self.storage.root_device.format)
             deficit = required - self.storage.root_device.size
             message = _("Not enough space in file systems for the current software selection. "
                         "An additional {} is needed.").format(deficit)

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -22,7 +22,8 @@ from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog
 from pyanaconda.threading import threadMgr, AnacondaThread
-from pyanaconda.payload import PackagePayload, payloadMgr
+from pyanaconda.payload import PackagePayload
+from pyanaconda.payload.manager import payloadMgr
 from pyanaconda.core.i18n import N_, _, C_
 from pyanaconda.image import opticalInstallMedia, potentialHdisoSources
 

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -77,7 +77,7 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
 
         threadMgr.add(AnacondaThread(name=THREAD_SOURCE_WATCHER,
                                      target=self._initialize))
-        payloadMgr.addListener(PayloadState.ERROR, self._payload_error)
+        payloadMgr.add_listener(PayloadState.ERROR, self._payload_error)
 
     def _initialize(self):
         """ Private initialize. """
@@ -241,7 +241,7 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
         # clear them at this point
         self._error = False
 
-        payloadMgr.restartThread(self.storage, self.data, self.payload, checkmount=False)
+        payloadMgr.restart_thread(self.storage, self.data, self.payload, checkmount=False)
 
 
 class SpecifyRepoSpoke(NormalTUISpoke, SourceSwitchHandler):

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -118,7 +118,7 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
             if not method.dir:
                 return _("Error setting up software source")
             return os.path.basename(method.dir)
-        elif self.payload.baseRepo:
+        elif self.payload.base_repo:
             return _("Closest mirror")
         else:
             return _("Nothing selected")
@@ -138,10 +138,10 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
 
     @property
     def completed(self):
-        if flags.automatedInstall and self.ready and not self.payload.baseRepo:
+        if flags.automatedInstall and self.ready and not self.payload.base_repo:
             return False
         else:
-            return not self._error and self.ready and (self.data.method.method or self.payload.baseRepo)
+            return not self._error and self.ready and (self.data.method.method or self.payload.base_repo)
 
     def refresh(self, args=None):
         NormalTUISpoke.refresh(self, args)

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -23,7 +23,7 @@ from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload import PackagePayload
-from pyanaconda.payload.manager import payloadMgr
+from pyanaconda.payload.manager import payloadMgr, PayloadState
 from pyanaconda.core.i18n import N_, _, C_
 from pyanaconda.image import opticalInstallMedia, potentialHdisoSources
 
@@ -77,7 +77,7 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
 
         threadMgr.add(AnacondaThread(name=THREAD_SOURCE_WATCHER,
                                      target=self._initialize))
-        payloadMgr.addListener(payloadMgr.STATE_ERROR, self._payload_error)
+        payloadMgr.addListener(PayloadState.ERROR, self._payload_error)
 
     def _initialize(self):
         """ Private initialize. """

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -248,7 +248,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     def mandatory(self):
         # the network spoke should be mandatory only if it is running
         # during the installation and if the installation source requires network
-        return ANACONDA_ENVIRON in flags.environs and self.payload.needsNetwork
+        return ANACONDA_ENVIRON in flags.environs and self.payload.needs_network
 
     @property
     def status(self):

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -408,7 +408,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         if self._apply:
             self._apply = False
             if ANACONDA_ENVIRON in flags.environs:
-                from pyanaconda.payload import payloadMgr
+                from pyanaconda.payload.manager import payloadMgr
                 payloadMgr.restartThread(self.storage, self.data, self.payload, checkmount=False)
 
 

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -409,7 +409,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
             self._apply = False
             if ANACONDA_ENVIRON in flags.environs:
                 from pyanaconda.payload.manager import payloadMgr
-                payloadMgr.restartThread(self.storage, self.data, self.payload, checkmount=False)
+                payloadMgr.restart_thread(self.storage, self.data, self.payload, checkmount=False)
 
 
 class ConfigureDeviceSpoke(NormalTUISpoke):

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -136,8 +136,8 @@ class SoftwareSpoke(NormalTUISpoke):
         """ Return all add-ons of the specific environment. """
         addons = []
 
-        if environment_id in self.payload.environmentAddons:
-            for addons_list in self.payload.environmentAddons[environment_id]:
+        if environment_id in self.payload.environment_addons:
+            for addons_list in self.payload.environment_addons[environment_id]:
                 addons.extend(addons_list)
 
         return addons
@@ -157,7 +157,7 @@ class SoftwareSpoke(NormalTUISpoke):
             return _("Error checking software selection")
         if not self.ready:
             return _("Processing...")
-        if not self.payload.baseRepo:
+        if not self.payload.base_repo:
             return _("Installation source not set up")
         if not self.txid_valid:
             return _("Source changed - please verify")
@@ -170,7 +170,7 @@ class SoftwareSpoke(NormalTUISpoke):
                 return _("Custom software selected")
             return _("Nothing selected")
 
-        return self.payload.environmentDescription(self.environment)[0]
+        return self.payload.environment_description(self.environment)[0]
 
     @property
     def completed(self):
@@ -183,9 +183,9 @@ class SoftwareSpoke(NormalTUISpoke):
         processing_done = self.ready and not self.errors and self.txid_valid
 
         if flags.automatedInstall or self._kickstarted:
-            return processing_done and self.payload.baseRepo and self.data.packages.seen
+            return processing_done and self.payload.base_repo and self.data.packages.seen
         else:
-            return processing_done and self.payload.baseRepo and self.environment is not None
+            return processing_done and self.payload.base_repo and self.environment is not None
 
     def refresh(self, args=None):
         """ Refresh screen. """
@@ -194,7 +194,7 @@ class SoftwareSpoke(NormalTUISpoke):
         threadMgr.wait(THREAD_PAYLOAD)
         self._container = None
 
-        if not self.payload.baseRepo:
+        if not self.payload.base_repo:
             message = TextWidget(_("Installation source needs to be set up first."))
             self.window.add_with_separator(message)
             return
@@ -214,7 +214,7 @@ class SoftwareSpoke(NormalTUISpoke):
         environments = self.payload.environments
 
         for env in environments:
-            name = self.payload.environmentDescription(env)[0]
+            name = self.payload.environment_description(env)[0]
             selected = (env == self._selected_environment)
             widget = CheckboxWidget(title="%s" % name, completed=selected)
             self._container.add(widget, callback=self._set_environment_callback, data=env)
@@ -223,7 +223,7 @@ class SoftwareSpoke(NormalTUISpoke):
 
     def _refresh_addons(self, available_addons):
         for addon_id in available_addons:
-            name = self.payload.groupDescription(addon_id)[0]
+            name = self.payload.group_description(addon_id)[0]
             selected = addon_id in self._addons_selection
             widget = CheckboxWidget(title="%s" % name, completed=selected)
             self._container.add(widget, callback=self._set_addons_callback, data=addon_id)
@@ -314,14 +314,14 @@ class SoftwareSpoke(NormalTUISpoke):
 
                 self.payload.data.packages.packageList = []
                 self.data.packages.groupList = []
-                self.payload.selectEnvironment(self.environment)
+                self.payload.select_environment(self.environment)
 
                 environment_id = self._translate_env_name_to_id(self.environment)
                 available_addons = self._get_available_addons(environment_id)
 
                 for addon_id in available_addons:
                     if addon_id in self.addons:
-                        self.payload.selectGroup(addon_id)
+                        self.payload.select_group(addon_id)
 
                 changed = True
 
@@ -342,9 +342,9 @@ class SoftwareSpoke(NormalTUISpoke):
             self._tx_id = None
             log.warning("Transaction error %s", str(e))
         else:
-            self._tx_id = self.payload.txID
+            self._tx_id = self.payload.tx_id
 
     @property
     def txid_valid(self):
         """ Whether we have a valid dnf tx id. """
-        return self._tx_id == self.payload.txID
+        return self._tx_id == self.payload.tx_id

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -68,9 +68,9 @@ class SoftwareSpoke(NormalTUISpoke):
         self._kickstarted = flags.automatedInstall and self.data.packages.seen
 
         # Register event listeners to update our status on payload events
-        payloadMgr.addListener(PayloadState.STARTED, self._payload_start)
-        payloadMgr.addListener(PayloadState.FINISHED, self._payload_finished)
-        payloadMgr.addListener(PayloadState.ERROR, self._payload_error)
+        payloadMgr.add_listener(PayloadState.STARTED, self._payload_start)
+        payloadMgr.add_listener(PayloadState.FINISHED, self._payload_finished)
+        payloadMgr.add_listener(PayloadState.ERROR, self._payload_error)
 
     def initialize(self):
         # Start a thread to wait for the payload and run the first, automatic

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -20,7 +20,8 @@ from pyanaconda.flags import flags
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.threading import threadMgr, AnacondaThread
-from pyanaconda.payload import DependencyError, PackagePayload, payloadMgr, NoSuchGroup
+from pyanaconda.payload import PackagePayload, payloadMgr
+from pyanaconda.payload.errors import DependencyError, NoSuchGroup
 from pyanaconda.core.i18n import N_, _, C_
 from pyanaconda.core.configuration.anaconda import conf
 

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -20,7 +20,8 @@ from pyanaconda.flags import flags
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.threading import threadMgr, AnacondaThread
-from pyanaconda.payload import PackagePayload, payloadMgr
+from pyanaconda.payload import PackagePayload
+from pyanaconda.payload.manager import payloadMgr
 from pyanaconda.payload.errors import DependencyError, NoSuchGroup
 from pyanaconda.core.i18n import N_, _, C_
 from pyanaconda.core.configuration.anaconda import conf

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -21,7 +21,7 @@ from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload import PackagePayload
-from pyanaconda.payload.manager import payloadMgr
+from pyanaconda.payload.manager import payloadMgr, PayloadState
 from pyanaconda.payload.errors import DependencyError, NoSuchGroup
 from pyanaconda.core.i18n import N_, _, C_
 from pyanaconda.core.configuration.anaconda import conf
@@ -68,9 +68,9 @@ class SoftwareSpoke(NormalTUISpoke):
         self._kickstarted = flags.automatedInstall and self.data.packages.seen
 
         # Register event listeners to update our status on payload events
-        payloadMgr.addListener(payloadMgr.STATE_START, self._payload_start)
-        payloadMgr.addListener(payloadMgr.STATE_FINISHED, self._payload_finished)
-        payloadMgr.addListener(payloadMgr.STATE_ERROR, self._payload_error)
+        payloadMgr.addListener(PayloadState.STARTED, self._payload_start)
+        payloadMgr.addListener(PayloadState.FINISHED, self._payload_finished)
+        payloadMgr.addListener(PayloadState.ERROR, self._payload_error)
 
     def initialize(self):
         # Start a thread to wait for the payload and run the first, automatic

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -128,7 +128,7 @@ class SoftwareSpoke(NormalTUISpoke):
             # None means environment is not set, no need to try translate that to an id
             return None
         try:
-            return self.payload.environmentId(environment)
+            return self.payload.environment_id(environment)
         except NoSuchGroup:
             return None
 
@@ -336,7 +336,7 @@ class SoftwareSpoke(NormalTUISpoke):
     def checkSoftwareSelection(self):
         """ Depsolving """
         try:
-            self.payload.checkSoftwareSelection()
+            self.payload.check_software_selection()
         except DependencyError as e:
             self.errors = [str(e)]
             self._tx_id = None

--- a/tests/nosetests/pyanaconda_tests/payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/payload_test.py
@@ -27,7 +27,7 @@ import hashlib
 import shutil
 
 from pyanaconda.payload.dnfpayload import RepoMDMetaHash
-from pyanaconda.payload import PayloadRequirements
+from pyanaconda.payload.requirement import PayloadRequirements
 from pyanaconda.payload.errors import PayloadRequirementsMissingApply
 
 

--- a/tests/nosetests/pyanaconda_tests/payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/payload_test.py
@@ -27,7 +27,8 @@ import hashlib
 import shutil
 
 from pyanaconda.payload.dnfpayload import RepoMDMetaHash
-from pyanaconda.payload import PayloadRequirements, PayloadRequirementsMissingApply
+from pyanaconda.payload import PayloadRequirements
+from pyanaconda.payload.errors import PayloadRequirementsMissingApply
 
 
 class PickLocation(unittest.TestCase):


### PR DESCRIPTION
Make payload classes pep8 compatible.
Split `payload/__init__.py` parts to multiple files.
Remove `ArchivePayload` & `ImagePayload` because they didn't have any implementation.