### PR TITLE
Reduce progress spinner repaints to save CPU (rhbz#1204242)

### DIFF
--- a/data/anaconda-gtk.css
+++ b/data/anaconda-gtk.css
@@ -139,3 +139,11 @@ AnacondaLayoutIndicator {
     background-color: #fdfdfd;
     color: black;
 }
+
+/* Fix the cpu-hogging spinner in progress spoke. This works by overriding the css property
+"animation-timing-function". The default Adwaita value "linear" requests infinitely fine-grained
+progress of the animation, so the component redraws every time it can. Using "steps(N)" makes the
+animation have only N discrete states with no interpolation, so there are effectively N intervals
+where the look is constant. This reduces redraws significantly and saves the CPU. See rhbz#1204242
+for measurements. */
+spinner { animation-timing-function: steps(24); }


### PR DESCRIPTION
This makes the spinner redraw less (at ~24 FPS), which in turn frees CPU for
actual install work. Consequently, this speeds up testing in single-processor
virtual machines.

The savings are proportional to the time the spinner would be visible, so
the more packages, the more time saved. Thus the effect is more significant
when installing Workstation with rich software selection.

Resolves: rhbz#1204242

(edited: 12 -> 24 according to changes)