### PR TITLE
We inherit self.data.repo.dataList() from parent class.

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -1289,15 +1289,16 @@ class DNFPayload(payload.PackagePayload):
             if base_repo_url is not None:
                 existing_urls.append(base_repo_url)
 
-            for ksrepo in self.data.repo.dataList():
-                existing_urls.append(ksrepo.baseurl)
+            for ksrepo in self.addons:
+                baseurl = self.get_addon_repo(ksrepo).baseurl
+                existing_urls.append(baseurl)
 
             for repo_md in self._install_tree_metadata.get_metadata_repos():
                 if repo_md.path not in existing_urls:
                     repo = RepoData(name=repo_md.name, baseurl=repo_md.path,
                                     install=False, enabled=True)
                     repo.treeinfo_origin = True
-                    self.data.repo.dataList().append(repo)
+                    self.add_repo(repo)
 
         return install_tree_url
 


### PR DESCRIPTION
Avoiding a direct call to permit clean change out if needed.

If payload decides to store things a different way, we shouldn't need to edit the specific instance class.

Semi-related:  I noticed https://github.com/rhinstaller/anaconda/commit/9a02cda015672a9eab3ce8d956ed1e05f2b63b61 set `enabled=True` for addon repos (then inherited by https://github.com/rhinstaller/anaconda/commit/57c6786b656ec57a84a4cf88c1b16cd16c2c3660).  Wasn't this `enabled=False` historically?