### PR TITLE
Don't prune and sort actions in the partitioning task

### DIFF
--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -195,9 +195,14 @@ class DeviceTreeViewer(ABC):
     def get_actions(self):
         """Get the device actions.
 
+        The actions are pruned and sorted.
+
         :return: a list of DeviceActionData
         """
         actions = []
+
+        self.storage.devicetree.actions.prune()
+        self.storage.devicetree.actions.sort()
 
         for action in self.storage.devicetree.actions.find():
             actions.append(self._get_action_data(action))

--- a/pyanaconda/modules/storage/partitioning/interactive_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/interactive_partitioning.py
@@ -32,7 +32,6 @@ class InteractivePartitioningTask(PartitioningTask):
         """Only set up the bootloader."""
         self._prepare_bootloader(storage)
         self._set_fstab_swaps(storage)
-        self._organize_actions(storage)
 
     def _prepare_bootloader(self, storage):
         """Prepare the bootloader."""
@@ -44,11 +43,6 @@ class InteractivePartitioningTask(PartitioningTask):
             d for d in storage.devices
             if d.direct and not d.format.exists and not d.partitioned and d.format.type == "swap"
         ])
-
-    def _organize_actions(self, storage):
-        """Prune and sort the scheduled actions."""
-        storage.devicetree.actions.prune()
-        storage.devicetree.actions.sort()
 
 
 class InteractiveAutoPartitioningTask(AutomaticPartitioningTask):

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -247,6 +247,8 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
             if not self._do_check():
                 return
 
+        self._storage_playground.devicetree.actions.prune()
+        self._storage_playground.devicetree.actions.sort()
         actions = self._storage_playground.devicetree.actions.find()
 
         if actions:

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -1478,6 +1478,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             if not self._do_check():
                 return
 
+        self._storage_playground.devicetree.actions.prune()
+        self._storage_playground.devicetree.actions.sort()
         actions = self._storage_playground.devicetree.actions.find()
 
         if actions:


### PR DESCRIPTION
Don't prune and sort actions in the interactive partitioning task,
because the scheduled partitioning doesn't have to be valid for the
storage checker. Organize the actions before displaying them to users
in the dialog window.