### PR TITLE
Fix other payload module cyclic imports

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -39,8 +39,6 @@ from pyanaconda.payload import utils as payload_utils
 from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
 from pyanaconda.payload.requirement import PayloadRequirements
 from pyanaconda.product import productName, productVersion
-from pyanaconda.modules.payload.base.initialization import PrepareSystemForInstallationTask, \
-    CopyDriverDisksFilesTask
 
 from pykickstart.parser import Group
 
@@ -499,6 +497,7 @@ class Payload(metaclass=ABCMeta):
     ###
     def pre_install(self):
         """Perform pre-installation tasks."""
+        from pyanaconda.modules.payload.base.initialization import PrepareSystemForInstallationTask
         PrepareSystemForInstallationTask(conf.target.system_root).run()
 
     def install(self):
@@ -573,6 +572,7 @@ class Payload(metaclass=ABCMeta):
 
         # write out static config (storage, modprobe, keyboard, ??)
         #   kickstart should handle this before we get here
+        from pyanaconda.modules.payload.base.initialization import CopyDriverDisksFilesTask
         CopyDriverDisksFilesTask(conf.target.system_root).run()
 
         log.info("Installation requirements: %s", self.requirements)

--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -49,8 +49,6 @@ from pyanaconda.progress import progressQ
 from pyanaconda.core.constants import INSTALL_TREE, THREAD_LIVE_PROGRESS
 from pyanaconda.core.constants import IMAGE_DIR, TAR_SUFFIX, NETWORK_CONNECTION_TIMEOUT
 
-from pyanaconda.modules.payload.base.utils import get_dir_size
-
 from blivet.size import Size
 
 from pyanaconda.anaconda_loggers import get_packaging_logger
@@ -226,6 +224,7 @@ class LiveImagePayload(Payload):
 
     @property
     def space_required(self):
+        from pyanaconda.modules.payload.base.utils import get_dir_size
         return Size(get_dir_size("/") * 1024)
 
     def _update_kernel_version_list(self):


### PR DESCRIPTION
Imports from the Payload module shouldn't be called on the global level,
otherwise it might cause a circular import.