### PR TITLE
Raise MountFilesystemError from DBus methods

### DIFF
--- a/pyanaconda/modules/common/errors/storage.py
+++ b/pyanaconda/modules/common/errors/storage.py
@@ -61,3 +61,9 @@ class UnknownDeviceError(AnacondaError):
 class ProtectedDeviceError(AnacondaError):
     """The device is protected."""
     pass
+
+
+@dbus_error("MountFilesystemError", namespace=STORAGE_NAMESPACE)
+class MountFilesystemError(AnacondaError):
+    """Failed to un/mount a filesystem."""
+    pass

--- a/pyanaconda/modules/storage/devicetree/handler_interface.py
+++ b/pyanaconda/modules/storage/devicetree/handler_interface.py
@@ -49,6 +49,7 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
 
         :param device_name: a name of the device
         :param mount_point: a path to the mount point
+        :raise: MountFilesystemError if mount fails
         """
         self.implementation.mount_device(device_name, mount_point)
 
@@ -57,6 +58,7 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
 
         :param device_name: a name of the device
         :param mount_point: a path to the mount point
+        :raise: MountFilesystemError if unmount fails
         """
         self.implementation.unmount_device(device_name, mount_point)
 


### PR DESCRIPTION
Propagate a DBus error `MountFilesystemError` from DBus methods `MountDevice`
and `UnmountDevice` if we failed to un/mount a filesystem.