### PR TITLE
Fix DBus error detection

### DIFF
--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -378,7 +378,7 @@ class ErrorHandler(object):
 
         if exn.__class__.__name__ in _map:
             rc = _map[exn.__class__.__name__](exn)
-        elif getattr(exn, "dbus_name") and exn.dbus_name in _dbus_map:
+        elif hasattr(exn, "dbus_name") and exn.dbus_name in _dbus_map:
             rc = _dbus_map[exn.dbus_name](exn)
 
         return rc

--- a/pyanaconda/installation_tasks.py
+++ b/pyanaconda/installation_tasks.py
@@ -450,7 +450,7 @@ class Task(BaseTask):
                 # we can handle.
                 if errors.errorHandler.cb(e) == errors.ERROR_RAISE:
                     log.error("Installation failed: %r", e)
-                    _failure_limbo()
+                    raise e
         else:
             log.error("Task %s callable not set.", self.name)
 


### PR DESCRIPTION
Use hasattr() instead of getattr() when trying to detect if an exception
comes from DBus. Otherwise the attempt would throw a traceback if an
unknown non-DBus exception is encountered.

Related: rhbz#1794767