### PR TITLE
Don't change the storage if the reset fails

### DIFF
--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -247,8 +247,7 @@ class StorageModule(KickstartModule):
 
         # Create the task.
         task = StorageResetTask(storage)
-        # FIXME: Don't set the storage if the task has failed.
-        task.stopped_signal.connect(lambda: self.set_storage(storage))
+        task.succeeded_signal.connect(lambda: self.set_storage(storage))
 
         # Publish the task.
         path = self.publish_task(STORAGE.namespace, task)

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -80,7 +80,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
         storage_changed_callback = Mock()
         self.storage_module.storage_changed.connect(storage_changed_callback)
 
-        obj.implementation.stopped_signal.emit()
+        obj.implementation.succeeded_signal.emit()
         storage_changed_callback.assert_called_once()
 
     @patch('pyanaconda.modules.storage.partitioning.validate.storage_checker')


### PR DESCRIPTION
Don't change the storage model of the Storage module unless the task
for the storage reset succeeds.