### PR TITLE
Detect and warn if SMT is enabled (#1678353)

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -53,6 +53,7 @@ pyanaconda/ui/tui/simpleline/widgets.py
 pyanaconda/ui/tui/simpleline/base.py
 pyanaconda/ui/tui/simpleline/__init__.py
 pyanaconda/ui/tui/spokes/askvnc.py
+pyanaconda/ui/tui/spokes/kernel_warning.py
 pyanaconda/ui/tui/spokes/langsupport.py
 pyanaconda/ui/tui/spokes/network.py
 pyanaconda/ui/tui/spokes/password.py
@@ -72,6 +73,7 @@ pyanaconda/ui/gui/__init__.py
 pyanaconda/ui/gui/helpers.py
 pyanaconda/ui/gui/hubs/__init__.py
 pyanaconda/ui/gui/hubs/progress.py
+pyanaconda/ui/gui/hubs/summary.py
 pyanaconda/ui/gui/spokes/custom.py
 pyanaconda/ui/gui/spokes/datetime_spoke.py
 pyanaconda/ui/gui/spokes/filter.py

--- a/pyanaconda/constants.py
+++ b/pyanaconda/constants.py
@@ -136,6 +136,23 @@ FIRSTBOOT_ENVIRON = "firstboot"
 # Tainted hardware
 UNSUPPORTED_HW = 1 << 28
 
+# SMT warnings
+WARNING_SMT_ENABLED_GUI = N_(
+    "Simultaneous Multithreading (SMT) technology can provide performance improvements for "
+    "certain workloads, but introduces several publicly disclosed security issues. You have "
+    "the option of disabling SMT, which may impact performance. If you choose to leave SMT "
+    "enabled, please read https://red.ht/rhel-smt to understand your potential risks and learn "
+    "about other ways to mitigate these risks."
+)
+
+# This message has to be shorter for serial console.
+WARNING_SMT_ENABLED_TUI = N_(
+    "Simultaneous Multithreading (SMT) may improve performance for certain workloads, but "
+    "introduces several publicly disclosed security issues. You can disable SMT, which may "
+    "impact performance. Please read https://red.ht/rhel-smt to understand potential risks "
+    "and learn about ways to mitigate these risks."
+)
+
 # Password validation
 PASSWORD_MIN_LEN = 6
 PASSWORD_EMPTY_ERROR = N_("The %(password)s is empty.")  # singular

--- a/pyanaconda/iutil.py
+++ b/pyanaconda/iutil.py
@@ -1289,3 +1289,19 @@ def synchronized(wrapped):
         with self._lock:
             return wrapped(self, *args, **kwargs)
     return _wrapper
+
+
+def is_smt_enabled():
+    """Is Simultaneous Multithreading (SMT) enabled?
+
+    :return: True or False
+    """
+    if flags.automatedInstall or flags.dirInstall or flags.imageInstall:
+        log.info("Skipping detection of SMT.")
+        return False
+
+    try:
+        return int(open("/sys/devices/system/cpu/smt/active").read()) == 1
+    except (IOError, ValueError):
+        log.warning("Failed to detect SMT.")
+        return False

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -239,11 +239,12 @@ class Hub(GUIObject, common.Hub):
         if update_continue:
             self._updateContinue()
 
-    def _updateContinue(self):
-        self.clear_info()
+    def _get_warning(self):
+        """Get the warning message for the hub."""
+        warning = None
         if len(self._incompleteSpokes) == 0:
             if self._checker and not self._checker.check():
-                self.set_warning(self._checker.error_message)
+                warning = self._checker.error_message
                 log.error(self._checker.error_message)
 
                 # If this is a kickstart, consider the user to be warned and
@@ -252,9 +253,17 @@ class Hub(GUIObject, common.Hub):
                     self._autoContinue = False
                     self._checker_ignore = True
         else:
-            msg = _("Please complete items marked with this icon before continuing to the next step.")
+            warning = _("Please complete items marked with this icon before continuing to the next step.")
 
-            self.set_warning(msg)
+        return warning
+
+    def _updateContinue(self):
+        warning = self._get_warning()
+
+        self.clear_info()
+
+        if warning:
+            self.set_warning(warning)
 
         self._updateContinueButton()
 

--- a/pyanaconda/ui/tui/spokes/kernel_warning.py
+++ b/pyanaconda/ui/tui/spokes/kernel_warning.py
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.ui.tui.simpleline import TextWidget
+
+from pyanaconda.constants import WARNING_SMT_ENABLED_TUI
+from pyanaconda.i18n import N_, _
+from pyanaconda.iutil import is_smt_enabled
+from pyanaconda.ui.tui.spokes import StandaloneTUISpoke
+from pyanaconda.ui.tui.hubs.summary import SummaryHub
+
+__all__ = ["KernelWarningSpoke"]
+
+
+class KernelWarningSpoke(StandaloneTUISpoke):
+    """Spoke for kernel-related warnings."""
+    preForHub = SummaryHub
+    priority = 0
+
+    def __init__(self, *args, **kwargs):
+        super(KernelWarningSpoke, self).__init__(*args, **kwargs)
+        self.title = N_("Warning: Processor has Simultaneous Multithreading (SMT) enabled")
+
+    @property
+    def completed(self):
+        """Show this spoke if SMT is enabled."""
+        return not is_smt_enabled()
+
+    def refresh(self, args=None):
+        """Refresh the window."""
+        super(KernelWarningSpoke, self).refresh(args)
+        self._window += [TextWidget(_(WARNING_SMT_ENABLED_TUI))]
+        return False
+
+    def prompt(self, args=None):
+        """Show the warning and close the screen."""
+        self.close()
+        return None
+
+    def apply(self):
+        """Nothing to apply."""
+        pass


### PR DESCRIPTION
Detect whether hyperthreading (SMT) is enabled on a system. If so,
we should display a warning in the info bar of the summary hub.

Resolves: rhbz#1678353