### PR TITLE
Set the flag lvm_metadata_backup (#1673901)

### DIFF
--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -80,7 +80,7 @@ def enable_installer_mode():
 
     # We don't want image installs writing backups of the *image* metadata
     # into the *host's* /etc/lvm. This can get real messy on build systems.
-    if blivet_flags.image_install:
+    if flags.imageInstall:
         blivet_flags.lvm_metadata_backup = False
 
     blivet_flags.auto_dev_updates = True


### PR DESCRIPTION
The flag `lvm_metadata_backup` should be set to False for image
installations. We shouldn't use the Blivet's flag `image_install`
to check the type of the installation, because it is not set at
this point. Let's use the Anaconda's flag `imageInstall` instead.

Resolves: rhbz#1673901