### PR TITLE
Fix pylint issues

### DIFF
--- a/pyanaconda/core/users.py
+++ b/pyanaconda/core/users.py
@@ -306,9 +306,7 @@ def create_user(username, password=False, is_crypted=False, lock=False,
 
     # resolve the optional arguments that need a default that can't be
     # reasonably set in the function signature
-    if homedir:
-        homedir = homedir
-    else:
+    if not homedir:
         homedir = "/home/" + username
 
     if groups is None:

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -83,7 +83,7 @@ env["PYTHONPATH"] = OTHER_MODULES_PATH
 
 print("Running pylint on %s" % " ".join(pylint_names))
 try:
-    check_output(["./tests/pylint/runpylint.py"] + pylint_files, env=env)
+    check_output(["./tests/pylint/runpylint.py"] + pylint_files)
 except CalledProcessError as e:
     print(e.output.decode('utf-8'))
     sys.exit(1)

--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -108,9 +108,9 @@ def _call_subprocess(cmd, stdout_pipe=False):
     print("Running command {}".format(cmd))
 
     if stdout_pipe:
-        return subprocess.run(cmd, stdout=subprocess.PIPE)
+        return subprocess.run(cmd, stdout=subprocess.PIPE)  # pylint: disable=subprocess-run-check
     else:
-        return subprocess.run(cmd)
+        return subprocess.run(cmd)  # pylint: disable=subprocess-run-check
 
 
 def parse_args():

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -20,7 +20,6 @@ class AnacondaLintConfig(PocketLintConfig):
                                 FalsePositive(r"^E1101.*: HostipGeoIPProvider._refresh: Instance of 'LookupDict' has no 'ok' member"),
                                 FalsePositive(r"^E1101.*: Geocoder._reverse_geocode_nominatim: Instance of 'LookupDict' has no 'ok' member"),
                                 FalsePositive(r"^E1101.*: Instance of 'Namespace' has no '.*' member$"),
-                                FalsePositive(r"^E1101.*: Module 'crypt' has no 'METHOD_SHA512' member$"),
                                 FalsePositive(r"^W0107.*: Unnecessary pass statement$"),
 
                                 # TODO: BlockDev introspection needs to be added to pylint to handle these
@@ -33,9 +32,6 @@ class AnacondaLintConfig(PocketLintConfig):
                                 FalsePositive(r"E1101.*: Instance of 'int' has no 'name_from_node' member"),
                                 FalsePositive(r"E1101.*: Instance of 'int' has no 'generate_backup_passphrase' member"),
                                 FalsePositive(r"E1101.*: Instance of 'int' has no 'dasd_is_ldl' member"),
-
-                                # TODO: Remove this when pylint start to support python 3.8 correctly
-                                FalsePositive(r"E1121.*: CheckValidity.checkGlade: Too many positional arguments for constructor call"),
                               ]
 
         # This will solve problems with C python extensions

--- a/tests/rpm_tests/__init__.py
+++ b/tests/rpm_tests/__init__.py
@@ -34,6 +34,7 @@ class RPMTestCase(TestCase):
     def call_subprocess(self, cmd, cwd=None):
         """Call external command and return result."""
         print("Running command \"{}\"".format(" ".join(cmd)))
+        # pylint: disable=subprocess-run-check
         return subprocess.run(cmd, stdout=subprocess.PIPE, cwd=cwd)
 
     @property


### PR DESCRIPTION
* We don't have to filter some of the false positives anymore.
* Remove the assignment of the same variable to itself.
* Remove the unexpected keyword argument `env`.
* Allow to handle the return value of `subprocess.run`.



