### PR TITLE
Don't always reset the interactive partitioning

### DIFF
--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -236,7 +236,7 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
             result = unwrap_variant(task_proxy.GetResult())
             report = ValidationReport.from_structure(result)
 
-            log.error("\n".join(report.get_messages()))
+            log.debug("Validation has been completed: %s", report)
             StorageCheckHandler.errors = report.error_messages
             StorageCheckHandler.warnings = report.warning_messages
 

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -902,7 +902,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             result = unwrap_variant(task_proxy.GetResult())
             report = ValidationReport.from_structure(result)
 
-            log.error("\n".join(report.get_messages()))
+            log.debug("Validation has been completed: %s", report)
             StorageCheckHandler.errors = report.error_messages
             StorageCheckHandler.warnings = report.warning_messages
 

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -25,8 +25,7 @@ from pyanaconda.core.async_utils import async_action_nowait
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import CLEAR_PARTITIONS_NONE, BOOTLOADER_ENABLED, \
     STORAGE_METADATA_RATIO, WARNING_NO_DISKS_SELECTED, WARNING_NO_DISKS_DETECTED, \
-    PARTITIONING_METHOD_AUTOMATIC, PARTITIONING_METHOD_CUSTOM, PARTITIONING_METHOD_BLIVET, \
-    PARTITIONING_METHOD_INTERACTIVE
+    PARTITIONING_METHOD_AUTOMATIC, PARTITIONING_METHOD_INTERACTIVE, PARTITIONING_METHOD_BLIVET
 from pyanaconda.core.i18n import _, C_, CN_
 from pyanaconda.core.timer import Timer
 from pyanaconda.flags import flags
@@ -308,7 +307,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         radio button is currently active.
         """
         if self._custom_part_radio_button.get_active():
-            return PARTITIONING_METHOD_CUSTOM
+            return PARTITIONING_METHOD_INTERACTIVE
 
         if self._blivet_gui_radio_button.get_active():
             return PARTITIONING_METHOD_BLIVET
@@ -836,7 +835,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             self._skip_to_automatic_partitioning()
             return
 
-        if partitioning_method == PARTITIONING_METHOD_CUSTOM:
+        if partitioning_method == PARTITIONING_METHOD_INTERACTIVE:
             self._skip_to_spoke("CustomPartitioningSpoke")
             return
 

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -370,6 +370,9 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             log.debug("Skipping the execute method for the BLIVET partitioning method.")
             return
 
+        log.debug("Running the execute method for the %s partitioning method.",
+                  self._last_partitioning_method)
+
         # Spawn storage execution as a separate thread so there's no big delay
         # going back from this spoke to the hub while StorageCheckHandler.run runs.
         # Yes, this means there's a thread spawning another thread.  Sorry.
@@ -384,6 +387,8 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         hubQ.send_not_ready(self.__class__.__name__)
 
         report = apply_partitioning(self._partitioning, self._show_execute_message)
+
+        log.debug("Partitioning has been applied: %s", report)
         StorageCheckHandler.errors = list(report.error_messages)
         StorageCheckHandler.warnings = list(report.warning_messages)
 
@@ -392,6 +397,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
 
     def _show_execute_message(self, msg):
         hubQ.send_message(self.__class__.__name__, msg)
+        log.debug(msg)
 
     @property
     def completed(self):

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -364,11 +364,18 @@ class StorageSpoke(NormalTUISpoke):
         apply_disk_selection(self._selected_disks, reset_boot_drive=True)
 
     def execute(self):
-        report = apply_partitioning(self._partitioning, print)
-        print("\n".join(report.get_messages()))
+        report = apply_partitioning(self._partitioning, self._show_execute_message)
+
+        log.debug("Partitioning has been applied: %s", report)
         self.errors = list(report.error_messages)
         self.warnings = list(report.warning_messages)
+
+        print("\n".join(report.get_messages()))
         self._ready = True
+
+    def _show_execute_message(self, msg):
+        print(msg)
+        log.debug(msg)
 
     def initialize(self):
         NormalTUISpoke.initialize(self)


### PR DESCRIPTION
Use the INTERACTIVE partitioning method instead of the CUSTOM partitioning method.
The CUSTOM method represents a custom partitioning defined by a kickstart file.
Otherwise, we will always reset the interactive partitioning before entering the
custom spoke.

Log messages and the validation report from the function apply_partitioning.
Log the partitioning method used in the execute method of the storage spoke.

Always log the data object that represents the validation report. Otherwise,
we log an empty string, when the validation is succesfull.