### PR TITLE
Fix links to a new pykickstart GitHub group

### DIFF
--- a/docs/kickstart.rst
+++ b/docs/kickstart.rst
@@ -4,7 +4,7 @@ Anaconda Kickstart Documentation
 :Authors:
     Brian C. Lane <bcl@redhat.com>
 
-Anaconda uses `kickstart <https://github.com/rhinstaller/pykickstart>`_ to automate
+Anaconda uses `kickstart <https://github.com/pykickstart/pykickstart>`_ to automate
 installation and as a data store for the user interface. It also extends the kickstart
 commands `documented here <https://pykickstart.readthedocs.io/>`_
 by adding a new kickstart section named ``%anaconda`` where commands to control the behavior

--- a/dracut/README-driver-updates.md
+++ b/dracut/README-driver-updates.md
@@ -294,7 +294,7 @@ handled by `parse-kickstart`:
 
 Check the [kickstart documentation] for more info.
 
-[kickstart documentation]: https://github.com/rhinstaller/pykickstart/blob/master/docs/kickstart-docs.rst#driverdisk
+[kickstart documentation]: https://github.com/pykickstart/pykickstart/blob/master/docs/kickstart-docs.rst#driverdisk
 
 ## initqueue: `driver-updates@.service`
 


### PR DESCRIPTION
Pykickstart is now under it's own organization. That is great because it won't be moving in the future.