### PR TITLE
Enable faulthandler in DBus modules

### DIFF
--- a/pyanaconda/modules/common/__init__.py
+++ b/pyanaconda/modules/common/__init__.py
@@ -25,6 +25,9 @@ def init():
     This method should be imported and called from __main__.py of every
     Anaconda DBus module before any other import.
     """
+    import faulthandler
+    faulthandler.enable()
+
     import logging
     logging.basicConfig(level=logging.DEBUG)
 


### PR DESCRIPTION
The faulthandler will dump the Python traceback to stderr for the
SIGSEGV, SIGFPE, SIGABRT, SIGBUS and SIGILL signals for
every running thread of the DBus module.