### PR TITLE
Replace the lang execute() method

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -423,12 +423,6 @@ class Lang(RemovedCommand):
         localization_proxy = LOCALIZATION.get_proxy()
         return localization_proxy.GenerateKickstart()
 
-    def execute(self):
-        localization_proxy = LOCALIZATION.get_proxy()
-        task_path = localization_proxy.InstallLanguageWithTask(util.getSysroot())
-        task_proxy = LOCALIZATION.get_proxy(task_path)
-        sync_run_task(task_proxy)
-
 # no overrides needed here
 Eula = COMMANDS.Eula
 

--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -136,18 +136,6 @@ class LocalizationModule(KickstartModule):
         self.language_seen_changed.emit()
         log.debug("Language seen set to %s.", seen)
 
-    def install_language_with_task(self, sysroot):
-        """Install language with an installation task.
-
-        FIXME: This is just a temporary method.
-
-        :param sysroot: a path to the root of the installed system
-        :return: a DBus path of an installation task
-        """
-        task = LanguageInstallationTask(sysroot, self.language)
-        path = self.publish_task(LOCALIZATION.namespace, task)
-        return path
-
     @property
     def keyboard(self):
         """Return keyboard."""
@@ -202,3 +190,19 @@ class LocalizationModule(KickstartModule):
         self._keyboard_seen = keyboard_seen
         self.keyboard_seen_changed.emit()
         log.debug("keyboard command considered seen in kicksatart: %s.", keyboard_seen)
+
+    def install_with_tasks(self, sysroot):
+        """Return the installation tasks of this module.
+
+        :param str sysroot: a path to the root of the installed system
+        :returns: list of object paths of installation tasks
+        """
+        tasks = [
+            LanguageInstallationTask(sysroot=sysroot, lang=self.language)
+        ]
+
+        paths = [
+            self.publish_task(LOCALIZATION.namespace, task) for task in tasks
+        ]
+
+        return paths

--- a/pyanaconda/modules/localization/localization_interface.py
+++ b/pyanaconda/modules/localization/localization_interface.py
@@ -60,16 +60,6 @@ class LocalizationInterface(KickstartModuleInterface):
         """
         self.implementation.set_language(language)
 
-    def InstallLanguageWithTask(self, sysroot: Str) -> ObjPath:
-        """Install language with an installation task.
-
-        FIXME: This is just a temporary method.
-
-        :param sysroot: a path to the root of the installed system
-        :return: a DBus path of an installation task
-        """
-        return self.implementation.install_language_with_task(sysroot)
-
     @property
     def LanguageSupport(self) -> List[Str]:
         """Supported languages on the system."""

--- a/tests/nosetests/pyanaconda_tests/module_localization_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_localization_test.py
@@ -132,7 +132,7 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
     def install_language_with_task_test(self, publisher):
         """Test InstallLanguageWithTask."""
         self.localization_interface.SetLanguage("cs_CZ.UTF-8")
-        task_path = self.localization_interface.InstallLanguageWithTask("/")
+        task_path = self.localization_interface.InstallWithTasks("/")[0]
 
         publisher.assert_called_once()
         object_path, obj = publisher.call_args[0]


### PR DESCRIPTION
We actually already have a DBus task for this, but it's called in a
rather antiquated manner. So let's switch it to that standardized
install_with_tasks() interface and run the task from installation.py
so that we can drop the execute() method.