### PR TITLE
Drop dhclient requirement

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -114,7 +114,6 @@ Requires: openssh
 Requires: NetworkManager >= %{nmver}
 Requires: NetworkManager-libnm >= %{nmver}
 Requires: NetworkManager-team
-Requires: dhclient
 Requires: kbd
 Requires: chrony
 Requires: python3-ntplib


### PR DESCRIPTION
With all networking configured by NetworkManager and NM now defaulting to
using it's own internal dhcp client there is no need to depend on dhclient.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>