### PR TITLE
Add DBus support for disk selection

### DIFF
--- a/pyanaconda/modules/storage/disk_selection/selection.py
+++ b/pyanaconda/modules/storage/disk_selection/selection.py
@@ -77,7 +77,7 @@ class DiskSelectionModule(KickstartBaseModule):
         :param drives: a list of drives names
         """
         self._selected_disks = drives
-        self.selected_disks_changed.emit()
+        self.selected_disks_changed.emit(list(drives))
         log.debug("Selected disks are set to '%s'.", drives)
 
     @property

--- a/pyanaconda/modules/storage/disk_selection/selection_interface.py
+++ b/pyanaconda/modules/storage/disk_selection/selection_interface.py
@@ -115,3 +115,10 @@ class DiskSelectionInterface(KickstartModuleInterfaceTemplate):
         :param disk_images: a dictionary of image names and file names
         """
         self.implementation.set_disk_images(disk_images)
+
+    def GetUsableDisks(self):
+        """Get a list of disks that can be used for the installation.
+
+        :return: a list of disk names
+        """
+        return self.implementation.get_usable_disks()

--- a/pyanaconda/modules/storage/partitioning/base.py
+++ b/pyanaconda/modules/storage/partitioning/base.py
@@ -39,6 +39,7 @@ class PartitioningModule(KickstartBaseModule):
         super().__init__()
         self._current_storage = None
         self._storage_playground = None
+        self._selected_disks = []
 
     @property
     def storage(self):
@@ -54,12 +55,17 @@ class PartitioningModule(KickstartBaseModule):
 
         if self._storage_playground is None:
             self._storage_playground = self._current_storage.copy()
+            self._storage_playground.select_disks(self._selected_disks)
 
         return self._storage_playground
 
     def on_storage_reset(self, storage):
         """Keep the instance of the current storage."""
         self._current_storage = storage
+
+    def on_selected_disks_changed(self, selection):
+        """Keep the current disk selection."""
+        self._selected_disks = selection
 
     @abstractmethod
     def configure_with_task(self):

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -122,8 +122,21 @@ class StorageModule(KickstartModule, DeviceTreeHandler):
         self._modules.append(partitioning_module)
         self._partitioning_modules[object_path] = partitioning_module
 
-        # Connect the callbacks.
-        self.storage_changed.connect(partitioning_module.on_storage_reset)
+        # Update the module.
+        partitioning_module.on_storage_reset(
+            self._storage
+        )
+        partitioning_module.on_selected_disks_changed(
+            self._disk_selection_module.selected_disks
+        )
+
+        # Connect the callbacks to signals.
+        self.storage_changed.connect(
+            partitioning_module.on_storage_reset
+        )
+        self._disk_selection_module.selected_disks_changed.connect(
+            partitioning_module.on_selected_disks_changed
+        )
 
     def publish(self):
         """Publish the module."""

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -109,8 +109,15 @@ class StorageModule(KickstartModule, DeviceTreeHandler):
         self._add_partitioning_module(BLIVET_PARTITIONING.object_path, self._blivet_part_module)
 
         # Connect modules to signals.
-        self.storage_changed.connect(self._snapshot_module.on_storage_reset)
-        self.storage_changed.connect(self._disk_init_module.on_storage_reset)
+        self.storage_changed.connect(
+            self._disk_init_module.on_storage_reset
+        )
+        self.storage_changed.connect(
+            self._disk_selection_module.on_storage_reset
+        )
+        self.storage_changed.connect(
+            self._snapshot_module.on_storage_reset
+        )
 
     def _add_module(self, storage_module):
         """Add a base kickstart module."""

--- a/pyanaconda/storage/format_dasd.py
+++ b/pyanaconda/storage/format_dasd.py
@@ -25,7 +25,6 @@ from gi.repository import BlockDev as blockdev
 from blivet import arch
 
 from pyanaconda.flags import flags
-from pyanaconda.storage.utils import get_available_disks
 from pyanaconda.core.signal import Signal
 from pyanaconda.storage.snapshot import on_disk_storage
 from pyanaconda.core.i18n import _
@@ -188,7 +187,7 @@ class DasdFormatting(object):
         if not DasdFormatting.is_supported():
             return
 
-        disks = get_available_disks(storage.devicetree)
+        disks = storage.usable_disks
 
         formatting = DasdFormatting()
         formatting.update_restrictions()

--- a/pyanaconda/storage/utils.py
+++ b/pyanaconda/storage/utils.py
@@ -475,41 +475,6 @@ def find_live_backing_device():
     return None
 
 
