### PR TITLE
Move code to exctract kernel version from tar to utils

### DIFF
--- a/pyanaconda/modules/payload/live/utils.py
+++ b/pyanaconda/modules/payload/live/utils.py
@@ -18,6 +18,8 @@
 import glob
 import functools
 import os
+import tarfile
+
 from pyanaconda.payload.utils import version_cmp
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.util import ProxyString, ProxyStringError, execWithRedirect
@@ -29,11 +31,24 @@ log = get_module_logger(__name__)
 
 def get_kernel_version_list(root_path):
     files = glob.glob(root_path + "/boot/vmlinuz-*")
-    files.extend(glob.glob(root_path + "/boot/efi/EFI/{}/vmlinuz-*".format(conf.bootloader.efi_dir)))
+    files.extend(
+        glob.glob(root_path + "/boot/efi/EFI/{}/vmlinuz-*".format(conf.bootloader.efi_dir))
+    )
 
     kernel_version_list = sorted((f.split("/")[-1][8:] for f in files
                                   if os.path.isfile(f) and "-rescue-" not in f),
                                  key=functools.cmp_to_key(version_cmp))
+    return kernel_version_list
+
+
+def get_kernel_version_list_from_tar(tarfile_path):
+    with tarfile.open(tarfile_path) as archive:
+        names = archive.getnames()
+
+        # Strip out vmlinuz- from the names
+        kernel_version_list = sorted((n.split("/")[-1][8:] for n in names
+                                      if "boot/vmlinuz-" in n),
+                                     key=functools.cmp_to_key(version_cmp))
     return kernel_version_list
 
 


### PR DESCRIPTION
First, there is already the original get kernel version function so having all the variants on one place seems like the best option. Even thought they are useful only on one a place.

Second, I want to strip the payload handler classes as much as possible and ideally have them only as a controller who will store actual settings of the payload. Everything else should be in functions, classes or tasks with one main purpose. We should try to avoid another DNF payload class with 1500 lines.