### PR TITLE
Clean up the custom spoke

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -201,6 +201,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                                   DEVICE_TYPE_DISK: ""}
 
         self._initialized = False
+        self._accordion = None
 
         self._bootloader_observer = STORAGE.get_observer(BOOTLOADER)
         self._bootloader_observer.connect()

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -239,14 +239,14 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     def status(self):
         return None
 
-    def _grabObjects(self):
+    def _grab_objects(self):
         self._partitionsViewport = self.builder.get_object("partitionsViewport")
         self._partitionsNotebook = self.builder.get_object("partitionsNotebook")
 
         # Connect partitionsNotebook focus events to scrolling in the parent viewport
-        partitionsNotebookViewport = self.builder.get_object("partitionsNotebookViewport")
+        partitions_notebook_viewport = self.builder.get_object("partitionsNotebookViewport")
         self._partitionsNotebook.set_focus_vadjustment(
-            Gtk.Scrollable.get_vadjustment(partitionsNotebookViewport))
+            Gtk.Scrollable.get_vadjustment(partitions_notebook_viewport))
 
         self._pageLabel = self.builder.get_object("pageLabel")
 
@@ -286,10 +286,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         # False so that the "Create a new..." row can overlap with the free space
         # on the other rows. These properties are not accessible from glade.
         cell_area = self._containerCombo.get_area()
-        descRenderer = self.builder.get_object("descRenderer")
-        freeSpaceRenderer = self.builder.get_object("freeSpaceRenderer")
-        cell_area.cell_set_property(descRenderer, "fixed-size", False)
-        cell_area.cell_set_property(freeSpaceRenderer, "fixed-size", False)
+        desc_renderer = self.builder.get_object("descRenderer")
+        free_space_renderer = self.builder.get_object("freeSpaceRenderer")
+        cell_area.cell_set_property(desc_renderer, "fixed-size", False)
+        cell_area.cell_set_property(free_space_renderer, "fixed-size", False)
 
         self._passphraseEntry = self.builder.get_object("passphraseEntry")
 
@@ -314,7 +314,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     def initialize(self):
         NormalSpoke.initialize(self)
         self.initialize_start()
-        self._grabObjects()
+        self._grab_objects()
 
         setViewportBackground(self.builder.get_object("availableSpaceViewport"), "#db3279")
         setViewportBackground(self.builder.get_object("totalSpaceViewport"), "#60605b")
@@ -344,12 +344,12 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self.initialize_done()
 
     @property
-    def _clearpartDevices(self):
+    def _clearpart_devices(self):
         drives_to_clear = self._disk_init_observer.proxy.DrivesToClear
         return [d for d in self._devices if d.name in drives_to_clear and d.partitioned]
 
     @property
-    def unusedDevices(self):
+    def unused_devices(self):
         unused_devices = [
             d for d in self._storage_playground.unused_devices
             if d.disks
@@ -370,7 +370,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         return unused_devices
 
     @property
-    def bootLoaderDevices(self):
+    def bootloader_devices(self):
         devices = []
         format_types = ["biosboot", "prepboot"]
         for device in self._devices:
@@ -385,22 +385,20 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         return devices
 
-    def _setCurrentFreeSpace(self):
+    def _set_current_free_space(self):
         """Add up all the free space on selected disks and return it as a Size."""
         self._free_space = self._storage_playground.get_disk_free_space()
 
-    def _currentTotalSpace(self):
+    def _current_total_space(self):
         """Add up the sizes of all selected disks and return it as a Size."""
-        totalSpace = sum((disk.size for disk in self._clearpartDevices),
-                         Size(0))
-        return totalSpace
+        return sum((disk.size for disk in self._clearpart_devices), Size(0))
 
-    def _updateSpaceDisplay(self):
+    def _update_space_display(self):
         # Set up the free space/available space displays in the bottom left.
-        self._setCurrentFreeSpace()
+        self._set_current_free_space()
 
         self._availableSpaceLabel.set_text(str(self._free_space))
-        self._totalSpaceLabel.set_text(str(self._currentTotalSpace()))
+        self._totalSpaceLabel.set_text(str(self._current_total_space()))
 
         count = len(self._disk_init_observer.proxy.DrivesToClear)
         summary = CP_("GUI|Custom Partitioning",
@@ -445,30 +443,30 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._reset_storage()
         self._do_refresh()
 
-        self._updateSpaceDisplay()
+        self._update_space_display()
         self._applyButton.set_sensitive(False)
 
     def _get_container_names(self):
         for data in self._containerStore:
             yield data[0]
 
-    def _get_fstype(self, fstypeCombo):
-        itr = fstypeCombo.get_active_iter()
+    def _get_fstype(self, fstype_combo):
+        itr = fstype_combo.get_active_iter()
         if not itr:
             return None
 
-        model = fstypeCombo.get_model()
+        model = fstype_combo.get_model()
         return model[itr][0]
 
-    def _get_autopart_type(self, autopartTypeCombo):
-        itr = autopartTypeCombo.get_active_iter()
+    def _get_autopart_type(self, autopart_type_combo):
+        itr = autopart_type_combo.get_active_iter()
         if not itr:
             return DEFAULT_AUTOPART_TYPE
 
-        model = autopartTypeCombo.get_model()
+        model = autopart_type_combo.get_model()
         return model[itr][1]
 
-    def _change_autopart_type(self, autopartTypeCombo):
+    def _change_autopart_type(self, autopart_type_combo):
         """
         This is called when the autopart type combo on the left hand side of
         custom partitioning is changed.  We already know how to handle the case
@@ -477,7 +475,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         clicks the '+' button.
 
         """
-        self._auto_part_observer.proxy.SetType(self._get_autopart_type(autopartTypeCombo))
+        self._auto_part_observer.proxy.SetType(self._get_autopart_type(autopart_type_combo))
 
     def get_new_devices(self):
         # A device scheduled for formatting only belongs in the new root.
@@ -491,7 +489,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         new_mounts = [d for d in self._storage_playground.mountpoints.values() if d.exists]
         if new_mounts or new_devices:
             new_devices.extend(self._storage_playground.mountpoints.values())
-            new_devices.extend(self.bootLoaderDevices)
+            new_devices.extend(self.bootloader_devices)
 
         new_devices = list(set(new_devices))
 
@@ -541,7 +539,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         new_devices = filter_unsupported_disklabel_devices(self.get_new_devices())
         all_devices = filter_unsupported_disklabel_devices(self._devices)
-        unused_devices = filter_unsupported_disklabel_devices(self.unusedDevices)
+        unused_devices = filter_unsupported_disklabel_devices(self.unused_devices)
 
         # Now it's time to populate the accordion.
         log.debug("ui: devices=%s", [d.name for d in all_devices])
@@ -581,7 +579,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                           if getattr(d.format, "mountpoint", None))
 
             for device in new_devices:
-                if device in self.bootLoaderDevices:
+                if device in self.bootloader_devices:
                     mounts[device.format.name] = device
 
             new_root = Root(mounts=mounts, swaps=swaps, name=translated_new_install_name())
@@ -617,7 +615,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             page.show_all()
 
         # Anything that doesn't go with an OS we understand?  Put it in the Other box.
-        if self.unusedDevices:
+        if self.unused_devices:
             page = UnknownPage(_("Unknown"))
             self._accordion.add_page(page, cb=self.on_page_clicked)
 
@@ -626,7 +624,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
             page.show_all()
 
-    def _do_refresh(self, mountpointToShow=None):
+    def _do_refresh(self, mountpoint_to_show=None):
         # block mountpoint selector signal handler for now
         self._initialized = False
         self._accordion.clear_current_selector()
@@ -641,9 +639,9 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         # And then open the first page by default.  Most of the time, this will
         # be fine since it'll be the new installation page.
         self._initialized = True
-        firstPage = self._accordion.all_pages[0]
-        self._accordion.expand_page(firstPage.pageTitle)
-        self._show_mountpoint(page=firstPage, mountpoint=mountpointToShow)
+        first_page = self._accordion.all_pages[0]
+        self._accordion.expand_page(first_page.pageTitle)
+        self._show_mountpoint(page=first_page, mountpoint=mountpoint_to_show)
 
         self._applyButton.set_sensitive(False)
         self._resetButton.set_sensitive(
@@ -666,7 +664,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             expander.add(page)
 
             # also pull in biosboot and prepboot that are on our boot disk
-            devices.extend(self.bootLoaderDevices)
+            devices.extend(self.bootloader_devices)
             devices = list(set(devices))
 
         for _device in devices:
@@ -769,7 +767,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
     def _update_size_props(self):
         self._update_selectors()
-        self._updateSpaceDisplay()
+        self._update_space_display()
 
     def _try_replace_device(self, selector, removed_device, new_device_info,
                             old_device_info):
@@ -1526,7 +1524,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         should_appear = {"DEVICE_TYPE_PARTITION", "DEVICE_TYPE_LVM", "DEVICE_TYPE_LVM_THINP"}
 
         # only include md if there are two or more disks
-        if use_dev.type == "mdarray" or len(self._clearpartDevices) > 1:
+        if use_dev.type == "mdarray" or len(self._clearpart_devices) > 1:
             should_appear.add("DEVICE_TYPE_MD")
 
         if self._btrfs_in_typecombo(device):
@@ -1964,7 +1962,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 dev_info["fstype"] in PARTITION_ONLY_FORMAT_TYPES):
             dev_info["encrypted"] = False
 
-        dev_info["disks"] = self._clearpartDevices
+        dev_info["disks"] = self._clearpart_devices
 
         ## clear errors and try to add the mountpoint/device
         self.clear_errors()
@@ -1973,10 +1971,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         ## refresh internal state and UI elements
         self._devices = self._storage_playground.devices
         if not self._error:
-            self._do_refresh(mountpointToShow=dev_info["mountpoint"] or dev_info["fstype"])
+            self._do_refresh(mountpoint_to_show=dev_info["mountpoint"] or dev_info["fstype"])
         else:
             self._do_refresh()
-        self._updateSpaceDisplay()
+        self._update_space_display()
 
     @ui_storage_logged
     def _remove_empty_parents(self, device):
@@ -2180,7 +2178,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                                 if s._device.id not in otherdevs):
                         # we only want to delete boot partitions if they're not
                         # shared *and* we have no unknown partitions
