### PR TITLE
Remove system root from DBus methods

### DIFF
--- a/pyanaconda/bootloader/base.py
+++ b/pyanaconda/bootloader/base.py
@@ -928,7 +928,7 @@ class BootLoader(object):
 
         self.write_config()
         os.sync()
-        self.stage2_device.format.sync(root=util.getTargetPhysicalRoot())
+        self.stage2_device.format.sync(root=conf.target.physical_root)
         self.install()
 
     def install(self, args=None):

--- a/pyanaconda/bootloader/base.py
+++ b/pyanaconda/bootloader/base.py
@@ -847,7 +847,7 @@ class BootLoader(object):
             pass
         else:
             util.resetRpmDb()
-            ts = rpm.TransactionSet(util.getSysroot())
+            ts = rpm.TransactionSet(conf.target.system_root)
 
             # Only add "rhgb quiet" on non-s390, non-serial installs.
             if util.isConsoleOnVirtualTerminal() \
@@ -904,7 +904,7 @@ class BootLoader(object):
         if not self.config_file:
             raise BootLoaderError("no config file defined for this boot loader")
 
-        config_path = os.path.normpath(util.getSysroot() + self.config_file)
+        config_path = os.path.normpath(conf.target.system_root + self.config_file)
         if os.access(config_path, os.R_OK):
             os.rename(config_path, config_path + ".anacbak")
 

--- a/pyanaconda/bootloader/efi.py
+++ b/pyanaconda/bootloader/efi.py
@@ -52,7 +52,7 @@ class EFIBase(object):
         else:
             exec_func = util.execWithRedirect
         if "root" not in kwargs:
-            kwargs["root"] = util.getSysroot()
+            kwargs["root"] = conf.target.system_root
 
         return exec_func("efibootmgr", list(args), **kwargs)
 
@@ -69,7 +69,7 @@ class EFIBase(object):
             "-c", "-w", "-L", productName.split("-")[0],  # pylint: disable=no-member
             "-d", boot_disk.path, "-p", boot_part_num,
             "-l", self.efi_dir_as_efifs_dir + self._efi_binary,  # pylint: disable=no-member
