### PR TITLE
Use numbers for user/group names when unpacking tar live image

### DIFF
--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -524,7 +524,7 @@ class LiveImageKSPayload(LiveImagePayload):
 
         cmd = "tar"
         # preserve: ACL's, xattrs, and SELinux context
-        args = ["--selinux", "--acls", "--xattrs", "--xattrs-include", "*",
+        args = ["--numeric-owner", "--selinux", "--acls", "--xattrs", "--xattrs-include", "*",
                 "--exclude", "dev/*", "--exclude", "proc/*", "--exclude", "tmp/*",
                 "--exclude", "sys/*", "--exclude", "run/*", "--exclude", "boot/*rescue*",
                 "--exclude", "boot/loader", "--exclude", "boot/efi/loader",


### PR DESCRIPTION
By default when using tar to unpack a live image, it maps files' uid/gid to the installer system user's uid/gid if the user exists in current system. 
But this behavior can cause issue for unpacking a live image. For example if the anaconda environment has the user 'chrony' and the live image also contains 'chrony' but with different uid/gid as anaconda environment. After unpacking the live image, the files in live image belonging to 'chrony' user will be changed to different uid/gid. It is not correct.

This PR is addressing the issue.