### PR TITLE
Don't add more devices in boot-device NVRAM than the maximum allowed

### DIFF
--- a/pyanaconda/bootloader/grub2.py
+++ b/pyanaconda/bootloader/grub2.py
@@ -584,9 +584,11 @@ class IPSeriesGRUB2(GRUB2):
 
         # The boot-device NVRAM variable has a maximum number of devices allowed,
         # don't add more than the limit in the ibm,max-boot-devices OF property.
-        with open("/sys/firmware/devicetree/base/ibm,max-boot-devices", "rb") as f:
-            limit = int.from_bytes(f.read(4), byteorder='big')
-            boot_list = boot_list[:limit]
+        max_dev_path = "/sys/firmware/devicetree/base/ibm,max-boot-devices"
+        if os.access(max_dev_path, os.F_OK):
+            with open(max_dev_path, "rb") as f:
+                limit = int.from_bytes(f.read(4), byteorder='big')
+                boot_list = boot_list[:limit]
 
         update_value = "boot-device=%s" % " ".join(boot_list)
 

--- a/pyanaconda/bootloader/grub2.py
+++ b/pyanaconda/bootloader/grub2.py
@@ -582,6 +582,12 @@ class IPSeriesGRUB2(GRUB2):
         # Remove all other occurances of it.
         boot_list = [boot_disk] + [x for x in boot_list if x != boot_disk]
 
+        # The boot-device NVRAM variable has a maximum number of devices allowed,
+        # don't add more than the limit in the ibm,max-boot-devices OF property.
+        with open("/sys/firmware/devicetree/base/ibm,max-boot-devices", "rb") as f:
+            limit = int.from_bytes(f.read(4), byteorder='big')
+            boot_list = boot_list[:limit]
+
         update_value = "boot-device=%s" % " ".join(boot_list)
 
         rc = util.execWithRedirect("nvram", ["--update-config", update_value])


### PR DESCRIPTION
Backport of https://github.com/rhinstaller/anaconda/pull/2119

The boot-device NVRAM variable has a maximum number of devices allowed, that is specified in /sys/firmware/devicetree/base/ibm,max-boot-devices OF property.

Adding more devices than the maximum number allowed in the boot-device NVRAM variable can cause issues so the device list need to be restricted to this maximum before updating the variable with nvram --update-config.

*Resolves: rhbz#1748756*

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
(cherry picked from commit 8d51f7659fd3abfb955d6edede96afaf6e0bbdac)