### PR TITLE
Drop redundant fallbacks to multi-user.target

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -611,15 +611,6 @@ if __name__ == "__main__":
     ksdata.displaymode.displayMode = display_mode_coversion_table[anaconda.display_mode]
     ksdata.displaymode.nonInteractive = not anaconda.interactive_mode
 
-    # if we're in text mode, the resulting system should be too
-    # ...unless the kickstart specified otherwise
-    from pyanaconda.modules.common.constants.services import SERVICES
-    from pyanaconda.core.constants import TEXT_ONLY_TARGET
-    services_proxy = SERVICES.get_proxy()
-
-    if not services_proxy.DefaultTarget and anaconda.tui_mode:
-        services_proxy.SetDefaultTarget(TEXT_ONLY_TARGET)
-
     # Set flag to prompt for missing ks data
     if not anaconda.interactive_mode:
         flags.ksprompt = False

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -641,8 +641,6 @@ class Payload(metaclass=ABCMeta):
                 # We only manipulate the ksdata.  The symlink is made later
                 # during the config write out.
                 services_proxy.SetDefaultTarget(GRAPHICAL_TARGET)
-            else:
-                services_proxy.SetDefaultTarget(TEXT_ONLY_TARGET)
 
     def post_install(self):
         """Perform post-installation tasks."""


### PR DESCRIPTION
With the Services DBus module making sure that
the multi-user.target is used if no target is set
we can drop the old fallbacks that are now redundant.