### PR TITLE
liveinst: Add support for plain squashfs root filesystem

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -39,6 +39,8 @@ if [ -z "$LIVE_BLOCK" ]; then
        LIVE_BLOCK="/dev/mapper/live-base"
     elif [ -b "/dev/mapper/live-osimg-min" ]; then
        LIVE_BLOCK="/dev/mapper/live-osimg-min"
+    elif [ -e "/run/rootfsbase" ]; then
+        LIVE_BLOCK="$(findmnt -n -o SOURCE /run/rootfsbase)"
     fi
 fi
 

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -24,6 +24,7 @@ from pyanaconda.dbus import DBus
 
 from pyanaconda.core.signal import Signal
 from pyanaconda.core.constants import INSTALL_TREE
+from pyanaconda.core.util import execWithCapture
 
 from pyanaconda.modules.common.constants.objects import LIVE_OS_HANDLER
 from pyanaconda.modules.payload.handler_base import PayloadHandlerBase
@@ -84,6 +85,16 @@ class LiveOSHandlerModule(PayloadHandlerBase):
                     log.debug("Detected live base image %s", block_device)
                     return block_device
             except FileNotFoundError:
+                pass
+
+        # Is it a squashfs+overlayfs base image?
+        if os.path.exists("/run/rootfsbase"):
+            try:
+                block_device = execWithCapture("findmnt", ["-n", "-o", "SOURCE", "/run/rootfsbase"]).strip()
+                if block_device:
+                    log.debug("Detected live base image %s", block_device)
+                    return block_device
+            except (OSError, FileNotFoundError):
                 pass
 
         log.debug("No live base image detected")


### PR DESCRIPTION
livemedia-creator-31.9-1 can now create a live iso where the
LiveOS/squashfs.img is the root filesystem instead of wrapping an ext4
filesystem inside of it.

dracut's dmsquash-live module already knows how to handle this and mount
an overlayfs on top of it.

After booting the base filesystem will be mounted at /run/rootfsbase,
this examines that mountpoint and sets the LIVE_BLOCK device, the device
to use as the source for the live install, to the mounted loop device.