### PR TITLE
Remove duplicated definition of PayloadContainer

### DIFF
--- a/pyanaconda/modules/common/containers.py
+++ b/pyanaconda/modules/common/containers.py
@@ -42,11 +42,6 @@ PayloadContainer = DBusContainer(
     message_bus=DBus
 )
 
-PayloadContainer = DBusContainer(
-    namespace=PAYLOAD_NAMESPACE,
-    message_bus=DBus
-)
-
 PayloadSourceContainer = DBusContainer(
     namespace=SOURCE_NAMESPACE,
     message_bus=DBus


### PR DESCRIPTION
There are two consecutive identical definitions on `PayloadContainer`. This removes the second one.