### PR TITLE
Skip version when processing kernel boot args (#1637472)

### DIFF
--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -143,6 +143,8 @@ class AnacondaArgumentParser(ArgumentParser):
         :returns: argparse option object or None if no suitable option is found
         :rtype argparse option or None
         """
+        if arg == "version" or arg == "help":
+            return None
         if self.bootarg_prefix and arg.startswith(self.bootarg_prefix):
             prefixed_option = True
             arg = arg[len(self.bootarg_prefix):]


### PR DESCRIPTION
Without this patch booting with version on kernel boot cmdline will just print anaconda version and quit. This is not expected behavior.

(based on commit ef48dab58bdc5ca388aa4a181a6215bc4f22394f)

*Resolves: rhbz#1637472*