### PR TITLE
Always use the Anaconda's kickstart version

### DIFF
--- a/pyanaconda/core/kickstart/specification.py
+++ b/pyanaconda/core/kickstart/specification.py
@@ -19,8 +19,8 @@
 #
 from pykickstart.base import KickstartHandler
 from pykickstart.parser import KickstartParser
-from pykickstart.version import DEVEL
 
+from pyanaconda.core.kickstart.version import VERSION
 from pyanaconda.core.kickstart.addon import AddonSection, AddonRegistry
 
 __all__ = ["KickstartSpecification", "NoKickstartSpecification",
@@ -56,7 +56,7 @@ class KickstartSpecification(object):
 
     """
 
-    version = DEVEL
+    version = VERSION
     commands = {}
     commands_data = {}
     sections = {}

--- a/pyanaconda/modules/localization/kickstart.py
+++ b/pyanaconda/modules/localization/kickstart.py
@@ -17,12 +17,10 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.core.kickstart import VERSION, KickstartSpecification, commands as COMMANDS
+from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
 
 
 class LocalizationKickstartSpecification(KickstartSpecification):
-
-    version = VERSION
 
     commands = {
         "keyboard": COMMANDS.Keyboard,

--- a/pyanaconda/modules/network/kickstart.py
+++ b/pyanaconda/modules/network/kickstart.py
@@ -17,7 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.core.kickstart import VERSION, KickstartSpecification, commands as COMMANDS
+from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
 
 DEFAULT_DEVICE_SPECIFICATION = "link"
 
@@ -35,8 +35,6 @@ class Network(COMMANDS.Network):
 
 
 class NetworkKickstartSpecification(KickstartSpecification):
-
-    version = VERSION
 
     commands = {
         "network": Network,

--- a/pyanaconda/modules/payloads/kickstart.py
+++ b/pyanaconda/modules/payloads/kickstart.py
@@ -24,7 +24,7 @@ from pykickstart.constants import KS_BROKEN_IGNORE
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.i18n import _
-from pyanaconda.core.kickstart import VERSION, KickstartSpecification, commands as COMMANDS
+from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
 
 
 class AnacondaPackageSection(PackageSection):
@@ -45,8 +45,6 @@ class AnacondaPackageSection(PackageSection):
 
 
 class PayloadKickstartSpecification(KickstartSpecification):
-
-    version = VERSION
 
     commands = {
         "liveimg": COMMANDS.Liveimg

--- a/pyanaconda/modules/security/kickstart.py
+++ b/pyanaconda/modules/security/kickstart.py
@@ -17,12 +17,10 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.core.kickstart import VERSION, KickstartSpecification, commands as COMMANDS
+from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
 
 
 class SecurityKickstartSpecification(KickstartSpecification):
-
-    version = VERSION
 
     commands = {
         "auth": COMMANDS.Authconfig,

--- a/pyanaconda/modules/services/kickstart.py
+++ b/pyanaconda/modules/services/kickstart.py
@@ -17,12 +17,11 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.core.kickstart import VERSION, KickstartSpecification, commands as COMMANDS
+from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
 
 
 class ServicesKickstartSpecification(KickstartSpecification):
 
-    version = VERSION
     commands = {
         "firstboot": COMMANDS.Firstboot,
         "services": COMMANDS.Services,

--- a/pyanaconda/modules/storage/kickstart.py
+++ b/pyanaconda/modules/storage/kickstart.py
@@ -29,7 +29,7 @@ from pykickstart.errors import KickstartParseError
 from pyanaconda.network import get_supported_devices, wait_for_network_devices
 from pyanaconda.modules.common.constants.services import NETWORK
 from pyanaconda.core.i18n import _
-from pyanaconda.core.kickstart import VERSION, KickstartSpecification, commands as COMMANDS
+from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
 from pyanaconda.storage.utils import device_matches
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -262,8 +262,6 @@ class ZFCP(COMMANDS.ZFCP):
 
 class StorageKickstartSpecification(KickstartSpecification):
     """Kickstart specification of the storage module."""
-
-    version = VERSION
 
     commands = {
         "autopart": AutoPart,

--- a/pyanaconda/modules/timezone/kickstart.py
+++ b/pyanaconda/modules/timezone/kickstart.py
@@ -17,12 +17,10 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.core.kickstart import VERSION, KickstartSpecification, commands as COMMANDS
+from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
 
 
 class TimezoneKickstartSpecification(KickstartSpecification):
-
-    version = VERSION
 
     commands = {
         "timezone": COMMANDS.Timezone,

--- a/pyanaconda/modules/users/kickstart.py
+++ b/pyanaconda/modules/users/kickstart.py
@@ -17,12 +17,11 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.core.kickstart import VERSION, KickstartSpecification, commands as COMMANDS
+from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
 
 
 class UsersKickstartSpecification(KickstartSpecification):
 
-    version = VERSION
     commands = {
         "rootpw": COMMANDS.RootPw,
         "user": COMMANDS.User,


### PR DESCRIPTION
The kickstart specification should use the Anaconda's kickstart version by
default. It means, that Anaconda DBus modules don't have to specify it in
their specifications.