### PR TITLE
Start live CD with explicit GUI (#1765650)

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -63,7 +63,7 @@ systemctl start zram.service
 # Allow running another command in the place of anaconda, but in this same
 # environment.  This allows storage testing to make use of all the module
 # loading and lvm control in this file, too.
-ANACONDA="${LIVECMD:=anaconda --liveinst --method=livecd:${LIVE_BLOCK}}"
+ANACONDA="${LIVECMD:=anaconda --liveinst --method=livecd:${LIVE_BLOCK} --graphical}"
 
 # load modules that would get loaded by the initramfs (#230945)
 for i in raid0 raid1 raid5 raid6 raid456 raid10 dm-mod dm-zero dm-mirror dm-snapshot dm-multipath dm-round-robin vfat dm-crypt cbc sha256 lrw xts iscsi_tcp iscsi_ibft; do /sbin/modprobe $i 2>/dev/null ; done


### PR DESCRIPTION
This prevents cases where unrelated use of `console=` for kernel is misunderstood as an instruction to use TUI instead of GUI.

Resolves: [rhbz#1765650](https://bugzilla.redhat.com/show_bug.cgi?id=1765650)