### PR TITLE
Convert VG reserved_space to Size

### DIFF
--- a/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
@@ -831,7 +831,7 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
 
             storage.create_device(request)
             if volgroup_data.reserved_space:
-                request.reserved_space = volgroup_data.reserved_space
+                request.reserved_space = Size("{:d} MiB".format(volgroup_data.reserved_space))
             elif volgroup_data.reserved_percent:
                 request.reserved_percent = volgroup_data.reserved_percent
 


### PR DESCRIPTION
We get amount of reserved space in MiB from kickstart but blivet
needs Size.

#2224 for master. This is related to https://github.com/storaged-project/blivet/pull/813 but it's not necessary to merge/build these together.