### PR TITLE
Support the %addon sections in the kickstart specification

### DIFF
--- a/pyanaconda/addons.py
+++ b/pyanaconda/addons.py
@@ -76,6 +76,8 @@ class AddonRegistry(object):
        maintains the ids and data structures for loaded
        addons.
 
+       FIXME: This class is deprecated and should be removed.
+
        It acts as a proxy during kickstart save.
     """
 
@@ -115,6 +117,8 @@ class AddonData(object):
        3rd party data to kickstart. It is instantiated by
        kickstart parser and stored as ksdata.addons.<name>
        to be used in the user interfaces.
+
+       FIXME: This class is deprecated and should be removed.
 
        The mandatory method handle_line receives all lines
        from the corresponding addon section in kickstart and
@@ -180,6 +184,10 @@ class AddonData(object):
         pass
 
 class AddonSection(Section):
+    """The section parser for %addon.
+
+    FIXME: This class is deprecated and should be removed.
+    """
     sectionOpen = "%addon"
 
     def __init__(self, *args, **kwargs):

--- a/pyanaconda/core/kickstart/addon.py
+++ b/pyanaconda/core/kickstart/addon.py
@@ -1,0 +1,183 @@
+#
+# Support for %addon sections.
+#
+# Copyright (C) 2019  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from abc import ABCMeta, abstractmethod
+from types import SimpleNamespace
+
+from pykickstart.errors import KickstartParseError
+from pykickstart.ko import KickstartObject
+from pykickstart.sections import Section
+
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.i18n import _
+
+log = get_module_logger(__name__)
+
+__all__ = ["AddonData", "AddonSection", "AddonRegistry"]
+
+
+class AddonData(KickstartObject, metaclass=ABCMeta):
+    """Kickstart data for addon.
+
+    This is a common parent class for loading and storing 3rd
+    party data to kickstart. It is instantiated by kickstart
+    parser and stored as ksdata.addons.<name> to be used in
+    the user interfaces.
+
+    The following methods have to be implemented:
+
+        * handle_header handles arguments of the section
+        * handle_line is called for every line of the section
+        * __str__ returns a kickstart representation of the section
+
+    """
+
+    @abstractmethod
+    def handle_header(self, args, line_number=None):
+        """Handle the arguments of the %addon line.
+
+        This function receives any arguments on the %addon line
+        after the name. For example, for the line:
+
+           %addon com_example_foo --argument='example'
+
+        This function would be called with:
+
+            args=["--argument='example'"].
+
+        :param args: a list of additional arguments
+        :param line_number: a line number
+        :raise: KickstartParseError for invalid arguments
+        """
+        pass
+
+    @abstractmethod
+    def handle_line(self, line, line_number=None):
+        """Handle one line of the section.
+
+        :param line: a line to parse
+        :param line_number: a line number
+        :raise: KickstartParseError for invalid lines
+        """
+        pass
+
+    def handle_end(self):
+        """Handle the end of the section.."""
+        pass
+
+    @abstractmethod
+    def __str__(self):
+        """Generate the kickstart representation.
+
+        Generate the %addon section for your addon.
+
+        For example:
+
+            %addon com_example_foo --argument='example'
+            My lines.
+            %end
+
+        :return: a string
+        """
+        return ""
+
+
+class AddonSection(Section):
+    """Parser of the %addon sections.
+
+    Parses the name of the current %addon section and propagates
+    all arguments and lines of this section to the addon with the
+    specified name.
+    """
+    sectionOpen = "%addon"
+
+    def __init__(self, handler, **kwargs):
+        super().__init__(handler, **kwargs)
+        self.data = None
+        self.line_number = None
+
+    def handleHeader(self, lineno, args):
+        """Handle a header of the current %addon section.
+
+        This method is called when the opening tag for a section is
+        seen. Not all sections will need this method, though all
+        provided with kickstart include one.
+
+        :param lineno: a number of the current line
+        :param args: a list of strings passed as arguments
+        """
+        super().handleHeader(lineno, args)
+
+        if not args:
+            raise KickstartParseError(
+                _("Missing name of the %addon section."),
+                lineno=lineno
+            )
+
+        name = args[1]
+        arguments = args[2:]
+        data = getattr(self.handler.addons, name, None)
+
+        if not data:
+            raise KickstartParseError(
+                _("Unknown name of the %addon section."),
+                lineno=lineno
+            )
+
+        self.data = data
+        self.line_number = lineno
+        self.data.handle_header(arguments, self.line_number)
+
+    def handleLine(self, line):
+        """Handle one line of the current %addon section.
+
+        This method is called for every line of a section. Take
+        whatever action is appropriate.  While this method is not
+        required to be provided, not providing it does not make
+        a whole lot of sense.
+
+        :param line: a complete line, with any trailing newline
+        """
+        if not self.handler:
+            return
+
+        self.line_number += 1
+        self.data.handle_line(line, self.line_number)
+
+    def finalize(self):
+        """Handle the end of the current %addon section.
+
+        This method is called when the %end tag for a section is
+        seen.
+        """
+        super().finalize()
+        self.data.handle_end()
+        self.data = None
+
+
+class AddonRegistry(SimpleNamespace):
+    """Data holder of the %addon sections.
+
+    Provides access to instances of AddonData from the handler.
+
+    For example:
+
+        handler.addons.com_example_foo
+
+    """
+    pass

--- a/pyanaconda/dbus_addons/baz/baz.py
+++ b/pyanaconda/dbus_addons/baz/baz.py
@@ -21,6 +21,7 @@ from time import sleep
 
 from pyanaconda.dbus import DBus
 from pyanaconda.dbus_addons.baz.baz_interface import BazInterface, BazCalculationTaskInterface
+from pyanaconda.dbus_addons.baz.kickstart import BazKickstartSpecification
 from pyanaconda.modules.common.base import KickstartModule
 from pyanaconda.modules.common.constants.services import BAZ
 from pyanaconda.modules.common.containers import TaskContainer
@@ -33,11 +34,37 @@ log = get_module_logger(__name__)
 class Baz(KickstartModule):
     """The Baz module."""
 
+    def __init__(self):
+        super().__init__()
+        self._seen = False
+        self._foo = None
+        self._bar = False
+        self._lines = []
+
     def publish(self):
         """Publish the module."""
         TaskContainer.set_namespace(BAZ.namespace)
         DBus.publish_object(BAZ.object_path, BazInterface(self))
         DBus.register_service(BAZ.service_name)
+
+    @property
+    def kickstart_specification(self):
+        """Return the kickstart specification."""
+        return BazKickstartSpecification
+
+    def process_kickstart(self, data):
+        """Process the kickstart data."""
+        self._seen = data.addons.my_example_baz.seen
+        self._foo = data.addons.my_example_baz.foo
+        self._bar = data.addons.my_example_baz.bar
+        self._lines = data.addons.my_example_baz.lines
+
+    def setup_kickstart(self, data):
+        """Set the given kickstart data."""
+        data.addons.my_example_baz.seen = self._seen
+        data.addons.my_example_baz.foo = self._foo
+        data.addons.my_example_baz.bar = self._bar
+        data.addons.my_example_baz.lines = self._lines
 
     def install_with_tasks(self):
         """Return installation tasks."""

--- a/pyanaconda/dbus_addons/baz/kickstart.py
+++ b/pyanaconda/dbus_addons/baz/kickstart.py
@@ -1,0 +1,96 @@
+#
+# Kickstart specification for baz.
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pykickstart.options import KSOptionParser
+
+from pyanaconda.core.kickstart import VERSION, KickstartSpecification
+from pyanaconda.core.kickstart.addon import AddonData
+
+
+class BazData(AddonData):
+    """The kickstart data for baz."""
+
+    def __init__(self):
+        super().__init__()
+        self.seen = False
+        self.foo = None
+        self.bar = False
+        self.lines = []
+
+    def handle_header(self, args, line_number=None):
+        # Create the argument parser.
+        op = KSOptionParser(
+            prog="%addon my_example_baz",
+            version=VERSION,
+            description="My addon baz."
+        )
+
+        op.add_argument(
+            "--foo",
+            type=int,
+            default=None,
+            version=VERSION,
+            help="Specify foo."
+        )
+
+        op.add_argument(
+            "--bar",
+            action="store_true",
+            default=False,
+            version=VERSION,
+            help="Specify bar."
+        )
+
+        # Parse the arguments.
+        ns = op.parse_args(args=args, lineno=line_number)
+
+        # Store the result of the parsing.
+        self.seen = True
+        self.foo = ns.foo
+        self.bar = ns.bar
+
+    def handle_line(self, line, line_number=None):
+        self.lines.append(line.strip())
+
+    def __str__(self):
+        if not self.seen:
+            return ""
+
+        section = "\n%addon my_example_baz"
+
+        if self.foo is not None:
+            section += " --foo={}".format(self.foo)
+
+        if self.bar:
+            section += " --bar"
+
+        for line in self.lines:
+            section += "\n" + line
+
+        section += "\n%end\n"
+        return section
+
+
+class BazKickstartSpecification(KickstartSpecification):
+
+    version = VERSION
+
+    addons = {
+        "my_example_baz": BazData
+    }

--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -179,8 +179,7 @@ class KickstartModule(MainModule, KickstartBaseModule):
     @property
     def kickstart_addon_names(self):
         """Return a list of kickstart addon names."""
-        # TODO: We need to add support for addons.
-        return list()
+        return list(self.kickstart_specification.addons.keys())
 
     @property
     def kickstarted(self):

--- a/tests/nosetests/pyanaconda_tests/module_baz_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_baz_test.py
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+
+from pyanaconda.dbus_addons.baz.baz import Baz
+from pyanaconda.dbus_addons.baz.baz_interface import BazInterface
+from tests.nosetests.pyanaconda_tests import check_kickstart_interface
+
+
+class BazInterfaceTestCase(unittest.TestCase):
+    """Test DBus interface for the Baz module."""
+
+    def setUp(self):
+        """Set up the localization module."""
+        self.module = Baz()
+        self.interface = BazInterface(self.module)
+
+    def kickstart_properties_test(self):
+        """Test kickstart properties."""
+        self.assertEqual(self.interface.KickstartCommands, [])
+        self.assertEqual(self.interface.KickstartSections, [])
+        self.assertEqual(self.interface.KickstartAddons, ["my_example_baz"])
+
+    def _test_kickstart(self, ks_in, ks_out):
+        check_kickstart_interface(self, self.interface, ks_in, ks_out)
+
+    def no_kickstart_test(self):
+        """Test with no kickstart."""
+        ks_in = None
+        ks_out = ""
+        self._test_kickstart(ks_in, ks_out)
+
+    def kickstart_test(self):
+        """Test with kickstart."""
+        ks_in = """
+        %addon my_example_baz --foo=1 --bar
+        The content of the baz section.
+        %end
+        """
+        ks_out = """
+        %addon my_example_baz --foo=1 --bar
+        The content of the baz section.
+        %end
+        """
+        self._test_kickstart(ks_in, ks_out)


### PR DESCRIPTION
Allow to parse and generate `%addon` sections using a kickstart
specification. This solution will eventually replace the current
implementation.