### PR TITLE
Handle the missing mountpoint attribute (#1743853)

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive_utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive_utils.py
@@ -382,7 +382,7 @@ def validate_device_info(storage, dev_info, reformat):
         if error:
             return error
 
-    changed_mount_point = dev_info["mountpoint"] != getattr(device.format, "mountpoint")
+    changed_mount_point = dev_info["mountpoint"] != getattr(device.format, "mountpoint", None)
 
     if reformat and not mount_point:
         return _("Please enter a mount point.")
@@ -686,7 +686,7 @@ def generate_device_info(storage, device):
     dev_info["encrypted"] = isinstance(device, LUKSDevice)
     dev_info["luks_version"] = get_device_luks_version(device)
     dev_info["label"] = getattr(device.format, "label", "")
-    dev_info["mountpoint"] = getattr(device.format, "mountpoint") or None
+    dev_info["mountpoint"] = getattr(device.format, "mountpoint", None) or None
     dev_info["raid_level"] = get_device_raid_level(device)
 
     if hasattr(device, "req_disks") and not device.exists:

--- a/pyanaconda/modules/storage/partitioning/interactive_utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive_utils.py
@@ -382,9 +382,10 @@ def validate_device_info(storage, dev_info, reformat):
         if error:
             return error
 
+    is_format_mountable = get_format(fs_type).mountable
     changed_mount_point = dev_info["mountpoint"] != getattr(device.format, "mountpoint", None)
 
-    if reformat and not mount_point:
+    if reformat and is_format_mountable and not mount_point:
         return _("Please enter a mount point.")
 
     if changed_mount_point and mount_point:

--- a/pyanaconda/storage/root.py
+++ b/pyanaconda/storage/root.py
@@ -102,7 +102,7 @@ def _find_existing_installations(devicetree):
     direct_devices = (dev for dev in devicetree.devices if dev.direct)
     for device in direct_devices:
         if not device.format.linux_native or not device.format.mountable or \
-           not device.controllable:
+           not device.controllable or not device.format.exists:
             continue
 
         try:


### PR DESCRIPTION
The functions generate_device_info and validate_device_info shouldn't
fail if the device format doesn't have the mountpoint attribute.
Use None instead.

Don't require to specify a mount point for swap.

Resolves: rhbz#1743853