### PR TITLE
Remove extra quotes from the doc strings

### DIFF
--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -134,7 +134,7 @@ class AnacondaConfiguration(Configuration):
         return self._license
 
     def set_from_defaults(self):
-        """"Set the configuration from the default configuration files.
+        """Set the configuration from the default configuration files.
 
         Read the current configuration from the temporary config file.
         Or load the default configuration file from:

--- a/pyanaconda/modules/boss/module_manager/module_observer.py
+++ b/pyanaconda/modules/boss/module_manager/module_observer.py
@@ -47,7 +47,7 @@ class ModuleObserver(DBusObserver):
 
     @property
     def proxy(self):
-        """"Returns a proxy of the remote object."""
+        """Returns a proxy of the remote object."""
         if not self._is_service_available:
             raise DBusObserverError("Service {} is not available."
                                     .format(self._service_name))

--- a/pyanaconda/modules/common/structures/device_factory.py
+++ b/pyanaconda/modules/common/structures/device_factory.py
@@ -454,7 +454,7 @@ class DeviceFactoryPermissions(DBusData):
 
     @property
     def container_size_policy(self) -> Bool:
-        """"Can the container size policy be changed?
+        """Can the container size policy be changed?
 
         :return: True or False
         """

--- a/pyanaconda/modules/storage/devicetree/handler.py
+++ b/pyanaconda/modules/storage/devicetree/handler.py
@@ -198,7 +198,7 @@ class DeviceTreeHandler(ABC):
         return [d.name for d in devices]
 
     def find_existing_systems_with_task(self):
-        """"Find existing GNU/Linux installations.
+        """Find existing GNU/Linux installations.
 
         The task will update data about existing installations.
 

--- a/pyanaconda/modules/storage/devicetree/handler_interface.py
+++ b/pyanaconda/modules/storage/devicetree/handler_interface.py
@@ -137,7 +137,7 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
         return self.implementation.find_mountable_partitions()
 
     def FindExistingSystemsWithTask(self) -> ObjPath:
-        """"Find existing GNU/Linux installations.
+        """Find existing GNU/Linux installations.
 
         The task will update data about existing installations.
 

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -420,7 +420,7 @@ class DeviceTreeViewer(ABC):
         return device.fstab_spec
 
     def get_existing_systems(self):
-        """"Get existing GNU/Linux installations.
+        """Get existing GNU/Linux installations.
 
         :return: a list of data about found installations
         """

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -181,7 +181,7 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
         return self.implementation.get_fstab_spec(name)
 
     def GetExistingSystems(self) -> List[Structure]:
-        """"Get existing GNU/Linux installations.
+        """Get existing GNU/Linux installations.
 
         :return: a list of data about found installations
         """

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -55,7 +55,7 @@ __all__ = ["BlivetGuiSpoke"]
 
 
 class BlivetGUIAnacondaClient(BlivetGUIClient):
-    """"The request handler for the Blivet-GUI."""
+    """The request handler for the Blivet-GUI."""
 
     def __init__(self):  # pylint: disable=super-init-not-called
         self.mutex = Lock()

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -378,7 +378,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         ))
 
     def _do_execute(self):
-        """"Apply a non-interactive partitioning."""
+        """Apply a non-interactive partitioning."""
         self._ready = False
         hubQ.send_not_ready(self.__class__.__name__)
 


### PR DESCRIPTION
There should be only tree quotation marks at the beginning of doc strings.