### PR TITLE
Improve the protection of live devices

### DIFF
--- a/pyanaconda/storage/osinstall.py
+++ b/pyanaconda/storage/osinstall.py
@@ -277,15 +277,12 @@ class InstallerStorage(Blivet):
                 protected.append(dev)
 
         # Find the live backing device and its parents.
-        live_device_name = find_live_backing_device()
+        live_device = find_live_backing_device(self.devicetree)
 
-        if live_device_name:
-            log.debug("Resolved live device to %s.", live_device_name)
-            dev = self.devicetree.get_device_by_name(live_device_name, hidden=True)
-
-            if dev is not None:
-                protected.append(dev)
-                protected.extend(dev.parents)
+        if live_device:
+            log.debug("Resolved live device to %s.", live_device.name)
+            protected.append(live_device)
+            protected.extend(live_device.parents)
 
         # For image installation setup_disk_images method marks all local
         # storage disks as ignored so they are protected from teardown.

--- a/pyanaconda/storage/utils.py
+++ b/pyanaconda/storage/utils.py
@@ -449,21 +449,34 @@ def lookup_alias(devicetree, alias):
     return None
 
 
-def find_live_backing_device():
+def find_live_backing_device(devicetree):
     """Find the backing device for the live image.
 
     Note that this is a little bit of a hack since we're assuming
     that /run/initramfs/live will exist
 
-    :return: a device name or None
+    :param devicetree: a device tree
+    :return: a device or None
     """
     for mnt in open("/proc/mounts").readlines():
         if " /run/initramfs/live " not in mnt:
             continue
 
-        live_device_path = mnt.split()[0]
-        live_device_name = live_device_path.split("/")[-1]
-        return live_device_name or None
+        # Return the device mounted at /run/initramfs/live.
+        device_path = mnt.split()[0]
+        device_name = device_path.split("/")[-1]
+        device = devicetree.get_device_by_name(device_name, hidden=True)
+
+        if device:
+            return device
+
+        # Or return the disk of this device.
+        info = udev.get_device(device_node=device_path)
+        disk_name = udev.device_get_partition_disk(info) if info else ""
+        disk = devicetree.get_device_by_name(disk_name, hidden=True)
+
+        if disk:
+            return disk
 
     return None
 


### PR DESCRIPTION
Raise the BootLoaderError instead of the IndexError, if there are no usable boot
drives, so the UI can handle the exception and show the error message to the user.

If the live device is not in the device tree, try to find the disk instead.
Otherwise, we will not be able to protect these devices.

Resolves: rhbz#1773412