### PR TITLE
Delegate locale parsing to langtable

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -28,7 +28,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define gtk3ver 3.22.17
 %define helpver 22.1-1
 %define isomd5sum 1.0.10
-%define langtablever 0.0.44
+%define langtablever 0.0.49
 %define libarchivever 3.0.4
 %define libblockdevver 2.1
 %define libtimezonemapver 0.4.1-2

--- a/pyanaconda/keyboard.py
+++ b/pyanaconda/keyboard.py
@@ -141,7 +141,7 @@ def set_x_keyboard_defaults(localization_proxy, xkl_wrapper):
     :param xkl_wrapper: XklWrapper instance
     :type xkl_wrapper: object instance
     :raise InvalidLocaleSpec: if an invalid locale is given (see
-                              localization.LANGCODE_RE)
+                              localization.is_valid_langcode)
     """
     x_layouts = localization_proxy.XLayouts
     # remove all X layouts that are not valid X layouts (unsupported)

--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -105,7 +105,7 @@ def is_supported_locale(locale):
     :type locale: str
     :return: whether the given locale is supported or not
     :rtype: bool
-    :raise InvalidLocaleSpec: if an invalid locale is given (see LANGCODE_RE)
+    :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
 
     """
 
@@ -122,7 +122,7 @@ def locale_supported_in_console(locale):
     :param str locale: locale to test
     :return: whether the given locale is supported by the console or not
     :rtype: bool
-    :raise InvalidLocaleSpec: if an invalid locale is given (see LANGCODE_RE)
+    :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
 
     """
 

--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -35,15 +35,18 @@ log = get_module_logger(__name__)
 
 SCRIPTS_SUPPORTED_BY_CONSOLE = {'Latn', 'Cyrl', 'Grek'}
 
+
 class LocalizationConfigError(Exception):
     """Exception class for localization configuration related problems"""
 
     pass
 
+
 class InvalidLocaleSpec(LocalizationConfigError):
     """Exception class for the errors related to invalid locale specs"""
 
     pass
+
 
 def is_valid_langcode(langcode):
     """Check if the given locale has a language specified.
@@ -54,6 +57,7 @@ def is_valid_langcode(langcode):
     parsed = langtable.parse_locale(langcode)
     return bool(parsed.language)
 
+
 def raise_on_invalid_locale(arg):
     """Helper to abort when a locale is not valid.
 
@@ -62,13 +66,14 @@ def raise_on_invalid_locale(arg):
     if not is_valid_langcode(arg):
         raise InvalidLocaleSpec("'{}' is not a valid locale".format(arg))
 
+
 def get_language_id(locale):
     """Return language id without territory or anything else."""
     return langtable.parse_locale(locale).language
 
+
 def is_supported_locale(locale):
-    """
-    Function that tells if the given locale is supported by the Anaconda or
+    """Function that tells if the given locale is supported by the Anaconda or
     not. We consider locales supported by the langtable as supported by the
     Anaconda.
 
@@ -77,15 +82,13 @@ def is_supported_locale(locale):
     :return: whether the given locale is supported or not
     :rtype: bool
     :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
-
     """
-
     en_name = get_english_name(locale)
     return bool(en_name)
 
+
 def locale_supported_in_console(locale):
-    """
-    Function that tells if the given locale can be displayed by the Linux console.
+    """Function that tells if the given locale can be displayed by the Linux console.
 
     The Linux console can display Latin, Cyrillic and Greek characters reliably,
     but others such as Japanese, can't be correctly installed.
@@ -94,11 +97,10 @@ def locale_supported_in_console(locale):
     :return: whether the given locale is supported by the console or not
     :rtype: bool
     :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
-
     """
-
     locale_scripts = get_locale_scripts(locale)
     return set(locale_scripts).issubset(SCRIPTS_SUPPORTED_BY_CONSOLE)
+
 
 def langcode_matches_locale(langcode, locale):
     """Function that tells if the given langcode matches the given locale. I.e. if
@@ -128,6 +130,7 @@ def langcode_matches_locale(langcode, locale):
             return False
 
     return True
+
 
 def find_best_locale_match(locale, langcodes):
     """Find the best match for the locale in a list of langcodes. This is useful
@@ -183,9 +186,9 @@ def find_best_locale_match(locale, langcodes):
     else:
         return None
 
+
 def setup_locale(locale, localization_proxy=None, text_mode=False):
-    """
-    Procedure setting the system to use the given locale and store it in to the
+    """Procedure setting the system to use the given locale and store it in to the
     localization module (if given). DOES NOT PERFORM ANY CHECKS OF THE GIVEN
     LOCALE.
 
@@ -205,9 +208,7 @@ def setup_locale(locale, localization_proxy=None, text_mode=False):
     :param bool text_mode: if the locale is being setup for text mode
     :return: the locale that was actually set
     :rtype: str
-
     """
-
     if localization_proxy:
         localization_proxy.SetLanguage(locale)
 
@@ -240,9 +241,9 @@ def setup_locale(locale, localization_proxy=None, text_mode=False):
         if not font_set:
             log.warning("can't set console font for locale %s", locale)
             # report what exactly went wrong
-            if not(script_supported):
+            if not script_supported:
                 log.warning("script not supported by console for locale %s", locale)
-            if not(console_fonts):  # no fonts known for locale
+            if not console_fonts:  # no fonts known for locale
                 log.warning("no console font found for locale %s", locale)
             if script_supported and console_fonts:
                 log.warning("none of the suggested fonts can be set for locale %s", locale)
