### PR TITLE
subscription: SubscriptionRequest DBus structure

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -403,3 +403,22 @@ URL_TYPE_METALINK = "METALINK"
 
 # Default values of DNF repository configuration
 DNF_DEFAULT_REPO_COST = 1000
+
+# Subscription request types
+#
+# Subscription request can currently be one of two types:
+# - using username and password for authentication
+# - using organization id and one or more authentication keys
+#   for authentication
+SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD = "username_password"
+SUBSCRIPTION_REQUEST_TYPE_ORG_KEY = "org_activation_key"
+
+SUBSCRIPTION_REQUEST_VALID_TYPES = {
+    SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD,
+    SUBSCRIPTION_REQUEST_TYPE_ORG_KEY,
+}
+
+# Default authentication for subscription requests is
+# username password - this is basically to avoid the invalid
+# case of request not having a type set.
+DEFAULT_SUBSCRIPTION_REQUEST_TYPE = SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD

--- a/pyanaconda/modules/common/structures/subscription.py
+++ b/pyanaconda/modules/common/structures/subscription.py
@@ -19,8 +19,11 @@
 from dasbus.structure import DBusData
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
-__all__ = ["SystemPurposeData"]
+from pyanaconda.core.constants import DEFAULT_SUBSCRIPTION_REQUEST_TYPE
 
+from pyanaconda.modules.common.structures.secret import SecretData, SecretDataList
+
+__all__ = ["SystemPurposeData", "SubscriptionRequest"]
 
 class SystemPurposeData(DBusData):
     """System purpose data."""
@@ -78,3 +81,274 @@ class SystemPurposeData(DBusData):
     @addons.setter
     def addons(self, addons: List[Str]):
         self._addons = addons
