### PR TITLE
Fix release in a mock tutorial and tools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,8 +48,7 @@ ARCHIVE_TAG   = $(PACKAGE_NAME)-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE)
 ZANATA_PULL_ARGS = --transdir $(srcdir)/po/
 ZANATA_PUSH_ARGS = --srcfile $(srcdir)/po/anaconda.pot --push-type source --force
 
-# the Zanata Python client is unfortunately Python 2 only at the moment
-ZANATA_CLIENT_PKG=python2-zanata-client
+ZANATA_CLIENT_BIN=zanata
 
 DIST_NAME ?= $(shell echo "$(GIT_BRANCH)" | sed \
 				-e 's/^f//' \
@@ -90,7 +89,7 @@ tag:
 	@echo "Tagged as $(ARCHIVE_TAG)"
 
 po-pull:
-	rpm -q $(ZANATA_CLIENT_PKG) &>/dev/null || ( echo "need to run: dnf install $(ZANATA_CLIENT_PKG)"; exit 1 )
+	which $(ZANATA_CLIENT_BIN) &>/dev/null || ( echo "need to install zanata python client package"; exit 1 )
 	( cd $(srcdir) && zanata pull $(ZANATA_PULL_ARGS) )
 
 po-push:

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -150,7 +150,7 @@ uncomment it and set it to True instead
 
 ::
 
-    ./scripts/testing/setup-mock-test-env.py --init -c -p --release fedora-rawhide-x86_64
+    ./scripts/testing/setup-mock-test-env.py --init -c --release fedora-rawhide-x86_64
 
 6. connect to the prepared mock environment
 

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -9,6 +9,7 @@ In that case just ignore all section that require you to be an Anaconda maintain
 0. prerequisites
 
 - you need an up to date anaconda source code checkout
+- it is recommended to make the release on a fresh clone (prevent you from pushing local work into the upstream repository)
 - you need to have commit access to the anaconda repository (so that you can push release commits)
 - you need to have write access to the corresponding Fedora Zanata project so that you can push .pot file updates
 - you need to have the ``rpmbuild`` or ``mock`` and ``fedpkg`` tools installed

--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -41,7 +41,7 @@ TEST_DEPENDENCIES = ["e2fsprogs", "git", "bzip2", "cppcheck", "rpm-ostree", "pyk
 
 PIP_DEPENDENCIES = ["rpmfluff", "dogtail", "pocketlint"]
 
-RELEASE_DEPENDENCIES = ["python2-zanata-client"]
+RELEASE_DEPENDENCIES = ["python3-zanata-client"]
 
 
 def _resolve_top_dir():


### PR DESCRIPTION
Fix dependency errors thanks to the switch from python2 to python3 zanata client.
Fix the tutorial mistakes and make improvements. 