### PR TITLE
Add payload state to Payload Live OS handler

### DIFF
--- a/pyanaconda/modules/payload/constants.py
+++ b/pyanaconda/modules/payload/constants.py
@@ -1,0 +1,31 @@
+#
+# Private constants for the payload module.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from enum import Enum, unique
+
+
+@unique
+class ModuleState(Enum):
+    """State of the payload handler."""
+
+    STARTED = "started"
+    READY = "ready"
+    UNREADY = "unready"
+    INSTALLING = "installing"
+    FINISHED = "finished"

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -25,6 +25,7 @@ from pyanaconda.dbus import DBus
 from pyanaconda.core.signal import Signal
 from pyanaconda.core.constants import INSTALL_TREE
 
+from pyanaconda.modules.payload.constants import ModuleState
 from pyanaconda.modules.common.constants.objects import LIVE_OS_HANDLER
 from pyanaconda.modules.common.base import KickstartBaseModule
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
@@ -41,6 +42,11 @@ class LiveOSHandlerModule(KickstartBaseModule):
     def __init__(self):
         super().__init__()
 
+        self._state = None
+        self.state_changed = Signal()
+
+        self.set_state(ModuleState.STARTED)
+
         self._image_path = ""
         self.image_path_changed = Signal()
 
@@ -53,6 +59,24 @@ class LiveOSHandlerModule(KickstartBaseModule):
 
     def setup_kickstart(self, data):
         """Setup the kickstart data."""
+
+    @property
+    def state(self):
+        """State of this payload handler.
+
+        :rtype: Enum pyanaconda.modules.payload.constants.ModuleState
+        """
+        return self._state
+
+    def set_state(self, state):
+        """Set state of this payload handler.
+
+        :param state: state of this payload handler
+        :type state: Enum pyanaconda.modules.payload.constants.ModuleState
+        """
+        self._state = state
+        self.state_changed.emit()
+        log.debug("LiveOS handler state has changed to %s", self._state)
 
     @property
     def image_path(self):

--- a/pyanaconda/modules/payload/live/live_os_interface.py
+++ b/pyanaconda/modules/payload/live/live_os_interface.py
@@ -23,6 +23,7 @@ from pyanaconda.dbus.property import emits_properties_changed
 
 from pyanaconda.modules.common.constants.objects import LIVE_OS_HANDLER
 from pyanaconda.modules.common.base import KickstartModuleInterfaceTemplate
+from pyanaconda.modules.payload.constants import ModuleState
 
 
 @dbus_interface(LIVE_OS_HANDLER.interface_name)
@@ -33,6 +34,7 @@ class LiveOSHandlerInterface(KickstartModuleInterfaceTemplate):
         super().connect_signals()
 
         self.watch_property("ImagePath", self.implementation.image_path_changed)
+        self.watch_property("State", self.implementation.state_changed)
 
     @property
     def ImagePath(self) -> Str:
@@ -49,6 +51,22 @@ class LiveOSHandlerInterface(KickstartModuleInterfaceTemplate):
         This image will be used as the installation source.
         """
         self.implementation.set_image_path(image_path)
+
+    @property
+    def State(self) -> Str:
+        """State of the payload handler.
+
+        For list of possible values see payload ModuleState enum.
+        """
+        return self.implementation.state.value
+
+    @emits_properties_changed
+    def SetState(self, state: Str):
+        """Set state of the payload handler.
+
+        For list of possible values see payload ModuleState enum.
+        """
+        self.implementation.set_state(ModuleState(state))
 
     def DetectLiveOSImage(self) -> Str:
         """Try to find valid live os image.

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -52,6 +52,17 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
         self.callback.assert_called_once_with(
             LIVE_OS_HANDLER.interface_name, {"ImagePath": "/my/supper/image/path"}, [])
 
+    def empty_state_properties_test(self):
+        """Test Live OS default state."""
+        self.assertEqual(self.live_os_interface.State, "started")
+
+    def state_properties_test(self):
+        """Test Live OS set state."""
+        self.live_os_interface.SetState("installing")
+        self.assertEqual(self.live_os_interface.State, "installing")
+        self.callback.assert_called_once_with(
+            LIVE_OS_HANDLER.interface_name, {"State": "installing"}, [])
+
     @patch("pyanaconda.modules.payload.live.live_os.stat")
     @patch("os.stat")
     def detect_live_os_image_test(self, os_stat, stat):


### PR DESCRIPTION
This state is defined in main payload module because it will be shared between payloads.