### PR TITLE
Replace the Timezone execute() method by a DBus Task

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -25,7 +25,7 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import BOOTLOADER_DISABLED
 from pyanaconda.modules.common.constants.objects import BOOTLOADER, SNAPSHOT, FIREWALL
 from pyanaconda.modules.common.constants.services import STORAGE, USERS, SERVICES, NETWORK, SECURITY, \
-    LOCALIZATION
+    LOCALIZATION, TIMEZONE
 from pyanaconda.modules.common.structures.requirement import Requirement
 from pyanaconda.modules.storage.snapshot.create import SnapshotCreateTask
 from pyanaconda.storage.kickstart import update_storage_ksdata
@@ -101,7 +101,11 @@ def _prepare_configuration(storage, payload, ksdata):
     os_config.append_dbus_tasks(SERVICES, services_dbus_tasks)
 
     os_config.append(Task("Configure keyboard", ksdata.keyboard.execute))
-    os_config.append(Task("Configure timezone", ksdata.timezone.execute))
+
+    # add installation tasks for the Timezone DBus module
+    timezone_proxy = TIMEZONE.get_proxy()
+    timezone_dbus_tasks = timezone_proxy.InstallWithTasks()
+    os_config.append_dbus_tasks(TIMEZONE, timezone_dbus_tasks)
 
     # add installation tasks for the Localization DBus module
     localization_proxy = LOCALIZATION.get_proxy()

--- a/pyanaconda/modules/common/errors/installation.py
+++ b/pyanaconda/modules/common/errors/installation.py
@@ -44,7 +44,14 @@ class NetworkInstallationError(InstallationError):
     """Exception for the network installation errors."""
     pass
 
+
 @dbus_error("FirewallConfigurationError", namespace=ANACONDA_NAMESPACE)
 class FirewallConfigurationError(InstallationError):
     """Exception for the firewall configuration errors."""
+    pass
+
+
+@dbus_error("TimezoneConfigurationError", namespace=ANACONDA_NAMESPACE)
+class TimezoneConfigurationError(InstallationError):
+    """Exception for the timezone configuration errors."""
     pass

--- a/pyanaconda/modules/timezone/installation.py
+++ b/pyanaconda/modules/timezone/installation.py
@@ -1,0 +1,166 @@
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import os
+import os.path
+
+from pyanaconda import ntp
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.modules.common.errors.installation import TimezoneConfigurationError
+from pyanaconda.modules.common.task import Task
+from pyanaconda.timezone import is_valid_timezone
+
+from blivet import arch
+
+__all__ = ["ConfigureNTPTask", "ConfigureTimezoneTask"]
+
+log = get_module_logger(__name__)
+
+
+class ConfigureTimezoneTask(Task):
+    """Installation task for timezone configuration."""
+
+    def __init__(self, sysroot, timezone, is_utc):
+        """Create a new task.
+
+        :param str sysroot: a path to the root of the installed system
+        :param str timezone: time zone to set
+        :param bool is_utc: whether time is UTC or local
+        """
+        super().__init__()
+        self._sysroot = sysroot
+        self._timezone = timezone
+        self._is_utc = is_utc
+
+    @property
+    def name(self):
+        return "Configure time zone"
+
+    def run(self):
+        """Perform the actual work of setting up timezone."""
+        self._correct_timezone()
+        self._make_timezone_symlink()
+        self._write_etc_adjtime()
+
+    def _correct_timezone(self):
+        """Ensure the timezone is valid."""
+        if not is_valid_timezone(self._timezone):
+            # this should never happen, but for pity's sake
+            log.warning("Timezone %s set in kickstart is not valid, "
+                        "falling back to default (America/New_York).", self._timezone)
+            self._timezone = "America/New_York"
+
+    def _make_timezone_symlink(self):
+        """Create the symlink that actually defines timezone."""
+
+        # we want to create a relative symlink
+        tz_file = "/usr/share/zoneinfo/" + self._timezone
+        rooted_tz_file = os.path.normpath(self._sysroot + tz_file)
+        relative_path = os.path.normpath("../" + tz_file)
+        link_path = os.path.normpath(self._sysroot + "/etc/localtime")
+
+        if not os.access(rooted_tz_file, os.R_OK):
+            log.error("Timezone to be linked (%s) doesn't exist", rooted_tz_file)
+            return
+
+        try:
+            # os.symlink fails if link_path exists, so try to remove it first
+            os.remove(link_path)
+        except OSError:
+            pass
+
+        try:
+            os.symlink(relative_path, link_path)
+        except OSError as oserr:
+            log.error("Error when symlinking timezone (from %s): %s",
+                      rooted_tz_file, oserr.strerror)
+
+    def _write_etc_adjtime(self):
+        """Write /etc/adjtime contents.
+
+        :raise: TimezoneConfigurationError
+        """
+        if arch.is_s390():
+            # there is no HW clock on s390(x)
+            return
+
+        try:
+            with open(os.path.normpath(self._sysroot + "/etc/adjtime"), "r") as fobj:
+                lines = fobj.readlines()
+        except IOError:
+            lines = ["0.0 0 0.0\n", "0\n"]
+
+        try:
+            with open(os.path.normpath(self._sysroot + "/etc/adjtime"), "w") as fobj:
+                fobj.write(lines[0])
+                fobj.write(lines[1])
+                if self._is_utc:
+                    fobj.write("UTC\n")
+                else:
+                    fobj.write("LOCAL\n")
+        except IOError as ioerr:
+            msg = "Error while writing /etc/adjtime file: {}".format(ioerr.strerror)
+            raise TimezoneConfigurationError(msg)
+
+
+class ConfigureNTPTask(Task):
+    """Installation task for NTP configuration."""
+
+    def __init__(self, sysroot, ntp_enabled, ntp_servers):
+        """Create a new task.
+
+        :param str sysroot: a path to the root of the installed system
+        :param bool ntp_enabled: is NTP enabled or not
+        :param ntp_servers: list of NTP servers and pools
+        :type ntp_servers: list of str
+        """
+        super().__init__()
+        self._sysroot = sysroot
+        self._ntp_enabled = ntp_enabled
+        self._ntp_servers = ntp_servers
+
+    @property
+    def name(self):
+        return "Configure NTP"
+
+    def run(self):
+        """Perform the actual work of setting up NTP."""
+        if not (self._ntp_enabled and self._ntp_servers):
+            return
+
+        chronyd_conf_path = os.path.normpath(self._sysroot + ntp.NTP_CONFIG_FILE)
+        pools, servers = ntp.internal_to_pools_and_servers(self._ntp_servers)
+
+        if os.path.exists(chronyd_conf_path):
+            log.debug("Modifying installed chrony configuration")
+            try:
+                ntp.save_servers_to_config(pools, servers, conf_file_path=chronyd_conf_path)
+            except ntp.NTPconfigError as ntperr:
+                log.warning("Failed to save NTP configuration: %s", ntperr)
+
+        # use chrony conf file from installation environment when
+        # chrony is not installed (chrony conf file is missing)
+        else:
+            log.debug("Creating chrony configuration based on the "
+                      "configuration from installation environment")
+            try:
+                ntp.save_servers_to_config(pools, servers,
+                                           conf_file_path=ntp.NTP_CONFIG_FILE,
+                                           out_file_path=chronyd_conf_path)
+            except ntp.NTPconfigError as ntperr:
+                log.warning("Failed to save NTP configuration without chrony package: %s",
+                            ntperr)

