### PR TITLE
Rename _test_dbus_property to _check_dbus_property

### DIFF
--- a/tests/nosetests/pyanaconda_tests/module_bootloader_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_bootloader_test.py
@@ -56,7 +56,7 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
         self.bootloader_module = BootloaderModule()
         self.bootloader_interface = BootloaderInterface(self.bootloader_module)
 
-    def _test_dbus_property(self, *args, **kwargs):
+    def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
             self,
             BOOTLOADER,
@@ -70,63 +70,63 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
 
     def bootloader_mode_property_test(self):
         """Test the bootloader mode property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "BootloaderMode",
             BOOTLOADER_SKIPPED
         )
 
     def preferred_location_property_test(self):
         """Test the preferred location property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "PreferredLocation",
             BOOTLOADER_LOCATION_PARTITION
         )
 
     def drive_property_test(self):
         """Test the drive property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "Drive",
             "sda"
         )
 
     def drive_order_property_test(self):
         """Test the drive order property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "DriveOrder",
             ["sda", "sdb"]
         )
 
     def keep_mbr_property_test(self):
         """Test the keep MBR property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "KeepMBR",
             True
         )
 
     def keep_boot_order_test(self):
         """Test the keep boot order property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "KeepBootOrder",
             True
         )
 
     def extra_arguments_property_test(self):
         """Test the extra arguments property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "ExtraArguments",
             ["hdd=ide-scsi", "ide=nodma"]
         )
 
     def timeout_property_test(self):
         """Test the timeout property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "Timeout",
             25
         )
 
     def password_property_test(self):
         """Test the password property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "Password",
             "12345",
             setter=self.bootloader_interface.SetEncryptedPassword,

--- a/tests/nosetests/pyanaconda_tests/module_disk_init_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_disk_init_test.py
@@ -41,7 +41,7 @@ class DiskInitializationInterfaceTestCase(unittest.TestCase):
         self.disk_init_module = DiskInitializationModule()
         self.disk_init_interface = DiskInitializationInterface(self.disk_init_module)
 
-    def _test_dbus_property(self, *args, **kwargs):
+    def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
             self,
             DISK_INITIALIZATION,
@@ -51,49 +51,49 @@ class DiskInitializationInterfaceTestCase(unittest.TestCase):
 
     def default_disk_label_property_test(self):
         """Test the default disk label property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "DefaultDiskLabel",
             "msdos"
         )
 
     def format_unrecognized_enabled_property_test(self):
         """Test the can format unrecognized property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "FormatUnrecognizedEnabled",
             False
         )
 
     def can_initialize_label_property_test(self):
         """Test the can initialize label property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "InitializeLabelsEnabled",
             False
         )
 
     def format_ldl_enabled_property_test(self):
         """Test the can format LDL property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "FormatLDLEnabled",
             True
         )
 
     def initialization_mode_property_test(self):
         """Test the type to clear property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "InitializationMode",
             CLEAR_PARTITIONS_LINUX
         )
 
     def devices_to_clear_property_test(self):
         """Test the devices to clear property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "DevicesToClear",
             ["sda2", "sda3", "sdb1"]
         )
 
     def drives_to_clear_property_test(self):
         """Test the drives to clear property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "DrivesToClear",
             ["sda", "sdb"]
         )

--- a/tests/nosetests/pyanaconda_tests/module_disk_select_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_disk_select_test.py
@@ -40,7 +40,7 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
         self.disk_selection_module = DiskSelectionModule()
         self.disk_selection_interface = DiskSelectionInterface(self.disk_selection_module)
 
-    def _test_dbus_property(self, *args, **kwargs):
+    def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
             self,
             DISK_SELECTION,
@@ -50,7 +50,7 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
 
     def selected_disks_property_test(self):
         """Test the selected disks property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "SelectedDisks",
             ["sda", "sdb"]
         )
@@ -135,28 +135,28 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
 
     def exclusive_disks_property_test(self):
         """Test the exclusive disks property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "ExclusiveDisks",
             ["sda", "sdb"]
         )
 
     def ignored_disks_property_test(self):
         """Test the ignored disks property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "IgnoredDisks",
             ["sda", "sdb"]
         )
 
     def protected_disks_property_test(self):
         """Test the protected disks property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "ProtectedDevices",
             ["sda", "sdb"]
         )
 
     def disk_images_property_test(self):
         """Test the protected disks property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "DiskImages",
             {
                 "image_1": "/path/1",

--- a/tests/nosetests/pyanaconda_tests/module_network_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_network_test.py
@@ -84,7 +84,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         self.assertEqual(self.network_interface.KickstartSections, [])
         self.assertEqual(self.network_interface.KickstartAddons, [])
 
-    def _test_dbus_property(self, *args, **kwargs):
+    def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
             self,
             NETWORK,
@@ -107,7 +107,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
     def hostname_property_test(self):
         """Test the hostname property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "Hostname",
             "dot.dot",
         )
