### PR TITLE
Move functions from pyanaconda.storage.utils

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -643,11 +643,11 @@ if __name__ == "__main__":
     disk_select_proxy.SetDiskImages(disk_images)
 
     # Ignore disks labeled OEMDRV
-    from pyanaconda.storage.utils import ignore_oemdrv_disks
+    from pyanaconda.ui.lib.storage import ignore_oemdrv_disks
     ignore_oemdrv_disks()
 
     # Ignore nvdimm devices.
-    from pyanaconda.storage.utils import ignore_nvdimm_blockdevs
+    from pyanaconda.ui.lib.storage import ignore_nvdimm_blockdevs
     ignore_nvdimm_blockdevs()
 
     # Specify protected devices.

--- a/pyanaconda/bootloader/execution.py
+++ b/pyanaconda/bootloader/execution.py
@@ -26,7 +26,7 @@ from pyanaconda.core.constants import BOOTLOADER_ENABLED, BOOTLOADER_SKIPPED, \
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.constants.objects import BOOTLOADER
 from pyanaconda.modules.common.constants.services import STORAGE
-from pyanaconda.storage.utils import device_matches
+from pyanaconda.core.storage import device_matches
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)

--- a/pyanaconda/core/storage.py
+++ b/pyanaconda/core/storage.py
@@ -1,0 +1,301 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import os
+
+from decimal import Decimal
+
+from blivet import udev
+from blivet.devicefactory import DEVICE_TYPE_LVM, DEVICE_TYPE_MD, DEVICE_TYPE_PARTITION, \
+    DEVICE_TYPE_BTRFS, DEVICE_TYPE_LVM_THINP, DEVICE_TYPE_DISK, is_supported_device_type
+from blivet.size import Size
+from blivet.util import total_memory
+
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.i18n import N_
+from pykickstart.constants import AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_BTRFS, AUTOPART_TYPE_LVM, \
+    AUTOPART_TYPE_LVM_THINP
+
+log = get_module_logger(__name__)
+
+# Maximum ratio of swap size to disk size (10 %).
+MAX_SWAP_DISK_RATIO = Decimal('0.1')
+
+NAMED_DEVICE_TYPES = (
+    DEVICE_TYPE_BTRFS,
+    DEVICE_TYPE_LVM,
+    DEVICE_TYPE_MD,
+    DEVICE_TYPE_LVM_THINP
+)
+
+CONTAINER_DEVICE_TYPES = (
+    DEVICE_TYPE_LVM,
+    DEVICE_TYPE_BTRFS,
+    DEVICE_TYPE_LVM_THINP
+)
+
+SUPPORTED_DEVICE_TYPES = (
+    DEVICE_TYPE_PARTITION,
+    DEVICE_TYPE_LVM,
+    DEVICE_TYPE_LVM_THINP
+)
+
+PARTITION_ONLY_FORMAT_TYPES = (
+    "macefi",
+    "prepboot",
+    "biosboot",
+    "appleboot"
+)
+
+
+# Used for info about device with
+# no more supported type (ie btrfs).
+DEVICE_TYPE_UNSUPPORTED = -1
+
+DEVICE_TEXT_MAP = {
+    DEVICE_TYPE_UNSUPPORTED: N_("Unsupported"),
+    DEVICE_TYPE_LVM: N_("LVM"),
+    DEVICE_TYPE_MD: N_("RAID"),
+    DEVICE_TYPE_PARTITION: N_("Standard Partition"),
+    DEVICE_TYPE_BTRFS: N_("Btrfs"),
+    DEVICE_TYPE_LVM_THINP: N_("LVM Thin Provisioning"),
+    DEVICE_TYPE_DISK: N_("Disk")
+}
+
+AUTOPART_CHOICES = (
+    (N_("Standard Partition"), AUTOPART_TYPE_PLAIN),
+    (N_("Btrfs"), AUTOPART_TYPE_BTRFS),
+    (N_("LVM"), AUTOPART_TYPE_LVM),
+    (N_("LVM Thin Provisioning"), AUTOPART_TYPE_LVM_THINP)
+)
+
+AUTOPART_DEVICE_TYPES = {
+    AUTOPART_TYPE_LVM: DEVICE_TYPE_LVM,
+    AUTOPART_TYPE_LVM_THINP: DEVICE_TYPE_LVM_THINP,
+    AUTOPART_TYPE_PLAIN: DEVICE_TYPE_PARTITION,
+    AUTOPART_TYPE_BTRFS: DEVICE_TYPE_BTRFS
+}
+
+MOUNTPOINT_DESCRIPTIONS = {
+    "Swap": N_("The 'swap' area on your computer is used by the operating\n"
+               "system when running low on memory."),
+    "Boot": N_("The 'boot' area on your computer is where files needed\n"
+               "to start the operating system are stored."),
+    "Root": N_("The 'root' area on your computer is where core system\n"
+               "files and applications are stored."),
+    "Home": N_("The 'home' area on your computer is where all your personal\n"
+               "data is stored."),
+    "BIOS Boot": N_("The BIOS boot partition is required to enable booting\n"
+                    "from GPT-partitioned disks on BIOS hardware."),
+    "PReP Boot": N_("The PReP boot partition is required as part of the\n"
+                    "boot loader configuration on some PPC platforms.")
+}
+
+# Private cache for the function device_matches.
+_udev_device_dict_cache = None
+
+
+def device_type_from_autopart(autopart_type):
+    """Get device type matching the given autopart type."""
+    return AUTOPART_DEVICE_TYPES.get(autopart_type, DEVICE_TYPE_LVM)
+
+
+def get_supported_autopart_choices():
+    """Get the supported autopart choices."""
+    return [c for c in AUTOPART_CHOICES if is_supported_device_type(AUTOPART_DEVICE_TYPES[c[1]])]
+
+
+def device_matches(spec, devicetree=None, disks_only=False):
+    """Return names of block devices matching the provided specification.
+
+    :param str spec: a device identifier (name, UUID=<uuid>, &c)
+    :keyword devicetree: device tree to look up devices in (optional)
+    :type devicetree: :class:`blivet.DeviceTree`
+    :param bool disks_only: if only disk devices matching the spec should be returned
+    :returns: names of matching devices
+    :rtype: list of str
+
+    The spec can contain multiple "sub specs" delimited by a |, for example:
+
+    "sd*|hd*|vd*"
+
+    In such case we resolve the specs from left to right and return all
+    unique matches, for example:
+
+    ["sda", "sda1", "sda2", "sdb", "sdb1", "vdb"]
+
+    If disks_only is specified we only return
+    disk devices matching the spec. For the example above
+    the output with disks_only=True would be:
+
+    ["sda", "sdb", "vdb"]
+
+    Also note that parse methods will not have access to a devicetree, while execute
+    methods will. The devicetree is superior in that it can resolve md
+    array names and in that it reflects scheduled device removals, but for
+    normal local disks udev.resolve_devspec should suffice.
+    """
+
+    matches = []
+    # the device specifications might contain multiple "sub specs" separated by a |
+    # - the specs are processed from left to right
+    for single_spec in spec.split("|"):
+        full_spec = single_spec
+        if not full_spec.startswith("/dev/"):
+            full_spec = os.path.normpath("/dev/" + full_spec)
+
+        # the regular case
+        single_spec_matches = udev.resolve_glob(full_spec)
+        for match in single_spec_matches:
+            if match not in matches:
+                # skip non-disk devices in disk-only mode
+                if disks_only and not _is_device_name_disk(match):
+                    continue
+                matches.append(match)
+
+        dev_name = None
+        # Use spec here instead of full_spec to preserve the spec and let the
+        # called code decide whether to treat the spec as a path instead of a name.
+        if devicetree is None:
+            # we run the spec through resolve_devspec() here as unlike resolve_glob()
+            # it can also resolve labels and UUIDs
+            dev_name = udev.resolve_devspec(single_spec)
+            if disks_only and dev_name:
+                if not _is_device_name_disk(dev_name):
+                    dev_name = None  # not a disk
+        else:
+            # devicetree can also handle labels and UUIDs
+            device = devicetree.resolve_device(single_spec)
+            if device:
+                dev_name = device.name
+                if disks_only and not _is_device_name_disk(dev_name, devicetree=devicetree):
+                    dev_name = None  # not a disk
+
+        # The dev_name variable can be None if the spec is not not found or is not valid,
+        # but we don't want that ending up in the list.
+        if dev_name and dev_name not in matches:
+            matches.append(dev_name)
+
+    log.debug("%s matches %s for devicetree=%s and disks_only=%s",
+              spec, matches, devicetree, disks_only)
+
+    return matches
+
+
+def _is_device_name_disk(device_name, devicetree=None, refresh_udev_cache=False):
+    """Report if the given device name corresponds to a disk device.
+
+    Check if the device name is a disk device or not. This function uses
+    the provided Blivet devicetree for the checking and Blivet udev module
+    if no devicetree is provided.
+
+    Please note that the udev based check uses an internal cache that is generated
+    when this function is first called in the udev checking mode. This basically
+    means that udev devices added later will not be taken into account.
+    If this is a problem for your usecase then use the refresh_udev_cache option
+    to force a refresh of the udev cache.
+
+    :param str device_name: name of the device to check
+    :param devicetree: device tree to look up devices in (optional)
+    :type devicetree: :class:`blivet.DeviceTree`
+    :param bool refresh_udev_cache: governs if the udev device cache should be refreshed
+    :returns: True if the device name corresponds to a disk, False if not
+    :rtype: bool
+    """
+    if devicetree is None:
+        global _udev_device_dict_cache
+        if device_name:
+            if _udev_device_dict_cache is None or refresh_udev_cache:
+                # Lazy load the udev dick that contains the {device_name : udev_device,..,}
+                # mappings. The operation could be quite costly due to udev_settle() calls,
+                # so we cache it in this non-elegant way.
+                # An unfortunate side effect of this is that udev devices that show up after
+                # this function is called for the first time will not be taken into account.
+                _udev_device_dict_cache = dict()
+
+                for d in udev.get_devices():
+                    # Add the device name to the cache.
+                    _udev_device_dict_cache[udev.device_get_name(d)] = d
+                    # If the device is md, add the md name as well.
+                    if udev.device_is_md(d) and udev.device_get_md_name(d):
+                        _udev_device_dict_cache[udev.device_get_md_name(d)] = d
+
+            udev_device = _udev_device_dict_cache.get(device_name)
+            return udev_device and udev.device_is_disk(udev_device)
+        else:
+            return False
+    else:
+        device = devicetree.get_device_by_name(device_name)
+        return device and device.is_disk
+
+
+def suggest_swap_size(quiet=False, hibernation=False, disk_space=None):
+    """Suggest the size of the swap partition that will be created.
+
+    :param bool quiet: whether to log size information or not
+    :param bool hibernation: calculate swap size big enough for hibernation
+    :param disk_space: how much disk space is available
+    :return: calculated swap size
+    """
+    mem = total_memory()
+    mem = ((mem / 16) + 1) * 16
+
+    if not quiet:
+        log.info("Detected %s of memory", mem)
+
+    sixty_four_gib = Size("64 GiB")
+
+    # the succeeding if-statement implements the following formula for
+    # suggested swap size.
+    #
+    # swap(mem) = 2 * mem, if mem < 2 GiB
+    #           = mem,     if 2 GiB <= mem < 8 GiB
+    #           = mem / 2, if 8 GIB <= mem < 64 GiB
+    #           = 4 GiB,   if mem >= 64 GiB
+    if mem < Size("2 GiB"):
+        swap = 2 * mem
+
+    elif mem < Size("8 GiB"):
+        swap = mem
+
+    elif mem < sixty_four_gib:
+        swap = mem / 2
+
+    else:
+        swap = Size("4 GiB")
+
+    if hibernation:
+        if mem <= sixty_four_gib:
+            swap = mem + swap
+        else:
+            log.info("Ignoring --hibernation option on systems with %s of RAM or more",
+                     sixty_four_gib)
+
+    if disk_space is not None and not hibernation:
+        max_swap = disk_space * MAX_SWAP_DISK_RATIO
+        if swap > max_swap:
+            log.info("Suggested swap size (%(swap)s) exceeds %(percent)d %% of "
+                     "disk space, using %(percent)d %% of disk space (%(size)s) "
+                     "instead.", {"percent": MAX_SWAP_DISK_RATIO * 100,
+                                  "swap": swap,
+                                  "size": max_swap})
+            swap = max_swap
+
+    if not quiet:
+        log.info("Swap attempt of %s", swap)
+
+    return swap

