### PR TITLE
Extend the support for storage validation

### DIFF
--- a/pyanaconda/modules/common/structures/validation.py
+++ b/pyanaconda/modules/common/structures/validation.py
@@ -1,0 +1,68 @@
+#
+# DBus structures for validation.
+#
+# Copyright (C) 2019  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from pyanaconda.dbus.structure import DBusData
+from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
+
+__all__ = ["ValidationReport"]
+
+
+class ValidationReport(DBusData):
+    """The validation report."""
+
+    def __init__(self):
+        self._error_messages = []
+        self._warning_messages = []
+
+    def is_valid(self):
+        """Is the validation successful?
+
+        :return: True or False
+        """
+        return not self._error_messages
+
+    def get_messages(self):
+        """Get all messages.
+
+        :return: a list of strings
+        """
+        return self.error_messages + self.warning_messages
+
+    @property
+    def error_messages(self) -> List[Str]:
+        """List of error messages.
+
+        :return: a list of strings
+        """
+        return self._error_messages
+
+    @error_messages.setter
+    def error_messages(self, messages: List[Str]):
+        self._error_messages = list(messages)
+
+    @property
+    def warning_messages(self) -> List[Str]:
+        """List of warning messages.
+
+        :return: a list of strings
+        """
+        return self._warning_messages
+
+    @warning_messages.setter
+    def warning_messages(self, messages: List[Str]):
+        self._warning_messages = list(messages)

--- a/pyanaconda/modules/common/task/task.py
+++ b/pyanaconda/modules/common/task/task.py
@@ -25,7 +25,7 @@ from abc import abstractmethod
 
 from pyanaconda.core.constants import THREAD_DBUS_TASK
 from pyanaconda.dbus.publishable import Publishable
-from pyanaconda.modules.common.task.task_interface import TaskInterface
+from pyanaconda.modules.common.task.task_interface import TaskInterface, ValidationTaskInterface
 from pyanaconda.modules.common.task.cancellable import Cancellable
 from pyanaconda.modules.common.task.progress import ProgressReporter
 from pyanaconda.modules.common.task.result import ResultProvider
@@ -35,7 +35,7 @@ from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
-__all__ = ['AbstractTask', 'Task']
+__all__ = ['AbstractTask', 'Task', 'ValidationTask']
 
 
 class AbstractTask(Runnable, Cancellable, Publishable, ProgressReporter, ResultProvider):
@@ -142,3 +142,22 @@ class Task(AbstractTask):
             cls.__name__,
             cls._thread_counter
         )
+
+
+class ValidationTask(Task):
+    """Abstract class for running a validation task."""
+
+    def for_publication(self):
+        """Return a DBus representation."""
+        return ValidationTaskInterface(self)
+
+    @abstractmethod
+    def run(self):
+        """The validation implementation.
+
+        Run the validation and return an validation report
+        with error and warning messages.
+
+        :return: an instance of ValidationReport
+        """
+        return None

--- a/pyanaconda/modules/common/task/task_interface.py
+++ b/pyanaconda/modules/common/task/task_interface.py
@@ -20,14 +20,15 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.dbus.interface import dbus_interface, dbus_signal
+from pyanaconda.dbus.interface import dbus_interface, dbus_signal, dbus_class
 from pyanaconda.dbus.namespace import get_dbus_path
 from pyanaconda.modules.common.constants.interfaces import TASK
 from pyanaconda.dbus.template import InterfaceTemplate
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.errors.task import NoResultError
+from pyanaconda.modules.common.structures.validation import ValidationReport
 
-__all__ = ['TaskInterface']
+__all__ = ['TaskInterface', 'ValidationTaskInterface']
 
 
 @dbus_interface(TASK.interface_name)
@@ -148,3 +149,19 @@ class TaskInterface(InterfaceTemplate):
         """
         result = self.implementation.get_result()
         return self.convert_result(result)
+
+
+@dbus_class
+class ValidationTaskInterface(TaskInterface):
+    """DBus interface for a validation task."""
+
+    @staticmethod
+    def convert_result(value) -> Variant:
+        """Convert the validation report.
+
+        Convert the validation report into a variant.
+
+        :param value: a validation report
+        :return: a variant with the structure
+        """
+        return get_variant(Structure, ValidationReport.to_structure(value))

--- a/pyanaconda/modules/common/task/task_interface.py
+++ b/pyanaconda/modules/common/task/task_interface.py
@@ -21,7 +21,6 @@
 # Red Hat, Inc.
 #
 from pyanaconda.dbus.interface import dbus_interface, dbus_signal, dbus_class
-from pyanaconda.dbus.namespace import get_dbus_path
 from pyanaconda.modules.common.constants.interfaces import TASK
 from pyanaconda.dbus.template import InterfaceTemplate
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
@@ -37,21 +36,6 @@ class TaskInterface(InterfaceTemplate):
 
     This class has only interface of the Task. Logic will be implemented by each module.
     """
