### PR TITLE
Only attempt to open the ibm,max-boot-devices sysfs entry if it exists

### DIFF
--- a/pyanaconda/bootloader.py
+++ b/pyanaconda/bootloader.py
@@ -2216,9 +2216,11 @@ class IPSeriesGRUB2(GRUB2):
 
         # The boot-device NVRAM variable has a maximum number of devices allowed,
         # don't add more than the limit in the ibm,max-boot-devices OF property.
-        with open("/sys/firmware/devicetree/base/ibm,max-boot-devices", "rb") as f:
-            limit = int.from_bytes(f.read(4), byteorder='big')
-            boot_list = boot_list[:limit]
+        max_dev_path = "/sys/firmware/devicetree/base/ibm,max-boot-devices"
+        if os.access(max_dev_path, os.F_OK):
+            with open(max_dev_path, "rb") as f:
+                limit = int.from_bytes(f.read(4), byteorder='big')
+                boot_list = boot_list[:limit]
 
         update_value = "boot-device=%s" % " ".join(boot_list)
 


### PR DESCRIPTION
The /sys/firmware/devicetree/base/ibm,max-boot-devices sysfs entry defines
a OF property that contains the maximum number of devices that are allowed
in the boot-device NVRAM variable.

But this property may not be present in some ppc64le machines so it should
only be read if the file exists.

Related: rhbz#1748756

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>