--- a/pyanaconda/modules/storage/kickstart.py
+++ b/pyanaconda/modules/storage/kickstart.py
@@ -30,7 +30,7 @@ from pyanaconda.network import get_supported_devices, wait_for_network_devices
 from pyanaconda.modules.common.constants.services import NETWORK
 from pyanaconda.core.i18n import _
 from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
-from pyanaconda.storage.utils import device_matches
+from pyanaconda.core.storage import device_matches
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)

--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
@@ -29,7 +29,8 @@ from pyanaconda.modules.storage.partitioning.automatic.utils import get_candidat
     schedule_implicit_partitions, schedule_volumes, schedule_partitions
 from pyanaconda.platform import platform
 from pyanaconda.storage.partspec import PartSpec
-from pyanaconda.storage.utils import suggest_swap_size, get_pbkdf_args
+from pyanaconda.storage.utils import get_pbkdf_args
+from pyanaconda.core.storage import suggest_swap_size
 
 log = get_module_logger(__name__)
 

--- a/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
@@ -36,7 +36,8 @@ from pyanaconda.modules.storage.partitioning.automatic.noninteractive_partitioni
 from pyanaconda.modules.storage.partitioning.automatic.utils import get_candidate_disks, \
     schedule_partitions
 from pyanaconda.platform import platform
