### PR TITLE
Return back AutoPart kickstart command

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -265,6 +265,12 @@ class Authselect(RemovedCommand):
         except RuntimeError as msg:
             authselect_log.error("Error running %s %s: %s", cmd, args, msg)
 
+# FIXME: We have to fix self.handler.autopart in the pykickstart project before replacing this by
+#        UselessCommand class. The self.handler.autopart won't be present, instead there will be
+#        self.handler.uselesscommand. Test handler.autopart availability before calling it.
+class AutoPart(RemovedCommand):
+    pass
+
 class BTRFS(COMMANDS.BTRFS):
     pass
 
@@ -591,7 +597,7 @@ commandMap = {
     "auth": UselessCommand,
     "authconfig": UselessCommand,
     "authselect": Authselect,
-    "autopart": UselessCommand,
+    "autopart": AutoPart,
     "btrfs": BTRFS,
     "bootloader": UselessCommand,
     "clearpart": UselessCommand,


### PR DESCRIPTION
The `AutoPart` command was completely removed by the commit d28a76fe1b19d4d0ac98b4f89020a99117278310. The command is tested in pykickstart for collisions with other storage commands by `handler.autopart.seen` call. That works until this command was replaced by `UselessCommand` which removed the `handler.autopart` command. It does not exists because this handler mapping is mapped based on the `__class__.__name__` so instead of having the `handler.autopart` we end up with `handler.uselesscommand`.

This is a hotfix for the issue to unblock installations. The correct fix should go to pykickstart and test if handler contains `autopart` attribute before touching it.