### PR TITLE
Cmdline deflagification

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -39,7 +39,7 @@ def exitHandler(rebootData, storage):
     if flags.usevnc:
         vnc.shutdownServer()
 
-    if "nokill" in flags.cmdline:
+    if "nokill" in kernel_arguments:
         util.vtActivate(1)
         print("anaconda halting due to nokill flag.")
         print("The system will be rebooted when you press Ctrl-Alt-Delete.")
@@ -248,7 +248,8 @@ if __name__ == "__main__":
 
     # do this early so we can set flags before initializing logging
     from pyanaconda.flags import flags
-    (opts, depr) = parse_arguments(boot_cmdline=flags.cmdline)
+    from pyanaconda.core.kernel import kernel_arguments
+    (opts, depr) = parse_arguments(boot_cmdline=kernel_arguments)
 
     from pyanaconda.core.configuration.anaconda import conf
     conf.set_from_opts(opts)
@@ -284,7 +285,7 @@ if __name__ == "__main__":
     # see if we're on s390x and if we've got an ssh connection
     uname = os.uname()
     if uname[4] == 's390x':
-        if 'TMUX' not in os.environ and 'ks' not in flags.cmdline and conf.target.is_hardware:
+        if 'TMUX' not in os.environ and 'ks' not in kernel_arguments and conf.target.is_hardware:
             startup_utils.prompt_for_ssh()
             sys.exit(0)
 
@@ -293,7 +294,7 @@ if __name__ == "__main__":
         log.info("Using updates in /tmp/updates/ from %s", opts.updateSrc)
 
     # TODO: uncomment this when we're sure that we're doing the right thing
-    # with flags.cmdline *everywhere* it appears...
+    # with kernel_arguments *everywhere* it appears...
     #for arg in depr:
     #    stdout_log.warn("Boot argument '%s' is deprecated. "
     #                   "In the future, use 'inst.%s'.", arg, arg)

--- a/pyanaconda/bootloader/base.py
+++ b/pyanaconda/bootloader/base.py
@@ -30,9 +30,9 @@ from pyanaconda import platform
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.bootloader.image import LinuxBootLoaderImage
 from pyanaconda.core import util
+from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.i18n import N_, _
-from pyanaconda.flags import flags
 from pyanaconda.modules.common.constants.objects import FCOE, ISCSI
 from pyanaconda.modules.common.structures.iscsi import Node
 from pyanaconda.modules.common.constants.services import STORAGE, NETWORK
@@ -701,7 +701,7 @@ class BootLoader(object):
 
         # FIPS
         boot_device = storage.mountpoints.get("/boot")
-        if flags.cmdline.get("fips") == "1" and boot_device:
+        if kernel_arguments.get("fips") == "1" and boot_device:
             self.boot_args.add("boot=%s" % self.stage2_device.fstab_spec)
 
         # Storage
@@ -806,10 +806,10 @@ class BootLoader(object):
     def _preserve_some_boot_args(self):
         """Preserve some of the boot args."""
         for opt in conf.bootloader.preserved_arguments:
-            if opt not in flags.cmdline:
+            if opt not in kernel_arguments:
                 continue
 
-            arg = flags.cmdline.get(opt)
+            arg = kernel_arguments.get(opt)
             new_arg = opt
             if arg:
                 new_arg += "=%s" % arg
@@ -854,7 +854,7 @@ class BootLoader(object):
 
     def _set_console(self):
         """ Set console options based on boot arguments. """
-        console = flags.cmdline.get("console", "")
+        console = kernel_arguments.get("console", "")
         console = os.path.basename(console)
         self.console, _x, self.console_options = console.partition(",")
 

--- a/pyanaconda/bootloader/efi.py
+++ b/pyanaconda/bootloader/efi.py
@@ -21,8 +21,8 @@ import re
 from pyanaconda.bootloader.base import BootLoaderError
 from pyanaconda.bootloader.grub2 import GRUB2
 from pyanaconda.core import util