-from pyanaconda.storage.utils import suggest_swap_size, get_pbkdf_args, lookup_alias
+from pyanaconda.storage.utils import get_pbkdf_args, lookup_alias
+from pyanaconda.core.storage import suggest_swap_size
 
 log = get_module_logger(__name__)
 

--- a/pyanaconda/modules/storage/partitioning/interactive/add_device.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/add_device.py
@@ -25,7 +25,7 @@ from pyanaconda.modules.common.structures.device_factory import DeviceFactoryReq
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.storage.partitioning.interactive.utils import \
     get_device_raid_level_name, get_container_size_policy, get_device_factory_arguments
-from pyanaconda.storage.utils import PARTITION_ONLY_FORMAT_TYPES
+from pyanaconda.core.storage import PARTITION_ONLY_FORMAT_TYPES
 
 log = get_module_logger(__name__)
 

--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -38,8 +38,9 @@ from pyanaconda.platform import platform
 from pyanaconda.product import productName, productVersion
 from pyanaconda.storage.root import Root
 from pyanaconda.storage.utils import filter_unsupported_disklabel_devices, bound_size, \
-    get_supported_filesystems, PARTITION_ONLY_FORMAT_TYPES, SUPPORTED_DEVICE_TYPES, \
-    CONTAINER_DEVICE_TYPES, DEVICE_TEXT_MAP, NAMED_DEVICE_TYPES
+    get_supported_filesystems
+from pyanaconda.core.storage import DEVICE_TEXT_MAP, PARTITION_ONLY_FORMAT_TYPES, \
+    NAMED_DEVICE_TYPES, CONTAINER_DEVICE_TYPES, SUPPORTED_DEVICE_TYPES
 
 log = get_module_logger(__name__)
 

