### PR TITLE
Always protect the live backing device (#1706335)

### DIFF
--- a/pyanaconda/modules/storage/partitioning/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic_partitioning.py
@@ -15,12 +15,10 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from blivet.errors import NoDisksError, NotEnoughFreeSpaceError
 from blivet.partitioning import do_partitioning, grow_lvm
 from blivet.static_data import luks_data
 
 from pyanaconda.anaconda_loggers import get_module_logger
-from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.constants.objects import AUTO_PARTITIONING
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.storage.partitioning.noninteractive_partitioning import \
@@ -133,18 +131,10 @@ class AutomaticPartitioningTask(NonInteractivePartitioningTask):
         log.debug("all names: %s", [d.name for d in storage.devices])
         log.debug("boot disk: %s", getattr(storage.bootloader.stage1_disk, "name", None))
 
-        if not any(d.format.supported for d in storage.partitioned):
-            raise NoDisksError(_("No usable disks selected"))
-
         disks = get_candidate_disks(storage)
+        log.debug("candidate disks: %s", [d.name for d in disks])
+
         devs = schedule_implicit_partitions(storage, disks, scheme, encrypted, luks_fmt_args)
-        log.debug("candidate disks: %s", disks)
-        log.debug("devs: %s", devs)
-
-        if not disks:
-            raise NotEnoughFreeSpaceError(_("Not enough free space on disks for "
-                                            "automatic partitioning"))
-
         devs = schedule_partitions(storage, disks, devs, scheme, requests, encrypted, luks_fmt_args)
 
         # run the autopart function to allocate and grow partitions

--- a/pyanaconda/modules/storage/partitioning/custom_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/custom_partitioning.py
@@ -21,7 +21,7 @@ from blivet.devicelibs.crypto import MIN_CREATE_ENTROPY
 from blivet.devicelibs.lvm import LVM_PE_SIZE, KNOWN_THPOOL_PROFILES
 from blivet.devices import LUKSDevice, LVMVolumeGroupDevice
 from blivet.devices.lvm import LVMCacheRequest
-from blivet.errors import StorageError, BTRFSValueError, NoDisksError, NotEnoughFreeSpaceError
+from blivet.errors import StorageError, BTRFSValueError
 from blivet.formats import get_format
 from blivet.partitioning import do_partitioning, grow_lvm
 from blivet.size import Size
@@ -121,14 +121,7 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
         if not reqs:
             return
 
-        if not any(d.format.supported for d in storage.partitioned):
-            raise NoDisksError(_("No usable disks selected"))
-
         disks = get_candidate_disks(storage)
-
-        if not disks:
-            raise NotEnoughFreeSpaceError(_("Not enough free space on disks for "
-                                            "automatic partitioning"))
 
         log.debug("Applying requirements:\n%s", "".join(map(str, reqs)))
         schedule_partitions(storage, disks, [], scheme=AUTOPART_TYPE_PLAIN, requests=reqs)

--- a/pyanaconda/storage/checker.py
+++ b/pyanaconda/storage/checker.py
@@ -368,6 +368,9 @@ def verify_mounted_partitions(storage, constraints, report_error, report_warning
     :param report_warning: a function for warning reporting
     """
     for disk in storage.disks:
+        if disk.protected:
+            continue
+
         if not disk.partitioned:
             continue
 

--- a/pyanaconda/storage/utils.py
+++ b/pyanaconda/storage/utils.py
@@ -470,13 +470,7 @@ def find_live_backing_device():
             continue
 
         live_device_path = mnt.split()[0]
-        udev_device = udev.get_device(device_node=live_device_path)
-
-        if udev_device and udev.device_is_partition(udev_device):
-            live_device_name = udev.device_get_partition_disk(udev_device)
-        else:
-            live_device_name = live_device_path.split("/")[-1]
-
+        live_device_name = live_device_path.split("/")[-1]
         return live_device_name or None
 
     return None


### PR DESCRIPTION
We protect the live backing device and its parents, so don't return
the parent of the live backing device. Otherwise, we will not protect
the live backing device.

Don't verify mounted partitions of protected disks.

Raise the exceptions NoDisksError and NotEnoughFreeSpaceError
from the function get_candidate_disks if no candidate disks are found.

Resolves: rhbz#1706335