### PR TITLE
Adapt networking to nm in dracut

### DIFF
--- a/pyanaconda/modules/network/device_configuration.py
+++ b/pyanaconda/modules/network/device_configuration.py
@@ -402,6 +402,12 @@ class DeviceConfigurations(object):
         device_type = self.setting_types.get(connection_type, None)
         iface = get_iface_from_connection(self.nm_client, uuid)
 
+        # Require interface name for physical devices
+        if device_type in supported_wired_device_types and not iface:
+            log.debug("add_connection: not adding %s: interface name is required for type %s",
+                      uuid, device_type)
+            return False
+
         # Handle also vlan connections without interface-name specified
         if device_type == NM.DeviceType.VLAN:
             if not iface:

--- a/pyanaconda/modules/network/initialization.py
+++ b/pyanaconda/modules/network/initialization.py
@@ -366,12 +366,14 @@ class DumpMissingIfcfgFilesTask(Task):
         s_con = con.get_setting_connection()
         s_con.set_property(NM.SETTING_CONNECTION_ID, iface)
         s_con.set_property(NM.SETTING_CONNECTION_INTERFACE_NAME, iface)
-        if not bound_hwaddr_of_device(self._nm_client, iface, self._ifname_option_values):
-            s_wired = con.get_setting_wired()
-            s_wired.set_property(NM.SETTING_WIRED_MAC_ADDRESS, None)
-        else:
-            log.debug("%s: iface %s bound to mac address by ifname boot option",
-                      self.name, iface)
+        s_wired = con.get_setting_wired()
+        # By default connections are bound to interface name
+        s_wired.set_property(NM.SETTING_WIRED_MAC_ADDRESS, None)
+        bound_mac = bound_hwaddr_of_device(self._nm_client, iface, self._ifname_option_values)
+        if bound_mac:
+            s_wired.set_property(NM.SETTING_WIRED_MAC_ADDRESS, bound_mac)
+            log.debug("%s: iface %s bound to mac address %s by ifname boot option",
+                      self.name, iface, bound_mac)
 
     @guard_by_system_configuration(return_value=[])
     def run(self):


### PR DESCRIPTION
This should fix the main issues caused by using NM in dracut (no ifcfg files created for activated devices).
There are still some non-critical use cases that need investigating (some 5 kickstart tests still failing).