### PR TITLE
Rename the icon (#1740864)

### DIFF
--- a/data/liveinst/gnome/fedora-welcome.js
+++ b/data/liveinst/gnome/fedora-welcome.js
@@ -97,7 +97,7 @@ const WelcomeWindow = new Lang.Class({
                                          spacing: 16 });
 
       // provided by the 'fedora-logos' package
-      installContent.add(new Gtk.Image({ icon_name: 'anaconda',
+      installContent.add(new Gtk.Image({ icon_name: 'org.fedoraproject.AnacondaInstaller',
                                          pixel_size: 256 }));
       installContent.add(makeLabel(anacondaApp.get_name(), true));
 

--- a/data/liveinst/liveinst.desktop
+++ b/data/liveinst/liveinst.desktop
@@ -7,6 +7,6 @@ Exec=/usr/bin/liveinst
 Terminal=false
 Type=Application
 # TRANSLATORS: Icon name, probably should not be translated
-Icon=anaconda
+Icon=org.fedoraproject.AnacondaInstaller
 StartupNotify=true
 NoDisplay=true

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -361,8 +361,8 @@ class MainWindow(Gtk.Window):
         self.set_title(_(WINDOW_TITLE_TEXT))
 
         # Set the icon used in the taskbar of window managers that have a taskbar
-        # The "anaconda" icon is part of fedora-logos
-        self.set_icon_name("anaconda")
+        # The "org.fedoraproject.AnacondaInstaller" icon is part of fedora-logos
+        self.set_icon_name("org.fedoraproject.AnacondaInstaller")
 
         # Treat an attempt to close the window the same as hitting quit
         self.connect("delete-event", self._on_delete_event)


### PR DESCRIPTION
**Merged to master at https://github.com/rhinstaller/anaconda/pull/2091, but it should be also part of F31.**

The new icon provided by fedora-logos has a different name.
We should use org.fedoraproject.AnacondaInstaller now.

Resolves: rhbz#1740864