### PR TITLE
Fix installation source switching to/from CDN

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -395,3 +395,12 @@ MOUNT_POINT_MOUNT_OPTIONS = "mount-options"
 RHSM_AUTH_NOT_SELECTED = -1
 RHSM_AUTH_USERNAME_PASSWORD = 0
 RHSM_AUTH_ORG_KEY = 1
+
+# Installation methods overriden by the CDN
+
+# This set lists methods the Red Hat CDN should automatically
+# override if the system gets registered during installation.
+# At the moment there is just the "cdrom" method, as almost
+# always the CDN content will be much more up to date and
+# more secure than the local content on the DVD image.
+INSTALLATION_METHODS_OVERRIDEN_BY_CDN = {"cdrom"}

--- a/pyanaconda/modules/payload/payload.py
+++ b/pyanaconda/modules/payload/payload.py
@@ -63,5 +63,6 @@ class PayloadModule(KickstartModule):
         return self._red_hat_cdn_enabled
 
     def set_red_hat_cdn_enabled(self, enabled):
+        log.debug("payload module: CDN enabled set to: %s", enabled)
         self._red_hat_cdn_enabled = enabled
         self.red_hat_cdn_enabled_changed.emit()


### PR DESCRIPTION
Fix various issues with switching between the Red Hat CDN
and a different source, such a on-media repos on a DVD image
or a user specified repository URL.

Also make sure repository priorities work as expected:
- if user provides repository URL via boot options or
  kickstart, it is always used, even on the boot ISO,
  where otherwise CDN is the default installation source
- on the DVD image the CDN should be automatically enabled
  once the user registers, as the on media content is generally
  outdated, while CDN content should be always up to date
- for a kickstart installation without a valid rhsm command
  from a DVD image the DVD image repository should be used
  as installation source without the need for specifying
  the "cdrom" command in kickstart

And lastly make sure Anaconda correctly falls back to the most
suitable installation source if CDN is set as installation source,
registers and then unregisters:
- if user provides repository URL via boot options or
  kickstart, then selects CDN, registers and then
  for some reason unregisters -> fall back to the URL source
- is user boots a DVD image, registers (this auto-activates CDN)
  and then unregisters -> fall back to local DVD repository

Resolves: rhbz#1791376
Resolves: rhbz#1790383
Resolves: rhbz#1788487