### PR TITLE
Remove pyanaconda.flags.cmdline

### DIFF
--- a/pyanaconda/core/kernel.py
+++ b/pyanaconda/core/kernel.py
@@ -103,8 +103,7 @@ class KernelArguments():
         inst_prefix = "inst."
 
         for i in lst:
-            # drop the inst. prefix (if found), so that getbool() works
-            # consistently for both "foo=0" and "inst.foo=0"
+            # drop the inst. prefix (if found)
             if i.startswith(inst_prefix):
                 i = i[len(inst_prefix):]
 
@@ -141,28 +140,6 @@ class KernelArguments():
             return False
         else:
             return True
-
-    def getbool(self, arg, default=False):
-        """Return the boolean value of the given argument.
-
-        The rules are:
-        - "arg", "arg=val": True
-        - "noarg", "noarg=val", "arg=[0|off|no]": False
-
-        :param arg: a name of the argument
-        :param default: a default value
-        :return: a boolean value of the argument
-        """
-        result = default
-        for a in self._data:
-            if a == arg:
-                if self._data[arg] in ("0", "off", "no"):
-                    result = False
-                else:
-                    result = True
-            elif a == 'no' + arg:
-                result = False  # XXX: should noarg=off -> True?
-        return result
 
     def get(self, arg, default=None):
         """Return the value of the given argument.

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from pyanaconda.core.constants import ANACONDA_ENVIRON
-from pyanaconda.core.kernel import kernel_arguments
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -53,8 +52,6 @@ class Flags(object):
         self.singlelang = False
         # current runtime environments
         self.environs = [ANACONDA_ENVIRON]
-        # pre-parsed boot commandline
-        self.cmdline = kernel_arguments
         # Lock it down: no more creating new flags!
         self.__dict__['_in_init'] = False
 

--- a/tests/nosetests/pyanaconda_tests/kernel_test.py
+++ b/tests/nosetests/pyanaconda_tests/kernel_test.py
@@ -41,23 +41,6 @@ class KernelArgumentsTests(unittest.TestCase):
         self.assertIsNone(ka.get("thisisnotthere"))
         self.assertEqual(ka.get("thisisnotthere", "fallback"), "fallback")
 
-        # test the getbool() method - presence
-        self.assertTrue(ka.getbool("blah"))  # is present
-        self.assertTrue(ka.getbool("foo"))  # has any value
-
-        # test the getbool() method - simple names and values
-        self.assertTrue(ka.getbool("bar"))  # 1
-        self.assertFalse(ka.getbool("baz"))  # 0
-        self.assertFalse(ka.getbool("beep"))  # off
-        self.assertFalse(ka.getbool("derp"))  # no
-
-        # test the getbool() method - the super magical "no" prefix
-        self.assertFalse(ka.getbool("where"))  # is present with no-prefix
-        self.assertFalse(ka.getbool("thing"))  # is set and has no-prefix
-        self.assertTrue(ka.getbool("nothing"))  # full name incl. the "no" prefix = is present
-        self.assertFalse(ka.getbool("nobody"))  # full name incl. the "no" prefix, value is 0
-        self.assertFalse(ka.get("body"))  # no-prefix and has a value
-
         # test the is_enabled() method
         self.assertTrue(ka.is_enabled("blah"))  # present
         self.assertTrue(ka.is_enabled("foo"))  # any value
@@ -77,7 +60,6 @@ class KernelArgumentsTests(unittest.TestCase):
         ka = KernelArguments()
         self.assertEqual(ka.read(["/proc/cmdlin*", "/nonexistent/file"]), ["/proc/cmdline"])
         self.assertEqual(ka.read("/another/futile/attempt"), [])
-        self.assertTrue(ka.getbool("root"))  # expect this to be set in most environments
 
     def special_argument_handling_test(self):
         """Test handling of special arguments in KernelArguments."""


### PR DESCRIPTION
Once kdump addon gets a new rawhide release, we can drop `pyanaconda.flags.cmdline` and leave only the replacement - `pyanaconda.kernel.kernel_arguments`. Also `getbool()` will be unused and removed then.

Blocked by https://github.com/daveyoung/kdump-anaconda-addon/pull/24