### PR TITLE
Tweak payload handlers

### DIFF
--- a/pyanaconda/modules/common/errors/payload.py
+++ b/pyanaconda/modules/common/errors/payload.py
@@ -1,5 +1,5 @@
 #
-# DBus errors related to the payload.
+# DBus errors related to the payload module and handlers.
 #
 # Copyright (C) 2019  Red Hat, Inc.  All rights reserved.
 #
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-
 from pyanaconda.dbus.error import dbus_error
 from pyanaconda.modules.common.constants.namespaces import PAYLOAD_NAMESPACE
 from pyanaconda.modules.common.errors import AnacondaError
@@ -27,7 +26,14 @@ class SourceSetupError(AnacondaError):
     """Error raised during the source setup."""
     pass
 
+
 @dbus_error("InstallError", namespace=PAYLOAD_NAMESPACE)
 class InstallError(AnacondaError):
     """Error raised during payload installation."""
+    pass
+
+
+@dbus_error("HandlerNotSetError", namespace=PAYLOAD_NAMESPACE)
+class HandlerNotSetError(AnacondaError):
+    """Payload handler is not set."""
     pass

--- a/pyanaconda/modules/payload/dnf/dnf.py
+++ b/pyanaconda/modules/payload/dnf/dnf.py
@@ -18,8 +18,8 @@
 # Red Hat, Inc.
 #
 from pyanaconda.dbus import DBus
-from pyanaconda.modules.common.base import KickstartBaseModule
 from pyanaconda.modules.common.constants.objects import PAYLOAD_DEFAULT
+from pyanaconda.modules.payload.handler_base import PayloadHandlerBase
 from pyanaconda.modules.payload.dnf.dnf_interface import DNFHandlerInterface
 from pyanaconda.modules.payload.dnf.packages.packages import PackagesHandlerModule
 
@@ -27,7 +27,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class DNFHandlerModule(KickstartBaseModule):
+class DNFHandlerModule(PayloadHandlerBase):
     """The DNF payload module."""
 
     def __init__(self):
@@ -47,3 +47,7 @@ class DNFHandlerModule(KickstartBaseModule):
     def setup_kickstart(self, data):
         """Setup the kickstart data."""
         self._packages_handler.setup_kickstart(data)
+
+    def get_handler_path(self):
+        """Get path of this payload handler."""
+        return PAYLOAD_DEFAULT.object_path

--- a/pyanaconda/modules/payload/dnf/dnf.py
+++ b/pyanaconda/modules/payload/dnf/dnf.py
@@ -34,11 +34,12 @@ class DNFHandlerModule(PayloadHandlerBase):
         super().__init__()
         self._packages_handler = PackagesHandlerModule()
 
-    def publish(self):
-        """Publish the module."""
+    def publish_handler(self):
+        """Publish the handler."""
         self._packages_handler.publish()
 
         DBus.publish_object(PAYLOAD_DEFAULT.object_path, DNFHandlerInterface(self))
+        return PAYLOAD_DEFAULT.object_path
 
     def process_kickstart(self, data):
         """Process the kickstart data."""

--- a/pyanaconda/modules/payload/dnf/dnf.py
+++ b/pyanaconda/modules/payload/dnf/dnf.py
@@ -48,7 +48,3 @@ class DNFHandlerModule(PayloadHandlerBase):
     def setup_kickstart(self, data):
         """Setup the kickstart data."""
         self._packages_handler.setup_kickstart(data)
-
-    def get_handler_path(self):
-        """Get path of this payload handler."""
-        return PAYLOAD_DEFAULT.object_path

--- a/pyanaconda/modules/payload/handler_base.py
+++ b/pyanaconda/modules/payload/handler_base.py
@@ -1,0 +1,39 @@
+#
+# Base object of all payload handlers.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from abc import ABCMeta, abstractmethod
+
+from pyanaconda.modules.common.base import KickstartBaseModule
+
+
+class PayloadHandlerBase(KickstartBaseModule, metaclass=ABCMeta):
+    """Base class for all the payload handler modules.
+
+    This will contain all API specific to payload handlers which will be called
+    by the base payload module.
+    """
+
+    @abstractmethod
+    def get_handler_path(self):
+        """Get path of this payload handler.
+
+        :returns: path to this handler
+        :rtype: string
+        """
+        pass

--- a/pyanaconda/modules/payload/handler_base.py
+++ b/pyanaconda/modules/payload/handler_base.py
@@ -37,12 +37,3 @@ class PayloadHandlerBase(KickstartBaseModule, metaclass=ABCMeta):
         :rtype: string
         """
         pass
-
-    @abstractmethod
-    def get_handler_path(self):
-        """Get path of this payload handler.
-
-        :returns: path to this handler
-        :rtype: string
-        """
-        pass

--- a/pyanaconda/modules/payload/handler_base.py
+++ b/pyanaconda/modules/payload/handler_base.py
@@ -30,6 +30,15 @@ class PayloadHandlerBase(KickstartBaseModule, metaclass=ABCMeta):
     """
 
     @abstractmethod
