### PR TITLE
Fix the entry for swap in /etc/fstab (#1258322)

### DIFF
--- a/pyanaconda/storage/fsset.py
+++ b/pyanaconda/storage/fsset.py
@@ -752,7 +752,7 @@ class FSSet(object):
 
             fstype = getattr(device.format, "mount_type", device.format.type)
             if fstype == "swap":
-                mountpoint = "swap"
+                mountpoint = "none"
                 options = device.format.options
             else:
                 mountpoint = device.format.mountpoint


### PR DESCRIPTION
In /etc/fstab, the field, that describes the mount point for the
filesystem, should be specified as 'none' for swap partitions. The
installer generated 'swap'.

Resolves: rhbz#1258322