### PR TITLE
Move get_anaconda_version_string to util

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -193,7 +193,7 @@ def parse_arguments(argv=None, boot_cmdline=None):
               anaconda options that have been found
     """
     from pyanaconda.argument_parsing import getArgumentParser
-    from pyanaconda.startup_utils import get_anaconda_version_string
+    from pyanaconda.core.util import get_anaconda_version_string
 
     ap = getArgumentParser(get_anaconda_version_string(), boot_cmdline)
 
@@ -316,7 +316,7 @@ if __name__ == "__main__":
             startup_utils.prompt_for_ssh()
             sys.exit(0)
 
-    log.info("%s %s", sys.argv[0], startup_utils.get_anaconda_version_string(build_time_version=True))
+    log.info("%s %s", sys.argv[0], util.get_anaconda_version_string(build_time_version=True))
     if os.path.exists("/tmp/updates"):
         log.info("Using updates in /tmp/updates/ from %s", opts.updateSrc)
 

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1513,3 +1513,32 @@ def decode_bytes(data):
         return data.decode('utf-8')
 
     raise ValueError("Unsupported type '{}'.".format(type(data).__name__))
+
+
+def get_anaconda_version_string(build_time_version=False):
+    """Return a string describing current Anaconda version.
+    If the current version can't be determined the string
+    "unknown" will be returned.
+
+    :param bool build_time_version: return build time version
+
+    Build time version is set at package build time and will
+    in most cases be identified by a build number or other identifier
+    appended to the upstream tarball version.
+
+    :returns: string describing Anaconda version
+    :rtype: str
+    """
+    # Ignore pylint not finding the version module, since thanks to automake
+    # there's a good chance that version.py is not in the same directory as
+    # the rest of pyanaconda.
+    try:
+        from pyanaconda import version  # pylint: disable=no-name-in-module
+        if build_time_version:
+            return version.__build_time_version__
+        else:
+            return version.__version__
+    except (ImportError, AttributeError):
+        # there is a slight chance version.py might be generated incorrectly
+        # during build, so don't crash in that case
+        return "unknown"

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -35,7 +35,6 @@ from meh.handler import ExceptionHandler
 
 from pyanaconda import kickstart
 from pyanaconda.core import util
-from pyanaconda import startup_utils
 from pyanaconda import product
 from pyanaconda.core.async_utils import run_in_loop
 from pyanaconda.core.configuration.anaconda import conf
@@ -272,7 +271,7 @@ def initExceptionHandling(anaconda):
         file_list.extend([anaconda.opts.ksfile])
 
     config = Config(programName="anaconda",
-                  programVersion=startup_utils.get_anaconda_version_string(),
+                  programVersion=util.get_anaconda_version_string(),
                   programArch=os.uname()[4],
                   attrSkipList=["_intf._actions",
                                 "_intf._currentAction._xklwrapper",

--- a/pyanaconda/modules/services/installation.py
+++ b/pyanaconda/modules/services/installation.py
@@ -20,9 +20,9 @@ from configparser import ConfigParser
 
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.core.util import get_anaconda_version_string
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.services.constants import SetupOnBootAction
-from pyanaconda.startup_utils import get_anaconda_version_string
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)

--- a/tests/nosetests/pyanaconda_tests/iutil_test.py
+++ b/tests/nosetests/pyanaconda_tests/iutil_test.py
@@ -23,6 +23,9 @@ import signal
 import shutil
 from threading import Lock
 
+import sys
+from unittest.mock import Mock, patch
+
 from pyanaconda.errors import ExitError
 from pyanaconda.core.process_watchers import WatchProcesses
 from pyanaconda.core import util
@@ -842,3 +845,17 @@ class MiscTests(unittest.TestCase):
         self.assertRaises(ValueError, util.decode_bytes, None)
         self.assertRaises(ValueError, util.decode_bytes, 0)
         self.assertRaises(ValueError, util.decode_bytes, [])
+
+    @patch.dict('sys.modules')
+    def get_anaconda_version_string_test(self):
+        # Disable the version module.
+        sys.modules['pyanaconda.version'] = None
+        self.assertEqual(util.get_anaconda_version_string(), "unknown")
+
+        # Mock the version module.
+        sys.modules['pyanaconda.version'] = Mock(
+            __version__="1.0",
+            __build_time_version__="1.0-1"
+        )
+        self.assertEqual(util.get_anaconda_version_string(), "1.0")
+        self.assertEqual(util.get_anaconda_version_string(build_time_version=True), "1.0-1")


### PR DESCRIPTION
Move get_anaconda_version_string from pyanaconda.startup_utils to
pyanaconda.core.util. Otherwise, the Services module will import
a lot of storage objects.

Also simplify the code of this function. It is not necessary to check
the existence of the module pyanaconda.version before its import.