### PR TITLE
Fix missing requests timeout

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -103,7 +103,11 @@ TEXT_ONLY_TARGET = 'multi-user.target'
 GRAPHICAL_TARGET = 'graphical.target'
 
 # Network
-NETWORK_CONNECTION_TIMEOUT = 45  # in seconds
+
+# Requests package (where this constant is used) recommends to have timeout slightly
+# above multiple of 3 because of it is default packet re-transmission window.
+# See: https://3.python-requests.org/user/advanced/#timeouts
+NETWORK_CONNECTION_TIMEOUT = 46  # in seconds
 NETWORK_CONNECTED_CHECK_INTERVAL = 0.1  # in seconds
 
 # DBus

--- a/pyanaconda/modules/payload/live/initialization.py
+++ b/pyanaconda/modules/payload/live/initialization.py
@@ -29,7 +29,7 @@ from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.payload.live.utils import get_local_image_path_from_url, \
     get_proxies_from_option, url_target_is_tarfile
 from pyanaconda.payload.utils import mount, unmount
-from pyanaconda.core.constants import IMAGE_DIR
+from pyanaconda.core.constants import IMAGE_DIR, NETWORK_CONNECTION_TIMEOUT
 
 from pyanaconda.core.util import lowerASCII, execWithRedirect
 
@@ -127,7 +127,8 @@ class CheckInstallationSourceImageTask(Task):
         # FIXME: validate earlier when setting?
         proxies = get_proxies_from_option(self._proxy)
         try:
-            response = self._session.get(url, proxies=proxies, verify=True)
+            response = self._session.get(url, proxies=proxies, verify=True,
+                                         timeout=NETWORK_CONNECTION_TIMEOUT)
 
             # At this point we know we can get the image and what its size is
             # Make a guess as to minimum size needed:
@@ -243,7 +244,8 @@ class SetupInstallationSourceImageTask(Task):
             with open(image_path, "wb") as f:
                 ssl_verify = not self._noverifyssl
                 proxies = get_proxies_from_option(self._proxy)
-                response = session.get(url, proxies=proxies, verify=ssl_verify, stream=True)
+                response = session.get(url, proxies=proxies, verify=ssl_verify, stream=True,
+                                       timeout=NETWORK_CONNECTION_TIMEOUT)
                 total_length = response.headers.get('content-length')
                 if total_length is None:
                     # just download the file in one go and fake the progress reporting once done

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -1450,7 +1450,8 @@ class RepoMDMetaHash(object):
         for url in self._urls:
             try:
                 result = session.get("%s/repodata/repomd.xml" % url, headers=headers,
-                                     proxies=proxies, verify=self._ssl_verify)
+                                     proxies=proxies, verify=self._ssl_verify,
+                                     timeout=constants.NETWORK_CONNECTION_TIMEOUT)
                 if result.ok:
                     repomd = result.text
                     break

--- a/pyanaconda/payload/install_tree_metadata.py
+++ b/pyanaconda/payload/install_tree_metadata.py
@@ -135,7 +135,8 @@ class InstallTreeMetadata(object):
     def _download_treeinfo_file(session, url, file_name, headers, proxies, verify, cert):
         try:
             result = session.get("%s/%s" % (url, file_name), headers=headers,
-                                 proxies=proxies, verify=verify, cert=cert)
+                                 proxies=proxies, verify=verify, cert=cert,
+                                 timeout=constants.NETWORK_CONNECTION_TIMEOUT)
             # Server returned HTTP 4XX or 5XX codes
             if 400 <= result.status_code < 600:
                 log.info("Server returned %i code", result.status_code)

--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -47,7 +47,7 @@ from pyanaconda.errors import errorHandler, ERROR_RAISE
 from pyanaconda.progress import progressQ
 
 from pyanaconda.core.constants import INSTALL_TREE, THREAD_LIVE_PROGRESS
-from pyanaconda.core.constants import IMAGE_DIR, TAR_SUFFIX
+from pyanaconda.core.constants import IMAGE_DIR, TAR_SUFFIX, NETWORK_CONNECTION_TIMEOUT
 
 from blivet.size import Size
 
@@ -309,7 +309,8 @@ class LiveImageKSPayload(LiveImagePayload):
 
         error = None
         try:
-            response = self._session.get(self.data.method.url, proxies=self._proxies, verify=True)
+            response = self._session.get(self.data.method.url, proxies=self._proxies, verify=True,
+                                         timeout=NETWORK_CONNECTION_TIMEOUT)
 
             # At this point we know we can get the image and what its size is
             # Make a guess as to minimum size needed:
@@ -369,7 +370,8 @@ class LiveImageKSPayload(LiveImagePayload):
             with open(self.image_path, "wb") as f:
                 ssl_verify = not self.data.method.noverifyssl
                 response = self._session.get(self.data.method.url, proxies=self._proxies,
-                                             verify=ssl_verify, stream=True)
+                                             verify=ssl_verify, stream=True,
+                                             timeout=NETWORK_CONNECTION_TIMEOUT)
                 total_length = response.headers.get('content-length')
                 if total_length is None:  # no content length header
                     # just download the file in one go and fake the progress reporting once done


### PR DESCRIPTION
Adding timeouts to `session.get` calls and increasing timeout value based on the requests upstream documentation.

See:
https://3.python-requests.org/user/advanced/#timeouts

This unfortunately also change also three timeouts in the network.py which is a side effect but I'm not convinced we want to create a new constant for just 1 second difference.