### PR TITLE
Add missing logs to the log-capture utility

### DIFF
--- a/scripts/log-capture
+++ b/scripts/log-capture
@@ -50,8 +50,10 @@ _to_log lsof
 _to_log ip -s li
 _to_log ip a
 _to_log ip r
+_to_log journalctl
 
 cp /tmp/*.log ${OUTDIR}
+cp /root/lorax-packages.log ${OUTDIR}
 
 if [[ -e /tmp/pre-anaconda-logs/ ]];then
     cp -r /tmp/pre-anaconda-logs ${OUTDIR}

--- a/scripts/log-capture
+++ b/scripts/log-capture
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-date=$(date +%F_%R)
+date=$(date +%F_%H%M%S)
 OUTDIR=/tmp/log-capture-${date}
 ARCHIVE=${1-/tmp/log-capture.tar.bz2}
 


### PR DESCRIPTION
The log-capture utility seems like a good thing for bug reports. However, it's missing a few interesting logs.

**Question:**
Do we want to add this to ``/usr/bin/``. Right now users have to type ``/usr/libexec/anaconda/log-capture`` to invoke this script. Installing this as a `anaconda-log-capture` could be easier to discover for users.

This could be even part of the documentation.


**Further improvements:**
We may extend this to automatically upload the tar file to an existing bugzilla with a BZ number as argument. 