### PR TITLE
Add DBus support for device actions

### DIFF
--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -19,7 +19,7 @@
 from pyanaconda.dbus.structure import dbus_structure
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
-__all__ = ["DeviceData"]
+__all__ = ["DeviceData", "DeviceActionData"]
 
 
 @dbus_structure
@@ -47,8 +47,10 @@ class DeviceData(object):
         self._name = ""
         self._path = ""
         self._size = 0
+        self._parents = []
         self._is_disk = False
         self._attrs = {}
+        self._description = ""
 
     @property
     def type(self) -> Str:
@@ -111,6 +113,18 @@ class DeviceData(object):
         self._is_disk = is_disk
 
     @property
+    def parents(self) -> List[Str]:
+        """Parents of the device.
+
+        :return: a list of device names
+        """
+        return self._parents
+
+    @parents.setter
+    def parents(self, names):
+        self._parents = names
+
+    @property
     def attrs(self) -> Dict[Str, Str]:
         """Additional attributes.
 
@@ -124,3 +138,85 @@ class DeviceData(object):
     @attrs.setter
     def attrs(self, attrs: Dict[Str, Str]):
         self._attrs = attrs
+
+    @property
+    def description(self) -> Str:
+        """Description of the device.
+
+        FIXME: This is a temporary property.
+
+        :return: a string with description
+        """
+        return self._description
+
+    @description.setter
+    def description(self, text):
+        self._description = text
+
+
+@dbus_structure
+class DeviceActionData(object):
+    """Device action data."""
+
+    def __init__(self):
+        self._action_type = ""
+        self._action_object = ""
+        self._device_name = ""
+        self._description = ""
+
+    @property
+    def action_type(self) -> Str:
+        """A type of the action.
+
+        For example:
+            destroy, resize, create,
+            add, remove, configure
+
+        :return: a string with the type
+        """
+        return self._action_type
+
+    @action_type.setter
+    def action_type(self, name: Str):
+        self._action_type = name
+
+    @property
+    def action_object(self) -> Str:
+        """A type of the action object.
+
+        For example:
+            format, device, container
+
+        :return: a string with the type
+        """
+        return self._action_object
+
+    @action_object.setter
+    def action_object(self, name: Str):
+        self._action_object = name
+
+    @property
+    def device_name(self) -> Str:
+        """A name of the device.
+
+        :return: a device name
+        """
+        return self._device_name
+
+    @device_name.setter
+    def device_name(self, name: Str):
+        self._device_name = name
+
+    @property
+    def description(self) -> Str:
+        """Description of the action.
+
+        FIXME: This is a temporary property.
+
+        :return: a string with description
+        """
+        return self._description
+
+    @description.setter
+    def description(self, text):
+        self._description = text

--- a/pyanaconda/modules/storage/devicetree/devicetree_interface.py
+++ b/pyanaconda/modules/storage/devicetree/devicetree_interface.py
@@ -68,3 +68,10 @@ class DeviceTreeInterface(InterfaceTemplate):
         :raise: UnknownDeviceError if the device is not found
         """
         return get_structure(self.implementation.get_device_data(name))
+
+    def GetActions(self) -> List[Structure]:
+        """Get the device actions.
+
+        :return: a list of structures with device action data
+        """
+        return list(map(get_structure, self.implementation.get_actions()))

--- a/pyanaconda/modules/storage/partitioning/interactive_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/interactive_partitioning.py
@@ -30,10 +30,16 @@ class InteractivePartitioningTask(PartitioningTask):
     def _run(self, storage):
         """Only set up the bootloader."""
         self._prepare_bootloader(storage)
+        self._organize_actions(storage)
 
     def _prepare_bootloader(self, storage):
         """Prepare the bootloader."""
         storage.set_up_bootloader()
+
+    def _organize_actions(self, storage):
+        """Prune and sort the scheduled actions."""
+        storage.devicetree.actions.prune()
+        storage.devicetree.actions.sort()
 
 
 class InteractiveAutoPartitioningTask(AutomaticPartitioningTask):

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -251,9 +251,12 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
             if not self._do_check():
                 return
 
