### PR TITLE
Simplify get_free_space

### DIFF
--- a/pyanaconda/modules/storage/partitioning/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic_partitioning.py
@@ -30,7 +30,7 @@ from pyanaconda.modules.storage.partitioning.schedule import get_candidate_disks
 from pyanaconda.platform import platform
 from pyanaconda.storage.partitioning import get_full_partitioning_requests, \
     get_default_partitioning
-from pyanaconda.storage.utils import get_available_disk_space, suggest_swap_size
+from pyanaconda.storage.utils import suggest_swap_size
 
 log = get_module_logger(__name__)
 
@@ -99,7 +99,7 @@ class AutomaticPartitioningTask(NonInteractivePartitioningTask):
         # Update the size of swap.
         for request in requests:
             if request.fstype == "swap":
-                disk_space = get_available_disk_space(storage)
+                disk_space = storage.get_disk_free_space()
                 request.size = suggest_swap_size(disk_space=disk_space)
                 break
 

--- a/pyanaconda/modules/storage/partitioning/interactive_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/interactive_partitioning.py
@@ -41,7 +41,6 @@ class InteractiveAutoPartitioningTask(AutomaticPartitioningTask):
 
     def _run(self, storage):
         """Do the partitioning."""
-        self._create_free_space_snapshot(storage)
         self._prepare_bootloader(storage)
         self._configure_partitioning(storage)
         self._update_size_policy(storage)

--- a/pyanaconda/modules/storage/partitioning/noninteractive_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/noninteractive_partitioning.py
@@ -37,7 +37,6 @@ class NonInteractivePartitioningTask(PartitioningTask, metaclass=ABCMeta):
     def _run(self, storage):
         """Do the partitioning."""
         self._clear_partitions(storage)
-        self._create_free_space_snapshot(storage)
         self._prepare_bootloader(storage)
         self._configure_partitioning(storage)
         self._setup_bootloader(storage)
@@ -65,15 +64,6 @@ class NonInteractivePartitioningTask(PartitioningTask, metaclass=ABCMeta):
         # Check the usable disks.
         if not any(d for d in storage.disks if not d.format.hidden and not d.protected):
             raise NoDisksError("No usable disks.")
-
-    def _create_free_space_snapshot(self, storage):
-        """Clear partitions.
-
-        Snapshot free space now, so that we know how much we had available.
-
-        :param storage: an instance of Blivet
-        """
-        storage.create_free_space_snapshot()
 
     def _prepare_bootloader(self, storage):
         """Prepare the bootloader.

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -311,6 +311,8 @@ class InstallerStorage(Blivet):
     def get_disk_free_space(self, disks=None):
         """Get total free space on the given disks.
 
+        Calculates free space available for use.
+
         :param disks: a list of disks or None
         :return: a total size
         """
@@ -323,6 +325,25 @@ class InstallerStorage(Blivet):
 
         # Calculate the total free space.
         return sum((disk_free for disk_free, fs_free in snapshot.values()), Size(0))
+
+    def get_disk_reclaimable_space(self, disks=None):
+        """Get total reclaimable space on the given disks.
+
+        Calculates free space unavailable but reclaimable
+        from existing partitions.
+
+        :param disks: a list of disks or None
+        :return: a total size
+        """
+        # Use all disks in the device tree by default.
+        if disks is None:
+            disks = self.disks
+
+        # Get the dictionary of free spaces for each disk.
+        snapshot = self.get_free_space(disks)
+
+        # Calculate the total reclaimable free space.
+        return sum((fs_free for disk_free, fs_free in snapshot.values()), Size(0))
 
     @property
     def free_space_snapshot(self):

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -282,14 +282,19 @@ class InstallerStorage(Blivet):
     def root_device(self):
         return self.fsset.root_device
 
-    @property
-    def file_system_free_space(self):
-        """ Combined free space in / and /usr as :class:`blivet.size.Size`. """
-        mountpoints = ["/", "/usr"]
+    def get_file_system_free_space(self, mount_points=("/", "/usr")):
+        """Get total file system free space on the given mount points.
+
+        Calculates total free space in / and /usr, by default.
+
+        :param mount_points: a list of mount points
+        :return: a total size
+        """
         free = Size(0)
         btrfs_volumes = []
-        for mountpoint in mountpoints:
-            device = self.mountpoints.get(mountpoint)
+
+        for mount_point in mount_points:
+            device = self.mountpoints.get(mount_point)
             if not device:
                 continue
 

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -77,7 +77,6 @@ class InstallerStorage(Blivet):
 
         self.__luks_devs = {}
         self.fsset = FSSet(self.devicetree)
-        self._free_space_snapshot = None
 
         self._short_product_name = shortProductName
         self._default_luks_version = DEFAULT_LUKS_VERSION
@@ -349,18 +348,6 @@ class InstallerStorage(Blivet):
 
         # Calculate the total reclaimable free space.
         return sum((fs_free for disk_free, fs_free in snapshot.values()), Size(0))
-
-    @property
-    def free_space_snapshot(self):
-        # if no snapshot is available, do it now and return it
-        self._free_space_snapshot = self._free_space_snapshot or self.get_free_space()
-
-        return self._free_space_snapshot
-
-    def create_free_space_snapshot(self):
-        self._free_space_snapshot = self.get_free_space()
-
-        return self._free_space_snapshot
 
     def reset(self, cleanup_only=False):
         """ Reset storage configuration to reflect actual system state.

