### PR TITLE
Set the correct attribute of the bootloader kickstart data

### DIFF
--- a/pyanaconda/modules/storage/bootloader/bootloader.py
+++ b/pyanaconda/modules/storage/bootloader/bootloader.py
@@ -130,10 +130,10 @@ class BootloaderModule(KickstartBaseModule):
             data.bootloader.disabled = False
             data.bootloader.location = "mbr"
         elif self.preferred_location == BOOTLOADER_LOCATION_PARTITION:
-            data.bootloader.location = False
+            data.bootloader.disabled = False
             data.bootloader.location = "partition"
         else:
-            data.bootloader.location = False
+            data.bootloader.disabled = False
             data.bootloader.location = None
 
         data.bootloader.bootDrive = self.drive


### PR DESCRIPTION
Set the attribute `disabled` of the bootloader kickstart data instead
of `location`. The attribute is False by default, so the bug didn't
cause any problems.