### PR TITLE
Disable package download to / /tmp (#1781517)

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -67,9 +67,7 @@ DNF_CACHE_DIR = '/tmp/dnf.cache'
 DNF_PLUGINCONF_DIR = '/tmp/dnf.pluginconf'
 DNF_PACKAGE_CACHE_DIR_SUFFIX = 'dnf.package.cache'
 DNF_LIBREPO_LOG = '/tmp/dnf.librepo.log'
-DOWNLOAD_MPOINTS = {'/tmp',
-                    '/',
-                    '/var/tmp',
+DOWNLOAD_MPOINTS = {'/var/tmp',
                     '/mnt/sysimage',
                     '/mnt/sysimage/home',
                     '/mnt/sysimage/tmp',


### PR DESCRIPTION
The `/` and `/tmp` mount points aren't good candidates for package download.

During stage2 installation they are on TMPFS or squashfs. Both these systems gives you an abstract number when you asking for a free space. It's getting even more complicated in case when zram/zswap is involved.

During the image install you have /tmp as TMPFS and / as your root. This is pretty similar situation, we don't want to download packages there neither.

We are not able reliably tell user that the packages will be downloaded
correctly.

*Resolves: rhbz#1781517*