### PR TITLE
Ignore the required package btrfs-progs in RHEL

### DIFF
--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -12,7 +12,10 @@ product_name = Red Hat Enterprise Linux
 default_on_boot = DEFAULT_ROUTE_DEVICE
 
 [Payload]
-ignored_packages = ntfsprogs
+ignored_packages =
+    ntfsprogs
+    btrfs-progs
+
 enable_updates = False
 enable_closest_mirror = False
 


### PR DESCRIPTION
The package btrfs-progs is not available in RHEL 8, so ignore this requirement.

Related: rhbz#1676403