### PR TITLE
Initial Setup and post install tool configuration improvements and fixes

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -739,14 +739,14 @@ if __name__ == "__main__":
 
     # Finish the initialization of the setup on boot action.
     # This should be done sooner and somewhere else once it is possible.
-    from pyanaconda.core.constants import SETUP_ON_BOOT_DEFAULT, SETUP_ON_BOOT_DISABLED
+    from pyanaconda.core.constants import SETUP_ON_BOOT_DEFAULT, SETUP_ON_BOOT_ENABLED
     from pyanaconda.modules.common.constants.services import SERVICES
     services_proxy = SERVICES.get_proxy()
 
     if services_proxy.SetupOnBoot == SETUP_ON_BOOT_DEFAULT:
-        if flags.automatedInstall:
-            # Disable by default after kickstart installations.
-            services_proxy.SetSetupOnBoot(SETUP_ON_BOOT_DISABLED)
+        if  not flags.automatedInstall:
+            # Enable by default for interactive installations.
+            services_proxy.SetSetupOnBoot(SETUP_ON_BOOT_ENABLED)
 
     # Create pre-install snapshots
     from pykickstart.constants import SNAPSHOT_WHEN_PRE_INSTALL

--- a/pyanaconda/modules/services/services_interface.py
+++ b/pyanaconda/modules/services/services_interface.py
@@ -37,6 +37,7 @@ class ServicesInterface(KickstartModuleInterface):
         self.implementation.default_target_changed.connect(self.changed("DefaultTarget"))
         self.implementation.default_desktop_changed.connect(self.changed("DefaultDesktop"))
         self.implementation.setup_on_boot_changed.connect(self.changed("SetupOnBoot"))
+        self.implementation.post_install_tools_enabled_changed.connect(self.changed("PostInstallToolsEnabled"))
 
     @property
     def DisabledServices(self) -> List[Str]:
@@ -127,3 +128,29 @@ class ServicesInterface(KickstartModuleInterface):
         :param value: a number of the action
         """
         self.implementation.set_setup_on_boot(SetupOnBootAction(value))
+
+    @property
+    def PostInstallToolsEnabled(self) -> Bool:
+        """Disable post installation setup tools.
+
+        This option tells post installation tools
+        if they should start after the installation.
+
+        :return: True to start post install tools, False otherwise
+        :rtype: bool
+        """
+        return self.implementation.post_install_tools_enabled
+
+    @emits_properties_changed
+    def SetPostInstallToolsEnabled(self, post_install_tools_enabled: Bool):
+        """Set if post installation tools should be disabled.
+
+        Setting this value to False will result in the post_install_tools_disabled
+        key being written to the user interaction config file with the value of 1.
+
+        Setting this value to True (the default value) will not result in the
+        post_install_tools_disabled key being written into th user interaction config file.
+
+        :param post_install_tools_enabled: set to False to disable post installation tools
+        """
+        self.implementation.set_post_install_tools_enabled(post_install_tools_enabled)

--- a/pyanaconda/screen_access.py
+++ b/pyanaconda/screen_access.py
@@ -42,7 +42,6 @@ from threading import RLock
 from pyanaconda import startup_utils
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.constants import SETUP_ON_BOOT_DISABLED
 from pyanaconda.modules.common.constants.services import SERVICES
 
 
@@ -248,7 +247,7 @@ class ScreenAccessManager(object):
         file is written out to the target system.
         """
         services_proxy = SERVICES.get_proxy()
-        if services_proxy.SetupOnBoot == SETUP_ON_BOOT_DISABLED:
+        if not services_proxy.PostInstallToolsEnabled:
             self.post_install_tools_disabled = True
 
 sam = None

--- a/tests/nosetests/pyanaconda_tests/module_services_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_services_test.py
@@ -88,6 +88,23 @@ class ServicesInterfaceTestCase(unittest.TestCase):
             SERVICES.interface_name, {'SetupOnBoot': SETUP_ON_BOOT_DISABLED}, []
         )
 
+    def post_install_tools_disabled_test(self):
+        """Test the post-install-tools-enabled property."""
+        # should not be marked as disabled by default
+        self.assertEqual(self.services_interface.PostInstallToolsEnabled, True)
+        # mark as disabled
+        self.services_interface.SetPostInstallToolsEnabled(False)
+        self.assertEqual(self.services_interface.PostInstallToolsEnabled, False)
+        self.callback.assert_called_once_with(
+            SERVICES.interface_name, {'PostInstallToolsEnabled': False}, []
+        )
+        # mark as not disabled again
+        self.services_interface.SetPostInstallToolsEnabled(True)
+        self.assertEqual(self.services_interface.PostInstallToolsEnabled, True)
+        self.callback.assert_called_with(
+            SERVICES.interface_name, {'PostInstallToolsEnabled': True}, []
+        )
+
     def _test_kickstart(self, ks_in, ks_out):
         check_kickstart_interface(self, self.services_interface, ks_in, ks_out)
 
@@ -97,6 +114,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         ks_out = ""
         self._test_kickstart(ks_in, ks_out)
         self.assertEqual(self.services_interface.SetupOnBoot, SETUP_ON_BOOT_DEFAULT)
+        self.assertEqual(self.services_interface.PostInstallToolsEnabled, True)
 
     def kickstart_empty_test(self):
         """Test with empty string."""
@@ -104,6 +122,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         ks_out = ""
         self._test_kickstart(ks_in, ks_out)
         self.assertEqual(self.services_interface.SetupOnBoot, SETUP_ON_BOOT_DEFAULT)
+        self.assertEqual(self.services_interface.PostInstallToolsEnabled, True)
 
     def services_kickstart_test(self):
         """Test the services command."""
@@ -148,6 +167,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         """
         self._test_kickstart(ks_in, ks_out)
         self.assertEqual(self.services_interface.SetupOnBoot, SETUP_ON_BOOT_DISABLED)
+        self.assertEqual(self.services_interface.PostInstallToolsEnabled, False)
 
     def firstboot_enabled_kickstart_test(self):
         """Test the firstboot command - enabled."""
@@ -160,6 +180,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         """
         self._test_kickstart(ks_in, ks_out)
         self.assertEqual(self.services_interface.SetupOnBoot, SETUP_ON_BOOT_ENABLED)
+        self.assertEqual(self.services_interface.PostInstallToolsEnabled, True)
 
     def firstboot_reconfig_kickstart_test(self):
         """Test the firstboot command - reconfig."""
@@ -172,3 +193,4 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         """
         self._test_kickstart(ks_in, ks_out)
         self.assertEqual(self.services_interface.SetupOnBoot, SETUP_ON_BOOT_RECONFIG)
+        self.assertEqual(self.services_interface.PostInstallToolsEnabled, True)


### PR DESCRIPTION
This pull request contains various fixes and improvements for Initial Setup & post install tool configuration in general.

The first commit adds a separate property that controls if all post installation tools (that read the config file we create) will be disabled or not. This makes it explicit if what will happen and makes it possible to control this option not only via kickstart, but also over DBus. The next commit makes use of this property when updating the user interaction config file, which hosts the actual `post_install_tools_disabled` key.

The third commit switches the default for Initial Setup to be disabled by default, dropping a bogus `firstboot --disable` from the output kickstart of every kickstart installation that has no `firstboot` command in its input kickstart.

And the last commit forwards the sysroot path to service enable/disable method invocations, that we apparently forgot to apply a while ago.
