### PR TITLE
Don't return anything from setup_kickstart

### DIFF
--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -134,9 +134,8 @@ class KickstartBaseModule(BaseModule):
         Use the module attributes to set the kickstart data.
 
         :param data: a kickstart handler
-        :return: a kickstart handler
         """
-        return data
+        pass
 
     def collect_requirements(self):
         """Return installation requirements.

--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -103,8 +103,6 @@ class LocalizationService(KickstartService):
         data.keyboard.x_layouts = self.x_layouts
         data.keyboard.switch_options = self.switch_options
 
-        return data
-
     @property
     def language(self):
         """Return the language."""

--- a/pyanaconda/modules/network/firewall/firewall.py
+++ b/pyanaconda/modules/network/firewall/firewall.py
@@ -88,7 +88,6 @@ class FirewallModule(KickstartBaseModule):
         data.firewall.trusts = self.trusts
         data.firewall.services = self.enabled_services
         data.firewall.remove_services = self.disabled_services
-        return data
 
     @property
     def firewall_seen(self):

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -156,8 +156,6 @@ class NetworkService(KickstartService):
         # firewall
         self._firewall_module.setup_kickstart(data)
 
-        return data
-
     def _is_device_activated(self, iface):
         device = self.nm_client.get_device_by_iface(iface)
         return device and device.get_state() == NM.DeviceState.ACTIVATED

--- a/pyanaconda/modules/payloads/payload/live_image/live_image.py
+++ b/pyanaconda/modules/payloads/payload/live_image/live_image.py
@@ -105,7 +105,6 @@ class LiveImageModule(PayloadBase):
     def setup_kickstart(self, data):
         """Setup the kickstart data."""
         liveimg = data.liveimg
-
         liveimg.url = self.url
         liveimg.proxy = self.proxy
         liveimg.checksum = self.checksum

--- a/pyanaconda/modules/payloads/payloads.py
+++ b/pyanaconda/modules/payloads/payloads.py
@@ -112,7 +112,7 @@ class PayloadsService(KickstartService):
 
     def setup_kickstart(self, data):
         """Set up the kickstart data."""
-        return data
+        pass
 
     def generate_temporary_kickstart(self):
         """Return the temporary kickstart string.

--- a/pyanaconda/modules/security/security.py
+++ b/pyanaconda/modules/security/security.py
@@ -105,8 +105,6 @@ class SecurityService(KickstartService):
             data.realm.discover_options = self.realm.discover_options
             data.realm.join_args = self.realm.join_options
 
-        return data
-
     @property
     def selinux(self):
         """The state of SELinux on the installed system.

--- a/pyanaconda/modules/services/services.py
+++ b/pyanaconda/modules/services/services.py
@@ -115,8 +115,6 @@ class ServicesService(KickstartService):
         firstboot = self._map_firstboot(self.setup_on_boot, reverse=True)
         data.firstboot.firstboot = firstboot
 
-        return data
-
     def _map_firstboot(self, value, reverse=False):
         """Convert the firstboot value to the setup on boot value.
 

--- a/pyanaconda/modules/storage/bootloader/bootloader.py
+++ b/pyanaconda/modules/storage/bootloader/bootloader.py
@@ -202,8 +202,6 @@ class BootloaderModule(KickstartBaseModule):
         data.bootloader.password = self.password
         data.bootloader.isCrypted = self.password_is_encrypted
 
-        return data
-
     @property
     def bootloader_mode(self):
         """The mode of the bootloader."""

--- a/pyanaconda/modules/storage/disk_initialization/initialization.py
+++ b/pyanaconda/modules/storage/disk_initialization/initialization.py
@@ -98,7 +98,6 @@ class DiskInitializationModule(KickstartBaseModule):
         """Setup the kickstart data."""
         self._setup_kickstart_from_module(data)
         self._setup_kickstart_from_storage(data)
-        return data
 
     def _setup_kickstart_from_module(self, data):
         """Update the configuration from the module.

--- a/pyanaconda/modules/storage/disk_selection/selection.py
+++ b/pyanaconda/modules/storage/disk_selection/selection.py
@@ -81,7 +81,6 @@ class DiskSelectionModule(KickstartBaseModule):
         """Setup the kickstart data."""
         data.ignoredisk.onlyuse = self.selected_disks
         data.ignoredisk.ignoredisk = self.ignored_disks
-        return data
 
     @property
     def selected_disks(self):

--- a/pyanaconda/modules/storage/snapshot/snapshot.py
+++ b/pyanaconda/modules/storage/snapshot/snapshot.py
@@ -87,7 +87,6 @@ class SnapshotModule(KickstartBaseModule):
     def setup_kickstart(self, data):
         """Setup the kickstart data."""
         data.snapshot.snapshotList = self._requests
-        return data
 
     def is_requested(self, when):
         """Is there a snapshot request of the given type?

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -181,8 +181,6 @@ class StorageService(KickstartService):
         if self.applied_partitioning:
             self.applied_partitioning.setup_kickstart(data)
 
-        return data
-
     @property
     def storage(self):
         """The storage model.

--- a/pyanaconda/modules/timezone/timezone.py
+++ b/pyanaconda/modules/timezone/timezone.py
@@ -81,8 +81,6 @@ class TimezoneService(KickstartService):
         if self.ntp_enabled:
             data.timezone.ntpservers = list(self.ntp_servers)
 
-        return data
-
     @property
     def timezone(self):
         """Return the timezone."""

--- a/pyanaconda/modules/users/users.py
+++ b/pyanaconda/modules/users/users.py
@@ -135,8 +135,6 @@ class UsersService(KickstartService):
             ssh_key_ksdata.username = ssh_key_data.username
             data.sshkey.sshUserList.append(ssh_key_ksdata)
 
-        return data
-
     def configure_groups_with_task(self):
         """Return the user group configuration task.
 


### PR DESCRIPTION
The method `setup_kickstart` shouldn't return anything. It sets up the given
kickstart handler, so there is no reason why it should return the same object.