+
+
+class SubscriptionRequest(DBusData):
+    """Data for a subscription request.
+
+    NOTE: Names of some of the fields are based on
+          how the given keys are called in rhsm.conf.
+    """
+
+    def __init__(self):
+        # subscription request type
+        # (based on authentication method used)
+        self._type = DEFAULT_SUBSCRIPTION_REQUEST_TYPE
+        # user identification
+        # - in case an account is member
+        #   of multiple organizations, both
+        #   organization and account username
+        #   need to be set
+        self._organization = ""
+        self._redhat_account_username = ""
+        # Candlepin instance
+        self._server_hostname = ""
+        # CDN base url
+        self._rhsm_baseurl = ""
+        # RHSM HTTP proxy
+        self._server_proxy_hostname = ""
+        self._server_proxy_port = -1
+        self._server_proxy_user = ""
+        # private data
+        # - we are using SecretData & SecretDataList
+        #   nested DBus structures to protect this
+        #   sensitive data
+        # - this way they can be set-only & easily
+        #   removed from SubscriptionRequest on
+        #   output from the Subscription module
+        # - they also support a robust way of clearing
+        #   previously set sensitive data if required
+        self._redhat_account_password = SecretData()
+        self._activation_keys = SecretDataList()
+        self._server_proxy_password = SecretData()
+
+    @property
+    def type(self) -> Str:
+        """Subscription request type.
+
+        Subscription request type is based on the authentication method used.
+
+        At the moment the following two are supported:
+        - username + password
+        - organization id + one or more activation keys
+
+        By default username + password is used.
+
+        Valid values are:
+        "username_password"
+        "org_activation_key"
+
+        :return: subscription request type
+        :rtype: str
+        """
+        return self._type
+
+    @type.setter
+    def type(self, request_type: Str):
+        self._type = request_type
+
+    @property
+    def organization(self) -> Str:
+        """Organization id for subscription purposes.
+
+        In most cases one of the following will be used:
+        - org id + one or more activation keys
+        - username + password
+
+        There is also a less often expected use case,
+        which applies if the same user account exists
+        in multiple organizations on the same Candlepin
+        instance. In such a case both username and
+        organization id needs to be set.
+
+        :return: organization id
+        :rtype: str
+        """
+        return self._organization
+
+    @organization.setter
+    def organization(self, organization: Str):
+        self._organization = organization
+
+    @property
+    def account_username(self) -> Str:
+        """Red Hat account username for subscription purposes.
+
+        In case the account for the given username is member
+        of multiple organizations, organization id needs to
+        be specified as well or else the registration attempt
+        will not be successful.
+
+        :return: Red Hat account username
+        :rtype: str
+        """
+        return self._redhat_account_username
+
+    @account_username.setter
+    def account_username(self, account_username: Str):
+        self._redhat_account_username = account_username
+
+    @property
+    def server_hostname(self) -> Str:
+        """Subscription server hostname.
+
+        This is basically a URL pointing to a Candlepin
+        instance to be used. It could be the one handling
+        general subscriptions hosted by Red Hat or one
+        embedded in a Satellite deployment.
+
+        If no custom server hostname is set, the default
+        value used by subscription manager will be used,
+        which is usually the URL pointing to the general
+        purpose Red Hat hosted Candlepin instance.
+
+        :return: Candlepin instance URL
+        :rtype: str
+        """
+        return self._server_hostname
+
+    @server_hostname.setter
+    def server_hostname(self, server_hostname: Str):
+        self._server_hostname = server_hostname
+
+    @property
+    def rhsm_baseurl(self) -> Str:
+        """CDN repository base URL.
+
+        Sets the base URL for the RHSM generated
+        repo file.
+
+        Setting this to a non default value only
+        makes sense if registering against Satellite
+        (as you would want to use the repos hosted
+        on the given Satellite instance) or possibly
+        during testing.
+
+        If no custom rhsm baseurl is set, the default
+        value used by subscription managed will be used,
+        which is generally baseurl for the Red Hat CDN.
+
+        :return: RHSM base url
+        :rtype: str
+        """
+        return self._rhsm_baseurl
+
+    @rhsm_baseurl.setter
+    def rhsm_baseurl(self, rhsm_baseurl: Str):
+        self._rhsm_baseurl = rhsm_baseurl
+
+    @property
+    def server_proxy_hostname(self) -> Str:
+        """RHSM HTTP proxy - hostname.
+
+        This is the hostname of the RHSM HTTP
+        proxy, which will be used for subscription
+        purposes only, eq. this will not configure
+        a system wide HTTP proxy.
+
+        :return: RHSM HTTP proxy hostname
+        :rtype: str
+        """
+        return self._server_proxy_hostname
+
+    @server_proxy_hostname.setter
+    def server_proxy_hostname(self, hostname: Str):
+        self._server_proxy_hostname = hostname
+
+    @property
+    def server_proxy_port(self) -> Int:
+        """RHSM HTTP proxy - port number.
+
+        -1 means port has not been set.
+
+        :returns: RHSM HTTP proxy port number
+        :rtype: int
+        """
+        return self._server_proxy_port
+
+    @server_proxy_port.setter
+    def server_proxy_port(self, port_number: Int):
+        self._server_proxy_port = port_number
+
+    @property
+    def server_proxy_user(self) -> Str:
+        """RHSM HTTP proxy - access username.
+
+        :return: RHSM HTTP proxy access username
+        :rtype: str
+        """
+        return self._server_proxy_user
+
+    @server_proxy_user.setter
+    def server_proxy_user(self, username: Str):
+        self._server_proxy_user = username
+
+    # private data
+    # - generally sensitive data such as passwords
+    #   or activation keys
+    # - these values should be "write only",
+    #   meaning data goes to the Subscription
+    #   module but can't be read out later one
+    #   via the public API
+    # - only the Subscription module should have
+    #   have access to these data internally &
+    #   use them appropriately (eq. register
+    #   the system, authenticate to HTTP proxy, etc.)
+    # - it should be also possible to explicitly
+    #   clear a previously set secret
+    # - to protect these values we are using
+    #   SecretData & SecretDataList, see their
+    #   implementation for more information
+
+    @property
+    def account_password(self) -> SecretData:
+        """Red Hat account password.
+
+        NOTE: This property is stored in SecretData
+              nested DBus structure to protect its contents.
+
+        :return: Red hat account password stored in a SecretData instance
+        :rtype: SecretData instance
+        """
+        return self._redhat_account_password
+
+    @account_password.setter
+    def account_password(self, password: SecretData):
+        if password:
+            self.account_password_set = True
+        self._redhat_account_password = password
+
+    @property
+    def activation_keys(self) -> SecretDataList:
+        """List of activation keys.
+
+        For a successful activation key based registration
+        at least one activation key needs to be set.
+
+        NOTE: This property is stored in SecretDataList
+              nested DBus structure to protect its contents.
+
+        :return: list of activation keys stored in SecretDataList instance
+        :rtype: SecretDataList instance
+        """
+        return self._activation_keys
+
+    @activation_keys.setter
+    def activation_keys(self, activation_keys: SecretDataList):
+        self._activation_keys = activation_keys
+
+    @property
+    def server_proxy_password(self) -> SecretData:
+        """RHSM HTTP proxy - access password.
+
+        NOTE: This property is stored in SecretData
+              nested DBus structure to protect its contents.
+
+        :return: RHSM HTTP proxy password stored in SecretData instance
+        :rtype: SecretData instance
+        """
+        return self._server_proxy_password
+
+    @server_proxy_password.setter
+    def server_proxy_password(self, password: SecretData):
+        self._server_proxy_password = password

