### PR TITLE
Add DBus methods GetDeviceMountOptions and SetDeviceMountOptions

### DIFF
--- a/pyanaconda/modules/storage/devicetree/handler.py
+++ b/pyanaconda/modules/storage/devicetree/handler.py
@@ -149,6 +149,29 @@ class DeviceTreeHandler(ABC):
         device.format.passphrase = passphrase
         self.storage.save_passphrase(device)
 
+    def get_device_mount_options(self, device_name):
+        """Get mount options of the specified device.
+
+        :param device_name: a name of the device
+        :return: a string with options
+        """
+        device = self._get_device(device_name)
+        return device.format.options or ""
+
+    def set_device_mount_options(self, device_name, mount_options):
+        """Set mount options of the specified device.
+
+        Specifies a free form string of options to be used when
+        mounting the filesystem. This string will be copied into
+        the /etc/fstab file of the installed system.
+
+        :param device_name: a name of the device
+        :param mount_options: a string with options
+        """
+        device = self._get_device(device_name)
+        device.format.options = mount_options or None
+        log.debug("Mount options of %s are set to '%s'.", device_name, mount_options)
+
     def find_devices_with_task(self):
         """Find new devices.
 

--- a/pyanaconda/modules/storage/devicetree/handler_interface.py
+++ b/pyanaconda/modules/storage/devicetree/handler_interface.py
@@ -91,6 +91,26 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
         """
         self.implementation.set_device_passphrase(device_name, passphrase)
 
+    def GetDeviceMountOptions(self, device_name: Str) -> Str:
+        """Get mount options of the specified device.
+
+        :param device_name: a name of the device
+        :return: a string with options
+        """
+        return self.implementation.get_device_mount_options(device_name)
+
+    def SetDeviceMountOptions(self, device_name: Str, mount_options: Str):
+        """Set mount options of the specified device.
+
+        Specifies a free form string of options to be used when
+        mounting the filesystem. This string will be copied into
+        the /etc/fstab file of the installed system.
+
+        :param device_name: a name of the device
+        :param mount_options: a string with options
+        """
+        self.implementation.set_device_mount_options(device_name, mount_options)
+
     def FindDevicesWithTask(self) -> ObjPath:
         """Find new devices.
 

--- a/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_device_tree_test.py
@@ -744,6 +744,38 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
         self.assertEqual(obj.implementation._devicetree, self.module.storage.devicetree)
 
+    def get_device_mount_options_test(self):
+        """Test GetDeviceMountOptions."""
+        dev1 = StorageDevice(
+            "dev1",
+            size=Size("10 GiB")
+        )
+        self._add_device(dev1)
+        self.assertEqual(self.interface.GetDeviceMountOptions("dev1"), "")
+
+        dev1.format = get_format("ext4")
+        dev1.format.options = "defaults,ro"
+        self.assertEqual(self.interface.GetDeviceMountOptions("dev1"), "defaults,ro")
+
+    def set_device_mount_options_test(self):
+        """Test SetDeviceMountOptions."""
+        dev1 = StorageDevice(
+            "dev1",
+            size=Size("10 GiB")
+        )
+        self._add_device(dev1)
+
+        self.interface.SetDeviceMountOptions("dev1", "auto")
+        self.assertEqual(dev1.format.options, "auto")
+
+        self.interface.SetDeviceMountOptions("dev1", "")
+        self.assertEqual(dev1.format.options, None)
+
+        dev1.format = get_format("ext4")
+        dev1.format.options = "defaults,ro"
+        self.interface.SetDeviceMountOptions("dev1", "")
+        self.assertEqual(dev1.format.options, "defaults")
+
 
 class DeviceTreeTasksTestCase(unittest.TestCase):
     """Test the storage tasks."""


### PR DESCRIPTION
Call the DBus methods GetDeviceMountOptions and SetDeviceMountOptions of
the DBus interface DeviceTreeHandlerInterface to get and set mount options
of a specified device. This functionality is required by the OSCAP addon.