### PR TITLE
Fix action buttons in the resize dialog (#1809950)

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -366,7 +366,14 @@ class ResizeDialog(GUIObject):
         self._resize_slider.add_mark(min_size, Gtk.PositionType.BOTTOM, str(Size(min_size)))
         self._resize_slider.add_mark(max_size, Gtk.PositionType.BOTTOM, str(Size(max_size)))
 
-    def _update_action_buttons(self, row):
+    def _update_action_buttons(self):
+        # Update buttons for the selected row.
+        itr = self._selection.get_selected()[1]
+
+        if not itr:
+            return
+
+        row = self._disk_store[itr]
         obj = PartStoreRow(*row)
 
         self._preserve_button.set_sensitive(obj.editable)
@@ -512,7 +519,7 @@ class ResizeDialog(GUIObject):
         self._disk_store.foreach(self._sum_reclaimable_space, None)
         self._update_labels(selected_reclaimable=self._selected_reclaimable_space)
         self._update_reclaim_button(self._selected_reclaimable_space)
-        self._update_action_buttons(selected_row)
+        self._update_action_buttons()
 
     def _schedule_actions(self, model, path, itr, *args):
         obj = PartStoreRow(*model[itr])
@@ -574,12 +581,7 @@ class ResizeDialog(GUIObject):
         # selection.  Thus, clicking on a disk header to collapse it and then
         # immediately clicking on it again to expand it would not work when
         # dealt with here.
-        itr = selection.get_selected()[1]
-
-        if not itr:
-            return
-
-        self._update_action_buttons(self._disk_store[itr])
+        self._update_action_buttons()
 
     @timed_action(delay=200, threshold=500, busy_cursor=False)
     def on_resize_value_changed(self, rng):

--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -368,20 +368,19 @@ class ResizeDialog(GUIObject):
 
     def _update_action_buttons(self, row):
         obj = PartStoreRow(*row)
-        device_name = obj.name
-        device_data = DeviceData.from_structure(
-            self._device_tree.GetDeviceData(device_name)
-        )
 
-        # Disks themselves may be editable in certain ways, but they are never
-        # shrinkable.
         self._preserve_button.set_sensitive(obj.editable)
-        self._shrink_button.set_sensitive(obj.editable and not device_data.is_disk)
+        self._shrink_button.set_sensitive(obj.editable)
         self._delete_button.set_sensitive(obj.editable)
         self._resize_slider.set_visible(False)
 
         if not obj.editable:
             return
+
+        device_name = obj.name
+        device_data = DeviceData.from_structure(
+            self._device_tree.GetDeviceData(device_name)
+        )
 
         # If the selected filesystem does not support shrinking, make that
         # button insensitive.


### PR DESCRIPTION
If the selected row in the resize dialog is not editable, just make all action
buttons insensitive and quit. The shrink button can be sensitive only for
editable rows with resizable devices.

Never update action buttons for other rows then the selected one. Otherwise,
the resize dialog will be in an invalid state and could crash with an exception.

Resolves: rhbz#1809950