-            root=util.getSysroot()
+            root=conf.target.system_root
         )
         if rc:
             raise BootLoaderError("Failed to set new efi boot target. This is most "
@@ -192,7 +192,7 @@ class MacEFIGRUB(EFIGRUB):
         self._packages64.extend(["grub2-tools-efi", "mactel-boot"])
 
     def mactel_config(self):
-        if os.path.exists(util.getSysroot() + "/usr/libexec/mactel-boot-setup"):
+        if os.path.exists(conf.target.system_root + "/usr/libexec/mactel-boot-setup"):
             rc = util.execInSysroot("/usr/libexec/mactel-boot-setup", [])
             if rc:
                 log.error("failed to configure Mac boot loader")

--- a/pyanaconda/bootloader/efi.py
+++ b/pyanaconda/bootloader/efi.py
@@ -116,7 +116,7 @@ class EFIBase(object):
 
         try:
             os.sync()
-            self.stage2_device.format.sync(root=util.getTargetPhysicalRoot()) # pylint: disable=no-member
+            self.stage2_device.format.sync(root=conf.target.physical_root) # pylint: disable=no-member
             self.install()
         finally:
             self.write_config()  # pylint: disable=no-member

--- a/pyanaconda/bootloader/extlinux.py
+++ b/pyanaconda/bootloader/extlinux.py
@@ -19,6 +19,7 @@ import os
 
 from pyanaconda.bootloader.base import BootLoader, Arguments, BootLoaderError
 from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.product import productName
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -106,7 +107,7 @@ class EXTLINUX(BootLoader):
             config.write("menu notabmsg Press [Tab] and enter the password to edit options")
 
     def write_config_post(self):
-        etc_extlinux = os.path.normpath(util.getSysroot() + "/etc/" + self._config_file)
+        etc_extlinux = os.path.normpath(conf.target.system_root + "/etc/" + self._config_file)
         if not os.access(etc_extlinux, os.R_OK):
             try:
                 os.symlink("../boot/%s" % self._config_file, etc_extlinux)

--- a/pyanaconda/bootloader/grub2.py
+++ b/pyanaconda/bootloader/grub2.py
@@ -437,15 +437,15 @@ class GRUB2(BootLoader):
 
         try:
             self.write_device_map()
-            self.stage2_device.format.sync(root=util.getTargetPhysicalRoot())
+            self.stage2_device.format.sync(root=conf.target.physical_root)
             os.sync()
             self.install()
             os.sync()
-            self.stage2_device.format.sync(root=util.getTargetPhysicalRoot())
+            self.stage2_device.format.sync(root=conf.target.physical_root)
         finally:
             self.write_config()
             os.sync()
-            self.stage2_device.format.sync(root=util.getTargetPhysicalRoot())
+            self.stage2_device.format.sync(root=conf.target.physical_root)
 
     def check(self):
         """When installing to the mbr of a disk grub2 needs enough space

--- a/pyanaconda/bootloader/grub2.py
+++ b/pyanaconda/bootloader/grub2.py
@@ -225,7 +225,7 @@ class GRUB2(BootLoader):
 
     def write_device_map(self):
         """Write out a device map containing all supported devices."""
-        map_path = os.path.normpath(util.getSysroot() + self.device_map_file)
+        map_path = os.path.normpath(conf.target.system_root + self.device_map_file)
         if os.access(map_path, os.R_OK):
             os.rename(map_path, map_path + ".anacbak")
 
@@ -250,7 +250,7 @@ class GRUB2(BootLoader):
         dev_map.close()
 
     def write_defaults(self):
-        defaults_file = "%s%s" % (util.getSysroot(), self.defaults_file)
+        defaults_file = "%s%s" % (conf.target.system_root, self.defaults_file)
         defaults = open(defaults_file, "w+")
         defaults.write("GRUB_TIMEOUT=%d\n" % self.timeout)
         defaults.write("GRUB_DISTRIBUTOR=\"$(sed 's, release .*$,,g' /etc/system-release)\"\n")
@@ -270,7 +270,7 @@ class GRUB2(BootLoader):
         defaults.write("GRUB_DISABLE_RECOVERY=\"true\"\n")
         #defaults.write("GRUB_THEME=\"/boot/grub2/themes/system/theme.txt\"\n")
 
-        if self.use_bls and os.path.exists(util.getSysroot() + "/usr/sbin/new-kernel-pkg"):
+        if self.use_bls and os.path.exists(conf.target.system_root + "/usr/sbin/new-kernel-pkg"):
             log.warning("BLS support disabled due new-kernel-pkg being present")
             self.use_bls = False
 
@@ -292,7 +292,7 @@ class GRUB2(BootLoader):
         os.close(pwrite)
         buf = util.execWithCapture("grub2-mkpasswd-pbkdf2", [],
                                    stdin=pread,
-                                   root=util.getSysroot())
+                                   root=conf.target.system_root)
         os.close(pread)
         self.encrypted_password = buf.split()[-1].strip()
         if not self.encrypted_password.startswith("grub.pbkdf2."):
@@ -302,7 +302,7 @@ class GRUB2(BootLoader):
         if not self.password and not self.encrypted_password:
             return
 
-        users_file = "%s%s/%s" % (util.getSysroot(), self.config_dir, self._passwd_file)
+        users_file = "%s%s/%s" % (conf.target.system_root, self.config_dir, self._passwd_file)
         header = util.open_with_perm(users_file, "w", 0o700)
         # XXX FIXME: document somewhere that the username is "root"
         self._encrypt_password()
@@ -327,7 +327,7 @@ class GRUB2(BootLoader):
 
         # make sure the default entry is the OS we are installing
         if self.default is not None:
-            machine_id_path = util.getSysroot() + "/etc/machine-id"
+            machine_id_path = conf.target.system_root + "/etc/machine-id"
             if not os.access(machine_id_path, os.R_OK):
                 log.error("failed to read machine-id, default entry not set")
                 return
@@ -421,7 +421,7 @@ class GRUB2(BootLoader):
                     log.info("bootloader.py: mbr will be updated for grub2")
 
             rc = util.execWithRedirect("grub2-install", grub_args,
-                                       root=util.getSysroot(),
+                                       root=conf.target.system_root,
                                        env_prune=['MALLOC_PERTURB_'])
             if rc:
                 raise BootLoaderError("boot loader install failed")
@@ -603,7 +603,7 @@ class IPSeriesGRUB2(GRUB2):
     def write_defaults(self):
         super().write_defaults()
 
-        defaults_file = "%s%s" % (util.getSysroot(), self.defaults_file)
+        defaults_file = "%s%s" % (conf.target.system_root, self.defaults_file)
         defaults = open(defaults_file, "a+")
         # The terminfo's X and Y size, and output location could change in the future
         defaults.write("GRUB_TERMINFO=\"terminfo -g 80x24 console\"\n")

--- a/pyanaconda/bootloader/installation.py
+++ b/pyanaconda/bootloader/installation.py
@@ -20,7 +20,6 @@ from glob import glob
 
 from pyanaconda.bootloader.base import BootLoaderError
 from pyanaconda.bootloader.image import LinuxBootLoaderImage
-from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.util import decode_bytes
 from pyanaconda.errors import errorHandler, ERROR_RAISE
@@ -44,7 +43,7 @@ def write_boot_loader(storage, payload):
     # Configure the boot loader.
     if not payload.handles_bootloader_configuration:
         configure_boot_loader(
-            sysroot=util.getSysroot(),
+            sysroot=conf.target.system_root,
             storage=storage,
             kernel_versions=payload.kernel_version_list
         )

--- a/pyanaconda/bootloader/zipl.py
+++ b/pyanaconda/bootloader/zipl.py
@@ -20,6 +20,7 @@ import re
 
 from pyanaconda.bootloader.base import BootLoader, Arguments, BootLoaderError
 from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.errors import errorHandler
 from pyanaconda.product import productName
 
@@ -83,7 +84,7 @@ class ZIPL(BootLoader):
         config.write(stanza)
 
     def update_bls_args(self, image, args):
-        machine_id_path = util.getSysroot() + "/etc/machine-id"
+        machine_id_path = conf.target.system_root + "/etc/machine-id"
         if not os.access(machine_id_path, os.R_OK):
             log.error("failed to read machine-id file")
             return
@@ -91,7 +92,7 @@ class ZIPL(BootLoader):
         with open(machine_id_path, "r") as fd:
             machine_id = fd.readline().strip()
 
-        bls_dir = "%s%s/loader/entries/" % (util.getSysroot(), self.boot_dir)
+        bls_dir = "%s%s/loader/entries/" % (conf.target.system_root, self.boot_dir)
 
         if image.kernel == "vmlinuz-0-rescue-" + machine_id:
             bls_path = "%s%s-0-rescue.conf" % (bls_dir, machine_id)
@@ -137,7 +138,7 @@ class ZIPL(BootLoader):
                   "target=/boot\n")
         config.write(header.format(self.timeout))
 
-        if self.use_bls and os.path.exists(util.getSysroot() + "/usr/sbin/new-kernel-pkg"):
+        if self.use_bls and os.path.exists(conf.target.system_root + "/usr/sbin/new-kernel-pkg"):
             log.warning("BLS support disabled due new-kernel-pkg being present")
             self.use_bls = False
 
@@ -149,7 +150,7 @@ class ZIPL(BootLoader):
     #
 
     def install(self, args=None):
-        buf = util.execWithCapture("zipl", [], root=util.getSysroot())
+        buf = util.execWithCapture("zipl", [], root=conf.target.system_root)
         for line in buf.splitlines():
             if line.startswith("Preparing boot device: "):
                 # Output here may look like:

--- a/pyanaconda/core/users.py
+++ b/pyanaconda/core/users.py
@@ -23,6 +23,7 @@ import os.path
 import subprocess
 from contextlib import contextmanager
 from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.util import strip_accents
 from pyanaconda.errors import errorHandler, PasswordCryptError, ERROR_RAISE
 from pyanaconda.core.regexes import GROUPLIST_FANCY_PARSE, NAME_VALID, PORTABLE_FS_CHARS, GROUPLIST_SIMPLE_VALID
@@ -247,10 +248,10 @@ def create_group(group_name, gid=None, root=None):
     :param int gid: The GID for the new user. If none is given, the next available one is used.
     :param str root: The directory of the system to create the new user in.
                      homedir will be interpreted relative to this. Defaults
-                     to util.getSysroot().
+                     to conf.target.system_root.
     """
     if root is None:
-        root = util.getSysroot()
+        root = conf.target.system_root
 
     if _getgrnam(group_name, root):
         raise ValueError("Group %s already exists" % group_name)
@@ -300,7 +301,7 @@ def create_user(username, password=False, is_crypted=False, lock=False,
                       Defaults to "".
     :param str root: The directory of the system to create the new user in.
                      The homedir option will be interpreted relative to this.
-                     Defaults to util.getSysroot().
+                     Defaults to conf.target.system_root.
     """
 
     # resolve the optional arguments that need a default that can't be
@@ -314,7 +315,7 @@ def create_user(username, password=False, is_crypted=False, lock=False,
         groups = []
 
     if root is None:
-        root = util.getSysroot()
+        root = conf.target.system_root
 
     if check_user_exists(username, root):
         raise ValueError("User %s already exists" % username)
@@ -427,7 +428,7 @@ def check_user_exists(username, root=None):
     :param str root: target system sysroot path
     """
     if root is None:
-        root = util.getSysroot()
+        root = conf.target.system_root
 
     if _getpwnam(username, root):
         return True
@@ -484,7 +485,7 @@ def set_user_ssh_key(username, key, root=None):
     :param str root: target system sysroot path
     """
     if root is None:
-        root = util.getSysroot()
+        root = conf.target.system_root
 
     pwent = _getpwnam(username, root)
     if not pwent:

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -85,21 +85,6 @@ def augmentEnv():
     return env
 
 
-def getTargetPhysicalRoot():
-    """Returns the path to the "physical" storage root, traditionally /mnt/sysimage.
-
-    This may be distinct from the sysroot, which could be a
-    chroot-type subdirectory of the physical root.  This is used for
-    example by all OSTree-based installations.
-    """
-
-    # We always use the traditional /mnt/sysimage - the physical OS
-    # target is never mounted anywhere else.  This API call just
-    # allows us to have a clean "git grep ROOT_PATH" in other parts of
-    # the code.
-    return conf.target.physical_root
-
-
 def getSysroot():
     """Returns the path to the target OS installation.
 
@@ -169,7 +154,7 @@ def startProgram(argv, root='/', stdin=None, stdout=subprocess.PIPE, stderr=subp
     # Transparently redirect callers requesting root=_root_path to the
     # configured system root.
     target_root = root
-    if target_root == getTargetPhysicalRoot():
+    if target_root == conf.target.physical_root:
         target_root = getSysroot()
 
     # Check for and save a preexec_fn argument

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -29,6 +29,7 @@ import string  # pylint: disable=deprecated-module
 import shutil
 import tempfile
 import re
+import warnings
 from urllib.parse import quote, unquote
 import gettext
 import signal
@@ -83,6 +84,22 @@ def augmentEnv():
     env.update({"ANA_INSTALL_PATH": conf.target.system_root})
     env.update(_child_env)
     return env
+
+
+def getSysroot():
+    """Returns the path to the target OS installation.
+
+    .. deprecated::
+
+        Use conf.target.system_root instead.
+
+    """
+    warnings.warn(
+        "The function getSysroot is deprecated. Use conf.target.system_root.",
+        category=DeprecationWarning, stacklevel=2
+    )
+
+    return conf.target.system_root
 
 
 def set_system_root(path):

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -85,12 +85,21 @@ def augmentEnv():
     return env
 
 
-def setSysroot(path):
+def set_system_root(path):
     """Change the OS root path.
-       :param path: The new OS root path
 
-    This should only be used by Payload subclasses which install operating
-    systems to non-default roots.
+    The path defined by conf.target.system_root will be bind mounted at the given
+    path, so conf.target.system_root can be used to access the root of the new OS.
+
+    We always call it after the root device is mounted at conf.target.physical_root
+    to set the physical root as the current system root.
+
+    Then, it can be used by Payload subclasses which install operating systems to
+    non-default roots.
+
+    If the given path is None, then conf.target.system_root is only unmounted.
+
+    :param path: the new OS root path or None
     """
     sysroot = conf.target.system_root
 

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -80,18 +80,9 @@ def setenv(name, value):
 
 def augmentEnv():
     env = os.environ.copy()
-    env.update({"ANA_INSTALL_PATH": getSysroot()})
+    env.update({"ANA_INSTALL_PATH": conf.target.system_root})
     env.update(_child_env)
     return env
-
-
-def getSysroot():
-    """Returns the path to the target OS installation.
-
-    For ordinary package-based installations, this is the same as the
-    target root.
-    """
-    return conf.target.system_root
 
 
 def setSysroot(path):
@@ -101,7 +92,7 @@ def setSysroot(path):
     This should only be used by Payload subclasses which install operating
     systems to non-default roots.
     """
-    sysroot = getSysroot()
+    sysroot = conf.target.system_root
 
     if sysroot == path:
         return
@@ -155,7 +146,7 @@ def startProgram(argv, root='/', stdin=None, stdout=subprocess.PIPE, stderr=subp
     # configured system root.
     target_root = root
     if target_root == conf.target.physical_root:
-        target_root = getSysroot()
+        target_root = conf.target.system_root
 
     # Check for and save a preexec_fn argument
     preexec_fn = kwargs.pop("preexec_fn", None)
@@ -344,7 +335,7 @@ def execInSysroot(command, argv, stdin=None, root=None):
         :return: The return code of the command
     """
     if root is None:
-        root = getSysroot()
+        root = conf.target.system_root
 
     return execWithRedirect(command, argv, stdin=stdin, root=root)
 
@@ -590,7 +581,7 @@ def reIPL(ipldev):
 
 
 def resetRpmDb():
-    for rpmfile in glob.glob("%s/var/lib/rpm/__db.*" % getSysroot()):
+    for rpmfile in glob.glob("%s/var/lib/rpm/__db.*" % conf.target.system_root):
         try:
             os.unlink(rpmfile)
         except OSError as e:
@@ -677,7 +668,7 @@ def enable_service(service, root=None):
     :param str root: path to the sysroot or None to use default sysroot path
     """
     if root is None:
-        root = getSysroot()
+        root = conf.target.system_root
 
     ret = _run_systemctl("enable", service, root=root)
 
@@ -692,7 +683,7 @@ def disable_service(service, root=None):
     :param str root: path to the sysroot or None to use default sysroot path
     """
     if root is None:
-        root = getSysroot()
+        root = conf.target.system_root
 
     # we ignore the error so we can disable services even if they don't
     # exist, because that's effectively disabled
@@ -1289,7 +1280,7 @@ def sysroot_path(path):
        :returns: sysrooted path
        :rtype: str
     """
-    return os.path.join(getSysroot(), path.lstrip(os.path.sep))
+    return os.path.join(conf.target.system_root, path.lstrip(os.path.sep))
 
 
 def save_screenshots():

--- a/pyanaconda/dbus_addons/baz/baz.py
+++ b/pyanaconda/dbus_addons/baz/baz.py
@@ -37,7 +37,7 @@ class Baz(KickstartModule):
         DBus.publish_object(BAZ.object_path, BazInterface(self))
         DBus.register_service(BAZ.service_name)
 
-    def install_with_tasks(self, sysroot):
+    def install_with_tasks(self):
         """Return installation tasks."""
         return [self.publish_task(BAZ.namespace, BazTask())]
 

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -24,6 +24,7 @@ import subprocess
 import time
 import pkgutil
 
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.process_watchers import WatchProcesses
 from pyanaconda import isys
 from pyanaconda import startup_utils
@@ -198,7 +199,7 @@ def do_extra_x11_actions(runres, gui_mode):
 def write_xdriver(driver, root=None):
     """Write the X driver."""
     if root is None:
-        root = util.getSysroot()
+        root = conf.target.system_root
 
     if not os.path.isdir("%s/etc/X11" % (root,)):
         os.makedirs("%s/etc/X11" % (root,), mode=0o755)

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -212,12 +212,12 @@ class AnacondaExceptionHandler(ExceptionHandler):
         anaconda = dump_info.object
 
         # See if there is a /root present in the root path and put exception there as well
-        if os.access(util.getSysroot() + "/root", os.X_OK):
+        if os.access(conf.target.system_root + "/root", os.X_OK):
             try:
-                dest = util.getSysroot() + "/root/%s" % os.path.basename(self.exnFile)
+                dest = conf.target.system_root + "/root/%s" % os.path.basename(self.exnFile)
                 shutil.copyfile(self.exnFile, dest)
             except (shutil.Error, IOError):
-                log.error("Failed to copy %s to %s/root", self.exnFile, util.getSysroot())
+                log.error("Failed to copy %s to %s/root", self.exnFile, conf.target.system_root)
 
         # run kickstart traceback scripts (if necessary)
         try:
@@ -260,7 +260,7 @@ def initExceptionHandling(anaconda):
     file_list = ["/tmp/anaconda.log", "/tmp/packaging.log",
                  "/tmp/program.log", "/tmp/storage.log",
                  "/tmp/dnf.librepo.log", "/tmp/hawkey.log",
-                 "/tmp/lvm.log", util.getSysroot() + "/root/install.log",
+                 "/tmp/lvm.log", conf.target.system_root + "/root/install.log",
                  "/proc/cmdline", "/root/lorax-packages.log",
                  "/tmp/blivet-gui-utils.log", "/tmp/dbus.log"]
 

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -91,14 +91,14 @@ def _prepare_configuration(storage, payload, ksdata):
     os_config.append(Task("Configure authselect", ksdata.authselect.execute))
 
     security_proxy = SECURITY.get_proxy()
-    security_dbus_tasks = security_proxy.InstallWithTasks(conf.target.system_root)
+    security_dbus_tasks = security_proxy.InstallWithTasks()
     # add one Task instance per DBUS task
     for dbus_task in security_dbus_tasks:
         task_proxy = SECURITY.get_proxy(dbus_task)
         os_config.append(Task(task_proxy.Name, sync_run_task, (task_proxy,)))
 
     services_proxy = SERVICES.get_proxy()
-    services_dbus_tasks = services_proxy.InstallWithTasks(conf.target.system_root)
+    services_dbus_tasks = services_proxy.InstallWithTasks()
     # add one Task instance per DBUS task
     for dbus_task in services_dbus_tasks:
         task_proxy = SERVICES.get_proxy(dbus_task)
@@ -108,14 +108,14 @@ def _prepare_configuration(storage, payload, ksdata):
     os_config.append(Task("Configure timezone", ksdata.timezone.execute))
 
     localization_proxy = LOCALIZATION.get_proxy()
-    localization_dbus_tasks = localization_proxy.InstallWithTasks(conf.target.system_root)
+    localization_dbus_tasks = localization_proxy.InstallWithTasks()
     # add one Task instance per DBUS task
     for dbus_task in localization_dbus_tasks:
         task_proxy = LOCALIZATION.get_proxy(dbus_task)
         os_config.append(Task(task_proxy.Name, sync_run_task, (task_proxy,)))
 
     firewall_proxy = NETWORK.get_proxy(FIREWALL)
-    firewall_dbus_task = firewall_proxy.InstallWithTask(conf.target.system_root)
+    firewall_dbus_task = firewall_proxy.InstallWithTask()
     task_proxy = NETWORK.get_proxy(firewall_dbus_task)
     os_config.append(Task(task_proxy.Name, sync_run_task, (task_proxy,)))
 
@@ -132,7 +132,7 @@ def _prepare_configuration(storage, payload, ksdata):
     user_config = TaskQueue("User creation", N_("Creating users"))
 
     users_proxy = USERS.get_proxy()
-    users_dbus_tasks = users_proxy.InstallWithTasks(conf.target.system_root)
+    users_dbus_tasks = users_proxy.InstallWithTasks()
     # add one Task instance per DBUS task
     for dbus_task in users_dbus_tasks:
         task_proxy = USERS.get_proxy(dbus_task)

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -67,11 +67,11 @@ class WriteResolvConfTask(Task):
         task queue was created, not when the task is actually executed, which could
         theoretically result in an incorrect path.
         """
-        network.copy_resolv_conf_to_root(util.getSysroot())
+        network.copy_resolv_conf_to_root(conf.target.system_root)
 
 
 def _writeKS(ksdata):
-    path = util.getSysroot() + "/root/anaconda-ks.cfg"
+    path = conf.target.system_root + "/root/anaconda-ks.cfg"
 
     # Make it so only root can read - could have passwords
     with util.open_with_perm(path, "w", 0o600) as f:
@@ -91,14 +91,14 @@ def _prepare_configuration(storage, payload, ksdata):
     os_config.append(Task("Configure authselect", ksdata.authselect.execute))
 
     security_proxy = SECURITY.get_proxy()
-    security_dbus_tasks = security_proxy.InstallWithTasks(util.getSysroot())
+    security_dbus_tasks = security_proxy.InstallWithTasks(conf.target.system_root)
     # add one Task instance per DBUS task
     for dbus_task in security_dbus_tasks:
         task_proxy = SECURITY.get_proxy(dbus_task)
         os_config.append(Task(task_proxy.Name, sync_run_task, (task_proxy,)))
 
     services_proxy = SERVICES.get_proxy()
-    services_dbus_tasks = services_proxy.InstallWithTasks(util.getSysroot())
+    services_dbus_tasks = services_proxy.InstallWithTasks(conf.target.system_root)
     # add one Task instance per DBUS task
     for dbus_task in services_dbus_tasks:
         task_proxy = SERVICES.get_proxy(dbus_task)
@@ -108,14 +108,14 @@ def _prepare_configuration(storage, payload, ksdata):
     os_config.append(Task("Configure timezone", ksdata.timezone.execute))
 
     localization_proxy = LOCALIZATION.get_proxy()
-    localization_dbus_tasks = localization_proxy.InstallWithTasks(util.getSysroot())
+    localization_dbus_tasks = localization_proxy.InstallWithTasks(conf.target.system_root)
     # add one Task instance per DBUS task
     for dbus_task in localization_dbus_tasks:
         task_proxy = LOCALIZATION.get_proxy(dbus_task)
         os_config.append(Task(task_proxy.Name, sync_run_task, (task_proxy,)))
 
     firewall_proxy = NETWORK.get_proxy(FIREWALL)
-    firewall_dbus_task = firewall_proxy.InstallWithTask(util.getSysroot())
+    firewall_dbus_task = firewall_proxy.InstallWithTask(conf.target.system_root)
     task_proxy = NETWORK.get_proxy(firewall_dbus_task)
     os_config.append(Task(task_proxy.Name, sync_run_task, (task_proxy,)))
 
@@ -132,7 +132,7 @@ def _prepare_configuration(storage, payload, ksdata):
     user_config = TaskQueue("User creation", N_("Creating users"))
 
     users_proxy = USERS.get_proxy()
-    users_dbus_tasks = users_proxy.InstallWithTasks(util.getSysroot())
+    users_dbus_tasks = users_proxy.InstallWithTasks(conf.target.system_root)
     # add one Task instance per DBUS task
     for dbus_task in users_dbus_tasks:
         task_proxy = USERS.get_proxy(dbus_task)

--- a/pyanaconda/kexec.py
+++ b/pyanaconda/kexec.py
@@ -21,7 +21,8 @@
 import shutil
 from collections import namedtuple
 
-from pyanaconda.core.util import getSysroot, execReadlines, execWithRedirect
+from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.core.util import execReadlines, execWithRedirect
 from pyanaconda.simpleconfig import unquote
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -54,7 +55,7 @@ def run_grubby(args=None):
     # loop when all of the needed values have been gathered.
     try:
 
-        for line in execReadlines("grubby", args, root=getSysroot()):
+        for line in execReadlines("grubby", args, root=conf.target.system_root):
             key, _sep, value = line.partition("=")
             value = unquote(value)
 
@@ -99,8 +100,8 @@ def setup_kexec():
             return
 
     # Copy the kernel and initrd to /tmp/
-    shutil.copy2(getSysroot() + boot_info.kernel, "/tmp/vmlinuz-kexec-reboot")
-    shutil.copy2(getSysroot() + boot_info.initrd, "/tmp/initrd-kexec-reboot")
+    shutil.copy2(conf.target.system_root + boot_info.kernel, "/tmp/vmlinuz-kexec-reboot")
+    shutil.copy2(conf.target.system_root + boot_info.initrd, "/tmp/initrd-kexec-reboot")
 
     append = "root=%s %s" % (boot_info.root, boot_info.args)
     args = ["--initrd", "/tmp/initrd-kexec-reboot", "--append", append, "-l", "/tmp/vmlinuz-kexec-reboot"]

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -226,8 +226,8 @@ class Authselect(RemovedCommand):
 
     @property
     def fingerprint_supported(self):
-        return (os.path.exists(util.getSysroot() + "/lib64/security/pam_fprintd.so") or
-                os.path.exists(util.getSysroot() + "/lib/security/pam_fprintd.so"))
+        return (os.path.exists(conf.target.system_root + "/lib64/security/pam_fprintd.so") or
+                os.path.exists(conf.target.system_root + "/lib/security/pam_fprintd.so"))
 
     def setup(self):
         security_proxy = SECURITY.get_proxy()
@@ -264,7 +264,7 @@ class Authselect(RemovedCommand):
             )
 
     def _run(self, cmd, args, required=True):
-        if not os.path.lexists(util.getSysroot() + cmd):
+        if not os.path.lexists(conf.target.system_root + cmd):
             if required:
                 msg = _("%s is missing. Cannot setup authentication.") % cmd
                 raise KickstartError(msg)
@@ -345,7 +345,7 @@ class Realm(RemovedCommand):
             # no explicit password arg using implicit --no-password
             pw_args = ["--no-password"]
 
-        argv = ["join", "--install", util.getSysroot(), "--verbose"] + pw_args + realm.join_options
+        argv = ["join", "--install", conf.target.system_root, "--verbose"] + pw_args + realm.join_options
         rc = -1
         try:
             rc = util.execWithRedirect("realm", argv)
@@ -443,7 +443,7 @@ class Network(COMMANDS.Network):
                        if dev.device_name in fcoe_nics]
         overwrite = network.can_overwrite_configuration(payload)
         network_proxy = NETWORK.get_proxy()
-        task_path = network_proxy.InstallNetworkWithTask(util.getSysroot(),
+        task_path = network_proxy.InstallNetworkWithTask(conf.target.system_root,
                                                          fcoe_ifaces,
                                                          overwrite)
         task_proxy = NETWORK.get_proxy(task_path)
@@ -595,13 +595,13 @@ class Timezone(RemovedCommand):
                                  "back to default (America/New_York).", kickstart_timezone)
             timezone_proxy.SetTimezone("America/New_York")
 
-        timezone.write_timezone_config(timezone_proxy, util.getSysroot())
+        timezone.write_timezone_config(timezone_proxy, conf.target.system_root)
 
         # write out NTP configuration (if set) and --nontp is not used
         kickstart_ntp_servers = timezone_proxy.NTPServers
 
         if timezone_proxy.NTPEnabled and kickstart_ntp_servers:
-            chronyd_conf_path = os.path.normpath(util.getSysroot() + ntp.NTP_CONFIG_FILE)
+            chronyd_conf_path = os.path.normpath(conf.target.system_root + ntp.NTP_CONFIG_FILE)
             pools, servers = ntp.internal_to_pools_and_servers(kickstart_ntp_servers)
             if os.path.exists(chronyd_conf_path):
                 timezone_log.debug("Modifying installed chrony configuration")
@@ -668,7 +668,7 @@ class Keyboard(RemovedCommand):
 
     def execute(self):
         localization_proxy = LOCALIZATION.get_proxy()
-        keyboard.write_keyboard_config(localization_proxy, util.getSysroot())
+        keyboard.write_keyboard_config(localization_proxy, conf.target.system_root)
 
 
 ###
@@ -972,7 +972,7 @@ def runPostScripts(scripts):
 
     script_log.info("Running kickstart %%post script(s)")
     for script in postScripts:
-        script.run(util.getSysroot())
+        script.run(conf.target.system_root)
     script_log.info("All kickstart %%post script(s) have been run")
 
 def runPreScripts(scripts):

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -443,8 +443,7 @@ class Network(COMMANDS.Network):
                        if dev.device_name in fcoe_nics]
         overwrite = network.can_overwrite_configuration(payload)
         network_proxy = NETWORK.get_proxy()
