### PR TITLE
Add support for device factory changes

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/add_device.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/add_device.py
@@ -1,0 +1,163 @@
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from blivet import devicefactory
+from blivet.errors import StorageError
+from blivet.size import Size
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.util import lowerASCII
+from pyanaconda.modules.common.structures.partitioning import DeviceFactoryRequest
+from pyanaconda.modules.common.task import Task
+from pyanaconda.modules.storage.partitioning.interactive.utils import \
+    get_device_raid_level_name, get_container_size_policy, get_device_factory_arguments
+from pyanaconda.storage.utils import PARTITION_ONLY_FORMAT_TYPES
+
+log = get_module_logger(__name__)
+
+__all__ = ["AddDeviceTask"]
+
+
+class AddDeviceTask(Task):
+    """A task for adding a new device to the device tree."""
+
+    def __init__(self, storage, request: DeviceFactoryRequest):
+        """Create a task.
+
+        :param storage: an instance of Blivet
+        :param request: a device factory request
+        """
+        super().__init__()
+        self._storage = storage
+        self._request = request
+
+    @property
+    def name(self):
+        """Name of this task."""
+        return "Add a device"
+
+    def run(self):
+        """Add a new device to the device tree.
+
+        :raise: StorageError if the device cannot be created
+        """
+        log.debug("Add device: %s", self._request)
+
+        # Complete the device info.
+        self._complete_device_factory_request(self._storage, self._request)
+
+        try:
+            # Trying to use a new container.
+            self._add_device(self._storage, self._request, use_existing_container=False)
+            return
+        except StorageError as e:
+            # Keep the first error.
+            error = e
+
+        try:
+            # Trying to use an existing container.
+            self._add_device(self._storage, self._request, use_existing_container=True)
+            return
+        except StorageError:
+            # Ignore the second error.
+            pass
+
+        raise error
+
+    def _complete_device_factory_request(self, storage, request: DeviceFactoryRequest):
+        """Complete the device factory request.
+
+        :param storage: an instance of Blivet
+        :param request: a device factory request
+        """
+        # Set the defaults.
+        if not request.luks_version:
+            request.luks_version = storage.default_luks_version
+
+        # Set the file system type for the given mount point.
+        if not request.format_type:
+            request.format_type = storage.get_fstype(request.mount_point)
+
+        # Fix the mount point.
+        if lowerASCII(request.mount_point) in ("swap", "biosboot", "prepboot"):
+            request.mount_point = ""
+
+        # We should create a partition in some cases.
+        # These devices should never be encrypted.
+        if (request.mount_point.startswith("/boot") or
+                request.format_type in PARTITION_ONLY_FORMAT_TYPES):
+            request.device_type = devicefactory.DEVICE_TYPE_PARTITION
+            request.device_encrypted = False
+
+        # We shouldn't create swap on a thinly provisioned volume.
+        if (request.format_type == "swap" and
+                request.device_type == devicefactory.DEVICE_TYPE_LVM_THINP):
+            request.device_type = devicefactory.DEVICE_TYPE_LVM
+
+        # Encryption of thinly provisioned volumes isn't supported.
+        if request.device_type == devicefactory.DEVICE_TYPE_LVM_THINP:
+            request.device_encrypted = False
+
+    def _add_device(self, storage, request: DeviceFactoryRequest, use_existing_container=False):
+        """Add a device to the storage model.
+
+        :param storage: an instance of Blivet
+        :param request: a device factory request
+        :param use_existing_container: should we use an existing container?
+        :raise: StorageError if the device cannot be created
+        """
+        # Create the device factory.
+        factory = devicefactory.get_device_factory(
+            storage,
+            device_type=request.device_type,
+            size=Size(request.device_size) if request.device_size else None
+        )
+
+        # Find a container.
+        container = factory.get_container(
+            allow_existing=use_existing_container
+        )
+
+        if use_existing_container and not container:
+            raise StorageError("No existing container found.")
+
+        # Update the device info.
+        if container:
+            # Don't override user-initiated changes to a defined container.
+            request.disks = [d.name for d in container.disks]
+            request.container_encrypted = container.encrypted
+            request.container_raid_level = get_device_raid_level_name(container)
+            request.container_size_policy = get_container_size_policy(container)
+
+            # The existing container has a name.
+            if use_existing_container:
+                request.container_name = container.name
+
+            # The container is already encrypted
+            if container.encrypted:
+                request.device_encrypted = False
+
+        # Create the device.
+        dev_info = get_device_factory_arguments(storage, request)
+
+        try:
+            storage.factory_device(**dev_info)
+        except StorageError as e:
+            log.error("The device creation has failed: %s", e)
+            raise
+        except OverflowError as e:
+            log.error("Invalid partition size set: %s", str(e))
+            raise StorageError("Invalid partition size set. Use a valid integer.") from None

