### PR TITLE
Add DBus support for disk images

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -651,21 +651,22 @@ if __name__ == "__main__":
     # Add a check for the snapshot requests.
     storage_checker.add_check(ksdata.snapshot.verify_requests)
 
+    # Set the disk images.
+    from pyanaconda.modules.common.constants.objects import DISK_SELECTION
     from pyanaconda.argument_parsing import name_path_pairs
+    disk_select_proxy = STORAGE.get_proxy(DISK_SELECTION)
+    disk_images = {}
 
-    image_count = 0
     try:
         for (name, path) in name_path_pairs(opts.images):
             log.info("naming disk image '%s' '%s'", path, name)
-            anaconda.storage.disk_images[name] = path
-            image_count += 1
+            disk_images[name] = path
     except ValueError as e:
         stdout_log.error("error specifying image file: %s", e)
         util.ipmi_abort(scripts=ksdata.scripts)
         sys.exit(1)
 
-    if image_count:
-        anaconda.storage.setup_disk_images()
+    disk_select_proxy.SetDiskImages(disk_images)
 
     # Ignore disks labeled OEMDRV
     from pyanaconda.storage.utils import ignore_oemdrv_disks
@@ -677,8 +678,6 @@ if __name__ == "__main__":
 
     # Specify protected devices.
     from pyanaconda.modules.common.constants.services import STORAGE
-    from pyanaconda.modules.common.constants.objects import DISK_SELECTION
-    disk_select_proxy = STORAGE.get_proxy(DISK_SELECTION)
 
     protected_devices = anaconda.get_protected_devices(opts)
     disk_select_proxy.SetProtectedDevices(protected_devices)

--- a/pyanaconda/modules/storage/disk_selection/selection.py
+++ b/pyanaconda/modules/storage/disk_selection/selection.py
@@ -44,6 +44,9 @@ class DiskSelectionModule(KickstartBaseModule):
         self.protected_devices_changed = Signal()
         self._protected_devices = []
 
+        self.disk_images_changed = Signal()
+        self._disk_images = {}
+
     def publish(self):
         """Publish the module."""
         DBus.publish_object(DISK_SELECTION.object_path, DiskSelectionInterface(self))
@@ -129,3 +132,17 @@ class DiskSelectionModule(KickstartBaseModule):
         self._protected_devices = devices
         self.protected_devices_changed.emit()
         log.debug("Protected devices are set to '%s'.", devices)
+
+    @property
+    def disk_images(self):
+        """The dictionary of disk images."""
+        return self._disk_images
+
+    def set_disk_images(self, disk_images):
+        """Set the dictionary of disk images.
+
+        :param disk_images: a dictionary of image names and file names
+        """
+        self._disk_images = disk_images
+        self.disk_images_changed.emit()
+        log.debug("Disk images are set to '%s'.", disk_images)

--- a/pyanaconda/modules/storage/disk_selection/selection_interface.py
+++ b/pyanaconda/modules/storage/disk_selection/selection_interface.py
@@ -35,6 +35,7 @@ class DiskSelectionInterface(KickstartModuleInterfaceTemplate):
         self.watch_property("ExclusiveDisks", self.implementation.exclusive_disks_changed)
         self.watch_property("IgnoredDisks", self.implementation.ignored_disks_changed)
         self.watch_property("ProtectedDevices", self.implementation.protected_devices_changed)
+        self.watch_property("DiskImages", self.implementation.disk_images_changed)
 
     @property
     def SelectedDisks(self) -> List[Str]:
@@ -101,3 +102,16 @@ class DiskSelectionInterface(KickstartModuleInterfaceTemplate):
         :param devices: a list of device names
         """
         self.implementation.set_protected_devices(devices)
+
+    @property
+    def DiskImages(self) -> Dict[Str, Str]:
+        """The dictionary of disk images."""
+        return self.implementation.disk_images
+
+    @emits_properties_changed
+    def SetDiskImages(self, disk_images: Dict[Str, Str]):
+        """Set the dictionary of disk images.
+
+        :param disk_images: a dictionary of image names and file names
+        """
+        self.implementation.set_disk_images(disk_images)

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -192,6 +192,7 @@ class StorageModule(KickstartModule, DeviceTreeHandler):
         storage.ignored_disks = self._disk_selection_module.ignored_disks
         storage.exclusive_disks = self._disk_selection_module.exclusive_disks
         storage.protected_devices = self._disk_selection_module.protected_devices
+        storage.disk_images = self._disk_selection_module.disk_images
 
         # Create the task.
         task = StorageResetTask(storage)

--- a/pyanaconda/storage/initialization.py
+++ b/pyanaconda/storage/initialization.py
@@ -209,6 +209,7 @@ def _reset_storage(storage):
     storage.ignored_disks = disk_select_proxy.IgnoredDisks
     storage.exclusive_disks = disk_select_proxy.ExclusiveDisks
     storage.protected_devices = disk_select_proxy.ProtectedDevices
+    storage.disk_images = disk_select_proxy.DiskImages
 
     # Reload additional modules.
     if not conf.target.is_image:

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -361,6 +361,10 @@ class InstallerStorage(Blivet):
             See :meth:`devicetree.Devicetree.populate` for more information
             about the cleanup_only keyword argument.
         """
+        # set up the disk images
+        if conf.target.is_image:
+            self.setup_disk_images()
+
         # save passphrases for luks devices so we don't have to reprompt
         self.encryption_passphrase = None
         for device in self.devices:

--- a/tests/nosetests/pyanaconda_tests/module_disk_select_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_disk_select_test.py
@@ -68,3 +68,13 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
             "ProtectedDevices",
             ["sda", "sdb"]
         )
+
+    def disk_images_property_test(self):
+        """Test the protected disks property."""
+        self._test_dbus_property(
+            "DiskImages",
+            {
+                "image_1": "/path/1",
+                "image_2": "/path/2"
+             }
+        )


### PR DESCRIPTION
Use DiskImages and SetDiskImages of the disk selection module to
get and specify the disk images for the image installation. Set up
disk images on reset of the storage module.