### PR TITLE
Set up advanced storage on the right device tree (#1812561)

### DIFF
--- a/pyanaconda/storage/utils.py
+++ b/pyanaconda/storage/utils.py
@@ -485,6 +485,11 @@ def check_disk_selection(storage, selected_disks):
 
     for name in selected_disks:
         selected = storage.devicetree.get_device_by_name(name, hidden=True)
+
+        if not selected:
+            errors.append(_("The selected disk {} is not recognized.").format(name))
+            continue
+
         related = sorted(storage.devicetree.get_related_disks(selected), key=lambda d: d.name)
         missing = [r.name for r in related if r.name not in selected_disks]
 

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -519,6 +519,7 @@ class FilterSpoke(NormalSpoke):
         self._selected_disks = []
         self._protected_disks = []
 
+        self._storage_module = STORAGE.get_proxy()
         self._device_tree = STORAGE.get_proxy(DEVICE_TREE)
         self._disk_selection = STORAGE.get_proxy(DISK_SELECTION)
 
@@ -571,6 +572,12 @@ class FilterSpoke(NormalSpoke):
 
     def refresh(self):
         super().refresh()
+
+        # Reset the scheduled partitioning if any to make sure that we
+        # are working with the current system’s storage configuration.
+        # FIXME: Change modules and UI to work with the right device tree.
+        self._storage_module.ResetPartitioning()
+
         self._disks = self._disk_selection.GetUsableDisks()
         self._selected_disks = self._disk_selection.SelectedDisks
         self._protected_disks = self._disk_selection.ProtectedDevices

--- a/tests/nosetests/pyanaconda_tests/module_disk_select_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_disk_select_test.py
@@ -91,6 +91,16 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
         self.assertEqual(report.is_valid(), True)
 
         report = ValidationReport.from_structure(
+            self.disk_selection_interface.ValidateSelectedDisks(["devX"])
+        )
+
+        self.assertEqual(report.is_valid(), False)
+        self.assertEqual(report.error_messages, [
+            "The selected disk devX is not recognized."
+        ])
+        self.assertEqual(report.warning_messages, [])
+
+        report = ValidationReport.from_structure(
             self.disk_selection_interface.ValidateSelectedDisks(["dev1"])
         )
 


### PR DESCRIPTION
When a user enters the spoke for the advanced storage, reset the scheduled
partitioning if any to make sure that we will work with the current system’s
storage configuration.

One day, we might want to change the DBus modules and UI to work with the right
device tree, but it won't be so trivial to implement.

Resolves: rhbz#1812561