### PR TITLE
Move the preserved arguments to the Anaconda configuration file

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -95,6 +95,13 @@ menu_auto_hide = False
 # Are non-iBFT iSCSI disks allowed?
 nonibft_iscsi_boot = False
 
+# Arguments preserved from the installation system.
+preserved_arguments =
+     cio_ignore rd.znet rd_ZNET zfcp.allow_lun_scan
+     speakup_synth apic noapic apm ide noht acpi video
+     pci nodmraid nompath nomodeset noiswmd fips selinux
+     biosdevname ipv6.disable net.ifnames
+
 
 [Storage]
 # Enable dmraid usage during the installation.

--- a/pyanaconda/bootloader/base.py
+++ b/pyanaconda/bootloader/base.py
@@ -154,14 +154,6 @@ class BootLoader(object):
     def stage2_format_types(self):
         return ["ext4", "ext3", "ext2"]
 
-    # this is so stupid...
-    global_preserve_args = ["speakup_synth", "apic", "noapic", "apm", "ide",
-                            "noht", "acpi", "video", "pci", "nodmraid",
-                            "nompath", "nomodeset", "noiswmd", "fips",
-                            "selinux", "biosdevname", "ipv6.disable",
-                            "net.ifnames"]
-    preserve_args = []
-
     def __init__(self):
         super().__init__()
         self.boot_args = Arguments()
@@ -826,7 +818,7 @@ class BootLoader(object):
 
     def _preserve_some_boot_args(self):
         """Preserve some of the boot args."""
-        for opt in self.global_preserve_args + self.preserve_args:
+        for opt in conf.bootloader.preserved_arguments:
             if opt not in flags.cmdline:
                 continue
 

--- a/pyanaconda/bootloader/zipl.py
+++ b/pyanaconda/bootloader/zipl.py
@@ -52,7 +52,6 @@ class ZIPL(BootLoader):
             return ["ext4", "ext3", "ext2", "xfs"]
 
     image_label_attr = "short_label"
-    preserve_args = ["cio_ignore", "rd.znet", "rd_ZNET", "zfcp.allow_lun_scan"]
 
     def __init__(self):
         super().__init__()

--- a/pyanaconda/core/configuration/bootloader.py
+++ b/pyanaconda/core/configuration/bootloader.py
@@ -41,3 +41,11 @@ class BootloaderSection(Section):
         which were not configured in iBFT.
         """
         return self._get_option("nonibft_iscsi_boot", bool)
+
+    @property
+    def preserved_arguments(self):
+        """Arguments preserved from the installation system.
+
+        :return: a list of kernel arguments
+        """
+        return self._get_option("preserved_arguments", str).split()

--- a/tests/nosetests/pyanaconda_tests/configuration_test.py
+++ b/tests/nosetests/pyanaconda_tests/configuration_test.py
@@ -309,3 +309,7 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
                 services.SERVICES
             ))
         )
+
+    def bootloader_test(self):
+        conf = AnacondaConfiguration.from_defaults()
+        self.assertIn("selinux", conf.bootloader.preserved_arguments)


### PR DESCRIPTION
Move the list of preserved bootloader arguments from the code
to the Anaconda configuration file, so it is easier to find it.