### PR TITLE
Deprecate DBusObjectObserver

### DIFF
--- a/pyanaconda/dbus/connection.py
+++ b/pyanaconda/dbus/connection.py
@@ -148,6 +148,11 @@ class Connection(ABC):
         :param service_name: a DBus name of a service
         :param object_path: a DBus path an object
         :return: an instance of DBusObjectObserver
+
+        .. deprecated::
+
+            Use get_proxy instead.
+
         """
         return DBusObjectObserver(self, service_name, object_path)
 

--- a/pyanaconda/dbus/connection.py
+++ b/pyanaconda/dbus/connection.py
@@ -24,7 +24,7 @@ import pydbus
 
 from pyanaconda.core.constants import ANACONDA_BUS_ADDR_FILE
 from pyanaconda.dbus.constants import DBUS_ANACONDA_SESSION_ADDRESS, DBUS_STARTER_ADDRESS
-from pyanaconda.dbus.observer import DBusObjectObserver, DBusCachedObserver
+from pyanaconda.dbus.observer import DBusObjectObserver
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -150,16 +150,6 @@ class Connection(ABC):
         :return: an instance of DBusObjectObserver
         """
         return DBusObjectObserver(self, service_name, object_path)
-
-    def get_cached_observer(self, service_name, object_path, interface_names):
-        """Returns a cached observer of a remote DBus object.
-
-        :param service_name: a DBus name of a service
-        :param object_path: a DBus path an object
-        :param interface_names: a list of interface names
-        :return: an instance of DBusCachedObserver
-        """
-        return DBusCachedObserver(self, service_name, object_path, interface_names)
 
     def disconnect(self):
         """Disconnect from DBus."""

--- a/pyanaconda/dbus/identifier.py
+++ b/pyanaconda/dbus/identifier.py
@@ -170,17 +170,3 @@ class DBusServiceIdentifier(DBusObjectIdentifier):
         """
         object_path = self._choose_object_path(object_path)
         return self._message_bus.get_observer(self.service_name, object_path)
-
-    def get_cached_observer(self, object_path=None, interface_names=None):
-        """Returns a cached observer of the DBus object.
-
-        :param object_path: a DBus path of an object or None
-        :param interface_names: a list of interface names or None
-        :return: an observer object
-        """
-        interface_names = self._choose_interface_names(object_path, interface_names)
-        object_path = self._choose_object_path(object_path)
-
-        return self._message_bus.get_cached_observer(
-            self.service_name, object_path, interface_names
-        )

--- a/pyanaconda/dbus/identifier.py
+++ b/pyanaconda/dbus/identifier.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import warnings
+
 from pyanaconda.dbus import DBus
 from pyanaconda.dbus.namespace import get_dbus_path, get_dbus_name
 
@@ -167,6 +169,14 @@ class DBusServiceIdentifier(DBusObjectIdentifier):
 
         :param object_path: a DBus path of an object or None
         :return: an observer object
+
+        .. deprecated::
+
+            Use get_proxy instead.
+
         """
+        warnings.warn("The method get_observer is deprecated. Use get_proxy.",
+                      category=DeprecationWarning, stacklevel=2)
+
         object_path = self._choose_object_path(object_path)
         return self._message_bus.get_observer(self.service_name, object_path)

--- a/pyanaconda/dbus/observer.py
+++ b/pyanaconda/dbus/observer.py
@@ -199,6 +199,11 @@ class DBusObjectObserver(DBusObserver):
     result = observer.proxy.ListConnections()
     print(result)
 
