### PR TITLE
Add permalink to 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,3 +1,6 @@
+---
+permalink: /404.html
+---
 <!DOCTYPE html>
 <html>
   <head>


### PR DESCRIPTION
The custom error page for GitHub Pages should have a permalink to 404.html.