### PR TITLE
storage gui: keep expanded mountpoints info on actions in UI by defau…

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -310,7 +310,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._selected_disks = filter_disks_by_names(partitioned_devices, selected_disks)
 
         # Update the UI elements.
-        self._do_refresh()
+        self._do_refresh(init_expanded_pages=True)
         self._applyButton.set_sensitive(False)
 
     def _get_file_system_type(self):
@@ -489,9 +489,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         selector.props.mountpoint = mount_point
         selector.root_name = root_name
 
-    def _do_refresh(self, mountpoint_to_show=None):
+    def _do_refresh(self, mountpoint_to_show=None, init_expanded_pages=False):
         # block mountpoint selector signal handler for now
         self._initialized = False
+        expanded_pages = self._accordion.get_expanded_pages()
         self._accordion.clear_current_selector()
 
         # Start with buttons disabled, since nothing is selected.
@@ -504,8 +505,11 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         # And then open the first page by default.  Most of the time, this will
         # be fine since it'll be the new installation page.
         self._initialized = True
+
         first_page = self._accordion.all_pages[0]
-        self._accordion.expand_page(first_page.page_title)
+        if init_expanded_pages:
+            expanded_pages = [first_page.page_title]
+        self._accordion.expand_pages(expanded_pages)
         self._show_mountpoint(page=first_page, mountpoint=mountpoint_to_show)
 
         self._applyButton.set_sensitive(False)

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -279,14 +279,20 @@ class Accordion(Gtk.Box):
                 if s is selector:
                     return page
 
-    def expand_page(self, page_title):
-        page = self.find_page_by_title(page_title)
-        expander = page.get_parent()
-        if not expander:
-            raise LookupError()
+    def get_expanded_pages(self):
+        """Return titles of expanded pages."""
+        return [page.page_title for page in self.all_pages if page.get_parent().get_expanded()]
 
-        if not expander.get_expanded():
-            expander.emit("activate")
+    def expand_pages(self, page_titles):
+        for page_title in page_titles:
+            page = self.find_page_by_title(page_title)
+            if page:
+                expander = page.get_parent()
+                if not expander:
+                    raise LookupError()
+
+                if not expander.get_expanded():
+                    expander.emit("activate")
 
     def remove_page(self, page_title):
         # First, remove the expander from the list of expanders we maintain.


### PR DESCRIPTION
…lt (#1210944)

Collapse the page showing existing system mountpoints only in case of "Reset
All" or spoke revisiting.

Keep system pages expanded in case of:
- removing a mountpoint
- unlocking a mountpoint
- adding a mountpoint
- creating autopartitioning
- updating with changes from right hand side