### PR TITLE
Switch to pypi pylint from RPM

### DIFF
--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -37,11 +37,12 @@ TEST_DEPENDENCIES = ["e2fsprogs", "git", "bzip2", "cppcheck", "rpm-ostree", "pyk
                      "python3-lxml", "python3-pip", "python3-coverage",
 
                      # contains restorecon which was removed in Fedora 28 mock
-                     "policycoreutils",
-                     "python3-rpmfluff", "python3-dogtail", "python3-pocketlint"]
+                     "policycoreutils"
+                     # "python3-pocketlint"
+                     ]
 
 PIP_DEPENDENCIES = [
-                    # "rpmfluff", "dogtail", "pocketlint"
+                    "rpmfluff", "dogtail", "pocketlint"
                    ]
 
 RELEASE_DEPENDENCIES = ["python3-zanata-client"]


### PR DESCRIPTION
~The reason to do this is that Fedora `pylint` have again some problems with the newer version on the other hand this works fine on pypi.~

~I also don't prefer that Fedora is packaging some random commits instead of the released versions on Rawhide.~

---------------
_EDIT:_
Fedora RPM version of astroid has a problem with dependency auto generation which works correctly in the pypi repository. This is a work-around for the issue.

See: rhbz#1758141