### PR TITLE
Start swap on ZRAM service

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -54,6 +54,10 @@ if [ $LIVE_INSTALL = 1 -a ! -b "$LIVE_BLOCK" ]; then
   exit 1
 fi
 
+# Start swap on ZRAM service. Do this for LiveOS only, rather than enabling
+# it on the target system, for the time being.
+systemctl start zram.service
+
 # Allow running another command in the place of anaconda, but in this same
 # environment.  This allows storage testing to make use of all the module
 # loading and lvm control in this file, too.


### PR DESCRIPTION
It's best if a system with too little RAM fails to completely startup, before anaconda can be launched. Hence, don't start swap-on-zram early. Starting it at anaconda launch time instead helps ensure anaconda will run and succeed in case free memory is marginal.

Proposal and discussion on anaconda-devel@
    https://www.redhat.com/archives/anaconda-devel-list/2019-June/msg00011.html

Previous Workstation WG approval
    https://pagure.io/fedora-workstation/issue/75

After this change lands in Rawhide, I will issue a PR on the following change to remove legacy swap setup from the Fedora live base kickstart.
https://pagure.io/fork/chrismurphy/fedora-kickstarts/c/370d389a3f172ac543a9e03e71160dc395c09786?branch=devel