### PR TITLE
Use the default file system type for /boot

### DIFF
--- a/pyanaconda/modules/storage/partitioning/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic_partitioning.py
@@ -80,7 +80,6 @@ class AutomaticPartitioningTask(NonInteractivePartitioningTask):
 
         if fstype:
             storage.set_default_fstype(fstype)
-            storage.set_default_boot_fstype(fstype)
 
         # Set the default pbkdf args.
         pbkdf_args = self._luks_format_args.get('pbkdf_args', None)

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -193,7 +193,6 @@ class StorageModule(KickstartModule):
         # Set the default filesystem type.
         if data.autopart.autopart and data.autopart.fstype:
             self.storage.set_default_fstype(data.autopart.fstype)
-            self.storage.set_default_boot_fstype(data.autopart.fstype)
 
     def generate_kickstart(self):
         """Return the kickstart string."""

--- a/pyanaconda/storage/initialization.py
+++ b/pyanaconda/storage/initialization.py
@@ -103,7 +103,6 @@ def set_storage_defaults_from_kickstart(storage):
 
     if auto_part_proxy.Enabled and fstype:
         storage.set_default_fstype(fstype)
-        storage.set_default_boot_fstype(fstype)
 
 
 def load_plugin_s390():

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -48,7 +48,6 @@ class InstallerStorage(Blivet):
         super().__init__()
         self.protected_devices = []
         self._escrow_certificates = {}
-        self._default_boot_fstype = None
         self._bootloader = None
         self.__luks_devs = {}
         self.fsset = FSSet(self.devicetree)
@@ -71,20 +70,10 @@ class InstallerStorage(Blivet):
     @property
     def default_boot_fstype(self):
         """The default filesystem type for the boot partition."""
-        if self._default_boot_fstype:
-            return self._default_boot_fstype
+        if self.default_fstype in self.bootloader.stage2_format_types:
+            return self.default_fstype
 
         return self.bootloader.stage2_format_types[0]
-
-    def set_default_boot_fstype(self, newtype):
-        """ Set the default /boot fstype for this instance.
-
-            Raise ValueError on invalid input.
-        """
-        log.debug("trying to set new default /boot fstype to '%s'", newtype)
-        # This will raise ValueError if it isn't valid
-        self._check_valid_fstype(newtype)
-        self._default_boot_fstype = newtype
 
     @property
     def default_luks_version(self):


### PR DESCRIPTION
Use the default file system type for /boot if this type is supported
by the bootloader, otherwise choose the first one from the list
of supported file system types.

Remove the method set_default_boot_fstype. It is enough to set up
the default file system type with set_default_fstype now.

Suggested-by: Pat Riehecky