### PR TITLE
Fix the default disk selection (#1805553)

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -53,7 +53,7 @@ from pyanaconda.ui.gui.utils import escape_markup, ignoreEscape
 from pyanaconda.ui.helpers import StorageCheckHandler
 from pyanaconda.ui.lib.format_dasd import DasdFormatting
 from pyanaconda.ui.lib.storage import find_partitioning, apply_partitioning, \
-    select_all_disks_by_default, apply_disk_selection, get_disks_summary, create_partitioning, \
+    select_default_disks, apply_disk_selection, get_disks_summary, create_partitioning, \
     is_local_disk
 
 import gi
@@ -628,8 +628,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         hubQ.send_message(self.__class__.__name__, _(constants.PAYLOAD_STATUS_PROBING_STORAGE))
 
         # Update the selected disks.
-        if flags.automatedInstall:
-            select_all_disks_by_default()
+        select_default_disks()
 
         # Apply the partitioning. Do not set ready in the automated
         # installation before the execute method is run.

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -601,7 +601,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             description,
             kind,
             str(Size(device_data.size)),
-            _("{} free").format(free_space),
+            _("{} free").format(str(Size(free_space))),
             device_data.name,
             serial_number
         )

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -29,7 +29,7 @@ from pyanaconda.modules.common.structures.storage import DeviceFormatData, Devic
 from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.lib.storage import find_partitioning, reset_storage, \
-    select_all_disks_by_default, apply_disk_selection, get_disks_summary, apply_partitioning, \
+    select_default_disks, apply_disk_selection, get_disks_summary, apply_partitioning, \
     create_partitioning
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog, PasswordDialog
@@ -394,8 +394,7 @@ class StorageSpoke(NormalTUISpoke):
         DasdFormatting.run_automatically(disks)
 
         # Update the selected disks.
-        if flags.automatedInstall:
-            select_all_disks_by_default()
+        select_default_disks()
 
         # Storage is ready.
         self._ready = True


### PR DESCRIPTION
If there are some disks already selected, do nothing. In the automatic
installation, select all disks. In the interactive installation, select
a disk if there is only one available.

Convert bytes to a readable string representation of the size.