+from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.flags import flags
 from pyanaconda.product import productName
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -43,7 +43,7 @@ class EFIBase(object):
             log.info("Skipping efibootmgr for image/directory install.")
             return ""
 
-        if "noefi" in flags.cmdline:
+        if "noefi" in kernel_arguments:
             log.info("Skipping efibootmgr for noefi")
             return ""
 

--- a/pyanaconda/core/kernel.py
+++ b/pyanaconda/core/kernel.py
@@ -21,12 +21,17 @@ import glob
 from collections import OrderedDict
 from pyanaconda.core.constants import CMDLINE_APPEND, CMDLINE_LIST, CMDLINE_FILES
 
+__all__ = ['KernelArguments', 'kernel_arguments']
 
-class KernelArguments(OrderedDict):
+
+class KernelArguments():
     """The kernel arguments.
 
     Hold boot arguments as an OrderedDict.
     """
+
+    def __init__(self):
+        self._data = OrderedDict()
 
     @classmethod
     def from_defaults(cls):
@@ -110,17 +115,17 @@ class KernelArguments(OrderedDict):
                 val = None
 
             # Some duplicate args create a space separated string
-            if key in CMDLINE_APPEND and self.get(key, None):
+            if key in CMDLINE_APPEND and self._data.get(key, None):
                 if val:
-                    self[key] = self[key] + " " + val
+                    self._data[key] = self._data[key] + " " + val
             # Some arguments can contain spaces so adding them in one string is not that helpful
             elif key in CMDLINE_LIST:
                 if val:
-                    if not self.get(key, None):
-                        self[key] = []
-                    self[key].append(val)
+                    if not self._data.get(key, None):
+                        self._data[key] = []
+                    self._data[key].append(val)
             else:
-                self[key] = val
+                self._data[key] = val
 
     def getbool(self, arg, default=False):
         """Return the boolean value of the given argument.
@@ -134,15 +139,36 @@ class KernelArguments(OrderedDict):
         :return: a boolean value of the argument
         """
         result = default
-        for a in self:
+        for a in self._data:
             if a == arg:
-                if self[arg] in ("0", "off", "no"):
+                if self._data[arg] in ("0", "off", "no"):
                     result = False
                 else:
                     result = True
             elif a == 'no' + arg:
                 result = False  # XXX: should noarg=off -> True?
         return result
+
+    def get(self, arg, default=None):
+        """Return the value of the given argument.
+
+        Propagates the call verbatim to the underlying dictionary.
+        """
+        return self._data.get(arg, default)
+
+    def __contains__(self, arg):
+        """Check for presence of an argument.
+
+        Propagates the call verbatim to the underlying dictionary.
+        """
+        return arg in self._data
+
+    def items(self):
+        """Return an iterator over all arguments.
+
+        Propagates the call verbatim to the underlying dictionary.
+        """
+        return self._data.items()
 
 
 kernel_arguments = KernelArguments.from_defaults()

--- a/pyanaconda/core/kernel.py
+++ b/pyanaconda/core/kernel.py
@@ -143,3 +143,6 @@ class KernelArguments(OrderedDict):
             elif a == 'no' + arg:
                 result = False  # XXX: should noarg=off -> True?
         return result
+
+
+kernel_arguments = KernelArguments.from_defaults()

--- a/pyanaconda/core/kernel.py
+++ b/pyanaconda/core/kernel.py
@@ -127,6 +127,21 @@ class KernelArguments():
             else:
                 self._data[key] = val
 