--- a/pyanaconda/storage/utils.py
+++ b/pyanaconda/storage/utils.py
@@ -17,11 +17,8 @@
 #
 
 """UI-independent storage utility functions"""
-import os
 import time
 import requests
-
-from decimal import Decimal
 
 from blivet import udev
 from blivet.size import Size
@@ -29,81 +26,16 @@ from blivet.errors import StorageError
 from blivet.formats import device_formats
 from blivet.formats.fs import FS
 from blivet.formats.luks import LUKS2PBKDFArgs
-from blivet.devicefactory import DEVICE_TYPE_LVM
-from blivet.devicefactory import DEVICE_TYPE_LVM_THINP
-from blivet.devicefactory import DEVICE_TYPE_BTRFS
-from blivet.devicefactory import DEVICE_TYPE_MD
-from blivet.devicefactory import DEVICE_TYPE_PARTITION
-from blivet.devicefactory import DEVICE_TYPE_DISK
-from blivet.devicefactory import is_supported_device_type
-from blivet.util import total_memory
 from bytesize.bytesize import ROUND_HALF_UP
 
 from pykickstart.errors import KickstartError
 
 from pyanaconda.core import util
-from pyanaconda.core.i18n import N_, _, P_
+from pyanaconda.core.i18n import _, P_
 from pyanaconda.modules.common.constants.services import NETWORK
