### PR TITLE
Add DBus support for device format data

### DIFF
--- a/pyanaconda/image.py
+++ b/pyanaconda/image.py
@@ -25,7 +25,7 @@ import tempfile
 from pyanaconda import isys
 from pyanaconda.errors import errorHandler, ERROR_RAISE, InvalidImageSizeError, MissingImageError
 from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
-from pyanaconda.storage.utils import find_optical_media
+from pyanaconda.storage.utils import find_optical_media, find_mountable_partitions
 
 import blivet.util
 import blivet.arch
@@ -223,8 +223,7 @@ def potentialHdisoSources(devicetree):
     """ Return a generator yielding Device instances that may have HDISO install
         media somewhere. Candidate devices are simply any that we can mount.
     """
-    return (d for d in devicetree.devices
-            if d.type == "partition" and d.format.exists and d.format.mountable)
+    return find_mountable_partitions(devicetree)
 
 
 def verifyMedia(tree, timestamp=None):

--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -31,6 +31,7 @@ class DeviceData(DBusData):
         "model",
         "bus",
         "wwn",
+        "uuid",
 
         # DASD
         "busid",

--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -19,7 +19,7 @@
 from pyanaconda.dbus.structure import DBusData
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
-__all__ = ["DeviceData", "DeviceActionData"]
+__all__ = ["DeviceData", "DeviceFormatData", "DeviceActionData"]
 
 
 class DeviceData(DBusData):
@@ -141,6 +141,61 @@ class DeviceData(DBusData):
     @property
     def description(self) -> Str:
         """Description of the device.
+
+        FIXME: This is a temporary property.
+
+        :return: a string with description
+        """
+        return self._description
+
+    @description.setter
+    def description(self, text):
+        self._description = text
+
+
+class DeviceFormatData(DBusData):
+    """Device format data."""
+
+    SUPPORTED_ATTRIBUTES = [
+        "uuid",
+        "label"
+    ]
+
+    def __init__(self):
+        self._type = ""
+        self._attrs = {}
+        self._description = ""
+
+    @property
+    def type(self) -> Str:
+        """A type of the format.
+
+        :return: a format type
+        """
+        return self._type
+
+    @type.setter
+    def type(self, value):
+        self._type = value
+
+    @property
+    def attrs(self) -> Dict[Str, Str]:
+        """Additional attributes.
+
+        The supported attributes are defined by
+        the list SUPPORTED_ATTRIBUTES.
+
+        :return: a dictionary of attributes
+        """
+        return self._attrs
+
+    @attrs.setter
+    def attrs(self, attrs: Dict[Str, Str]):
+        self._attrs = attrs
+
+    @property
+    def description(self) -> Str:
+        """Description of the format.
 
         FIXME: This is a temporary property.
 

--- a/pyanaconda/modules/storage/devicetree/handler.py
+++ b/pyanaconda/modules/storage/devicetree/handler.py
@@ -21,7 +21,7 @@ from abc import abstractmethod, ABC
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.common.errors.storage import UnknownDeviceError
-from pyanaconda.storage.utils import find_optical_media
+from pyanaconda.storage.utils import find_optical_media, find_mountable_partitions
 
 log = get_module_logger(__name__)
 
@@ -90,4 +90,12 @@ class DeviceTreeHandler(ABC):
         :return: a list of device names
         """
         devices = find_optical_media(self.storage.devicetree)
+        return [d.name for d in devices]
+
+    def find_mountable_partitions(self):
+        """Find all mountable partitions.
+
+        :return: a list of device names
+        """
+        devices = find_mountable_partitions(self.storage.devicetree)
         return [d.name for d in devices]

--- a/pyanaconda/modules/storage/devicetree/handler.py
+++ b/pyanaconda/modules/storage/devicetree/handler.py
@@ -21,7 +21,7 @@ from abc import abstractmethod, ABC
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.common.errors.storage import UnknownDeviceError
-from pyanaconda.storage.utils import find_optical_media, find_mountable_partitions
+from pyanaconda.storage.utils import find_optical_media, find_mountable_partitions, unlock_device
 
 log = get_module_logger(__name__)
 
@@ -83,6 +83,16 @@ class DeviceTreeHandler(ABC):
         """
         device = self._get_device(device_name)
         device.format.unmount(mountpoint=mount_point)
+
+    def unlock_device(self, device_name, passphrase):
+        """Unlock a device.
+
+        :param device_name: a name of the device
+        :param passphrase: a passphrase
+        :return: True if success, otherwise False
+        """
+        device = self._get_device(device_name)
+        return unlock_device(self.storage, device, passphrase)
 
     def find_optical_media(self):
         """Find all devices with mountable optical media.

