### PR TITLE
Fix output kickstart generation for subscription commands

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -2199,12 +2199,6 @@ class User(COMMANDS.User):
             except ValueError as e:
                 user_log.warning(str(e))
 
-class RHSM(RemovedCommand):
-
-    def __str__(self):
-        subscription_proxy = SUBSCRIPTION.get_proxy()
-        return subscription_proxy.GenerateKickstart()
-
 class VolGroup(COMMANDS.VolGroup):
     def execute(self, storage, ksdata, instClass):
         for v in self.vgList:
@@ -2581,7 +2575,7 @@ commandMap = {
     "part": Partition,
     "partition": Partition,
     "raid": Raid,
-    "rhsm" : RHSM,
+    "rhsm" : UselessCommand,
     "realm": Realm,
     "reqpart": ReqPart,
     "rootpw": RootPw,

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -299,20 +299,6 @@ class SubscriptionModule(KickstartModule):
         data.syspurpose.usage = self.usage
         data.syspurpose.addons = self.addons
 
-        # subscription
-        data.rhsm.organization = self.organization
-        data.rhsm.activation_keys = self.activation_keys
-        data.rhsm.server_hostname = self.server_hostname
-        data.rhsm.rhsm_baseurl = self.rhsm_baseurl
-
-        # HTTP proxy
-        if self.server_proxy_hostname:
-            proxy = util.ProxyString(host=self.server_proxy_hostname,
-                                port=self.server_proxy_port,
-                                username=self.server_proxy_user,
-                                password=self._server_proxy_password)
-            data.rhsm.proxy = proxy.url
-
         return str(data)
 
     # utility


### PR DESCRIPTION
Previously, the output kickstart contained all subscription related data
(syspurpose & rhsm commands) twice. It also generated an invalid
rhsm command, as we strip organization id and activation keys from the
output kickstart for security reasons.

The output kickstart can be stored on the installed machine for years,
so leaving behind authentication tokens for a Red Hat subscription in
plaintext would not be a very good idea.

So prevent the data to be generated twice (by calling generate_kickstart()
only once) and prevent rhsm command to be written out to output kickstart,
as it is not considered valid without at least org id & at least one
activation key.

The syspurpose command still should be present in the output kickstart,
with no change since RHEL 8.0 behavior.

This should also fix the issue of Initial Setup not starting after the
installation due to invalid kickstart (eq. rhsm command without org id
& activation key).

Resolves: rhbz#1788513
Resolves: rhbz#1788579