+    def is_enabled(self, arg):
+        """Return boolean value for the given argument.
+
+        Rules:
+        - 0, off, not present -> False
+        - the rest -> True
+        """
+        # None is stored when arg is present but had no value when parsing.
+        # So the "miss" value must be something else.
+        val = self._data.get(arg, False)
+        if val in ["0", "off", False]:
+            return False
+        else:
+            return True
+
     def getbool(self, arg, default=False):
         """Return the boolean value of the given argument.
 

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from pyanaconda.core.constants import ANACONDA_ENVIRON
-from pyanaconda.core.kernel import KernelArguments
+from pyanaconda.core.kernel import kernel_arguments
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -53,8 +53,8 @@ class Flags(object):
         self.singlelang = False
         # current runtime environments
         self.environs = [ANACONDA_ENVIRON]
-        # parse the boot commandline
-        self.cmdline = KernelArguments.from_defaults()
+        # pre-parsed boot commandline
+        self.cmdline = kernel_arguments
         # Lock it down: no more creating new flags!
         self.__dict__['_in_init'] = False
 

--- a/pyanaconda/geoloc.py
+++ b/pyanaconda/geoloc.py
@@ -193,10 +193,7 @@ class Geolocation(object):
                 geolocation_enabled = False
 
         # and also check if geolocation was not disabled by boot or command like option
-        if not kernel_arguments.getbool('geoloc', True):
-            # kernel_arguments.getbool is used as it handles values such as
-            # 0, no, off and also nogeoloc as False
-            # and other values or geoloc not being present as True
+        if not kernel_arguments.is_enabled('geoloc'):
             geolocation_enabled = False
 
         # log the result
@@ -218,7 +215,7 @@ class Geolocation(object):
                 log.info("Geolocation is disabled for image or directory installation.")
             elif flags.automatedInstall:
                 log.info("Geolocation is disabled due to automated kickstart based installation.")
-            if not kernel_arguments.getbool('geoloc', True):
+            if not kernel_arguments.is_enabled('geoloc'):
                 log.info("Geolocation is disabled by the geoloc option.")
 
     def refresh(self):

--- a/pyanaconda/geoloc.py
+++ b/pyanaconda/geoloc.py
@@ -109,6 +109,7 @@ Backends that could possibly be used in the future
    * cell tower geolocation
 
 """
+from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.util import requests_session
 import requests
 import urllib.parse
@@ -192,8 +193,8 @@ class Geolocation(object):
                 geolocation_enabled = False
 
         # and also check if geolocation was not disabled by boot or command like option
-        if not flags.cmdline.getbool('geoloc', True):
-            # flags.cmdline.getbool is used as it handles values such as
+        if not kernel_arguments.getbool('geoloc', True):
+            # kernel_arguments.getbool is used as it handles values such as
             # 0, no, off and also nogeoloc as False
             # and other values or geoloc not being present as True
             geolocation_enabled = False
@@ -217,7 +218,7 @@ class Geolocation(object):
                 log.info("Geolocation is disabled for image or directory installation.")
             elif flags.automatedInstall:
                 log.info("Geolocation is disabled due to automated kickstart based installation.")
-            if not flags.cmdline.getbool('geoloc', True):
+            if not kernel_arguments.getbool('geoloc', True):
                 log.info("Geolocation is disabled by the geoloc option.")
 
     def refresh(self):

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -319,7 +319,7 @@ def _prepare_installation(storage, payload, ksdata):
 
         if can_install_bootloader:
             payload.requirements.add_packages(storage.bootloader.packages, reason="bootloader")
-        if kernel_arguments.getbool("fips"):
+        if kernel_arguments.is_enabled("fips"):
             payload.requirements.add_packages(['/usr/bin/fips-mode-setup'], reason="compliance")
 
         payload.requirements.add_groups(payload.language_groups(), reason="language groups")

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -23,6 +23,7 @@ from blivet.devices import BTRFSDevice
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import BOOTLOADER_DISABLED
+from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.modules.common.constants.objects import BOOTLOADER, SNAPSHOT, FIREWALL
 from pyanaconda.modules.common.constants.services import STORAGE, USERS, SERVICES, NETWORK, SECURITY, \
     LOCALIZATION, TIMEZONE, BOSS
@@ -318,7 +319,7 @@ def _prepare_installation(storage, payload, ksdata):
 
         if can_install_bootloader:
             payload.requirements.add_packages(storage.bootloader.packages, reason="bootloader")
