### PR TITLE
network: fix GUI crash on invalid devices in the list

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -934,6 +934,8 @@ class NetworkControlBox(GObject.GObject):
             dt = "wired"
         elif dev_cfg.get_device_type() == NM.DeviceType.WIFI:
             dt = "wireless"
+        else:
+            return
 
         if dev_cfg.device:
             ipv4cfg = dev_cfg.device.get_ip4_config()
@@ -1038,6 +1040,8 @@ class NetworkControlBox(GObject.GObject):
             dt = "wired"
         elif dev_type == NM.DeviceType.WIFI:
             dt = "wireless"
+        else:
+            return
 
         # Speed
         speed = None
@@ -1104,6 +1108,8 @@ class NetworkControlBox(GObject.GObject):
             dev_type_str = "wired"
         elif dev_cfg.get_device_type() == NM.DeviceType.WIFI:
             dev_type_str = "wireless"
+        else:
+            return
 
         if dev_type_str == "wired":
             # update icon according to device status


### PR DESCRIPTION
Resolves: rhbz#1697256

This fix only tries to make sure GUI does not crash on invalid devices in
device list. Making sure such devices are not there is for another fix.

The invalid devices are appearing for example when vlan device IP configuration
fails.