### PR TITLE
Wait for entropy in the DBus Storage module

### DIFF
--- a/pyanaconda/installation_tasks.py
+++ b/pyanaconda/installation_tasks.py
@@ -19,8 +19,10 @@
 #
 from threading import RLock
 
+from dasbus.error import DBusError
 from pyanaconda.core.signal import Signal
 from pyanaconda.core.util import synchronized
+from pyanaconda.errors import errorHandler, ERROR_RAISE
 from pyanaconda.modules.common.task import sync_run_task
 import time
 
@@ -517,6 +519,10 @@ class DBusTask(Task):
 
             # Run the task.
             sync_run_task(self._task_proxy)
+        except DBusError as e:
+            # Handle a remote error.
+            if errorHandler.cb(e) == ERROR_RAISE:
+                raise
         finally:
             # Disconnect from the signal.
             self._task_proxy.ProgressChanged.disconnect()

--- a/pyanaconda/installation_tasks.py
+++ b/pyanaconda/installation_tasks.py
@@ -18,12 +18,15 @@
 # Red Hat, Inc.
 #
 from threading import RLock
+
 from pyanaconda.core.signal import Signal
 from pyanaconda.core.util import synchronized
 from pyanaconda.modules.common.task import sync_run_task
 import time
 
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.progress import progress_message
+
 log = get_module_logger(__name__)
 
 
@@ -332,7 +335,7 @@ class TaskQueue(BaseTask):
         """
         for dbus_task_path in dbus_tasks:
             task_proxy = service_id.get_proxy(dbus_task_path)
-            self.append(Task(task_proxy.Name, sync_run_task, (task_proxy,)))
+            self.append(DBusTask(task_proxy))
 
     @synchronized
     def insert(self, index, item):
@@ -490,3 +493,44 @@ class Task(BaseTask):
                 self._running = False
                 self._done = True
                 self._done_timestamp = time.time()
+
+
+class DBusTask(Task):
+    """Wrapper for a DBus installation task."""
+
+    def __init__(self, task_proxy):
+        """Create a new task.
+
+        :param task_proxy: a DBus proxy of the task
+        """
+        super().__init__(task_proxy.Name)
+        self._task_proxy = task_proxy
+        self._msg_counter = 0
+
+    def run_task(self):
+        """Run the DBus task."""
+        try:
+            # Report the progress messages.
+            self._task_proxy.ProgressChanged.connect(
+                self._show_message
+            )
+
+            # Run the task.
+            sync_run_task(self._task_proxy)
+        finally:
+            # Disconnect from the signal.
+            self._task_proxy.ProgressChanged.disconnect()
+
+    def _show_message(self, step, msg):
+        """Show a progress message.
+
+        Always drop the first message, because it is the same
+        as the name of the DBus task, so it was probably already
+        reported.
+
+        FIXME: Drop the ugly workaround for the first message.
+        """
+        self._msg_counter += 1
+
+        if self._msg_counter > 1:
+            progress_message(msg)

--- a/pyanaconda/modules/storage/installation.py
+++ b/pyanaconda/modules/storage/installation.py
@@ -17,7 +17,10 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from blivet import callbacks
+
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.i18n import _
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.modules.common.task import Task
 from pyanaconda.storage.installation import turn_on_filesystems, write_storage_configuration
@@ -47,7 +50,23 @@ class ActivateFilesystemsTask(Task):
                       "the installation to a directory.")
             return
 
-        turn_on_filesystems(self._storage)
+        register = callbacks.create_new_callbacks_register(
+            create_format_pre=self._report_message,
+            resize_format_pre=self._report_message,
+            wait_for_entropy=self._report_message
+        )
+
+        turn_on_filesystems(
+            self._storage,
+            callbacks=register
+        )
+
+    def _report_message(self, data):
+        """Report a Blivet message.
+
+        :param data: Blivet's callback data
+        """
+        self.report_progress(data.msg)
 
 
 class MountFilesystemsTask(Task):

--- a/pyanaconda/modules/storage/installation.py
+++ b/pyanaconda/modules/storage/installation.py
@@ -17,7 +17,11 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from datetime import timedelta
+from time import sleep
+
 from blivet import callbacks
+from blivet.util import get_current_entropy
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
@@ -34,10 +38,15 @@ __all__ = ["ActivateFilesystemsTask", "MountFilesystemsTask", "WriteConfiguratio
 class ActivateFilesystemsTask(Task):
     """Installation task for activation of the storage configuration."""
 
-    def __init__(self, storage):
-        """Create a new task."""
+    def __init__(self, storage, entropy_timeout=600):
+        """Create a new task.
+
+        :param storage: the storage model
+        :param entropy_timeout: a number of seconds for entropy gathering
+        """
         super().__init__()
         self._storage = storage
+        self._entropy_timeout = entropy_timeout
 
     @property
     def name(self):
@@ -53,7 +62,7 @@ class ActivateFilesystemsTask(Task):
         register = callbacks.create_new_callbacks_register(
             create_format_pre=self._report_message,
             resize_format_pre=self._report_message,
-            wait_for_entropy=self._report_message
+            wait_for_entropy=self._wait_for_entropy
         )
 
         turn_on_filesystems(
@@ -67,6 +76,56 @@ class ActivateFilesystemsTask(Task):
         :param data: Blivet's callback data
         """
         self.report_progress(data.msg)
+
+    def _wait_for_entropy(self, data):
+        """Wait for entropy.
+
+        :param data: Blivet's callback data
+        :return: True if we are out of time, otherwise False
+        """
+        log.debug(data.msg)
+        required_entropy = data.min_entropy
+        total_time = self._entropy_timeout
+        current_time = 0
+
+        while True:
+            # Report the current status.
+            current_entropy = get_current_entropy()
+            current_percents = min(int(current_entropy / required_entropy * 100), 100)
+            remaining_time = max(total_time - current_time, 0)
+            self._report_entropy_message(current_percents, remaining_time)
+
+            sleep(5)
+            current_time += 5
+
+            # Enough entropy gathered.
+            if current_percents == 100:
+                return False
+
+            # Out of time.
+            if remaining_time == 0:
+                return True
+
+    def _report_entropy_message(self, percents, time):
+        """Report an entropy message.
+
+        :param percents: the percentage of gathered entropy
+        :param time: a number of seconds of remaining time
+        """
+        if percents == 100:
+            self.report_progress(_("Gathering entropy 100%"))
+            return
+
+        if time == 0:
+            self.report_progress(_("Gathering entropy (time ran out)"))
+            return
+
+        message = _("Gathering entropy {percents}% (remaining time {time})").format(
+            percents=percents,
+            time=timedelta(seconds=time)
+        )
+
+        self.report_progress(message)
 
 
 class MountFilesystemsTask(Task):


### PR DESCRIPTION
The installation task ActivateFilesystemsTask should report Blivet's messages.

The task ActivateFilesystemsTask should report that the entropy is lower than
requested and wait for a limited time to increase it.

Connect to the ProgressChanged signal of the DBus tasks and show their progress
messages. Always drop the first message, because it is the same as the name of
the DBus task, so it was probably already shown.

If a DBus installation task raises an error, call the error handler to
show a correct dialog.