### PR TITLE
Call teardown_all explicitly

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -81,7 +81,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 Summary: Core of the Anaconda installer
 Requires: python3-libs
 Requires: python3-dnf >= %{dnfver}
-Requires: python3-blivet >= 1:3.1.4-1
+Requires: python3-blivet >= 1:3.1.4-2
 Requires: python3-blockdev >= %{libblockdevver}
 Requires: python3-meh >= %{mehver}
 Requires: libreport-anaconda >= 2.0.21-1

--- a/pyanaconda/modules/storage/devicetree/populate.py
+++ b/pyanaconda/modules/storage/devicetree/populate.py
@@ -40,3 +40,4 @@ class FindDevicesTask(Task):
     def run(self):
         """Run the task."""
         self._devicetree.populate()
+        self._devicetree.teardown_all()

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -218,12 +218,14 @@ class InstallerStorage(Blivet):
 
         super().reset(cleanup_only=cleanup_only)
 
+        # Protect devices from teardown.
+        self._mark_protected_devices()
+        self.devicetree.teardown_all()
+
         self.fsset = FSSet(self.devicetree)
 
         # Clear out attributes that refer to devices that are no longer in the tree.
         self.bootloader.reset()
-
-        self._mark_protected_devices()
 
         self.roots = []
         self.roots = find_existing_installations(self.devicetree)

--- a/pyanaconda/storage/utils.py
+++ b/pyanaconda/storage/utils.py
@@ -195,6 +195,7 @@ def try_populate_devicetree(devicetree):
     while True:
         try:
             devicetree.populate()
+            devicetree.teardown_all()
         except StorageError as e:
             if errorHandler.cb(e) == ERROR_RAISE:
                 raise


### PR DESCRIPTION
The Blivet's `populate` method doesn't call `teardown_all` anymore,
so we have to call it explicitly after populating the device tree and
resetting the storage. It allows us to protect devices from teardown
during the reset.

**Depends on:** https://github.com/storaged-project/blivet/pull/780