### PR TITLE
Change mock imports to use the unittest.mock full import path

### DIFF
--- a/tests/nosetests/pyanaconda_tests/clearpart_test.py
+++ b/tests/nosetests/pyanaconda_tests/clearpart_test.py
@@ -1,5 +1,5 @@
 import unittest
-import mock
+import unittest.mock as mock
 
 import blivet
 

--- a/tests/nosetests/pyanaconda_tests/module_boss_install_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_boss_install_test.py
@@ -16,7 +16,7 @@
 # Red Hat, Inc.
 #
 import unittest
-from mock import Mock, call
+from unittest.mock import Mock, call
 
 from pyanaconda.modules.boss.install_manager import InstallManager
 from pyanaconda.modules.common.task import DBusMetaTask

--- a/tests/nosetests/pyanaconda_tests/module_boss_kickstart_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_boss_kickstart_test.py
@@ -19,7 +19,7 @@
 import unittest
 import os
 from contextlib import contextmanager
-from mock import Mock
+from unittest.mock import Mock
 
 from dasbus.typing import get_native
 from pyanaconda.modules.boss.kickstart_manager import KickstartManager

--- a/tests/nosetests/pyanaconda_tests/module_network_ifcfg_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_network_ifcfg_test.py
@@ -18,7 +18,7 @@
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 #
 import unittest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import tempfile
 import shutil
 import os

--- a/tests/nosetests/pyanaconda_tests/module_network_nm_client_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_network_nm_client_test.py
@@ -18,7 +18,7 @@
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 #
 import unittest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from pyanaconda.modules.network.nm_client import get_slaves_from_connections, \
     get_dracut_arguments_from_connection

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_image_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_image_test.py
@@ -19,7 +19,7 @@
 #
 import unittest
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from tests.nosetests.pyanaconda_tests import check_task_creation, check_task_creation_list, \
     patch_dbus_publish_object, PropertiesChangedCallback

--- a/tests/nosetests/pyanaconda_tests/module_security_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_security_test.py
@@ -20,7 +20,7 @@
 import unittest
 import tempfile
 import os
-from mock import patch
+from unittest.mock import patch
 
 from pykickstart.constants import SELINUX_ENFORCING, SELINUX_PERMISSIVE
 

--- a/tests/nosetests/pyanaconda_tests/module_services_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_services_test.py
@@ -22,7 +22,7 @@ import tempfile
 import unittest
 from textwrap import dedent
 
-from mock import patch
+from unittest.mock import patch
 
 from tests.nosetests.pyanaconda_tests import patch_dbus_publish_object, check_kickstart_interface, \
     PropertiesChangedCallback

--- a/tests/nosetests/pyanaconda_tests/payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/payload_test.py
@@ -26,7 +26,7 @@ import shutil
 import gi
 
 from tempfile import TemporaryDirectory
-from mock import patch, Mock, call
+from unittest.mock import patch, Mock, call
 
 from blivet.size import Size
 


### PR DESCRIPTION
This changes mock imports to use the unittest.mock full import path, everywhere it's possible.