### PR TITLE
Test unwrapped DBus values

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -40,6 +40,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define rpmver 4.10.0
 %define simplelinever 1.1-1
 %define utillinuxver 2.15.1
+%define dasbusver 0.2
 
 BuildRequires: audit-libs-devel
 BuildRequires: libtool
@@ -99,7 +100,7 @@ Requires: python3-dbus
 Requires: python3-pwquality
 Requires: python3-systemd
 Requires: python3-productmd
-Requires: python3-dasbus
+Requires: python3-dasbus >= %{dasbusver}
 Requires: flatpak-libs
 
 # pwquality only "recommends" the dictionaries it needs to do anything useful,

--- a/pyanaconda/modules/common/errors/__init__.py
+++ b/pyanaconda/modules/common/errors/__init__.py
@@ -17,18 +17,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from pykickstart.errors import KickstartError
-from dasbus.error import dbus_error_by_default, dbus_error
+from dasbus.error import DBusError, dbus_error
 from pyanaconda.modules.common.constants.namespaces import ANACONDA_NAMESPACE
 
-
-@dbus_error_by_default
-class DBusError(Exception):
-    """A default DBus error."""
-    pass
+__all__ = ["DBusError", "AnacondaError", "InvalidValueError"]
 
 
 @dbus_error("Error", namespace=ANACONDA_NAMESPACE)
-class AnacondaError(Exception):
+class AnacondaError(DBusError):
     """A default Anaconda error."""
     pass
 

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -204,7 +204,7 @@ class NetworkService(KickstartService):
 
     def _hostname_service_properties_changed(self, interface, changed, invalid):
         if interface == HOSTNAME.interface_name and "Hostname" in changed:
-            hostname = changed["Hostname"]
+            hostname = changed["Hostname"].unpack()
             self.current_hostname_changed.emit(hostname)
             log.debug("Current hostname changed to %s", hostname)
 

