### PR TITLE
Don't set up a warning label to None (#1745933)

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -277,7 +277,7 @@ class AddDialog(GUIObject):
         else:
             self._error = validate_mount_point(self.mount_point, self.mount_points)
 
-        self._warningLabel.set_text(self._error)
+        self._warningLabel.set_text(self._error or "")
         self.window.show_all()
         if self._error:
             return


### PR DESCRIPTION
If the error is None, set the warning label to an empty string.

Resolves: rhbz#1745933