### PR TITLE
Add support for installation tasks of DBus addons

### DIFF
--- a/pyanaconda/core/signal.py
+++ b/pyanaconda/core/signal.py
@@ -39,12 +39,12 @@ class Signal(object):
 
     def emit(self, *args, **kargs):
         # Call handler functions
-        for func in self._functions:
+        for func in self._functions.copy():
             func(*args, **kargs)
 
         # Call handler methods
-        for obj, funcs in self._methods.items():
-            for func in funcs:
+        for obj, funcs in self._methods.copy().items():
+            for func in funcs.copy():
                 func(obj, *args, **kargs)
 
     def connect(self, slot):

--- a/pyanaconda/dbus_addons/baz/baz.py
+++ b/pyanaconda/dbus_addons/baz/baz.py
@@ -66,35 +66,39 @@ class Baz(KickstartService):
         data.addons.my_example_baz.bar = self._bar
         data.addons.my_example_baz.lines = self._lines
 
+    def configure_with_tasks(self):
+        """Return configuration tasks."""
+        return [BazConfigurationTask()]
+
     def install_with_tasks(self):
         """Return installation tasks."""
-        return [BazTask()]
+        return [BazInstallationTask()]
 
     def calculate_with_task(self):
         """Return a calculation task."""
         return BazCalculationTask()
 
 
-class BazTask(Task):
-    """The Baz task."""
+class BazConfigurationTask(Task):
+    """The Baz configuration task."""
 
     @property
     def name(self):
         return "Configure Baz"
 
+    def run(self):
+        pass
+
+
+class BazInstallationTask(Task):
+    """The Baz installation task."""
+
     @property
-    def steps(self):
-        return 5
+    def name(self):
+        return "Install Baz"
 
     def run(self):
-        self.report_progress("Working..", step_size=1)
-        sleep(5)
-
-        self.report_progress("Taking a nap...", step_size=1)
-        sleep(5)
-
-        self.report_progress("Finishing...", step_size=1)
-        sleep(5)
+        pass
 
 
 class BazCalculationTask(Task):

--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -79,10 +79,21 @@ class Boss(Service):
         log.info("Generating kickstart data...")
         return self._kickstart_manager.generate_kickstart()
 
+    def configure_runtime_with_task(self):
+        """Configure the runtime environment.
+
+        FIXME: This method temporarily uses only addons.
+
+        :return: a task
+        """
+        return self._install_manager.configure_runtime_with_task()
+
     def install_system_with_task(self):
         """Install the system.
 
-        :return: the main installation task
+        FIXME: This method temporarily uses only addons.
+
+        :return: a task
         """
         return self._install_manager.install_system_with_task()
 

