### PR TITLE
Rename zanata rhel-devel version

### DIFF
--- a/zanata.xml
+++ b/zanata.xml
@@ -2,7 +2,7 @@
 <config xmlns="http://zanata.org/namespace/config/">
   <url>https://fedora.zanata.org/</url>
   <project>anaconda</project>
-  <project-version>rhel-devel</project-version>
+  <project-version>rhel-8</project-version>
   <project-type>gettext</project-type>
 
 </config>


### PR DESCRIPTION
We will be using rhel-8, the same name as the anaconda branch has.

Related: rhbz#1666319