### PR TITLE
Handle translation of an empty string in widgets (#1815461)

### DIFF
--- a/widgets/src/intl.h
+++ b/widgets/src/intl.h
@@ -18,10 +18,12 @@
 #ifndef _INTL_H
 #define _INTL_H
 
+#include <string.h>
+
 #include "config.h"
 #include "gettext.h"
 
-#define _(x) dgettext("anaconda", x)
+#define _(x) (strcmp(x, "") ? dgettext("anaconda", x) : "")
 #define N_(String) String
 #define C_(Context, String) dpgettext("anaconda", Context, String)
 #define CN_(Context, String) String


### PR DESCRIPTION
Don't try to translate an empty string. It will return translation metadata.

Resolves: rhbz#1815461