### PR TITLE
Add root password SSH login override checkbox (#1716282)

### DIFF
--- a/pyanaconda/modules/users/installation.py
+++ b/pyanaconda/modules/users/installation.py
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 
+import os
+
 from pyanaconda.core import users
 
 from pyanaconda.modules.common.task import Task
@@ -24,7 +26,8 @@ from pyanaconda.modules.common.structures.user import USER_GID_NOT_SET, USER_UID
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
-__all__ = ["SetRootPasswordTask", "CreateUsersTask", "CreateGroupsTask", "SetSshKeysTask"]
+__all__ = ["SetRootPasswordTask", "CreateUsersTask", "CreateGroupsTask", "SetSshKeysTask",
+           "ConfigureRootPasswordSSHLoginTask"]
 
 
 class SetRootPasswordTask(Task):
@@ -161,3 +164,37 @@ class SetSshKeysTask(Task):
     def _set_ssh_keys(self):
         for key_data in self._ssh_key_data_list:
             users.set_user_ssh_key(key_data.username, key_data.key)
+
+class ConfigureRootPasswordSSHLoginTask(Task):
+    """Optionally add an override allowing root to login with password over SSH."""
+
+    SSHD_OVERRIDE_DROP_DIR = "etc/systemd/system/sshd.service.d/"
+    OVERRIDE_CONFIG_NAME = "anaconda.conf"
+
+    def __init__(self, sysroot, password_allowed):
+        """Create a new root password SSH login configuration task.
+
+        :param str sysroot: a path to the root of the installed system
+        :param bool password_allowed: True allows root to login via SSH with password auth.
+                                      False prevents it by not changing the default OpenSSH
+                                      behavior
+        """
+        super().__init__()
+        self._sysroot = sysroot
+        self._password_allowed = password_allowed
+
+    @property
+    def name(self):
+        return "Configure optional root password SSH login"
+
+    def run(self):
+        # TODO: don't instantiate and run this Task if the override is not needed
+        if self._password_allowed:
+            log.debug("adding an override allowing root login with password via SSH")
+            dropdir_path = os.path.join(self._sysroot, self.SSHD_OVERRIDE_DROP_DIR)
+            os.makedirs(dropdir_path)
+            config_path = os.path.join(dropdir_path, self.OVERRIDE_CONFIG_NAME)
+            with open(config_path, "wt") as f:
+                f.write('[Service]\nEnvironment=OPTIONS="-oPermitRootLogin=yes"')
+        else:
+            log.debug("not adding an override allowing root login with password via SSH")

--- a/pyanaconda/modules/users/users.py
+++ b/pyanaconda/modules/users/users.py
@@ -28,7 +28,8 @@ from pyanaconda.modules.common.structures.sshkey import SshKeyData
 from pyanaconda.modules.users.kickstart import UsersKickstartSpecification
 from pyanaconda.modules.users.users_interface import UsersInterface
 from pyanaconda.modules.users.installation import SetRootPasswordTask, CreateUsersTask, \
-                                                  CreateGroupsTask, SetSshKeysTask
+                                                  CreateGroupsTask, SetSshKeysTask, \
+                                                  ConfigureRootPasswordSSHLoginTask
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -48,6 +49,9 @@ class UsersModule(KickstartModule):
 
         self.root_account_locked_changed = Signal()
         self._root_account_locked = True
+
+        self._root_password_ssh_login_allowed = False
+        self.root_password_ssh_login_allowed_changed = Signal()
 
         self.users_changed = Signal()
         self._users = []
@@ -173,6 +177,18 @@ class UsersModule(KickstartModule):
         task = SetSshKeysTask(sysroot=sysroot, ssh_key_data_list=self.ssh_keys)
         return self.publish_task(USERS.namespace, task)
 
+    def configure_root_password_ssh_login_with_task(self, sysroot):
+        """Return the root password SSH login configuration task.
+
+        :param str sysroot: a path to the root of the installed system
+        :param bool root_password_ssh_login_allowed: if root login via SSH with password
+                                                     should be allowed
+        :returns: object path of the root password SSH login configuration task
+        """
+        task = ConfigureRootPasswordSSHLoginTask(sysroot=sysroot,
+                                                 password_allowed=self.root_password_ssh_login_allowed)
+        return self.publish_task(USERS.namespace, task)
+
     def install_with_tasks(self, sysroot):
         """Return the installation tasks of this module.
 
@@ -183,7 +199,8 @@ class UsersModule(KickstartModule):
             self.configure_groups_with_task(sysroot=sysroot),
             self.configure_users_with_task(sysroot=sysroot),
             self.set_root_password_with_task(sysroot=sysroot),
-            self.set_ssh_keys_with_task(sysroot=sysroot)
+            self.set_ssh_keys_with_task(sysroot=sysroot),
+            self.configure_root_password_ssh_login_with_task(sysroot=sysroot)
         ]
         return paths
 
@@ -353,6 +370,25 @@ class UsersModule(KickstartModule):
     def root_account_locked(self):
         """Is the root account locked ?"""
         return self._root_account_locked
+
+    def set_root_password_ssh_login_allowed(self, root_password_ssh_login_allowed):
+        """Allow/disable root login via SSH with password.
+
+        (Login as root with key is always allowed)
+
+        param bool root_password_ssh_login_allowed: True to allow, False to disallow
+        """
+        self._root_password_ssh_login_allowed = root_password_ssh_login_allowed
+        self.root_password_ssh_login_allowed_changed.emit()
+        if root_password_ssh_login_allowed:
+            log.debug("SSH login as root with password will be allowed.")
+        else:
+            log.debug("SSH login as root with password will not be allowed.")
+
+    @property
+    def root_password_ssh_login_allowed(self):
+        """Is logging in as root via SSH with password allowed ?"""
+        return self._root_password_ssh_login_allowed
 
     @property
     def check_admin_user_exists(self):

--- a/pyanaconda/modules/users/users_interface.py
+++ b/pyanaconda/modules/users/users_interface.py
@@ -39,6 +39,7 @@ class UsersInterface(KickstartModuleInterface):
         self.watch_property("SshKeys", self.implementation.ssh_keys_changed)
         self.watch_property("IsRootPasswordSet", self.implementation.root_password_is_set_changed)
         self.watch_property("IsRootAccountLocked", self.implementation.root_account_locked_changed)
+        self.watch_property("RootPasswordSSHLoginAllowed", self.implementation.root_password_ssh_login_allowed_changed)
         self.watch_property("CanChangeRootPassword", self.implementation.can_change_root_password_changed)
 
     @property
@@ -107,6 +108,18 @@ class UsersInterface(KickstartModuleInterface):
         """
         return self.implementation.root_account_locked
 
+    @emits_properties_changed
+    def SetRootPasswordSSHLoginAllowed(self, root_password_ssh_login_allowed: Bool):
+        """Allow or disallow the root from logging in via SSH with password authetication."""
+        self.implementation.set_root_password_ssh_login_allowed(root_password_ssh_login_allowed)
+
+    @property
+    def RootPasswordSSHLoginAllowed(self) -> Bool:
+        """Is logging in as root via SSH with password allowed ?
+
+        :return: True if root SSH loggin with password is allowed, False otherwise
+        """
+        return self.implementation.root_password_ssh_login_allowed
 
     @property
     def Users(self) -> List[Structure]:

--- a/pyanaconda/ui/gui/spokes/root_password.glade
+++ b/pyanaconda/ui/gui/spokes/root_password.glade
@@ -180,9 +180,6 @@
                   </packing>
                 </child>
                 <child>
-                  <placeholder/>
-                </child>
-                <child>
                   <object class="GtkCheckButton" id="lock">
                     <property name="label" translatable="yes">Lock root account</property>
                     <property name="visible">True</property>
@@ -195,8 +192,26 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="root_password_ssh_login_override">
+                    <property name="label" translatable="yes">Allow root SSH login with password</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
+                </child>
+                <child>
+                  <placeholder/>
                 </child>
               </object>
             </child>

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -75,6 +75,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self._password_bar = self.builder.get_object("password_bar")
         self._password_label = self.builder.get_object("password_label")
         self._lock = self.builder.get_object("lock")
+        self._root_password_ssh_login_override = self.builder.get_object("root_password_ssh_login_override")
 
         # Install the password checks:
         # - Has a password been specified?
@@ -185,6 +186,11 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         pw = self.password
 
         self._users_module.SetRootAccountLocked(self._lock.get_active())
+
+        # the checkbox makes it possible to override the default Open SSH
+        # policy of not allowing root to login with password
+        ssh_login_override = self._root_password_ssh_login_override.get_active()
+        self._users_module.SetRootPasswordSSHLoginAllowed(ssh_login_override)
 
         if not pw:
             self._users_module.ClearRootPassword()


### PR DESCRIPTION
Open SSH, which provides the SSH server Fedora uses already for some
time disallowed password based root logins. Fedora used to patch this
out so far, but this patch has been recently dropped, restoring the
upstream behavior.

This change does not affect key based SSH logins and it will continue
to be possible to login as root with key based authentication.

To make the transition easier for user who might have valid use cases
for logging in as root with password over SSH we will add a checkbox
to the root password spoke. This checkbox makes it possible to manually
enable password based SSH logins for the root account.

Resolves: rhbz#1716282

**TODO:**
- ~unit tests for DBus API~
- ~unit tests for DBus Task~