+    .. deprecated::
+
+        Use a DBus proxy to access a DBus object or DBusObserver to monitor
+        a DBus service.
+
     """
 
     def __init__(self, message_bus, service_name, object_path):

--- a/pyanaconda/dbus/observer.py
+++ b/pyanaconda/dbus/observer.py
@@ -22,7 +22,7 @@ from pyanaconda.core.signal import Signal
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
-__all__ = ["DBusObserverError", "DBusObjectObserver", "DBusCachedObserver"]
+__all__ = ["DBusObserverError", "DBusObjectObserver"]
 
 
 class DBusObserverError(Exception):
@@ -284,101 +284,3 @@ class PropertiesCache(object):
             return super().__setattr__(name, value)
 
         raise AttributeError("It is not allowed to set {}.".format(name))
-
-
-class DBusCachedObserver(DBusObjectObserver):
-    """Observer of a DBus object with cached properties.
-
-    This is an extension of DBusObjectObserver that allows to cache properties
-    of the remote object. The observer is connected to the PropertiesChanged
-    signal of the remote object and updates its cache every time the signal
-    is emitted. Then it emits its own cached_properties_changed signal.
-
-    Only properties of specified interfaces will be cached.
-
-    Usage:
-    observer = DBusCachedObserver(SystemBus, "org.freedesktop.NetworkManager",
-                                  "org/freedesktop/NetworkManager/Settings",
-                                  ["org.freedesktop.NetworkManager.Settings"])
-    observer.connect()
-    print(observer.cache.Hostname)
-    """
-
-    def __init__(self, message_bus, service_name, object_path, watched_interfaces=None):
-        """Create an observer with cached properties.
-
-        Only properties of specified interfaces will be watched and cached.
-
-        :param message_bus: a message bus
-        :param service_name: a DBus name of a service
-        :param object_path:  a DBus path of an object
-        :param watched_interfaces: a list of interface names
-        """
-        super().__init__(message_bus, service_name, object_path)
-        self._cache = PropertiesCache()
-        self._cached_properties_changed = Signal()
-        self._watched_interfaces = set()
-
-        if watched_interfaces:
-            self._watched_interfaces.update(watched_interfaces)
-
-    @property
-    def cache(self):
-        """Returns a cache with properties of the remote object."""
-        return self._cache
-
-    @property
-    def cached_properties_changed(self):
-        """Signal that emits when cached properties are changed.
-
-        The signal emits this observer with updated cache, a set of
-        properties names that are changed and a set of properties
-        names that are invalid
-
-        Example of a callback:
-
-            def callback(observer, changed, invalid):
-                pass
-
-        """
-        return self._cached_properties_changed
-
-    def force_update(self):
-        """Force the update of the cache."""
-        for interface in self._watched_interfaces:
-            self._cache.update(self.proxy.GetAll(interface))
-
-    def _enable_service(self):
-        """Enable the service."""
-        self._proxy = None
-        self._is_service_available = True
-
-        # Synchronize properties with the remote object.
-        self.proxy.PropertiesChanged.connect(self._properties_changed_callback)
-        self.force_update()
-
-        # Send cached_properties_changed signal.
-        observer = self
-        names_changed = set(self._cache.properties.keys())
-        names_invalid = set()
-
-        self.service_available.emit(self)
-
-        if names_changed or names_invalid:
-            self.cached_properties_changed.emit(observer, names_changed, names_invalid)
-
-    def _properties_changed_callback(self, interface, changed, invalid):
-        """Callback for the DBus signal PropertiesChanged."""
-        if interface not in self._watched_interfaces:
-            return
-
-        # Update the cache
-        self._cache.update(changed)
-
-        # Send a signal.
-        observer = self
-        names_changed = set(changed.keys())
-        names_invalid = set(invalid)
-
-        if names_changed or names_invalid:
-            self.cached_properties_changed.emit(observer, names_changed, names_invalid)

--- a/tests/nosetests/pyanaconda_tests/dbus_identifier_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_identifier_test.py
@@ -189,39 +189,3 @@ class DBusServiceIdentifierTestCase(unittest.TestCase):
         service.get_observer(obj.object_path)
         bus.get_observer.assert_called_with("a.b.c", "/a/b/c/d")
         bus.reset_mock()
-
-    def get_cached_observer_test(self):
-        """Test getting a cached observer."""
-        bus = Mock()
-        namespace = ("a", "b", "c")
-
-        service = DBusServiceIdentifier(
-            namespace=namespace,
-            message_bus=bus
-        )
-
-        obj = DBusObjectIdentifier(
-            basename="object",
-            namespace=namespace
-        )
-
-        interface = DBusInterfaceIdentifier(
-            basename="interface",
-            namespace=namespace
-        )
-
-        service.get_cached_observer()
-        bus.get_cached_observer.assert_called_with("a.b.c", "/a/b/c", ["a.b.c"])
-        bus.reset_mock()
-
-        service.get_cached_observer(obj.object_path)
-        bus.get_cached_observer.assert_called_with("a.b.c", "/a/b/c/object", None)
-        bus.reset_mock()
-
-        service.get_cached_observer(interface_names=[interface.interface_name])
-        bus.get_cached_observer.assert_called_with("a.b.c", "/a/b/c", ["a.b.c.interface"])
-        bus.reset_mock()
-
-        service.get_cached_observer(obj.object_path, interface_names=[interface.interface_name])
-        bus.get_cached_observer.assert_called_with("a.b.c", "/a/b/c/object", ["a.b.c.interface"])
-        bus.reset_mock()


### PR DESCRIPTION
We will deprecate the `DBusObjectObserver`, so it doesn't make sense to
keep around the `DBusCachedObserver` anymore. It doesn't look like we
need this functionality anyway, because we don't use it anywhere.

The class `DBusObjectObserver` is deprecated. Use a DBus proxy to access
a DBus object and the class `DBusObserve`r to monitor a DBus service.
This combination provides the same functionality as `DBusObjectObserver`,
but in a better and understandable way.

This will also prevent bugs caused by access to a proxy of the object
observer through the proxy property.

We use almost always the `get_observer` method of `DBusServiceIdentifier`
to get an object observer, so let's issue the warning from there.

