### PR TITLE
network module: fix updating of ONBOOT value on installed system

### DIFF
--- a/pyanaconda/modules/network/ifcfg.py
+++ b/pyanaconda/modules/network/ifcfg.py
@@ -434,7 +434,7 @@ def update_onboot_value(connection_uuid, onboot, root_path=""):
     :rtype: bool
     """
 
-    ifcfg = get_ifcfg_file([("UUID", connection_uuid)])
+    ifcfg = get_ifcfg_file([("UUID", connection_uuid)], root_path)
     if not ifcfg:
         log.debug("can't find ifcfg file of %s", connection_uuid)
         return False


### PR DESCRIPTION
We are updating ifcfg files on target system in this case so we need to pass the root argument.