### PR TITLE
Don't mark the network command as removed

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -292,7 +292,7 @@ class Logging(COMMANDS.Logging):
                 remote_server = "%s:%s" % (self.host, self.port)
             anaconda_logging.logger.updateRemote(remote_server)
 
-class Network(RemovedCommand):
+class Network(COMMANDS.Network):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.packages = []


### PR DESCRIPTION
The network command uses its own parse method, so it cannot be marked
as removed yet.