### PR TITLE
Fix noverifyssl when downloading .treeinfo file (#1723811)

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -395,7 +395,7 @@ class Payload(metaclass=ABCMeta):
         #   - the path to a cert file
         #   - True, to use the system's certificates
         #   - False, to not verify
-        ssl_verify = getattr(self.data.method, "sslcacert", conf.payload.verify_ssl)
+        ssl_verify = getattr(self.data.method, "sslcacert", None) or conf.payload.verify_ssl
 
         ssl_client_cert = getattr(self.data.method, "ssl_client_cert", None)
         ssl_client_key = getattr(self.data.method, "ssl_client_key", None)


### PR DESCRIPTION
Fix ssl error when downloading .treeinfo. The ssl error happens because the ssl check is not disabled even when `inst.noverifyssl` is used.

When 'cacert' is `None` then the ssl_verify variable results to `None` (the bug). However, the real problem is that `None` for the session.get means True...

This was a problem mainly for unified source because when the treeinfo file is not found, the place where the .treeinfo should be taken is used as a base repository. In other words when .treeinfo is not downloaded no redirect is used for base repo and no additional repositories are added from the treeinfo file.

*Resolves: rhbz#1723811*