### PR TITLE
Don't override the method generate_kickstart

### DIFF
--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -253,6 +253,7 @@ class KickstartService(Service, KickstartBaseModule):
 
         :return: a kickstart string
         """
+        log.debug("Generating kickstart...")
         handler = self.get_kickstart_handler()
         self.setup_kickstart(handler)
         return str(handler)

--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -76,8 +76,6 @@ class LocalizationService(KickstartService):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
-        log.debug("Processing kickstart data...")
-
         # lang
         self.set_language(data.lang.lang)
         self.set_language_support(data.lang.addsupport)

--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -94,11 +94,8 @@ class LocalizationService(KickstartService):
 
         self.set_keyboard_seen(data.keyboard.seen)
 
-    def generate_kickstart(self):
-        """Return the kickstart string."""
-        log.debug("Generating kickstart data...")
-        data = self.get_kickstart_handler()
-
+    def setup_kickstart(self, data):
+        """Set up the kickstart data."""
         # lang
         data.lang.lang = self.language
         data.lang.addsupport = self.language_support
@@ -108,7 +105,7 @@ class LocalizationService(KickstartService):
         data.keyboard.x_layouts = self.x_layouts
         data.keyboard.switch_options = self.switch_options
 
-        return str(data)
+        return data
 
     @property
     def language(self):

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -141,10 +141,8 @@ class NetworkService(KickstartService):
             self.set_hostname(data.network.hostname)
         self._firewall_module.process_kickstart(data)
 
-    def generate_kickstart(self):
-        """Return the kickstart string."""
-        data = self.get_kickstart_handler()
-
+    def setup_kickstart(self, data):
+        """Set up the kickstart data."""
         if self._device_configurations and self._use_device_configurations:
             log.debug("using device configurations to generate kickstart")
             device_data = self.generate_kickstart_network_data(data.NetworkData)
@@ -160,7 +158,7 @@ class NetworkService(KickstartService):
         # firewall
         self._firewall_module.setup_kickstart(data)
 
-        return str(data)
+        return data
 
     def _is_device_activated(self, iface):
         device = self.nm_client.get_device_by_iface(iface)

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -127,8 +127,6 @@ class NetworkService(KickstartService):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
-        log.debug("Processing kickstart data...")
-
         # Handle default value for --device
         spec = self.default_device_specification
         if update_network_data_with_default_device(data.network.network, spec):

--- a/pyanaconda/modules/payloads/payloads.py
+++ b/pyanaconda/modules/payloads/payloads.py
@@ -112,14 +112,16 @@ class PayloadsService(KickstartService):
         # The packages module should be replaces with a DBus structure.
         self._packages.process_kickstart(data)
 
-    def generate_kickstart(self):
-        """Return the kickstart string."""
-        log.debug("Generating kickstart data...")
-        return ""
+    def setup_kickstart(self, data):
+        """Set up the kickstart data."""
+        return data
 
     def generate_temporary_kickstart(self):
-        """Return the kickstart string."""
-        log.debug("Generating kickstart data...")
+        """Return the temporary kickstart string.
+
+        FIXME: This is a temporary workaround.
+        """
+        log.debug("Generating temporary kickstart data...")
         data = self.get_kickstart_handler()
 
         try:

--- a/pyanaconda/modules/payloads/payloads.py
+++ b/pyanaconda/modules/payloads/payloads.py
@@ -96,8 +96,6 @@ class PayloadsService(KickstartService):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
-        log.debug("Processing kickstart data...")
-
         # Create a new payload module.
         payload_type = PayloadFactory.get_type_for_kickstart(data)
 

--- a/pyanaconda/modules/security/security.py
+++ b/pyanaconda/modules/security/security.py
@@ -91,11 +91,8 @@ class SecurityService(KickstartService):
 
             self.set_realm(realm)
 
-    def generate_kickstart(self):
-        """Return the kickstart string."""
-        log.debug("Generating kickstart data...")
-        data = self.get_kickstart_handler()
-
+    def setup_kickstart(self, data):
+        """Set up the kickstart data."""
         if self.selinux != SELinuxMode.DEFAULT:
             data.selinux.selinux = self.selinux.value
 
@@ -110,7 +107,7 @@ class SecurityService(KickstartService):
             data.realm.discover_options = self.realm.discover_options
             data.realm.join_args = self.realm.join_options
 
-        return str(data)
+        return data
 
     @property
     def selinux(self):

--- a/pyanaconda/modules/security/security.py
+++ b/pyanaconda/modules/security/security.py
@@ -72,8 +72,6 @@ class SecurityService(KickstartService):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
-        log.debug("Processing kickstart data...")
-
         if data.selinux.selinux is not None:
             self.set_selinux(SELinuxMode(data.selinux.selinux))
 

--- a/pyanaconda/modules/services/services.py
+++ b/pyanaconda/modules/services/services.py
@@ -76,7 +76,6 @@ class ServicesService(KickstartService):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
-        log.debug("Processing kickstart data...")
         self.set_enabled_services(data.services.enabled)
         self.set_disabled_services(data.services.disabled)
 

--- a/pyanaconda/modules/services/services.py
+++ b/pyanaconda/modules/services/services.py
@@ -101,11 +101,8 @@ class ServicesService(KickstartService):
         if data.firstboot.firstboot == FIRSTBOOT_SKIP:
             self.set_post_install_tools_enabled(False)
 
-    def generate_kickstart(self):
-        """Return the kickstart string."""
-        log.debug("Generating kickstart data...")
-        data = self.get_kickstart_handler()
-
+    def setup_kickstart(self, data):
+        """Set up the kickstart data."""
         data.services.enabled = self.enabled_services
         data.services.disabled = self.disabled_services
 
@@ -119,7 +116,7 @@ class ServicesService(KickstartService):
         firstboot = self._map_firstboot(self.setup_on_boot, reverse=True)
         data.firstboot.firstboot = firstboot
 
-        return str(data)
+        return data
 
     def _map_firstboot(self, value, reverse=False):
         """Convert the firstboot value to the setup on boot value.

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -158,8 +158,6 @@ class StorageService(KickstartService):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
-        log.debug("Processing kickstart data...")
-
         # Process the kickstart data in modules.
         for kickstart_module in self._modules:
             kickstart_module.process_kickstart(data)

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -175,18 +175,15 @@ class StorageService(KickstartService):
             partitioning_module = self.create_partitioning(partitioning_method)
             partitioning_module.process_kickstart(data)
 