@@ -289,6 +290,7 @@ def get_english_name(locale):
     name = langtable.language_name(languageId=locale, languageIdQuery="en")
     return upcase_first_letter(name)
 
+
 def get_native_name(locale):
     """Function returning native name for the given locale.
 
@@ -303,17 +305,15 @@ def get_native_name(locale):
     name = langtable.language_name(languageId=locale)
     return upcase_first_letter(name)
 
+
 def get_available_translations(localedir=None):
-    """
-    Method that generates (i.e. returns a generator) available translations for
-    the installer in the given localedir.
+    """Method that generates (i.e. returns a generator) available translations
+    for the installer in the given localedir.
 
     :type localedir: str
     :return: generator yielding available translations (languages)
     :rtype: generator yielding strings
-
     """
-
     localedir = localedir or gettext._default_localedir
 
     # usually there are no message files for en
@@ -334,6 +334,7 @@ def get_available_translations(localedir=None):
 
             yield lang
 
+
 def get_language_locales(lang):
     """Function returning all locales available for the given language.
 
@@ -347,9 +348,9 @@ def get_language_locales(lang):
 
     return langtable.list_locales(languageId=lang)
 
+
 def get_territory_locales(territory):
-    """
-    Function returning list of locales for the given territory. The list is
+    """Function returning list of locales for the given territory. The list is
     sorted from the most probable locale to the least probable one (based on
     langtable's ranking.
 
@@ -357,10 +358,9 @@ def get_territory_locales(territory):
     :type territory: str
     :return: list of locales
     :rtype: list of strings
-
     """
-
     return langtable.list_locales(territoryId=territory)
+
 
 def get_locale_keyboards(locale):
     """Function returning preferred keyboard layouts for the given locale.
@@ -375,6 +375,7 @@ def get_locale_keyboards(locale):
 
     return langtable.list_keyboards(languageId=locale)
 
+
 def get_locale_timezones(locale):
     """Function returning preferred timezones for the given locale.
 
@@ -388,6 +389,7 @@ def get_locale_timezones(locale):
 
     return langtable.list_timezones(languageId=locale)
 
+
 def get_locale_console_fonts(locale):
     """Function returning preferred console fonts for the given locale.
 
@@ -399,6 +401,7 @@ def get_locale_console_fonts(locale):
     raise_on_invalid_locale(locale)
 
     return langtable.list_consolefonts(languageId=locale)
+
 
 def get_locale_scripts(locale):
     """Function returning preferred scripts (writing systems) for the given locale.
@@ -412,6 +415,7 @@ def get_locale_scripts(locale):
     raise_on_invalid_locale(locale)
 
     return langtable.list_scripts(languageId=locale)
+
 
 def get_xlated_timezone(tz_spec_part):
     """Function returning translated name of a region, city or complete timezone
@@ -430,15 +434,14 @@ def get_xlated_timezone(tz_spec_part):
     xlated = langtable.timezone_name(tz_spec_part, languageIdQuery=locale)
     return xlated
 
+
 def get_firmware_language(text_mode=False):
-    """
-    Procedure that returns the firmware language information (if any).
+    """Procedure that returns the firmware language information (if any).
 
     :param boot text_mode: if the locale is being setup for text mode
     :return: the firmware language translated into a locale string, or None
     :rtype: str
     """
-
     try:
         n = "/sys/firmware/efi/efivars/PlatformLang-8be4df61-93ca-11d2-aa0d-00e098032b8c"
         with open(n, 'r') as f:
@@ -481,11 +484,12 @@ def get_firmware_language(text_mode=False):
     log.debug("Using UEFI PlatformLang '%s' ('%s') as our language.", d, locales[0])
     return locales[0]
 
+
 _DateFieldSpec = namedtuple("DateFieldSpec", ["format", "suffix"])
 
+
 def resolve_date_format(year, month, day, fail_safe=True):
-    """
-    Puts the year, month and day objects in the right order according to the
+    """Puts the year, month and day objects in the right order according to the
     currently set locale and provides format specification for each of the
     fields.
 
@@ -505,9 +509,7 @@ def resolve_date_format(year, month, day, fail_safe=True):
     :rtype: tuple
     :raise ValueError: in case currently set locale has unsupported date
                        format and fail_safe is set to False
-
     """
-
     FAIL_SAFE_DEFAULT = "%Y-%m-%d"
 
     def order_terms_formats(fmt_str):
@@ -567,14 +569,13 @@ def resolve_date_format(year, month, day, fail_safe=True):
             # should be informed about it
             return order_terms_formats(FAIL_SAFE_DEFAULT)
 
+
 def set_console_font(font):
-    """
-    Try to set console font to the given value.
+    """Try to set console font to the given value.
 
     :param str font: console font name
     :returns: True on success, False on failure
-    :rtype: Bool
-
+    :rtype: bool
     """
     log.debug("setting console font to %s", font)
     rc = execWithRedirect("setfont", [font])
@@ -585,9 +586,9 @@ def set_console_font(font):
         log.error("setting console font to %s failed", font)
         return False
 
+
 def setup_locale_environment(locale=None, text_mode=False, prefer_environment=False):
-    """
-    Clean and configure the local environment variables.
+    """Clean and configure the local environment variables.
 
     This function will attempt to determine the desired locale and configure
     the process environment (os.environ) in the least surprising way. If a
