### PR TITLE
Add the option decorated_window to the Anaconda configuration

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -146,6 +146,10 @@ blivet_gui_supported = True
 # FIXME: Use other identification then names of the spokes.
 hidden_spokes =
 
+# Run GUI installer in a decorated window.
+decorated_window = False
+
+
 [License]
 # A path to EULA (if any)
 #

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -280,7 +280,3 @@ as a comma separated list, for example: "all_ks,logs"
 waitfornet
 Wait for network connectivity at the beginning of the installation with the
 timeout in seconds specified as a mandatory value of the option.
-
-decorated
-Run GUI installer in a decorated window. By default, the window is not decorated, so it doesn't have a title bar,
-resize controls, etc.

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -579,14 +579,6 @@ installation progresses to debug or monitor its progress.
     The ``root`` account has no password by default. You can set one using
     the ``sshpw`` kickstart command.
 
-.. inst.decorated
-
-inst.decorated
-^^^^^^^^^^^^^^
-
-Run GUI installer in a decorated window. By default, the window is not decorated,
-so it doesn't have a title bar, resize controls, etc.
-
 
 Debugging and Troubleshooting
 -----------------------------

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -48,7 +48,6 @@ class Anaconda(object):
         self.opts = None
         self._payload = None
         self.proxy = None
-        self.decorated = False
         self._storage = None
         self.mehConfig = None
 
@@ -67,7 +66,6 @@ class Anaconda(object):
     def set_from_opts(self, opts):
         """Load argument to variables from self.opts."""
         self.opts = opts
-        self.decorated = opts.decorated
         self.proxy = opts.proxy
         self.methodstr = opts.method
         self.additional_repos = opts.addRepo
@@ -281,7 +279,7 @@ class Anaconda(object):
             # use the window manager
             self._intf = GraphicalUserInterface(self.storage, self.payload,
                                                 gui_lock=self.gui_initialized,
-                                                fullscreen=False, decorated=self.decorated)
+                                                fullscreen=False)
 
             # needs to be refreshed now we know if gui or tui will take place
             addon_paths = addons.collect_addon_paths(constants.ADDON_PATHS,

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -479,8 +479,6 @@ def getArgumentParser(version_string, boot_cmdline=None):
                     default=None, metavar="DRIVER", help=help_parser.help_text("xdriver"))
     ap.add_argument("--xtimeout", dest="xtimeout", action="store", type=int, default=X_TIMEOUT,
                     metavar="TIMEOUT_IN_SECONDS", help=help_parser.help_text("xtimeout"))
-    ap.add_argument("--decorated", dest="decorated", action="store_true", default=False,
-                    help=help_parser.help_text("decorated"))
 
     # Language
     ap.add_argument("--keymap", metavar="KEYMAP", help=help_parser.help_text("keymap"))

--- a/pyanaconda/core/configuration/ui.py
+++ b/pyanaconda/core/configuration/ui.py
@@ -53,3 +53,14 @@ class UserInterfaceSection(Section):
         :return: a list of strings
         """
         return self._get_option("hidden_spokes", str).split()
+
+    @property
+    def decorated_window(self):
+        """Run GUI installer in a decorated window.
+
+        By default, the window is not decorated, so it doesn't
+        have a title bar, resize controls, etc.
+
+        :return: True or False
+        """
+        return self._get_option("decorated_window", bool)

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -646,7 +646,7 @@ class GraphicalUserInterface(UserInterface):
     """
     def __init__(self, storage, payload,
                  distributionText=product.distributionText, isFinal=product.isFinal,
-                 quitDialog=QuitDialog, gui_lock=None, fullscreen=False, decorated=False):
+                 quitDialog=QuitDialog, gui_lock=None, fullscreen=False):
 
         super().__init__(storage, payload)
 
@@ -656,7 +656,7 @@ class GraphicalUserInterface(UserInterface):
 
         self.data = None
 
-        self.mainWindow = MainWindow(fullscreen=fullscreen, decorated=decorated)
+        self.mainWindow = MainWindow(fullscreen=fullscreen, decorated=conf.ui.decorated_window)
 
         self._distributionText = distributionText
         self._isFinal = isFinal


### PR DESCRIPTION
Add a new configuration option decorated_window to the User Interface
section of the Anaconda configuration file and use it instead of the
Anaconda option decorated.