### PR TITLE
Set up the kickstart partitioning from the storage by default

### DIFF
--- a/pyanaconda/modules/storage/partitioning/custom.py
+++ b/pyanaconda/modules/storage/partitioning/custom.py
@@ -61,11 +61,6 @@ class CustomPartitioningModule(PartitioningModule):
         # FIXME: Remove this ugly hack.
         self._data.onPart = {}
 
-    def setup_kickstart(self, data):
-        """Setup the kickstart data."""
-        # TODO: Provide the kickstart data.
-        pass
-
     def configure_with_task(self):
         """Schedule the partitioning actions."""
         task = StorageConfigureTask(self.storage, CustomPartitioningExecutor(self.data))

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -807,6 +807,18 @@ class StorageInterfaceTestCase(unittest.TestCase):
         with self.assertLogs(level=logging.WARN):
             self._test_kickstart(ks_in, ks_out)
 
+    @patch("pyanaconda.dbus.DBus.get_proxy")
+    def custom_partitioning_kickstart_test(self, proxy_getter):
+        """Smoke test for the custom partitioning."""
+        # Make sure that the storage model is created.
+        self.assertTrue(self.storage_module.storage)
+
+        # Make sure that the storage playground is created.
+        self.assertTrue(self.storage_module._custom_part_module.storage)
+
+        # Try to get kickstart data.
+        self._test_kickstart("", "")
+
 
 class StorageTasksTestCase(unittest.TestCase):
     """Test the storage tasks."""


### PR DESCRIPTION
A partitioning module should set up the kickstart data from the storage
playground by default. The automatic and manual partitioning modules
override this method, but the custom partitioning module will use it.