@@ -609,7 +610,6 @@ def setup_locale_environment(locale=None, text_mode=False, prefer_environment=Fa
     :return: None
     :rtype: None
     """
-
     # pylint: disable=environment-modify
 
     # Look for a locale in the environment. If the variable is setup but

--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -51,6 +51,23 @@ class InvalidLocaleSpec(LocalizationConfigError):
 
     pass
 
+def is_valid_langcode(langcode):
+    """Check if the given locale has a language specified.
+
+    :return: whether the language or locale is valid
+    :rtype: bool
+    """
+    parsed = langtable.parse_locale(langcode)
+    return bool(parsed.language)
+
+def raise_on_invalid_locale(arg):
+    """Helper to abort when a locale is not valid.
+
+    :raise: InvalidLocaleSpec
+    """
+    if not is_valid_langcode(arg):
+        raise InvalidLocaleSpec("'{}' is not a valid locale".format(arg))
+
 def parse_langcode(langcode):
     """
     For a given langcode (e.g. 'SR_RS.UTF-8@latin') returns a dictionary
@@ -290,43 +307,31 @@ def set_modules_locale(locale):
 
 
 def get_english_name(locale):
-    """
-    Function returning english name for the given locale.
+    """Function returning english name for the given locale.
 
     :param locale: locale to return english name for
     :type locale: str
     :return: english name for the locale or empty string if unknown
     :rtype: st
-    :raise InvalidLocaleSpec: if an invalid locale is given (see LANGCODE_RE)
-
+    :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
     """
-
-    parts = parse_langcode(locale)
-    if "language" not in parts:
-        raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
+    raise_on_invalid_locale(locale)
 
     name = langtable.language_name(languageId=locale, languageIdQuery="en")
-
     return upcase_first_letter(name)
 
 def get_native_name(locale):
-    """
-    Function returning native name for the given locale.
+    """Function returning native name for the given locale.
 
     :param locale: locale to return native name for
     :type locale: str
     :return: english name for the locale or empty string if unknown
     :rtype: st
-    :raise InvalidLocaleSpec: if an invalid locale is given (see LANGCODE_RE)
-
+    :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
     """
-
-    parts = parse_langcode(locale)
-    if "language" not in parts:
-        raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
+    raise_on_invalid_locale(locale)
 
     name = langtable.language_name(languageId=locale)
-
     return upcase_first_letter(name)
 
 def get_available_translations(localedir=None):
@@ -362,20 +367,15 @@ def get_available_translations(localedir=None):
             yield lang
 
 def get_language_locales(lang):
-    """
-    Function returning all locales available for the given language.
+    """Function returning all locales available for the given language.
 
     :param lang: language to get available locales for
     :type lang: str
     :return: a list of available locales
     :rtype: list of strings
-    :raise InvalidLocaleSpec: if an invalid locale is given (see LANGCODE_RE)
-
+    :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
     """
-
-    parts = parse_langcode(lang)
-    if "language" not in parts:
-        raise InvalidLocaleSpec("'%s' is not a valid language" % lang)
+    raise_on_invalid_locale(lang)
 
     return langtable.list_locales(languageId=lang)
 
@@ -395,92 +395,69 @@ def get_territory_locales(territory):
     return langtable.list_locales(territoryId=territory)
 
 def get_locale_keyboards(locale):
-    """
-    Function returning preferred keyboard layouts for the given locale.
+    """Function returning preferred keyboard layouts for the given locale.
 
-    :param locale: locale string (see LANGCODE_RE)
+    :param locale: locale string
     :type locale: str
     :return: list of preferred keyboard layouts
     :rtype: list of strings
-    :raise InvalidLocaleSpec: if an invalid locale is given (see LANGCODE_RE)
-
+    :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
     """
-
-    parts = parse_langcode(locale)
-    if "language" not in parts:
-        raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
+    raise_on_invalid_locale(locale)
 
     return langtable.list_keyboards(languageId=locale)
 
 def get_locale_timezones(locale):
-    """
-    Function returning preferred timezones for the given locale.
+    """Function returning preferred timezones for the given locale.
 
-    :param locale: locale string (see LANGCODE_RE)
+    :param locale: locale string
     :type locale: str
     :return: list of preferred timezones
     :rtype: list of strings
-    :raise InvalidLocaleSpec: if an invalid locale is given (see LANGCODE_RE)
-
+    :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
     """
-
-    parts = parse_langcode(locale)
-    if "language" not in parts:
-        raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
+    raise_on_invalid_locale(locale)
 
     return langtable.list_timezones(languageId=locale)
 
 def get_locale_console_fonts(locale):
-    """
-    Function returning preferred console fonts for the given locale.
+    """Function returning preferred console fonts for the given locale.
 
-    :param str locale: locale string (see LANGCODE_RE)
+    :param str locale: locale string
     :return: list of preferred console fonts
     :rtype: list of strings
-    :raise InvalidLocaleSpec: if an invalid locale is given (see LANGCODE_RE)
-
+    :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
     """
-
-    parts = parse_langcode(locale)
-    if "language" not in parts:
-        raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
+    raise_on_invalid_locale(locale)
 
     return langtable.list_consolefonts(languageId=locale)
 
 def get_locale_scripts(locale):
-    """
-    Function returning preferred scripts (writing systems) for the given locale.
+    """Function returning preferred scripts (writing systems) for the given locale.
 
-    :param locale: locale string (see LANGCODE_RE)
+    :param locale: locale string
     :type locale: str
     :return: list of preferred scripts
     :rtype: list of strings
-    :raise InvalidLocaleSpec: if an invalid locale is given (see LANGCODE_RE)
-
+    :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
     """
-
-    parts = parse_langcode(locale)
-    if "language" not in parts:
-        raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
+    raise_on_invalid_locale(locale)
 
     return langtable.list_scripts(languageId=locale)
 
 def get_xlated_timezone(tz_spec_part):
-    """
-    Function returning translated name of a region, city or complete timezone
+    """Function returning translated name of a region, city or complete timezone
     name according to the current value of the $LANG variable.
 
     :param tz_spec_part: a region, city or complete timezone name
     :type tz_spec_part: str
     :return: translated name of the given region, city or timezone
     :rtype: str
-
+    :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
     """
-
     locale = os.environ.get("LANG", constants.DEFAULT_LANG)
-    parts = parse_langcode(locale)
-    if "language" not in parts:
-        raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
+
+    raise_on_invalid_locale(locale)
 
     xlated = langtable.timezone_name(tz_spec_part, languageIdQuery=locale)
     return xlated

--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -35,12 +35,6 @@ log = get_module_logger(__name__)
 
 SCRIPTS_SUPPORTED_BY_CONSOLE = {'Latn', 'Cyrl', 'Grek'}
 
-#e.g. 'SR_RS.UTF-8@latin'
-LANGCODE_RE = re.compile(r'(?P<language>[A-Za-z]+)'
-                         r'(_(?P<territory>[A-Za-z]+))?'
-                         r'(\.(?P<encoding>[-A-Za-z0-9]+))?'
-                         r'(@(?P<script>[-A-Za-z0-9]+))?')
-
 class LocalizationConfigError(Exception):
     """Exception class for localization configuration related problems"""
 
@@ -71,29 +65,6 @@ def raise_on_invalid_locale(arg):
 def get_language_id(locale):
     """Return language id without territory or anything else."""
     return langtable.parse_locale(locale).language
-
-def parse_langcode(langcode):
-    """
-    For a given langcode (e.g. 'SR_RS.UTF-8@latin') returns a dictionary
-    with the following keys and example values:
-
-    'language' : 'SR'
-    'territory' : 'RS'
-    'encoding' : 'UTF-8'
-    'script' : 'latin'
-
-    or None if the given string doesn't match the LANGCODE_RE.
-
-    """
-
-    if not langcode:
-        return None
-
-    match = LANGCODE_RE.match(langcode)
-    if match:
-        return match.groupdict()
-    else:
-        return None
 
 def is_supported_locale(locale):
     """

--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -441,7 +441,8 @@ def get_firmware_language(text_mode=False):
 
     try:
         n = "/sys/firmware/efi/efivars/PlatformLang-8be4df61-93ca-11d2-aa0d-00e098032b8c"
-        d = open(n, 'r').read()
+        with open(n, 'r') as f:
+            d = f.read()
     except IOError:
         return None
 
@@ -629,11 +630,11 @@ def setup_locale_environment(locale=None, text_mode=False, prefer_environment=Fa
 
     # parse the locale using langtable
     if locale:
-        env_langs = get_language_locales(locale)
-        if env_langs:
-            # the first langauge is the best match
+        try:
+            env_langs = get_language_locales(locale)
+            # the first language is the best match
             locale = env_langs[0]
-        else:
+        except (InvalidLocaleSpec, IndexError):
             log.error("Invalid locale '%s' given on command line, kickstart or environment", locale)
             locale = None
 

--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -68,6 +68,10 @@ def raise_on_invalid_locale(arg):
     if not is_valid_langcode(arg):
         raise InvalidLocaleSpec("'{}' is not a valid locale".format(arg))
 
+def get_language_id(locale):
+    """Return language id without territory or anything else."""
+    return langtable.parse_locale(locale).language
+
 def parse_langcode(langcode):
     """
     For a given langcode (e.g. 'SR_RS.UTF-8@latin') returns a dictionary
@@ -355,8 +359,7 @@ def get_available_translations(localedir=None):
     langs = set()
 
     for trans in trans_gen:
-        parts = parse_langcode(trans)
-        lang = parts.get("language", "")
+        lang = get_language_id(trans)
         if lang and lang not in langs:
             langs.add(lang)
             # check if there are any locales for the language

--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -305,10 +305,7 @@ def get_english_name(locale):
     if "language" not in parts:
         raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
 
-    name = langtable.language_name(languageId=parts["language"],
-                                   territoryId=parts.get("territory", ""),
-                                   scriptId=parts.get("script", ""),
-                                   languageIdQuery="en")
+    name = langtable.language_name(languageId=locale, languageIdQuery="en")
 
     return upcase_first_letter(name)
 
@@ -328,12 +325,7 @@ def get_native_name(locale):
     if "language" not in parts:
         raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
 
-    name = langtable.language_name(languageId=parts["language"],
-                                   territoryId=parts.get("territory", ""),
-                                   scriptId=parts.get("script", ""),
-                                   languageIdQuery=parts["language"],
-                                   territoryIdQuery=parts.get("territory", ""),
-                                   scriptIdQuery=parts.get("script", ""))
+    name = langtable.language_name(languageId=locale)
 
     return upcase_first_letter(name)
 
@@ -385,9 +377,7 @@ def get_language_locales(lang):
     if "language" not in parts:
         raise InvalidLocaleSpec("'%s' is not a valid language" % lang)
 
-    return langtable.list_locales(languageId=parts["language"],
-                                  territoryId=parts.get("territory", ""),
-                                  scriptId=parts.get("script", ""))
+    return langtable.list_locales(languageId=lang)
 
 def get_territory_locales(territory):
     """
@@ -420,9 +410,7 @@ def get_locale_keyboards(locale):
     if "language" not in parts:
         raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
 
-    return langtable.list_keyboards(languageId=parts["language"],
-                                    territoryId=parts.get("territory", ""),
-                                    scriptId=parts.get("script", ""))
+    return langtable.list_keyboards(languageId=locale)
 
 def get_locale_timezones(locale):
     """
@@ -440,9 +428,7 @@ def get_locale_timezones(locale):
     if "language" not in parts:
         raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
 
-    return langtable.list_timezones(languageId=parts["language"],
-                                    territoryId=parts.get("territory", ""),
-                                    scriptId=parts.get("script", ""))
+    return langtable.list_timezones(languageId=locale)
 
 def get_locale_console_fonts(locale):
     """
@@ -459,9 +445,7 @@ def get_locale_console_fonts(locale):
     if "language" not in parts:
         raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
 
-    return langtable.list_consolefonts(languageId=parts["language"],
-                                       territoryId=parts.get("territory", ""),
-                                       scriptId=parts.get("script", ""))
+    return langtable.list_consolefonts(languageId=locale)
 
 def get_locale_scripts(locale):
     """
@@ -479,9 +463,7 @@ def get_locale_scripts(locale):
     if "language" not in parts:
         raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
 
-    return langtable.list_scripts(languageId=parts["language"],
-                                  territoryId=parts.get("territory", ""),
-                                  scriptId=parts.get("script", ""))
+    return langtable.list_scripts(languageId=locale)
 
 def get_xlated_timezone(tz_spec_part):
     """
@@ -500,9 +482,7 @@ def get_xlated_timezone(tz_spec_part):
     if "language" not in parts:
         raise InvalidLocaleSpec("'%s' is not a valid locale" % locale)
 
-    xlated = langtable.timezone_name(tz_spec_part, languageIdQuery=parts["language"],
-                                     territoryIdQuery=parts.get("territory", ""),
-                                     scriptIdQuery=parts.get("script", ""))
+    xlated = langtable.timezone_name(tz_spec_part, languageIdQuery=locale)
     return xlated
 
 def get_firmware_language(text_mode=False):

--- a/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
+++ b/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
@@ -146,12 +146,12 @@ class LangLocaleHandler(object):
         """
 
         # get lang and select it
-        parts = localization.parse_langcode(locale)
-        if "language" not in parts:
+        language = localization.get_language_id(locale)
+        if not language:
             # invalid locale, cannot select
             return (None, None)
 
-        lang_itr = set_treeview_selection(self._langView, parts["language"], col=2)
+        lang_itr = set_treeview_selection(self._langView, language, col=2)
 
         # find matches and use the one with the highest rank
         locales = localization.get_language_locales(locale)

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -159,7 +159,7 @@ class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
         store = filter_store.get_model()
 
         # get language codes for the locales
-        langs = [localization.parse_langcode(locale)['language'] for locale in locales]
+        langs = [localization.get_language_id(locale) for locale in locales]
 
         # check which of the geolocated languages have translations
         # and store the iterators for those languages in a dictionary
@@ -190,8 +190,7 @@ class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
             else:
                 # we don't have translation for this language,
                 # so dump all locales for it
-                locales = [l for l in locales
-                           if localization.parse_langcode(l)['language'] != lang]
+                locales = [l for l in locales if localization.get_language_id(l) != lang]
 
         # And then we add a separator after the selected best language
         # and any additional languages (that have translations) from geoip

--- a/tests/nosetests/pyanaconda_tests/localization_test.py
+++ b/tests/nosetests/pyanaconda_tests/localization_test.py
@@ -156,7 +156,6 @@ class SetupLocaleEnvironmentTest(unittest.TestCase):
                 {"LANGUAGE": "de", "LANG": "de", "LC_ALL": "de", "LC_MESSAGES": "de"})
     def setup_locale_environment_param_ok_test(self, locales_mock):
         """Test setup_locale_environment() with parameter"""