--- a/pyanaconda/modules/subscription/kickstart.py
+++ b/pyanaconda/modules/subscription/kickstart.py
@@ -17,7 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.core.kickstart import VERSION, KickstartSpecification, commands as COMMANDS
+from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
 
 
 class SubscriptionKickstartSpecification(KickstartSpecification):

--- a/pyanaconda/modules/subscription/system_purpose.py
+++ b/pyanaconda/modules/subscription/system_purpose.py
@@ -21,7 +21,6 @@
 import os
 import json
 
-from pyanaconda.core import util
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
@@ -23,12 +23,19 @@ import tempfile
 
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
+from pyanaconda.core.constants import SECRET_TYPE_NONE, SECRET_TYPE_HIDDEN, SECRET_TYPE_TEXT, \
+    SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY, \
+    DEFAULT_SUBSCRIPTION_REQUEST_TYPE
+
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION
-from pyanaconda.modules.common.structures.subscription import SystemPurposeData
+from pyanaconda.modules.common.structures.subscription import SystemPurposeData, \
+    SubscriptionRequest
+
 from pyanaconda.modules.subscription.subscription import SubscriptionService
 from pyanaconda.modules.subscription.subscription_interface import SubscriptionInterface
 from pyanaconda.modules.subscription.system_purpose import get_valid_fields, _normalize_field, \
     _match_field, process_field
+
 from tests.nosetests.pyanaconda_tests import check_kickstart_interface, check_dbus_property, \
     PropertiesChangedCallback
 
@@ -161,7 +168,11 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         self.callback = PropertiesChangedCallback()
         self.subscription_interface.PropertiesChanged.connect(self.callback)
 
-    def _test_dbus_property(self, *args, **kwargs):
+        # some of the diffs might be long if a test fails, but we still
+        # want to see them
+        self.maxDiff = None
+
+    def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
             self,
             SUBSCRIPTION,
@@ -197,6 +208,15 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         # compare the two
         self.assertEqual(SystemPurposeData.to_structure(system_purpose_data), expected_dict)
 
+        # feed it to the DBus interface
+        self.subscription_interface.SetSystemPurposeData(
+            SystemPurposeData.to_structure(system_purpose_data)
+        )
+
+        # compare the result with expected data
+        output = self.subscription_interface.SystemPurposeData
+        self.assertEqual(output, expected_dict)
+
     def set_system_purpose_test(self):
         """Test if setting system purpose data from DBUS works correctly."""
         system_purpose_data = {
@@ -206,7 +226,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
             "addons": get_variant(List[Str], ["a", "b", "c"])
         }
 