-        task_path = network_proxy.InstallNetworkWithTask(conf.target.system_root,
-                                                         fcoe_ifaces,
+        task_path = network_proxy.InstallNetworkWithTask(fcoe_ifaces,
                                                          overwrite)
         task_proxy = NETWORK.get_proxy(task_path)
         sync_run_task(task_proxy)

--- a/pyanaconda/modules/boss/install_manager/install_manager.py
+++ b/pyanaconda/modules/boss/install_manager/install_manager.py
@@ -16,7 +16,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.boss.install_manager.installation import SystemInstallationTask
 
@@ -62,7 +62,7 @@ class InstallManager(object):
         tasks = []
 
         # FIXME: We need to figure out how to handle the sysroot.
-        sysroot = util.getSysroot()
+        sysroot = conf.target.system_root
 
         if not self._module_observers:
             log.error("Starting installation without available modules.")

--- a/pyanaconda/modules/boss/install_manager/install_manager.py
+++ b/pyanaconda/modules/boss/install_manager/install_manager.py
@@ -16,7 +16,6 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.boss.install_manager.installation import SystemInstallationTask
 
@@ -61,9 +60,6 @@ class InstallManager(object):
         """
         tasks = []
 
-        # FIXME: We need to figure out how to handle the sysroot.
-        sysroot = conf.target.system_root
-
         if not self._module_observers:
             log.error("Starting installation without available modules.")
 
@@ -76,7 +72,7 @@ class InstallManager(object):
                 continue
 
             service_name = observer.service_name
-            task_paths = observer.proxy.InstallWithTasks(sysroot)
+            task_paths = observer.proxy.InstallWithTasks()
 
             for object_path in task_paths:
                 log.debug("Getting task %s from module %s", object_path, service_name)

--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -237,10 +237,9 @@ class KickstartModule(MainModule, KickstartBaseModule):
         """
         return self.generate_kickstart()
 
-    def install_with_tasks(self, sysroot):
+    def install_with_tasks(self):
         """Return installation tasks of this module.
 
-        :param sysroot: a path to the root of the installed system
         :return: a list of DBus paths of the installation tasks
         """
         return []

--- a/pyanaconda/modules/common/base/base_interface.py
+++ b/pyanaconda/modules/common/base/base_interface.py
@@ -123,13 +123,12 @@ class KickstartModuleInterface(KickstartModuleInterfaceTemplate):
         """
         return Requirement.to_structure_list(self.implementation.collect_requirements())
 
-    def InstallWithTasks(self, sysroot: Str) -> List[ObjPath]:
+    def InstallWithTasks(self) -> List[ObjPath]:
         """Returns installation tasks of this module.
 
-        :param sysroot: a path to the root of the installed system
         :returns: list of object paths of installation tasks
         """
-        return self.implementation.install_with_tasks(sysroot)
+        return self.implementation.install_with_tasks()
 
     def TeardownWithTasks(self) -> List[ObjPath]:
         """Returns teardown tasks for this module.

--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -17,6 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.dbus import DBus
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.base import KickstartModule
@@ -191,14 +192,13 @@ class LocalizationModule(KickstartModule):
         self.keyboard_seen_changed.emit()
         log.debug("keyboard command considered seen in kicksatart: %s.", keyboard_seen)
 
-    def install_with_tasks(self, sysroot):
+    def install_with_tasks(self):
         """Return the installation tasks of this module.
 
-        :param str sysroot: a path to the root of the installed system
         :returns: list of object paths of installation tasks
         """
         tasks = [
-            LanguageInstallationTask(sysroot=sysroot, lang=self.language)
+            LanguageInstallationTask(sysroot=conf.target.system_root, lang=self.language)
         ]
 
         paths = [

--- a/pyanaconda/modules/network/firewall/firewall.py
+++ b/pyanaconda/modules/network/firewall/firewall.py
@@ -17,6 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.signal import Signal
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.base import KickstartBaseModule
@@ -205,14 +206,13 @@ class FirewallModule(KickstartBaseModule):
         self.disabled_services_changed.emit()
         log.debug("Services that will be explicitly disabled on the firewall: %s", self._disabled_services)
 
-    def install_with_task(self, sysroot):
+    def install_with_task(self):
         """Return the installation tasks of this module.
 
-        :param str sysroot: a path to the root of the installed system
         :returns: list of object paths of installation tasks
         """
         firewall_configuration_task = ConfigureFirewallTask(
-                sysroot=sysroot,
+                sysroot=conf.target.system_root,
                 firewall_mode=self.firewall_mode,
                 enabled_services=self.enabled_services,
                 disabled_services=self.disabled_services,

--- a/pyanaconda/modules/network/firewall/firewall_interface.py
+++ b/pyanaconda/modules/network/firewall/firewall_interface.py
@@ -115,12 +115,11 @@ class FirewallInterface(KickstartModuleInterfaceTemplate):
         """
         self.implementation.set_disabled_services(disabled_services)
 
-    def InstallWithTask(self, sysroot: Str) -> ObjPath:
+    def InstallWithTask(self) -> ObjPath:
         """Install the bootloader.
 
         FIXME: This is just a temporary method.
 
-        :param sysroot: a path to the root of the installed system
         :return: a path to a DBus task
         """
-        return self.implementation.install_with_task(sysroot)
+        return self.implementation.install_with_task()

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -278,10 +278,9 @@ class NetworkModule(KickstartModule):
         self._disable_ipv6 = disable_ipv6
         log.debug("disable IPv6 is set to %s", disable_ipv6)
 
-    def install_network_with_task(self, sysroot, onboot_ifaces, overwrite):
+    def install_network_with_task(self, onboot_ifaces, overwrite):
         """Install network with an installation task.
 
-        :param sysroot: a path to the root of the installed system
         :param onboot_ifaces: list of network interfaces which should have ONBOOT=yes
         :param overwrite: overwrite existing configuration
         :return: a DBus path of an installation task
@@ -299,9 +298,17 @@ class NetworkModule(KickstartModule):
         log.debug("ONBOOT will be set to yes for %s (fcoe) %s (policy)",
                   onboot_ifaces, onboot_ifaces_by_policy)
 
-        task = NetworkInstallationTask(sysroot, self.hostname, disable_ipv6, overwrite,
-                                       onboot_yes_uuids, network_ifaces, self.ifname_option_values)
-        task.succeeded_signal.connect(lambda: self.log_task_result(task, root_path=sysroot))
+        task = NetworkInstallationTask(
+            conf.target.system_root,
+            self.hostname,
+            disable_ipv6,
+            overwrite,
+            onboot_yes_uuids,
+            network_ifaces,
+            self.ifname_option_values
+        )
+
+        task.succeeded_signal.connect(lambda: self.log_task_result(task, conf.target.system_root))
         path = self.publish_task(NETWORK.namespace, task)
         return path
 

--- a/pyanaconda/modules/network/network_interface.py
+++ b/pyanaconda/modules/network/network_interface.py
@@ -124,16 +124,15 @@ class NetworkInterface(KickstartModuleInterface):
         """
         return self.implementation.get_activated_interfaces()
 
-    def InstallNetworkWithTask(self, sysroot: Str, onboot_ifaces: List[Str], overwrite: Bool) -> ObjPath:
+    def InstallNetworkWithTask(self, onboot_ifaces: List[Str], overwrite: Bool) -> ObjPath:
         """Install network with an installation task.
 
-        :param sysroot: a path to the root of the installed system
         :param onboot_ifaces: list of network interfaces which should have ONBOOT=yes
         FIXME: does overwrite still apply?
         :param overwrite: overwrite existing configuration
         :return: a DBus path of an installation task
         """
-        return self.implementation.install_network_with_task(sysroot, onboot_ifaces, overwrite)
+        return self.implementation.install_network_with_task(onboot_ifaces, overwrite)
 
     def CreateDeviceConfigurations(self):
         """Create and populate the state of network devices configuration."""

--- a/pyanaconda/modules/payload/live/live_image.py
+++ b/pyanaconda/modules/payload/live/live_image.py
@@ -21,8 +21,8 @@ import os
 
 from pyanaconda.dbus import DBus
 from pyanaconda.core.signal import Signal
-from pyanaconda.core.util import requests_session, getSysroot
-
+from pyanaconda.core.util import requests_session
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.modules.common.constants.objects import LIVE_IMAGE_HANDLER
 from pyanaconda.modules.common.errors.payload import SourceSetupError
@@ -62,7 +62,7 @@ class LiveImageHandlerModule(PayloadHandlerBase):
         self._kernel_version_list = []
         self.kernel_version_list_changed = Signal()
 
-        self._image_path = getSysroot() + "/disk.img"
+        self._image_path = conf.target.system_root + "/disk.img"
 
         self._requests_session = None
 
@@ -233,7 +233,7 @@ class LiveImageHandlerModule(PayloadHandlerBase):
     def post_install_with_task(self):
         """Do post installation tasks."""
         task = UpdateBLSConfigurationTask(
-            getSysroot(),
+            conf.target.system_root,
             self.kernel_version_list
         )
         return self.publish_task(LIVE_IMAGE_HANDLER.namespace, task)
@@ -243,12 +243,12 @@ class LiveImageHandlerModule(PayloadHandlerBase):
         if url_target_is_tarfile(self._url):
             task = InstallFromTarTask(
                 self.image_path,
-                getSysroot(),
+                conf.target.system_root,
                 self.kernel_version_list
             )
         else:
             task = InstallFromImageTask(
-                getSysroot(),
+                conf.target.system_root,
                 self.kernel_version_list
             )
         return self.publish_task(LIVE_IMAGE_HANDLER.namespace, task)

--- a/pyanaconda/modules/security/security.py
+++ b/pyanaconda/modules/security/security.py
@@ -19,6 +19,7 @@
 #
 import shlex
 
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.dbus import DBus
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.base import KickstartModule
@@ -176,14 +177,13 @@ class SecurityModule(KickstartModule):
         log.debug("Realm is set to %s.", realm)
 
 
-    def install_with_tasks(self, sysroot):
+    def install_with_tasks(self):
         """Return the installation tasks of this module.
 
-        :param str sysroot: a path to the root of the installed system
         :returns: list of object paths of installation tasks
         """
         tasks = [
-            ConfigureSELinuxTask(sysroot=sysroot, selinux_mode=self.selinux)
+            ConfigureSELinuxTask(sysroot=conf.target.system_root, selinux_mode=self.selinux)
         ]
 
         paths = [

--- a/pyanaconda/modules/services/installation.py
+++ b/pyanaconda/modules/services/installation.py
@@ -216,7 +216,7 @@ class ConfigureSystemdDefaultTargetTask(Task):
         except ImportError:
             log.info("failed to import rpm -- not adjusting default runlevel")
         else:
-            ts = rpm.TransactionSet(util.getSysroot())
+            ts = rpm.TransactionSet(conf.target.system_root)
 
             if ts.dbMatch("provides", 'service(graphical-login)').count():
                 log.debug("A package with provides == service(graphical-login) is installed, using graphical.target.")

--- a/pyanaconda/modules/services/services.py
+++ b/pyanaconda/modules/services/services.py
@@ -19,6 +19,7 @@
 #
 from pykickstart.constants import FIRSTBOOT_DEFAULT, FIRSTBOOT_SKIP, FIRSTBOOT_RECONFIG
 
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import TEXT_ONLY_TARGET, GRAPHICAL_TARGET
 from pyanaconda.dbus import DBus
 from pyanaconda.core.signal import Signal
@@ -242,28 +243,33 @@ class ServicesModule(KickstartModule):
         else:
             log.debug("Post installation tools will be disabled.")
 
-    def install_with_tasks(self, sysroot):
+    def install_with_tasks(self):
         """Return the installation tasks of this module.
 
-        :param str sysroot: a path to the root of the installed system
         :returns: list of object paths of installation tasks
         """
         tasks = [
             ConfigureInitialSetupTask(
-                sysroot=sysroot,
+                sysroot=conf.target.system_root,
                 setup_on_boot=self.setup_on_boot
             ),
             ConfigurePostInstallationToolsTask(
-                sysroot=sysroot,
+                sysroot=conf.target.system_root,
                 tools_enabled=self.post_install_tools_enabled
             ),
             ConfigureServicesTask(
-                sysroot=sysroot,
+                sysroot=conf.target.system_root,
                 disabled_services=self.disabled_services,
                 enabled_services=self.enabled_services
             ),
-            ConfigureSystemdDefaultTargetTask(sysroot=sysroot, default_target=self.default_target),
-            ConfigureDefaultDesktopTask(sysroot=sysroot, default_desktop=self.default_desktop),
+            ConfigureSystemdDefaultTargetTask(
+                sysroot=conf.target.system_root,
+                default_target=self.default_target
+            ),
+            ConfigureDefaultDesktopTask(
+                sysroot=conf.target.system_root,
+                default_desktop=self.default_desktop
+            ),
         ]
 
         paths = [

--- a/pyanaconda/modules/storage/bootloader/bootloader.py
+++ b/pyanaconda/modules/storage/bootloader/bootloader.py
@@ -412,12 +412,11 @@ class BootloaderModule(KickstartBaseModule):
 
         return requirements
 
-    def configure_with_task(self, sysroot, kernel_versions):
+    def configure_with_task(self, kernel_versions):
         """Configure the bootloader.
 
         FIXME: This is just a temporary method.
 
-        :param sysroot: a path to the root of the installed system
         :param kernel_versions: a list of kernel versions
         :return: a path to a DBus task
         """
@@ -425,23 +424,21 @@ class BootloaderModule(KickstartBaseModule):
             storage=self.storage,
             mode=self.bootloader_mode,
             kernel_versions=kernel_versions,
-            sysroot=sysroot
+            sysroot=conf.target.system_root
         )
         path = self.publish_task(BOOTLOADER.namespace, task)
         return path
 
-    def install_with_task(self, sysroot):
+    def install_with_task(self):
         """Install the bootloader.
 
         FIXME: This is just a temporary method.
 
-        :param sysroot: a path to the root of the installed system
         :return: a path to a DBus task
         """
         task = InstallBootloaderTask(
             storage=self.storage,
-            mode=self.bootloader_mode,
-            sysroot=sysroot
+            mode=self.bootloader_mode
         )
         path = self.publish_task(BOOTLOADER.namespace, task)
         return path

--- a/pyanaconda/modules/storage/bootloader/bootloader_interface.py
+++ b/pyanaconda/modules/storage/bootloader/bootloader_interface.py
@@ -260,23 +260,21 @@ class BootloaderInterface(KickstartModuleInterfaceTemplate):
         """
         return self.implementation.detect_windows()
 
-    def ConfigureWithTask(self, sysroot: Str, kernel_versions: List[Str]):
+    def ConfigureWithTask(self, kernel_versions: List[Str]):
         """Configure the bootloader.
 
         FIXME: This is just a temporary method.
 
-        :param sysroot: a path to the root of the installed system
         :param kernel_versions: a list of kernel versions
         :return: a path to a DBus task
         """
-        return self.implementation.configure_with_task(sysroot, kernel_versions)
+        return self.implementation.configure_with_task(kernel_versions)
 
-    def InstallWithTask(self, sysroot: Str):
+    def InstallWithTask(self):
         """Install the bootloader.
 
         FIXME: This is just a temporary method.
 
-        :param sysroot: a path to the root of the installed system
         :return: a path to a DBus task
         """
-        return self.implementation.install_with_task(sysroot)
+        return self.implementation.install_with_task()

--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -65,12 +65,11 @@ class ConfigureBootloaderTask(Task):
 class InstallBootloaderTask(Task):
     """Installation task for the bootloader."""
 
-    def __init__(self, storage, mode, sysroot):
+    def __init__(self, storage, mode):
         """Create a new task."""
         super().__init__()
         self._storage = storage
         self._mode = mode
-        self._sysroot = sysroot
 
     @property
     def name(self):

--- a/pyanaconda/modules/storage/devicetree/handler.py
+++ b/pyanaconda/modules/storage/devicetree/handler.py
@@ -182,17 +182,15 @@ class DeviceTreeHandler(ABC):
         """
         self.storage.roots = roots
 
-    def mount_existing_system_with_task(self, sysroot, device_name, read_only):
+    def mount_existing_system_with_task(self, device_name, read_only):
         """Mount existing GNU/Linux installation.
 
-        :param sysroot: a path to the root of the system
         :param device_name: a name of the root device
         :param read_only: mount the system in read-only mode
         :return: a path to the task
         """
         task = MountExistingSystemTask(
             storage=self.storage,
-            sysroot=sysroot,
             device=self._get_device(device_name),
             read_only=read_only
         )

--- a/pyanaconda/modules/storage/devicetree/handler_interface.py
+++ b/pyanaconda/modules/storage/devicetree/handler_interface.py
@@ -118,12 +118,11 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
         """
         return self.implementation.find_existing_systems_with_task()
 
-    def MountExistingSystemWithTask(self, sysroot: Str, device_name: Str, read_only: Bool) -> ObjPath:
+    def MountExistingSystemWithTask(self, device_name: Str, read_only: Bool) -> ObjPath:
         """Mount existing GNU/Linux installation.
 
-        :param sysroot: a path to the root of the system
         :param device_name: a name of the root device
         :param read_only: mount the system in read-only mode
         :return: a path to the task
         """
-        return self.implementation.mount_existing_system_with_task(sysroot, device_name, read_only)
+        return self.implementation.mount_existing_system_with_task(device_name, read_only)

--- a/pyanaconda/modules/storage/devicetree/rescue.py
+++ b/pyanaconda/modules/storage/devicetree/rescue.py
@@ -49,17 +49,15 @@ class FindExistingSystemsTask(Task):
 class MountExistingSystemTask(Task):
     """A task to mount an existing GNU/Linux installation."""
 
-    def __init__(self, storage, sysroot, device, read_only):
+    def __init__(self, storage, device, read_only):
         """Create a new task.
 
         :param storage: an instance of the Blivet's storage
-        :param sysroot: a path to the root of the system
         :param device: a root device of the system
         :param read_only: mount the system in read-only mode
         """
         super().__init__()
         self._storage = storage
-        self._sysroot = sysroot
         self._device = device
         self._read_only = read_only
 
@@ -72,6 +70,5 @@ class MountExistingSystemTask(Task):
         mount_existing_system(
             storage=self._storage,
             root_device=self._device,
-            read_only=self._read_only,
-            sysroot=self._sysroot
+            read_only=self._read_only
         )

--- a/pyanaconda/modules/storage/fcoe/fcoe.py
+++ b/pyanaconda/modules/storage/fcoe/fcoe.py
@@ -19,6 +19,7 @@
 #
 from blivet.fcoe import fcoe
 
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.base import KickstartBaseModule
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -58,10 +59,10 @@ class FCOEModule(KickstartBaseModule):
         path = self.publish_task(FCOE.namespace, task)
         return path
 
-    def write_configuration(self, sysroot):
+    def write_configuration(self):
         """Write the configuration to sysroot."""
-        log.debug("Write FCoE configuration to %s.", sysroot)
-        fcoe.write(sysroot)
+        log.debug("Write FCoE configuration.")
+        fcoe.write(conf.target.system_root)
 
     def get_nics(self):
         """Get all NICs.

--- a/pyanaconda/modules/storage/fcoe/fcoe_interface.py
+++ b/pyanaconda/modules/storage/fcoe/fcoe_interface.py
@@ -44,12 +44,12 @@ class FCOEInterface(KickstartModuleInterfaceTemplate):
         """
         return self.implementation.discover_with_task(nic, dcb, auto_vlan)
 
-    def WriteConfiguration(self, sysroot: Str):
+    def WriteConfiguration(self):
         """Write the configuration to sysroot.
 
         FIXME: This is just a temporary method.
         """
-        self.implementation.write_configuration(sysroot)
+        self.implementation.write_configuration()
 
     def GetNics(self) -> List[Str]:
         """Get all NICs.

--- a/pyanaconda/modules/storage/installation.py
+++ b/pyanaconda/modules/storage/installation.py
@@ -60,11 +60,10 @@ class MountFilesystemsTask(Task):
 class WriteConfigurationTask(Task):
     """Installation task for writing out the storage configuration."""
 
-    def __init__(self, storage, sysroot):
+    def __init__(self, storage):
         """Create a new task."""
         super().__init__()
         self._storage = storage
-        self._sysroot = sysroot
 
     @property
     def name(self):
@@ -72,4 +71,4 @@ class WriteConfigurationTask(Task):
 
     def run(self):
         """Mount the filesystems."""
-        write_storage_configuration(self._storage, sysroot=self._sysroot)
+        write_storage_configuration(self._storage)

--- a/pyanaconda/modules/storage/iscsi/iscsi.py
+++ b/pyanaconda/modules/storage/iscsi/iscsi.py
@@ -20,6 +20,7 @@
 from blivet.iscsi import iscsi
 
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.signal import Signal
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.base import KickstartBaseModule
@@ -118,10 +119,10 @@ class ISCSIModule(KickstartBaseModule):
         path = self.publish_task(ISCSI.namespace, task)
         return path
 
-    def write_configuration(self, sysroot):
+    def write_configuration(self):
         """Write the configuration to sysroot."""
-        log.debug("Write iSCSI configuration to %s.", sysroot)
-        iscsi.write(sysroot, None)
+        log.debug("Write iSCSI configuration.")
+        iscsi.write(conf.target.system_root, None)
 
     def process_kickstart(self, data):
         """Process the kickstart data."""

--- a/pyanaconda/modules/storage/iscsi/iscsi_interface.py
+++ b/pyanaconda/modules/storage/iscsi/iscsi_interface.py
@@ -145,9 +145,9 @@ class ISCSIInterface(KickstartModuleInterfaceTemplate):
         node = Node.from_structure(node)
         return self.implementation.get_dracut_arguments(node)
 
-    def WriteConfiguration(self, sysroot: Str):
+    def WriteConfiguration(self):
         """Write the configuration to sysroot.
 
         FIXME: This is just a temporary method.
         """
-        self.implementation.write_configuration(sysroot)
+        self.implementation.write_configuration()

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -291,12 +291,11 @@ class StorageModule(KickstartModule):
 
         return requirements
 
-    def install_with_tasks(self, sysroot):
+    def install_with_tasks(self):
         """Returns installation tasks of this module.
 
         FIXME: This is a simplified version of the storage installation.
 
-        :param sysroot: a path to the root of the installed system
         :returns: list of object paths of installation tasks
         """
         storage = self.storage
@@ -304,7 +303,7 @@ class StorageModule(KickstartModule):
         tasks = [
             ActivateFilesystemsTask(storage),
             MountFilesystemsTask(storage),
-            WriteConfigurationTask(storage, sysroot)
+            WriteConfigurationTask(storage)
         ]
 
         paths = [

--- a/pyanaconda/modules/storage/zfcp/zfcp.py
+++ b/pyanaconda/modules/storage/zfcp/zfcp.py
@@ -19,6 +19,7 @@
 #
 from blivet.zfcp import zfcp
 
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.base import KickstartBaseModule
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -58,10 +59,10 @@ class ZFCPModule(KickstartBaseModule):
         path = self.publish_task(ZFCP.namespace, task)
         return path
 
-    def write_configuration(self, sysroot):
+    def write_configuration(self):
         """Write the configuration to sysroot."""
-        log.debug("Write zFCP configuration to %s.", sysroot)
-        zfcp.write(sysroot)
+        log.debug("Write zFCP configuration.")
+        zfcp.write(conf.target.system_root)
 
     def process_kickstart(self, data):
         """Process the kickstart data."""

--- a/pyanaconda/modules/storage/zfcp/zfcp_interface.py
+++ b/pyanaconda/modules/storage/zfcp/zfcp_interface.py
@@ -44,9 +44,9 @@ class ZFCPInterface(KickstartModuleInterfaceTemplate):
         """
         return self.implementation.discover_with_task(device_number, wwpn, lun)
 
-    def WriteConfiguration(self, sysroot: Str):
+    def WriteConfiguration(self):
         """Write the configuration to sysroot.
 
         FIXME: This is just a temporary method.
         """
-        self.implementation.write_configuration(sysroot)
+        self.implementation.write_configuration()

--- a/pyanaconda/modules/users/users.py
+++ b/pyanaconda/modules/users/users.py
@@ -17,6 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.dbus import DBus
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.base import KickstartModule
@@ -139,68 +140,74 @@ class UsersModule(KickstartModule):
 
         return str(data)
 
-    def configure_groups_with_task(self, sysroot):
+    def configure_groups_with_task(self):
         """Return the user group configuration task.
 
-        :param str sysroot: a path to the root of the installed system
         :returns: object path of the user group configuration task
         """
-        task = CreateGroupsTask(sysroot=sysroot, group_data_list=self.groups)
+        task = CreateGroupsTask(
+            sysroot=conf.target.system_root,
+            group_data_list=self.groups
+        )
         return self.publish_task(USERS.namespace, task)
 
-    def configure_users_with_task(self, sysroot):
+    def configure_users_with_task(self):
         """Return the user configuration task.
 
-        :param str sysroot: a path to the root of the installed system
         :returns: object path of the user configuration task
         """
-        task = CreateUsersTask(sysroot=sysroot, user_data_list=self.users)
+        task = CreateUsersTask(
+            sysroot=conf.target.system_root,
+            user_data_list=self.users
+        )
         return self.publish_task(USERS.namespace, task)
 
-    def set_root_password_with_task(self, sysroot):
+    def set_root_password_with_task(self):
         """Return the root password configuration task.
 
-        :param str sysroot: a path to the root of the installed system
         :returns: object path of the root password configuration task
         """
-        task =  SetRootPasswordTask(sysroot=sysroot, password=self.root_password,
-                                    crypted=self.root_password_is_crypted,
-                                    locked=self.root_account_locked)
+        task = SetRootPasswordTask(
+            sysroot=conf.target.system_root,
+            password=self.root_password,
+            crypted=self.root_password_is_crypted,
+            locked=self.root_account_locked
+        )
         return self.publish_task(USERS.namespace, task)
 
-    def set_ssh_keys_with_task(self, sysroot):
+    def set_ssh_keys_with_task(self):
         """Return the SSH key configuration task.
 
-        :param str sysroot: a path to the root of the installed system
         :returns: object path of the SSH key configuration task
         """
-        task = SetSshKeysTask(sysroot=sysroot, ssh_key_data_list=self.ssh_keys)
+        task = SetSshKeysTask(
+            sysroot=conf.target.system_root,
+            ssh_key_data_list=self.ssh_keys
+        )
         return self.publish_task(USERS.namespace, task)
 
-    def configure_root_password_ssh_login_with_task(self, sysroot):
+    def configure_root_password_ssh_login_with_task(self):
         """Return the root password SSH login configuration task.
 
-        :param str sysroot: a path to the root of the installed system
         :returns: object path of the root password SSH login configuration task
         """
         task = ConfigureRootPasswordSSHLoginTask(
-            sysroot=sysroot,
+            sysroot=conf.target.system_root,
             password_allowed=self.root_password_ssh_login_allowed
         )
         return self.publish_task(USERS.namespace, task)
 
-    def install_with_tasks(self, sysroot):
+    def install_with_tasks(self):
         """Return the installation tasks of this module.
 
-        :param str sysroot: a path to the root of the installed system
         :returns: list of object paths of installation tasks
         """
         paths = [
-            self.configure_groups_with_task(sysroot=sysroot),
-            self.configure_users_with_task(sysroot=sysroot),
-            self.set_root_password_with_task(sysroot=sysroot),
-            self.set_ssh_keys_with_task(sysroot=sysroot),
-            self.configure_root_password_ssh_login_with_task(sysroot=sysroot)
+            self.configure_groups_with_task(),
+            self.configure_users_with_task(),
+            self.set_root_password_with_task(),
+            self.set_ssh_keys_with_task(),
+            self.configure_root_password_ssh_login_with_task()
         ]
         return paths
 

--- a/pyanaconda/modules/users/users_interface.py
+++ b/pyanaconda/modules/users/users_interface.py
@@ -201,23 +201,23 @@ class UsersInterface(KickstartModuleInterface):
         """
         return self.implementation.check_admin_user_exists
 
-    def ConfigureGroupsWithTask(self, sysroot: Str) -> ObjPath:
+    def ConfigureGroupsWithTask(self) -> ObjPath:
         """Configure user groups via a DBus task.
 
         :returns: DBus path of the task
         """
-        return self.implementation.configure_groups_with_task(sysroot)
+        return self.implementation.configure_groups_with_task()
 
-    def ConfigureUsersWithTask(self, sysroot: Str) -> ObjPath:
+    def ConfigureUsersWithTask(self) -> ObjPath:
         """Configure users via a DBus task.
 
         :returns: DBus path of the task
         """
-        return self.implementation.configure_users_with_task(sysroot)
+        return self.implementation.configure_users_with_task()
 
-    def SetRootPasswordWithTask(self, sysroot: Str) -> ObjPath:
+    def SetRootPasswordWithTask(self) -> ObjPath:
         """Set root password via a DBus task.
 
         :returns: DBus path of the task
         """
-        return self.implementation.set_root_password_with_task(sysroot)
+        return self.implementation.set_root_password_with_task()

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -508,7 +508,7 @@ class Payload(metaclass=ABCMeta):
     ###
     def pre_install(self):
         """Perform pre-installation tasks."""
-        util.mkdirChain(util.getSysroot() + "/root")
+        util.mkdirChain(conf.target.system_root + "/root")
 
         self._write_module_blacklist()
 
@@ -524,8 +524,8 @@ class Payload(metaclass=ABCMeta):
         if "modprobe.blacklist" not in flags.cmdline:
             return
 
-        util.mkdirChain(util.getSysroot() + "/etc/modprobe.d")
-        with open(util.getSysroot() + "/etc/modprobe.d/anaconda-blacklist.conf", "w") as f:
+        util.mkdirChain(conf.target.system_root + "/etc/modprobe.d")
+        with open(conf.target.system_root + "/etc/modprobe.d/anaconda-blacklist.conf", "w") as f:
             f.write("# Module blacklists written by anaconda\n")
             for module in flags.cmdline["modprobe.blacklist"].split():
                 f.write("blacklist %s\n" % module)
@@ -535,18 +535,18 @@ class Payload(metaclass=ABCMeta):
         # the firmware files in the common DD firmware directory
         for f in glob(DD_FIRMWARE + "/*"):
             try:
-                shutil.copyfile(f, "%s/lib/firmware/" % util.getSysroot())
+                shutil.copyfile(f, "%s/lib/firmware/" % conf.target.system_root)
             except IOError as e:
                 log.error("Could not copy firmware file %s: %s", f, e.strerror)
 
         # copy RPMS
         for d in glob(DD_RPMS):
-            shutil.copytree(d, util.getSysroot() + "/root/" + os.path.basename(d))
+            shutil.copytree(d, conf.target.system_root + "/root/" + os.path.basename(d))
 
         # copy modules and firmware into root's home directory
         if os.path.exists(DD_ALL):
             try:
-                shutil.copytree(DD_ALL, util.getSysroot() + "/root/DD")
+                shutil.copytree(DD_ALL, conf.target.system_root + "/root/DD")
             except IOError as e:
                 log.error("failed to copy driver disk files: %s", e.strerror)
                 # XXX TODO: real error handling, as this is probably going to
@@ -576,7 +576,7 @@ class Payload(metaclass=ABCMeta):
 
         :returns: None
         """
-        if os.path.exists(util.getSysroot() + "/usr/sbin/new-kernel-pkg"):
+        if os.path.exists(conf.target.system_root + "/usr/sbin/new-kernel-pkg"):
             use_dracut = False
         else:
             log.warning("new-kernel-pkg does not exist - grubby wasn't installed? "
@@ -707,7 +707,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
 
         files = []
 
-        ts = rpm.TransactionSet(util.getSysroot())
+        ts = rpm.TransactionSet(conf.target.system_root)
         mi = ts.dbMatch('providename', 'kernel')
         for hdr in mi:
             unicode_fnames = (decode_bytes(f) for f in hdr.filenames)

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -123,15 +123,15 @@ def _pick_mpoint(df, download_size, install_size, download_only):
         '/tmp',
         '/',
         '/var/tmp',
-        util.getSysroot(),
-        os.path.join(util.getSysroot(), 'home'),
-        os.path.join(util.getSysroot(), 'tmp'),
-        os.path.join(util.getSysroot(), 'var'),
+        conf.target.system_root,
+        os.path.join(conf.target.system_root, 'home'),
+        os.path.join(conf.target.system_root, 'tmp'),
+        os.path.join(conf.target.system_root, 'var'),
     }
 
     requested = download_size
     requested_root = requested + install_size
-    root_mpoint = util.getSysroot()
+    root_mpoint = conf.target.system_root
     log.debug('Input mount points: %s', df)
     log.info('Estimated size: download %s & install %s', requested,
              (requested_root - requested))
@@ -668,7 +668,7 @@ class DNFPayload(payload.PackagePayload):
             self._base.conf.module_platform_id = platform_id
 
         config.releasever = self._get_release_version(None)
-        config.installroot = util.getSysroot()
+        config.installroot = conf.target.system_root
         config.prepend_installroot('persistdir')
 
         self._base.conf.substitutions.update_from_etc(config.installroot)
@@ -828,7 +828,7 @@ class DNFPayload(payload.PackagePayload):
 
         download_size = self._download_space
         valid_points = _df_map()
-        root_mpoint = util.getSysroot()
+        root_mpoint = conf.target.system_root
         for (key, val) in self.storage.mountpoints.items():
             new_key = key
             if key.endswith('/'):
@@ -1380,7 +1380,7 @@ class DNFPayload(payload.PackagePayload):
                     continue
             except (dnf.exceptions.RepoError, KeyError):
                 continue
-            repo_path = util.getSysroot() + YUM_REPOS_DIR + "%s.repo" % repo.id
+            repo_path = conf.target.system_root + YUM_REPOS_DIR + "%s.repo" % repo.id
             try:
                 log.info("Writing %s.repo to target system.", repo.id)
                 self._write_dnf_repo(repo, repo_path)

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -277,7 +277,7 @@ class RPMOSTreePayload(Payload):
         assert len(deployments) > 0
         deployment = deployments[0]
         deployment_path = sysroot.get_deployment_directory(deployment)
-        util.setSysroot(deployment_path.get_path())
+        util.set_system_root(deployment_path.get_path())
 
         try:
             self._copy_bootloader_data()

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -141,7 +141,7 @@ class RPMOSTreePayload(Payload):
         # be fixed to *copy* data into /boot at install time, instead
         # of shipping it in the RPM).
         is_efi = isinstance(self.storage.bootloader, EFIBase)
-        physboot = util.getTargetPhysicalRoot() + '/boot'
+        physboot = conf.target.physical_root + '/boot'
         ostree_boot_source = util.getSysroot() + '/usr/lib/ostree-boot'
         if not os.path.isdir(ostree_boot_source):
             ostree_boot_source = util.getSysroot() + '/boot'
@@ -188,12 +188,12 @@ class RPMOSTreePayload(Payload):
 
         # Initialize the filesystem - this will create the repo as well
         self._safe_exec_with_redirect("ostree",
-                                      ["admin", "--sysroot=" + util.getTargetPhysicalRoot(),
-                                       "init-fs", util.getTargetPhysicalRoot()])
+                                      ["admin", "--sysroot=" + conf.target.physical_root,
+                                       "init-fs", conf.target.physical_root])
 
         # Here, we use the physical root as sysroot, because we haven't
         # yet made a deployment.
-        sysroot_file = Gio.File.new_for_path(util.getTargetPhysicalRoot())
+        sysroot_file = Gio.File.new_for_path(conf.target.physical_root)
         sysroot = OSTree.Sysroot.new(sysroot_file)
         sysroot.load(cancellable)
         repo = sysroot.get_repo(None)[1]
@@ -257,10 +257,10 @@ class RPMOSTreePayload(Payload):
         repo.remote_delete(self.data.ostreesetup.remote, None)
 
         self._safe_exec_with_redirect("ostree",
-                                      ["admin", "--sysroot=" + util.getTargetPhysicalRoot(),
+                                      ["admin", "--sysroot=" + conf.target.physical_root,
                                        "os-init", ostreesetup.osname])
 
-        admin_deploy_args = ["admin", "--sysroot=" + util.getTargetPhysicalRoot(),
+        admin_deploy_args = ["admin", "--sysroot=" + conf.target.physical_root,
                              "deploy", "--os=" + ostreesetup.osname]
 
         admin_deploy_args.append(ostreesetup.remote + ':' + ref)
@@ -310,7 +310,7 @@ class RPMOSTreePayload(Payload):
             dest = src
         # Almost all of our mounts go from physical to sysroot
         if src_physical:
-            src = util.getTargetPhysicalRoot() + src
+            src = conf.target.physical_root + src
         else:
             src = util.getSysroot() + src
         # Canonicalize dest to the full path

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -206,9 +206,9 @@ class Rescue(object):
         # mount root fs
         try:
             mount_existing_system(self._storage, root.device, read_only=self.ro)
-            log.info("System has been mounted under: %s", util.getSysroot())
+            log.info("System has been mounted under: %s", conf.target.system_root)
         except StorageError as e:
-            log.error("Mounting system under %s failed: %s", util.getSysroot(), e)
+            log.error("Mounting system under %s failed: %s", conf.target.system_root, e)
             self.status = RescueModeStatus.MOUNT_FAILED
             return False
 
@@ -217,7 +217,7 @@ class Rescue(object):
             # we have to catch the possible exception, because we
             # support read-only mounting
             try:
-                fd = open("%s/.autorelabel" % util.getSysroot(), "w+")
+                fd = open("%s/.autorelabel" % conf.target.system_root, "w+")
                 fd.close()
             except IOError as e:
                 log.warning("Error turning on selinux: %s", e)
@@ -237,7 +237,7 @@ class Rescue(object):
         # make resolv.conf in chroot
         if not self.ro:
             try:
-                makeResolvConf(util.getSysroot())
+                makeResolvConf(conf.target.system_root)
             except(OSError, IOError) as e:
                 log.error("Error making resolv.conf: %s", e)
 
@@ -324,7 +324,7 @@ class RescueModeSpoke(NormalTUISpoke):
                 "this step.\nYou can choose to mount your file "
                 "systems read-only instead of read-write by choosing "
                 "'2'.\nIf for some reason this process does not work "
-                "choose '3' to skip directly to a shell.\n\n") % (util.getSysroot())
+                "choose '3' to skip directly to a shell.\n\n") % (conf.target.system_root)
         self.window.add_with_separator(TextWidget(msg))
 
         self._container = ListColumnContainer(1)
@@ -464,7 +464,7 @@ class RescueStatusAndShellSpoke(NormalTUISpoke):
                                     "If you would like to make the root of your system the "
                                     "root of the active system, run the command:\n\n"
                                     "\tchroot %(mountpoint)s\n\n")
-                                  % {"mountpoint": util.getSysroot()} + finish_msg)
+                                  % {"mountpoint": conf.target.system_root} + finish_msg)
             elif status == RescueModeStatus.MOUNT_FAILED:
                 if self._rescue.reboot:
                     finish_msg = exit_reboot_msg
