### PR TITLE
Change the path to the system root

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -40,6 +40,8 @@ type = HARDWARE
 # A path to the physical root of the target.
 physical_root = /mnt/sysimage
 
+# A path to the system root of the target.
+system_root = /mnt/sysroot
 
 [Network]
 # Network device to be activated on boot if none was configured so.

--- a/pyanaconda/core/configuration/target.py
+++ b/pyanaconda/core/configuration/target.py
@@ -43,6 +43,11 @@ class TargetSection(Section):
         return self._get_option("physical_root")
 
     @property
+    def system_root(self):
+        """A path to the system root of the target."""
+        return self._get_option("system_root")
+
+    @property
     def is_hardware(self):
         """Are we installing on hardware?"""
         return self.type is TargetType.HARDWARE

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -421,12 +421,21 @@ class InstallerStorage(Blivet):
     def turn_on_swap(self):
         self.fsset.turn_on_swap(root_path=util.getSysroot())
 
-    def mount_filesystems(self, read_only=None, skip_root=False):
-        self.fsset.mount_filesystems(root_path=util.getSysroot(),
-                                     read_only=read_only, skip_root=skip_root)
+    def mount_filesystems(self):
+        root_path = util.getTargetPhysicalRoot()
+
+        # Mount the root and the filesystems.
+        self.fsset.mount_filesystems(root_path=root_path)
+
+        # Set up the sysroot.
+        util.setSysroot(root_path)
 
     def umount_filesystems(self, swapoff=True):
+        # Unmount the root and the filesystems.
         self.fsset.umount_filesystems(swapoff=swapoff)
+
+        # Unmount the sysroot.
+        util.setSysroot(None)
 
     def parse_fstab(self, chroot=None):
         self.fsset.parse_fstab(chroot=chroot)

--- a/pyanaconda/ui/lib/space.py
+++ b/pyanaconda/ui/lib/space.py
@@ -114,7 +114,7 @@ class DirInstallSpaceChecker(FileSystemSpaceChecker):
 
     def _calculate_free_space(self):
         """Calculate the available space."""
-        stat = os.statvfs(util.getSysroot())
+        stat = os.statvfs(util.getTargetPhysicalRoot())
         return Size(stat.f_bsize * stat.f_bfree)
 
     def _calculate_deficit(self, needed):

--- a/tests/nosetests/pyanaconda_tests/iutil_test.py
+++ b/tests/nosetests/pyanaconda_tests/iutil_test.py
@@ -826,15 +826,7 @@ class MiscTests(unittest.TestCase):
 
     def sysroot_test(self):
         self.assertEqual(util.getTargetPhysicalRoot(), "/mnt/sysimage")
-        self.assertEqual(util.getSysroot(), "/mnt/sysimage")
-
-        util.setSysroot("/what/ever")
-        self.assertEqual(util.getTargetPhysicalRoot(), "/mnt/sysimage")
-        self.assertEqual(util.getSysroot(), "/what/ever")
-
-        util.setSysroot(None)
-        self.assertEqual(util.getTargetPhysicalRoot(), "/mnt/sysimage")
-        self.assertEqual(util.getSysroot(), "/mnt/sysimage")
+        self.assertEqual(util.getSysroot(), "/mnt/sysroot")
 
     def decode_bytes_test(self):
         self.assertEqual("STRING", util.decode_bytes("STRING"))

--- a/tests/nosetests/pyanaconda_tests/payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/payload_test.py
@@ -24,6 +24,7 @@ import os
 import hashlib
 import shutil
 
+from pyanaconda.core.util import getSysroot
 from pyanaconda.payload import dnfpayload
 from blivet.size import Size
 
@@ -35,15 +36,15 @@ from pyanaconda.payload.errors import PayloadRequirementsMissingApply
 class PickLocation(unittest.TestCase):
     def pick_download_location_test(self):
         """Take the biggest mountpoint which can be used for download"""
