### PR TITLE
Fix the unit tests

### DIFF
--- a/tests/nosetests/pyanaconda_tests/module_bootloader_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_bootloader_test.py
@@ -132,7 +132,7 @@ class BootloaderTasksTestCase(unittest.TestCase):
             ConfigureBootloaderTask(storage, [version], root).run()
 
         bootloader = storage.bootloader
-        bootloader.add_image.called_once()
+        bootloader.add_image.assert_called_once()
 
         image = bootloader.add_image.call_args[0][0]
 
@@ -150,5 +150,5 @@ class BootloaderTasksTestCase(unittest.TestCase):
         InstallBootloaderTask(storage).run()
 
         bootloader = storage.bootloader
-        bootloader.set_boot_args.called_once()
-        bootloader.write.called_once()
+        bootloader.set_boot_args.assert_called_once()
+        bootloader.write.assert_called_once()

--- a/tests/nosetests/pyanaconda_tests/module_disk_init_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_disk_init_test.py
@@ -40,19 +40,30 @@ class DiskInitializationInterfaceTestCase(unittest.TestCase):
 
     def on_partitioning_changed_test(self):
         """Smoke test for on_partitioning_changed callback."""
-        mode_changed_callback = Mock()
-        devices_changed_callback = Mock()
-        drives_changed_callback = Mock()
-
+        # Set up the module.
         self.disk_init_module.set_initialization_mode(InitializationMode.CLEAR_NONE)
+
+        mode_changed_callback = Mock()
         self.disk_init_module.initialization_mode_changed.connect(mode_changed_callback)
+
+        devices_changed_callback = Mock()
         self.disk_init_module.devices_to_clear_changed.connect(devices_changed_callback)
+
+        drives_changed_callback = Mock()
         self.disk_init_module.drives_to_clear_changed.connect(drives_changed_callback)
+
+        # Change the partitioning.
         self.disk_init_module.on_partitioning_changed(create_storage())
 
