### PR TITLE
Don't add more devices in boot-device NVRAM than the maximum allowed

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -2214,6 +2214,12 @@ class IPSeriesGRUB2(GRUB2):
         # Remove all other occurances of it.
         boot_list = [boot_disk] + [x for x in boot_list if x != boot_disk]
 
+        # The boot-device NVRAM variable has a maximum number of devices allowed,
+        # don't add more than the limit in the ibm,max-boot-devices OF property.
+        with open("/sys/firmware/devicetree/base/ibm,max-boot-devices", "rb") as f:
+            limit = int.from_bytes(f.read(4), byteorder='big')
+            boot_list = boot_list[:limit]
+
         update_value = "boot-device=%s" % " ".join(boot_list)
 
         rc = util.execWithRedirect("nvram", ["--update-config", update_value])


### PR DESCRIPTION
The boot-device NVRAM variable has a maximum number of devices allowed,
that is specified in /sys/firmware/devicetree/base/ibm,max-boot-devices
OF property.

Adding more devices than the maximum number allowed in the boot-device
NVRAM variable can cause issues so the device list need to be restricted
to this maximum before updating the variable with nvram --update-config.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>