### PR TITLE
Don't set the device names (#1797274)

### DIFF
--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -181,7 +181,6 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
         self.storage.devicetree._devices = self._storage_playground.devicetree._devices
         self.storage.devicetree._actions = self._storage_playground.devicetree._actions
         self.storage.devicetree._hidden = self._storage_playground.devicetree._hidden
-        self.storage.devicetree.names = self._storage_playground.devicetree.names
         self.storage.roots = self._storage_playground.roots
 
         # set up bootloader and check the configuration

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -1023,7 +1023,6 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self.storage.devicetree._devices = self._storage_playground.devicetree._devices
         self.storage.devicetree._actions = self._storage_playground.devicetree._actions
         self.storage.devicetree._hidden = self._storage_playground.devicetree._hidden
-        self.storage.devicetree.names = self._storage_playground.devicetree.names
         self.storage.roots = self._storage_playground.roots
 
         # set up bootloader and check the configuration


### PR DESCRIPTION
When we are updating the state of our device tree, we shouldn't set the device
names. These names are calculated on demand in a property now.

Resolves: rhbz#1797274