### PR TITLE
Get the required device size for the given space from DBus

### DIFF
--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -18,6 +18,7 @@
 # Red Hat, Inc.
 #
 from blivet import arch
+from blivet.size import Size
 
 from pyanaconda.core.signal import Signal
 from pyanaconda.dbus import DBus
@@ -42,6 +43,7 @@ from pyanaconda.modules.storage.snapshot import SnapshotModule
 from pyanaconda.modules.storage.storage_interface import StorageInterface
 from pyanaconda.modules.storage.zfcp import ZFCPModule
 from pyanaconda.storage.initialization import enable_installer_mode, create_storage
+from pyanaconda.storage.utils import get_required_device_size
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -198,6 +200,14 @@ class StorageModule(KickstartModule):
         # Publish the task.
         path = self.publish_task(STORAGE.namespace, task)
         return path
+
+    def get_required_device_size(self, required_space):
+        """Get device size we need to get the required space on the device.
+
+        :param int required_space: a required space in bytes
+        :return int: a required device size in bytes
+        """
+        return get_required_device_size(Size(required_space)).get_bytes()
 
     def apply_partitioning(self, object_path):
         """Apply a partitioning.

--- a/pyanaconda/modules/storage/storage_interface.py
+++ b/pyanaconda/modules/storage/storage_interface.py
@@ -34,6 +34,14 @@ class StorageInterface(KickstartModuleInterface):
         """
         return self.implementation.reset_with_task()
 
+    def GetRequiredDeviceSize(self, required_space: UInt64) -> UInt64:
+        """Get device size we need to get the required space on the device.
+
+        :param required_space: a required space in bytes
+        :return: a required device size in bytes
+        """
+        return self.implementation.get_required_device_size(required_space)
+
     def ApplyPartitioning(self, partitioning: ObjPath):
         """Apply the partitioning.
 

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -49,7 +49,6 @@ from pykickstart.parser import Group
 import blivet.util
 import blivet.arch
 from blivet.errors import StorageError
-from blivet.size import Size, ROUND_HALF_UP
 
 from pyanaconda.anaconda_loggers import get_module_logger
 
@@ -118,20 +117,6 @@ class Payload(metaclass=ABCMeta):
         not exist.  Used by the RPMOSTreePayload subclass.
         """
         pass
-
-    def required_device_size(self, format_class):
-        """We need to provide information how big device is required to have successful
-        installation. ``format_class`` should be filesystem format
-        class for the **root** filesystem this class carry information about
-        metadata size.
-
-        :param format_class: Class of the filesystem format.
-        :type format_class: Class which inherits :class:`blivet.formats.fs.FS`
-        :returns: Size of the device with given filesystem format.
-        :rtype: :class:`blivet.size.Size`
-        """
-        device_size = format_class.get_required_size(self.space_required)
-        return device_size.round_to_nearest(Size("1 MiB"), ROUND_HALF_UP)
 
     ###
     # METHODS FOR WORKING WITH REPOSITORIES

--- a/pyanaconda/storage/utils.py
+++ b/pyanaconda/storage/utils.py
@@ -36,6 +36,8 @@ from blivet.devicefactory import DEVICE_TYPE_MD
 from blivet.devicefactory import DEVICE_TYPE_PARTITION
 from blivet.devicefactory import DEVICE_TYPE_DISK
 from blivet.devicefactory import is_supported_device_type
+from bytesize.bytesize import ROUND_HALF_UP
+
 from pykickstart.errors import KickstartError
 
 from pyanaconda.core import util
@@ -603,3 +605,22 @@ def check_disk_selection(storage, selected_disks):
         })
 
     return errors
+
+
+def get_required_device_size(required_space, format_class=None):
+    """Get the required device size for the given space.
+
+    We need to provide information how big device is required to
+    have successful installation. The argument ``format_class``
+    should be filesystem format class for the **root** filesystem
+    this class carry information about metadata size.
+
+    :param required_space: the required space
+    :param format_class: the class of the filesystem format.
+    :returns: Size of the device with given filesystem format.
+    """
+    if not format_class:
+        format_class = FS.biggest_overhead_FS()
+
+    device_size = format_class.get_required_size(required_space)
+    return device_size.round_to_nearest(Size("1 MiB"), ROUND_HALF_UP)

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -23,6 +23,8 @@ import unittest
 from unittest.mock import patch, call, Mock
 
 from blivet.errors import StorageError
+from blivet.size import Size
+
 from pyanaconda.bootloader import BootLoaderError
 from pykickstart.constants import AUTOPART_TYPE_LVM_THINP, AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_LVM
 
@@ -96,6 +98,11 @@ class StorageInterfaceTestCase(unittest.TestCase):
 
         obj.implementation.stopped_signal.emit()
         storage_changed_callback.called_once()
+
+    def get_required_device_size_test(self):
+        """Test GetRequiredDeviceSize."""
+        required_size = self.storage_interface.GetRequiredDeviceSize(Size("1 GiB").get_bytes())
+        self.assertEqual(Size("1280 MiB").get_bytes(), required_size, Size(required_size))
 
     @patch('pyanaconda.modules.storage.partitioning.validate.storage_checker')
     def apply_partitioning_test(self, storage_checker):


### PR DESCRIPTION
Remove the method required_device_size from Payload and use the
method GetRequiredDeviceSize from the Storage module instead.

Let's try to always use the format class with largest space taken
by metadata for the calculation of the required size.