-        if flags.flags.cmdline.getbool("fips"):
+        if kernel_arguments.getbool("fips"):
             payload.requirements.add_packages(['/usr/bin/fips-mode-setup'], reason="compliance")
 
         payload.requirements.add_groups(payload.language_groups(), reason="language groups")

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -19,9 +19,9 @@
 #
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.configuration.network import NetworkOnBoot
+from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.dbus import DBus, SystemBus
 from pyanaconda.core.signal import Signal
-from pyanaconda.flags import flags
 from pyanaconda.modules.common.base import KickstartService
 from pyanaconda.modules.common.containers import TaskContainer
 from pyanaconda.modules.common.structures.requirement import Requirement
@@ -93,7 +93,7 @@ class NetworkService(KickstartService):
         self._bootif = None
         self._ifname_option_values = []
         self._disable_ipv6 = False
-        self._apply_boot_options(flags.cmdline)
+        self._apply_boot_options(kernel_arguments)
 
     def publish(self):
         """Publish the module."""

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -652,20 +652,20 @@ class NetworkService(KickstartService):
         ))
         return dracut_args
 
-    def _apply_boot_options(self, kernel_arguments):
+    def _apply_boot_options(self, kernel_args):
         """Apply boot options to the module.
 
-        :param kernel_arguments: structure holding installer boot options
-        :type kernel_arguments: KernelArguments
+        :param kernel_args: structure holding installer boot options
+        :type kernel_args: KernelArguments
         """
-        log.debug("Applying boot options %s", kernel_arguments)
-        if 'ksdevice' in kernel_arguments:
-            self.default_device_specification = kernel_arguments.get('ksdevice')
-        if 'BOOTIF' in kernel_arguments:
-            self.bootif = kernel_arguments['BOOTIF'][3:].replace("-", ":").upper()
-        if 'ifname' in kernel_arguments:
-            self.ifname_option_values = kernel_arguments.get("ifname", "").split()
-        if 'noipv6' in kernel_arguments:
+        log.debug("Applying boot options %s", kernel_args)
+        if 'ksdevice' in kernel_args:
+            self.default_device_specification = kernel_args.get('ksdevice')
+        if 'BOOTIF' in kernel_args:
+            self.bootif = kernel_args['BOOTIF'][3:].replace("-", ":").upper()
+        if 'ifname' in kernel_args:
+            self.ifname_option_values = kernel_args.get("ifname", "").split()
+        if 'noipv6' in kernel_args:
             self.disable_ipv6 = True
 
     def log_task_result(self, task, check_result=False, root_path=""):

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -662,9 +662,9 @@ class NetworkService(KickstartService):
         if 'ksdevice' in kernel_args:
             self.default_device_specification = kernel_args.get('ksdevice')
         if 'BOOTIF' in kernel_args:
-            self.bootif = kernel_args['BOOTIF'][3:].replace("-", ":").upper()
+            self.bootif = kernel_args.get('BOOTIF')[3:].replace("-", ":").upper()
         if 'ifname' in kernel_args:
-            self.ifname_option_values = kernel_args.get("ifname", "").split()
+            self.ifname_option_values = kernel_args.get("ifname").split()
         if 'noipv6' in kernel_args:
             self.disable_ipv6 = True
 

--- a/pyanaconda/modules/payloads/base/utils.py
+++ b/pyanaconda/modules/payloads/base/utils.py
@@ -49,7 +49,7 @@ def write_module_blacklist(sysroot):
     mkdirChain(os.path.join(sysroot, "etc/modprobe.d"))
     with open(os.path.join(sysroot, "etc/modprobe.d/anaconda-blacklist.conf"), "w") as f:
         f.write("# Module blacklists written by anaconda\n")
-        for module in kernel_arguments["modprobe.blacklist"].split():
+        for module in kernel_arguments.get("modprobe.blacklist").split():
             f.write("blacklist %s\n" % module)
 
 

--- a/pyanaconda/modules/payloads/base/utils.py
+++ b/pyanaconda/modules/payloads/base/utils.py
@@ -22,9 +22,9 @@ import glob
 import os
 import stat
 
