### PR TITLE
Add DBus support for the device specifier for use in /etc/fstab

### DIFF
--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -255,3 +255,12 @@ class DeviceTreeViewer(ABC):
         """
         disks = self._get_devices(disk_names)
         return self.storage.get_disk_reclaimable_space(disks).get_bytes()
+
+    def get_fstab_spec(self, name):
+        """Get the device specifier for use in /etc/fstab.
+
+        :param name: a name of the device
+        :return: a device specifier for /etc/fstab
+        """
+        device = self._get_device(name)
+        return device.fstab_spec

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -135,3 +135,11 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
         :return: a total size in bytes
         """
         return self.implementation.get_disk_reclaimable_space(disk_names)
+
+    def GetFstabSpec(self, name: Str) -> Str:
+        """Get the device specifier for use in /etc/fstab.
+
+        :param name: a name of the device
+        :return: a device specifier for /etc/fstab
+        """
+        return self.implementation.get_fstab_spec(name)

--- a/pyanaconda/modules/storage/partitioning/interactive_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/interactive_partitioning.py
@@ -31,11 +31,19 @@ class InteractivePartitioningTask(PartitioningTask):
     def _run(self, storage):
         """Only set up the bootloader."""
         self._prepare_bootloader(storage)
+        self._set_fstab_swaps(storage)
         self._organize_actions(storage)
 
     def _prepare_bootloader(self, storage):
         """Prepare the bootloader."""
         setup_bootloader(storage)
+
+    def _set_fstab_swaps(self, storage):
+        """Set swap devices that should appear in the fstab."""
+        storage.set_fstab_swaps([
+            d for d in storage.devices
+            if d.direct and not d.format.exists and not d.partitioned and d.format.type == "swap"
+        ])
 
     def _organize_actions(self, storage):
         """Prune and sort the scheduled actions."""

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -160,10 +160,8 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
         """
         The apply method that is called when the spoke is left. It should
         update the contents of self.data with values set in the GUI elements.
-
         """
-
-        self._set_new_swaps()
+        pass
 
     @property
     def indirect(self):
@@ -215,12 +213,6 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
     def activate_action_buttons(self, activate):
         self.button_undo.set_sensitive(activate)
         self.button_reset.set_sensitive(activate)
-
-    def _set_new_swaps(self):
-        new_swaps = [d for d in self._storage_playground.devices if d.direct and
-                     not d.format.exists and not d.partitioned and d.format.type == "swap"]
-
-        self.storage.set_fstab_swaps(new_swaps)
 
     ### handlers ###
     def on_info_bar_clicked(self, *args):

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -223,11 +223,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
     def apply(self):
         self.clear_errors()
-
         self._unhide_unusable_disks()
-
-        new_swaps = (dev for dev in self.get_new_devices() if dev.format.type == "swap")
-        self.storage.set_fstab_swaps(new_swaps)
 
         # update the global passphrase
         self._auto_part_observer.proxy.SetPassphrase(self.passphrase)

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -369,3 +369,8 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
         device_teardown.assert_called_once()
         self.assertFalse(dev2.format.has_key)
+
+    def get_fstab_spec_test(self):
+        """Test GetFstabSpec."""
+        self._add_device(StorageDevice("dev1", fmt=get_format("ext4", uuid="123")))
+        self.assertEqual(self.interface.GetFstabSpec("dev1"), "UUID=123")


### PR DESCRIPTION
Call the method `GetFstabSpec` to get the device specifier for use
in `/etc/fstab`.

Move the code that sets swap devices that should appear in the fstab
to the task `InteractivePartitioningTask`.
