### PR TITLE
Simplify update_storage_ksdata

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -23,8 +23,7 @@ from blivet.devices import BTRFSDevice
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import BOOTLOADER_DISABLED
-from pyanaconda.modules.common.constants.objects import BOOTLOADER, AUTO_PARTITIONING, \
-    MANUAL_PARTITIONING, SNAPSHOT
+from pyanaconda.modules.common.constants.objects import BOOTLOADER, AUTO_PARTITIONING, SNAPSHOT
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.storage.snapshot.create import SnapshotCreateTask
 from pyanaconda.storage.kickstart import update_storage_ksdata
@@ -264,13 +263,10 @@ def doInstall(storage, payload, ksdata):
     # So let's have two task queues - early storage & late storage.
     early_storage = TaskQueue("Early storage configuration", N_("Configuring storage"))
 
-    # put custom storage info into ksdata, but not if just assigning mount points
-    manual_part_proxy = STORAGE.get_proxy(MANUAL_PARTITIONING)
-
-    if not manual_part_proxy.Enabled:
-        early_storage.append(Task("Insert custom storage to ksdata",
-                                  task=update_storage_ksdata,
-                                  task_args=(storage, ksdata)))
+    # put custom storage info into ksdata
+    early_storage.append(Task("Insert custom storage to ksdata",
+                              task=update_storage_ksdata,
+                              task_args=(storage, ksdata)))
 
     # callbacks for blivet
     message_clbk = lambda clbk_data: progress_message(clbk_data.msg)

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1277,7 +1277,3 @@ def runTracebackScripts(scripts):
     for script in filter(lambda s: s.type == KS_SCRIPT_TRACEBACK, scripts):
         script.run("/")
     script_log.info("All kickstart %%traceback script(s) have been run")
-
-def resetCustomStorageData(ksdata):
-    for command in ["partition", "raid", "volgroup", "logvol", "btrfs"]:
-        ksdata.resetCommand(command)

--- a/pyanaconda/storage/kickstart.py
+++ b/pyanaconda/storage/kickstart.py
@@ -17,15 +17,15 @@
 #
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.constants import CLEAR_PARTITIONS_NONE
-from pyanaconda.modules.common.constants.objects import DISK_SELECTION, AUTO_PARTITIONING, \
-    DISK_INITIALIZATION
+from pyanaconda.modules.common.constants.objects import AUTO_PARTITIONING, \
+    DISK_INITIALIZATION, MANUAL_PARTITIONING
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.storage.partitioning.base import PartitioningModule
 from pyanaconda.modules.storage.disk_initialization.initialization import DiskInitializationModule
 
 log = get_module_logger(__name__)
 
-__all__ = ["update_storage_ksdata"]
+__all__ = ["update_storage_ksdata", "reset_custom_storage_data"]
 
 
 def update_storage_ksdata(storage, ksdata):
@@ -39,43 +39,8 @@ def update_storage_ksdata(storage, ksdata):
     if not ksdata or not storage.mountpoints:
         return
 
-    _update_disk_selection(storage)
-    _update_autopart(storage)
     _update_clearpart(storage)
     _update_custom_storage(storage, ksdata)
-
-
-def _update_disk_selection(storage):
-    """Update data for disk selection.
-
-    :param storage: an instance of the storage
-    """
-    disk_select_proxy = STORAGE.get_proxy(DISK_SELECTION)
-
-    if storage.ignored_disks:
-        disk_select_proxy.SetIgnoredDisks(storage.ignored_disks)
-    elif storage.exclusive_disks:
-        disk_select_proxy.SetSelectedDisks(storage.exclusive_disks)
-
-
-def _update_autopart(storage):
-    """Update data for automatic partitioning.
-
-    :param storage: an instance of the storage
-    """
-    auto_part_proxy = STORAGE.get_proxy(AUTO_PARTITIONING)
-    auto_part_proxy.SetEnabled(storage.do_autopart)
-    auto_part_proxy.SetType(storage.autopart_type)
-    auto_part_proxy.SetEncrypted(storage.encrypted_autopart)
-
-    if storage.encrypted_autopart:
-        auto_part_proxy.SetLUKSVersion(storage.autopart_luks_version)
-
-        if storage.autopart_pbkdf_args:
-            auto_part_proxy.SetPBKDF(storage.autopart_pbkdf_args.type or "")
-            auto_part_proxy.SetPBKDFMemory(storage.autopart_pbkdf_args.max_memory_kb)
-            auto_part_proxy.SetPBKDFIterations(storage.autopart_pbkdf_args.iterations)
-            auto_part_proxy.SetPBKDFTime(storage.autopart_pbkdf_args.time_ms)
 
 
 def _update_clearpart(storage):
