### PR TITLE
Update the kickstart data for iSCSI and NVDIMM during the installation

### DIFF
--- a/pyanaconda/storage/kickstart.py
+++ b/pyanaconda/storage/kickstart.py
@@ -15,10 +15,13 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from blivet.devices import MultipathDevice, iScsiDiskDevice, NVDIMMNamespaceDevice
+from blivet.iscsi import iscsi
+
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.constants import CLEAR_PARTITIONS_NONE
 from pyanaconda.modules.common.constants.objects import AUTO_PARTITIONING, \
-    DISK_INITIALIZATION, MANUAL_PARTITIONING
+    DISK_INITIALIZATION, MANUAL_PARTITIONING, NVDIMM
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.storage.partitioning.base import PartitioningModule
 from pyanaconda.modules.storage.disk_initialization.initialization import DiskInitializationModule
@@ -41,6 +44,8 @@ def update_storage_ksdata(storage, ksdata):
 
     _update_clearpart(storage)
     _update_custom_storage(storage, ksdata)
+    _update_iscsi_data(storage, ksdata)
+    _update_nvdimm_data(storage)
 
 
 def _update_clearpart(storage):
@@ -87,3 +92,90 @@ def reset_custom_storage_data(ksdata):
     """
     for command in ["partition", "raid", "volgroup", "logvol", "btrfs"]:
         ksdata.resetCommand(command)
+
+
+def _update_iscsi_data(storage, ksdata):
+    """Update kickstart data for iSCSI.
+
+    FIXME: Move the logic to the iSCSI DBus module.
+
+    :param storage: an instance of the storage
+    :param ksdata: an instance of kickstart data
+    """
+    # Find all iSCSI devices.
+    iscsi_devices = []
+
+    for d in storage.disks:
+        # Get parents of a multipath devices.
+        if isinstance(d, MultipathDevice):
+            for parent_dev in d.parents:
+                if (isinstance(parent_dev, iScsiDiskDevice)
+                        and not parent_dev.ibft
+                        and not parent_dev.offload):
+                    iscsi_devices.append(parent_dev)
+        # Add no-ibft iScsiDiskDevice. IBFT disks are added automatically
+        # so there is no need to have them in the kickstart.
+        elif isinstance(d, iScsiDiskDevice) and not d.ibft and not d.offload:
+            iscsi_devices.append(d)
+
+    if not iscsi_devices:
+        return
+
+    # Set the initiator name.
+    ksdata.iscsiname.iscsiname = iscsi.initiator
+
+    # Generate the iSCSI data.
+    ksdata.iscsi.iscsi = []
+
+    for device in iscsi_devices:
+        iscsi_data = ksdata.IscsiData()
+
+        _setup_iscsi_data_from_node(iscsi_data, device.node)
+
+        for saved_iscsi in ksdata.iscsi.iscsi:
+            if (iscsi_data.ipaddr == saved_iscsi.ipaddr and
+                    iscsi_data.target == saved_iscsi.target and
+                    iscsi_data.port == saved_iscsi.port):
+                break
+        else:
+            ksdata.iscsi.iscsi.append(iscsi_data)
+
+
+def _setup_iscsi_data_from_node(iscsi_data, dev_node):
+    """Set up iSCSI data from a device node.
+
+    FIXME: Move the logic to the iSCSI DBus module.
+
+    :param iscsi_data: an instance of iSCSI data
+    :param dev_node: a device node
+    """
+    iscsi_data.ipaddr = dev_node.address
+    iscsi_data.target = dev_node.name
+    iscsi_data.port = dev_node.port
+
+    if iscsi.ifaces:
+        iscsi_data.iface = iscsi.ifaces[dev_node.iface]
+
+    if dev_node.username and dev_node.password:
+        iscsi_data.user = dev_node.username
+        iscsi_data.password = dev_node.password
+
+    if dev_node.r_username and dev_node.r_password:
+        iscsi_data.user_in = dev_node.r_username
+        iscsi_data.password_in = dev_node.r_password
+
+    return iscsi_data
+
+
+def _update_nvdimm_data(storage):
+    """Update kickstart data for NVDIMM.
+
+    FIXME: Move the logic to the iSCSI DBus module.
+
+    :param storage: an instance of the storage
+    """
+    nvdimm_proxy = STORAGE.get_proxy(NVDIMM)
+    nvdimm_proxy.SetNamespacesToUse([
+        d.devname for d in storage.disks
+        if isinstance(d, NVDIMMNamespaceDevice)
+    ])

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -64,9 +64,8 @@ from pyanaconda.core.timer import Timer
 from pyanaconda.storage.kickstart import reset_custom_storage_data
 
 from blivet.size import Size
-from blivet.devices import MultipathDevice, ZFCPDiskDevice, iScsiDiskDevice, NVDIMMNamespaceDevice
+from blivet.devices import MultipathDevice, ZFCPDiskDevice, NVDIMMNamespaceDevice
 from blivet.formats.disklabel import DiskLabel
-from blivet.iscsi import iscsi
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.product import productName
 from pyanaconda.flags import flags
@@ -84,7 +83,7 @@ from pyanaconda.screen_access import sam
 from pyanaconda.modules.common.errors.configuration import StorageConfigurationError, \
     BootloaderConfigurationError
 from pyanaconda.modules.common.constants.objects import DISK_SELECTION, DISK_INITIALIZATION, \
-    BOOTLOADER, AUTO_PARTITIONING, NVDIMM
+    BOOTLOADER, AUTO_PARTITIONING
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.payload.livepayload import LiveImagePayload
 
@@ -435,50 +434,6 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         threadMgr.add(AnacondaThread(name=constants.THREAD_EXECUTE_STORAGE,
                                      target=self._do_execute))
 
-        # Get the selected disks.
-        selected_disks = filter_disks_by_names(
-            disks=get_available_disks(self.storage.devicetree),
-            names=self._selected_disks
-        )
-
-        # Register iSCSI to kickstart data
-        iscsi_devices = []
-
-        # Find all selected disks and add all iscsi disks to iscsi_devices list
-        for d in selected_disks:
-            # Get parents of a multipath devices
-            if isinstance(d, MultipathDevice):
-                for parent_dev in d.parents:
-                    if (isinstance(parent_dev, iScsiDiskDevice)
-                        and not parent_dev.ibft
-                        and not parent_dev.offload):
-                        iscsi_devices.append(parent_dev)
-            # Add no-ibft iScsiDiskDevice. IBFT disks are added automatically so there is
-            # no need to have them in KS.
-            elif isinstance(d, iScsiDiskDevice) and not d.ibft and not d.offload:
-                iscsi_devices.append(d)
-
-        if iscsi_devices:
-            self.data.iscsiname.iscsiname = iscsi.initiator
-            # Remove the old iscsi data information and generate new one
-            self.data.iscsi.iscsi = []
-            for device in iscsi_devices:
-                iscsi_data = self._create_iscsi_data(device)
-                for saved_iscsi in self.data.iscsi.iscsi:
-                    if (iscsi_data.ipaddr == saved_iscsi.ipaddr and
-                        iscsi_data.target == saved_iscsi.target and
-                        iscsi_data.port == saved_iscsi.port):
-                        break
-                else:
-                    self.data.iscsi.iscsi.append(iscsi_data)
-
-        # Update kickstart data for NVDIMM devices used in GUI.
-        selected_nvdimm_namespaces = [d.devname for d in selected_disks
-                                      if isinstance(d, NVDIMMNamespaceDevice)]
-
-        nvdimm_proxy = STORAGE.get_proxy(NVDIMM)
-        nvdimm_proxy.SetNamespacesToUse(selected_nvdimm_namespaces)
-
     def _do_execute(self):
         self._ready = False
         hubQ.send_not_ready(self.__class__.__name__)
@@ -527,27 +482,6 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             reset_custom_storage_data(self.data)
             self._ready = True
             hubQ.send_ready(self.__class__.__name__, True)
-
-    def _create_iscsi_data(self, device):
-        from pyanaconda.kickstart import AnacondaKSHandler
-        handler = AnacondaKSHandler()
-        # pylint: disable=E1101
-        iscsi_data = handler.IscsiData()
-        dev_node = device.node
-        iscsi_data.ipaddr = dev_node.address
-        iscsi_data.target = dev_node.name
-        iscsi_data.port = dev_node.port
-        # Bind interface to target
-        if iscsi.ifaces:
-            iscsi_data.iface = iscsi.ifaces[dev_node.iface]
-
-        if dev_node.username and dev_node.password:
-            iscsi_data.user = dev_node.username
-            iscsi_data.password = dev_node.password
-        if dev_node.r_username and dev_node.r_password:
-            iscsi_data.user_in = dev_node.r_username
-            iscsi_data.password_in = dev_node.r_password
-        return iscsi_data
 
     @property
     def completed(self):


### PR DESCRIPTION
We don't need to update the kickstart data for iSCSI and NVDIMM after
every partitioning. Let's move the code to the update_storage_ksdata
function that we run during the installation.

This code should be eventually moved to the Storage module.