### PR TITLE
default bootfs to product file_system_type if valid

### DIFF
--- a/pyanaconda/bootloader/base.py
+++ b/pyanaconda/bootloader/base.py
@@ -152,7 +152,12 @@ class BootLoader(object):
 
     @property
     def stage2_format_types(self):
-        return ["ext4", "ext3", "ext2"]
+        # If the product file_system_type is valid, use it by default
+        valid_fs = ["ext4", "ext3", "ext2"]
+        if conf.storage.file_system_type in valid_fs:
+            valid_fs.insert(0, conf.storage.file_system_type)
+
+        return valid_fs
 
     # this is so stupid...
     global_preserve_args = ["speakup_synth", "apic", "noapic", "apm", "ide",

--- a/pyanaconda/bootloader/extlinux.py
+++ b/pyanaconda/bootloader/extlinux.py
@@ -32,12 +32,20 @@ class EXTLINUX(BootLoader):
     _config_file = "extlinux.conf"
     _config_dir = "/boot/extlinux"
 
-    stage2_format_types = ["ext4", "ext3", "ext2"]
     stage2_device_types = ["partition"]
     stage2_bootable = True
 
     # The extlinux bootloader doesn't have BLS support, the old grubby is needed
     packages = ["syslinux-extlinux", "grubby-deprecated"]
+
+    @property
+    def stage2_format_types(self):
+        # If the product file_system_type is valid, use it by default
+        valid_fs = ["ext4", "ext3", "ext2"]
+        if conf.storage.file_system_type in valid_fs:
+            valid_fs.insert(0, conf.storage.file_system_type)
+
+        return valid_fs
 
     @property
     def config_file(self):

--- a/pyanaconda/bootloader/grub2.py
+++ b/pyanaconda/bootloader/grub2.py
@@ -183,10 +183,12 @@ class GRUB2(BootLoader):
 
     @property
     def stage2_format_types(self):
-        if productName.startswith("Red Hat "): # pylint: disable=no-member
-            return ["xfs", "ext4", "ext3", "ext2"]
-        else:
-            return ["ext4", "ext3", "ext2", "btrfs", "xfs"]
+        # If the product file_system_type is valid, use it by default
+        valid_fs = ["ext4", "ext3", "ext2", "btrfs", "xfs"]
+        if conf.storage.file_system_type in valid_fs:
+            valid_fs.insert(0, conf.storage.file_system_type)
+
+        return valid_fs
 
     #
     # grub-related conveniences

--- a/pyanaconda/bootloader/zipl.py
+++ b/pyanaconda/bootloader/zipl.py
@@ -46,10 +46,12 @@ class ZIPL(BootLoader):
 
     @property
     def stage2_format_types(self):
-        if productName.startswith("Red Hat "):          # pylint: disable=no-member
-            return ["xfs", "ext4", "ext3", "ext2"]
-        else:
-            return ["ext4", "ext3", "ext2", "xfs"]
+        # If the product file_system_type is valid, use it by default
+        valid_fs = ["ext4", "ext3", "ext2", "xfs"]
+        if conf.storage.file_system_type in valid_fs:
+            valid_fs.insert(0, conf.storage.file_system_type)
+
+        return valid_fs
 
     image_label_attr = "short_label"
     preserve_args = ["cio_ignore", "rd.znet", "rd_ZNET", "zfcp.allow_lun_scan"]


### PR DESCRIPTION
Right now anaconda has a special path for bootloaders that doesn't consider the product default filesystem type.

With this fix, each bootloader can list its preferred filesystems, but if the product Default File System is compatible it will become the default file system for the bootloader.

This PR will drop two patches carried by rebuilds and eliminate the need for a RHEL specific path.