-        mode_changed_callback.called_once_with(InitializationMode.CLEAR_NONE)
-        drives_changed_callback.called_once_with([])
-        devices_changed_callback.called_once_with([])
+        # Check the module.
+        mode_changed_callback.assert_called_once()
+        self.assertEqual(self.disk_init_module.initialization_mode, InitializationMode.CLEAR_NONE)
+
+        devices_changed_callback.assert_called_once()
+        self.assertEqual(self.disk_init_module.devices_to_clear, [])
+
+        drives_changed_callback.assert_called_once()
+        self.assertEqual(self.disk_init_module.drives_to_clear, [])
 
     def _test_dbus_property(self, *args, **kwargs):
         check_dbus_property(

--- a/tests/nosetests/pyanaconda_tests/module_network_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_network_test.py
@@ -217,7 +217,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         self.network_module.log_task_result = Mock()
 
         obj.implementation.succeeded_signal.emit()
-        self.network_module.log_task_result.called_once()
+        self.network_module.log_task_result.assert_called_once()
 
     def _mock_supported_devices(self, devices_attributes):
         ret_val = []
@@ -245,7 +245,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         self.network_module.log_task_result = Mock()
 
         obj.implementation.succeeded_signal.emit()
-        self.network_module.log_task_result.called_once()
+        self.network_module.log_task_result.assert_called_once()
 
     @patch('pyanaconda.dbus.DBus.publish_object')
     def apply_kickstart_with_task_test(self, publisher):
@@ -264,7 +264,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         self.network_module.log_task_result = Mock()
 
         obj.implementation.succeeded_signal.emit()
-        self.network_module.log_task_result.called_once()
+        self.network_module.log_task_result.assert_called_once()
 
     @patch('pyanaconda.dbus.DBus.publish_object')
     def set_real_onboot_values_from_kickstart_with_task_test(self, publisher):
@@ -283,7 +283,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         self.network_module.log_task_result = Mock()
 
         obj.implementation.succeeded_signal.emit()
-        self.network_module.log_task_result.called_once()
+        self.network_module.log_task_result.assert_called_once()
 
     @patch('pyanaconda.dbus.DBus.publish_object')
     def dump_missing_ifcfg_files_with_task_test(self, publisher):
@@ -301,7 +301,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         self.network_module.log_task_result = Mock()
 
         obj.implementation.succeeded_signal.emit()
-        self.network_module.log_task_result.called_once()
+        self.network_module.log_task_result.assert_called_once()
 
     def __mock_nm_client_devices(self, device_specs):
         """Mock NM Client devices obtained by get_devices() method.

--- a/tests/nosetests/pyanaconda_tests/module_nvdimm_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_nvdimm_test.py
@@ -87,8 +87,13 @@ class NVDIMMTasksTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.storage.nvdimm.reconfigure.nvdimm")
     def reconfiguration_test(self, nvdimm):
         """Test the reconfiguration test."""
-        NVDIMMReconfigureTask("namespace0.0", "sector", 512).run()
-        nvdimm.reconfigure_namespace.called_once_with("namespace0.0", "sector", 512)
+        NVDIMMReconfigureTask(
+            "namespace0.0", "sector", sector_size=512
+        ).run()
+
+        nvdimm.reconfigure_namespace.assert_called_once_with(
+            "namespace0.0", "sector", sector_size=512
+        )
 
 
 class NVDIMMKickstartTestCase(unittest.TestCase):

--- a/tests/nosetests/pyanaconda_tests/module_snapshot_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_snapshot_test.py
@@ -77,12 +77,12 @@ class SnapshotInterfaceTestCase(unittest.TestCase):
         self.assertEqual(obj.implementation._requests, [])
         self.assertEqual(obj.implementation._when, SNAPSHOT_WHEN_PRE_INSTALL)
 
-    @patch('pyanaconda.modules.storage.snapshot.device.get_snapshot_device')
+    @patch('pyanaconda.modules.storage.snapshot.snapshot.get_snapshot_device')
     def verify_requests_test(self, device_getter):
         """Test the verify_requests method."""
         report_error = Mock()
         report_warning = Mock()
-        self.module._requests = [Mock()]
+        self.module._requests = [Mock(when=SNAPSHOT_WHEN_POST_INSTALL)]
 
         # Test passing check.
         self.module.verify_requests(Mock(), Mock(), report_error, report_warning)
@@ -92,7 +92,7 @@ class SnapshotInterfaceTestCase(unittest.TestCase):
         # Test failing check.
         device_getter.side_effect = KickstartParseError("Fake error")
         self.module.verify_requests(Mock(), Mock(), report_error, report_warning)
-        report_error.called_once_with("Fake error")
+        report_error.assert_called_once_with("Fake error")
         report_warning.assert_not_called()
 
 
@@ -123,4 +123,4 @@ class SnapshotTasksTestCase(unittest.TestCase):
         device_getter.assert_not_called()
 
         SnapshotCreateTask(Mock(), [Mock()], SNAPSHOT_WHEN_POST_INSTALL).run()
-        device_getter.called_once()
+        device_getter.assert_called_once()

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -93,7 +93,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
         self.storage_module.storage_changed.connect(storage_changed_callback)
 
         obj.implementation.stopped_signal.emit()
-        storage_changed_callback.called_once()
+        storage_changed_callback.assert_called_once()
 
     def get_required_device_size_test(self):
         """Test GetRequiredDeviceSize."""
@@ -833,7 +833,7 @@ class StorageTasksTestCase(unittest.TestCase):
         storage = Mock()
         task = StorageResetTask(storage)
         task.run()
-        storage.reset.called_once()
+        storage.reset.assert_called_once()
 
 
 class AutopartitioningInterfaceTestCase(unittest.TestCase):

--- a/tests/nosetests/pyanaconda_tests/module_tasks_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_tasks_test.py
@@ -126,17 +126,17 @@ class TaskInterfaceTestCase(unittest.TestCase):
 
         object_path = publish_task(message_bus, ("A", "B", "C"), self.SimpleTask())
         self.assertEqual("/A/B/C/Tasks/1", object_path)
-        message_bus.publish_object.called_once()
+        message_bus.publish_object.assert_called_once()
         message_bus.reset_mock()
 
         object_path = publish_task(message_bus, ("A", "B", "C"), self.SimpleTask())
         self.assertEqual("/A/B/C/Tasks/2", object_path)
-        message_bus.publish_object.called_once()
+        message_bus.publish_object.assert_called_once()
         message_bus.reset_mock()
 
         object_path = publish_task(message_bus, ("A", "B", "C"), self.SimpleTask())
         self.assertEqual("/A/B/C/Tasks/3", object_path)
-        message_bus.publish_object.called_once()
+        message_bus.publish_object.assert_called_once()
         message_bus.reset_mock()
 
     @dbus_class
@@ -156,7 +156,7 @@ class TaskInterfaceTestCase(unittest.TestCase):
         )
 
         self.assertEqual("/A/B/C/Tasks/1", object_path)
-        message_bus.publish_object.called_once()
+        message_bus.publish_object.assert_called_once()
 
         publishable = message_bus.publish_object.call_args[0][1]
         self.assertIsInstance(publishable, self.SimpleTaskInterface)


### PR DESCRIPTION
Call the method assert_called_once instead of called_once on the
mocked objects, because the latter one doesn't do anything. Some
tests had to be fixed, but the code seems to be fine.