-
-from pykickstart.constants import AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_BTRFS
-from pykickstart.constants import AUTOPART_TYPE_LVM, AUTOPART_TYPE_LVM_THINP
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
-
-# TODO: all those constants and mappings should go to blivet
-# Used for info about device with no more supported type (ie btrfs).
-DEVICE_TYPE_UNSUPPORTED = -1
-
-DEVICE_TEXT_MAP = {
-    DEVICE_TYPE_UNSUPPORTED: N_("Unsupported"),
-    DEVICE_TYPE_LVM: N_("LVM"),
-    DEVICE_TYPE_MD: N_("RAID"),
-    DEVICE_TYPE_PARTITION: N_("Standard Partition"),
-    DEVICE_TYPE_BTRFS: N_("Btrfs"),
-    DEVICE_TYPE_LVM_THINP: N_("LVM Thin Provisioning"),
-    DEVICE_TYPE_DISK: N_("Disk")
-}
-
-PARTITION_ONLY_FORMAT_TYPES = ("macefi", "prepboot", "biosboot", "appleboot")
-
-MOUNTPOINT_DESCRIPTIONS = {"Swap": N_("The 'swap' area on your computer is used by the operating\n"
-                                      "system when running low on memory."),
-                           "Boot": N_("The 'boot' area on your computer is where files needed\n"
-                                      "to start the operating system are stored."),
-                           "Root": N_("The 'root' area on your computer is where core system\n"
-                                      "files and applications are stored."),
-                           "Home": N_("The 'home' area on your computer is where all your personal\n"
-                                      "data is stored."),
-                           "BIOS Boot": N_("The BIOS boot partition is required to enable booting\n"
-                                           "from GPT-partitioned disks on BIOS hardware."),
-                           "PReP Boot": N_("The PReP boot partition is required as part of the\n"
-                                           "boot loader configuration on some PPC platforms.")}
-
-AUTOPART_CHOICES = ((N_("Standard Partition"), AUTOPART_TYPE_PLAIN),
-                    (N_("Btrfs"), AUTOPART_TYPE_BTRFS),
-                    (N_("LVM"), AUTOPART_TYPE_LVM),
-                    (N_("LVM Thin Provisioning"), AUTOPART_TYPE_LVM_THINP))
-
-AUTOPART_DEVICE_TYPES = {AUTOPART_TYPE_LVM: DEVICE_TYPE_LVM,
-                         AUTOPART_TYPE_LVM_THINP: DEVICE_TYPE_LVM_THINP,
-                         AUTOPART_TYPE_PLAIN: DEVICE_TYPE_PARTITION,
-                         AUTOPART_TYPE_BTRFS: DEVICE_TYPE_BTRFS}
-
-NAMED_DEVICE_TYPES = (DEVICE_TYPE_BTRFS, DEVICE_TYPE_LVM, DEVICE_TYPE_MD, DEVICE_TYPE_LVM_THINP)
-CONTAINER_DEVICE_TYPES = (DEVICE_TYPE_LVM, DEVICE_TYPE_BTRFS, DEVICE_TYPE_LVM_THINP)
-SUPPORTED_DEVICE_TYPES = (DEVICE_TYPE_PARTITION, DEVICE_TYPE_LVM, DEVICE_TYPE_LVM_THINP)
-
-# maximum ratio of swap size to disk size (10 %)
-MAX_SWAP_DISK_RATIO = Decimal('0.1')
-
-udev_device_dict_cache = None
-
-
-def device_type_from_autopart(autopart_type):
-    """Get device type matching the given autopart type."""
-
-    return AUTOPART_DEVICE_TYPES.get(autopart_type, DEVICE_TYPE_LVM)
 
 
 def bound_size(size, device, old_size):
@@ -153,130 +85,6 @@ def filter_unsupported_disklabel_devices(devices):
             if not any(not getattr(p, "disklabel_supported", True) for p in d.ancestors)]
 
 
