### PR TITLE
Fix network & CDN installation source switching

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -43,7 +43,7 @@ from pyanaconda.core.constants import DRACUT_ISODIR, DRACUT_REPODIR, DD_ALL, DD_
     DD_RPMS, INSTALL_TREE, ISO_DIR, THREAD_STORAGE, THREAD_PAYLOAD, THREAD_PAYLOAD_RESTART, \
     THREAD_WAIT_FOR_CONNECTING_NM, THREAD_SUBSCRIPTION, PayloadRequirementType, \
     GRAPHICAL_TARGET, TEXT_ONLY_TARGET
-from pyanaconda.modules.common.constants.services import SERVICES
+from pyanaconda.modules.common.constants.services import SERVICES, SUBSCRIPTION, PAYLOAD
 from pykickstart.constants import GROUP_ALL, GROUP_DEFAULT, GROUP_REQUIRED
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _, N_
@@ -1635,6 +1635,7 @@ class PayloadManager(object):
     # Error strings
     ERROR_SETUP = N_("Failed to set up installation source")
     ERROR_MD = N_("Error downloading package metadata")
+    ERROR_NO_REGISTRATION = N_("Red Hat CDN requires registration")
 
     def __init__(self):
         self._event_lock = threading.Lock()
@@ -1785,8 +1786,19 @@ class PayloadManager(object):
 
         # Check if that failed
         if not payload.baseRepo:
-            log.error("No base repo configured")
-            self._error = self.ERROR_MD
+            # Missing base repo could be caused by CDN install source
+            # being set on a system that is not subscribed, let's check
+            # for that.
+            subscription_proxy = SUBSCRIPTION.get_proxy()
+            payload_proxy = PAYLOAD.get_proxy()
+            subscribed = subscription_proxy.IsSubscriptionAttached
+            cdn_source = payload_proxy.RedHatCDNEnabled
+            if cdn_source and not subscribed:
+                log.error("CDN set as installation source but system is not registered")
+                self._error = self.ERROR_NO_REGISTRATION
+            else:
+                log.error("No base repo configured")
+                self._error = self.ERROR_MD
             self._setState(self.STATE_ERROR)
             payload.unsetup()
             return

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -450,6 +450,12 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
                 return False
         elif self._hmcButton.get_active():
             self.data.method.method = "hmc"
+        elif self._cdnButton.get_active():
+            # clear method if the CDN button is active,
+            # otherwise a non CDN method (such as URL, etc.)
+            # will interfere with CDN being used as the
+            # installation source
+            self.data.method.method = None
         elif self._isoButton.get_active():
             # If the user didn't select a partition (not sure how that would
             # happen) or didn't choose a directory (more likely), then return
@@ -955,8 +961,8 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
         # something different later, we can change it.
         self._protocolComboBox.set_active_id(PROTOCOL_MIRROR)
 
-        if self._payload_module.proxy.RedHatCDNEnabled:
-            # prevent the Red Hat CDN from being overrun by method ad refresh time,
+        if not self.data.method.method and self._payload_module.proxy.RedHatCDNEnabled:
+            # prevent the Red Hat CDN from being overrun by method at refresh time,
             # if CDN was set as installation source before
             self._cdnButton.set_active(True)
         elif self.data.method.method == "url":


### PR DESCRIPTION
If the user requested a custom network installation source
(say via the inst.repo boot option), keep it as installation
source even if the system is then registered.

Also make sure that user can switch from such a network
installation source to CDN and back.

Resolves: rhbz#1791376

**NOTE:** WiP, not yet to be merged