-
         # success case
         locales_mock.return_value = ["fr_FR.UTF-8"]
 
@@ -178,7 +177,6 @@ class SetupLocaleEnvironmentTest(unittest.TestCase):
     @patch.dict("pyanaconda.localization.os.environ", dict())
     def setup_locale_environment_vars_test(self):
         """Test setup_locale_environment() with multiple environment variables"""
-
         for varname in ("LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG"):
 
             localization.os.environ.clear()
@@ -193,7 +191,6 @@ class SetupLocaleEnvironmentTest(unittest.TestCase):
     @patch.dict("pyanaconda.localization.os.environ", {"LANG": "blah"})
     def setup_locale_environment_vars_invalid_test(self):
         """Test setup_locale_environment() with invalid environment variable input"""
-
         localization.setup_locale_environment(None)
 
         self.assertEqual(DEFAULT_LANG, localization.os.environ["LANG"])
@@ -202,7 +199,6 @@ class SetupLocaleEnvironmentTest(unittest.TestCase):
     @patch.dict("pyanaconda.localization.os.environ", dict())
     def setup_locale_environment_fallback_efi_ok_test(self, open_mock):
         """Test setup_locale_environment() fallback to EFI vars"""
-
         # success with valid data
         # first 4 bytes binary attributes, then language with - instead of _, minimum 10 bytes
         open_mock.return_value = StringIO("\x07\x00\x00\x00de-DE\x00")
