### PR TITLE
Remove pointless '../../' to clean up NFS mounts

### DIFF
--- a/pyanaconda/payload/install_tree_metadata.py
+++ b/pyanaconda/payload/install_tree_metadata.py
@@ -236,7 +236,7 @@ class RepoMetadata(object):
         if self.relative_path == ".":
             return self._root_path
         else:
-            return os.path.join(self._root_path, self.relative_path)
+            return os.path.normpath(os.path.join(self._root_path, self.relative_path))
 
     def is_valid(self):
         """Quick check if the repo is a valid repository.


### PR DESCRIPTION
NFS mounts on CentOS 8 get confused when `../../../` takes you below the mounted NFS volume.  The repo base is being mounted by anaconda, but the pointed to repo is well below the repo base.

For non-NFS users this will result in cleaner looking URLs.