### PR TITLE
[WIP] Use unsquashfs to install the Live system

### DIFF
--- a/pyanaconda/payload/live/payload_liveimg.py
+++ b/pyanaconda/payload/live/payload_liveimg.py
@@ -287,7 +287,7 @@ class LiveImagePayload(BaseLivePayload):
             Otherwise fall back to rsync of INSTALL_TREE
         """
         # If it doesn't look like a tarfile use the super's install()
-        if not self.is_tarfile:
+        if not self.is_tarfile and not self.is_plain_squashfs_image:
             super().install()
             return
 


### PR DESCRIPTION
This will allow for multi-threaded decompression and will result in lower installation time.
The unsquashfs command is more efficient than rsync to decompress the entire image.

Note, that this patch will crash anaconda installer.
I did not investigate why exactly. The unsquashfs command will complete and you'll see Fedora installed in /mnt/sysimage, but other steps will not be performed.

This patch requires polishing before merging:
0. Investigate and fix the crash, so that unsquashfs can be used to install the Live image.
1. Remove assumption that squashfs is always plain, a check should be added.
2. Remove assumption, that the installation is performed from local media, see comments in the patch.
   I'd suggest falling back to /dev/loopX in case the file in /run/initramfs is not found.

This is a follow-up effort of optimizing the squashFS image size: https://fedoraproject.org/wiki/Category:Changes/OptimizeSquashFS