### PR TITLE
Add the class DBusData

### DIFF
--- a/pyanaconda/bootloader/base.py
+++ b/pyanaconda/bootloader/base.py
@@ -36,7 +36,6 @@ from pyanaconda.flags import flags
 from pyanaconda.modules.common.constants.objects import FCOE
 from pyanaconda.modules.common.constants.services import STORAGE, NETWORK
 from pyanaconda.modules.common.structures.network import NetworkDeviceInfo
-from pyanaconda.dbus.structure import apply_structure
 
 log = get_module_logger(__name__)
 
@@ -906,8 +905,8 @@ class BootLoader(object):
 def get_interface_hw_address(iface):
     """Get hardware address of network interface."""
     network_proxy = NETWORK.get_proxy()
-    device_infos = [apply_structure(device, NetworkDeviceInfo())
-                    for device in network_proxy.GetSupportedDevices()]
+    device_infos = NetworkDeviceInfo.from_structure_list(network_proxy.GetSupportedDevices())
+
     for info in device_infos:
         if info.device_name == iface:
             return info.hw_address

--- a/pyanaconda/dbus/structure.py
+++ b/pyanaconda/dbus/structure.py
@@ -22,7 +22,7 @@ from typing import get_type_hints
 
 from pyanaconda.dbus.typing import get_variant, Structure, Dict, List
 
-__all__ = ["get_structure", "DBusStructureError", "generate_string_from_data", "DBusData"]
+__all__ = ["DBusStructureError", "generate_string_from_data", "DBusData"]
 
 
 # Class attribute for DBus fields.
@@ -146,7 +146,13 @@ class DBusData(ABC):
 
         :return: a DBus structure
         """
-        return get_structure(data, fields=get_fields(cls))
+        structure = {}
+        fields = get_fields(cls)
+
+        for name, field in fields.items():
+            structure[name] = field.get_data_variant(data)
+
+        return structure
 
     @classmethod
     def from_structure_list(cls, structures: List[Dict]):
@@ -183,26 +189,6 @@ def get_fields(obj):
         raise DBusStructureError("Fields are not defined at '{}'.".format(DBUS_FIELDS_ATTRIBUTE))
 
     return fields
-
-
-def get_structure(obj, fields=None) -> Structure:
-    """Return a DBus structure.
-
-    The returned DBus structure is ready to be send on DBus.
-
-    :param obj: a data object
-    :param fields: a map of DBus fields or None
-    :return: a DBus structure
-    """
-    structure = {}
-
-    if fields is None:
-        fields = get_fields(obj)
-
-    for name, field in fields.items():
-        structure[name] = field.get_data_variant(obj)
-
-    return structure
 
 
 def generate_fields(cls):

--- a/pyanaconda/dbus/structure.py
+++ b/pyanaconda/dbus/structure.py
@@ -22,8 +22,8 @@ from typing import get_type_hints
 
 from pyanaconda.dbus.typing import get_variant, Structure, Dict, List
 
-__all__ = ["get_structure", "apply_structure", "dbus_structure", "DBusStructureError",
-           "generate_string_from_data", "DBusData"]
+__all__ = ["get_structure", "apply_structure", "DBusStructureError", "generate_string_from_data",
+           "DBusData"]
 
 
 # Class attribute for DBus fields.
@@ -300,20 +300,3 @@ def generate_string_from_data(obj, skip=None, add=None):
         attributes.sort()
 
     return "{}({})".format(obj.__class__.__name__, ", ".join(attributes))
-
-
-def dbus_structure(cls):
-    """Decorator for DBus structures.
-
-    This decorator will use the class to generate DBus fields from the class
-    properties and set the class attribute __dbus_fields__ with the generated
-    fields.
-
-    Instances of the decorated class can be used to create and apply
-    DBus structures with method get_structure and apply_structure.
-
-    :param cls: a data class
-    :return: a data class with generated DBus fields
-    """
-    setattr(cls, DBUS_FIELDS_ATTRIBUTE, generate_fields(cls))
-    return cls

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -42,7 +42,6 @@ from pyanaconda.addons import AddonSection, AddonData, AddonRegistry, collect_ad
 from pyanaconda.core.constants import ADDON_PATHS, IPMI_ABORTED, SELINUX_DEFAULT, \
     SETUP_ON_BOOT_DISABLED, SETUP_ON_BOOT_RECONFIG, FIREWALL_ENABLED, FIREWALL_DISABLED, \
     FIREWALL_USE_SYSTEM_DEFAULTS
-from pyanaconda.dbus.structure import apply_structure
 from pyanaconda.desktop import Desktop
 from pyanaconda.errors import ScriptError, errorHandler
 from pyanaconda.flags import flags
@@ -308,7 +307,7 @@ class Realm(RemovedCommand):
 
     def setup(self):
         security_proxy = SECURITY.get_proxy()
-        realm = apply_structure(security_proxy.Realm, RealmData())
+        realm = RealmData.from_structure(security_proxy.Realm)
 
         if not realm.name:
             return
@@ -345,7 +344,7 @@ class Realm(RemovedCommand):
             return
 
         security_proxy = SECURITY.get_proxy()
-        realm = apply_structure(security_proxy.Realm, RealmData())
+        realm = RealmData.from_structure(security_proxy.Realm)
 
         for arg in realm.join_options:
             if arg.startswith("--no-password") or arg.startswith("--one-time-password"):

--- a/pyanaconda/modules/common/structures/network.py
+++ b/pyanaconda/modules/common/structures/network.py
@@ -16,14 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from pyanaconda.dbus.structure import dbus_structure, generate_string_from_data
+from pyanaconda.dbus.structure import DBusData
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
 __all__ = ["NetworkDeviceConfiguration"]
 
 
-@dbus_structure
-class NetworkDeviceConfiguration(object):
+class NetworkDeviceConfiguration(DBusData):
     """Holds reference to persistent configuration of a network device.
 
     Binds device name and NM connection (by its uuid).
