### PR TITLE
Redirect all GitHub Pages of Anaconda

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://anaconda-installer.readthedocs.io</title>
+<meta http-equiv="refresh" content="0; URL=https://anaconda-installer.readthedocs.io">
+<link href="https://anaconda-installer.readthedocs.io">

--- a/404.html
+++ b/404.html
@@ -1,5 +1,12 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to https://anaconda-installer.readthedocs.io</title>
-<meta http-equiv="refresh" content="0; URL=https://anaconda-installer.readthedocs.io">
-<link href="https://anaconda-installer.readthedocs.io">
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Anaconda Installer</title>
+    <meta http-equiv="refresh" content="0; URL=https://anaconda-installer.readthedocs.io" />
+    <link href="https://anaconda-installer.readthedocs.io" />
+  </head>
+  <body>
+    <p>Please follow <a href="https://anaconda-installer.readthedocs.io">this link</a>.</p>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,12 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to https://anaconda-installer.readthedocs.io</title>
-<meta http-equiv="refresh" content="0; URL=https://anaconda-installer.readthedocs.io">
-<link rel="canonical" href="https://anaconda-installer.readthedocs.io">
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Anaconda Installer</title>
+    <meta http-equiv="refresh" content="0; URL=https://anaconda-installer.readthedocs.io" />
+    <link rel="canonical" href="https://anaconda-installer.readthedocs.io" />
+  </head>
+  <body>
+    <p>Please follow <a href="https://anaconda-installer.readthedocs.io">this link</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
Redirect the page 404.html, so all links to the Anaconda GitHub Pages will be
redirected to https://anaconda-installer.readthedocs.io.
