### PR TITLE
Add the install class for Red Hat Virtualization (#1753316)

### DIFF
--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -319,6 +319,9 @@ class Anaconda(object):
         if luks_version:
             storage.set_default_luks_version(luks_version)
 
+        # Set the default partitioning scheme.
+        storage.autopart_type = self.instClass.default_autopart_type
+
     def _load_plugin_s390(self):
         # Make sure s390 plugin is loaded.
         import gi

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -292,10 +292,14 @@ NTP_SERVER_QUERY = 2
 STORAGE_MIN_RAM = "min_ram"
 STORAGE_MIN_ROOT = "min_root"
 STORAGE_MIN_PARTITION_SIZES = "min_partition_sizes"
+STORAGE_REQ_PARTITION_SIZES = "req_partition_sizes"
 STORAGE_MUST_BE_ON_LINUXFS = "must_be_on_linuxfs"
 STORAGE_MUST_BE_ON_ROOT = "must_be_on_root"
+STORAGE_MUST_NOT_BE_ON_ROOT = "must_not_be_on_root"
+STORAGE_ROOT_DEVICE_TYPES = "root_device_types"
 STORAGE_SWAP_IS_RECOMMENDED = "swap_is_recommended"
 STORAGE_LUKS2_MIN_RAM = "luks2_min_ram"
+
 
 # Display modes
 class DisplayModes(Enum):

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -29,8 +29,6 @@ SELINUX_DEFAULT = -1
 # where to look for 3rd party addons
 ADDON_PATHS = ["/usr/share/anaconda/addons"]
 
-from pykickstart.constants import AUTOPART_TYPE_LVM
-
 # common string needs to be easy to change
 from pyanaconda import product
 productName = product.productName
@@ -249,10 +247,6 @@ SCREENSHOTS_TARGET_DIRECTORY = "/root/anaconda-screenshots"
 # cmdline arguments that append instead of overwrite
 CMDLINE_APPEND = ["modprobe.blacklist", "ifname", "ip"]
 CMDLINE_LIST = ["addrepo"]
-
-# The default autopart type is lvm.
-# FIXME: Move this constant to the storage module.
-DEFAULT_AUTOPART_TYPE = AUTOPART_TYPE_LVM
 
 # Is the default autopart type selected?
 AUTOPART_TYPE_DEFAULT = -1

--- a/pyanaconda/installclass.py
+++ b/pyanaconda/installclass.py
@@ -26,6 +26,7 @@ import os
 import sys
 
 from blivet.size import Size
+from pykickstart.constants import AUTOPART_TYPE_LVM
 
 from pyanaconda.kickstart import getAvailableDiskSpace
 from pyanaconda.core.constants import STORAGE_SWAP_IS_RECOMMENDED, SETUP_ON_BOOT_DEFAULT
@@ -70,6 +71,9 @@ class BaseInstallClass(object):
 
     # Default version of LUKS.
     default_luks_version = None
+
+    # The default partitioning scheme to use for automatic partitioning.
+    default_autopart_type = AUTOPART_TYPE_LVM
 
     # help
     help_folder = "/usr/share/anaconda/help"

--- a/pyanaconda/installclasses/rhv.py
+++ b/pyanaconda/installclasses/rhv.py
@@ -1,0 +1,129 @@
+#
+# rhv.py
+#
+# Copyright (C) 2019  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from blivet.devicefactory import DEVICE_TYPE_LVM_THINP
+from blivet.size import Size
+from pykickstart.constants import AUTOPART_TYPE_LVM_THINP
+
+from pyanaconda import network
+from pyanaconda import nm
+from pyanaconda.core.constants import STORAGE_ROOT_DEVICE_TYPES, STORAGE_MUST_NOT_BE_ON_ROOT, \
+    STORAGE_REQ_PARTITION_SIZES
+from pyanaconda.installclass import BaseInstallClass
+from pyanaconda.kickstart import getAvailableDiskSpace
+from pyanaconda.platform import platform
+from pyanaconda.product import productName
+from pyanaconda.storage.autopart import swap_suggestion
+from pyanaconda.storage.partspec import PartSpec
+
+__all__ = ["OvirtBaseInstallClass", "RHEVInstallClass"]
+
+
+class OvirtBaseInstallClass(BaseInstallClass):
+    name = "oVirt Node Next"
+    sortPriority = 21000
+    hidden = not productName.startswith("oVirt")
+
+    efi_dir = "centos"
+    default_autopart_type = AUTOPART_TYPE_LVM_THINP
+
+    # there is a RHV branded help content variant
+    help_folder = "/usr/share/anaconda/help/rhv"
+
+    def setNetworkOnbootDefault(self, ksdata):
+        if any(nd.onboot for nd in ksdata.network.network if nd.device):
+            return
+        # choose the device used during installation
+        # (ie for majority of cases the one having the default route)
+        dev = network.default_route_device() or network.default_route_device(family="inet6")
+        if not dev:
+            return
+        # ignore wireless (its ifcfgs would need to be handled differently)
+        if nm.nm_device_type_is_wifi(dev):
+            return
+        network.update_onboot_value(dev, True, ksdata=ksdata)
+
+    def setDefaultPartitioning(self, storage):
+        autorequests = [PartSpec(mountpoint="/", fstype=storage.default_fstype,
+                                 size=Size("6GiB"), thin=True,
+                                 grow=True, lv=True),
+                        PartSpec(mountpoint="/home",
+                                 fstype=storage.default_fstype,
+                                 size=Size("1GiB"), thin=True, lv=True),
+                        PartSpec(mountpoint="/tmp",
+                                 fstype=storage.default_fstype,
+                                 size=Size("1GiB"), thin=True, lv=True),
+                        PartSpec(mountpoint="/var",
+                                 fstype=storage.default_fstype,
+                                 size=Size("15GiB"), thin=True, lv=True),
+                        PartSpec(mountpoint="/var/log",
+                                 fstype=storage.default_fstype,
+                                 size=Size("8GiB"), thin=True, lv=True),
+                        PartSpec(mountpoint="/var/log/audit",
+                                 fstype=storage.default_fstype,
+                                 size=Size("2GiB"), thin=True, lv=True)]
+
+        bootreqs = platform.set_default_partitioning()
+        if bootreqs:
+            autorequests.extend(bootreqs)
+
+        disk_space = getAvailableDiskSpace(storage)
+        swp = swap_suggestion(disk_space=disk_space)
+        autorequests.append(PartSpec(fstype="swap", size=swp, grow=False,
+                                     lv=True, encrypted=True))
+
+        for autoreq in autorequests:
+            if autoreq.fstype is None:
+                if autoreq.mountpoint == "/boot":
+                    autoreq.fstype = storage.default_boot_fstype
+                    autoreq.size = Size("1GiB")
+                else:
+                    autoreq.fstype = storage.default_fstype
+
+        storage.autopart_requests = autorequests
+
+    def setStorageChecker(self, storage_checker):
+        # / needs to be thin LV
+        storage_checker.add_constraint(STORAGE_ROOT_DEVICE_TYPES, {
+            DEVICE_TYPE_LVM_THINP
+        })
+
+        # /var must be on a separate LV or partition
+        storage_checker.update_constraint(STORAGE_MUST_NOT_BE_ON_ROOT, {
+            '/var'
+        })
+
+        # /var must be at least 10GB, /boot must be at least 1GB
+        storage_checker.update_constraint(STORAGE_REQ_PARTITION_SIZES, {
+            '/var': Size("10 GiB"),
+            '/boot': Size("1 GiB")
+        })
+
+    def __init__(self):
+        BaseInstallClass.__init__(self)
+
+
+class RHEVInstallClass(OvirtBaseInstallClass):
+    name = "Red Hat Virtualization"
+
+    hidden = not productName.startswith(
+        ("RHV", "Red Hat Virtualization")
+    )
+
+    efi_dir = "redhat"

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -548,6 +548,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             page = CreateNewPage(translated_new_install_name(),
                                  self.on_create_clicked,
                                  self._change_autopart_type,
+                                 defaultType=self.instclass.default_autopart_type,
                                  partitionsToReuse=bool(ui_roots) or bool(unused_devices))
             self._accordion.add_page(page, cb=self.on_page_clicked)
 

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -22,7 +22,6 @@
 from pyanaconda.core.i18n import _, C_
 from pyanaconda.product import productName, productVersion
 from pyanaconda.ui.gui.utils import escape_markup, really_hide, really_show
-from pyanaconda.core.constants import DEFAULT_AUTOPART_TYPE
 from pyanaconda.storage_utils import get_supported_autopart_choices
 
 import gi
@@ -509,7 +508,8 @@ class CreateNewPage(BasePage):
         packed into the Accordion first and then when the new installation
         is created, it will be removed and replaced with a Page for it.
     """
-    def __init__(self, title, createClickedCB, autopartTypeChangedCB, partitionsToReuse=True):
+    def __init__(self, title, createClickedCB, autopartTypeChangedCB, defaultType=None,
+                 partitionsToReuse=True):
         super().__init__(title)
 
         # Create a box where we store the "Here's how you create a new blah" info.
@@ -575,7 +575,7 @@ class CreateNewPage(BasePage):
         default = None
         for name, code in get_supported_autopart_choices():
             itr = store.append([_(name), code])
-            if code == DEFAULT_AUTOPART_TYPE:
+            if code == defaultType:
                 default = itr
 
         combo.set_margin_start(18)

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -82,7 +82,6 @@ from pyanaconda.modules.common.constants.objects import DISK_SELECTION, DISK_INI
     BOOTLOADER, AUTO_PARTITIONING
 from pyanaconda.modules.common.constants.services import STORAGE
 
-from pykickstart.constants import AUTOPART_TYPE_LVM
 from pykickstart.errors import KickstartParseError
 
 import sys
@@ -667,7 +666,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
 
         self.autoPartType = self._auto_part_observer.proxy.Type
         if self.autoPartType == AUTOPART_TYPE_DEFAULT:
-            self.autoPartType = AUTOPART_TYPE_LVM
+            self.autoPartType = self.instclass.default_autopart_type
 
         self.encrypted = self._auto_part_observer.proxy.Encrypted
         self.passphrase = self._auto_part_observer.proxy.Passphrase

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -41,7 +41,7 @@ from pyanaconda.flags import flags
 from pyanaconda.kickstart import doKickstartStorage, resetCustomStorageData
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core.constants import THREAD_STORAGE, THREAD_STORAGE_WATCHER, \
-    DEFAULT_AUTOPART_TYPE, PAYLOAD_STATUS_PROBING_STORAGE, CLEAR_PARTITIONS_ALL, \
+    PAYLOAD_STATUS_PROBING_STORAGE, CLEAR_PARTITIONS_ALL, \
     CLEAR_PARTITIONS_LINUX, CLEAR_PARTITIONS_NONE, CLEAR_PARTITIONS_DEFAULT, \
     BOOTLOADER_LOCATION_MBR, BOOTLOADER_DRIVE_UNSET, AUTOPART_TYPE_DEFAULT, SecretType, \
     MOUNT_POINT_REFORMAT, MOUNT_POINT_PATH, MOUNT_POINT_DEVICE, MOUNT_POINT_FORMAT
@@ -50,7 +50,6 @@ from pyanaconda.bootloader import BootLoaderError
 from pyanaconda.storage.osinstall import storage_initialize, select_all_disks_by_default
 
 from pykickstart.base import BaseData
-from pykickstart.constants import AUTOPART_TYPE_LVM
 from pykickstart.errors import KickstartParseError
 
 from simpleline.render.containers import ListColumnContainer
@@ -421,7 +420,7 @@ class StorageSpoke(NormalTUISpoke):
         self._disk_init_observer.proxy.SetDrivesToClear(self.selected_disks)
 
         if self.autopart and self._auto_part_observer.proxy.Type == AUTOPART_TYPE_DEFAULT:
-            self._auto_part_observer.proxy.SetType(AUTOPART_TYPE_LVM)
+            self._auto_part_observer.proxy.SetType(self.instclass.default_autopart_type)
 
         for disk in self.disks:
             if disk.name not in self.selected_disks and \
@@ -676,7 +675,7 @@ class PartitionSchemeSpoke(NormalTUISpoke):
         pre_select = self._auto_part_proxy.Type
 
         if pre_select == AUTOPART_TYPE_DEFAULT:
-            pre_select = DEFAULT_AUTOPART_TYPE
+            pre_select = instclass.default_autopart_type
 
         supported_choices = get_supported_autopart_choices()
         if supported_choices:


### PR DESCRIPTION
The default partitioning scheme can be defined in an install class.
If the kickstart file defines the scheme, it will be used instead.

(based on a commit 106ffe9)

Red Hat Virtualization has some extra requirements on partitioning
that need to be checked.

(based on a commit a5a8aca)

Backport the install class from RHEL 7.

Resolves: rhbz#1753316