### PR TITLE
Add support for decomposing DBus values

### DIFF
--- a/pyanaconda/dbus/typing.py
+++ b/pyanaconda/dbus/typing.py
@@ -29,7 +29,7 @@ from pydbus import Variant
 __all__ = ["Bool", "Double", "Str", "Int", "Byte", "Int16", "UInt16",
            "Int32", "UInt32", "Int64", "UInt64", "File", "ObjPath",
            "Tuple", "List", "Dict", "Variant", "Structure",
-           "get_variant"]
+           "get_variant", "get_native"]
 
 # Basic types.
 Bool = bool
@@ -85,6 +85,30 @@ def get_variant(type_hint, value):
     :return: an instance of Variant
     """
     return Variant(get_dbus_type(type_hint), value)
+
+
+def get_native(value):
+    """Decompose a DBus value into a native Python object.
+
+    This function is useful for testing, when pydbus doesn't
+    decompose arguments and return values of DBus calls.
+
+    :param value: a DBus value
+    :return: a native Python object
+    """
+    if isinstance(value, Variant):
+        return value.unpack()
+
+    if isinstance(value, tuple):
+        return tuple(map(get_native, value))
+
+    if isinstance(value, list):
+        return list(map(get_native, value))
+
+    if isinstance(value, dict):
+        return {k: get_native(v) for k, v in value.items()}
+
+    return value
 
 
 class DBusType(object):

--- a/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_structure_test.py
@@ -339,6 +339,18 @@ class DBusStructureTestCase(unittest.TestCase):
             )
         ))
 
+    def get_native_complicated_structure_test(self):
+        dictionary = {
+            'dictionary': {1: "1", 2: "2"},
+            'bool-list': [True, False, False],
+            'very-long-property-name': "My String Value"
+        }
+        data = self.ComplicatedData.from_structure(dictionary)
+        structure = self.ComplicatedData.to_structure(data)
+
+        self.assertEqual(get_native(structure), dictionary)
+        self.assertEqual(get_native(dictionary), dictionary)
+
     class StringData(DBusData):
 
         def __init__(self):

--- a/tests/nosetests/pyanaconda_tests/dbus_typing_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_typing_test.py
@@ -137,6 +137,10 @@ class DBusTypingVariantTests(unittest.TestCase):
         v2 = Variant(expected_string, value)
         self.assertTrue(v2.equal(v1))
 
+        self.assertEqual(get_native(v1), value)
+        self.assertEqual(get_native(v1), get_native(v2))
+        self.assertEqual(get_native(value), value)
+
     def variant_invalid_test(self):
         """Test invalid variants."""
 
@@ -181,3 +185,46 @@ class DBusTypingVariantTests(unittest.TestCase):
         """Test variants with type aliases."""
         AliasType = List[Double]
         self._test_variant(Dict[Str, AliasType], "a{sad}", {"test": [1.1, 2.2]})
+
+    def _test_native(self, variants, values):
+        """Test native values of variants."""
+        for variant, value in zip(variants, values):
+            self.assertEqual(get_native(variant), value)
+
+        self.assertEqual(get_native(tuple(variants)), tuple(values))
+        self.assertEqual(get_native(list(variants)), list(values))
+        self.assertEqual(get_native(dict(enumerate(variants))), dict(enumerate(values)))
+
+    def basic_native_test(self):
+        """Test get_native with basic variants."""
+        self._test_native(
+            [
+                get_variant(Double, 1.2),
+                get_variant(List[Int], [0, -1]),
+                get_variant(Tuple[Bool, Bool], (True, False)),
+                get_variant(Dict[Str, Int], {"key": 0}),
+            ],
+            [
+                1.2,
+                [0, -1],
+                (True, False),
+                {"key": 0}
+            ]
+        )
+
+    def complex_native_test(self):
+        """Test get_native with complex variants."""
+        self._test_native(
+            [
+                get_variant(Variant, get_variant(Double, 1.2)),
+                get_variant(List[Variant], [get_variant(Int, 0), get_variant(Int, -1)]),
+                get_variant(Tuple[Variant, Bool], (get_variant(Bool, True), False)),
+                get_variant(Dict[Str, Variant], {"key": get_variant(Int, 0)})
+            ],
+            [
+                1.2,
+                [0, -1],
+                (True, False),
+                {"key": 0}
+            ]
+        )


### PR DESCRIPTION
Call `get_native` to decompose a DBus value into a native Python object.
This function is useful for testing, when pydbus doesn't decompose
arguments and return values of DBus calls.