### PR TITLE
Give payload a hook for adding disabled repos.

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -239,6 +239,16 @@ class Payload(metaclass=ABCMeta):
         ksrepo.enabled = True
         self.data.repo.dataList().append(ksrepo)
 
+    def add_disabled_repo(self, ksrepo):
+        """Add the repo given by the pykickstart Repo object ksrepo to the
+        list of known repos.  The repo will be automatically disabled.
+
+        Duplicate repos will not raise an error.  They should just silently
+        take the place of the previous value.
+        """
+        ksrepo.enabled = False
+        self.data.repo.dataList().append(ksrepo)
+
     def remove_repo(self, repo_id):
         repos = self.data.repo.dataList()
         try:


### PR DESCRIPTION
I'm beginning to rework my anaconda addon for the dbus interface and the new products.d directory.  The ability to easily add disabled repos through anaconda cuts a significant number of lines from my code base and would probably be helpful to others too.

