### PR TITLE
Cleanup long removed "headless" option from docs

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -512,14 +512,6 @@ inst.vncconnect
 
     Use with ``vncviewer -listen``.
 
-.. inst.headless:
-
-inst.headless
-^^^^^^^^^^^^^
-
-Specify that the machine being installed onto doesn't have any display
-hardware, and that anaconda shouldn't bother looking for it.
-
 .. inst.xdriver:
 
 inst.xdriver


### PR DESCRIPTION
The headless option has been removed long ago (2014)
in commit ff7f7dba8fbcfddb93d52df21c7d709fe38ea7c5,
but it apparently remained to be documented.

So lets drop it from the docs as well to avoid
further confusion.