### PR TITLE
Add PARTUUID to lsblk_output log

### DIFF
--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -321,7 +321,9 @@ def initExceptionHandling(anaconda):
 def lsblk_callback():
     """Callback to get info about block devices."""
 
-    return util.execWithCapture("lsblk", ["--perms", "--fs", "--bytes"])
+    options = "NAME,SIZE,OWNER,GROUP,MODE,FSTYPE,LABEL,UUID,PARTUUID,MOUNTPOINT"
+
+    return util.execWithCapture("lsblk", ["--bytes", "-o", options])
 
 
 def nmcli_dev_list_callback():

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -321,7 +321,7 @@ def initExceptionHandling(anaconda):
 def lsblk_callback():
     """Callback to get info about block devices."""
 
-    options = "NAME,SIZE,OWNER,GROUP,MODE,FSTYPE,LABEL,UUID,PARTUUID,MOUNTPOINT"
+    options = "NAME,SIZE,OWNER,GROUP,MODE,FSTYPE,LABEL,UUID,PARTUUID,FSAVAIL,FSUSE%,MOUNTPOINT"
 
     return util.execWithCapture("lsblk", ["--bytes", "-o", options])
 


### PR DESCRIPTION
Modified lsblk_output log creation so it includes partition UUID.

UUID collisions are commonly reported issue. It isusually caused by cloning partitions/disks, so it is not something we can fix.
Since blivet works with partition UUID which is not included in `lsblk_output` log, this change
should improve understanding what is actually going on.