### PR TITLE
Handle bytes and strings from RPM (#1693766)

### DIFF
--- a/pyanaconda/bootloader/installation.py
+++ b/pyanaconda/bootloader/installation.py
@@ -22,6 +22,7 @@ from pyanaconda.bootloader.base import BootLoaderError
 from pyanaconda.bootloader.image import LinuxBootLoaderImage
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.core.util import decode_bytes
 from pyanaconda.errors import errorHandler, ERROR_RAISE
 from pyanaconda.product import productName
 
@@ -152,7 +153,7 @@ def _write_sysconfig_kernel(sysroot, storage):
         log.error("failed to get package name for default kernel")
         return
 
-    kernel = h.name.decode()
+    kernel = decode_bytes(h.name)
 
     f = open(sysroot + "/etc/sysconfig/kernel", "w+")
     f.write("# UPDATEDEFAULT specifies if new-kernel-pkg should make\n"

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1479,3 +1479,20 @@ def synchronized(wrapped):
         with self._lock:
             return wrapped(self, *args, **kwargs)
     return _wrapper
+
+
+def decode_bytes(data):
+    """Decode the given bytes.
+
+    Return the given string or a string decoded from the given bytes.
+
+    :param data: bytes or a string
+    :return: a string
+    """
+    if isinstance(data, str):
+        return data
+
+    if isinstance(data, bytes):
+        return data.decode('utf-8')
+
+    raise ValueError("Unsupported type '{}'.".format(type(data).__name__))

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -36,7 +36,7 @@ from pyanaconda import isys
 from pyanaconda.image import findFirstIsoImage
 from pyanaconda.image import mountImage
 from pyanaconda.image import opticalInstallMedia, verifyMedia, verify_valid_installtree
-from pyanaconda.core.util import ProxyString, ProxyStringError
+from pyanaconda.core.util import ProxyString, ProxyStringError, decode_bytes
 from pyanaconda.core.regexes import VERSION_DIGITS
 from pyanaconda.payload.errors import PayloadError, PayloadSetupError, NoSuchGroup
 from pyanaconda.payload import utils as payload_utils
@@ -726,7 +726,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
         ts = rpm.TransactionSet(util.getSysroot())
         mi = ts.dbMatch('providename', 'kernel')
         for hdr in mi:
-            unicode_fnames = (f.decode("utf-8") for f in hdr.filenames)
+            unicode_fnames = (decode_bytes(f) for f in hdr.filenames)
             # Find all /boot/vmlinuz- files and strip off vmlinuz-
             files.extend((f.split("/")[-1][8:] for f in unicode_fnames
                          if fnmatch(f, "/boot/vmlinuz-*") or

--- a/tests/nosetests/pyanaconda_tests/iutil_test.py
+++ b/tests/nosetests/pyanaconda_tests/iutil_test.py
@@ -835,3 +835,10 @@ class MiscTests(unittest.TestCase):
         util.setSysroot(None)
         self.assertEqual(util.getTargetPhysicalRoot(), "/mnt/sysimage")
         self.assertEqual(util.getSysroot(), "/mnt/sysimage")
+
+    def decode_bytes_test(self):
+        self.assertEqual("STRING", util.decode_bytes("STRING"))
+        self.assertEqual("BYTES", util.decode_bytes(b"BYTES"))
+        self.assertRaises(ValueError, util.decode_bytes, None)
+        self.assertRaises(ValueError, util.decode_bytes, 0)
+        self.assertRaises(ValueError, util.decode_bytes, [])


### PR DESCRIPTION
RPM can return bytes or strings, so let's use the function
decode_bytes that can handle both and always returns a string.

Resolves: rhbz#1693766