### PR TITLE
Add initial Subscription DBus module & system purpose data support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -200,6 +200,7 @@ AC_CONFIG_FILES([Makefile
                  pyanaconda/modules/storage/snapshot/Makefile
                  pyanaconda/modules/storage/zfcp/Makefile
                  pyanaconda/modules/services/Makefile
+                 pyanaconda/modules/subscription/Makefile
                  data/post-scripts/Makefile
                  data/pixmaps/Makefile
                  tests/Makefile

--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -3,6 +3,19 @@
 [Product]
 product_name = Red Hat Enterprise Linux
 
+[Anaconda]
+# List of enabled Anaconda DBus modules for RHEL.
+kickstart_modules =
+     org.fedoraproject.Anaconda.Modules.Timezone
+     org.fedoraproject.Anaconda.Modules.Network
+     org.fedoraproject.Anaconda.Modules.Localization
+     org.fedoraproject.Anaconda.Modules.Security
+     org.fedoraproject.Anaconda.Modules.Users
+     org.fedoraproject.Anaconda.Modules.Payloads
+     org.fedoraproject.Anaconda.Modules.Storage
+     org.fedoraproject.Anaconda.Modules.Services
+     org.fedoraproject.Anaconda.Modules.Subscription
+
 [Installation System]
 # The detection is disabled since #1645686.
 # can_detect_unsupported_hardware = True

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -67,6 +67,7 @@ from pykickstart.commands.reboot import F23_Reboot as Reboot
 from pykickstart.commands.repo import F30_Repo as Repo
 from pykickstart.commands.reqpart import F23_ReqPart as ReqPart
 from pykickstart.commands.rescue import F10_Rescue as Rescue
+from pykickstart.commands.rhsm import RHEL8_RHSM as RHSM
 from pykickstart.commands.rootpw import F18_RootPw as RootPw
 from pykickstart.commands.selinux import FC3_SELinux as SELinux
 from pykickstart.commands.services import FC6_Services as Services
@@ -74,6 +75,7 @@ from pykickstart.commands.skipx import FC3_SkipX as SkipX
 from pykickstart.commands.snapshot import F26_Snapshot as Snapshot
 from pykickstart.commands.sshpw import F24_SshPw as SshPw
 from pykickstart.commands.sshkey import F22_SshKey as SshKey
+from pykickstart.commands.syspurpose import RHEL8_Syspurpose as Syspurpose
 from pykickstart.commands.timezone import F32_Timezone as Timezone
 from pykickstart.commands.updates import F7_Updates as Updates
 from pykickstart.commands.url import F30_Url as Url

--- a/pyanaconda/modules/common/constants/namespaces.py
+++ b/pyanaconda/modules/common/constants/namespaces.py
@@ -81,6 +81,11 @@ SERVICES_NAMESPACE = (
     "Services"
 )
 
+SUBSCRIPTION_NAMESPACE = (
+    *MODULES_NAMESPACE,
+    "Subscription"
+)
+
 PAYLOADS_NAMESPACE = (
     *MODULES_NAMESPACE,
     "Payloads"

--- a/pyanaconda/modules/common/constants/services.py
+++ b/pyanaconda/modules/common/constants/services.py
@@ -20,7 +20,7 @@ from pyanaconda.core.dbus import SystemBus, DBus
 from dasbus.identifier import DBusServiceIdentifier
 from pyanaconda.modules.common.constants.namespaces import BOSS_NAMESPACE, TIMEZONE_NAMESPACE, \
     NETWORK_NAMESPACE, LOCALIZATION_NAMESPACE, SECURITY_NAMESPACE, USERS_NAMESPACE, \
-    PAYLOADS_NAMESPACE, STORAGE_NAMESPACE, SERVICES_NAMESPACE
+    PAYLOADS_NAMESPACE, STORAGE_NAMESPACE, SERVICES_NAMESPACE, SUBSCRIPTION_NAMESPACE
 
 # Anaconda services.
 
@@ -66,6 +66,11 @@ STORAGE = DBusServiceIdentifier(
 
 SERVICES = DBusServiceIdentifier(
     namespace=SERVICES_NAMESPACE,
+    message_bus=DBus
+)
+
+SUBSCRIPTION = DBusServiceIdentifier(
+    namespace=SUBSCRIPTION_NAMESPACE,
     message_bus=DBus
 )
 

--- a/pyanaconda/modules/common/structures/subscription.py
+++ b/pyanaconda/modules/common/structures/subscription.py
@@ -1,0 +1,80 @@
+#
+# DBus structures for subscription related data.
+#
+# Copyright (C) 2020  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from dasbus.structure import DBusData
+from dasbus.typing import *  # pylint: disable=wildcard-import
+
+__all__ = ["SystemPurposeData"]
+
+
+class SystemPurposeData(DBusData):
+    """System purpose data."""
+
+    def __init__(self):
+        self._role = ""
+        self._sla = ""
+        self._usage = ""
+        self._addons = []
+
+    @property
+    def role(self) -> Str:
+        """Return the System Purpose role (if any).
+
+        :return: system purpose role
+        """
+        return self._role
+
+    @role.setter
+    def role(self, role: Str):
+        self._role = role
+
+    @property
+    def sla(self) -> Str:
+        """Return the System Purpose SLA (if any).
+
+        :return: system purpose SLA
+        """
+        return self._sla
+
+    @sla.setter
+    def sla(self, sla: Str):
+        self._sla = sla
+
+    @property
+    def usage(self) -> Str:
+        """Return the System Purpose usage (if any).
+
+        :return: system purpose usage
+        """
+        return self._usage
+
+    @usage.setter
+    def usage(self, usage: Str):
+        self._usage = usage
+
+    @property
+    def addons(self) -> List[Str]:
+        """Return list of additional layered products or features (if any).
+
+        :return: system purpose addons
+        """
+        return self._addons
+
+    @addons.setter
+    def addons(self, addons: List[Str]):
+        self._addons = addons

--- a/pyanaconda/modules/subscription/Makefile.am
+++ b/pyanaconda/modules/subscription/Makefile.am
@@ -1,6 +1,5 @@
-# modules/Makefile.am for anaconda
 #
-# Copyright (C) 2017  Red Hat, Inc.
+# Copyright (C) 2020  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published
@@ -15,10 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = common boss timezone network localization security users payloads storage services subscription
-
 pkgpyexecdir = $(pyexecdir)/py$(PACKAGE_NAME)
-modulesdir = $(pkgpyexecdir)/modules
-modules_PYTHON = $(srcdir)/*.py
+subscriptiondir = $(pkgpyexecdir)/modules/subscription
+subscription_PYTHON = $(srcdir)/*.py
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/pyanaconda/modules/subscription/__main__.py
+++ b/pyanaconda/modules/subscription/__main__.py
@@ -1,0 +1,6 @@
+from pyanaconda.modules.common import init
+init()
+
+from pyanaconda.modules.subscription.subscription import SubscriptionService
+service = SubscriptionService()
+service.run()

--- a/pyanaconda/modules/subscription/kickstart.py
+++ b/pyanaconda/modules/subscription/kickstart.py
@@ -1,0 +1,28 @@
+#
+# Kickstart handler for the subscription module.
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.core.kickstart import VERSION, KickstartSpecification, commands as COMMANDS
+
+
+class SubscriptionKickstartSpecification(KickstartSpecification):
+
+    commands = {
+        "syspurpose": COMMANDS.Syspurpose,
+        "rhsm": COMMANDS.RHSM
+    }

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -17,7 +17,19 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import os
+
+from pyanaconda.core import util
+from pyanaconda.core.signal import Signal
+
 from pyanaconda.modules.common.base import KickstartService
+from pyanaconda.modules.common.structures.subscription import SystemPurposeData
+
+from pyanaconda.modules.subscription import system_purpose
+from pyanaconda.modules.subscription.kickstart import SubscriptionKickstartSpecification
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
 
 
 class SubscriptionService(KickstartService):
@@ -26,3 +38,139 @@ class SubscriptionService(KickstartService):
     def __init__(self):
         super().__init__()
 
+        # system purpose
+
+        self._valid_roles = []
+        self._valid_slas = []
+        self._valid_usage_types = []
+
+        self._system_purpose_data = SystemPurposeData()
+        self.system_purpose_data_changed = Signal()
+
+        self._load_valid_system_purpose_values()
+
+        # FIXME: handle rhsm.service startup in a safe manner
+
+    @property
+    def kickstart_specification(self):
+        """Return the kickstart specification."""
+        return SubscriptionKickstartSpecification
+
+    def process_kickstart(self, data):
+        """Process the kickstart data."""
+        log.debug("Processing kickstart data...")
+
+        # system purpose
+        #
+        # Try if any of the values in kickstart match a valid field.
+        # If it does, write the valid field value instead of the value from kickstart.
+        #
+        # This way a value in kickstart that has a different case and/or trailing white space
+        # can still be used to preselect a value in a UI instead of being marked as a custom
+        # user specified value.
+        system_purpose_data = SystemPurposeData()
+
+        system_purpose_data.role = system_purpose.process_field(
+            data.syspurpose.role,
+            self.valid_roles,
+            "role"
+        )
+
+        system_purpose_data.sla = system_purpose.process_field(
+            data.syspurpose.sla,
+            self.valid_slas,
+            "sla"
+        )
+
+        system_purpose_data.usage = system_purpose.process_field(
+            data.syspurpose.usage,
+            self.valid_usage_types,
+            "usage"
+        )
+
+        if data.syspurpose.addons:
+            # As we do not have a list of valid addons available, we just use what was provided
+            # by the user in kickstart verbatim.
+            system_purpose_data.addons = data.syspurpose.addons
+
+        self.set_system_purpose_data(system_purpose_data)
+
+    def setup_kickstart(self, data):
+        """Return the kickstart string."""
+
+        # system purpose
+        data.syspurpose.role = self.system_purpose_data.role
+        data.syspurpose.sla = self.system_purpose_data.sla
+        data.syspurpose.usage = self.system_purpose_data.usage
+        data.syspurpose.addons = self.system_purpose_data.addons
+
+    # system purpose configuration
+
+    def _load_valid_system_purpose_values(self):
+        """Load lists of valid roles, SLAs and usage types.
+
+        About role/sla/validity:
+        - an older installation image might have older list of valid fields,
+          missing fields that have become valid after the image has been released
+        - fields that have been valid in the past might be dropped in the future
+        - there is no list of valid addons
+
+        Due to this we need to take into account that the listing might not always be
+        comprehensive and that we need to allow what might on a first glance look like
+        invalid values to be written to the target system.
+        """
+        roles, slas, usage_types = system_purpose.get_valid_fields()
+        self._valid_roles = roles
+        self._valid_slas = slas
+        self._valid_usage_types = usage_types
+
+    @property
+    def valid_roles(self):
+        """Return a list of valid roles.
+
+        :return: list of valid roles
+        :rtype: list of strings
+        """
+        return self._valid_roles
+
+    @property
+    def valid_slas(self):
+        """Return a list of valid SLAs.
+
+        :return: list of valid SLAs
+        :rtype: list of strings
+        """
+        return self._valid_slas
+
+    @property
+    def valid_usage_types(self):
+        """Return a list of valid usage types.
+
+        :return: list of valid usage types
+        :rtype: list of strings
+        """
+        return self._valid_usage_types
+
+    @property
+    def system_purpose_data(self):
+        """System purpose data.
+
+        A DBus structure holding information about system purpose,
+        such as role, sla, usage and addons.
+
+        :return: system purpose DBus structure
+        :rtype: DBusData instance
+        """
+        return self._system_purpose_data
+
+    def set_system_purpose_data(self, system_purpose_data):
+        """Set system purpose data.
+
+        Set the complete DBus structure containing system purpose data.
+
+        :param system_purpose_data: system purpose data structure to be set
+        :type system_purpose_data: DBus structure
+        """
+        self._system_purpose_data = system_purpose_data
+        self.system_purpose_data_changed.emit()
+        log.debug("System purpose data set to %s.", system_purpose_data)

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -1,0 +1,28 @@
+#
+# Kickstart module for subscription handling.
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.modules.common.base import KickstartService
+
+
+class SubscriptionService(KickstartService):
+    """The Subscription service."""
+
+    def __init__(self):
+        super().__init__()
+

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -1,0 +1,29 @@
+#
+# DBus interface for the subscription module.
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.modules.common.constants.services import SUBSCRIPTION
+from pyanaconda.modules.common.base import KickstartModuleInterface
+from pyanaconda.dbus.interface import dbus_interface
+
+
+@dbus_interface(SUBSCRIPTION.interface_name)
+class SubscriptionInterface(KickstartModuleInterface):
+    """DBus interface for the Subscription service."""
+
+

--- a/pyanaconda/modules/subscription/system_purpose.py
+++ b/pyanaconda/modules/subscription/system_purpose.py
@@ -1,0 +1,140 @@
+#
+# System purpose library.
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import os
+import json
+
+from pyanaconda.core import util
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+VALID_FIELDS_FILE_PATH = "/etc/rhsm/syspurpose/valid_fields.json"
+
+
+def get_valid_fields(valid_fields_file_path=VALID_FIELDS_FILE_PATH):
+    """Get valid role, sla and usage fields for system purpose use.
+
+    If no valid fields are provided, the fields file is not found or can not be
+    parsed then all three lists will be empty.
+
+    :param str valid_fields_file_path: path to a JSON file holding the valid field listings
+
+    :return: role, sla and usage type lists
+    :rtype: [roles], [slas], [usages]
+    """
+    valid_roles = []
+    valid_slas = []
+    valid_usage_types = []
+    if os.path.exists(valid_fields_file_path):
+        try:
+            with open(valid_fields_file_path, "rt") as f:
+                valid_fields_json = json.load(f)
+                valid_roles = valid_fields_json.get("role", [])
+                valid_slas = valid_fields_json.get("service_level_agreement", [])
+                valid_usage_types = valid_fields_json.get("usage", [])
+        except (IOError, json.JSONDecodeError):
+            log.exception("parsing of syspurpose valid fields file at %s failed",
+                          valid_fields_file_path)
+    else:
+        log.warning("system purpose valid fields file not found at %s", valid_fields_file_path)
+    return valid_roles, valid_slas, valid_usage_types
+
+
+def _normalize_field(raw_field):
+    """Normalize a field for matching.
+
+    Fields specified in free form by users can have different case or trailing white space,
+    while still technically being a match on a valid field.
+
+    So convert the field to lower case and strip any trailing white space and return the result.
+
+    :param str raw_field: raw not normalized field
+    :return: normalized field suitable for matching
+    :rtype: str
+    """
+    return raw_field.strip().lower()
+
+
+def _match_field(raw_field, valid_fields):
+    """Try to match the field on an item in a list of fields.
+
+    If a match is found return the first matching item from the list.
+    If no match is found, return None.
+
+    :param raw_field str: field to match
+    :param list valid_fields: list of valid fields to match against
+    :return: a matching valid field or None if no match is found
+    :rtype: str or None
+    """
+    matching_valid_field = None
+    normalized_field = _normalize_field(raw_field)
+
+    for valid_field in valid_fields:
+        if normalized_field == _normalize_field(valid_field):
+            # looks like the fields match, no need to search any further
+            matching_valid_field = valid_field
+            break
+
+    return matching_valid_field
+
+
+def process_field(syspurpose_value, valid_values, value_name):
+    """Process a single system purpose value provided by the user.
+
+    At the moment this value generally comes from kickstart
+    as we don't support free form system purpose value entry in the UI.
+
+    We try to match the user provided value to value in a lit of well
+    known valid values, so that it can be displayed correct in the UI.
+
+    If the user for example uses "production" for usage, we will match
+    it to Production and then display that in the UI.
+
+    If the value does not match any known one, we will just return
+    it & display it in its current form.
+
+    :param str syspurpose_value: system purpose value to be processed
+    :param valid_values: list of well known valid values for the given
+                         type of system purpose value
+    :type valid_values: list of str
+    :param str value_name: name of the system purpose value to be used
+                           in log messages
+
+    :return: matched well known or original value if no match was found
+    :rtype: str
+    """
+    if syspurpose_value:
+        value_match = _match_field(syspurpose_value, valid_values)
+    else:
+        value_match = None
+
+    if value_match:
+        log.info("%s system purpose value %s from kickstart matched to known valid field %s",
+                 value_name,
+                 syspurpose_value,
+                 value_match)
+        return value_match
+    elif syspurpose_value:
+        log.info("using custom %s system purpose value from kickstart: %s",
+                 value_name,
+                 syspurpose_value)
+        return syspurpose_value
+    else:
+        return ""

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
@@ -1,0 +1,303 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
+import os
+import unittest
+import tempfile
+
+from dasbus.typing import *  # pylint: disable=wildcard-import
+
+from pyanaconda.modules.common.constants.services import SUBSCRIPTION
+from pyanaconda.modules.common.structures.subscription import SystemPurposeData
+from pyanaconda.modules.subscription.subscription import SubscriptionService
+from pyanaconda.modules.subscription.subscription_interface import SubscriptionInterface
+from pyanaconda.modules.subscription.system_purpose import get_valid_fields, _normalize_field, \
+    _match_field, process_field
+from tests.nosetests.pyanaconda_tests import check_kickstart_interface, check_dbus_property, \
+    PropertiesChangedCallback
+
+# content of a valid populated valid values json file for system purpose testing
+SYSPURPOSE_VALID_VALUES_JSON = """
+{
+"role" : ["role_a", "role_b", "role_c"],
+"service_level_agreement" : ["sla_a", "sla_b", "sla_c"],
+"usage" : ["usage_a", "usage_b", "usage_c"]
+}
+"""
+
+# content of a valid but not populated valid values json file for system purpose testing
+SYSPURPOSE_VALID_VALUES_JSON_EMPTY = """
+{
+"role" : [],
+"service_level_agreement" : [],
+"usage" : []
+}
+"""
+
+
+class SystemPurposeLibraryTestCase(unittest.TestCase):
+    """Test the system purpose data handling code."""
+
+    def system_purpose_valid_json_parsing_test(self):
+        """Test that the JSON file holding valid system purpose values is parsed correctly."""
+        # check file missing completely
+        # - use path in tempdir to a file that has not been created and thus does not exist
+        with tempfile.TemporaryDirectory() as tempdir:
+            no_file = os.path.join(tempdir, "foo.json")
+            roles, slas, usage_types = get_valid_fields(valid_fields_file_path=no_file)
+            self.assertListEqual(roles, [])
+            self.assertListEqual(slas, [])
+            self.assertListEqual(usage_types, [])
+
+        # check empty value list is handled correctly
+        with tempfile.NamedTemporaryFile(mode="w+t") as testfile:
+            testfile.write(SYSPURPOSE_VALID_VALUES_JSON_EMPTY)
+            testfile.flush()
+            roles, slas, usage_types = get_valid_fields(valid_fields_file_path=testfile.name)
+            self.assertListEqual(roles, [])
+            self.assertListEqual(slas, [])
+            self.assertListEqual(usage_types, [])
+
+        # check correctly populated json file is parsed correctly
+        with tempfile.NamedTemporaryFile(mode="w+t") as testfile:
+            testfile.write(SYSPURPOSE_VALID_VALUES_JSON)
+            testfile.flush()
+            roles, slas, usage_types = get_valid_fields(valid_fields_file_path=testfile.name)
+            self.assertListEqual(roles, ["role_a", "role_b", "role_c"])
+            self.assertListEqual(slas, ["sla_a", "sla_b", "sla_c"])
+            self.assertListEqual(usage_types, ["usage_a", "usage_b", "usage_c"])
+
+    def normalize_field_test(self):
+        """Test that the system purpose valid field normalization works."""
+        # this should basically just lower case the input
+        self.assertEqual(_normalize_field("AAA"), "aaa")
+        self.assertEqual(_normalize_field("Ab"), "ab")
+        self.assertEqual(_normalize_field("A b C"), "a b c")
+
+    def match_field_test(self):
+        """Test that the system purpose valid field matching works."""
+        # The function is used on system purpose data from kickstart
+        # and it tries to match the given value to a well known value
+        # from the valid field.json. This way we can pre-select values
+        # in the GUI even if the user typosed the case or similar.
+
+        # these should match
+        self.assertEqual(
+            _match_field("production", ["Production", "Development", "Testing"]),
+            "Production"
+        )
+        self.assertEqual(
+            _match_field("Production", ["Production", "Development", "Testing"]),
+            "Production"
+        )
+        self.assertEqual(
+            _match_field("DEVELOPMENT", ["Production", "Development", "Testing"]),
+            "Development"
+        )
+
+        # these should not match but return the original value
+        self.assertIsNone(
+            _match_field("custom", ["Production", "Development", "Testing"]),
+        )
+        self.assertIsNone(
+            _match_field("Prod", ["Production", "Development", "Testing"]),
+        )
+        self.assertIsNone(
+            _match_field("Production 1", ["Production", "Development", "Testing"]),
+        )
+        self.assertIsNone(
+            _match_field("Production Development", ["Production", "Development", "Testing"]),
+        )
+
+    def process_field_test(self):
+        """Test that the system purpose field processing works."""
+
+        valid_values = ["Production", "Development", "Testing"]
+
+        # empty string
+        self.assertEqual(process_field("", valid_values, "usage"), "")
+
+        # well known value with different case
+        self.assertEqual(process_field("production", valid_values, "usage"), "Production")
+        self.assertEqual(process_field("PRODUCTION", valid_values, "usage"), "Production")
+
+        # well known value with matching case
+        self.assertEqual(process_field("Production", valid_values, "usage"), "Production")
+
+        # fully custom value
+        self.assertEqual(process_field("foo", valid_values, "usage"), "foo")
+        self.assertEqual(process_field("foo BAR", valid_values, "usage"), "foo BAR")
+
+        # empty list of well known values
+        self.assertEqual(process_field("PRODUCTION", [], "usage"), "PRODUCTION")
+        self.assertEqual(process_field("foo", [], "usage"), "foo")
+
+
+class SubscriptionInterfaceTestCase(unittest.TestCase):
+    """Test DBus interface for the subscription module."""
+
+    def setUp(self):
+        """Set up the subscription module."""
+        self.subscription_module = SubscriptionService()
+        self.subscription_interface = SubscriptionInterface(self.subscription_module)
+
+        # Connect to the properties changed signal.
+        self.callback = PropertiesChangedCallback()
+        self.subscription_interface.PropertiesChanged.connect(self.callback)
+
+    def _test_dbus_property(self, *args, **kwargs):
+        check_dbus_property(
+            self,
+            SUBSCRIPTION,
+            self.subscription_interface,
+            *args, **kwargs
+        )
+
+    def kickstart_properties_test(self):
+        """Test kickstart properties."""
+        self.assertEqual(self.subscription_interface.KickstartCommands, ["syspurpose", "rhsm"])
+        self.assertEqual(self.subscription_interface.KickstartSections, [])
+        self.assertEqual(self.subscription_interface.KickstartAddons, [])
+        self.callback.assert_not_called()
+
+    def system_purpose_data_test(self):
+        """Test the SystemPurposeData DBus structure."""
+
+        # create the SystemPurposeData structure
+        system_purpose_data = SystemPurposeData()
+        system_purpose_data.role = "foo"
+        system_purpose_data.sla = "bar"
+        system_purpose_data.usage = "baz"
+        system_purpose_data.addons = ["a", "b", "c"]
+
+        # create its expected representation
+        expected_dict = {
+            "role": get_variant(Str, "foo"),
+            "sla": get_variant(Str, "bar"),
+            "usage": get_variant(Str, "baz"),
+            "addons": get_variant(List[Str], ["a", "b", "c"])
+        }
+
+        # compare the two
+        self.assertEqual(SystemPurposeData.to_structure(system_purpose_data), expected_dict)
+
+    def set_system_purpose_test(self):
+        """Test if setting system purpose data from DBUS works correctly."""
+        system_purpose_data = {
+            "role": get_variant(Str, "foo"),
+            "sla": get_variant(Str, "bar"),
+            "usage": get_variant(Str, "baz"),
+            "addons": get_variant(List[Str], ["a", "b", "c"])
+        }
+
+        self._test_dbus_property(
+          "SystemPurposeData",
+          system_purpose_data
+        )
+
+        output_structure = self.subscription_interface.SystemPurposeData
+        output_system_purpose_data = SystemPurposeData.from_structure(output_structure)
+
+        self.assertEqual(output_system_purpose_data.role, "foo")
+        self.assertEqual(output_system_purpose_data.sla, "bar")
+        self.assertEqual(output_system_purpose_data.usage, "baz")
+        self.assertEqual(output_system_purpose_data.addons, ["a", "b", "c"])
+
+    def _test_kickstart(self, ks_in, ks_out):
+        check_kickstart_interface(self, self.subscription_interface, ks_in, ks_out)
+
+    def ks_out_no_kickstart_test(self):
+        """Test with no kickstart."""
+        ks_in = None
+        ks_out = ""
+        self._test_kickstart(ks_in, ks_out)
+
+    def ks_out_command_only_test(self):
+        """Test with only syspurpose command being used."""
+        ks_in = "syspurpose"
+        ks_out = ""
+        self._test_kickstart(ks_in, ks_out)
+
+        # also test resulting module state
+        structure = self.subscription_interface.SystemPurposeData
+        system_purpose_data = SystemPurposeData.from_structure(structure)
+        self.assertEqual(system_purpose_data.role, "")
+        self.assertEqual(system_purpose_data.sla, "")
+        self.assertEqual(system_purpose_data.usage, "")
+        self.assertEqual(system_purpose_data.addons, [])
+
+    def ks_out_set_role_test(self):
+        """Check kickstart with role being used."""
+        ks_in = '''
+        syspurpose --role="FOO ROLE"
+        '''
+        ks_out = '''
+        # Intended system purpose\nsyspurpose --role="FOO ROLE"
+        '''
+        self._test_kickstart(ks_in, ks_out)
+
+    def ks_out_set_sla_test(self):
+        """Check kickstart with SLA being used."""
+        ks_in = '''
+        syspurpose --sla="FOO SLA"
+        '''
+        ks_out = '''
+        # Intended system purpose\nsyspurpose --sla="FOO SLA"
+        '''
+        self._test_kickstart(ks_in, ks_out)
+
+    def ks_out_set_usage_test(self):
+        """Check kickstart with usage being used."""
+        ks_in = '''
+        syspurpose --usage="FOO USAGE"
+        '''
+        ks_out = '''
+        # Intended system purpose
+        syspurpose --usage="FOO USAGE"
+        '''
+        self._test_kickstart(ks_in, ks_out)
+
+    def ks_out_set_addons_test(self):
+        """Check kickstart with addons being used."""
+        ks_in = '''
+        syspurpose --addon="Foo Product" --addon="Bar Feature"
+        '''
+        ks_out = '''
+        # Intended system purpose
+        syspurpose --addon="Foo Product" --addon="Bar Feature"
+        '''
+        self._test_kickstart(ks_in, ks_out)
+
+    def ks_out_set_all_usage_test(self):
+        """Check kickstart with all options being used."""
+        ks_in = '''
+        syspurpose --role="FOO" --sla="BAR" --usage="BAZ" --addon="F Product" --addon="B Feature"
+        '''
+        ks_out = '''
+        # Intended system purpose
+        syspurpose --role="FOO" --sla="BAR" --usage="BAZ" --addon="F Product" --addon="B Feature"
+        '''
+        self._test_kickstart(ks_in, ks_out)
+
+        structure = self.subscription_interface.SystemPurposeData
+        system_purpose_data = SystemPurposeData.from_structure(structure)
+        self.assertEqual(system_purpose_data.role, 'FOO')
+        self.assertEqual(system_purpose_data.sla, 'BAR')
+        self.assertEqual(system_purpose_data.usage, 'BAZ')
+        self.assertEqual(system_purpose_data.addons, ["F Product", "B Feature"])

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -68,6 +68,18 @@ class ProductConfigurationTestCase(unittest.TestCase):
 
         config.validate()
 
+    def _get_config(self, product_name, variant_name=""):
+        """Get parsed config file."""
+        config = AnacondaConfiguration.from_defaults()
+        paths = self._loader.collect_configurations(product_name, variant_name)
+
+        for path in paths:
+            config.read(path)
+
+        config.validate()
+
+        return config
+
     def fedora_products_test(self):
         self._check_default_product(
             "Fedora", "",
@@ -109,6 +121,19 @@ class ProductConfigurationTestCase(unittest.TestCase):
             "Scientific Linux", "",
             ["rhel.conf", "scientific-linux.conf"]
         )
+
+    def product_module_list_difference_test(self):
+        """Test for expected Fedora & RHEL module list differences."""
+        fedora_config = self._get_config("Fedora")
+        fedora_modules = fedora_config.anaconda.kickstart_modules
+
+        rhel_config = self._get_config("Red Hat Enterprise Linux")
+        rhel_modules = rhel_config.anaconda.kickstart_modules
+
+        difference = list(set(rhel_modules) - set(fedora_modules))
+        expected_difference = ["org.fedoraproject.Anaconda.Modules.Subscription"]
+
+        self.assertListEqual(difference, expected_difference)
 
     def valid_product_test(self):
         content = dedent("""


### PR DESCRIPTION
The first commit creates the initial empty structure of the Subscription DBus module.
The second commit then adds support for handling system purpose data via kickstart and DBus API.