### PR TITLE
Don't check the storage in a separate thread

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -109,7 +109,6 @@ DEFAULT_DBUS_TIMEOUT = -1       # use default
 THREAD_EXECUTE_STORAGE = "AnaExecuteStorageThread"
 THREAD_STORAGE = "AnaStorageThread"
 THREAD_STORAGE_WATCHER = "AnaStorageWatcher"
-THREAD_CHECK_STORAGE = "AnaCheckStorageThread"
 THREAD_CUSTOM_STORAGE_INIT = "AnaCustomStorageInit"
 THREAD_WAIT_FOR_CONNECTING_NM = "AnaWaitForConnectingNMThread"
 THREAD_PAYLOAD = "AnaPayloadThread"

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -197,7 +197,7 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
             StorageCheckHandler.errors = str(e).split("\n")
             reset_bootloader(self.storage)
 
-        StorageCheckHandler.checkStorage(self)
+        StorageCheckHandler.check_storage(self)
 
         if self.errors:
             self.set_warning(_("Error checking storage configuration.  <a href=\"\">Click for details</a> or press Done again to continue."))

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -1722,7 +1722,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             bootloader_errors = str(e).split("\n")
             reset_bootloader(self.storage)
 
-        StorageCheckHandler.checkStorage(self)
+        StorageCheckHandler.check_storage(self)
 
         if self.errors or bootloader_errors:
             self.set_warning(_("Error checking storage configuration.  <a href=\"\">Click for details</a> or press Done again to continue."))

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -470,8 +470,8 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             if self._auto_part_enabled or \
                     (flags.automatedInstall and
                      (self._auto_part_observer.proxy.Enabled or self.data.partition.seen)):
-                # run() executes StorageCheckHandler.checkStorage in a seperate thread
-                self.run()
+                hubQ.send_message(self.__class__.__name__, _("Checking storage configuration..."))
+                StorageCheckHandler.check_storage(self)
         finally:
             reset_custom_storage_data(self.data)
             self._ready = True
@@ -480,7 +480,6 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
     @property
     def completed(self):
         retval = (threadMgr.get(constants.THREAD_EXECUTE_STORAGE) is None and
-                  not self.checking_storage and
                   self.storage.root_device is not None and
                   not self.errors)
         return retval


### PR DESCRIPTION
Let's run the storage checks in the same thread as the storage
configuration, so there will be no race conditions what might
cause a failure of the noninteractive installation.