### PR TITLE
Migrate payload requirements

### DIFF
--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -109,3 +109,8 @@ DNF_PACKAGES = DBusObjectIdentifier(
     namespace=DNF_NAMESPACE,
     basename="Packages"
 )
+
+REQUIREMENTS = DBusObjectIdentifier(
+    namespace=PAYLOAD_NAMESPACE,
+    basename="Requirements"
+)

--- a/pyanaconda/modules/common/structures/payload.py
+++ b/pyanaconda/modules/common/structures/payload.py
@@ -1,0 +1,88 @@
+#
+# DBus structures for the payload data.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.dbus.structure import DBusData
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
+
+
+class Requirement(DBusData):
+    """An object to store a payload requirement with info about its reasons.
+
+    For each requirement multiple reasons together with their strength
+    can be stored in this object using the add_reason method.
+    A reason should be just a string with description (ie for tracking purposes).
+    Strength is a boolean flag that can be used to indicate whether missing the
+    requirement should be considered fatal. Strength of the requirement is
+    given by strength of all its reasons.
+    """
+    def __init__(self):
+        self._id = None
+        self._reasons = []
+        self._strong = False
+
+    @property
+    def id(self) -> Str:
+        """Identifier of the requirement (eg. a package name)"""
+        return self._id
+
+    @id.setter
+    def id(self, req_id: Str):
+        """Set identifier of the requirement (eg. a package name)"""
+        self._id = req_id
+
+    @property
+    def reasons(self) -> List[Str]:
+        """List of reasons for the requirement"""
+        return self._reasons
+
+    @reasons.setter
+    def reasons(self, reasons: List[Str]):
+        """Set list of reasons for this requirement"""
+        self._reasons = reasons
+
+    @property
+    def strong(self) -> Bool:
+        """Strength of the requirement (ie. should it be considered fatal?)"""
+        return self._strong
+
+    @strong.setter
+    def strong(self, strong: Bool):
+        """Set strength of the requirement (ie. should it be considered fatal?)"""
+        self._strong = strong
+
+    def add_reason(self, reason, strong=False):
+        """Adds a reason to the requirement with optional strength of the reason
+
+        :param reason: add a new reason for this requirement
+        :type reason: string
+        :param strong: set if this reason is a strong requirement
+        :type strong: bool
+        """
+        if not self._strong and strong:
+            self._strong = True
+
+        self._reasons.append(reason)
+
+    def __str__(self):
+        return "PayloadRequirement(id=%s, reasons=%s, strong=%s)" % (self.id,
+                                                                     self.reasons,
+                                                                     self.strong)
+
+    def __repr__(self):
+        return 'PayloadRequirement(id=%s, reasons=%s)' % (self.id, self._reasons)

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -23,6 +23,7 @@ from pyanaconda.modules.common.constants.services import PAYLOAD
 from pyanaconda.modules.payload.kickstart import PayloadKickstartSpecification
 from pyanaconda.modules.payload.payload_interface import PayloadInterface
 from pyanaconda.modules.payload.dnf.dnf import DNFHandlerModule
+from pyanaconda.modules.payload.requirements import RequirementsModule
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -34,10 +35,12 @@ class PayloadModule(KickstartModule):
     def __init__(self):
         super().__init__()
         self._payload_handler = DNFHandlerModule()
+        self._requirements_module = RequirementsModule()
 
     def publish(self):
         """Publish the module."""
         self._payload_handler.publish()
+        self._requirements_module.publish()
 
         DBus.publish_object(PAYLOAD.object_path, PayloadInterface(self))
         DBus.register_service(PAYLOAD.service_name)

--- a/pyanaconda/modules/payload/requirements.py
+++ b/pyanaconda/modules/payload/requirements.py
@@ -1,0 +1,38 @@
+#
+# Module for Payload requirements.
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.dbus import DBus
+from pyanaconda.modules.common.base import BaseModule
+from pyanaconda.modules.common.constants.objects import REQUIREMENTS
+from pyanaconda.modules.payload.requirements_interface import RequirementsInterface
+
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+
+class RequirementsModule(BaseModule):
+    """The payload requirements module."""
+
+    def __init__(self):
+        super().__init__()
+
+    def publish(self):
+        """Publish the module."""
+        DBus.publish_object(REQUIREMENTS.object_path, RequirementsInterface(self))

--- a/pyanaconda/modules/payload/requirements.py
+++ b/pyanaconda/modules/payload/requirements.py
@@ -17,6 +17,10 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from collections import OrderedDict, namedtuple
+
+from pyanaconda.core.constants import PayloadRequirementType
+from pyanaconda.payload.errors import PayloadRequirementsMissingApply
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.base import BaseModule
 from pyanaconda.modules.common.constants.objects import REQUIREMENTS