--- a/pyanaconda/modules/storage/partitioning/interactive/change_device.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/change_device.py
@@ -1,0 +1,269 @@
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from blivet.errors import StorageError
+from blivet.size import Size
+
+from dasbus.structure import compare_data
+
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.modules.common.structures.partitioning import DeviceFactoryRequest
+from pyanaconda.modules.common.task import Task
+from pyanaconda.modules.storage.partitioning.interactive.utils import destroy_device, \
+    get_device_factory_arguments, revert_reformat, resize_device, reformat_device, \
+    validate_label, change_encryption
+
+log = get_module_logger(__name__)
+
+__all__ = ["ChangeDeviceTask"]
+
+
+class ChangeDeviceTask(Task):
+    """A task for changing a device in the device tree."""
+
+    def __init__(self, storage, device, request: DeviceFactoryRequest,
+                 original_request: DeviceFactoryRequest):
+        """Create a task.
+
+        FIXME: Remove device and original request from the arguments.
+
+        :param storage: an instance of Blivet
+        :param device: a device to change
+        :param request: a device factory request
+        :param original_request: an original device factory request
+        """
+        super().__init__()
+        self._storage = storage
+        self._device = device
+        self._request = request
+        self._original_request = original_request
+
+    @property
+    def name(self):
+        """Name of this task."""
+        return "Change a device"
+
+    def run(self):
+        """Change a device in the device tree.
+
+        :raise: StorageError if the device cannot be changed
+        """
+        log.debug("Change device: %s", self._request)
+
+        if compare_data(self._request, self._original_request):
+            log.debug("Nothing to change.")
+            return
+
+        if not self._device.raw_device.exists:
+            self._replace_device()
+        else:
+            self._change_device()
+
+    def _replace_device(self):
+        """Replace the nonexistent device with a new one.
+
+        If something has changed but the device does not exist,
+        there is no need to schedule actions on the device. It
+        is only necessary to create a new device object which
+        reflects the current choices.
+        """
+        log.debug("Replacing a nonexistent device.")
+        device = self._device
+
+        if self._should_remove_device():
+            # Remove the current device.
+            destroy_device(self._storage, device)
+
+            # We don't want to pass the device if we removed it.
+            self._request.device_spec = ""
+
+        # Create a new device.
+        log.debug("Creating a new device.")
+        arguments = get_device_factory_arguments(self._storage, self._request)
+        device = self._storage.factory_device(**arguments)
+
+        # Update the device.
+        self._device = device
+
+    def _should_remove_device(self):
+        """Should we remove the current device?"""
+        new_request = self._request
+        old_request = self._original_request
+
+        # Check the device type.
+        if old_request.device_type != new_request.device_type:
+            return True
+
+        # Check the container name.
+        if old_request.container_name and new_request.container_name != old_request.container_name:
+            return True
+
+        return False
+
+    def _change_device(self):
+        """Change the configuration of the existing device."""
+        log.debug("Modifying an existing device.")
+
+        self._revert_device_reformat()
+        self._change_device_size()
+
+        if self._should_reformat_device():
+            self._change_device_encryption()
+            self._change_device_format()
+        else:
+            self._change_device_label()
+            self._change_device_mount_point()
+
+        self._change_device_name()
+
+    def _revert_device_reformat(self):
+        """Revert reformat of the device."""
+        if self._request.reformat:
+            return
+
+        log.debug("Reverting device reformat.")
+        revert_reformat(self._storage, self._device)
+
+    def _change_device_size(self):
+        """Resize the device."""
+        size = Size(self._request.device_size)
+        original_size = Size(self._original_request.device_size)
+
+        if size == original_size:
+            return
+
+        log.debug("Changing device size: %s", size)
+        resize_device(self._storage, self._device, size, original_size)
+
+    def _should_reformat_device(self):
+        """Should we reformat the device?
+
+        :return: True of False
+        """
+        if not self._request.reformat:
+            return False
+
+        if self._device.format.exists:
+            return True
+
+        if self._original_request.device_encrypted != self._request.device_encrypted:
+            return True
+
+        if self._original_request.luks_version != self._request.luks_version:
+            return True
+
+        if self._original_request.format_type != self._request.format_type:
+            return True
+
+        return False
+
+    def _change_device_encryption(self):
+        """Change the device encryption."""
+        storage = self._storage
+        device = self._device
+        encrypted = self._request.device_encrypted
+        luks_version = self._request.luks_version
+
+        if self._original_request.device_encrypted != encrypted:
+            log.debug("Changing device encryption: %s", encrypted)
+            device = change_encryption(
+                storage=storage,
+                device=device,
+                encrypted=encrypted,
+                luks_version=luks_version
+            )
+        elif encrypted and self._original_request.luks_version != luks_version:
+            log.debug("Changing LUKS version: %s", luks_version)
+
+            # LUKS version cannot be easily changed,
+            # so remove the current LUKS device.
+            device = change_encryption(
+                storage=storage,
+                device=device,
+                encrypted=False,
+                luks_version=luks_version
+            )
+
+            # And create a new one with the requested
+            # LUKS version.
+            device = change_encryption(
+                storage=storage,
+                device=device,
+                encrypted=True,
+                luks_version=luks_version
+            )
+
+        self._device = device
+
+    def _change_device_format(self):
+        """Change the device format."""
+        log.debug("Changing device format: %s", self._request.format_type)
+
+        reformat_device(
+            storage=self._storage,
+            device=self._device,
+            fstype=self._request.format_type,
+            mountpoint=self._request.mount_point,
+            label=self._request.label
+        )
+
+    def _change_device_label(self):
+        """Change the device label."""
+        label = self._request.label
+
+        if self._original_request.label == label:
+            return
+
+        if not hasattr(self._device.format, "label"):
+            log.warning("Cannot set a label to the current format.")
+            return
+
+        if validate_label(label, self._device.format):
+            log.warning("Cannot set an invalid label.")
+            return
+
+        log.debug("Changing device label: %s", label)
+        self._device.format.label = label
+
+    def _change_device_mount_point(self):
+        """Change the device mount point."""
+        mount_point = self._request.mount_point
+
+        if not mount_point:
+            return
+
+        if self._original_request.mount_point == mount_point:
+            return
+
+        log.debug("Changing device mount point: %s", mount_point)
+        self._device.format.mountpoint = mount_point
+
+    def _change_device_name(self):
+        """Change the device name."""
+        name = self._request.device_name
+        original_name = self._original_request.device_name
+
+        if name == original_name:
+            return
+
+        log.debug("Changing device name: %s", name)
+
+        try:
+            self._device.raw_device.name = name
+        except ValueError as e:
+            log.error("Invalid device name: %s", e)
+            raise StorageError(str(e))

