### PR TITLE
Set up the disk initialization module from the partitioned storage

### DIFF
--- a/tests/nosetests/pyanaconda_tests/module_disk_init_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_disk_init_test.py
@@ -1,0 +1,93 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+import unittest
+
+from pyanaconda.core.constants import CLEAR_PARTITIONS_LINUX
+from pyanaconda.modules.common.constants.objects import DISK_INITIALIZATION
+from pyanaconda.modules.storage.disk_initialization import DiskInitializationModule
+from pyanaconda.modules.storage.disk_initialization.initialization_interface import \
+    DiskInitializationInterface
+from tests.nosetests.pyanaconda_tests import check_dbus_property
+
+
+class DiskInitializationInterfaceTestCase(unittest.TestCase):
+    """Test DBus interface of the disk initialization module."""
+
+    def setUp(self):
+        """Set up the module."""
+        self.disk_init_module = DiskInitializationModule()
+        self.disk_init_interface = DiskInitializationInterface(self.disk_init_module)
+
+    def _test_dbus_property(self, *args, **kwargs):
+        check_dbus_property(
+            self,
+            DISK_INITIALIZATION,
+            self.disk_init_interface,
+            *args, **kwargs
+        )
+
+    def default_disk_label_property_test(self):
+        """Test the default disk label property."""
+        self._test_dbus_property(
+            "DefaultDiskLabel",
+            "msdos"
+        )
+
+    def format_unrecognized_enabled_property_test(self):
+        """Test the can format unrecognized property."""
+        self._test_dbus_property(
+            "FormatUnrecognizedEnabled",
+            False
+        )
+
+    def can_initialize_label_property_test(self):
+        """Test the can initialize label property."""
+        self._test_dbus_property(
+            "InitializeLabelsEnabled",
+            False
+        )
+
+    def format_ldl_enabled_property_test(self):
+        """Test the can format LDL property."""
+        self._test_dbus_property(
+            "FormatLDLEnabled",
+            True
+        )
+
+    def initialization_mode_property_test(self):
+        """Test the type to clear property."""
+        self._test_dbus_property(
+            "InitializationMode",
+            CLEAR_PARTITIONS_LINUX
+        )
+
+    def devices_to_clear_property_test(self):
+        """Test the devices to clear property."""
+        self._test_dbus_property(
+            "DevicesToClear",
+            ["sda2", "sda3", "sdb1"]
+        )
+
+    def drives_to_clear_property_test(self):
+        """Test the drives to clear property."""
+        self._test_dbus_property(
+            "DrivesToClear",
+            ["sda", "sdb"]
+        )

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -26,12 +26,10 @@ from blivet.errors import StorageError
 from pyanaconda.bootloader import BootLoaderError
 from pykickstart.constants import AUTOPART_TYPE_LVM_THINP, AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_LVM
 
-from pyanaconda.core.constants import CLEAR_PARTITIONS_LINUX, \
-    MOUNT_POINT_PATH, MOUNT_POINT_DEVICE, MOUNT_POINT_REFORMAT, MOUNT_POINT_FORMAT, \
-    MOUNT_POINT_FORMAT_OPTIONS, MOUNT_POINT_MOUNT_OPTIONS
+from pyanaconda.core.constants import MOUNT_POINT_PATH, MOUNT_POINT_DEVICE, MOUNT_POINT_REFORMAT, \
+    MOUNT_POINT_FORMAT, MOUNT_POINT_FORMAT_OPTIONS, MOUNT_POINT_MOUNT_OPTIONS
 from pyanaconda.dbus.typing import get_variant, Str, Bool, ObjPath
-from pyanaconda.modules.common.constants.objects import DISK_INITIALIZATION, \
-    DISK_SELECTION, AUTO_PARTITIONING, MANUAL_PARTITIONING
+from pyanaconda.modules.common.constants.objects import DISK_SELECTION, AUTO_PARTITIONING, MANUAL_PARTITIONING
 from pyanaconda.modules.common.errors.configuration import StorageDiscoveryError, \
     StorageConfigurationError, BootloaderConfigurationError
 from pyanaconda.modules.common.errors.storage import InvalidStorageError, UnavailableStorageError, \
@@ -41,9 +39,6 @@ from pyanaconda.modules.storage.dasd import DASDModule
 from pyanaconda.modules.storage.dasd.dasd_interface import DASDInterface
 from pyanaconda.modules.storage.dasd.discover import DASDDiscoverTask
 from pyanaconda.modules.storage.dasd.format import DASDFormatTask
-from pyanaconda.modules.storage.disk_initialization import DiskInitializationModule
-from pyanaconda.modules.storage.disk_initialization.initialization_interface import \
-    DiskInitializationInterface
 from pyanaconda.modules.storage.disk_selection import DiskSelectionModule
 from pyanaconda.modules.storage.disk_selection.selection_interface import DiskSelectionInterface
 from pyanaconda.modules.storage.fcoe import FCOEModule
@@ -829,72 +824,6 @@ class StorageTasksTestCase(unittest.TestCase):
         task = StorageResetTask(storage)
         task.run()
         storage.reset.called_once()
-
-
-class DiskInitializationInterfaceTestCase(unittest.TestCase):
-    """Test DBus interface of the disk initialization module."""
-
-    def setUp(self):
-        """Set up the module."""
-        self.disk_init_module = DiskInitializationModule()
-        self.disk_init_interface = DiskInitializationInterface(self.disk_init_module)
-
-    def _test_dbus_property(self, *args, **kwargs):
-        check_dbus_property(
-            self,
-            DISK_INITIALIZATION,
-            self.disk_init_interface,
-            *args, **kwargs
-        )
-
-    def default_disk_label_property_test(self):
-        """Test the default disk label property."""
-        self._test_dbus_property(
-            "DefaultDiskLabel",
-            "msdos"
-        )
-
-    def format_unrecognized_enabled_property_test(self):
-        """Test the can format unrecognized property."""
-        self._test_dbus_property(
-            "FormatUnrecognizedEnabled",
-            False
-        )
-
-    def can_initialize_label_property_test(self):
-        """Test the can initialize label property."""
-        self._test_dbus_property(
-            "InitializeLabelsEnabled",
-            False
-        )
-
-    def format_ldl_enabled_property_test(self):
-        """Test the can format LDL property."""
-        self._test_dbus_property(
-            "FormatLDLEnabled",
-            True
-        )
-
-    def initialization_mode_property_test(self):
-        """Test the type to clear property."""
-        self._test_dbus_property(
-            "InitializationMode",
-            CLEAR_PARTITIONS_LINUX
-        )
-
-    def devices_to_clear_property_test(self):
-        """Test the devices to clear property."""
-        self._test_dbus_property(
-            "DevicesToClear",
-            ["sda2", "sda3", "sdb1"]
-        )
-
-    def drives_to_clear_property_test(self):
-        """Test the drives to clear property."""
-        self._test_dbus_property(
-            "DrivesToClear",
-            ["sda", "sdb"]
-        )
 
 
 class DiskSelectionInterfaceTestCase(unittest.TestCase):


### PR DESCRIPTION
The disk initialization module should set up its configuration from
the partitioned storage. The callback is not connected to a signal
for now, however the code will be used in UI.

Move the tests for the disk initialization module to a new file.