### PR TITLE
Add support for getting an object path of a DBus proxy

### DIFF
--- a/pyanaconda/dbus/proxy.py
+++ b/pyanaconda/dbus/proxy.py
@@ -1,0 +1,29 @@
+#
+# Support for object proxies
+#
+# Copyright (C) 2019  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+__all__ = ["get_object_path"]
+
+
+def get_object_path(proxy):
+    """Get an object path of the remote DBus object.
+
+    :param proxy: a DBus proxy
+    :return: a DBus path
+    """
+    return getattr(proxy, "_path")

--- a/tests/nosetests/pyanaconda_tests/dbus_proxy_test.py
+++ b/tests/nosetests/pyanaconda_tests/dbus_proxy_test.py
@@ -1,0 +1,32 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
+#
+import unittest
+from unittest.mock import Mock
+from pydbus.proxy import ProxyObject
+from pyanaconda.dbus.proxy import get_object_path
+
+
+class DBusProxyTestCase(unittest.TestCase):
+    """Test support for object proxies."""
+
+    def get_object_path_test(self):
+        """Test get_object_path."""
+        proxy = ProxyObject(Mock(), "my.service", "/my/path")
+        self.assertEqual(get_object_path(proxy), "/my/path")


### PR DESCRIPTION
Call the function `get_object_path` to get an object path of
a remote DBus object represented by the given proxy object.