### PR TITLE
Don't enable BLS for Xen machines

### DIFF
--- a/pyanaconda/bootloader/grub2.py
+++ b/pyanaconda/bootloader/grub2.py
@@ -273,6 +273,13 @@ class GRUB2(BootLoader):
             log.warning("BLS support disabled due new-kernel-pkg being present")
             self.use_bls = False
 
+        hv_type_path = "/sys/hypervisor/type"
+        if self.use_bls and os.access(hv_type_path, os.F_OK):
+            with open(hv_type_path, "r") as fd:
+                if fd.readline().strip() == "xen":
+                    log.warning("BLS support disabled because is a Xen machine")
+                    self.use_bls = False
+
         if self.use_bls:
             defaults.write("GRUB_ENABLE_BLSCFG=true\n")
         defaults.close()


### PR DESCRIPTION
PV and PVH Xen DomU guests boot with pygrub that doesn't have BLS support.
Also Xen Dom0 use the menuentries from 20_linux_xen and not the ones from
10_linux. So BLS support needs to be disabled for both Xen Dom0 and DomU
and use a traditional grub.cfg file generated by the grub2-mkconfig tool.

Related: rhbz#1703700