-                        if not self.unusedDevices or dev.format.type not in protected_types:
+                        if not self.unused_devices or dev.format.type not in protected_types:
                             log.debug("deleteall: removed %s", dev.name)
                             self._destroy_device(dev)
                         else:
@@ -2197,11 +2195,11 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         if part_removed:
             self._storage_playground.roots = find_existing_installations(
                 self._storage_playground.devicetree)
-            self._updateSpaceDisplay()
+            self._update_space_display()
             self._do_refresh()
 
     def on_summary_clicked(self, button):
-        disks = self._clearpartDevices
+        disks = self._clearpart_devices
         dialog = SelectedDisksDialog(self.data, self.storage, disks, show_remove=False,
                                      set_boot=False)
 
@@ -2227,7 +2225,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         dialog = DisksDialog(
             self.data,
             self._storage_playground,
-            disks=self._clearpartDevices,
+            disks=self._clearpart_devices,
             selected=self._device_disks
         )
         with self.main_window.enlightbox(dialog.window):
@@ -2284,7 +2282,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             encrypted=self._device_container_encrypted,
             size_policy=size_policy,
             size=size,
-            disks=self._clearpartDevices,
+            disks=self._clearpart_devices,
             selected=self._device_disks,
             exists=getattr(container, "exists", False)
         )
@@ -2338,9 +2336,9 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         return True
 
-    def _container_store_row(self, name, freeSpace=None):
-        if freeSpace is not None:
-            return [name, _("(%s free)") % freeSpace]
+    def _container_store_row(self, name, free_space=None):
+        if free_space is not None:
+            return [name, _("(%s free)") % free_space]
         else:
             return [name, ""]
 
@@ -2403,12 +2401,12 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             return
 
         c = self._storage_playground.devicetree.get_device_by_name(self._device_container_name)
-        freeSpace = getattr(c, "free_space", None)
+        free_space = getattr(c, "free_space", None)
 
         # else branch of for loop above ensures idx is defined
         # pylint: disable=undefined-loop-variable
         self._containerStore.insert(idx, self._container_store_row(self._device_container_name,
-                                                                   freeSpace))
+                                                                   free_space))
         self._containerCombo.set_active(idx)
         self._modifyContainerButton.set_sensitive(not container_exists)
         self._containerStore.remove(self._containerStore.get_iter_from_string("%s" % (idx + 1)))
@@ -2444,8 +2442,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 if user_changed_container and data[0] == new_text:
                     c = self._storage_playground.devicetree.get_device_by_name(
                         self._device_container_name)
-                    freeSpace = getattr(c, "free_space", None)
-                    row = self._container_store_row(self._device_container_name, freeSpace)
+                    free_space = getattr(c, "free_space", None)
+                    row = self._container_store_row(self._device_container_name, free_space)
 
                     self._containerStore.insert(idx, row)
                     combo.set_active(idx)  # triggers a call to this method
@@ -2497,21 +2495,21 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         curr_selector = self._accordion.current_selector
         no_edit = False
-        currentPageType = None
+        current_page_type = None
         if self._accordion.is_multiselection or not curr_selector:
-            currentPageType = NOTEBOOK_LABEL_PAGE
+            current_page_type = NOTEBOOK_LABEL_PAGE
             self._set_page_label_text()
             no_edit = True
         elif curr_selector.device.format.type == "luks" and \
                 curr_selector.device.format.exists:
-            currentPageType = NOTEBOOK_LUKS_PAGE
-            selectedDeviceLabel = self._encryptedDeviceLabel
-            selectedDeviceDescLabel = self._encryptedDeviceDescLabel
+            current_page_type = NOTEBOOK_LUKS_PAGE
+            selected_device_label = self._encryptedDeviceLabel
+            selected_device_desc_label = self._encryptedDeviceDescLabel
             no_edit = True
         elif not getattr(curr_selector.device, "complete", True):
-            currentPageType = NOTEBOOK_INCOMPLETE_PAGE
-            selectedDeviceLabel = self._incompleteDeviceLabel
-            selectedDeviceDescLabel = self._incompleteDeviceDescLabel
+            current_page_type = NOTEBOOK_INCOMPLETE_PAGE
+            selected_device_label = self._incompleteDeviceLabel
+            selected_device_desc_label = self._incompleteDeviceDescLabel
 
             if isinstance(curr_selector.device, MDRaidArrayDevice):
                 total = curr_selector.device.member_devices
@@ -2532,17 +2530,17 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             self._incompleteDeviceOptionsLabel.set_text(txt)
             no_edit = True
         elif devicefactory.get_device_type(curr_selector.device) is None:
-            currentPageType = NOTEBOOK_UNEDITABLE_PAGE
-            selectedDeviceLabel = self._uneditableDeviceLabel
-            selectedDeviceDescLabel = self._uneditableDeviceDescLabel
+            current_page_type = NOTEBOOK_UNEDITABLE_PAGE
+            selected_device_label = self._uneditableDeviceLabel
+            selected_device_desc_label = self._uneditableDeviceDescLabel
             no_edit = True
 
         if no_edit:
-            self._partitionsNotebook.set_current_page(currentPageType)
-            if currentPageType != NOTEBOOK_LABEL_PAGE:
-                selectedDeviceLabel.set_text(curr_selector.device.name)
+            self._partitionsNotebook.set_current_page(current_page_type)
+            if current_page_type != NOTEBOOK_LABEL_PAGE:
+                selected_device_label.set_text(curr_selector.device.name)
                 desc = _(MOUNTPOINT_DESCRIPTIONS.get(curr_selector.device.type, ""))
-                selectedDeviceDescLabel.set_text(desc)
+                selected_device_desc_label.set_text(desc)
 
             self._configButton.set_sensitive(False)
             self._removeButton.set_sensitive(True)
@@ -2563,7 +2561,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                                          not container_device)
         self._removeButton.set_sensitive(not curr_selector.device.protected)
 
-    def on_page_clicked(self, page, mountpointToShow=None):
+    def on_page_clicked(self, page, mountpoint_to_show=None):
         if not self._initialized:
             return
 
@@ -2571,7 +2569,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         if self._accordion.is_current_selected:
             self._save_current_page()
 
-        self._show_mountpoint(page=page, mountpoint=mountpointToShow)
+        self._show_mountpoint(page=page, mountpoint=mountpoint_to_show)
 
         # This is called when a Page header is clicked upon so we can support
         # deleting an entire installation at once and displaying something
@@ -2627,17 +2625,17 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 "<a href=\"\">Click for details.</a>"
             ))
 
-    def on_create_clicked(self, button, autopartTypeCombo):
+    def on_create_clicked(self, button, autopart_type_combo):
         # Then do autopartitioning.  We do not do any clearpart first.  This is
         # custom partitioning, so you have to make your own room.
-        self._do_autopart(self._get_autopart_type(autopartTypeCombo))
+        self._do_autopart(self._get_autopart_type(autopart_type_combo))
 
         # Refresh the spoke to make the new partitions appear.
         log.debug("refreshing ui")
         self._do_refresh()
         log.debug("finished refreshing ui")
         log.debug("updating space display")
-        self._updateSpaceDisplay()
+        self._update_space_display()
         log.debug("finished updating space display")
 
     def on_reformat_toggled(self, widget):

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -1027,7 +1027,6 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         # NAME
         old_name = getattr(use_dev, "lvname", use_dev.name)
-        name = old_name
         changed_name = False
         if self._nameEntry.get_sensitive():
             name = self._nameEntry.get_text()
@@ -1185,7 +1184,6 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         container = factory.get_container()
         old_container_encrypted = False
         old_container_raid_level = None
-        old_container = None
         old_container_size = SIZE_POLICY_AUTO
         if not changed_device_type:
             old_container = factory.get_container(device=use_dev)

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -26,6 +26,7 @@
 # - Implement striping and mirroring for LVM.
 # - Activating reformat should always enable resize for existing devices.
 import gi
+
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gdk", "3.0")
 gi.require_version("AnacondaWidgets", "3.3")
@@ -105,12 +106,14 @@ NOTEBOOK_INCOMPLETE_PAGE = 4
 NEW_CONTAINER_TEXT = N_("Create a new %(container_type)s ...")
 CONTAINER_TOOLTIP = N_("Create or select %(container_type)s")
 
-DEVICE_CONFIGURATION_ERROR_MSG = N_("Device reconfiguration failed. <a href=\"\">Click for "
-                                    "details.</a>")
+DEVICE_CONFIGURATION_ERROR_MSG = N_("Device reconfiguration failed. "
+                                    "<a href=\"\">Click for details.</a>")
+
 UNRECOVERABLE_ERROR_MSG = N_("Storage configuration reset due to unrecoverable "
                              "error. <a href=\"\">Click for details.</a>")
 
 DEVICE_TYPE_CONST_UNSUPPORTED = "DEVICE_TYPE_UNSUPPORTED"
+
 
 def dev_type_from_const(dev_type_const):
     """ Return integer corresponding to name for device type defined as
@@ -150,6 +153,7 @@ def ui_storage_logged(func):
 
     return decorated
 
+
 class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     """
        .. inheritance-diagram:: CustomPartitioningSpoke
@@ -185,7 +189,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._devices = []
         self._error = None
         self._hidden_disks = []
-        self._fs_types = set()             # set of supported fstypes
+        self._fs_types = set()  # set of supported fstypes
         self._free_space = Size(0)
 
         self._device_disks = []
@@ -193,12 +197,14 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._device_container_raid_level = None
         self._device_container_encrypted = False
         self._device_container_size = SIZE_POLICY_AUTO
