### PR TITLE
Handle missing support for Blivet-GUI in the Storage module (#1685645)

### DIFF
--- a/pyanaconda/modules/common/errors/storage.py
+++ b/pyanaconda/modules/common/errors/storage.py
@@ -37,3 +37,9 @@ class UnavailableDataError(AnacondaError):
 class InvalidStorageError(AnacondaError):
     """The storage model is not valid."""
     pass
+
+
+@dbus_error("UnsupportedPartitioningError", namespace=STORAGE_NAMESPACE)
+class UnsupportedPartitioningError(AnacondaError):
+    """The partitioning method is not supported."""
+    pass

--- a/pyanaconda/modules/storage/partitioning/blivet_handler.py
+++ b/pyanaconda/modules/storage/partitioning/blivet_handler.py
@@ -1,0 +1,77 @@
+#
+# Handlers for the Blivet partitioning module.
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import pickle
+from pyanaconda.modules.common.errors.storage import UnsupportedPartitioningError
+
+try:
+    # Fail if the support for Blivet-GUI is missing.
+    from blivetgui.communication.server import BlivetUtilsServer
+    from blivetgui.osinstall import BlivetUtilsAnaconda
+except ImportError as e:
+    raise UnsupportedPartitioningError("Missing support for Blivet-GUI") from e
+
+__all__ = ["BlivetStorageHandler", "BlivetRequestHandler"]
+
+
+class BlivetStorageHandler(BlivetUtilsAnaconda):
+    """The storage handler for the Blivet."""
+    pass
+
+
+class BlivetRequestHandler(BlivetUtilsServer):
+    """The request handler for the Blivet."""
+
+    def __init__(self):  # pylint: disable=super-init-not-called
+        self._data = None
+        self._result = None
+
+    def get_reply(self, request):
+        """Get a reply to a request."""
+        self._data = request
+
+        # Handle the request.
+        self.handle()
+
+        # Return the reply.
+        return self._result
+
+    def handle(self):
+        """Handle a message."""
+        msg = self._recv_msg()
+        unpickled_msg = pickle.loads(msg)
+
+        if unpickled_msg[0] == "call":
+            self._call_utils_method(unpickled_msg)
+        elif unpickled_msg[0] == "param":
+            self._get_param(unpickled_msg)
+        elif unpickled_msg[0] == "method":
+            self._call_method(unpickled_msg)
+        elif unpickled_msg[0] == "next":
+            self._get_next(unpickled_msg)
+        elif unpickled_msg[0] == "key":
+            self._get_key(unpickled_msg)
+
+    def _recv_msg(self):
+        """Receive a message from a client."""
+        return self._data
+
+    def _send(self, data):
+        """Send a message to a client."""
+        self._result = data

--- a/pyanaconda/modules/storage/partitioning/blivet_interface.py
+++ b/pyanaconda/modules/storage/partitioning/blivet_interface.py
@@ -17,9 +17,6 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-import pickle
-
-from blivetgui.communication.server import BlivetUtilsServer
 
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
@@ -31,58 +28,10 @@ from pyanaconda.modules.storage.partitioning.base_interface import PartitioningI
 class BlivetPartitioningInterface(PartitioningInterface):
     """DBus interface for the Blivet partitioning module."""
 
-    def __init__(self, implementation):
-        """Initialize the interface."""
-        super().__init__(implementation)
-        self._request_handler = BlivetRequestHandler()
-
     def SendRequest(self, data: List[Byte]) -> List[Byte]:
         """Send a request to the storage handler.
 
         :param data: a request data in bytes
         :return: a reply data in bytes
         """
-        return self._request_handler.get_reply(bytes(data), self.implementation.storage_handler)
-
-
-class BlivetRequestHandler(BlivetUtilsServer):
-    """The request handler for the Blivet."""
-
-    def __init__(self):  # pylint: disable=super-init-not-called
-        self._data = None
-        self._result = None
-
-    def get_reply(self, request, utils):
-        """Get a reply to a request."""
-        self.blivet_utils = utils
-        self._data = request
-
-        # Handle the request.
-        self.handle()
-
-        # Return the reply.
-        return self._result
-
-    def handle(self):
-        """Handle a message."""
-        msg = self._recv_msg()
-        unpickled_msg = pickle.loads(msg)
-
-        if unpickled_msg[0] == "call":
-            self._call_utils_method(unpickled_msg)
-        elif unpickled_msg[0] == "param":
-            self._get_param(unpickled_msg)
-        elif unpickled_msg[0] == "method":
-            self._call_method(unpickled_msg)
-        elif unpickled_msg[0] == "next":
-            self._get_next(unpickled_msg)
-        elif unpickled_msg[0] == "key":
-            self._get_key(unpickled_msg)
-
-    def _recv_msg(self):
-        """Receive a message from a client."""
-        return self._data
-
-    def _send(self, data):
-        """Send a message to a client."""
-        self._result = data
+        return self._implementation.send_request(bytes(data))

--- a/tests/nosetests/pyanaconda_tests/module_blivet_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_blivet_test.py
@@ -17,6 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
+import sys
 import pickle
 import unittest
 from unittest.mock import patch, Mock
@@ -40,11 +41,53 @@ class BlivetPartitioningInterfaceTestCase(unittest.TestCase):
         self.module = BlivetPartitioningModule()
         self.interface = BlivetPartitioningInterface(self.module)
 
-    def handler_test(self):
-        """Test the handler property."""
+    @patch.dict('sys.modules')
+    def unsupported_partitioning_test(self):
+        """Test the UnsupportedPartitioningError."""
+        # Forget imported modules from pyanaconda and blivetgui.
+        for name in list(sys.modules):
+            if name.startswith('pyanaconda') or name.startswith('blivetgui'):
+                sys.modules.pop(name)
+
+        # Disable the blivetgui package.
+        sys.modules['blivetgui'] = None
+
+        # Import the StorageModule again.
+        from pyanaconda.modules.storage.storage import StorageModule
+
+        # We should be able to create the Storage module
+        storage_module = StorageModule()
+        self.assertIsNotNone(storage_module.storage)
+
+        # We should be able to access the Blivet module.
+        blivet_module = storage_module._blivet_part_module
+        self.assertIsNotNone(blivet_module.storage)
+
+        # Import the exception again.
+        from pyanaconda.modules.common.errors.storage import UnsupportedPartitioningError
+
+        # Handle the missing support.
+        with self.assertRaises(UnsupportedPartitioningError):
+            self.assertFalse(blivet_module.storage_handler)
+
+        with self.assertRaises(UnsupportedPartitioningError):
+            self.assertFalse(blivet_module.request_handler)
+
+        with self.assertRaises(UnsupportedPartitioningError):
+            request = pickle.dumps(("call", "get_disks", []))
+            blivet_module.send_request(request)
+
+    def storage_handler_test(self):
+        """Test the storage_handler property."""
         self.module.on_storage_reset(Mock())
         self.assertIsNotNone(self.module.storage_handler)
         self.assertEqual(self.module.storage, self.module.storage_handler.storage)
+
+    def request_handler_test(self):
+        """Test the request_handler property."""
+        self.module.on_storage_reset(Mock())
+        self.assertIsNotNone(self.module.request_handler)
+        self.assertEqual(self.module.storage_handler, self.module.request_handler.blivet_utils)
 
     def send_request_test(self):
         """Test SendRequest."""


### PR DESCRIPTION
The Blivet partitioning module should be able to exist without support
for Blivet-GUI. In this case, the method `SendRequest` will raise the
`UnsupportedPartitioningError` exception.

In the future, we will raise this exception once the Blivet
partitioning is requested.

Resolves: rhbz#1685645