### PR TITLE
Rename add-ons to additional software (#1674011)

### DIFF
--- a/pyanaconda/ui/gui/spokes/software_selection.glade
+++ b/pyanaconda/ui/gui/spokes/software_selection.glade
@@ -81,7 +81,7 @@
                         <property name="margin_bottom">6</property>
                         <property name="hexpand">True</property>
                         <property name="xalign">0</property>
-                        <property name="label" translatable="yes">Add-Ons for Selected Environment</property>
+                        <property name="label" translatable="yes">Additional software for Selected Environment</property>
                         <attributes>
                           <attribute name="font-desc" value="Cantarell 12"/>
                           <attribute name="weight" value="normal"/>

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -229,9 +229,9 @@ class SoftwareSpoke(NormalTUISpoke):
             self._container.add(widget, callback=self._set_addons_callback, data=addon_id)
 
         if available_addons:
-            return _("Add-ons for selected environment")
+            return _("Additional software for selected environment")
         else:
-            return _("No add-ons to select.")
+            return _("No additional software to select.")
 
     def _set_environment_callback(self, data):
         self._selected_environment = data


### PR DESCRIPTION
Rename TUI and GUI add-ons in the software spoke to the 'Additional
software'.

Resolves: rhbz#1674011

Port of commit e8fe507986543978b41e578949084d640b0de60b

This is port to Fedora of https://github.com/rhinstaller/anaconda/pull/1978