### PR TITLE
Forbid trailing fullstop (dot) in hostname validation (#1648107)

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -94,10 +94,11 @@ def check_ip_address(address, version=None):
         return False
 
 
-def is_valid_hostname(hostname):
+def is_valid_hostname(hostname, local=False):
     """Check if the given string is (syntactically) a valid hostname.
 
-    :param hostname: a string to check
+    :param str hostname: a string to check
+    :param bool local: is the hostname static (for this system) or not (on the network)
     :returns: a pair containing boolean value (valid or invalid) and
               an error message (if applicable)
     :rtype: (bool, str)
@@ -107,6 +108,9 @@ def is_valid_hostname(hostname):
 
     if len(hostname) > 255:
         return (False, _("Host name must be 255 or fewer characters in length."))
+
+    if local and hostname[-1] == ".":
+        return (False, _("Local host name must not end with period '.'."))
 
     if not re.match('^' + HOSTNAME_PATTERN_WITHOUT_ANCHORS + '$', hostname):
         return (False, _("Host names can only contain the characters 'a-z', "

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1516,7 +1516,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
     def on_apply_hostname(self, *args):
         hostname = self.network_control_box.hostname
-        (valid, error) = network.is_valid_hostname(hostname)
+        (valid, error) = network.is_valid_hostname(hostname, local=True)
         if not valid:
             self.clear_info()
             msg = _("Host name is not valid: %s") % error
@@ -1535,7 +1535,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
     def on_back_clicked(self, button):
         hostname = self.network_control_box.hostname
-        (valid, error) = network.is_valid_hostname(hostname)
+        (valid, error) = network.is_valid_hostname(hostname, local=True)
         if not valid:
             self.clear_info()
             msg = _("Host name is not valid: %s") % error
@@ -1627,7 +1627,7 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
 
     def _on_continue_clicked(self, window, user_data=None):
         hostname = self.network_control_box.hostname
-        (valid, error) = network.is_valid_hostname(hostname)
+        (valid, error) = network.is_valid_hostname(hostname, local=True)
         if not valid:
             self.clear_info()
             msg = _("Host name is not valid: %s") % error
@@ -1645,7 +1645,7 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
 
     def on_apply_hostname(self, *args):
         hostname = self.network_control_box.hostname
-        (valid, error) = network.is_valid_hostname(hostname)
+        (valid, error) = network.is_valid_hostname(hostname, local=True)
         if not valid:
             self.clear_info()
             msg = _("Host name is not valid: %s") % error

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -418,7 +418,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         # (persistent NM / ifcfg configuration), instead of using original kickstart.
         self._network_module.NetworkDeviceConfigurationChanged()
 
-        (valid, error) = network.is_valid_hostname(self.hostname)
+        (valid, error) = network.is_valid_hostname(self.hostname, local=True)
         if valid:
             self._network_module.SetHostname(self.hostname)
         else:

--- a/tests/nosetests/pyanaconda_tests/network_test.py
+++ b/tests/nosetests/pyanaconda_tests/network_test.py
@@ -52,6 +52,9 @@ class NetworkTests(unittest.TestCase):
 
         self.assertFalse(network.is_valid_hostname("Lennart's Laptop")[0])
 
+        self.assertFalse(network.is_valid_hostname("own.hostname.cannot.end.in.dot.",
+                                                   local=True)[0])
+
     def prefix2netmask2prefix_test(self):
         lore = [
                 (0, "0.0.0.0"),

--- a/tests/nosetests/pyanaconda_tests/network_test.py
+++ b/tests/nosetests/pyanaconda_tests/network_test.py
@@ -19,9 +19,11 @@
 from pyanaconda import network
 import unittest
 
+
 class NetworkTests(unittest.TestCase):
 
     def is_valid_hostname_test(self):
+        """Test hostname validation."""
 
         self.assertFalse(network.is_valid_hostname("")[0])
         self.assertFalse(network.is_valid_hostname(None)[0])
@@ -56,6 +58,7 @@ class NetworkTests(unittest.TestCase):
                                                    local=True)[0])
 
     def prefix2netmask2prefix_test(self):
+        """Test netmask and prefix conversion."""
         lore = [
                 (0, "0.0.0.0"),
                 (1, "128.0.0.0"),
@@ -98,6 +101,7 @@ class NetworkTests(unittest.TestCase):
         self.assertEqual(network.prefix_to_netmask(33), "255.255.255.255")
 
     def nm_check_ip_address_test(self,):
+        """Test IPv4 and IPv6 address checks."""
         good_IPv4_tests = [
                 '1.2.3.4',
                 '0.0.0.0',
@@ -222,6 +226,7 @@ class NetworkTests(unittest.TestCase):
             self.assertFalse(network.check_ip_address(i, version=4))
 
     def hostname_from_cmdline_test(self):
+        """Test extraction of hostname from cmdline."""
         cmdline = {"ip": "10.34.102.244::10.34.102.54:255.255.255.0:myhostname:ens9:none"}
         self.assertEqual(network.hostname_from_cmdline(cmdline), "myhostname")
         # ip takes precedence


### PR DESCRIPTION
Since some time we use systemd for setting hostname immediately, and it does not accept the dot. Systemd claims this is according to kernel and only propagates the limitation closer to user. Survey of other hostname change methods shows this is consistently obeyed, by either:
a) refusing the dot (hostnamectl --static)
b) silently dropping the dot (hostnamectl)
c) sanitizing the input and using pretty hostname (GNOME control center)

For more details see bug 1648107: https://bugzilla.redhat.com/show_bug.cgi?id=1648107

Hostname ks module validation test is also extended for this case.