### PR TITLE
Add DBus support for device trees of partitioning modules

### DIFF
--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -62,6 +62,11 @@ CUSTOM_PARTITIONING = DBusObjectIdentifier(
     basename="Custom"
 )
 
+INTERACTIVE_PARTITIONING = DBusObjectIdentifier(
+    namespace=PARTITIONING_NAMESPACE,
+    basename="Interactive"
+)
+
 BLIVET_PARTITIONING = DBusObjectIdentifier(
     namespace=PARTITIONING_NAMESPACE,
     basename="Blivet"

--- a/pyanaconda/modules/storage/devicetree/__init__.py
+++ b/pyanaconda/modules/storage/devicetree/__init__.py
@@ -16,5 +16,21 @@
 # Red Hat, Inc.
 #
 from pyanaconda.modules.storage.devicetree.devicetree import DeviceTreeModule
+from pyanaconda.modules.storage.devicetree.devicetree_interface import DeviceTreeInterface
 
-__all__ = ["DeviceTreeModule"]
+__all__ = ["DeviceTreeModule", "publish_device_tree"]
+
+
+def publish_device_tree(message_bus, namespace, device_tree, interface=DeviceTreeInterface):
+    """Publish a device tree module on the given message bus.
+
+    :param message_bus: a message bus
+    :param namespace: a sequence of names
+    :param device_tree: an instance of a DeviceTreeModule
+    :param interface: an interface class
+    :return: a DBus path of the published task
+    """
+    publishable = interface(device_tree)
+    object_path = interface.get_object_path(namespace)
+    message_bus.publish_object(object_path, publishable)
+    return object_path

--- a/pyanaconda/modules/storage/devicetree/devicetree_interface.py
+++ b/pyanaconda/modules/storage/devicetree/devicetree_interface.py
@@ -19,6 +19,7 @@
 #
 
 from pyanaconda.dbus.interface import dbus_class
+from pyanaconda.dbus.namespace import get_dbus_path
 from pyanaconda.modules.storage.devicetree.handler_interface import DeviceTreeHandlerInterface
 from pyanaconda.modules.storage.devicetree.viewer_interface import DeviceTreeViewerInterface
 
@@ -28,4 +29,18 @@ __all__ = ["DeviceTreeInterface"]
 @dbus_class
 class DeviceTreeInterface(DeviceTreeViewerInterface, DeviceTreeHandlerInterface):
     """DBus interface for the device tree module."""
-    pass
+
+    _tree_counter = 1
+
+    @staticmethod
+    def get_object_path(namespace):
+        """Get the unique object path in the given namespace.
+
+        This method is not thread safe for now.
+
+        :param namespace: a sequence of names
+        :return: a DBus path of a device tree
+        """
+        tree_number = DeviceTreeInterface._tree_counter
+        DeviceTreeInterface._tree_counter += 1
+        return get_dbus_path(*namespace, "DeviceTree", str(tree_number))

--- a/pyanaconda/modules/storage/partitioning/base.py
+++ b/pyanaconda/modules/storage/partitioning/base.py
@@ -22,9 +22,12 @@ from abc import abstractmethod
 from blivet.devices import PartitionDevice, TmpFSDevice, LVMLogicalVolumeDevice, \
     LVMVolumeGroupDevice, MDRaidArrayDevice, BTRFSDevice
 
+from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.base.base import KickstartBaseModule
+from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.errors.storage import UnavailableStorageError
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.modules.storage.devicetree import DeviceTreeModule, publish_device_tree
 
 log = get_module_logger(__name__)
 
@@ -40,6 +43,8 @@ class PartitioningModule(KickstartBaseModule):
         self._current_storage = None
         self._storage_playground = None
         self._selected_disks = []
+        self._device_tree_module = None
+        self._device_tree_path = ""
 
     @property
     def storage(self):
@@ -66,6 +71,25 @@ class PartitioningModule(KickstartBaseModule):
     def on_selected_disks_changed(self, selection):
         """Keep the current disk selection."""
         self._selected_disks = selection
+
+    def get_device_tree(self):
+        """Get the device tree.
+
+        :return: a DBus path to a device tree
+        """
+        if not self._device_tree_module:
+            module = DeviceTreeModule()
+            module.on_storage_reset(self.storage)
+            self._device_tree_module = module
+
+        if not self._device_tree_path:
+            self._device_tree_path = publish_device_tree(
+                message_bus=DBus,
+                namespace=STORAGE.namespace,
+                device_tree=self._device_tree_module
+            )
+
+        return self._device_tree_path
 
     @abstractmethod
     def configure_with_task(self):

--- a/pyanaconda/modules/storage/partitioning/base_interface.py
+++ b/pyanaconda/modules/storage/partitioning/base_interface.py
@@ -29,6 +29,13 @@ __all__ = ["PartitioningInterface"]
 class PartitioningInterface(ModuleInterfaceTemplate):
     """DBus interface for a partitioning module."""
 
+    def GetDeviceTree(self) -> ObjPath:
+        """Get the device tree.
+
+        :return: a DBus path to a device tree
+        """
+        return self.implementation.get_device_tree()
+
     def ConfigureWithTask(self) -> ObjPath:
         """Schedule the partitioning actions.
 

--- a/pyanaconda/modules/storage/partitioning/interactive.py
+++ b/pyanaconda/modules/storage/partitioning/interactive.py
@@ -1,0 +1,53 @@
+#
+# The interactive partitioning module
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.dbus import DBus
+from pyanaconda.modules.common.constants.objects import INTERACTIVE_PARTITIONING
+from pyanaconda.modules.storage.partitioning.base import PartitioningModule
+from pyanaconda.modules.storage.partitioning.interactive_interface import \
+    InteractivePartitioningInterface
+from pyanaconda.modules.storage.partitioning.interactive_partitioning import \
+    InteractivePartitioningTask
+from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
+
+log = get_module_logger(__name__)
+
+
+class InteractivePartitioningModule(PartitioningModule):
+    """The interactive partitioning module."""
+
+    def publish(self):
+        """Publish the module."""
+        DBus.publish_object(
+            INTERACTIVE_PARTITIONING.object_path,
+            InteractivePartitioningInterface(self)
+        )
+
+    def configure_with_task(self):
+        """Complete the scheduled partitioning."""
+        task = InteractivePartitioningTask(self.storage)
+        path = self.publish_task(INTERACTIVE_PARTITIONING.namespace, task)
+        return path
+
+    def validate_with_task(self):
+        """Validate the scheduled partitions."""
+        task = StorageValidateTask(self.storage)
+        path = self.publish_task(INTERACTIVE_PARTITIONING.namespace, task)
+        return path

--- a/pyanaconda/modules/storage/partitioning/interactive_interface.py
+++ b/pyanaconda/modules/storage/partitioning/interactive_interface.py
@@ -1,0 +1,27 @@
+#
+# DBus interface for the interactive partitioning module
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.dbus.interface import dbus_interface
+from pyanaconda.modules.common.constants.objects import INTERACTIVE_PARTITIONING
+from pyanaconda.modules.storage.partitioning.base_interface import PartitioningInterface
+
+
+@dbus_interface(INTERACTIVE_PARTITIONING.interface_name)
+class InteractivePartitioningInterface(PartitioningInterface):
+    """DBus interface for the interactive partitioning module."""

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -23,7 +23,7 @@ from pyanaconda.core.signal import Signal
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.base import KickstartModule
 from pyanaconda.modules.common.constants.objects import AUTO_PARTITIONING, MANUAL_PARTITIONING, \
-    CUSTOM_PARTITIONING, BLIVET_PARTITIONING
+    CUSTOM_PARTITIONING, BLIVET_PARTITIONING, INTERACTIVE_PARTITIONING
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.structures.requirement import Requirement
 from pyanaconda.modules.storage.bootloader import BootloaderModule
@@ -40,6 +40,7 @@ from pyanaconda.modules.storage.kickstart import StorageKickstartSpecification
 from pyanaconda.modules.storage.nvdimm import NVDIMMModule
 from pyanaconda.modules.storage.partitioning import AutoPartitioningModule, \
     ManualPartitioningModule, CustomPartitioningModule, BlivetPartitioningModule
+from pyanaconda.modules.storage.partitioning.interactive import InteractivePartitioningModule
 from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 from pyanaconda.modules.storage.reset import StorageResetTask
 from pyanaconda.modules.storage.snapshot import SnapshotModule
@@ -115,6 +116,9 @@ class StorageModule(KickstartModule):
 
         self._custom_part_module = CustomPartitioningModule()
         self._add_partitioning_module(CUSTOM_PARTITIONING.object_path, self._custom_part_module)
+
+        self._interactive_part_module = InteractivePartitioningModule()
+        self._add_partitioning_module(INTERACTIVE_PARTITIONING.object_path,self._interactive_part_module)
 
         self._blivet_part_module = BlivetPartitioningModule()
         self._add_partitioning_module(BLIVET_PARTITIONING.object_path, self._blivet_part_module)

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -32,7 +32,7 @@ from blivet.size import Size
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.errors.storage import UnknownDeviceError
 from pyanaconda.modules.common.task import TaskInterface
-from pyanaconda.modules.storage.devicetree import DeviceTreeModule
+from pyanaconda.modules.storage.devicetree import DeviceTreeModule, publish_device_tree
 from pyanaconda.modules.storage.devicetree.devicetree_interface import DeviceTreeInterface
 from pyanaconda.modules.storage.devicetree.populate import FindDevicesTask
 from pyanaconda.modules.storage.devicetree.rescue import FindExistingSystemsTask, \
@@ -50,6 +50,26 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
         # Set the storage.
         self.module.on_storage_reset(create_storage())
+
+    def publish_device_tree_test(self):
+        """Test publish_device_tree."""
+        DeviceTreeInterface._tree_counter = 1
+        message_bus = Mock()
+
+        object_path = publish_device_tree(message_bus, ("A", "B", "C"), DeviceTreeModule())
+        self.assertEqual("/A/B/C/DeviceTree/1", object_path)
+        message_bus.publish_object.assert_called_once()
+        message_bus.reset_mock()
+
+        object_path = publish_device_tree(message_bus, ("A", "B", "C"), DeviceTreeModule())
+        self.assertEqual("/A/B/C/DeviceTree/2", object_path)
+        message_bus.publish_object.assert_called_once()
+        message_bus.reset_mock()
+
+        object_path = publish_device_tree(message_bus, ("A", "B", "C"), DeviceTreeModule())
+        self.assertEqual("/A/B/C/DeviceTree/3", object_path)
+        message_bus.publish_object.assert_called_once()
+        message_bus.reset_mock()
 
     @property
     def storage(self):

--- a/tests/nosetests/pyanaconda_tests/module_part_interactive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_interactive_test.py
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+import unittest
+from unittest.mock import Mock, patch
+
+from pyanaconda.modules.common.task import TaskInterface
+from pyanaconda.modules.storage.partitioning.interactive import InteractivePartitioningModule
+from pyanaconda.modules.storage.partitioning.interactive_interface import \
+    InteractivePartitioningInterface
+from pyanaconda.modules.storage.partitioning.interactive_partitioning import \
+    InteractivePartitioningTask
+from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
+
+
+class InteractivePartitioningInterfaceTestCase(unittest.TestCase):
+    """Test DBus interface of the interactive partitioning module."""
+
+    def setUp(self):
+        """Set up the module."""
+        self.module = InteractivePartitioningModule()
+        self.interface = InteractivePartitioningInterface(self.module)
+
+    @patch('pyanaconda.dbus.DBus.publish_object')
+    def configure_with_task_test(self, publisher):
+        """Test ConfigureWithTask."""
+        self.module.on_storage_reset(Mock())
+        task_path = self.interface.ConfigureWithTask()
+
+        publisher.assert_called_once()
+        object_path, obj = publisher.call_args[0]
+
+        self.assertEqual(task_path, object_path)
+        self.assertIsInstance(obj, TaskInterface)
+
+        self.assertIsInstance(obj.implementation, InteractivePartitioningTask)
+        self.assertEqual(obj.implementation._storage, self.module.storage)
+
+    @patch('pyanaconda.dbus.DBus.publish_object')
+    def validate_with_task_test(self, publisher):
+        """Test ValidateWithTask."""
+        self.module.on_storage_reset(Mock())
+        task_path = self.interface.ValidateWithTask()
+
+        publisher.assert_called_once()
+        object_path, obj = publisher.call_args[0]
+
+        self.assertEqual(task_path, object_path)
+        self.assertIsInstance(obj, TaskInterface)
+
+        self.assertIsInstance(obj.implementation, StorageValidateTask)
+        self.assertEqual(obj.implementation._storage, self.module.storage)


### PR DESCRIPTION
Call the DBus method GetDeviceTree of a partitioning module to get
access to its device tree. The method will create a new device tree
module and publish it on a unique DBus path.

Create a new partitioning module for the custom partitioning spoke.