### PR TITLE
Define the quit message in TUI (#1686116)

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -91,6 +91,9 @@ HELP_MAIN_PAGE_TUI = "Installation_Guide.txt"
 USEVNC = N_("Start VNC")
 USETEXT = N_("Use text mode")
 
+# Quit message
+QUIT_MESSAGE = N_("Do you really want to quit?")
+
 # Runlevel files
 TEXT_ONLY_TARGET = 'multi-user.target'
 GRAPHICAL_TARGET = 'graphical.target'

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -20,7 +20,7 @@ from blivet.errors import StorageError
 
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.constants import ANACONDA_CLEANUP, THREAD_STORAGE
+from pyanaconda.core.constants import ANACONDA_CLEANUP, THREAD_STORAGE, QUIT_MESSAGE
 from pyanaconda.threading import threadMgr
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _, N_
@@ -367,7 +367,7 @@ class RescueModeSpoke(NormalTUISpoke):
         self._show_result_and_prompt_for_shell()
 
     def _quit_callback(self, data):
-        d = YesNoDialog(_(u"Do you really want to quit?"))
+        d = YesNoDialog(_(QUIT_MESSAGE))
         ScreenHandler.push_screen_modal(d)
         self.redraw()
         if d.answer:

--- a/pyanaconda/ui/tui/__init__.py
+++ b/pyanaconda/ui/tui/__init__.py
@@ -16,9 +16,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
 from pyanaconda import ui
-from pyanaconda.core.constants import IPMI_ABORTED
+from pyanaconda.core.constants import IPMI_ABORTED, QUIT_MESSAGE
 from pyanaconda.flags import flags
 from pyanaconda.threading import threadMgr
 from pyanaconda.core.util import ipmi_report
@@ -87,7 +86,7 @@ class TextUserInterface(ui.UserInterface):
 
     def __init__(self, storage, payload,
                  productTitle=u"Anaconda", isFinal=True,
-                 quitMessage=None):
+                 quitMessage=QUIT_MESSAGE):
         """
         For detailed description of the arguments see
         the parent class.

--- a/pyanaconda/ui/tui/spokes/askvnc.py
+++ b/pyanaconda/ui/tui/spokes/askvnc.py
@@ -21,7 +21,7 @@ import sys
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
-from pyanaconda.core.constants import USEVNC, USETEXT
+from pyanaconda.core.constants import USEVNC, USETEXT, QUIT_MESSAGE
 from pyanaconda.core.i18n import N_, _, C_
 from pyanaconda.ui.tui import exception_msg_handler
 from pyanaconda.core.util import execWithRedirect, ipmi_abort
@@ -100,7 +100,7 @@ class AskVNCSpoke(NormalTUISpoke):
         else:
             # TRANSLATORS: 'q' to quit
             if key.lower() == C_('TUI|Spoke Navigation', 'q'):
-                d = YesNoDialog(_(u"Do you really want to quit?"))
+                d = YesNoDialog(_(QUIT_MESSAGE))
                 ScreenHandler.push_screen_modal(d)
                 if d.answer:
                     ipmi_abort(scripts=self.data.scripts)


### PR DESCRIPTION
We should always define the quit message in TUI, because the quit
dialog looks weird without it.

Resolves: rhbz#1686116