### PR TITLE
Remove the storage object from TUI

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -31,7 +31,7 @@ import signal
 import pid
 
 
-def exitHandler(rebootData, storage):
+def exitHandler(rebootData):
     # Clear the list of watched PIDs.
     from pyanaconda.core.process_watchers import WatchProcesses
     WatchProcesses.unwatch_all_processes()
@@ -55,13 +55,12 @@ def exitHandler(rebootData, storage):
     if anaconda.payload:
         anaconda.payload.unsetup()
 
-    # Unmount the filesystems.
-    if not conf.target.is_hardware:
-        anaconda.storage.umount_filesystems(swapoff=False)
+    from pyanaconda.modules.common.task import sync_run_task
+    storage_proxy = STORAGE.get_proxy()
 
-    # Tear down disk images.
-    if conf.target.is_image:
-        anaconda.storage.devicetree.teardown_disk_images()
+    for task_path in storage_proxy.TeardownWithTasks():
+        task_proxy = STORAGE.get_proxy(task_path)
+        sync_run_task(task_proxy)
 
     # Clean up the PID file
     if pidfile:
@@ -73,9 +72,16 @@ def exitHandler(rebootData, storage):
         from pykickstart.constants import KS_SHUTDOWN, KS_WAIT
 
         if flags.eject or rebootData.eject:
-            for cdrom in (d for d in storage.devices if d.type == "cdrom"):
-                if util.get_mount_paths(cdrom.path):
-                    util.dracut_eject(cdrom.path)
+            from pyanaconda.modules.common.constants.objects import DEVICE_TREE
+            from pyanaconda.modules.common.structures.storage import DeviceData
+            device_tree_proxy = STORAGE.get_proxy(DEVICE_TREE)
+
+            for device_name in device_tree_proxy.FindOpticalMedia:
+                device_data = DeviceData.from_structure(
+                    device_tree_proxy.GetDeviceData(device_name)
+                )
+                if util.get_mount_paths(device_data.path):
+                    util.dracut_eject(device_data.path)
 
         if flags.kexec:
             util.execWithRedirect("systemctl", ["--no-wall", "kexec"])
@@ -556,9 +562,6 @@ if __name__ == "__main__":
     # Now that LANG is set, do something with it
     localization.setup_locale(os.environ["LANG"], localization_proxy, text_mode=anaconda.tui_mode)
 
-    from pyanaconda.storage.initialization import enable_installer_mode, reset_storage
-    enable_installer_mode()
-
     # Initialize the network now, in case the display needs it
     from pyanaconda.network import initialize_network, wait_for_connecting_NM_thread, wait_for_connected_NM
 
@@ -654,9 +657,9 @@ if __name__ == "__main__":
     from pyanaconda.timezone import time_initialize
 
     if not conf.target.is_directory:
+        from pyanaconda.storage.initialization import reset_storage
         threadMgr.add(AnacondaThread(name=constants.THREAD_STORAGE,
-                                     target=reset_storage,
-                                     args=(anaconda.storage, )))
+                                     target=reset_storage))
 
     from pyanaconda.modules.common.constants.services import TIMEZONE
     timezone_proxy = TIMEZONE.get_proxy()
@@ -664,8 +667,7 @@ if __name__ == "__main__":
     if conf.system.can_initialize_system_clock:
         threadMgr.add(AnacondaThread(name=constants.THREAD_TIME_INIT,
                                      target=time_initialize,
-                                     args=(timezone_proxy,
-                                           anaconda.storage)))
+                                     args=(timezone_proxy, )))
 
     if flags.rescue_mode:
         rescue.start_rescue_mode_ui(anaconda)
@@ -681,7 +683,7 @@ if __name__ == "__main__":
     signal.signal(signal.SIGUSR1, lambda signum, frame:
                   exception.test_exception_handling())
     signal.signal(signal.SIGUSR2, lambda signum, frame: anaconda.dumpState())
-    atexit.register(exitHandler, ksdata.reboot, anaconda.storage)
+    atexit.register(exitHandler, ksdata.reboot)
 
     from pyanaconda import exception
     anaconda.mehConfig = exception.initExceptionHandling(anaconda)
@@ -739,7 +741,7 @@ if __name__ == "__main__":
         # Run the tasks.
         with check_kickstart_error():
             from pyanaconda.modules.storage.snapshot.create import SnapshotCreateTask
-            SnapshotCreateTask(anaconda.storage, requests, SNAPSHOT_WHEN_PRE_INSTALL).run()
+            SnapshotCreateTask(None, requests, SNAPSHOT_WHEN_PRE_INSTALL).run()
 
     anaconda.intf.setup(ksdata)
     anaconda.intf.run()

--- a/anaconda.py
+++ b/anaconda.py
@@ -55,7 +55,6 @@ def exitHandler(rebootData):
     if anaconda.payload:
         anaconda.payload.unsetup()
 
-    from pyanaconda.modules.common.task import sync_run_task
     storage_proxy = STORAGE.get_proxy()
 
     for task_path in storage_proxy.TeardownWithTasks():
@@ -727,6 +726,7 @@ if __name__ == "__main__":
     from pykickstart.constants import SNAPSHOT_WHEN_PRE_INSTALL
     from pyanaconda.kickstart import check_kickstart_error
     from pyanaconda.modules.common.constants.objects import SNAPSHOT
+    from pyanaconda.modules.common.task import sync_run_task
     snapshot_proxy = STORAGE.get_proxy(SNAPSHOT)
 
     if snapshot_proxy.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL):
@@ -734,13 +734,12 @@ if __name__ == "__main__":
         # FIXME: Don't block the main thread!
         threadMgr.wait(constants.THREAD_STORAGE)
 
-        # Prepare the requests.
-        requests = ksdata.snapshot.get_requests(SNAPSHOT_WHEN_PRE_INSTALL)
+        # Run the task.
+        snapshot_task_path = snapshot_proxy.CreateWithTask(SNAPSHOT_WHEN_PRE_INSTALL)
+        snapshot_task_proxy = STORAGE.get_proxy(snapshot_task_path)
 
-        # Run the tasks.
         with check_kickstart_error():
-            from pyanaconda.modules.storage.snapshot.create import SnapshotCreateTask
-            SnapshotCreateTask(None, requests, SNAPSHOT_WHEN_PRE_INSTALL).run()
+            sync_run_task(snapshot_task_proxy)
 
     anaconda.intf.setup(ksdata)
     anaconda.intf.run()

--- a/anaconda.py
+++ b/anaconda.py
@@ -616,11 +616,10 @@ if __name__ == "__main__":
     else:
         min_ram = isys.MIN_RAM
 
-    from pyanaconda.storage.checker import storage_checker
-    storage_checker.set_constraint(constants.STORAGE_MIN_RAM, min_ram)
-
-    # Add a check for the snapshot requests.
-    storage_checker.add_check(ksdata.snapshot.verify_requests)
+    from pyanaconda.modules.common.constants.objects import STORAGE_CHECKER
+    from pyanaconda.dbus.typing import get_variant, Int
+    storage_checker = STORAGE.get_proxy(STORAGE_CHECKER)
+    storage_checker.SetConstraint(constants.STORAGE_MIN_RAM, get_variant(Int, min_ram))
 
     # Set the disk images.
     from pyanaconda.modules.common.constants.objects import DISK_SELECTION

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -49,7 +49,6 @@ class Anaconda(object):
         self.opts = None
         self._payload = None
         self.proxy = None
-        self._storage = None
         self.mehConfig = None
 
         # Data for inhibiting the screensaver
@@ -100,7 +99,7 @@ class Anaconda(object):
                 from pyanaconda.payload.dnfpayload import DNFPayload
                 klass = DNFPayload
 
-            self._payload = klass(self.ksdata, self.storage)
+            self._payload = klass(self.ksdata)
 
         return self._payload
 
@@ -135,17 +134,6 @@ class Anaconda(object):
             raise RuntimeError("addrepo boot option has incorrect format. Correct format is: "
                                "inst.addrepo=<name>,<url>") from None
         return name, rest
-
-    @property
-    def storage(self):
-        if not self._storage:
-            from pyanaconda.storage.initialization import create_storage
-            self._storage = create_storage()
-
-            from pyanaconda.storage.initialization import set_storage_defaults_from_kickstart
-            set_storage_defaults_from_kickstart(self._storage)
-
-        return self._storage
 
     @property
     def display_mode(self):
@@ -282,7 +270,7 @@ class Anaconda(object):
             from pyanaconda.ui.gui import GraphicalUserInterface
             # Run the GUI in non-fullscreen mode, so live installs can still
             # use the window manager
