### PR TITLE
Remove ldconfig spec macros

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -265,10 +265,6 @@ desktop-file-install --dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_d
 # If no langs found, keep going
 %find_lang %{name} || :
 
-%post widgets -p /sbin/ldconfig
-%postun widgets -p /sbin/ldconfig
-
-
 %ifarch %livearches
 %post
 update-desktop-database &> /dev/null || :


### PR DESCRIPTION
This macros are not required from Fedora 28 (base of RHEL-8):

https://fedoraproject.org/wiki/Changes/Removing_ldconfig_scriptlets

The macros will be called on transaction and not for every package.

This will solve the bug when anaconda-widgets package raised an error when it was removed or updated on S390x or aarch64 architectures.

*Resolves: rhbz#1700685*