--- a/pyanaconda/modules/storage/devicetree/handler_interface.py
+++ b/pyanaconda/modules/storage/devicetree/handler_interface.py
@@ -59,6 +59,15 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
         """
         self.implementation.unmount_device(device_name, mount_point)
 
+    def UnlockDevice(self, device_name: Str, passphrase: Str) -> Bool:
+        """Unlock a device.
+
+        :param device_name: a name of the device
+        :param passphrase: a passphrase
+        :return: True if success, otherwise False
+        """
+        return self.implementation.unlock_device(device_name, passphrase)
+
     def FindOpticalMedia(self) -> List[Str]:
         """Find all devices with mountable optical media.
 

--- a/pyanaconda/modules/storage/devicetree/handler_interface.py
+++ b/pyanaconda/modules/storage/devicetree/handler_interface.py
@@ -65,3 +65,10 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
         :return: a list of device names
         """
         return self.implementation.find_optical_media()
+
+    def FindMountablePartitions(self) -> List[Str]:
+        """Find all mountable partitions.
+
+        :return: a list of device names
+        """
+        return self.implementation.find_mountable_partitions()

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -23,7 +23,8 @@ from blivet.size import Size
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.common.errors.storage import UnknownDeviceError
-from pyanaconda.modules.common.structures.storage import DeviceData, DeviceActionData
+from pyanaconda.modules.common.structures.storage import DeviceData, DeviceActionData, \
+    DeviceFormatData
 from pyanaconda.storage.utils import get_required_device_size
 
 log = get_module_logger(__name__)
@@ -101,7 +102,27 @@ class DeviceTreeViewer(ABC):
         data.description = getattr(device, "description", "")
 
         # Collect the additional attributes.
-        attrs = self._get_device_attrs(device)
+        attrs = self._get_attributes(device, DeviceData.SUPPORTED_ATTRIBUTES)
+        data.attrs = attrs
+
+        return data
+
+    def get_format_data(self, device_name):
+        """Get the device format.
+
+        :param device_name: a name of the device
+        :return: an instance of DeviceFormatData
+        """
+        # Find the device.
+        device = self._get_device(device_name)
+
+        # Collect the format data.
+        data = DeviceFormatData()
+        data.type = device.format.type or ""
+        data.description = device.format.name or ""
+
+        # Collect the additional attributes.
+        attrs = self._get_attributes(device.format, DeviceFormatData.SUPPORTED_ATTRIBUTES)
         data.attrs = attrs
 
         return data
@@ -128,17 +149,18 @@ class DeviceTreeViewer(ABC):
         """
         return list(map(self._get_device, names))
 
-    def _get_device_attrs(self, device):
-        """Get the device attributes.
+    def _get_attributes(self, obj, names):
+        """Get the attributes of the given object.
 
-        :param device: an instance of the device
+        :param obj: an object
+        :param names: names of the supported attributes
         :return: a dictionary of attributes
         """
         attrs = {}
 
-        for name in DeviceData.SUPPORTED_ATTRIBUTES:
+        for name in names:
             try:
-                value = getattr(device, name)
+                value = getattr(obj, name)
             except AttributeError:
                 # Skip if the attribute doesn't exist.
                 continue

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -21,7 +21,8 @@ from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.dbus.template import InterfaceTemplate
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.constants.interfaces import DEVICE_TREE_VIEWER
-from pyanaconda.modules.common.structures.storage import DeviceData, DeviceActionData
+from pyanaconda.modules.common.structures.storage import DeviceData, DeviceActionData, \
+    DeviceFormatData
 
 __all__ = ["DeviceTreeViewerInterface"]
 
@@ -68,6 +69,14 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
         :raise: UnknownDeviceError if the device is not found
         """
         return DeviceData.to_structure(self.implementation.get_device_data(name))
