### PR TITLE
Extend DBus support for the Resize dialog window

### DIFF
--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -32,6 +32,7 @@ class DeviceData(DBusData):
         self._size = 0
         self._parents = []
         self._is_disk = False
+        self._protected = False
         self._removable = False
         self._attrs = {}
         self._description = ""
@@ -95,6 +96,15 @@ class DeviceData(DBusData):
     @is_disk.setter
     def is_disk(self, is_disk: Bool):
         self._is_disk = is_disk
+
+    @property
+    def protected(self) -> Bool:
+        """Is this device protected?"""
+        return self._protected
+
+    @protected.setter
+    def protected(self, value):
+        self._protected = value
 
     @property
     def removable(self) -> Bool:

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -115,6 +115,7 @@ class DeviceTreeViewer(ABC):
         data.size = device.size.get_bytes()
         data.parents = [d.name for d in device.parents]
         data.is_disk = device.is_disk
+        data.protected = device.protected
         data.removable = device.removable
 
         # FIXME: We should generate the description from the device data.

--- a/pyanaconda/modules/storage/partitioning/automatic.py
+++ b/pyanaconda/modules/storage/partitioning/automatic.py
@@ -170,6 +170,20 @@ class AutoPartitioningModule(PartitioningModule):
         request.passphrase = passphrase
         self.set_request(request)
 
+    def _get_device(self, name):
+        """Find a device by its name.
+
+        :param name: a name of the device
+        :return: an instance of the Blivet's device
+        :raise: UnknownDeviceError if no device is found
+        """
+        device = self.storage.devicetree.get_device_by_name(name, hidden=True)
+
+        if not device:
+            raise UnknownDeviceError(name)
+
+        return device
+
     def remove_device(self, device_name):
         """Remove a device after removing its dependent devices.
 
@@ -178,10 +192,7 @@ class AutoPartitioningModule(PartitioningModule):
 
         :param device_name: a name of the device
         """
-        device = self.storage.devicetree.get_device_by_name(device_name)
-
-        if not device:
-            raise UnknownDeviceError(device_name)
+        device = self._get_device(device_name)
 
         if device.protected:
             raise ProtectedDeviceError(device_name)
@@ -206,10 +217,7 @@ class AutoPartitioningModule(PartitioningModule):
         :param size: a new size in bytes
         """
         size = Size(size)
-        device = self.storage.devicetree.get_device_by_name(device_name)
-
-        if not device:
-            raise UnknownDeviceError(device_name)
+        device = self._get_device(device_name)
 
         if device.protected:
             raise ProtectedDeviceError(device_name)
@@ -223,6 +231,15 @@ class AutoPartitioningModule(PartitioningModule):
         log.debug("Shrinking a size of %s to %s.", device_name, size)
         aligned_size = device.align_target_size(size)
         self.storage.resize_device(device, aligned_size)
+
+    def get_device_size_limits(self, device_name):
+        """Get size limits of the given device.
+
+        :param device_name: a name of the device
+        :return: a tuple of min and max sizes in bytes
+        """
+        device = self._get_device(device_name)
+        return device.min_size.get_bytes(), device.max_size.get_bytes()
 
     def configure_with_task(self):
         """Schedule the partitioning actions."""

--- a/pyanaconda/modules/storage/partitioning/automatic.py
+++ b/pyanaconda/modules/storage/partitioning/automatic.py
@@ -263,6 +263,15 @@ class AutoPartitioningModule(PartitioningModule):
             and not (d.is_extended and d.format.logical_partitions)
         ]
 
+    def is_device_resizable(self, device_name):
+        """Is the specified device resizable?
+
+        :param device_name: a name of the device
+        :return: True or False
+        """
+        device = self._get_device(device_name)
+        return device.resizable
+
     def get_device_size_limits(self, device_name):
         """Get size limits of the given device.
 

--- a/pyanaconda/modules/storage/partitioning/automatic_interface.py
+++ b/pyanaconda/modules/storage/partitioning/automatic_interface.py
@@ -110,6 +110,14 @@ class AutoPartitioningInterface(PartitioningInterface):
         """
         return self.implementation.get_device_partitions(device_name)
 
+    def IsDeviceResizable(self, device_name: Str) -> Bool:
+        """Is the specified device resizable?
+
+        :param device_name: a name of the device
+        :return: True or False
+        """
+        return self.implementation.is_device_resizable(device_name)
+
     def GetDeviceSizeLimits(self, device_name: Str) -> Tuple[UInt64, UInt64]:
         """Get size limits of the given device.
 

