### PR TITLE
Collect addons after running the %pre section

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -268,8 +268,6 @@ if __name__ == "__main__":
     # init threading before Gtk can do anything and before we start using threads
     from pyanaconda.threading import AnacondaThread, threadMgr
     from pyanaconda.core.i18n import _
-
-    from pyanaconda.addons import collect_addon_paths
     from pyanaconda.core import util, constants
     from pyanaconda import startup_utils
 
@@ -455,13 +453,19 @@ if __name__ == "__main__":
         time.sleep(10)
         sys.exit(1)
 
+    # Find a kickstart file.
+    kspath = startup_utils.find_kickstart(opts)
+    log.info("Found a kickstart file: %s", kspath)
+
+    # Run %pre scripts.
+    startup_utils.run_pre_scripts(kspath)
+
     # Collect all addon paths
+    from pyanaconda.addons import collect_addon_paths
     addon_paths = collect_addon_paths(constants.ADDON_PATHS)
 
-    # If we were given a kickstart file on the command line, parse (but do not
-    # execute) that now.  Otherwise, load in defaults from kickstart files
-    # shipped with the installation media.
-    ksdata = startup_utils.parse_kickstart(opts, addon_paths, pass_to_boss=True)
+    # Parse the kickstart file.
+    ksdata = startup_utils.parse_kickstart(kspath, addon_paths, strict_mode=opts.ksstrict)
 
     # Pick up any changes from interactive-defaults.ks that would
     # otherwise be covered by the dracut KS parser.

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -35,8 +35,8 @@ from pyanaconda import keyboard, network, ntp, timezone
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.kickstart import VERSION, commands as COMMANDS
-from pyanaconda.addons import AddonSection, AddonData, AddonRegistry, collect_addon_paths
-from pyanaconda.core.constants import ADDON_PATHS, IPMI_ABORTED
+from pyanaconda.addons import AddonSection, AddonData, AddonRegistry
+from pyanaconda.core.constants import IPMI_ABORTED
 from pyanaconda.errors import ScriptError, errorHandler
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _
@@ -878,13 +878,10 @@ def preScriptPass(f):
     # run %pre scripts
     runPreScripts(ksparser.handler.scripts)
 
-def parseKickstart(f, strict_mode=False, pass_to_boss=False):
+def parseKickstart(handler, f, strict_mode=False, pass_to_boss=False):
     # preprocessing the kickstart file has already been handled in initramfs.
 
-    addon_paths = collect_addon_paths(ADDON_PATHS)
-    handler = AnacondaKSHandler(addon_paths["ks"])
     ksparser = AnacondaKSParser(handler)
-
     kswarnings = []
     ksmodule = "pykickstart"
     kscategories = (UserWarning, SyntaxWarning, DeprecationWarning)
@@ -944,8 +941,6 @@ def parseKickstart(f, strict_mode=False, pass_to_boss=False):
         util.ipmi_report(IPMI_ABORTED)
         time.sleep(10)
         sys.exit(1)
-
-    return handler
 
 def appendPostScripts(ksdata):
     scripts = ""


### PR DESCRIPTION
Don't collect addons until we run the `%pre` section, so the addons
can be generated in this section. Simplify the code for processing
a kickstart file and run specific steps in `anaconda.py`.