@@ -472,7 +472,7 @@ class RescueStatusAndShellSpoke(NormalTUISpoke):
                     finish_msg = umount_msg
                 text = TextWidget(_("An error occurred trying to mount some or all of "
                                     "your system.  Some of it may be mounted under %s\n\n") %
-                                  util.getSysroot() + finish_msg)
+                                  conf.target.system_root + finish_msg)
             elif status == RescueModeStatus.ROOT_NOT_FOUND:
                 if self._rescue.reboot:
                     finish_msg = _("Rebooting.")

--- a/pyanaconda/storage/fsset.py
+++ b/pyanaconda/storage/fsset.py
@@ -30,7 +30,6 @@ from blivet.errors import UnrecognizedFSTabEntryError, FSTabTypeMismatchError, S
 from blivet.formats import get_format, get_device_format_class
 from blivet.storage_log import log_exception_info
 
-from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.errors import errorHandler as error_handler, ERROR_RAISE
 from pyanaconda.platform import platform as _platform, EFI
@@ -47,7 +46,7 @@ def copy_to_system(source):
         log.info("copy_to_system: source '%s' does not exist.", source)
         return False
 
-    target = util.getSysroot() + source
+    target = conf.target.system_root + source
     target_dir = os.path.dirname(target)
     log.debug("copy_to_system: '%s' -> '%s'.", source, target)
     if not os.path.isdir(target_dir):
