### PR TITLE
Add DBus support for the rescue mode

### DIFF
--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -274,3 +274,65 @@ class DeviceActionData(DBusData):
     @description.setter
     def description(self, text):
         self._description = text
+
+
+class OSData(DBusData):
+    """Data of an existing OS installation."""
+
+    def __init__(self):
+        self._os_name = ""
+        self._mount_points = {}
+        self._swap_devices = []
+
+    @property
+    def os_name(self) -> Str:
+        """Name of the OS.
+
+        :return: a string with name
+        """
+        return self._os_name
+
+    @os_name.setter
+    def os_name(self, name: Str):
+        self._os_name = name
+
+    @property
+    def mount_points(self) -> Dict[Str, Str]:
+        """Mount points.
+
+        :return: a dictionary of mount points and device names
+        """
+        return self._mount_points
+
+    @mount_points.setter
+    def mount_points(self, mount_points: Dict[Str, Str]):
+        self._mount_points = mount_points
+
+    @property
+    def swap_devices(self) -> List[Str]:
+        """Swap devices.
+
+        :return: a list of device names
+        """
+        return self._swap_devices
+
+    @swap_devices.setter
+    def swap_devices(self, devices: List[Str]):
+        self._swap_devices = devices
+
+    def get_root_device(self):
+        """Get the root device.
+
+        :return: a device name or None
+        """
+        return self.mount_points.get("/")
+
+    def get_devices(self):
+        """Get all devices.
+
+        :return: a list of device names
+        """
+        devices = []
+        devices.extend(self.swap_devices)
+        devices.extend(self.mount_points.values())
+        return devices

--- a/pyanaconda/modules/storage/devicetree/handler.py
+++ b/pyanaconda/modules/storage/devicetree/handler.py
@@ -20,7 +20,11 @@
 from abc import abstractmethod, ABC
 
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.dbus import DBus
+from pyanaconda.modules.common.constants.interfaces import DEVICE_TREE_HANDLER
 from pyanaconda.modules.common.errors.storage import UnknownDeviceError
+from pyanaconda.modules.common.task import TaskInterface
+from pyanaconda.modules.storage.devicetree.rescue import FindExistingSystemsTask
 from pyanaconda.storage.utils import find_optical_media, find_mountable_partitions, unlock_device
 
 log = get_module_logger(__name__)
@@ -49,6 +53,18 @@ class DeviceTreeHandler(ABC):
         :raise: UnknownDeviceError if no device is found
         """
         raise UnknownDeviceError(name)
+
+    @abstractmethod
+    def publish_task(self, namespace, task, interface=TaskInterface, message_bus=DBus):
+        """Publish a task.
+
+        :param namespace: a DBus namespace
+        :param task: an instance of task
+        :param interface: an interface class
+        :param message_bus: a message bus
+        :return: a DBus path of the published task
+        """
+        raise NotImplementedError()
 
     def setup_device(self, device_name):
         """Open, or set up, a device.
@@ -109,3 +125,24 @@ class DeviceTreeHandler(ABC):
         """
         devices = find_mountable_partitions(self.storage.devicetree)
         return [d.name for d in devices]
+
+    def find_existing_systems_with_task(self):
+        """"Find existing GNU/Linux installations.
+
+        The task will update data about existing installations.
+
+        :return: a path to the task
+        """
+        task = FindExistingSystemsTask(self.storage.devicetree)
+        task.succeeded_signal.connect(
+            lambda: self._update_existing_systems(task.get_result())
+        )
+        path = self.publish_task(DEVICE_TREE_HANDLER.namespace, task)
+        return path
+
+    def _update_existing_systems(self, roots):
+        """Update existing GNU/Linux installations.
+
+        :param roots: a list of found OS installations
+        """
+        self.storage.roots = roots

--- a/pyanaconda/modules/storage/devicetree/handler.py
+++ b/pyanaconda/modules/storage/devicetree/handler.py
@@ -24,7 +24,8 @@ from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.constants.interfaces import DEVICE_TREE_HANDLER
 from pyanaconda.modules.common.errors.storage import UnknownDeviceError
 from pyanaconda.modules.common.task import TaskInterface
-from pyanaconda.modules.storage.devicetree.rescue import FindExistingSystemsTask
+from pyanaconda.modules.storage.devicetree.rescue import FindExistingSystemsTask, \
+    MountExistingSystemTask
 from pyanaconda.storage.utils import find_optical_media, find_mountable_partitions, unlock_device
 
 log = get_module_logger(__name__)
@@ -146,3 +147,21 @@ class DeviceTreeHandler(ABC):
         :param roots: a list of found OS installations
         """
         self.storage.roots = roots
+
+    def mount_existing_system_with_task(self, sysroot, device_name, read_only):
+        """Mount existing GNU/Linux installation.
+
+        :param sysroot: a path to the root of the system
+        :param device_name: a name of the root device
+        :param read_only: mount the system in read-only mode
+        :return: a path to the task
+        """
+        task = MountExistingSystemTask(
+            storage=self.storage,
+            sysroot=sysroot,
+            device=self._get_device(device_name),
+            read_only=read_only
+        )
+
+        path = self.publish_task(DEVICE_TREE_HANDLER.namespace, task)
+        return path

