### PR TITLE
Skip scaling if there is no primary monitor (#1592014)

### DIFF
--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -709,6 +709,11 @@ class GraphicalUserInterface(UserInterface):
 
         # Get the primary monitor dimensions in pixels and mm from Gdk
         primary_monitor = display.get_primary_monitor()
+
+        # It can be None if no primary monitor is configured by the user.
+        if not primary_monitor:
+            return
+
         monitor_geometry = primary_monitor.get_geometry()
         monitor_scale = primary_monitor.get_scale_factor()
         monitor_width_mm = primary_monitor.get_width_mm()


### PR DESCRIPTION
The method get_primary_monitor can return None if no primary monitor
is configured by the user, so we shouldn't try to change the widget
scaling in this case.

Resolves: rhbz#1592014