@@ -412,7 +411,7 @@ class FSSet(object):
             loop mounts?
         """
         if not chroot or not os.path.isdir(chroot):
-            chroot = util.getSysroot()
+            chroot = conf.target.system_root
 
         path = "%s/etc/fstab" % chroot
         if not os.access(path, os.R_OK):
@@ -612,7 +611,7 @@ class FSSet(object):
 
     def mk_dev_root(self):
         root = self.root_device
-        sysroot = util.getSysroot()
+        sysroot = conf.target.system_root
         dev = "%s/%s" % (sysroot, root.path)
         if not os.path.exists("%s/dev/root" % (sysroot,)) and os.path.exists(dev):
             rdev = os.stat(dev).st_rdev
@@ -640,7 +639,7 @@ class FSSet(object):
 
     def write(self):
         """Write out all config files based on the set of filesystems."""
-        sysroot = util.getSysroot()
+        sysroot = conf.target.system_root
         # /etc/fstab
         fstab_path = os.path.normpath("%s/etc/fstab" % sysroot)
         fstab = self.fstab()

--- a/pyanaconda/storage/fsset.py
+++ b/pyanaconda/storage/fsset.py
@@ -31,6 +31,7 @@ from blivet.formats import get_format, get_device_format_class
 from blivet.storage_log import log_exception_info
 
 from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.errors import errorHandler as error_handler, ERROR_RAISE
 from pyanaconda.platform import platform as _platform, EFI
 
@@ -591,7 +592,7 @@ class FSSet(object):
         """Create and activate a swap file under storage root."""
         filename = "/SWAP"
         count = 0
-        basedir = os.path.normpath("%s/%s" % (util.getTargetPhysicalRoot(),
+        basedir = os.path.normpath("%s/%s" % (conf.target.physical_root,
                                               device.format.mountpoint))
         while os.path.exists("%s/%s" % (basedir, filename)) or \
                 self.devicetree.get_device_by_name(filename):
@@ -627,7 +628,7 @@ class FSSet(object):
 
     @property
     def root_device(self):
-        for path in ["/", util.getTargetPhysicalRoot()]:
+        for path in ["/", conf.target.physical_root]:
             for device in self.devices:
                 try:
                     mountpoint = device.format.mountpoint

--- a/pyanaconda/storage/installation.py
+++ b/pyanaconda/storage/installation.py
@@ -173,14 +173,14 @@ def write_storage_configuration(storage, sysroot=None):
     storage.fsset.write()
 
     iscsi_proxy = STORAGE.get_proxy(ISCSI)
-    iscsi_proxy.WriteConfiguration(sysroot)
+    iscsi_proxy.WriteConfiguration()
 
     fcoe_proxy = STORAGE.get_proxy(FCOE)
-    fcoe_proxy.WriteConfiguration(sysroot)
+    fcoe_proxy.WriteConfiguration()
 
     if arch.is_s390():
         zfcp_proxy = STORAGE.get_proxy(ZFCP)
-        zfcp_proxy.WriteConfiguration(sysroot)
+        zfcp_proxy.WriteConfiguration()
 
     _write_dasd_conf(storage, sysroot)
 

--- a/pyanaconda/storage/installation.py
+++ b/pyanaconda/storage/installation.py
@@ -25,7 +25,7 @@ from gi.repository import BlockDev as blockdev
 from blivet import util as blivet_util, arch
 from blivet.errors import FSResizeError, FormatResizeError
 
-from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.errors import errorHandler as error_handler, ERROR_RAISE
 from pyanaconda.modules.common.constants.objects import FCOE, ZFCP, ISCSI
 from pyanaconda.modules.common.constants.services import STORAGE
@@ -162,7 +162,7 @@ def write_storage_configuration(storage, sysroot=None):
     :param sysroot: a path to the target OS installation
     """
     if sysroot is None:
