### PR TITLE
Skip buildins when processing kernel boot args (#1637472)

### DIFF
--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -142,6 +142,8 @@ class AnacondaArgumentParser(ArgumentParser):
         :returns: argparse option object or None if no suitable option is found
         :rtype argparse option or None
         """
+        if arg == "version" or arg == "help":
+            return None
         if self.bootarg_prefix and arg.startswith(self.bootarg_prefix):
             prefixed_option = True
             arg = arg[len(self.bootarg_prefix):]


### PR DESCRIPTION
Skip version and help from a kernel parameters.

Without this patch booting with version or help on kernel boot cmdline will just print anaconda version/help and quit. This is not the expected behavior.

(based on commit ef48dab58bdc5ca388aa4a181a6215bc4f22394f)

Resolves: rhbz#1637472