### PR TITLE
Handle exceptions without GTK (#1712987)

### DIFF
--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -133,7 +133,7 @@ class AnacondaExceptionHandler(ExceptionHandler):
                     super(AnacondaExceptionHandler, self).handleException(
                                                             dump_info)
 
-            except (RuntimeError, ImportError):
+            except (RuntimeError, ImportError, ValueError):
                 log.debug("Gtk cannot be initialized")
                 # X not running (Gtk cannot be initialized)
                 if threadMgr.in_main_thread():


### PR DESCRIPTION
The call to gi.require_version will raise ValueError, if GTK
is not installed, so catch it in the exception handler.

(cherry-picked from a commit 4f1e121)

Resolves: rhbz#1712987