### PR TITLE
iscsi: do not generate initiator for generated kickstart if iscsi is …

### DIFF
--- a/pyanaconda/modules/storage/iscsi/iscsi.py
+++ b/pyanaconda/modules/storage/iscsi/iscsi.py
@@ -128,8 +128,9 @@ class ISCSIModule(KickstartBaseModule):
 
     def setup_kickstart(self, data):
         """Setup the kickstart data."""
-        data.iscsiname.iscsiname = self.initiator
         data.iscsi.iscsi = self.generate_iscsi_data(data.IscsiData)
+        if data.iscsi.iscsi:
+            data.iscsiname.iscsiname = self.initiator
 
     def generate_iscsi_data(self, iscsi_data_class):
         """Generate kickstart data based on original kickstart and attached nodes.


### PR DESCRIPTION
…not used

The initiator name would be generated by blivet iscsi module when accessing its
initiator attribute when generating kickstart.