### PR TITLE
Parse the output of df correctly (#1708701)

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -103,9 +103,7 @@ def _df_map():
     lines = output.splitlines()
     structured = {}
     for line in lines:
-        items = line.split()
-        key = items[0]
-        val = items[1]
+        key, val = line.rsplit(maxsplit=1)
         if not key.startswith('/'):
             continue
         structured[key] = Size(int(val) * 1024)


### PR DESCRIPTION
Split each line only once and in the rightmost way to get a mount
point and a number of available blocks. The mount point can contain
white spaces.

Resolves: rhbz#1708701