### PR TITLE
Specify sizes of nonexistent devices in tests

### DIFF
--- a/tests/nosetests/pyanaconda_tests/grub_raid_test.py
+++ b/tests/nosetests/pyanaconda_tests/grub_raid_test.py
@@ -70,7 +70,14 @@ class GRUBRaidSimpleTest(unittest.TestCase):
         for part in (self.sda1, self.sda2, self.sda3, self.sda4, self.sdb1, self.sdb2, self.sdb4):
             part.parents = part.req_disks
 
-        self.boot_md = MDRaidArrayDevice(name="md1", parents=[self.sda2, self.sdb2], level=1)
+        self.boot_md = MDRaidArrayDevice(
+            name="md1",
+            size=Size("500 MiB"),
+            parents=[self.sda2, self.sdb2],
+            level=1,
+            member_devices=2,
+            total_devices=2
+        )
         self.boot_md.format = get_format("ext4", mountpoint="/boot")
 
         # Set up the btrfs raid1 volume with a subvolume for /boot

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -94,8 +94,17 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         """Test GetDevices."""
         self.assertEqual(self.interface.GetDevices(), [])
 
-        self._add_device(DiskDevice("dev1", fmt=get_format("ext4")))
-        self._add_device(StorageDevice("dev2", fmt=get_format("ext4")))
+        self._add_device(DiskDevice(
+            "dev1",
+            fmt=get_format("ext4"),
+            size=Size("10 GiB")
+        ))
+
+        self._add_device(StorageDevice(
+            "dev2",
+            fmt=get_format("ext4"),
+            size=Size("10 GiB")
+        ))
 
         self.assertEqual(self.interface.GetDevices(), ["dev1", "dev2"])
 
@@ -168,6 +177,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         self._add_device(DASDDevice(
             "dev1",
             fmt=get_format("ext4"),
+            size=Size("10 GiB"),
             busid="0.0.0201",
             opts={}
         ))
@@ -181,6 +191,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         self._add_device(ZFCPDiskDevice(
             "dev1",
             fmt=get_format("ext4"),
+            size=Size("10 GiB"),
             fcp_lun="0x5719000000000000",
             wwpn="0x5005076300c18154",
             hba_id="0.0.010a"


### PR DESCRIPTION
Specify sizes of nonexistent devices in tests. Otherwise, these tests
will fail with a message "device is too small for new format".