### PR TITLE
Add pep8 check

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -197,6 +197,10 @@ run-tests:
 	@rm -rf $(USER_SITE_BASE)
 	$(MAKE) coverage-report
 
+tests-pep8:
+	$(MAKE)
+	$(MAKE) TMPDIR=/var/tmp TEST_SUITE_LOG=test-suite.log TESTS=pep8/runpep8.sh check
+
 tests-nose-only:
 	@mkdir -p $(USER_SITE_PACKAGES)
 	@cp $(abs_builddir)/tests/usercustomize.py $(USER_SITE_PACKAGES)

--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -36,6 +36,9 @@ TEST_DEPENDENCIES = ["e2fsprogs", "git", "bzip2", "cppcheck", "rpm-ostree", "pyk
                      "python3-mock", "python3-nose-testconfig", "python3-sphinx_rtd_theme",
                      "python3-lxml", "python3-pip", "python3-coverage",
 
+                     # pep8 check
+                     "python-pycodestyle",
+
                      # contains restorecon which was removed in Fedora 28 mock
                      "policycoreutils"
                      # "python3-pocketlint"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,6 +40,7 @@ EXTRA_DIST += $(top_srcdir)/translation-canary/translation_canary/*.py \
 
 NOSE_TESTS_ARGS ?= ""
 RPM_TESTS_ARGS ?= ""
+PEP8_TARGETS ?= ""
 
 # Test scripts need to be listed both here and in TESTS
 dist_check_SCRIPTS = $(srcdir)/glade/*.py \
@@ -58,7 +59,8 @@ dist_check_SCRIPTS = $(srcdir)/glade/*.py \
 		     $(srcdir)/gui/*.py \
 		     $(srcdir)/storage/cases/*.py \
 		     $(srcdir)/*_tests/*.py \
-		     $(srcdir)/nosetests/*_tests/*.py
+		     $(srcdir)/nosetests/*_tests/*.py \
+		     pep8/runpep8.sh
 
 TESTS = nosetests.sh \
 	pylint/runpylint.py \

--- a/tests/pep8/config
+++ b/tests/pep8/config
@@ -1,0 +1,7 @@
+# Configuration file for pep8 checker (pycodestyle or pep8)
+
+[pycodestyle]
+max-line-length = 99
+
+[pep8]
+max-line-length = 99

--- a/tests/pep8/config.target
+++ b/tests/pep8/config.target
@@ -1,0 +1,1 @@
+DEFAULT_PEP8_TARGETS="pyanaconda/"

--- a/tests/pep8/runpep8.sh
+++ b/tests/pep8/runpep8.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# If $top_srcdir has not been set by automake, import the test environment
+if [ -z "$top_srcdir" ]; then
+    top_srcdir="$(dirname "$0")/../.."
+fi
+
+. ${top_srcdir}/tests/testenv.sh
+. ${top_srcdir}/tests/pep8/config.target
+
+pep8_command=""
+for cmd in pep8 pycodestyle pycodestyle-3
+do
+    which ${cmd} >/dev/null 2>&1
+    if [[ $? -eq 0 ]]; then
+        pep8_command=${cmd}
+    fi
+done
+
+if [[ ${pep8_command} == "" ]]; then
+    echo "No pep8 checker (pycodestyle, pep8) found."
+    exit 99
+fi
+
+PEP8_TARGETS=${PEP8_TARGETS:-${DEFAULT_PEP8_TARGETS}}
+
+PEP8_TARGET_PATHS=""
+for target in ${PEP8_TARGETS}
+do
+    PEP8_TARGET_PATHS+=" ${top_srcdir}/${target}"
+done
+
+${pep8_command} --config ${top_srcdir}/tests/pep8/config ${PEP8_TARGET_PATHS}


### PR DESCRIPTION
* Example:

scripts/testing/setup-mock-test-env.py --init --copy --run-pep8-check --result results0 fedora-rawhide-x86_64
scripts/testing/setup-mock-test-env.py --init --copy --run-pep8-check "pyanaconda/modules/ pyanaconda/network.py" --result results0 fedora-rawhide-x86_64

make tests-pep8
make tests-pep8 PEP8_TARGETS="pyanaconda/modules/ pyanaconda/network.py"

Default PEP8_TARGETS are defined in tests/pep8/config.targets

* Configuration:

tests/pep8/config

It would be possible to share the configuration with pep8speaks in setup.cfg
located in the repository root but I think we might want to have the both checks
configured separately with some differences.

* Including into ci tests:

Add pep8/runpep8.sh to TESTS in tests/Makefile.am.
Configure targets to be tested in tests/pep8/config.targets