+    def publish_handler(self):
+        """Publish object on DBus and return its path.
+
+        :returns: path to this handler
+        :rtype: string
+        """
+        pass
+
+    @abstractmethod
     def get_handler_path(self):
         """Get path of this payload handler.
 

--- a/pyanaconda/modules/payload/handler_factory.py
+++ b/pyanaconda/modules/payload/handler_factory.py
@@ -1,0 +1,76 @@
+#
+# Factory class to create payload handlers.
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+from enum import Enum, unique
+
+from pyanaconda.modules.payload.dnf.dnf import DNFHandlerModule
+from pyanaconda.modules.payload.live.live_image import LiveImageHandlerModule
+from pyanaconda.modules.payload.live.live_os import LiveOSHandlerModule
+
+
+@unique
+class HandlerType(Enum):
+    """Type of the payload handler."""
+    DNF = "DNF"
+    LIVE_OS = "LIVE_OS"
+    LIVE_IMAGE = "LIVE_IMAGE"
+
+
+class HandlerFactory(object):
+    """Factory to create payload handlers."""
+
+    @classmethod
+    def create_handler(cls, handler_type):
+        """Create handler of the given type.
+
+        :param handler_type: value from the HandlerType enum
+        """
+        handler = cls._create_handler(handler_type)
+
+        return handler
+
+    @classmethod
+    def create_handler_from_ks_data(cls, data):
+        """Create handler based on the KS data.
+
+        :param data: kickstart data
+        """
+        handler_type = cls._get_handler_type_from_ks(data)
+
+        if handler_type is None:
+            return None
+
+        return cls.create_handler(handler_type)
+
+    @classmethod
+    def _get_handler_type_from_ks(cls, data):
+        if data.liveimg.seen:
+            return HandlerType.LIVE_IMAGE
+        elif data.packages.seen:
+            return HandlerType.DNF
+        else:
+            return None
+
+    @classmethod
+    def _create_handler(cls, handler_type):
+        if handler_type == HandlerType.LIVE_IMAGE:
+            return LiveImageHandlerModule()
+        elif handler_type == HandlerType.LIVE_OS:
+            return LiveOSHandlerModule()
+        elif handler_type == HandlerType.DNF:
+            return DNFHandlerModule()

--- a/pyanaconda/modules/payload/live/live_image.py
+++ b/pyanaconda/modules/payload/live/live_image.py
@@ -25,8 +25,8 @@ from pyanaconda.core.util import requests_session, getSysroot
 
 from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.modules.common.constants.objects import LIVE_IMAGE_HANDLER
-from pyanaconda.modules.common.base import KickstartBaseModule
 from pyanaconda.modules.common.errors.payload import SourceSetupError
+from pyanaconda.modules.payload.handler_base import PayloadHandlerBase
 from pyanaconda.modules.payload.live.live_image_interface import LiveImageHandlerInterface
 from pyanaconda.modules.payload.live.initialization import CheckInstallationSourceImageTask, \
     SetupInstallationSourceImageTask, UpdateBLSConfigurationTask, \
@@ -39,7 +39,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class LiveImageHandlerModule(KickstartBaseModule):
+class LiveImageHandlerModule(PayloadHandlerBase):
     """The Live Image payload module."""
 
     def __init__(self):
@@ -90,6 +90,10 @@ class LiveImageHandlerModule(KickstartBaseModule):
         liveimg.checksum = self.checksum
         liveimg.noverifyssl = not self.verifyssl
         liveimg.seen = True
+
+    def get_handler_path(self):
+        """Get path of this payload handler."""
+        return LIVE_IMAGE_HANDLER.object_path
 
     @property
     def url(self):

--- a/pyanaconda/modules/payload/live/live_image.py
+++ b/pyanaconda/modules/payload/live/live_image.py
@@ -92,10 +92,6 @@ class LiveImageHandlerModule(PayloadHandlerBase):
         liveimg.noverifyssl = not self.verifyssl
         liveimg.seen = True
 
-    def get_handler_path(self):
-        """Get path of this payload handler."""
-        return LIVE_IMAGE_HANDLER.object_path
-
     @property
     def url(self):
         """Get url where to obtain the live image for installation.

--- a/pyanaconda/modules/payload/live/live_image.py
+++ b/pyanaconda/modules/payload/live/live_image.py
@@ -66,9 +66,10 @@ class LiveImageHandlerModule(PayloadHandlerBase):
 
         self._requests_session = None
 
-    def publish(self):
-        """Publish the module."""
+    def publish_handler(self):
+        """Publish the handler."""
         DBus.publish_object(LIVE_IMAGE_HANDLER.object_path, LiveImageHandlerInterface(self))
+        return LIVE_IMAGE_HANDLER.object_path
 
     def process_kickstart(self, data):
         """Process the kickstart data."""

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -26,7 +26,7 @@ from pyanaconda.core.signal import Signal
 from pyanaconda.core.constants import INSTALL_TREE
 
 from pyanaconda.modules.common.constants.objects import LIVE_OS_HANDLER
-from pyanaconda.modules.common.base import KickstartBaseModule
+from pyanaconda.modules.payload.handler_base import PayloadHandlerBase
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
 from pyanaconda.modules.payload.live.initialization import SetupInstallationSourceTask, \
     TeardownInstallationSourceTask
@@ -35,7 +35,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class LiveOSHandlerModule(KickstartBaseModule):
+class LiveOSHandlerModule(PayloadHandlerBase):
     """The Live OS payload module."""
 
     def __init__(self):
@@ -53,6 +53,10 @@ class LiveOSHandlerModule(KickstartBaseModule):
 
     def setup_kickstart(self, data):
         """Setup the kickstart data."""
