### PR TITLE
Use new ssl certificate kickstart options

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -37,7 +37,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.16.2-1
+%define pykickstartver 3.16.4-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 1.1-1

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -50,7 +50,7 @@ from pykickstart.commands.cdrom import FC3_Cdrom as Cdrom
 from pykickstart.commands.harddrive import FC3_HardDrive as HardDrive
 from pykickstart.commands.hmc import F28_Hmc as Hmc
 from pykickstart.commands.nfs import FC6_NFS as NFS
-from pykickstart.commands.url import F27_Url as Url
+from pykickstart.commands.url import RHEL8_Url as Url
 from pykickstart.commands.updates import F7_Updates as Updates
 from pykickstart.commands.mediacheck import FC4_MediaCheck as MediaCheck
 from pykickstart.commands.driverdisk import F14_DriverDisk as DriverDisk

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -64,7 +64,7 @@ from pykickstart.commands.partition import RHEL8_Partition as Partition
 from pykickstart.commands.raid import RHEL8_Raid as Raid
 from pykickstart.commands.realm import F19_Realm as Realm
 from pykickstart.commands.reboot import F23_Reboot as Reboot
-from pykickstart.commands.repo import F27_Repo as Repo
+from pykickstart.commands.repo import RHEL8_Repo as Repo
 from pykickstart.commands.reqpart import F23_ReqPart as ReqPart
 from pykickstart.commands.rescue import F10_Rescue as Rescue
 from pykickstart.commands.rootpw import F18_RootPw as RootPw
@@ -77,7 +77,7 @@ from pykickstart.commands.sshkey import F22_SshKey as SshKey
 from pykickstart.commands.syspurpose import RHEL8_Syspurpose as Syspurpose
 from pykickstart.commands.timezone import F25_Timezone as Timezone
 from pykickstart.commands.updates import F7_Updates as Updates
-from pykickstart.commands.url import F27_Url as Url
+from pykickstart.commands.url import RHEL8_Url as Url
 from pykickstart.commands.user import F24_User as User
 from pykickstart.commands.vnc import F9_Vnc as Vnc
 from pykickstart.commands.volgroup import RHEL8_VolGroup as VolGroup
@@ -101,7 +101,7 @@ from pykickstart.commands.network import F27_NetworkData as NetworkData
 from pykickstart.commands.nvdimm import F28_NvdimmData as NvdimmData
 from pykickstart.commands.partition import RHEL8_PartData as PartData
 from pykickstart.commands.raid import RHEL8_RaidData as RaidData
-from pykickstart.commands.repo import F27_RepoData as RepoData
+from pykickstart.commands.repo import RHEL8_RepoData as RepoData
 from pykickstart.commands.snapshot import F26_SnapshotData as SnapshotData
 from pykickstart.commands.sshpw import F24_SshPwData as SshPwData
 from pykickstart.commands.sshkey import F22_SshKeyData as SshKeyData

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -379,6 +379,15 @@ class DNFPayload(payload.PackagePayload):
         if ksrepo.excludepkgs:
             repo.exclude = ksrepo.excludepkgs
 
+        if ksrepo.sslcacert:
+            repo.sslcacert = ksrepo.sslcacert
+
+        if ksrepo.sslclientcert:
+            repo.sslclientcert = ksrepo.sslclientcert
+
+        if ksrepo.sslclientkey:
+            repo.sslclientkey = ksrepo.sslclientkey
+
         # If this repo is already known, it's one of two things:
         # (1) The user is trying to do "repo --name=updates" in a kickstart file
         #     and we should just know to enable the already existing on-disk
@@ -1178,7 +1187,10 @@ class DNFPayload(payload.PackagePayload):
                 base_ksrepo = self.data.RepoData(
                     name=constants.BASE_REPO_NAME, baseurl=base_repo_url,
                     mirrorlist=mirrorlist, metalink=metalink,
-                    noverifyssl=not sslverify, proxy=proxy)
+                    noverifyssl=not sslverify, proxy=proxy,
+                    sslcacert=getattr(method, 'sslcacert', None),
+                    sslclientcert=getattr(method, 'sslclientcert', None),
+                    sslclientkey=getattr(method, 'sslclientkey', None))
                 self._add_repo(base_ksrepo)
                 self._fetch_md(base_ksrepo.name)
             except (payload.MetadataError, payload.PayloadError) as e:

--- a/pyanaconda/payload/install_tree_metadata.py
+++ b/pyanaconda/payload/install_tree_metadata.py
@@ -56,7 +56,7 @@ class InstallTreeMetadata(object):
 
         return True
 
-    def load_url(self, url, proxies, sslverify, headers):
+    def load_url(self, url, proxies, sslverify, sslcert, headers):
         """Load URL link.
 
         This can be also to local file.
@@ -87,13 +87,13 @@ class InstallTreeMetadata(object):
             # Downloading .treeinfo
             log.info("Trying to download '.treeinfo'")
             (response, ret_code[0]) = self._download_treeinfo_file(session, url, ".treeinfo",
-                                                                   headers, proxies, sslverify)
+                                                                   headers, proxies, sslverify, sslcert)
             if response:
                 break
             # Downloading treeinfo
             log.info("Trying to download 'treeinfo'")
             (response, ret_code[1]) = self._download_treeinfo_file(session, url, "treeinfo",
-                                                                   headers, proxies, sslverify)
+                                                                   headers, proxies, sslverify, sslcert)
             if response:
                 break
 
@@ -130,10 +130,10 @@ class InstallTreeMetadata(object):
         return False
 
     @staticmethod
-    def _download_treeinfo_file(session, url, file_name, headers, proxies, verify):
+    def _download_treeinfo_file(session, url, file_name, headers, proxies, verify, cert):
         try:
             result = session.get("%s/%s" % (url, file_name), headers=headers,
-                                 proxies=proxies, verify=verify)
+                                 proxies=proxies, verify=verify, cert=cert)
             # Server returned HTTP 4XX or 5XX codes
             if 400 <= result.status_code < 600:
                 log.info("Server returned %i code", result.status_code)


### PR DESCRIPTION
The `repo` and `url` commands can now contain --sslcacert,
--sslclientcert, and --sslclientkey options. Use those when accessing
repositories.