-        self._test_dbus_property(
+        self._check_dbus_property(
           "SystemPurposeData",
           system_purpose_data
         )
@@ -218,6 +238,481 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         self.assertEqual(output_system_purpose_data.sla, "bar")
         self.assertEqual(output_system_purpose_data.usage, "baz")
         self.assertEqual(output_system_purpose_data.addons, ["a", "b", "c"])
+
+    def subscription_request_data_defaults_test(self):
+        """Test the SubscriptionRequest DBus structure defaults."""
+
+        # create empty SubscriptionRequest structure
+        empty_request = SubscriptionRequest()
+
+        # compare with expected default values
+        expected_default_dict = {
+            "type": DEFAULT_SUBSCRIPTION_REQUEST_TYPE,
+            "organization": "",
+            "account-username": "",
+            "server-hostname": "",
+            "rhsm-baseurl": "",
+            "server-proxy-hostname": "",
+            "server-proxy-port": -1,
+            "server-proxy-user": "",
+            "account-password": {"type": SECRET_TYPE_NONE, "value": ""},
+            "activation-keys": {"type": SECRET_TYPE_NONE, "value": []},
+            "server-proxy-password": {"type": SECRET_TYPE_NONE, "value": ""},
+        }
+
+        # compare the empty structure with expected default values
+        self.assertEqual(
+            get_native(SubscriptionRequest.to_structure(empty_request)),
+            expected_default_dict
+        )
+
+    def subscription_request_data_full_test(self):
+        """Test completely populated SubscriptionRequest DBus structure."""
+
+        # create fully populated SubscriptionRequest structure
+        full_request = SubscriptionRequest()
+        full_request.type = SUBSCRIPTION_REQUEST_TYPE_ORG_KEY
+        full_request.organization = "123456789"
+        full_request.account_username = "foo_user"
+        full_request.server_hostname = "candlepin.foo.com"
+        full_request.rhsm_baseurl = "cdn.foo.com"
+        full_request.server_proxy_hostname = "proxy.foo.com"
+        full_request.server_proxy_port = 9001
+        full_request.server_proxy_user = "foo_proxy_user"
+        full_request.account_password.set_secret("foo_password")
+        full_request.activation_keys.set_secret(["key1", "key2", "key3"])
+        full_request.server_proxy_password.set_secret("foo_proxy_password")
+
+        expected_full_dict = {
+            "type": SUBSCRIPTION_REQUEST_TYPE_ORG_KEY,
+            "organization": "123456789",
+            "account-username": "foo_user",
+            "server-hostname": "candlepin.foo.com",
+            "rhsm-baseurl": "cdn.foo.com",
+            "server-proxy-hostname": "proxy.foo.com",
+            "server-proxy-port": 9001,
+            "server-proxy-user": "foo_proxy_user",
+            "account-password": {"type": SECRET_TYPE_TEXT, "value": "foo_password"},
+            "activation-keys": {"type": SECRET_TYPE_TEXT, "value": ["key1", "key2", "key3"]},
+            "server-proxy-password": {"type": SECRET_TYPE_TEXT, "value": "foo_proxy_password"},
+        }
+
+        # compare the fully populated structure with expected values
+        self.assertEqual(
+            get_native(SubscriptionRequest.to_structure(full_request)),
+            expected_full_dict
+        )
+
+        # set it to the module interface
+        self.subscription_interface.SetSubscriptionRequest(
+            SubscriptionRequest.to_structure(full_request)
+        )
+
+        # compare the output with expected values
+        output = self.subscription_interface.SubscriptionRequest
+        output_dict = get_native(output)
+
+        expected_full_output_dict = {
+            "type": SUBSCRIPTION_REQUEST_TYPE_ORG_KEY,
+            "organization": "123456789",
+            "account-username": "foo_user",
+            "server-hostname": "candlepin.foo.com",
+            "rhsm-baseurl": "cdn.foo.com",
+            "server-proxy-hostname": "proxy.foo.com",
+            "server-proxy-port": 9001,
+            "server-proxy-user": "foo_proxy_user",
+            "account-password": {"type": SECRET_TYPE_HIDDEN, "value": ""},
+            "activation-keys": {"type": SECRET_TYPE_HIDDEN, "value": []},
+            "server-proxy-password": {"type": SECRET_TYPE_HIDDEN, "value": ""},
+        }
+
+        self.assertEqual(
+            output_dict,
+            expected_full_output_dict
+        )
+
+    def set_subscription_request_password_test(self):
+        """Test if setting username+password subscription request from DBUS works correctly."""
+        subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD),
+            "account-username": get_variant(Str, "foo_user"),
+            "account-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "TEXT"),
+                             "value": get_variant(Str, "bar_password")})
+        }
+        expected_subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD),
+            "organization": get_variant(Str, ""),
+            "account-username": get_variant(Str, "foo_user"),
+            "server-hostname": get_variant(Str, ""),
+            "rhsm-baseurl": get_variant(Str, ""),
+            "server-proxy-hostname": get_variant(Str, ""),
+            "server-proxy-port": get_variant(Int, -1),
+            "server-proxy-user": get_variant(Str, ""),
+            "account-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(Str, "")}),
+            "activation-keys":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(List[Str], [])}),
+            "server-proxy-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(Str, "")})
+        }
+
+        self._check_dbus_property(
+          "SubscriptionRequest",
+          subscription_request,
+          expected_subscription_request
+        )
+
+    def set_subscription_request_activation_key_test(self):
+        """Test if setting org + key subscription request from DBUS works correctly."""
+        subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY),
+            "organization": get_variant(Str, "123456789"),
+            "activation-keys":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "TEXT"),
+                             "value": get_variant(List[Str],
+                                                  ["key_foo", "key_bar", "key_baz"])}),
+        }
+        expected_subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY),
+            "organization": get_variant(Str, "123456789"),
+            "account-username": get_variant(Str, ""),
+            "server-hostname": get_variant(Str, ""),
+            "rhsm-baseurl": get_variant(Str, ""),
+            "server-proxy-hostname": get_variant(Str, ""),
+            "server-proxy-port": get_variant(Int, -1),
+            "server-proxy-user": get_variant(Str, ""),
+            "account-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(Str, "")}),
+            "activation-keys":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(List[Str], [])}),
+            "server-proxy-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(Str, "")})
+        }
+
+        self._check_dbus_property(
+          "SubscriptionRequest",
+          subscription_request,
+          expected_subscription_request
+        )
+
+    def set_subscription_request_proxy_test(self):
+        """Test if setting HTTP proxy in subscription request from DBUS works correctly."""
+        subscription_request = {
+            "server-proxy-hostname": get_variant(Str, "proxy.foo.bar"),
+            "server-proxy-port": get_variant(Int, 9001),
+            "server-proxy-user": get_variant(Str, "foo_proxy_user"),
+            "server-proxy-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "TEXT"),
+                             "value": get_variant(Str, "foo_proxy_password")})
+        }
+
+        expected_subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD),
+            "organization": get_variant(Str, ""),
+            "account-username": get_variant(Str, ""),
+            "server-hostname": get_variant(Str, ""),
+            "rhsm-baseurl": get_variant(Str, ""),
+            "server-proxy-hostname": get_variant(Str, "proxy.foo.bar"),
+            "server-proxy-port": get_variant(Int, 9001),
+            "server-proxy-user": get_variant(Str, "foo_proxy_user"),
+            "account-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(Str, "")}),
+            "activation-keys":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(List[Str], [])}),
+            "server-proxy-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(Str, "")})
+        }
+
+        self._check_dbus_property(
+          "SubscriptionRequest",
+          subscription_request,
+          expected_subscription_request
+        )
+
+    def set_subscription_request_custom_urls_test(self):
+        """Test if setting custom URLs in subscription request from DBUS works correctly."""
+        subscription_request = {
+            "server-hostname": get_variant(Str, "candlepin.foo.bar"),
+            "rhsm-baseurl": get_variant(Str, "cdn.foo.bar"),
+        }
+        expected_subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD),
+            "organization": get_variant(Str, ""),
+            "account-username": get_variant(Str, ""),
+            "server-hostname": get_variant(Str, "candlepin.foo.bar"),
+            "rhsm-baseurl": get_variant(Str, "cdn.foo.bar"),
+            "server-proxy-hostname": get_variant(Str, ""),
+            "server-proxy-port": get_variant(Int, -1),
+            "server-proxy-user": get_variant(Str, ""),
+            "account-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(Str, "")}),
+            "activation-keys":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(List[Str], [])}),
+            "server-proxy-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(Str, "")})
+        }
+
+        self._check_dbus_property(
+          "SubscriptionRequest",
+          subscription_request,
+          expected_subscription_request
+        )
+
+    def set_subscription_request_sensitive_data_wipe_test(self):
+        """Test if it is possible to wipe sensitive data in SubscriptionRequest."""
+        subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD),
+            "account-username": get_variant(Str, "foo_user"),
+            "account-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "TEXT"),
+                             "value": get_variant(Str, "bar_password")}),
+            "activation-keys":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "TEXT"),
+                             "value": get_variant(List[Str],
+                                                  ["key_foo", "key_bar", "key_baz"])}),
+            "server-proxy-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "TEXT"),
+                             "value": get_variant(Str, "foo_proxy_password")})
+        }
+        expected_subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD),
+            "organization": get_variant(Str, ""),
+            "account-username": get_variant(Str, "foo_user"),
+            "server-hostname": get_variant(Str, ""),
+            "rhsm-baseurl": get_variant(Str, ""),
+            "server-proxy-hostname": get_variant(Str, ""),
+            "server-proxy-port": get_variant(Int, -1),
+            "server-proxy-user": get_variant(Str, ""),
+            "account-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(Str, "")}),
+            "activation-keys":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(List[Str], [])}),
+            "server-proxy-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(Str, "")})
+        }
+
+        # check all three sensitive values are hidden
+        self._check_dbus_property(
+          "SubscriptionRequest",
+          subscription_request,
+          expected_subscription_request
+        )
+
+        # indicate in SubscriptionRequest that the values should be wiped,
+        # be setting all three SecureData/SecureDataList structures type
+        # to NONE
+        subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD),
+            "account-username": get_variant(Str, "foo_user"),
+            "account-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(Str, "")}),
+            "activation-keys":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(List[Str], [])}),
+            "server-proxy-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(Str, "")})
+        }
+        expected_subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD),
+            "organization": get_variant(Str, ""),
+            "account-username": get_variant(Str, "foo_user"),
+            "server-hostname": get_variant(Str, ""),
+            "rhsm-baseurl": get_variant(Str, ""),
+            "server-proxy-hostname": get_variant(Str, ""),
+            "server-proxy-port": get_variant(Int, -1),
+            "server-proxy-user": get_variant(Str, ""),
+            "account-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(Str, "")}),
+            "activation-keys":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(List[Str], [])}),
+            "server-proxy-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "NONE"),
+                             "value": get_variant(Str, "")})
+        }
+
+        # check all three sensitive values are wiped
+        self._check_dbus_property(
+          "SubscriptionRequest",
+          subscription_request,
+          expected_subscription_request
+        )
+
+    def set_subscription_request_sensitive_data_keep_test(self):
+        """Test if sensitive data is kept in SubscriptionRequest if a blank value comes in."""
+        subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD),
+            "account-username": get_variant(Str, "foo_user"),
+            "account-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "TEXT"),
+                             "value": get_variant(Str, "bar_password")}),
+            "activation-keys":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "TEXT"),
+                             "value": get_variant(List[Str],
+                                                  ["key_foo", "key_bar", "key_baz"])}),
+            "server-proxy-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "TEXT"),
+                             "value": get_variant(Str, "foo_proxy_password")})
+        }
+        expected_subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD),
+            "organization": get_variant(Str, ""),
+            "account-username": get_variant(Str, "foo_user"),
+            "server-hostname": get_variant(Str, ""),
+            "rhsm-baseurl": get_variant(Str, ""),
+            "server-proxy-hostname": get_variant(Str, ""),
+            "server-proxy-port": get_variant(Int, -1),
+            "server-proxy-user": get_variant(Str, ""),
+            "account-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(Str, "")}),
+            "activation-keys":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(List[Str], [])}),
+            "server-proxy-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(Str, "")})
+        }
+
+        # check all three sensitive values are hidden
+        self._check_dbus_property(
+          "SubscriptionRequest",
+          subscription_request,
+          expected_subscription_request
+        )
+
+        # check all three values are actually set to what we expect
+        internal_request = self.subscription_module._subscription_request
+        self.assertEqual(internal_request.account_password.value,
+                         "bar_password")
+        self.assertEqual(internal_request.activation_keys.value,
+                         ["key_foo", "key_bar", "key_baz"])
+        self.assertEqual(internal_request.server_proxy_password.value,
+                         "foo_proxy_password")
+
+        # set SubscriptionRequest on input with empty value
+        # and type set to HIDDEN
+        subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD),
+            "account-username": get_variant(Str, "foo_user"),
+            "account-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(Str, "")}),
+            "activation-keys":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(List[Str], [])}),
+            "server-proxy-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(Str, "")})
+        }
+        expected_subscription_request = {
+            "type": get_variant(Str, SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD),
+            "organization": get_variant(Str, ""),
+            "account-username": get_variant(Str, "foo_user"),
+            "server-hostname": get_variant(Str, ""),
+            "rhsm-baseurl": get_variant(Str, ""),
+            "server-proxy-hostname": get_variant(Str, ""),
+            "server-proxy-port": get_variant(Int, -1),
+            "server-proxy-user": get_variant(Str, ""),
+            "account-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(Str, "")}),
+            "activation-keys":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(List[Str], [])}),
+            "server-proxy-password":
+                get_variant(Structure,
+                            {"type": get_variant(Str, "HIDDEN"),
+                             "value": get_variant(Str, "")})
+        }
+
+        # check all the sensitive values appear to be in the correct state
+        self._check_dbus_property(
+          "SubscriptionRequest",
+          subscription_request,
+          expected_subscription_request
+        )
+
+        # check all three values are actually still set to what we expect
+        internal_request = self.subscription_module._subscription_request
+        self.assertEqual(internal_request.account_password.value,
+                         "bar_password")
+        self.assertEqual(internal_request.activation_keys.value,
+                         ["key_foo", "key_bar", "key_baz"])
+        self.assertEqual(internal_request.server_proxy_password.value,
+                         "foo_proxy_password")
+
+    def insights_property_test(self):
+        """Test the InsightsEnabled property."""
+        # should be False by default
+        self.assertFalse(self.subscription_interface.InsightsEnabled)
+
+        # try setting the property
+        self._check_dbus_property(
+          "InsightsEnabled",
+          True
+        )
+        self._check_dbus_property(
+          "InsightsEnabled",
+          False
+        )
 
     def _test_kickstart(self, ks_in, ks_out):
         check_kickstart_interface(self, self.subscription_interface, ks_in, ks_out)
