### PR TITLE
network: fix GUI crash on invalid devices in the list

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -810,6 +810,8 @@ class NetworkControlBox(GObject.GObject):
             dt = "wired"
         elif dev_cfg.device_type  == NM.DeviceType.WIFI:
             dt = "wireless"
+        else:
+            return
 
         device = self.client.get_device_by_iface(dev_cfg.device_name)
         if device:
@@ -920,6 +922,8 @@ class NetworkControlBox(GObject.GObject):
             dt = "wired"
         elif dev_type == NM.DeviceType.WIFI:
             dt = "wireless"
+        else:
+            return
 
         device = self.client.get_device_by_iface(dev_cfg.device_name)
 
@@ -990,6 +994,8 @@ class NetworkControlBox(GObject.GObject):
             dev_type_str = "wired"
         elif dev_cfg.device_type == NM.DeviceType.WIFI:
             dev_type_str = "wireless"
+        else:
+            return
 
         if dev_type_str == "wired":
             # update icon according to device status


### PR DESCRIPTION
Resolves: rhbz#1697256

This fix only tries to make sure GUI does not crash on invalid devices in
device list. Making sure such devices are not there is for another fix.

The invalid devices are appearing for example when vlan device IP configuration
fails.