### PR TITLE
Remove useless support for boot loader update

### DIFF
--- a/pyanaconda/bootloader/base.py
+++ b/pyanaconda/bootloader/base.py
@@ -131,7 +131,6 @@ class BootLoader(object):
     config_file = None
     config_file_mode = 0o600
     can_dual_boot = False
-    can_update = False
     keep_boot_order = False
     keep_mbr = False
     image_label_attr = "label"
@@ -184,10 +183,7 @@ class BootLoader(object):
 
         # default image
         self._default_image = None
-
-        self._update_only = False
         self.skip_bootloader = False
-
         self.use_bls = True
 
         self.errors = []
@@ -692,17 +688,6 @@ class BootLoader(object):
     def timeout(self, seconds):
         self._timeout = seconds
 
-    @property
-    def update_only(self):
-        return self._update_only
-
-    @update_only.setter
-    def update_only(self, value):
-        if value and not self.can_update:
-            raise ValueError("this boot loader does not support updates")
-        elif self.can_update:
-            self._update_only = value
-
     def set_boot_args(self, storage):
         """Set up the boot command line."""
         self._set_storage_boot_args(storage)
@@ -916,10 +901,6 @@ class BootLoader(object):
         if self.skip_bootloader:
             return
 
-        if self.update_only:
-            self.update()
-            return
-
         self.write_config()
         os.sync()
         self.stage2_device.format.sync(root=conf.target.physical_root)
@@ -927,10 +908,6 @@ class BootLoader(object):
 
     def install(self, args=None):
         raise NotImplementedError()
-
-    def update(self):
-        """ Update an existing bootloader configuration. """
-        pass
 
 
 def get_interface_hw_address(iface):

--- a/pyanaconda/bootloader/efi.py
+++ b/pyanaconda/bootloader/efi.py
@@ -102,16 +102,9 @@ class EFIBase(object):
                     raise BootLoaderError("Failed to remove old efi boot entry. This is most "
                                           "likely a kernel or firmware bug.")
 
-    def update(self):
-        self.install()
-
     def write(self):
         """ Write the bootloader configuration and install the bootloader. """
         if self.skip_bootloader:  # pylint: disable=no-member
-            return
-
-        if self.update_only:  # pylint: disable=no-member
-            self.update()
             return
 
         try:

--- a/pyanaconda/bootloader/grub2.py
+++ b/pyanaconda/bootloader/grub2.py
@@ -108,7 +108,6 @@ class GRUB2(BootLoader):
 
     _device_map_file = "device.map"
     can_dual_boot = True
-    can_update = True
 
     stage2_is_valid_stage1 = True
     stage2_bootable = True
@@ -399,9 +398,6 @@ class GRUB2(BootLoader):
 
         return targets
 
-    def update(self):
-        self.install()
-
     def install(self, args=None):
         if args is None:
             args = []
@@ -429,10 +425,6 @@ class GRUB2(BootLoader):
     def write(self):
         """Write the bootloader configuration and install the bootloader."""
         if self.skip_bootloader:
-            return
-
-        if self.update_only:
-            self.update()
             return
 
         try:


### PR DESCRIPTION
The boot loader seems to support updates of the existing configuration,
but Anaconda never uses this code, so let's remove it.