### PR TITLE
Specify the sysroot when you call the DBus method InstallWithTasks

### DIFF
--- a/pyanaconda/dbus_addons/baz/baz.py
+++ b/pyanaconda/dbus_addons/baz/baz.py
@@ -37,7 +37,7 @@ class Baz(KickstartModule):
         DBus.publish_object(BAZ.object_path, BazInterface(self))
         DBus.register_service(BAZ.service_name)
 
-    def install_with_tasks(self):
+    def install_with_tasks(self, sysroot):
         """Return installation tasks."""
         return [self.publish_task(BAZ.namespace, BazTask())]
 

--- a/pyanaconda/modules/boss/install_manager/install_manager.py
+++ b/pyanaconda/modules/boss/install_manager/install_manager.py
@@ -16,6 +16,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.core import util
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.boss.install_manager.installation import SystemInstallationTask
 
@@ -60,6 +61,9 @@ class InstallManager(object):
         """
         tasks = []
 
+        # FIXME: We need to figure out how to handle the sysroot.
+        sysroot = util.getSysroot()
+
         if not self._module_observers:
             log.error("Starting installation without available modules.")
 
@@ -72,7 +76,7 @@ class InstallManager(object):
                 continue
 
             service_name = observer.service_name
-            task_paths = observer.proxy.InstallWithTasks()
+            task_paths = observer.proxy.InstallWithTasks(sysroot)
 
             for object_path in task_paths:
                 log.debug("Getting task %s from module %s", object_path, service_name)

--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -231,9 +231,10 @@ class KickstartModule(MainModule, KickstartBaseModule):
         """
         return self.generate_kickstart()
 
-    def install_with_tasks(self):
+    def install_with_tasks(self, sysroot):
         """Return installation tasks of this module.
 
+        :param sysroot: a path to the root of the installed system
         :return: a list of DBus paths of the installation tasks
         """
         return []

--- a/pyanaconda/modules/common/base/base_interface.py
+++ b/pyanaconda/modules/common/base/base_interface.py
@@ -115,12 +115,13 @@ class KickstartModuleInterface(KickstartModuleInterfaceTemplate):
         """
         return self.implementation.generate_temporary_kickstart()
 
-    def InstallWithTasks(self) -> List[ObjPath]:
+    def InstallWithTasks(self, sysroot: Str) -> List[ObjPath]:
         """Returns installation tasks of this module.
 
+        :param sysroot: a path to the root of the installed system
         :returns: list of object paths of installation tasks.
         """
-        return self.implementation.install_with_tasks()
+        return self.implementation.install_with_tasks(sysroot)
 
     def Quit(self):
         """Shut the module down."""

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -19,7 +19,6 @@
 #
 from blivet import arch
 
-from pyanaconda.core import util
 from pyanaconda.core.signal import Signal
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.base import KickstartModule
@@ -214,15 +213,15 @@ class StorageModule(KickstartModule):
         self.set_storage(storage.copy())
         log.debug("Applied the partitioning from %s.", object_path)
 
-    def install_with_tasks(self):
+    def install_with_tasks(self, sysroot):
         """Returns installation tasks of this module.
 
         FIXME: This is a simplified version of the storage installation.
 
+        :param sysroot: a path to the root of the installed system
         :returns: list of object paths of installation tasks.
         """
         storage = self.storage
-        sysroot = util.getSysroot()
 
         tasks = [
             ActivateFilesystemsTask(storage),

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -126,7 +126,8 @@ class StorageInterfaceTestCase(unittest.TestCase):
         ]
 
         # Get the installation tasks.
-        task_paths = self.storage_interface.InstallWithTasks()
+        with tempfile.TemporaryDirectory() as sysroot:
+            task_paths = self.storage_interface.InstallWithTasks(sysroot)
 
         # Check the number of installation tasks.
         task_number = len(task_classes)


### PR DESCRIPTION
For now, we should specify the path to the root of the installed
system when we call the DBus method InstallWithTasks, because
the sysroot can change during the installation.