### PR TITLE
Fix wrong kdump boot option in boot options docs

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -810,10 +810,10 @@ Since Fedora 19 the Anaconda installer supports third-party extensions called
 *addons*. The *addons* can support their own set of boot options which should be
 documented in their documentation or submitted here.
 
-.. inst.kdump:
+.. inst.kdump_addon:
 
-inst.kdump
-++++++++++
+inst.kdump_addon
+++++++++++++++++
 
 ``inst.kdump_addon=on/off``
 


### PR DESCRIPTION
Apparently the text was changed in the past but not really enough.