### PR TITLE
Detect HTTPS as a protocol that requires the network

### DIFF
--- a/pyanaconda/payload/__init__.py
+++ b/pyanaconda/payload/__init__.py
@@ -183,7 +183,7 @@ class Payload(metaclass=ABCMeta):
         :type sources: list
         :returns: True if any source requires network
         """
-        network_protocols = ["http:", "ftp:", "nfs:", "nfsiso:"]
+        network_protocols = ["http:", "https:", "ftp:", "nfs:", "nfsiso:"]
         for s in sources:
             if s and any(s.startswith(p) for p in network_protocols):
                 log.debug("Source %s needs network for installation", s)


### PR DESCRIPTION
Currently the network is not automatically set up if all the repos are
HTTPS, because HTTPS is not in the whitelist of protocols that require
a network connection.

Signed-off-by: Michel Alexandre Salim <michel@fb.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rhinstaller/anaconda/2321)
<!-- Reviewable:end -->
