### PR TITLE
Add blog links to docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,6 +1,11 @@
 Contribution guidelines
 =======================
 
+This guide describes rules for how to get your contributions into Anaconda. However, if you seek
+help with implementing changes in Anaconda, please follow our
+`blog series <https://rhinstaller.wordpress.com/2019/10/11/anaconda-debugging-and-testing-part-1/>`_ or
+an `addon guide <http://rhinstaller.github.io/anaconda-addon-development-guide/index.html>`_ to create Anaconda addon.
+
 How to Contribute to the Anaconda Installer (the short version)
 ----------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -28,3 +28,8 @@ I want to do an automated installation!
 ---------------------------------------
 
 Kickstart has you covered! Check out the docs at: https://pykickstart.readthedocs.io
+
+I want to follow the project!
+-----------------------------
+
+Subscribe to our blog website at: https://rhinstaller.wordpress.com

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -22,3 +22,5 @@ partitioning program. Anaconda provides advanced debugging features such as
 remote logging, access to the python interactive debugger, and remote saving of
 exception dumps.
 
+For more news about Anaconda development and planned features you can follow
+`our blog <https://rhinstaller.wordpress.com>`_.


### PR DESCRIPTION
Link our blog with the Anaconda upstream documentation.