### PR TITLE
Use opts in geoloc instead of kernel_arguments

### DIFF
--- a/pyanaconda/geoloc.py
+++ b/pyanaconda/geoloc.py
@@ -20,21 +20,25 @@
 A GeoIP and WiFi location module - location detection based on IP address
 
 How to use the geolocation module
-   First call init_geolocation() with appropriate parameters - this creates the Geolocation singleton and
-   specifies what geolocation provider will be used.
+   First call init_geolocation() with appropriate parameters - this creates
+   the Geolocation singleton and specifies what geolocation provider will be
+   used.
 
-   To actually look up current position, call the refresh() function of the singleton,
-   this will trigger the actual online geolocation query, which runs in a thread.
+   To actually look up current position, call the refresh() function of the
+   singleton, this will trigger the actual online geolocation query, which
+   runs in a thread.
 
-   It's possible to wait for the lookup to finish by calling the wait_for_refresh_to_finish() method
-   of the singleton. If a lookup is in progress it will block until the lookup finishes or a timeout
-   is reached. If no lookup is in progress in till return at once.
+   It's possible to wait for the lookup to finish by calling the
+   wait_for_refresh_to_finish() method of the singleton. If a lookup is in
+   progress it will block until the lookup finishes or a timeout is reached.
+   If no lookup is in progress it will return at once.
 
    After the look-up thread finishes, the results are stored in the singleton
    and can be retrieved using the territory, timezone and result properties.
 
-   If you use these properties without calling refresh() first or if the look-up is currently
-   in progress or failed to return any results all properties will return None.
+   If you use these properties without calling refresh() first or if the
+   look-up is currently in progress or failed to return any results, all
+   properties will return None.
 
 ====================
 Geolocation backends
@@ -82,13 +86,13 @@ This could have severe privacy issues and should be carefully considered before
 enabling it to be used by default. Also the Google WiFi geolocation API seems to
 lack official documentation.
 
-As a result its long-term stability might not be guarantied.
+As a result its long-term stability might not be guaranteed.
 
 
 
 Possible issues with GeoIP
    "I'm in Switzerland connected to corporate VPN and anaconda tells me
-   I'm in Netherlands."
+   I'm in the Netherlands."
    The public IP address is not directly mapped to the physical location
    of a computer. So while your world visible IP address is registered to
    an IP block assigned to an ISP in Netherlands, it is just the external
@@ -148,7 +152,8 @@ class Geolocation(object):
         :param options_override:
         :type options_override: bool
         """
-        self._geolocation_enabled = self._check_if_geolocation_should_be_used(geoloc_option, options_override)
+        self._geolocation_enabled = self._check_if_geolocation_should_be_used(geoloc_option,
+                                                                              options_override)
         provider_id = constants.GEOLOC_DEFAULT_PROVIDER
 
         # check if a provider was specified by an option
@@ -469,7 +474,9 @@ class FedoraGeoIPProvider(GeolocationBackend):
 
     def _refresh(self):
         try:
-            reply = self._session.get(self.API_URL, timeout=constants.NETWORK_CONNECTION_TIMEOUT, verify=True)
+            reply = self._session.get(self.API_URL,
+                                      timeout=constants.NETWORK_CONNECTION_TIMEOUT,
+                                      verify=True)
             if reply.status_code == requests.codes.ok:
                 json_reply = reply.json()
                 territory = json_reply.get("country_code", None)
@@ -486,7 +493,8 @@ class FedoraGeoIPProvider(GeolocationBackend):
                                                     timezone=timezone_code,
                                                     timezone_source=timezone_source))
             else:
-                log.error("Geoloc: Fedora GeoIP API lookup failed with status code: %s", reply.status_code)
+                log.error("Geoloc: Fedora GeoIP API lookup failed with status code: %s",
+                          reply.status_code)
         except requests.exceptions.RequestException as e:
             log.debug("Geoloc: RequestException for Fedora GeoIP API lookup:\n%s", e)
         except ValueError as e:
@@ -504,7 +512,9 @@ class HostipGeoIPProvider(GeolocationBackend):
 
     def _refresh(self):
         try:
-            reply = self._session.get(self.API_URL, timeout=constants.NETWORK_CONNECTION_TIMEOUT, verify=True)
+            reply = self._session.get(self.API_URL,
+                                      timeout=constants.NETWORK_CONNECTION_TIMEOUT,
+                                      verify=True)
             if reply.status_code == requests.codes.ok:
                 reply_dict = reply.json()
                 territory = reply_dict.get("country_code", None)
@@ -539,8 +549,9 @@ class GoogleWiFiLocationProvider(GeolocationBackend):
         access_points = scanner.get_results()
         if access_points:
             try:
-                url = self._get_url(access_points)
-                reply = self._session.get(url, timeout=constants.NETWORK_CONNECTION_TIMEOUT, verify=True)
+                reply = self._session.get(self._get_url(access_points),
+                                          timeout=constants.NETWORK_CONNECTION_TIMEOUT,
+                                          verify=True)
                 result_dict = reply.json()
                 status = result_dict.get('status', 'NOT OK')
                 if status == 'OK':
@@ -632,14 +643,17 @@ class Geocoder(object):
             coordinates.latitude,
             coordinates.longitude)
         try:
-            reply = requests_session().get(url, timeout=constants.NETWORK_CONNECTION_TIMEOUT, verify=True)
+            reply = requests_session().get(url,
+                                           timeout=constants.NETWORK_CONNECTION_TIMEOUT,
+                                           verify=True)
             if reply.status_code == requests.codes.ok:
                 reply_dict = reply.json()
                 territory_code = reply_dict['address']['country_code'].upper()
                 return GeocodingResult(coordinates=coordinates,
                                        territory_code=territory_code)
             else:
-                log.error("Geoloc: Nominatim reverse geocoding failed with status code: %s", reply.status_code)
+                log.error("Geoloc: Nominatim reverse geocoding failed with status code: %s",
+                          reply.status_code)
                 return None
         except requests.exceptions.RequestException as e:
             log.debug("Geoloc: RequestException during Nominatim reverse geocoding:\n%s", e)


### PR DESCRIPTION
This makes `geoloc` behave like a normal Anaconda module should - read boot options from `opts` instead of looking at kernel cmdline with `kernel_arguments`.

First commit is the actual switch,
second cleans up the surrounding code,
third cleans up style & conventions in the file.