-def device_name_is_disk(device_name, devicetree=None, refresh_udev_cache=False):
-    """Report if the given device name corresponds to a disk device.
-
-    Check if the device name is a disk device or not. This function uses
-    the provided Blivet devicetree for the checking and Blivet udev module
-    if no devicetree is provided.
-
-    Please note that the udev based check uses an internal cache that is generated
-    when this function is first called in the udev checking mode. This basically
-    means that udev devices added later will not be taken into account.
-    If this is a problem for your usecase then use the refresh_udev_cache option
-    to force a refresh of the udev cache.
-
-    :param str device_name: name of the device to check
-    :param devicetree: device tree to look up devices in (optional)
-    :type devicetree: :class:`blivet.DeviceTree`
-    :param bool refresh_udev_cache: governs if the udev device cache should be refreshed
-    :returns: True if the device name corresponds to a disk, False if not
-    :rtype: bool
-    """
-    if devicetree is None:
-        global udev_device_dict_cache
-        if device_name:
-            if udev_device_dict_cache is None or refresh_udev_cache:
-                # Lazy load the udev dick that contains the {device_name : udev_device,..,}
-                # mappings. The operation could be quite costly due to udev_settle() calls,
-                # so we cache it in this non-elegant way.
-                # An unfortunate side effect of this is that udev devices that show up after
-                # this function is called for the first time will not be taken into account.
-                udev_device_dict_cache = dict()
-
-                for d in udev.get_devices():
-                    # Add the device name to the cache.
-                    udev_device_dict_cache[udev.device_get_name(d)] = d
-                    # If the device is md, add the md name as well.
-                    if udev.device_is_md(d) and udev.device_get_md_name(d):
-                        udev_device_dict_cache[udev.device_get_md_name(d)] = d
-
-            udev_device = udev_device_dict_cache.get(device_name)
-            return udev_device and udev.device_is_disk(udev_device)
-        else:
-            return False
-    else:
-        device = devicetree.get_device_by_name(device_name)
-        return device and device.is_disk
-
-
-def device_matches(spec, devicetree=None, disks_only=False):
-    """Return names of block devices matching the provided specification.
-
-    :param str spec: a device identifier (name, UUID=<uuid>, &c)
-    :keyword devicetree: device tree to look up devices in (optional)
-    :type devicetree: :class:`blivet.DeviceTree`
-    :param bool disks_only: if only disk devices matching the spec should be returned
-    :returns: names of matching devices
-    :rtype: list of str
-
-    The spec can contain multiple "sub specs" delimited by a |, for example:
-
-    "sd*|hd*|vd*"
-
-    In such case we resolve the specs from left to right and return all
-    unique matches, for example:
-
-    ["sda", "sda1", "sda2", "sdb", "sdb1", "vdb"]
-
-    If disks_only is specified we only return
-    disk devices matching the spec. For the example above
-    the output with disks_only=True would be:
-
-    ["sda", "sdb", "vdb"]
-
-    Also note that parse methods will not have access to a devicetree, while execute
-    methods will. The devicetree is superior in that it can resolve md
-    array names and in that it reflects scheduled device removals, but for
-    normal local disks udev.resolve_devspec should suffice.
-    """
-
-    matches = []
-    # the device specifications might contain multiple "sub specs" separated by a |
-    # - the specs are processed from left to right
-    for single_spec in spec.split("|"):
-        full_spec = single_spec
-        if not full_spec.startswith("/dev/"):
-            full_spec = os.path.normpath("/dev/" + full_spec)
-
-        # the regular case
-        single_spec_matches = udev.resolve_glob(full_spec)
-        for match in single_spec_matches:
-            if match not in matches:
-                # skip non-disk devices in disk-only mode
-                if disks_only and not device_name_is_disk(match):
-                    continue
-                matches.append(match)
-
-        dev_name = None
-        # Use spec here instead of full_spec to preserve the spec and let the
-        # called code decide whether to treat the spec as a path instead of a name.
-        if devicetree is None:
-            # we run the spec through resolve_devspec() here as unlike resolve_glob()
-            # it can also resolve labels and UUIDs
-            dev_name = udev.resolve_devspec(single_spec)
-            if disks_only and dev_name:
-                if not device_name_is_disk(dev_name):
-                    dev_name = None  # not a disk
-        else:
-            # devicetree can also handle labels and UUIDs
-            device = devicetree.resolve_device(single_spec)
-            if device:
-                dev_name = device.name
-                if disks_only and not device_name_is_disk(dev_name, devicetree=devicetree):
-                    dev_name = None  # not a disk
-
-        # The dev_name variable can be None if the spec is not not found or is not valid,
-        # but we don't want that ending up in the list.
-        if dev_name and dev_name not in matches:
-            matches.append(dev_name)
-
-    log.debug("%s matches %s for devicetree=%s and disks_only=%s",
-              spec, matches, devicetree, disks_only)
-
-    return matches
-
-
 def get_supported_filesystems():
     fs_types = []
     for cls in device_formats.values():
@@ -290,10 +98,6 @@ def get_supported_filesystems():
             fs_types.append(obj)
 
     return fs_types
-
-
-def get_supported_autopart_choices():
-    return [c for c in AUTOPART_CHOICES if is_supported_device_type(AUTOPART_DEVICE_TYPES[c[1]])]
 
 
 def get_pbkdf_args(luks_version, pbkdf_type=None, max_memory_kb=0, iterations=0, time_ms=0):
