### PR TITLE
Make clear where repo names are used not objects

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -116,7 +116,7 @@ class Payload(metaclass=ABCMeta):
     ###
     @property
     def addons(self):
-        """A list of addon repo identifiers."""
+        """A list of addon repo names."""
         return [r.name for r in self.data.repo.dataList()]
 
     @property
@@ -133,7 +133,7 @@ class Payload(metaclass=ABCMeta):
 
     @property
     def disabled_repos(self):
-        """A list of disabled repos."""
+        """A list of names of the disabled repos."""
         disabled = []
         for repo in self.addons:
             if not self.is_repo_enabled(repo):
@@ -143,7 +143,7 @@ class Payload(metaclass=ABCMeta):
 
     @property
     def enabled_repos(self):
-        """A list of enabled repos."""
+        """A list of names of the enabled repos."""
         enabled = []
         for repo in self.addons:
             if self.is_repo_enabled(repo):

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -1246,9 +1246,9 @@ class DNFPayload(payload.PackagePayload):
 
             # fetch md for enabled repos
             enabled_repos = self.enabled_repos
-            for repo in self.addons:
-                if repo in enabled_repos:
-                    self._fetch_md(repo)
+            for repo_name in self.addons:
+                if repo_name in enabled_repos:
+                    self._fetch_md(repo_name)
 
     def _get_base_repo_location(self, install_tree_url):
         """Try to find base repository from the treeinfo file.


### PR DESCRIPTION
The ``enabled_repos`` give us names not a repo objects.

I was pointed on this by @AdamWill's [PR](https://github.com/rhinstaller/anaconda/pull/1519) thanks a lot for that!