### PR TITLE
F31 devel network remove onboot workarounds

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -353,8 +353,12 @@ class Network(COMMANDS.Network):
                        if dev.device_name in fcoe_nics]
         overwrite = network.can_overwrite_configuration(payload)
         network_proxy = NETWORK.get_proxy()
-        task_path = network_proxy.InstallNetworkWithTask(fcoe_ifaces,
-                                                         overwrite)
+
+        task_path = network_proxy.ConfigureActivationOnBootWithTask(fcoe_ifaces)
+        task_proxy = NETWORK.get_proxy(task_path)
+        sync_run_task(task_proxy)
+
+        task_path = network_proxy.InstallNetworkWithTask(overwrite)
         task_proxy = NETWORK.get_proxy(task_path)
         sync_run_task(task_proxy)
 

--- a/pyanaconda/modules/network/ifcfg.py
+++ b/pyanaconda/modules/network/ifcfg.py
@@ -462,8 +462,8 @@ def update_onboot_value(connection_uuid, onboot, root_path=""):
     return True
 
 
-def update_slaves_onboot_value(nm_client, master_devname, onboot, root_path="", uuid=None):
-    """Update onboot value in slave ifcfg files of given master.
+def get_master_slaves_from_ifcfgs(nm_client, master_devname, root_path="", uuid=None):
+    """Get all slaves based on ifcfg files of given master.
 
     Master can be identified by device name or uuid. If uuid is not provided
     as argument it will be looked up in master's ifcfg file.