--- a/pyanaconda/modules/timezone/timezone.py
+++ b/pyanaconda/modules/timezone/timezone.py
@@ -17,13 +17,15 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.dbus import DBus
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.signal import Signal
+from pyanaconda.dbus import DBus
 from pyanaconda.modules.common.base import KickstartService
 from pyanaconda.modules.common.constants.services import TIMEZONE
 from pyanaconda.modules.common.containers import TaskContainer
-from pyanaconda.modules.timezone.timezone_interface import TimezoneInterface
+from pyanaconda.modules.timezone.installation import ConfigureNTPTask, ConfigureTimezoneTask
 from pyanaconda.modules.timezone.kickstart import TimezoneKickstartSpecification
+from pyanaconda.modules.timezone.timezone_interface import TimezoneInterface
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -121,3 +123,21 @@ class TimezoneService(KickstartService):
         self._ntp_servers = list(servers)
         self.ntp_servers_changed.emit()
         log.debug("NTP servers are set to %s.", servers)
+
+    def install_with_tasks(self):
+        """Return the installation tasks of this module.
+
+        :return: list of installation tasks
+        """
+        return [
+            ConfigureTimezoneTask(
+                sysroot=conf.target.system_root,
+                timezone=self.timezone,
+                is_utc=self.is_utc
+            ),
+            ConfigureNTPTask(
+                sysroot=conf.target.system_root,
+                ntp_enabled=self.ntp_enabled,
+                ntp_servers=self.ntp_servers
+            )
+        ]

--- a/tests/nosetests/pyanaconda_tests/module_timezone_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_timezone_test.py
@@ -57,7 +57,8 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         """Test the Timezone property."""
         self.timezone_interface.SetTimezone("Europe/Prague")
         self.assertEqual(self.timezone_interface.Timezone, "Europe/Prague")
-        self.callback.assert_called_once_with(TIMEZONE.interface_name, {'Timezone': 'Europe/Prague'}, [])
+        self.callback.assert_called_once_with(
+            TIMEZONE.interface_name, {'Timezone': 'Europe/Prague'}, [])
 
     def utc_property_test(self):
         """Test the IsUtc property."""
@@ -75,7 +76,8 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         """Test the NTPServers property."""
         self.timezone_interface.SetNTPServers(["ntp.cesnet.cz"])
         self.assertEqual(self.timezone_interface.NTPServers, ["ntp.cesnet.cz"])
-        self.callback.assert_called_once_with(TIMEZONE.interface_name, {'NTPServers': ["ntp.cesnet.cz"]}, [])
+        self.callback.assert_called_once_with(
+            TIMEZONE.interface_name, {'NTPServers': ["ntp.cesnet.cz"]}, [])
 
     def _test_kickstart(self, ks_in, ks_out):
         check_kickstart_interface(self, self.timezone_interface, ks_in, ks_out)


### PR DESCRIPTION
Replace the Timezone execute() method within Kickstart by a DBus-based ConfigureTimezoneTask.