### PR TITLE
A couple Initial Setup related fixes

### DIFF
--- a/pyanaconda/modules/users/users.py
+++ b/pyanaconda/modules/users/users.py
@@ -135,25 +135,56 @@ class UsersModule(KickstartModule):
 
         return str(data)
 
+    def configure_groups_with_task(self, sysroot):
+        """Return the user group configuration task.
+
+        :param str sysroot: a path to the root of the installed system
+        :returns: object path of the user group configuration task
+        """
+        task = CreateGroupsTask(sysroot=sysroot, group_data_list=self.groups)
+        return self.publish_task(USERS.namespace, task)
+
+    def configure_users_with_task(self, sysroot):
+        """Return the user configuration task.
+
+        :param str sysroot: a path to the root of the installed system
+        :returns: object path of the user configuration task
+        """
+        task = CreateUsersTask(sysroot=sysroot, user_data_list=self.users)
+        return self.publish_task(USERS.namespace, task)
+
+    def set_root_password_with_task(self, sysroot):
+        """Return the root password configuration task.
+
+        :param str sysroot: a path to the root of the installed system
+        :returns: object path of the root password configuration task
+        """
+        task =  SetRootPasswordTask(sysroot=sysroot, password=self.root_password,
+                                    crypted=self.root_password_is_crypted,
+                                    locked=self.root_account_locked)
+        return self.publish_task(USERS.namespace, task)
+
+    def set_ssh_keys_with_task(self, sysroot):
+        """Return the SSH key configuration task.
+
+        :param str sysroot: a path to the root of the installed system
+        :returns: object path of the SSH key configuration task
+        """
+        task = SetSshKeysTask(sysroot=sysroot, ssh_key_data_list=self.ssh_keys)
+        return self.publish_task(USERS.namespace, task)
+
     def install_with_tasks(self, sysroot):
         """Return the installation tasks of this module.
 
         :param str sysroot: a path to the root of the installed system
         :returns: list of object paths of installation tasks
         """
-        tasks = [
-            SetRootPasswordTask(sysroot=sysroot, password=self.root_password,
-                crypted=self.root_password_is_crypted,
-                locked=self.root_account_locked),
-            CreateGroupsTask(sysroot=sysroot, group_data_list=self.groups),
-            CreateUsersTask(sysroot=sysroot, user_data_list=self.users),
-            SetSshKeysTask(sysroot=sysroot, ssh_key_data_list=self.ssh_keys)
-        ]
-
         paths = [
-            self.publish_task(USERS.namespace, task) for task in tasks
+            self.configure_groups_with_task(sysroot=sysroot),
+            self.configure_users_with_task(sysroot=sysroot),
+            self.set_root_password_with_task(sysroot=sysroot),
+            self.set_ssh_keys_with_task(sysroot=sysroot)
         ]
-
         return paths
 
     def _ksdata_to_user_data(self, user_ksdata):

--- a/pyanaconda/modules/users/users_interface.py
+++ b/pyanaconda/modules/users/users_interface.py
@@ -187,3 +187,24 @@ class UsersInterface(KickstartModuleInterface):
         :return: if at least one admin user exists
         """
         return self.implementation.check_admin_user_exists
+
+    def ConfigureGroupsWithTask(self, sysroot: Str) -> ObjPath:
+        """Configure user groups via a DBus task.
+
+        :returns: DBus path of the task
+        """
+        return self.implementation.configure_groups_with_task(sysroot)
+
+    def ConfigureUsersWithTask(self, sysroot: Str) -> ObjPath:
+        """Configure users via a DBus task.
+
+        :returns: DBus path of the task
+        """
+        return self.implementation.configure_users_with_task(sysroot)
+
+    def SetRootPasswordWithTask(self, sysroot: Str) -> ObjPath:
+        """Set root password via a DBus task.
+
+        :returns: DBus path of the task
+        """
+        return self.implementation.set_root_password_with_task(sysroot)

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -242,7 +242,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
             # cannot decide, stay in the game and let another call with data
             # available (will come) decide
             return True
-        elif environment == constants.FIRSTBOOT_ENVIRON and data and user_list:
+        elif environment == constants.FIRSTBOOT_ENVIRON and data and not user_list:
             return True
         else:
             return False


### PR DESCRIPTION
The first commit exposes the individual user group, user and root password tasks via the DBUS interface so that Initial Setup can run them on demand. Initial Setup does not expose SSH key configuration so we don't need that task to be available on demand via DBUS.

The second commit fixes a minor logic error that was preventing the user spoke from correctly showing up in Initial Setup. Also we still need to continue checking for the "data" variable in should_run as that's used by the User spoke to access the password policy data.