### PR TITLE
Add packages ignore broken parameter support

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -35,7 +35,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.21-1
+%define pykickstartver 3.22-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 1.1-1

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -76,6 +76,9 @@ enabled_repositories_from_treeinfo = addon optional variant
 # Enable installation from the closest mirror.
 enable_closest_mirror = True
 
+# Enable possibility to skip packages with conflicts and broken dependencies.
+enable_ignore_broken_packages = True
+
 # Check if payload supports the locales.
 check_supported_locales = False
 

--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -16,6 +16,12 @@ ignored_packages = ntfsprogs
 enable_updates = False
 enable_closest_mirror = False
 
+# This feature may result in an installed system which won't have everything installed
+# as expected. Because of this problem this feature will be disabled on RHEL based variants.
+# When disabled the installation won't be started with --ignorebroken, instead it will inform user
+# that the feature is not supported on their product. This will also block usage of related DBus API.
+enable_ignore_broken_packages = False
+
 [Bootloader]
 efi_dir = redhat
 

--- a/pyanaconda/core/configuration/payload.py
+++ b/pyanaconda/core/configuration/payload.py
@@ -72,6 +72,19 @@ class PayloadSection(Section):
         return self._get_option("enable_closest_mirror", bool)
 
     @property
+    def enable_ignore_broken_packages(self):
+        """Enable possibility to skip packages with conflicts and broken dependencies.
+
+        This enables --ignorebroken parameter of the packages section and related DBus API.
+
+        If this feature is disabled Anaconda won't start the installation when
+        --ignorebroken paramater is used. Instead print error message to user
+        when Anaconda is started and quit the installation process.
+        It will also block use of related DBus API.
+        """
+        return self._get_option("enable_ignore_broken_packages", bool)
+
+    @property
     def check_supported_locales(self):
         """Check if payload supports the locales.
 

--- a/pyanaconda/modules/common/errors/__init__.py
+++ b/pyanaconda/modules/common/errors/__init__.py
@@ -39,5 +39,11 @@ class InvalidValueError(AnacondaError):
     pass
 
 
+@dbus_error("UnsupportedValueError", namespace=ANACONDA_NAMESPACE)
+class UnsupportedValueError(AnacondaError):
+    """Value passed is not supported."""
+    pass
+
+
 # Define mapping for existing exceptions.
 dbus_error("KickstartError", namespace=ANACONDA_NAMESPACE)(KickstartError)

--- a/pyanaconda/modules/payloads/kickstart.py
+++ b/pyanaconda/modules/payloads/kickstart.py
@@ -17,10 +17,31 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pykickstart.errors import KickstartParseError
 from pykickstart.sections import PackageSection
 from pykickstart.parser import Packages
+from pykickstart.constants import KS_BROKEN_IGNORE
 
+from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.core.i18n import _
 from pyanaconda.core.kickstart import VERSION, KickstartSpecification, commands as COMMANDS
+
+
+class AnacondaPackageSection(PackageSection):
+
+    def handleHeader(self, lineno, args):
+        """Process packages section header.
+
+        Add checks based on configuration settings.
+        """
+        super().handleHeader(lineno, args)
+
+        if not conf.payload.enable_ignore_broken_packages \
+           and self.handler.packages.handleBroken == KS_BROKEN_IGNORE:
+            raise KickstartParseError(
+                _("The %packages --ignorebroken feature is not supported on your product!"),
+                lineno=lineno
+            )
 
 
 class PayloadKickstartSpecification(KickstartSpecification):
@@ -32,7 +53,7 @@ class PayloadKickstartSpecification(KickstartSpecification):
     }
 
     sections = {
-        "packages": PackageSection
+        "packages": AnacondaPackageSection
     }
 
     sections_data = {

--- a/pyanaconda/modules/payloads/payload/dnf/packages/packages_interface.py
+++ b/pyanaconda/modules/payloads/payload/dnf/packages/packages_interface.py
@@ -41,6 +41,7 @@ class PackagesInterface(KickstartModuleInterfaceTemplate):
         self.watch_property("DocsExcluded", self.implementation.docs_excluded_changed)
         self.watch_property("WeakdepsExcluded", self.implementation.weakdeps_excluded_changed)
         self.watch_property("MissingIgnored", self.implementation.missing_ignored_changed)
+        self.watch_property("BrokenIgnored", self.implementation.broken_ignored_changed)
         self.watch_property("Languages", self.implementation.languages_changed)
         self.watch_property("MultilibPolicy", self.implementation.multilib_policy_changed)
         self.watch_property("Timeout", self.implementation.timeout_changed)
@@ -150,6 +151,16 @@ class PackagesInterface(KickstartModuleInterfaceTemplate):
     def SetMissingIgnored(self, missing_ignored: Bool):
         """Set if the missing packages should be ignored."""
         self.implementation.set_missing_ignored(missing_ignored)
+
+    @property
+    def BrokenIgnored(self) -> Bool:
+        """Should the broken packages be ignored?"""
+        return self.implementation.broken_ignored
+
+    @emits_properties_changed
+    def SetBrokenIgnored(self, broken_ignored: Bool):
+        """Set if the broken packages should be ignored."""
+        self.implementation.set_broken_ignored(broken_ignored)
 
     @property
     def Languages(self) -> Str:

--- a/pyanaconda/modules/payloads/payload/dnf/packages/packages_interface.py
+++ b/pyanaconda/modules/payloads/payload/dnf/packages/packages_interface.py
@@ -159,7 +159,10 @@ class PackagesInterface(KickstartModuleInterfaceTemplate):
 
     @emits_properties_changed
     def SetBrokenIgnored(self, broken_ignored: Bool):
-        """Set if the broken packages should be ignored."""
+        """Set if the broken packages should be ignored.
+
+        :raise: UnsupportedValueError if this feature is not supported on this product.
+        """
         self.implementation.set_broken_ignored(broken_ignored)
 
     @property

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -57,7 +57,7 @@ import rpm
 from dnf.const import GROUP_PACKAGE_TYPES
 
 from blivet.size import Size
-from pykickstart.constants import GROUP_ALL, GROUP_DEFAULT, KS_MISSING_IGNORE
+from pykickstart.constants import GROUP_ALL, GROUP_DEFAULT, KS_MISSING_IGNORE, KS_BROKEN_IGNORE
 
 from pyanaconda.anaconda_loggers import get_packaging_logger, get_dnf_logger
 log = get_packaging_logger()
@@ -573,8 +573,10 @@ class DNFPayload(payload.PackagePayload):
 
         # feed it to DNF
         try:
+            # FIXME: Remove self._base.conf.strict workaround when bz1761518 is fixed
             # install_specs() returns a list of specs that appear to be missing
-            self._base.install_specs(install=include_list, exclude=exclude_list)
+            self._base.install_specs(install=include_list, exclude=exclude_list,
+                                     strict=self._base.conf.strict)
         except dnf.exceptions.MarkingErrors as e:
             log.debug("install_specs(): some packages, groups or modules "
                       " are missing or broken:\n%s", e)
@@ -695,6 +697,13 @@ class DNFPayload(payload.PackagePayload):
 
         if self.data.packages.retries is not None:
             config.retries = self.data.packages.retries
+
+        if self.data.packages.handleBroken == KS_BROKEN_IGNORE:
+            log.warning("\n*********************************************************************\n"
+                        "User has requested to skip broken packages. Using this option may result "
+                        "in an UNUSABLE system!\n"
+                        "*********************************************************************")
+            config.strict = False
 
         self._configure_proxy()
 

--- a/tests/nosetests/pyanaconda_tests/__init__.py
+++ b/tests/nosetests/pyanaconda_tests/__init__.py
@@ -82,6 +82,8 @@ def check_kickstart_interface(test, interface, ks_in, ks_out=None, ks_valid=True
     callback = PropertiesChangedCallback()
     interface.PropertiesChanged.connect(callback)
 
+    result = None
+
     # Read a kickstart,
     if ks_in is not None:
         ks_in = dedent(ks_in).strip()
@@ -89,10 +91,10 @@ def check_kickstart_interface(test, interface, ks_in, ks_out=None, ks_valid=True
         test.assertEqual(ks_valid, result.is_valid())
 
     if not ks_valid:
-        return
+        return result
 
     if ks_out is None:
-        return
+        return result
 
     # Generate a kickstart
     ks_out = dedent(ks_out).strip()
@@ -111,6 +113,8 @@ def check_kickstart_interface(test, interface, ks_in, ks_out=None, ks_valid=True
 
     ks_tmp = dedent(ks_tmp).strip()
     test.assertEqual(ks_tmp, interface.GenerateTemporaryKickstart().strip())
+
+    return result
 
 
 class PropertiesChangedCallback(Mock):

--- a/tests/nosetests/pyanaconda_tests/module_payload_shared.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_shared.py
@@ -40,7 +40,7 @@ class PayloadSharedTest(object):
         self.payload_service = PayloadsService()
         self.payload_service_interface = PayloadsInterface(self.payload_service)
 
-    def check_kickstart(self, ks_in, ks_out, expected_publish_calls=1):
+    def check_kickstart(self, ks_in, ks_out, ks_valid=True, expected_publish_calls=1):
         """Test kickstart processing.
 
         :param test_obj: TestCase object (probably self)
@@ -50,12 +50,15 @@ class PayloadSharedTest(object):
         :type expected_publish_calls: int
         """
         with patch('pyanaconda.core.dbus.DBus.publish_object') as publisher:
-            check_kickstart_interface(self._test,
-                                      self.payload_service_interface,
-                                      ks_in, "", ks_tmp=ks_out)
+            result = check_kickstart_interface(self._test,
+                                               self.payload_service_interface,
+                                               ks_in, "", ks_valid, ks_tmp=ks_out)
 
-            publisher.assert_called()
-            self._test.assertEqual(publisher.call_count, expected_publish_calls)
+            if ks_valid:
+                publisher.assert_called()
+                self._test.assertEqual(publisher.call_count, expected_publish_calls)
+
+            return result
 
     def get_payload(self):
         """Get payload created."""


### PR DESCRIPTION
This option is not recommended but there are a valid use-cases. It should be used only if user know what he/she is doing!

**Blocked by https://github.com/pykickstart/pykickstart/pull/282**

*Resolves: rhbz#1642013*