### PR TITLE
Don't generate temporary kickstart in the Storage module

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -402,7 +402,7 @@ class Realm(RemovedCommand):
 class ClearPart(RemovedCommand):
     def __str__(self):
         storage_module_proxy = STORAGE.get_proxy()
-        return storage_module_proxy.GenerateTemporaryKickstart()
+        return storage_module_proxy.GenerateKickstart()
 
 class Firewall(RemovedCommand):
     def __init__(self, *args, **kwargs):

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -149,11 +149,7 @@ class StorageModule(KickstartModule):
             self.storage.set_default_fstype(data.autopart.fstype)
             self.storage.set_default_boot_fstype(data.autopart.fstype)
 
-    def generate_temporary_kickstart(self):
-        """Return the temporary kickstart string."""
-        return self.generate_kickstart(skip_unsupported=True)
-
-    def generate_kickstart(self, skip_unsupported=False):  # pylint: disable=arguments-differ
+    def generate_kickstart(self):
         """Return the kickstart string."""
         log.debug("Generating kickstart data...")
         data = self.get_kickstart_handler()


### PR DESCRIPTION
It doesn't look like we will need this functionality in the Storage
module anymore, so let's drop the support and call GenerateKickstart
instead.