### PR TITLE
Define the __eq__ method of DBusData

### DIFF
--- a/pyanaconda/dbus/structure.py
+++ b/pyanaconda/dbus/structure.py
@@ -182,6 +182,10 @@ class DBusData(ABC):
         """Convert this data object to a string."""
         return generate_string_from_data(self)
 
+    def __eq__(self, other):
+        """Compare data of the data objects."""
+        return compare_data(self, other)
+
 
 def get_fields(obj):
     """Return DBus fields of a data object.
@@ -246,6 +250,18 @@ def generate_fields(cls):
     return fields
 
 
+def generate_dictionary_from_data(obj):
+    """Generate a dictionary from a data object.
+
+    :param obj: a data object
+    :return: a dictionary representation of the data object
+    """
+    return {
+        field.data_name: field.get_data(obj)
+        for field in get_fields(obj).values()
+    }
+
+
 def generate_string_from_data(obj, skip=None, add=None):
     """Generate a string representation of a data object.
 
@@ -276,3 +292,14 @@ def generate_string_from_data(obj, skip=None, add=None):
         attributes.sort()
 
     return "{}({})".format(obj.__class__.__name__, ", ".join(attributes))
+
+
+def compare_data(obj, other):
+    """Compare data of the given data objects.
+
+    :param obj: a data object
+    :param other: another data object
+    :return: True if the data is equal, otherwise False
+    """
+    return isinstance(obj, DBusData) and isinstance(other, DBusData) \
+        and generate_dictionary_from_data(obj) == generate_dictionary_from_data(other)

--- a/pyanaconda/dbus/structure.py
+++ b/pyanaconda/dbus/structure.py
@@ -273,23 +273,20 @@ def generate_string_from_data(obj, skip=None, add=None):
 
     :param obj: a data object
     :param skip: a list of names that should be skipped or None
-    :param add: a list of strings to add or None
+    :param add: a dictionary of attributes to add or None
     :return: a string representation of the data object
     """
-    attributes = []
-    skipped_names = set(skip) if skip else set()
-    extra_attributes = list(add) if add else []
+    dictionary = generate_dictionary_from_data(obj)
 
-    for field in get_fields(obj).values():
-        if field.data_name in skipped_names:
-            continue
+    for name in skip or list():
+        dictionary.pop(name, None)
 
-        attribute = "{}={}".format(field.data_name, repr(field.get_data(obj)))
-        attributes.append(attribute)
+    for name in add or dict():
+        dictionary[name] = add[name]
 
-    if extra_attributes:
-        attributes.extend(extra_attributes)
-        attributes.sort()
+    attributes = sorted([
+        "{}={}".format(name, repr(value)) for name, value in dictionary.items()
+    ])
 
     return "{}({})".format(obj.__class__.__name__, ", ".join(attributes))
 

--- a/pyanaconda/modules/common/structures/user.py
+++ b/pyanaconda/modules/common/structures/user.py
@@ -252,8 +252,9 @@ class UserData(DBusData):
         :return: a string describing the UserData instance
         :rtype: str
         """
-        pw_string = "password_set={}".format(bool(self.password))
-        return generate_string_from_data(self, skip=["password"], add=[pw_string])
+        return generate_string_from_data(
+            self, skip=["password"], add={"password_set": bool(self.password)}
+        )
 
     def has_admin_priviledges(self):
         """Report if the user described by this structure is an admin.

--- a/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
@@ -420,7 +420,7 @@ class DBusStructureTestCase(unittest.TestCase):
             return generate_string_from_data(
                 obj=self,
                 skip=["b"],
-                add=["b_is_set={}".format(bool(self.b))]
+                add={"b_is_set": bool(self.b)}
             )
 
     def advanced_string_representation_test(self):

--- a/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
@@ -181,6 +181,25 @@ class DBusStructureTestCase(unittest.TestCase):
         self.assertEqual(data[1].x, 2)
         self.assertEqual(data[2].x, 3)
 
+    def compare_simple_structure_test(self):
+        data = self.SimpleData()
+
+        self.assertEqual(data, data)
+        self.assertEqual(data, self.SimpleData())
+
+        self.assertNotEqual(data, None)
+        self.assertNotEqual(None, data)
+
+        self.assertEqual(
+            self.SimpleData.from_structure({'x': 10}),
+            self.SimpleData.from_structure({'x': 10})
+        )
+
+        self.assertNotEqual(
+            self.SimpleData.from_structure({'x': 10}),
+            self.SimpleData.from_structure({'x': 9})
+        )
+
     class OtherData(DBusData):
 
         def __init__(self):
@@ -268,6 +287,56 @@ class DBusStructureTestCase(unittest.TestCase):
         self.assertEqual(data.dictionary, {1: "1", 2: "2"})
         self.assertEqual(data.bool_list, [True, False, False])
         self.assertEqual(data.very_long_property_name, "My String Value")
+
+    def compare_complicated_structure_test(self):
+        self.assertEqual(
+            self.ComplicatedData(),
+            self.ComplicatedData(),
+        )
+
+        self.assertNotEqual(
+            self.ComplicatedData(),
+            self.SimpleData()
+        )
+
+        self.assertNotEqual(
+            self.SimpleData(),
+            self.ComplicatedData()
+        )
+
+        self.assertEqual(
+            self.ComplicatedData.from_structure(
+                {
+                    'dictionary': {1: "1", 2: "2"},
+                    'bool-list': [True, False, False],
+                    'very-long-property-name': "My String Value"
+                }
+            ),
+            self.ComplicatedData.from_structure(
+                {
+                    'dictionary': {1: "1", 2: "2"},
+                    'bool-list': [True, False, False],
+                    'very-long-property-name': "My String Value"
+                }
+            )
+        )
+
+        self.assertNotEqual(
+            self.ComplicatedData.from_structure(
+                {
+                    'dictionary': {1: "1", 2: "2"},
+                    'bool-list': [True, False, False],
+                    'very-long-property-name': "My String Value"
+                }
+            ),
+            self.ComplicatedData.from_structure(
+                {
+                    'dictionary': {1: "1", 2: "2"},
+                    'bool-list': [True, False, True],
+                    'very-long-property-name': "My String Value"
+                }
+            )
+        )
 
     class StringData(DBusData):
 


### PR DESCRIPTION
Compare the values of all data fields by default.

Use a dictionary from `generate_dictionary_from_data`
to generate a string representation of the data. Change the
argument `add` to a dictionary of attributes to make it more
user-friendly.