-            self._intf = GraphicalUserInterface(self.storage, self.payload,
+            self._intf = GraphicalUserInterface(None, self.payload,
                                                 gui_lock=self.gui_initialized,
                                                 fullscreen=False)
 
@@ -292,7 +280,7 @@ class Anaconda(object):
         elif self.tui_mode:
             # TUI and noninteractive TUI are the same in this regard
             from pyanaconda.ui.tui import TextUserInterface
-            self._intf = TextUserInterface(self.storage, self.payload)
+            self._intf = TextUserInterface(None, self.payload)
 
             # needs to be refreshed now we know if gui or tui will take place
             addon_paths = addons.collect_addon_paths(constants.ADDON_PATHS,

--- a/pyanaconda/bootloader/installation.py
+++ b/pyanaconda/bootloader/installation.py
@@ -28,29 +28,7 @@ from pyanaconda.product import productName
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
-__all__ = ["write_boot_loader", "configure_boot_loader", "install_boot_loader"]
-
-
-def write_boot_loader(storage, payload):
-    """Write bootloader configuration to disk.
-
-    FIXME: A temporary workaround for UI.
-
-    When we get here, the bootloader will already have a default linux
-    image. We only have to add images for the non-default kernels and
-    adjust the default to reflect whatever the default variant is.
-    """
-    # Configure the boot loader.
-    if not payload.handles_bootloader_configuration:
-        configure_boot_loader(
-            sysroot=conf.target.system_root,
-            storage=storage,
-            kernel_versions=payload.kernel_version_list
-        )
-
-    # Install the boot loader.
-    if not storage.bootloader.skip_bootloader:
-        install_boot_loader(storage)
+__all__ = ["configure_boot_loader", "install_boot_loader"]
 
 
 def configure_boot_loader(sysroot, storage, kernel_versions):

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -17,20 +17,11 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
-from blivet import callbacks, arch
-from blivet.devices import BTRFSDevice
-
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.constants import BOOTLOADER_DISABLED
 from pyanaconda.modules.common.constants.objects import BOOTLOADER, SNAPSHOT, FIREWALL
 from pyanaconda.modules.common.constants.services import STORAGE, USERS, SERVICES, NETWORK, SECURITY, \
     LOCALIZATION
 from pyanaconda.modules.common.structures.requirement import Requirement
-from pyanaconda.modules.storage.snapshot.create import SnapshotCreateTask
-from pyanaconda.storage.kickstart import update_storage_ksdata
-from pyanaconda.storage.installation import turn_on_filesystems, write_storage_configuration
-from pyanaconda.bootloader.installation import write_boot_loader
 from pyanaconda.payload.livepayload import LiveImagePayload
 from pyanaconda.progress import progress_message, progress_step, progress_complete, progress_init
 from pyanaconda import flags
@@ -39,7 +30,6 @@ from pyanaconda import timezone
 from pyanaconda import network
 from pyanaconda.core.i18n import N_
 from pyanaconda.threading import threadMgr
-from pyanaconda.ui.lib.entropy import wait_for_entropy
 from pyanaconda.kickstart import runPostScripts, runPreInstallScripts
 from pyanaconda.kexec import setup_kexec
 from pyanaconda.installation_tasks import Task, TaskQueue
@@ -143,18 +133,15 @@ def _prepare_configuration(storage, payload, ksdata):
     # This works around 2 problems, /boot on BTRFS and BTRFS installations where the initrd is
     # recreated after the first writeBootLoader call. This reruns it after the new initrd has
     # been created, fixing the kernel root and subvol args and adding the missing initrd entry.
-    boot_on_btrfs = isinstance(storage.mountpoints.get("/"), BTRFSDevice)
-
     bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
-    bootloader_enabled = bootloader_proxy.BootloaderMode != BOOTLOADER_DISABLED
 
-    if isinstance(payload, LiveImagePayload) and boot_on_btrfs and bootloader_enabled:
-        generate_initramfs.append(Task("Write BTRFS bootloader fix", write_boot_loader, (storage, payload)))
+    if isinstance(payload, LiveImagePayload):
+        btrfs_task = bootloader_proxy.FixBTRFSWithTask(payload.kernel_version_list)
+        generate_initramfs.append_dbus_tasks(STORAGE, [btrfs_task])
 
     # Invoking zipl should be the last thing done on a s390x installation (see #1652727).
-    if arch.is_s390() and not conf.target.is_directory and bootloader_enabled:
-        generate_initramfs.append(Task("Rerun zipl", lambda: util.execInSysroot("zipl", [])))
-
+    zipl_task = bootloader_proxy.FixZIPLWithTask()
+    generate_initramfs.append_dbus_tasks(STORAGE, [zipl_task])
     configuration_queue.append(generate_initramfs)
 
     # realm join
@@ -198,10 +185,6 @@ def _prepare_installation(storage, payload, ksdata):
        The two main tasks for this are putting filesystems onto disks and
        installing packages onto those filesystems.
     """
-    bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
-    bootloader_enabled = bootloader_proxy.BootloaderMode != BOOTLOADER_DISABLED
-    can_install_bootloader = not conf.target.is_directory and bootloader_enabled
-
     installation_queue = TaskQueue("Installation queue")
     # connect progress reporting
     installation_queue.queue_started.connect(lambda x: progress_message(x.status_message))
@@ -241,32 +224,13 @@ def _prepare_installation(storage, payload, ksdata):
     # Depending on current payload the storage might be apparently configured
     # either before or after package/payload installation.
     # So let's have two task queues - early storage & late storage.
+    storage_proxy = STORAGE.get_proxy()
     early_storage = TaskQueue("Early storage configuration", N_("Configuring storage"))
+    early_storage.append_dbus_tasks(STORAGE, storage_proxy.InstallWithTasks())
 
-    # put custom storage info into ksdata
-    early_storage.append(Task("Insert custom storage to ksdata",
-                              task=update_storage_ksdata,
-                              task_args=(storage, ksdata)))
-
-    # callbacks for blivet
-    message_clbk = lambda clbk_data: progress_message(clbk_data.msg)
-    entropy_wait_clbk = lambda clbk_data: wait_for_entropy(clbk_data.msg,
-                                                           clbk_data.min_entropy, ksdata)
-    callbacks_reg = callbacks.create_new_callbacks_register(create_format_pre=message_clbk,
-                                                            resize_format_pre=message_clbk,
-                                                            wait_for_entropy=entropy_wait_clbk)
-    if not conf.target.is_directory:
-        early_storage.append(Task("Activate filesystems",
-                                  task=turn_on_filesystems,
-                                  task_args=(storage,),
-                                  task_kwargs={"callbacks": callbacks_reg}))
-
-    early_storage.append(Task("Mount filesystems", task=storage.mount_filesystems))
-
-    if payload.needs_storage_configuration and not conf.target.is_directory:
-        early_storage.append(Task("Write early storage",
-                                  task=write_storage_configuration,
-                                  task_args=(storage,)))
+    if payload.needs_storage_configuration:
+        conf_task = storage_proxy.WriteConfigurationWithTask()
+        early_storage.append_dbus_tasks(STORAGE, [conf_task])
 
     installation_queue.append(early_storage)
 
@@ -299,12 +263,9 @@ def _prepare_installation(storage, payload, ksdata):
         # anaconda requires storage packages in order to make sure the target
         # system is bootable and configurable, and some other packages in order
         # to finish setting up the system.
-        payload.requirements.add_packages(storage.packages, reason="storage")
         payload.requirements.add_packages(ksdata.authselect.packages, reason="authselect")
         payload.requirements.add_packages(ksdata.timezone.packages, reason="ntp", strong=False)
 
-        if can_install_bootloader:
-            payload.requirements.add_packages(storage.bootloader.packages, reason="bootloader")
         if flags.flags.cmdline.getbool("fips"):
             payload.requirements.add_packages(['/usr/bin/fips-mode-setup'], reason="compliance")
 
@@ -314,7 +275,7 @@ def _prepare_installation(storage, payload, ksdata):
         # add package requirements from modules
         # - iterate over all modules we know have valid package requirements
         # - add any requirements found to the payload requirement tracking
-        modules_with_package_requirements = [SECURITY, NETWORK]
+        modules_with_package_requirements = [SECURITY, NETWORK, STORAGE]
         for module in modules_with_package_requirements:
             module_proxy = module.get_proxy()
             module_requirements = Requirement.from_structure_list(module_proxy.CollectRequirements())
@@ -331,19 +292,22 @@ def _prepare_installation(storage, payload, ksdata):
     installation_queue.append(payload_install)
 
     # for some payloads storage is configured after the payload is installed
-    if not payload.needs_storage_configuration and not conf.target.is_directory:
+    if not payload.needs_storage_configuration:
         late_storage = TaskQueue("Late storage configuration", N_("Configuring storage"))
-        late_storage.append(Task("Write late storage",
-                                 task=write_storage_configuration,
-                                 task_args=(storage, )))
-
+        conf_task = storage_proxy.WriteConfigurationWithTask()
+        late_storage.append_dbus_tasks(STORAGE, [conf_task])
         installation_queue.append(late_storage)
 
     # Do bootloader.
-    if can_install_bootloader:
-        bootloader_install = TaskQueue("Bootloader installation", N_("Installing boot loader"))
-        bootloader_install.append(Task("Install bootloader", write_boot_loader, (storage, payload)))
-        installation_queue.append(bootloader_install)
+    bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
+    bootloader_install = TaskQueue("Bootloader installation", N_("Installing boot loader"))
+
+    if not payload.handles_bootloader_configuration:
+        boot_task = bootloader_proxy.ConfigureWithTask(payload.kernel_version_list)
+        bootloader_install.append_dbus_tasks(STORAGE, [boot_task])
+
+    bootloader_install.append_dbus_tasks(STORAGE, [bootloader_proxy.InstallWithTask()])
+    installation_queue.append(bootloader_install)
 
     post_install = TaskQueue("Post-installation setup tasks", (N_("Performing post-installation setup tasks")))
     post_install.append(Task("Run post-installation setup tasks", payload.post_install))
@@ -354,9 +318,8 @@ def _prepare_installation(storage, payload, ksdata):
 
     if snapshot_proxy.IsRequested(SNAPSHOT_WHEN_POST_INSTALL):
         snapshot_creation = TaskQueue("Creating post installation snapshots", N_("Creating snapshots"))
-        snapshot_requests = ksdata.snapshot.get_requests(SNAPSHOT_WHEN_POST_INSTALL)
-        snapshot_task = SnapshotCreateTask(storage, snapshot_requests, SNAPSHOT_WHEN_POST_INSTALL)
-        snapshot_creation.append(Task("Create post-install snapshots", snapshot_task.run))
+        snapshot_task = snapshot_proxy.CreateWithTask(SNAPSHOT_WHEN_POST_INSTALL)
+        snapshot_creation.append_dbus_tasks(STORAGE, [snapshot_task])
         installation_queue.append(snapshot_creation)
 
     return installation_queue

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -265,20 +265,8 @@ class Authselect(RemovedCommand):
         except RuntimeError as msg:
             authselect_log.error("Error running %s %s: %s", cmd, args, msg)
 
-# FIXME: We have to fix self.handler.autopart in the pykickstart project before replacing this by
-#        UselessCommand class. The self.handler.autopart won't be present, instead there will be
-#        self.handler.uselesscommand. Test handler.autopart availability before calling it.
-class AutoPart(RemovedCommand):
-    pass
-
-class BTRFS(COMMANDS.BTRFS):
-    pass
-
 # no overrides needed here
 Eula = COMMANDS.Eula
-
-class LogVol(COMMANDS.LogVol):
-    pass
 
 class Logging(COMMANDS.Logging):
     def execute(self):
@@ -342,14 +330,6 @@ class Network(COMMANDS.Network):
             if hostname != network.DEFAULT_HOSTNAME:
                 network_proxy.SetCurrentHostname(hostname)
 
-
-
-class Partition(COMMANDS.Partition):
-    pass
-
-class Raid(COMMANDS.Raid):
-    pass
-
 class RepoData(COMMANDS.RepoData):
 
     __mount_counter = 0
@@ -406,9 +386,6 @@ class RepoData(COMMANDS.RepoData):
 
     def is_harddrive_based(self):
         return self.partition is not None
-
-class ReqPart(COMMANDS.ReqPart):
-    pass
 
 class Timezone(RemovedCommand):
 
@@ -486,44 +463,6 @@ class Timezone(RemovedCommand):
                 except ntp.NTPconfigError as ntperr:
                     timezone_log.warning("Failed to save NTP configuration without chrony package: %s", ntperr)
 
-class VolGroup(COMMANDS.VolGroup):
-    pass
-
-class Snapshot(COMMANDS.Snapshot):
-    """The snapshot kickstart command.
-
-    The command will be parsed here and in the Storage module for now.
-    The data don't change, so it is ok, to use the Snapshot module
-    when we can.
-    """
-
-    def __str__(self):
-        # Provided by the Storage module.
-        return ""
-
-    def get_requests(self, when):
-        """Get a list of snapshot requests of the given type.
-
-        :param when: a type of the requests
-        :returns: a list of requests
-        """
-        return [request for request in self.dataList() if request.when == when]
-
-    def verify_requests(self, storage, constraints, report_error, report_warning):
-        """Verify the validity of snapshot requests for the given storage.
-
-        This is a callback for the storage checker.
-
-        :param storage: a storage to check
-        :param constraints: a dictionary of constraints
-        :param report_error: a function for error reporting
-        :param report_warning: a function for warning reporting
-        """
-        # FIXME: This is an ugly temporary workaround for UI.
-        from pyanaconda.modules.storage.snapshot import SnapshotModule
-        SnapshotModule.verify_requests(self, storage, constraints, report_error, report_warning)
-
-
 class Keyboard(RemovedCommand):
 
     def execute(self):
@@ -597,8 +536,8 @@ commandMap = {
     "auth": UselessCommand,
     "authconfig": UselessCommand,
     "authselect": Authselect,
-    "autopart": AutoPart,
-    "btrfs": BTRFS,
+    "autopart": UselessCommand,
+    "btrfs": UselessCommand,
     "bootloader": UselessCommand,
     "clearpart": UselessCommand,
     "eula": Eula,
@@ -612,24 +551,24 @@ commandMap = {
     "keyboard": Keyboard,
     "lang": UselessCommand,
     "logging": Logging,
-    "logvol": LogVol,
+    "logvol": UselessCommand,
     "mount": UselessCommand,
     "network": Network,
     "nvdimm": UselessCommand,
-    "part": Partition,
-    "partition": Partition,
-    "raid": Raid,
+    "part": UselessCommand,
+    "partition": UselessCommand,
+    "raid": UselessCommand,
     "realm": UselessCommand,
-    "reqpart": ReqPart,
+    "reqpart": UselessCommand,
     "rootpw": UselessCommand,
     "selinux": UselessCommand,
     "services": UselessCommand,
     "sshkey" : UselessCommand,
     "skipx": UselessCommand,
-    "snapshot": Snapshot,
+    "snapshot": UselessCommand,
     "timezone": Timezone,
     "user": UselessCommand,
-    "volgroup": VolGroup,
+    "volgroup": UselessCommand,
     "xconfig": UselessCommand,
     "zerombr": UselessCommand,
     "zfcp": UselessCommand,

--- a/pyanaconda/modules/storage/partitioning/automatic.py
+++ b/pyanaconda/modules/storage/partitioning/automatic.py
@@ -23,9 +23,7 @@ from blivet.size import Size
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.constants import DEFAULT_AUTOPART_TYPE
-from pyanaconda.dbus import DBus
 from pyanaconda.core.signal import Signal
-from pyanaconda.modules.common.constants.objects import AUTO_PARTITIONING
 from pyanaconda.modules.common.errors.storage import UnknownDeviceError, ProtectedDeviceError
 from pyanaconda.modules.common.structures.partitioning import PartitioningRequest
 from pyanaconda.modules.storage.partitioning.base import PartitioningModule
@@ -54,10 +52,6 @@ class AutoPartitioningModule(PartitioningModule):
     def for_publication(self):
         """Return a DBus representation."""
         return AutoPartitioningInterface(self)
-
-    def publish(self):
-        """Publish the module."""
-        DBus.publish_object(AUTO_PARTITIONING.object_path, self.for_publication())
 
     def process_kickstart(self, data):
         """Process the kickstart data."""

--- a/pyanaconda/modules/storage/partitioning/automatic.py
+++ b/pyanaconda/modules/storage/partitioning/automatic.py
@@ -43,9 +43,6 @@ class AutoPartitioningModule(PartitioningModule):
     def __init__(self):
         """Initialize the module."""
         super().__init__()
-        self.enabled_changed = Signal()
-        self._enabled = False
-
         self.request_changed = Signal()
         self._request = PartitioningRequest()
 
@@ -64,7 +61,6 @@ class AutoPartitioningModule(PartitioningModule):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
-        self.set_enabled(data.autopart.autopart)
         request = PartitioningRequest()
 
         if data.autopart.type is not None:
@@ -100,7 +96,7 @@ class AutoPartitioningModule(PartitioningModule):
 
     def setup_kickstart(self, data):
         """Setup the kickstart data."""
-        data.autopart.autopart = self.enabled
+        data.autopart.autopart = True
         data.autopart.fstype = self.request.file_system_type
 
         if self.request.partitioning_scheme != DEFAULT_AUTOPART_TYPE:
@@ -124,20 +120,6 @@ class AutoPartitioningModule(PartitioningModule):
 
         data.autopart.escrowcert = self.request.escrow_certificate
         data.autopart.backuppassphrase = self.request.backup_passphrase_enabled
-
-    @property
-    def enabled(self):
-        """Is the auto partitioning enabled?"""
-        return self._enabled
-
-    def set_enabled(self, enabled):
-        """Is the auto partitioning enabled?
-
-        :param enabled: a boolean value
-        """
-        self._enabled = enabled
-        self.enabled_changed.emit()
-        log.debug("Enabled is set to '%s'.", enabled)
 
     @property
     def request(self):

--- a/pyanaconda/modules/storage/partitioning/automatic_interface.py
+++ b/pyanaconda/modules/storage/partitioning/automatic_interface.py
@@ -32,21 +32,7 @@ class AutoPartitioningInterface(PartitioningInterface):
     def connect_signals(self):
         """Connect the signals."""
         super().connect_signals()
-        self.watch_property("Enabled", self.implementation.enabled_changed)
         self.watch_property("Request", self.implementation.request_changed)
-
-    @property
-    def Enabled(self) -> Bool:
-        """Is the auto partitioning enabled?"""
-        return self.implementation.enabled
-
-    @emits_properties_changed
-    def SetEnabled(self, enabled: Bool):
-        """Is the auto partitioning enabled?
-
-        :param enabled: True if the autopartitioning is enabled, otherwise False
-        """
-        self.implementation.set_enabled(enabled)
 
     @property
     def Request(self) -> Structure:

--- a/pyanaconda/modules/storage/partitioning/blivet.py
+++ b/pyanaconda/modules/storage/partitioning/blivet.py
@@ -18,8 +18,6 @@
 # Red Hat, Inc.
 #
 from pyanaconda.anaconda_loggers import get_module_logger
-from pyanaconda.dbus import DBus
-from pyanaconda.modules.common.constants.objects import BLIVET_PARTITIONING
 from pyanaconda.modules.storage.partitioning.base import PartitioningModule
 from pyanaconda.modules.storage.partitioning.blivet_interface import \
     BlivetPartitioningInterface
@@ -46,10 +44,6 @@ class BlivetPartitioningModule(PartitioningModule):
     def for_publication(self):
         """Return a DBus representation."""
         return BlivetPartitioningInterface(self)
-
-    def publish(self):
-        """Publish the module."""
-        DBus.publish_object(BLIVET_PARTITIONING.object_path, self.for_publication())
 
     @property
     def storage_handler(self):

--- a/pyanaconda/modules/storage/partitioning/custom.py
+++ b/pyanaconda/modules/storage/partitioning/custom.py
@@ -18,8 +18,6 @@
 # Red Hat, Inc.
 #
 from pyanaconda.anaconda_loggers import get_module_logger
-from pyanaconda.dbus import DBus
-from pyanaconda.modules.common.constants.objects import CUSTOM_PARTITIONING
 from pyanaconda.modules.common.errors.storage import UnavailableDataError
 from pyanaconda.modules.storage.partitioning.base import PartitioningModule
 from pyanaconda.modules.storage.partitioning.constants import PartitioningMethod
@@ -56,10 +54,6 @@ class CustomPartitioningModule(PartitioningModule):
     def for_publication(self):
         """Return a DBus representation."""
         return CustomPartitioningInterface(self)
-
-    def publish(self):
-        """Publish the module."""
-        DBus.publish_object(CUSTOM_PARTITIONING.object_path, self.for_publication())
 
     def process_kickstart(self, data):
         """Process the kickstart data."""

--- a/pyanaconda/modules/storage/partitioning/interactive.py
+++ b/pyanaconda/modules/storage/partitioning/interactive.py
@@ -18,8 +18,6 @@
 # Red Hat, Inc.
 #
 from pyanaconda.anaconda_loggers import get_module_logger
-from pyanaconda.dbus import DBus
-from pyanaconda.modules.common.constants.objects import INTERACTIVE_PARTITIONING
 from pyanaconda.modules.storage.partitioning.base import PartitioningModule
 from pyanaconda.modules.storage.partitioning.constants import PartitioningMethod
 from pyanaconda.modules.storage.partitioning.interactive_interface import \
@@ -41,10 +39,6 @@ class InteractivePartitioningModule(PartitioningModule):
     def for_publication(self):
         """Return a DBus representation."""
         return InteractivePartitioningInterface(self)
-
-    def publish(self):
-        """Publish the module."""
-        DBus.publish_object(INTERACTIVE_PARTITIONING.object_path, self.for_publication())
 
     def configure_with_task(self):
         """Complete the scheduled partitioning."""

--- a/pyanaconda/modules/storage/partitioning/manual.py
+++ b/pyanaconda/modules/storage/partitioning/manual.py
@@ -20,9 +20,7 @@
 from blivet.size import Size
 
 from pyanaconda.anaconda_loggers import get_module_logger
-from pyanaconda.dbus import DBus
 from pyanaconda.core.signal import Signal
-from pyanaconda.modules.common.constants.objects import MANUAL_PARTITIONING
 from pyanaconda.modules.common.structures.partitioning import MountPointRequest
 from pyanaconda.modules.storage.partitioning.base import PartitioningModule
 from pyanaconda.modules.storage.partitioning.constants import PartitioningMethod
@@ -49,10 +47,6 @@ class ManualPartitioningModule(PartitioningModule):
     def for_publication(self):
         """Return a DBus representation."""
         return ManualPartitioningInterface(self)
-
-    def publish(self):
-        """Publish the module."""
-        DBus.publish_object(MANUAL_PARTITIONING.object_path, self.for_publication())
 
     def process_kickstart(self, data):
         """Process the kickstart data."""

--- a/pyanaconda/modules/storage/partitioning/manual.py
+++ b/pyanaconda/modules/storage/partitioning/manual.py
@@ -38,10 +38,6 @@ class ManualPartitioningModule(PartitioningModule):
     def __init__(self):
         """Initialize the module."""
         super().__init__()
-
-        self.enabled_changed = Signal()
-        self._enabled = False
-
         self.requests_changed = Signal()
         self._requests = list()
 
@@ -60,11 +56,6 @@ class ManualPartitioningModule(PartitioningModule):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
-        if not data.mount.seen:
-            self.set_requests(list())
-            self.set_enabled(False)
-            return
-
         requests = []
 
         for mount_data in data.mount.mount_points:
@@ -78,13 +69,9 @@ class ManualPartitioningModule(PartitioningModule):
             requests.append(request)
 
         self.set_requests(requests)
-        self.set_enabled(True)
 
     def setup_kickstart(self, data):
         """Setup the kickstart data."""
-        if not self.enabled:
-            return
-
         data_list = []
 
         for request in self.requests:
@@ -98,20 +85,6 @@ class ManualPartitioningModule(PartitioningModule):
             data_list.append(mount_data)
 
         data.mount.mount_points = data_list
-
-    @property
-    def enabled(self):
-        """Is the auto partitioning enabled?"""
-        return self._enabled
-
-    def set_enabled(self, enabled):
-        """Is the auto partitioning enabled?
-
-        :param enabled: a boolean value
-        """
-        self._enabled = enabled
-        self.enabled_changed.emit()
-        log.debug("Enabled is set to '%s'.", enabled)
 
     @property
     def requests(self):

--- a/pyanaconda/modules/storage/partitioning/manual_interface.py
+++ b/pyanaconda/modules/storage/partitioning/manual_interface.py
@@ -32,21 +32,7 @@ class ManualPartitioningInterface(PartitioningInterface):
     def connect_signals(self):
         """Connect the signals."""
         super().connect_signals()
-        self.watch_property("Enabled", self.implementation.enabled_changed)
         self.watch_property("Requests", self.implementation.requests_changed)
-
-    @property
-    def Enabled(self) -> Bool:
-        """Is the manual partitioning enabled?"""
-        return self.implementation.enabled
-
-    @emits_properties_changed
-    def SetEnabled(self, enabled: Bool):
-        """Is the manual partitioning enabled?
-
-        :param enabled: True if enabled, otherwise False
-        """
-        self.implementation.set_enabled(enabled)
 
     @property
     def Requests(self) -> List[Structure]:

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -123,17 +123,6 @@ class StorageService(KickstartService):
             self._zfcp_module = ZFCPModule()
             self._add_module(self._zfcp_module)
 
-        # Initialize the partitioning modules.
-        # TODO: Remove the static partitioning modules.
-        self._add_module(self.create_partitioning(PartitioningMethod.AUTOMATIC))
-        self._add_module(self.create_partitioning(PartitioningMethod.MANUAL))
-        self._add_module(self.create_partitioning(PartitioningMethod.CUSTOM))
-        self._add_module(self.create_partitioning(PartitioningMethod.INTERACTIVE))
-        self._add_module(self.create_partitioning(PartitioningMethod.BLIVET))
-        # Forget the static partitioning modules.
-        # TODO: Remove with the static partitioning modules.
-        self._created_partitioning = []
-
         # Connect modules to signals.
         self.storage_changed.connect(
             self._device_tree_module.on_storage_reset

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -54,14 +54,12 @@ USER_AGENT = "%s (anaconda)/%s" % (productName, productVersion)
 
 class Payload(metaclass=ABCMeta):
     """Payload is an abstract class for OS install delivery methods."""
-    def __init__(self, data, storage):
+    def __init__(self, data):
         """Initialize Payload class
 
         :param data: This param is a kickstart.AnacondaKSHandler class.
-        :param storage: an instance of Blivet's storage model
         """
         self.data = data
-        self.storage = storage
         self.tx_id = None
 
         self._install_tree_metadata = None
@@ -732,7 +730,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
     def _unmount_source_directory(self, mount_point):
         if os.path.ismount(mount_point):
             device_path = payload_utils.get_mount_device_path(mount_point)
-            device = payload_utils.resolve_device(self.storage, device_path)
+            device = payload_utils.resolve_device(device_path)
             if device:
                 payload_utils.teardown_device(device)
             else:
@@ -858,7 +856,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
                 # We don't setup an install_device here
                 # because we can't tear it down
 
-        iso_device = payload_utils.resolve_device(self.storage, dev_spec)
+        iso_device = payload_utils.resolve_device(dev_spec)
         if need_mount:
             if not iso_device:
                 raise PayloadSetupError("device for HDISO install %s does not exist" % dev_spec)
@@ -992,11 +990,11 @@ class PackagePayload(Payload, metaclass=ABCMeta):
 
         # Check for valid optical media if we didn't boot from one
         if not verifyMedia(DRACUT_REPODIR):
-            self.install_device = find_optical_install_media(self.storage)
+            self.install_device = find_optical_install_media()
 
         # Only look at the dracut mount if we don't already have a cdrom
         if repo_device_path and not self.install_device:
-            self.install_device = payload_utils.resolve_device(self.storage, repo_device_path)
+            self.install_device = payload_utils.resolve_device(repo_device_path)
             url = "file://" + DRACUT_REPODIR
             if not method.method:
                 # See if this is a nfs mount
@@ -1022,7 +1020,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
         return url
 
     def _setup_harddrive_addon_repo(self, ksrepo):
-        iso_device = payload_utils.resolve_device(self.storage, ksrepo.partition)
+        iso_device = payload_utils.resolve_device(ksrepo.partition)
         if not iso_device:
             raise PayloadSetupError("device for HDISO addon repo install %s does not exist" %
                                     ksrepo.partition)

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -443,7 +443,7 @@ class Payload(metaclass=ABCMeta):
     @staticmethod
     def _setup_device(device, mountpoint):
         """Prepare an install CD/DVD for use as a package source."""
-        log.info("setting up device %s and mounting on %s", device.name, mountpoint)
+        log.info("setting up device %s and mounting on %s", device, mountpoint)
         # Is there a symlink involved?  If so, let's get the actual path.
         # This is to catch /run/install/isodir vs. /mnt/install/isodir, for
         # instance.
@@ -453,7 +453,7 @@ class Payload(metaclass=ABCMeta):
         if mount_device_path:
             log.warning("%s is already mounted on %s", mount_device_path, mountpoint)
 
-            if mount_device_path == device.path:
+            if mount_device_path == payload_utils.get_device_path(device):
                 return
             else:
                 payload_utils.unmount(real_mountpoint)
@@ -687,16 +687,18 @@ class PackagePayload(Payload, metaclass=ABCMeta):
         # hd: umount INSTALL_TREE, install_device.teardown (ISO_DIR)
         # nfs: umount INSTALL_TREE
         # nfsiso: umount INSTALL_TREE, umount ISO_DIR
+        install_device_path = payload_utils.get_device_path(self.install_device)
+
         if os.path.ismount(INSTALL_TREE):
             if self.install_device and \
-               payload_utils.get_mount_device_path(INSTALL_TREE) == self.install_device.path:
+               payload_utils.get_mount_device_path(INSTALL_TREE) == install_device_path:
                 payload_utils.teardown_device(self.install_device)
             else:
                 payload_utils.unmount(INSTALL_TREE, raise_exc=True)
 
         if os.path.ismount(ISO_DIR):
             if self.install_device and \
-               payload_utils.get_mount_device_path(ISO_DIR) == self.install_device.path:
+               payload_utils.get_mount_device_path(ISO_DIR) == install_device_path:
                 payload_utils.teardown_device(self.install_device)
             # The below code will fail when nfsiso is the stage2 source
             # But if we don't do this we may not be able to switch from
@@ -738,6 +740,8 @@ class PackagePayload(Payload, metaclass=ABCMeta):
 
     def _setup_media(self, device):
         method = self.data.method
+        device_path = payload_utils.get_device_path(device)
+
         if method.method == "harddrive":
             try:
                 method.dir = self._find_and_mount_iso(device, ISO_DIR, method.dir, INSTALL_TREE)
@@ -752,7 +756,7 @@ class PackagePayload(Payload, metaclass=ABCMeta):
 
         # Check to see if the device is already mounted, in which case
         # we don't need to mount it again
-        elif method.method == "cdrom" and payload_utils.get_mount_paths(device.path):
+        elif method.method == "cdrom" and payload_utils.get_mount_paths(device_path):
             return
         else:
             payload_utils.mount_device(device, INSTALL_TREE)

--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -41,6 +41,8 @@ from pyanaconda.kickstart import RepoData
 from pyanaconda.product import productName, productVersion
 from pyanaconda.payload.errors import MetadataError, NoSuchGroup, DependencyError, \
     PayloadInstallError, PayloadSetupError, PayloadError
+from pyanaconda.payload import utils as payload_utils
+
 
 import pyanaconda.errors as errors
 import pyanaconda.localization
@@ -836,14 +838,11 @@ class DNFPayload(payload.PackagePayload):
     @property
     def space_required(self):
         size = self._space_required()
-        if not self.storage:
-            log.warning("Payload doesn't have storage")
-            return size
-
         download_size = self._download_space
         valid_points = _df_map()
         root_mpoint = conf.target.system_root
-        for (key, val) in self.storage.mountpoints.items():
+
+        for (key, val) in payload_utils.get_mount_points():
             new_key = key
             if key.endswith('/'):
                 new_key = key[:-1]

--- a/pyanaconda/payload/image.py
+++ b/pyanaconda/payload/image.py
@@ -24,9 +24,10 @@ import tempfile
 
 from pyanaconda import isys
 from pyanaconda.errors import errorHandler, ERROR_RAISE, InvalidImageSizeError, MissingImageError
+from pyanaconda.modules.common.constants.objects import DEVICE_TREE
+from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.payload import utils as payload_utils
 from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
-from pyanaconda.storage.utils import find_optical_media, find_mountable_partitions
 
 import blivet.util
 import blivet.arch
@@ -190,16 +191,17 @@ def mountImage(isodir, tree):
             break
 
 
-def find_optical_install_media(storage):
+def find_optical_install_media():
     """Find a device with a valid optical install media.
 
     Return the first device containing a valid optical install
     media for this product.
 
-    :param storage: an instance of Blivet's storage
-    :return: a device or None
+    :return: a device name or None
     """
-    for dev in find_optical_media(storage.devicetree):
+    device_tree = STORAGE.get_proxy(DEVICE_TREE)
+
+    for dev in device_tree.FindOpticalMedia():
         mountpoint = tempfile.mkdtemp()
 
         try:
@@ -220,16 +222,16 @@ def find_optical_install_media(storage):
     return None
 
 
-def find_potential_hdiso_sources(storage):
+def find_potential_hdiso_sources():
     """Find potential HDISO sources.
 
     Return a generator yielding Device instances that may have HDISO install
     media somewhere. Candidate devices are simply any that we can mount.
 
-    :param storage: an instance of Blivet's storage
-    :return: a list of devices
+    :return: a list of device names
     """
-    return find_mountable_partitions(storage.devicetree)
+    device_tree = STORAGE.get_proxy(DEVICE_TREE)
+    return device_tree.FindMountablePartitions()
 
 
 def verifyMedia(tree, timestamp=None):

--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -74,7 +74,7 @@ class LiveImagePayload(Payload):
         super().setup()
 
         # Mount the live device and copy from it instead of the overlay at /
-        osimg = payload_utils.resolve_device(self.storage, self.data.method.partition)
+        osimg = payload_utils.resolve_device(self.data.method.partition)
         if not osimg:
             raise PayloadInstallError("Unable to find osimg for %s" % self.data.method.partition)
 
@@ -108,8 +108,9 @@ class LiveImagePayload(Payload):
         """Monitor the amount of disk space used on the target and source and
            update the hub's progress bar.
         """
-        mountpoints = self.storage.mountpoints.copy()
+        mountpoints = payload_utils.get_mount_points()
         last_pct = -1
+
         while self.pct < 100:
             dest_size = 0
             for mnt in mountpoints:

--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -78,12 +78,13 @@ class LiveImagePayload(Payload):
         if not osimg:
             raise PayloadInstallError("Unable to find osimg for %s" % self.data.method.partition)
 
-        if not stat.S_ISBLK(os.stat(osimg.path)[stat.ST_MODE]):
+        osimg_path = payload_utils.get_device_path(osimg)
+        if not stat.S_ISBLK(os.stat(osimg_path)[stat.ST_MODE]):
             exn = PayloadSetupError("%s is not a valid block device" %
                                     (self.data.method.partition,))
             if errorHandler.cb(exn) == ERROR_RAISE:
                 raise exn
-        rc = payload_utils.mount(osimg.path, INSTALL_TREE, fstype="auto", options="ro")
+        rc = payload_utils.mount(osimg_path, INSTALL_TREE, fstype="auto", options="ro")
         if rc != 0:
             raise PayloadInstallError("Failed to mount the install tree")
 

--- a/pyanaconda/payload/utils.py
+++ b/pyanaconda/payload/utils.py
@@ -23,53 +23,74 @@ import blivet.arch
 from distutils.version import LooseVersion
 
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.modules.common.constants.objects import DEVICE_TREE
+from pyanaconda.modules.common.constants.services import STORAGE
+from pyanaconda.modules.common.structures.storage import DeviceData
 from pyanaconda.payload.errors import PayloadSetupError
 
 log = get_module_logger(__name__)
 
 
-def resolve_device(storage, dev_spec):
+def resolve_device(dev_spec):
     """Get the device matching the provided device specification.
 
-    :param storage: an instance of Blivet's storage
     :param str dev_spec: a string describing a block device
     :return: an instance of a device or None
     """
-    return storage.devicetree.resolve_device(dev_spec)
+    device_tree = STORAGE.get_proxy(DEVICE_TREE)
+    return device_tree.ResolveDevice(dev_spec) or None
 
 
-def setup_device(device):
+def get_device_path(device_name):
+    """Return a device path.
+
+    :param device_name: a device name
+    :return: a device path
+    """
+    if device_name is None:
+        return None
+
+    device_tree = STORAGE.get_proxy(DEVICE_TREE)
+    device_data = DeviceData.from_structure(device_tree.GetDeviceData(device_name))
+    return device_data.path
+
+
+def setup_device(device_name):
     """Open, or set up, a device.
 
-    :param device: an instance of a device
+    :param device_name: a device name
     """
-    device.setup()
+    device_tree = STORAGE.get_proxy(DEVICE_TREE)
+    device_tree.SetupDevice(device_name)
 
 
-def mount_device(device, mount_point):
+def mount_device(device_name, mount_point):
     """Mount a filesystem on the device.
 
-    :param device: an instance of a device
+    :param device_name: a device name
     :param str mount_point: a path to the mount point
     """
-    device.format.mount(mountpoint=mount_point)
+    device_tree = STORAGE.get_proxy(DEVICE_TREE)
+    device_tree.MountDevice(device_name, mount_point)
 
 
-def unmount_device(device, mount_point):
+def unmount_device(device_name, mount_point):
     """Unmount a filesystem on the device.
 
-    :param device: an instance of a device
+    :param device_name: a device name
     :param str mount_point: a path to the mount point or None
     """
-    device.format.unmount(mountpoint=mount_point)
+    device_tree = STORAGE.get_proxy(DEVICE_TREE)
+    device_tree.UnmountDevice(device_name, mount_point)
 
 
-def teardown_device(device):
+def teardown_device(device_name):
     """Close, or tear down, a device.
 
-    :param device: an instance of a device
+    :param device_name: a device name
     """
-    device.teardown(recursive=True)
+    device_tree = STORAGE.get_proxy(DEVICE_TREE)
+    device_tree.TeardownDevice(device_name)
 
 
 def get_mount_device_path(mount_point):

--- a/pyanaconda/payload/utils.py
+++ b/pyanaconda/payload/utils.py
@@ -93,6 +93,15 @@ def teardown_device(device_name):
     device_tree.TeardownDevice(device_name)
 
 
+def get_mount_points():
+    """Get mount points in the device tree.
+
+    :return: a dictionary of mount points and device names
+    """
+    device_tree = STORAGE.get_proxy(DEVICE_TREE)
+    return device_tree.GetMountPoints()
+
+
 def get_mount_device_path(mount_point):
     """Given a mount point, return the device node path mounted there.
 

--- a/pyanaconda/storage/execution.py
+++ b/pyanaconda/storage/execution.py
@@ -15,39 +15,16 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.modules.common.constants.objects import AUTO_PARTITIONING, MANUAL_PARTITIONING
-from pyanaconda.modules.common.constants.services import STORAGE
-from pyanaconda.modules.common.structures.partitioning import PartitioningRequest, \
-    MountPointRequest
-from pyanaconda.modules.storage.partitioning.automatic_partitioning import \
-    AutomaticPartitioningTask
-from pyanaconda.modules.storage.partitioning.custom_partitioning import CustomPartitioningTask
-from pyanaconda.modules.storage.partitioning.interactive_partitioning import \
-    InteractivePartitioningTask
-from pyanaconda.modules.storage.partitioning.manual_partitioning import ManualPartitioningTask
-
 __all__ = ["configure_storage"]
 
 
 def configure_storage(storage, data=None, interactive=False):
     """Setup storage state from the kickstart data.
 
+    FIXME: Remove this function.
+
     :param storage: an instance of the Blivet's storage object
     :param data: an instance of kickstart data or None
     :param interactive: use a task for the interactive partitioning
     """
-    auto_part_proxy = STORAGE.get_proxy(AUTO_PARTITIONING)
-    manual_part_proxy = STORAGE.get_proxy(MANUAL_PARTITIONING)
-
-    if interactive:
-        task = InteractivePartitioningTask(storage)
-    elif auto_part_proxy.Enabled:
-        request = PartitioningRequest.from_structure(auto_part_proxy.Request)
-        task = AutomaticPartitioningTask(storage, request)
-    elif manual_part_proxy.Enabled:
-        requests = MountPointRequest.from_structure_list(manual_part_proxy.Requests)
-        task = ManualPartitioningTask(storage, requests)
-    else:
-        task = CustomPartitioningTask(storage, data)
-
-    task.run()
+    raise NotImplementedError("This function is not implemented.")

--- a/pyanaconda/storage/initialization.py
+++ b/pyanaconda/storage/initialization.py
@@ -29,7 +29,7 @@ from pyanaconda.anaconda_logging import program_log_lock
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import BOOTLOADER_DRIVE_UNSET
 from pyanaconda.errors import errorHandler as error_handler, ERROR_RAISE
-from pyanaconda.modules.common.constants.objects import DISK_SELECTION, BOOTLOADER
+from pyanaconda.modules.common.constants.objects import DISK_SELECTION, BOOTLOADER, DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.task import sync_run_task
 from pyanaconda.storage.osinstall import InstallerStorage
@@ -148,21 +148,24 @@ def reset_storage(storage=None, scan_all=False, retry=True):
             break
 
 
-def reset_bootloader(storage):
+def reset_bootloader(storage=None):
     """Reset the bootloader.
+
+    FIXME: Remove the storage argument.
 
     :param storage: an instance of the Blivet's storage object
     """
     bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
     bootloader_proxy.SetDrive(BOOTLOADER_DRIVE_UNSET)
-    storage.bootloader.reset()
 
 
-def select_all_disks_by_default(storage):
+def select_all_disks_by_default(storage=None):
     """Select all disks for the partitioning by default.
 
     It will select all disks for the partitioning if there are
     no disks selected. Kickstart uses all the disks by default.
+
+    FIXME: Remove the storage argument.
 
     :param storage: an instance of the Blivet's storage object
     :return: a list of selected disks
@@ -172,7 +175,12 @@ def select_all_disks_by_default(storage):
     ignored_disks = disk_select_proxy.IgnoredDisks
 
     if not selected_disks:
-        selected_disks = [d.name for d in storage.disks if d.name not in ignored_disks]
+        # Get all disks.
+        device_tree = STORAGE.get_proxy(DEVICE_TREE)
+        all_disks = device_tree.GetDisks()
+
+        # Select all disks.
+        selected_disks = [d for d in all_disks if d not in ignored_disks]
         disk_select_proxy.SetSelectedDisks(selected_disks)
         log.debug("Selecting all disks by default: %s", ",".join(selected_disks))
 

--- a/pyanaconda/storage/initialization.py
+++ b/pyanaconda/storage/initialization.py
@@ -29,9 +29,9 @@ from pyanaconda.anaconda_logging import program_log_lock
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import BOOTLOADER_DRIVE_UNSET
 from pyanaconda.errors import errorHandler as error_handler, ERROR_RAISE
-from pyanaconda.modules.common.constants.objects import DISK_SELECTION, FCOE, ZFCP, BOOTLOADER, \
-    ISCSI
+from pyanaconda.modules.common.constants.objects import DISK_SELECTION, BOOTLOADER
 from pyanaconda.modules.common.constants.services import STORAGE
+from pyanaconda.modules.common.task import sync_run_task
 from pyanaconda.storage.osinstall import InstallerStorage
 from pyanaconda.platform import platform
 
@@ -113,10 +113,11 @@ def load_plugin_s390():
     blockdev.reinit([plugin], reload=False)
 
 
-def reset_storage(storage, scan_all=False, retry=True):
+def reset_storage(storage=None, scan_all=False, retry=True):
     """Reset the storage model.
 
-    :param storage: an instance of the Blivet's storage object
+    FIXME: Remove the storage argument.
+
     :param scan_all: should we scan all devices in the system?
     :param retry: should we allow to retry the reset?
     """
@@ -128,7 +129,10 @@ def reset_storage(storage, scan_all=False, retry=True):
     # Do the reset.
     while True:
         try:
-            _reset_storage(storage)
+            storage_proxy = STORAGE.get_proxy()
+            task_path = storage_proxy.ResetWithTask()
+            task_proxy = STORAGE.get_proxy(task_path)
+            sync_run_task(task_proxy)
         except StorageError as e:
             # Is the retry allowed?
             if not retry:
@@ -173,33 +177,3 @@ def select_all_disks_by_default(storage):
         log.debug("Selecting all disks by default: %s", ",".join(selected_disks))
 
     return selected_disks
-
-
-def _reset_storage(storage):
-    """Do reset the storage.
-
-    FIXME: Call the DBus task instead of this function.
-
-    :param storage: an instance of the Blivet's storage object
-    """
-    # Set the ignored and exclusive disks.
-    disk_select_proxy = STORAGE.get_proxy(DISK_SELECTION)
-    storage.ignored_disks = disk_select_proxy.IgnoredDisks
-    storage.exclusive_disks = disk_select_proxy.ExclusiveDisks
-    storage.protected_devices = disk_select_proxy.ProtectedDevices
-    storage.disk_images = disk_select_proxy.DiskImages
-
-    # Reload additional modules.
-    if not conf.target.is_image:
-        iscsi_proxy = STORAGE.get_proxy(ISCSI)
-        iscsi_proxy.ReloadModule()
-
-        fcoe_proxy = STORAGE.get_proxy(FCOE)
-        fcoe_proxy.ReloadModule()
-
-        if arch.is_s390():
-            zfcp_proxy = STORAGE.get_proxy(ZFCP)
-            zfcp_proxy.ReloadModule()
-
-    # Do the reset.
-    storage.reset()

--- a/pyanaconda/storage/initialization.py
+++ b/pyanaconda/storage/initialization.py
@@ -27,13 +27,11 @@ from blivet.static_data import luks_data
 
 from pyanaconda.anaconda_logging import program_log_lock
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.constants import BOOTLOADER_DRIVE_UNSET, STORAGE_SWAP_IS_RECOMMENDED
+from pyanaconda.core.constants import BOOTLOADER_DRIVE_UNSET
 from pyanaconda.errors import errorHandler as error_handler, ERROR_RAISE
-from pyanaconda.modules.common.constants.objects import DISK_SELECTION, AUTO_PARTITIONING, \
-    FCOE, ZFCP, BOOTLOADER, ISCSI
+from pyanaconda.modules.common.constants.objects import DISK_SELECTION, FCOE, ZFCP, BOOTLOADER, \
+    ISCSI
 from pyanaconda.modules.common.constants.services import STORAGE
-from pyanaconda.modules.common.structures.partitioning import PartitioningRequest
-from pyanaconda.storage.checker import storage_checker
 from pyanaconda.storage.osinstall import InstallerStorage
 from pyanaconda.platform import platform
 
@@ -96,22 +94,6 @@ def create_storage():
     storage.set_default_luks_version(conf.storage.luks_version or storage.default_luks_version)
 
     return storage
-
-
-def set_storage_defaults_from_kickstart(storage):
-    """Set the storage default values from a kickstart file.
-
-    FIXME: A temporary workaround for UI.
-    """
-    # Set the default filesystem types.
-    auto_part_proxy = STORAGE.get_proxy(AUTO_PARTITIONING)
-    request = PartitioningRequest.from_structure(auto_part_proxy.Request)
-
-    if request.file_system_type:
-        storage.set_default_fstype(request.file_system_type)
-
-    if "swap" in request.excluded_mount_points:
-        storage_checker.set_constraint(STORAGE_SWAP_IS_RECOMMENDED, False)
 
 
 def load_plugin_s390():

--- a/pyanaconda/storage/utils.py
+++ b/pyanaconda/storage/utils.py
@@ -49,7 +49,9 @@ from pyanaconda.core.i18n import N_, _, P_
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.errors import errorHandler, ERROR_RAISE
 from pyanaconda.modules.common.constants.services import NETWORK, STORAGE
-from pyanaconda.modules.common.constants.objects import DISK_SELECTION, NVDIMM, DISK_INITIALIZATION
+from pyanaconda.modules.common.constants.objects import DISK_SELECTION, NVDIMM, \
+    DISK_INITIALIZATION, DEVICE_TREE
+from pyanaconda.modules.common.structures.storage import DeviceData
 
 from pykickstart.constants import AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_BTRFS
 from pykickstart.constants import AUTOPART_TYPE_LVM, AUTOPART_TYPE_LVM_THINP
@@ -473,9 +475,9 @@ def filter_disks_by_names(disks, names):
 
     :param disks: a list of disks
     :param names: a list of disk names
-    :return: a list of filtered disks
+    :return: a list of filtered disk names
     """
-    return [d for d in disks if d.name in names]
+    return list(filter(lambda name: name in disks, names))
 
 
 def is_local_disk(disk):
@@ -500,18 +502,30 @@ def is_local_disk(disk):
 def apply_disk_selection(storage, selected_names):
     """Apply the disks selection.
 
+    FIXME: Remove the storage argument.
+
     :param storage: blivet.Blivet instance
     :param selected_names: a list of selected disk names
     """
-    # Get the selected disks.
-    selected_disks = filter_disks_by_names(storage.disks, selected_names)
+    device_tree = STORAGE.get_proxy(DEVICE_TREE)
 
-    # Get names of their ancestors.
-    ancestor_names = [
-        ancestor.name
-        for disk in selected_disks for ancestor in disk.ancestors
-        if ancestor.is_disk and ancestor.name not in selected_names
-    ]
+    # Get disks.
+    disks = set(device_tree.GetDisks())
+
+    # Get ancestors.
+    ancestor_names = []
+
+    for device in selected_names:
+        if device not in disks:
+            continue
+
+        ancestors = device_tree.GetDeviceAncestors(device)
+
+        for ancestor in ancestors:
+            if ancestor not in disks:
+                continue
+
+            ancestor_names.append(ancestor)
 
     # Set the disks to select.
     disk_select_proxy = STORAGE.get_proxy(DISK_SELECTION)
@@ -577,16 +591,24 @@ def get_required_device_size(required_space, format_class=None):
     return device_size.round_to_nearest(Size("1 MiB"), ROUND_HALF_UP)
 
 
-def get_disks_summary(storage, selected):
+def get_disks_summary(storage, disks):
     """Get a summary of the selected disks
 
+    FIXME: Remove the storage argument.
+
     :param storage: an instance of the storage
-    :param selected: a list of selected disks
+    :param disks: a list of names of selected disks
     :return: a string with a summary
     """
-    count = len(selected)
-    capacity = sum((disk.size for disk in selected), Size(0))
-    free_space = storage.get_disk_free_space(selected)
+    device_tree = STORAGE.get_proxy(DEVICE_TREE)
+
+    data = DeviceData.from_structure_list([
+        device_tree.GetDeviceData(d) for d in disks
+    ])
+
+    count = len(disks)
+    capacity = Size(sum((disk.size for disk in data), 0))
+    free_space = Size(device_tree.GetDiskFreeSpace(disks))
 
     return P_(
         "{count} disk selected; {capacity} capacity; {free} free",
@@ -606,7 +628,6 @@ def mark_protected_device(storage, spec):
     if spec not in protected_devices:
         protected_devices.add(spec)
 
-    storage.protect_devices(protected_devices)
     disk_selection_proxy.SetProtectedDevices(protected_devices)
 
 
@@ -622,7 +643,6 @@ def unmark_protected_device(storage, spec):
     if spec in protected_devices:
         protected_devices.remove(spec)
 
-    storage.protect_devices(protected_devices)
     disk_selection_proxy.SetProtectedDevices(protected_devices)
 
 

--- a/pyanaconda/timezone.py
+++ b/pyanaconda/timezone.py
@@ -30,7 +30,8 @@ from collections import OrderedDict
 from pyanaconda.core import util
 from pyanaconda.core.constants import THREAD_STORAGE
 from pyanaconda.flags import flags
-from pyanaconda.modules.common.constants.services import TIMEZONE
+from pyanaconda.modules.common.constants.objects import BOOTLOADER
+from pyanaconda.modules.common.constants.services import TIMEZONE, STORAGE
 from pyanaconda.threading import threadMgr
 from blivet import arch
 
@@ -53,16 +54,14 @@ class TimezoneConfigError(Exception):
     """Exception class for timezone configuration related problems"""
     pass
 
-def time_initialize(timezone_proxy, storage):
+def time_initialize(timezone_proxy):
     """
     Try to guess if RTC uses UTC time or not, set timezone.isUtc properly and
     set system time from RTC using the UTC guess.
     Guess is done by searching for bootable ntfs devices.
 
     :param timezone_proxy: DBus proxy of the timezone module
-    :param storage: pyanaconda.storage.InstallerStorage instance
     """
-
     if arch.is_s390():
         # nothing to do on s390(x) were hwclock doesn't exist
         return
@@ -70,10 +69,9 @@ def time_initialize(timezone_proxy, storage):
     if not timezone_proxy.IsUTC and not flags.automatedInstall:
         # if set in the kickstart, no magic needed here
         threadMgr.wait(THREAD_STORAGE)
-        ntfs_devs = filter(lambda dev: dev.format.name == "ntfs",
-                           storage.devices)
-
-        timezone_proxy.SetIsUTC(not storage.bootloader.has_windows(ntfs_devs))
+        bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
+        is_utc = not bootloader_proxy.DetectWindows()
+        timezone_proxy.SetIsUTC(is_utc)
 
     cmd = "hwclock"
     args = ["--hctosys"]

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -469,7 +469,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
             # The / gets stripped off by payload.ISO_image
             self.data.method.dir = "/" + self._current_iso_file
             if old_method == "harddrive" \
-               and payload_utils.resolve_device(self.storage, old_partition) == part \
+               and payload_utils.resolve_device(old_partition) == part \
                and old_dir in [self._current_iso_file, "/" + self._current_iso_file]:
                 return False
 
@@ -851,7 +851,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         if self.data.method.method == "cdrom":
             self._cdrom = self.payload.install_device
         elif not flags.automatedInstall:
-            self._cdrom = find_optical_install_media(self.storage)
+            self._cdrom = find_optical_install_media()
 
         if self._cdrom:
             self._show_autodetect_box_with_device(self._cdrom)
@@ -912,7 +912,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         if self.data.method.method == "harddrive":
             method_dev_name = self._get_harddrive_partition_name()
 
-        for dev in find_potential_hdiso_sources(self.storage):
+        for dev in find_potential_hdiso_sources():
             # path model size format type uuid of format
             dev_info = {"model": self._sanitize_model(dev.disk.model or ""),
                         "path": dev.path,

--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -123,14 +123,15 @@ class SourceSwitchHandler(object, metaclass=ABCMeta):
         if self.data.method.method == "harddrive" and self.data.method.partition:
             unmark_protected_device(self.storage, self.data.method.partition)
 
-    def set_source_hdd_iso(self, device, iso_path):
+    def set_source_hdd_iso(self, device_name, iso_path):
         """ Switch to the HDD ISO install source
-        :param partition: name of the partition hosting the ISO
-        :type partition: string
+
+        :param device_name: name of the partition hosting the ISO
+        :type device_name: string
         :param iso_path: full path to the source ISO file
         :type iso_path: string
         """
-        partition = device.name
+        partition = device_name
         # the GUI source spoke also does the copy
         old_source = copy.copy(self.data.method)
 
@@ -138,15 +139,15 @@ class SourceSwitchHandler(object, metaclass=ABCMeta):
         if old_source.method == "harddrive" and old_source.partition != partition:
             self._clean_hdd_iso()
 
-        # protect current device
-        mark_protected_device(self.storage, device.name)
+        # protect current device_name
+        mark_protected_device(self.storage, device_name)
 
         self.data.method.method = "harddrive"
         self.data.method.partition = partition
         # the / gets stripped off by payload.ISO_image
         self.data.method.dir = "/" + iso_path
 
-        # as we already made the device protected when
+        # as we already made the device_name protected when
         # switching to it, we don't need to protect it here
 
     def set_source_url(self, url=None):

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -16,8 +16,12 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from blivet.size import Size
 
 from pyanaconda.flags import flags
+from pyanaconda.modules.common.constants.objects import DEVICE_TREE
+from pyanaconda.modules.common.constants.services import STORAGE
+from pyanaconda.modules.common.structures.storage import DeviceData, DeviceFormatData
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog
@@ -88,7 +92,7 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
         if self.data.method.method == "cdrom":
             self._cdrom = self.payload.install_device
         elif not flags.automatedInstall:
-            self._cdrom = find_optical_install_media(self.storage)
+            self._cdrom = find_optical_install_media()
 
         # Enable the SE/HMC option.
         if self.payload.is_hmc_enabled:
@@ -393,6 +397,7 @@ class SelectDeviceSpoke(NormalTUISpoke):
         super().__init__(data, storage, payload)
         self.title = N_("Select device containing the ISO file")
         self._container = None
+        self._device_tree = STORAGE.get_proxy(DEVICE_TREE)
         self._mountable_devices = self._get_mountable_devices()
         self._device = None
 
@@ -400,21 +405,30 @@ class SelectDeviceSpoke(NormalTUISpoke):
     def indirect(self):
         return True
 
-    def _sanitize_model(self, model):
-        return model.replace("_", " ")
-
     def _get_mountable_devices(self):
         disks = []
         fstring = "%(model)s %(path)s (%(size)s MB) %(format)s %(label)s"
-        for dev in find_potential_hdiso_sources(self.storage):
-            # path model size format type uuid of format
-            dev_info = {"model": self._sanitize_model(dev.disk.model),
-                        "path": dev.path,
-                        "size": dev.size,
-                        "format": dev.format.name or "",
-                        "label": dev.format.label or dev.format.uuid or ""
-                        }
-            disks.append([dev, fstring % dev_info])
+        for device_name in find_potential_hdiso_sources():
+            # Get the device data.
+            device_data = DeviceData.from_structure(
+                self._device_tree.GetDeviceData(device_name)
+            )
+            format_data = DeviceFormatData.from_structure(
+                self._device_tree.GetFormatData(device_name)
+            )
+            disk_data = DeviceData.from_structure(
+                self._device_tree.GetDeviceData(device_data.parents[0])
+            )
+
+            # Generate the device info.
+            dev_info = {
+                "model": disk_data.attrs.get("model", "").replace("_", " "),
+                "path": device_data.path,
+                "size": Size(device_data.size),
+                "format": format_data.description,
+                "label": format_data.attrs.get("label") or format_data.attrs.get("uuid") or ""
+            }
+            disks.append([device_name, fstring % dev_info])
         return disks
 
     def refresh(self, args=None):

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -19,36 +19,34 @@
 
 from collections import OrderedDict
 
+from pyanaconda.dbus.proxy import get_object_path
 from pyanaconda.input_checking import get_policy
 from pyanaconda.modules.common.constants.objects import DISK_SELECTION, DISK_INITIALIZATION, \
-    BOOTLOADER, AUTO_PARTITIONING, MANUAL_PARTITIONING
+    BOOTLOADER, DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.structures.partitioning import MountPointRequest, \
     PartitioningRequest
 from pyanaconda.modules.common.errors.configuration import StorageConfigurationError, \
     BootloaderConfigurationError
+from pyanaconda.modules.common.structures.storage import DeviceFormatData, DeviceData
+from pyanaconda.modules.common.structures.validation import ValidationReport
+from pyanaconda.modules.common.task import sync_run_task
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog, PasswordDialog
-from pyanaconda.storage.utils import get_supported_filesystems, get_supported_autopart_choices, \
-    filter_disks_by_names, apply_disk_selection, check_disk_selection, \
-    get_disks_summary
-from pyanaconda.storage.execution import configure_storage
-from pyanaconda.storage.checker import storage_checker
+from pyanaconda.storage.utils import get_supported_autopart_choices, filter_disks_by_names, \
+    apply_disk_selection, get_disks_summary
 from pyanaconda.storage.format_dasd import DasdFormatting
 
 from blivet.size import Size
-from blivet.devices import DASDDevice, FcoeDiskDevice, iScsiDiskDevice, MultipathDevice, \
-    ZFCPDiskDevice
-from blivet.formats import get_format
 from pyanaconda.flags import flags
-from pyanaconda.storage.kickstart import reset_custom_storage_data
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import THREAD_STORAGE, THREAD_STORAGE_WATCHER, \
     PAYLOAD_STATUS_PROBING_STORAGE, CLEAR_PARTITIONS_ALL, \
     CLEAR_PARTITIONS_LINUX, CLEAR_PARTITIONS_NONE, CLEAR_PARTITIONS_DEFAULT, \
-    BOOTLOADER_LOCATION_MBR, SecretType, WARNING_NO_DISKS_DETECTED, WARNING_NO_DISKS_SELECTED
+    BOOTLOADER_LOCATION_MBR, SecretType, WARNING_NO_DISKS_DETECTED, WARNING_NO_DISKS_SELECTED, \
+    PARTITIONING_METHOD_AUTOMATIC, PARTITIONING_METHOD_CUSTOM, PARTITIONING_METHOD_MANUAL
 from pyanaconda.core.i18n import _, N_, C_
 from pyanaconda.storage.initialization import reset_bootloader, reset_storage, \
     select_all_disks_by_default
@@ -68,8 +66,8 @@ CLEARALL = N_("Use All Space")
 CLEARLINUX = N_("Replace Existing Linux system(s)")
 CLEARNONE = N_("Use Free Space")
 
-PARTTYPES = {CLEARALL: CLEAR_PARTITIONS_ALL, CLEARLINUX: CLEAR_PARTITIONS_LINUX,
-             CLEARNONE: CLEAR_PARTITIONS_NONE}
+INIT_MODES = {CLEARALL: CLEAR_PARTITIONS_ALL, CLEARLINUX: CLEAR_PARTITIONS_LINUX,
+              CLEARNONE: CLEAR_PARTITIONS_NONE}
 
 
 class StorageSpoke(NormalTUISpoke):
@@ -87,10 +85,11 @@ class StorageSpoke(NormalTUISpoke):
         self.title = N_("Installation Destination")
         self._container = None
 
+        self._storage_module = STORAGE.get_proxy()
+        self._device_tree = STORAGE.get_proxy(DEVICE_TREE)
         self._bootloader_module = STORAGE.get_proxy(BOOTLOADER)
         self._disk_init_module = STORAGE.get_proxy(DISK_INITIALIZATION)
         self._disk_select_module = STORAGE.get_proxy(DISK_SELECTION)
-        self._auto_part_module = STORAGE.get_proxy(AUTO_PARTITIONING)
 
         self._selected_disks = self._disk_select_module.SelectedDisks
 
@@ -99,20 +98,28 @@ class StorageSpoke(NormalTUISpoke):
         # of disks that can be included in the install.
         self._available_disks = []
 
-        if not flags.automatedInstall:
-            # default to using autopart for interactive installs
-            self._auto_part_module.SetEnabled(True)
+        # Find a partitioning to use or create a new one.
+        object_paths = self._storage_module.CreatedPartitioning
+
+        if object_paths:
+            # Choose the last created partitioning.
+            object_path = object_paths[-1]
+        else:
+            # Or create the automatic partitioning.
+            object_path = self._storage_module.CreatePartitioning(
+                PARTITIONING_METHOD_AUTOMATIC
+            )
+
+        self._partitioning = STORAGE.get_proxy(object_path)
 
         self._ready = False
         self._select_all = False
-        self._auto_part_enabled = None
-
         self.errors = []
         self.warnings = []
 
     @property
     def completed(self):
-        return self.ready and not self.errors and self.storage.root_device
+        return self.ready and not self.errors and self._device_tree.GetRootDevice()
 
     @property
     def ready(self):
@@ -135,7 +142,7 @@ class StorageSpoke(NormalTUISpoke):
         """ A short string describing the current status of storage setup. """
         if not self.ready:
             return _("Processing...")
-        elif flags.automatedInstall and not self.storage.root_device:
+        elif flags.automatedInstall and not self._device_tree.GetRootDevice():
             return _("Kickstart insufficient")
         elif not self._disk_select_module.SelectedDisks:
             return _("No disks selected")
@@ -143,15 +150,13 @@ class StorageSpoke(NormalTUISpoke):
             return _("Error checking storage configuration")
         elif self.warnings:
             return _("Warning checking storage configuration")
-        elif self._auto_part_module.Enabled:
+        elif self._partitioning.PartitioningMethod == PARTITIONING_METHOD_AUTOMATIC:
             return _("Automatic partitioning selected")
         else:
             return _("Custom partitioning selected")
 
-    def _update_disk_list(self, disk):
+    def _update_disk_list(self, name):
         """ Update self.selected_disks based on the selection."""
-        name = disk.name
-
         # if the disk isn't already selected, select it.
         if name not in self._selected_disks:
             self._selected_disks.append(name)
@@ -184,8 +189,8 @@ class StorageSpoke(NormalTUISpoke):
         print(_(PAYLOAD_STATUS_PROBING_STORAGE))
         threadMgr.wait(THREAD_STORAGE_WATCHER)
 
-        if not any(d in self.storage.disks for d in self._available_disks):
-            # something happened to self.storage (probably reset), need to
+        if not any(d in self._device_tree.GetDisks() for d in self._available_disks):
+            # something happened to the storage (probably reset), need to
             # reinitialize the list of disks
             self.update_disks()
 
@@ -193,17 +198,18 @@ class StorageSpoke(NormalTUISpoke):
         # Commment out because there is no way to select a disk right
         # now without putting it in ksdata.  Seems wrong?
         # self.selected_disks = self.data.ignoredisk.onlyuse[:]
-        self._auto_part_enabled = self._auto_part_module.Enabled
+        object_path = self._storage_module.CreatedPartitioning[-1]
+        self._partitioning = STORAGE.get_proxy(object_path)
 
         self._container = ListColumnContainer(1, spacing=1)
 
         message = self._update_summary()
 
         # loop through the disks and present them.
-        for disk in self._available_disks:
-            disk_info = self._format_disk_info(disk)
-            c = CheckboxWidget(title=disk_info, completed=(disk.name in self._selected_disks))
-            self._container.add(c, self._update_disk_list_callback, disk)
+        for disk_name in self._available_disks:
+            disk_info = self._format_disk_info(disk_name)
+            c = CheckboxWidget(title=disk_info, completed=(disk_name in self._selected_disks))
+            self._container.add(c, self._update_disk_list_callback, disk_name)
 
         # if we have more than one disk, present an option to just
         # select all disks
@@ -217,9 +223,9 @@ class StorageSpoke(NormalTUISpoke):
     def _select_all_disks_callback(self, data):
         """ Mark all disks as selected for use in partitioning. """
         self._select_all = True
-        for disk in self._available_disks:
-            if disk.name not in self._selected_disks:
-                self._update_disk_list(disk)
+        for disk_name in self._available_disks:
+            if disk_name not in self._selected_disks:
+                self._update_disk_list(disk_name)
 
     def _update_disk_list_callback(self, data):
         disk = data
@@ -233,28 +239,22 @@ class StorageSpoke(NormalTUISpoke):
             Since this is going to be ugly to do within the confines of the
             CheckboxWidget, pre-format the display string right here.
         """
-        # show this info for all disks
-        format_str = "%s: %s (%s)" % (disk.model, disk.size, disk.name)
+        data = DeviceData.from_structure(
+            self._device_tree.GetDeviceData(disk)
+        )
 
-        disk_attrs = []
-        # now check for/add info about special disks
-        if (isinstance(disk, MultipathDevice) or
-                isinstance(disk, iScsiDiskDevice) or
-                isinstance(disk, FcoeDiskDevice)):
-            if hasattr(disk, "wwn"):
-                disk_attrs.append(disk.wwn)
-        elif isinstance(disk, DASDDevice):
-            if hasattr(disk, "busid"):
-                disk_attrs.append(disk.busid)
-        elif isinstance(disk, ZFCPDiskDevice):
-            if hasattr(disk, "fcp_lun"):
-                disk_attrs.append(disk.fcp_lun)
-            if hasattr(disk, "wwpn"):
-                disk_attrs.append(disk.wwpn)
-            if hasattr(disk, "hba_id"):
-                disk_attrs.append(disk.hba_id)
+        # show this info for all disks
+        format_str = "{}: {} ({})".format(
+            data.attrs.get("model", "DISK"),
+            Size(data.size),
+            data.name
+        )
 
         # now append all additional attributes to our string
+        disk_attrs = filter(None, map(data.attrs.get, (
+            "wwn", "busid", "fcp_lun", "wwpn", "hba_id"
+        )))
+
         for attr in disk_attrs:
             format_str += ", %s" % attr
 
@@ -292,16 +292,21 @@ class StorageSpoke(NormalTUISpoke):
 
                     # make sure no containers were split up by the user's disk
                     # selection
-                    self.errors.extend(check_disk_selection(self.storage,
-                                                            self._selected_disks))
+                    report = ValidationReport.from_structure(
+                        self._disk_select_module.ValidateSelectedDisks(self._selected_disks)
+                    )
+                    self.errors.extend(report.get_messages())
+
                     if self.errors:
                         # The disk selection has to make sense before we can
                         # proceed.
                         return InputState.PROCESSED_AND_REDRAW
 
                     self.apply()
-                    new_spoke = PartTypeSpoke(self.data, self.storage, self.payload)
+                    new_spoke = PartTypeSpoke(self.data, self.storage, self.payload,
+                                              self._storage_module, self._partitioning)
                     ScreenHandler.push_screen_modal(new_spoke)
+                    self._partitioning = new_spoke.partitioning
                     self.apply()
                     self.execute()
 
@@ -363,40 +368,16 @@ class StorageSpoke(NormalTUISpoke):
 
     def _is_passphrase_required(self):
         """Is the default passphrase required?"""
-        if self._auto_part_module.RequiresPassphrase():
-            return True
-
-        if self._find_data_without_passphrase():
-            return True
-
-        return False
+        return self._partitioning.PartitioningMethod in (
+            PARTITIONING_METHOD_AUTOMATIC,
+            PARTITIONING_METHOD_CUSTOM
+        ) and self._partitioning.RequiresPassphrase()
 
     def _set_required_passphrase(self, passphrase):
         """Set the required passphrase."""
-        self._auto_part_module.SetPassphrase(passphrase)
-        self._set_data_without_passphrase(passphrase)
-
-    def _find_data_without_passphrase(self):
-        """Collect kickstart data and DBus proxies that require a passphrase.
-
-        FIXME: This is a temporary workaround.
-        """
-        from pyanaconda.modules.storage.partitioning.custom import CustomPartitioningModule
-        return CustomPartitioningModule._find_data_without_passphrase(self)
-
-    def _set_data_without_passphrase(self, passphrase):
-        """Set a passphrase to the collected kickstart data.
-
-        FIXME: This is a temporary workaround.
-        """
-        from pyanaconda.modules.storage.partitioning.custom import CustomPartitioningModule
-        return CustomPartitioningModule._set_data_without_passphrase(self, passphrase)
+        self._partitioning.SetPassphrase(passphrase)
 
     def apply(self):
-        self._auto_part_enabled = self._auto_part_module.Enabled
-
-        self.storage.select_disks(self._selected_disks)
-
         self._bootloader_module.SetPreferredLocation(BOOTLOADER_LOCATION_MBR)
         boot_drive = self._bootloader_module.Drive
 
@@ -406,27 +387,38 @@ class StorageSpoke(NormalTUISpoke):
         apply_disk_selection(self.storage, self._selected_disks)
 
     def execute(self):
-        print(_("Generating updated storage configuration"))
         try:
-            configure_storage(self.storage, self.data)
+            print(_("Generating updated storage configuration"))
+            task_path = self._partitioning.ConfigureWithTask()
+            task_proxy = STORAGE.get_proxy(task_path)
+            sync_run_task(task_proxy)
         except StorageConfigurationError as e:
-            print(_("storage configuration failed: %s") % e)
+            print(_("Storage configuration failed: %s") % e)
             self.errors = [str(e)]
             reset_bootloader(self.storage)
             reset_storage(self.storage, scan_all=True)
         except BootloaderConfigurationError as e:
-            print(_("storage configuration failed: %s") % e)
+            print(_("Boot loader configuration failed: %s") % e)
             self.errors = [str(e)]
             reset_bootloader(self.storage)
         else:
             print(_("Checking storage configuration..."))
-            report = storage_checker.check(self.storage)
-            print("\n".join(report.all_errors))
-            report.log(log)
-            self.errors = report.errors
-            self.warnings = report.warnings
+            task_path = self._partitioning.ValidateWithTask()
+            task_proxy = STORAGE.get_proxy(task_path)
+            sync_run_task(task_proxy)
+            report = ValidationReport.from_structure(
+                task_proxy.GetResult()
+            )
+
+            print("\n".join(report.get_messages()))
+            self.errors = report.error_messages
+            self.warnings = report.warning_messages
+
+            if report.is_valid():
+                self._storage_module.ApplyPartitioning(
+                    get_object_path(self._partitioning)
+                )
         finally:
-            reset_custom_storage_data(self.data)
             self._ready = True
 
     def initialize(self):
@@ -452,7 +444,8 @@ class StorageSpoke(NormalTUISpoke):
         threadMgr.wait(THREAD_STORAGE)
 
         # Automatically format DASDs if allowed.
-        DasdFormatting.run_automatically(self.storage, self.data)
+        disks = self._disk_select_module.GetUsableDisks()
+        DasdFormatting.run_automatically(disks)
 
         # Update the selected disks.
         if flags.automatedInstall:
@@ -469,7 +462,7 @@ class StorageSpoke(NormalTUISpoke):
 
     def update_disks(self):
         threadMgr.wait(THREAD_STORAGE)
-        self._available_disks = self.storage.usable_disks
+        self._available_disks = self._disk_select_module.GetUsableDisks()
 
         # if only one disk is available, go ahead and mark it as selected
         if len(self._available_disks) == 1:
@@ -484,46 +477,48 @@ class PartTypeSpoke(NormalTUISpoke):
     """
     category = SystemCategory
 
-    def __init__(self, data, storage, payload):
+    def __init__(self, data, storage, payload, storage_module, partitioning):
         super().__init__(data, storage, payload)
         self.title = N_("Partitioning Options")
         self._container = None
-        self._part_type_list = sorted(PARTTYPES.keys())
 
-        # remember the original values so that we can detect a change
+        # Choose the initialization mode.
         self._disk_init_proxy = STORAGE.get_proxy(DISK_INITIALIZATION)
         self._orig_init_mode = self._disk_init_proxy.InitializationMode
-        self._manual_part_proxy = STORAGE.get_proxy(MANUAL_PARTITIONING)
-        self._orig_mount_assign = self._manual_part_proxy.Enabled
+        self._init_mode = self._disk_init_proxy.InitializationMode
+        self._init_mode_list = sorted(INIT_MODES.keys())
 
-        # Create the auto partitioning proxy
-        self._auto_part_proxy = STORAGE.get_proxy(AUTO_PARTITIONING)
+        # Choose the partitioning method.
+        self._storage_module = storage_module
+        self._partitioning = partitioning
+        self._orig_part_method = self._partitioning.PartitioningMethod
+        self._part_method = self._orig_part_method
 
-        # default to mount point assignment if it is already (partially)
-        # configured
-        self._do_mount_assign = self._orig_mount_assign
-        if not self._do_mount_assign:
-            self._init_mode = self._disk_init_proxy.InitializationMode
-        else:
+        if self._part_method == PARTITIONING_METHOD_MANUAL:
             self._init_mode = CLEAR_PARTITIONS_NONE
 
     @property
     def indirect(self):
         return True
 
+    @property
+    def partitioning(self):
+        return self._partitioning
+
     def refresh(self, args=None):
         super().refresh(args)
         self._container = ListColumnContainer(1)
 
-        for part_type in self._part_type_list:
-            c = CheckboxWidget(title=_(part_type),
-                               completed=(not self._do_mount_assign
-                                          and PARTTYPES[part_type] == self._init_mode)
-                               )
-            self._container.add(c, self._select_partition_type_callback, part_type)
+        for init_mode in self._init_mode_list:
+            c = CheckboxWidget(title=_(init_mode), completed=(
+                self._part_method == PARTITIONING_METHOD_AUTOMATIC
+                and self._init_mode == INIT_MODES[init_mode]
+            ))
+            self._container.add(c, self._select_partition_type_callback, init_mode)
 
-        c = CheckboxWidget(title=_("Manually assign mount points"),
-                           completed=self._do_mount_assign)
+        c = CheckboxWidget(title=_("Manually assign mount points"), completed=(
+            self._part_method == PARTITIONING_METHOD_MANUAL
+        ))
 
         self._container.add(c, self._select_mount_assign)
         self.window.add_with_separator(self._container)
@@ -535,14 +530,12 @@ class PartTypeSpoke(NormalTUISpoke):
         self.window.add_with_separator(TextWidget(message))
 
     def _select_mount_assign(self, data=None):
+        self._part_method = PARTITIONING_METHOD_MANUAL
         self._init_mode = CLEAR_PARTITIONS_NONE
-        self._do_mount_assign = True
-        self.apply()
 
     def _select_partition_type_callback(self, data):
-        self._do_mount_assign = False
-        self._init_mode = PARTTYPES[data]
-        self.apply()
+        self._part_method = PARTITIONING_METHOD_AUTOMATIC
+        self._init_mode = INIT_MODES[data]
 
     def apply(self):
         # kind of a hack, but if we're actually getting to this spoke, there
@@ -550,16 +543,15 @@ class PartTypeSpoke(NormalTUISpoke):
         # True. In the case of ks installs which may not have defined any
         # partition options, autopart was never set to True, causing some
         # issues. (rhbz#1001061)
-        if not self._do_mount_assign:
-            self._auto_part_proxy.SetEnabled(True)
-            self._manual_part_proxy.SetEnabled(False)
-            self._disk_init_proxy.SetInitializationMode(self._init_mode)
-            self._disk_init_proxy.SetInitializeLabelsEnabled(True)
-        else:
-            self._auto_part_proxy.SetEnabled(False)
-            self._manual_part_proxy.SetEnabled(True)
-            self._disk_init_proxy.SetInitializationMode(CLEAR_PARTITIONS_NONE)
-            self._disk_init_proxy.SetInitializeLabelsEnabled(False)
+        self._disk_init_proxy.SetInitializationMode(self._init_mode)
+        self._disk_init_proxy.SetInitializeLabelsEnabled(
+            self._part_method == PARTITIONING_METHOD_AUTOMATIC
+        )
+
+        if self._orig_part_method != self._part_method:
+            self._partitioning = STORAGE.get_proxy(
+                self._storage_module.CreatePartitioning(self._part_method)
+            )
 
     def _ensure_init_storage(self):
         """
@@ -574,15 +566,12 @@ class PartTypeSpoke(NormalTUISpoke):
             return
 
         # 2) mount point assignment was done before and user just wants to tweak it
-        if self._orig_mount_assign and self._do_mount_assign:
+        if self._orig_part_method == self._part_method == PARTITIONING_METHOD_MANUAL:
             return
 
         # else
         print(_("Reverting previous configuration. This may take a moment..."))
         reset_storage(self.storage, scan_all=True)
-
-        # Forget the mount point requests.
-        self._manual_part_proxy.SetRequests([])
 
     def input(self, args, key):
         """Grab the choice and update things"""
@@ -591,10 +580,14 @@ class PartTypeSpoke(NormalTUISpoke):
             if key.lower() == C_('TUI|Spoke Navigation', 'c'):
                 self.apply()
                 self._ensure_init_storage()
-                if self._do_mount_assign:
-                    new_spoke = MountPointAssignSpoke(self.data, self.storage, self.payload)
+                if self._part_method == PARTITIONING_METHOD_MANUAL:
+                    new_spoke = MountPointAssignSpoke(
+                        self.data, self.storage, self.payload, self._partitioning
+                    )
                 else:
-                    new_spoke = PartitionSchemeSpoke(self.data, self.storage, self.payload)
+                    new_spoke = PartitionSchemeSpoke(
+                        self.data, self.storage, self.payload, self._partitioning
+                    )
                 ScreenHandler.push_screen_modal(new_spoke)
                 return InputState.PROCESSED_AND_CLOSE
             else:
@@ -607,15 +600,14 @@ class PartitionSchemeSpoke(NormalTUISpoke):
     """ Spoke to select what partitioning scheme to use on disk(s). """
     category = SystemCategory
 
-    def __init__(self, data, storage, payload):
+    def __init__(self, data, storage, payload, partitioning):
         super().__init__(data, storage, payload)
         self.title = N_("Partition Scheme Options")
         self._container = None
-        self.part_schemes = OrderedDict()
-
-        self._auto_part_proxy = STORAGE.get_proxy(AUTO_PARTITIONING)
+        self._part_schemes = OrderedDict()
+        self._partitioning = partitioning
         self._request = PartitioningRequest.from_structure(
-            self._auto_part_proxy.Request
+            self._partitioning.Request
         )
 
         supported_choices = get_supported_autopart_choices()
@@ -627,7 +619,7 @@ class PartitionSchemeSpoke(NormalTUISpoke):
         selected_choice = self._request.partitioning_scheme
 
         for item in supported_choices:
-            self.part_schemes[item[0]] = item[1]
+            self._part_schemes[item[0]] = item[1]
             if item[1] == selected_choice:
                 self._selected_scheme_value = item[1]
 
@@ -640,7 +632,7 @@ class PartitionSchemeSpoke(NormalTUISpoke):
 
         self._container = ListColumnContainer(1)
 
-        for scheme, value in self.part_schemes.items():
+        for scheme, value in self._part_schemes.items():
             box = CheckboxWidget(title=_(scheme), completed=(value == self._selected_scheme_value))
             self._container.add(box, self._set_part_scheme_callback, value)
 
@@ -651,6 +643,7 @@ class PartitionSchemeSpoke(NormalTUISpoke):
 
     def _set_part_scheme_callback(self, data):
         self._selected_scheme_value = data
+        self._request.partitioning_scheme = data
 
     def input(self, args, key):
         """ Grab the choice and update things. """
@@ -666,22 +659,23 @@ class PartitionSchemeSpoke(NormalTUISpoke):
 
     def apply(self):
         """ Apply our selections. """
-        self._request.partitioning_scheme = self._selected_scheme_value
-        self._auto_part_proxy.SetRequest(PartitioningRequest.to_structure(self._request))
+        self._partitioning.SetRequest(
+            PartitioningRequest.to_structure(self._request)
+        )
 
 
 class MountPointAssignSpoke(NormalTUISpoke):
     """ Assign mount points to block devices. """
     category = SystemCategory
 
-    def __init__(self, data, storage, payload):
+    def __init__(self, data, storage, payload, partitioning):
         super().__init__(data, storage, payload)
         self.title = N_("Assign mount points")
         self._container = None
-
+        self._partitioning = partitioning
+        self._device_tree = STORAGE.get_proxy(self._partitioning.GetDeviceTree())
         self._disk_select_proxy = STORAGE.get_proxy(DISK_SELECTION)
-        self._manual_part_proxy = STORAGE.get_proxy(MANUAL_PARTITIONING)
-        self._mount_info = self._gather_mount_info()
+        self._requests = self._gather_requests()
 
     @property
     def indirect(self):
@@ -692,9 +686,9 @@ class MountPointAssignSpoke(NormalTUISpoke):
         super().refresh(args)
         self._container = ListColumnContainer(2)
 
-        for info in self._mount_info:
-            widget = TextWidget(self._get_mount_info_description(info))
-            self._container.add(widget, self._configure_mount_info, info)
+        for request in self._requests:
+            widget = TextWidget(self._get_request_description(request))
+            self._container.add(widget, self._configure_request, request)
 
         message = _(
             "Choose device from above to assign mount point and set format.\n"
@@ -733,80 +727,50 @@ class MountPointAssignSpoke(NormalTUISpoke):
         """ Apply our selections. """
         mount_points = []
 
-        for _device, request in self._mount_info:
+        for request in self._requests:
             if request.reformat or request.mount_point:
                 if not request.mount_point:
                     request.mount_point = "none"
 
                 mount_points.append(request)
 
-        self._manual_part_proxy.SetRequests(MountPointRequest.to_structure_list(mount_points))
+        self._partitioning.SetRequests(
+            MountPointRequest.to_structure_list(mount_points)
+        )
 
-    def _gather_mount_info(self):
+    def _gather_requests(self):
         """Gather info about mount points."""
-        selected_disks = self._disk_select_proxy.SelectedDisks
-        requests = MountPointRequest.from_structure_list(self._manual_part_proxy.Requests)
+        return MountPointRequest.from_structure_list(
+            self._partitioning.GatherRequests()
+        )
 
-        mount_info = []
-
-        for device in self.storage.devicetree.leaves:
-            # Is the device usable?
-            if device.protected or device.size == Size(0):
-                continue
-
-            # All device's disks have to be in selected disks.
-            device_disks = {d.name for d in device.disks}
-            if selected_disks and not set(selected_disks).issuperset(device_disks):
-                continue
-
-            # Append new info about this device.
-            request = self._get_mount_point_request(device, requests)
-            mount_info.append((device, request))
-
-            # Use the data only once.
-            if request in requests:
-                requests.remove(request)
-
-        return mount_info
-
-    def _get_mount_point_request(self, device, requests):
-        """Get the mount point data for the given device."""
-
-        # Try to find existing assignment for this device.
-        for request in requests:
-            if device is self.storage.devicetree.resolve_device(request.device_spec):
-                return request
-
-        # Or create a new assignment.
-        request = MountPointRequest()
-        request.device_spec = device.path
-        request.format_type = device.format.type
-        request.reformat = False
-
-        if device.format.mountable and device.format.mountpoint:
-            request.mount_point = device.format.mountpoint
-
-        return request
-
-    def _get_mount_info_description(self, info):
+    def _get_request_description(self, request):
         """Get description of the given mount info."""
-        device, data = info
-        description = "{} ({})".format(data.device_spec, device.size)
+        # Get the device data.
+        device_name = self._device_tree.ResolveDevice(request.device_spec)
+        device_data = DeviceData.from_structure(
+            self._device_tree.GetDeviceData(device_name)
+        )
 
-        if data.format_type:
-            description += "\n {}".format(data.format_type)
+        # Generate the description.
+        description = "{} ({})".format(request.device_spec, Size(device_data.size))
 
-            if data.reformat:
+        if request.format_type:
+            description += "\n {}".format(request.format_type)
+
+            if request.reformat:
                 description += "*"
 
-            if data.mount_point:
-                description += ", {}".format(data.mount_point)
+            if request.mount_point:
+                description += ", {}".format(request.mount_point)
 
         return description
 
-    def _configure_mount_info(self, info):
-        """Configure the given mount info."""
-        spoke = ConfigureDeviceSpoke(self.data, self.storage, self.payload, *info)
+    def _configure_request(self, request):
+        """Configure the given mount request."""
+        spoke = ConfigureDeviceSpoke(
+            self.data, self.storage, self.payload, self._device_tree, request
+        )
         ScreenHandler.push_screen(spoke)
 
     def _rescan_devices(self):
@@ -824,22 +788,21 @@ class MountPointAssignSpoke(NormalTUISpoke):
         reset_storage(self.storage, scan_all=True)
 
         # Forget the mount point requests.
-        self._manual_part_proxy.SetRequests([])
-        self._mount_info = self._gather_mount_info()
+        self._partitioning.SetRequests([])
+        self._requests = self._gather_requests()
 
 
 class ConfigureDeviceSpoke(NormalTUISpoke):
     """ Assign mount point to a block device and (optionally) reformat it. """
     category = SystemCategory
 
-    def __init__(self, data, storage, payload, device, request):
+    def __init__(self, data, storage, payload, device_tree, request):
         super().__init__(data, storage, payload)
         self.title = N_("Configure device: %s") % request.device_spec
         self._container = None
-
-        self._supported_filesystems = [fmt.type for fmt in get_supported_filesystems()]
+        self._device_tree = device_tree
         self._request = request
-        self._device = device
+        self._supported_filesystems = set(device_tree.GetSupportedFileSystems())
 
     @property
     def indirect(self):
@@ -872,13 +835,15 @@ class ConfigureDeviceSpoke(NormalTUISpoke):
     def _add_mount_point_widget(self):
         """Add a widget for mount point assignment."""
         title = _("Mount point")
-        fmt = get_format(self._request.format_type)
+        fmt = DeviceFormatData.from_structure(
+            self._device_tree.GetFormatTypeData(self._request.format_type)
+        )
 
-        if fmt and fmt.mountable:
+        if fmt.mountable:
             # mount point can be set
             value = self._request.mount_point or _("none")
             callback = self._assign_mount_point
-        elif fmt and fmt.type is None:
+        elif not fmt.type:
             # mount point cannot be set for no format
             # (fmt.name = "Unknown" in this case which would look weird)
             value = _("none")
@@ -886,7 +851,7 @@ class ConfigureDeviceSpoke(NormalTUISpoke):
         else:
             # mount point cannot be set for format that is not mountable, just
             # show the format's name in square brackets instead
-            value = fmt.name
+            value = fmt.description
             callback = None
 
         dialog = Dialog(title, conditions=[self._check_assign_mount_point])
@@ -948,7 +913,13 @@ class ConfigureDeviceSpoke(NormalTUISpoke):
 
     def _switch_reformat(self, data):
         """Change value of reformat."""
-        device_format = self._device.format.type
+        device_name = self._device_tree.ResolveDevice(
+            self._request.device_spec
+        )
+        format_data = DeviceFormatData.from_structure(
+            self._device_tree.GetFormatData(device_name)
+        )
+        device_format = format_data.type
 
         if device_format and device_format != self._request.format_type:
             reformat = True

--- a/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
@@ -65,13 +65,6 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
         """Test the DBus representation."""
         self.assertIsInstance(self.module.for_publication(), AutoPartitioningInterface)
 
-    def enabled_property_test(self):
-        """Test the property enabled."""
-        self._test_dbus_property(
-            "Enabled",
-            True
-        )
-
     def request_property_test(self):
         """Test the property request."""
         in_value = {

--- a/tests/nosetests/pyanaconda_tests/module_part_manual_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_manual_test.py
@@ -57,18 +57,6 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
             *args, **kwargs
         )
 
-    def enabled_property_test(self):
-        """Test the enabled property."""
-        self._test_dbus_property(
-            "Enabled",
-            True
-        )
-
-        self._test_dbus_property(
-            "Enabled",
-            False
-        )
-
     def mount_points_property_test(self):
         """Test the mount points property."""
         self._test_dbus_property(

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -933,6 +933,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
         ks_out = """
         autopart --encrypted --pbkdf-time=100
         """
+        self._apply_partitioning_when_created()
         self._test_kickstart(ks_in, ks_out)
         self._check_dbus_partitioning(publisher, PartitioningMethod.AUTOMATIC)
 

--- a/tests/nosetests/pyanaconda_tests/timezone_test.py
+++ b/tests/nosetests/pyanaconda_tests/timezone_test.py
@@ -68,5 +68,5 @@ class s390HWclock(unittest.TestCase):
     def s390_time_initialize_test(self):
         """Check that time_initialize doesn't call hwclock on s390."""
 
-        timezone.time_initialize(mock.Mock(), mock.Mock())
+        timezone.time_initialize(mock.Mock())
         self.assertFalse(self.util_mock.execWithRedirect.called)


### PR DESCRIPTION
**DO NOT MERGE!**

* Extends the implementation from https://github.com/rhinstaller/anaconda/pull/2059.
* Remove the local storage object from TUI.
* Remove the UI workarounds for storage.
* Remove the static partitioning modules.

**TODO:**
* Remove the local storage object from GUI.
* Remove storage from method arguments and instance attributes.
* Split the storage-related code between the Storage module and UI.