--- a/pyanaconda/modules/storage/partitioning/interactive/scheduler_interface.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/scheduler_interface.py
@@ -217,3 +217,17 @@ class DeviceTreeSchedulerInterface(DeviceTreeInterface):
         self.implementation.add_device(
             DeviceFactoryRequest.from_structure(request)
         )
+
+    def ChangeDevice(self, request: Structure, original_request: Structure):
+        """Change a device in the storage model.
+
+        FIXME: Remove the original request from the arguments.
+
+        :param request: a device factory request
+        :param original_request: an original device factory request
+        :raise: StorageError if the device cannot be changed
+        """
+        self.implementation.change_device(
+            DeviceFactoryRequest.from_structure(request),
+            DeviceFactoryRequest.from_structure(original_request)
+        )

--- a/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
@@ -20,6 +20,7 @@
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.modules.storage.devicetree import DeviceTreeModule
+from pyanaconda.modules.storage.partitioning.interactive.add_device import AddDeviceTask
 from pyanaconda.modules.storage.partitioning.interactive.scheduler_interface import \
     DeviceTreeSchedulerInterface
 from pyanaconda.modules.storage.partitioning.interactive import utils
@@ -238,4 +239,5 @@ class DeviceTreeSchedulerModule(DeviceTreeModule):
         :param request: a device factory request
         :raise: StorageError if the device cannot be created
         """
-        utils.add_device(self.storage, request)
+        task = AddDeviceTask(self.storage, request)
+        task.run()

--- a/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
@@ -21,6 +21,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.modules.storage.devicetree import DeviceTreeModule
 from pyanaconda.modules.storage.partitioning.interactive.add_device import AddDeviceTask
+from pyanaconda.modules.storage.partitioning.interactive.change_device import ChangeDeviceTask
 from pyanaconda.modules.storage.partitioning.interactive.scheduler_interface import \
     DeviceTreeSchedulerInterface
 from pyanaconda.modules.storage.partitioning.interactive import utils
@@ -240,4 +241,17 @@ class DeviceTreeSchedulerModule(DeviceTreeModule):
         :raise: StorageError if the device cannot be created
         """
         task = AddDeviceTask(self.storage, request)
