### PR TITLE
Remove unused import for DNF

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -53,7 +53,6 @@ import dnf.repo
 import dnf.callback
 import dnf.transaction
 import libdnf.conf
-import dnf.conf.substitutions
 import rpm
 from dnf.const import GROUP_PACKAGE_TYPES
 


### PR DESCRIPTION
We are using this as variable from dnf library but we don't need this import for using instantiated object.