-        if len(self._storage_playground.devicetree.actions.find()) > 0:
-            dialog = ActionSummaryDialog(self.data)
-            dialog.refresh(self._storage_playground.devicetree.actions.find())
+        actions = self._storage_playground.devicetree.actions.find()
+
+        if actions:
+            dialog = ActionSummaryDialog(self.data, actions)
+            dialog.refresh()
+
             with self.main_window.enlightbox(dialog.window):
                 rc = dialog.run()
 

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -263,10 +263,6 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
             if rc != 1:
                 # Cancel.  Stay on the blivet-gui screen.
                 return
-            else:
-                # remove redundant actions and sort them now
-                self._storage_playground.devicetree.actions.prune()
-                self._storage_playground.devicetree.actions.sort()
 
         NormalSpoke.on_back_clicked(self, button)
 

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -1786,9 +1786,12 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             if not self._do_check():
                 return
 
-        if len(self._storage_playground.devicetree.actions.find()) > 0:
-            dialog = ActionSummaryDialog(self.data)
-            dialog.refresh(self._storage_playground.devicetree.actions.find())
+        actions = self._storage_playground.devicetree.actions.find()
+
+        if actions:
+            dialog = ActionSummaryDialog(self.data, actions)
+            dialog.refresh()
+
             with self.main_window.enlightbox(dialog.window):
                 rc = dialog.run()
 

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -1752,10 +1752,6 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         # And then display the summary screen.  From there, the user will either
         # head back to the hub, or stay on the custom screen.
-        self._storage_playground.devicetree.actions.prune()
-        self._storage_playground.devicetree.actions.sort()
-
-
         # If back has been clicked on once already and no other changes made on the screen,
         # run the storage check now.  This handles displaying any errors in the info bar.
         if not self._back_already_clicked:

--- a/pyanaconda/ui/gui/spokes/lib/summary.py
+++ b/pyanaconda/ui/gui/spokes/lib/summary.py
@@ -16,7 +16,6 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.utils import escape_markup
 from pyanaconda.core.i18n import _
@@ -25,26 +24,26 @@ from blivet.deviceaction import ACTION_TYPE_DESTROY, ACTION_TYPE_RESIZE, ACTION_
 
 __all__ = ["ActionSummaryDialog"]
 
+
 class ActionSummaryDialog(GUIObject):
     builderObjects = ["actionStore", "summaryDialog"]
     mainWidgetName = "summaryDialog"
     uiFile = "spokes/lib/summary.glade"
 
-    def __init__(self, data):
+    def __init__(self, data, actions):
         super().__init__(data)
         self._store = self.builder.get_object("actionStore")
 
-    # pylint: disable=arguments-differ
-    def initialize(self, actions):
         for (i, action) in enumerate(actions, start=1):
             mountpoint = ""
 
             if action.type in [ACTION_TYPE_DESTROY, ACTION_TYPE_RESIZE]:
-                typeString = """<span foreground='red'>%s</span>""" % \
+                action_type = """<span foreground='red'>%s</span>""" % \
                         escape_markup(action.type_desc.title())
             else:
-                typeString = """<span foreground='green'>%s</span>""" % \
+                action_type = """<span foreground='green'>%s</span>""" % \
                         escape_markup(action.type_desc.title())
+
                 if action.obj == ACTION_OBJECT_FORMAT:
                     mountpoint = getattr(action.device.format, "mountpoint", "")
 
@@ -61,18 +60,11 @@ class ActionSummaryDialog(GUIObject):
                 serial = action.device.serial
 
             self._store.append([i,
-                                typeString,
+                                action_type,
                                 action.object_type_string,
                                 desc,
                                 mountpoint,
                                 serial])
-
-    # pylint: disable=arguments-differ
-    def refresh(self, actions):
-        super().refresh()
-
-        self._store.clear()
-        self.initialize(actions)
 
     def run(self):
         rc = self.window.run()


### PR DESCRIPTION
Simplify the code for the `ActionSummaryDialog`.

Call `GetActions` to get device actions of the device tree.
Use `DeviceActionData` to represent the DBus structures.

Prune and sort the scheduled device actions in the class
`InteractivePartitioningTask`.