### PR TITLE
Add DBus support for teardown tasks

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -80,15 +80,13 @@ def exitHandler(rebootData, storage):
     if anaconda.payload:
         anaconda.payload.unsetup()
 
+    # Unmount the filesystems.
     if not conf.target.is_hardware:
         anaconda.storage.umount_filesystems(swapoff=False)
-        devicetree = anaconda.storage.devicetree
-        devicetree.teardown_all()
-        for imageName in devicetree.disk_images:
-            dev = devicetree.get_device_by_name(imageName)
-            for loop in dev.parents:
-                loop.controllable = True
-            dev.deactivate(recursive=True)
+
+    # Tear down disk images.
+    if conf.target.is_image:
+        anaconda.storage.devicetree.teardown_disk_images()
 
     # Clean up the PID file
     if pidfile:

--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -245,3 +245,10 @@ class KickstartModule(MainModule, KickstartBaseModule):
         :return: a list of DBus paths of the installation tasks
         """
         return []
+
+    def teardown_with_tasks(self):
+        """Returns teardown tasks for this module.
+
+        :return: a list of DBus paths of the installation tasks
+        """
+        return []

--- a/pyanaconda/modules/common/base/base_interface.py
+++ b/pyanaconda/modules/common/base/base_interface.py
@@ -127,9 +127,16 @@ class KickstartModuleInterface(KickstartModuleInterfaceTemplate):
         """Returns installation tasks of this module.
 
         :param sysroot: a path to the root of the installed system
-        :returns: list of object paths of installation tasks.
+        :returns: list of object paths of installation tasks
         """
         return self.implementation.install_with_tasks(sysroot)
+
+    def TeardownWithTasks(self) -> List[ObjPath]:
+        """Returns teardown tasks for this module.
+
+        :returns: list of object paths of installation tasks
+        """
+        return self.implementation.teardown_with_tasks()
 
     def Quit(self):
         """Shut the module down."""

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -44,6 +44,7 @@ from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 from pyanaconda.modules.storage.reset import StorageResetTask
 from pyanaconda.modules.storage.snapshot import SnapshotModule
 from pyanaconda.modules.storage.storage_interface import StorageInterface
+from pyanaconda.modules.storage.teardown import UnmountFilesystemsTask, TeardownDiskImagesTask
 from pyanaconda.modules.storage.zfcp import ZFCPModule
 from pyanaconda.storage.initialization import enable_installer_mode, create_storage
 
@@ -294,7 +295,7 @@ class StorageModule(KickstartModule):
         FIXME: This is a simplified version of the storage installation.
 
         :param sysroot: a path to the root of the installed system
-        :returns: list of object paths of installation tasks.
+        :returns: list of object paths of installation tasks
         """
         storage = self.storage
 
@@ -302,6 +303,24 @@ class StorageModule(KickstartModule):
             ActivateFilesystemsTask(storage),
             MountFilesystemsTask(storage),
             WriteConfigurationTask(storage, sysroot)
+        ]
+
+        paths = [
+            self.publish_task(STORAGE.namespace, task) for task in tasks
+        ]
+
+        return paths
+
+    def teardown_with_tasks(self):
+        """Returns teardown tasks for this module.
+
+        :return: a list of DBus paths of the installation tasks
+        """
+        storage = self.storage
+
+        tasks = [
+            UnmountFilesystemsTask(storage),
+            TeardownDiskImagesTask(storage)
         ]
 
         paths = [

--- a/pyanaconda/modules/storage/teardown.py
+++ b/pyanaconda/modules/storage/teardown.py
@@ -1,0 +1,66 @@
+#
+# Storage teardown.
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.modules.common.task import Task
+
+__all__ = ["UnmountFilesystemsTask", "TeardownDiskImagesTask"]
+
+
+class UnmountFilesystemsTask(Task):
+    """A task for unmounting the filesystems."""
+
+    def __init__(self, storage):
+        """Create a new task."""
+        super().__init__()
+        self._storage = storage
+
+    @property
+    def name(self):
+        return "Unmount filesystems"
+
+    def run(self):
+        """Run the task."""
+        if conf.target.is_hardware:
+            return
+
+        self._storage.umount_filesystems(swapoff=False)
+
+
+class TeardownDiskImagesTask(Task):
+    """A task for teardown of disk images."""
+
+    def __init__(self, storage):
+        """Create a new task.
+
+        :param storage: an instance of Blivet
+        """
+        super().__init__()
+        self._storage = storage
+
+    @property
+    def name(self):
+        return "Tear down disk images"
+
+    def run(self):
+        """Run the task."""
+        if not conf.target.is_image:
+            return
+
+        self._storage.devicetree.teardown_disk_images()

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -48,6 +48,7 @@ from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 from pyanaconda.modules.storage.reset import StorageResetTask
 from pyanaconda.modules.storage.storage import StorageModule
 from pyanaconda.modules.storage.storage_interface import StorageInterface
+from pyanaconda.modules.storage.teardown import UnmountFilesystemsTask, TeardownDiskImagesTask
 from pyanaconda.modules.storage.zfcp import ZFCPModule
 from pyanaconda.modules.storage.zfcp.discover import ZFCPDiscoverTask
 from pyanaconda.modules.storage.zfcp.zfcp_interface import ZFCPInterface
@@ -143,6 +144,29 @@ class StorageInterfaceTestCase(unittest.TestCase):
             task_paths = self.storage_interface.InstallWithTasks(sysroot)
 
         # Check the number of installation tasks.
+        task_number = len(task_classes)
+        self.assertEqual(task_number, len(task_paths))
+        self.assertEqual(task_number, publisher.call_count)
+
+        # Check the tasks.
+        for i in range(task_number):
+            object_path, obj = publisher.call_args_list[i][0]
+            self.assertEqual(object_path, task_paths[i])
+            self.assertIsInstance(obj, TaskInterface)
+            self.assertIsInstance(obj.implementation, task_classes[i])
+
+    @patch('pyanaconda.dbus.DBus.publish_object')
+    def teardown_with_tasks_test(self, publisher):
+        """Test TeardownWithTask."""
+        task_classes = [
+            UnmountFilesystemsTask,
+            TeardownDiskImagesTask
+        ]
+
+        # Get the teardown tasks.
+        task_paths = self.storage_interface.TeardownWithTasks()
+
+        # Check the number of teardown tasks.
         task_number = len(task_classes)
         self.assertEqual(task_number, len(task_paths))
         self.assertEqual(task_number, publisher.call_count)


### PR DESCRIPTION
We set up the disk images with `setup_disk_images` of the device tree
instance, so we should call `teardown_disk_images` to tear them down.

Call the DBus method `TeardownWithTasks` of the Storage module before
the module shutdown.