### PR TITLE
 Use test dependencies from Fedora instead of pip

### DIFF
--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -37,9 +37,12 @@ TEST_DEPENDENCIES = ["e2fsprogs", "git", "bzip2", "cppcheck", "rpm-ostree", "pyk
                      "python3-lxml", "python3-pip", "python3-coverage",
 
                      # contains restorecon which was removed in Fedora 28 mock
-                     "policycoreutils"]
+                     "policycoreutils",
+                     "python3-rpmfluff", "python3-dogtail", "python3-pocketlint"]
 
-PIP_DEPENDENCIES = ["rpmfluff", "dogtail", "pocketlint"]
+PIP_DEPENDENCIES = [
+                    # "rpmfluff", "dogtail", "pocketlint"
+                   ]
 
 RELEASE_DEPENDENCIES = ["python3-zanata-client"]
 

--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -256,7 +256,8 @@ def install_required_packages(mock_command, release=False):
 
 def install_required_pip_packages(mock_command):
     packages = get_required_pip_packages()
-    install_pip_packages_to_mock(mock_command, packages)
+    if packages:
+        install_pip_packages_to_mock(mock_command, packages)
 
 
 def create_dir_in_mock(mock_command, path):

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -33,6 +33,9 @@ class AnacondaLintConfig(PocketLintConfig):
                                 FalsePositive(r"E1101.*: Instance of 'int' has no 'name_from_node' member"),
                                 FalsePositive(r"E1101.*: Instance of 'int' has no 'generate_backup_passphrase' member"),
                                 FalsePositive(r"E1101.*: Instance of 'int' has no 'dasd_is_ldl' member"),
+
+                                # TODO: Remove this when pylint start to support python 3.8 correctly
+                                FalsePositive(r"E1121.*: CheckValidity.checkGlade: Too many positional arguments for constructor call"),
                               ]
 
         # This will solve problems with C python extensions

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -35,6 +35,9 @@ class AnacondaLintConfig(PocketLintConfig):
                                 FalsePositive(r"E1101.*: Instance of 'int' has no 'dasd_is_ldl' member"),
                               ]
 
+        # This will solve problems with C python extensions
+        self.loadAllExtensions = True
+
     @property
     def extraArgs(self):
         return ["--init-import", "y"]


### PR DESCRIPTION
Use Fedora official repositories instead of pip.

This is especially required on Rawhide where we now have downstream patches for pylint and other tooling.