### PR TITLE
Add payload sources

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -182,6 +182,7 @@ AC_CONFIG_FILES([Makefile
                  pyanaconda/modules/payload/dnf/Makefile
                  pyanaconda/modules/payload/dnf/packages/Makefile
                  pyanaconda/modules/payload/live/Makefile
+                 pyanaconda/modules/payload/sources/Makefile
                  pyanaconda/modules/storage/Makefile
                  pyanaconda/modules/storage/bootloader/Makefile
                  pyanaconda/modules/storage/checker/Makefile

--- a/pyanaconda/modules/common/constants/interfaces.py
+++ b/pyanaconda/modules/common/constants/interfaces.py
@@ -62,3 +62,8 @@ DNF_HANDLER = DBusInterfaceIdentifier(
 PAYLOAD_SOURCE = DBusInterfaceIdentifier(
     namespace=PAYLOAD_SOURCE_NAMESPACE
 )
+
+PAYLOAD_SOURCE_LIVE_OS = DBusInterfaceIdentifier(
+    namespace=PAYLOAD_SOURCE_NAMESPACE,
+    basename="LiveOS"
+)

--- a/pyanaconda/modules/common/constants/interfaces.py
+++ b/pyanaconda/modules/common/constants/interfaces.py
@@ -19,7 +19,7 @@
 from pyanaconda.dbus.identifier import DBusInterfaceIdentifier
 from pyanaconda.modules.common.constants.namespaces import ANACONDA_NAMESPACE, BOSS_NAMESPACE, \
     MODULES_NAMESPACE, USERS_NAMESPACE, PARTITIONING_NAMESPACE, DNF_NAMESPACE, \
-    DEVICE_TREE_NAMESPACE
+    DEVICE_TREE_NAMESPACE, PAYLOAD_SOURCE_NAMESPACE
 
 
 KICKSTART_MODULE = DBusInterfaceIdentifier(
@@ -57,4 +57,8 @@ DEVICE_TREE_HANDLER = DBusInterfaceIdentifier(
 
 DNF_HANDLER = DBusInterfaceIdentifier(
     namespace=DNF_NAMESPACE
+)
+
+PAYLOAD_SOURCE = DBusInterfaceIdentifier(
+    namespace=PAYLOAD_SOURCE_NAMESPACE
 )

--- a/pyanaconda/modules/common/constants/namespaces.py
+++ b/pyanaconda/modules/common/constants/namespaces.py
@@ -95,3 +95,8 @@ BAZ_NAMESPACE = (
     *ADDONS_NAMESPACE,
     "Baz"
 )
+
+PAYLOAD_SOURCE_NAMESPACE = (
+    *PAYLOAD_NAMESPACE,
+    "Source"
+)

--- a/pyanaconda/modules/common/containers.py
+++ b/pyanaconda/modules/common/containers.py
@@ -17,7 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from pyanaconda.dbus.container import DBusContainer
-from pyanaconda.modules.common.constants.namespaces import STORAGE_NAMESPACE, ANACONDA_NAMESPACE
+from pyanaconda.modules.common.constants.namespaces import STORAGE_NAMESPACE, ANACONDA_NAMESPACE, \
+    PAYLOAD_NAMESPACE
 
 TaskContainer = DBusContainer(
     namespace=ANACONDA_NAMESPACE,
@@ -32,4 +33,9 @@ DeviceTreeContainer = DBusContainer(
 PartitioningContainer = DBusContainer(
     namespace=STORAGE_NAMESPACE,
     basename="Partitioning"
+)
+
+PayloadSourceContainer = DBusContainer(
+    namespace=PAYLOAD_NAMESPACE,
+    basename="Source"
 )

--- a/pyanaconda/modules/common/errors/payload.py
+++ b/pyanaconda/modules/common/errors/payload.py
@@ -27,6 +27,17 @@ class SourceSetupError(AnacondaError):
     pass
 
 
+@dbus_error("SourceTearDownError", namespace=PAYLOAD_NAMESPACE)
+class SourceTearDownError(AnacondaError):
+    """Error raised during the source tear down."""
+
+    def __init__(self, message, errors=None):
+        if errors:
+            message = message + "\n" + "\n".join(errors)
+
+        super().__init__(message)
+
+
 @dbus_error("IncompatibleSourceError", namespace=PAYLOAD_NAMESPACE)
 class IncompatibleSourceError(AnacondaError):
     """Error raised when handler does not support given source."""

--- a/pyanaconda/modules/common/errors/payload.py
+++ b/pyanaconda/modules/common/errors/payload.py
@@ -27,6 +27,12 @@ class SourceSetupError(AnacondaError):
     pass
 
 
+@dbus_error("IncompatibleSourceError", namespace=PAYLOAD_NAMESPACE)
+class IncompatibleSourceError(AnacondaError):
+    """Error raised when handler does not support given source."""
+    pass
+
+
 @dbus_error("InstallError", namespace=PAYLOAD_NAMESPACE)
 class InstallError(AnacondaError):
     """Error raised during payload installation."""

--- a/pyanaconda/modules/payload/base/constants.py
+++ b/pyanaconda/modules/payload/base/constants.py
@@ -1,0 +1,33 @@
+#
+# Constants shared in the payload module.
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+from enum import Enum, unique
+
+
+@unique
+class HandlerType(Enum):
+    """Type of the payload handler."""
+    DNF = "DNF"
+    LIVE_OS = "LIVE_OS"
+    LIVE_IMAGE = "LIVE_IMAGE"
+
+
+@unique
+class SourceType(Enum):
+    """Type of the payload source."""
+    LIVE_OS_IMAGE = "LIVE_OS_IMAGE"

--- a/pyanaconda/modules/payload/base/handler_base.py
+++ b/pyanaconda/modules/payload/base/handler_base.py
@@ -40,7 +40,7 @@ class PayloadHandlerBase(KickstartBaseModule, metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def supported_source_kinds(self):
+    def supported_source_types(self):
         """Get list of supported source types.
 
         :return: list of supported source types
@@ -65,13 +65,13 @@ class PayloadHandlerBase(KickstartBaseModule, metaclass=ABCMeta):
         :raises: IncompatibleSourceError
         """
         # TODO: Add test for this when there will be public API
-        if source.kind not in self.supported_source_kinds:
+        if source.type not in self.supported_source_types:
             raise IncompatibleSourceError("Source type {} is not supported by this handler."
-                                          .format(source.kind))
+                                          .format(source.type))
 
         if source not in self._sources:
             self._sources.add(source)
-            log.debug("New source %s was added.", source.kind)
+            log.debug("New source %s was added.", source.type)
             self.sources_changed.emit()
 
     def has_source(self):

--- a/pyanaconda/modules/payload/base/handler_base.py
+++ b/pyanaconda/modules/payload/base/handler_base.py
@@ -80,7 +80,7 @@ class PayloadHandlerBase(KickstartBaseModule, metaclass=ABCMeta):
                 raise IncompatibleSourceError("Source type {} is not supported by this handler."
                                               .format(source.type))
 
-        if any(source.is_ready for source in self.sources):
+        if any(source.is_ready() for source in self.sources):
             raise SourceSetupError("Can't change list of sources if there is at least one source "
                                    "initialized! Please tear down the sources first.")
 

--- a/pyanaconda/modules/payload/base/handler_base.py
+++ b/pyanaconda/modules/payload/base/handler_base.py
@@ -20,7 +20,7 @@
 from abc import ABCMeta, abstractmethod
 
 from pyanaconda.core.signal import Signal
-from pyanaconda.modules.common.errors.payload import IncompatibleSourceError
+from pyanaconda.modules.common.errors.payload import IncompatibleSourceError, SourceSetupError
 from pyanaconda.modules.common.base import KickstartBaseModule
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -60,15 +60,29 @@ class PayloadHandlerBase(KickstartBaseModule, metaclass=ABCMeta):
     def set_sources(self, sources):
         """Set a new list of sources to this payload handler.
 
+        Before setting the sources, please make sure the sources are not initialized otherwise
+        the SourceSetupError exception will be raised. Payload have to cleanup after itself.
+
+        ..NOTE:
+        The SourceSetupError is a reasonable effort to solve the race condition. However,
+        there is still a possibility that the task to initialize sources (`SetupSourcesWithTask()`)
+        was created with the old list but not run yet. In that case this check will not work and
+        the initialization task will run with the old list.
+
         :param sources: set a new sources
         :type sources: instance of pyanaconda.modules.payload.base.source_base.PayloadSourceBase
         :raise: IncompatibleSourceError when source is not a supported type
+                SourceSetupError when attached sources are initialized
         """
         # TODO: Add test for this when there will be public API
         for source in sources:
             if source.type not in self.supported_source_types:
                 raise IncompatibleSourceError("Source type {} is not supported by this handler."
                                               .format(source.type))
+
+        if any(source.is_ready for source in self.sources):
+            raise SourceSetupError("Can't change list of sources if there is at least one source "
+                                   "initialized! Please tear down the sources first.")
 
         self._sources = sources
         log.debug("New sources %s was added.", sources)

--- a/pyanaconda/modules/payload/base/handler_base.py
+++ b/pyanaconda/modules/payload/base/handler_base.py
@@ -74,6 +74,14 @@ class PayloadHandlerBase(KickstartBaseModule, metaclass=ABCMeta):
             log.debug("New source %s was added.", source.kind)
             self.sources_changed.emit()
 
+    def has_source(self):
+        """Check if any source is set.
+
+        :return: True if source object is set
+        :rtype: bool
+        """
+        return bool(self.sources)
+
     @abstractmethod
     def publish_handler(self):
         """Publish object on DBus and return its path.

--- a/pyanaconda/modules/payload/base/handler_base.py
+++ b/pyanaconda/modules/payload/base/handler_base.py
@@ -35,7 +35,7 @@ class PayloadHandlerBase(KickstartBaseModule, metaclass=ABCMeta):
     """
     def __init__(self):
         super().__init__()
-        self._sources = set()
+        self._sources = []
         self.sources_changed = Signal()
 
     @property
@@ -53,26 +53,26 @@ class PayloadHandlerBase(KickstartBaseModule, metaclass=ABCMeta):
         """Get list of sources attached to this payload handler.
 
         :return: list of source objects attached to this handler
-        :rtype: set(instance of PayloadSourceBase class)
+        :rtype: [instance of PayloadSourceBase class]
         """
         return self._sources
 
-    def add_source(self, source):
-        """Add source to the list of sources.
+    def set_sources(self, sources):
+        """Set a new list of sources to this payload handler.
 
-        :param source: source object
-        :type source: instance of pyanaconda.modules.payload.base.source_base.PayloadSourceBase
-        :raises: IncompatibleSourceError
+        :param sources: set a new sources
+        :type sources: instance of pyanaconda.modules.payload.base.source_base.PayloadSourceBase
+        :raise: IncompatibleSourceError when source is not a supported type
         """
         # TODO: Add test for this when there will be public API
-        if source.type not in self.supported_source_types:
-            raise IncompatibleSourceError("Source type {} is not supported by this handler."
-                                          .format(source.type))
+        for source in sources:
+            if source.type not in self.supported_source_types:
+                raise IncompatibleSourceError("Source type {} is not supported by this handler."
+                                              .format(source.type))
 
-        if source not in self._sources:
-            self._sources.add(source)
-            log.debug("New source %s was added.", source.type)
-            self.sources_changed.emit()
+        self._sources = sources
+        log.debug("New sources %s was added.", sources)
+        self.sources_changed.emit()
 
     def has_source(self):
         """Check if any source is set.
@@ -90,11 +90,3 @@ class PayloadHandlerBase(KickstartBaseModule, metaclass=ABCMeta):
         :rtype: string
         """
         pass
-
-    def attach_source(self, source):
-        """Attach source to this payload handler.
-
-        :param source: source object
-        :type source: instance of pyanaconda.modules.payload.base.source_base.PayloadSourceBase
-        """
-        self.add_source(source)

--- a/pyanaconda/modules/payload/base/initialization.py
+++ b/pyanaconda/modules/payload/base/initialization.py
@@ -137,3 +137,37 @@ class SetUpSourcesTask(Task):
             for task in tasks:
                 log.debug("Running task %s", task.name)
                 task.run()
+
+
+class TearDownSourcesTask(Task):
+    """Tear down all the installation sources of the payload handler."""
+
+    def __init__(self, sources):
+        """Create tear down sources task.
+
+        The task will group all the sources tear down tasks under this one.
+
+        :param sources: list of sources
+        :type sources: [instance of PayloadSourceBase class]
+        """
+        super().__init__()
+        self._sources = sources
+
+    @property
+    def name(self):
+        return "Tear Down Installation Sources"
+
+    def run(self):
+        """Collect and call tear down tasks for all the sources."""
+        if not self._sources:
+            raise SourceSetupError("No sources specified for tear down!")
+
+        for source in self._sources:
+            tasks = source.tear_down_with_tasks()
+            log.debug("Collected %s tasks from %s source",
+                      [task.name for task in tasks],
+                      source.type)
+
+            for task in tasks:
+                log.debug("Running task %s", task.name)
+                task.run()

--- a/pyanaconda/modules/payload/base/source_base.py
+++ b/pyanaconda/modules/payload/base/source_base.py
@@ -38,7 +38,7 @@ class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def kind(self):
+    def type(self):
         """Get type of this source object.
 
         :return: type of this source

--- a/pyanaconda/modules/payload/base/source_base.py
+++ b/pyanaconda/modules/payload/base/source_base.py
@@ -1,0 +1,85 @@
+#
+# Base object of all payload sources.
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from abc import ABCMeta, abstractmethod
+
+from pyanaconda.core.signal import Signal
+from pyanaconda.dbus.publishable import Publishable
+from pyanaconda.modules.common.base import KickstartBaseModule
+
+
+class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
+    """Base class for all the payload source modules.
+
+    This object contains API shared by all the sources. Everything in this object has
+    to be implemented by a source to be used.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._is_ready = False
+        self.is_ready_changed = Signal()
+
+    @property
+    def is_ready(self):
+        """This source is ready for the installation to start.
+
+        This method will not be part of the public API. There is no need for others than the
+        payload owner to see the status of the source.
+
+        :rtype: bool
+        """
+        return self._is_ready
+
+    def _set_is_ready(self, value):
+        """Set if the source is ready to be used for the installation process.
+
+        :param value: True if the source is ready
+        :type value: bool
+        """
+        self._is_ready = value
+        self.is_ready_changed.emit()
+
+    @abstractmethod
+    def set_up_with_tasks(self):
+        """Prepare this payload source.
+
+        Do everything it requires to be able to use this source for installation.
+
+        This method will not be part of the public API. Having this private only will prevent race
+        conditions and there is no real use outside of payload.
+
+        :return: list of tasks to prepare this source
+        :rtype: list[task]
+        """
+        pass
+
+    @abstractmethod
+    def tear_down_with_tasks(self):
+        """Tear down this payload source.
+
+        Cleanup everything done by the setup method.
+
+        This method will not be part of the public API. Having this private only will prevent race
+        conditions and there is no real use outside of payload.
+
+        :return: list of tasks to tear down this source
+        :rtype: list[task]
+        """
+        pass

--- a/pyanaconda/modules/payload/base/source_base.py
+++ b/pyanaconda/modules/payload/base/source_base.py
@@ -83,3 +83,15 @@ class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         :rtype: list[task]
         """
         pass
+
+    @abstractmethod
+    def validate(self):
+        """Do a quick validation of the source.
+
+        This validation should be quick and only check if resources could be used. It doesn't mean
+        that the source could be used for the installation, it only tell you it can't be used.
+
+        :return: False if the source is not valid
+        :rtype: bool
+        """
+        pass

--- a/pyanaconda/modules/payload/base/source_base.py
+++ b/pyanaconda/modules/payload/base/source_base.py
@@ -45,7 +45,9 @@ class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         """This source is ready for the installation to start.
 
         This method will not be part of the public API. There is no need for others than the
-        payload owner to see the status of the source.
+        payload owner to see the status of the source. It is also not really useful, in time when
+        user gets the ready state the state could be different because of the DBus parallelism.
+        In general we should not share state.
 
         :rtype: bool
         """

--- a/pyanaconda/modules/payload/base/source_base.py
+++ b/pyanaconda/modules/payload/base/source_base.py
@@ -37,6 +37,16 @@ class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         self.is_ready_changed = Signal()
 
     @property
+    @abstractmethod
+    def kind(self):
+        """Get type of this source object.
+
+        :return: type of this source
+        :type: value of payload.base.constants.SourceType
+        """
+        pass
+
+    @property
     def is_ready(self):
         """This source is ready for the installation to start.
 

--- a/pyanaconda/modules/payload/base/source_base.py
+++ b/pyanaconda/modules/payload/base/source_base.py
@@ -19,7 +19,6 @@
 #
 from abc import ABCMeta, abstractmethod
 
-from pyanaconda.core.signal import Signal
 from pyanaconda.dbus.publishable import Publishable
 from pyanaconda.modules.common.base import KickstartBaseModule
 
@@ -31,11 +30,6 @@ class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
     to be implemented by a source to be used.
     """
 
-    def __init__(self):
-        super().__init__()
-        self._is_ready = False
-        self.is_ready_changed = Signal()
-
     @property
     @abstractmethod
     def type(self):
@@ -46,7 +40,7 @@ class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         """
         pass
 
-    @property
+    @abstractmethod
     def is_ready(self):
         """This source is ready for the installation to start.
 
@@ -55,7 +49,11 @@ class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
 
         :rtype: bool
         """
-        return self._is_ready
+        # TODO: Add needs_teardown property which will tell us if the source has to be cleaned up
+        # before removing the source from a payload handler. The is_ready will work for now but it
+        # will not work for for example HTTP source which is always ready. That source would cause
+        # troubles for the base handler set_sources method ready check.
+        pass
 
     @abstractmethod
     def set_up_with_tasks(self):

--- a/pyanaconda/modules/payload/base/source_base.py
+++ b/pyanaconda/modules/payload/base/source_base.py
@@ -93,15 +93,3 @@ class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         :rtype: list[task]
         """
         pass
-
-    @abstractmethod
-    def validate(self):
-        """Do a quick validation of the source.
-
-        This validation should be quick and only check if resources could be used. It doesn't mean
-        that the source could be used for the installation, it only tell you it can't be used.
-
-        :return: False if the source is not valid
-        :rtype: bool
-        """
-        pass

--- a/pyanaconda/modules/payload/base/source_base.py
+++ b/pyanaconda/modules/payload/base/source_base.py
@@ -57,15 +57,6 @@ class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         """
         return self._is_ready
 
-    def _set_is_ready(self, value):
-        """Set if the source is ready to be used for the installation process.
-
-        :param value: True if the source is ready
-        :type value: bool
-        """
-        self._is_ready = value
-        self.is_ready_changed.emit()
-
     @abstractmethod
     def set_up_with_tasks(self):
         """Prepare this payload source.

--- a/pyanaconda/modules/payload/base/source_base_interface.py
+++ b/pyanaconda/modules/payload/base/source_base_interface.py
@@ -32,3 +32,11 @@ class PayloadSourceBaseInterface(ModuleInterfaceTemplate, metaclass=ABCMeta):
     This object contains API shared by all the sources. Everything in this object has
     to be implemented by a source to be used.
     """
+
+    def Validate(self) -> Bool:
+        """Do a quick validation of the source.
+
+        This validation should be quick and only check if resources could be used. It doesn't mean
+        that the source could be used for the installation, it only tell you it can't be used.
+        """
+        return self.implementation.validate()

--- a/pyanaconda/modules/payload/base/source_base_interface.py
+++ b/pyanaconda/modules/payload/base/source_base_interface.py
@@ -41,11 +41,3 @@ class PayloadSourceBaseInterface(ModuleInterfaceTemplate, metaclass=ABCMeta):
          - LIVE_OS_IMAGE
         """
         return self.implementation.type.value
-
-    def Validate(self) -> Bool:
-        """Do a quick validation of the source.
-
-        This validation should be quick and only check if resources could be used. It doesn't mean
-        that the source could be used for the installation, it only tell you it can't be used.
-        """
-        return self.implementation.validate()

--- a/pyanaconda/modules/payload/base/source_base_interface.py
+++ b/pyanaconda/modules/payload/base/source_base_interface.py
@@ -34,13 +34,13 @@ class PayloadSourceBaseInterface(ModuleInterfaceTemplate, metaclass=ABCMeta):
     """
 
     @property
-    def Kind(self) -> Str:
+    def Type(self) -> Str:
         """Get the type of this source.
 
         Possible values are:
          - LIVE_OS_IMAGE
         """
-        return self.implementation.kind.value
+        return self.implementation.type.value
 
     def Validate(self) -> Bool:
         """Do a quick validation of the source.

--- a/pyanaconda/modules/payload/base/source_base_interface.py
+++ b/pyanaconda/modules/payload/base/source_base_interface.py
@@ -1,0 +1,34 @@
+#
+# Base object of all payload sources.
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from abc import ABCMeta
+
+from pyanaconda.dbus.interface import dbus_interface
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
+from pyanaconda.modules.common.base.base_template import ModuleInterfaceTemplate
+from pyanaconda.modules.common.constants.interfaces import PAYLOAD_SOURCE
+
+
+@dbus_interface(PAYLOAD_SOURCE.interface_name)
+class PayloadSourceBaseInterface(ModuleInterfaceTemplate, metaclass=ABCMeta):
+    """Base class for all the payload source module interfaces.
+
+    This object contains API shared by all the sources. Everything in this object has
+    to be implemented by a source to be used.
+    """

--- a/pyanaconda/modules/payload/base/source_base_interface.py
+++ b/pyanaconda/modules/payload/base/source_base_interface.py
@@ -33,6 +33,15 @@ class PayloadSourceBaseInterface(ModuleInterfaceTemplate, metaclass=ABCMeta):
     to be implemented by a source to be used.
     """
 
+    @property
+    def Kind(self) -> Str:
+        """Get the type of this source.
+
+        Possible values are:
+         - LIVE_OS_IMAGE
+        """
+        return self.implementation.kind.value
+
     def Validate(self) -> Bool:
         """Do a quick validation of the source.
 

--- a/pyanaconda/modules/payload/dnf/dnf.py
+++ b/pyanaconda/modules/payload/dnf/dnf.py
@@ -35,7 +35,7 @@ class DNFHandlerModule(PayloadHandlerBase):
         self._packages_handler = PackagesHandlerModule()
 
     @property
-    def supported_source_kinds(self):
+    def supported_source_types(self):
         """Get list of sources supported by DNF module."""
         # TODO: Add supported sources when implemented
         return None

--- a/pyanaconda/modules/payload/dnf/dnf.py
+++ b/pyanaconda/modules/payload/dnf/dnf.py
@@ -34,6 +34,12 @@ class DNFHandlerModule(PayloadHandlerBase):
         super().__init__()
         self._packages_handler = PackagesHandlerModule()
 
+    @property
+    def supported_source_kinds(self):
+        """Get list of sources supported by DNF module."""
+        # TODO: Add supported sources when implemented
+        return None
+
     def publish_handler(self):
         """Publish the handler."""
         self._packages_handler.publish()

--- a/pyanaconda/modules/payload/factory.py
+++ b/pyanaconda/modules/payload/factory.py
@@ -17,28 +17,14 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 from abc import ABC, abstractclassmethod
-from enum import Enum, unique
 
+from pyanaconda.modules.payload.base.constants import HandlerType, SourceType
 from pyanaconda.modules.payload.dnf.dnf import DNFHandlerModule
 from pyanaconda.modules.payload.live.live_image import LiveImageHandlerModule
 from pyanaconda.modules.payload.live.live_os import LiveOSHandlerModule
 from pyanaconda.modules.payload.sources.live_os import LiveOSSourceModule
 
-__all__ = ["HandlerFactory", "HandlerType", "SourceFactory", "SourceType"]
-
-
-@unique
-class HandlerType(Enum):
-    """Type of the payload handler."""
-    DNF = "DNF"
-    LIVE_OS = "LIVE_OS"
-    LIVE_IMAGE = "LIVE_IMAGE"
-
-
-@unique
-class SourceType(Enum):
-    """Type of the payload source."""
-    LIVE_OS_IMAGE = "LIVE_OS_IMAGE"
+__all__ = ["HandlerFactory", "SourceFactory"]
 
 
 class BaseFactory(ABC):

--- a/pyanaconda/modules/payload/factory.py
+++ b/pyanaconda/modules/payload/factory.py
@@ -22,8 +22,9 @@ from enum import Enum, unique
 from pyanaconda.modules.payload.dnf.dnf import DNFHandlerModule
 from pyanaconda.modules.payload.live.live_image import LiveImageHandlerModule
 from pyanaconda.modules.payload.live.live_os import LiveOSHandlerModule
+from pyanaconda.modules.payload.sources.live_os import LiveOSSourceModule
 
-__all__ = ["HandlerFactory", "HandlerType"]
+__all__ = ["HandlerFactory", "HandlerType", "SourceFactory", "SourceType"]
 
 
 @unique
@@ -32,6 +33,12 @@ class HandlerType(Enum):
     DNF = "DNF"
     LIVE_OS = "LIVE_OS"
     LIVE_IMAGE = "LIVE_IMAGE"
+
+
+@unique
+class SourceType(Enum):
+    """Type of the payload source."""
+    LIVE_OS_IMAGE = "LIVE_OS_IMAGE"
 
 
 class BaseFactory(ABC):
@@ -89,3 +96,12 @@ class HandlerFactory(BaseFactory):
             return LiveOSHandlerModule()
         elif object_type == HandlerType.DNF:
             return DNFHandlerModule()
+
+
+class SourceFactory(BaseFactory):
+    """Factory to create payload sources."""
+
+    @classmethod
+    def _create(cls, object_type):
+        if object_type == SourceType.LIVE_OS_IMAGE:
+            return LiveOSSourceModule()

--- a/pyanaconda/modules/payload/factory.py
+++ b/pyanaconda/modules/payload/factory.py
@@ -16,11 +16,14 @@
 # source code or documentation are not subject to the GNU General Public
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
+from abc import ABC, abstractclassmethod
 from enum import Enum, unique
 
 from pyanaconda.modules.payload.dnf.dnf import DNFHandlerModule
 from pyanaconda.modules.payload.live.live_image import LiveImageHandlerModule
 from pyanaconda.modules.payload.live.live_os import LiveOSHandlerModule
+
+__all__ = ["HandlerFactory", "HandlerType"]
 
 
 @unique
@@ -31,21 +34,33 @@ class HandlerType(Enum):
     LIVE_IMAGE = "LIVE_IMAGE"
 
 
-class HandlerFactory(object):
-    """Factory to create payload handlers."""
+class BaseFactory(ABC):
+    """Factory to create payload objects."""
 
     @classmethod
-    def create_handler(cls, handler_type):
-        """Create handler of the given type.
+    def create(cls, handler_type):
+        """Create an object of the given type.
 
-        :param handler_type: value from the HandlerType enum
+        :param handler_type: value from the enum of given type
         """
-        handler = cls._create_handler(handler_type)
+        handler = cls._create(handler_type)
 
         return handler
 
+    @abstractclassmethod
+    def _create(cls, object_type):
+        """Return class from the type.
+
+        :rtype: class
+        """
+        pass
+
+
+class HandlerFactory(BaseFactory):
+    """Factory to create payload handlers."""
+
     @classmethod
-    def create_handler_from_ks_data(cls, data):
+    def create_from_ks_data(cls, data):
         """Create handler based on the KS data.
 
         :param data: kickstart data
@@ -55,7 +70,7 @@ class HandlerFactory(object):
         if handler_type is None:
             return None
 
-        return cls.create_handler(handler_type)
+        return cls.create(handler_type)
 
     @classmethod
     def _get_handler_type_from_ks(cls, data):
@@ -67,10 +82,10 @@ class HandlerFactory(object):
             return None
 
     @classmethod
-    def _create_handler(cls, handler_type):
-        if handler_type == HandlerType.LIVE_IMAGE:
+    def _create(cls, object_type):
+        if object_type == HandlerType.LIVE_IMAGE:
             return LiveImageHandlerModule()
-        elif handler_type == HandlerType.LIVE_OS:
+        elif object_type == HandlerType.LIVE_OS:
             return LiveOSHandlerModule()
-        elif handler_type == HandlerType.DNF:
+        elif object_type == HandlerType.DNF:
             return DNFHandlerModule()

--- a/pyanaconda/modules/payload/live/initialization.py
+++ b/pyanaconda/modules/payload/live/initialization.py
@@ -21,9 +21,6 @@ import hashlib
 import glob
 from requests.exceptions import RequestException
 
-from pyanaconda.modules.common.constants.services import STORAGE
-from pyanaconda.modules.common.structures.storage import DeviceData
-from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.payload.live.utils import get_local_image_path_from_url, \
@@ -35,40 +32,6 @@ from pyanaconda.core.util import lowerASCII, execWithRedirect
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
-
-
-class SetupInstallationSourceTask(Task):
-    """Task to setup installation source."""
-
-    def __init__(self, live_partition, target_mount):
-        super().__init__()
-        self._live_partition = live_partition
-        self._target_mount = target_mount
-
-    @property
-    def name(self):
-        return "Setup Installation Source"
-
-    def run(self):
-        """Run live installation source setup."""
-        # Mount the live device and copy from it instead of the overlay at /
-        device_tree = STORAGE.get_proxy(DEVICE_TREE)
-        device_name = device_tree.ResolveDevice(self._live_partition)
-        if not device_name:
-            raise SourceSetupError("Failed to find liveOS image!")
-
-        device_data = DeviceData.from_structure(device_tree.GetDeviceData(device_name))
-
-        if not stat.S_ISBLK(os.stat(device_data.path)[stat.ST_MODE]):
-            raise SourceSetupError("{} is not a valid block device".format(
-                self._live_partition))
-        rc = mount(device_data.path, self._target_mount, fstype="auto", options="ro")
-        if rc != 0:
-            raise SourceSetupError("Failed to mount the install tree")
-
-        # FIXME: This should be done by the module
-        # source = os.statvfs(self._target_mount)
-        # self.source_size = source.f_frsize * (source.f_blocks - source.f_bfree)
 
 
 class TeardownInstallationSourceTask(Task):

--- a/pyanaconda/modules/payload/live/initialization.py
+++ b/pyanaconda/modules/payload/live/initialization.py
@@ -34,22 +34,6 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class TeardownInstallationSourceTask(Task):
-    """Task to teardown installation source."""
-
-    def __init__(self, target_mount):
-        super().__init__()
-        self._target_mount = target_mount
-
-    @property
-    def name(self):
-        return "Teardown Installation Source"
-
-    def run(self):
-        """Run live installation source unsetup."""
-        unmount(self._target_mount)
-
-
 class CheckInstallationSourceImageTask(Task):
     """Task to check installation source image and get its size."""
 

--- a/pyanaconda/modules/payload/live/installation.py
+++ b/pyanaconda/modules/payload/live/installation.py
@@ -50,7 +50,7 @@ class InstallFromImageTask(Task):
         """Run installation of the payload from image."""
         # TODO: remove this check for None when Live Image payload will support sources
         # The None check is just a temporary hack that Live OS has source but Live Image don't
-        if self._source is not None and not self._source.is_ready:
+        if self._source is not None and not self._source.is_ready():
             raise InstallError("Source is not set up!")
 
         cmd = "rsync"

--- a/pyanaconda/modules/payload/live/live_image.py
+++ b/pyanaconda/modules/payload/live/live_image.py
@@ -70,7 +70,7 @@ class LiveImageHandlerModule(PayloadHandlerBase):
         self._requests_session = None
 
     @property
-    def supported_source_kinds(self):
+    def supported_source_types(self):
         """Get list of sources supported by Live Image module."""
         # TODO: Add supported sources when implemented
         return None

--- a/pyanaconda/modules/payload/live/live_image.py
+++ b/pyanaconda/modules/payload/live/live_image.py
@@ -69,6 +69,12 @@ class LiveImageHandlerModule(PayloadHandlerBase):
 
         self._requests_session = None
 
+    @property
+    def supported_source_kinds(self):
+        """Get list of sources supported by Live Image module."""
+        # TODO: Add supported sources when implemented
+        return None
+
     def publish_handler(self):
         """Publish the handler."""
         DBus.publish_object(LIVE_IMAGE_HANDLER.object_path, LiveImageHandlerInterface(self))

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -97,13 +97,6 @@ class LiveOSHandlerModule(PayloadHandlerBase):
         if not self._image_source:
             raise SourceSetupError(message)
 
-    def _check_source_readiness(self, message):
-        """Test if source is ready for the installation."""
-        self._check_source_availability(message)
-
-        if not self._image_source.is_ready:
-            raise SourceSetupError(message)
-
     @property
     def space_required(self):
         """Get space required for the source image.
@@ -132,13 +125,13 @@ class LiveOSHandlerModule(PayloadHandlerBase):
 
     def pre_install_with_task(self):
         """Prepare intallation task."""
-        self._check_source_readiness("Source is not setup!")
+        self._check_source_availability("Pre install task failed - source is not available!")
 
         return PrepareSystemForInstallationTask(conf.target.system_root)
 
     def install_with_task(self):
         """Install the payload."""
-        self._check_source_readiness("Source is not setup!")
+        self._check_source_availability("Installation task failed - source is not available!")
 
         return InstallFromImageTask(
             conf.target.system_root,

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -28,6 +28,7 @@ from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.core.util import execWithCapture
 
 from pyanaconda.modules.common.constants.objects import LIVE_OS_HANDLER
+from pyanaconda.modules.payload.base.constants import SourceType
 from pyanaconda.modules.payload.base.handler_base import PayloadHandlerBase
 from pyanaconda.modules.payload.base.initialization import PrepareSystemForInstallationTask, \
     CopyDriverDisksFilesTask
@@ -54,6 +55,11 @@ class LiveOSHandlerModule(PayloadHandlerBase):
 
         self._kernel_version_list = []
         self.kernel_version_list_changed = Signal()
+
+    @property
+    def supported_source_kinds(self):
+        """Get list of sources supported by Live Image module."""
+        return [SourceType.LIVE_OS_IMAGE]
 
     def publish_handler(self):
         """Publish the handler."""

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -31,8 +31,6 @@ from pyanaconda.modules.payload.base.initialization import PrepareSystemForInsta
 from pyanaconda.modules.payload.base.utils import get_dir_size
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
 from pyanaconda.modules.payload.live.initialization import UpdateBLSConfigurationTask
-from pyanaconda.modules.payload.sources.initialization import TearDownInstallationSourceTask, \
-    SetUpInstallationSourceTask
 from pyanaconda.modules.payload.live.installation import InstallFromImageTask
 from pyanaconda.modules.payload.live.utils import get_kernel_version_list
 
@@ -109,13 +107,13 @@ class LiveOSHandlerModule(PayloadHandlerBase):
         """
         return get_dir_size("/") * 1024
 
-    def setup_installation_source_with_task(self):
-        """Setup installation source device."""
-        return SetUpInstallationSourceTask(self._image_source.image_path, INSTALL_TREE)
+    def setup_installation_source_with_tasks(self):
+        """Setup installation source."""
+        return self._image_source.set_up_with_tasks()
 
-    def teardown_installation_source_with_task(self):
+    def teardown_installation_source_with_tasks(self):
         """Teardown installation source device."""
-        return TearDownInstallationSourceTask(INSTALL_TREE)
+        return self._image_source.tear_down_with_tasks()
 
     def pre_install_with_task(self):
         """Prepare intallation task."""

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -120,7 +120,8 @@ class LiveOSHandlerModule(PayloadHandlerBase):
         # Is it a squashfs+overlayfs base image?
         if os.path.exists("/run/rootfsbase"):
             try:
-                block_device = execWithCapture("findmnt", ["-n", "-o", "SOURCE", "/run/rootfsbase"]).strip()
+                block_device = execWithCapture("findmnt",
+                                               ["-n", "-o", "SOURCE", "/run/rootfsbase"]).strip()
                 if block_device:
                     log.debug("Detected live base image %s", block_device)
                     return block_device

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -134,6 +134,7 @@ class LiveOSHandlerModule(PayloadHandlerBase):
         self._check_source_availability("Installation task failed - source is not available!")
 
         return InstallFromImageTask(
+            self._image_source,
             conf.target.system_root,
             self.kernel_version_list
         )

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -33,9 +33,9 @@ from pyanaconda.modules.payload.base.initialization import PrepareSystemForInsta
     CopyDriverDisksFilesTask
 from pyanaconda.modules.payload.base.utils import get_dir_size
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
-from pyanaconda.modules.payload.live.initialization import TeardownInstallationSourceTask, \
-    UpdateBLSConfigurationTask
-from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask
+from pyanaconda.modules.payload.live.initialization import UpdateBLSConfigurationTask
+from pyanaconda.modules.payload.sources.initialization import TearDownInstallationSourceTask, \
+    SetUpInstallationSourceTask
 from pyanaconda.modules.payload.live.installation import InstallFromImageTask
 from pyanaconda.modules.payload.live.utils import get_kernel_version_list
 
@@ -130,7 +130,7 @@ class LiveOSHandlerModule(PayloadHandlerBase):
 
     def teardown_installation_source_with_task(self):
         """Teardown installation source device."""
-        return TeardownInstallationSourceTask(INSTALL_TREE)
+        return TearDownInstallationSourceTask(INSTALL_TREE)
 
     def pre_install_with_task(self):
         """Prepare intallation task."""

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -61,6 +61,23 @@ class LiveOSHandlerModule(PayloadHandlerBase):
         """Get list of sources supported by Live Image module."""
         return [SourceType.LIVE_OS_IMAGE]
 
+    def add_source(self, source):
+        """Add source to this payload.
+
+        This payload is specific that it can't have more than only one source attached. It will
+        instead replace the old source with the new one.
+
+        :param source: source object
+        :type source: instance of pyanaconda.modules.payload.base.source_base.PayloadSourceBase
+        :raises: IncompatibleSourceError
+        """
+        if self.sources:
+            if source not in self.sources:
+                log.debug("Newly added source is replacing the original one.")
+                self.sources.clear()
+
+        super().add_source(source)
+
     def publish_handler(self):
         """Publish the handler."""
         DBus.publish_object(LIVE_OS_HANDLER.object_path, LiveOSHandlerInterface(self))

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -17,15 +17,11 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-import os
-import stat
-
 from pyanaconda.dbus import DBus
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.signal import Signal
 from pyanaconda.core.constants import INSTALL_TREE
-from pyanaconda.core.util import execWithCapture
 
 from pyanaconda.modules.common.constants.objects import LIVE_OS_HANDLER
 from pyanaconda.modules.payload.base.constants import SourceType
@@ -112,31 +108,6 @@ class LiveOSHandlerModule(PayloadHandlerBase):
         :rtype: int
         """
         return get_dir_size("/") * 1024
-
-    def detect_live_os_base_image(self):
-        """Detect live os image in the system."""
-        log.debug("Trying to detect live os base image automatically")
-        for block_device in ["/dev/mapper/live-base", "/dev/mapper/live-osimg-min"]:
-            try:
-                if stat.S_ISBLK(os.stat(block_device)[stat.ST_MODE]):
-                    log.debug("Detected live base image %s", block_device)
-                    return block_device
-            except FileNotFoundError:
-                pass
-
-        # Is it a squashfs+overlayfs base image?
-        if os.path.exists("/run/rootfsbase"):
-            try:
-                block_device = execWithCapture("findmnt",
-                                               ["-n", "-o", "SOURCE", "/run/rootfsbase"]).strip()
-                if block_device:
-                    log.debug("Detected live base image %s", block_device)
-                    return block_device
-            except (OSError, FileNotFoundError):
-                pass
-
-        log.debug("No live base image detected")
-        return ""
 
     def setup_installation_source_with_task(self):
         """Setup installation source device."""

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -24,7 +24,7 @@ from pyanaconda.core.signal import Signal
 from pyanaconda.core.constants import INSTALL_TREE
 
 from pyanaconda.modules.common.constants.objects import LIVE_OS_HANDLER
-from pyanaconda.modules.common.errors.payload import SourceSetupError
+from pyanaconda.modules.common.errors.payload import SourceSetupError, IncompatibleSourceError
 from pyanaconda.modules.payload.base.constants import SourceType
 from pyanaconda.modules.payload.base.handler_base import PayloadHandlerBase
 from pyanaconda.modules.payload.base.initialization import PrepareSystemForInstallationTask, \
@@ -53,8 +53,8 @@ class LiveOSHandlerModule(PayloadHandlerBase):
         """Get list of sources supported by Live Image module."""
         return [SourceType.LIVE_OS_IMAGE]
 
-    def add_source(self, source):
-        """Add source to this payload.
+    def set_sources(self, sources):
+        """Set new sources to this handler.
 
         This payload is specific that it can't have more than only one source attached. It will
         instead replace the old source with the new one.
@@ -63,12 +63,10 @@ class LiveOSHandlerModule(PayloadHandlerBase):
         :type source: instance of pyanaconda.modules.payload.base.source_base.PayloadSourceBase
         :raises: IncompatibleSourceError
         """
-        if self.sources:
-            if source not in self.sources:
-                log.debug("Newly added source is replacing the original one.")
-                self.sources.clear()
+        if len(sources) > 1:
+            raise IncompatibleSourceError("You can set only one source for this payload type.")
 
-        super().add_source(source)
+        super().set_sources(sources)
 
     def publish_handler(self):
         """Publish the handler."""

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -28,7 +28,7 @@ from pyanaconda.modules.common.errors.payload import SourceSetupError, Incompati
 from pyanaconda.modules.payload.base.constants import SourceType
 from pyanaconda.modules.payload.base.handler_base import PayloadHandlerBase
 from pyanaconda.modules.payload.base.initialization import PrepareSystemForInstallationTask, \
-    CopyDriverDisksFilesTask
+    CopyDriverDisksFilesTask, SetUpSourcesTask
 from pyanaconda.modules.payload.base.utils import get_dir_size
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
 from pyanaconda.modules.payload.live.initialization import UpdateBLSConfigurationTask
@@ -111,11 +111,11 @@ class LiveOSHandlerModule(PayloadHandlerBase):
         """
         return get_dir_size("/") * 1024
 
-    def setup_installation_source_with_tasks(self):
-        """Setup installation source."""
+    def set_up_sources_with_task(self):
+        """Set up installation source."""
         self._check_source_availability("Set up source failed - source is not set!")
 
-        return self._image_source.set_up_with_tasks()
+        return SetUpSourcesTask(self._sources)
 
     def teardown_installation_source_with_tasks(self):
         """Teardown installation source device."""

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -49,7 +49,7 @@ class LiveOSHandlerModule(PayloadHandlerBase):
         self.kernel_version_list_changed = Signal()
 
     @property
-    def supported_source_kinds(self):
+    def supported_source_types(self):
         """Get list of sources supported by Live Image module."""
         return [SourceType.LIVE_OS_IMAGE]
 

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -33,8 +33,9 @@ from pyanaconda.modules.payload.base.initialization import PrepareSystemForInsta
     CopyDriverDisksFilesTask
 from pyanaconda.modules.payload.base.utils import get_dir_size
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
-from pyanaconda.modules.payload.live.initialization import SetupInstallationSourceTask, \
-    TeardownInstallationSourceTask, UpdateBLSConfigurationTask
+from pyanaconda.modules.payload.live.initialization import TeardownInstallationSourceTask, \
+    UpdateBLSConfigurationTask
+from pyanaconda.modules.payload.sources.initialization import SetupInstallationSourceTask
 from pyanaconda.modules.payload.live.installation import InstallFromImageTask
 from pyanaconda.modules.payload.live.utils import get_kernel_version_list
 

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -50,9 +50,6 @@ class LiveOSHandlerModule(PayloadHandlerBase):
     def __init__(self):
         super().__init__()
 
-        self._image_path = ""
-        self.image_path_changed = Signal()
-
         self._kernel_version_list = []
         self.kernel_version_list_changed = Signal()
 
@@ -90,24 +87,17 @@ class LiveOSHandlerModule(PayloadHandlerBase):
         """Setup the kickstart data."""
 
     @property
-    def image_path(self):
-        """Path to the source live OS image.
+    def _image_source(self):
+        """Get the attached source object.
 
-        This image will be used for the installation.
+        This is a shortcut for this handler because it only support one source at a time.
 
-        :rtype: str
+        :return: a source object
         """
-        return self._image_path
+        if self.sources:
+            return list(self.sources)[0]
 
-    def set_image_path(self, image_path):
-        """Set path to the live os OS image.
-
-        :param image_path: path to the image
-        :type image_path: str
-        """
-        self._image_path = image_path
-        self.image_path_changed.emit()
-        log.debug("LiveOS image path is set to '%s'", self._image_path)
+        return None
 
     @property
     def space_required(self):
@@ -150,7 +140,7 @@ class LiveOSHandlerModule(PayloadHandlerBase):
 
     def setup_installation_source_with_task(self):
         """Setup installation source device."""
-        return SetUpInstallationSourceTask(self.image_path, INSTALL_TREE)
+        return SetUpInstallationSourceTask(self._image_source.image_path, INSTALL_TREE)
 
     def teardown_installation_source_with_task(self):
         """Teardown installation source device."""

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -28,7 +28,7 @@ from pyanaconda.modules.common.errors.payload import SourceSetupError, Incompati
 from pyanaconda.modules.payload.base.constants import SourceType
 from pyanaconda.modules.payload.base.handler_base import PayloadHandlerBase
 from pyanaconda.modules.payload.base.initialization import PrepareSystemForInstallationTask, \
-    CopyDriverDisksFilesTask, SetUpSourcesTask
+    CopyDriverDisksFilesTask, SetUpSourcesTask, TearDownSourcesTask
 from pyanaconda.modules.payload.base.utils import get_dir_size
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
 from pyanaconda.modules.payload.live.initialization import UpdateBLSConfigurationTask
@@ -117,11 +117,11 @@ class LiveOSHandlerModule(PayloadHandlerBase):
 
         return SetUpSourcesTask(self._sources)
 
-    def teardown_installation_source_with_tasks(self):
-        """Teardown installation source device."""
+    def tear_down_sources_with_task(self):
+        """Tear down installation sources."""
         self._check_source_availability("Tear down source failed - source is not set!")
 
-        return self._image_source.tear_down_with_tasks()
+        return TearDownSourcesTask(self._sources)
 
     def pre_install_with_task(self):
         """Prepare intallation task."""

--- a/pyanaconda/modules/payload/live/live_os.py
+++ b/pyanaconda/modules/payload/live/live_os.py
@@ -35,7 +35,7 @@ from pyanaconda.modules.payload.base.utils import get_dir_size
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
 from pyanaconda.modules.payload.live.initialization import TeardownInstallationSourceTask, \
     UpdateBLSConfigurationTask
-from pyanaconda.modules.payload.sources.initialization import SetupInstallationSourceTask
+from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask
 from pyanaconda.modules.payload.live.installation import InstallFromImageTask
 from pyanaconda.modules.payload.live.utils import get_kernel_version_list
 
@@ -126,7 +126,7 @@ class LiveOSHandlerModule(PayloadHandlerBase):
 
     def setup_installation_source_with_task(self):
         """Setup installation source device."""
-        return SetupInstallationSourceTask(self.image_path, INSTALL_TREE)
+        return SetUpInstallationSourceTask(self.image_path, INSTALL_TREE)
 
     def teardown_installation_source_with_task(self):
         """Teardown installation source device."""

--- a/pyanaconda/modules/payload/live/live_os_interface.py
+++ b/pyanaconda/modules/payload/live/live_os_interface.py
@@ -41,16 +41,16 @@ class LiveOSHandlerInterface(KickstartModuleInterfaceTemplate):
         """
         return self.implementation.space_required
 
-    def SetupInstallationSourceWithTask(self) -> ObjPath:
+    def SetupInstallationSourceWithTasks(self) -> List[ObjPath]:
         """Setup installation source resources."""
-        return TaskContainer.to_object_path(
-            self.implementation.setup_installation_source_with_task()
+        return TaskContainer.to_object_path_list(
+            self.implementation.setup_installation_source_with_tasks()
         )
 
-    def TeardownInstallationSourceWithTask(self) -> ObjPath:
+    def TeardownInstallationSourceWithTasks(self) -> List[ObjPath]:
         """Teardown installation source resources."""
-        return TaskContainer.to_object_path(
-            self.implementation.teardown_installation_source_with_task()
+        return TaskContainer.to_object_path_list(
+            self.implementation.teardown_installation_source_with_tasks()
         )
 
     def PreInstallWithTask(self) -> ObjPath:

--- a/pyanaconda/modules/payload/live/live_os_interface.py
+++ b/pyanaconda/modules/payload/live/live_os_interface.py
@@ -41,10 +41,10 @@ class LiveOSHandlerInterface(KickstartModuleInterfaceTemplate):
         """
         return self.implementation.space_required
 
-    def SetupInstallationSourceWithTasks(self) -> List[ObjPath]:
-        """Setup installation source resources."""
-        return TaskContainer.to_object_path_list(
-            self.implementation.setup_installation_source_with_tasks()
+    def SetUpSourcesWithTask(self) -> ObjPath:
+        """Set up installation source."""
+        return TaskContainer.to_object_path(
+            self.implementation.set_up_sources_with_task()
         )
 
     def TeardownInstallationSourceWithTasks(self) -> List[ObjPath]:

--- a/pyanaconda/modules/payload/live/live_os_interface.py
+++ b/pyanaconda/modules/payload/live/live_os_interface.py
@@ -41,13 +41,6 @@ class LiveOSHandlerInterface(KickstartModuleInterfaceTemplate):
         """
         return self.implementation.space_required
 
-    def DetectLiveOSImage(self) -> Str:
-        """Try to find valid live os image.
-
-        :return: path to the base image
-        """
-        return self.implementation.detect_live_os_base_image()
-
     def SetupInstallationSourceWithTask(self) -> ObjPath:
         """Setup installation source resources."""
         return TaskContainer.to_object_path(

--- a/pyanaconda/modules/payload/live/live_os_interface.py
+++ b/pyanaconda/modules/payload/live/live_os_interface.py
@@ -19,7 +19,6 @@
 #
 from pyanaconda.dbus.interface import dbus_interface, dbus_signal
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
-from pyanaconda.dbus.property import emits_properties_changed
 
 from pyanaconda.modules.common.constants.objects import LIVE_OS_HANDLER
 from pyanaconda.modules.common.base import KickstartModuleInterfaceTemplate
@@ -32,24 +31,7 @@ class LiveOSHandlerInterface(KickstartModuleInterfaceTemplate):
 
     def connect_signals(self):
         super().connect_signals()
-        self.watch_property("ImagePath", self.implementation.image_path_changed)
         self.implementation.kernel_version_list_changed.connect(self.KernelVersionListChanged)
-
-    @property
-    def ImagePath(self) -> Str:
-        """Get the path to the Live OS base image.
-
-        This image will be used as the installation.
-        """
-        return self.implementation.image_path
-
-    @emits_properties_changed
-    def SetImagePath(self, image_path: Str):
-        """Set the path to the Live OS base image.
-
-        This image will be used as the installation source.
-        """
-        self.implementation.set_image_path(image_path)
 
     @property
     def SpaceRequired(self) -> UInt64:

--- a/pyanaconda/modules/payload/live/live_os_interface.py
+++ b/pyanaconda/modules/payload/live/live_os_interface.py
@@ -47,10 +47,10 @@ class LiveOSHandlerInterface(KickstartModuleInterfaceTemplate):
             self.implementation.set_up_sources_with_task()
         )
 
-    def TeardownInstallationSourceWithTasks(self) -> List[ObjPath]:
-        """Teardown installation source resources."""
-        return TaskContainer.to_object_path_list(
-            self.implementation.teardown_installation_source_with_tasks()
+    def TearDownSourcesWithTask(self) -> ObjPath:
+        """Tear down installation sources."""
+        return TaskContainer.to_object_path(
+            self.implementation.tear_down_sources_with_task()
         )
 
     def PreInstallWithTask(self) -> ObjPath:

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -119,7 +119,7 @@ class PayloadModule(KickstartModule):
         """Create handler based on the passed type.
 
         :param handler_type: type of the desirable handler
-        :type handler_type: value of the payload.handler_factory.HandlerType enum
+        :type handler_type: value of the payload.base.constants.HandlerType enum
         """
         handler = HandlerFactory.create(handler_type)
         self._initialize_handler(handler)
@@ -129,6 +129,6 @@ class PayloadModule(KickstartModule):
         """Create source based on the passed type.
 
         :param source_type: type of the desirable source
-        :type source_type: value of the payload.factory.SourceType enum
+        :type source_type: value of the payload.base.constants.SourceType enum
         """
         return SourceFactory.create(source_type)

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -22,7 +22,7 @@ from pyanaconda.modules.common.base import KickstartModule
 from pyanaconda.modules.common.constants.services import PAYLOAD
 from pyanaconda.modules.common.containers import TaskContainer
 from pyanaconda.modules.common.errors.payload import HandlerNotSetError
-from pyanaconda.modules.payload.handler_factory import HandlerFactory
+from pyanaconda.modules.payload.factory import HandlerFactory
 from pyanaconda.modules.payload.kickstart import PayloadKickstartSpecification
 from pyanaconda.modules.payload.payload_interface import PayloadInterface
 
@@ -90,7 +90,7 @@ class PayloadModule(KickstartModule):
 
         # create handler if no handler is set already
         if not self.is_handler_set():
-            handler = HandlerFactory.create_handler_from_ks_data(data)
+            handler = HandlerFactory.create_from_ks_data(data)
             if not handler:
                 log.warning("No handler was created. Kickstart data passed in are lost.")
                 return
@@ -121,6 +121,6 @@ class PayloadModule(KickstartModule):
         :param handler_type: type of the desirable handler
         :type handler_type: value of the payload.handler_factory.HandlerType enum
         """
-        handler = HandlerFactory.create_handler(handler_type)
+        handler = HandlerFactory.create(handler_type)
         self._initialize_handler(handler)
         return self._payload_handler_path

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -22,7 +22,7 @@ from pyanaconda.modules.common.base import KickstartModule
 from pyanaconda.modules.common.constants.services import PAYLOAD
 from pyanaconda.modules.common.containers import TaskContainer
 from pyanaconda.modules.common.errors.payload import HandlerNotSetError
-from pyanaconda.modules.payload.factory import HandlerFactory
+from pyanaconda.modules.payload.factory import HandlerFactory, SourceFactory
 from pyanaconda.modules.payload.kickstart import PayloadKickstartSpecification
 from pyanaconda.modules.payload.payload_interface import PayloadInterface
 
@@ -124,3 +124,11 @@ class PayloadModule(KickstartModule):
         handler = HandlerFactory.create(handler_type)
         self._initialize_handler(handler)
         return self._payload_handler_path
+
+    def create_source(self, source_type):
+        """Create source based on the passed type.
+
+        :param source_type: type of the desirable source
+        :type source_type: value of the payload.factory.SourceType enum
+        """
+        return SourceFactory.create(source_type)

--- a/pyanaconda/modules/payload/payload_interface.py
+++ b/pyanaconda/modules/payload/payload_interface.py
@@ -23,7 +23,7 @@ from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.modules.common.containers import PayloadSourceContainer
 from pyanaconda.modules.common.constants.services import PAYLOAD
-from pyanaconda.modules.payload.factory import HandlerType, SourceType
+from pyanaconda.modules.payload.base.constants import HandlerType, SourceType
 
 
 @dbus_interface(PAYLOAD.interface_name)

--- a/pyanaconda/modules/payload/payload_interface.py
+++ b/pyanaconda/modules/payload/payload_interface.py
@@ -23,7 +23,7 @@ from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.constants.services import PAYLOAD
 from pyanaconda.modules.common.base import KickstartModuleInterface
 
-from pyanaconda.modules.payload.handler_factory import HandlerType
+from pyanaconda.modules.payload.factory import HandlerType
 
 
 @dbus_interface(PAYLOAD.interface_name)

--- a/pyanaconda/modules/payload/payload_interface.py
+++ b/pyanaconda/modules/payload/payload_interface.py
@@ -20,9 +20,9 @@
 from pyanaconda.dbus.interface import dbus_interface
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 
-from pyanaconda.modules.common.constants.services import PAYLOAD
 from pyanaconda.modules.common.base import KickstartModuleInterface
-
+from pyanaconda.modules.common.containers import PayloadSourceContainer
+from pyanaconda.modules.common.constants.services import PAYLOAD
 from pyanaconda.modules.payload.factory import HandlerType, SourceType
 
 
@@ -54,4 +54,7 @@ class PayloadInterface(KickstartModuleInterface):
         source_type could contain these values:
          - LIVE_OS_IMAGE
         """
-        return self.implementation.create_source(SourceType(source_type))
+
+        return PayloadSourceContainer.to_object_path(
+            self.implementation.create_source(SourceType(source_type))
+        )

--- a/pyanaconda/modules/payload/payload_interface.py
+++ b/pyanaconda/modules/payload/payload_interface.py
@@ -23,7 +23,7 @@ from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.constants.services import PAYLOAD
 from pyanaconda.modules.common.base import KickstartModuleInterface
 
-from pyanaconda.modules.payload.factory import HandlerType
+from pyanaconda.modules.payload.factory import HandlerType, SourceType
 
 
 @dbus_interface(PAYLOAD.interface_name)
@@ -47,3 +47,11 @@ class PayloadInterface(KickstartModuleInterface):
          - LIVE_IMAGE
         """
         return self.implementation.create_handler(HandlerType(handler_type))
+
+    def CreateSource(self, source_type: Str) -> ObjPath:
+        """Create payload source and publish it on a dbus.
+
+        source_type could contain these values:
+         - LIVE_OS_IMAGE
+        """
+        return self.implementation.create_source(SourceType(source_type))

--- a/pyanaconda/modules/payload/payload_interface.py
+++ b/pyanaconda/modules/payload/payload_interface.py
@@ -39,7 +39,7 @@ class PayloadInterface(KickstartModuleInterface):
         return self.implementation.is_handler_set()
 
     def CreateHandler(self, handler_type: Str) -> ObjPath:
-        """Create payload handler and publish it on a dbus.
+        """Create payload handler and publish it on DBus.
 
         handler_type could contain these values:
          - DNF
@@ -49,7 +49,7 @@ class PayloadInterface(KickstartModuleInterface):
         return self.implementation.create_handler(HandlerType(handler_type))
 
     def CreateSource(self, source_type: Str) -> ObjPath:
-        """Create payload source and publish it on a dbus.
+        """Create payload source and publish it on DBus.
 
         source_type could contain these values:
          - LIVE_OS_IMAGE

--- a/pyanaconda/modules/payload/sources/Makefile.am
+++ b/pyanaconda/modules/payload/sources/Makefile.am
@@ -14,10 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = base dnf live sources
-
 pkgpyexecdir = $(pyexecdir)/py$(PACKAGE_NAME)
-payload_moduledir = $(pkgpyexecdir)/modules/payload
+payload_moduledir = $(pkgpyexecdir)/modules/payload/sources
 payload_module_PYTHON = $(srcdir)/*.py
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/pyanaconda/modules/payload/sources/initialization.py
+++ b/pyanaconda/modules/payload/sources/initialization.py
@@ -35,7 +35,7 @@ class TearDownInstallationSourceTask(Task):
 
     @property
     def name(self):
-        return "Teardown Installation Source"
+        return "Tear down Live OS Installation Source"
 
     def run(self):
         """Run live installation source un-setup."""

--- a/pyanaconda/modules/payload/sources/initialization.py
+++ b/pyanaconda/modules/payload/sources/initialization.py
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import os
+import stat
+
+from pyanaconda.payload.utils import mount
+from pyanaconda.modules.common.constants.objects import DEVICE_TREE
+from pyanaconda.modules.common.constants.services import STORAGE
+from pyanaconda.modules.common.errors.payload import SourceSetupError
+from pyanaconda.modules.common.structures.storage import DeviceData
+from pyanaconda.modules.common.task import Task
+
+
+class SetupInstallationSourceTask(Task):
+    """Task to setup installation source."""
+
+    def __init__(self, live_partition, target_mount):
+        super().__init__()
+        self._live_partition = live_partition
+        self._target_mount = target_mount
+
+    @property
+    def name(self):
+        return "Setup Installation Source"
+
+    def run(self):
+        """Run live installation source setup."""
+        # Mount the live device and copy from it instead of the overlay at /
+        device_tree = STORAGE.get_proxy(DEVICE_TREE)
+        device_name = device_tree.ResolveDevice(self._live_partition)
+        if not device_name:
+            raise SourceSetupError("Failed to find liveOS image!")
+
+        device_data = DeviceData.from_structure(device_tree.GetDeviceData(device_name))
+
+        if not stat.S_ISBLK(os.stat(device_data.path)[stat.ST_MODE]):
+            raise SourceSetupError("{} is not a valid block device".format(
+                self._live_partition))
+        rc = mount(device_data.path, self._target_mount, fstype="auto", options="ro")
+        if rc != 0:
+            raise SourceSetupError("Failed to mount the install tree")
+
+        # FIXME: This should be done by the module
+        # source = os.statvfs(self._target_mount)
+        # self.source_size = source.f_frsize * (source.f_blocks - source.f_bfree)

--- a/pyanaconda/modules/payload/sources/initialization.py
+++ b/pyanaconda/modules/payload/sources/initialization.py
@@ -26,7 +26,7 @@ from pyanaconda.modules.common.structures.storage import DeviceData
 from pyanaconda.modules.common.task import Task
 
 
-class SetupInstallationSourceTask(Task):
+class SetUpInstallationSourceTask(Task):
     """Task to setup installation source."""
 
     def __init__(self, live_partition, target_mount):
@@ -36,7 +36,7 @@ class SetupInstallationSourceTask(Task):
 
     @property
     def name(self):
-        return "Setup Installation Source"
+        return "Set up Live OS Installation Source"
 
     def run(self):
         """Run live installation source setup."""

--- a/pyanaconda/modules/payload/sources/initialization.py
+++ b/pyanaconda/modules/payload/sources/initialization.py
@@ -26,7 +26,7 @@ from pyanaconda.modules.common.structures.storage import DeviceData
 from pyanaconda.modules.common.task import Task
 
 
-class TearDownInstallationSourceTask(Task):
+class TearDownLiveOSSourceTask(Task):
     """Task to teardown installation source."""
 
     def __init__(self, target_mount):
@@ -42,7 +42,7 @@ class TearDownInstallationSourceTask(Task):
         unmount(self._target_mount)
 
 
-class SetUpInstallationSourceTask(Task):
+class SetUpLiveOSSourceTask(Task):
     """Task to setup installation source."""
 
     def __init__(self, live_partition, target_mount):

--- a/pyanaconda/modules/payload/sources/initialization.py
+++ b/pyanaconda/modules/payload/sources/initialization.py
@@ -18,12 +18,28 @@
 import os
 import stat
 
-from pyanaconda.payload.utils import mount
+from pyanaconda.payload.utils import mount, unmount
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.structures.storage import DeviceData
 from pyanaconda.modules.common.task import Task
+
+
+class TearDownInstallationSourceTask(Task):
+    """Task to teardown installation source."""
+
+    def __init__(self, target_mount):
+        super().__init__()
+        self._target_mount = target_mount
+
+    @property
+    def name(self):
+        return "Teardown Installation Source"
+
+    def run(self):
+        """Run live installation source un-setup."""
+        unmount(self._target_mount)
 
 
 class SetUpInstallationSourceTask(Task):

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -102,9 +102,6 @@ class LiveOSSourceModule(PayloadSourceBase):
         :rtype: [Task]
         """
         task = SetUpLiveOSSourceTask(self._image_path, INSTALL_TREE)
-
-        task.succeeded_signal.connect(lambda: self._set_is_ready(True))
-
         return [task]
 
     def tear_down_with_tasks(self):
@@ -114,7 +111,4 @@ class LiveOSSourceModule(PayloadSourceBase):
         :rtype: [Task]
         """
         task = TearDownLiveOSSourceTask(INSTALL_TREE)
-
-        task.succeeded_signal.connect(lambda: self._set_is_ready(False))
-
         return [task]

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -17,10 +17,16 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import os
+import stat
+
 from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.modules.payload.base.source_base import PayloadSourceBase
 from pyanaconda.modules.payload.sources.live_os_interface import LiveOSSourceInterface
 from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
 
 
 class LiveOSSourceModule(PayloadSourceBase):
@@ -50,4 +56,18 @@ class LiveOSSourceModule(PayloadSourceBase):
         pass
 
     def validate(self):
-        return True
+        """Test if the image exists on the given path.
+
+        :return: True if file on the path exists.
+        """
+        try:
+            res = stat.S_ISBLK(os.stat(self._image_path)[stat.ST_MODE])
+            if res:
+                log.debug("Live OS source is valid %s", self._image_path)
+                return True
+            else:
+                log.warning("Live OS source is not valid %s", self._image_path)
+        except FileNotFoundError:
+            log.warning("Live OS source is not available %s", self._image_path)
+
+        return False

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -46,6 +46,11 @@ class LiveOSSourceModule(PayloadSourceBase):
         """Get type of this source."""
         return SourceType.LIVE_OS_IMAGE
 
+    def is_ready(self):
+        """This source is ready for the installation to start."""
+        # TODO: this should be check on a special directory for every source
+        return os.path.ismount(INSTALL_TREE)
+
     @property
     def image_path(self):
         """Path to the live OS source image.

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -48,3 +48,6 @@ class LiveOSSourceModule(PayloadSourceBase):
 
     def tear_down_with_tasks(self):
         pass
+
+    def validate(self):
+        return True

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -1,0 +1,38 @@
+#
+# Kickstart module for Live OS payload source.
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.modules.payload.base.source_base import PayloadSourceBase
+from pyanaconda.modules.payload.sources.live_os_interface import LiveOSSourceInterface
+
+
+class LiveOSSourceModule(PayloadSourceBase):
+    """The Live OS source payload module."""
+
+    def __init__(self):
+        super().__init__()
+
+    def for_publication(self):
+        """Get the interface used to publish this source."""
+        return LiveOSSourceInterface(self)
+
+    def set_up_with_tasks(self):
+        pass
+
+    def tear_down_with_tasks(self):
+        pass

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -48,16 +48,16 @@ class LiveOSSourceModule(PayloadSourceBase):
 
     @property
     def image_path(self):
-        """Path to the source live OS image.
+        """Path to the live OS source image.
 
-        This image will be used for the installation.
+        This image will be used as the installation source.
 
         :rtype: str
         """
         return self._image_path
 
     def set_image_path(self, image_path):
-        """Set path to the live os OS image.
+        """Set path to the live OS source image.
 
         :param image_path: path to the image
         :type image_path: str

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -42,7 +42,7 @@ class LiveOSSourceModule(PayloadSourceBase):
         self.image_path_changed = Signal()
 
     @property
-    def kind(self):
+    def type(self):
         """Get type of this source."""
         return SourceType.LIVE_OS_IMAGE
 

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -49,7 +49,9 @@ class LiveOSSourceModule(PayloadSourceBase):
     def is_ready(self):
         """This source is ready for the installation to start."""
         # TODO: this should be check on a special directory for every source
-        return os.path.ismount(INSTALL_TREE)
+        res = os.path.ismount(INSTALL_TREE)
+        log.debug("Source is set to %s ready state", res)
+        return res
 
     @property
     def image_path(self):

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -21,6 +21,7 @@ import os
 import stat
 
 from pyanaconda.core.constants import INSTALL_TREE
+from pyanaconda.core.signal import Signal
 from pyanaconda.modules.payload.base.constants import SourceType
 from pyanaconda.modules.payload.base.source_base import PayloadSourceBase
 from pyanaconda.modules.payload.sources.live_os_interface import LiveOSSourceInterface
@@ -37,6 +38,7 @@ class LiveOSSourceModule(PayloadSourceBase):
     def __init__(self):
         super().__init__()
         self._image_path = ""
+        self.image_path_changed = Signal()
 
     @property
     def kind(self):
@@ -53,14 +55,15 @@ class LiveOSSourceModule(PayloadSourceBase):
         """
         return self._image_path
 
-    @image_path.setter
-    def image_path(self, image_path):
+    def set_image_path(self, image_path):
         """Set path to the live os OS image.
 
         :param image_path: path to the image
         :type image_path: str
         """
         self._image_path = image_path
+        self.image_path_changed.emit()
+        log.debug("LiveOS image path is set to '%s'", self._image_path)
 
     def for_publication(self):
         """Get the interface used to publish this source."""

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -17,22 +17,34 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.modules.payload.base.source_base import PayloadSourceBase
 from pyanaconda.modules.payload.sources.live_os_interface import LiveOSSourceInterface
+from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask
 
 
 class LiveOSSourceModule(PayloadSourceBase):
     """The Live OS source payload module."""
 
-    def __init__(self):
+    def __init__(self, image_path):
         super().__init__()
+        self._image_path = image_path
 
     def for_publication(self):
         """Get the interface used to publish this source."""
         return LiveOSSourceInterface(self)
 
     def set_up_with_tasks(self):
-        pass
+        """Set up the installation source for installation.
+
+        :return: list of tasks required for the source setup
+        :rtype: [Task]
+        """
+        task = SetUpInstallationSourceTask(self._image_path, INSTALL_TREE)
+
+        task.succeeded_signal.connect(lambda: self._set_is_ready(True))
+
+        return [task]
 
     def tear_down_with_tasks(self):
         pass

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -33,8 +33,27 @@ log = get_module_logger(__name__)
 class LiveOSSourceModule(PayloadSourceBase):
     """The Live OS source payload module."""
 
-    def __init__(self, image_path):
+    def __init__(self):
         super().__init__()
+        self._image_path = ""
+
+    @property
+    def image_path(self):
+        """Path to the source live OS image.
+
+        This image will be used for the installation.
+
+        :rtype: str
+        """
+        return self._image_path
+
+    @image_path.setter
+    def image_path(self, image_path):
+        """Set path to the live os OS image.
+
+        :param image_path: path to the image
+        :type image_path: str
+        """
         self._image_path = image_path
 
     def for_publication(self):

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -118,20 +118,3 @@ class LiveOSSourceModule(PayloadSourceBase):
         task.succeeded_signal.connect(lambda: self._set_is_ready(False))
 
         return [task]
-
-    def validate(self):
-        """Test if the image exists on the given path.
-
-        :return: True if file on the path exists.
-        """
-        try:
-            res = stat.S_ISBLK(os.stat(self._image_path)[stat.ST_MODE])
-            if res:
-                log.debug("Live OS source is valid %s", self._image_path)
-                return True
-            else:
-                log.warning("Live OS source is not valid %s", self._image_path)
-        except FileNotFoundError:
-            log.warning("Live OS source is not available %s", self._image_path)
-
-        return False

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -21,6 +21,7 @@ import os
 import stat
 
 from pyanaconda.core.constants import INSTALL_TREE
+from pyanaconda.modules.payload.base.constants import SourceType
 from pyanaconda.modules.payload.base.source_base import PayloadSourceBase
 from pyanaconda.modules.payload.sources.live_os_interface import LiveOSSourceInterface
 from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask, \
@@ -36,6 +37,11 @@ class LiveOSSourceModule(PayloadSourceBase):
     def __init__(self):
         super().__init__()
         self._image_path = ""
+
+    @property
+    def kind(self):
+        """Get type of this source."""
+        return SourceType.LIVE_OS_IMAGE
 
     @property
     def image_path(self):

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -26,8 +26,8 @@ from pyanaconda.core.util import execWithCapture
 from pyanaconda.modules.payload.base.constants import SourceType
 from pyanaconda.modules.payload.base.source_base import PayloadSourceBase
 from pyanaconda.modules.payload.sources.live_os_interface import LiveOSSourceInterface
-from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask, \
-    TearDownInstallationSourceTask
+from pyanaconda.modules.payload.sources.initialization import SetUpLiveOSSourceTask, \
+    TearDownLiveOSSourceTask
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -101,7 +101,7 @@ class LiveOSSourceModule(PayloadSourceBase):
         :return: list of tasks required for the source setup
         :rtype: [Task]
         """
-        task = SetUpInstallationSourceTask(self._image_path, INSTALL_TREE)
+        task = SetUpLiveOSSourceTask(self._image_path, INSTALL_TREE)
 
         task.succeeded_signal.connect(lambda: self._set_is_ready(True))
 
@@ -113,7 +113,7 @@ class LiveOSSourceModule(PayloadSourceBase):
         :return: list of tasks required for the source clean-up
         :rtype: [Task]
         """
-        task = TearDownInstallationSourceTask(INSTALL_TREE)
+        task = TearDownLiveOSSourceTask(INSTALL_TREE)
 
         task.succeeded_signal.connect(lambda: self._set_is_ready(False))
 

--- a/pyanaconda/modules/payload/sources/live_os.py
+++ b/pyanaconda/modules/payload/sources/live_os.py
@@ -23,7 +23,8 @@ import stat
 from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.modules.payload.base.source_base import PayloadSourceBase
 from pyanaconda.modules.payload.sources.live_os_interface import LiveOSSourceInterface
-from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask
+from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask, \
+    TearDownInstallationSourceTask
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -53,7 +54,16 @@ class LiveOSSourceModule(PayloadSourceBase):
         return [task]
 
     def tear_down_with_tasks(self):
-        pass
+        """Tear down the installation source for installation.
+
+        :return: list of tasks required for the source clean-up
+        :rtype: [Task]
+        """
+        task = TearDownInstallationSourceTask(INSTALL_TREE)
+
+        task.succeeded_signal.connect(lambda: self._set_is_ready(False))
+
+        return [task]
 
     def validate(self):
         """Test if the image exists on the given path.

--- a/pyanaconda/modules/payload/sources/live_os_interface.py
+++ b/pyanaconda/modules/payload/sources/live_os_interface.py
@@ -18,6 +18,8 @@
 # Red Hat, Inc.
 #
 from pyanaconda.dbus.interface import dbus_interface
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
+from pyanaconda.dbus.property import emits_properties_changed
 from pyanaconda.modules.common.constants.interfaces import PAYLOAD_SOURCE_LIVE_OS
 from pyanaconda.modules.payload.base.source_base_interface import PayloadSourceBaseInterface
 
@@ -25,4 +27,23 @@ from pyanaconda.modules.payload.base.source_base_interface import PayloadSourceB
 @dbus_interface(PAYLOAD_SOURCE_LIVE_OS.interface_name)
 class LiveOSSourceInterface(PayloadSourceBaseInterface):
     """Interface for the payload Live OS image source."""
-    pass
+
+    def connect_signals(self):
+        super().connect_signals()
+        self.watch_property("ImagePath", self.implementation.image_path_changed)
+
+    @property
+    def ImagePath(self) -> Str:
+        """Get the path to the Live OS base image.
+
+        This image will be used as the installation.
+        """
+        return self.implementation.image_path
+
+    @emits_properties_changed
+    def SetImagePath(self, image_path: Str):
+        """Set the path to the Live OS base image.
+
+        This image will be used as the installation source.
+        """
+        self.implementation.set_image_path(image_path)

--- a/pyanaconda/modules/payload/sources/live_os_interface.py
+++ b/pyanaconda/modules/payload/sources/live_os_interface.py
@@ -1,0 +1,28 @@
+#
+# DBus interface for payload Live OS image source.
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.dbus.interface import dbus_interface
+from pyanaconda.modules.common.constants.interfaces import PAYLOAD_SOURCE_LIVE_OS
+from pyanaconda.modules.payload.base.source_base_interface import PayloadSourceBaseInterface
+
+
+@dbus_interface(PAYLOAD_SOURCE_LIVE_OS.interface_name)
+class LiveOSSourceInterface(PayloadSourceBaseInterface):
+    """Interface for the payload Live OS image source."""
+    pass

--- a/pyanaconda/modules/payload/sources/live_os_interface.py
+++ b/pyanaconda/modules/payload/sources/live_os_interface.py
@@ -47,3 +47,10 @@ class LiveOSSourceInterface(PayloadSourceBaseInterface):
         This image will be used as the installation source.
         """
         self.implementation.set_image_path(image_path)
+
+    def DetectLiveOSImage(self) -> Str:
+        """Try to find valid live os image.
+
+        :return: path to the base image
+        """
+        return self.implementation.detect_live_os_image()

--- a/tests/nosetests/pyanaconda_tests/__init__.py
+++ b/tests/nosetests/pyanaconda_tests/__init__.py
@@ -177,11 +177,32 @@ def check_task_creation(test, task_path, publisher, task_class):
     :param task_path: DBus path of the task
     :param publisher: Mock instance of the pyanaconda.dbus.DBus.publish_object
     :param task_class: class of the tested task
+
+    :return: instance of the task
     """
     obj = check_dbus_object_creation(test, task_path, publisher, task_class)
     test.assertIsInstance(obj, TaskInterface)
 
     return obj
+
+
+def check_task_creation_list(test, task_paths, publisher, task_classes):
+    """Check that the list of DBus task is correctly created.
+
+    :param test: instance of TestCase
+    :param task_paths: DBus paths of the tasks
+    :type task_paths: [str]
+    :param publisher: Mock instance of the pyanaconda.dbus.DBus.publish_object
+    :param task_classes: list of classes of the tested tasks; the order is important here
+
+    :return: list of instances of tasks
+    """
+    res = []
+
+    for i in range(len(task_paths)):
+        res.append(check_task_creation(test, task_paths[i], publisher, task_classes[i]))
+
+    return res
 
 
 def check_dbus_object_creation(test, path, publisher, klass):

--- a/tests/nosetests/pyanaconda_tests/__init__.py
+++ b/tests/nosetests/pyanaconda_tests/__init__.py
@@ -26,6 +26,7 @@ from unittest.mock import Mock, patch
 from xml.etree import ElementTree
 
 from pyanaconda.core.constants import DEFAULT_LANG
+from pyanaconda.dbus.template import InterfaceTemplate
 from pyanaconda.modules.common.constants.interfaces import KICKSTART_MODULE
 from pyanaconda.modules.common.task import TaskInterface
 from pyanaconda.dbus.xml import XMLGenerator
@@ -177,12 +178,26 @@ def check_task_creation(test, task_path, publisher, task_class):
     :param publisher: Mock instance of the pyanaconda.dbus.DBus.publish_object
     :param task_class: class of the tested task
     """
+    obj = check_dbus_object_creation(test, task_path, publisher, task_class)
+    test.assertIsInstance(obj, TaskInterface)
+
+    return obj
+
+
+def check_dbus_object_creation(test, path, publisher, klass):
+    """Check that the custom DBus object is correctly created.
+
+    :param test: instance of TestCase
+    :param task: DBus path of the published object
+    :param publisher: Mock instance of the pyanaconda.dbus.DBus.publish_object
+    :param klass: class of the tested DBus object
+    """
     publisher.assert_called_once()
     object_path, obj = publisher.call_args[0]
 
-    test.assertEqual(task_path, object_path)
-    test.assertIsInstance(obj, TaskInterface)
-    test.assertIsInstance(obj.implementation, task_class)
+    test.assertEqual(path, object_path)
+    test.assertIsInstance(obj.implementation, klass)
+    test.assertIsInstance(obj, InterfaceTemplate)
 
     return obj
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -123,15 +123,6 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
             self.live_os_interface.PreInstallWithTask()
 
     @patch_dbus_publish_object
-    def prepare_system_for_installation_task_source_not_ready_test(self, publisher):
-        """Test Live OS prepare installation task with a not ready source fail."""
-        source = LiveOSSourceModule()
-        self.live_os_module.set_sources([source])
-
-        with self.assertRaises(SourceSetupError):
-            self.live_os_interface.PreInstallWithTask()
-
-    @patch_dbus_publish_object
     def teardown_installation_source_task_test(self, publisher):
         """Test Live OS is able to create a teardown installation source task."""
         self._prepare_and_use_source()
@@ -152,15 +143,6 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
     @patch_dbus_publish_object
     def install_with_task_no_source_test(self, publisher):
         """Test Live OS install with tasks with no source fail."""
-        with self.assertRaises(SourceSetupError):
-            self.live_os_interface.InstallWithTask()
-
-    @patch_dbus_publish_object
-    def install_with_task_source_not_ready_test(self, publisher):
-        """Test Live OS installation task with a not ready source fail."""
-        source = LiveOSSourceModule()
-        self.live_os_module.set_sources([source])
-
         with self.assertRaises(SourceSetupError):
             self.live_os_interface.InstallWithTask()
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -85,41 +85,6 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
         self.assertListEqual(self.live_os_interface.GetKernelVersionList(), kernel_list)
         kernel_list_callback.assert_called_once_with(kernel_list)
 
-    @patch("pyanaconda.modules.payload.live.live_os.stat")
-    @patch("pyanaconda.modules.payload.live.live_os.os.stat")
-    def detect_live_os_image_failed_block_device_test(self, os_stat_mock, stat_mock):
-        """Test Live OS image detection failed block device check."""
-        # we have to patch this even thought that result is used in another mock
-        # otherwise we will skip the whole sequence
-        os_stat_mock.return_value = {stat_mock.ST_MODE: "whatever"}
-
-        stat_mock.S_ISBLK = Mock()
-        stat_mock.S_ISBLK.return_value = False
-
-        self.assertEqual(self.live_os_interface.DetectLiveOSImage(), "")
-
-    @patch("pyanaconda.modules.payload.live.live_os.os.stat")
-    def detect_live_os_image_failed_nothing_found_test(self, os_stat_mock):
-        """Test Live OS image detection failed missing file."""
-        # we have to patch this even thought that result is used in another mock
-        # otherwise we will skip the whole sequence
-        os_stat_mock.side_effect = FileNotFoundError()
-
-        self.assertEqual(self.live_os_interface.DetectLiveOSImage(), "")
-
-    @patch("pyanaconda.modules.payload.live.live_os.stat")
-    @patch("pyanaconda.modules.payload.live.live_os.os.stat")
-    def detect_live_os_image_test(self, os_stat_mock, stat_mock):
-        """Test Live OS image detection."""
-        # we have to patch this even thought that result is used in another mock
-        # otherwise we will skip the whole sequence
-        stat_mock.S_ISBLK = Mock(return_value=True)
-
-        detected_image = self.live_os_interface.DetectLiveOSImage()
-        stat_mock.S_ISBLK.assert_called_once()
-
-        self.assertEqual(detected_image, "/dev/mapper/live-base")
-
     @patch_dbus_publish_object
     def setup_installation_source_task_test(self, publisher):
         """Test Live OS is able to create a setup installation source task."""

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -30,9 +30,9 @@ from pyanaconda.modules.payload.base.initialization import PrepareSystemForInsta
     CopyDriverDisksFilesTask
 from pyanaconda.modules.payload.live.live_os import LiveOSHandlerModule
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
-from pyanaconda.modules.payload.live.initialization import TeardownInstallationSourceTask, \
-    UpdateBLSConfigurationTask
-from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask
+from pyanaconda.modules.payload.live.initialization import UpdateBLSConfigurationTask
+from pyanaconda.modules.payload.sources.initialization import TearDownInstallationSourceTask, \
+    SetUpInstallationSourceTask
 from pyanaconda.modules.payload.live.installation import InstallFromImageTask
 
 
@@ -150,7 +150,7 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
         """Test Live OS is able to create a teardown installation source task."""
         task_path = self.live_os_interface.TeardownInstallationSourceWithTask()
 
-        check_task_creation(self, task_path, publisher, TeardownInstallationSourceTask)
+        check_task_creation(self, task_path, publisher, TearDownInstallationSourceTask)
 
     @patch_dbus_publish_object
     def install_with_task_test(self, publisher):

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -19,7 +19,7 @@
 #
 import unittest
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch, create_autospec
 
 from tests.nosetests.pyanaconda_tests import check_task_creation, patch_dbus_publish_object
 
@@ -28,6 +28,7 @@ from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.task.task_interface import TaskInterface
 from pyanaconda.modules.payload.base.initialization import PrepareSystemForInstallationTask, \
     CopyDriverDisksFilesTask, SetUpSourcesTask, TearDownSourcesTask
+from pyanaconda.modules.payload.base.constants import SourceType
 from pyanaconda.modules.payload.live.live_os import LiveOSHandlerModule
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
 from pyanaconda.modules.payload.live.initialization import UpdateBLSConfigurationTask
@@ -45,9 +46,10 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
         self.live_os_interface.PropertiesChanged.connect(self.callback)
 
     def _prepare_and_use_source(self):
-        source = LiveOSSourceModule()
-        source.set_image_path("/test/path")
-        source._is_ready = True
+        source = create_autospec(LiveOSSourceModule())
+        source.image_path = "/test/path"
+        source.type = SourceType.LIVE_OS_IMAGE
+        source.is_ready.return_value = True
 
         self.live_os_module.set_sources([source])
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -32,8 +32,8 @@ from pyanaconda.modules.payload.base.initialization import PrepareSystemForInsta
 from pyanaconda.modules.payload.live.live_os import LiveOSHandlerModule
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
 from pyanaconda.modules.payload.live.initialization import UpdateBLSConfigurationTask
-from pyanaconda.modules.payload.sources.initialization import TearDownInstallationSourceTask, \
-    SetUpInstallationSourceTask
+from pyanaconda.modules.payload.sources.initialization import \
+    TearDownLiveOSSourceTask, SetUpLiveOSSourceTask
 from pyanaconda.modules.payload.sources.live_os import LiveOSSourceModule
 from pyanaconda.modules.payload.live.installation import InstallFromImageTask
 
@@ -105,7 +105,7 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
 
         # Live os has only one task now
         self.assertEqual(len(task_paths), 1)
-        check_task_creation(self, task_paths[0], publisher, SetUpInstallationSourceTask)
+        check_task_creation(self, task_paths[0], publisher, SetUpLiveOSSourceTask)
 
     @patch_dbus_publish_object
     def prepare_system_for_installation_task_test(self, publisher):
@@ -129,7 +129,7 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
 
         task_path = self.live_os_interface.TeardownInstallationSourceWithTasks()
 
-        check_task_creation_list(self, task_path, publisher, [TearDownInstallationSourceTask])
+        check_task_creation_list(self, task_path, publisher, [TearDownLiveOSSourceTask])
 
     @patch_dbus_publish_object
     def install_with_task_test(self, publisher):

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -35,7 +35,7 @@ from pyanaconda.modules.payload.live.live_os import LiveOSHandlerModule
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
 from pyanaconda.modules.payload.live.initialization import TeardownInstallationSourceTask, \
     UpdateBLSConfigurationTask
-from pyanaconda.modules.payload.sources.initialization import SetupInstallationSourceTask
+from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask
 from pyanaconda.modules.payload.live.installation import InstallFromImageTask
 
 
@@ -139,7 +139,7 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
         """Test Live OS is able to create a setup installation source task."""
         task_path = self.live_os_interface.SetupInstallationSourceWithTask()
 
-        check_task_creation(self, task_path, publisher, SetupInstallationSourceTask)
+        check_task_creation(self, task_path, publisher, SetUpInstallationSourceTask)
 
     @patch_dbus_publish_object
     def prepare_system_for_installation_task_test(self, publisher):
@@ -213,7 +213,7 @@ class LiveOSHandlerTasksTestCase(unittest.TestCase):
 
         mount.return_value = 0
 
-        SetupInstallationSourceTask(
+        SetUpInstallationSourceTask(
             "/path/to/base/image",
             "/path/to/mount/source/image"
         ).run()
@@ -230,7 +230,7 @@ class LiveOSHandlerTasksTestCase(unittest.TestCase):
         device_tree.ResolveDevice.return_value = ""
 
         with self.assertRaises(SourceSetupError):
-            SetupInstallationSourceTask(
+            SetUpInstallationSourceTask(
                 "/path/to/base/image",
                 "/path/to/mount/source/image"
             ).run()
@@ -255,7 +255,7 @@ class LiveOSHandlerTasksTestCase(unittest.TestCase):
         mount.return_value = -20
 
         with self.assertRaises(SourceSetupError):
-            SetupInstallationSourceTask(
+            SetUpInstallationSourceTask(
                 "/path/to/base/image",
                 "/path/to/mount/source/image"
             ).run()

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -25,6 +25,7 @@ from tests.nosetests.pyanaconda_tests import check_task_creation, check_task_cre
     patch_dbus_publish_object
 
 from pyanaconda.core.constants import INSTALL_TREE
+from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.task.task_interface import TaskInterface
 from pyanaconda.modules.payload.base.initialization import PrepareSystemForInstallationTask, \
     CopyDriverDisksFilesTask
@@ -116,6 +117,21 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
         check_task_creation(self, task_path, publisher, PrepareSystemForInstallationTask)
 
     @patch_dbus_publish_object
+    def prepare_system_for_installation_task_no_source_test(self, publisher):
+        """Test Live OS prepare installation task with no source fail."""
+        with self.assertRaises(SourceSetupError):
+            self.live_os_interface.PreInstallWithTask()
+
+    @patch_dbus_publish_object
+    def prepare_system_for_installation_task_source_not_ready_test(self, publisher):
+        """Test Live OS prepare installation task with a not ready source fail."""
+        source = LiveOSSourceModule()
+        self.live_os_module.attach_source(source)
+
+        with self.assertRaises(SourceSetupError):
+            self.live_os_interface.PreInstallWithTask()
+
+    @patch_dbus_publish_object
     def teardown_installation_source_task_test(self, publisher):
         """Test Live OS is able to create a teardown installation source task."""
         self._prepare_and_use_source()
@@ -132,6 +148,21 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
         task_path = self.live_os_interface.InstallWithTask()
 
         check_task_creation(self, task_path, publisher, InstallFromImageTask)
+
+    @patch_dbus_publish_object
+    def install_with_task_no_source_test(self, publisher):
+        """Test Live OS install with tasks with no source fail."""
+        with self.assertRaises(SourceSetupError):
+            self.live_os_interface.InstallWithTask()
+
+    @patch_dbus_publish_object
+    def install_with_task_source_not_ready_test(self, publisher):
+        """Test Live OS installation task with a not ready source fail."""
+        source = LiveOSSourceModule()
+        self.live_os_module.attach_source(source)
+
+        with self.assertRaises(SourceSetupError):
+            self.live_os_interface.InstallWithTask()
 
     @patch_dbus_publish_object
     def post_install_with_tasks_test(self, publisher):

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -21,19 +21,16 @@ import unittest
 
 from mock import Mock, patch
 
-from tests.nosetests.pyanaconda_tests import check_task_creation, check_task_creation_list, \
-    patch_dbus_publish_object
+from tests.nosetests.pyanaconda_tests import check_task_creation, patch_dbus_publish_object
 
 from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.task.task_interface import TaskInterface
 from pyanaconda.modules.payload.base.initialization import PrepareSystemForInstallationTask, \
-    CopyDriverDisksFilesTask
+    CopyDriverDisksFilesTask, SetUpSourcesTask, TearDownSourcesTask
 from pyanaconda.modules.payload.live.live_os import LiveOSHandlerModule
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
 from pyanaconda.modules.payload.live.initialization import UpdateBLSConfigurationTask
-from pyanaconda.modules.payload.sources.initialization import \
-    TearDownLiveOSSourceTask, SetUpLiveOSSourceTask
 from pyanaconda.modules.payload.sources.live_os import LiveOSSourceModule
 from pyanaconda.modules.payload.live.installation import InstallFromImageTask
 
@@ -97,15 +94,13 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
         kernel_list_callback.assert_called_once_with(kernel_list)
 
     @patch_dbus_publish_object
-    def setup_installation_source_task_test(self, publisher):
-        """Test Live OS is able to create a setup installation source task."""
+    def set_up_installation_sources_task_test(self, publisher):
+        """Test Live OS is able to create a set up installation sources task."""
         self._prepare_and_use_source()
 
-        task_paths = self.live_os_interface.SetupInstallationSourceWithTasks()
+        task_path = self.live_os_interface.SetUpSourcesWithTask()
 
-        # Live os has only one task now
-        self.assertEqual(len(task_paths), 1)
-        check_task_creation(self, task_paths[0], publisher, SetUpLiveOSSourceTask)
+        check_task_creation(self, task_path, publisher, SetUpSourcesTask)
 
     @patch_dbus_publish_object
     def prepare_system_for_installation_task_test(self, publisher):
@@ -123,13 +118,13 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
             self.live_os_interface.PreInstallWithTask()
 
     @patch_dbus_publish_object
-    def teardown_installation_source_task_test(self, publisher):
-        """Test Live OS is able to create a teardown installation source task."""
+    def tear_down_installation_source_task_test(self, publisher):
+        """Test Live OS is able to create a tear down installation sources task."""
         self._prepare_and_use_source()
 
-        task_path = self.live_os_interface.TeardownInstallationSourceWithTasks()
+        task_path = self.live_os_interface.TearDownSourcesWithTask()
 
-        check_task_creation_list(self, task_path, publisher, [TearDownLiveOSSourceTask])
+        check_task_creation(self, task_path, publisher, TearDownSourcesTask)
 
     @patch_dbus_publish_object
     def install_with_task_test(self, publisher):

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -33,8 +33,9 @@ from pyanaconda.modules.payload.base.initialization import PrepareSystemForInsta
     CopyDriverDisksFilesTask
 from pyanaconda.modules.payload.live.live_os import LiveOSHandlerModule
 from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInterface
-from pyanaconda.modules.payload.live.initialization import SetupInstallationSourceTask, \
-    TeardownInstallationSourceTask, UpdateBLSConfigurationTask
+from pyanaconda.modules.payload.live.initialization import TeardownInstallationSourceTask, \
+    UpdateBLSConfigurationTask
+from pyanaconda.modules.payload.sources.initialization import SetupInstallationSourceTask
 from pyanaconda.modules.payload.live.installation import InstallFromImageTask
 
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -24,7 +24,6 @@ from mock import Mock, patch
 from tests.nosetests.pyanaconda_tests import check_task_creation, patch_dbus_publish_object
 
 from pyanaconda.core.constants import INSTALL_TREE
-from pyanaconda.modules.common.constants.objects import LIVE_OS_HANDLER
 from pyanaconda.modules.common.task.task_interface import TaskInterface
 from pyanaconda.modules.payload.base.initialization import PrepareSystemForInstallationTask, \
     CopyDriverDisksFilesTask
@@ -33,6 +32,7 @@ from pyanaconda.modules.payload.live.live_os_interface import LiveOSHandlerInter
 from pyanaconda.modules.payload.live.initialization import UpdateBLSConfigurationTask
 from pyanaconda.modules.payload.sources.initialization import TearDownInstallationSourceTask, \
     SetUpInstallationSourceTask
+from pyanaconda.modules.payload.sources.live_os import LiveOSSourceModule
 from pyanaconda.modules.payload.live.installation import InstallFromImageTask
 
 
@@ -44,17 +44,6 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
 
         self.callback = Mock()
         self.live_os_interface.PropertiesChanged.connect(self.callback)
-
-    def image_path_empty_properties_test(self):
-        """Test Live OS handler image path property when not set."""
-        self.assertEqual(self.live_os_interface.ImagePath, "")
-
-    def image_path_properties_test(self):
-        """Test Live OS handler image path property is correctly set."""
-        self.live_os_interface.SetImagePath("/my/supper/image/path")
-        self.assertEqual(self.live_os_interface.ImagePath, "/my/supper/image/path")
-        self.callback.assert_called_once_with(
-            LIVE_OS_HANDLER.interface_name, {"ImagePath": "/my/supper/image/path"}, [])
 
     @patch("pyanaconda.modules.payload.live.live_os.get_dir_size")
     def space_required_properties_test(self, get_dir_size_mock):
@@ -134,6 +123,11 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
     @patch_dbus_publish_object
     def setup_installation_source_task_test(self, publisher):
         """Test Live OS is able to create a setup installation source task."""
+        source = LiveOSSourceModule()
+        source.set_image_path("/test/path")
+
+        self.live_os_module.add_source(source)
+
         task_path = self.live_os_interface.SetupInstallationSourceWithTask()
 
         check_task_creation(self, task_path, publisher, SetUpInstallationSourceTask)

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -52,7 +52,7 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
         source.set_image_path("/test/path")
         source._is_ready = True
 
-        self.live_os_module.add_source(source)
+        self.live_os_module.set_sources([source])
 
         return source
 
@@ -126,7 +126,7 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
     def prepare_system_for_installation_task_source_not_ready_test(self, publisher):
         """Test Live OS prepare installation task with a not ready source fail."""
         source = LiveOSSourceModule()
-        self.live_os_module.attach_source(source)
+        self.live_os_module.set_sources([source])
 
         with self.assertRaises(SourceSetupError):
             self.live_os_interface.PreInstallWithTask()
@@ -159,7 +159,7 @@ class LiveOSHandlerInterfaceTestCase(unittest.TestCase):
     def install_with_task_source_not_ready_test(self, publisher):
         """Test Live OS installation task with a not ready source fail."""
         source = LiveOSSourceModule()
-        self.live_os_module.attach_source(source)
+        self.live_os_module.set_sources([source])
 
         with self.assertRaises(SourceSetupError):
             self.live_os_interface.InstallWithTask()

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_test.py
@@ -203,6 +203,26 @@ class LiveTasksTestCase(unittest.TestCase):
 
     @patch("pyanaconda.modules.payload.live.installation.create_rescue_image")
     @patch("pyanaconda.modules.payload.live.installation.execWithRedirect")
+    def install_image_task_source_unready_test(self, exec_with_redirect, create_rescue_image_mock):
+        """Test installation from an image task when source is not ready."""
+        dest_path = "/destination/path"
+        kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
+        source = Mock()
+        exec_with_redirect.return_value = 0
+
+        InstallFromImageTask(dest_path, kernel_version_list, source).run()
+
+        expected_rsync_args = ["-pogAXtlHrDx", "--exclude", "/dev/", "--exclude", "/proc/",
+                               "--exclude", "/tmp/*", "--exclude", "/sys/", "--exclude", "/run/",
+                               "--exclude", "/boot/*rescue*", "--exclude", "/boot/loader/",
+                               "--exclude", "/boot/efi/loader/",
+                               "--exclude", "/etc/machine-id", INSTALL_TREE + "/", dest_path]
+
+        exec_with_redirect.assert_called_once_with("rsync", expected_rsync_args)
+        create_rescue_image_mock.assert_called_once_with(dest_path, kernel_version_list)
+
+    @patch("pyanaconda.modules.payload.live.installation.create_rescue_image")
+    @patch("pyanaconda.modules.payload.live.installation.execWithRedirect")
     def install_image_task_failed_exception_test(self, exec_with_redirect,
                                                  create_rescue_image_mock):
         """Test installation from an image task with exception."""

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_test.py
@@ -21,7 +21,7 @@ import os
 import stat
 import unittest
 
-from mock import patch, call
+from unittest.mock import patch, call, Mock
 from tempfile import TemporaryDirectory
 
 from pyanaconda.core.constants import INSTALL_TREE
@@ -187,9 +187,10 @@ class LiveTasksTestCase(unittest.TestCase):
         """Test installation from an image task."""
         dest_path = "/destination/path"
         kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
+        source = Mock()
         exec_with_redirect.return_value = 0
 
-        InstallFromImageTask(dest_path, kernel_version_list).run()
+        InstallFromImageTask(dest_path, kernel_version_list, source).run()
 
         expected_rsync_args = ["-pogAXtlHrDx", "--exclude", "/dev/", "--exclude", "/proc/",
                                "--exclude", "/tmp/*", "--exclude", "/sys/", "--exclude", "/run/",
@@ -207,11 +208,12 @@ class LiveTasksTestCase(unittest.TestCase):
         """Test installation from an image task with exception."""
         dest_path = "/destination/path"
         kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
+        source = Mock()
         exec_with_redirect.side_effect = OSError("mock exception")
 
         with self.assertLogs(level="ERROR") as cm:
             with self.assertRaises(InstallError):
-                InstallFromImageTask(dest_path, kernel_version_list).run()
+                InstallFromImageTask(dest_path, kernel_version_list, source).run()
 
             self.assertTrue(any(map(lambda x: "mock exception" in x, cm.output)))
 
@@ -231,11 +233,12 @@ class LiveTasksTestCase(unittest.TestCase):
         """Test installation from an image task with bad return code."""
         dest_path = "/destination/path"
         kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
+        source = Mock()
         exec_with_redirect.return_value = 11
 
         with self.assertLogs(level="INFO") as cm:
             with self.assertRaises(InstallError):
-                InstallFromImageTask(dest_path, kernel_version_list).run()
+                InstallFromImageTask(dest_path, kernel_version_list, source).run()
 
             self.assertTrue(any(map(lambda x: "exited with code 11" in x, cm.output)))
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
@@ -24,6 +24,7 @@ from mock import Mock, patch
 from pyanaconda.dbus.typing import get_native
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.structures.storage import DeviceData
+from pyanaconda.modules.payload.base.constants import SourceType
 from pyanaconda.modules.payload.sources.live_os import LiveOSSourceModule
 from pyanaconda.modules.payload.sources.live_os_interface import LiveOSSourceInterface
 from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask, \
@@ -35,6 +36,10 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
     def setUp(self):
         self.live_os_source_module = LiveOSSourceModule()
         self.live_os_source_interface = LiveOSSourceInterface(self.live_os_source_module)
+
+    def kind_test(self):
+        """Test Live OS source has a correct kind specified."""
+        self.assertEqual(SourceType.LIVE_OS_IMAGE.value, self.live_os_source_interface.Kind)
 
     @patch("pyanaconda.modules.payload.sources.live_os.stat")
     @patch("pyanaconda.modules.payload.sources.live_os.os.stat")
@@ -58,6 +63,10 @@ class LiveOSSourceTestCase(unittest.TestCase):
 
     def setUp(self):
         self.live_os_source_module = LiveOSSourceModule()
+
+    def kind_test(self):
+        """Test Live OS source module has a correct kind."""
+        self.assertEqual(SourceType.LIVE_OS_IMAGE, self.live_os_source_module.kind)
 
     def set_up_with_tasks_test(self):
         """Test Live OS Source set up call."""

--- a/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
@@ -58,6 +58,41 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
 
     @patch("pyanaconda.modules.payload.sources.live_os.stat")
     @patch("pyanaconda.modules.payload.sources.live_os.os.stat")
+    def detect_live_os_image_failed_block_device_test(self, os_stat_mock, stat_mock):
+        """Test Live OS image detection failed block device check."""
+        # we have to patch this even thought that result is used in another mock
+        # otherwise we will skip the whole sequence
+        os_stat_mock.return_value = {stat_mock.ST_MODE: "whatever"}
+
+        stat_mock.S_ISBLK = Mock()
+        stat_mock.S_ISBLK.return_value = False
+
+        self.assertEqual(self.live_os_source_interface.DetectLiveOSImage(), "")
+
+    @patch("pyanaconda.modules.payload.sources.live_os.os.stat")
+    def detect_live_os_image_failed_nothing_found_test(self, os_stat_mock):
+        """Test Live OS image detection failed missing file."""
+        # we have to patch this even thought that result is used in another mock
+        # otherwise we will skip the whole sequence
+        os_stat_mock.side_effect = FileNotFoundError()
+
+        self.assertEqual(self.live_os_source_interface.DetectLiveOSImage(), "")
+
+    @patch("pyanaconda.modules.payload.sources.live_os.stat")
+    @patch("pyanaconda.modules.payload.sources.live_os.os.stat")
+    def detect_live_os_image_test(self, os_stat_mock, stat_mock):
+        """Test Live OS image detection."""
+        # we have to patch this even thought that result is used in another mock
+        # otherwise we will skip the whole sequence
+        stat_mock.S_ISBLK = Mock(return_value=True)
+
+        detected_image = self.live_os_source_interface.DetectLiveOSImage()
+        stat_mock.S_ISBLK.assert_called_once()
+
+        self.assertEqual(detected_image, "/dev/mapper/live-base")
+
+    @patch("pyanaconda.modules.payload.sources.live_os.stat")
+    @patch("pyanaconda.modules.payload.sources.live_os.os.stat")
     def validate_test(self, os_stat_mock, stat_mock):
         """Test Live OS source validation call."""
         # we have to patch this even thought that result is used in another mock

--- a/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
@@ -91,23 +91,6 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
 
         self.assertEqual(detected_image, "/dev/mapper/live-base")
 
-    @patch("pyanaconda.modules.payload.sources.live_os.stat")
-    @patch("pyanaconda.modules.payload.sources.live_os.os.stat")
-    def validate_test(self, os_stat_mock, stat_mock):
-        """Test Live OS source validation call."""
-        # we have to patch this even thought that result is used in another mock
-        # otherwise we will skip the whole sequence
-        os_stat_mock.return_value = {stat_mock.ST_MODE: "evil is near!"}
-
-        stat_mock.S_ISBLK = Mock()
-        stat_mock.S_ISBLK.return_value = True
-
-        self.assertTrue(self.live_os_source_interface.Validate())
-
-    def validate_failed_test(self):
-        """Test Live OS source failed validation call."""
-        self.assertFalse(self.live_os_source_interface.Validate())
-
 
 class LiveOSSourceTestCase(unittest.TestCase):
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
@@ -28,8 +28,8 @@ from pyanaconda.modules.common.structures.storage import DeviceData
 from pyanaconda.modules.payload.base.constants import SourceType
 from pyanaconda.modules.payload.sources.live_os import LiveOSSourceModule
 from pyanaconda.modules.payload.sources.live_os_interface import LiveOSSourceInterface
-from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask, \
-    TearDownInstallationSourceTask
+from pyanaconda.modules.payload.sources.initialization import SetUpLiveOSSourceTask, \
+    TearDownLiveOSSourceTask
 
 
 class LiveOSSourceInterfaceTestCase(unittest.TestCase):
@@ -104,7 +104,7 @@ class LiveOSSourceTestCase(unittest.TestCase):
     def set_up_with_tasks_test(self):
         """Test Live OS Source set up call."""
         task_classes = [
-            SetUpInstallationSourceTask
+            SetUpLiveOSSourceTask
         ]
 
         # task will not be public so it won't be published
@@ -120,7 +120,7 @@ class LiveOSSourceTestCase(unittest.TestCase):
     def tear_down_with_tasks_test(self):
         """Test Live OS Source ready state for tear down."""
         task_classes = [
-            TearDownInstallationSourceTask
+            TearDownLiveOSSourceTask
         ]
 
         # task will not be public so it won't be published
@@ -183,7 +183,7 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
 
         mount.return_value = 0
 
-        SetUpInstallationSourceTask(
+        SetUpLiveOSSourceTask(
             "/path/to/base/image",
             "/path/to/mount/source/image"
         ).run()
@@ -200,7 +200,7 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
         device_tree.ResolveDevice.return_value = ""
 
         with self.assertRaises(SourceSetupError):
-            SetUpInstallationSourceTask(
+            SetUpLiveOSSourceTask(
                 "/path/to/base/image",
                 "/path/to/mount/source/image"
             ).run()
@@ -225,7 +225,7 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
         mount.return_value = -20
 
         with self.assertRaises(SourceSetupError):
-            SetUpInstallationSourceTask(
+            SetUpLiveOSSourceTask(
                 "/path/to/base/image",
                 "/path/to/mount/source/image"
             ).run()

--- a/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
@@ -1,0 +1,96 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+#
+import unittest
+
+from mock import Mock, patch
+
+from pyanaconda.dbus.typing import get_native
+from pyanaconda.modules.common.errors.payload import SourceSetupError
+from pyanaconda.modules.common.structures.storage import DeviceData
+from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask
+
+
+class LiveOSSourceTasksTestCase(unittest.TestCase):
+
+    @patch("pyanaconda.modules.payload.sources.initialization.mount")
+    @patch("pyanaconda.modules.payload.sources.initialization.stat")
+    @patch("os.stat")
+    @patch("pyanaconda.dbus.DBus.get_proxy")
+    def setup_install_source_task_test(self, proxy_getter, os_stat, stat, mount):
+        """Test Live OS Source setup installation source task."""
+        device_tree = Mock()
+        proxy_getter.return_value = device_tree
+        device_tree.ResolveDevice = Mock()
+        device_tree.ResolveDevice.return_value = "resolvedDeviceName"
+
+        device = DeviceData()
+        device.path = "/resolved/path/to/base/image"
+
+        device_tree.GetDeviceData = Mock()
+        device_tree.GetDeviceData.return_value = get_native(DeviceData.to_structure(device))
+
+        mount.return_value = 0
+
+        SetUpInstallationSourceTask(
+            "/path/to/base/image",
+            "/path/to/mount/source/image"
+        ).run()
+
+        device_tree.ResolveDevice.assert_called_once_with("/path/to/base/image")
+        os_stat.assert_called_once_with("/resolved/path/to/base/image")
+
+    @patch("pyanaconda.dbus.DBus.get_proxy")
+    def setup_install_source_task_missing_image_test(self, proxy_getter):
+        """Test Live OS Source setup installation source task missing image error."""
+        device_tree = Mock()
+        proxy_getter.return_value = device_tree
+        device_tree.ResolveDevice = Mock()
+        device_tree.ResolveDevice.return_value = ""
+
+        with self.assertRaises(SourceSetupError):
+            SetUpInstallationSourceTask(
+                "/path/to/base/image",
+                "/path/to/mount/source/image"
+            ).run()
+
+    @patch("pyanaconda.modules.payload.sources.initialization.mount")
+    @patch("pyanaconda.modules.payload.sources.initialization.stat")
+    @patch("os.stat")
+    @patch("pyanaconda.dbus.DBus.get_proxy")
+    def setup_install_source_task_failed_to_mount_test(self, proxy_getter, os_stat, stat, mount):
+        """Test Live OS Source setup installation source task mount error."""
+        device_tree = Mock()
+        proxy_getter.return_value = device_tree
+        device_tree.ResolveDevice = Mock()
+        device_tree.ResolveDevice.return_value = "resolvedDeviceName"
+
+        device = DeviceData()
+        device.path = "/resolved/path/to/base/image"
+
+        device_tree.GetDeviceData = Mock()
+        device_tree.GetDeviceData.return_value = get_native(DeviceData.to_structure(device))
+
+        mount.return_value = -20
+
+        with self.assertRaises(SourceSetupError):
+            SetUpInstallationSourceTask(
+                "/path/to/base/image",
+                "/path/to/mount/source/image"
+            ).run()

--- a/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
@@ -22,6 +22,7 @@ import unittest
 from mock import Mock, patch
 
 from pyanaconda.dbus.typing import get_native
+from pyanaconda.modules.common.constants.interfaces import PAYLOAD_SOURCE_LIVE_OS
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.structures.storage import DeviceData
 from pyanaconda.modules.payload.base.constants import SourceType
@@ -37,9 +38,23 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
         self.live_os_source_module = LiveOSSourceModule()
         self.live_os_source_interface = LiveOSSourceInterface(self.live_os_source_module)
 
+        self.callback = Mock()
+        self.live_os_source_interface.PropertiesChanged.connect(self.callback)
+
     def kind_test(self):
         """Test Live OS source has a correct kind specified."""
         self.assertEqual(SourceType.LIVE_OS_IMAGE.value, self.live_os_source_interface.Kind)
+
+    def image_path_empty_properties_test(self):
+        """Test Live OS handler image path property when not set."""
+        self.assertEqual(self.live_os_source_interface.ImagePath, "")
+
+    def image_path_properties_test(self):
+        """Test Live OS handler image path property is correctly set."""
+        self.live_os_source_interface.SetImagePath("/my/supper/image/path")
+        self.assertEqual(self.live_os_source_interface.ImagePath, "/my/supper/image/path")
+        self.callback.assert_called_once_with(
+            PAYLOAD_SOURCE_LIVE_OS.interface_name, {"ImagePath": "/my/supper/image/path"}, [])
 
     @patch("pyanaconda.modules.payload.sources.live_os.stat")
     @patch("pyanaconda.modules.payload.sources.live_os.os.stat")

--- a/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
@@ -33,7 +33,7 @@ from pyanaconda.modules.payload.sources.initialization import SetUpInstallationS
 class LiveOSSourceInterfaceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.live_os_source_module = LiveOSSourceModule("/mock/image/path")
+        self.live_os_source_module = LiveOSSourceModule()
         self.live_os_source_interface = LiveOSSourceInterface(self.live_os_source_module)
 
     @patch("pyanaconda.modules.payload.sources.live_os.stat")
@@ -57,7 +57,7 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
 class LiveOSSourceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.live_os_source_module = LiveOSSourceModule("/mock/image/path")
+        self.live_os_source_module = LiveOSSourceModule()
 
     def set_up_with_tasks_test(self):
         """Test Live OS Source set up call."""

--- a/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
@@ -25,7 +25,32 @@ from pyanaconda.dbus.typing import get_native
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.structures.storage import DeviceData
 from pyanaconda.modules.payload.sources.live_os import LiveOSSourceModule
+from pyanaconda.modules.payload.sources.live_os_interface import LiveOSSourceInterface
 from pyanaconda.modules.payload.sources.initialization import SetUpInstallationSourceTask
+
+
+class LiveOSSourceInterfaceTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.live_os_source_module = LiveOSSourceModule("/mock/image/path")
+        self.live_os_source_interface = LiveOSSourceInterface(self.live_os_source_module)
+
+    @patch("pyanaconda.modules.payload.sources.live_os.stat")
+    @patch("pyanaconda.modules.payload.sources.live_os.os.stat")
+    def validate_test(self, os_stat_mock, stat_mock):
+        """Test Live OS source validation call."""
+        # we have to patch this even thought that result is used in another mock
+        # otherwise we will skip the whole sequence
+        os_stat_mock.return_value = {stat_mock.ST_MODE: "evil is near!"}
+
+        stat_mock.S_ISBLK = Mock()
+        stat_mock.S_ISBLK.return_value = True
+
+        self.assertTrue(self.live_os_source_interface.Validate())
+
+    def validate_failed_test(self):
+        """Test Live OS source failed validation call."""
+        self.assertFalse(self.live_os_source_interface.Validate())
 
 
 class LiveOSSourceTestCase(unittest.TestCase):

--- a/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
@@ -41,9 +41,9 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
         self.callback = Mock()
         self.live_os_source_interface.PropertiesChanged.connect(self.callback)
 
-    def kind_test(self):
-        """Test Live OS source has a correct kind specified."""
-        self.assertEqual(SourceType.LIVE_OS_IMAGE.value, self.live_os_source_interface.Kind)
+    def type_test(self):
+        """Test Live OS source has a correct type specified."""
+        self.assertEqual(SourceType.LIVE_OS_IMAGE.value, self.live_os_source_interface.Type)
 
     def image_path_empty_properties_test(self):
         """Test Live OS handler image path property when not set."""
@@ -114,9 +114,9 @@ class LiveOSSourceTestCase(unittest.TestCase):
     def setUp(self):
         self.live_os_source_module = LiveOSSourceModule()
 
-    def kind_test(self):
-        """Test Live OS source module has a correct kind."""
-        self.assertEqual(SourceType.LIVE_OS_IMAGE, self.live_os_source_module.kind)
+    def type_test(self):
+        """Test Live OS source module has a correct type."""
+        self.assertEqual(SourceType.LIVE_OS_IMAGE, self.live_os_source_module.type)
 
     def set_up_with_tasks_test(self):
         """Test Live OS Source set up call."""

--- a/tests/nosetests/pyanaconda_tests/module_payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_test.py
@@ -28,15 +28,17 @@ from tests.nosetests.pyanaconda_tests import patch_dbus_publish_object
 
 from pyanaconda.modules.common.constants.objects import PAYLOAD_DEFAULT, LIVE_OS_HANDLER, \
     LIVE_IMAGE_HANDLER
-from pyanaconda.modules.payload.payload_interface import PayloadInterface
-from pyanaconda.modules.payload.payload import PayloadModule
-from pyanaconda.modules.payload.factory import HandlerType, HandlerFactory
-from pyanaconda.modules.payload.dnf.dnf import DNFHandlerModule
-from pyanaconda.modules.payload.live.live_image import LiveImageHandlerModule
-from pyanaconda.modules.payload.live.live_os import LiveOSHandlerModule
 from pyanaconda.modules.payload.base.utils import create_root_dir, write_module_blacklist, \
     get_dir_size
 from pyanaconda.modules.payload.base.initialization import PrepareSystemForInstallationTask
+from pyanaconda.modules.payload.factory import HandlerType, HandlerFactory, SourceType, \
+    SourceFactory
+from pyanaconda.modules.payload.payload_interface import PayloadInterface
+from pyanaconda.modules.payload.payload import PayloadModule
+from pyanaconda.modules.payload.dnf.dnf import DNFHandlerModule
+from pyanaconda.modules.payload.live.live_image import LiveImageHandlerModule
+from pyanaconda.modules.payload.live.live_os import LiveOSHandlerModule
+from pyanaconda.modules.payload.sources.live_os import LiveOSSourceModule
 
 
 class PayloadInterfaceTestCase(TestCase):
@@ -224,3 +226,8 @@ class FactoryTestCase(TestCase):
         data.liveimg.seen = False
         data.packages.seen = False
         self.assertIsNone(HandlerFactory.create_from_ks_data(data))
+
+    def create_source_test(self):
+        """Test SourceFactory create method."""
+        self.assertIsInstance(SourceFactory.create(SourceType.LIVE_OS_IMAGE),
+                              LiveOSSourceModule)

--- a/tests/nosetests/pyanaconda_tests/module_payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_test.py
@@ -24,7 +24,7 @@ from mock import patch, Mock
 from textwrap import dedent
 from tempfile import TemporaryDirectory
 
-from tests.nosetests.pyanaconda_tests import patch_dbus_publish_object
+from tests.nosetests.pyanaconda_tests import patch_dbus_publish_object, check_dbus_object_creation
 
 from pyanaconda.modules.common.constants.objects import PAYLOAD_DEFAULT, LIVE_OS_HANDLER, \
     LIVE_IMAGE_HANDLER
@@ -118,6 +118,19 @@ class PayloadInterfaceTestCase(TestCase):
         self.assertEqual(self.payload_interface.GetActiveHandlerPath(),
                          LIVE_OS_HANDLER.object_path)
         self.assertEqual(publisher.call_count, 3)
+
+    @patch_dbus_publish_object
+    def create_live_os_source_test(self, publisher):
+        """Test creation of the Live OS source module."""
+        source_path = self.payload_interface.CreateSource(SourceType.LIVE_OS_IMAGE.value)
+
+        check_dbus_object_creation(self, source_path, publisher, LiveOSSourceModule)
+
+    @patch_dbus_publish_object
+    def create_invalid_source_test(self, publisher):
+        """Test creation of the not existing source."""
+        with self.assertRaises(ValueError):
+            self.payload_interface.CreateSource("NotASource")
 
 
 class PayloadSharedTasksTest(TestCase):

--- a/tests/nosetests/pyanaconda_tests/module_payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_test.py
@@ -30,7 +30,7 @@ from pyanaconda.modules.common.constants.objects import PAYLOAD_DEFAULT, LIVE_OS
     LIVE_IMAGE_HANDLER
 from pyanaconda.modules.payload.payload_interface import PayloadInterface
 from pyanaconda.modules.payload.payload import PayloadModule
-from pyanaconda.modules.payload.handler_factory import HandlerType
+from pyanaconda.modules.payload.factory import HandlerType
 from pyanaconda.modules.payload.base.utils import create_root_dir, write_module_blacklist, \
     get_dir_size
 from pyanaconda.modules.payload.base.initialization import PrepareSystemForInstallationTask

--- a/tests/nosetests/pyanaconda_tests/module_payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_test.py
@@ -31,8 +31,8 @@ from pyanaconda.modules.common.constants.objects import PAYLOAD_DEFAULT, LIVE_OS
 from pyanaconda.modules.payload.base.utils import create_root_dir, write_module_blacklist, \
     get_dir_size
 from pyanaconda.modules.payload.base.initialization import PrepareSystemForInstallationTask
-from pyanaconda.modules.payload.factory import HandlerType, HandlerFactory, SourceType, \
-    SourceFactory
+from pyanaconda.modules.payload.factory import HandlerFactory, SourceFactory
+from pyanaconda.modules.payload.base.constants import HandlerType, SourceType
 from pyanaconda.modules.payload.payload_interface import PayloadInterface
 from pyanaconda.modules.payload.payload import PayloadModule
 from pyanaconda.modules.payload.dnf.dnf import DNFHandlerModule


### PR DESCRIPTION
This is a first payload source implementation which is applied to Live OS Source. The Live OS Source is specific for Live OS payload only.

Payload sources are designed this way:
* Payload handler must have at least one source but maximum is not set.
* The source set up and tear down is private API which will be used between payload and source.
* Move source set up and tear down logic from payload to source including API
* Source is created by main `Payload` API and then attached to the specific payload handler.
* All the sources have to implement `Validate` check which will do a quick check for the validity. Beware this will not tell you if the source is working but only if the source is really wrong.
* Sources DBus objects are dynamically created. 
* Payload handlers have list of supported sources to check if the source can be attached to the handler.

Workflow should look like this:
1) User use main payload API method `CreateSource` to create a new source and get the source path.
2) User will set up the source appropriately.
3) User will attach source to the payload handler by calling method `add_source` with a source DBus path. (this will get a public API in the future PR)
4) Payload will use these sources to get things done.

Future work:
* ~Add a possibility to remove attached source.~ set_sources can do that now.
* Add public API for the `add_source` method in shared API for handlers.
* Dynamically create targets of the installation and provide API to read these targets. For example directories for the NFS mount.
* Change directory structure of sources and handlers to make this consistent.