### PR TITLE
Make default state of addon repos configurable by product

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -64,6 +64,15 @@ ignored_packages =
 # Enable installation of latest updates.
 enable_updates = True
 
+# List of .treeinfo variant types to enable.
+# Valid items:
+#
+#   addon
+#   optional
+#   variant
+#
+enabled_repositories_from_treeinfo = addon optional variant
+
 # Enable installation from the closest mirror.
 enable_closest_mirror = True
 

--- a/pyanaconda/core/configuration/payload.py
+++ b/pyanaconda/core/configuration/payload.py
@@ -52,6 +52,16 @@ class PayloadSection(Section):
         return self._get_option("enable_updates", bool)
 
     @property
+    def enabled_repositories_from_treeinfo(self):
+        """List of .treeinfo variant types to enable
+
+        This flag controls which .treeinfo variant repos Anaconda
+        will automatically enable.  For a list of valid types see
+        .treeinfo documentation.
+        """
+        return self._get_option("enabled_repositories_from_treeinfo", str).split()
+
+    @property
     def enable_closest_mirror(self):
         """Enable installation from the closest mirror.
 

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -1301,10 +1301,14 @@ class DNFPayload(payload.PackagePayload):
                 baseurl = self.get_addon_repo(ksrepo).baseurl
                 existing_urls.append(baseurl)
 
+            enabled_repositories_from_treeinfo = conf.payload.enabled_repositories_from_treeinfo
+
             for repo_md in self._install_tree_metadata.get_metadata_repos():
                 if repo_md.path not in existing_urls:
+                    repo_treeinfo = self._install_tree_metadata.get_treeinfo_for(repo_md.name)
+                    repo_enabled = repo_treeinfo.type in enabled_repositories_from_treeinfo
                     repo = RepoData(name=repo_md.name, baseurl=repo_md.path,
-                                    install=False, enabled=True)
+                                    install=False, enabled=repo_enabled)
                     repo.treeinfo_origin = True
                     self.add_repo(repo)
 

--- a/pyanaconda/payload/install_tree_metadata.py
+++ b/pyanaconda/payload/install_tree_metadata.py
@@ -199,6 +199,10 @@ class InstallTreeMetadata(object):
 
         return None
 
+    def get_treeinfo_for(self, variant_name):
+        """Return the productmd.Variant object for variant_name."""
+        return self._tree_info.variants[variant_name]
+
     def _read_variants(self):
         for variant_name in self._tree_info.variants:
             variant_object = self._tree_info.variants[variant_name]


### PR DESCRIPTION
For Scientific Linux we are planning to make use of the addon repos for optional software.  So I've added a flag where a product or variant can define if it wants them enabled or disabled by default.

I set Fedora to disabled (the pre https://github.com/rhinstaller/anaconda/commit/9a02cda015672a9eab3ce8d956ed1e05f2b63b61 behavior) as Fedora doesn't use addon repos in its `.treeinfo`