-        self._device_name_dict = {DEVICE_TYPE_LVM: None,
-                                  DEVICE_TYPE_MD: None,
-                                  DEVICE_TYPE_LVM_THINP: None,
-                                  DEVICE_TYPE_PARTITION: "",
-                                  DEVICE_TYPE_BTRFS: "",
-                                  DEVICE_TYPE_DISK: ""}
+        self._device_name_dict = {
+            DEVICE_TYPE_LVM: None,
+            DEVICE_TYPE_MD: None,
+            DEVICE_TYPE_LVM_THINP: None,
+            DEVICE_TYPE_PARTITION: "",
+            DEVICE_TYPE_BTRFS: "",
+            DEVICE_TYPE_DISK: ""
+        }
 
         self._initialized = False
         self._accordion = None
@@ -239,7 +245,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         # Connect partitionsNotebook focus events to scrolling in the parent viewport
         partitionsNotebookViewport = self.builder.get_object("partitionsNotebookViewport")
-        self._partitionsNotebook.set_focus_vadjustment(Gtk.Scrollable.get_vadjustment(partitionsNotebookViewport))
+        self._partitionsNotebook.set_focus_vadjustment(
+            Gtk.Scrollable.get_vadjustment(partitionsNotebookViewport))
 
         self._pageLabel = self.builder.get_object("pageLabel")
 
@@ -295,10 +302,13 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._encryptedDeviceLabel = self.builder.get_object("encryptedDeviceLabel")
         self._encryptedDeviceDescLabel = self.builder.get_object("encryptedDeviceDescriptionLabel")
         self._incompleteDeviceLabel = self.builder.get_object("incompleteDeviceLabel")
-        self._incompleteDeviceDescLabel = self.builder.get_object("incompleteDeviceDescriptionLabel")
-        self._incompleteDeviceOptionsLabel = self.builder.get_object("incompleteDeviceOptionsLabel")
+        self._incompleteDeviceDescLabel = self.builder.get_object(
+            "incompleteDeviceDescriptionLabel")
+        self._incompleteDeviceOptionsLabel = self.builder.get_object(
+            "incompleteDeviceOptionsLabel")
         self._uneditableDeviceLabel = self.builder.get_object("uneditableDeviceLabel")
-        self._uneditableDeviceDescLabel = self.builder.get_object("uneditableDeviceDescriptionLabel")
+        self._uneditableDeviceDescLabel = self.builder.get_object(
+            "uneditableDeviceDescriptionLabel")
         self._containerLabel = self.builder.get_object("containerLabel")
 
     def initialize(self):
@@ -315,8 +325,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._partitionsViewport.add(self._accordion)
 
         # Connect viewport scrolling with accordion focus events
-        self._accordion.set_focus_hadjustment(Gtk.Scrollable.get_hadjustment(self._partitionsViewport))
-        self._accordion.set_focus_vadjustment(Gtk.Scrollable.get_vadjustment(self._partitionsViewport))
+        self._accordion.set_focus_hadjustment(
+            Gtk.Scrollable.get_hadjustment(self._partitionsViewport))
+        self._accordion.set_focus_vadjustment(
+            Gtk.Scrollable.get_vadjustment(self._partitionsViewport))
 
         threadMgr.add(AnacondaThread(name=THREAD_CUSTOM_STORAGE_INIT, target=self._initialize))
 
@@ -325,7 +337,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
             Restrict the set to ones that we might allow users to select.
         """
-        self._fs_types = {fs.name for fs in get_supported_filesystems()} - set(UNSUPPORTED_FILESYSTEMS)
+        supported_filesystems = {fs.name for fs in get_supported_filesystems()}
+        self._fs_types = supported_filesystems - set(UNSUPPORTED_FILESYSTEMS)
 
         # report that the custom spoke has been initialized
         self.initialize_done()
@@ -337,14 +350,23 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
     @property
     def unusedDevices(self):
-        unused_devices = [d for d in self._storage_playground.unused_devices
-                                if d.disks and d.media_present and
-                                not d.partitioned and (d.direct or d.isleaf)]
+        unused_devices = [
+            d for d in self._storage_playground.unused_devices
+            if d.disks
+            and d.media_present
+            and not d.partitioned
+            and (d.direct or d.isleaf)
+        ]
         # add incomplete VGs and MDs
-        incomplete = [d for d in self._storage_playground.devicetree._devices
-                            if not getattr(d, "complete", True)]
+        incomplete = [
+            d for d in self._storage_playground.devicetree._devices
+            if not getattr(d, "complete", True)
+        ]
         unused_devices.extend(incomplete)
-        unused_devices.extend(d for d in self._storage_playground.partitioned if not d.format.supported)
+        unused_devices.extend(
+            d for d in self._storage_playground.partitioned
+            if not d.format.supported
+        )
         return unused_devices
 
     @property
@@ -382,9 +404,9 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         count = len(self._disk_init_observer.proxy.DrivesToClear)
         summary = CP_("GUI|Custom Partitioning",
-                "%d _storage device selected",
-                "%d _storage devices selected",
-                count) % count
+                      "%d _storage device selected",
+                      "%d _storage devices selected",
+                      count) % count
 
         self._summaryLabel.set_text(summary)
         self._summaryLabel.set_use_underline(True)
@@ -460,8 +482,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     def get_new_devices(self):
         # A device scheduled for formatting only belongs in the new root.
         new_devices = [d for d in self._devices if d.direct and
-                                                   not d.format.exists and
-                                                   not d.partitioned]
+                       not d.format.exists and
+                       not d.partitioned]
 
         # If mountpoints have been assigned to any existing devices, go ahead
         # and pull those in along with any existing swap devices. It doesn't
@@ -498,19 +520,20 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 page_name = span_tmpl % (escape_markup(highlight_color),
                                          escape_markup(page.pageTitle))
 
-                page_line = page_text_tmpl % {"items_selected" : selected_str,
-                                              "items_total"    : total_str,
-                                              "page_name"      : page_name}
+                page_line = page_text_tmpl % {"items_selected": selected_str,
+                                              "items_total": total_str,
+                                              "page_name": page_name}
                 pages_count += page_line + "\n"
 
-            self._pageLabel.set_markup(_("Please select a single mount point to edit properties.\n\n"
-                                         "You have currently selected:\n"
-                                         "%s") % (pages_count))
+            self._pageLabel.set_markup(
+                _("Please select a single mount point to edit properties.\n\n"
+                  "You have currently selected:\n"
+                  "%s") % pages_count)
         else:
-            self._pageLabel.set_text(_("When you create mount points for "
-                    "your %(name)s %(version)s installation, you'll be able to "
-                    "view their details here.") % {"name"    : productName,
-                                                   "version" : productVersion})
+            self._pageLabel.set_text(
+                _("When you create mount points for your %(name)s %(version)s "
+                  "installation, you'll be able to view their details here.")
+                % {"name": productName, "version": productVersion})
 
     def _populate_accordion(self):
         # Make sure we start with a clean state.
@@ -530,8 +553,9 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             root_devices = list(chain(root.swaps, root.mounts.values()))
             # Don't make a page if none of the root's devices are left.
             # Also, only include devices in an old page if the format is intact.
-            if not any(d for d in root_devices if d in all_devices and d.disks and
-                       (root.name == translated_new_install_name() or d.format.exists)):
+            if not any(d for d in root_devices
+                       if d in all_devices and d.disks
+                       and (root.name == translated_new_install_name() or d.format.exists)):
                 continue
 
             if not filter_unsupported_disklabel_devices(root_devices):
@@ -554,7 +578,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         else:
             swaps = [d for d in new_devices if d.format.type == "swap"]
             mounts = dict((d.format.mountpoint, d) for d in new_devices
-                                if getattr(d.format, "mountpoint", None))
+                          if getattr(d.format, "mountpoint", None))
 
             for device in new_devices:
                 if device in self.bootLoaderDevices:
@@ -569,20 +593,22 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             self._accordion.add_page(page, cb=self.on_page_clicked)
 
             for (mountpoint, device) in root.mounts.items():
-                # by using all_devices we've already accounted for devices on unsupported disklabels
+                # by using all_devices we've already accounted
+                # for devices on unsupported disklabels
                 if device not in all_devices or \
-                   not device.disks or \
-                   (root.name != translated_new_install_name() and not device.format.exists):
+                        not device.disks or \
+                        (root.name != translated_new_install_name() and not device.format.exists):
                     continue
 
                 selector = page.add_selector(device, self.on_selector_clicked,
-                                            mountpoint=mountpoint)
+                                             mountpoint=mountpoint)
                 selector.root = root
 
             for device in root.swaps:
-                # by using all_devices we've already accounted for devices on unsupported disklabels
+                # by using all_devices we've already accounted
+                # for devices on unsupported disklabels
                 if device not in all_devices or \
-                   (root.name != translated_new_install_name() and not device.format.exists):
+                        (root.name != translated_new_install_name() and not device.format.exists):
                     continue
 
                 selector = page.add_selector(device, self.on_selector_clicked)
@@ -620,7 +646,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._show_mountpoint(page=firstPage, mountpoint=mountpointToShow)
 
         self._applyButton.set_sensitive(False)
-        self._resetButton.set_sensitive(len(self._storage_playground.devicetree.actions.find()) > 0)
+        self._resetButton.set_sensitive(
+            len(self._storage_playground.devicetree.actions.find()) > 0)
 
     ###
     ### RIGHT HAND SIDE METHODS
@@ -631,7 +658,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         devices = [device]
         if not page.members:
             # remove the CreateNewPage and replace it with a regular Page
-            expander = self._accordion.find_page_by_title(translated_new_install_name()).get_parent()
+            expander = self._accordion.find_page_by_title(
+                translated_new_install_name()).get_parent()
             expander.remove(expander.get_child())
 
             page = Page(translated_new_install_name())
@@ -672,10 +700,13 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     def _update_all_devices_in_selectors(self):
         for s in self._accordion.all_selectors:
             for new_device in self._storage_playground.devices:
-                if ((s._device.name == new_device.name) or
-                    (getattr(s._device, "req_name", 1) == getattr(new_device, "req_name", 2)) and
-                    s._device.type == new_device.type and
-                    s._device.format.type == new_device.format.type):
+                d1 = s._device
+                d2 = new_device
+
+                if ((d1.name == d2.name) or
+                        (getattr(d1, "req_name", 1) == getattr(d2, "req_name", 2)) and
+                        d1.type == d2.type and
+                        d1.format.type == d2.format.type):
                     update_selector_from_device(s, new_device)
                     break
             else:
@@ -695,7 +726,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         return False
 
     def _validate_mountpoint(self, mountpoint, device, device_type, new_fs_type,
-                            reformat, encrypted, raid_level):
+                             reformat, encrypted, raid_level):
         """ Validate various aspects of a mountpoint.
 
             :param str mountpoint: the mountpoint
