### PR TITLE
 Fix bad assumption about base repo identification

### DIFF
--- a/pyanaconda/image.py
+++ b/pyanaconda/image.py
@@ -98,7 +98,7 @@ def findFirstIsoImage(path):
         # If there's no repodata, there's no point in trying to
         # install from it.
         if not _check_repodata(mount_path):
-            log.warning("%s doesn't have repodata, skipping", what)
+            log.warning("%s doesn't have a valid repodata, skipping", what)
             blivet.util.umount(mount_path)
             continue
 
@@ -140,9 +140,26 @@ def _check_repodata(mount_path):
     repo_md = install_tree_meta.get_base_repo_metadata()
 
     if not repo_md:
+        repo_mds = install_tree_meta.get_metadata_repos()
+        repo_md = _search_for_install_root_repository(repo_mds)
+
+    if not repo_md:
+        log.debug("There is no usable repository available")
         return False
 
-    return repo_md.is_valid()
+    if repo_md.is_valid():
+        return True
+
+    log.debug("There is no valid repository available.")
+    return False
+
+
+def _search_for_install_root_repository(repos):
+    for repo in repos:
+        if repo.relative_path == ".":
+            return repo
+
+    return None
 
 
 def mountImage(isodir, tree):


### PR DESCRIPTION
Fix bad assumption about base repo identification (#1691832) ￼…
This works for ISO and I have a feeling this is not true for repo files.

Fedora don't have naming of the repository that we are able to identify base repository so when we don't found base repository on the ISO we will just use root of the ISO as base repository and see how it goes.

Our tests for valid ISO where too strict about this. Right now we will look for base repo and if that is not found we will look on repo which has repository in the root.

Also fail (Source spoke fail) instead of trying to use ISO as directory source and fallbacking to closest mirror then.

I will test properly if this won't break something else... :(