### PR TITLE
Fix default value for pwpolicy emptyok (#1664704)

### DIFF
--- a/pyanaconda/pwpolicy.py
+++ b/pyanaconda/pwpolicy.py
@@ -131,8 +131,8 @@ class F22_PwPolicy(KickstartCommand):
                         version=F22, help="""
                         Do not allow UI to be used to change the password/user
                         if it has been set in the kickstart.""")
-        op.add_argument("--emptyok", action="store_true", version=F22, help="""
-                        Allow empty password.""")
+        op.add_argument("--emptyok", action="store_true", version=F22, default=True,
+                        help="""Allow empty password.""")
         op.add_argument("--notempty", dest="emptyok", action="store_false",
                         version=F22, help="""
                         Don't allow an empty password.""")


### PR DESCRIPTION
The pwpolicy command supported in the %anaconda
section of kickstart uses KSOptionParser provided
by the Pykickstart module.

In RHEL7 Pykickstart still uses OptionParser for option
parsing, while on RHEL8 & in Fedora Pykickstart now uses
Argparse. This has apprently caused a subtle regression
in the default value of the emptyok option of the
pwpolicy command. On RHEL7 the default value was True
which on RHEL8 it changed to False.

So explicitely set the default value of the emptyok option
to be True, to fix this issue.

Resolves: rhbz#1664704