### PR TITLE
Set the default filesystem type for /boot in the Storage module

### DIFF
--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -142,6 +142,7 @@ class StorageModule(KickstartModule):
         # Set the default filesystem type.
         if data.autopart.autopart and data.autopart.fstype:
             self.storage.set_default_fstype(data.autopart.fstype)
+            self.storage.set_default_boot_fstype(data.autopart.fstype)
 
     def generate_temporary_kickstart(self):
         """Return the temporary kickstart string."""


### PR DESCRIPTION
Set the default filesystem type for /boot in the Storage module, if
the autopart command is specified, to better reflect the behavior
of the `set_storage_defaults_from_kickstart` function.