### PR TITLE
Enable Packit for Anaconda

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,8 @@
+specfile_path: anaconda.spec
+actions:
+  post-upstream-clone:
+    - ./autogen.sh
+    - ./configure
+  create-archive:
+    - make release
+    - bash -c "ls | grep 'tar.bz2'"

--- a/.packit.yml
+++ b/.packit.yml
@@ -6,3 +6,15 @@ actions:
   create-archive:
     - make release
     - bash -c "ls | grep 'tar.bz2'"
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+        - fedora-rawhide-x86_64
+        - fedora-rawhide-aarch64
+
+  - job: propose_downstream
+    trigger: release
+    metadata:
+      dist-git-branch: master


### PR DESCRIPTION
We have to replace Packit actions because archive creation for Anaconda is a complicated process.

This needs to be validated on this PR if it is working correctly.

*Resolves:#1697339*