+
+    def get_handler_path(self):
+        """Get path of this payload handle."""
+        return LIVE_OS_HANDLER.object_path
 
     @property
     def image_path(self):

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -44,9 +44,10 @@ class LiveOSHandlerModule(PayloadHandlerBase):
         self._image_path = ""
         self.image_path_changed = Signal()
 
-    def publish(self):
-        """Publish the module."""
+    def publish_handler(self):
+        """Publish the handler."""
         DBus.publish_object(LIVE_OS_HANDLER.object_path, LiveOSHandlerInterface(self))
+        return LIVE_OS_HANDLER.object_path
 
     def process_kickstart(self, data):
         """Process the kickstart data."""

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -55,10 +55,6 @@ class LiveOSHandlerModule(PayloadHandlerBase):
     def setup_kickstart(self, data):
         """Setup the kickstart data."""
 
-    def get_handler_path(self):
-        """Get path of this payload handle."""
-        return LIVE_OS_HANDLER.object_path
-
     @property
     def image_path(self):
         """Path to the source live OS image.

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -117,6 +117,15 @@ class PayloadModule(KickstartModule):
 
         return str(data)
 
+    def create_dnf_handler(self):
+        """Create the DNF payload handler and publish it.
+
+        :returns: DBus path to the handler
+        :rtype: str
+        """
+        self._initialize_handler(DNFHandlerModule)
+        return self.payload_handler.get_handler_path()
+
     def create_live_os_handler(self):
         """Create the live os payload handler and publish it.
 

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -80,20 +80,30 @@ class PayloadModule(KickstartModule):
         """Process the kickstart data."""
         log.debug("Processing kickstart data...")
 
-        self._create_correct_handler(data)
+        handler_class = self._get_correct_handler_class(data)
+        self._initialize_handler(handler_class)
 
         self.payload_handler.process_kickstart(data)
 
-    def _create_correct_handler(self, data):
-        handler = None
-
+    def _get_correct_handler_class(self, data):
         if data.liveimg.seen:
-            handler = LiveImageHandlerModule()
+            return LiveImageHandlerModule
         else:
-            handler = DNFHandlerModule()
+            return DNFHandlerModule
 
-        handler.publish()
+    def _initialize_handler(self, handler_class):
+        handler = handler_class()
+
+        self._publish_handler(handler)
         self.set_payload_handler(handler)
+
+    @staticmethod
+    def _publish_handler(handler):
+        """Publish handler passed in.
+
+        This method is really helpful for testing purpose.
+        """
+        handler.publish()
 
     def generate_kickstart(self):
         """Return the kickstart string."""
@@ -108,14 +118,10 @@ class PayloadModule(KickstartModule):
         return str(data)
 
     def create_live_os_handler(self):
-        """Create the live os payload handler and publish it and return DBus path.
+        """Create the live os payload handler and publish it.
 
         :returns: DBus path to the handler
         :rtype: str
         """
-        handler = LiveOSHandlerModule()
-
-        handler.publish()
-        self.set_payload_handler(handler)
-
+        self._initialize_handler(LiveOSHandlerModule)
         return self.payload_handler.get_handler_path()

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -70,6 +70,10 @@ class PayloadModule(KickstartModule):
         self._payload_handler = payload_handler
         log.debug("Payload handler %s used.", payload_handler.__class__.__name__)
 
+    def get_active_handler_path(self):
+        """Get path of the active payload handler."""
+        return self.payload_handler.get_handler_path()
+
     def process_kickstart(self, data):
         """Process the kickstart data."""
         log.debug("Processing kickstart data...")

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -71,8 +71,14 @@ class PayloadModule(KickstartModule):
         log.debug("Payload handler %s used.", payload_handler.__class__.__name__)
 
     def get_active_handler_path(self):
-        """Get path of the active payload handler."""
-        return self.payload_handler.get_handler_path()
+        """Get path of the active payload handler.
+
+        :rtype: str
+        """
+        try:
+            return self.payload_handler.get_handler_path()
+        except HandlerNotSetError:
+            return ""
 
     def process_kickstart(self, data):
         """Process the kickstart data."""

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -134,3 +134,12 @@ class PayloadModule(KickstartModule):
         """
         self._initialize_handler(LiveOSHandlerModule)
         return self.payload_handler.get_handler_path()
+
+    def create_live_image_handler(self):
+        """Create the live image payload handler and publish it.
+
+        :returns: DBus path to the handler
+        :rtype: str
+        """
+        self._initialize_handler(LiveImageHandlerModule)
+        return self.payload_handler.get_handler_path()

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -100,7 +100,10 @@ class PayloadModule(KickstartModule):
         log.debug("Generating kickstart data...")
         data = self.get_kickstart_handler()
 
-        self.payload_handler.setup_kickstart(data)
+        try:
+            self.payload_handler.setup_kickstart(data)
+        except HandlerNotSetError:
+            log.warning("Generating kickstart data without set handler - data will be empty!")
 
         return str(data)
 

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -99,9 +99,11 @@ class PayloadModule(KickstartModule):
         return str(data)
 
     def create_live_os_handler(self):
-        """Create the live os payload handler and publish it on dbus.
+        """Create the live os payload handler and publish it and return DBus path.
 
