### PR TITLE
Change dd extract help

### DIFF
--- a/utils/dd/dd_extract.c
+++ b/utils/dd/dd_extract.c
@@ -50,7 +50,8 @@ static const struct option longopts[] = {
 
 static const char *options_help [][2] = {
     {"directory", "Directory to extract into"},
-    {"rpm",       "rpm to extract"},
+    {"rpm",       "rpm to extract - must be absolute path"},
+    // FIXME: It seems that this argument is not used anywhere. Check and remove it.
     {"kernel",    "kernel version"},
     {"verbose",   "Verbose output"},
     {"binaries",  "Extract binaries"},


### PR DESCRIPTION
Specify that you have to specify an absolute path to RPM file. It should be fixed to take also relative paths but this tool is used only in the Dracut in our scripts so this should be enough for debugging in the future.

Add FIXME because it looks that there is required parameter which is not used at all.