### PR TITLE
Fix the function _del_xdg_runtime_dir

### DIFF
--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -118,7 +118,7 @@ def setup_environment():
         os.mkdir(os.environ["PYLINTHOME"])
 
 
-def _del_xdg_runtime_dir(self):
+def _del_xdg_runtime_dir():
     shutil.rmtree(os.environ["XDG_RUNTIME_DIR"])
 
 


### PR DESCRIPTION
Remove the useless argument `self` from the function `_del_xdg_runtime_dir`.