@@ -217,7 +213,6 @@ class SetupLocaleEnvironmentTest(unittest.TestCase):
     @patch.dict("pyanaconda.localization.os.environ", dict())
     def setup_locale_environment_fallback_efi_bad_test(self, open_mock):
         """Test setup_locale_environment() fallback to EFI vars with bad contents"""
-
         # failure with invalid data - too short
         open_mock.return_value = StringIO("\x00")
 
@@ -229,7 +224,6 @@ class SetupLocaleEnvironmentTest(unittest.TestCase):
 class LangcodeLocaleMatchingTests(unittest.TestCase):
     def langcode_matches_locale_test(self):
         """Langcode-locale matching should work as expected."""
-
         # should match
         self.assertTrue(localization.langcode_matches_locale("sr", "sr"))
         self.assertTrue(localization.langcode_matches_locale("sr", "sr_RS"))
@@ -267,7 +261,6 @@ class LangcodeLocaleMatchingTests(unittest.TestCase):
 
     def find_best_locale_match_test(self):
         """Finding best locale matches should work as expected."""
-
         # can find best matches
         self.assertEqual(localization.find_best_locale_match("cs_CZ", ["cs", "cs_CZ", "en", "en_US"]), "cs_CZ")
         self.assertEqual(localization.find_best_locale_match("cs", ["cs_CZ", "cs", "en", "en_US"]), "cs")
