### PR TITLE
Fix ignore broken tests

### DIFF
--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -74,7 +74,7 @@ from pykickstart.commands.skipx import FC3_SkipX as SkipX
 from pykickstart.commands.snapshot import F26_Snapshot as Snapshot
 from pykickstart.commands.sshpw import F24_SshPw as SshPw
 from pykickstart.commands.sshkey import F22_SshKey as SshKey
-from pykickstart.commands.timezone import F25_Timezone as Timezone
+from pykickstart.commands.timezone import F32_Timezone as Timezone
 from pykickstart.commands.updates import F7_Updates as Updates
 from pykickstart.commands.url import F30_Url as Url
 from pykickstart.commands.user import F24_User as User

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
@@ -189,12 +189,12 @@ class PackagesKSTestCase(unittest.TestCase):
     def packages_section_multiple_attributes_kickstart_test(self, publisher):
         """Test the packages section with multiple attributes."""
         ks_in = """
-        %packages --nocore --multilib --instLangs en_US.UTF-8
+        %packages --nocore --multilib --inst-langs en_US.UTF-8
 
         %end
         """
         ks_out = """
-        %packages --nocore --instLangs=en_US.UTF-8 --multilib
+        %packages --nocore --inst-langs=en_US.UTF-8 --multilib
 
         %end
         """
@@ -224,7 +224,7 @@ class PackagesKSTestCase(unittest.TestCase):
     def packages_section_complex_exclude_kickstart_test(self, publisher):
         """Test the packages section with complex exclude example."""
         ks_in = """
-        %packages --nocore --ignoremissing --ignorebroken --instLangs=
+        %packages --nocore --ignoremissing --ignorebroken --inst-langs=
         @^environment1
         @group1
         package1
@@ -235,7 +235,7 @@ class PackagesKSTestCase(unittest.TestCase):
         %end
         """
         ks_out = """
-        %packages --nocore --ignoremissing --ignorebroken --instLangs=
+        %packages --nocore --ignoremissing --ignorebroken --inst-langs=
         @^environment1
         @group1
         @group3

--- a/tests/nosetests/pyanaconda_tests/module_timezone_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_timezone_test.py
@@ -116,7 +116,7 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         """
         ks_out = """
         # System timezone
-        timezone Europe/Prague --isUtc --nontp
+        timezone Europe/Prague --utc --nontp
         """
         self._test_kickstart(ks_in, ks_out)
 


### PR DESCRIPTION
Fix master tests.

--instLangs is now --langs
--IsUtc is now --utc

Fix pykickstart Timezone command to F32.