### PR TITLE
Use id_path as a long identifier of a disk

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -82,7 +82,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 Summary: Core of the Anaconda installer
 Requires: python3-libs
 Requires: python3-dnf >= %{dnfver}
-Requires: python3-blivet >= 1:3.1.5-1
+Requires: python3-blivet >= 1:3.2.0-1
 Requires: python3-blockdev >= %{libblockdevver}
 Requires: python3-meh >= %{mehver}
 Requires: libreport-anaconda >= 2.0.21-1

--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -158,15 +158,20 @@ class DeviceData(DBusData):
         Attributes for DASD:
             bus-id
 
+        Attributes for FCoE:
+            path-id
+
         Attributes for iSCSI:
             port
             initiator
             lun
             target
+            path-id
 
         Attributes for NVDIMM:
             mode
             namespace
+            path-id
 
         Attributes for ZFCP:
             fcp-lun

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -96,6 +96,8 @@ class DeviceTreeViewer(ABC):
         # Collect the specialized data.
         if device.type == "dasd":
             self._set_device_data_dasd(device, data)
+        elif device.type == "fcoe":
+            self._set_device_data_fcoe(device, data)
         elif device.type == "iscsi":
             self._set_device_data_iscsi(device, data)
         elif device.type == "nvdimm":
@@ -133,17 +135,23 @@ class DeviceTreeViewer(ABC):
         """Set data for a DASD device."""
         data.attrs["bus-id"] = self._get_attribute(device, "busid")
 
+    def _set_device_data_fcoe(self, device, data):
+        """Set data for an FCoE device."""
+        data.attrs["path-id"] = self._get_attribute(device, "id_path")
+
     def _set_device_data_iscsi(self, device, data):
         """Set data for an iSCSI device."""
         data.attrs["port"] = self._get_attribute(device, "port")
         data.attrs["initiator"] = self._get_attribute(device, "initiator")
         data.attrs["lun"] = self._get_attribute(device, "lun")
         data.attrs["target"] = self._get_attribute(device, "target")
+        data.attrs["path-id"] = self._get_attribute(device, "id_path")
 
     def _set_device_data_nvdimm(self, device, data):
         """Set data for an NVDIMM device."""
         data.attrs["mode"] = self._get_attribute(device, "mode")
         data.attrs["namespace"] = self._get_attribute(device, "devname")
+        data.attrs["path-id"] = self._get_attribute(device, "id_path")
 
     def _set_device_data_zfcp(self, device, data):
         """Set data for a ZFCP device."""

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -24,7 +24,7 @@ from unittest.mock import patch, Mock, PropertyMock
 from tests.nosetests.pyanaconda_tests import patch_dbus_publish_object, check_task_creation
 
 from blivet.devices import StorageDevice, DiskDevice, DASDDevice, ZFCPDiskDevice, PartitionDevice, \
-    LUKSDevice, iScsiDiskDevice, NVDIMMNamespaceDevice
+    LUKSDevice, iScsiDiskDevice, NVDIMMNamespaceDevice, FcoeDiskDevice
 from blivet.errors import StorageError, FSError
 from blivet.formats import get_format
 from blivet.formats.fs import FS
@@ -175,6 +175,23 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             "bus-id": "0.0.0201"
         }))
 
+    def get_fcoe_device_data_test(self):
+        """Test GetDeviceData for FCoE."""
+        self._add_device(FcoeDiskDevice(
+            "dev1",
+            fmt=get_format("disklabel"),
+            size=Size("10 GiB"),
+            nic=None,
+            identifier=None,
+            id_path="pci-0000:00:00.0-bla-1"
+        ))
+
+        data = self.interface.GetDeviceData("dev1")
+        self.assertEqual(data['type'], get_variant(Str, 'fcoe'))
+        self.assertEqual(data['attrs'], get_variant(Dict[Str, Str], {
+            "path-id": "pci-0000:00:00.0-bla-1"
+        }))
+
     def get_iscsi_device_data_test(self):
         """Test GetDeviceData for iSCSI."""
         self._add_device(iScsiDiskDevice(
@@ -185,6 +202,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             initiator="iqn.1994-05.com.redhat:blabla",
             lun="0",
             target="iqn.2014-08.com.example:t1",
+            id_path="pci-0000:00:00.0-bla-1",
             node=None,
             ibft=None,
             nic=None,
@@ -200,7 +218,8 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             "port": "3260",
             "initiator": "iqn.1994-05.com.redhat:blabla",
             "lun": "0",
-            "target": "iqn.2014-08.com.example:t1"
+            "target": "iqn.2014-08.com.example:t1",
+            "path-id": "pci-0000:00:00.0-bla-1"
         }))
 
     def get_nvdimm_device_data_test(self):
@@ -211,14 +230,16 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             size=Size("10 GiB"),
             mode="sector",
             devname="namespace0.0",
-            sector_size=512
+            sector_size=512,
+            id_path="pci-0000:00:00.0-bla-1"
         ))
 
         data = self.interface.GetDeviceData("dev1")
         self.assertEqual(data['type'], get_variant(Str, 'nvdimm'))
         self.assertEqual(data['attrs'], get_variant(Dict[Str, Str], {
             "mode": "sector",
-            "namespace": "namespace0.0"
+            "namespace": "namespace0.0",
+            "path-id": "pci-0000:00:00.0-bla-1"
         }))
 
     def get_zfcp_device_data_test(self):


### PR DESCRIPTION
Remove the function `get_long_identifier` and use the attribute `id_path` instead.
Extend the attributes of the device data with a new attribute `path-id`.

**Depends on:** https://github.com/storaged-project/blivet/pull/814