@@ -708,13 +739,13 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         """
         error = None
         if device_type not in (DEVICE_TYPE_PARTITION, DEVICE_TYPE_MD) and \
-           mountpoint == "/boot/efi":
+                mountpoint == "/boot/efi":
             error = (_("/boot/efi must be on a device of type %(oneFsType)s or %(anotherFsType)s")
-                       % {"oneFsType": _(DEVICE_TEXT_PARTITION), "anotherFsType": _(DEVICE_TEXT_MD)})
+                     % {"oneFsType": _(DEVICE_TEXT_PARTITION), "anotherFsType": _(DEVICE_TEXT_MD)})
         elif device_type != DEVICE_TYPE_PARTITION and \
-             new_fs_type in PARTITION_ONLY_FORMAT_TYPES:
+                new_fs_type in PARTITION_ONLY_FORMAT_TYPES:
             error = (_("%(fs)s must be on a device of type %(type)s")
-                       % {"fs" : new_fs_type, "type" : _(DEVICE_TEXT_PARTITION)})
+                     % {"fs": new_fs_type, "type": _(DEVICE_TEXT_PARTITION)})
         elif mountpoint and encrypted and mountpoint.startswith("/boot"):
             error = _("%s cannot be encrypted") % mountpoint
         elif encrypted and new_fs_type in PARTITION_ONLY_FORMAT_TYPES:
@@ -723,15 +754,15 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             error = _("You must create a new file system on the root device.")
 
         if not error and \
-           (raid_level is not None or requiresRaidSelection(device_type)) and \
-           raid_level not in raidLevelsSupported(device_type):
+                (raid_level is not None or requiresRaidSelection(device_type)) and \
+                raid_level not in raidLevelsSupported(device_type):
             error = _("Device does not support RAID level selection %s.") % raid_level
 
         if not error and raid_level is not None:
             min_disks = raid_level.min_members
             if len(self._device_disks) < min_disks:
                 error = _(RAID_NOT_ENOUGH_DISKS) % {"level": raid_level,
-                                                    "min" : min_disks,
+                                                    "min": min_disks,
                                                     "count": len(self._device_disks)}
 
         return error
@@ -766,7 +797,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 # of the devices with copies in the devicefactory error
                 # handler
                 old_disk_names = (d.name for d in old_device_info["disks"])
-                old_device_info["disks"] = [self._storage_playground.devicetree.get_device_by_name(n) for n in old_disk_names]
+                old_device_info["disks"] = [
+                    self._storage_playground.devicetree.get_device_by_name(n)
+                    for n in old_disk_names
+                ]
                 try:
                     self._replace_device(selector=selector, **old_device_info)
                     return True
@@ -829,8 +863,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             log.debug("removing resize of device %s", use_dev.name)
 
             actions = self._storage_playground.devicetree.actions.find(
-               action_type="resize",
-               devid=use_dev.id
+                action_type="resize",
+                devid=use_dev.id
             )
             for action in reversed(actions):
                 self._storage_playground.devicetree.actions.remove(action)
@@ -891,7 +925,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._devices = self._storage_playground.devices
 
         # possibly changed device and old_device, need to return the new ones
-        return (device, old_device)
+        return device, old_device
 
     @ui_storage_logged
     def _do_reformat(self, device, mountpoint, label, changed_encryption, encrypted,
@@ -920,8 +954,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         log.info("scheduling reformat of %s as %s", device.name, fs_type)
         old_format = device.format
         new_format = get_format(fs_type,
-                               mountpoint=mountpoint, label=label,
-                               device=device.path)
+                                mountpoint=mountpoint, label=label,
+                                device=device.path)
         try:
             self._storage_playground.format_device(device, new_format)
         except (StorageError, ValueError) as e:
@@ -968,7 +1002,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         # only call _save_right_side if on the right page and some changes need
         # to be saved (sensitivity of the Update Settings button reflects that)
         if self._partitionsNotebook.get_current_page() != NOTEBOOK_DETAILS_PAGE or \
-           not self._applyButton.get_sensitive():
+                not self._applyButton.get_sensitive():
             return
 
         device = selector.device
@@ -1014,9 +1048,9 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             size = old_size
         else:
             size = size_from_entry(
-               self._sizeEntry,
-               lower_bound=self.MIN_SIZE_ENTRY,
-               units=SIZE_UNITS_DEFAULT
+                self._sizeEntry,
+                lower_bound=self.MIN_SIZE_ENTRY,
+                units=SIZE_UNITS_DEFAULT
             )
         changed_size = ((use_dev.resizable or not use_dev.exists) and
                         size != old_size)
@@ -1074,7 +1108,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 return
 
         # MOUNTPOINT
-        mountpoint = None   # None means format type is not mountable
+        mountpoint = None  # None means format type is not mountable
         if self._mountPointEntry.get_sensitive():
             mountpoint = self._mountPointEntry.get_text()
 
@@ -1133,14 +1167,16 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         with ui_storage_logger():
             # create a new factory using the appropriate size and type
-            factory = devicefactory.get_device_factory(self._storage_playground,
-                                                      device_type=device_type,
-                                                      size=size,
-                                                      disks=device.disks,
-                                                      encrypted=encrypted,
-                                                      luks_version=luks_version,
-                                                      raid_level=raid_level,
-                                                      min_luks_entropy=crypto.MIN_CREATE_ENTROPY)
+            factory = devicefactory.get_device_factory(
+                self._storage_playground,
+                device_type=device_type,
+                size=size,
+                disks=device.disks,
+                encrypted=encrypted,
+                luks_version=luks_version,
+                raid_level=raid_level,
+                min_luks_entropy=crypto.MIN_CREATE_ENTROPY
+            )
 
         # CONTAINER
         changed_container = False
@@ -1158,7 +1194,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 old_container_encrypted = old_container.encrypted
                 old_container_raid_level = get_raid_level(old_container)
                 old_container_size = getattr(old_container, "size_policy",
-                                                            old_container.size)
+                                             old_container.size)
 
             container = factory.get_container(name=container_name)
             if old_container and container_name != old_container.name:
@@ -1280,12 +1316,14 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         # Handle reformat
         if do_reformat:
-            device = self._do_reformat(device, mountpoint, label, changed_encryption, encrypted,
-                                       changed_luks_version, luks_version, selector, fs_type)
+            device = self._do_reformat(
+                device, mountpoint, label, changed_encryption, encrypted,
+                changed_luks_version, luks_version, selector, fs_type
+            )
         else:
             # Set various attributes that do not require actions.
             if old_label != label and hasattr(device.format, "label") and \
-               validate_label(label, device.format) == "":
+                    validate_label(label, device.format) == "":
                 self.clear_errors()
                 log.debug("updating label on %s to %s", device.name, label)
                 device.format.label = label
@@ -1419,8 +1457,9 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             self._device_container_encrypted = False
             self._device_container_size = SIZE_POLICY_AUTO
 
-        self._device_container_raid_level = self._device_container_raid_level \
-           or defaultContainerRaidLevel(devicefactory.get_device_type(use_dev))
+        self._device_container_raid_level = \
+            self._device_container_raid_level or \
+            defaultContainerRaidLevel(devicefactory.get_device_type(use_dev))
 
     def _setup_fstype_combo(self, device):
         """ Setup the filesystem combo box.
@@ -1431,8 +1470,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         # Possibly unsupported but still required filesystem names
         if device.exists and \
-           device.format.type != device.original_format.type and \
-           device.original_format.type not in self._fs_types:
+                device.format.type != device.original_format.type and \
+                device.original_format.type not in self._fs_types:
             extra_names = (type_name, device.original_format.name)
         else:
             extra_names = (type_name,)
@@ -1468,8 +1507,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         # Return True if btrfs filesystem is both allowed and supported.
         fmt = get_format("btrfs")