+from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.util import mkdirChain, execWithRedirect
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.flags import flags
 from pyanaconda.payload.utils import version_cmp
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -43,13 +43,13 @@ def write_module_blacklist(sysroot):
     /etc/modprobe.d/anaconda-blacklist.conf so that modules will
     continue to be blacklisted when the system boots.
     """
-    if "modprobe.blacklist" not in flags.cmdline:
+    if "modprobe.blacklist" not in kernel_arguments:
         return
 
     mkdirChain(os.path.join(sysroot, "etc/modprobe.d"))
     with open(os.path.join(sysroot, "etc/modprobe.d/anaconda-blacklist.conf"), "w") as f:
         f.write("# Module blacklists written by anaconda\n")
-        for module in flags.cmdline["modprobe.blacklist"].split():
+        for module in kernel_arguments["modprobe.blacklist"].split():
             f.write("blacklist %s\n" % module)
 
 

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -198,16 +198,16 @@ def get_hostname():
     return hostname
 
 
-def hostname_from_cmdline(kernel_arguments):
+def hostname_from_cmdline(kernel_args):
     """Get hostname defined by boot options.
 
-    :param kernel_arguments: structure holding installer boot options
-    :type kernel_arguments: KernelArguments
+    :param kernel_args: structure holding installer boot options
+    :type kernel_args: KernelArguments
     """
     # legacy hostname= option
-    hostname = kernel_arguments.get('hostname', "")
+    hostname = kernel_args.get('hostname', "")
     # ip= option
-    ipopts = kernel_arguments.get('ip')
+    ipopts = kernel_args.get('ip')
     # Example (2 options):
     # ens3:dhcp 10.34.102.244::10.34.102.54:255.255.255.0:myhostname:ens9:none
     if ipopts:

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -32,8 +32,8 @@ import threading
 import re
 import ipaddress
 
-from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _
+from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.regexes import HOSTNAME_PATTERN_WITHOUT_ANCHORS, \
     IPV6_ADDRESS_IN_DRACUT_IP_OPTION
 from pyanaconda.core.configuration.anaconda import conf
@@ -285,7 +285,7 @@ def initialize_network():
     run_network_initialization_task(network_proxy.SetRealOnbootValuesFromKickstartWithTask())
 
     if network_proxy.Hostname == DEFAULT_HOSTNAME:
-        bootopts_hostname = hostname_from_cmdline(flags.cmdline)
+        bootopts_hostname = hostname_from_cmdline(kernel_arguments)
         if bootopts_hostname:
             log.debug("Updating host name from boot options: %s", bootopts_hostname)
             network_proxy.SetHostname(bootopts_hostname)

--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -26,12 +26,12 @@ from abc import ABCMeta
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import DRACUT_ISODIR, DRACUT_REPODIR, INSTALL_TREE, ISO_DIR
 from pykickstart.constants import GROUP_ALL, GROUP_DEFAULT, GROUP_REQUIRED
-from pyanaconda.flags import flags
 
 from pyanaconda import isys
 from pyanaconda.payload.image import findFirstIsoImage, mountImage, find_optical_install_media,\
     verifyMedia, verify_valid_installtree
 from pyanaconda.core import util
+from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.util import ProxyString, ProxyStringError, decode_bytes
 from pyanaconda.core.regexes import VERSION_DIGITS
 from pyanaconda.payload.errors import PayloadError, PayloadSetupError, NoSuchGroup
@@ -551,7 +551,7 @@ class Payload(metaclass=ABCMeta):
 
                 # if the installation is running in fips mode then make sure
                 # fips is also correctly enabled in the installed system
-                if flags.cmdline.get("fips") == "1":
+                if kernel_arguments.get("fips") == "1":
                     # We use the --no-bootcfg option as we don't want fips-mode-setup to
                     # modify the bootloader configuration.
                     # Anaconda already does everything needed & it would require grubby to

--- a/tests/nosetests/pyanaconda_tests/kernel_test.py
+++ b/tests/nosetests/pyanaconda_tests/kernel_test.py
@@ -1,0 +1,93 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import unittest
+from pyanaconda.core.kernel import KernelArguments, kernel_arguments
+import collections
+
+
+class KernelArgumentsTests(unittest.TestCase):
+
+    def value_retrieval_test(self):
+        """KernelArguments value retrieval test."""
+
+        ka = KernelArguments.from_string(
+            "blah foo=anything bar=1 baz=0 nowhere nothing=indeed beep=off derp=no nobody=0")
+
+        # test using "in" operator on the class
+        self.assertTrue("blah" in ka)
+        self.assertTrue("foo" in ka)
+        self.assertFalse("thisisnotthere" in ka)
+        self.assertFalse("body" in ka)
+        self.assertTrue("nobody" in ka)
+
+        # test the get() method
+        self.assertEqual(ka.get("foo"), "anything")
+        self.assertIsNone(ka.get("thisisnotthere"))
+        self.assertEqual(ka.get("thisisnotthere", "fallback"), "fallback")
+
+        # test the getbool() method - presence
+        self.assertTrue(ka.getbool("blah"))  # is present
+        self.assertTrue(ka.getbool("foo"))  # has any value
+
+        # test the getbool() method - simple names and values
+        self.assertTrue(ka.getbool("bar"))  # 1
+        self.assertFalse(ka.getbool("baz"))  # 0
+        self.assertFalse(ka.getbool("beep"))  # off
+        self.assertFalse(ka.getbool("derp"))  # no
+
+        # test the getbool() method - the super magical "no" prefix
+        self.assertFalse(ka.getbool("where"))  # is present with no-prefix
+        self.assertFalse(ka.getbool("thing"))  # is set and has no-prefix
+        self.assertTrue(ka.getbool("nothing"))  # full name incl. the "no" prefix = is present
+        self.assertFalse(ka.getbool("nobody"))  # full name incl. the "no" prefix, value is 0
+        self.assertFalse(ka.get("body"))  # no-prefix and has a value
+
+    def real_parsing_and_adding_test(self):
+        """Test file spec handling in KernelArguments."""
+
+        ka = KernelArguments()
+        self.assertEqual(ka.read(["/proc/cmdlin*", "/nonexistent/file"]), ["/proc/cmdline"])
+        self.assertEqual(ka.read("/another/futile/attempt"), [])
+        self.assertTrue(ka.getbool("root"))  # expect this to be set in most environments
+
+    def special_argument_handling_test(self):
+        """Test handling of special arguments in KernelArguments."""
+
+        ka = KernelArguments.from_string("modprobe.blacklist=floppy modprobe.blacklist=reiserfs")
+        self.assertEqual(ka.get("modprobe.blacklist"), "floppy reiserfs")
+        ka.read_string("inst.addrepo=yum inst.addrepo=dnf")
+        self.assertEqual(ka.get("addrepo"), ["yum", "dnf"])
+        ka.read_string("inst.ks=kickstart")
+        self.assertEqual(ka.get("ks"), "kickstart")
+
+    def items_test(self):
+        """Test KernelArguments access to contents with iterator."""
+
+        ka = KernelArguments.from_defaults()
+        it = ka.items()
+        self.assertIsInstance(it, collections.Iterable)
+        root_seen = False
+        for k, v in it:  # pylint: disable=unused-variable
+            if k == "root":
+                root_seen = True
+        self.assertTrue(root_seen)
+
+    def shared_instance_test(self):
+        """Test the kernel.kernel_arguments instance."""
+        self.assertTrue("root" in kernel_arguments)

--- a/tests/nosetests/pyanaconda_tests/kernel_test.py
+++ b/tests/nosetests/pyanaconda_tests/kernel_test.py
@@ -58,6 +58,19 @@ class KernelArgumentsTests(unittest.TestCase):
         self.assertFalse(ka.getbool("nobody"))  # full name incl. the "no" prefix, value is 0
         self.assertFalse(ka.get("body"))  # no-prefix and has a value
 
+        # test the is_enabled() method
+        self.assertTrue(ka.is_enabled("blah"))  # present
+        self.assertTrue(ka.is_enabled("foo"))  # any value
+        self.assertTrue(ka.is_enabled("bar"))  # 1 = any value
+        self.assertFalse(ka.is_enabled("baz"))  # 0
+        self.assertTrue(ka.is_enabled("nowhere"))  # present
+        self.assertTrue(ka.is_enabled("nothing"))  # present
+        self.assertFalse(ka.is_enabled("beep"))  # off
+        self.assertTrue(ka.is_enabled("derp"))  # no = any value
+        self.assertFalse(ka.is_enabled("nobody"))  # 0
+        self.assertFalse(ka.is_enabled("thing"))  # not present
+        self.assertFalse(ka.is_enabled("where"))  # not present
+
     def real_parsing_and_adding_test(self):
         """Test file spec handling in KernelArguments."""
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_test.py
@@ -299,12 +299,11 @@ class PayloadSharedUtilsTest(TestCase):
 
             self.assertTrue(os.path.isdir(root_dir))
 
-    @patch('pyanaconda.modules.payloads.base.utils.flags')
-    def write_module_blacklist_test(self, flags):
+    @patch('pyanaconda.modules.payload.base.utils.kernel_arguments',
+           {"modprobe.blacklist": "mod1 mod2 nonono_mod"})
+    def write_module_blacklist_test(self):
         """Test write kernel module blacklist to the install root."""
         with TemporaryDirectory() as temp:
-            flags.cmdline = {"modprobe.blacklist": "mod1 mod2 nonono_mod"}
-
             write_module_blacklist(temp)
 
             blacklist_file = os.path.join(temp, "etc/modprobe.d/anaconda-blacklist.conf")
@@ -320,12 +319,10 @@ class PayloadSharedUtilsTest(TestCase):
                 """
                 self.assertEqual(dedent(expected_content).lstrip(), f.read())
 
