### PR TITLE
Fix systemd default target setting (#1722950)

### DIFF
--- a/pyanaconda/modules/services/installation.py
+++ b/pyanaconda/modules/services/installation.py
@@ -20,6 +20,7 @@ from configparser import ConfigParser
 
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.core.constants import TEXT_ONLY_TARGET
 from pyanaconda.core.util import get_anaconda_version_string
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.services.constants import SetupOnBootAction
@@ -203,14 +204,16 @@ class ConfigureSystemdDefaultTargetTask(Task):
         return "Configure systemd default target"
 
     def run(self):
-        log.debug("Setting systemd default target to: %s", self._default_target)
+        # if nothing decided on a default by now, go with text
+        default_target = self._default_target or TEXT_ONLY_TARGET
+        log.debug("Setting systemd default target to: %s", default_target)
 
         default_target_path = os.path.join(self._sysroot, 'etc/systemd/system/default.target')
         # unlink any links already in place
         if os.path.islink(default_target_path):
             os.unlink(default_target_path)
         # symlink the selected target
-        selected_target_path = os.path.join(self._sysroot, 'etc/systemd/system', self._default_target)
+        selected_target_path = os.path.join('/usr/lib/systemd/system', default_target)
         log.debug("Linking %s as systemd default target.", selected_target_path)
         os.symlink(selected_target_path, default_target_path)
 

--- a/pyanaconda/modules/services/services.py
+++ b/pyanaconda/modules/services/services.py
@@ -105,12 +105,9 @@ class ServicesModule(KickstartModule):
         data.services.enabled = self.enabled_services
         data.services.disabled = self.disabled_services
 
-        # Use the _default_target attribute directly instead of the
-        # default_target property to differentiate if default
-        # target has been set.
-        if self._default_target == TEXT_ONLY_TARGET:
+        if self.default_target == TEXT_ONLY_TARGET:
             data.skipx.skipx = True
-        elif self._default_target == GRAPHICAL_TARGET:
+        elif self.default_target == GRAPHICAL_TARGET:
             data.xconfig.startX = True
 
         data.xconfig.defaultdesktop = self.default_desktop
@@ -170,11 +167,7 @@ class ServicesModule(KickstartModule):
     @property
     def default_target(self):
         """Default target of the installed system."""
-        # if no target has been set, default to the text only target
-        if not self._default_target:
-            return TEXT_ONLY_TARGET
-        else:
-            return self._default_target
+        return self._default_target
 
     def set_default_target(self, target):
         """Set the default target of the installed system.


### PR DESCRIPTION
There are three things wrong with this since 91586cc171 landed:

1) The symlink target includes the sysroot, which is wrong;
when you create a symlink the target is absolute and permanent.
You don't want to include /mnt/sysroot in the symlink target
just because the installed system is mounted under /mnt/sysroot
in the installer environment, because the target needs to be
correct *when the installed system is booted*. If you include
/mnt/sysroot in the target it'll still be there when the system
is booted, which means it'll be pointing nowhere since there
won't be a /mnt/sysroot there.

2) The symlink target is set using /etc/systemd/system , but
the stock targets that we actually want our symlink to point to
(multi-user.target or graphical.target) aren't there. They are
in (/usr)/lib/systemd/system .

3) The change to have the service module's `default_target`
property always return a value broke setting the default target
in most cases. It would work as intended if the kickstart set
'xconfig --startxonboot' (setting graphical.target) or 'skipx'
(setting multi-user.target), but it doesn't work correctly in
any other case, because unless those kickstart settings are set,
we rely on `_set_default_boot_target()` in the payload post
install phase to decide on the correct default target (based on
whether any graphical login manager was installed), but that
method bails out if the service proxy's `DefaultTarget` (which
is basically the service module's `default_target`) is true-y.
So if `default_target` always has a value, that method always
gets skipped.

This fixes all three problems (I hope). The symlink target no
longer includes the sysroot, and uses /usr/lib/systemd/system
not /etc/systemd/system (both of these are how things were
before 91586cc171 ). The old behaviour for the service module's
`default_target` is restored, and we do the 'if no default
was explicitly set, use TEXT_ONLY_TARGET' work in
ConfigureSystemdDefaultTargetTask instead now. I believe there
shouldn't be an ordering problem here, as I believe
ConfigureSystemdDefaultTargetTask will be instantiated as part
of the 'configuration' install phase, which should run only
after the 'install' install phase - including post_install,
with `_set_default_boot_target()` - is complete. So by the
time we instantiate ConfigureSystemdDefaultTargetTask, both
the kickstart-y and post-install-y attempts to set a default
target should have run.

Resolves: rhbz#1722950

Signed-off-by: Adam Williamson <awilliam@redhat.com>