--- a/pyanaconda/modules/storage/partitioning/automatic_interface.py
+++ b/pyanaconda/modules/storage/partitioning/automatic_interface.py
@@ -93,3 +93,11 @@ class AutoPartitioningInterface(PartitioningInterface):
         :param size: a new size in bytes
         """
         self.implementation.shrink_device(device_name, size)
+
+    def GetDeviceSizeLimits(self, device_name: Str) -> Tuple[UInt64, UInt64]:
+        """Get size limits of the given device.
+
+        :param device_name: a name of the device
+        :return: a tuple of min and max sizes in bytes
+        """
+        return self.implementation.get_device_size_limits(device_name)

--- a/pyanaconda/modules/storage/partitioning/automatic_interface.py
+++ b/pyanaconda/modules/storage/partitioning/automatic_interface.py
@@ -94,6 +94,22 @@ class AutoPartitioningInterface(PartitioningInterface):
         """
         self.implementation.shrink_device(device_name, size)
 
+    def IsDevicePartitioned(self, device_name: Str) -> Bool:
+        """Is the specified device partitioned?
+
+        :param device_name: a name of the device
+        :return: True or False
+        """
+        return self.implementation.is_device_partitioned(device_name)
+
+    def GetDevicePartitions(self, device_name: Str) -> List[Str]:
+        """Get partitions of the specified device.
+
+        :param device_name: a name of the device
+        :return: a list of device names
+        """
+        return self.implementation.get_device_partitions(device_name)
+
     def GetDeviceSizeLimits(self, device_name: Str) -> Tuple[UInt64, UInt64]:
         """Get size limits of the given device.
 

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -137,6 +137,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             'path': get_variant(Str, '/dev/dev1'),
             'size': get_variant(UInt64, Size("10 MiB").get_bytes()),
             'is-disk': get_variant(Bool, True),
+            'protected': get_variant(Bool, False),
             'removable': get_variant(Bool, False),
             'parents': get_variant(List[Str], []),
             'attrs': get_variant(Dict[Str, Str], {

--- a/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
@@ -264,6 +264,14 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
         self.assertEqual(self.interface.GetDevicePartitions("dev2"), ["dev3"])
         self.assertEqual(self.interface.GetDevicePartitions("dev3"), [])
 
+    def is_device_resizable_test(self):
+        """Test IsDeviceResizable."""
+        self.module.on_storage_changed(create_storage())
+        self._add_device(StorageDevice(
+            "dev1"
+        ))
+        self.assertEqual(self.interface.IsDeviceResizable("dev1"), False)
+
     def get_device_size_limits_test(self):
         """Test GetDeviceSizeLimits."""
         self.module.on_storage_changed(create_storage())

--- a/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
@@ -53,6 +53,15 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
         self.module = AutoPartitioningModule()
         self.interface = AutoPartitioningInterface(self.module)
 
+    @property
+    def storage(self):
+        """Get the storage object."""
+        return self.module.storage
+
+    def _add_device(self, device):
+        """Add a device to the device tree."""
+        self.storage.devicetree._add_device(device)
+
     def _test_dbus_property(self, *args, **kwargs):
         check_dbus_property(
             self,
@@ -216,6 +225,19 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
 
         self.interface.ShrinkDevice("sda1", Size("5 GiB").get_bytes())
         self.assertEqual(sda1.size, Size("3 GiB"))
+
+    def get_device_size_limits_test(self):
+        """Test GetDeviceSizeLimits."""
+        self.module.on_storage_changed(create_storage())
+        self._add_device(StorageDevice(
+            "dev1",
+            fmt=get_format("ext4"),
+            size=Size("10 MiB")
+        ))
+
+        min_size, max_size = self.interface.GetDeviceSizeLimits("dev1")
+        self.assertEqual(min_size, 0)
+        self.assertEqual(max_size, 0)
 
     @patch_dbus_publish_object
     def configure_with_task_test(self, publisher):


### PR DESCRIPTION
Extend the DBus support of the Storage module to be able to
remove the local storage object from the Resize dialog window.