-    def generate_kickstart(self):
-        """Return the kickstart string."""
-        log.debug("Generating kickstart data...")
-        data = self.get_kickstart_handler()
-
+    def setup_kickstart(self, data):
+        """Set up the kickstart data."""
         for kickstart_module in self._modules:
             kickstart_module.setup_kickstart(data)
 
         if self.applied_partitioning:
             self.applied_partitioning.setup_kickstart(data)
 
-        return str(data)
+        return data
 
     @property
     def storage(self):

--- a/pyanaconda/modules/timezone/timezone.py
+++ b/pyanaconda/modules/timezone/timezone.py
@@ -73,10 +73,8 @@ class TimezoneService(KickstartService):
         self.set_ntp_enabled(not data.timezone.nontp)
         self.set_ntp_servers(data.timezone.ntpservers)
 
-    def generate_kickstart(self):
-        """Return the kickstart string."""
-        log.debug("Generating kickstart data...")
-        data = self.get_kickstart_handler()
+    def setup_kickstart(self, data):
+        """Set up the kickstart data."""
         data.timezone.timezone = self.timezone
         data.timezone.isUtc = self.is_utc
         data.timezone.nontp = not self.ntp_enabled
@@ -84,7 +82,7 @@ class TimezoneService(KickstartService):
         if self.ntp_enabled:
             data.timezone.ntpservers = list(self.ntp_servers)
 
-        return str(data)
+        return data
 
     @property
     def timezone(self):

--- a/pyanaconda/modules/timezone/timezone.py
+++ b/pyanaconda/modules/timezone/timezone.py
@@ -67,7 +67,6 @@ class TimezoneService(KickstartService):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
-        log.debug("Processing kickstart data...")
         self.set_timezone(data.timezone.timezone)
         self.set_is_utc(data.timezone.isUtc)
         self.set_ntp_enabled(not data.timezone.nontp)

--- a/pyanaconda/modules/users/users.py
+++ b/pyanaconda/modules/users/users.py
@@ -114,10 +114,8 @@ class UsersService(KickstartService):
         self.set_ssh_keys(ssh_key_data_list)
 
     # pylint: disable=arguments-differ
-    def generate_kickstart(self):
-        """Return the kickstart string."""
-        log.debug("Generating kickstart data...")
-        data = self.get_kickstart_handler()
+    def setup_kickstart(self, data):
+        """Set up the kickstart data."""
         data.rootpw.password = self._root_password
         data.rootpw.isCrypted = self._root_password_is_crypted
         data.rootpw.lock = self.root_account_locked
@@ -139,7 +137,7 @@ class UsersService(KickstartService):
             ssh_key_ksdata.username = ssh_key_data.username
             data.sshkey.sshUserList.append(ssh_key_ksdata)
 
-        return str(data)
+        return data
 
     def configure_groups_with_task(self):
         """Return the user group configuration task.

--- a/pyanaconda/modules/users/users.py
+++ b/pyanaconda/modules/users/users.py
@@ -78,8 +78,6 @@ class UsersService(KickstartService):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
-        log.debug("Processing kickstart data...")
-
         self.set_root_password(data.rootpw.password, crypted=data.rootpw.isCrypted)
         self.set_root_account_locked(data.rootpw.lock)
         # make sure the root account is locked unless a password is set in kickstart


### PR DESCRIPTION
The kickstart modules should implement the method setup_kickstart instead
of overriding the method generate_kickstart.

The method process_kickstart is called by the method read_kickstart that
handles the logging, so it is not necessary to do it again.