@@ -472,17 +472,14 @@ def update_slaves_onboot_value(nm_client, master_devname, onboot, root_path="", 
     :type nm_client: NM.Client
     :param master_devname: name of master device
     :type devname: str
-    :param onboot: value of ONBOOT setting
-    :type onboot: bool
-    :param root_path: optional root path for ifcfg files to be updated
+    :param root_path: optional root path for ifcfg files
     :type root_path: str
     :param uuid: uuid of master connection (optional)
     :type uuid: str
-    :returns: True if the value was updated, False otherwise
-    :rtype: bool
+    :returns: list of slaves represented by tuple (<CONNECTION_NAME>, <UUID>)
+    :rtype: list((str, str))
     """
-    new_value = "yes" if onboot else "no"
-    updated_devices = []
+    slaves = []
     # Master can be identified by devname or uuid, try to find master uuid
     if not uuid:
         uuid = find_ifcfg_uuid_of_device(nm_client, master_devname, root_path=root_path)
@@ -490,15 +487,9 @@ def update_slaves_onboot_value(nm_client, master_devname, onboot, root_path="", 
         ifcfg = IfcfgFile(ifcfg_path)
         ifcfg.read()
         master = ifcfg.get("MASTER") or ifcfg.get("TEAM_MASTER") or ifcfg.get("BRIDGE")
-        if master in (master_devname, uuid):
-            old_value = ifcfg.get('ONBOOT')
-            slave = ifcfg.get("NAME")
-            log.debug("updating ONBOOT value of slave %s from %s to %s", slave, old_value, new_value)
-            ifcfg.set(('ONBOOT', new_value))
-            ifcfg.write()
-            updated_devices.append(slave)
-
-    return updated_devices
+        if master and master in (master_devname, uuid):
+            slaves.append((ifcfg.get("NAME"), ifcfg.get("UUID")))
+    return slaves
 
 
 def get_dracut_arguments_from_ifcfg(nm_client, ifcfg, iface, target_ip, hostname):

--- a/pyanaconda/modules/network/ifcfg.py
+++ b/pyanaconda/modules/network/ifcfg.py
@@ -434,34 +434,6 @@ def get_kickstart_network_data(ifcfg, nm_client, network_data_class, root_path="
     return nd
 
 
-def update_onboot_value(connection_uuid, onboot, root_path=""):
-    """Update onboot value in ifcfg files.
-
-    :param connection_uuid: uuid of the connection to be updated
-    :type connection_uuid: str
-    :param onboot: value of ONBOOT setting
-    :type onboot: bool
-    :param root_path: optional root path for ifcfg files to be updated
-    :type root_path: str
-    :returns: True if the value was updated, False otherwise
-    :rtype: bool
-    """
-
-    ifcfg = get_ifcfg_file([("UUID", connection_uuid)], root_path)
-    if not ifcfg:
-        log.debug("can't find ifcfg file of %s", connection_uuid)
-        return False
-
-    ifcfg.read()
-    old_value = ifcfg.get('ONBOOT')
-    new_value = "yes" if onboot else "no"
-    log.debug("updating ONBOOT value of %s from %s to %s", connection_uuid, old_value, new_value)
-    ifcfg.set(('ONBOOT', new_value))
-    ifcfg.write()
-
-    return True
-
-
 def get_master_slaves_from_ifcfgs(nm_client, master_devname, root_path="", uuid=None):
     """Get all slaves based on ifcfg files of given master.
 

--- a/pyanaconda/modules/network/initialization.py
+++ b/pyanaconda/modules/network/initialization.py
@@ -25,27 +25,13 @@ from pyanaconda.modules.network.nm_client import get_device_name_from_network_da
 from pyanaconda.modules.network.ifcfg import get_ifcfg_file_of_device, find_ifcfg_uuid_of_device, \
     get_master_slaves_from_ifcfgs
 from pyanaconda.modules.network.device_configuration import supported_wired_device_types
-from pyanaconda.core.configuration.anaconda import conf
-from functools import wraps
+from pyanaconda.modules.network.utils import guard_by_system_configuration
 
 log = get_module_logger(__name__)
 
 import gi
 gi.require_version("NM", "1.0")
 from gi.repository import NM
-
-
-def guard_by_system_configuration(return_value):
-    def wrap(function):
-        @wraps(function)
-        def wrapped(*args, **kwargs):
-            if not conf.system.can_configure_network:
-                log.debug("Network configuration is disabled on this system.")
-                return return_value
-            else:
-                return function(*args, **kwargs)
-        return wrapped
-    return wrap
 
 
 class ApplyKickstartTask(Task):

--- a/pyanaconda/modules/network/initialization.py
+++ b/pyanaconda/modules/network/initialization.py
@@ -21,9 +21,9 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.network.network_interface import NetworkInitializationTaskInterface
 from pyanaconda.modules.network.nm_client import get_device_name_from_network_data, \
     ensure_active_connection_for_device, update_connection_from_ksdata, add_connection_from_ksdata, \
-    update_iface_setting_values, bound_hwaddr_of_device
+    bound_hwaddr_of_device, get_connections_available_for_iface, update_connection_values
 from pyanaconda.modules.network.ifcfg import get_ifcfg_file_of_device, find_ifcfg_uuid_of_device, \
-    update_onboot_value, update_slaves_onboot_value
+    get_master_slaves_from_ifcfgs
 from pyanaconda.modules.network.device_configuration import supported_wired_device_types
 from pyanaconda.core.configuration.anaconda import conf
 from functools import wraps
@@ -297,40 +297,46 @@ class SetRealOnbootValuesFromKickstartTask(Task):
                 master = network_data.device
                 devices_to_update.append(master)
 
+            cons_to_update = []
             for devname in devices_to_update:
-                if network_data.onboot:
-                    # We need to handle "no" -> "yes" change by changing ifcfg file instead of the NM connection
-                    # so the device does not get autoactivated (BZ #1261864)
-                    uuid = find_ifcfg_uuid_of_device(self._nm_client, devname) or ""
-                    if not update_onboot_value(uuid, network_data.onboot, root_path=""):
-                        continue
+                cons = get_connections_available_for_iface(self._nm_client, devname)
+                n_cons = len(cons)
+                con = None
+                if n_cons == 1:
+                    cons_to_update.append((devname, cons[0]))
                 else:
-                    n_cons = update_iface_setting_values(self._nm_client, devname,
-                        [("connection", NM.SETTING_CONNECTION_AUTOCONNECT, network_data.onboot)])
-                    if n_cons != 1:
-                        log.debug("%s: %d connections found for %s", self.name, n_cons, devname)
-                        if n_cons > 1:
-                            # In case of multiple connections for a device, update ifcfg directly
-                            uuid = find_ifcfg_uuid_of_device(self._nm_client, devname) or ""
-                            if not update_onboot_value(uuid, network_data.onboot, root_path=""):
-                                continue
-
-                updated_devices.append(devname)
+                    log.debug("%s: %d connections found for %s", self.name, n_cons, devname)
+                    if n_cons > 1:
+                        ifcfg_uuid = find_ifcfg_uuid_of_device(self._nm_client, devname) or ""
+                        con = self._nm_client.get_connection_by_uuid(ifcfg_uuid)
+                        if con:
+                            cons_to_update.append((devname, con))
 
             # Handle slaves if there are any
             if network_data.bondslaves or network_data.teamslaves or network_data.bridgeslaves:
                 # Master can be identified by devname or uuid, try to find master uuid
-                uuid = None
+                master_uuid = None
                 device = self._nm_client.get_device_by_iface(master)
                 if device:
                     cons = device.get_available_connections()
                     n_cons = len(cons)
                     if n_cons == 1:
-                        uuid = cons[0].get_uuid()
+                        master_uuid = cons[0].get_uuid()
                     else:
                         log.debug("%s: %d connections found for %s", self.name, n_cons, master)
-                updated_slaves = update_slaves_onboot_value(self._nm_client, master, network_data.onboot, uuid=uuid)
-                updated_devices.extend(updated_slaves)
+
+                for name, con_uuid in get_master_slaves_from_ifcfgs(self._nm_client, master, uuid=master_uuid):
+                    con = self._nm_client.get_connection_by_uuid(con_uuid)
+                    cons_to_update.append((name, con))
+
+            for devname, con in cons_to_update:
+                log.debug("updating ONBOOT values of connection %s for device %s",
+                          con.get_uuid(), devname)
+                update_connection_values(
+                    con,
+                    [("connection", NM.SETTING_CONNECTION_AUTOCONNECT, network_data.onboot)]
+                )
+                updated_devices.append(devname)
 
         return updated_devices
 

--- a/pyanaconda/modules/network/installation.py
+++ b/pyanaconda/modules/network/installation.py
@@ -24,6 +24,7 @@ from pyanaconda.modules.common.task import Task
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.network.nm_client import update_connection_values
 from pyanaconda.modules.network.ifcfg import find_ifcfg_uuid_of_device
+from pyanaconda.modules.network.utils import guard_by_system_configuration
 
 log = get_module_logger(__name__)
 
@@ -257,7 +258,12 @@ class ConfigureActivationOnBootTask(Task):
     def name(self):
         return "Configure automatic activation on boot."
 
+    @guard_by_system_configuration(return_value=None)
     def run(self):
+        if not self._nm_client:
+            log.debug("%s: No NetworkManager available.", self.name)
+            return None
+
         for iface in self._onboot_ifaces:
             con_uuid = find_ifcfg_uuid_of_device(self._nm_client, iface)
             if con_uuid:

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -344,10 +344,13 @@ class NetworkModule(KickstartModule):
         uuids = [dev_cfg.connection_uuid for dev_cfg in device_configurations.get_all()
                  if dev_cfg.connection_uuid]
         for uuid in uuids:
-            ifcfg = get_ifcfg_file([("UUID", uuid)])
-            if ifcfg:
-                ifcfg.read()
-                if ifcfg.get('ONBOOT') != "no":
+            con = self.nm_client.get_connection_by_uuid(uuid)
+            if con:
+                if (con.get_flags() & NM.SettingsConnectionFlags.UNSAVED):
+                    log.debug("ONBOOT policy: not considering UNSAVED connection %s", con.get_uuid())
+                    continue
+                if con.get_setting_connection().get_autoconnect():
+                    log.debug("ONBOOT policy: %s has 'autoconnect' == True", con.get_uuid())
                     return True
         return False
 

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -36,8 +36,7 @@ from pyanaconda.modules.network.device_configuration import DeviceConfigurations
 from pyanaconda.modules.network.nm_client import get_device_name_from_network_data, devices_ignore_ipv6, \
     get_connections_dump
 from pyanaconda.modules.network.ifcfg import get_ifcfg_file_of_device, find_ifcfg_uuid_of_device, \
-    get_dracut_arguments_from_ifcfg, get_kickstart_network_data, get_ifcfg_file, get_ifcfg_files_content, \
-    update_onboot_value
+    get_dracut_arguments_from_ifcfg, get_kickstart_network_data, get_ifcfg_file, get_ifcfg_files_content
 from pyanaconda.modules.network.installation import NetworkInstallationTask
 from pyanaconda.modules.network.initialization import ApplyKickstartTask, \
     ConsolidateInitramfsConnectionsTask, SetRealOnbootValuesFromKickstartTask, \
@@ -647,32 +646,3 @@ class NetworkModule(KickstartModule):
         if self.nm_available:
             for line in get_connections_dump(self.nm_client).splitlines():
                 log.debug(line)
-
-    def set_connection_onboot_value(self, uuid, onboot):
-        """Sets ONBOOT value of connection given by uuid.
-
-        The value is stored in ifcfg file because setting the value in
-        NetworkManager connection ('autoconnect') to True could cause
-        activating of the connection.
-
-        :param uuid: UUID of the connection to be set
-        :param onboot: value of ONBOOT for the connection
-        """
-        return update_onboot_value(uuid, onboot)
-
-    def get_connection_onboot_value(self, uuid):
-        """Gets ONBOOT value of connection given by uuid.
-
-        The value is stored in ifcfg file because setting the value in
-        NetworkManager connection ('autoconnect') to True could cause
-        activating of the connection.
-
-        :param uuid: UUID of the connection
-        :return: ONBOOT value
-        """
-        ifcfg = get_ifcfg_file([('UUID', uuid)])
-        if not ifcfg:
-            log.error("Can't get ONBOOT value for connection %s", uuid)
-            return False
-        ifcfg.read()
-        return ifcfg.get('ONBOOT') != "no"

--- a/pyanaconda/modules/network/network_interface.py
+++ b/pyanaconda/modules/network/network_interface.py
@@ -125,16 +125,27 @@ class NetworkInterface(KickstartModuleInterface):
         """
         return self.implementation.get_activated_interfaces()
 
-    def InstallNetworkWithTask(self, onboot_ifaces: List[Str], overwrite: Bool) -> ObjPath:
+    def InstallNetworkWithTask(self, overwrite: Bool) -> ObjPath:
         """Install network with an installation task.
 
-        :param onboot_ifaces: list of network interfaces which should have ONBOOT=yes
         FIXME: does overwrite still apply?
         :param overwrite: overwrite existing configuration
         :return: a DBus path of an installation task
         """
         return TaskContainer.to_object_path(
-            self.implementation.install_network_with_task(onboot_ifaces, overwrite)
+            self.implementation.install_network_with_task(overwrite)
+        )
+
+    def ConfigureActivationOnBootWithTask(self, onboot_ifaces: List[Str]) -> ObjPath:
+        """Configure automatic activation of devices on system boot.
+
+        1) Specified devices are set to be activated automatically.
+        2) Policy set in anaconda configuration (default_on_boot) is applied.
+
+        :param onboot_ifaces: list of network interfaces which should have ONBOOT=yes
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.configure_activation_on_boot_with_task(onboot_ifaces)
         )
 
     def CreateDeviceConfigurations(self):

