### PR TITLE
Handle bytes and strings from RPM (#1689909)

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -29,6 +29,7 @@ import crypt
 from ordered_set import OrderedSet
 
 from pyanaconda.core import util
+from pyanaconda.core.util import decode_bytes
 from blivet.devicelibs import raid
 from blivet.formats.disklabel import DiskLabel
 from pyanaconda.product import productName
@@ -2541,7 +2542,7 @@ def writeSysconfigKernel(storage, version, instClass):
         log.error("failed to get package name for default kernel")
         return
 
-    kernel = h.name.decode()
+    kernel = decode_bytes(h.name)
 
     f = open(util.getSysroot() + "/etc/sysconfig/kernel", "w+")
     f.write("# UPDATEDEFAULT specifies if new-kernel-pkg should make\n"

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1522,3 +1522,20 @@ def is_smt_enabled():
     except (IOError, ValueError):
         log.warning("Failed to detect SMT.")
         return False
+
+
+def decode_bytes(data):
+    """Decode the given bytes.
+
+    Return the given string or a string decoded from the given bytes.
+
+    :param data: bytes or a string
+    :return: a string
+    """
+    if isinstance(data, str):
+        return data
+
+    if isinstance(data, bytes):
+        return data.decode('utf-8')
+
+    raise ValueError("Unsupported type '{}'.".format(type(data).__name__))

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -52,7 +52,7 @@ from pyanaconda import isys
 from pyanaconda.image import findFirstIsoImage
 from pyanaconda.image import mountImage
 from pyanaconda.image import opticalInstallMedia, verifyMedia, verify_valid_installtree
-from pyanaconda.core.util import ProxyString, ProxyStringError
+from pyanaconda.core.util import ProxyString, ProxyStringError, decode_bytes
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core.regexes import VERSION_DIGITS
 from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
@@ -1073,7 +1073,7 @@ class PackagePayload(Payload):
         ts = rpm.TransactionSet(util.getSysroot())
         mi = ts.dbMatch('providename', 'kernel')
         for hdr in mi:
-            unicode_fnames = (f.decode("utf-8") for f in hdr.filenames)
+            unicode_fnames = (decode_bytes(f) for f in hdr.filenames)
             # Find all /boot/vmlinuz- files and strip off vmlinuz-
             files.extend((f.split("/")[-1][8:] for f in unicode_fnames
                 if fnmatch(f, "/boot/vmlinuz-*") or

--- a/tests/nosetests/pyanaconda_tests/iutil_test.py
+++ b/tests/nosetests/pyanaconda_tests/iutil_test.py
@@ -823,3 +823,10 @@ class MiscTests(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             test_function()
+
+    def decode_bytes_test(self):
+        self.assertEqual("STRING", util.decode_bytes("STRING"))
+        self.assertEqual("BYTES", util.decode_bytes(b"BYTES"))
+        self.assertRaises(ValueError, util.decode_bytes, None)
+        self.assertRaises(ValueError, util.decode_bytes, 0)
+        self.assertRaises(ValueError, util.decode_bytes, [])


### PR DESCRIPTION
RPM can return bytes or strings, so let's use the function
decode_bytes that can handle both and always returns a string.

(cherry-picked from a commit 1c45e7b3a)

Resolves: rhbz#1689909