### PR TITLE
Handle the variant from GetResult (#1798392)

### DIFF
--- a/pyanaconda/modules/storage/checker/checker_interface.py
+++ b/pyanaconda/modules/storage/checker/checker_interface.py
@@ -36,4 +36,4 @@ class StorageCheckerInterface(InterfaceTemplate):
         :param value: a value of the constraint
         :raise: KeyError if the constraint does not exist
         """
-        self.implementation.set_constraint(name, value)
+        self.implementation.set_constraint(name, get_native(value))

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -32,6 +32,8 @@ import threading
 import re
 import ipaddress
 
+from dasbus.typing import get_native
+
 from pyanaconda.core.i18n import _
 from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.regexes import HOSTNAME_PATTERN_WITHOUT_ANCHORS, \
@@ -261,7 +263,7 @@ def run_network_initialization_task(task_path):
     task_proxy = NETWORK.get_proxy(task_path)
     log.debug("Running task %s", task_proxy.Name)
     sync_run_task(task_proxy)
-    result = task_proxy.GetResult()
+    result = get_native(task_proxy.GetResult())
     msg = "%s result: %s" % (task_proxy.Name, result)
     log.debug(msg)
 

--- a/pyanaconda/ui/gui/spokes/advstorage/iscsi.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/iscsi.py
@@ -18,6 +18,7 @@
 #
 
 from collections import namedtuple
+from dasbus.typing import unwrap_variant
 
 from pyanaconda.modules.common.errors.configuration import StorageDiscoveryError
 from pyanaconda.modules.common.task import async_run_task
@@ -203,7 +204,7 @@ class ISCSIDialog(GUIObject):
             self._discoveryErrorLabel.set_text(str(e))
             self._conditionNotebook.set_current_page(2)
         else:
-            nodes = task_proxy.GetResult()
+            nodes = unwrap_variant(task_proxy.GetResult())
             # Discovery succeeded.
             # Populate the node store.
             self._discovered_nodes = Node.from_structure_list(nodes)

--- a/tests/nosetests/pyanaconda_tests/module_storage_checker_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_checker_test.py
@@ -20,6 +20,7 @@
 import unittest
 from unittest.mock import patch
 
+from dasbus.typing import get_variant, Int
 from pyanaconda.core.constants import STORAGE_MIN_RAM
 from pyanaconda.modules.storage.checker import StorageCheckerModule
 from pyanaconda.modules.storage.checker.checker_interface import StorageCheckerInterface
@@ -36,5 +37,5 @@ class StorageCheckerInterfaceTestCase(unittest.TestCase):
     def set_constraint_test(self):
         """Test SetConstraint."""
         with patch.dict(storage_checker.constraints):
-            self.interface.SetConstraint(STORAGE_MIN_RAM, 987)
+            self.interface.SetConstraint(STORAGE_MIN_RAM, get_variant(Int, 987))
             self.assertEqual(storage_checker.constraints[STORAGE_MIN_RAM], 987)


### PR DESCRIPTION
The method GetResult of the interface TaskInterface returns a variant.
Unwrap or unpack the variant, so we can work with the variant value.

Resolves: rhbz#1798392