-        FIXME: This is only temporary and the solution to manage handlers will change.
+        :returns: DBus path to the handler
+        :rtype: str
         """
-        self._payload_handler = LiveOSHandlerModule()
+        self.set_payload_handler(LiveOSHandlerModule())
         self._publish_handler()
+        return self.payload_handler.get_handler_path()

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -98,15 +98,8 @@ class PayloadModule(KickstartModule):
         self._initialize_handler(handler)
 
     def _initialize_handler(self, handler):
-        self._publish_handler(handler)
-        self.set_payload_handler(handler)
-
-    def _publish_handler(self, handler):
-        """Publish handler passed in.
-
-        This method is really helpful for testing purpose.
-        """
         self._payload_handler_path = handler.publish_handler()
+        self.set_payload_handler(handler)
 
     def generate_kickstart(self):
         """Return the kickstart string."""

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -92,9 +92,9 @@ class PayloadModule(KickstartModule):
                 log.warning("No handler was created. Kickstart data passed in are lost.")
                 return
 
-        self._initialize_handler(handler)
-
         handler.process_kickstart(data)
+
+        self._initialize_handler(handler)
 
     def _initialize_handler(self, handler):
         self._publish_handler(handler)

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -87,15 +87,22 @@ class PayloadModule(KickstartModule):
         """Process the kickstart data."""
         log.debug("Processing kickstart data...")
 
+        # create handler if no handler is set already
+        if not self.is_handler_set():
+            if not self._create_handler_from_ks_data(data):
+                log.warning("No handler was created. Kickstart data passed in are lost.")
+                return
+
+        self.payload_handler.process_kickstart(data)
+
+    def _create_handler_from_ks_data(self, data):
         handler_class = self._get_correct_handler_class(data)
 
         if not handler_class:
-            log.warning("No handler was created. Kickstart data passed in are lost.")
-            return
+            return False
 
         self._initialize_handler(handler_class)
-
-        self.payload_handler.process_kickstart(data)
+        return True
 
     def _get_correct_handler_class(self, data):
         if data.liveimg.seen:

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -66,6 +66,13 @@ class PayloadModule(KickstartModule):
         self._payload_handler = payload_handler
         log.debug("Payload handler %s used.", payload_handler.__class__.__name__)
 
+    def is_handler_set(self):
+        """Test if any handler is created and used.
+
+        :rtype: bool
+        """
+        return self._payload_handler is not None
+
     def get_active_handler_path(self):
         """Get path of the active payload handler.
 

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -81,6 +81,11 @@ class PayloadModule(KickstartModule):
         log.debug("Processing kickstart data...")
 
         handler_class = self._get_correct_handler_class(data)
+
+        if not handler_class:
+            log.warning("No handler was created. Kickstart data passed in are lost.")
+            return
+
         self._initialize_handler(handler_class)
 
         self.payload_handler.process_kickstart(data)
@@ -88,8 +93,10 @@ class PayloadModule(KickstartModule):
     def _get_correct_handler_class(self, data):
         if data.liveimg.seen:
             return LiveImageHandlerModule
-        else:
+        elif data.packages.seen:
             return DNFHandlerModule
+        else:
+            return None
 
     def _initialize_handler(self, handler_class):
         handler = handler_class()

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -21,7 +21,7 @@ from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.base import KickstartModule
 from pyanaconda.modules.common.constants.services import PAYLOAD
 from pyanaconda.modules.common.errors.payload import HandlerNotSetError
-from pyanaconda.modules.payload.handler_factory import HandlerFactory, HandlerType
+from pyanaconda.modules.payload.handler_factory import HandlerFactory
 from pyanaconda.modules.payload.kickstart import PayloadKickstartSpecification
 from pyanaconda.modules.payload.payload_interface import PayloadInterface
 
@@ -120,32 +120,12 @@ class PayloadModule(KickstartModule):
 
         return str(data)
 
-    def create_dnf_handler(self):
-        """Create the DNF payload handler and publish it.
+    def create_handler(self, handler_type):
+        """Create handler based on the passed type.
 
-        :returns: DBus path to the handler
-        :rtype: str
+        :param handler_type: type of the desirable handler
+        :type handler_type: value of the payload.handler_factory.HandlerType enum
         """
-        handler = HandlerFactory.create_handler(HandlerType.DNF)
-        self._initialize_handler(handler)
-        return self.payload_handler.get_handler_path()
-
-    def create_live_os_handler(self):
-        """Create the live os payload handler and publish it.
-
-        :returns: DBus path to the handler
-        :rtype: str
-        """
-        handler = HandlerFactory.create_handler(HandlerType.LIVE_OS)
-        self._initialize_handler(handler)
-        return self.payload_handler.get_handler_path()
-
-    def create_live_image_handler(self):
-        """Create the live image payload handler and publish it.
-
-        :returns: DBus path to the handler
-        :rtype: str
-        """
-        handler = HandlerFactory.create_handler(HandlerType.LIVE_IMAGE)
+        handler = HandlerFactory.create_handler(handler_type)
         self._initialize_handler(handler)
         return self.payload_handler.get_handler_path()

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -35,6 +35,7 @@ class PayloadModule(KickstartModule):
     def __init__(self):
         super().__init__()
         self._payload_handler = None
+        self._payload_handler_path = None
 
     def publish(self):
         """Publish the module."""
@@ -76,10 +77,10 @@ class PayloadModule(KickstartModule):
 
         :rtype: str
         """