-
-    _task_counter = 1
-
-    @staticmethod
-    def get_object_path(namespace):
-        """Get the unique object path in the given namespace.
-
-        This method is not thread safe for now.
-
-        :param namespace: a sequence of names
-        :return: a DBus path of a task
-        """
-        task_number = TaskInterface._task_counter
-        TaskInterface._task_counter += 1
-        return get_dbus_path(*namespace, "Tasks", str(task_number))
 
     def connect_signals(self):
         """Connect signals to the implementation."""

--- a/pyanaconda/modules/storage/partitioning/automatic.py
+++ b/pyanaconda/modules/storage/partitioning/automatic.py
@@ -31,7 +31,6 @@ from pyanaconda.modules.common.structures.partitioning import PartitioningReques
 from pyanaconda.modules.storage.partitioning.base import PartitioningModule
 from pyanaconda.modules.storage.partitioning.automatic_interface import AutoPartitioningInterface
 from pyanaconda.modules.storage.partitioning.constants import PartitioningMethod
-from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 from pyanaconda.modules.storage.partitioning.automatic_partitioning import \
     AutomaticPartitioningTask
 
@@ -228,7 +227,3 @@ class AutoPartitioningModule(PartitioningModule):
     def configure_with_task(self):
         """Schedule the partitioning actions."""
         return AutomaticPartitioningTask(self.storage, self.request)
-
-    def validate_with_task(self):
-        """Validate the scheduled partitions."""
-        return StorageValidateTask(self.storage)

--- a/pyanaconda/modules/storage/partitioning/base.py
+++ b/pyanaconda/modules/storage/partitioning/base.py
@@ -27,6 +27,7 @@ from pyanaconda.modules.common.base.base import KickstartBaseModule
 from pyanaconda.modules.common.errors.storage import UnavailableStorageError
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.storage.devicetree import DeviceTreeModule
+from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 
 log = get_module_logger(__name__)
 
@@ -93,20 +94,19 @@ class PartitioningModule(KickstartBaseModule, Publishable):
     def configure_with_task(self):
         """Schedule the partitioning actions.
 
-        :return: a DBus path to a task
+        :return: a task
         """
         pass
 
-    @abstractmethod
     def validate_with_task(self):
         """Validate the scheduled partitioning.
 
         Run sanity checks on the current storage model to
         verify if the partitioning is valid.
 
-        :return: a DBus path to a task
+        :return: a task
         """
-        pass
+        return StorageValidateTask(self.storage)
 
     def setup_kickstart(self, data):
         """Setup the kickstart data."""

--- a/pyanaconda/modules/storage/partitioning/base.py
+++ b/pyanaconda/modules/storage/partitioning/base.py
@@ -104,6 +104,8 @@ class PartitioningModule(KickstartBaseModule, Publishable):
         Run sanity checks on the current storage model to
         verify if the partitioning is valid.
 
