### PR TITLE
Detect and warn if SMT is enabled (#1684056)

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -158,6 +158,13 @@ WARNING_HARDWARE_UNSUPPORTED = N_(
     "on supported hardware, please refer to http://www.redhat.com/hardware."
 )
 
+WARNING_SMT_ENABLED = N_(
+    "Simultaneous Multithreading (SMT) technology can provide performance improvements for "
+    "certain workloads, but also has several known security issues. If you choose to leave SMT "
+    "enabled, please read https://red.ht/rhel-smt to ensure you understand the risks."
+)
+
+
 # Password type
 class SecretType(Enum):
     PASSWORD = "password"

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1506,3 +1506,19 @@ def synchronized(wrapped):
         with self._lock:
             return wrapped(self, *args, **kwargs)
     return _wrapper
+
+
+def is_smt_enabled():
+    """Is Simultaneous Multithreading (SMT) enabled?
+
+    :return: True or False
+    """
+    if flags.automatedInstall or flags.dirInstall or flags.imageInstall:
+        log.info("Skipping detection of SMT.")
+        return False
+
+    try:
+        return int(open("/sys/devices/system/cpu/smt/active").read()) == 1
+    except (IOError, ValueError):
+        log.warning("Failed to detect SMT.")
+        return False

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -257,7 +257,8 @@ class Hub(GUIObject, common.Hub):
         if update_continue:
             self._updateContinue()
 
-    def _updateContinue(self):
+    def _get_warning(self):
+        """Get the warning message for the hub."""
         warning = None
         if len(self._incompleteSpokes) == 0:
             if self._checker and not self._checker.check():
@@ -272,8 +273,13 @@ class Hub(GUIObject, common.Hub):
         else:
             warning = _("Please complete items marked with this icon before continuing to the next step.")
 
+        return warning
+
+    def _updateContinue(self):
         # Check that this warning isn't already set to avoid spamming the
         # info bar with incomplete spoke messages when the hub starts
+        warning = self._get_warning()
+
         if warning != self._warningMsg:
             self.clear_info()
             self._warningMsg = warning

--- a/pyanaconda/ui/gui/hubs/summary.py
+++ b/pyanaconda/ui/gui/hubs/summary.py
@@ -16,8 +16,11 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
+from pyanaconda.core.constants import WARNING_SMT_ENABLED
+from pyanaconda.core.i18n import _, C_
+from pyanaconda.core.util import is_smt_enabled
 from pyanaconda.ui.gui.hubs import Hub
+from pyanaconda.ui.gui.spokes.lib.detailederror import DetailedErrorDialog
 from pyanaconda.ui.lib.space import FileSystemSpaceChecker, DirInstallSpaceChecker
 from pyanaconda.flags import flags
 
@@ -56,6 +59,7 @@ class SummaryHub(Hub):
                            selections and default partitioning.
         """
         super().__init__(data, storage, payload, instclass)
+        self._show_details_callback = None
 
         if not flags.dirInstall:
             self._checker = FileSystemSpaceChecker(storage, payload)
@@ -65,8 +69,50 @@ class SummaryHub(Hub):
         # Add a continue-clicked handler
         self.window.connect("continue-clicked", self._on_continue_clicked)
 
+        # Add an info-bar-clicked handler
+        self.window.connect("info-bar-clicked", self._on_info_bar_clicked)
+
     def _on_continue_clicked(self, window, user_data=None):
         """Call finished method of spokes when leaving the hub.
         """
         for spoke in sorted(self._spokes.values(), key=lambda x: x.__class__.__name__):
             spoke.finished()
+
+    def _on_info_bar_clicked(self, *args):
+        """Call the callback to show a detailed message."""
+        if self._show_details_callback:
+            self._show_details_callback()
+
+    def _get_warning(self):
+        """Get the warning message for the hub."""
+        warning = super()._get_warning()
+        callback = None
+
+        if not warning and is_smt_enabled():
+            warning = _("Warning: Processor has Simultaneous Multithreading (SMT) enabled.  "
+                        "<a href=\"\">Click for details.</a>")
+
+            callback = self._show_detailed_smt_warning
+
+        self._show_details_callback = callback
+        return warning
+
+    def _show_detailed_smt_warning(self):
+        """Show details for the SMT warning."""
+        label = _("The following warnings were encountered when checking your kernel "
+                  "configuration. These are not fatal, but you may wish to make changes "
+                  "to your kernel config.")
+
+        warning = _(WARNING_SMT_ENABLED)
+
+        dialog = DetailedErrorDialog(
+            self.data,
+            buttons=[C_("GUI|Summary|Warning Dialog", "_OK")],
+            label=label
+        )
+
+        with self.main_window.enlightbox(dialog.window):
+            dialog.refresh(warning)
+            dialog.run()
+
+        dialog.window.destroy()

--- a/pyanaconda/ui/tui/spokes/kernel_warning.py
+++ b/pyanaconda/ui/tui/spokes/kernel_warning.py
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from simpleline.render.widgets import TextWidget
+
+from pyanaconda.core.constants import WARNING_SMT_ENABLED
+from pyanaconda.core.i18n import N_, _
+from pyanaconda.core.util import is_smt_enabled
+from pyanaconda.ui.tui.spokes import StandaloneTUISpoke
+from pyanaconda.ui.tui.hubs.summary import SummaryHub
+
+__all__ = ["KernelWarningSpoke"]
+
+
+class KernelWarningSpoke(StandaloneTUISpoke):
+    """Spoke for kernel-related warnings."""
+    preForHub = SummaryHub
+    priority = 0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.title = N_("Warning: Processor has Simultaneous Multithreading (SMT) enabled")
+        self.input_required = False
+
+    @property
+    def completed(self):
+        """Show this spoke if SMT is enabled."""
+        return not is_smt_enabled()
+
+    def refresh(self, args=None):
+        """Refresh the window."""
+        super().refresh(args)
+        self.window.add_with_separator(TextWidget(_(WARNING_SMT_ENABLED)))
+
+    def show_all(self):
+        """Show the warning and close the screen."""
+        super().show_all()
+        self.close()
+
+    def apply(self):
+        """Nothing to apply."""
+        pass


### PR DESCRIPTION
Detect whether hyperthreading (SMT) is enabled on a system. If so,
we should display a warning in the info bar of the summary hub.

Resolves: rhbz#1684056