### PR TITLE
Require langtable-0.0.44, drop langtable-data requirement

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -28,7 +28,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define gtk3ver 3.22.17
 %define helpver 22.1-1
 %define isomd5sum 1.0.10
-%define langtablever 0.0.34
+%define langtablever 0.0.44
 %define libarchivever 3.0.4
 %define libblockdevver 2.1
 %define libtimezonemapver 0.4.1-2
@@ -92,8 +92,7 @@ Requires: python3-requests
 Requires: python3-requests-file
 Requires: python3-requests-ftp
 Requires: python3-kickstart >= %{pykickstartver}
-Requires: langtable-data >= %{langtablever}
-Requires: langtable-python3 >= %{langtablever}
+Requires: python3-langtable >= %{langtablever}
 Requires: util-linux >= %{utillinuxver}
 Requires: python3-gobject-base
 Requires: python3-dbus


### PR DESCRIPTION
langtable >= 0.0.44 does not have the langtable-data subpackage
anymore, the *.xml.gz files are now contained in the python3-langtable package.