### PR TITLE
Fix the unit tests for BTRFS

### DIFF
--- a/tests/nosetests/pyanaconda_tests/module_bootloader_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_bootloader_test.py
@@ -304,12 +304,15 @@ class BootloaderTasksTestCase(unittest.TestCase):
         storage.devicetree._add_device(dev1)
 
         dev2 = BTRFSDevice(
-            "dev1",
+            "dev2",
             fmt=get_format("btrfs", mountpoint="/"),
             size=Size("5 GiB"),
             parents=[dev1]
         )
         storage.devicetree._add_device(dev2)
+
+        # Make the btrfs format mountable.
+        dev2.format._mount = Mock(available=True)
 
         conf.target.is_directory = False
         FixBTRFSBootloaderTask(storage, BootloaderMode.ENABLED, [version], sysroot).run()

--- a/tests/nosetests/pyanaconda_tests/module_scheduler_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_scheduler_test.py
@@ -561,10 +561,13 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(dev1)
         self._add_device(dev2)
 
+        # Make the btrfs format not mountable.
+        dev2.format._mount = Mock(available=False)
+
         request = self.interface.GenerateDeviceFactoryRequest(dev2.name)
         permissions = self.interface.GenerateDeviceFactoryPermissions(request)
         self.assertEqual(get_native(permissions), {
-            'mount-point': True,
+            'mount-point': False,
             'reformat': False,
             'format-type': False,
             'label': True,


### PR DESCRIPTION
The unit tests should be able to run without the btrfs kernel module enabled.