@@ -26,13 +30,181 @@ from pyanaconda.modules.payload.requirements_interface import RequirementsInterf
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
+PayloadRequirementReason = namedtuple('PayloadRequirementReason', ['reason', 'strong'])
+
 
 class RequirementsModule(BaseModule):
-    """The payload requirements module."""
+    """The payload requirements module.
+
+    Stores names of packages and groups required by used installer features,
+    together with descriptions of reasons why the object is required and if the
+    requirement is strong. Not satisfying strong requirement would be fatal for
+    installation.
+    """
 
     def __init__(self):
         super().__init__()
+        self._apply_called_for_all_requirements = True
+        self._apply_cb = None
+        self._reqs = {}
+        for req_type in PayloadRequirementType:
+            self._reqs[req_type] = OrderedDict()
 
     def publish(self):
         """Publish the module."""
         DBus.publish_object(REQUIREMENTS.object_path, RequirementsInterface(self))
+
+    def add_packages(self, package_names, reason, strong=True):
+        """Add packages required for the reason.
+
+        If a package is already required, the new reason will be
+        added and the strength of the requirement will be updated.
+
+        :param package_names: names of packages to be added
+        :type package_names: list of str
+        :param reason: description of reason for adding the packages
+        :type reason: str
+        :param strong: is the requirement strong (ie is not satisfying it fatal?)
+        :type strong: bool
+        """
+        self._add(PayloadRequirementType.package, package_names, reason, strong)
+
+    def add_groups(self, group_ids, reason, strong=True):
+        """Add groups required for the reason.
+
+        If a group is already required, the new reason will be
+        added and the strength of the requirement will be updated.
+
+        :param group_ids: ids of groups to be added
+        :type group_ids: list of str
+        :param reason: descripiton of reason for adding the groups
+        :type reason: str
+        :param strong: is the requirement strong
+        :type strong: bool
+        """
+        self._add(PayloadRequirementType.group, group_ids, reason, strong)
+
+    def _add(self, req_type, ids, reason, strong):
+        if not ids:
+            log.debug("no %s requirement added for %s", req_type.value, reason)
+        reqs = self._reqs[req_type]
+        for r_id in ids:
+            if r_id not in reqs:
+                reqs[r_id] = PayloadRequirement(r_id)
+            reqs[r_id].add_reason(reason, strong)
+            self._apply_called_for_all_requirements = False
+            log.debug("added %s requirement '%s' for %s, strong=%s",
+                      req_type.value, r_id, reason, strong)
+
+    @property
+    def packages(self):
+        """List of package requirements.
+
+        return: list of package requirements
+        rtype: list of PayloadRequirement
+        """
+        return list(self._reqs[PayloadRequirementType.package].values())
+
+    @property
+    def groups(self):
+        """List of group requirements.
+
+        return: list of group requirements
+        rtype: list of PayloadRequirement
+        """
+        return list(self._reqs[PayloadRequirementType.group].values())
+
+    def set_apply_callback(self, callback):
+        """Set the callback for applying requirements.
+
+        The callback will be called by apply() method.
+        param callback: callback function to be called by apply() method
+        type callback: a function taking one argument (requirements object)
+        """
+        self._apply_cb = callback
+
+    def apply(self):
+        """Apply requirements using callback function.
+
+        Calls the callback supplied via set_apply_callback() method. If no
+        callback was set, an axception is raised.
+
+        return: return value of the callback
+        rtype: type of the callback return value
+        raise PayloadRequirementsMissingApply: if there is no callback set
+
+        """
+        if self._apply_cb:
+            self._apply_called_for_all_requirements = True
+            rv = self._apply_cb(self)
+            log.debug("apply with result %s called on requirements %s", rv, self)
+            return rv
+        else:
+            raise PayloadRequirementsMissingApply
+
+    @property
+    def applied(self):
+        """Was all requirements applied?
+
+        return: Was apply called for all current requirements?
+        rtype: bool
+        """
+        return self.empty or self._apply_called_for_all_requirements
+
+    @property
+    def empty(self):
+        """Are requirements empty?
+
+        return: True if there are no requirements, else False
+        rtype: bool
+        """
+        return not any(self._reqs.values())
+
+    def __str__(self):
+        r = []
+        for req_type in PayloadRequirementType:
+            for rid, req in self._reqs[req_type].items():
+                r.append((req_type.value, rid, req))
+        return str(r)
+
+
+class PayloadRequirement(object):
+    """An object to store a payload requirement with info about its reasons.
+
+    For each requirement multiple reasons together with their strength
+    can be stored in this object using the add_reason method.
+    A reason should be just a string with description (ie for tracking purposes).
+    Strength is a boolean flag that can be used to indicate whether missing the
+    requirement should be considered fatal. Strength of the requirement is
+    given by strength of all its reasons.
+    """
+    def __init__(self, req_id, reasons=None):
+        self._id = req_id
+        self._reasons = reasons or []
+
+    @property
+    def id(self):
+        """Identifier of the requirement (eg a package name)"""
+        return self._id
+
+    @property
+    def reasons(self):
+        """List of reasons for the requirement"""
+        return [reason for reason, strong in self._reasons]
+
+    @property
+    def strong(self):
+        """Strength of the requirement (ie should it be considered fatal?)"""
+        return any(strong for reason, strong in self._reasons)
+
+    def add_reason(self, reason, strong=False):
+        """Adds a reason to the requirement with optional strength of the reason"""
+        self._reasons.append(PayloadRequirementReason(reason, strong))
+
+    def __str__(self):
+        return "PayloadRequirement(id=%s, reasons=%s, strong=%s)" % (self.id,
+                                                                     self.reasons,
+                                                                     self.strong)
+
+    def __repr__(self):
+        return 'PayloadRequirement(id=%s, reasons=%s)' % (self.id, self._reasons)

