### PR TITLE
Fix pylint warning

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1008,7 +1008,7 @@ def detect_unsupported_hardware():
 
     :return: a list of warnings
     """
-    warnings = []
+    warnings = []  # pylint: disable=redefined-outer-name
 
     if flags.automatedInstall or not conf.target.is_hardware:
         log.info("Skipping detection of unsupported hardware.")


### PR DESCRIPTION
Ignore redefined name `warnings` from outer scope of the function
`detect_unsupported_hardware`.