### PR TITLE
Add support for localization of modules

### DIFF
--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -28,6 +28,7 @@ from collections import namedtuple
 
 from pyanaconda.core import constants, util
 from pyanaconda.core.util import upcase_first_letter, setenv, execWithRedirect
+from pyanaconda.modules.common.constants.services import BOSS
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -277,7 +278,16 @@ def setup_locale(locale, localization_proxy=None, text_mode=False):
         setenv("LANG", locale)
         locale_mod.setlocale(locale_mod.LC_ALL, locale)
 
+    set_modules_locale(locale)
+
     return locale
+
+
+def set_modules_locale(locale):
+    """Set locale of all modules."""
+    boss_proxy = BOSS.get_proxy()
+    boss_proxy.SetLocale(locale)
+
 
 def get_english_name(locale):
     """

--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -132,3 +132,12 @@ class Boss(MainModule):
         task = self._install_manager.install_system_with_task()
         path = self.publish_task(BOSS.namespace, task)
         return path
+
+    def set_locale(self, locale):
+        """Set locale of boss and all modules.
+
+        :param str locale: locale to set
+        """
+        log.info("Setting locale of all modules to %s.", locale)
+        super().set_locale(locale)
+        self._module_manager.set_modules_locale(locale)

--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -84,3 +84,10 @@ class AnacondaBossInterface(BossInterface):
             "line_number": get_variant(Int, result["line_number"]),
             "error_message": get_variant(Str, result["error_message"])
         } for result in results]
+
+    def SetLocale(self, locale: Str):
+        """Set locale of boss and all modules.
+
+        Examples: "cs_CZ.UTF-8", "fr_FR"
+        """
+        self.implementation.set_locale(locale)

--- a/pyanaconda/modules/boss/module_manager/module_manager.py
+++ b/pyanaconda/modules/boss/module_manager/module_manager.py
@@ -103,6 +103,18 @@ class ModuleManager(object):
 
         return True
 
+    def set_modules_locale(self, locale):
+        """Set locale of all modules.
+
+        :param str locale: locale to set
+        """
+        log.info("Setting locale of all modules to %s.", locale)
+        for observer in self.module_observers:
+            if not observer.is_service_available:
+                log.warning("%s is not available when setting locale", observer)
+                continue
+            observer.proxy.SetLocale(locale)
+
     def stop_modules(self):
         """Tell all running modules to quit."""
         log.debug("Stop modules.")

--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -18,10 +18,13 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import os
 from abc import ABC
+from locale import setlocale, LC_ALL
 
 from pyanaconda.core.event_loop import EventLoop
 from pyanaconda.core.timer import Timer
+from pyanaconda.core.util import setenv
 from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.task import publish_task, TaskInterface
 from pyanaconda.core.signal import Signal
@@ -102,6 +105,26 @@ class MainModule(BaseModule):
         """Stop the module's loop."""
         DBus.disconnect()
         Timer().timeout_sec(1, self.loop.quit)
+
+    def set_locale(self, locale):
+        """Set the locale for the module.
+
+        This function modifies the process environment, which is not thread-safe.
+        It should be called before any threads are run.
+
+        We cannot get around setting $LANG. Python's gettext implementation
+        differs from C in that consults only the environment for the current
+        language and not the data set via setlocale. If we want translations
+        from python modules to work, something needs to be set in the
+        environment when the language changes.
+
+        :param str locale: locale to set
+        """
+        os.environ["LANG"] = locale  # pylint: disable=environment-modify
+        setlocale(LC_ALL, locale)
+        # Set locale for child processes
+        setenv("LANG", locale)
+        log.debug("Locale is set to %s.", locale)
 
 
 class KickstartBaseModule(BaseModule):

--- a/pyanaconda/modules/common/base/base_interface.py
+++ b/pyanaconda/modules/common/base/base_interface.py
@@ -123,6 +123,22 @@ class KickstartModuleInterface(KickstartModuleInterfaceTemplate):
         """
         return Requirement.to_structure_list(self.implementation.collect_requirements())
 
+    def SetLocale(self, locale: Str):
+        """Set the locale for the module.
+
+        This function modifies the process environment, which is not thread-safe.
+        It should be called before any threads are run.
+
+        We cannot get around setting $LANG. Python's gettext implementation
+        differs from C in that consults only the environment for the current
+        language and not the data set via setlocale. If we want translations
+        from python modules to work, something needs to be set in the
+        environment when the language changes.
+
+        Examples: "cs_CZ.UTF-8", "fr_FR"
+        """
+        return self.implementation.set_locale(locale)
+
     def InstallWithTasks(self) -> List[ObjPath]:
         """Returns installation tasks of this module.
 

--- a/tests/nosetests/pyanaconda_tests/module_network_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_network_test.py
@@ -97,6 +97,19 @@ class NetworkInterfaceTestCase(unittest.TestCase):
             *args, **kwargs
         )
 
+    @patch("pyanaconda.modules.common.base.base.setlocale")
+    @patch("pyanaconda.modules.common.base.base.os")
+    def set_locale_test(self, mocked_os, setlocale):
+        """Test setting locale of the module."""
+        from locale import LC_ALL
+        import pyanaconda.core.util
+        locale = "en_US.UTF-8"
+        mocked_os.environ = {}
+        self.network_interface.SetLocale(locale)
+        self.assertEqual(mocked_os.environ["LANG"], locale)
+        setlocale.assert_called_once_with(LC_ALL, locale)
+        self.assertEqual(pyanaconda.core.util._child_env['LANG'], locale)
+
     def hostname_property_test(self):
         """Test the hostname property."""
         self._test_dbus_property(


### PR DESCRIPTION
The pull request is still modifying os.enviorn which is non-thread-safe.
For how we do it currently look for os.environ assignments in https://github.com/rhinstaller/anaconda/blob/master/pyanaconda/localization.py and https://github.com/rhinstaller/anaconda/blob/master/pyanaconda/ui/gui/spokes/welcome.py
Hopefully the PR is not doing something more dangerous than our current code does.