--- a/pyanaconda/storage/utils.py
+++ b/pyanaconda/storage/utils.py
@@ -450,19 +450,6 @@ def lookup_alias(devicetree, alias):
     return None
 
 
-def get_available_disk_space(storage):
-    """Get overall disk space available on disks we may use.
-
-    :param storage: blivet.Blivet instance
-    :return: overall disk space available
-    :rtype: :class:`blivet.size.Size`
-    """
-    free_space = storage.free_space_snapshot
-    # Blivet creates a new free space dict to instead of modifying the old one,
-    # so there is no worry about the dictionary changing during iteration.
-    return sum(disk_free for disk_free, fs_free in free_space.values())
-
-
 def find_live_backing_device():
     """Find the backing device for the live image.
 

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -711,15 +711,11 @@ class FilterSpoke(NormalSpoke):
         super().on_back_clicked(button)
 
     def on_summary_clicked(self, button):
-        dialog = SelectedDisksDialog(self.data)
-
-        # Include any disks selected in the initial storage spoke, plus any
-        # selected in this filter UI.
         disks = filter_disks_by_names(self.disks, self.selected_disks)
-        free_space = self.storage.get_free_space(disks=disks)
+        dialog = SelectedDisksDialog(self.data, self.storage, disks, show_remove=False, set_boot=False)
 
         with self.main_window.enlightbox(dialog.window):
-            dialog.refresh(disks, free_space, showRemove=False, setBoot=False)
+            dialog.refresh()
             dialog.run()
 
     @timed_action(delay=1200, busy_cursor=False)

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -2154,10 +2154,11 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             self._do_refresh()
 
     def on_summary_clicked(self, button):
-        dialog = SelectedDisksDialog(self.data)
-        dialog.refresh(self._clearpartDevices, self._currentFreeInfo,
-                       showRemove=False, setBoot=False)
+        disks = self._clearpartDevices
+        dialog = SelectedDisksDialog(self.data, self.storage, disks, show_remove=False, set_boot=False)
+
         with self.main_window.enlightbox(dialog.window):
+            dialog.refresh()
             dialog.run()
 
     def on_configure_clicked(self, button):

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -379,13 +379,9 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         return devices
 
-    @property
-    def _currentFreeInfo(self):
-        return self._storage_playground.get_free_space()
-
     def _setCurrentFreeSpace(self):
         """Add up all the free space on selected disks and return it as a Size."""
-        self._free_space = sum(f[0] for f in self._currentFreeInfo.values())
+        self._free_space = self._storage_playground.get_disk_free_space()
 
     def _currentTotalSpace(self):
         """Add up the sizes of all selected disks and return it as a Size."""
@@ -2177,8 +2173,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self.clear_errors()
 
         dialog = DisksDialog(self.data,
+                             self._storage_playground,
                              disks=self._clearpartDevices,
-                             free=self._currentFreeInfo,
                              selected=self._device_disks)
         with self.main_window.enlightbox(dialog.window):
             rc = dialog.run()
@@ -2226,6 +2222,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 size_policy = SIZE_POLICY_AUTO
 
         dialog = ContainerDialog(self.data,
+                                 self._storage_playground,
                                  device_type=self._get_current_device_type(),
                                  name=container_name,
                                  raid_level=self._device_container_raid_level,
@@ -2233,9 +2230,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                                  size_policy=size_policy,
                                  size=size,
                                  disks=self._clearpartDevices,
-                                 free=self._currentFreeInfo,
                                  selected=self._device_disks,
-                                 storage=self._storage_playground,
                                  exists=getattr(container, "exists", False))
 
         with self.main_window.enlightbox(dialog.window):

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -40,7 +40,7 @@ from pyanaconda.core.i18n import _, N_, CP_, C_
 from pyanaconda.product import productName, productVersion, translated_new_install_name
 from pyanaconda.threading import AnacondaThread, threadMgr
 from pyanaconda.core.constants import THREAD_EXECUTE_STORAGE, THREAD_STORAGE, \
-    THREAD_CUSTOM_STORAGE_INIT, SIZE_UNITS_DEFAULT, UNSUPPORTED_FILESYSTEMS, CLEAR_PARTITIONS_NONE, \
+    THREAD_CUSTOM_STORAGE_INIT, SIZE_UNITS_DEFAULT, UNSUPPORTED_FILESYSTEMS, \
     DEFAULT_AUTOPART_TYPE
 from pyanaconda.core.util import lowerASCII
 from pyanaconda.modules.common.constants.objects import DISK_INITIALIZATION, BOOTLOADER, \
@@ -381,7 +381,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
     @property
     def _currentFreeInfo(self):
-        return self._storage_playground.get_free_space(clear_part_type=CLEAR_PARTITIONS_NONE)
+        return self._storage_playground.get_free_space()
 
     def _setCurrentFreeSpace(self):
         """Add up all the free space on selected disks and return it as a Size."""

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -414,17 +414,16 @@ class DisksDialog(GUIObject):
     mainWidgetName = "disks_dialog"
     uiFile = "spokes/lib/custom_storage_helpers.glade"
 
-    def __init__(self, *args, **kwargs):
-        self._disks = kwargs.pop("disks")
-        free = kwargs.pop("free")
-        self.selected = kwargs.pop("selected")[:]
-        super().__init__(*args, **kwargs)
+    def __init__(self, data, storage, disks, selected):
+        super().__init__(data)
+        self._disks = disks
+        self.selected = selected
         self._store = self.builder.get_object("disk_store")
         # populate the store
         for disk in self._disks:
             self._store.append(["%s (%s)" % (disk.description, disk.serial),
                                 str(disk.size),
-                                str(free[disk.name][0]),
+                                str(storage.get_disk_free_space([disk])),
                                 disk.name,
                                 disk.id])
 
@@ -474,14 +473,14 @@ class ContainerDialog(GUIObject, GUIDialogInputCheckHandler):
     # If the user enters a smaller size, the GUI changes it to this value
     MIN_SIZE_ENTRY = Size("1 MiB")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, data, storage, **kwargs):
+        GUIObject.__init__(self, data)
         # these are all absolutely required. not getting them is fatal.
+        self.storage = storage
         self._disks = kwargs.pop("disks")
-        free = kwargs.pop("free")
         self.selected = kwargs.pop("selected")[:]
         self.name = kwargs.pop("name") or "" # make sure it's a string
         self.device_type = kwargs.pop("device_type")
-        self.storage = kwargs.pop("storage")
 
         # these are less critical
         self.raid_level = kwargs.pop("raid_level", None) or None # not ""
@@ -492,7 +491,6 @@ class ContainerDialog(GUIObject, GUIDialogInputCheckHandler):
         self.size = kwargs.pop("size", Size(0))
 
         self._error = None
-        GUIObject.__init__(self, *args, **kwargs)
 
         self._grabObjects()
         GUIDialogInputCheckHandler.__init__(self, self._save_button)
@@ -512,7 +510,7 @@ class ContainerDialog(GUIObject, GUIDialogInputCheckHandler):
         for disk in self._disks:
             self._store.append([disk.description,
                                 str(disk.size),
-                                str(free[disk.name][0]),
+                                str(storage.get_disk_free_space([disk])),
                                 disk.name,
                                 disk.id])
 

--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -134,8 +134,6 @@ class ResizeDialog(GUIObject):
 
         canShrinkSomething = False
 
-        free_space = self.storage.get_free_space(disks=disks)
-
         for disk in disks:
             # First add the disk itself.
             editable = not disk.protected
@@ -195,7 +193,8 @@ class ResizeDialog(GUIObject):
 
             # And then add another uneditable line that lists how much space is
             # already free in the disk.
-            diskFree = free_space[disk.name][0]
+            diskFree = self.storage.get_disk_free_space([disk])
+
             if diskFree >= Size("1MiB"):
                 freeSpaceString = "<span foreground='grey' style='italic'>%s</span>" % \
                         escape_markup(_("Free space"))

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -767,7 +767,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         else:
             description = disk.description
 
-        free = self.storage.get_free_space(disks=[disk])[disk.name][0]
+        free = self.storage.get_disk_free_space([disk])
 
         overview = AnacondaWidgets.DiskOverview(description,
                                                 kind,
@@ -967,9 +967,8 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             log.debug("Need disklabel: %s have: %s", ", ".join(platform_labels),
                                                      ", ".join(disk_labels))
         else:
-            free_space = self.storage.get_free_space(disks=disks)
-            disk_free = sum(f[0] for f in free_space.values())
-            fs_free = sum(f[1] for f in free_space.values())
+            disk_free = self.storage.get_disk_free_space(disks)
+            fs_free = self.storage.get_disk_reclaimable_space(disks)
 
         disks_size = sum((d.size for d in disks), Size(0))
         sw_space = self.payload.space_required

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -967,8 +967,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             log.debug("Need disklabel: %s have: %s", ", ".join(platform_labels),
                                                      ", ".join(disk_labels))
         else:
-            free_space = self.storage.get_free_space(disks=disks,
-                                                     clear_part_type=CLEAR_PARTITIONS_NONE)
+            free_space = self.storage.get_free_space(disks=disks)
             disk_free = sum(f[0] for f in free_space.values())
             fs_free = sum(f[1] for f in free_space.values())
 

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -868,10 +868,10 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
     # signal handlers
     def on_summary_clicked(self, button):
         # show the selected disks dialog
-        # pass in our disk list so hidden disks' free space is available
-        free_space = self.storage.get_free_space(disks=self._available_disks)
-        dialog = SelectedDisksDialog(self.data,)
-        dialog.refresh(filter_disks_by_names(self._available_disks, self._selected_disks), free_space)
+        disks = filter_disks_by_names(self._available_disks, self._selected_disks)
+        dialog = SelectedDisksDialog(self.data, self.storage, disks)
+        dialog.refresh()
+
         self.run_lightbox_dialog(dialog)
 
         # update selected disks since some may have been removed

--- a/pyanaconda/ui/lib/space.py
+++ b/pyanaconda/ui/lib/space.py
@@ -48,7 +48,7 @@ class FileSystemSpaceChecker(object):
 
     def _calculate_free_space(self):
         """Calculate the available space."""
-        return Size(self.storage.file_system_free_space)
+        return self.storage.get_file_system_free_space()
 
     def _calculate_needed_space(self):
         """Calculate the needed space."""


### PR DESCRIPTION
Let's remove the code that estimates the free space based on the
clearpart settings and use the original get_free_space method of
the Blivet class that calculates the current free space of the
storage model. We don't really need to know the estimation.

Use get_disk_free_space, get_disk_reclaimable_space and
get_file_system_free_space to calculate the available space,
because later we will provide DBus support only for these
methods.
