### PR TITLE
Reset the storage and the playground of partitioning modules

### DIFF
--- a/pyanaconda/modules/storage/partitioning/base.py
+++ b/pyanaconda/modules/storage/partitioning/base.py
@@ -71,6 +71,7 @@ class PartitioningModule(KickstartBaseModule, Publishable):
     def on_storage_reset(self, storage):
         """Keep the instance of the current storage."""
         self._current_storage = storage
+        self._storage_playground = None
 
     def on_selected_disks_changed(self, selection):
         """Keep the current disk selection."""

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -63,6 +63,7 @@ class StorageModule(KickstartModule):
         # The storage model.
         self._storage = None
         self.storage_changed = Signal()
+        self.storage_reset = Signal()
 
         # The created partitioning modules.
         self._created_partitioning = []
@@ -205,10 +206,14 @@ class StorageModule(KickstartModule):
 
         return self._storage
 
-    def set_storage(self, storage):
+    def set_storage(self, storage, reset=False):
         """Set the storage model."""
         self._storage = storage
         self.storage_changed.emit(storage)
+
+        if reset:
+            self.storage_reset.emit(storage)
+
         log.debug("The storage model has changed.")
 
     def on_protected_devices_changed(self, protected_devices):
@@ -237,7 +242,7 @@ class StorageModule(KickstartModule):
 
         # Create the task.
         task = StorageResetTask(storage)
-        task.succeeded_signal.connect(lambda: self.set_storage(storage))
+        task.succeeded_signal.connect(lambda: self.set_storage(storage, reset=True))
         return task
 
     def create_partitioning(self, method: PartitioningMethod):
@@ -264,7 +269,7 @@ class StorageModule(KickstartModule):
         )
 
         # Connect the callbacks to signals.
-        self.storage_changed.connect(
+        self.storage_reset.connect(
             module.on_storage_reset
         )
         self._disk_selection_module.selected_disks_changed.connect(

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -118,6 +118,18 @@ class StorageInterfaceTestCase(unittest.TestCase):
 
         self.storage_module.created_partitioning_changed.connect(_apply_partitioning)
 
+    def create_storage_test(self):
+        """Test the storage created by default."""
+        storage_changed_callback = Mock()
+        self.storage_module.storage_changed.connect(storage_changed_callback)
+
+        storage_reset_callback = Mock()
+        self.storage_module.storage_reset.connect(storage_reset_callback)
+
+        self.assertIsNotNone(self.storage_module.storage)
+        storage_changed_callback.assert_called_once()
+        storage_reset_callback.assert_not_called()
+
     @patch_dbus_publish_object
     def reset_with_task_test(self, publisher):
         """Test ResetWithTask."""
@@ -131,8 +143,12 @@ class StorageInterfaceTestCase(unittest.TestCase):
         storage_changed_callback = Mock()
         self.storage_module.storage_changed.connect(storage_changed_callback)
 
+        storage_reset_callback = Mock()
+        self.storage_module.storage_reset.connect(storage_reset_callback)
+
         obj.implementation.succeeded_signal.emit()
         storage_changed_callback.assert_called_once()
+        storage_reset_callback.assert_called_once()
 
     @patch_dbus_publish_object
     def create_partitioning_test(self, published):


### PR DESCRIPTION
On storage reset, update the current model of the storage and
drop the current playground of the partitioning modules. On
storage changed, do nothing in these modules.