### PR TITLE
Enable networking in the testing environment by default

### DIFF
--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -314,7 +314,7 @@ def copy_result(mock_command, out_dir):
 
 
 def create_mock_command(mock_conf, uniqueext):
-    cmd = ['mock', '-r', mock_conf, ]
+    cmd = ['mock', '-r', mock_conf, '--enable-network']
 
     if uniqueext:
         cmd.append('--uniqueext')


### PR DESCRIPTION
We cannot set up the testing environment without enabled networking, so
enable it by default. The `--enable-network` option of the `mock` command
overrides the configuration option.