@@ -450,64 +254,6 @@ def get_required_device_size(required_space, format_class=None):
 
     device_size = format_class.get_required_size(required_space)
     return device_size.round_to_nearest(Size("1 MiB"), ROUND_HALF_UP)
-
-
-def suggest_swap_size(quiet=False, hibernation=False, disk_space=None):
-    """Suggest the size of the swap partition that will be created.
-
-    :param bool quiet: whether to log size information or not
-    :param bool hibernation: calculate swap size big enough for hibernation
-    :param disk_space: how much disk space is available
-    :return: calculated swap size
-    """
-    mem = total_memory()
-    mem = ((mem / 16) + 1) * 16
-
-    if not quiet:
-        log.info("Detected %s of memory", mem)
-
-    sixty_four_gib = Size("64 GiB")
-
-    # the succeeding if-statement implements the following formula for
-    # suggested swap size.
-    #
-    # swap(mem) = 2 * mem, if mem < 2 GiB
-    #           = mem,     if 2 GiB <= mem < 8 GiB
-    #           = mem / 2, if 8 GIB <= mem < 64 GiB
-    #           = 4 GiB,   if mem >= 64 GiB
-    if mem < Size("2 GiB"):
-        swap = 2 * mem
-
-    elif mem < Size("8 GiB"):
-        swap = mem
-
-    elif mem < sixty_four_gib:
-        swap = mem / 2
-
-    else:
-        swap = Size("4 GiB")
-
-    if hibernation:
-        if mem <= sixty_four_gib:
-            swap = mem + swap
-        else:
-            log.info("Ignoring --hibernation option on systems with %s of RAM or more",
-                     sixty_four_gib)
-
-    if disk_space is not None and not hibernation:
-        max_swap = disk_space * MAX_SWAP_DISK_RATIO
-        if swap > max_swap:
-            log.info("Suggested swap size (%(swap)s) exceeds %(percent)d %% of "
-                     "disk space, using %(percent)d %% of disk space (%(size)s) "
-                     "instead.", {"percent": MAX_SWAP_DISK_RATIO * 100,
-                                  "swap": swap,
-                                  "size": max_swap})
-            swap = max_swap
-
-    if not quiet:
-        log.info("Swap attempt of %s", swap)
-
-    return swap
 
 
 def find_optical_media(devicetree):

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -24,8 +24,8 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import CN_, CP_
 from pyanaconda.modules.common.structures.storage import DeviceData
-from pyanaconda.storage.utils import filter_disks_by_names
-from pyanaconda.ui.lib.storage import apply_disk_selection, try_populate_devicetree
+from pyanaconda.ui.lib.storage import apply_disk_selection, try_populate_devicetree, \
+    filter_disks_by_names
 from pyanaconda.modules.common.constants.objects import DISK_SELECTION, FCOE, ISCSI, DASD, \
     DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -50,10 +50,9 @@ from pyanaconda.modules.common.structures.device_factory import DeviceFactoryReq
     DeviceFactoryPermissions
 from pyanaconda.platform import platform
 from pyanaconda.product import productName, productVersion
-from pyanaconda.ui.lib.storage import reset_bootloader, create_partitioning
+from pyanaconda.ui.lib.storage import reset_bootloader, create_partitioning, filter_disks_by_names
 from pyanaconda.storage.utils import DEVICE_TEXT_MAP, MOUNTPOINT_DESCRIPTIONS, NAMED_DEVICE_TYPES, \
-    CONTAINER_DEVICE_TYPES, device_type_from_autopart, DEVICE_TYPE_UNSUPPORTED, \
-    filter_disks_by_names
+    CONTAINER_DEVICE_TYPES, device_type_from_autopart, DEVICE_TYPE_UNSUPPORTED
 from pyanaconda.threading import threadMgr
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.communication import hubQ

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -51,8 +51,8 @@ from pyanaconda.modules.common.structures.device_factory import DeviceFactoryReq
 from pyanaconda.platform import platform
 from pyanaconda.product import productName, productVersion
 from pyanaconda.ui.lib.storage import reset_bootloader, create_partitioning, filter_disks_by_names
