### PR TITLE
Always schedule the installation task for joining realm (#1732620)

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -168,10 +168,9 @@ def _prepare_configuration(storage, payload, ksdata):
     configuration_queue.append(generate_initramfs)
 
     # join a realm (if required)
-    if ksdata.realm.discovered:
-        join_realm = TaskQueue("Realm join", N_("Joining realm: %s") % ksdata.realm.discovered)
-        join_realm.append(Task("Join a realm", ksdata.realm.execute))
-        configuration_queue.append(join_realm)
+    join_realm = TaskQueue("Realm join", N_("Joining realm"))
+    join_realm.append(Task("Join a realm", ksdata.realm.execute))
+    configuration_queue.append(join_realm)
 
     post_scripts = TaskQueue("Post installation scripts", N_("Running post-installation scripts"))
     post_scripts.append(Task("Run post installation scripts", runPostScripts, (ksdata.scripts,)))


### PR DESCRIPTION
We don't know the result of the realm discovery during the scheduling,
because the task for the realm discovery hasn't run yet. So always
schedule the task for joining the realm and check the result there.

Resolves: rhbz#1732620