+        The result of the task is a validation report.
+
         :return: a task
         """
         return StorageValidateTask(self.storage)

--- a/pyanaconda/modules/storage/partitioning/base_interface.py
+++ b/pyanaconda/modules/storage/partitioning/base_interface.py
@@ -62,6 +62,8 @@ class PartitioningInterface(ModuleInterfaceTemplate):
         Run sanity checks on the current storage model to
         verify if the partitioning is valid.
 
+        The result of the task is a validation report.
+
         :return: a DBus path to a task
         """
         return TaskContainer.to_object_path(

--- a/pyanaconda/modules/storage/partitioning/blivet.py
+++ b/pyanaconda/modules/storage/partitioning/blivet.py
@@ -26,7 +26,6 @@ from pyanaconda.modules.storage.partitioning.blivet_interface import \
 from pyanaconda.modules.storage.partitioning.constants import PartitioningMethod
 from pyanaconda.modules.storage.partitioning.interactive_partitioning import \
     InteractivePartitioningTask
-from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 
 log = get_module_logger(__name__)
 
@@ -93,7 +92,3 @@ class BlivetPartitioningModule(PartitioningModule):
     def configure_with_task(self):
         """Complete the scheduled partitioning."""
         return InteractivePartitioningTask(self.storage)
-
-    def validate_with_task(self):
-        """Validate the scheduled partitions."""
-        return StorageValidateTask(self.storage)

--- a/pyanaconda/modules/storage/partitioning/custom.py
+++ b/pyanaconda/modules/storage/partitioning/custom.py
@@ -25,7 +25,6 @@ from pyanaconda.modules.storage.partitioning.base import PartitioningModule
 from pyanaconda.modules.storage.partitioning.constants import PartitioningMethod
 from pyanaconda.modules.storage.partitioning.custom_interface import CustomPartitioningInterface
 from pyanaconda.modules.storage.partitioning.custom_partitioning import CustomPartitioningTask
-from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 
 log = get_module_logger(__name__)
 
@@ -107,7 +106,3 @@ class CustomPartitioningModule(PartitioningModule):
     def configure_with_task(self):
         """Schedule the partitioning actions."""
         return CustomPartitioningTask(self.storage, self.data)
-
-    def validate_with_task(self):
-        """Validate the scheduled partitions."""
-        return StorageValidateTask(self.storage)

--- a/pyanaconda/modules/storage/partitioning/interactive.py
+++ b/pyanaconda/modules/storage/partitioning/interactive.py
@@ -26,7 +26,6 @@ from pyanaconda.modules.storage.partitioning.interactive_interface import \
     InteractivePartitioningInterface
 from pyanaconda.modules.storage.partitioning.interactive_partitioning import \
     InteractivePartitioningTask
-from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 
 log = get_module_logger(__name__)
 
@@ -50,7 +49,3 @@ class InteractivePartitioningModule(PartitioningModule):
     def configure_with_task(self):
         """Complete the scheduled partitioning."""
         return InteractivePartitioningTask(self.storage)
-
-    def validate_with_task(self):
-        """Validate the scheduled partitions."""
-        return StorageValidateTask(self.storage)

--- a/pyanaconda/modules/storage/partitioning/manual.py
+++ b/pyanaconda/modules/storage/partitioning/manual.py
@@ -28,7 +28,6 @@ from pyanaconda.modules.storage.partitioning.base import PartitioningModule
 from pyanaconda.modules.storage.partitioning.constants import PartitioningMethod
 from pyanaconda.modules.storage.partitioning.manual_interface import ManualPartitioningInterface
 from pyanaconda.modules.storage.partitioning.manual_partitioning import ManualPartitioningTask
-from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 
 log = get_module_logger(__name__)
 
@@ -206,7 +205,3 @@ class ManualPartitioningModule(PartitioningModule):
     def configure_with_task(self):
         """Schedule the partitioning actions."""
         return ManualPartitioningTask(self.storage)
-
-    def validate_with_task(self):
-        """Validate the scheduled partitions."""
-        return StorageValidateTask(self.storage)

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -24,6 +24,7 @@ from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.base import KickstartModule
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.containers import TaskContainer
+from pyanaconda.modules.common.errors.storage import InvalidStorageError
 from pyanaconda.modules.common.structures.requirement import Requirement
 from pyanaconda.modules.storage.bootloader import BootloaderModule
 from pyanaconda.modules.storage.checker import StorageCheckerModule
@@ -269,7 +270,10 @@ class StorageModule(KickstartModule):
         # Validate the partitioning.
         storage = module.storage
         task = StorageValidateTask(storage)
-        task.run()
+        report = task.run()
+
+        if not report.is_valid():
+            raise InvalidStorageError(" ".join(report.error_messages))
 
         # Apply the partitioning.
         self.set_storage(storage.copy())

--- a/tests/nosetests/pyanaconda_tests/__init__.py
+++ b/tests/nosetests/pyanaconda_tests/__init__.py
@@ -15,16 +15,12 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
 import gi
-
 gi.require_version("GLib", "2.0")
-
 from gi.repository import GLib
 
 from textwrap import dedent
-from mock import Mock, patch
-from functools import wraps
+from unittest.mock import Mock, patch
 from xml.etree import ElementTree
 
 from pyanaconda.modules.common.constants.interfaces import KICKSTART_MODULE
@@ -192,12 +188,4 @@ def patch_dbus_publish_object(func):
 
     # TODO: Extend this to patch the whole DBus object and pass in a useful abstraction.
     """
-
-    @wraps(func)
-    def function_wrapper(*args, **kwargs):
-        with patch('pyanaconda.dbus.DBus.publish_object') as publisher:
-            # FIXME: Find a way how to add publisher on the same position as @patch
-            # Right now it's always the last
-            func(*args, publisher, **kwargs)
-
-    return function_wrapper
+    return patch('pyanaconda.dbus.DBus.publish_object')

--- a/tests/nosetests/pyanaconda_tests/module_blivet_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_blivet_test.py
@@ -31,7 +31,6 @@ from pyanaconda.modules.storage.partitioning.blivet_interface import \
     BlivetPartitioningInterface
 from pyanaconda.modules.storage.partitioning.interactive_partitioning import \
     InteractivePartitioningTask
-from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 
 
 class BlivetPartitioningInterfaceTestCase(unittest.TestCase):
@@ -108,15 +107,5 @@ class BlivetPartitioningInterfaceTestCase(unittest.TestCase):
         task_path = self.interface.ConfigureWithTask()
 
         obj = check_task_creation(self, task_path, publisher, InteractivePartitioningTask)
-
-        self.assertEqual(obj.implementation._storage, self.module.storage)
-
-    @patch_dbus_publish_object
-    def validate_with_task_test(self, publisher):
-        """Test ValidateWithTask."""
-        self.module.on_storage_reset(Mock())
-        task_path = self.interface.ValidateWithTask()
-
-        obj = check_task_creation(self, task_path, publisher, StorageValidateTask)
 
         self.assertEqual(obj.implementation._storage, self.module.storage)

--- a/tests/nosetests/pyanaconda_tests/module_part_custom_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_custom_test.py
@@ -31,7 +31,6 @@ from pyanaconda.modules.common.errors.storage import UnavailableDataError
 from pyanaconda.modules.storage.partitioning import CustomPartitioningModule
 from pyanaconda.modules.storage.partitioning.custom_interface import CustomPartitioningInterface
 from pyanaconda.modules.storage.partitioning.custom_partitioning import CustomPartitioningTask
-from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 from pyanaconda.modules.storage.storage import StorageModule
 from pyanaconda.modules.storage.storage_interface import StorageInterface
 from pyanaconda.storage.initialization import create_storage
@@ -67,16 +66,6 @@ class CustomPartitioningInterfaceTestCase(unittest.TestCase):
         task_path = self.interface.ConfigureWithTask()
 
         obj = check_task_creation(self, task_path, publisher, CustomPartitioningTask)
-
-        self.assertEqual(obj.implementation._storage, self.module.storage)
-
-    @patch_dbus_publish_object
-    def validate_with_task_test(self, publisher):
-        """Test ValidateWithTask."""
-        self.module.on_storage_reset(Mock())
-        task_path = self.interface.ValidateWithTask()
-
-        obj = check_task_creation(self, task_path, publisher, StorageValidateTask)
 
         self.assertEqual(obj.implementation._storage, self.module.storage)
 

--- a/tests/nosetests/pyanaconda_tests/module_part_interactive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_interactive_test.py
@@ -39,7 +39,6 @@ from pyanaconda.modules.storage.partitioning.interactive_interface import \
     InteractivePartitioningInterface
 from pyanaconda.modules.storage.partitioning.interactive_partitioning import \
     InteractivePartitioningTask
-from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 from pyanaconda.storage.initialization import create_storage
 
 from tests.nosetests.pyanaconda_tests import patch_dbus_publish_object, check_task_creation
@@ -94,16 +93,6 @@ class InteractivePartitioningInterfaceTestCase(unittest.TestCase):
         task_path = self.interface.ConfigureWithTask()
 
         obj = check_task_creation(self, task_path, publisher, InteractivePartitioningTask)
-
-        self.assertEqual(obj.implementation._storage, self.module.storage)
-
-    @patch_dbus_publish_object
-    def validate_with_task_test(self, publisher):
-        """Test ValidateWithTask."""
-        self.module.on_storage_reset(Mock())
-        task_path = self.interface.ValidateWithTask()
-
-        obj = check_task_creation(self, task_path, publisher, StorageValidateTask)
 
         self.assertEqual(obj.implementation._storage, self.module.storage)
 

--- a/tests/nosetests/pyanaconda_tests/module_part_manual_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_manual_test.py
@@ -34,7 +34,6 @@ from pyanaconda.modules.common.structures.partitioning import MountPointRequest
 from pyanaconda.modules.storage.partitioning import ManualPartitioningModule
 from pyanaconda.modules.storage.partitioning.manual_interface import ManualPartitioningInterface
 from pyanaconda.modules.storage.partitioning.manual_partitioning import ManualPartitioningTask
-from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 from pyanaconda.storage.initialization import create_storage
 
 
@@ -300,15 +299,5 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
         task_path = self.interface.ConfigureWithTask()
 
         obj = check_task_creation(self, task_path, publisher, ManualPartitioningTask)
-
-        self.assertEqual(obj.implementation._storage, self.module.storage)
-
-    @patch_dbus_publish_object
-    def validate_with_task_test(self, publisher):
-        """Test ValidateWithTask."""
-        self.module.on_storage_reset(Mock())
-        task_path = self.interface.ValidateWithTask()
-
-        obj = check_task_creation(self, task_path, publisher, StorageValidateTask)
 
         self.assertEqual(obj.implementation._storage, self.module.storage)


### PR DESCRIPTION
Define a subclass of `ValidationTask` to create a validation task
and return a validation report with results of the validation. The
report is accessible with the method `get_result` or the DBus
method `GetResult`.

The task `StorageValidateTask` should return a report instead
of raising an exception. Raise the exception if a partitioning to
apply is invalid.