### PR TITLE
Don't measure code coverage during the installation

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -24,42 +24,17 @@
 # A lot less messy now. :) (2016-10-13)
 
 import os
-import site
-
-
-coverage = None
-
-# setup code coverage monitoring
-proc_cmdline = open("/proc/cmdline", "r").read()
-proc_cmdline = proc_cmdline.split()
-if ("inst.debug=1" in proc_cmdline) or ("inst.debug" in proc_cmdline):
-    import coverage
-    pyanaconda_dir = "pyanaconda"
-    for sitepkg in site.getsitepackages():
-        possible_dir = os.path.join(sitepkg, "pyanaconda")
-        if os.path.isdir(possible_dir):
-            pyanaconda_dir = possible_dir
-            break
-    cov = coverage.coverage(data_file="/mnt/sysimage/root/anaconda.coverage",
-                            branch=True,
-                            source=["/usr/sbin/anaconda", pyanaconda_dir]
-                            )
-    cov.start()
-
-
-import atexit, sys, time, signal
+import atexit
+import sys
+import time
+import signal
 import pid
+
 
 def exitHandler(rebootData, storage):
     # Clear the list of watched PIDs.
     from pyanaconda.core.process_watchers import WatchProcesses
     WatchProcesses.unwatch_all_processes()
-
-    # stop and save coverage here b/c later the file system may be unavailable
-    if coverage is not None:
-        cov.stop()
-        if os.path.isdir('/mnt/sysimage/root'):
-            cov.save()
 
     if flags.usevnc:
         vnc.shutdownServer()

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -121,8 +121,6 @@ Requires: systemd
 Requires: python3-pid
 Requires: python3-ordered-set >= 2.0.0
 
-Requires: python3-coverage >= 4.0-0.12.b3
-
 # required because of the rescue mode and VNC question
 Requires: anaconda-tui = %{version}-%{release}
 

--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -34,7 +34,7 @@ ANACONDA_SPEC_NAME = "anaconda.spec.in"
 
 TEST_DEPENDENCIES = ["e2fsprogs", "git", "bzip2", "cppcheck", "rpm-ostree", "pykickstart",
                      "python3-mock", "python3-nose-testconfig", "python3-sphinx_rtd_theme",
-                     "python3-lxml", "python3-pip",
+                     "python3-lxml", "python3-pip", "python3-coverage",
 
                      # contains restorecon which was removed in Fedora 28 mock
                      "policycoreutils"]


### PR DESCRIPTION
Remove the support for measuring the code coverage during the
installation. The results don't include DBus modules, only UI,
so they are not so useful anymore. We focus on the coverage of
the unit tests instead.