--- a/pyanaconda/modules/storage/devicetree/handler_interface.py
+++ b/pyanaconda/modules/storage/devicetree/handler_interface.py
@@ -81,3 +81,12 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
         :return: a list of device names
         """
         return self.implementation.find_mountable_partitions()
+
+    def FindExistingSystemsWithTask(self) -> ObjPath:
+        """"Find existing GNU/Linux installations.
+
+        The task will update data about existing installations.
+
+        :return: a path to the task
+        """
+        return self.implementation.find_existing_systems_with_task()

--- a/pyanaconda/modules/storage/devicetree/handler_interface.py
+++ b/pyanaconda/modules/storage/devicetree/handler_interface.py
@@ -90,3 +90,13 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
         :return: a path to the task
         """
         return self.implementation.find_existing_systems_with_task()
+
+    def MountExistingSystemWithTask(self, sysroot: Str, device_name: Str, read_only: Bool) -> ObjPath:
+        """Mount existing GNU/Linux installation.
+
+        :param sysroot: a path to the root of the system
+        :param device_name: a name of the root device
+        :param read_only: mount the system in read-only mode
+        :return: a path to the task
+        """
+        return self.implementation.mount_existing_system_with_task(sysroot, device_name, read_only)

--- a/pyanaconda/modules/storage/devicetree/rescue.py
+++ b/pyanaconda/modules/storage/devicetree/rescue.py
@@ -1,0 +1,46 @@
+#
+# Rescue tasks
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.storage.root import find_existing_installations
+from pyanaconda.modules.common.task import Task
+
+__all__ = ["FindExistingSystemsTask"]
+
+
+class FindExistingSystemsTask(Task):
+    """A task to find existing GNU/Linux installations."""
+
+    def __init__(self, devicetree):
+        """Create a new task.
+
+        :param devicetree: a device tree to search
+        """
+        super().__init__()
+        self._devicetree = devicetree
+
+    @property
+    def name(self):
+        return "Find existing operating systems"
+
+    def run(self):
+        """Run the task.
+
+        :return: a list of data about found systems
+        """
+        return find_existing_installations(devicetree=self._devicetree)

--- a/pyanaconda/modules/storage/devicetree/rescue.py
+++ b/pyanaconda/modules/storage/devicetree/rescue.py
@@ -17,10 +17,10 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.storage.root import find_existing_installations
+from pyanaconda.storage.root import find_existing_installations, mount_existing_system
 from pyanaconda.modules.common.task import Task
 
-__all__ = ["FindExistingSystemsTask"]
+__all__ = ["FindExistingSystemsTask", "MountExistingSystemTask"]
 
 
 class FindExistingSystemsTask(Task):
@@ -44,3 +44,34 @@ class FindExistingSystemsTask(Task):
         :return: a list of data about found systems
         """
         return find_existing_installations(devicetree=self._devicetree)
+
+
+class MountExistingSystemTask(Task):
+    """A task to mount an existing GNU/Linux installation."""
+
+    def __init__(self, storage, sysroot, device, read_only):
+        """Create a new task.
+
+        :param storage: an instance of the Blivet's storage
+        :param sysroot: a path to the root of the system
+        :param device: a root device of the system
+        :param read_only: mount the system in read-only mode
+        """
+        super().__init__()
+        self._storage = storage
+        self._sysroot = sysroot
+        self._device = device
+        self._read_only = read_only
+
+    @property
+    def name(self):
+        return "Mount an existing operating system"
+
+    def run(self):
+        """Run the task."""
+        mount_existing_system(
+            storage=self._storage,
+            root_device=self._device,
+            read_only=self._read_only,
+            sysroot=self._sysroot
+        )

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -24,7 +24,7 @@ from blivet.size import Size
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.common.errors.storage import UnknownDeviceError
 from pyanaconda.modules.common.structures.storage import DeviceData, DeviceActionData, \
-    DeviceFormatData
+    DeviceFormatData, OSData
 from pyanaconda.storage.utils import get_required_device_size
 
 log = get_module_logger(__name__)
@@ -264,3 +264,26 @@ class DeviceTreeViewer(ABC):
         """
         device = self._get_device(name)
         return device.fstab_spec
+
+    def get_existing_systems(self):
+        """"Get existing GNU/Linux installations.
+
+        :return: a list of data about found installations
+        """
+        return list(map(self._get_os_data, self.storage.roots))
+
+    def _get_os_data(self, root):
+        """Get the OS data.
+
+        :param root: an instance of Root
+        :return: an instance of OSData
+        """
+        data = OSData()
+        data.os_name = root.name or ""
+        data.swap_devices = [
+            device.name for device in root.swaps
+        ]
+        data.mount_points = {
+            path: device.name for path, device in root.mounts.items()
+        }
+        return data

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -22,7 +22,7 @@ from pyanaconda.dbus.template import InterfaceTemplate
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.constants.interfaces import DEVICE_TREE_VIEWER
 from pyanaconda.modules.common.structures.storage import DeviceData, DeviceActionData, \
