### PR TITLE
Improve tests speed

### DIFF
--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -235,6 +235,12 @@ def check_args(namespace):
             or namespace.pep8_targets is not None or namespace.run_linter is not None:
         namespace.prepare = False
 
+    if not any([namespace.init, namespace.copy, namespace.update,
+                namespace.run_tests, namespace.install, namespace.install_pip]):
+        print("You need to specify one of the main commands!", file=sys.stderr)
+        print("Run './setup-mock-test-env.py --help' for more info.", file=sys.stderr)
+        exit(1)
+
 
 def get_required_packages():
     """Get required packages for running Anaconda tests."""
@@ -467,11 +473,6 @@ if __name__ == "__main__":
 
     mock_cmd = create_mock_command(ns.mock_config, ns.uniqueext)
     anaconda_prepare_requested = False
-
-    if not any([ns.init, ns.copy, ns.update, ns.run_tests, ns.install, ns.install_pip]):
-        print("You need to specify one of the main commands!", file=sys.stderr)
-        print("Run './setup-mock-test-env.py --help' for more info.", file=sys.stderr)
-        exit(1)
 
     # quit immediately if the result dir exists
     if ns.result_folder:

--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -128,8 +128,11 @@ When the init is done the mock environment stays for later use.
 It is possible to connect to mock by calling:
     mock -r <mock configuration> --shell
 
-Or just update Anaconda and start CI by:
+Or copy Anaconda and start CI by:
     setup-mock-test-env.py <mock configuration> --copy --run-tests --result /tmp/result
+
+Or update existing Anaconda in a mock and start unit tests only by:
+    setup-mock-test-env.py <mock configuration> --update --run-nosetests --result /tmp/result
 
 For further info look on the mock manual page.
 """)
@@ -175,11 +178,18 @@ One of these commands must be used. Tests commands can't be combined!
                        prepare mock environment to be able to make a release from there
                        """)
 
-    group.add_argument('--copy', '-c', action='store_true', dest='copy',
-                       help="""
-                       keep existing mock and only replace Anaconda folder in it;
-                       this will not re-init mock chroot
-                       """)
+    group_copy = group.add_mutually_exclusive_group()
+    group_copy.add_argument('--copy', '-c', action='store_true', dest='copy',
+                            help="""
+                            keep existing mock and only replace Anaconda folder in it;
+                            this will not re-init mock chroot
+                            """)
+    group_copy.add_argument('--update', '-u', action='store_true', dest='update',
+                            help="""
+                            keep existing mock and replace updated files in Anaconda;
+                            this way you can re-run tests without autogen and configure call;
+                            this will not re-init mock chroot
+                            """)
     group.add_argument('--prepare', '-p', action='store_true', dest='prepare',
                        help="""
                        run configure and autogen.sh on Anaconda inside of mock
@@ -445,7 +455,7 @@ if __name__ == "__main__":
     mock_cmd = create_mock_command(ns.mock_config, ns.uniqueext)
     success = True
 
-    if not any([ns.init, ns.copy, ns.run_tests, ns.install, ns.install_pip]):
+    if not any([ns.init, ns.copy, ns.update, ns.run_tests, ns.install, ns.install_pip]):
         print("You need to specify one of the main commands!", file=sys.stderr)
         print("Run './setup-mock-test-env.py --help' for more info.", file=sys.stderr)
         exit(1)

--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -230,11 +230,6 @@ One of these commands must be used. Tests commands can't be combined!
 
 
 def check_args(namespace):
-    # prepare will be called by tests automatically
-    if namespace.run_tests or namespace.nose_targets is not None \
-            or namespace.pep8_targets is not None or namespace.run_linter is not None:
-        namespace.prepare = False
-
     if not any([namespace.init, namespace.copy, namespace.update, namespace.prepare,
                 namespace.run_tests, namespace.install, namespace.install_pip, namespace.release]):
         print("You need to specify one of the main commands!", file=sys.stderr)

--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -292,24 +292,31 @@ def create_dir_in_mock(mock_command, path):
     _check_subprocess(cmd, "Can't create directory {} to the mock.".format(path))
 
 
-def remove_anaconda_in_mock(mock_command):
+def remove_anaconda_in_mock(mock_command, target_mock_path=None):
     cmd = _prepare_command(mock_command)
 
+    if not target_mock_path:
+        target_mock_path = ANACONDA_MOCK_PATH
+
     cmd = _run_cmd_in_chroot(cmd)
-    cmd.append('rm -rf ' + ANACONDA_MOCK_PATH)
+    cmd.append('rm -rf ' + target_mock_path)
 
-    _check_subprocess(cmd, "Can't remove existing anaconda.")
+    _check_subprocess(cmd, "Can't remove existing Anaconda.")
 
 
-def copy_anaconda_to_mock(mock_command):
-    remove_anaconda_in_mock(mock_command)
+def copy_anaconda_to_mock(mock_command, target_mock_path=None):
+    remove_anaconda_in_mock(mock_command, target_mock_path)
 
     anaconda_dir = _resolve_top_dir()
+
+    if not target_mock_path:
+        target_mock_path = ANACONDA_MOCK_PATH
+
     cmd = _prepare_command(mock_command)
 
     cmd.append('--copyin')
     cmd.append('{}'.format(anaconda_dir))
-    cmd.append(ANACONDA_MOCK_PATH)
+    cmd.append(target_mock_path)
 
     _check_subprocess(cmd, "Can't copy Anaconda to mock.")
 

--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -235,8 +235,8 @@ def check_args(namespace):
             or namespace.pep8_targets is not None or namespace.run_linter is not None:
         namespace.prepare = False
 
-    if not any([namespace.init, namespace.copy, namespace.update,
-                namespace.run_tests, namespace.install, namespace.install_pip]):
+    if not any([namespace.init, namespace.copy, namespace.update, namespace.prepare,
+                namespace.run_tests, namespace.install, namespace.install_pip, namespace.release]):
         print("You need to specify one of the main commands!", file=sys.stderr)
         print("Run './setup-mock-test-env.py --help' for more info.", file=sys.stderr)
         exit(1)


### PR DESCRIPTION
This will add parameter `-u` `--update` which will basically copy anaconda directory to temporary location in a mock and then rsync to the original location.

First version with removing only python files did not work because you can't run tests if you remove directories containing Makefiles. Makefile is that "smart" that it will check all these files first. :(