### PR TITLE
Disable package download to / /tmp (#1781517)

### DIFF
--- a/pyanaconda/payload/dnfpayload.py
+++ b/pyanaconda/payload/dnfpayload.py
@@ -120,8 +120,6 @@ def _paced(fn):
 
 def _pick_mpoint(df, download_size, install_size, download_only):
     reasonable_mpoints = {
-        '/tmp',
-        '/',
         '/var/tmp',
         conf.target.system_root,
         os.path.join(conf.target.system_root, 'home'),


### PR DESCRIPTION
The / and /tmp mount points aren't good candidates for package download.

During stage2 installation they are on TMPFS or squashfs. Both these
systems gives you an abstract number when you asking for a free space.
It's getting even more complicated in case when zram/zswap is involved.

During the image install you have /tmp as TMPFS and / as your root. This
is pretty similar situation, we don't want to download packages there
neither.

We are not able reliably tell user that the packages will be downloaded
correctly.

*Resolves: rhbz#1781517*

Backport of https://github.com/rhinstaller/anaconda/pull/2299 .