-        sysroot = util.getSysroot()
+        sysroot = conf.target.system_root
 
     if not os.path.isdir("%s/etc" % sysroot):
         os.mkdir("%s/etc" % sysroot)

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -405,7 +405,7 @@ class InstallerStorage(Blivet):
         self.fsset.turn_on_swap(root_path=util.getSysroot())
 
     def mount_filesystems(self):
-        root_path = util.getTargetPhysicalRoot()
+        root_path = conf.target.physical_root
 
         # Mount the root and the filesystems.
         self.fsset.mount_filesystems(root_path=root_path)

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -411,14 +411,14 @@ class InstallerStorage(Blivet):
         self.fsset.mount_filesystems(root_path=root_path)
 
         # Set up the sysroot.
-        util.setSysroot(root_path)
+        util.set_system_root(root_path)
 
     def umount_filesystems(self, swapoff=True):
         # Unmount the root and the filesystems.
         self.fsset.umount_filesystems(swapoff=swapoff)
 
         # Unmount the sysroot.
-        util.setSysroot(None)
+        util.set_system_root(None)
 
     def parse_fstab(self, chroot=None):
         self.fsset.parse_fstab(chroot=chroot)

--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -402,7 +402,7 @@ class InstallerStorage(Blivet):
         return template
 
     def turn_on_swap(self):
-        self.fsset.turn_on_swap(root_path=util.getSysroot())
+        self.fsset.turn_on_swap(root_path=conf.target.system_root)
 
     def mount_filesystems(self):
         root_path = conf.target.physical_root
@@ -432,7 +432,7 @@ class InstallerStorage(Blivet):
     def make_mtab(self, chroot=None):
         path = "/etc/mtab"
         target = "/proc/self/mounts"