-    DeviceFormatData
+    DeviceFormatData, OSData
 
 __all__ = ["DeviceTreeViewerInterface"]
 
@@ -143,3 +143,10 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
         :return: a device specifier for /etc/fstab
         """
         return self.implementation.get_fstab_spec(name)
+
+    def GetExistingSystems(self) -> List[Structure]:
+        """"Get existing GNU/Linux installations.
+
+        :return: a list of data about found installations
+        """
+        return OSData.to_structure_list(self.implementation.get_existing_systems())

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -205,19 +205,12 @@ class Rescue(object):
         """Mounts selected root and runs scripts."""
         # mount root fs
         try:
-            mount_existing_system(self._storage.fsset, root.device, read_only=self.ro)
+            mount_existing_system(self._storage, root.device, read_only=self.ro)
             log.info("System has been mounted under: %s", util.getSysroot())
         except StorageError as e:
             log.error("Mounting system under %s failed: %s", util.getSysroot(), e)
             self.status = RescueModeStatus.MOUNT_FAILED
             return False
-
-        # turn on swap
-        if not conf.target.is_image or not self.ro:
-            try:
-                self._storage.turn_on_swap()
-            except StorageError:
-                log.error("Error enabling swap.")
 
         # turn on selinux also
         if conf.security.selinux:
@@ -243,7 +236,6 @@ class Rescue(object):
 
         # make resolv.conf in chroot
         if not self.ro:
-            self._storage.make_mtab()
             try:
                 makeResolvConf(util.getSysroot())
             except(OSError, IOError) as e:

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -437,10 +437,11 @@ class InstallerStorage(Blivet):
     def create_swap_file(self, device, size):
         self.fsset.create_swap_file(device, size)
 
-    def make_mtab(self):
+    def make_mtab(self, chroot=None):
         path = "/etc/mtab"
         target = "/proc/self/mounts"
-        path = os.path.normpath("%s/%s" % (util.getSysroot(), path))
+        chroot = chroot or util.getSysroot()
+        path = os.path.normpath("%s/%s" % (chroot, path))
 
         if os.path.islink(path):
             # return early if the mtab symlink is already how we like it

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -34,7 +34,8 @@ from pyanaconda.modules.common.errors.storage import UnknownDeviceError
 from pyanaconda.modules.common.task import TaskInterface
 from pyanaconda.modules.storage.devicetree import DeviceTreeModule
 from pyanaconda.modules.storage.devicetree.devicetree_interface import DeviceTreeInterface
-from pyanaconda.modules.storage.devicetree.rescue import FindExistingSystemsTask
+from pyanaconda.modules.storage.devicetree.rescue import FindExistingSystemsTask, \
+    MountExistingSystemTask
 from pyanaconda.storage.initialization import create_storage
 from pyanaconda.storage.root import Root
 
@@ -416,6 +417,26 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         obj.implementation.succeeded_signal.emit()
         self.assertEqual(self.storage.roots, roots)
 
+    @patch('pyanaconda.dbus.DBus.publish_object')
+    def mount_existing_system_with_task_test(self, publisher):
+        """Test MountExistingSystemWithTask."""
+        self._add_device(StorageDevice("dev1", fmt=get_format("ext4")))
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            task_path = self.interface.MountExistingSystemWithTask(sysroot, "dev1", True)
+
+        publisher.assert_called_once()
+        object_path, obj = publisher.call_args[0]
+
+        self.assertEqual(task_path, object_path)
+        self.assertIsInstance(obj, TaskInterface)
+
+        self.assertIsInstance(obj.implementation, MountExistingSystemTask)
+        self.assertEqual(obj.implementation._storage, self.module.storage)
+        self.assertEqual(obj.implementation._sysroot, sysroot)
+        self.assertEqual(obj.implementation._device.name, "dev1")
+        self.assertEqual(obj.implementation._read_only, True)
+
 
 class DeviceTreeTasksTestCase(unittest.TestCase):
     """Test the storage tasks."""
@@ -424,3 +445,20 @@ class DeviceTreeTasksTestCase(unittest.TestCase):
         storage = create_storage()
         task = FindExistingSystemsTask(storage.devicetree)
         self.assertEqual(task.run(), [])
+
+    @patch('pyanaconda.modules.storage.devicetree.rescue.mount_existing_system')
+    def mount_existing_system_test(self, mount):
+        storage = create_storage()
+        device = StorageDevice("dev1", fmt=get_format("ext4"))
+        storage.devicetree._add_device(device)
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            task = MountExistingSystemTask(storage, sysroot, device, True)
+            task.run()
+
+        mount.assert_called_once_with(
+            storage=storage,
+            sysroot=sysroot,
+            root_device=device,
+            read_only=True
+        )


### PR DESCRIPTION
Call the DBus method GetExistingSystems of the device tree module to
get a list of existing installations on devices from the device tree.

Call the DBus method FindExistingSystemsWithTask to update this list.

Call the DBus method MountExistingSystemWithTask of the device tree
module to mount an existing system.