-        try:
-            return self.payload_handler.get_handler_path()
-        except HandlerNotSetError:
-            return ""
+        if self._payload_handler_path:
+            return self._payload_handler_path
+
+        return ""
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
@@ -100,13 +101,12 @@ class PayloadModule(KickstartModule):
         self._publish_handler(handler)
         self.set_payload_handler(handler)
 
-    @staticmethod
-    def _publish_handler(handler):
+    def _publish_handler(self, handler):
         """Publish handler passed in.
 
         This method is really helpful for testing purpose.
         """
-        handler.publish()
+        self._payload_handler_path = handler.publish_handler()
 
     def generate_kickstart(self):
         """Return the kickstart string."""
@@ -128,4 +128,4 @@ class PayloadModule(KickstartModule):
         """
         handler = HandlerFactory.create_handler(handler_type)
         self._initialize_handler(handler)
-        return self.payload_handler.get_handler_path()
+        return self._payload_handler_path

--- a/pyanaconda/modules/payload/payload_interface.py
+++ b/pyanaconda/modules/payload/payload_interface.py
@@ -36,6 +36,10 @@ class PayloadInterface(KickstartModuleInterface):
         """Create Live OS payload handler and publish it on dbus."""
         return self.implementation.create_live_os_handler()
 
+    def CreateLiveImageHandler(self) -> ObjPath:
+        """Create Live image payload handler and publish it on dbus."""
+        return self.implementation.create_live_image_handler()
+
     def GetActiveHandlerPath(self) -> ObjPath:
         """Get path to the payload which is used now."""
         return self.implementation.get_active_handler_path()

--- a/pyanaconda/modules/payload/payload_interface.py
+++ b/pyanaconda/modules/payload/payload_interface.py
@@ -31,3 +31,7 @@ class PayloadInterface(KickstartModuleInterface):
     def CreateLiveOSHandler(self) -> ObjPath:
         """Create Live OS payload handler and publish it on dbus."""
         return self.implementation.create_live_os_handler()
+
+    def GetActiveHandlerPath(self) -> ObjPath:
+        """Get path to the payload which is used now."""
+        return self.implementation.get_active_handler_path()

--- a/pyanaconda/modules/payload/payload_interface.py
+++ b/pyanaconda/modules/payload/payload_interface.py
@@ -28,6 +28,10 @@ from pyanaconda.modules.common.base import KickstartModuleInterface
 class PayloadInterface(KickstartModuleInterface):
     """DBus interface for Payload module."""
 
+    def CreateDNFHandler(self) -> ObjPath:
+        """Create DNF payload handler and publish it on a dbus."""
+        return self.implementation.create_dnf_handler()
+
     def CreateLiveOSHandler(self) -> ObjPath:
         """Create Live OS payload handler and publish it on dbus."""
         return self.implementation.create_live_os_handler()

--- a/pyanaconda/modules/payload/payload_interface.py
+++ b/pyanaconda/modules/payload/payload_interface.py
@@ -30,5 +30,4 @@ class PayloadInterface(KickstartModuleInterface):
 
     def CreateLiveOSHandler(self) -> ObjPath:
         """Create Live OS payload handler and publish it on dbus."""
-        self.implementation.create_live_os_handler()
-        return self.implementation.get_active_handler_path()
+        return self.implementation.create_live_os_handler()

--- a/pyanaconda/modules/payload/payload_interface.py
+++ b/pyanaconda/modules/payload/payload_interface.py
@@ -18,6 +18,7 @@
 # Red Hat, Inc.
 #
 from pyanaconda.dbus.interface import dbus_interface
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
 from pyanaconda.modules.common.constants.services import PAYLOAD
 from pyanaconda.modules.common.base import KickstartModuleInterface
@@ -27,9 +28,7 @@ from pyanaconda.modules.common.base import KickstartModuleInterface
 class PayloadInterface(KickstartModuleInterface):
     """DBus interface for Payload module."""
 
-    def CreateLiveOSHandler(self):
-        """Create Live OS payload handler and publish it on dbus.
-
-        # FIXME: This is a temporary solution which will change in the future commits
-        """
+    def CreateLiveOSHandler(self) -> ObjPath:
+        """Create Live OS payload handler and publish it on dbus."""
         self.implementation.create_live_os_handler()
+        return self.implementation.get_active_handler_path()

--- a/pyanaconda/modules/payload/payload_interface.py
+++ b/pyanaconda/modules/payload/payload_interface.py
@@ -43,3 +43,7 @@ class PayloadInterface(KickstartModuleInterface):
     def GetActiveHandlerPath(self) -> ObjPath:
         """Get path to the payload which is used now."""
         return self.implementation.get_active_handler_path()
+
+    def IsHandlerSet(self) -> Bool:
+        """Test if any handler is set and used."""
+        return self.implementation.is_handler_set()

--- a/pyanaconda/modules/payload/payload_interface.py
+++ b/pyanaconda/modules/payload/payload_interface.py
@@ -23,22 +23,12 @@ from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.constants.services import PAYLOAD
 from pyanaconda.modules.common.base import KickstartModuleInterface
 
+from pyanaconda.modules.payload.handler_factory import HandlerType
+
 
 @dbus_interface(PAYLOAD.interface_name)
 class PayloadInterface(KickstartModuleInterface):
     """DBus interface for Payload module."""
-
-    def CreateDNFHandler(self) -> ObjPath:
-        """Create DNF payload handler and publish it on a dbus."""
-        return self.implementation.create_dnf_handler()
-
-    def CreateLiveOSHandler(self) -> ObjPath:
-        """Create Live OS payload handler and publish it on dbus."""
-        return self.implementation.create_live_os_handler()
-
-    def CreateLiveImageHandler(self) -> ObjPath:
-        """Create Live image payload handler and publish it on dbus."""
-        return self.implementation.create_live_image_handler()
 
     def GetActiveHandlerPath(self) -> ObjPath:
         """Get path to the payload which is used now."""
@@ -47,3 +37,13 @@ class PayloadInterface(KickstartModuleInterface):
     def IsHandlerSet(self) -> Bool:
         """Test if any handler is set and used."""
         return self.implementation.is_handler_set()
+
+    def CreateHandler(self, handler_type: Str) -> ObjPath:
+        """Create payload handler and publish it on a dbus.
+
+        handler_type could contain these values:
+         - DNF
+         - LIVE_OS
+         - LIVE_IMAGE
+        """
+        return self.implementation.create_handler(HandlerType(handler_type))

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
@@ -78,7 +78,7 @@ class PackagesHandlerKSTestCase(unittest.TestCase, PayloadHandlerMixin):
 
         %end
         """
