### PR TITLE
Bump Workstation root partition max size to 70 GiB

### DIFF
--- a/pyanaconda/storage/partitioning.py
+++ b/pyanaconda/storage/partitioning.py
@@ -50,7 +50,7 @@ WORKSTATION_PARTITIONING = [
     PartSpec(
         mountpoint="/",
         size=Size("1GiB"),
-        max_size=Size("50GiB"),
+        max_size=Size("70GiB"),
         grow=True,
         btr=True,
         lv=True,


### PR DESCRIPTION
As agreed in today's Workstation WG meeting.

https://pagure.io/fedora-workstation/issue/54#comment-564995

(Not sure if I got the git branch to merge this to right; can you cherry-pick it to master and everywhere else where necessary to make this apply to both F30 and F31? Thanks!)