--- a/tests/nosetests/pyanaconda_tests/__init__.py
+++ b/tests/nosetests/pyanaconda_tests/__init__.py
@@ -85,7 +85,9 @@ def check_kickstart_interface(test, interface, ks_in, ks_out=None, ks_valid=True
     # Read a kickstart,
     if ks_in is not None:
         ks_in = dedent(ks_in).strip()
-        result = KickstartReport.from_structure(get_native(interface.ReadKickstart(ks_in)))
+        result = KickstartReport.from_structure(
+            interface.ReadKickstart(ks_in)
+        )
         test.assertEqual(ks_valid, result.is_valid())
 
     if not ks_valid:

--- a/tests/nosetests/pyanaconda_tests/module_boss_kickstart_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_boss_kickstart_test.py
@@ -21,7 +21,6 @@ import os
 from contextlib import contextmanager
 from unittest.mock import Mock
 
-from dasbus.typing import get_native
 from pyanaconda.modules.boss.kickstart_manager import KickstartManager
 from pyanaconda.modules.boss.module_manager.module_observer import ModuleObserver
 from pyanaconda.modules.common.structures.kickstart import KickstartReport, KickstartMessage
@@ -379,7 +378,7 @@ class TestModule(object):
                 data.line_number = lnum
                 report.error_messages.append(data)
 
-        return get_native(KickstartReport.to_structure(report))
+        return KickstartReport.to_structure(report)
 
     def GenerateKickstart(self):
         """Mock generating a kickstart."""

--- a/tests/nosetests/pyanaconda_tests/module_disk_select_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_disk_select_test.py
@@ -23,7 +23,6 @@ from blivet.devices import DiskDevice
 from blivet.formats import get_format
 from blivet.size import Size
 
-from dasbus.typing import get_native
 from pyanaconda.modules.common.constants.objects import DISK_SELECTION
 from pyanaconda.modules.common.errors.storage import UnavailableStorageError
 from pyanaconda.modules.common.structures.validation import ValidationReport
@@ -85,15 +84,15 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
         storage.devicetree._add_device(dev2)
         storage.devicetree._add_device(dev3)
 
-        report = ValidationReport.from_structure(get_native(
+        report = ValidationReport.from_structure(
             self.disk_selection_interface.ValidateSelectedDisks([])
-        ))
+        )
 
         self.assertEqual(report.is_valid(), True)
 
-        report = ValidationReport.from_structure(get_native(
+        report = ValidationReport.from_structure(
             self.disk_selection_interface.ValidateSelectedDisks(["dev1"])
-        ))
+        )
 
         self.assertEqual(report.is_valid(), False)
         self.assertEqual(report.error_messages, [
@@ -103,9 +102,9 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
         ])
         self.assertEqual(report.warning_messages, [])
 
-        report = ValidationReport.from_structure(get_native(
+        report = ValidationReport.from_structure(
             self.disk_selection_interface.ValidateSelectedDisks(["dev1", "dev2"])
-        ))
+        )
 
         self.assertEqual(report.is_valid(), False)
         self.assertEqual(report.error_messages, [
@@ -118,9 +117,9 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
         ])
         self.assertEqual(report.warning_messages, [])
 
-        report = ValidationReport.from_structure(get_native(
+        report = ValidationReport.from_structure(
             self.disk_selection_interface.ValidateSelectedDisks(["dev1", "dev2", "dev3"])
-        ))
+        )
 
         self.assertEqual(report.is_valid(), True)
 

--- a/tests/nosetests/pyanaconda_tests/module_iscsi_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_iscsi_test.py
@@ -94,7 +94,7 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
         """Test IsNodeFromIbft method."""
         iscsi.ibft_nodes = []
         result = self.iscsi_interface.IsNodeFromIbft(
-            self._unpack_structure_content(Node.to_structure(self._node))
+            Node.to_structure(self._node)
         )
         self.assertFalse(result)
 
@@ -105,7 +105,7 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
         blivet_node.iface = self._node.iface
         iscsi.ibft_nodes = [blivet_node]
         result = self.iscsi_interface.IsNodeFromIbft(
-            self._unpack_structure_content(Node.to_structure(self._node))
+            Node.to_structure(self._node)
         )
         self.assertTrue(result)
 
@@ -119,16 +119,13 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
         self.assertEqual(self.iscsi_interface.GetInterface("iface0"), "ens3")
         self.assertEqual(self.iscsi_interface.GetInterface("nonexisting"), "")
 
-    def _unpack_structure_content(self, structure):
-        return {key: value.unpack() for key, value in structure.items()}
-
     @patch_dbus_publish_object
     def discover_with_task_test(self, publisher):
         """Test the discover task."""
         interfaces_mode = "default"
         task_path = self.iscsi_interface.DiscoverWithTask(
-            self._unpack_structure_content(Portal.to_structure(self._portal)),
-            self._unpack_structure_content(Credentials.to_structure(self._credentials)),
+            Portal.to_structure(self._portal),
+            Credentials.to_structure(self._credentials),
             interfaces_mode
         )
 
@@ -144,9 +141,9 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
     def login_with_task_test(self, publisher):
         """Test the login task."""
         task_path = self.iscsi_interface.LoginWithTask(
-            self._unpack_structure_content(Portal.to_structure(self._portal)),
-            self._unpack_structure_content(Credentials.to_structure(self._credentials)),
-            self._unpack_structure_content(Node.to_structure(self._node)),
+            Portal.to_structure(self._portal),
+            Credentials.to_structure(self._credentials),
+            Node.to_structure(self._node),
         )
 
         obj = check_task_creation(self, task_path, publisher, ISCSILoginTask)

--- a/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
@@ -92,23 +92,7 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
 
     def request_property_test(self):
         """Test the property request."""
-        in_value = {
-            'partitioning-scheme': AUTOPART_TYPE_LVM_THINP,
-            'file-system-type': 'ext4',
-            'excluded-mount-points': ['/home', '/boot', 'swap'],
-            'encrypted': True,
-            'passphrase': '123456',
-            'cipher': 'aes-xts-plain64',
-            'luks-version': 'luks1',
-            'pbkdf': 'argon2i',
-            'pbkdf-memory': 256,
-            'pbkdf-time': 100,
-            'pbkdf-iterations': 1000,
-            'escrow-certificate': 'file:///tmp/escrow.crt',
-            'backup-passphrase-enabled': True,
-        }
-
-        out_value = {
+        request = {
             'partitioning-scheme': get_variant(Int, AUTOPART_TYPE_LVM_THINP),
             'file-system-type': get_variant(Str, 'ext4'),
             'excluded-mount-points': get_variant(List[Str], ['/home', '/boot', 'swap']),
@@ -123,11 +107,9 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
             'escrow-certificate': get_variant(Str, 'file:///tmp/escrow.crt'),
             'backup-passphrase-enabled': get_variant(Bool, True),
         }
-
         self._test_dbus_property(
             "Request",
-            in_value,
-            out_value
+            request
         )
 
     def requires_passphrase_test(self):

--- a/tests/nosetests/pyanaconda_tests/module_part_manual_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_manual_test.py
@@ -78,93 +78,51 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
             []
         )
 
-        in_value = [
-            {
-                "mount-point": "/boot",
-                "device-spec": "/dev/sda1"
-            }
-        ]
-
-        out_value = [
-            {
-                "mount-point": get_variant(Str, "/boot"),
-                "device-spec": get_variant(Str, "/dev/sda1"),
-                "reformat": get_variant(Bool, False),
-                "format-type": get_variant(Str, ""),
-                "format-options": get_variant(Str, ""),
-                "mount-options": get_variant(Str, "")
-            }
-        ]
-
+        request = {
+            "mount-point": get_variant(Str, "/boot"),
+            "device-spec": get_variant(Str, "/dev/sda1"),
+            "reformat": get_variant(Bool, False),
+            "format-type": get_variant(Str, ""),
+            "format-options": get_variant(Str, ""),
+            "mount-options": get_variant(Str, "")
+        }
         self._test_dbus_property(
             "Requests",
-            in_value,
-            out_value
+            [request]
         )
 
-        in_value = [
-            {
-                "mount-point":  "/boot",
-                "device-spec": "/dev/sda1",
-                "reformat": True,
-                "format-type": "xfs",
-                "format-options": "-L BOOT",
-                "mount-options": "user"
-            }
-        ]
-
-        out_value = [
-            {
-                "mount-point": get_variant(Str, "/boot"),
-                "device-spec": get_variant(Str, "/dev/sda1"),
-                "reformat": get_variant(Bool, True),
-                "format-type": get_variant(Str, "xfs"),
-                "format-options": get_variant(Str, "-L BOOT"),
-                "mount-options": get_variant(Str, "user")
-            }
-        ]
-
+        request = {
+            "mount-point": get_variant(Str, "/boot"),
+            "device-spec": get_variant(Str, "/dev/sda1"),
+            "reformat": get_variant(Bool, True),
+            "format-type": get_variant(Str, "xfs"),
+            "format-options": get_variant(Str, "-L BOOT"),
+            "mount-options": get_variant(Str, "user")
+        }
         self._test_dbus_property(
             "Requests",
-            in_value,
-            out_value,
+            [request]
         )
 
-        in_value = [
-            {
-                "mount-point": "/boot",
-                "device-spec": "/dev/sda1"
-            },
-            {
-                "mount-point": "/",
-                "device-spec": "/dev/sda2",
-                "reformat": True
-            }
-        ]
-
-        out_value = [
-            {
-                "mount-point": get_variant(Str, "/boot"),
-                "device-spec": get_variant(Str, "/dev/sda1"),
-                "reformat": get_variant(Bool, False),
-                "format-type": get_variant(Str, ""),
-                "format-options": get_variant(Str, ""),
-                "mount-options": get_variant(Str, "")
-            },
-            {
-                "mount-point": get_variant(Str, "/"),
-                "device-spec": get_variant(Str, "/dev/sda2"),
-                "reformat": get_variant(Bool, True),
-                "format-type": get_variant(Str, ""),
-                "format-options": get_variant(Str, ""),
-                "mount-options": get_variant(Str, "")
-            }
-        ]
-
+        request_1 = {
+            "mount-point": get_variant(Str, "/boot"),
+            "device-spec": get_variant(Str, "/dev/sda1"),
+            "reformat": get_variant(Bool, False),
+            "format-type": get_variant(Str, ""),
+            "format-options": get_variant(Str, ""),
+            "mount-options": get_variant(Str, "")
+        }
+        request_2 = {
+            "mount-point": get_variant(Str, "/"),
+            "device-spec": get_variant(Str, "/dev/sda2"),
+            "reformat": get_variant(Bool, True),
+            "format-type": get_variant(Str, ""),
+            "format-options": get_variant(Str, ""),
+            "mount-options": get_variant(Str, "")
+        }
         self._test_dbus_property(
             "Requests",
-            in_value,
-            out_value
+            [request_1, request_2]
         )
 
     def _add_device(self, device):

--- a/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_sources_test.py
@@ -22,7 +22,6 @@ import unittest
 from unittest.mock import Mock, patch
 
 from pyanaconda.core.constants import INSTALL_TREE
-from dasbus.typing import get_native
 from pyanaconda.modules.common.constants.interfaces import PAYLOAD_SOURCE_LIVE_OS
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.structures.storage import DeviceData
@@ -176,7 +175,7 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
         device.path = "/resolved/path/to/base/image"
 
         device_tree.GetDeviceData = Mock()
-        device_tree.GetDeviceData.return_value = get_native(DeviceData.to_structure(device))
+        device_tree.GetDeviceData.return_value = DeviceData.to_structure(device)
 
         mount.return_value = 0
 
@@ -216,7 +215,7 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
         device.path = "/resolved/path/to/base/image"
 
         device_tree.GetDeviceData = Mock()
-        device_tree.GetDeviceData.return_value = get_native(DeviceData.to_structure(device))
+        device_tree.GetDeviceData.return_value = DeviceData.to_structure(device)
 
         stat_mock.S_ISBLK = Mock()
         stat_mock.S_ISBLK.return_value = False
@@ -243,7 +242,7 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
         device.path = "/resolved/path/to/base/image"
 
         device_tree.GetDeviceData = Mock()
-        device_tree.GetDeviceData.return_value = get_native(DeviceData.to_structure(device))
+        device_tree.GetDeviceData.return_value = DeviceData.to_structure(device)
 
         mount.return_value = -20
 


### PR DESCRIPTION
The DBus library only unwraps the received DBus values now, so we don't have
to use the unpacked form of DBus values in the unit tests anymore.

The DBus library raises DBusError from dasbus.error by default now. All Anaconda
DBus errors should be descendants of DBusError, so they are easier to handle.

**Depends on:** https://github.com/rhinstaller/dasbus/pull/13