-from pyanaconda.storage.utils import DEVICE_TEXT_MAP, MOUNTPOINT_DESCRIPTIONS, NAMED_DEVICE_TYPES, \
-    CONTAINER_DEVICE_TYPES, device_type_from_autopart, DEVICE_TYPE_UNSUPPORTED
+from pyanaconda.core.storage import DEVICE_TYPE_UNSUPPORTED, DEVICE_TEXT_MAP, \
+    MOUNTPOINT_DESCRIPTIONS, NAMED_DEVICE_TYPES, CONTAINER_DEVICE_TYPES, device_type_from_autopart
 from pyanaconda.threading import threadMgr
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.communication import hubQ

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -50,7 +50,7 @@ from pyanaconda.core.regexes import REPO_NAME_VALID, URL_PARSE, HOSTNAME_PATTERN
 from pyanaconda.modules.common.constants.services import NETWORK, STORAGE
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.structures.storage import DeviceData
-from pyanaconda.storage.utils import device_matches
+from pyanaconda.core.storage import device_matches
 from pyanaconda.ui.lib.storage import mark_protected_device, unmark_protected_device
 
 from pyanaconda.anaconda_loggers import get_module_logger

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -21,7 +21,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.constants import DEFAULT_AUTOPART_TYPE
 from pyanaconda.core.i18n import _, C_
 from pyanaconda.product import productName, productVersion
-from pyanaconda.storage.utils import get_supported_autopart_choices
+from pyanaconda.core.storage import get_supported_autopart_choices
 from pyanaconda.ui.gui.utils import escape_markup, really_hide, really_show
 
 import gi

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -32,7 +32,7 @@ from pyanaconda.modules.common.structures.device_factory import DeviceFactoryReq
 from pyanaconda.modules.common.structures.storage import DeviceFormatData, DeviceData
 from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.platform import platform
-from pyanaconda.storage.utils import size_from_input
+from pyanaconda.ui.lib.storage import size_from_input
 from pyanaconda.ui.helpers import InputCheck
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.helpers import GUIDialogInputCheckHandler

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -37,7 +37,7 @@ from pyanaconda.modules.common.structures.storage import DeviceData
 from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.payload.livepayload import LiveImagePayload
 from pyanaconda.product import productName
-from pyanaconda.storage.utils import suggest_swap_size
+from pyanaconda.core.storage import suggest_swap_size
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.communication import hubQ

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -37,7 +37,7 @@ from pyanaconda.modules.common.structures.storage import DeviceData
 from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.payload.livepayload import LiveImagePayload
 from pyanaconda.product import productName
-from pyanaconda.storage.utils import filter_disks_by_names, suggest_swap_size
+from pyanaconda.storage.utils import suggest_swap_size
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.communication import hubQ
@@ -54,7 +54,7 @@ from pyanaconda.ui.helpers import StorageCheckHandler
 from pyanaconda.ui.lib.format_dasd import DasdFormatting
 from pyanaconda.ui.lib.storage import find_partitioning, apply_partitioning, \
     select_default_disks, apply_disk_selection, get_disks_summary, create_partitioning, \
-    is_local_disk
+    is_local_disk, filter_disks_by_names
 
 import gi
 gi.require_version("Gtk", "3.0")

--- a/pyanaconda/ui/lib/storage.py
+++ b/pyanaconda/ui/lib/storage.py
@@ -37,7 +37,7 @@ from pyanaconda.modules.common.errors.configuration import StorageConfigurationE
     BootloaderConfigurationError
 from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.modules.common.task import sync_run_task
-from pyanaconda.storage.utils import device_matches
+from pyanaconda.core.storage import device_matches
 
 log = get_module_logger(__name__)
 

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -30,10 +30,10 @@ from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.lib.storage import find_partitioning, reset_storage, \
     select_default_disks, apply_disk_selection, get_disks_summary, apply_partitioning, \
-    create_partitioning
+    create_partitioning, filter_disks_by_names
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog, PasswordDialog
-from pyanaconda.storage.utils import get_supported_autopart_choices, filter_disks_by_names
+from pyanaconda.storage.utils import get_supported_autopart_choices
 from pyanaconda.ui.lib.format_dasd import DasdFormatting
 
 from blivet.size import Size

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -33,7 +33,7 @@ from pyanaconda.ui.lib.storage import find_partitioning, reset_storage, \
     create_partitioning, filter_disks_by_names
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog, PasswordDialog
-from pyanaconda.storage.utils import get_supported_autopart_choices
+from pyanaconda.core.storage import get_supported_autopart_choices
 from pyanaconda.ui.lib.format_dasd import DasdFormatting
 
 from blivet.size import Size


### PR DESCRIPTION
Move functions that are used only by UI to pyanaconda.ui.lib.storage.
Move functions that are used by the Storage module and UI to pyanaconda.core.storage.