-        return fmt.supported and fmt.formattable and \
-           device.format.type not in PARTITION_ONLY_FORMAT_TYPES + ("swap",)
+
+        return fmt.supported and \
+            fmt.formattable and \
+            device.format.type not in PARTITION_ONLY_FORMAT_TYPES + ("swap",)
 
     def _setup_device_type_combo(self, device, device_name):
         """ Set up device type combo.
@@ -1487,7 +1528,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         should_appear = {"DEVICE_TYPE_PARTITION", "DEVICE_TYPE_LVM", "DEVICE_TYPE_LVM_THINP"}
 
         # only include md if there are two or more disks
-        if (use_dev.type == "mdarray" or len(self._clearpartDevices) > 1):
+        if use_dev.type == "mdarray" or len(self._clearpartDevices) > 1:
             should_appear.add("DEVICE_TYPE_MD")
 
         if self._btrfs_in_typecombo(device):
@@ -1530,8 +1571,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             mountpoint = getattr(device.format, "mountpoint", None)
 
             with ui_storage_logger():
-                name = self._storage_playground.suggest_device_name(swap=is_swap,
-                                                        mountpoint=mountpoint)
+                name = self._storage_playground.suggest_device_name(
+                    swap=is_swap,
+                    mountpoint=mountpoint
+                )
 
             self._device_name_dict[_type] = name
 
@@ -1540,8 +1583,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                                           in should_appear - should_appear_supported)
             if unsupported:
                 # For existing unsupported device add the information in the UI
-                log.debug("Existing device with unsupported type %s found", DEVICE_TEXT_MAP[device_type])
-                itr = self._typeStore.append([_(DEVICE_TEXT_UNSUPPORTED), DEVICE_TYPE_CONST_UNSUPPORTED])
+                log.debug("Existing device with unsupported type %s found",
+                          DEVICE_TEXT_MAP[device_type])
+                itr = self._typeStore.append(
+                    [_(DEVICE_TEXT_UNSUPPORTED), DEVICE_TYPE_CONST_UNSUPPORTED])
                 self._typeCombo.set_active_iter(itr)
             else:
                 msg = "Didn't find device type %s in device type combobox" % device_type
@@ -1633,8 +1678,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         if orig_device_type == device_type:
             self.on_device_type_changed(self._typeCombo)
 
-        fancy_set_sensitive(self._fsCombo, self._reformatCheckbox.get_active() and
-                                           device_type != DEVICE_TYPE_BTRFS)
+        fancy_set_sensitive(
+            self._fsCombo,
+            self._reformatCheckbox.get_active() and device_type != DEVICE_TYPE_BTRFS
+        )
 
         # you can't change the type of an existing device
         fancy_set_sensitive(self._typeCombo, not use_dev.exists)
@@ -1654,14 +1701,22 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         # new devices that are not btrfs subvolumes.
         # Do this after the device type combo is set since
         # on_device_type_changed doesn't account for device existence.
-        fancy_set_sensitive(self._sizeEntry, device.resizable or (not device.exists and device.format.type != "btrfs"))
+        fancy_set_sensitive(
+            self._sizeEntry,
+            device.resizable or (not device.exists and device.format.type != "btrfs")
+        )
 
         if self._sizeEntry.get_sensitive():
             self._sizeEntry.props.has_tooltip = False
         elif device.format.type == "btrfs":
-            self._sizeEntry.set_tooltip_text(_("The space available to this mount point can be changed by modifying the volume below."))
+            self._sizeEntry.set_tooltip_text(_(
+                "The space available to this mount point can "
+                "be changed by modifying the volume below."
+            ))
         else:
-            self._sizeEntry.set_tooltip_text(_("This file system may not be resized."))
+            self._sizeEntry.set_tooltip_text(_(
+                "This file system may not be resized."
+            ))
 
         self._populate_raid(get_raid_level(device))
         self._populate_container(device=use_dev)
@@ -1716,9 +1771,13 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         StorageCheckHandler.check_storage(self)
 
         if self.errors or bootloader_errors:
-            self.set_warning(_("Error checking storage configuration.  <a href=\"\">Click for details</a> or press Done again to continue."))
+            self.set_warning(_(
+                "Error checking storage configuration. <a href=\"\">Click for details</a> "
+                "or press Done again to continue."))
         elif self.warnings:
-            self.set_warning(_("Warning checking storage configuration.  <a href=\"\">Click for details</a> or press Done again to continue."))
+            self.set_warning(_(
+                "Warning checking storage configuration. <a href=\"\">Click for details</a> "
+                "or press Done again to continue."))
 
         # on_info_bar_clicked requires self._error to be set, so set it to the
         # list of all errors and warnings that storage checking found.
@@ -1779,10 +1838,13 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
     @ui_storage_logged
     def _add_device(self, dev_info):
-        factory = devicefactory.get_device_factory(self._storage_playground,
-                                                   device_type=dev_info["device_type"],
-                                                   size=dev_info["size"],
-                                                   min_luks_entropy=crypto.MIN_CREATE_ENTROPY)
+        factory = devicefactory.get_device_factory(
+            self._storage_playground,
+            device_type=dev_info["device_type"],
+            size=dev_info["size"],
+            min_luks_entropy=crypto.MIN_CREATE_ENTROPY
+        )
+
         container = factory.get_container()
         if container:
             # don't override user-initiated changes to a defined container
@@ -1809,7 +1871,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 dev_info.update({"container_encrypted": container.encrypted,
                                  "container_raid_level": get_raid_level(container),
                                  "container_size": getattr(container, "size_policy",
-                                                               container.size),
+                                                           container.size),
                                  "container_name": container.name})
                 try:
                     self._storage_playground.factory_device(**dev_info)
@@ -1819,7 +1881,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                     type_str = _(DEVICE_TEXT_MAP[dev_info["device_type"]])
                     self.set_info(_("Added new %(type)s to existing "
                                     "container %(name)s.")
-                                    % {"type" : type_str, "name" : container.name})
+                                  % {"type": type_str, "name": container.name})
                     e = None
 
             # the factory's error handling has replaced all of the devices
@@ -1887,8 +1949,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         dev_info["device_type"] = device_type_from_autopart(self._auto_part_observer.proxy.Type)
         if (dev_info["device_type"] != DEVICE_TYPE_PARTITION and
-            ((dev_info["mountpoint"] and dev_info["mountpoint"].startswith("/boot")) or
-             dev_info["fstype"] in PARTITION_ONLY_FORMAT_TYPES)):
+                ((dev_info["mountpoint"] and dev_info["mountpoint"].startswith("/boot")) or
+                 dev_info["fstype"] in PARTITION_ONLY_FORMAT_TYPES)):
             dev_info["device_type"] = DEVICE_TYPE_PARTITION
 
         # we shouldn't create swap on a thinly provisioned volume
@@ -1901,7 +1963,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         # some devices should never be encrypted
         if ((dev_info["mountpoint"] and dev_info["mountpoint"].startswith("/boot")) or
-            dev_info["fstype"] in PARTITION_ONLY_FORMAT_TYPES):
+                dev_info["fstype"] in PARTITION_ONLY_FORMAT_TYPES):
             dev_info["encrypted"] = False
 
         dev_info["disks"] = self._clearpartDevices
@@ -1976,20 +2038,22 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         # adjust container to size of remaining devices, if auto-sized
         if container and not container.exists and container.children and \
-           container.size_policy == SIZE_POLICY_AUTO:
+                container.size_policy == SIZE_POLICY_AUTO:
             cont_encrypted = container.encrypted
             cont_raid = get_raid_level(container)
             cont_size = container.size_policy
             cont_name = container.name
-            factory = devicefactory.get_device_factory(self._storage_playground,
-                                        device_type=device_type,
-                                        size=Size(0),
-                                        disks=container.disks,
-                                        container_name=cont_name,
-                                        container_encrypted=cont_encrypted,
-                                        container_raid_level=cont_raid,
-                                        container_size=cont_size,
-                                        min_luks_entropy=crypto.MIN_CREATE_ENTROPY)
+            factory = devicefactory.get_device_factory(
+                self._storage_playground,
+                device_type=device_type,
+                size=Size(0),
+                disks=container.disks,
+                container_name=cont_name,
+                container_encrypted=cont_encrypted,
+                container_raid_level=cont_raid,
+                container_size=cont_size,
+                min_luks_entropy=crypto.MIN_CREATE_ENTROPY
+            )
             factory.configure()
 
         self._remove_empty_parents(device)
@@ -2006,11 +2070,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             return
 
         if not mountpoint and len(self._accordion.selected_items) == 0 \
-           and not page.get_parent().get_expanded():
+                and not page.get_parent().get_expanded():
             self._accordion.select(page.members[0])
             self.on_selector_clicked(None, page.members[0])
             return
-
 
         if mountpoint:
             for member in page.members:
@@ -2029,12 +2092,15 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 root_name = root_name.replace("_", "__")
 
             if root_name:
-                checkbox_text = (C_("GUI|Custom Partitioning|Confirm Delete Dialog",
-                                    "Delete _all file systems which are only used by %s.")
-                                    % root_name)
+                checkbox_text = (C_(
+                    "GUI|Custom Partitioning|Confirm Delete Dialog",
+                    "Delete _all file systems which are only used by %s."
+                ) % root_name)
         else:
-            checkbox_text = C_("GUI|Custom Partitioning|Confirm Delete Dialog",
-                               "Do _not show this dialog for other selected file systems.")
+            checkbox_text = C_(
+                "GUI|Custom Partitioning|Confirm Delete Dialog",
+                "Do _not show this dialog for other selected file systems."
+            )
         dialog.refresh(getattr(device.format, "mountpoint", ""),
                        device.name, checkbox_text=checkbox_text,
                        snapshots=snapshots, bootpart=bootpart)
@@ -2042,7 +2108,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             rc = dialog.run()
             option_checked = dialog.option_checked
             dialog.window.destroy()
-            return (rc, option_checked)
+            return rc, option_checked
 
     def on_remove_clicked(self, button):
         # Nothing selected?  Nothing to remove.
@@ -2066,11 +2132,13 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
             if root_name == translated_new_install_name():
                 if is_multiselection and not option_checked:
-                    (rc, option_checked) = self._show_confirmation_dialog(root_name, device, protected_types)
+                    (rc, option_checked) = self._show_confirmation_dialog(
+                        root_name, device, protected_types
+                    )
 
                     if rc != 1:
                         if option_checked:
-                            break # skip evaluation of all other mountpoints
+                            break  # skip evaluation of all other mountpoints
                         continue
 
                 if device.exists:
@@ -2092,11 +2160,13 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 # In multiselection user could confirm once for all next
                 # selections.
                 if not option_checked:
-                    (rc, option_checked) = self._show_confirmation_dialog(root_name, device, protected_types)
+                    (rc, option_checked) = self._show_confirmation_dialog(
+                        root_name, device, protected_types
+                    )
 
                     if rc != 1:
                         if option_checked:
-                            break # skip evaluation of all other mountpoints
+                            break  # skip evaluation of all other mountpoints
                         continue
 
                 if option_checked and not is_multiselection:
@@ -2112,7 +2182,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                                 if s._device.id not in otherdevs):
                         # we only want to delete boot partitions if they're not
                         # shared *and* we have no unknown partitions
-                        if (not self.unusedDevices or dev.format.type not in protected_types):
+                        if not self.unusedDevices or dev.format.type not in protected_types:
                             log.debug("deleteall: removed %s", dev.name)
                             self._destroy_device(dev)
                         else:
@@ -2127,13 +2197,15 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         # refreshing the display will have the effect of making them disappear.
         # It's like they never existed.
         if part_removed:
-            self._storage_playground.roots = find_existing_installations(self._storage_playground.devicetree)
+            self._storage_playground.roots = find_existing_installations(
+                self._storage_playground.devicetree)
             self._updateSpaceDisplay()
             self._do_refresh()
 
     def on_summary_clicked(self, button):
         disks = self._clearpartDevices
-        dialog = SelectedDisksDialog(self.data, self.storage, disks, show_remove=False, set_boot=False)
+        dialog = SelectedDisksDialog(self.data, self.storage, disks, show_remove=False,
+                                     set_boot=False)
 
         with self.main_window.enlightbox(dialog.window):
             dialog.refresh()
@@ -2154,10 +2226,12 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         self.clear_errors()
 
-        dialog = DisksDialog(self.data,
-                             self._storage_playground,
-                             disks=self._clearpartDevices,
-                             selected=self._device_disks)
+        dialog = DisksDialog(
+            self.data,
+            self._storage_playground,
+            disks=self._clearpartDevices,
+            selected=self._device_disks
+        )
         with self.main_window.enlightbox(dialog.window):
             rc = dialog.run()
 
@@ -2203,17 +2277,19 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 # creating a new container -- switch to the default
                 size_policy = SIZE_POLICY_AUTO
 
-        dialog = ContainerDialog(self.data,
-                                 self._storage_playground,
-                                 device_type=self._get_current_device_type(),
-                                 name=container_name,
-                                 raid_level=self._device_container_raid_level,
-                                 encrypted=self._device_container_encrypted,
-                                 size_policy=size_policy,
-                                 size=size,
-                                 disks=self._clearpartDevices,
-                                 selected=self._device_disks,
-                                 exists=getattr(container, "exists", False))
+        dialog = ContainerDialog(
+            self.data,
+            self._storage_playground,
+            device_type=self._get_current_device_type(),
+            name=container_name,
+            raid_level=self._device_container_raid_level,
+            encrypted=self._device_container_encrypted,
+            size_policy=size_policy,
+            size=size,
+            disks=self._clearpartDevices,
+            selected=self._device_disks,
+            exists=getattr(container, "exists", False)
+        )
 
         with self.main_window.enlightbox(dialog.window):
             rc = dialog.run()
@@ -2233,7 +2309,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         log.debug("new container name: %s", name)
         if (name != container_name and name in self._storage_playground.names or
-            name in self._get_container_names() and new_container):
+                name in self._get_container_names() and new_container):
             self._error = _("Volume Group name %s is already in use. Not "
                             "saving changes.") % name
             self.set_info(self._error)
@@ -2241,11 +2317,11 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             return
 
         if (new_container or
-            set(disks) != set(self._device_disks) or
-            name != container_name or
-            dialog.raid_level != self._device_container_raid_level or
-            dialog.encrypted != self._device_container_encrypted or
-            dialog.size_policy != self._device_container_size):
+                set(disks) != set(self._device_disks) or
+                name != container_name or
+                dialog.raid_level != self._device_container_raid_level or
+                dialog.encrypted != self._device_container_encrypted or
+                dialog.size_policy != self._device_container_size):
             self._applyButton.set_sensitive(True)
 
         log.debug("new container raid level: %s", dialog.raid_level)
@@ -2333,7 +2409,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         # else branch of for loop above ensures idx is defined
         # pylint: disable=undefined-loop-variable
-        self._containerStore.insert(idx, self._container_store_row(self._device_container_name, freeSpace))
+        self._containerStore.insert(idx, self._container_store_row(self._device_container_name,
+                                                                   freeSpace))
         self._containerCombo.set_active(idx)
         self._modifyContainerButton.set_sensitive(not container_exists)
         self._containerStore.remove(self._containerStore.get_iter_from_string("%s" % (idx + 1)))
@@ -2367,12 +2444,13 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             user_changed_container = self.run_container_editor(name=name, new_container=True)
             for idx, data in enumerate(self._containerStore):
                 if user_changed_container and data[0] == new_text:
-                    c = self._storage_playground.devicetree.get_device_by_name(self._device_container_name)
+                    c = self._storage_playground.devicetree.get_device_by_name(
+                        self._device_container_name)
                     freeSpace = getattr(c, "free_space", None)
                     row = self._container_store_row(self._device_container_name, freeSpace)
 
                     self._containerStore.insert(idx, row)
-                    combo.set_active(idx)   # triggers a call to this method
+                    combo.set_active(idx)  # triggers a call to this method
                     return
                 elif not user_changed_container and data[0] == self._device_container_name:
                     combo.set_active(idx)
@@ -2384,14 +2462,15 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         if user_changed_container:
             self._applyButton.set_sensitive(True)
 
-        container = self._storage_playground.devicetree.get_device_by_name(self._device_container_name)
-        container_exists = getattr(container, "exists", False)    # might not be in the tree
+        container = self._storage_playground.devicetree.get_device_by_name(
+            self._device_container_name)
+        container_exists = getattr(container, "exists", False)  # might not be in the tree
 
         if container:
             self._device_container_raid_level = get_raid_level(container)
             self._device_container_encrypted = container.encrypted
             self._device_container_size = getattr(container, "size_policy",
-                                                             container.size)
+                                                  container.size)
         else:
             self._device_container_raid_level = None
             self._device_container_encrypted = self._auto_part_observer.proxy.Encrypted
@@ -2399,16 +2478,19 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         self._modifyContainerButton.set_sensitive(not container_exists)
 
-    def _save_current_page(self, selector = None):
+    def _save_current_page(self, selector=None):
         if selector is None:
             selector = self._accordion.current_selector
         log.debug("Saving current selector: %s", selector.device)
         self._save_right_side(selector)
 
     def on_selector_clicked(self, old_selector, selector):
-        if not self._initialized \
-           or ((old_selector or self._accordion.current_selector)   # one of them must be set
-               and (old_selector is self._accordion.current_selector)): # and they need to differ
+        if not self._initialized:
+            return
+
+        # one of them must be set and they need to differ
+        if (old_selector or self._accordion.current_selector) \
+                and (old_selector is self._accordion.current_selector):
             return
 
         # Take care of the previously chosen selector.
@@ -2423,7 +2505,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             self._set_page_label_text()
             no_edit = True
         elif curr_selector.device.format.type == "luks" and \
-           curr_selector.device.format.exists:
+                curr_selector.device.format.exists:
             currentPageType = NOTEBOOK_LUKS_PAGE
             selectedDeviceLabel = self._encryptedDeviceLabel
             selectedDeviceDescLabel = self._encryptedDeviceDescLabel
@@ -2436,18 +2518,18 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             if isinstance(curr_selector.device, MDRaidArrayDevice):
                 total = curr_selector.device.member_devices
                 missing = total - len(curr_selector.device.parents)
-                txt = _("This Software RAID array is missing %(missingMembers)d of %(totalMembers)d member "
-                        "partitions. You can remove it or select a different "
-                        "device.") % {"missingMembers": missing, "totalMembers": total}
+                txt = _("This Software RAID array is missing %(missing)d of %(total)d "
+                        "member partitions. You can remove it or select a different "
+                        "device.") % {"missing": missing, "total": total}
             elif isinstance(curr_selector.device, LVMVolumeGroupDevice):
                 total = curr_selector.device.pv_count
                 missing = total - len(curr_selector.device.parents)
-                txt = _("This LVM Volume Group is missing %(missingPVs)d of %(totalPVs)d physical "
-                        "volumes. You can remove it or select a different "
+                txt = _("This LVM Volume Group is missing %(missingPVs)d of %(totalPVs)d "
+                        "physical volumes. You can remove it or select a different "
                         "device.") % {"missingPVs": missing, "totalPVs": total}
             else:
-                txt = _("This %(type)s device is missing member devices. You can remove it or"
-                        " select a different device.") % curr_selector.device.type
+                txt = _("This %(type)s device is missing member devices. You can remove "
+                        "it or select a different device.") % curr_selector.device.type
 
             self._incompleteDeviceOptionsLabel.set_text(txt)
             no_edit = True
@@ -2476,7 +2558,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._populate_right_side(curr_selector)
 
         self._applyButton.set_sensitive(False)
-        container_device = devicefactory.get_device_type(curr_selector.device) in CONTAINER_DEVICE_TYPES
+        container_device = devicefactory.get_device_type(
+            curr_selector.device) in CONTAINER_DEVICE_TYPES
         self._configButton.set_sensitive(not curr_selector.device.exists and
                                          not curr_selector.device.protected and
                                          not container_device)
@@ -2541,8 +2624,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             log.error("do_autopart failed: %s", messages)
             self._reset_storage()
             self._error = messages
-            self.set_error(_("Automatic partitioning failed. <a href=\"\">Click "
-                             "for details.</a>"))
+            self.set_error(_(
+                "Automatic partitioning failed. "
+                "<a href=\"\">Click for details.</a>"
+            ))
 
     def on_create_clicked(self, button, autopartTypeCombo):
         # Then do autopartitioning.  We do not do any clearpart first.  This is
@@ -2601,7 +2686,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         for widget in [self._luksLabel, self._luksCombo]:
             hide_or_show(widget)
 
-        fancy_set_sensitive(self._luksCombo, encrypted.get_active() and encrypted.get_sensitive())
+        fancy_set_sensitive(
+            self._luksCombo,
+            encrypted.get_active() and encrypted.get_sensitive()
+        )
 
     def _populate_container(self, device=None):
         """ Set up the vg widgets for lvm or hide them for other types. """
@@ -2617,7 +2705,9 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         container_size_policy = SIZE_POLICY_AUTO
         if device_type not in CONTAINER_DEVICE_TYPES:
             # just hide the buttons with no meaning for non-container devices
-            for widget in [self._containerLabel, self._containerCombo, self._modifyContainerButton]:
+            for widget in [self._containerLabel,
+                           self._containerCombo,
+                           self._modifyContainerButton]:
                 really_hide(widget)
             return
 
@@ -2629,17 +2719,21 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             _device = None
 
         with ui_storage_logger():
-            factory = devicefactory.get_device_factory(self._storage_playground,
-                                                     device_type=device_type,
-                                                     size=Size(0),
-                                                     min_luks_entropy=crypto.MIN_CREATE_ENTROPY)
+            factory = devicefactory.get_device_factory(
+                self._storage_playground,
+                device_type=device_type,
+                size=Size(0),
+                min_luks_entropy=crypto.MIN_CREATE_ENTROPY
+            )
             container = factory.get_container(device=_device)
             default_container_name = getattr(container, "name", None)
             if container:
                 container_size_policy = container.size_policy
 
         container_type = get_container_type(device_type)
-        self._containerLabel.set_text(C_("GUI|Custom Partitioning|Configure|Devices", container_type.label).title())
+        self._containerLabel.set_text(
+            C_("GUI|Custom Partitioning|Configure|Devices", container_type.label).title()
+        )
         self._containerLabel.set_use_underline(True)
         self._containerStore.clear()
         if device_type == DEVICE_TYPE_BTRFS:
@@ -2649,7 +2743,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         default_seen = False
         for c in containers:
-            self._containerStore.append(self._container_store_row(c.name, getattr(c, "free_space", None)))
+            self._containerStore.append(
+                self._container_store_row(c.name, getattr(c, "free_space", None)))
             if default_container_name and c.name == default_container_name:
                 default_seen = True
                 self._containerCombo.set_active(containers.index(c))
@@ -2665,12 +2760,16 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             self._containerStore.append(self._container_store_row(default_container_name))
             self._containerCombo.set_active(len(self._containerStore) - 1)
 
-        self._containerStore.append(self._container_store_row(_(NEW_CONTAINER_TEXT) % {"container_type": _(container_type.name).lower()}))
-        self._containerCombo.set_tooltip_text(_(CONTAINER_TOOLTIP) % {"container_type": _(container_type.name).lower()})
+        self._containerStore.append(self._container_store_row(
+            _(NEW_CONTAINER_TEXT) % {"container_type": _(container_type.name).lower()}))
+        self._containerCombo.set_tooltip_text(
+            _(CONTAINER_TOOLTIP) % {"container_type": _(container_type.name).lower()})
         if default_container_name is None:
             self._containerCombo.set_active(len(self._containerStore) - 1)
 
-        for widget in [self._containerLabel, self._containerCombo, self._modifyContainerButton]:
+        for widget in [self._containerLabel,
+                       self._containerCombo,
+                       self._modifyContainerButton]:
             really_show(widget)
 
         # make the combo and button insensitive for existing LVs
@@ -2723,7 +2822,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
                 # If btrfs previously selected, select default filesystem
                 if active_index == btrfs_idx:
-                    active_index = next(idx for idx, data in enumerate(self._fsCombo.get_model()) if data[0] == self.storage.default_fstype)
+                    active_index = next(
+                        idx for idx, data in enumerate(self._fsCombo.get_model())
+                        if data[0] == self.storage.default_fstype
+                    )
                 # Otherwise, shift index left by one if after removed entry
                 elif active_index > btrfs_idx:
                     active_index = active_index - 1
@@ -2732,7 +2834,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 pass
 
         self._fsCombo.set_active(active_index)
-        fancy_set_sensitive(self._fsCombo, self._reformatCheckbox.get_active() and device_type != DEVICE_TYPE_BTRFS)
+        fancy_set_sensitive(
+            self._fsCombo,
+            self._reformatCheckbox.get_active() and device_type != DEVICE_TYPE_BTRFS
+        )
 
     def on_device_type_changed(self, combo):
         if combo is not self._typeCombo:
@@ -2757,8 +2862,13 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             return
 
         # lvm uses the RHS to set disk set. no foolish minds here.
-        exists = self._accordion.current_selector and self._accordion.current_selector.device.exists
-        self._configButton.set_sensitive(not exists and new_type not in CONTAINER_DEVICE_TYPES)
+        exists = \
+            self._accordion.current_selector and \
+            self._accordion.current_selector.device.exists
+
+        self._configButton.set_sensitive(
+            not exists and new_type not in CONTAINER_DEVICE_TYPES
+        )
 
         # this has to be done before calling populate_raid since it will need
         # the raid level combo to contain the relevant raid levels for the new
@@ -2784,13 +2894,19 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         msg = _("Continuing with this action will reset all your partitioning selections "
                 "to their current on-disk state.")
 
-        dlg = Gtk.MessageDialog(flags=Gtk.DialogFlags.MODAL,
-                                message_type=Gtk.MessageType.WARNING,
-                                buttons=Gtk.ButtonsType.NONE,
-                                message_format=msg)
+        dlg = Gtk.MessageDialog(
+            flags=Gtk.DialogFlags.MODAL,
+            message_type=Gtk.MessageType.WARNING,
+            buttons=Gtk.ButtonsType.NONE,
+            message_format=msg
+        )
         dlg.set_decorated(False)
-        dlg.add_buttons(C_("GUI|Custom Partitioning|Reset Dialog", "_Reset selections"), 0,
-                        C_("GUI|Custom Partitioning|Reset Dialog", "_Preserve current selections"), 1)
+        dlg.add_buttons(
+            C_("GUI|Custom Partitioning|Reset Dialog", "_Reset selections"),
+            0,
+            C_("GUI|Custom Partitioning|Reset Dialog", "_Preserve current selections"),
+            1
+        )
         dlg.set_default_response(1)
 
         with self.main_window.enlightbox(dlg):
@@ -2832,10 +2948,12 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         if not self._error:
             return
 
-        dlg = Gtk.MessageDialog(flags=Gtk.DialogFlags.MODAL,
-                                message_type=Gtk.MessageType.ERROR,
-                                buttons=Gtk.ButtonsType.CLOSE,
-                                message_format=str(self._error))
+        dlg = Gtk.MessageDialog(
+            flags=Gtk.DialogFlags.MODAL,
+            message_type=Gtk.MessageType.ERROR,
+            buttons=Gtk.ButtonsType.CLOSE,
+            message_format=str(self._error)
+        )
         dlg.set_decorated(False)
 
         with self.main_window.enlightbox(dlg):
@@ -2870,7 +2988,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         with ui_storage_logger():
             # look for new roots
-            self._storage_playground.roots = find_existing_installations(self._storage_playground.devicetree)
+            self._storage_playground.roots = find_existing_installations(
+                self._storage_playground.devicetree)
 
         self._devices = self._storage_playground.devices
         self._accordion.clear_current_selector()

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -30,7 +30,15 @@ from collections import namedtuple
 import functools
 import re
 
+from blivet.devicefactory import SIZE_POLICY_AUTO, SIZE_POLICY_MAX, DEVICE_TYPE_LVM, \
+    DEVICE_TYPE_BTRFS, DEVICE_TYPE_LVM_THINP, DEVICE_TYPE_MD, get_supported_raid_levels
+from blivet.devicelibs import btrfs, mdraid, raid
+from blivet.formats import get_format
+from blivet.size import Size
+
+from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.constants import SIZE_UNITS_DEFAULT
+from pyanaconda.core.i18n import _, N_, CN_
 from pyanaconda.core.util import lowerASCII
 from pyanaconda.platform import platform
 from pyanaconda.storage.utils import size_from_input
@@ -38,22 +46,7 @@ from pyanaconda.ui.helpers import InputCheck
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.helpers import GUIDialogInputCheckHandler
 from pyanaconda.ui.gui.utils import fancy_set_sensitive, really_hide, really_show
-from pyanaconda.core.i18n import _, N_, CN_
 
-from blivet.size import Size
-from blivet.formats import get_format
-from blivet.devicefactory import SIZE_POLICY_AUTO
-from blivet.devicefactory import SIZE_POLICY_MAX
-from blivet.devicefactory import DEVICE_TYPE_LVM
-from blivet.devicefactory import DEVICE_TYPE_BTRFS
-from blivet.devicefactory import DEVICE_TYPE_LVM_THINP
-from blivet.devicefactory import DEVICE_TYPE_MD
-from blivet.devicefactory import get_supported_raid_levels
-from blivet.devicelibs import btrfs
-from blivet.devicelibs import mdraid
-from blivet.devicelibs import raid
-
-from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 RAID_NOT_ENOUGH_DISKS = N_("The RAID level you have selected (%(level)s) "

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -59,12 +59,21 @@ CONTAINER_DIALOG_TEXT = N_("Please create a name for this %(container_type)s "
 
 ContainerType = namedtuple("ContainerType", ["name", "label"])
 
-CONTAINER_TYPES = {DEVICE_TYPE_LVM:       ContainerType(N_("Volume Group"), CN_("GUI|Custom Partitioning|Configure|Devices", "_Volume Group:")),
-                   DEVICE_TYPE_LVM_THINP: ContainerType(N_("Volume Group"), CN_("GUI|Custom Partitioning|Configure|Devices", "_Volume Group:")),
-                   DEVICE_TYPE_BTRFS:     ContainerType(N_("Volume"), CN_("GUI|Custom Partitioning|Configure|Devices", "_Volume:"))}
+CONTAINER_TYPES = {
+    DEVICE_TYPE_LVM: ContainerType(
+        N_("Volume Group"),
+        CN_("GUI|Custom Partitioning|Configure|Devices", "_Volume Group:")),
+    DEVICE_TYPE_LVM_THINP: ContainerType(
+        N_("Volume Group"),
+        CN_("GUI|Custom Partitioning|Configure|Devices", "_Volume Group:")),
+    DEVICE_TYPE_BTRFS: ContainerType(
+        N_("Volume"),
+        CN_("GUI|Custom Partitioning|Configure|Devices", "_Volume:"))
+}
 
 # These cannot be specified as mountpoints
 system_mountpoints = ["/dev", "/proc", "/run", "/sys"]
+
 
 def size_from_entry(entry, lower_bound=None, units=None):
     """ Get a Size object from an entry field.
