### PR TITLE
Patch DBus proxies in GUI and TUI simple import tests

### DIFF
--- a/tests/nosetests/pyanaconda_tests/__init__.py
+++ b/tests/nosetests/pyanaconda_tests/__init__.py
@@ -189,3 +189,11 @@ def patch_dbus_publish_object(func):
     # TODO: Extend this to patch the whole DBus object and pass in a useful abstraction.
     """
     return patch('pyanaconda.dbus.DBus.publish_object')
+
+
+def patch_dbus_get_proxy(func):
+    """Patch DBus proxies.
+
+    This is a shortcut to avoid creating of DBus proxies using DBus.
+    """
+    return patch('pyanaconda.dbus.DBus.get_proxy')

--- a/tests/nosetests/pyanaconda_tests/__init__.py
+++ b/tests/nosetests/pyanaconda_tests/__init__.py
@@ -188,7 +188,7 @@ def patch_dbus_publish_object(func):
 
     # TODO: Extend this to patch the whole DBus object and pass in a useful abstraction.
     """
-    return patch('pyanaconda.dbus.DBus.publish_object')
+    return patch('pyanaconda.dbus.DBus.publish_object')(func)
 
 
 def patch_dbus_get_proxy(func):
@@ -196,4 +196,4 @@ def patch_dbus_get_proxy(func):
 
     This is a shortcut to avoid creating of DBus proxies using DBus.
     """
-    return patch('pyanaconda.dbus.DBus.get_proxy')
+    return patch('pyanaconda.dbus.DBus.get_proxy')(func)

--- a/tests/nosetests/pyanaconda_tests/module_network_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_network_test.py
@@ -183,8 +183,8 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         """Test LogConfigurationState."""
         self.network_interface.LogConfigurationState("message")
 
-    @patch('pyanaconda.modules.network.network.devices_ignore_ipv6', return_value=True)
     @patch_dbus_publish_object
+    @patch('pyanaconda.modules.network.network.devices_ignore_ipv6', return_value=True)
     def install_network_with_task_test(self, devices_ignore_ipv6, publisher):
         """Test InstallNetworkWithTask."""
         self.network_module._hostname = "my_hostname"
@@ -214,9 +214,9 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         obj.implementation.succeeded_signal.emit()
         self.network_module.log_task_result.assert_called_once()
 
+    @patch_dbus_publish_object
     @patch('pyanaconda.modules.network.installation.update_connection_values')
     @patch('pyanaconda.modules.network.installation.find_ifcfg_uuid_of_device')
-    @patch_dbus_publish_object
     def configure_activation_on_boot_with_task_test(self, find_ifcfg_uuid_of_device,
                                                     update_connection_values, publisher):
         """Test ConfigureActivationOnBootWithTask."""

--- a/tests/nosetests/pyanaconda_tests/simple_ui_test.py
+++ b/tests/nosetests/pyanaconda_tests/simple_ui_test.py
@@ -22,6 +22,7 @@ import unittest
 
 from unittest.mock import Mock, patch
 from pyanaconda.ui.common import StandaloneSpoke
+from tests.nosetests.pyanaconda_tests import patch_dbus_get_proxy
 
 
 class SimpleUITestCase(unittest.TestCase):
@@ -69,7 +70,8 @@ class SimpleUITestCase(unittest.TestCase):
         categories = self._get_categories(hub_class)
         return {c.__name__:  list(sorted(s.__name__ for s in categories[c])) for c in categories}
 
-    def tui_test(self):
+    @patch_dbus_get_proxy
+    def tui_test(self, proxy_getter):
         # Create the interface.
         from pyanaconda.ui.tui import TextUserInterface
         self.interface = TextUserInterface(self.storage, self.payload)
@@ -107,11 +109,12 @@ class SimpleUITestCase(unittest.TestCase):
             ]
         })
 
+    @patch_dbus_get_proxy
     @patch("pyanaconda.ui.gui.Gtk.Builder")
     @patch("pyanaconda.ui.gui.meh")
     @patch("pyanaconda.ui.gui.MainWindow")
     @patch("pyanaconda.ui.gui.ANACONDA_WINDOW_GROUP")
-    def gui_test(self, window_group, window, meh, builder):
+    def gui_test(self, window_group, window, meh, builder, proxy_getter):
         # Create the interface.
         from pyanaconda.ui.gui import GraphicalUserInterface
         self.interface = GraphicalUserInterface(self.storage, self.payload)


### PR DESCRIPTION
The import and initialization of hubs and spokes will eventually start to
trigger DBus. Use the new function `patch_dbus_get_proxy` to patch
this calls.

The functions `patch_dbus_publish_object` and `patch_dbus_get_proxy`
didn't work correctly, because the patch wasn't applied on the decorated
function.