@@ -68,12 +67,8 @@ class NetworkDeviceConfiguration(object):
     def __eq__(self, other):
         return (self._device_name, self._connection_uuid) == (other.device_name, other.connection_uuid)
 
-    def __repr__(self):
-        return generate_string_from_data(self)
 
-
-@dbus_structure
-class NetworkDeviceInfo(object):
+class NetworkDeviceInfo(DBusData):
     """Holds information about network device."""
 
     DEVICE_TYPE_UNKNOWN = 0
@@ -123,6 +118,3 @@ class NetworkDeviceInfo(object):
         except AttributeError:
             perm_hw_address = None
         self.hw_address = perm_hw_address or device.get_hw_address() or ""
-
-    def __repr__(self):
-        return generate_string_from_data(self)

--- a/pyanaconda/modules/common/structures/realm.py
+++ b/pyanaconda/modules/common/structures/realm.py
@@ -16,14 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from pyanaconda.dbus.structure import dbus_structure, generate_string_from_data
+from pyanaconda.dbus.structure import DBusData
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
 __all__ = ["RealmData"]
 
 
-@dbus_structure
-class RealmData(object):
+class RealmData(DBusData):
     """Realm data."""
 
     def __init__(self):
@@ -72,6 +71,3 @@ class RealmData(object):
     @join_options.setter
     def join_options(self, options: List[Str]):
         self._join_options = options
-
-    def __repr__(self):
-        return generate_string_from_data(self)

--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -16,14 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from pyanaconda.dbus.structure import dbus_structure, generate_string_from_data
+from pyanaconda.dbus.structure import DBusData
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
 __all__ = ["DeviceData", "DeviceActionData"]
 
 