-        self.check_kickstart(ks_in, ks_out)
+        self.check_kickstart(ks_in, ks_out, expected_publish_calls=2)
         self._check_properties()
 
     def packages_section_kickstart_test(self):
@@ -102,7 +102,7 @@ class PackagesHandlerKSTestCase(unittest.TestCase, PayloadHandlerMixin):
 
         %end
         """
-        self.check_kickstart(ks_in, ks_out)
+        self.check_kickstart(ks_in, ks_out, expected_publish_calls=2)
 
         self._expected_env = "environment"
         self._expected_packages = ["package"]
@@ -146,7 +146,7 @@ class PackagesHandlerKSTestCase(unittest.TestCase, PayloadHandlerMixin):
 
         %end
         """
-        self.check_kickstart(ks_in, ks_out)
+        self.check_kickstart(ks_in, ks_out, expected_publish_calls=2)
 
         self._expected_env = "environment2"
         self._expected_packages = ["package1", "package2"]
@@ -164,7 +164,7 @@ class PackagesHandlerKSTestCase(unittest.TestCase, PayloadHandlerMixin):
 
         %end
         """
-        self.check_kickstart(ks_in, ks_out)
+        self.check_kickstart(ks_in, ks_out, expected_publish_calls=2)
         self._check_properties(nocore=True)
 
     def packages_section_multiple_attributes_kickstart_test(self):
@@ -179,7 +179,7 @@ class PackagesHandlerKSTestCase(unittest.TestCase, PayloadHandlerMixin):
 
         %end
         """
-        self.check_kickstart(ks_in, ks_out)
+        self.check_kickstart(ks_in, ks_out, expected_publish_calls=2)
         self._check_properties(nocore=True, multilib="all", langs="en_US.UTF-8")
 
     def packages_section_excludes_kickstart_test(self):
@@ -195,7 +195,7 @@ class PackagesHandlerKSTestCase(unittest.TestCase, PayloadHandlerMixin):
 
         %end
         """
-        self.check_kickstart(ks_in, ks_out)
+        self.check_kickstart(ks_in, ks_out, expected_publish_calls=2)
 
         self._expected_excluded_packages = ["vim"]
         self._check_properties()
@@ -225,7 +225,7 @@ class PackagesHandlerKSTestCase(unittest.TestCase, PayloadHandlerMixin):
 
         %end
         """
-        self.check_kickstart(ks_in, ks_out)
+        self.check_kickstart(ks_in, ks_out, expected_publish_calls=2)
 
         self._expected_env = "environment1"
         self._expected_packages = ["package1", "package3"]

--- a/tests/nosetests/pyanaconda_tests/module_payload_shared.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_shared.py
@@ -39,4 +39,4 @@ class PayloadHandlerMixin(object):
         self.publish_mock.assert_called_once()
 
     def get_payload_handler(self):
-        return self.payload_module._payload_handler
+        return self.payload_module.payload_handler

--- a/tests/nosetests/pyanaconda_tests/module_payload_shared.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_shared.py
@@ -17,7 +17,8 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 #
-from mock import Mock
+from abc import abstractmethod
+from mock import patch
 
 from tests.nosetests.pyanaconda_tests import check_kickstart_interface
 from pyanaconda.modules.payload.payload_interface import PayloadInterface
@@ -26,17 +27,45 @@ from pyanaconda.modules.payload.payload import PayloadModule
 
 class PayloadHandlerMixin(object):
 
+    @abstractmethod
+    def assertEqual(self, first, second, msg=None):
+        """Required implementation from the TestCase class.
+
+        This method will be implemented by TestCase class, which should be parent of the
+        class using this mixin.
+        """
+        pass
+
+    @abstractmethod
+    def assertIn(self, member, container, msg=None):
+        """Required implementation from the TestCase class.
+
+        This method will be implemented by TestCase class, which should be parent of the
+        class using this mixin.
+        """
+        pass
+
     def setup_payload(self):
