### PR TITLE
Change service_start_timeout

### DIFF
--- a/data/dbus/anaconda-bus.conf
+++ b/data/dbus/anaconda-bus.conf
@@ -112,7 +112,7 @@
   <limit name="max_message_size">1000000000</limit>
   <!-- We do not override max_message_unix_fds here since the in-kernel
        limit is also relatively low -->
-  <limit name="service_start_timeout">120000</limit>
+  <limit name="service_start_timeout">600000</limit>
   <limit name="auth_timeout">240000</limit>
   <limit name="pending_fd_timeout">150000</limit>
   <limit name="max_completed_connections">100000</limit>

--- a/pyanaconda/modules/boss/module_manager/start_modules.py
+++ b/pyanaconda/modules/boss/module_manager/start_modules.py
@@ -32,20 +32,24 @@ __all__ = ["StartModulesTask"]
 
 
 class StartModulesTask(Task):
+    """A task for starting DBus modules.
 
-    def __init__(self, message_bus, module_names, addons_enabled, timeout=600000):
+    The timeout service_start_timeout from the Anaconda bus
+    configuration file is applied by default when the DBus
+    method StartServiceByName is called.
+    """
+
+    def __init__(self, message_bus, module_names, addons_enabled):
         """Create a new task.
 
         :param message_bus: a message bus
         :param module_names: a list of DBus names of modules
         :param addons_enabled: True to enable addons, otherwise False
-        :param timeout: a timeout of a DBus call in milliseconds
         """
         super().__init__()
         self._message_bus = message_bus
         self._module_names = module_names
         self._addons_enabled = addons_enabled
-        self._service_timeout = timeout
         self._module_observers = []
         self._callbacks = SimpleQueue()
 
@@ -65,7 +69,7 @@ class StartModulesTask(Task):
         # All modules are unavailable now.
         unavailable = set(self._module_observers)
 
-        # Asynchronously start the modules with a timeout.
+        # Asynchronously start the modules.
         self._start_modules(self._module_observers)
 
         # Process callbacks of the asynchronous calls until all modules
@@ -126,8 +130,7 @@ class StartModulesTask(Task):
                 observer.service_name,
                 DBUS_FLAG_NONE,
                 callback=self._start_service_by_name_callback,
-                callback_args=(observer,),
-                timeout=self._service_timeout
+                callback_args=(observer,)
             )
 
     def _start_service_by_name_callback(self, *args, **kwargs):

--- a/tests/nosetests/pyanaconda_tests/module_boss_modules_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_boss_modules_test.py
@@ -70,8 +70,7 @@ class ModuleManagerTestCase(unittest.TestCase):
             "org.fedoraproject.Anaconda.Modules.A",
             DBUS_FLAG_NONE,
             callback=task._start_service_by_name_callback,
-            callback_args=(observer,),
-            timeout=600000
+            callback_args=(observer,)
         )
 
         gio.bus_watch_name_on_connection.assert_called_once()


### PR DESCRIPTION
Set the timeout `service_start_timeout` in the Anaconda bus configuration file
to 10 minutes and remove the timeout for DBus calls in `StartModulesTask`.
Otherwise, the modules can fail to start in time.