### PR TITLE
Revert "Fix Timezone pykickstart command version"

### DIFF
--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -74,7 +74,7 @@ from pykickstart.commands.skipx import FC3_SkipX as SkipX
 from pykickstart.commands.snapshot import F26_Snapshot as Snapshot
 from pykickstart.commands.sshpw import F24_SshPw as SshPw
 from pykickstart.commands.sshkey import F22_SshKey as SshKey
-from pykickstart.commands.timezone import F32_Timezone as Timezone
+from pykickstart.commands.timezone import F25_Timezone as Timezone
 from pykickstart.commands.updates import F7_Updates as Updates
 from pykickstart.commands.url import F30_Url as Url
 from pykickstart.commands.user import F24_User as User

--- a/tests/nosetests/pyanaconda_tests/module_timezone_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_timezone_test.py
@@ -116,7 +116,7 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         """
         ks_out = """
         # System timezone
-        timezone Europe/Prague --utc --nontp
+        timezone Europe/Prague --isUtc --nontp
         """
         self._test_kickstart(ks_in, ks_out)
 


### PR DESCRIPTION
This reverts the commit e89e45d, because the change requires a new release
of pykickstart which is not available at this moment.