### PR TITLE
Add DBus support for populating a device tree

### DIFF
--- a/pyanaconda/modules/storage/devicetree/handler.py
+++ b/pyanaconda/modules/storage/devicetree/handler.py
@@ -24,6 +24,7 @@ from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.constants.interfaces import DEVICE_TREE_HANDLER
 from pyanaconda.modules.common.errors.storage import UnknownDeviceError
 from pyanaconda.modules.common.task import TaskInterface
+from pyanaconda.modules.storage.devicetree.populate import FindDevicesTask
 from pyanaconda.modules.storage.devicetree.rescue import FindExistingSystemsTask, \
     MountExistingSystemTask
 from pyanaconda.storage.utils import find_optical_media, find_mountable_partitions, unlock_device
@@ -110,6 +111,17 @@ class DeviceTreeHandler(ABC):
         """
         device = self._get_device(device_name)
         return unlock_device(self.storage, device, passphrase)
+
+    def find_devices_with_task(self):
+        """Find new devices.
+
+        The task will populate the device tree with new devices.
+
+        :return: a path to the task
+        """
+        task = FindDevicesTask(self.storage.devicetree)
+        path = self.publish_task(DEVICE_TREE_HANDLER.namespace, task)
+        return path
 
     def find_optical_media(self):
         """Find all devices with mountable optical media.

--- a/pyanaconda/modules/storage/devicetree/handler_interface.py
+++ b/pyanaconda/modules/storage/devicetree/handler_interface.py
@@ -68,6 +68,15 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
         """
         return self.implementation.unlock_device(device_name, passphrase)
 
+    def FindDevicesWithTask(self) -> ObjPath:
+        """Find new devices.
+
+        The task will populate the device tree with new devices.
+
+        :return: a path to the task
+        """
+        return self.implementation.find_devices_with_task()
+
     def FindOpticalMedia(self) -> List[Str]:
         """Find all devices with mountable optical media.
 

--- a/pyanaconda/modules/storage/devicetree/populate.py
+++ b/pyanaconda/modules/storage/devicetree/populate.py
@@ -1,0 +1,42 @@
+#
+# Populate tasks
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.modules.common.task import Task
+
+__all__ = ["FindDevicesTask"]
+
+
+class FindDevicesTask(Task):
+    """A task to find new devices."""
+
+    def __init__(self, devicetree):
+        """Create a new task.
+
+        :param devicetree: a device tree to populate
+        """
+        super().__init__()
+        self._devicetree = devicetree
+
+    @property
+    def name(self):
+        return "Find devices"
+
+    def run(self):
+        """Run the task."""
+        self._devicetree.populate()


### PR DESCRIPTION
Call the DBus method `FindDevicesWithTask` of the device tree module
to populate the device tree with new devices.