### PR TITLE
dracut/parse-kickstart: Set DEVICETYPE instead of TYPE in a team mast…

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -566,7 +566,7 @@ def ksnet_to_ifcfg(net, filename=None):
     if net.teamslaves:
 
         ifcfg.pop('HWADDR', None)
-        ifcfg['TYPE'] = "Team"
+        ifcfg['DEVICETYPE'] = "Team"
         ifcfg['NAME'] = "Team connection %s" % dev
         ifcfg['TEAM_CONFIG'] = net.teamconfig
 


### PR DESCRIPTION
…er ifcfg file

Both NetworkManager and the legacy network service scripts expect a team master
ifcfg file to have DEVICETYPE="Team" set. Currently, only TYPE is set which
means the legacy network service will not assign IP addressing as expected.

Signed-off-by: Patrick Talbert <ptalbert@redhat.com>