### PR TITLE
Fix dd from kickstart with space

### DIFF
--- a/dracut/driver-updates-genrules.sh
+++ b/dracut/driver-updates-genrules.sh
@@ -30,14 +30,17 @@ for dd in $DD_OEMDRV $DD_DISKS; do
             driver-updates --disk $dd $dd
     # otherwise, tell udev to do driver-updates when the device appears
     else
+        # replace '\' with '\\' for udev rules
+        # otherwise '\' will be lost during the command execution (required for \x20)
+        dd_whitespace_fix=${dd//\\/\\\\}
         # this is a disk with path to specific RPM file on it
         if [ "${dd##*.}" = "rpm" ]; then
             splitsep ":" "$dd" dd_type dd_dev dd_path
             when_diskdev_appears "$(disk_to_dev_path $dd_type)" \
-                driver-updates --disk $dd \$devnode $dd_dev
+                driver-updates --disk $dd_whitespace_fix \$devnode $dd_dev
         else
             when_diskdev_appears "$(disk_to_dev_path $dd)" \
-                driver-updates --disk $dd \$devnode
+                driver-updates --disk $dd_whitespace_fix \$devnode
         fi
     fi
 done

--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -778,6 +778,8 @@ def main(args):
         else:
             request, dev = args
 
+        log.debug("Processing: %s with dev %s", request, dev)
+
         # Guess whether this is an ISO or RPM based on the filename.
         # If neither matches, assume it is a device node and processes as an ISO.
         # This is relevant for both --disk and --net since --disk could be

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -139,7 +139,9 @@ class DracutHardDrive(HardDrive, DracutArgsMixin):
         if self.biospart:
             return "inst.repo=bd:%s:%s" % (self.partition, self.dir)
         else:
-            return "inst.repo=hd:%s:%s" % (self.partition, self.dir)
+            args = "inst.repo=hd:%s:%s" % (self.partition, self.dir)
+            # Escape spaces
+            return args.replace(" ", "\\x20")
 
 class DracutHmc(Hmc, DracutArgsMixin):
     def dracut_args(self, args, lineno, obj):
@@ -196,7 +198,9 @@ class DracutDriverDisk(DriverDisk, DracutArgsMixin):
             elif dd.biospart:
                 dd_args.append("inst.dd=bd:%s" % dd.biospart)
 
-        return "\n".join(dd_args)
+        args = "\n".join(dd_args)
+        # Escape spaces
+        return args.replace(" ", "\\x20")
 
 class DracutNetwork(Network, DracutArgsMixin):
     def dracut_args(self, args, lineno, obj):


### PR DESCRIPTION
This is correct version of https://github.com/rhinstaller/anaconda/pull/2223 which works correctly only for Kickstart argument parsing but not for processing later in the Dracut.

This PR is replacing https://github.com/rhinstaller/anaconda/pull/2223.

P.S.: The harddrive part is again working for Kickstart processing but during the installation we are not able to handle whitespace characters so I'm leaving it here but using spaces for hardrive is not supported by Anaconda and it will not be.