### PR TITLE
Add a temporary hack to fix installations on ppc64le and aarch64 (#1764666)

### DIFF
--- a/data/tmux.conf
+++ b/data/tmux.conf
@@ -18,7 +18,12 @@ set-option -g history-limit 10000
 
 # The idea here is to detach the client started here via anaconda.service, and
 # then re-attach to it in the tmux service run on the console tty.
-new-session -d -s anaconda -n main "anaconda"
+
+# FIXME: Temporary hot fix added to make Fedora installable on aarch64 and ppc64le.
+# For more infromation see:
+# rhbz#1764666
+# rhbz#1722181
+new-session -d -s anaconda -n main "LD_PRELOAD=libgomp.so.1 anaconda
 
 set-option status-right '#[fg=blue]#(echo -n "Switch tab: Alt+Tab | Help: F1 ")'
 


### PR DESCRIPTION
Quoting bug 1764666:

"Currently Rawhide isn't installable on aarch64 and ppc64le,
because we are hitting bug #1722181 again.
The reasons are increased size of TLS in current distro
(resp. in the libs the python interpreter loads for anaconda to run)
combined with internal limitations of TLS support on these platforms.
I talked to the toolchain people and they think it can be fixed,
but it will take some months before the fix is available.
You can read the details in the thread starting with
https://sourceware.org/ml/libc-alpha/2019-09/msg00512.html,
https://sourceware.org/bugzilla/show_bug.cgi?id=25051
is the current plan for a fix.

So to unblock Rawhide on aarch64 and ppc64le, I propose we carry a patch
in the Fedora anaconda rpms, that workarounds the problem. Although the
change is harmless, I don't think it belongs to upstream anaconda, thus
the request for a patch. I have tested the patch thru an updates image
on ppc64le and it makes anaconda run again."

Unfortunately due to how our release process works, it's easier to
temporarily have this patch in upstream rather than to carry it as
a downstream patch for Rawhide.

Resolves: rhbz#1764666
Related: rhbz#1722181