### PR TITLE
Disable updates-testing (#1670091)

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -908,14 +908,17 @@ class DNFPayload(payload.PackagePayload):
         """
         self._updates_enabled = state
 
+        # Enable or disable updates.
         if self._updates_enabled:
             self.enable_repo("updates")
-            if not constants.isFinal:
-                self.enable_repo("updates-testing")
+            self.enable_repo("updates-modular")
         else:
             self.disable_repo("updates")
-            if not constants.isFinal:
-                self.disable_repo("updates-testing")
+            self.disable_repo("updates-modular")
+
+        # Disable updates-testing.
+        self.disable_repo("updates-testing")
+        self.disable_repo("updates-testing-modular")
 
     def disable_repo(self, repo_id):
         try:
@@ -1138,7 +1141,7 @@ class DNFPayload(payload.PackagePayload):
         # to use that instead of the default repos.
         self._base.read_all_repos()
 
-        # If setup updates/updates-testing
+        # Enable or disable updates.
         self.set_updates_enabled(self._updates_enabled)
 
         # Repos on disk are always enabled. When reloaded their state needs to

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1633,10 +1633,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         self._remove_url_prefix(editable, self._protocol_combo_box, self.on_urlEntry_changed)
 
     def on_noUpdatesCheckbox_toggled(self, *args):
-        """ Toggle the enable state of the updates repo
-
-            Before final release this will also toggle the updates-testing repo
-        """
+        """Toggle the enable state of the updates repo."""
         if self._no_updates_checkbox.get_active():
             self.payload.set_updates_enabled(False)
         else:


### PR DESCRIPTION
Always disable `updates-testing` and `updates-testing-modular` repos.
Only `updates` and `updates-modular` repos should be controlled by the
checkbox of the installation source spoke.

Resolves: rhbz#1670091