### PR TITLE
Don't touch storage until it is ready

### DIFF
--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -113,8 +113,6 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
         self.button_reset = self.builder.get_object("resetAllButton")
         self.button_undo = self.builder.get_object("undoLastActionButton")
 
-        config.default_fstype = self._storage.default_fstype
-
         self.blivetgui = osinstall.BlivetGUIAnaconda(self.client, self, box)
 
         # this needs to be done when the spoke is already "realized"
@@ -141,6 +139,7 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
 
         self._back_already_clicked = False
 
+        config.default_fstype = self._storage.default_fstype
         self._storage_playground = self.storage.copy()
         self.client.initialize(self._storage_playground)
         self.blivetgui.initialize()

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -112,13 +112,15 @@ class StorageSpoke(NormalTUISpoke):
 
     @property
     def completed(self):
-        return bool(self.storage.root_device and not self.errors)
+        return self.ready and not self.errors and self.storage.root_device
 
     @property
     def ready(self):
         # By default, the storage spoke is not ready.  We have to wait until
         # storageInitialize is done.
-        return self._ready and not threadMgr.get(THREAD_STORAGE_WATCHER)
+        return self._ready \
+            and not threadMgr.get(THREAD_STORAGE) \
+            and not threadMgr.get(THREAD_STORAGE_WATCHER)
 
     @property
     def mandatory(self):
@@ -131,7 +133,9 @@ class StorageSpoke(NormalTUISpoke):
     @property
     def status(self):
         """ A short string describing the current status of storage setup. """
-        if flags.automatedInstall and not self.storage.root_device:
+        if not self.ready:
+            return _("Processing...")
+        elif flags.automatedInstall and not self.storage.root_device:
             return _("Kickstart insufficient")
         elif not self._disk_select_module.SelectedDisks:
             return _("No disks selected")


### PR DESCRIPTION
UI should never do anything with the storage until all long-term
tasks are finished, because the access to all Blivet objects is
locked with one global lock, so we might block the main thread.