@@ -84,10 +49,6 @@ def _update_clearpart(storage):
     :param storage: an instance of the storage
     """
     disk_init_proxy = STORAGE.get_proxy(DISK_INITIALIZATION)
-    disk_init_proxy.SetInitializationMode(storage.config.clear_part_type)
-    disk_init_proxy.SetDrivesToClear(storage.config.clear_part_disks)
-    disk_init_proxy.SetDevicesToClear(storage.config.clear_part_devices)
-    disk_init_proxy.SetInitializeLabelsEnabled(storage.config.initialize_disks)
 
     if disk_init_proxy.InitializationMode == CLEAR_PARTITIONS_NONE:
         # FIXME: This is an ugly temporary workaround for UI.
@@ -104,15 +65,25 @@ def _update_custom_storage(storage, ksdata):
     :param storage: an instance of the storage
     :param ksdata: an instance of kickstart data
     """
-    # clear out whatever was there before
-    ksdata.partition.partitions = []
-    ksdata.logvol.lvList = []
-    ksdata.raid.raidList = []
-    ksdata.volgroup.vgList = []
-    ksdata.btrfs.btrfsList = []
+    auto_part_proxy = STORAGE.get_proxy(AUTO_PARTITIONING)
+    manual_part_proxy = STORAGE.get_proxy(MANUAL_PARTITIONING)
 
-    if storage.do_autopart:
+    # Clear out whatever was there before.
+    reset_custom_storage_data(ksdata)
+
+    # Check if the custom partitioning was used.
+    if auto_part_proxy.Enabled or manual_part_proxy.Enabled:
+        log.debug("Custom partitioning is disabled.")
         return
 
     # FIXME: This is an ugly temporary workaround for UI.
     PartitioningModule._setup_kickstart_from_storage(ksdata, storage)
+
+
+def reset_custom_storage_data(ksdata):
+    """Reset the custom storage data.
+
+    :param ksdata: an instance of kickstart data
+    """
+    for command in ["partition", "raid", "volgroup", "logvol", "btrfs"]:
+        ksdata.resetCommand(command)

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -60,9 +60,9 @@ from pyanaconda.ui.gui.utils import escape_markup, ignoreEscape
 from pyanaconda.core.async_utils import async_action_nowait
 from pyanaconda.ui.helpers import StorageCheckHandler
 from pyanaconda.core.timer import Timer
-
-from pyanaconda.kickstart import resetCustomStorageData
+from pyanaconda.storage.kickstart import reset_custom_storage_data
 from pyanaconda.storage.execution import do_kickstart_storage
+
 from blivet.size import Size
 from blivet.devices import MultipathDevice, ZFCPDiskDevice, iScsiDiskDevice, NVDIMMNamespaceDevice
 from blivet.errors import StorageError
@@ -540,7 +540,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
                 # run() executes StorageCheckHandler.checkStorage in a seperate thread
                 self.run()
         finally:
-            resetCustomStorageData(self.data)
+            reset_custom_storage_data(self.data)
             self._ready = True
             hubQ.send_ready(self.__class__.__name__, True)
 

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -39,7 +39,7 @@ from blivet.devices import DASDDevice, FcoeDiskDevice, iScsiDiskDevice, Multipat
     ZFCPDiskDevice
 from blivet.formats import get_format
 from pyanaconda.flags import flags
-from pyanaconda.kickstart import resetCustomStorageData
+from pyanaconda.storage.kickstart import reset_custom_storage_data
 from pyanaconda.storage.execution import do_kickstart_storage
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core.configuration.anaconda import conf
@@ -459,7 +459,7 @@ class StorageSpoke(NormalTUISpoke):
             self.errors = report.errors
             self.warnings = report.warnings
         finally:
-            resetCustomStorageData(self.data)
+            reset_custom_storage_data(self.data)
             self._ready = True
 
     def initialize(self):

--- a/tests/nosetests/pyanaconda_tests/ksdata_test.py
+++ b/tests/nosetests/pyanaconda_tests/ksdata_test.py
@@ -19,6 +19,9 @@ class BlivetTestCase(unittest.TestCase):
     @patch('pyanaconda.storage.osinstall.InstallerStorage.mountpoints', new_callable=PropertyMock)
     def test_prepboot_bootloader_in_kickstart(self, mock_mountpoints, mock_bootloader_device, dbus):
         """Test that a prepboot bootloader shows up in the ks data."""
+        # disable other partitioning modules
+        dbus.return_value.Enabled = False
+
         # set up prepboot partition
         bootloader_device_obj = PartitionDevice("test_partition_device")
         bootloader_device_obj.size = Size('5 MiB')
@@ -40,6 +43,9 @@ class BlivetTestCase(unittest.TestCase):
     @patch('pyanaconda.storage.osinstall.InstallerStorage.mountpoints', new_callable=PropertyMock)
     def test_biosboot_bootloader_in_kickstart(self, mock_mountpoints, mock_devices, dbus):
         """Test that a biosboot bootloader shows up in the ks data."""
+        # disable other partitioning modules
+        dbus.return_value.Enabled = False
+
         # set up biosboot partition
         biosboot_device_obj = PartitionDevice("biosboot_partition_device")
         biosboot_device_obj.size = Size('1MiB')


### PR DESCRIPTION
The storage module should be already set to correct values in most
cases, so there is no reason the update it. Use the function
reset_custom_storage_data to do the clean up in the kickstart data.