-@dbus_structure
-class DeviceData(object):
+class DeviceData(DBusData):
     """Device data."""
 
     SUPPORTED_ATTRIBUTES = [
@@ -153,12 +152,8 @@ class DeviceData(object):
     def description(self, text):
         self._description = text
 
-    def __repr__(self):
-        return generate_string_from_data(self)
 
-
-@dbus_structure
-class DeviceActionData(object):
+class DeviceActionData(DBusData):
     """Device action data."""
 
     def __init__(self):
@@ -223,6 +218,3 @@ class DeviceActionData(object):
     @description.setter
     def description(self, text):
         self._description = text
-
-    def __repr__(self):
-        return generate_string_from_data(self)

--- a/pyanaconda/modules/network/network_interface.py
+++ b/pyanaconda/modules/network/network_interface.py
@@ -23,7 +23,8 @@ from pyanaconda.dbus.property import emits_properties_changed
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.dbus.interface import dbus_interface, dbus_signal, dbus_class
-from pyanaconda.dbus.structure import get_structure
+from pyanaconda.modules.common.structures.network import NetworkDeviceInfo, \
+    NetworkDeviceConfiguration
 from pyanaconda.modules.common.task import TaskInterface
 
 
@@ -111,7 +112,7 @@ class NetworkInterface(KickstartModuleInterface):
         :return: list of objects describing supported devices found on the system
         """
         dev_infos = self.implementation.get_supported_devices()
-        return [get_structure(dev_info) for dev_info in dev_infos]
+        return NetworkDeviceInfo.to_structure_list(dev_infos)
 
     def GetActivatedInterfaces(self) -> List[Str]:
         """Get activated network interfaces.
@@ -161,11 +162,16 @@ class NetworkInterface(KickstartModuleInterface):
         their uuid.
         """
         dev_cfgs = self.implementation.get_device_configurations()
-        return [get_structure(dev_cfg) for dev_cfg in dev_cfgs]
+        return NetworkDeviceConfiguration.to_structure_list(dev_cfgs)
 
     def _device_configurations_changed(self, changes):
-        self.DeviceConfigurationChanged([(get_structure(old), get_structure(new))
-                                         for old, new in changes])
+        self.DeviceConfigurationChanged([
+            (
+                NetworkDeviceConfiguration.to_structure(old),
+                NetworkDeviceConfiguration.to_structure(new)
+            )
+            for old, new in changes
+        ])
 
     @dbus_signal
     def DeviceConfigurationChanged(self, changes: List[Tuple[Structure, Structure]]):

--- a/pyanaconda/modules/security/security.py
+++ b/pyanaconda/modules/security/security.py
@@ -48,7 +48,7 @@ class SecurityModule(KickstartModule):
         self._authconfig_args = []
 
         self.realm_changed = Signal()
-        self._realm = self.create_realm()
+        self._realm = RealmData()
 
     def publish(self):
         """Publish the module."""
@@ -74,8 +74,7 @@ class SecurityModule(KickstartModule):
             self.set_authconfig(shlex.split(data.authconfig.authconfig))
 
         if data.realm.join_realm:
-
-            realm = self.create_realm()
+            realm = RealmData()
             realm.name = data.realm.join_realm
             realm.discover_options = data.realm.discover_options
             realm.join_options = data.realm.join_args
@@ -174,10 +173,3 @@ class SecurityModule(KickstartModule):
         self._realm = realm
         self.realm_changed.emit()
         log.debug("Realm is set to %s.", realm)
-
-    def create_realm(self):
-        """Create a new instance of realm data.
-
-        :return: an instance of RealmData
-        """
-        return RealmData()

--- a/pyanaconda/modules/security/security_interface.py
+++ b/pyanaconda/modules/security/security_interface.py
@@ -17,12 +17,13 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.dbus.structure import get_structure, apply_structure
+from pyanaconda.dbus.structure import get_structure
 from pyanaconda.modules.common.constants.services import SECURITY
 from pyanaconda.dbus.property import emits_properties_changed
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.dbus.interface import dbus_interface
+from pyanaconda.modules.common.structures.realm import RealmData
 from pyanaconda.modules.security.constants import SELinuxMode
 
 
@@ -117,6 +118,4 @@ class SecurityInterface(KickstartModuleInterface):
 
         :param realm: a dictionary with a specification
         """
-        realm_data = self.implementation.create_realm()
-        apply_structure(realm, realm_data)
-        self.implementation.set_realm(realm_data)
+        self.implementation.set_realm(RealmData.from_structure(realm))

--- a/pyanaconda/modules/security/security_interface.py
+++ b/pyanaconda/modules/security/security_interface.py
@@ -17,7 +17,6 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.dbus.structure import get_structure
 from pyanaconda.modules.common.constants.services import SECURITY
 from pyanaconda.dbus.property import emits_properties_changed
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
@@ -108,7 +107,7 @@ class SecurityInterface(KickstartModuleInterface):
 
         :return: a dictionary with a specification
         """
-        return get_structure(self.implementation.realm)
+        return RealmData.to_structure(self.implementation.realm)
 
     @emits_properties_changed
     def SetRealm(self, realm: Structure):

--- a/pyanaconda/modules/storage/devicetree/devicetree_interface.py
+++ b/pyanaconda/modules/storage/devicetree/devicetree_interface.py
@@ -17,6 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+
 from pyanaconda.dbus.interface import dbus_class
 from pyanaconda.modules.storage.devicetree.handler_interface import DeviceTreeHandlerInterface
 from pyanaconda.modules.storage.devicetree.viewer_interface import DeviceTreeViewerInterface

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -20,8 +20,8 @@
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.dbus.template import InterfaceTemplate
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
-from pyanaconda.dbus.structure import get_structure
 from pyanaconda.modules.common.constants.interfaces import DEVICE_TREE_VIEWER
+from pyanaconda.modules.common.structures.storage import DeviceData, DeviceActionData
 
 __all__ = ["DeviceTreeViewerInterface"]
 
@@ -67,14 +67,14 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
         :return: a structure with device data
         :raise: UnknownDeviceError if the device is not found
         """
-        return get_structure(self.implementation.get_device_data(name))
+        return DeviceData.to_structure(self.implementation.get_device_data(name))
 
     def GetActions(self) -> List[Structure]:
         """Get the device actions.
 
         :return: a list of structures with device action data
         """
-        return list(map(get_structure, self.implementation.get_actions()))
+        return DeviceActionData.to_structure_list(self.implementation.get_actions())
 
     def ResolveDevice(self, dev_spec: Str) -> Str:
         """Get the device matching the provided device specification.

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -39,7 +39,6 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.modules.common.constants.services import NETWORK, TIMEZONE
 from pyanaconda.modules.common.task import sync_run_task
 from pyanaconda.payload.livepayload import LiveImagePayload
-from pyanaconda.dbus.structure import apply_structure
 from pyanaconda.modules.common.structures.network import NetworkDeviceInfo
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -556,8 +555,7 @@ def get_supported_devices():
     :rtype: list(NetworkDeviceInfo)
     """
     network_proxy = NETWORK.get_proxy()
-    return [apply_structure(device, NetworkDeviceInfo())
-            for device in network_proxy.GetSupportedDevices()]
+    return NetworkDeviceInfo.from_structure_list(network_proxy.GetSupportedDevices())
 
 
 def get_team_devices():

--- a/pyanaconda/ui/gui/spokes/advstorage/fcoe.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/fcoe.py
@@ -19,7 +19,6 @@
 from pyanaconda.modules.common.constants.objects import FCOE
 from pyanaconda.modules.common.constants.services import STORAGE, NETWORK
 from pyanaconda.modules.common.structures.network import NetworkDeviceInfo
-from pyanaconda.dbus.structure import apply_structure
 from pyanaconda.modules.common.errors.configuration import StorageDiscoveryError
 from pyanaconda.modules.common.task import async_run_task
 from pyanaconda.ui.gui import GUIObject
@@ -60,7 +59,7 @@ class FCoEDialog(GUIObject):
         self._nicCombo.remove_all()
 
         network_proxy = NETWORK.get_proxy()
-        ethernet_devices = [apply_structure(device, NetworkDeviceInfo())
+        ethernet_devices = [NetworkDeviceInfo.from_structure(device)
                             for device in network_proxy.GetSupportedDevices()
                             if device['device-type'] == NM.DeviceType.ETHERNET]
         for dev_info in ethernet_devices:

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -43,7 +43,6 @@ from pyanaconda.core.constants import ANACONDA_ENVIRON
 from pyanaconda.core import glib
 from pyanaconda.modules.common.constants.services import NETWORK
 from pyanaconda.modules.common.structures.network import NetworkDeviceConfiguration
-from pyanaconda.dbus.structure import apply_structure
 
 from pyanaconda import network
 
@@ -386,8 +385,8 @@ class NetworkControlBox(GObject.GObject):
 
     def _update_device_configurations(self, changes):
         for old_values, new_values in changes:
-            old_cfg = apply_structure(old_values, NetworkDeviceConfiguration())
-            new_cfg = apply_structure(new_values, NetworkDeviceConfiguration())
+            old_cfg = NetworkDeviceConfiguration.from_structure(old_values)
+            new_cfg = NetworkDeviceConfiguration.from_structure(new_values)
 
             device_type = old_cfg.device_type or new_cfg.device_type
             # physical devices - devices persist in store
@@ -422,7 +421,7 @@ class NetworkControlBox(GObject.GObject):
         device_configurations = self._network_module.proxy.GetDeviceConfigurations()
         self.dev_cfg_store.clear()
         for device_configuration in device_configurations:
-            dev_cfg = apply_structure(device_configuration, NetworkDeviceConfiguration())
+            dev_cfg = NetworkDeviceConfiguration.from_structure(device_configuration)
             self.add_dev_cfg(dev_cfg)
             self.watch_dev_cfg_device(dev_cfg)
 

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -27,7 +27,6 @@ from pyanaconda import network
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.modules.common.constants.services import NETWORK
 from pyanaconda.modules.common.structures.network import NetworkDeviceConfiguration
-from pyanaconda.dbus.structure import apply_structure
 from pyanaconda.flags import flags
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
@@ -233,7 +232,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     def _update_editable_configurations(self):
         device_configurations = self._network_module.proxy.GetDeviceConfigurations()
-        self.editable_configurations = [apply_structure(dc, NetworkDeviceConfiguration())
+        self.editable_configurations = [NetworkDeviceConfiguration.from_structure(dc)
                                         for dc in device_configurations
                                         if dc['device-type'] in self.configurable_device_types]
 

--- a/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
@@ -20,8 +20,8 @@
 import unittest
 
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
-from pyanaconda.dbus.structure import DBusData, get_structure, apply_structure, \
-    DBusStructureError, generate_string_from_data
+from pyanaconda.dbus.structure import DBusData, get_structure, DBusStructureError, \
+    generate_string_from_data
 
 
 class DBusStructureTestCase(unittest.TestCase):
@@ -107,39 +107,8 @@ class DBusStructureTestCase(unittest.TestCase):
         structure = get_structure(self.SkipData())
         self.assertEqual(structure, {'x': get_variant(Int, 0)})
 
-        data = apply_structure({'x': 10}, self.SkipData())
+        data = self.SkipData.from_structure({'x': 10})
         self.assertEqual(data.x, 10)
-
-    class InvalidData(object):
-
-        def __init__(self):
-            self._x = 0
-
-        @property
-        def x(self) -> Int:
-            return self._x
-
-        @x.setter
-        def x(self, x):
-            self._x = x
-
-    def apply_to_invalid_data_test(self):
-        data = self.InvalidData()
-        self.assertEqual(data.x, 0)
-
-        with self.assertRaises(DBusStructureError) as cm:
-            get_structure(data)
-
-        self.assertEqual(str(cm.exception), """Fields are not defined at '__dbus_fields__'.""")
-
-    def get_from_invalid_data_test(self):
-        data = self.InvalidData()
-        self.assertEqual(data.x, 0)
-
-        with self.assertRaises(DBusStructureError) as cm:
-            apply_structure({'y': 10}, self.InvalidData())
-
-        self.assertEqual(str(cm.exception), """Fields are not defined at '__dbus_fields__'.""")
 
     class SimpleData(DBusData):
 
@@ -259,13 +228,12 @@ class DBusStructureTestCase(unittest.TestCase):
         )
 
     def apply_complicated_structure_test(self):
-        data = apply_structure(
+        data = self.ComplicatedData.from_structure(
             {
                 'dictionary': {1: "1", 2: "2"},
                 'bool-list': [True, False, False],
                 'very-long-property-name': "My String Value"
-            },
-            self.ComplicatedData()
+            }
         )
 
         self.assertEqual(data.dictionary, {1: "1", 2: "2"})

--- a/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
@@ -20,8 +20,7 @@
 import unittest
 
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
-from pyanaconda.dbus.structure import DBusData, get_structure, DBusStructureError, \
-    generate_string_from_data
+from pyanaconda.dbus.structure import DBusData, DBusStructureError, generate_string_from_data
 
 
 class DBusStructureTestCase(unittest.TestCase):
@@ -104,7 +103,8 @@ class DBusStructureTestCase(unittest.TestCase):
             pass
 
     def skip_members_test(self):
-        structure = get_structure(self.SkipData())
+        data = self.SkipData()
+        structure = self.SkipData.to_structure(data)
         self.assertEqual(structure, {'x': get_variant(Int, 0)})
 
         data = self.SkipData.from_structure({'x': 10})
@@ -224,7 +224,7 @@ class DBusStructureTestCase(unittest.TestCase):
                 'bool-list': get_variant(List[Bool], [True, False, False]),
                 'very-long-property-name': get_variant(Str, "My String Value")
             },
-            get_structure(data)
+            self.ComplicatedData.to_structure(data)
         )
 
     def apply_complicated_structure_test(self):


### PR DESCRIPTION
Classes derived from the `DBusData` class should represent specific
types of DBus structures. They will support a conversion from a DBus
structure of the specified type to a Python object and back.

Replace the decorator `@dbus_structure` with the class `DBusData`,
the function `apply_structure` with the method `from_structure` and
the function `get_structure` with the method `to_structure`.
