### PR TITLE
Fix the installation from NFS (#1708070)

### DIFF
--- a/pyanaconda/packaging/__init__.py
+++ b/pyanaconda/packaging/__init__.py
@@ -136,7 +136,7 @@ class SSLOptions(object):
 
     @classmethod
     def createFromMethod(cls, method):
-        sslverify = not (method.noverifyssl or flags.noverifyssl)
+        sslverify = not (getattr(method, "noverifyssl", False) or flags.noverifyssl)
         return cls(sslverify=sslverify,
                    cacert=getattr(method, "sslcacert", None),
                    clientcert=getattr(method, "sslclientcert", None),


### PR DESCRIPTION
The kickstart command nfs doesn't support the noverifyssl option.
Use the function getattr to get the value of this attribute.

Resolves: rhbz#1708070