@@ -601,7 +601,7 @@ class FirewallInterfaceTestCase(unittest.TestCase):
         self.callback = PropertiesChangedCallback()
         self.firewall_interface.PropertiesChanged.connect(self.callback)
 
-    def _test_dbus_property(self, *args, **kwargs):
+    def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
             self,
             FIREWALL,
@@ -622,85 +622,85 @@ class FirewallInterfaceTestCase(unittest.TestCase):
 
     def set_use_system_defaults_test(self):
         """Test if the use-system-firewall-defaults option can be set."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "FirewallMode",
             FIREWALL_USE_SYSTEM_DEFAULTS,
         )
 
     def disable_firewall_test(self):
         """Test if firewall can be disabled."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "FirewallMode",
             FIREWALL_DISABLED,
         )
 
     def toggle_firewall_test(self):
         """Test if firewall can be toggled."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "FirewallMode",
             FIREWALL_DISABLED,
         )
-        self._test_dbus_property(
+        self._check_dbus_property(
             "FirewallMode",
             FIREWALL_ENABLED,
         )
 
     def set_enabled_ports_test(self):
         """Test if enabled ports can be set."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "EnabledPorts",
             ["imap:tcp","1234:udp","47"],
         )
-        self._test_dbus_property(
+        self._check_dbus_property(
             "EnabledPorts",
             [],
         )
-        self._test_dbus_property(
+        self._check_dbus_property(
             "EnabledPorts",
             ["1337:udp","9001"],
         )
 
     def set_trusts_test(self):
         """Tests if trusts can be set."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "Trusts",
             ["eth1", "eth2", "enps1337"],
         )
-        self._test_dbus_property(
+        self._check_dbus_property(
             "Trusts",
             [],
         )
-        self._test_dbus_property(
+        self._check_dbus_property(
             "Trusts",
             ["virbr0", "wl01", "foo", "bar"],
         )
 
     def set_enabled_services_test(self):
         """Tests if enabled services can be set."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "EnabledServices",
             ["tftp", "rsyncd", "ssh"],
         )
-        self._test_dbus_property(
+        self._check_dbus_property(
             "EnabledServices",
             [],
         )
-        self._test_dbus_property(
+        self._check_dbus_property(
             "EnabledServices",
             ["ptp", "syslog", "ssh"],
         )
 
     def set_disabled_services_test(self):
         """Tests if disabled services can be set."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "DisabledServices",
             ["samba", "nfs", "ssh"],
         )
-        self._test_dbus_property(
+        self._check_dbus_property(
             "DisabledServices",
             [],
         )
-        self._test_dbus_property(
+        self._check_dbus_property(
             "DisabledServices",
             ["ldap", "ldaps", "ssh"],
         )

--- a/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
@@ -64,7 +64,7 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
         """Add a device to the device tree."""
         self.storage.devicetree._add_device(device)
 
-    def _test_dbus_property(self, *args, **kwargs):
+    def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
             self,
             AUTO_PARTITIONING,
@@ -107,7 +107,7 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
             'escrow-certificate': get_variant(Str, 'file:///tmp/escrow.crt'),
             'backup-passphrase-enabled': get_variant(Bool, True),
         }
-        self._test_dbus_property(
+        self._check_dbus_property(
             "Request",
             request
         )

--- a/tests/nosetests/pyanaconda_tests/module_part_manual_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_manual_test.py
@@ -51,7 +51,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
         """Test the DBus representation."""
         self.assertIsInstance(self.module.for_publication(), ManualPartitioningInterface)
 
-    def _test_dbus_property(self, *args, **kwargs):
+    def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
             self,
             MANUAL_PARTITIONING,
@@ -61,7 +61,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
 
     def mount_points_property_test(self):
         """Test the mount points property."""
-        self._test_dbus_property(
+        self._check_dbus_property(
             "Requests",
             []
         )
@@ -74,7 +74,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
             "format-options": get_variant(Str, ""),
             "mount-options": get_variant(Str, "")
         }
-        self._test_dbus_property(
+        self._check_dbus_property(
             "Requests",
             [request]
         )
@@ -87,7 +87,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
             "format-options": get_variant(Str, "-L BOOT"),
             "mount-options": get_variant(Str, "user")
         }
-        self._test_dbus_property(
+        self._check_dbus_property(
             "Requests",
             [request]
         )
@@ -108,7 +108,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
             "format-options": get_variant(Str, ""),
             "mount-options": get_variant(Str, "")
         }
-        self._test_dbus_property(
+        self._check_dbus_property(
             "Requests",
             [request_1, request_2]
         )


### PR DESCRIPTION
First make it consistent in all tests. Second we should use test word only to define test case.