### PR TITLE
Add support for the ZIPL Secure Boot (#1659400)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -37,7 +37,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.16.6-1
+%define pykickstartver 3.16.8-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 1.1-1

--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -2287,6 +2287,7 @@ class ZIPL(BootLoader):
     def __init__(self):
         super().__init__()
         self.stage1_name = None
+        self.secure = "auto"
 
     #
     # configuration
@@ -2357,12 +2358,18 @@ class ZIPL(BootLoader):
             self.update_bls_args(image, args)
 
     def write_config_header(self, config):
-        header = ("[defaultboot]\n"
-                  "defaultauto\n"
-                  "prompt=1\n"
-                  "timeout={}\n"
-                  "target=/boot\n")
-        config.write(header.format(self.timeout))
+        header = (
+            "[defaultboot]\n"
+            "defaultauto\n"
+            "prompt=1\n"
+            "timeout={}\n"
+            "target=/boot\n"
+            "secure={}\n"
+        )
+        config.write(header.format(
+            self.timeout,
+            self.secure
+        ))
 
     #
     # installation

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -84,6 +84,7 @@ from pykickstart.commands.volgroup import RHEL8_VolGroup as VolGroup
 from pykickstart.commands.xconfig import F14_XConfig as XConfig
 from pykickstart.commands.zerombr import F9_ZeroMbr as ZeroMbr
 from pykickstart.commands.zfcp import F14_ZFCP as ZFCP
+from pykickstart.commands.zipl import RHEL8_Zipl as Zipl
 
 # Supported kickstart data.
 from pykickstart.commands.btrfs import F23_BTRFSData as BTRFSData

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -503,6 +503,7 @@ class Bootloader(RemovedCommand):
         self._apply_location(storage, bootloader_proxy)
         self._apply_password(storage, bootloader_proxy)
         self._apply_timeout(storage, bootloader_proxy)
+        self._apply_zipl_secure_boot(storage, bootloader_proxy)
         self._apply_drive_order(storage, bootloader_proxy, dry_run=dry_run)
         self._apply_boot_drive(storage, bootloader_proxy, dry_run=dry_run)
 
@@ -547,6 +548,15 @@ class Bootloader(RemovedCommand):
         if timeout != BOOTLOADER_TIMEOUT_UNSET:
             bootloader_log.debug("Applying bootloader timeout: %s", timeout)
             storage.bootloader.timeout = timeout
+
+    def _apply_zipl_secure_boot(self, storage, bootloader_proxy):
+        """Set up the ZIPL Secure Boot."""
+        if not blivet.arch.is_s390():
+            return
+
+        secure_boot = bootloader_proxy.ZIPLSecureBoot
+        log.debug("Applying ZIPL Secure Boot: %s", secure_boot)
+        storage.bootloader.secure = secure_boot
 
     def _is_usable_disk(self, d):
         """Is the disk usable for the bootloader?

--- a/pyanaconda/modules/storage/bootloader/bootloader_interface.py
+++ b/pyanaconda/modules/storage/bootloader/bootloader_interface.py
@@ -22,7 +22,7 @@ from pyanaconda.dbus.property import emits_properties_changed
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterfaceTemplate
 from pyanaconda.modules.common.constants.objects import BOOTLOADER
-from pyanaconda.modules.storage.constants import BootloaderMode, BootloaderType
+from pyanaconda.modules.storage.constants import BootloaderMode, BootloaderType, ZIPLSecureBoot
 
 
 @dbus_interface(BOOTLOADER.interface_name)
@@ -43,6 +43,7 @@ class BootloaderInterface(KickstartModuleInterfaceTemplate):
         self.watch_property("KeepBootOrder", self.implementation.keep_boot_order_changed)
         self.watch_property("ExtraArguments", self.implementation.extra_arguments_changed)
         self.watch_property("Timeout", self.implementation.timeout_changed)
+        self.watch_property("ZIPLSecureBoot", self.implementation.zipl_secure_boot_changed)
         self.watch_property("IsPasswordSet", self.implementation.password_is_set_changed)
 
     @property
@@ -204,6 +205,31 @@ class BootloaderInterface(KickstartModuleInterfaceTemplate):
         :param timeout: a number of seconds
         """
         self.implementation.set_timeout(timeout)
+
+    @property
+    def ZIPLSecureBoot(self) -> Str:
+        """The ZIPL Secure Boot for s390x."""
+        return self.implementation.zipl_secure_boot.value
+
+    @emits_properties_changed
+    def SetZIPLSecureBoot(self, value: Str):
+        """Set up the ZIPL Secure Boot for s390x.
+
+        Supported values:
+            0     Disable Secure Boot.
+            1     Enable Secure Boot (or fail if unsupported).
+            auto  Enable Secure Boot if supported.
+
+        Firmware will verify the integrity of the Linux kernel during
+        boot if the Secure Boot is enabled and configured on the machine.
+
+        Note: Secure Boot is not supported on IBM z14 and earlier models,
+        therefore choose to disable it if you intend to boot the installed
+        system on such models.
+
+        :param value: a string
+        """
+        self.implementation.set_zipl_secure_boot(ZIPLSecureBoot(value))
 
     @property
     def Password(self) -> Str:

--- a/pyanaconda/modules/storage/constants.py
+++ b/pyanaconda/modules/storage/constants.py
@@ -61,3 +61,10 @@ class InitializationMode(Enum):
     CLEAR_ALL = CLEAR_PARTITIONS_ALL
     CLEAR_LIST = CLEAR_PARTITIONS_LIST
     CLEAR_LINUX = CLEAR_PARTITIONS_LINUX
+
+
+class ZIPLSecureBoot(Enum):
+    """The ZIPL Secure Boot options."""
+    DISABLED = "0"
+    ENABLED = "1"
+    AUTO = "auto"

--- a/pyanaconda/modules/storage/kickstart.py
+++ b/pyanaconda/modules/storage/kickstart.py
@@ -154,6 +154,7 @@ class StorageKickstartSpecification(KickstartSpecification):
         "volgroup": COMMANDS.VolGroup,
         "zerombr": COMMANDS.ZeroMbr,
         "zfcp": ZFCP,
+        "zipl": COMMANDS.Zipl
     }
 
     commands_data = {

--- a/pyanaconda/ui/gui/spokes/lib/cart.glade
+++ b/pyanaconda/ui/gui/spokes/lib/cart.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkListStore" id="disk_store">
@@ -20,20 +20,22 @@
   </object>
   <object class="GtkDialog" id="selected_disks_dialog">
     <property name="width_request">600</property>
-    <property name="height_request">400</property>
+    <property name="height_request">450</property>
     <property name="can_focus">False</property>
     <property name="border_width">6</property>
-    <property name="title" translatable="yes">SELECTED DISKS</property>
+    <property name="title" translatable="yes">SELECTED DISKS AND BOOT LOADER</property>
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">6</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area1">
             <property name="can_focus">False</property>
@@ -74,8 +76,8 @@
               <object class="GtkLabel" id="label4">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="label" translatable="yes">SELECTED DISKS AND BOOT LOADER</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">SELECTED DISKS</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -84,6 +86,23 @@
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="selected_disks_title">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">10</property>
+                <property name="label" translatable="yes">Selected disks</property>
+                <property name="xalign">0</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
@@ -170,7 +189,7 @@
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child>
@@ -215,21 +234,85 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="secure_boot_box">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkLabel" id="secure_boot_title">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_top">10</property>
+                    <property name="label" translatable="yes">Secure Boot</property>
+                    <property name="xalign">0</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="secure_boot_description">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Firmware will verify the integrity of the Linux kernel during boot if the Secure Boot is enabled and configured on the machine. Secure Boot is not supported on IBM z14 and earlier models, therefore choose to disable it if you intend to boot the installed system on such models.</property>
+                    <property name="wrap">True</property>
+                    <property name="max_width_chars">80</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBoxText" id="secure_boot_combo">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="active">0</property>
+                    <items>
+                      <item id="auto" translatable="yes">Enabled if supported by the installing machine</item>
+                      <item id="1" translatable="yes">Enabled unconditionally</item>
+                      <item id="0" translatable="yes">Disabled</item>
+                    </items>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">4</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="summary_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="xalign">0</property>
+                <property name="margin_top">10</property>
                 <property name="label" translatable="yes">Disk summary goes here</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="pack_type">end</property>
-                <property name="position">3</property>
+                <property name="position">6</property>
               </packing>
             </child>
           </object>

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -79,7 +79,8 @@ class StorageInterfaceTestCase(unittest.TestCase):
                 'reqpart',
                 'volgroup',
                 'zerombr',
-                'zfcp'
+                'zfcp',
+                'zipl',
             ]
         )
         self.assertEqual(self.storage_interface.KickstartSections, [])
