### PR TITLE
Remove nosslverify flag

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -414,7 +414,6 @@ if __name__ == "__main__":
 
     # set flags
     flags.rescue_mode = opts.rescue
-    flags.noverifyssl = opts.noverifyssl
     flags.debug = opts.debug
     flags.mpath = opts.mpath
     flags.eject = opts.eject
@@ -541,8 +540,8 @@ if __name__ == "__main__":
             util.setenv("ftp_proxy", proxy.url)
             util.setenv("HTTPS_PROXY", proxy.url)
 
-    if flags.noverifyssl and hasattr(ksdata.method, "noverifyssl"):
-        ksdata.method.noverifyssl = flags.noverifyssl
+    if not conf.payload.verify_ssl and hasattr(ksdata.method, "noverifyssl"):
+        ksdata.method.noverifyssl = not conf.payload.verify_ssl
     if opts.multiLib:
         # sets dnf's multilib_policy to "all" (as opposed to "best")
         ksdata.packages.multiLib = opts.multiLib

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -68,6 +68,9 @@ enable_closest_mirror = True
 # Check if payload supports the locales.
 check_supported_locales = False
 
+# Enable ssl verification for all HTTP connection
+verify_ssl = True
+
 
 [Security]
 # Enable SELinux usage in the installed system.

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -144,8 +144,10 @@ inst.noverifyssl
 ^^^^^^^^^^^^^^^^
 
 Prevents Anaconda from verifying the ssl certificate for all HTTPS connections
-with an exception of the additional kickstart repos (where --noverifyssl can be
-set per repo).
+with an exception of the additional repositories added by kickstart (where
+--noverifyssl can be set per repo). Newly created additional repositories will honor
+this option.
+
 
 .. inst.proxy:
 

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -257,6 +257,10 @@ class AnacondaConfiguration(Configuration):
             self.target._set_option("type", TargetType.DIRECTORY.value)
             self.target._set_option("physical_root", opts.dirinstall)
 
+        # Set the payload flags.
+        if opts.noverifyssl:
+            self.payload._set_option("verify_ssl", not opts.noverifyssl)
+
         self.validate()
 
 

--- a/pyanaconda/core/configuration/payload.py
+++ b/pyanaconda/core/configuration/payload.py
@@ -69,3 +69,14 @@ class PayloadSection(Section):
         are supported by the payload?
         """
         return self._get_option("check_supported_locales", bool)
+
+    @property
+    def verify_ssl(self):
+        """Global option if the ssl verification is enabled.
+
+        If disabled it prevents Anaconda from verifying the ssl certificate for all HTTPS
+        connections with an exception of the additional repositories added by kickstart (where
+        --noverifyssl can be set per repo). Newly created additional repositories will honor
+        this option.
+        """
+        return self._get_option("verify_ssl", bool)

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -39,7 +39,6 @@ class Flags(object):
         self.mpath = True
         self.debug = False
         self.preexisting_x11 = False
-        self.noverifyssl = False
         self.automatedInstall = False
         self.eject = True
         # ksprompt is whether or not to prompt for missing ksdata

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -394,7 +394,7 @@ class Payload(metaclass=ABCMeta):
         #   - the path to a cert file
         #   - True, to use the system's certificates
         #   - False, to not verify
-        ssl_verify = getattr(self.data.method, "sslcacert", not flags.noverifyssl)
+        ssl_verify = getattr(self.data.method, "sslcacert", conf.payload.verify_ssl)
 
         ssl_client_cert = getattr(self.data.method, "ssl_client_cert", None)
         ssl_client_key = getattr(self.data.method, "ssl_client_key", None)

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -24,7 +24,6 @@ from subprocess import CalledProcessError
 
 import pyanaconda.errors as errors
 from pyanaconda.core import util
-from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _
 from pyanaconda.localization import get_locale_map_from_ostree, strip_codeset_and_modifier
 from pyanaconda.progress import progressQ
@@ -206,7 +205,7 @@ class RPMOSTreePayload(Payload):
         if hasattr(ostreesetup, 'nogpg') and ostreesetup.nogpg:
             self._remoteOptions['gpg-verify'] = Variant('b', False)
 
-        if flags.noverifyssl:
+        if not conf.payload.verify_ssl:
             self._remoteOptions['tls-permissive'] = Variant('b', True)
 
         repo.remote_change(None, OSTree.RepoRemoteChange.ADD_IF_NOT_EXISTS,

--- a/tests/nosetests/pyanaconda_tests/payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/payload_test.py
@@ -18,13 +18,14 @@
 # Authors: Jiri Konecny <jkonecny@redhat.com>
 #
 
-from pyanaconda.payload import dnfpayload
-from blivet.size import Size
 import unittest
 import tempfile
 import os
 import hashlib
 import shutil
+
+from pyanaconda.payload import dnfpayload
+from blivet.size import Size
 
 from pyanaconda.payload.dnfpayload import RepoMDMetaHash
 from pyanaconda.payload.requirement import PayloadRequirements
@@ -89,6 +90,7 @@ class DummyRepo(object):
     def __init__(self):
         self.id = "anaconda"
         self.baseurl = []
+        self.sslverify = True
 
 
 class DummyPayload(object):


### PR DESCRIPTION
Replace the `inst.nosslverify` option by the configuration file.

---------------------------------
Looking for advice. Based on the [documentation](https://anaconda-installer.readthedocs.io/en/latest/boot-options.html#inst-noverifyssl) it should not be used for additional repositories but based on the code it is not completely true. The point is that it will use also this flag for new additional repositories but if I remove this option then you basically can't add additional repositories from GUI with disabled ssl verification. So I leaved it the way it was before, if it is not set from the ksrepo (kickstart) then it will use this option.

What do you think, should I change it somehow? 