### PR TITLE
Fix setting and reporting ready state in Source Spoke.

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -817,6 +817,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
 
     def _payload_finished(self):
         hubQ.send_ready("SoftwareSelectionSpoke", False)
+        self._ready = True
         hubQ.send_ready(self.__class__.__name__, False)
 
     def _payload_error(self):
@@ -830,6 +831,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         if self.payload.verbose_errors:
             self._error_msg += _(CLICK_FOR_DETAILS)
 
+        self._ready = True
         hubQ.send_ready(self.__class__.__name__, False)
 
     def _initialize(self):


### PR DESCRIPTION
Actually set _ready internal attribute before reporting being ready to the
summary hub.  Not doing that resulted in hangs (UI input request) for kickstart
noniteractive installations if the ready state was sent to the hub based on
payload thread finishing callback (_payload_finished()) earlier then from the
source spoke initialization thread (_initialize()).