### PR TITLE
Do not run hwclock when using image install mode

### DIFF
--- a/anaconda
+++ b/anaconda
@@ -1316,6 +1316,8 @@ if __name__ == "__main__":
     if not flags.dirInstall:
         threadMgr.add(AnacondaThread(name=constants.THREAD_STORAGE, target=storageInitialize,
                                      args=(anaconda.storage, ksdata, anaconda.protected)))
+
+    if not flags.dirInstall and not flags.imageInstall:
         threadMgr.add(AnacondaThread(name=constants.THREAD_TIME_INIT, target=time_initialize,
                                      args=(ksdata.timezone, anaconda.storage, anaconda.bootloader)))
 


### PR DESCRIPTION
Currently anaconda --image=... results in it calling the hwclock
program which copies the hardware clock value to the system time. And
depending on the kickstart settings, can cause large time jumps eg.
using --localtime on a --utc based hwclock system.

Resolves: rhbz#1766785