-def get_available_disks(devicetree):
-    """Get disks that can be used for the installation.
-
-    :param devicetree: a device tree to look up devices
-    :return: a list of devices
-    """
-    # Get all devices.
-    devices = devicetree.devices
-
-    # Add the hidden devices.
-    if conf.target.is_image:
-        devices += [
-            d for d in devicetree._hidden
-            if d.name in devicetree.disk_images
-        ]
-    else:
-        devices += devicetree._hidden
-
-    # Filter out the usable disks.
-    disks = []
-    for d in devices:
-        if d.is_disk and not d.format.hidden and not d.protected:
-            # Unformatted DASDs are detected with a size of 0, but they should
-            # still show up as valid disks if this function is called, since we
-            # can still use them; anaconda will know how to handle them, so they
-            # don't need to be ignored anymore.
-            if d.type == "dasd":
-                disks.append(d)
-            elif d.size > 0 and d.media_present:
-                disks.append(d)
-
-    # Remove duplicate names from the list.
-    return sorted(set(disks), key=lambda d: d.name)
-
-
 def filter_disks_by_names(disks, names):
     """Filter disks by the given names.
 

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -32,8 +32,8 @@ from blivet.iscsi import iscsi
 
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import CN_, CP_
-from pyanaconda.storage.utils import try_populate_devicetree, get_available_disks, \
-    apply_disk_selection, filter_disks_by_names
+from pyanaconda.storage.utils import try_populate_devicetree, apply_disk_selection, \
+    filter_disks_by_names
 from pyanaconda.storage.snapshot import on_disk_storage
 from pyanaconda.modules.common.constants.objects import DISK_SELECTION
 from pyanaconda.modules.common.constants.services import STORAGE
@@ -646,7 +646,7 @@ class FilterSpoke(NormalSpoke):
     def refresh(self):
         super().refresh()
 
-        self.disks = get_available_disks(self.storage.devicetree)
+        self.disks = self.storage.usable_disks
 
         disk_select_proxy = STORAGE.get_proxy(DISK_SELECTION)
         self.selected_disks = disk_select_proxy.SelectedDisks

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -30,7 +30,7 @@ from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog, PasswordDialog
 from pyanaconda.storage.utils import get_supported_filesystems, get_supported_autopart_choices, \
-    get_available_disks, filter_disks_by_names, apply_disk_selection, check_disk_selection, \
+    filter_disks_by_names, apply_disk_selection, check_disk_selection, \
     get_disks_summary
 from pyanaconda.storage.execution import configure_storage
 from pyanaconda.storage.checker import storage_checker
@@ -401,13 +401,7 @@ class StorageSpoke(NormalTUISpoke):
     def apply(self):
         self._auto_part_enabled = self._auto_part_observer.proxy.Enabled
 
-        for disk in self._available_disks:
-            if disk.name not in self._selected_disks and \
-               disk in self.storage.devices:
-                self.storage.devicetree.hide(disk)
-            elif disk.name in self._selected_disks and \
-                 disk not in self.storage.devices:
-                self.storage.devicetree.unhide(disk)
+        self.storage.select_disks(self._selected_disks)
 
         self._bootloader_observer.proxy.SetPreferredLocation(BOOTLOADER_LOCATION_MBR)
         boot_drive = self._bootloader_observer.proxy.Drive
@@ -488,7 +482,7 @@ class StorageSpoke(NormalTUISpoke):
 
     def update_disks(self):
         threadMgr.wait(THREAD_STORAGE)
-        self._available_disks = get_available_disks(self.storage.devicetree)
+        self._available_disks = self.storage.usable_disks
 
         # if only one disk is available, go ahead and mark it as selected
         if len(self._available_disks) == 1:

--- a/tests/nosetests/pyanaconda_tests/module_disk_select_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_disk_select_test.py
@@ -20,8 +20,10 @@
 import unittest
 
 from pyanaconda.modules.common.constants.objects import DISK_SELECTION
+from pyanaconda.modules.common.errors.storage import UnavailableStorageError
 from pyanaconda.modules.storage.disk_selection import DiskSelectionModule
 from pyanaconda.modules.storage.disk_selection.selection_interface import DiskSelectionInterface
+from pyanaconda.storage.initialization import create_storage
 from tests.nosetests.pyanaconda_tests import check_dbus_property
 
 
@@ -78,3 +80,11 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
                 "image_2": "/path/2"
              }
         )
+
+    def get_usable_disks_test(self):
+        """Test the GetUsableDisks method."""
+        with self.assertRaises(UnavailableStorageError):
+            self.disk_selection_interface.GetUsableDisks()
+
+        self.disk_selection_module.on_storage_reset(create_storage())
+        self.assertEqual(self.disk_selection_interface.GetUsableDisks(), [])


### PR DESCRIPTION
Move the code from the function `get_available_disks` to the
`InstallerStorage` class. Use the property `usable_disks` to get a
list of disks usable for the installation and the method `select_disks`
to select the disks that should be used for the installation.

We need to hide the unselected disks before we start the partitioning.
Therefore, we can apply the selection only on the copy of the storage
model and leave the original model unchanged.

Call `GetUsableDisks` of the disk selection module to get a list
of disk names that can be used for the installation.