### PR TITLE
Calculate ip address for kickstart URL ending in /

### DIFF
--- a/dracut/fetch-kickstart-net.sh
+++ b/dracut/fetch-kickstart-net.sh
@@ -44,7 +44,7 @@ case $kickstart in
 
         # URLs that end in '/' get '$IP_ADDR-kickstart' appended.
         if [[ $kickstart == nfs*/ ]]; then
-            kickstart="${kickstart}${new_ip_address}-kickstart"
+            kickstart="${kickstart}${new_ip_address:=$(ip -4 addr show ${netif} | sed -n -e '/^ *inet / s|^ *inet \([^/]\+\)/.*$|\1|p')}-kickstart"
         fi
 
         # Use the prepared url.


### PR DESCRIPTION
In the past (until Fedora 30) anaconda uses dhclient which sets environment variable new_ip_address before calling script fetch-kickstart.net in dracut hook initqueue.
This variable is used for creating the filename of the kickstart file when the URL for the kickstart file is of type nfs and ends with a slash.
Now dhclient is not used anymore, NetworkManager uses it's own dhcp client, but NetworkManager does not define variable new_ip_address. So this variable is empty when this script is called, the result was that anaconda wants to download a kickstart file with name "-kickstart" instead of "${new_ip_address}-kickstart" which does not exist.
This patch calculates the ipv4 address of the network interface if this variable is not set or empty.
See also rhbz #1769825 .