+        task.run()
+
+    def change_device(self, request, original_request):
+        """Change a device in the storage model.
+
+        FIXME: Remove the original request from the arguments.
+
+        :param request: a device factory request
+        :param original_request: an original device factory request
+        :raise: StorageError if the device cannot be changed
+        """
+        device = self._get_device(request.device_spec)
+        task = ChangeDeviceTask(self.storage, device, request, original_request)
         task.run()

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -58,10 +58,11 @@ from pyanaconda.modules.storage.partitioning.interactive.utils import collect_un
     collect_bootloader_devices, collect_new_devices, collect_selected_disks, collect_roots, \
     create_new_root, revert_reformat, resize_device, change_encryption, reformat_device, \
     collect_file_system_types, collect_device_types, \
-    get_device_raid_level, add_device, destroy_device, rename_container, get_container, \
+    get_device_raid_level, destroy_device, rename_container, get_container, \
     collect_containers, validate_label, suggest_device_name, get_new_root_name, \
     generate_device_factory_request, validate_device_factory_request, \
     get_device_factory_arguments, get_raid_level_by_name, get_container_size_policy_by_number
+from pyanaconda.modules.storage.partitioning.interactive.add_device import AddDeviceTask
 from pyanaconda.platform import platform
 from pyanaconda.product import productName, productVersion
 from pyanaconda.storage.checker import verify_luks_devices_have_key, storage_checker
@@ -1453,7 +1454,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self.clear_errors()
 
         try:
-            add_device(self._storage_playground, request)
+            task = AddDeviceTask(self._storage_playground, request)
+            task.run()
         except StorageError as e:
             self.set_detailed_error(_("Failed to add new device."), e)
             self._do_refresh()


### PR DESCRIPTION
Move the code for adding a new device to a device tree to the new task
called `AddDeviceTask` and fix the related code.

Move the code for changing a device in a device tree to the new task called
`ChangeDeviceTask` and fix the related code.

Call the DBus method `ChangeDevice` to change a device in the storage model.