@@ -301,3 +796,90 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         self.assertEqual(system_purpose_data.sla, 'BAR')
         self.assertEqual(system_purpose_data.usage, 'BAZ')
         self.assertEqual(system_purpose_data.addons, ["F Product", "B Feature"])
+
+    def ks_out_rhsm_parse_test(self):
+        """Check the rhsm kickstart command is parsed correctly."""
+        # triple quoting will not help here as the single rhsm command line
+        # is longer than 100 characters & will not make our PEP8 checker happy
+        ks_in = 'rhsm --organization="123" --activation-key="foo_key" --connect-to-insights ' \
+                '--server-hostname="candlepin.foo.com" --rhsm-baseurl="cdn.foo.com" ' \
+                '--proxy=user:pass@proxy.com:9001'
+
+        # rhsm command is never output as we don't write out activation keys &
+        # the command thus would be incomplete, resulting in an invalid kickstart
+        ks_out = ""
+        self._test_kickstart(ks_in, ks_out)
+
+        structure = self.subscription_interface.SubscriptionRequest
+        subscription_request = SubscriptionRequest.from_structure(structure)
+        # both org id and one key have been used, request should be org & key type
+        self.assertEqual(subscription_request.type, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY)
+        self.assertEqual(subscription_request.organization, "123")
+        self.assertEqual(subscription_request.activation_keys.value, [])
+        # keys should be hidden
+        self.assertEqual(subscription_request.activation_keys.type,
+                         SECRET_TYPE_HIDDEN)
+        # account username & password should be empty
+        self.assertEqual(subscription_request.account_username, "")
+        self.assertEqual(subscription_request.account_password.value, "")
+        self.assertEqual(subscription_request.account_password.type,
+                         SECRET_TYPE_NONE)
+        self.assertEqual(subscription_request.server_hostname, "candlepin.foo.com")
+        self.assertEqual(subscription_request.rhsm_baseurl, "cdn.foo.com")
+        self.assertEqual(subscription_request.server_proxy_hostname, "proxy.com")
+        self.assertEqual(subscription_request.server_proxy_port, 9001)
+        self.assertEqual(subscription_request._server_proxy_user, "user")
+        self.assertEqual(subscription_request._server_proxy_password.value, "")
+        self.assertEqual(subscription_request._server_proxy_password.type,
+                         SECRET_TYPE_HIDDEN)
+
+        # insights should be enabled
+        self.assertTrue(self.subscription_interface.InsightsEnabled)
+
+    def ks_out_rhsm_no_insights_test(self):
+        """Check Insights is not enabled from kickstart without --connect-to-insights."""
+        ks_in = '''
+        rhsm --organization="123" --activation-key="foo_key"
+        '''
+        # rhsm command is never output as we don't write out activation keys &
+        # the command thus would be incomplete resulting in an invalid kickstart
+        ks_out = ""
+        self._test_kickstart(ks_in, ks_out)
+
+        # insights should not be
+        self.assertFalse(self.subscription_interface.InsightsEnabled)
+
+    def ks_out_rhsm_and_syspurpose_test(self):
+        """Check that if both rhsm and syspurpose are used all works correctly."""
+        ks_in = '''
+        rhsm --organization="123" --activation-key="foo_key" --connect-to-insights
+        syspurpose --role="FOO" --sla="BAR" --usage="BAZ" --addon="F Product" --addon="B Feature"
+        '''
+        # rhsm command is never output as we don't write out activation keys &
+        # the command thus would be incomplete, resulting in an invalid kickstart
+        ks_out = '''
+        # Intended system purpose
+        syspurpose --role="FOO" --sla="BAR" --usage="BAZ" --addon="F Product" --addon="B Feature"
+        '''
+        self._test_kickstart(ks_in, ks_out)
+
+        # check system purpose
+
+        structure = self.subscription_interface.SystemPurposeData
+        system_purpose_data = SystemPurposeData.from_structure(structure)
+        self.assertEqual(system_purpose_data.role, 'FOO')
+        self.assertEqual(system_purpose_data.sla, 'BAR')
+        self.assertEqual(system_purpose_data.usage, 'BAZ')
+        self.assertEqual(system_purpose_data.addons, ["F Product", "B Feature"])
+
+        # check subscription request and insights
+
+        structure = self.subscription_interface.SubscriptionRequest
+        subscription_request = SubscriptionRequest.from_structure(structure)
+        # both org id and one key have been used, request should be org & key type
+        self.assertEqual(subscription_request.type, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY)
+        self.assertEqual(subscription_request.organization, "123")
+        self.assertEqual(subscription_request.activation_keys.value, [])
+        self.assertEqual(subscription_request.activation_keys.type, SECRET_TYPE_HIDDEN)
+        # insights should be enabled
+        self.assertTrue(self.subscription_interface.InsightsEnabled)


### PR DESCRIPTION
Add a SubscriptionRequest DBus structure, holding data needed
for a successful subscription attempt.

SubscriptionRequest can hold the following credentials:
- username & password
- org id & activation key/-s

As possibly both set of credentials could be set,
SubscriptionRequest has a type, that specifies which
credentials should be used for the subscription attempt.

SubscriptionRequest also holds the proxy configuration
and custom URL configuration (if any).

Red Hat account password, activation keys and HTTP proxy
password are all considered sensitive data, due to which
they are set-only. Once they are set to the Subscription
module, they will be stored internally and wiped in
SubscriptionRequest instances returned by the module.

It is still possible to check if a given sensitive value
has been set by inspecting the account_password_set,
activation_keys_set ans server_proxy_password_set properties.

Also included is the InsightsEnabled property that tracks
the intent to connect the target system to Red Hat Insights.

And of course, all this is covered by extensive unit tests.