### PR TITLE
Handle storage errors in UI (#1808650)

### DIFF
--- a/pyanaconda/bootloader/zipl.py
+++ b/pyanaconda/bootloader/zipl.py
@@ -21,18 +21,12 @@ import re
 from pyanaconda.bootloader.base import BootLoader, Arguments, BootLoaderError
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.errors import errorHandler
 from pyanaconda.product import productName
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 __all__ = ["ZIPL"]
-
-
-class ZIPLError(Exception):
-    """An exception class for ZIPL errors."""
-    pass
 
 
 class ZIPL(BootLoader):
@@ -162,7 +156,7 @@ class ZIPL(BootLoader):
             # exceed 896 bytes; there is nothing we can do about this, so just
             # catch the error and show it to the user instead of crashing
             elif line.startswith("Error: The length of the parameters "):
-                errorHandler.cb(ZIPLError(line))
+                raise BootLoaderError(line)
 
         if not self.stage1_name:
             raise BootLoaderError("could not find IPL device")

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -18,7 +18,8 @@
 
 from pyanaconda.core.i18n import _, C_
 from pyanaconda.flags import flags
-from pyanaconda.modules.common.errors.installation import BootloaderInstallationError
+from pyanaconda.modules.common.errors.installation import BootloaderInstallationError, \
+    StorageInstallationError
 from pyanaconda.modules.common.errors.storage import UnusableStorageError
 
 __all__ = ["ERROR_RAISE", "ERROR_CONTINUE", "ERROR_RETRY", "errorHandler", "InvalidImageSizeError",
@@ -107,13 +108,11 @@ class ErrorHandler(object):
     def __init__(self, ui=None):
         self.ui = ui
 
-    def _fsResizeHandler(self, exn):
-        message = _("An error occurred while resizing the device %s.") % exn
+    def _storage_install_handler(self, exn):
+        message = _("An error occurred while activating your storage configuration.")
+        details = str(exn)
 
-        if exn.details:
-            message += "\n\n%s" % exn.details
-
-        self.ui.showError(message)
+        self.ui.showDetailedError(message, details)
         return ERROR_RAISE
 
     def _storage_reset_handler(self, exn):
@@ -280,7 +279,7 @@ class ErrorHandler(object):
             raise NonInteractiveError("Non interactive installation failed: %s" % exn)
 
         _map = {
-            "FSResizeError": self._fsResizeHandler,
+            StorageInstallationError.__name__: self._storage_install_handler,
             UnusableStorageError.__name__: self._storage_reset_handler,
             "InvalidImageSizeError": self._invalidImageSizeHandler,
             "MissingImageError": self._missingImageHandler,

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -133,13 +133,6 @@ class ErrorHandler(object):
         else:
             return ERROR_RAISE
 
-    def _noDisksHandler(self, exn):
-        message = _("An error has occurred - no valid devices were found on "
-                    "which to create new file systems.  Please check your "
-                    "hardware for the cause of this problem.")
-        self.ui.showError(message)
-        return ERROR_RAISE
-
     def _fstabTypeMismatchHandler(self, exn):
         # FIXME: include the two types in the message instead of including
         #        the raw exception text
@@ -306,7 +299,6 @@ class ErrorHandler(object):
         _map = {
             "FSResizeError": self._fsResizeHandler,
             UnusableStorageError.__name__: self._storage_reset_handler,
-            "NoDisksError": self._noDisksHandler,
             "FSTabTypeMismatchError": self._fstabTypeMismatchHandler,
             "InvalidImageSizeError": self._invalidImageSizeHandler,
             "MissingImageError": self._missingImageHandler,

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -107,12 +107,6 @@ class ErrorHandler(object):
     def __init__(self, ui=None):
         self.ui = ui
 
-    def _partitionErrorHandler(self, exn):
-        message = _("The following errors occurred with your partitioning:\n\n%(errortxt)s\n\n"
-                    "The installation will now terminate.") % {"errortxt": exn}
-        self.ui.showError(message)
-        return ERROR_RAISE
-
     def _fsResizeHandler(self, exn):
         message = _("An error occurred while resizing the device %s.") % exn
 
@@ -310,7 +304,6 @@ class ErrorHandler(object):
             raise NonInteractiveError("Non interactive installation failed: %s" % exn)
 
         _map = {
-            "PartitioningError": self._partitionErrorHandler,
             "FSResizeError": self._fsResizeHandler,
             UnusableStorageError.__name__: self._storage_reset_handler,
             "NoDisksError": self._noDisksHandler,

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -133,14 +133,6 @@ class ErrorHandler(object):
         else:
             return ERROR_RAISE
 
-    def _fstabTypeMismatchHandler(self, exn):
-        # FIXME: include the two types in the message instead of including
-        #        the raw exception text
-        message = _("There is an entry in your /etc/fstab file that contains "
-                    "an invalid or incorrect file system type:\n\n")
-        message += " " + str(exn)
-        self.ui.showError(message)
-
     def _invalidImageSizeHandler(self, exn):
         message = _("The ISO image %s has a size which is not "
                     "a multiple of 2048 bytes.  This may mean "
@@ -290,7 +282,6 @@ class ErrorHandler(object):
         _map = {
             "FSResizeError": self._fsResizeHandler,
             UnusableStorageError.__name__: self._storage_reset_handler,
-            "FSTabTypeMismatchError": self._fstabTypeMismatchHandler,
             "InvalidImageSizeError": self._invalidImageSizeHandler,
             "MissingImageError": self._missingImageHandler,
             "NoSuchGroup": self._noSuchGroupHandler,

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -269,15 +269,6 @@ class ErrorHandler(object):
         self.ui.showError(message)
         return ERROR_RAISE
 
-    def _ziplErrorHandler(self, exn):
-        details = str(exn)
-        message = _("Installation was stopped due to an error installing the "
-                    "boot loader. The exact error message is:\n\n%s\n\n"
-                    "The installer will now terminate.") % details
-
-        self.ui.showError(message)
-        return ERROR_RAISE
-
     def cb(self, exn):
         """This method is the callback that all error handling should pass
            through.  The return value is one of the ERROR_* constants defined
@@ -311,7 +302,6 @@ class ErrorHandler(object):
             "DependencyError": self._dependencyErrorHandler,
             BootloaderInstallationError.__name__: self._bootLoaderErrorHandler,
             "PasswordCryptError": self._passwordCryptErrorHandler,
-            "ZIPLError": self._ziplErrorHandler
         }
 
         if exn.__class__.__name__ in _map:

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -41,6 +41,7 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import THREAD_EXCEPTION_HANDLING_TEST, IPMI_FAILED
 from pyanaconda.errors import NonInteractiveError
 from pyanaconda.core.i18n import _
+from pyanaconda.modules.common.errors.storage import UnusableStorageError
 from pyanaconda.threading import threadMgr
 from pyanaconda.ui.communication import hubQ
 
@@ -111,7 +112,7 @@ class AnacondaExceptionHandler(ExceptionHandler):
                              "The installer will now terminate.") % str(value)
             self.intf.messageWindow(_("Hardware error occurred"), hw_error_msg)
             sys.exit(0)
-        elif isinstance(value, blivet.errors.UnusableConfigurationError):
+        elif isinstance(value, UnusableStorageError):
             sys.exit(0)
         elif isinstance(value, NonInteractiveError):
             sys.exit(0)

--- a/pyanaconda/modules/common/errors/installation.py
+++ b/pyanaconda/modules/common/errors/installation.py
@@ -73,3 +73,9 @@ class SecurityInstallationError(InstallationError):
 class BootloaderInstallationError(InstallationError):
     """Exception for the bootloader installation errors."""
     pass
+
+
+@dbus_error("StorageInstallationError", namespace=ANACONDA_NAMESPACE)
+class StorageInstallationError(InstallationError):
+    """Exception for the storage installation errors."""
+    pass

--- a/pyanaconda/modules/common/errors/storage.py
+++ b/pyanaconda/modules/common/errors/storage.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from blivet.errors import StorageError
 from dasbus.error import dbus_error
 from pyanaconda.modules.common.constants.namespaces import STORAGE_NAMESPACE
 from pyanaconda.modules.common.errors import AnacondaError
@@ -80,8 +79,3 @@ class DeviceSetupError(AnacondaError):
 class MountFilesystemError(AnacondaError):
     """Failed to un/mount a filesystem."""
     pass
-
-
-# Define mapping for existing exceptions.
-# FIXME: This is a temporary solution for the interactive partitioning.
-dbus_error("StorageError", namespace=STORAGE_NAMESPACE)(StorageError)

--- a/pyanaconda/modules/common/errors/storage.py
+++ b/pyanaconda/modules/common/errors/storage.py
@@ -34,6 +34,12 @@ class UnavailableDataError(AnacondaError):
     pass
 
 
+@dbus_error("UnusableStorageError", namespace=STORAGE_NAMESPACE)
+class UnusableStorageError(AnacondaError):
+    """The storage model is not usable."""
+    pass
+
+
 @dbus_error("InvalidStorageError", namespace=STORAGE_NAMESPACE)
 class InvalidStorageError(AnacondaError):
     """The storage model is not valid."""

--- a/pyanaconda/storage/fsset.py
+++ b/pyanaconda/storage/fsset.py
@@ -31,6 +31,7 @@ from blivet.formats import get_format, get_device_format_class
 from blivet.storage_log import log_exception_info
 
 from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.core.i18n import _
 from pyanaconda.errors import errorHandler as error_handler, ERROR_RAISE
 from pyanaconda.platform import platform as _platform, EFI
 
@@ -386,8 +387,15 @@ class FSSet(object):
                 device.format = fmt
             else:
                 device.teardown()
-                raise FSTabTypeMismatchError("%s: detected as %s, fstab says %s"
-                                             % (mountpoint, dtype, ftype))
+                raise FSTabTypeMismatchError(_(
+                    "There is an entry in your /etc/fstab file that contains "
+                    "an invalid or incorrect file system type. The file says that "
+                    "{detected_type} at {mount_point} is {fstab_type}.").format(
+                    detected_type=dtype,
+                    mount_point=mountpoint,
+                    fstab_type=ftype
+                ))
+
         del ftype
         del dtype
 

--- a/pyanaconda/storage/fsset.py
+++ b/pyanaconda/storage/fsset.py
@@ -26,13 +26,12 @@ from gi.repository import BlockDev as blockdev
 
 from blivet.devices import NoDevice, DirectoryDevice, NFSDevice, FileDevice, MDRaidArrayDevice, \
     NetworkStorageDevice, OpticalDevice
-from blivet.errors import UnrecognizedFSTabEntryError, FSTabTypeMismatchError, StorageError
+from blivet.errors import UnrecognizedFSTabEntryError, FSTabTypeMismatchError
 from blivet.formats import get_format, get_device_format_class
 from blivet.storage_log import log_exception_info
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.i18n import _
-from pyanaconda.errors import errorHandler as error_handler, ERROR_RAISE
 from pyanaconda.platform import platform as _platform, EFI
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -502,9 +501,6 @@ class FSSet(object):
                         blockdev.SwapUnknownError, blockdev.SwapPagesizeError) as e:
                     log.error("Failed to activate swap on '%s': %s", device.name, str(e))
                     break
-                except (StorageError, blockdev.BlockDevError) as e:
-                    if error_handler.cb(e) == ERROR_RAISE:
-                        raise
                 else:
                     break
 
@@ -551,25 +547,14 @@ class FSSet(object):
                 else:
                     device.parents = [parent]
 
-            try:
-                device.setup()
-            except Exception as e:  # pylint: disable=broad-except
-                log_exception_info(fmt_str="unable to set up device %s", fmt_args=[device])
-                if error_handler.cb(e) == ERROR_RAISE:
-                    raise
-                else:
-                    continue
-
             if read_only:
                 options = "%s,%s" % (options, read_only)
 
-            try:
-                device.format.setup(options=options,
-                                    chroot=root_path)
-            except Exception as e:  # pylint: disable=broad-except
-                log_exception_info(log.error, "error mounting %s on %s", [device.path, device.format.mountpoint])
-                if error_handler.cb(e) == ERROR_RAISE:
-                    raise
+            device.setup()
+            device.format.setup(
+                options=options,
+                chroot=root_path
+            )
 
         self.active = True
 

--- a/pyanaconda/storage/installation.py
+++ b/pyanaconda/storage/installation.py
@@ -23,10 +23,8 @@ gi.require_version("BlockDev", "2.0")
 from gi.repository import BlockDev as blockdev
 
 from blivet import util as blivet_util, arch
-from blivet.errors import FSResizeError, FormatResizeError
 
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.errors import errorHandler as error_handler, ERROR_RAISE
 from pyanaconda.modules.common.constants.objects import FCOE, ZFCP, ISCSI
 from pyanaconda.modules.common.constants.services import STORAGE
 
@@ -45,15 +43,9 @@ def turn_on_filesystems(storage, callbacks=None):
     :type callbacks: return value of the :func:`blivet.callbacks.create_new_callbacks_register`
     """
     storage.devicetree.teardown_all()
-
-    try:
-        storage.do_it(callbacks)
-        _setup_bootable_devices(storage)
-        storage.dump_state("final")
-    except (FSResizeError, FormatResizeError) as e:
-        if error_handler.cb(e) == ERROR_RAISE:
-            raise
-
+    storage.do_it(callbacks)
+    _setup_bootable_devices(storage)
+    storage.dump_state("final")
     storage.turn_on_swap()
 
 

--- a/pyanaconda/ui/gui/spokes/lib/detailederror.glade
+++ b/pyanaconda/ui/gui/spokes/lib/detailederror.glade
@@ -24,6 +24,7 @@
             <property name="xalign">0</property>
             <property name="label" translatable="yes">An unknown error occurred during installation.  Details are below.</property>
             <property name="wrap">True</property>
+            <property name="max_width_chars">60</property>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/pyanaconda/ui/lib/storage.py
+++ b/pyanaconda/ui/lib/storage.py
@@ -15,8 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from blivet.errors import StorageError
 from blivet.size import Size
+from dasbus.error import DBusError
 
 from dasbus.typing import unwrap_variant
 from dasbus.client.proxy import get_object_path
@@ -90,7 +90,7 @@ def reset_storage(scan_all=False, retry=True):
             task_path = storage_proxy.ScanDevicesWithTask()
             task_proxy = STORAGE.get_proxy(task_path)
             sync_run_task(task_proxy)
-        except StorageError as e:
+        except DBusError as e:
             # Is the retry allowed?
             if not retry:
                 raise
@@ -249,7 +249,7 @@ def try_populate_devicetree():
             task_path = device_tree.FindDevicesWithTask()
             task_proxy = STORAGE.get_proxy(task_path)
             sync_run_task(task_proxy)
-        except StorageError as e:
+        except DBusError as e:
             if error_handler.cb(e) == ERROR_RAISE:
                 raise
             else:

--- a/tests/gettext_tests/style_guide.py
+++ b/tests/gettext_tests/style_guide.py
@@ -58,6 +58,9 @@ expected_badness = {
     },
     'pyanaconda/startup_utils.py': {
         'HOSTNAME': 1,    # ssh to install@HOSTNAME
+    },
+    'pyanaconda/storage/fsset.py': {
+        'mountpoint': 1,  # format string specifier mount_point
     }
 }
 


### PR DESCRIPTION
Update the error handlers of the storage-related exceptions.
Replace exceptions with DBus errors and make sure that these
errors will be raised when it is expected.

Remove the error handler from the DBus Storage module.

Resolves: rhbz#1808650