### PR TITLE
Support logging of Anaconda DBus modules to files (#1812380)

### DIFF
--- a/pyanaconda/anaconda_loggers.py
+++ b/pyanaconda/anaconda_loggers.py
@@ -71,9 +71,5 @@ def get_dnf_logger():
     return logging.getLogger(constants.LOGGER_DNF)
 
 
-def get_blivet_logger():
-    return logging.getLogger(constants.LOGGER_BLIVET)
-
-
 def get_sensitive_info_logger():
     return logging.getLogger(constants.LOGGER_SENSITIVE_INFO)

--- a/pyanaconda/anaconda_logging.py
+++ b/pyanaconda/anaconda_logging.py
@@ -39,7 +39,6 @@ ANACONDA_SYSLOG_FORMAT = "anaconda: %(log_prefix)s: %(message)s"
 
 MAIN_LOG_FILE = "/tmp/anaconda.log"
 PROGRAM_LOG_FILE = "/tmp/program.log"
-STORAGE_LOG_FILE = "/tmp/storage.log"
 PACKAGING_LOG_FILE = "/tmp/packaging.log"
 SENSITIVE_INFO_LOG_FILE = "/tmp/sensitive-info.log"
 ANACONDA_SYSLOG_FACILITY = SysLogHandler.LOG_LOCAL1
@@ -184,27 +183,15 @@ class AnacondaLog(object):
         # handled by a FileHandler(/dev/null), which can deadlock.
         self.anaconda_logger = logging.getLogger("anaconda")
         self.anaconda_logger.propagate = False
+        self.anaconda_logger.setLevel(logging.DEBUG)
+        warnings.showwarning = self.showwarning
         self.addFileHandler(MAIN_LOG_FILE, self.anaconda_logger,
                             minLevel=logging.DEBUG,
                             fmtStr=ANACONDA_ENTRY_FORMAT,
                             log_filter=AnacondaPrefixFilter())
-        warnings.showwarning = self.showwarning
-
-        # Create the storage logger.
-        storage_logger = logging.getLogger(constants.LOGGER_BLIVET)
-        storage_logger.propagate = False
-        self.addFileHandler(STORAGE_LOG_FILE, storage_logger,
-                            minLevel=logging.DEBUG)
-
-        # Set the common parameters for anaconda and storage loggers.
-        for logr in [self.anaconda_logger, storage_logger]:
-            logr.setLevel(logging.DEBUG)
-
-        # forward both logs to syslog
         self.forwardToJournal(self.anaconda_logger,
                               log_filter=AnacondaPrefixFilter(),
                               log_formatter=logging.Formatter(ANACONDA_SYSLOG_FORMAT))
-        self.forwardToJournal(storage_logger)
 
         # External program output log
         program_logger = logging.getLogger(constants.LOGGER_PROGRAM)

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -53,13 +53,12 @@ from pykickstart.sections import NullSection, PackageSection, PostScriptSection,
 from pykickstart.version import returnClassForVersion
 
 from pyanaconda import anaconda_logging
-from pyanaconda.anaconda_loggers import get_module_logger, get_stdout_logger, get_blivet_logger,\
+from pyanaconda.anaconda_loggers import get_module_logger, get_stdout_logger, \
     get_anaconda_root_logger
 
 log = get_module_logger(__name__)
 
 stdoutLog = get_stdout_logger()
-storage_log = get_blivet_logger()
 
 # kickstart parsing and kickstart script
 script_log = log.getChild("script")
@@ -217,8 +216,6 @@ class Logging(COMMANDS.Logging):
             anaconda_logging.logger.loglevel = level
             # set log level for the "anaconda" root logger
             anaconda_logging.setHandlersLevel(get_anaconda_root_logger(), level)
-            # set log level for the storage logger
-            anaconda_logging.setHandlersLevel(storage_log, level)
 
         if anaconda_logging.logger.remote_syslog is None and len(self.host) > 0:
             # not set from the command line, ok to use kickstart

--- a/pyanaconda/modules/common/__init__.py
+++ b/pyanaconda/modules/common/__init__.py
@@ -15,21 +15,40 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import sys
 
 __all__ = ["init"]
 
 
-def init():
+def init(log_filename=None, log_stream=sys.stderr):
     """Do initial configuration of an Anaconda DBus module.
 
     This method should be imported and called from __main__.py of every
     Anaconda DBus module before any other import.
+
+    :param log_filename: a file for logging or None
+    :param log_stream: a stream for logging or None
     """
     import faulthandler
     faulthandler.enable()
 
     import logging
-    logging.basicConfig(level=logging.DEBUG)
+    handlers = []
+
+    if log_stream:
+        handlers.append(
+            logging.StreamHandler(log_stream)
+        )
+
+    if log_filename:
+        handlers.append(
+            logging.FileHandler(log_filename)
+        )
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        handlers=handlers
+    )
 
     import locale
     from pyanaconda.core.constants import DEFAULT_LANG

--- a/pyanaconda/modules/storage/__main__.py
+++ b/pyanaconda/modules/storage/__main__.py
@@ -1,5 +1,5 @@
 from pyanaconda.modules.common import init
-init()
+init("/tmp/storage.log")
 
 from pyanaconda.modules.storage.storage import StorageService
 service = StorageService()


### PR DESCRIPTION
Add support for writing logs of the Anaconda DBus modules to files.
Enable logging to the file /tmp/storage.log for the Storage module.

Don't set up the Blivet's logger in UI. Blivet is used mostly by the Storage
module now, so the logging should be handled there as well.

Resolves: rhbz#1812380