+        """Create main payload module and its interface."""
         self.payload_module = PayloadModule()
         self.payload_interface = PayloadInterface(self.payload_module)
 
-        # avoid publishing
-        self.publish_mock = Mock()
-        self.payload_module._publish_handler = self.publish_mock
+    def check_kickstart(self, ks_in, ks_out, expected_publish_calls=1):
+        """Test kickstart processing.
 
-    def check_kickstart(self, ks_in, ks_out):
-        check_kickstart_interface(self, self.payload_interface, ks_in, ks_out)
-        self.publish_mock.assert_called_once()
+        :param test_obj: TestCase object (probably self)
+        :param ks_in: input kickstart for testing
+        :param ks_out: expected output kickstart
+        :param expected_publish_calls: how many times times the publisher should be called
+        :type expected_publish_calls: int
+        """
+        with patch('pyanaconda.dbus.DBus.publish_object') as publisher:
+
+            check_kickstart_interface(self, self.payload_interface, ks_in, ks_out)
+
+            publisher.assert_called()
+            self.assertEqual(publisher.call_count, expected_publish_calls)
 
     def get_payload_handler(self):
+        """Get payload handler created."""
         return self.payload_module.payload_handler

--- a/tests/nosetests/pyanaconda_tests/module_payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_test.py
@@ -17,13 +17,15 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 #
-import unittest
+from unittest import TestCase
+from mock import patch
 
 from pyanaconda.modules.payload.payload_interface import PayloadInterface
 from pyanaconda.modules.payload.payload import PayloadModule
+from pyanaconda.modules.common.constants.objects import PAYLOAD_DEFAULT, LIVE_OS_HANDLER
 
 
-class PayloadInterfaceTestCase(unittest.TestCase):
+class PayloadInterfaceTestCase(TestCase):
 
     def setUp(self):
         """Set up the payload module."""
@@ -35,3 +37,39 @@ class PayloadInterfaceTestCase(unittest.TestCase):
         self.assertEqual(self.payload_interface.KickstartCommands, ['liveimg'])
         self.assertEqual(self.payload_interface.KickstartSections, ["packages"])
         self.assertEqual(self.payload_interface.KickstartAddons, [])
+
+    def no_handler_set_test(self):
+        """Test empty string is returned when no handler is set."""
+        self.assertEqual(self.payload_interface.GetActiveHandlerPath(), "")
+
+    def generate_kickstart_without_handler_test(self):
+        """Test kickstart parsing without handler set."""
+        self.assertEqual(self.payload_interface.GenerateKickstart(), "")
+
+    @patch('pyanaconda.dbus.DBus.publish_object')
+    def create_dnf_handler_test(self, publisher):
+        """Test creation and publishing of the DNF handler module."""
+        self.payload_interface.CreateDNFHandler()
+        self.assertEqual(self.payload_interface.GetActiveHandlerPath(),
+                         PAYLOAD_DEFAULT.object_path)
+        # here the publisher is called twice because the Packages section is also published
+        self.assertEqual(publisher.call_count, 2)
+
+    @patch('pyanaconda.dbus.DBus.publish_object')
+    def create_live_os_handler_test(self, publisher):
+        """Test creation and publishing of the Live OS handler module."""
+        self.payload_interface.CreateLiveOSHandler()
+        self.assertEqual(self.payload_interface.GetActiveHandlerPath(),
+                         LIVE_OS_HANDLER.object_path)
+        publisher.assert_called_once()
+
+    @patch('pyanaconda.dbus.DBus.publish_object')
+    def create_multiple_handlers_test(self, publisher):
+        """Test creating two handlers."""
+        self.payload_interface.CreateDNFHandler()
+        self.payload_interface.CreateLiveOSHandler()
+
+        # The last one should win
+        self.assertEqual(self.payload_interface.GetActiveHandlerPath(),
+                         LIVE_OS_HANDLER.object_path)
+        self.assertEqual(publisher.call_count, 3)

--- a/tests/nosetests/pyanaconda_tests/module_payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_test.py
@@ -22,7 +22,8 @@ from mock import patch
 
 from pyanaconda.modules.payload.payload_interface import PayloadInterface
 from pyanaconda.modules.payload.payload import PayloadModule
-from pyanaconda.modules.common.constants.objects import PAYLOAD_DEFAULT, LIVE_OS_HANDLER
+from pyanaconda.modules.common.constants.objects import PAYLOAD_DEFAULT, LIVE_OS_HANDLER, \
+    LIVE_IMAGE_HANDLER
 
 
 class PayloadInterfaceTestCase(TestCase):
@@ -61,6 +62,14 @@ class PayloadInterfaceTestCase(TestCase):
         self.payload_interface.CreateLiveOSHandler()
         self.assertEqual(self.payload_interface.GetActiveHandlerPath(),
                          LIVE_OS_HANDLER.object_path)
+        publisher.assert_called_once()
+
+    @patch('pyanaconda.dbus.DBus.publish_object')
+    def create_live_image_handler_test(self, publisher):
+        """Test creation and publishing of the Live image handler module."""
+        self.payload_interface.CreateLiveImageHandler()
+        self.assertEqual(self.payload_interface.GetActiveHandlerPath(),
+                         LIVE_IMAGE_HANDLER.object_path)
         publisher.assert_called_once()
 
     @patch('pyanaconda.dbus.DBus.publish_object')