-    @patch('pyanaconda.modules.payloads.base.utils.flags')
-    def write_empty_module_blacklist_test(self, flags):
+    @patch('pyanaconda.modules.payload.base.utils.kernel_arguments', {})
+    def write_empty_module_blacklist_test(self):
         """Test write kernel module blacklist to the install root -- empty list."""
         with TemporaryDirectory() as temp:
-            flags.cmdline = {}
-
             write_module_blacklist(temp)
 
             blacklist_file = os.path.join(temp, "etc/modprobe.d/anaconda-blacklist.conf")

--- a/tests/nosetests/pyanaconda_tests/module_payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_test.py
@@ -299,7 +299,7 @@ class PayloadSharedUtilsTest(TestCase):
 
             self.assertTrue(os.path.isdir(root_dir))
 
-    @patch('pyanaconda.modules.payload.base.utils.kernel_arguments',
+    @patch('pyanaconda.modules.payloads.base.utils.kernel_arguments',
            {"modprobe.blacklist": "mod1 mod2 nonono_mod"})
     def write_module_blacklist_test(self):
         """Test write kernel module blacklist to the install root."""
@@ -319,7 +319,7 @@ class PayloadSharedUtilsTest(TestCase):
                 """
                 self.assertEqual(dedent(expected_content).lstrip(), f.read())
 
-    @patch('pyanaconda.modules.payload.base.utils.kernel_arguments', {})
+    @patch('pyanaconda.modules.payloads.base.utils.kernel_arguments', {})
     def write_empty_module_blacklist_test(self):
         """Test write kernel module blacklist to the install root -- empty list."""
         with TemporaryDirectory() as temp:


### PR DESCRIPTION
This adds `pyanaconda.kernel.cmdline` so that `pyanaconda.flags.flags.cmdline` can be eventually removed.
- All functionality is identical.
- The old name still exists, works, and in fact returns the same instance of `KernelArguments`.
- All internal uses of the old are replaced with the new.
- Same for tests.

A quick check of other potential consumers shows no use in:
- Initial setup
- KDdump addon
- OSCAP addon

Up for discussion: What level of refactoring is desired? I'm not entirely happy that `KernelArguments` exposes its various `read_` and `from_` methods which makes it possible to potentially call them on the global shared instance and fill it with nonsense. So far it was apparently not a problem though.