@@ -288,7 +281,6 @@ class LangcodeLocaleMatchingTests(unittest.TestCase):
 
     def resolve_date_format_test(self):
         """All locales' date formats should be properly resolved."""
-
         locales = (line.strip() for line in execWithCaptureBinary("locale", ["-a"]).splitlines())
         for locale in locales:
             # "locale -a" might return latin-1 encoded local identifiers:

--- a/tests/nosetests/pyanaconda_tests/localization_test.py
+++ b/tests/nosetests/pyanaconda_tests/localization_test.py
@@ -21,68 +21,6 @@ from pyanaconda.core.util import execWithCaptureBinary
 import locale as locale_mod
 import unittest
 
-class ParsingTests(unittest.TestCase):
-    def invalid_langcodes_test(self):
-        """Should return None for invalid langcodes."""
-
-        # None
-        parts = localization.parse_langcode(None)
-        self.assertIsNone(parts)
-
-        # nonsense
-        parts = localization.parse_langcode("*_&!")
-        self.assertIsNone(parts)
-
-        # no language
-        parts = localization.parse_langcode("_CZ")
-        self.assertIsNone(parts)
-
-    def parsing_test(self):
-        """Should correctly parse valid langcodes."""
-
-        parts = localization.parse_langcode("cs")
-        self.assertIn("language", parts)
-        self.assertEqual(parts["language"], "cs")
-
-        parts = localization.parse_langcode("cs_CZ")
-        self.assertIn("language", parts)
-        self.assertIn("territory", parts)
-        self.assertEqual(parts["language"], "cs")
-        self.assertEqual(parts["territory"], "CZ")
-
-        parts = localization.parse_langcode("cs_CZ.UTF-8")
-        self.assertIn("language", parts)
-        self.assertIn("territory", parts)
-        self.assertIn("encoding", parts)
-        self.assertEqual(parts["language"], "cs")
-        self.assertEqual(parts["territory"], "CZ")
-        self.assertEqual(parts["encoding"], "UTF-8")
-
-        parts = localization.parse_langcode("cs_CZ.UTF-8@latin")
-        self.assertIn("language", parts)
-        self.assertIn("territory", parts)
-        self.assertIn("encoding", parts)
-        self.assertIn("script", parts)
-        self.assertEqual(parts["language"], "cs")
-        self.assertEqual(parts["territory"], "CZ")
-        self.assertEqual(parts["encoding"], "UTF-8")
-        self.assertEqual(parts["script"], "latin")
-
-        parts = localization.parse_langcode("cs.UTF-8@latin")
-        self.assertIn("language", parts)
-        self.assertIn("encoding", parts)
-        self.assertIn("script", parts)
-        self.assertEqual(parts["language"], "cs")
-        self.assertEqual(parts["encoding"], "UTF-8")
-        self.assertEqual(parts["script"], "latin")
-
-        parts = localization.parse_langcode("cs_CZ@latin")
-        self.assertIn("language", parts)
-        self.assertIn("territory", parts)
-        self.assertIn("script", parts)
-        self.assertEqual(parts["language"], "cs")
-        self.assertEqual(parts["territory"], "CZ")
-        self.assertEqual(parts["script"], "latin")
 
 class LangcodeLocaleMatchingTests(unittest.TestCase):
     def langcode_matches_locale_test(self):

--- a/tests/nosetests/pyanaconda_tests/localization_test.py
+++ b/tests/nosetests/pyanaconda_tests/localization_test.py
@@ -17,9 +17,213 @@
 #
 
 from pyanaconda import localization
+from pyanaconda.core.constants import DEFAULT_LANG
 from pyanaconda.core.util import execWithCaptureBinary
 import locale as locale_mod
 import unittest
