### PR TITLE
Add missing quotation mark to tmux.conf

### DIFF
--- a/data/tmux.conf
+++ b/data/tmux.conf
@@ -23,7 +23,7 @@ set-option -g history-limit 10000
 # For more infromation see:
 # rhbz#1764666
 # rhbz#1722181
-new-session -d -s anaconda -n main "LD_PRELOAD=libgomp.so.1 anaconda
+new-session -d -s anaconda -n main "LD_PRELOAD=libgomp.so.1 anaconda"
 
 set-option status-right '#[fg=blue]#(echo -n "Switch tab: Alt+Tab | Help: F1 ")'
 


### PR DESCRIPTION
It's fix for a workaround from commit:

ff06b13c273bcabd538eec2095d480867166f0fd

*Related: rhbz#1764666*