### PR TITLE
Remove __main__ functions for testing

### DIFF
--- a/pyanaconda/geoloc.py
+++ b/pyanaconda/geoloc.py
@@ -813,33 +813,3 @@ def init_geolocation(geoloc_option, options_override):
     """Initialize the geolocation singleton."""
     global geoloc
     geoloc = Geolocation(geoloc_option=geoloc_option, options_override=options_override)
-
-
-if __name__ == "__main__":
-    print("GeoIP directly started")
-
-    print("trying the default backend")
-    location_info = LocationInfo()
-    location_info.refresh()
-    print("  provider used: %s" % location_info._provider)
-    print("  territory code: %s" % location_info.result.territory_code)
-
-    print("trying the Fedora GeoIP backend")
-    location_info = LocationInfo(provider_id=
-                                 constants.GEOLOC_PROVIDER_FEDORA_GEOIP)
-    location_info.refresh()
-    print("  provider used: %s" % location_info._provider)
-    print("  territory code: %s" % location_info.result.territory_code)
-
-    print("trying the Google WiFi location backend")
-    location_info = LocationInfo(provider_id=
-                                 constants.GEOLOC_PROVIDER_GOOGLE_WIFI)
-    location_info.refresh()
-    print("  provider used: %s" % location_info._provider)
-    print("  territory code: %s" % location_info.result.territory_code)
-
-    print("trying the Hostip backend")
-    location_info = LocationInfo(provider_id=constants.GEOLOC_PROVIDER_HOSTIP)
-    location_info.refresh()
-    print("  provider used: %s" % location_info._provider)
-    print("  territory code: %s" % location_info.result.territory_code)

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1661,28 +1661,3 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
 
     def _update_hostname(self):
         self.network_control_box.current_hostname = self._network_module.GetCurrentHostname()
-
-
-def test():
-    win = Gtk.Window()
-    win.connect("delete-event", Gtk.main_quit)
-
-    builder = Gtk.Builder()
-    import os
-    ui_file_path = os.environ.get('UIPATH')+'spokes/network.glade'
-    builder.add_from_file(ui_file_path)
-
-    network_module = NETWORK.get_proxy()
-    nmclient = NM.Client.new(None)
-
-    n = NetworkControlBox(builder, nmclient, network_module)
-    n.initialize()
-    n.refresh()
-
-    n.vbox.reparent(win)
-
-    win.show_all()
-    Gtk.main()
-
-if __name__ == "__main__":
-    test()


### PR DESCRIPTION
Some of the pyanaconda modules define `__main__` functions
with a code for testing. These functions shouldn't be part of the
pyanaconda module, so let's remove them.