### PR TITLE
 Make from_structure and to_structure more strict

### DIFF
--- a/pyanaconda/dbus/structure.py
+++ b/pyanaconda/dbus/structure.py
@@ -127,6 +127,9 @@ class DBusData(ABC):
         :param structure: a DBus structure
         :return: a data object
         """
+        if not isinstance(structure, dict):
+            raise TypeError("Invalid type '{}'.".format(type(structure).__name__))
+
         data = cls()
         fields = get_fields(cls)
 
@@ -146,6 +149,9 @@ class DBusData(ABC):
 
         :return: a DBus structure
         """
+        if not isinstance(data, cls):
+            raise TypeError("Invalid type '{}'.".format(type(data).__name__))
+
         structure = {}
         fields = get_fields(cls)
 

--- a/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
@@ -181,6 +181,35 @@ class DBusStructureTestCase(unittest.TestCase):
         self.assertEqual(data[1].x, 2)
         self.assertEqual(data[2].x, 3)
 
+    class OtherData(DBusData):
+
+        def __init__(self):
+            self._x = 0
+
+        @property
+        def x(self) -> Int:
+            return self._x
+
+        @x.setter
+        def x(self, x):
+            self._x = x
+
+    def get_structure_from_invalid_type_test(self):
+        data = self.OtherData()
+
+        with self.assertRaises(TypeError) as cm:
+            self.SimpleData.to_structure(data)
+
+        self.assertEqual(str(cm.exception), "Invalid type 'OtherData'.")
+
+    def apply_structure_with_invalid_type_test(self):
+        structure = ["x"]
+
+        with self.assertRaises(TypeError) as cm:
+            self.SimpleData.from_structure(structure)
+
+        self.assertEqual(str(cm.exception), "Invalid type 'list'.")
+
     class ComplicatedData(DBusData):
 
         def __init__(self):

--- a/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
@@ -368,3 +368,9 @@ class DBusStructureTestCase(unittest.TestCase):
         expected = "AdvancedStringData(a='A', b_is_set=True, c='C')"
         self.assertEqual(expected, repr(data))
         self.assertEqual(expected, str(data))
+
+    def generate_string_from_invalid_type_test(self):
+        with self.assertRaises(DBusStructureError) as cm:
+            generate_string_from_data({"x": 1})
+
+        self.assertEqual(str(cm.exception), "Fields are not defined at '__dbus_fields__'.")


### PR DESCRIPTION
Check the argument type of the methods `from_structure` and `to_structure`
of the `DBusData` class.

Test the function `generate_string_from_data` with an invalid argument.