--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -62,10 +62,23 @@ class BossInterface(InterfaceTemplate):
         """
         self.implementation.set_locale(locale)
 
+    def ConfigureRuntimeWithTask(self) -> ObjPath:
+        """Configure the runtime environment.
+
+        FIXME: This method temporarily uses only addons.
+
+        :return: a DBus path a task
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.configure_runtime_with_task()
+        )
+
     def InstallSystemWithTask(self) -> ObjPath:
         """Install the system.
 
-        :return: a DBus path of the main installation task
+        FIXME: This method temporarily uses only addons.
+
+        :return: a DBus path of a task
         """
         return TaskContainer.to_object_path(
             self.implementation.install_system_with_task()

--- a/pyanaconda/modules/boss/install_manager/install_manager.py
+++ b/pyanaconda/modules/boss/install_manager/install_manager.py
@@ -17,7 +17,7 @@
 # Red Hat, Inc.
 #
 from pyanaconda.dbus import DBus
-from pyanaconda.modules.boss.install_manager.installation import SystemInstallationTask
+from pyanaconda.modules.common.task import DBusMetaTask
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -45,7 +45,7 @@ class InstallManager(object):
         :return: an instance of the main installation task
         """
         installation_tasks = self._collect_installation_tasks()
-        system_task = SystemInstallationTask(installation_tasks)
+        system_task = DBusMetaTask("Install the system", installation_tasks)
         return system_task
 
     def _collect_installation_tasks(self):

--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -256,8 +256,19 @@ class KickstartService(Service, KickstartBaseModule):
         """
         return self.generate_kickstart()
 
+    def configure_with_tasks(self):
+        """Configure the runtime environment.
+
+        Note: Addons should use it instead of the setup method.
+
+        :return: a list of DBus paths of the installation tasks
+        """
+        return []
+
     def install_with_tasks(self):
         """Return installation tasks of this module.
+
+        Note: Addons should use it instead of the execute method.
 
         :return: a list of DBus paths of the installation tasks
         """

--- a/pyanaconda/modules/common/base/base_interface.py
+++ b/pyanaconda/modules/common/base/base_interface.py
@@ -132,8 +132,21 @@ class KickstartModuleInterface(KickstartModuleInterfaceTemplate):
         """
         return self.implementation.set_locale(locale)
 
+    def ConfigureWithTasks(self) -> List[ObjPath]:
+        """Configure the runtime environment.
+
+        Note: Addons should use it instead of the setup method.
+
+        :returns: a list of object paths of installation tasks
+        """
+        return TaskContainer.to_object_path_list(
+            self.implementation.configure_with_tasks()
+        )
+
     def InstallWithTasks(self) -> List[ObjPath]:
         """Returns installation tasks of this module.
+
+        Note: Addons should use it instead of the execute method.
 
         :returns: list of object paths of installation tasks
         """

--- a/pyanaconda/modules/common/task/__init__.py
+++ b/pyanaconda/modules/common/task/__init__.py
@@ -19,8 +19,10 @@ from time import sleep
 
 from pyanaconda.modules.common.task.task_interface import TaskInterface
 from pyanaconda.modules.common.task.task import Task, AbstractTask
+from pyanaconda.modules.common.task.meta import DBusMetaTask
 
-__all__ = ["sync_run_task", "async_run_task", "AbstractTask", "Task", "TaskInterface"]
+__all__ = ["sync_run_task", "async_run_task", "AbstractTask", "Task", "TaskInterface",
+           "DBusMetaTask"]
 
 
 def sync_run_task(task_proxy, callback=None):

--- a/tests/nosetests/pyanaconda_tests/module_baz_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_baz_test.py
@@ -17,9 +17,10 @@
 #
 import unittest
 
-from pyanaconda.dbus_addons.baz.baz import Baz
+from pyanaconda.dbus_addons.baz.baz import Baz, BazConfigurationTask, BazInstallationTask
 from pyanaconda.dbus_addons.baz.baz_interface import BazInterface
-from tests.nosetests.pyanaconda_tests import check_kickstart_interface
+from tests.nosetests.pyanaconda_tests import check_kickstart_interface, patch_dbus_publish_object, \
+    check_task_creation_list
 
 
 class BazInterfaceTestCase(unittest.TestCase):
@@ -58,3 +59,21 @@ class BazInterfaceTestCase(unittest.TestCase):
         %end
         """
         self._test_kickstart(ks_in, ks_out)
+
+    @patch_dbus_publish_object
+    def configure_with_tasks_test(self, publisher):
+        """Test ConfigureWithTasks."""
+        task_classes = [BazConfigurationTask]
+        task_paths = self.interface.ConfigureWithTasks()
+        task_proxies = check_task_creation_list(self, task_paths, publisher, task_classes)
+        self.assertEqual(len(task_proxies), 1)
+        self.assertEqual(task_proxies[0].implementation.name, "Configure Baz")
+
+    @patch_dbus_publish_object
+    def install_with_tasks_test(self, publisher):
+        """Test InstallWithTasks."""
+        task_classes = [BazInstallationTask]
+        task_paths = self.interface.InstallWithTasks()
+        task_proxies = check_task_creation_list(self, task_paths, publisher, task_classes)
+        self.assertEqual(len(task_proxies), 1)
+        self.assertEqual(task_proxies[0].implementation.name, "Install Baz")

--- a/tests/nosetests/pyanaconda_tests/module_boss_install_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_boss_install_test.py
@@ -20,7 +20,7 @@ import unittest
 from mock import Mock, patch, call
 
 from pyanaconda.modules.boss.install_manager import InstallManager
-from pyanaconda.modules.boss.install_manager.installation import SystemInstallationTask
+from pyanaconda.modules.common.task import DBusMetaTask
 
 
 class InstallManagerTestCase(unittest.TestCase):
@@ -31,7 +31,8 @@ class InstallManagerTestCase(unittest.TestCase):
         install_manager = InstallManager()
         install_manager.on_module_observers_changed([])
         main_task = install_manager.install_system_with_task()
-        self.assertIsInstance(main_task, SystemInstallationTask)
+        self.assertIsInstance(main_task, DBusMetaTask)
+        self.assertEqual(main_task.name, "Install the system")
         self.assertEqual(main_task._subtasks, [])
 
     def install_with_no_tasks_test(self):
@@ -45,7 +46,8 @@ class InstallManagerTestCase(unittest.TestCase):
         install_manager.on_module_observers_changed([observer])
         main_task = install_manager.install_system_with_task()
 
-        self.assertIsInstance(main_task, SystemInstallationTask)
+        self.assertIsInstance(main_task, DBusMetaTask)
+        self.assertEqual(main_task.name, "Install the system")
         self.assertEqual(main_task._subtasks, [])
 
     @patch('pyanaconda.dbus.DBus.get_proxy')
@@ -65,7 +67,8 @@ class InstallManagerTestCase(unittest.TestCase):
         main_task = install_manager.install_system_with_task()
 
         proxy_getter.assert_called_once_with("A", "/A/1")
-        self.assertIsInstance(main_task, SystemInstallationTask)
+        self.assertIsInstance(main_task, DBusMetaTask)
+        self.assertEqual(main_task.name, "Install the system")
         self.assertEqual(main_task._subtasks, [task_proxy])
 
     @patch('pyanaconda.dbus.DBus.get_proxy')
@@ -100,5 +103,6 @@ class InstallManagerTestCase(unittest.TestCase):
             call("B", "/B/1"),
             call("B", "/B/2")
         ])
