### PR TITLE
Remove blank line in the SMT warning (#1684056)

### DIFF
--- a/pyanaconda/ui/tui/spokes/kernel_warning.py
+++ b/pyanaconda/ui/tui/spokes/kernel_warning.py
@@ -44,7 +44,7 @@ class KernelWarningSpoke(StandaloneTUISpoke):
     def refresh(self, args=None):
         """Refresh the window."""
         super().refresh(args)
-        self.window.add_with_separator(TextWidget(_(WARNING_SMT_ENABLED)))
+        self.window.add(TextWidget(_(WARNING_SMT_ENABLED)))
 
     def show_all(self):
         """Show the warning and close the screen."""


### PR DESCRIPTION
We are fighting with too long message so make it one line smaller this way.

*Related: rhbz#1684056*