@@ -90,6 +99,7 @@ def size_from_entry(entry, lower_bound=None, units=None):
         return lower_bound
     return size
 
+
 def populate_mountpoint_store(store, used_mountpoints):
     # sure, add whatever you want to this list. this is just a start.
     paths = ["/", "/boot", "/home", "/var"] + \
@@ -107,6 +117,7 @@ def populate_mountpoint_store(store, used_mountpoints):
     for path in paths:
         if path not in used_mountpoints:
             store.append([path])
+
 
 def validate_label(label, fmt):
     """Returns a code indicating either that the given label can be set for
@@ -130,6 +141,7 @@ def validate_label(label, fmt):
     if not fmt.label_format_ok(label):
         return _("Unacceptable label format for file system.")
     return ""
+
 
 def validate_mountpoint(mountpoint, used_mountpoints, strict=True):
     if strict:
@@ -158,6 +170,7 @@ def validate_mountpoint(mountpoint, used_mountpoints, strict=True):
     else:
         return ""
 
+
 def get_raid_level(device):
     use_dev = device.raw_device
 
@@ -172,6 +185,7 @@ def get_raid_level(device):
         raid_level = get_raid_level(use_dev.parents[0])
 
     return raid_level
+
 
 def selectedRaidLevel(raidLevelCombo):
     """Interpret the selection of a RAID level combo box.
