### PR TITLE
Rename an attribute of the action data structure

### DIFF
--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -224,7 +224,7 @@ class DeviceActionData(DBusData):
 
     def __init__(self):
         self._action_type = ""
-        self._action_object = ""
+        self._object_type = ""
         self._device_name = ""
         self._description = ""
 
@@ -245,7 +245,7 @@ class DeviceActionData(DBusData):
         self._action_type = name
 
     @property
-    def action_object(self) -> Str:
+    def object_type(self) -> Str:
         """A type of the action object.
 
         For example:
@@ -253,11 +253,11 @@ class DeviceActionData(DBusData):
 
         :return: a string with the type
         """
-        return self._action_object
+        return self._object_type
 
-    @action_object.setter
-    def action_object(self, name: Str):
-        self._action_object = name
+    @object_type.setter
+    def object_type(self, name: Str):
+        self._object_type = name
 
     @property
     def device_name(self) -> Str:

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -217,7 +217,7 @@ class DeviceTreeViewer(ABC):
         """
         data = DeviceActionData()
         data.action_type = action.type_string.lower()
-        data.action_object = action.object_string.lower()
+        data.object_type = action.object_string.lower()
         data.device_name = action.device.name
         data.description = action.type_desc
         return data

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -242,7 +242,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
         self.assertEqual(self.interface.GetActions(), [{
             'action-type': get_variant(Str, 'destroy'),
-            'action-object': get_variant(Str, 'device'),
+            'object-type': get_variant(Str, 'device'),
             'device-name': get_variant(Str, 'dev1'),
             'description': get_variant(Str, 'destroy device'),
         }])


### PR DESCRIPTION
Rename the property action_object of the class DeviceActionData to object_type.