+
+    def GetFormatData(self, name: Str) -> Structure:
+        """Get the device format.
+
+        :param name: a name of the device
+        :return: an instance of DeviceFormatData
+        """
+        return DeviceFormatData.to_structure(self.implementation.get_format_data(name))
 
     def GetActions(self) -> List[Structure]:
         """Get the device actions.

--- a/pyanaconda/storage/utils.py
+++ b/pyanaconda/storage/utils.py
@@ -781,3 +781,43 @@ def unlock_device(storage, device, passphrase):
         try_populate_devicetree(storage.devicetree)
 
         return True
+
+
+def find_unconfigured_luks(storage):
+    """Find all unconfigured LUKS devices.
+
+    Returns a list of devices that require a passphrase
+    for their configuration.
+
+    :param storage: an instance of Blivet
+    :return: a list of devices
+    """
+    devices = []
+
+    for device in storage.devices:
+        # Only LUKS devices.
+        if not device.format.type == "luks":
+            continue
+
+        # Skip existing formats.
+        if device.format.exists:
+            continue
+
+        # Skip formats with keys.
+        if device.format.has_key:
+            continue
+
+        devices.append(device)
+
+    return devices
+
+
+def setup_passphrase(storage, passphrase):
+    """Set up the given passphrase on unconfigured LUKS devices.
+
+    :param storage: an instance of Blivet
+    :param passphrase: a passphrase to use
+    """
+    for device in find_unconfigured_luks(storage):
+        device.format.passphrase = passphrase
+        storage.save_passphrase(device)

--- a/pyanaconda/storage/utils.py
+++ b/pyanaconda/storage/utils.py
@@ -718,3 +718,26 @@ def find_optical_media(devicetree):
         devices.append(device)
 
     return devices
+
+
+def find_mountable_partitions(devicetree):
+    """Find all mountable partitions.
+
+    :param devicetree: an instance of a device tree
+    :return: a list of devices
+    """
+    devices = []
+
+    for device in devicetree.devices:
+        if device.type != "partition":
+            continue
+
+        if not device.format.exists:
+            continue
+
+        if not device.format.mountable:
+            continue
+
+        devices.append(device)
+
+    return devices

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -45,7 +45,7 @@ from gi.repository import Gdk, AnacondaWidgets, Gtk
 
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.storage.utils import filter_disks_by_names, is_local_disk, apply_disk_selection, \
-    check_disk_selection, get_disks_summary, suggest_swap_size
+    check_disk_selection, get_disks_summary, suggest_swap_size, setup_passphrase
 from pyanaconda.storage.execution import configure_storage
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.spokes import NormalSpoke
@@ -833,10 +833,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
 
         self._auto_part_passphrase = dialog.passphrase
 
-        for device in self.storage.devices:
-            if device.format.type == "luks" and not device.format.exists:
-                if not device.format.has_key:
-                    device.format.passphrase = self._auto_part_passphrase
+        setup_passphrase(self.storage, self._auto_part_passphrase)
 
         return True
 

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -109,6 +109,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             model="MODEL_ID",
             bus="BUS_ID",
             wwn="0x0000000000000000",
+            uuid="1234-56-7890"
         ))
 
         self.assertEqual(self.interface.GetDeviceData("dev1"), {
@@ -124,6 +125,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
                 "model": "MODEL_ID",
                 "bus": "BUS_ID",
                 "wwn": "0x0000000000000000",
+                "uuid": "1234-56-7890"
             }),
             'description': get_variant(
                 Str, "VENDOR_ID MODEL_ID 0x0000000000000000"

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -21,7 +21,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from blivet.devices import StorageDevice, DiskDevice, DASDDevice, ZFCPDiskDevice
+from blivet.devices import StorageDevice, DiskDevice, DASDDevice, ZFCPDiskDevice, PartitionDevice
 from blivet.formats import get_format
 from blivet.formats.fs import FS
 from blivet.size import Size
@@ -297,3 +297,17 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
     def find_install_media_test(self):
         """Test FindInstallMedia."""
         self.assertEqual(self.interface.FindOpticalMedia(), [])
+
+    @patch.object(FS, "update_size_info")
+    def find_mountable_partitions_test(self, update_size_info):
+        """Test FindMountablePartitions."""
+        self._add_device(StorageDevice(
+            "dev1",
+            fmt=get_format("ext4"))
+        )
+        self._add_device(PartitionDevice(
+            "dev2",
+            fmt=get_format("ext4", exists=True)
+        ))
+
+        self.assertEqual(self.interface.FindMountablePartitions(), ["dev2"])

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -166,6 +166,33 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             "hba_id": "0.0.010a"
         }))
 
+    def get_format_data_test(self):
+        """Test GetFormatData."""
+        fmt1 = get_format("ext4", uuid="1234-56-7890", label="LABEL")
+        dev1 = StorageDevice("dev1", fmt=fmt1, size=Size("10 GiB"))
+
+        self._add_device(dev1)
+
+        self.assertEqual(self.interface.GetFormatData("dev1"), {
+            'type': get_variant(Str, 'ext4'),
+            'attrs': get_variant(Dict[Str, Str], {
+                "uuid": "1234-56-7890",
+                "label": "LABEL",
+            }),
+            'description': get_variant(Str, 'ext4'),
+        })
+
+        fmt2 = get_format("luks")
+        dev2 = LUKSDevice("dev2", parents=[dev1], fmt=fmt2, size=Size("10 GiB"))
+
+        self._add_device(dev2)
+
+        self.assertEqual(self.interface.GetFormatData("dev2"), {
+            'type': get_variant(Str, 'luks'),
+            'attrs': get_variant(Dict[Str, Str], {}),
+            'description': get_variant(Str, 'LUKS'),
+        })
+
     def get_actions_test(self):
         """Test GetActions."""
         self.assertEqual(self.interface.GetActions(), [])


### PR DESCRIPTION
Call the DBus method `FindMountablePartitions` to get a list
of device names for all mountable partitions.

Call the DBus method `UnlockDevice` to unlock a LUKS device.

Call `GetFormatData` to get data about formatting on the given
device.

Call `GetDeviceData` to find out the UUID of the given device.

Use functions `find_unconfigured_luks` and `setup_passphrase`
to set up the passphrase on unconfigured LUKS devices.