### PR TITLE
Don't override bg color of gtk-themes

### DIFF
--- a/data/anaconda-gtk.css
+++ b/data/anaconda-gtk.css
@@ -84,7 +84,7 @@ levelbar.discrete trough block.filled.high {
 
 /* theme colors/images */
 
-@define-color theme_bg_color @fedora;
+@define-color product_bg_color @fedora;
 
 /* logo and sidebar classes */
 
@@ -94,7 +94,7 @@ levelbar.discrete trough block.filled.high {
  */
 .logo-sidebar {
     background-image: url('/usr/share/anaconda/pixmaps/sidebar-bg.png');
-    background-color: @theme_bg_color;
+    background-color: @product_bg_color;
     background-repeat: no-repeat;
 }
 
@@ -113,7 +113,7 @@ levelbar.discrete trough block.filled.high {
 }
 
 AnacondaSpokeWindow #nav-box {
-    background-color: @theme_bg_color;
+    background-color: @product_bg_color;
     background-image: url('/usr/share/anaconda/pixmaps/topbar-bg.png');
     background-repeat: repeat;
     color: white;


### PR DESCRIPTION
A lot of themes use theme_bg_color as define for their css.
So, don't override their settings with fedora's blue color
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1684808
fixes https://github.com/rhinstaller/anaconda/issues/1859