-        self.assertIsInstance(main_task, SystemInstallationTask)
+        self.assertIsInstance(main_task, DBusMetaTask)
+        self.assertEqual(main_task.name, "Install the system")
         self.assertEqual(main_task._subtasks, [task_proxy, task_proxy, task_proxy])

--- a/tests/nosetests/pyanaconda_tests/module_boss_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_boss_test.py
@@ -24,6 +24,7 @@ from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.boss.boss import Boss
 from pyanaconda.modules.boss.boss_interface import BossInterface
 from pyanaconda.modules.boss.module_manager.start_modules import StartModulesTask
+from pyanaconda.modules.common.task import DBusMetaTask
 from tests.nosetests.pyanaconda_tests import patch_dbus_publish_object, check_task_creation
 
 
@@ -67,6 +68,22 @@ class BossInterfaceTestCase(unittest.TestCase):
     def set_locale_test(self):
         """Test SetLocale."""
         self.assertEqual(self.interface.SetLocale(DEFAULT_LANG), None)
+
+    @patch_dbus_publish_object
+    def configure_runtime_with_task_test(self, publisher):
+        """Test ConfigureRuntimeWithTask."""
+        task_path = self.interface.ConfigureRuntimeWithTask()
+        task_proxy = check_task_creation(self, task_path, publisher, DBusMetaTask)
+        self.assertEqual(task_proxy.implementation._name, "Configure the runtime system")
+        self.assertEqual(task_proxy.implementation._subtasks, [])
+
+    @patch_dbus_publish_object
+    def install_system_with_task_test(self, publisher):
+        """Test InstallSystemWithTask."""
+        task_path = self.interface.InstallSystemWithTask()
+        task_proxy = check_task_creation(self, task_path, publisher, DBusMetaTask)
+        self.assertEqual(task_proxy.implementation._name, "Install the system")
+        self.assertEqual(task_proxy.implementation._subtasks, [])
 
     def quit_test(self):
         """Test Quit."""

--- a/tests/nosetests/pyanaconda_tests/module_tasks_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_tasks_test.py
@@ -21,10 +21,9 @@ from mock import Mock, call
 
 from pyanaconda.dbus.interface import dbus_class
 from pyanaconda.dbus.typing import *  # pylint: disable=wildcard-import
-from pyanaconda.modules.boss.install_manager.installation import SystemInstallationTask
 from pyanaconda.modules.common.errors.task import NoResultError
 from pyanaconda.modules.common.task import Task, TaskInterface, sync_run_task, \
-    async_run_task
+    async_run_task, DBusMetaTask
 from tests.nosetests.pyanaconda_tests import run_in_glib
 
 
@@ -360,7 +359,7 @@ class TaskInterfaceTestCase(unittest.TestCase):
 
     def install_with_no_tasks_test(self):
         """Install with no tasks."""
-        self._set_up_task(SystemInstallationTask([]))
+        self._set_up_task(DBusMetaTask("Task", []))
         self._check_steps(0)
         self._run_task()
         self._finish_task()
@@ -369,7 +368,7 @@ class TaskInterfaceTestCase(unittest.TestCase):
     def install_with_one_task_test(self):
         """Install with one task."""
         self._set_up_task(
-            SystemInstallationTask([
+            DBusMetaTask("Task", [
                 TaskInterface(self.SimpleTask())
             ])
         )
@@ -382,7 +381,7 @@ class TaskInterfaceTestCase(unittest.TestCase):
     def install_with_failing_task_test(self):
         """Install with one failing task."""
         self._set_up_task(
-            SystemInstallationTask([
+            DBusMetaTask("Task", [
                 TaskInterface(self.FailingTask())
             ])
         )
@@ -395,7 +394,7 @@ class TaskInterfaceTestCase(unittest.TestCase):
     def install_with_canceled_task_test(self):
         """Install with one canceled task."""
         self._set_up_task(
-            SystemInstallationTask([
+            DBusMetaTask("Task", [
                 TaskInterface(self.CanceledTask())
             ])
         )
@@ -435,7 +434,7 @@ class TaskInterfaceTestCase(unittest.TestCase):
     def install_with_three_tasks_test(self):
         """Install with three tasks."""
         self._set_up_task(
-            SystemInstallationTask([
+            DBusMetaTask("Task", [
                 TaskInterface(self.InstallationTaskA()),
                 TaskInterface(self.InstallationTaskB()),
                 TaskInterface(self.InstallationTaskC())
@@ -467,7 +466,7 @@ class TaskInterfaceTestCase(unittest.TestCase):
     def install_with_incomplete_tasks_test(self):
         """Install with incomplete tasks."""
         self._set_up_task(
-            SystemInstallationTask([
+            DBusMetaTask("Task", [
                 TaskInterface(self.InstallationTaskA()),
                 TaskInterface(self.IncompleteTask()),
                 TaskInterface(self.InstallationTaskB()),


### PR DESCRIPTION
DBus addons should return their "setup" tasks in the `ConfigureWithTasks` method
and their "execute" tasks in the `InstallWithTasks` method.

Anaconda will schedule and run the installation tasks of the DBus addons during
the installation.