--- a/pyanaconda/modules/payload/requirements_interface.py
+++ b/pyanaconda/modules/payload/requirements_interface.py
@@ -19,11 +19,65 @@
 #
 
 from pyanaconda.dbus.interface import dbus_interface
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
 from pyanaconda.modules.common.constants.objects import REQUIREMENTS
 from pyanaconda.modules.common.base import ModuleInterfaceTemplate
+from pyanaconda.modules.common.structures.payload import Requirement
 
 
 @dbus_interface(REQUIREMENTS.interface_name)
 class RequirementsInterface(ModuleInterfaceTemplate):
     """DBus interface for Requirements payload module."""
+
+    def AddPackages(self, package_ids: List[Str], reason: Str, strong: Bool):
+        """Add packages required for the reason.
+
+        If a package is already required, the new reason will be
+        added and the strength of the requirement will be updated.
+
+        :param package_ids: names of packages to be added
+        :param reason: description of reason for adding the packages
+        :param strong: is the requirement strong (ie is not satisfying it fatal?)
+        """
+        self.implementation.add_packages(package_ids, reason, strong)
+
+    def AddGroups(self, group_ids: List[Str], reason: Str, strong: Bool):
+        """Add groups required for the reason.
+
+        If a group is already required, the new reason will be
+        added and the strength of the requirement will be updated.
+
+        :param group_ids: ids of groups to be added
+        :param reason: descripiton of reason for adding the groups
+        :param strong: is the requirement strong
+        """
+        self.implementation.add_groups(group_ids, reason, strong)
+
+    @property
+    def Packages(self) -> List[Structure]:
+        """List of package requirements.
+
+        return: list of package requirements
+        rtype: list of Requirement
+        """
+        requirements = self.implementation.packages
+        return Requirement.to_structure_list(requirements)
+
+    @property
+    def Groups(self) -> List[Structure]:
+        """List of group requirements.
+
+        return: list of group requirements
+        rtype: list of Requirement
+        """
+        requirements = self.implementation.groups
+        return Requirement.to_structure_list(requirements)
+
+    @property
+    def Empty(self) -> Bool:
+        """Are requirements empty?
+
+        return: True if there are no requirements, else False
+        """
+        return self.implementation.empty

--- a/pyanaconda/modules/payload/requirements_interface.py
+++ b/pyanaconda/modules/payload/requirements_interface.py
@@ -1,0 +1,29 @@
+#
+# DBus interface for Payload requirements.
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from pyanaconda.dbus.interface import dbus_interface
+
+from pyanaconda.modules.common.constants.objects import REQUIREMENTS
+from pyanaconda.modules.common.base import ModuleInterfaceTemplate
+
+
+@dbus_interface(REQUIREMENTS.interface_name)
+class RequirementsInterface(ModuleInterfaceTemplate):
+    """DBus interface for Requirements payload module."""


### PR DESCRIPTION
**WIP - do not merge**
This is not working version of the PR so please bear that in mind. I will update it when fixing these issues. The PR is created mainly to show the structure of the module and start a discussion about possible changes.

* Migrate ``payload/requirement.py`` new ``Payload/Requirements`` module. 
* Add new Requirement DBus structure.

This module will collect groups and packages requirements during the installation and then they will be used by the payload module in the future changes. Now it will be used instead of the old solution.

There are a few differences between the old solution and the new one:
- `Strong` value is only one value for the whole Requirement structure.
  Reasoning for this is that this was the only use case. The `strong` property looked on all the reasons and if any was `True` it returned `True`. This is a code simplification so we don't have to store named tuple and the functionality stays the same.  
- The set_callback and call it later was removed. 
  There is not much a reason and it is not trivial to migrate that to DBus structure. The only caller and also who sets the callback is the dnf payload so why complicate things. New planning solution is that the payload will have a responsibility to collect all the requirements without itself (which is doing now so or so).