### PR TITLE
Fix fd leak while fchmod failed

### DIFF
--- a/utils/dd/dd_extract.c
+++ b/utils/dd/dd_extract.c
@@ -155,14 +155,17 @@ int main(int argc, char *argv[])
             break;
 
         case 'd':
+            free(directory);
             directory = strdup(optarg);
             break;
 
         case 'k':
+            free(kernel);
             kernel = strdup(optarg);
             break;
 
         case 'r':
+            free(rpm);
             rpm = strdup(optarg);
             break;
 

--- a/utils/dd/dd_list.c
+++ b/utils/dd/dd_list.c
@@ -190,14 +190,17 @@ int main(int argc, char *argv[])
             break;
 
         case 'd':
+            free(path);
             path = strdup(optarg);
             break;
 
         case 'k':
+            free(versions.kernel);
             versions.kernel = strdup(optarg);
             break;
 
         case 'a':
+            free(versions.anaconda);
             versions.anaconda = strdup(optarg);
             break;
 

--- a/utils/dd/rpmutils.c
+++ b/utils/dd/rpmutils.c
@@ -400,6 +400,7 @@ int explodeDDRPM(const char *source,
 
             /* call chmod to set any bits that were removed by umask during open */
             if (fchmod(fd, fstat->st_mode) != 0) {
+                close(fd);
                 rc = 33;
                 break;
             }

--- a/utils/dd/rpmutils.c
+++ b/utils/dd/rpmutils.c
@@ -336,6 +336,7 @@ int explodeDDRPM(const char *source,
     /* check the status of archive_open */
     if (rc != ARCHIVE_OK){
         Fclose(gzdi);
+        archive_read_free(cpio);
         headerFree(h);
         return -1;
     }


### PR DESCRIPTION
In explodeDDRPM(), we will break the while loop if fchmod() exec failed, which
cause the open fd leak. So we close the fd before brak.