### PR TITLE
Remove dead dracut code

### DIFF
--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -90,15 +90,6 @@ anaconda_live_root_dir() {
         img=$(find_runtime $repodir) || { warn "$iso has no suitable runtime"; }
         anaconda_auto_updates $repodir/images
     fi
-    # FIXME: make rd.live.ram clever enough to do this for us
-    if [ "$1" = "--copy-to-ram" ]; then
-        echo "Copying installer image to RAM..."
-        echo "(this may take a few minutes)"
-        cp $img /run/install/install.img
-        img=/run/install/install.img
-        umount $repodir
-        [ -n "$iso" ] && umount $isodir
-    fi
     anaconda_mount_sysroot $img
 }
 


### PR DESCRIPTION
**Clean-up time in Dracut!!!** :fireworks: :fireworks: 

Dracut has code to copy stage2 image to RAM. However, this is not used anymore (from 2012).

This code was added by:
99854685688efd9ee5d582953c790e264919dcc8

And disabled / not completely removed by:
adfcd4ba7bae513d4f51bf36ab37bc6fc0bdc28e

This code was used only for Anaconda upgrades and Anaconda does not handle upgrades long time. Git rid of it.