-        chroot = chroot or util.getSysroot()
+        chroot = chroot or conf.target.system_root
         path = os.path.normpath("%s/%s" % (chroot, path))
 
         if os.path.islink(path):

--- a/pyanaconda/storage/root.py
+++ b/pyanaconda/storage/root.py
@@ -33,9 +33,9 @@ log = get_module_logger(__name__)
 __all__ = ["mount_existing_system", "find_existing_installations", "Root"]
 
 
-def mount_existing_system(storage, root_device, read_only=None, sysroot=None):
+def mount_existing_system(storage, root_device, read_only=None):
     """Mount filesystems specified in root_device's /etc/fstab file."""
-    root_path = sysroot or conf.target.physical_root
+    root_path = conf.target.physical_root
     read_only = "ro" if read_only else ""
 
     # Mount the root device.
@@ -60,7 +60,7 @@ def mount_existing_system(storage, root_device, read_only=None, sysroot=None):
     # Turn on swap.
     if not conf.target.is_image or not read_only:
         try:
-            storage.fsset.turn_on_swap(root_path=sysroot)
+            storage.fsset.turn_on_swap(root_path=root_path)
         except StorageError as e:
             log.error("Error enabling swap: %s", str(e))
 

--- a/pyanaconda/storage/root.py
+++ b/pyanaconda/storage/root.py
@@ -35,7 +35,7 @@ __all__ = ["mount_existing_system", "find_existing_installations", "Root"]
 
 def mount_existing_system(storage, root_device, read_only=None, sysroot=None):
     """Mount filesystems specified in root_device's /etc/fstab file."""
-    root_path = sysroot or util.getTargetPhysicalRoot()
+    root_path = sysroot or conf.target.physical_root
     read_only = "ro" if read_only else ""
 
     # Mount the root device.
@@ -94,10 +94,10 @@ def _find_existing_installations(devicetree):
     :param devicetree: a device tree to find existing installations in
     :return: roots of all found installations
     """
-    if not os.path.exists(util.getTargetPhysicalRoot()):
-        blivet_util.makedirs(util.getTargetPhysicalRoot())
+    if not os.path.exists(conf.target.physical_root):
+        blivet_util.makedirs(conf.target.physical_root)
 
-    sysroot = util.getTargetPhysicalRoot()
+    sysroot = conf.target.physical_root
     roots = []
     direct_devices = (dev for dev in devicetree.devices if dev.direct)
     for device in direct_devices:

--- a/pyanaconda/storage/root.py
+++ b/pyanaconda/storage/root.py
@@ -51,7 +51,7 @@ def mount_existing_system(storage, root_device, read_only=None, sysroot=None):
                                  options="%s,%s" % (root_device.format.options, read_only))
 
     # Set up the sysroot.
-    util.setSysroot(root_path)
+    util.set_system_root(root_path)
 
     # Mount the filesystems.
     storage.fsset.parse_fstab(chroot=root_path)

--- a/pyanaconda/ui/lib/space.py
+++ b/pyanaconda/ui/lib/space.py
@@ -18,7 +18,7 @@
 #
 import os
 from blivet.size import Size
-from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
@@ -114,7 +114,7 @@ class DirInstallSpaceChecker(FileSystemSpaceChecker):
 
     def _calculate_free_space(self):
         """Calculate the available space."""
-        stat = os.statvfs(util.getTargetPhysicalRoot())
+        stat = os.statvfs(conf.target.physical_root)
         return Size(stat.f_bsize * stat.f_bfree)
 
     def _calculate_deficit(self, needed):

--- a/tests/nosetests/pyanaconda_tests/iutil_test.py
+++ b/tests/nosetests/pyanaconda_tests/iutil_test.py
@@ -30,6 +30,7 @@ from pyanaconda.errors import ExitError
 from pyanaconda.core.process_watchers import WatchProcesses
 from pyanaconda.core import util
 from pyanaconda.core.util import synchronized
+from pyanaconda.core.configuration.anaconda import conf
 
 from timer import timer
 
@@ -828,7 +829,7 @@ class MiscTests(unittest.TestCase):
             test_function()
 
     def sysroot_test(self):
-        self.assertEqual(util.getTargetPhysicalRoot(), "/mnt/sysimage")
+        self.assertEqual(conf.target.physical_root, "/mnt/sysimage")
         self.assertEqual(util.getSysroot(), "/mnt/sysroot")
 
     def decode_bytes_test(self):

--- a/tests/nosetests/pyanaconda_tests/iutil_test.py
+++ b/tests/nosetests/pyanaconda_tests/iutil_test.py
@@ -830,7 +830,7 @@ class MiscTests(unittest.TestCase):
 
     def sysroot_test(self):
         self.assertEqual(conf.target.physical_root, "/mnt/sysimage")
-        self.assertEqual(util.getSysroot(), "/mnt/sysroot")
+        self.assertEqual(conf.target.system_root, "/mnt/sysroot")
 
     def decode_bytes_test(self):
         self.assertEqual("STRING", util.decode_bytes("STRING"))

--- a/tests/nosetests/pyanaconda_tests/module_bootloader_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_bootloader_test.py
@@ -181,31 +181,27 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
     def configure_with_task_test(self, publisher):
         """Test ConfigureWithTask."""
         storage = Mock()
-        sysroot = "/mnt/sysroot"
         version = "4.17.7-200.fc28.x86_64"
 
         self.bootloader_module.on_storage_reset(storage)
-        task_path = self.bootloader_interface.ConfigureWithTask(sysroot, [version])
+        task_path = self.bootloader_interface.ConfigureWithTask([version])
 
         obj = check_task_creation(self, task_path, publisher, ConfigureBootloaderTask)
 
         self.assertEqual(obj.implementation._storage, storage)
-        self.assertEqual(obj.implementation._sysroot, sysroot)
         self.assertEqual(obj.implementation._versions, [version])
 
     @patch_dbus_publish_object
     def install_with_task_test(self, publisher):
         """Test InstallWithTask."""
         storage = Mock()
-        sysroot = "/mnt/sysroot"
 
         self.bootloader_module.on_storage_reset(storage)
-        task_path = self.bootloader_interface.InstallWithTask(sysroot)
+        task_path = self.bootloader_interface.InstallWithTask()
 
         obj = check_task_creation(self, task_path, publisher, InstallBootloaderTask)
 
         self.assertEqual(obj.implementation._storage, storage)
-        self.assertEqual(obj.implementation._sysroot, sysroot)
 
 
 class BootloaderTasksTestCase(unittest.TestCase):
@@ -241,19 +237,13 @@ class BootloaderTasksTestCase(unittest.TestCase):
         bootloader = Mock()
         storage = Mock(bootloader=bootloader)
 
-        with tempfile.TemporaryDirectory() as root:
-            InstallBootloaderTask(storage, BootloaderMode.DISABLED, root).run()
-
+        InstallBootloaderTask(storage, BootloaderMode.DISABLED).run()
         bootloader.write.assert_not_called()
 
-        with tempfile.TemporaryDirectory() as root:
-            InstallBootloaderTask(storage, BootloaderMode.SKIPPED, root).run()
-
+        InstallBootloaderTask(storage, BootloaderMode.SKIPPED).run()
         bootloader.write.assert_not_called()
 
-        with tempfile.TemporaryDirectory() as root:
-            InstallBootloaderTask(storage, BootloaderMode.ENABLED, root).run()
-
+        InstallBootloaderTask(storage, BootloaderMode.ENABLED).run()
         bootloader.set_boot_args.assert_called_once()
         bootloader.write.assert_called_once()
 

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -487,13 +487,11 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         """Test MountExistingSystemWithTask."""
         self._add_device(StorageDevice("dev1", fmt=get_format("ext4")))
 
-        with tempfile.TemporaryDirectory() as sysroot:
-            task_path = self.interface.MountExistingSystemWithTask(sysroot, "dev1", True)
+        task_path = self.interface.MountExistingSystemWithTask("dev1", True)
 
         obj = check_task_creation(self, task_path, publisher, MountExistingSystemTask)
 
         self.assertEqual(obj.implementation._storage, self.module.storage)
-        self.assertEqual(obj.implementation._sysroot, sysroot)
         self.assertEqual(obj.implementation._device.name, "dev1")
         self.assertEqual(obj.implementation._read_only, True)
 
@@ -521,13 +519,11 @@ class DeviceTreeTasksTestCase(unittest.TestCase):
         device = StorageDevice("dev1", fmt=get_format("ext4"))
         storage.devicetree._add_device(device)
 
-        with tempfile.TemporaryDirectory() as sysroot:
-            task = MountExistingSystemTask(storage, sysroot, device, True)
-            task.run()
+        task = MountExistingSystemTask(storage, device, True)
+        task.run()
 
         mount.assert_called_once_with(
             storage=storage,
-            sysroot=sysroot,
             root_device=device,
             read_only=True
         )

--- a/tests/nosetests/pyanaconda_tests/module_localization_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_localization_test.py
@@ -133,11 +133,9 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
     def install_language_with_task_test(self, publisher):
         """Test InstallLanguageWithTask."""
         self.localization_interface.SetLanguage("cs_CZ.UTF-8")
-        task_path = self.localization_interface.InstallWithTasks("/")[0]
+        task_path = self.localization_interface.InstallWithTasks()[0]
 
         obj = check_task_creation(self, task_path, publisher, LanguageInstallationTask)
-
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._lang, "cs_CZ.UTF-8")
 
     def _test_kickstart(self, ks_in, ks_out):

--- a/tests/nosetests/pyanaconda_tests/module_network_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_network_test.py
@@ -200,14 +200,12 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         self.network_module._get_onboot_ifaces_by_policy = Mock(return_value=["ens4"])
 
         task_path = self.network_interface.InstallNetworkWithTask(
-            "/mnt/sysimage",
             ["ens3"],
             False,
         )
 
         obj = check_task_creation(self, task_path, publisher, NetworkInstallationTask)
 
-        self.assertEqual(obj.implementation._sysroot, "/mnt/sysimage")
         self.assertEqual(obj.implementation._hostname, "my_hostname")
         self.assertEqual(obj.implementation._disable_ipv6, True)
         self.assertEqual(obj.implementation._overwrite, False)
@@ -677,11 +675,10 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
     @patch_dbus_publish_object
     def firewall_config_task_basic_test(self, publisher):
         """Test the Firewall configuration task - basic."""
-        task_path = self.firewall_interface.InstallWithTask("/")
+        task_path = self.firewall_interface.InstallWithTask()
 
         obj = check_task_creation(self, task_path, publisher, ConfigureFirewallTask)
 
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._firewall_mode, FirewallMode.DEFAULT)
         self.assertEqual(obj.implementation._enabled_services, [])
         self.assertEqual(obj.implementation._disabled_services, [])

--- a/tests/nosetests/pyanaconda_tests/module_services_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_services_test.py
@@ -305,7 +305,7 @@ class ServicesTasksTestCase(unittest.TestCase):
     @patch_dbus_publish_object
     def install_with_tasks_default_test(self, publisher):
         """Test default install tasks behavior."""
-        tasks = self.services_interface.InstallWithTasks("/")
+        tasks = self.services_interface.InstallWithTasks()
         is_task_path = tasks[0]
         post_install_tools_task = tasks[1]
         services_task_path = tasks[2]
@@ -321,7 +321,6 @@ class ServicesTasksTestCase(unittest.TestCase):
         self.assertEqual(is_task_path, object_path)
         self.assertIsInstance(obj, TaskInterface)
         self.assertIsInstance(obj.implementation, ConfigureInitialSetupTask)
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._setup_on_boot, SetupOnBootAction.DEFAULT)
 
         # post install tools configuration
@@ -331,7 +330,6 @@ class ServicesTasksTestCase(unittest.TestCase):
         self.assertEqual(post_install_tools_task, object_path)
         self.assertIsInstance(obj, TaskInterface)
         self.assertIsInstance(obj.implementation, ConfigurePostInstallationToolsTask)
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._tools_enabled, True)
 
         # Services configuration
@@ -341,7 +339,6 @@ class ServicesTasksTestCase(unittest.TestCase):
         self.assertEqual(services_task_path, object_path)
         self.assertIsInstance(obj, TaskInterface)
         self.assertIsInstance(obj.implementation, ConfigureServicesTask)
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._enabled_services, [])
         self.assertEqual(obj.implementation._disabled_services, [])
 
@@ -352,7 +349,6 @@ class ServicesTasksTestCase(unittest.TestCase):
         self.assertEqual(target_task_path, object_path)
         self.assertIsInstance(obj, TaskInterface)
         self.assertIsInstance(obj.implementation, ConfigureSystemdDefaultTargetTask)
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._default_target, "")
 
         # Default desktop configuration
@@ -362,14 +358,13 @@ class ServicesTasksTestCase(unittest.TestCase):
         self.assertEqual(desktop_task_path, object_path)
         self.assertIsInstance(obj, TaskInterface)
         self.assertIsInstance(obj.implementation, ConfigureDefaultDesktopTask)
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._default_desktop, "")
 
     @patch_dbus_publish_object
     def initial_setup_config_task_enable_test(self, publisher):
         """Test the Initial Setup conifg task - enable."""
         self.services_interface.SetSetupOnBoot(SETUP_ON_BOOT_ENABLED)
-        tasks = self.services_interface.InstallWithTasks("/")
+        tasks = self.services_interface.InstallWithTasks()
         is_task_path = tasks[0]
 
         publisher.assert_called()
@@ -381,14 +376,13 @@ class ServicesTasksTestCase(unittest.TestCase):
         self.assertEqual(is_task_path, object_path)
         self.assertIsInstance(obj, TaskInterface)
         self.assertIsInstance(obj.implementation, ConfigureInitialSetupTask)
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._setup_on_boot, SetupOnBootAction.ENABLED)
 
     @patch_dbus_publish_object
     def initial_setup_config_task_disable_test(self, publisher):
         """Test the Initial Setup config task - disable."""
         self.services_interface.SetSetupOnBoot(SETUP_ON_BOOT_DISABLED)
-        tasks = self.services_interface.InstallWithTasks("/")
+        tasks = self.services_interface.InstallWithTasks()
         is_task_path = tasks[0]
 
         publisher.assert_called()
@@ -400,14 +394,13 @@ class ServicesTasksTestCase(unittest.TestCase):
         self.assertEqual(is_task_path, object_path)
         self.assertIsInstance(obj, TaskInterface)
         self.assertIsInstance(obj.implementation, ConfigureInitialSetupTask)
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._setup_on_boot, SetupOnBootAction.DISABLED)
 
     @patch_dbus_publish_object
     def initial_setup_config_task_reconfig_test(self, publisher):
         """Test the Initial Setup config task - reconfig."""
         self.services_interface.SetSetupOnBoot(SETUP_ON_BOOT_RECONFIG)
-        tasks = self.services_interface.InstallWithTasks("/")
+        tasks = self.services_interface.InstallWithTasks()
         is_task_path = tasks[0]
 
         publisher.assert_called()
@@ -419,7 +412,6 @@ class ServicesTasksTestCase(unittest.TestCase):
         self.assertEqual(is_task_path, object_path)
         self.assertIsInstance(obj, TaskInterface)
         self.assertIsInstance(obj.implementation, ConfigureInitialSetupTask)
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._setup_on_boot, SetupOnBootAction.RECONFIG)
 
     @patch_dbus_publish_object
@@ -427,7 +419,7 @@ class ServicesTasksTestCase(unittest.TestCase):
         """Test the services configuration task."""
         self.services_interface.SetEnabledServices(["a", "b", "c"])
         self.services_interface.SetDisabledServices(["c", "e", "f"])
-        tasks = self.services_interface.InstallWithTasks("/")
+        tasks = self.services_interface.InstallWithTasks()
         services_task_path = tasks[2]
 
         publisher.assert_called()
@@ -439,7 +431,6 @@ class ServicesTasksTestCase(unittest.TestCase):
         self.assertEqual(services_task_path, object_path)
         self.assertIsInstance(obj, TaskInterface)
         self.assertIsInstance(obj.implementation, ConfigureServicesTask)
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._enabled_services, ["a", "b", "c"])
         self.assertEqual(obj.implementation._disabled_services, ["c", "e", "f"])
 
@@ -447,7 +438,7 @@ class ServicesTasksTestCase(unittest.TestCase):
     def configure_systemd_target_task_text_test(self, publisher):
         """Test the systemd default traget configuration task - text."""
         self.services_interface.SetDefaultTarget(TEXT_ONLY_TARGET)
-        tasks = self.services_interface.InstallWithTasks("/")
+        tasks = self.services_interface.InstallWithTasks()
         target_task_path = tasks[3]
 
         publisher.assert_called()
@@ -459,14 +450,13 @@ class ServicesTasksTestCase(unittest.TestCase):
         self.assertEqual(target_task_path, object_path)
         self.assertIsInstance(obj, TaskInterface)
         self.assertIsInstance(obj.implementation, ConfigureSystemdDefaultTargetTask)
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._default_target, TEXT_ONLY_TARGET)
 
     @patch_dbus_publish_object
     def configure_systemd_target_task_graphical_test(self, publisher):
         """Test the systemd default traget configuration task - graphical."""
         self.services_interface.SetDefaultTarget(GRAPHICAL_TARGET)
-        tasks = self.services_interface.InstallWithTasks("/")
+        tasks = self.services_interface.InstallWithTasks()
         target_task_path = tasks[3]
 
         publisher.assert_called()
@@ -478,14 +468,13 @@ class ServicesTasksTestCase(unittest.TestCase):
         self.assertEqual(target_task_path, object_path)
         self.assertIsInstance(obj, TaskInterface)
         self.assertIsInstance(obj.implementation, ConfigureSystemdDefaultTargetTask)
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._default_target, GRAPHICAL_TARGET)
 
     @patch_dbus_publish_object
     def configure_default_desktop_task_test(self, publisher):
         """Test the default desktop configuration task."""
         self.services_interface.SetDefaultDesktop("GNOME")
-        tasks = self.services_interface.InstallWithTasks("/")
+        tasks = self.services_interface.InstallWithTasks()
         desktop_task_path = tasks[4]
 
         publisher.assert_called()
@@ -497,5 +486,4 @@ class ServicesTasksTestCase(unittest.TestCase):
         self.assertEqual(desktop_task_path, object_path)
         self.assertIsInstance(obj, TaskInterface)
         self.assertIsInstance(obj.implementation, ConfigureDefaultDesktopTask)
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._default_desktop, "GNOME")

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -18,17 +18,16 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import logging
-import tempfile
 import unittest
 from unittest.mock import patch, call, Mock
 
 from tests.nosetests.pyanaconda_tests import check_kickstart_interface, check_task_creation, \
     patch_dbus_publish_object
 
-from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
-
 from pyanaconda.bootloader.grub2 import IPSeriesGRUB2, GRUB2
 from pyanaconda.bootloader.zipl import ZIPL
+from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.constants.objects import AUTO_PARTITIONING
 from pyanaconda.modules.common.errors.configuration import StorageDiscoveryError
 from pyanaconda.modules.common.errors.storage import InvalidStorageError
@@ -138,9 +137,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
             WriteConfigurationTask
         ]
 
-        # Get the installation tasks.
-        with tempfile.TemporaryDirectory() as sysroot:
-            task_paths = self.storage_interface.InstallWithTasks(sysroot)
+        task_paths = self.storage_interface.InstallWithTasks()
 
         # Check the number of installation tasks.
         task_number = len(task_classes)
@@ -1295,9 +1292,8 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
     @patch('pyanaconda.modules.storage.iscsi.iscsi.iscsi')
     def write_configuration_test(self, iscsi):
         """Test WriteConfiguration."""
-        with tempfile.TemporaryDirectory() as root:
-            self.iscsi_interface.WriteConfiguration(root)
-            iscsi.write.assert_called_once_with(root, None)
+        self.iscsi_interface.WriteConfiguration()
+        iscsi.write.assert_called_once_with(conf.target.system_root, None)
 
 
 class FCOEInterfaceTestCase(unittest.TestCase):
@@ -1340,10 +1336,8 @@ class FCOEInterfaceTestCase(unittest.TestCase):
     @patch('pyanaconda.modules.storage.fcoe.fcoe.fcoe')
     def write_configuration_test(self, fcoe):
         """Test WriteConfiguration."""
-
-        with tempfile.TemporaryDirectory() as root:
-            self.fcoe_interface.WriteConfiguration(root)
-            fcoe.write.assert_called_once_with(root)
+        self.fcoe_interface.WriteConfiguration()
+        fcoe.write.assert_called_once_with(conf.target.system_root)
 
 
 class FCOETasksTestCase(unittest.TestCase):
@@ -1402,10 +1396,8 @@ class ZFCPInterfaceTestCase(unittest.TestCase):
     @patch('pyanaconda.modules.storage.zfcp.zfcp.zfcp')
     def write_configuration_test(self, zfcp):
         """Test WriteConfiguration."""
-
-        with tempfile.TemporaryDirectory() as root:
-            self.zfcp_interface.WriteConfiguration(root)
-            zfcp.write.assert_called_once_with(root)
+        self.zfcp_interface.WriteConfiguration()
+        zfcp.write.assert_called_once_with(conf.target.system_root)
 
 
 class ZFCPTasksTestCase(unittest.TestCase):

--- a/tests/nosetests/pyanaconda_tests/module_users_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_users_test.py
@@ -1563,7 +1563,7 @@ class UsersModuleTasksTestCase(unittest.TestCase):
     def root_ssh_password_config_task_basic_test(self, publisher):
         """Test the root password SSH login configuration task - basic."""
         self.users_interface.SetRootPasswordSSHLoginAllowed(True)
-        task_path = self.users_interface.InstallWithTasks("/")[4]
+        task_path = self.users_interface.InstallWithTasks()[4]
 
         publisher.assert_called()
 
@@ -1573,7 +1573,6 @@ class UsersModuleTasksTestCase(unittest.TestCase):
         self.assertEqual(task_path, object_path)
         self.assertIsInstance(obj, TaskInterface)
         self.assertIsInstance(obj.implementation, ConfigureRootPasswordSSHLoginTask)
-        self.assertEqual(obj.implementation._sysroot, "/")
         self.assertEqual(obj.implementation._password_allowed, True)
 
     def root_ssh_password_config_task_enabled_test(self):

--- a/tests/nosetests/pyanaconda_tests/payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/payload_test.py
@@ -24,7 +24,7 @@ import os
 import hashlib
 import shutil
 
-from pyanaconda.core.util import getSysroot
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.payload import dnfpayload
 from blivet.size import Size
 
@@ -36,15 +36,15 @@ from pyanaconda.payload.errors import PayloadRequirementsMissingApply
 class PickLocation(unittest.TestCase):
     def pick_download_location_test(self):
         """Take the biggest mountpoint which can be used for download"""
-        df_map = {os.path.join(getSysroot(), "not_used"): Size("20 G"),
-                  os.path.join(getSysroot(), "home"): Size("2 G"),
-                  os.path.join(getSysroot()): Size("5 G")}
+        df_map = {os.path.join(conf.target.system_root, "not_used"): Size("20 G"),
+                  os.path.join(conf.target.system_root, "home"): Size("2 G"),
+                  os.path.join(conf.target.system_root): Size("5 G")}
         download_size = Size("1.5 G")
         install_size = Size("1.8 G")
 
         mpoint = dnfpayload._pick_mpoint(df_map, download_size, install_size, True)
 
-        self.assertEqual(mpoint, os.path.join(getSysroot(), "home"))
+        self.assertEqual(mpoint, os.path.join(conf.target.system_root, "home"))
 
     def pick_download_root_test(self):
         """Take the root for download because there are no other available mountpoints
