### PR TITLE
network: fix copying of resolv.conf for cases where target /etc does …

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -279,6 +279,9 @@ def copy_resolv_conf_to_root(root=""):
     if os.path.isfile(dst):
         log.debug("%s already exists", dst)
         return
+    dst_dir = os.path.dirname(dst)
+    if not os.path.isdir(dst_dir):
+        util.mkdirChain(dst_dir)
     shutil.copyfile(src, dst)
 
 


### PR DESCRIPTION
…not exist

For example on Silverblue.

We used to check for this case before it was removed in cleanup in
8bdcce8b62d54770ae175e5809a37b8ddae05bd0