@@ -395,6 +396,39 @@ class StorageInterfaceTestCase(unittest.TestCase):
         ks_out = """
         # System bootloader configuration
         bootloader --location=mbr --nombr
+        """
+        self._test_kickstart(ks_in, ks_out)
+
+    def zipl_secure_boot_kickstart_test(self):
+        """Test the zipl command with the secure boot option."""
+        ks_in = """
+        zipl --secure-boot
+        """
+        ks_out = """
+        # ZIPL configuration
+        zipl --secure-boot
+        """
+        self._test_kickstart(ks_in, ks_out)
+
+    def zipl_disable_secure_boot_kickstart_test(self):
+        """Test the zipl command with the disable secure boot option."""
+        ks_in = """
+        zipl --no-secure-boot
+        """
+        ks_out = """
+        # ZIPL configuration
+        zipl --no-secure-boot
+        """
+        self._test_kickstart(ks_in, ks_out)
+
+    def zipl_enable_secure_boot_kickstart_test(self):
+        """Test the zipl command with the force secure boot option."""
+        ks_in = """
+        zipl --force-secure-boot
+        """
+        ks_out = """
+        # ZIPL configuration
+        zipl --force-secure-boot
         """
         self._test_kickstart(ks_in, ks_out)
 
@@ -805,6 +839,13 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
         self._test_dbus_property(
             "Timeout",
             25
+        )
+
+    def secure_boot_property_test(self):
+        """Test the secure boot property."""
+        self._test_dbus_property(
+            "ZIPLSecureBoot",
+            "auto"
         )
 
     def password_property_test(self):


### PR DESCRIPTION
Use the DBus property `ZIPLSecureBoot` of the Bootloader module to set up the ZIPL
Secure Boot on s390x. The property can be set with the kickstart command `zipl` and
one of the options `--secure-boot`, `--no-secure-boot` and `--force-secure-boot`.

Allow to set up the ZIPL Secure Boot on s390x in the dialog window for selected
disks and the boot loader of the Storage spoke in GUI.

**Depends on:** https://github.com/pykickstart/pykickstart/pull/281
Resolves: rhbz#1659400
