### PR TITLE
payload: don't force host-only mode when executing dracut

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -587,8 +587,7 @@ class Payload(metaclass=ABCMeta):
                 if use_dracut:
                     util.execInSysroot("depmod", ["-a", kernel])
                     util.execInSysroot("dracut",
-                                       ["-H", "--persistent-policy", "by-uuid",
-                                        "-f",
+                                       ["-f",
                                         "/boot/initramfs-%s.img" % kernel,
                                         kernel])
                 else:


### PR DESCRIPTION
When the initramfs are generated on kernel installs, dracuts default for
enabling or disabling host-only mode is used. But when recreating them
at the end of the installation, dracut is executed with host-only mode.

This means that host-only mode can't be disabled (i.e: by installing the
dracut-config-generic package) which is needed to create aarch64 images.

Also don't force the persistent policy to be by-uuid and use whatever is
the default, which is also the case when initrds are generated on kernel
package installs.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>