### PR TITLE
Fix the string representation of the data objects

### DIFF
--- a/pyanaconda/dbus/structure.py
+++ b/pyanaconda/dbus/structure.py
@@ -21,7 +21,8 @@ from typing import get_type_hints
 
 from pyanaconda.dbus.typing import get_variant, Structure
 
-__all__ = ["get_structure", "apply_structure", "dbus_structure", "DBusStructureError"]
+__all__ = ["get_structure", "apply_structure", "dbus_structure", "DBusStructureError",
+           "generate_string_from_data"]
 
 
 # Class attribute for DBus fields.
@@ -226,7 +227,7 @@ def dbus_structure(cls):
 
     This decorator will use the class to generate DBus fields from the class
     properties and set the class attribute __dbus_fields__ with the generated
-    fields. It also sets the __repr__ method.
+    fields.
 
     Instances of the decorated class can be used to create and apply
     DBus structures with method get_structure and apply_structure.
@@ -235,5 +236,4 @@ def dbus_structure(cls):
     :return: a data class with generated DBus fields
     """
     setattr(cls, DBUS_FIELDS_ATTRIBUTE, generate_fields(cls))
-    setattr(cls, '__repr__', generate_string_from_data)
     return cls

--- a/pyanaconda/dbus/structure.py
+++ b/pyanaconda/dbus/structure.py
@@ -207,15 +207,22 @@ def generate_fields(cls):
     return fields
 
 
-def generate_string_from_data(obj):
+def generate_string_from_data(obj, skip=None):
     """Generate a string representation of a data object.
 
+    Set the argument 'skip' to skip attributes with sensitive data.
+
     :param obj: a data object
+    :param skip: a list of names that should be skipped or None
     :return: a string representation of the data object
     """
     attributes = []
+    skipped_names = set(skip) if skip else set()
 
     for field in get_fields(obj).values():
+        if field.data_name in skipped_names:
+            continue
+
         attribute = "{}={}".format(field.data_name, repr(field.get_data(obj)))
         attributes.append(attribute)
 

--- a/pyanaconda/modules/common/structures/network.py
+++ b/pyanaconda/modules/common/structures/network.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from pyanaconda.dbus.structure import dbus_structure
+from pyanaconda.dbus.structure import dbus_structure, generate_string_from_data
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
 __all__ = ["NetworkDeviceConfiguration"]
@@ -67,6 +67,9 @@ class NetworkDeviceConfiguration(object):
 
     def __eq__(self, other):
         return (self._device_name, self._connection_uuid) == (other.device_name, other.connection_uuid)
+
+    def __repr__(self):
+        return generate_string_from_data(self)
 
 
 @dbus_structure
@@ -120,3 +123,6 @@ class NetworkDeviceInfo(object):
         except AttributeError:
             hw_address = device.get_hw_address()
         self.hw_address = hw_address
+
+    def __repr__(self):
+        return generate_string_from_data(self)

--- a/pyanaconda/modules/common/structures/realm.py
+++ b/pyanaconda/modules/common/structures/realm.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from pyanaconda.dbus.structure import dbus_structure
+from pyanaconda.dbus.structure import dbus_structure, generate_string_from_data
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
 __all__ = ["RealmData"]
@@ -72,3 +72,6 @@ class RealmData(object):
     @join_options.setter
     def join_options(self, options: List[Str]):
         self._join_options = options
+
+    def __repr__(self):
+        return generate_string_from_data(self)

--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from pyanaconda.dbus.structure import dbus_structure
+from pyanaconda.dbus.structure import dbus_structure, generate_string_from_data
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
 __all__ = ["DeviceData", "DeviceActionData"]
@@ -153,6 +153,9 @@ class DeviceData(object):
     def description(self, text):
         self._description = text
 
+    def __repr__(self):
+        return generate_string_from_data(self)
+
 
 @dbus_structure
 class DeviceActionData(object):
@@ -220,3 +223,6 @@ class DeviceActionData(object):
     @description.setter
     def description(self, text):
         self._description = text
+
+    def __repr__(self):
+        return generate_string_from_data(self)

--- a/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
@@ -21,7 +21,7 @@ import unittest
 
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.dbus.structure import dbus_structure, get_structure, apply_structure, \
-    DBusStructureError
+    DBusStructureError, generate_string_from_data
 
 
 class DBusStructureTestCase(unittest.TestCase):
@@ -276,6 +276,9 @@ class DBusStructureTestCase(unittest.TestCase):
         @c.setter
         def c(self, value):
             self._c = value
+
+        def __repr__(self):
+            return generate_string_from_data(self)
 
     def init_string_representation_test(self):
         self.assertEqual(repr(self.StringData()), "StringData(a=1, b='', c=[])")

--- a/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
@@ -252,6 +252,7 @@ class DBusStructureTestCase(unittest.TestCase):
             self._a = 1
             self._b = ""
             self._c = []
+            self._d = []
 
         @property
         def a(self) -> Int:
@@ -277,8 +278,16 @@ class DBusStructureTestCase(unittest.TestCase):
         def c(self, value):
             self._c = value
 
+        @property
+        def d(self) -> List[Str]:
+            return self._d
+
+        @d.setter
+        def d(self, value):
+            self._d = value
+
         def __repr__(self):
-            return generate_string_from_data(self)
+            return generate_string_from_data(self, skip=["d"])
 
     def init_string_representation_test(self):
         self.assertEqual(repr(self.StringData()), "StringData(a=1, b='', c=[])")
@@ -289,5 +298,6 @@ class DBusStructureTestCase(unittest.TestCase):
         data.a = 123
         data.b = "HELLO"
         data.c = [True, False]
+        data.d = ["SECRET"]
 
         self.assertEqual(repr(data), "StringData(a=123, b='HELLO', c=[True, False])")


### PR DESCRIPTION
We shouldn't implicitly set the `__repr__ `methods of the data classes
decorated with the `@dbus_structure` decorator, because then it is
difficult to override them. We should define these methods explicitly.

We should skip attributes with sensitive data in the string representations
of the data classes. For example, passwords and passphrases.