### PR TITLE
Add the attribute children to the device data

### DIFF
--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -31,6 +31,7 @@ class DeviceData(DBusData):
         self._path = ""
         self._size = 0
         self._parents = []
+        self._children = []
         self._is_disk = False
         self._protected = False
         self._removable = False
@@ -126,6 +127,18 @@ class DeviceData(DBusData):
     @parents.setter
     def parents(self, names):
         self._parents = names
+
+    @property
+    def children(self) -> List[Str]:
+        """Children of the device.
+
+        :return: a list of device names
+        """
+        return self._children
+
+    @children.setter
+    def children(self, value):
+        self._children = value
 
     @property
     def attrs(self) -> Dict[Str, Str]:

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -114,6 +114,7 @@ class DeviceTreeViewer(ABC):
         data.path = device.path
         data.size = device.size.get_bytes()
         data.parents = [d.name for d in device.parents]
+        data.children = [d.name for d in device.children]
         data.is_disk = device.is_disk
         data.protected = device.protected
         data.removable = device.removable

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -140,6 +140,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             'protected': get_variant(Bool, False),
             'removable': get_variant(Bool, False),
             'parents': get_variant(List[Str], []),
+            'children': get_variant(List[Str], []),
             'attrs': get_variant(Dict[Str, Str], {
                 "serial": "SERIAL_ID",
                 "vendor": "VENDOR_ID",


### PR DESCRIPTION
Return a list of names the device's children in a DBus structure.