### PR TITLE
Initialize DNF plugins (#1717016)

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -666,6 +666,9 @@ class DNFPayload(payload.PackagePayload):
         conf.logdir = '/tmp/'
         # enable depsolver debugging if in debug mode
         self._base.conf.debug_solver = flags.debug
+        # REMOVE BEFORE MERGE
+        # - temporarily increse DNF debug level
+        self._base.conf.debuglevel = 10
         # set the platform id based on the /os/release
         # present in the installation environment
         platform_id = self.get_platform_id()
@@ -712,6 +715,9 @@ class DNFPayload(payload.PackagePayload):
         # Do this here to prevent import side-effects in anaconda_logging
         dnf_logger = get_dnf_logger()
         dnf_logger.setLevel(dnf.logging.DDEBUG)
+
+        # initialize plugins
+        self._base.init_plugins()
 
         log.debug("Dnf configuration:\n%s", conf.dump())
 


### PR DESCRIPTION
For the upcoming support for swid tag handling during the
installation RPM transaction the swidtags DNF plugin needs to run.

As Anaconda uses DNF via its Python API, DNF plugins are not
loaded by default unless init_plugins() is called on the DNF
Base class instance.

So call init_plugins() at appropriate time so that DNF
plugins, including the swidtags plugin, are properly
loaded.

Resolves: rhbz#1717016

NOTE - PROTOTYPE, NOT MERGEABLE YET

there are a couple things that need to be done/checked before this PR can be merged:
- the DNF debug level override should be dropped
- `init_plugins()` currently enables **all** plugins DNF can find, regardless if the plugins are useful or even suitable for the installation environment, we should proably either filter what plugins are enabled or at least check all the plugins not cause detectable issues