@@ -52,33 +52,33 @@ class PickLocation(unittest.TestCase):
 
            This is required when user skipped the space check.
         """
-        df_map = {os.path.join(getSysroot(), "not_used"): Size("20 G"),
-                  os.path.join(getSysroot(), "home"): Size("2 G"),
-                  os.path.join(getSysroot()): Size("5 G")}
+        df_map = {os.path.join(conf.target.system_root, "not_used"): Size("20 G"),
+                  os.path.join(conf.target.system_root, "home"): Size("2 G"),
+                  os.path.join(conf.target.system_root): Size("5 G")}
         download_size = Size("2.5 G")
         install_size = Size("3.0 G")
 
         mpoint = dnfpayload._pick_mpoint(df_map, download_size, install_size, True)
 
-        self.assertEqual(mpoint, os.path.join(getSysroot()))
+        self.assertEqual(mpoint, os.path.join(conf.target.system_root))
 
     def pick_install_location_test(self):
         """Take the root for download and install."""
-        df_map = {os.path.join(getSysroot(), "not_used"): Size("20 G"),
-                  os.path.join(getSysroot(), "home"): Size("2 G"),
-                  os.path.join(getSysroot()): Size("6 G")}
+        df_map = {os.path.join(conf.target.system_root, "not_used"): Size("20 G"),
+                  os.path.join(conf.target.system_root, "home"): Size("2 G"),
+                  os.path.join(conf.target.system_root): Size("6 G")}
         download_size = Size("1.5 G")
         install_size = Size("3.0 G")
 
         mpoint = dnfpayload._pick_mpoint(df_map, download_size, install_size, False)
 
-        self.assertEqual(mpoint, getSysroot())
+        self.assertEqual(mpoint, conf.target.system_root)
 
     def pick_install_location_error_test(self):
         """No suitable location is found."""
-        df_map = {os.path.join(getSysroot(), "not_used"): Size("20 G"),
-                  os.path.join(getSysroot(), "home"): Size("1 G"),
-                  os.path.join(getSysroot()): Size("4 G")}
+        df_map = {os.path.join(conf.target.system_root, "not_used"): Size("20 G"),
+                  os.path.join(conf.target.system_root, "home"): Size("1 G"),
+                  os.path.join(conf.target.system_root): Size("4 G")}
         download_size = Size("1.5 G")
         install_size = Size("3.0 G")
 


### PR DESCRIPTION
Remove the argument for the system root from the DBus methods that
return installation and configuration tasks. The path to the system
root doesn't change anymore.

Replace functions getSysroot, setSysroot and getTargetPhysicalRoot.

**Depends on:**
https://github.com/rhinstaller/initial-setup/pull/73
https://github.com/daveyoung/kdump-anaconda-addon/pull/23