--- a/tests/nosetests/pyanaconda_tests/module_payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_test.py
@@ -22,6 +22,7 @@ from mock import patch
 
 from pyanaconda.modules.payload.payload_interface import PayloadInterface
 from pyanaconda.modules.payload.payload import PayloadModule
+from pyanaconda.modules.payload.handler_factory import HandlerType
 from pyanaconda.modules.common.constants.objects import PAYLOAD_DEFAULT, LIVE_OS_HANDLER, \
     LIVE_IMAGE_HANDLER
 
@@ -59,13 +60,13 @@ class PayloadInterfaceTestCase(TestCase):
         """Test IsHandlerSet API."""
         self.assertFalse(self.payload_interface.IsHandlerSet())
 
-        self.payload_interface.CreateDNFHandler()
+        self.payload_interface.CreateHandler(HandlerType.DNF.value)
         self.assertTrue(self.payload_interface.IsHandlerSet())
 
     @patch('pyanaconda.dbus.DBus.publish_object')
     def create_dnf_handler_test(self, publisher):
         """Test creation and publishing of the DNF handler module."""
-        self.payload_interface.CreateDNFHandler()
+        self.payload_interface.CreateHandler(HandlerType.DNF.value)
         self.assertEqual(self.payload_interface.GetActiveHandlerPath(),
                          PAYLOAD_DEFAULT.object_path)
         # here the publisher is called twice because the Packages section is also published
@@ -74,7 +75,7 @@ class PayloadInterfaceTestCase(TestCase):
     @patch('pyanaconda.dbus.DBus.publish_object')
     def create_live_os_handler_test(self, publisher):
         """Test creation and publishing of the Live OS handler module."""
-        self.payload_interface.CreateLiveOSHandler()
+        self.payload_interface.CreateHandler(HandlerType.LIVE_OS.value)
         self.assertEqual(self.payload_interface.GetActiveHandlerPath(),
                          LIVE_OS_HANDLER.object_path)
         publisher.assert_called_once()
@@ -82,7 +83,7 @@ class PayloadInterfaceTestCase(TestCase):
     @patch('pyanaconda.dbus.DBus.publish_object')
     def create_live_image_handler_test(self, publisher):
         """Test creation and publishing of the Live image handler module."""
-        self.payload_interface.CreateLiveImageHandler()
+        self.payload_interface.CreateHandler(HandlerType.LIVE_IMAGE.value)
         self.assertEqual(self.payload_interface.GetActiveHandlerPath(),
                          LIVE_IMAGE_HANDLER.object_path)
         publisher.assert_called_once()
@@ -90,8 +91,8 @@ class PayloadInterfaceTestCase(TestCase):
     @patch('pyanaconda.dbus.DBus.publish_object')
     def create_multiple_handlers_test(self, publisher):
         """Test creating two handlers."""
-        self.payload_interface.CreateDNFHandler()
-        self.payload_interface.CreateLiveOSHandler()
+        self.payload_interface.CreateHandler(HandlerType.DNF.value)
+        self.payload_interface.CreateHandler(HandlerType.LIVE_OS.value)
 
         # The last one should win
         self.assertEqual(self.payload_interface.GetActiveHandlerPath(),

--- a/tests/nosetests/pyanaconda_tests/module_payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_test.py
@@ -89,6 +89,12 @@ class PayloadInterfaceTestCase(TestCase):
         publisher.assert_called_once()
 
     @patch('pyanaconda.dbus.DBus.publish_object')
+    def create_invalid_handler_test(self, publisher):
+        """Test creation of the not existing handler."""
+        with self.assertRaises(ValueError):
+            self.payload_interface.CreateHandler("NotAHandler")
+
+    @patch('pyanaconda.dbus.DBus.publish_object')
     def create_multiple_handlers_test(self, publisher):
         """Test creating two handlers."""
         self.payload_interface.CreateHandler(HandlerType.DNF.value)

--- a/tests/nosetests/pyanaconda_tests/module_payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_test.py
@@ -47,6 +47,21 @@ class PayloadInterfaceTestCase(TestCase):
         """Test kickstart parsing without handler set."""
         self.assertEqual(self.payload_interface.GenerateKickstart(), "")
 
+    def process_kickstart_with_no_handler_test(self):
+        """Test kickstart processing when no handler set or created based on KS data."""
+        with self.assertLogs('anaconda.modules.payload.payload', level="WARNING") as log:
+            self.payload_interface.ReadKickstart("")
+
+            self.assertTrue(any(map(lambda x: "No handler was created" in x, log.output)))
+
+    @patch('pyanaconda.dbus.DBus.publish_object')
+    def is_handler_set_test(self, publisher):
+        """Test IsHandlerSet API."""
+        self.assertFalse(self.payload_interface.IsHandlerSet())
+
+        self.payload_interface.CreateDNFHandler()
+        self.assertTrue(self.payload_interface.IsHandlerSet())
+
     @patch('pyanaconda.dbus.DBus.publish_object')
     def create_dnf_handler_test(self, publisher):
         """Test creation and publishing of the DNF handler module."""


### PR DESCRIPTION
Handler is now property which will raise an exception when no handler is set.
Remove logic choosing active handler based on the KS data. This logic will be moved to Boss.
Add base class for all the handlers.
Create handler API of the main payload module now returns the path to the handler.
Add API to get the active handler.

EDIT: This is prepared for a merge.