### PR TITLE
Avoid downloading payload image in set up phase

### DIFF
--- a/pyanaconda/modules/payloads/payload/live_image/initialization.py
+++ b/pyanaconda/modules/payloads/payload/live_image/initialization.py
@@ -68,8 +68,8 @@ class CheckInstallationSourceImageTask(Task):
         # FIXME: validate earlier when setting?
         proxies = get_proxies_from_option(self._proxy)
         try:
-            response = self._session.get(url, proxies=proxies, verify=True,
-                                         timeout=NETWORK_CONNECTION_TIMEOUT)
+            response = self._session.head(url, proxies=proxies, verify=True,
+                                          timeout=NETWORK_CONNECTION_TIMEOUT)
 
             # At this point we know we can get the image and what its size is
             # Make a guess as to minimum size needed:

--- a/pyanaconda/payload/livepayload.py
+++ b/pyanaconda/payload/livepayload.py
@@ -318,8 +318,8 @@ class LiveImageKSPayload(LiveImagePayload):
 
         error = None
         try:
-            response = self._session.get(self.data.method.url, proxies=self._proxies, verify=True,
-                                         timeout=NETWORK_CONNECTION_TIMEOUT)
+            response = self._session.head(self.data.method.url, proxies=self._proxies, verify=True,
+                                          timeout=NETWORK_CONNECTION_TIMEOUT)
 
             # At this point we know we can get the image and what its size is
             # Make a guess as to minimum size needed:


### PR DESCRIPTION
Before this change Anaconda will download stage2 image in the set up phase. Result was that with big image Payload reset took ages and whole image was downloaded to RAM without any check if the image could be downloaded.

In my case the above resulted in this process: Anaconda started, waited on thread and then OOM killer killed it to free up RAM. Then systemd again started Anaconda and the whole cycle repeated in an never ending cycle.