-        df_map = {"/mnt/sysimage/not_used" : Size("20 G"),
-                  "/mnt/sysimage/home"     : Size("2 G"),
-                  "/mnt/sysimage/"         : Size("5 G")}
+        df_map = {os.path.join(getSysroot(), "not_used"): Size("20 G"),
+                  os.path.join(getSysroot(), "home"): Size("2 G"),
+                  os.path.join(getSysroot()): Size("5 G")}
         download_size = Size("1.5 G")
         install_size = Size("1.8 G")
 
         mpoint = dnfpayload._pick_mpoint(df_map, download_size, install_size, True)
 
-        self.assertEqual(mpoint, "/mnt/sysimage/home")
+        self.assertEqual(mpoint, os.path.join(getSysroot(), "home"))
 
     def pick_download_root_test(self):
         """Take the root for download because there are no other available mountpoints
@@ -51,33 +52,33 @@ class PickLocation(unittest.TestCase):
 
            This is required when user skipped the space check.
         """
-        df_map = {"/mnt/sysimage/not_used" : Size("20 G"),
-                  "/mnt/sysimage/home"     : Size("2 G"),
-                  "/mnt/sysimage"         : Size("5 G")}
+        df_map = {os.path.join(getSysroot(), "not_used"): Size("20 G"),
+                  os.path.join(getSysroot(), "home"): Size("2 G"),
+                  os.path.join(getSysroot()): Size("5 G")}
         download_size = Size("2.5 G")
         install_size = Size("3.0 G")
 
         mpoint = dnfpayload._pick_mpoint(df_map, download_size, install_size, True)
 
-        self.assertEqual(mpoint, "/mnt/sysimage")
+        self.assertEqual(mpoint, os.path.join(getSysroot()))
 
     def pick_install_location_test(self):
         """Take the root for download and install."""
-        df_map = {"/mnt/sysimage/not_used" : Size("20 G"),
-                  "/mnt/sysimage/home"     : Size("2 G"),
-                  "/mnt/sysimage"         : Size("6 G")}
+        df_map = {os.path.join(getSysroot(), "not_used"): Size("20 G"),
+                  os.path.join(getSysroot(), "home"): Size("2 G"),
+                  os.path.join(getSysroot()): Size("6 G")}
         download_size = Size("1.5 G")
         install_size = Size("3.0 G")
 
         mpoint = dnfpayload._pick_mpoint(df_map, download_size, install_size, False)
 
-        self.assertEqual(mpoint, "/mnt/sysimage")
+        self.assertEqual(mpoint, getSysroot())
 
     def pick_install_location_error_test(self):
         """No suitable location is found."""
-        df_map = {"/mnt/sysimage/not_used" : Size("20 G"),
-                  "/mnt/sysimage/home"     : Size("1 G"),
-                  "/mnt/sysimage"         : Size("4 G")}
+        df_map = {os.path.join(getSysroot(), "not_used"): Size("20 G"),
+                  os.path.join(getSysroot(), "home"): Size("1 G"),
+                  os.path.join(getSysroot()): Size("4 G")}
         download_size = Size("1.5 G")
         install_size = Size("3.0 G")
 


### PR DESCRIPTION
The physical root of the installed system will stay mounted at
/mnt/sysimage. However, the system root of the installed system
will be always mounted at /mnt/sysroot now.

These paths are defined by the Anaconda configuration and cannot
be changed during the installation. The function setSysroot only
remounts the given system root to /mnt/sysroot.

This will simplify communication with the DBus modules, because we
don't have to inform them about the current path to the system root
anymore. It is safe to use getSysroot in the modules now.

**TODO:**
* ~~Test hardware installation with DNF payload~~
* ~~Test hardware installation with RPM OSTree~~
* ~~Test live installation~~
* ~~Test the rescue mode~~
* ~~Test image installation~~
* ~~Test dir installation~~
* ~~Test dir installation in a mock environment~~
* ~~Run livemedia-creator~~
* ~~Run initial setup~~
* ~~Run kickstart tests~~