### PR TITLE
A couple of cleanups for mentions to new-kernel-pkg script

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -2546,7 +2546,7 @@ def writeSysconfigKernel(storage, version, instClass):
     kernel = decode_bytes(h.name)
 
     f = open(util.getSysroot() + "/etc/sysconfig/kernel", "w+")
-    f.write("# UPDATEDEFAULT specifies if new-kernel-pkg should make\n"
+    f.write("# UPDATEDEFAULT specifies if kernel-install should make\n"
             "# new kernels the default\n")
     # only update the default if we're setting the default to linux (#156678)
     if storage.bootloader.default.device == storage.root_device:

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -844,7 +844,7 @@ class Payload(object):
         if os.path.exists(util.getSysroot() + "/usr/sbin/new-kernel-pkg"):
             useDracut = False
         else:
-            log.warning("new-kernel-pkg does not exist - grubby wasn't installed?  using dracut instead.")
+            log.debug("new-kernel-pkg does not exist, using dracut instead.")
             useDracut = True
 
         for kernel in self.kernelVersionList:

--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -181,7 +181,7 @@ class LiveImagePayload(ImagePayload):
         if os.path.exists(util.getSysroot() + "/usr/sbin/new-kernel-pkg"):
             useNKP = True
         else:
-            log.warning("new-kernel-pkg does not exist - grubby wasn't installed?")
+            log.debug("new-kernel-pkg does not exist, calling scripts directly.")
             useNKP = False
 
         for kernel in self.kernelVersionList:


### PR DESCRIPTION
There are a couple of warning messages that mention that the `new-kernel-pkg` script isn't present but that's expected now that a BLS configuration is used, so if anything it should be a debug message.

The script is also mentioned in `/etc/sysconfig/kernel`, but it's not used anymore and instead the `kernel-install` script should be mentioned.

This pull-request fixes both issues.