### PR TITLE
Fix typos in docstrings

### DIFF
--- a/pyanaconda/modules/network/ifcfg.py
+++ b/pyanaconda/modules/network/ifcfg.py
@@ -171,8 +171,8 @@ def get_ifcfg_file_of_device(nm_client, device_name, device_hwaddr=None, root_pa
     :type nm_client: NM.Client
     :param device_name: name of the device
     :type device_name: str
-    :param hwaddr: hardware address of the device
-    :type hwaddr: str
+    :param device_hwaddr: hardware address of the device
+    :type device_hwaddr: str
     :param root_path: search in the filesystem specified by root path
     :type root_path: str
     :returns: ifcfg file object
@@ -444,7 +444,7 @@ def get_master_slaves_from_ifcfgs(nm_client, master_devname, root_path="", uuid=
     :param nm_client: instance of NetworkManager client
     :type nm_client: NM.Client
     :param master_devname: name of master device
-    :type devname: str
+    :type master_devname: str
     :param root_path: optional root path for ifcfg files
     :type root_path: str
     :param uuid: uuid of master connection (optional)

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -119,7 +119,7 @@ class NetworkService(KickstartService):
     def default_device_specification(self, specification):
         """Set the default specification for missing kickstart --device option.
 
-        :param specifiacation: device specification accepted by network --device option
+        :param specification: device specification accepted by network --device option
         :type specification: str
         """
         self._default_device_specification = specification
@@ -522,7 +522,7 @@ class NetworkService(KickstartService):
     def bootif(self, specification):
         """Set the value of kickstart --device bootif option.
 
-        :param specifiacation: mac address specified by kickstart --device bootif option
+        :param specification: mac address specified by kickstart --device bootif option
         :type specification: str
         """
         self._bootif = specification

--- a/pyanaconda/modules/network/nm_client.py
+++ b/pyanaconda/modules/network/nm_client.py
@@ -542,8 +542,8 @@ def bound_hwaddr_of_device(nm_client, device_name, ifname_option_values):
     hwaddress of the device devname is the same as the MAC address, its value
     is returned.
 
-    :param devname: device name
-    :type devname: str
+    :param device_name: device name
+    :type device_name: str
     :param ifname_option_values: list of ifname boot option values
     :type ifname_option_values: list(str)
     :return: hwaddress of the device if bound, or None
@@ -659,7 +659,7 @@ def bind_settings_to_mac(nm_client, s_connection, s_wired, device_name=None, bin
     :param s_wired: wired setting to be updated
     :type s_wired: NM.SettingWired
     :param device_name: name of the device to be bound
-    :type evice_name: str
+    :type device_name: str
     :param bind_exclusively: remove reference to the device name from the settings
     :type bind_exclusively: bool
     :returns: True if the settings were modified, False otherwise
@@ -700,7 +700,7 @@ def bind_settings_to_device(nm_client, s_connection, s_wired, device_name=None,
     :param s_wired: wired setting to be updated
     :type s_wired: NM.SettingWired
     :param device_name: name of the device to be bound
-    :type evice_name: str
+    :type device_name: str
     :param bind_exclusively: remove reference to the mac address from the settings
     :type bind_exclusively: bool
     :returns: True if the settings were modified, False otherwise

--- a/pyanaconda/modules/payloads/base/initialization.py
+++ b/pyanaconda/modules/payloads/base/initialization.py
@@ -65,7 +65,7 @@ class UpdateBLSConfigurationTask(Task):
         :param sysroot: a path to the root of the installed system
         :type sysroot: str
         :param kernel_version_list: list of kernel versions for updating of BLS configuration
-        :type krenel_version_list: list(str)
+        :type kernel_version_list: list(str)
         """
         super().__init__()
         self._sysroot = sysroot

--- a/pyanaconda/modules/payloads/base/installation.py
+++ b/pyanaconda/modules/payloads/base/installation.py
@@ -35,7 +35,7 @@ class InstallFromImageTask(Task):
         :type dest_path: str
         :param kernel_version_list: list of kernel versions for rescue initrd images
                                     to be created
-        :type krenel_version_list: list(str)
+        :type kernel_version_list: list(str)
         """
         super().__init__()
         self._source = source

--- a/pyanaconda/modules/payloads/base/utils.py
+++ b/pyanaconda/modules/payloads/base/utils.py
@@ -56,7 +56,7 @@ def write_module_blacklist(sysroot):
 def get_dir_size(directory):
     """Get the size of a directory and all its subdirectories.
 
-    :param dir: the name of the directory to find the size of
+    :param str directory: the name of the directory to find the size of
     :return: the size of the directory in kilobytes
     """
     def get_subdir_size(directory):

--- a/pyanaconda/modules/payloads/packages/packages.py
+++ b/pyanaconda/modules/payloads/packages/packages.py
@@ -378,8 +378,8 @@ class PackagesModule(KickstartBaseModule):
     def set_broken_ignored(self, broken_ignored):
         """Set if the packages that have conflicts with other packages should be ignored.
 
-        :param missing_ignored: True if broken packages should be ignored.
-        :type missing_ignored: bool
+        :param broken_ignored: True if broken packages should be ignored.
+        :type broken_ignored: bool
         :raise: UnsupportedValueError if ignorebroken is disabled on this product.
         """
         if not conf.payload.enable_ignore_broken_packages:

--- a/pyanaconda/modules/payloads/payload/live_image/initialization.py
+++ b/pyanaconda/modules/payloads/payload/live_image/initialization.py
@@ -315,7 +315,7 @@ class DownloadProgress(object):
         :param size: length of the file
         :type size: int
         :param report_callback: callback with progress message argument
-        :type task: callable taking str argument
+        :type report_callback: callable taking str argument
         """
         self.report = report_callback
         self.url = url

--- a/pyanaconda/modules/payloads/payload/live_os/live_os.py
+++ b/pyanaconda/modules/payloads/payload/live_os/live_os.py
@@ -66,8 +66,9 @@ class LiveOSModule(PayloadBase):
         This payload is specific that it can't have more than only one source attached. It will
         instead replace the old source with the new one.
 
-        :param source: source object
-        :type source: instance of pyanaconda.modules.payloads.source.source_base.PayloadSourceBase
+        :param sources: source objects
+        :type sources:
+            list of pyanaconda.modules.payloads.source.source_base.PayloadSourceBase instances
         :raises: IncompatibleSourceError
         """
         if len(sources) > 1:

--- a/pyanaconda/modules/security/security.py
+++ b/pyanaconda/modules/security/security.py
@@ -183,7 +183,7 @@ class SecurityService(KickstartService):
     def handle_realm_discover_results(self, realm_data):
         """ Handle results from the RealmDiscover task.
 
-        :param results: an updated instance of realm data
+        :param realm_data: an updated instance of realm data
         """
         log.debug("Updating realm data with results from realm discover task.")
         self.set_realm(realm_data)

--- a/pyanaconda/modules/users/installation.py
+++ b/pyanaconda/modules/users/installation.py
@@ -148,7 +148,7 @@ class SetSshKeysTask(Task):
 
         :param str sysroot: a path to the root of the installed system
         :param ssh_key_data_list: list of keys to install
-        :type ssk_key_data_list: list of SshKeyData instances
+        :type ssh_key_data_list: list of SshKeyData instances
         """
         super().__init__()
         self._sysroot = sysroot

--- a/pyanaconda/storage/utils.py
+++ b/pyanaconda/storage/utils.py
@@ -185,7 +185,7 @@ def try_populate_devicetree(devicetree):
     them).
 
     :param devicetree: devicetree to try to populate
-    :type decicetree: :class:`blivet.devicetree.DeviceTree`
+    :type devicetree: :class:`blivet.devicetree.DeviceTree`
 
     """
 


### PR DESCRIPTION
This fixes some docstrings that have parameter names with typos or different from the actual method signatures.

Does not change any functionality.

No guarantees about completeness.