### PR TITLE
Use %autosetup instead of %setup

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -251,7 +251,7 @@ options. This includes driver disks, kickstarts, and finding the anaconda
 runtime on NFS/HTTP/FTP servers or local disks.
 
 %prep
-%setup -q
+%autosetup -p 1
 
 %build
 # use actual build-time release number, not tarball creation time release number


### PR DESCRIPTION
If we use %autosetup instead of %setup
we no longer need to manually apply
each individual patch, like we did so
far for all patch-only Anaconda builds
on Fedora.

Also we have been using %autosetup in
the RHEL 8 Anaconda spec file for the
last ~year, without issues.

For more information about %autosetup see:
https://rpm.org/user_doc/autosetup.html