### PR TITLE
Remove ldconfig scriptlet from a spec file

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -269,9 +269,6 @@ desktop-file-install --dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_d
 # If no langs found, keep going
 %find_lang %{name} || :
 
-%ldconfig_scriptlets widgets
-
-
 
 # main package and install-env-deps are metapackages
 %files


### PR DESCRIPTION
This scriptlet is required only if we want to have backward
compatibility with RHEL-7 but that is not a problem in our case.

See:
https://fedoraproject.org/wiki/Changes/Removing_ldconfig_scriptlets