### PR TITLE
network gui: wrap multiple IP addresses in network spoke (#1593561)

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.glade
+++ b/pyanaconda/ui/gui/spokes/network.glade
@@ -455,6 +455,8 @@
                                             <property name="wrap">True</property>
                                             <property name="xalign">0</property>
                                             <property name="yalign">0</property>
+                                            <property name="max_width_chars">2</property>
+                                            <property name="halign">start</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>
@@ -492,6 +494,7 @@
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">IPv6 Address</property>
+                                            <property name="yalign">0</property>
                                             <property name="xalign">1</property>
                                           </object>
                                           <packing>
@@ -504,7 +507,10 @@
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="label">::1</property>
+                                            <property name="wrap">True</property>
                                             <property name="xalign">0</property>
+                                            <property name="max_width_chars">2</property>
+                                            <property name="halign">start</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>
@@ -518,6 +524,7 @@
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">IPv4 Address</property>
                                             <property name="xalign">1</property>
+                                            <property name="yalign">0</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">0</property>
@@ -530,6 +537,8 @@
                                             <property name="can_focus">False</property>
                                             <property name="label">127.0.0.1</property>
                                             <property name="xalign">0</property>
+                                            <property name="max_width_chars">2</property>
+                                            <property name="halign">start</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -819,10 +819,10 @@ class NetworkControlBox(GObject.GObject):
             ipv4cfg = ipv6cfg = None
 
         if ipv4cfg:
-            addr_str = ",".join("%s/%d" % (a.get_address(), a.get_prefix())
+            addr_str = " ".join("%s/%d" % (a.get_address(), a.get_prefix())
                                            for a in ipv4cfg.get_addresses())
             gateway_str = ipv4cfg.get_gateway()
-            dnss_str = ",".join(ipv4cfg.get_nameservers())
+            dnss_str = " ".join(ipv4cfg.get_nameservers())
         else:
             addr_str = dnss_str = gateway_str = None
         self._set_device_info_value(dt, "ipv4", addr_str)
@@ -831,7 +831,7 @@ class NetworkControlBox(GObject.GObject):
 
         addr6_str = ""
         if ipv6cfg:
-            addr6_str = ",".join("%s/%d" % (a.get_address(), a.get_prefix())
+            addr6_str = " ".join("%s/%d" % (a.get_address(), a.get_prefix())
                                             for a in ipv6cfg.get_addresses()
                                             # Do not display link-local addresses
                                             if not a.get_address().startswith("fe80:"))


### PR DESCRIPTION
So the window is not horizontally expanded potentially overflowing the screen
width.