### PR TITLE
Ellipsize description in configure mount point

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
@@ -218,6 +218,9 @@
                       <object class="GtkTreeViewColumn" id="description_column">
                         <property name="spacing">6</property>
                         <property name="title" translatable="yes">Description</property>
+                        <property name="expand">True</property>
+                        <property name="resizable">True</property>
+                        <property name="min-width">100</property>
                         <property name="clickable">True</property>
                         <child>
                           <object class="GtkCellRendererText" id="description_renderer">

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
@@ -220,7 +220,9 @@
                         <property name="title" translatable="yes">Description</property>
                         <property name="clickable">True</property>
                         <child>
-                          <object class="GtkCellRendererText" id="description_renderer"/>
+                          <object class="GtkCellRendererText" id="description_renderer">
+                             <property name="ellipsize">middle</property>
+                          </object>
                           <attributes>
                             <attribute name="text">0</attribute>
                           </attributes>

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -393,6 +393,7 @@ class DisksDialog(GUIObject):
         self._view = self.builder.get_object("disk_view")
         self._populate_disks()
         self._select_disks()
+        self._view.set_tooltip_column(0)
 
     @property
     def selected_disks(self):


### PR DESCRIPTION
The patches make Description of a disk in disk list which can be sometimes (eg iSCSI disks) pretty long shorter by ellipsizing so that other columns don't run out of the dialog (with scrollbar added).
Like in the screenshot of https://bugzilla.redhat.com/show_bug.cgi?id=1530410#c2

Now to make the complete description available, two approaches are used:
1) Adding a tooltip with complete description. It might be considered too distracting given it is enabled for all descriptions - including the non-ellipsized, but perhaps it is fine, the delay before showing the tooltip seems making this no problem.
2) Making the description column resizable. Added value of this approach can be it makes the info Copy-able, but I am not sure if it would be actually useful for current use case.

A screencast is missing cursor, you have to think it up a bit but I hope it shows enough.
https://rvykydal.fedorapeople.org/ellipsize_disk_description.webm

Personally I'd go only with 2), but I don't mind 1) and see 2) as nice complement.
(I wonder which of the two is actually more discoverable;))