### PR TITLE
Rhel 8 fix status for manual org key registration

### DIFF
--- a/pyanaconda/modules/subscription/installation.py
+++ b/pyanaconda/modules/subscription/installation.py
@@ -37,7 +37,7 @@ from pyanaconda.modules.common.task import Task, TaskInterface
 from pyanaconda.modules.common.constants.interfaces import SUBSCRIPTION_TASK
 from pyanaconda.modules.common.constants.services import RHSM
 from pyanaconda.modules.common.constants.objects import RHSM_ATTACH, RHSM_UNREGISTER, \
-        RHSM_SYSPURPOSE, RHSM_REGISTER_SERVER, RHSM_CONFIG
+        RHSM_REGISTER_SERVER, RHSM_CONFIG
 from pyanaconda.modules.common.errors.installation import SubscriptionTokenTransferError, \
         InsightsConnectError, InsightsClientMissingError
 from pyanaconda.modules.common.errors import DBusError
@@ -158,10 +158,6 @@ class SubscriptionTask(Task, metaclass=ABCMeta):
         # JSON data returned by the respective
         # RHSM DBus method (if any)
         self.subscription_json = ""
-        # post attach syspurpose data,
-        # available only after AutoAttach()
-        # calls
-        self.final_syspurpose_json = ""
 
 @dbus_interface(SUBSCRIPTION_TASK.interface_name)
 class SubscriptionTaskInterface(TaskInterface):
@@ -317,11 +313,6 @@ class AttachSubscriptionTask(SubscriptionTask):
             result = attach_proxy.AutoAttach(self._sla, {}, locale)
             self.subscription_json = result
             log.debug("RHSM: auto-attached a subscription")
-            # fetch final system purpose data
-            log.debug("RHSM: fetching final syspurpose data")
-            syspurpose_proxy = RHSM.get_proxy(RHSM_SYSPURPOSE)
-            self.final_syspurpose_json = syspurpose_proxy.GetSyspurpose(locale)
-            log.debug("RHSM: final syspurpose data: %s", self.final_syspurpose_json)
         except DBusError as e:
             log.debug("RHSM: auto-attach failed: %s", str(e))
             exception_dict = json.loads(str(e))

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -896,7 +896,16 @@ class SubscriptionModule(KickstartModule):
             self.set_subscription_attached(True)
 
             # retrieve subscription data
-            subscription_json, syspurpose_json = self._get_subscription_state_data()
+            # - for some reason exceptions raised in this method are not logged,
+            #   so wrap it in a try-except block for now
+            # - as we don't know beforehand what exceptions might be raised by
+            #   the method, we also need to disable a pylint warning about
+            #   except not specifying a concrete exception to catch
+            try:
+                subscription_json, syspurpose_json = self._get_subscription_state_data()
+            # pylint: disable=broad-except
+            except Exception:
+                log.exception("RHSM: failed to fetch subscription status data")
             self.set_subscription_data(subscription_json=subscription_json,
                                        final_syspurpose_json=syspurpose_json)
 


### PR DESCRIPTION
The aim of this pull request is to make sure, that correct subscription status is shown to users after a successful subscription attempt.

The first commit fixes a case where manually entered system purpose data has not been set to the installation environment, resulting in the data not being used at registration time and not displayed on the subscription status tab.

The second commit switches to a different DBus method for fetching overall subscription status as the current way of doing that turned out to be unreliable.

**Update**

Looks like this PR actually fixes not only rhbz#1788036, but also rhbz#1788207. :)