@@ -195,6 +209,7 @@ def selectedRaidLevel(raidLevelCombo):
     else:
         return raid.get_raid_level(selected_level)
 
+
 def raidLevelSelection(raid_level):
     """ Returns a string corresponding to the RAID level.
 
@@ -204,6 +219,7 @@ def raidLevelSelection(raid_level):
         :rtype: str
     """
     return raid_level.name if raid_level else "none"
+
 
 def defaultRaidLevel(device_type):
     """ Returns the default RAID level for this device type.
@@ -217,6 +233,7 @@ def defaultRaidLevel(device_type):
 
     return None
 
+
 def defaultContainerRaidLevel(device_type):
     """ Returns the default RAID level for this device type's container type.
 
@@ -229,9 +246,11 @@ def defaultContainerRaidLevel(device_type):
 
     return None
 
+
 def requiresRaidSelection(device_type):
     """ Whether GUI requires a RAID level be selected for this device type."""
     return device_type == DEVICE_TYPE_MD
+
 
 def memoizer(f):
     """ A simple decorator that memoizes by means of the shared default
@@ -240,6 +259,7 @@ def memoizer(f):
         :param f: a function of a single argument
         :returns: a memoizing version of f
     """
+
     @functools.wraps(f)
     def new_func(arg, cache={}):
         # pylint: disable=dangerous-default-value
