### PR TITLE
Enable /boot on btrfs subvolume with GRUB2

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -207,7 +207,7 @@ Below is a list of pure community features, their community maintainers, and mai
 /boot on btrfs subvolume
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-* Origin: https://github.com/rhinstaller/anaconda/pull/1375
+* Origin: https://github.com/rhinstaller/anaconda/pull/2255
 * Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1418336
 * Maintainer: Neal Gompa <ngompa13@gmail.com>
 * Description:

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -131,6 +131,10 @@ Requires: glibc-langpack-en
 # even though the distro default is dbus-broker in F30+
 Requires: dbus-daemon
 
+# Ensure it's not possible for a version of grubby to be installed
+# that doesn't work with btrfs subvolumes correctly...
+Conflicts: grubby < 8.40-10
+
 Obsoletes: anaconda-images <= 10
 Provides: anaconda-images = %{version}-%{release}
 Obsoletes: anaconda-runtime < %{version}-%{release}

--- a/pyanaconda/bootloader/grub2.py
+++ b/pyanaconda/bootloader/grub2.py
@@ -114,7 +114,7 @@ class GRUB2(BootLoader):
     stage2_must_be_primary = False
 
     # requirements for boot devices
-    stage2_device_types = ["partition", "mdarray"]
+    stage2_device_types = ["partition", "mdarray", "btrfs subvolume"]
     stage2_raid_levels = [raid.RAID0, raid.RAID1, raid.RAID4,
                           raid.RAID5, raid.RAID6, raid.RAID10]
     stage2_raid_member_types = ["partition"]


### PR DESCRIPTION
This depends on a version of grubby with btrfs subvolume support. For example, `grubby >= 8.40-10`.

This essentially reverses the block imposed in response to [rhbz#864198](https://bugzilla.redhat.com/864198) and correctly fixes [rhbz#1038885](https://bugzilla.redhat.com/1038885).

Resolves: [rhbz#1418336](https://bugzilla.redhat.com/1418336)

This pull request obsoletes #1375.