--- a/pyanaconda/modules/network/network_interface.py
+++ b/pyanaconda/modules/network/network_interface.py
@@ -268,27 +268,3 @@ class NetworkInterface(KickstartModuleInterface):
         :param msg_header: header of the log messages
         """
         return self.implementation.log_configuration_state(msg_header)
-
-    def SetConnectionOnbootValue(self, uuid: Str, onboot: Bool):
-        """Sets ONBOOT value of connection given by uuid.
-
-        The value is stored in ifcfg file because setting the value in
-        NetworkManager connection ('autoconnect') to True could cause
-        activating of the connection.
-
-        :param uuid: UUID of the connection to be set
-        :param onboot: value of ONBOOT for the connection
-        """
-        return self.implementation.set_connection_onboot_value(uuid, onboot)
-
-    def GetConnectionOnbootValue(self, uuid: Str) -> Bool:
-        """Gets ONBOOT value of connection given by uuid.
-
-        The value is stored in ifcfg file because setting the value in
-        NetworkManager connection ('autoconnect') to True could cause
-        activating of the connection.
-
-        :param uuid: UUID of the connection
-        :return: ONBOOT value
-        """
-        return self.implementation.get_connection_onboot_value(uuid)

--- a/pyanaconda/modules/network/nm_client.py
+++ b/pyanaconda/modules/network/nm_client.py
@@ -24,6 +24,7 @@ from gi.repository import NM
 
 import socket
 from pykickstart.constants import BIND_TO_MAC
+from pyanaconda.modules.network.constants import NM_CONNECTION_UUID_LENGTH
 from pyanaconda.modules.network.kickstart import default_ks_vlan_interface_name
 from pyanaconda.modules.network.utils import is_s390, get_s390_settings, netmask2prefix
 
@@ -48,6 +49,29 @@ def get_iface_from_connection(nm_client, uuid):
             mac = wired_setting.get_mac_address()
             if mac:
                 iface = get_iface_from_hwaddr(nm_client, mac)
+    return iface
+
+
+def get_vlan_interface_name_from_connection(nm_client, connection):
+    """Get vlan interface name from vlan connection.
+
+    :param connection: NetworkManager connection
+    :type connection: NM.RemoteConnection
+
+    If no interface name is specified in the connection settings, infer the
+    value as <PARENT_IFACE>.<VLAN_ID> - same as NetworkManager.
+    """
+    iface = connection.get_setting_connection().get_interface_name()
+    if not iface:
+        setting_vlan = connection.get_setting_vlan()
+        if setting_vlan:
+            vlanid = setting_vlan.get_id()
+            parent = setting_vlan.get_parent()
+            # if parent is specified by UUID
+            if len(parent) == NM_CONNECTION_UUID_LENGTH:
+                parent = get_iface_from_connection(nm_client, parent)
+            if vlanid is not None and parent:
+                iface = default_ks_vlan_interface_name(parent, vlanid)
     return iface
 
 
@@ -758,8 +782,12 @@ def get_connections_available_for_iface(nm_client, iface):
             # Getting available connections does not seem to work quite well for
             # non-real team - try to look them up in all connections.
             for con in nm_client.get_connections():
-                if con.get_interface_name() == iface:
+                interface_name = con.get_interface_name()
+                if not interface_name and con.get_connection_type() == "vlan":
+                    interface_name = get_vlan_interface_name_from_connection(nm_client, con)
+                if interface_name == iface:
                     cons.append(con)
+
     return cons
 
 

--- a/pyanaconda/modules/network/nm_client.py
+++ b/pyanaconda/modules/network/nm_client.py
@@ -570,13 +570,12 @@ def update_connection_from_ksdata(nm_client, connection, network_data, device_na
     # IP configuration
     update_connection_ip_settings_from_ksdata(connection, network_data)
 
-    # ONBOOT workaround so that the connection is not activated
     s_con = connection.get_setting_connection()
-    s_con.set_property(NM.SETTING_CONNECTION_AUTOCONNECT, False)
+    s_con.set_property(NM.SETTING_CONNECTION_AUTOCONNECT, network_data.onboot)
 
     bind_connection(nm_client, connection, network_data.bindto, device_name)
 
-    connection.commit_changes(True, None)
+    commit_changes_with_autoconnection_blocked(connection)
 
     log.debug("updated connection %s:\n%s", connection.get_uuid(),
               connection.to_dbus(NM.ConnectionSerializationFlags.NO_SECRETS))

--- a/pyanaconda/modules/network/utils.py
+++ b/pyanaconda/modules/network/utils.py
@@ -20,8 +20,10 @@
 
 import os
 import glob
+from functools import wraps
 
 from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -110,3 +112,16 @@ def get_default_route_iface(family="inet"):
                 return None
 
     return None
+
+
+def guard_by_system_configuration(return_value):
+    def wrap(function):
+        @wraps(function)
+        def wrapped(*args, **kwargs):
+            if not conf.system.can_configure_network:
+                log.debug("Network configuration is disabled on this system.")
+                return return_value
+            else:
+                return function(*args, **kwargs)
+        return wrapped
+    return wrap

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -180,6 +180,9 @@ class WiredTUIConfigurationData():
                 else:
                     log.error("IP address %s is not valid", ns)
 
+        s_con = connection.get_setting_connection()
+        s_con.set_property(NM.SETTING_CONNECTION_AUTOCONNECT, self.onboot)
+
     def __str__(self):
         return "WiredTUIConfigurationData ip:{} netmask:{} gateway:{} ipv6:{} ipv6gateway:{} " \
             "nameserver:{} onboot:{}".format(self.ip, self.netmask, self.gateway, self.ipv6,
@@ -433,18 +436,9 @@ class ConfigureDeviceSpoke(NormalTUISpoke):
 
         self._data = WiredTUIConfigurationData()
         self._data.set_from_connection(self._connection)
-        # ONBOOT workaround - changing autoconnect connection value would
-        # activate the device
-        self._data.onboot = self._get_onboot(self._connection_uuid)
 
         log.debug("Configure iface %s: connection %s -> %s", self._iface, self._connection_uuid,
                   self._data)
-
-    def _get_onboot(self, connection_uuid):
-        return self._network_module.GetConnectionOnbootValue(connection_uuid)
-
-    def _set_onboot(self, connection_uuid, onboot):
-        return self._network_module.SetConnectionOnbootValue(connection_uuid, onboot)
 
     def refresh(self, args=None):
         """ Refresh window. """
@@ -571,19 +565,24 @@ class ConfigureDeviceSpoke(NormalTUISpoke):
         """Apply changes to NM connection."""
         log.debug("updating connection %s:\n%s", self._connection_uuid,
                   self._connection.to_dbus(NM.ConnectionSerializationFlags.ALL))
-        self._data.update_connection(self._connection)
 
-        # ONBOOT workaround
-        s_con = self._connection.get_setting_connection()
-        s_con.set_property(NM.SETTING_CONNECTION_AUTOCONNECT, False)
+        updated_connection = NM.SimpleConnection.new_clone(self._connection)
+        self._data.update_connection(updated_connection)
 
-        self._connection.commit_changes(True, None)
-        log.debug("updated connection %s:\n%s", self._connection_uuid,
-                  self._connection.to_dbus(NM.ConnectionSerializationFlags.ALL))
+        # Commit the changes
+        self._connection.update2(
+            updated_connection.to_dbus(NM.ConnectionSerializationFlags.ALL),
+            NM.SettingsUpdate2Flags.TO_DISK | NM.SettingsUpdate2Flags.BLOCK_AUTOCONNECT,
+            None,
+            None,
+            self._connection_updated_cb,
+            self._connection_uuid
+        )
 
-        # ONBOOT workaround
-        self._set_onboot(self._connection_uuid, self._data.onboot)
-
+    def _connection_updated_cb(self, connection, result, connection_uuid):
+        connection.update2_finish(result)
+        log.debug("updated connection %s:\n%s", connection_uuid,
+                  connection.to_dbus(NM.ConnectionSerializationFlags.ALL))
 
 def get_default_connection(iface, device_type, autoconnect=False):
     """Get default connection to be edited by the UI."""

--- a/tests/nosetests/pyanaconda_tests/module_network_ifcfg_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_network_ifcfg_test.py
@@ -27,8 +27,7 @@ from pyanaconda.core.kickstart.commands import NetworkData
 
 from pyanaconda.modules.network.ifcfg import get_dracut_arguments_from_ifcfg, IFCFG_DIR, \
     IfcfgFile, get_ifcfg_files_paths, get_ifcfg_file, get_ifcfg_file_of_device, \
-    get_slaves_from_ifcfgs, get_kickstart_network_data, update_onboot_value, \
-    get_master_slaves_from_ifcfgs
+    get_slaves_from_ifcfgs, get_kickstart_network_data, get_master_slaves_from_ifcfgs
 
 HWADDR_TO_IFACE = {
     "52:54:00:0c:77:e3": "ens6",
@@ -1733,92 +1732,6 @@ class IfcfgFileTestCase(unittest.TestCase):
             if generated_ks:
                 generated_ks = dedent(str(generated_ks)).strip()
             self.assertEqual(generated_ks, expected_ks)
-
-    def update_onboot_value_test(self):
-        """Test update_onboot_value."""
-        onboot_yes_uuid = "c9e36ab2-de90-4321-98fb-63fba02dec87"
-        onboot_no_uuid = "9ca1144d-ceba-4454-b800-b58e39ebeab8"
-        onboot_missing_uuid = "7eb32ca0-dbc3-4ea9-89ca-0185b017f3d6"
-        not_found_uuid = "7201c278-c3ed-4d6b-8f3e-7c290cfb23cc"
-        initial_ifcfg_files = [
-            ("ifcfg-ens3",
-             """
-             ONBOOT=yes
-             UUID={}
-             """.format(onboot_yes_uuid),
-             None),
-            ("ifcfg-ens5",
-             """
-             ONBOOT=no
-             UUID={}
-             """.format(onboot_no_uuid),
-             None),
-            ("ifcfg-ens6",
-             """
-             UUID={}
-             """.format(onboot_missing_uuid),
-             None),
-        ]
-
-        # Test setting to True
-        ifcfg_files_set_to_yes = [
-            ("ifcfg-ens3",
-             # NOTE: nothing is actually written as nothing has changed,
-             # therefore no quotes.
-             """
-             ONBOOT=yes
-             UUID={}
-             """.format(onboot_yes_uuid),
-             None),
-            ("ifcfg-ens5",
-             """
-             ONBOOT="yes"
-             UUID="{}"
-             """.format(onboot_no_uuid),
-             None),
-            ("ifcfg-ens6",
-             """
-             UUID="{}"
-             ONBOOT="yes"
-             """.format(onboot_missing_uuid),
-             None),
-        ]
-        self._dump_ifcfg_files(initial_ifcfg_files)
-        self.assertTrue(update_onboot_value(onboot_yes_uuid, True, root_path=self._root_dir))
-        self.assertTrue(update_onboot_value(onboot_no_uuid, True, root_path=self._root_dir))
-        self.assertTrue(update_onboot_value(onboot_missing_uuid, True, root_path=self._root_dir))
-        self.assertFalse(update_onboot_value(not_found_uuid, True, root_path=self._root_dir))
-        self._check_ifcfg_files(ifcfg_files_set_to_yes)
-
-        # Test setting to False
-        ifcfg_files_set_to_no = [
-            ("ifcfg-ens3",
-             """
-             ONBOOT="no"
-             UUID="{}"
-             """.format(onboot_yes_uuid),
-             None),
-            # NOTE: nothing is actually written as nothing has changed,
-            # therefore no quotes.
-            ("ifcfg-ens5",
-             """
-             ONBOOT=no
-             UUID={}
-             """.format(onboot_no_uuid),
-             None),
-            ("ifcfg-ens6",
-             """
-             UUID="{}"
-             ONBOOT="no"
-             """.format(onboot_missing_uuid),
-             None),
-        ]
-        self._dump_ifcfg_files(initial_ifcfg_files)
-        self.assertTrue(update_onboot_value(onboot_yes_uuid, False, root_path=self._root_dir))
-        self.assertTrue(update_onboot_value(onboot_no_uuid, False, root_path=self._root_dir))
-        self.assertTrue(update_onboot_value(onboot_missing_uuid, False, root_path=self._root_dir))
-        self.assertFalse(update_onboot_value(not_found_uuid, False, root_path=self._root_dir))
-        self._check_ifcfg_files(ifcfg_files_set_to_no)
 
     @patch("pyanaconda.modules.network.ifcfg.find_ifcfg_uuid_of_device",
            lambda client, device_name, root_path: DEVNAME_TO_UUID[device_name])

--- a/tests/nosetests/pyanaconda_tests/module_network_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_network_test.py
@@ -60,15 +60,6 @@ class MockedNMClient():
     def get_state(self):
         return self.state
 
-class MockedSimpleIfcfgFileGetter():
-    def __init__(self, values):
-        self.values = {}
-        for key, value in values:
-            self.values[key] = value
-    def get(self, key):
-        return self.values.get(key, "")
-    def read(self):
-        pass
 
 class NetworkInterfaceTestCase(unittest.TestCase):
     """Test DBus interface for the Network module."""
@@ -366,37 +357,6 @@ class NetworkInterfaceTestCase(unittest.TestCase):
                 'hw-address': get_variant(Str, "33:33:33:33:33:33"),
                 'device-type': get_variant(Int, NM.DeviceType.TEAM)
             }
-        )
-
-    def set_connection_onboot_value_test(self):
-        """Test SetConnectionOnbootValue."""
-        self.network_interface.SetConnectionOnbootValue(
-            "ddc991d3-a495-4f24-9416-30a6fae01469",
-            False
-        )
-
-    @patch('pyanaconda.modules.network.network.get_ifcfg_file')
-    def get_connection_onboot_value_test(self, get_ifcfg_file):
-        """Test GetConnectionOnbootValue."""
-        get_ifcfg_file.return_value = MockedSimpleIfcfgFileGetter([('ONBOOT', "yes")])
-        self.assertEqual(
-            self.network_interface.GetConnectionOnbootValue("ddc991d3-a495-4f24-9416-30a6fae01469"),
-            True
-        )
-        get_ifcfg_file.return_value = MockedSimpleIfcfgFileGetter([])
-        self.assertEqual(
-            self.network_interface.GetConnectionOnbootValue("ddc991d3-a495-4f24-9416-30a6fae01469"),
-            True
-        )
-        get_ifcfg_file.return_value = MockedSimpleIfcfgFileGetter([('ONBOOT', "no")])
-        self.assertEqual(
-            self.network_interface.GetConnectionOnbootValue("ddc991d3-a495-4f24-9416-30a6fae01469"),
-            False
-        )
-        get_ifcfg_file.return_value = MockedSimpleIfcfgFileGetter([('ONBOOT', "whatever")])
-        self.assertEqual(
-            self.network_interface.GetConnectionOnbootValue("ddc991d3-a495-4f24-9416-30a6fae01469"),
-            True
         )
 
     def _mock_nm_active_connections(self, connection_specs):


### PR DESCRIPTION
I am going to migrate to handling ONBOOT via NM API at the end of installation (target system ONBOOT policy and network storage) ~~in another PR~~ later.