### PR TITLE
Add a space after the comma in the description

### DIFF
--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-DESCRIPTION = "Anaconda is the installation program used by Fedora," \
+DESCRIPTION = "Anaconda is the installation program used by Fedora, " \
               "Red Hat Enterprise Linux and some other distributions."
 
 import itertools


### PR DESCRIPTION
Add a space after the comma in the (anaconda --help) description.
