### PR TITLE
Handle a failed bootloader installation (#1806103)

### DIFF
--- a/pyanaconda/bootloader/installation.py
+++ b/pyanaconda/bootloader/installation.py
@@ -18,11 +18,9 @@
 import os
 from glob import glob
 
-from pyanaconda.bootloader.base import BootLoaderError
 from pyanaconda.bootloader.image import LinuxBootLoaderImage
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.util import decode_bytes
-from pyanaconda.errors import errorHandler, ERROR_RAISE
 from pyanaconda.product import productName
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -150,6 +148,7 @@ def install_boot_loader(storage):
     """Do the final write of the boot loader.
 
     :param storage: an instance of the storage
+    :raise: BootLoaderError if the installation fails
     """
     log.debug("Installing the boot loader.")
 
@@ -159,12 +158,9 @@ def install_boot_loader(storage):
     stage2_device = storage.bootloader.stage2_device
     log.info("boot loader stage2 target device is %s", stage2_device.name)
 
+    # Set up the arguments.
     # FIXME: do this from elsewhere?
     storage.bootloader.set_boot_args(storage)
 
-    try:
-        storage.bootloader.write()
-    except BootLoaderError as e:
-        log.error("bootloader.write failed: %s", e)
-        if errorHandler.cb(e) == ERROR_RAISE:
-            raise
+    # Install the bootloader.
+    storage.bootloader.write()

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -18,6 +18,7 @@
 
 from pyanaconda.core.i18n import _, C_
 from pyanaconda.flags import flags
+from pyanaconda.modules.common.errors.installation import BootloaderInstallationError
 
 __all__ = ["ERROR_RAISE", "ERROR_CONTINUE", "ERROR_RETRY", "errorHandler", "InvalidImageSizeError",
            "MissingImageError", "ScriptError", "NonInteractiveError", "CmdlineError", "ExitError"]
@@ -324,7 +325,7 @@ class ErrorHandler(object):
                 "ScriptError": self._scriptErrorHandler,
                 "PayloadInstallError": self._payloadInstallHandler,
                 "DependencyError": self._dependencyErrorHandler,
-                "BootLoaderError": self._bootLoaderErrorHandler,
+                BootloaderInstallationError.__name__: self._bootLoaderErrorHandler,
                 "PasswordCryptError": self._passwordCryptErrorHandler,
                 "ZIPLError": self._ziplErrorHandler}
 

--- a/pyanaconda/modules/common/errors/installation.py
+++ b/pyanaconda/modules/common/errors/installation.py
@@ -67,3 +67,9 @@ class TimezoneConfigurationError(InstallationError):
 class SecurityInstallationError(InstallationError):
     """Exception for the security installation errors."""
     pass
+
+
+@dbus_error("BootloaderInstallationError", namespace=ANACONDA_NAMESPACE)
+class BootloaderInstallationError(InstallationError):
+    """Exception for the bootloader installation errors."""
+    pass

--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -19,8 +19,10 @@
 #
 from blivet import arch
 from blivet.devices import BTRFSDevice
+from pyanaconda.bootloader import BootLoaderError
 
 from pyanaconda.core.util import execInSysroot
+from pyanaconda.modules.common.errors.installation import BootloaderInstallationError
 from pyanaconda.modules.storage.constants import BootloaderMode
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -81,7 +83,10 @@ class InstallBootloaderTask(Task):
         return "Install the bootloader"
 
     def run(self):
-        """Run the task."""
+        """Run the task.
+
+        :raise: BootloaderInstallationError if the installation fails
+        """
         if conf.target.is_directory:
             log.debug("The bootloader installation is disabled for dir installations.")
             return
@@ -94,7 +99,11 @@ class InstallBootloaderTask(Task):
             log.debug("The bootloader installation is skipped.")
             return
 
-        install_boot_loader(storage=self._storage)
+        try:
+            install_boot_loader(storage=self._storage)
+        except BootLoaderError as e:
+            log.error("Bootloader installation has failed: %s", e)
+            raise BootloaderInstallationError(str(e)) from None
 
 
 class FixBTRFSBootloaderTask(Task):


### PR DESCRIPTION
If the bootloader installation fails, raise BootloaderInstallationError.
Map BootloaderInstallationError to the bootloader error handler, so UI
can show the correct dialog.

Resolves: rhbz#1806103
**Depends on:** https://github.com/rhinstaller/anaconda/pull/2334