### PR TITLE
Compare normalized XML strings

### DIFF
--- a/tests/nosetests/pyanaconda_tests/dbus_interface_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_interface_test.py
@@ -21,9 +21,9 @@
 import unittest
 
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
-from pyanaconda.dbus.xml import XMLGenerator
 from pyanaconda.dbus.interface import DBusSpecification, DBusSpecificationError, dbus_interface, \
     dbus_class, dbus_signal
+from tests.nosetests.pyanaconda_tests import compare_xml
 
 
 class InterfaceGeneratorTestCase(unittest.TestCase):
@@ -35,8 +35,7 @@ class InterfaceGeneratorTestCase(unittest.TestCase):
     def _compare(self, cls, expected_xml):
         """Compare cls specification with the given xml."""
         generated_xml = cls.dbus  # pylint: disable=no-member
-        self.assertMultiLineEqual(XMLGenerator.prettify_xml(generated_xml),
-                                  XMLGenerator.prettify_xml(expected_xml))
+        compare_xml(self, generated_xml, expected_xml)
 
     def exportable_test(self):
         """Test if the given name should be exported."""

--- a/tests/nosetests/pyanaconda_tests/dbus_xml_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_xml_test.py
@@ -20,12 +20,13 @@
 
 import unittest
 from pyanaconda.dbus.interface import XMLGenerator
+from tests.nosetests.pyanaconda_tests import compare_xml
 
 
 class XMLGeneratorTestCase(unittest.TestCase):
 
     def _compare(self, element, xml):
-        self.assertEqual(XMLGenerator.element_to_xml(element), xml)
+        compare_xml(self, XMLGenerator.element_to_xml(element), xml)
 
     def node_test(self):
         """Test the node element."""


### PR DESCRIPTION
Use the function compare_xml to compare two XML strings in tests.
The order of the XML attributes has changed in Python 3.8, so we
have to call the function canonicalize to normalize the strings.