### PR TITLE
Use the right field of DiskStoreRow (#1816256)

### DIFF
--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -323,7 +323,7 @@ class MultipathPage(FilterPage):
             return row.vendor == self._vendor_combo.get_active_text()
 
         if filter_by == self.SEARCH_TYPE_INTERCONNECT:
-            return row.bus == self._ic_combo.get_active_text()
+            return row.interconnect == self._ic_combo.get_active_text()
 
         if filter_by == self.SEARCH_TYPE_WWID:
             return self._wwid_entry.get_text() in row.wwid


### PR DESCRIPTION
The named tuple DiskStoreRow doesn't have a field called bus, use the field
interconnect instead.

Resolves: rhbz#1816256