### PR TITLE
Change the DBus support for collecting ancestors

### DIFF
--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -241,17 +241,24 @@ class DeviceTreeViewer(ABC):
 
         return device.name
 
-    def get_device_ancestors(self, device_name):
-        """Get all ancestors of the specified device.
+    def get_ancestors(self, device_names):
+        """Collect ancestors of the specified devices.
 
-        The specified device is not part of the list.
+        Ancestors of a device don't include the device itself.
         The list is sorted by names of the devices.
 
-        :param device_name: a device name
+        :param device_names: a list of device names
         :return: a list of device names
         """
-        device = self._get_device(device_name)
-        return list(sorted(ancestor.name for ancestor in device.ancestors if ancestor != device))
+        devices = self._get_devices(device_names)
+        ancestors = set()
+
+        for device in devices:
+            for ancestor in device.ancestors:
+                if ancestor != device:
+                    ancestors.add(ancestor.name)
+
+        return sorted(ancestors)
 
     def get_supported_file_systems(self):
         """Get the supported types of filesystems.

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -109,13 +109,16 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
         """
         return self.implementation.resolve_device(dev_spec)
 
-    def GetDeviceAncestors(self, device_name: Str) -> List[Str]:
-        """Get all ancestors of the specified device.
+    def GetAncestors(self, device_names: List[Str]) -> List[Str]:
+        """Collect ancestors of the specified devices.
 
-        :param device_name: a device name
+        Ancestors of a device don't include the device itself.
+        The list is sorted by names of the devices.
+
+        :param device_names: a list of device names
         :return: a list of device names
         """
-        return self.implementation.get_device_ancestors(device_name)
+        return self.implementation.get_ancestors(device_names)
 
     def GetSupportedFileSystems(self) -> List[Str]:
         """Get the supported types of filesystems.

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -335,8 +335,8 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         self.assertEqual(self.interface.ResolveDevice("dev1"), "dev1")
         self.assertEqual(self.interface.ResolveDevice("/dev/dev1"), "dev1")
 
-    def get_device_ancestors_test(self):
-        """Test GetDeviceAncestors."""
+    def get_ancestors_test(self):
+        """Test GetAncestors."""
         dev1 = StorageDevice("dev1")
         self._add_device(dev1)
 
@@ -346,9 +346,17 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         dev3 = StorageDevice("dev3", parents=[dev2])
         self._add_device(dev3)
 
-        self.assertEqual(self.interface.GetDeviceAncestors("dev1"), [])
-        self.assertEqual(self.interface.GetDeviceAncestors("dev2"), ["dev1"])
-        self.assertEqual(self.interface.GetDeviceAncestors("dev3"), ["dev1", "dev2"])
+        dev4 = StorageDevice("dev4")
+        self._add_device(dev4)
+
+        dev5 = StorageDevice("dev5", parents=[dev4])
+        self._add_device(dev5)
+
+        self.assertEqual(self.interface.GetAncestors(["dev1"]), [])
+        self.assertEqual(self.interface.GetAncestors(["dev2"]), ["dev1"])
+        self.assertEqual(self.interface.GetAncestors(["dev3"]), ["dev1", "dev2"])
+        self.assertEqual(self.interface.GetAncestors(["dev2", "dev3"]), ["dev1", "dev2"])
+        self.assertEqual(self.interface.GetAncestors(["dev2", "dev5"]), ["dev1", "dev4"])
 
     @patch.object(StorageDevice, "setup")
     def setup_device_test(self, setup):


### PR DESCRIPTION
Call the DBus method GetAncestors with a list of device names to collect all
ancestors of the specified devices. It replaces the method GetDeviceAncestors.