@@ -251,6 +271,7 @@ def memoizer(f):
         return result
 
     return new_func
+
 
 @memoizer
 def raidLevelsSupported(device_type):
@@ -275,6 +296,7 @@ def raidLevelsSupported(device_type):
         supported = set()
     return get_supported_raid_levels(device_type).intersection(supported)
 
+
 @memoizer
 def containerRaidLevelsSupported(device_type):
     """ The raid levels anaconda supports for a container for this
@@ -294,11 +316,15 @@ def containerRaidLevelsSupported(device_type):
         return get_supported_raid_levels(DEVICE_TYPE_BTRFS).intersection(supported)
     return set()
 
+
 def get_container_type(device_type):
-    return CONTAINER_TYPES.get(device_type, ContainerType(N_("container"), CN_("GUI|Custom Partitioning|Configure|Devices", "container")))
+    return CONTAINER_TYPES.get(device_type, ContainerType(N_("container"), CN_(
+        "GUI|Custom Partitioning|Configure|Devices", "container")))
+
 
 class AddDialog(GUIObject):
-    builderObjects = ["addDialog", "mountPointStore", "mountPointCompletion", "mountPointEntryBuffer"]
+    builderObjects = ["addDialog", "mountPointStore", "mountPointCompletion",
+                      "mountPointEntryBuffer"]
     mainWidgetName = "addDialog"
     uiFile = "spokes/lib/custom_storage_helpers.glade"
 
@@ -332,9 +358,9 @@ class AddDialog(GUIObject):
             return
 
         self.size = size_from_entry(
-           self.builder.get_object("addSizeEntry"),
-           lower_bound=self.MIN_SIZE_ENTRY,
-           units=SIZE_UNITS_DEFAULT
+            self.builder.get_object("addSizeEntry"),
+            lower_bound=self.MIN_SIZE_ENTRY,
+            units=SIZE_UNITS_DEFAULT
         )
         self.window.destroy()
 
@@ -348,6 +374,7 @@ class AddDialog(GUIObject):
             rc = self.window.run()
             if not self._error:
                 return rc
+
 
 class ConfirmDeleteDialog(GUIObject):
     builderObjects = ["confirmDeleteDialog"]
@@ -366,7 +393,7 @@ class ConfirmDeleteDialog(GUIObject):
         self.window.destroy()
 
     # pylint: disable=arguments-differ
-    def refresh(self, mountpoint, device, checkbox_text = "", snapshots=False, bootpart = False):
+    def refresh(self, mountpoint, device, checkbox_text="", snapshots=False, bootpart=False):
         """ Show confirmation dialog with the optional checkbox. If the
             `checkbox_text` for the checkbox is not set then the checkbox
             will not be showed.
@@ -375,7 +402,7 @@ class ConfirmDeleteDialog(GUIObject):
             :param str device: Name of the device.
             :param str checkbox_text: Text for checkbox. If nothing set do
                                       not display the checkbox.
-            :param bool snapshot: If true warn user he's going to delete snapshots too.
+            :param bool snapshots: If true warn user he's going to delete snapshots too.
         """
         super().refresh()
         label = self.builder.get_object("confirmLabel")
@@ -391,16 +418,19 @@ class ConfirmDeleteDialog(GUIObject):
             txt = device
 
         if bootpart:
-            label_text = _("%s may be a system boot partition! Deleting it may break other operating systems. Are you sure you want to delete it?") % txt
+            label_text = _("%s may be a system boot partition! Deleting it may break other "
+                           "operating systems. Are you sure you want to delete it?") % txt
         elif not snapshots:
             label_text = _("Are you sure you want to delete all of the data on %s?") % txt
         else:
-            label_text = _("Are you sure you want to delete all of the data on %s, including snapshots and/or subvolumes?") % txt
+            label_text = _("Are you sure you want to delete all of the data on %s, including "
+                           "snapshots and/or subvolumes?") % txt
 
         label.set_text(label_text)
 
     def run(self):
         return self.window.run()
+
 
 class DisksDialog(GUIObject):
     builderObjects = ["disks_dialog", "disk_store", "disk_view"]
@@ -454,6 +484,7 @@ class DisksDialog(GUIObject):
     def run(self):
         return self.window.run()
 
+
 class ContainerDialog(GUIObject, GUIDialogInputCheckHandler):
     builderObjects = ["container_dialog", "disk_store", "container_disk_view",
                       "containerRaidStoreFiltered", "containerRaidLevelLabel",
@@ -472,11 +503,11 @@ class ContainerDialog(GUIObject, GUIDialogInputCheckHandler):
         self.storage = storage
         self._disks = kwargs.pop("disks")
         self.selected = kwargs.pop("selected")[:]
-        self.name = kwargs.pop("name") or "" # make sure it's a string
+        self.name = kwargs.pop("name") or ""  # make sure it's a string
         self.device_type = kwargs.pop("device_type")
 
         # these are less critical
-        self.raid_level = kwargs.pop("raid_level", None) or None # not ""
+        self.raid_level = kwargs.pop("raid_level", None) or None  # not ""
         self.encrypted = kwargs.pop("encrypted", False)
         self.exists = kwargs.pop("exists", False)
 
@@ -584,9 +615,9 @@ class ContainerDialog(GUIObject, GUIDialogInputCheckHandler):
         if raid_level:
             min_disks = raid_level.min_members
             if len(paths) < min_disks:
-                self._error = (_(RAID_NOT_ENOUGH_DISKS) % {"level" : raid_level,
-                                                           "min" : min_disks,
-                                                           "count" : len(paths)})
+                self._error = (_(RAID_NOT_ENOUGH_DISKS) % {"level": raid_level,
+                                                           "min": min_disks,
+                                                           "count": len(paths)})
                 self._error_label.set_text(self._error)
                 self.window.show_all()
                 return
@@ -599,9 +630,9 @@ class ContainerDialog(GUIObject, GUIDialogInputCheckHandler):
         elif idx == 2:
             if self._original_size_text != self._sizeEntry.get_text():
                 size = size_from_entry(
-                   self._sizeEntry,
-                   lower_bound=self.MIN_SIZE_ENTRY,
-                   units=SIZE_UNITS_DEFAULT
+                    self._sizeEntry,
+                    lower_bound=self.MIN_SIZE_ENTRY,
+                    units=SIZE_UNITS_DEFAULT
                 )
                 if size is None:
                     size = SIZE_POLICY_MAX
@@ -655,7 +686,6 @@ class ContainerDialog(GUIObject, GUIDialogInputCheckHandler):
             self._sizeEntry.set_sensitive(False)
         else:
             self._sizeEntry.set_sensitive(True)
-
 
     def _raid_level_visible(self, model, itr, user_data):
         raid_level_str = model[itr][1]


### PR DESCRIPTION
* Reorganize imports.
* Initialize attributes in the `__init__` method of the custom spoke.
* Fix alignment and indentation of the code.
* Remove local variables with unused values.
* Rename attributes and variables with camel case names.