### PR TITLE
Move updates repo names to constants

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -66,6 +66,10 @@ DEFAULT_REPOS = [productName.split('-')[0].lower(),
                  "rawhide",
                  "BaseOS"]
 
+# Get list of repo names which should be used as updates repos
+DEFAULT_UPDATE_REPOS = ["updates",
+                        "updates-modular"]
+
 ANACONDA_BUS_CONF_FILE = "/usr/share/anaconda/dbus/anaconda-bus.conf"
 ANACONDA_BUS_ADDR_FILE = "/run/anaconda/bus.address"
 

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -907,11 +907,11 @@ class DNFPayload(payload.PackagePayload):
 
         # Enable or disable updates.
         if self._updates_enabled:
-            self.enable_repo("updates")
-            self.enable_repo("updates-modular")
+            for repo in constants.DEFAULT_UPDATE_REPOS:
+                self.enable_repo(repo)
         else:
-            self.disable_repo("updates")
-            self.disable_repo("updates-modular")
+            for repo in constants.DEFAULT_UPDATE_REPOS:
+                self.disable_repo(repo)
 
         # Disable updates-testing.
         self.disable_repo("updates-testing")


### PR DESCRIPTION
Rather than having the updates repo names hard coded this moves them into the constants list so that they can be more centrally reviewed.  And maybe moved into the products.d definitions....