### PR TITLE
network: do not pass None value from NM device object to data holder …

### DIFF
--- a/pyanaconda/modules/common/structures/network.py
+++ b/pyanaconda/modules/common/structures/network.py
@@ -116,13 +116,13 @@ class NetworkDeviceInfo(object):
         :param device: NetworkManager device object
         :type device: NMDevice
         """
-        self._device_name = device.get_iface()
-        self._device_type = device.get_device_type()
+        self._device_name = device.get_iface() or ""
+        self._device_type = device.get_device_type() or self.DEVICE_TYPE_UNKNOWN
         try:
-            hw_address = device.get_permanent_hw_address()
+            perm_hw_address = device.get_permanent_hw_address()
         except AttributeError:
-            hw_address = device.get_hw_address()
-        self.hw_address = hw_address
+            perm_hw_address = None
+        self.hw_address = perm_hw_address or device.get_hw_address() or ""
 
     def __repr__(self):
         return generate_string_from_data(self)

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -424,6 +424,8 @@ class NetworkModule(KickstartModule):
                 continue
             dev_info = NetworkDeviceInfo()
             dev_info.set_from_nm_device(device)
+            if not all((dev_info.device_name, dev_info.device_type, dev_info.hw_address)):
+                log.warning("Missing value when setting NetworkDeviceInfo from NM device: %s", dev_info)
             supported_devices.append(dev_info)
 
         return supported_devices


### PR DESCRIPTION
…(#1695967)

It would crash when generating dbus structure from the object.
https://bugzilla.redhat.com/show_bug.cgi?id=1695967#c4