### PR TITLE
Define a method required by _schedule_actions (#1782463)

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -441,6 +441,16 @@ class ResizeDialog(GUIObject):
         self._update_reclaim_button(self._selected_reclaimable_space)
         self._update_action_buttons(selected_row)
 
+    def _get_device(self, name):
+        """Find a device by its name.
+
+        FIXME: This method is necessary for the hack below.
+
+        :param name: a name of the device
+        :return: an instance of the Blivet's device
+        """
+        return self.storage.devicetree.get_device_by_name(name)
+
     def _schedule_actions(self, model, path, itr, *args):
         obj = PartStoreRow(*model[itr])
 


### PR DESCRIPTION
The method _schedule_actions of the Resize dialog uses an ugly hack that
requires to define the method _get_device. This is part of the temporary
workaround that will be removed.

Resolves: rhbz#1782463