### PR TITLE
Set the locale for unit tests

### DIFF
--- a/tests/nosetests/pyanaconda_tests/__init__.py
+++ b/tests/nosetests/pyanaconda_tests/__init__.py
@@ -19,13 +19,19 @@ import gi
 gi.require_version("GLib", "2.0")
 from gi.repository import GLib
 
+import locale
+
 from textwrap import dedent
 from unittest.mock import Mock, patch
 from xml.etree import ElementTree
 
+from pyanaconda.core.constants import DEFAULT_LANG
 from pyanaconda.modules.common.constants.interfaces import KICKSTART_MODULE
 from pyanaconda.modules.common.task import TaskInterface
 from pyanaconda.dbus.xml import XMLGenerator
+
+# Set the default locale.
+locale.setlocale(locale.LC_ALL, DEFAULT_LANG)
 
 
 class run_in_glib(object):


### PR DESCRIPTION
Make sure that the locale is set to `en_US.UTF-8` in the testing
environment. Tests with translated strings will fail for other
locales.