+from unittest.mock import call, patch, MagicMock
+from io import StringIO
+
+# pylint: disable=environment-modify
+# required due to mocking os.environ
+
+class LangcodeLocaleParsingTests(unittest.TestCase):
+    def is_valid_test(self):
+
+        self.assertTrue(localization.is_valid_langcode("en"))
+        self.assertTrue(localization.is_valid_langcode("eo"))
+        self.assertTrue(localization.is_valid_langcode("en_US"))
+        self.assertTrue(localization.is_valid_langcode("csb"))
+        self.assertTrue(localization.is_valid_langcode("cs_CZ.UTF-8@latin"))
+        self.assertTrue(localization.is_valid_langcode("ca_ES.UTF-8@valencia"))
+
+        self.assertTrue(localization.is_valid_langcode("cs_JA.iso8859-1@cyrl"))
+        # nonsensical but still valid - parses correctly and has a language name
+
+        self.assertFalse(localization.is_valid_langcode("blah"))
+        self.assertFalse(localization.is_valid_langcode(""))
+        self.assertFalse(localization.is_valid_langcode(None))
+
+    def invalid_raise_decorator_test(self):
+        self.assertRaises(localization.InvalidLocaleSpec, localization.get_native_name, "blah")
+        self.assertRaises(localization.InvalidLocaleSpec, localization.is_supported_locale, "blah")
+
+    def is_supported_test(self):
+        self.assertTrue(localization.is_supported_locale("en"))
+        self.assertTrue(localization.is_supported_locale("en_US"))
+        self.assertTrue(localization.locale_supported_in_console("en"))
+        self.assertTrue(localization.locale_supported_in_console("en_US"))
+
+    def native_name_test(self):
+        self.assertEqual(localization.get_native_name("de"), "Deutsch")
+        self.assertEqual(localization.get_native_name("cs_CZ"), "Čeština (Česko)")
+
+    def english_name_test(self):
+        self.assertEqual(localization.get_english_name("de"), "German")
+        self.assertEqual(localization.get_english_name("cs_CZ"), "Czech (Czechia)")
+
+    def available_translations_test(self):
+        self.assertIn("en", localization.get_available_translations())
+
+    def territory_locales_test(self):
+        self.assertIn("en_US.UTF-8", localization.get_territory_locales("US"))
+        self.assertIn("en_GB.UTF-8", localization.get_territory_locales("GB"))
+
+    def locale_keyboards_test(self):
+        self.assertEqual(localization.get_locale_keyboards("en_US"), ["us"])
+        self.assertEqual(localization.get_locale_keyboards("en_GB"), ["gb"])
+
+    def locale_timezones_test(self):
+        self.assertIn("Europe/Oslo", localization.get_locale_timezones("no"))
+
+    @patch.dict("pyanaconda.localization.os.environ", dict())
+    def xlated_tz_test(self):
+        localization.os.environ["LANG"] = "en_US"
+        self.assertEqual("Europe/Barcelona", localization.get_xlated_timezone("Europe/Barcelona"))
+        localization.os.environ["LANG"] = "cs_CZ"
+        self.assertEqual("Evropa/Praha", localization.get_xlated_timezone("Europe/Prague"))
+        localization.os.environ["LANG"] = "blah"
+        self.assertRaises(localization.InvalidLocaleSpec,
+                          localization.get_xlated_timezone,
+                          "America/New_York")
+
+
+class SetupLocaleTest(unittest.TestCase):
+
+    @patch("pyanaconda.localization.setenv")
+    @patch("pyanaconda.localization.locale_mod.setlocale")
+    @patch("pyanaconda.localization.set_modules_locale")
+    def setup_locale_notext_test(self, set_modules_locale_mock, setlocale_mock, setenv_mock):
+        """Test setup_locale in GUI mode"""
+
+        loc_proxy = MagicMock()
+
+        locale = localization.setup_locale("sk", localization_proxy=loc_proxy)
+
+        loc_proxy.SetLanguage.assert_called_once_with("sk")
+        setenv_mock.assert_called_once_with("LANG", "sk")
+        setlocale_mock.assert_called_once_with(locale_mod.LC_ALL, "sk")
+        set_modules_locale_mock.assert_called_once_with("sk")
+
+        self.assertEqual(locale, "sk")
+
+    @patch.dict("pyanaconda.localization.os.environ", dict())
+    @patch("pyanaconda.localization.locale_supported_in_console", return_value=False)
+    @patch("pyanaconda.localization.setenv")
+    @patch("pyanaconda.localization.locale_mod.setlocale")
+    @patch("pyanaconda.localization.set_modules_locale")
+    def setup_locale_text_test(self, set_modules_locale_mock, setlocale_mock, setenv_mock,
+                               locale_supported_in_console_mock):
+        """Test setup_locale in TUI mode"""
+        # note: to eliminate unpredictable support in console, mocking such that it always fails
+
+        locale = localization.setup_locale("ja_JP", text_mode=True)
+
+        locale_supported_in_console_mock.assert_called_once_with("ja_JP")
+        self.assertEqual(localization.os.environ["LANG"], DEFAULT_LANG)
+        setenv_mock.assert_called_once_with("LANG", DEFAULT_LANG)
+        setlocale_mock.assert_called_once_with(locale_mod.LC_ALL, DEFAULT_LANG)
+        set_modules_locale_mock.assert_called_once_with(DEFAULT_LANG)
+
+        self.assertEqual(locale, DEFAULT_LANG)
+
+    @patch("pyanaconda.localization.setenv")
+    @patch("pyanaconda.localization.locale_mod.setlocale", side_effect=[locale_mod.Error, None])
+    @patch("pyanaconda.localization.set_modules_locale")
+    def setup_locale_setlocale_fail_test(self, set_modules_locale_mock, setlocale_mock, setenv_mock):
+        """Test setup_locale with failure in setlocale"""
+
+        locale = localization.setup_locale("es_ES")
+
+        setenv_mock.assert_has_calls([
+            call("LANG", "es_ES"),
+            call("LANG", DEFAULT_LANG)
+        ])
+        setlocale_mock.assert_has_calls([
+            call(locale_mod.LC_ALL, "es_ES"),
+            call(locale_mod.LC_ALL, DEFAULT_LANG)
+        ])
+        setlocale_mock.assert_called_with(locale_mod.LC_ALL, DEFAULT_LANG)
+        set_modules_locale_mock.assert_called_once_with(DEFAULT_LANG)
+
+        self.assertEqual(locale, DEFAULT_LANG)
+
+
+class SetupLocaleEnvironmentTest(unittest.TestCase):
+
+    @patch("pyanaconda.localization.get_language_locales")
+    @patch.dict("pyanaconda.localization.os.environ",
+                {"LANGUAGE": "de", "LANG": "de", "LC_ALL": "de", "LC_MESSAGES": "de"})
+    def setup_locale_environment_param_ok_test(self, locales_mock):
+        """Test setup_locale_environment() with parameter"""
+
+        # success case
+        locales_mock.return_value = ["fr_FR.UTF-8"]
+
+        localization.setup_locale_environment("fr")
+
+        self.assertEqual("fr_FR.UTF-8", localization.os.environ["LANG"])
+        self.assertNotIn("LANGUAGE", localization.os.environ)
+        self.assertNotIn("LC_MESSAGES", localization.os.environ)
+        self.assertNotIn("LC_ALL", localization.os.environ)
+
+        # mock a failure
+        locales_mock.return_value = []
+        locales_mock.side_effect = localization.InvalidLocaleSpec
+
+        localization.setup_locale_environment("iu")
+
+        self.assertIn(DEFAULT_LANG, localization.os.environ["LANG"])
+
+    @patch.dict("pyanaconda.localization.os.environ", dict())
+    def setup_locale_environment_vars_test(self):
+        """Test setup_locale_environment() with multiple environment variables"""
+
+        for varname in ("LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG"):
+
+            localization.os.environ.clear()
+            localization.os.environ[varname] = "ko"
+
+            localization.setup_locale_environment(None)
+
+            self.assertEqual("ko_KR.UTF-8", localization.os.environ["LANG"])
+            if varname != "LANG":
+                self.assertNotIn(varname, localization.os.environ)
+
+    @patch.dict("pyanaconda.localization.os.environ", {"LANG": "blah"})
+    def setup_locale_environment_vars_invalid_test(self):
+        """Test setup_locale_environment() with invalid environment variable input"""
+
+        localization.setup_locale_environment(None)
+
+        self.assertEqual(DEFAULT_LANG, localization.os.environ["LANG"])
+
+    @patch("pyanaconda.localization.open")
+    @patch.dict("pyanaconda.localization.os.environ", dict())
+    def setup_locale_environment_fallback_efi_ok_test(self, open_mock):
+        """Test setup_locale_environment() fallback to EFI vars"""
+
+        # success with valid data
+        # first 4 bytes binary attributes, then language with - instead of _, minimum 10 bytes
+        open_mock.return_value = StringIO("\x07\x00\x00\x00de-DE\x00")
+        localization.os.environ.clear()
+
+        localization.setup_locale_environment(None)
+
+        self.assertTrue(open_mock.called)
+        self.assertIn("de", localization.os.environ["LANG"])
+
+    @patch("pyanaconda.localization.open")
+    @patch.dict("pyanaconda.localization.os.environ", dict())
+    def setup_locale_environment_fallback_efi_bad_test(self, open_mock):
+        """Test setup_locale_environment() fallback to EFI vars with bad contents"""
+
+        # failure with invalid data - too short
+        open_mock.return_value = StringIO("\x00")
+
+        localization.setup_locale_environment(None)
+
+        self.assertEqual(DEFAULT_LANG, localization.os.environ["LANG"])
 
 
 class LangcodeLocaleMatchingTests(unittest.TestCase):
@@ -77,6 +281,10 @@ class LangcodeLocaleMatchingTests(unittest.TestCase):
         # no matches
         self.assertIsNone(localization.find_best_locale_match("pt_BR", ["en_BR", "en"]))
         self.assertIsNone(localization.find_best_locale_match("cs_CZ.UTF-8", ["en", "en.UTF-8"]))
+
+        # nonsense
+        self.assertIsNone(localization.find_best_locale_match("ja", ["blah"]))
+        self.assertIsNone(localization.find_best_locale_match("blah", ["en_US.UTF-8"]))
 
     def resolve_date_format_test(self):
         """All locales' date formats should be properly resolved."""


### PR DESCRIPTION
Use parsing function from last (.49) release of langtable instead of our custom parsing with regexp. This simplifies considerably large portions of the localization code and  enables a few more languages. Tests are adjusted accordingly. Some errors found during testing are fixed too.

All of this is possible thanks to @mike-fabian who exposed the parsing method in langtable!