### PR TITLE
Detect and warn if SMT is enabled (#1684056)

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -32,6 +32,9 @@ can_detect_unsupported_hardware = False
 # Should the installer show a warning about removed support for hardware?
 can_detect_support_removed = False
 
+# Should the installer show a warning about enabled SMT?
+can_detect_enabled_smt = False
+
 
 [Installation Target]
 # Type of the installation target.

--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -21,6 +21,9 @@ kickstart_modules =
 # can_detect_unsupported_hardware = True
 # can_detect_support_removed = True
 
+# Show a warning if SMT is enabled.
+can_detect_enabled_smt = True
+
 [Network]
 default_on_boot = DEFAULT_ROUTE_DEVICE
 

--- a/pyanaconda/core/configuration/system.py
+++ b/pyanaconda/core/configuration/system.py
@@ -148,6 +148,11 @@ class SystemSection(Section):
         return self._get_option("can_detect_support_removed", bool)
 
     @property
+    def can_detect_enabled_smt(self):
+        """Can we try to detect enabled SMT?"""
+        return self._get_option("can_detect_enabled_smt", bool)
+
+    @property
     def provides_network_config(self):
         """Can we copy network configuration to the target system?
 

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -176,6 +176,25 @@ WARNING_NO_DISKS_SELECTED = N_(
     "No disks selected; please select at least one disk to install to."
 )
 
+# Kernel messages.
+WARNING_SMT_ENABLED_GUI = N_(
+    "Simultaneous Multithreading (SMT) technology can provide performance "
+    "improvements for certain workloads, but introduces several publicly "
+    "disclosed security issues. You have the option of disabling SMT, which "
+    "may impact performance. If you choose to leave SMT enabled, please read "
+    "https://red.ht/rhel-smt to understand your potential risks and learn "
+    "about other ways to mitigate these risks."
+)
+
+# This message is shorter to fit on the screen.
+WARNING_SMT_ENABLED_TUI = N_(
+    "Simultaneous Multithreading (SMT) may improve performance for certain "
+    "workloads, but introduces several publicly disclosed security issues. "
+    "You can disable SMT, which may impact performance. Please read "
+    "https://red.ht/rhel-smt to understand potential risks and learn about "
+    "ways to mitigate these risks."
+)
+
 
 # Password type
 class SecretType(Enum):

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1517,7 +1517,9 @@ def is_smt_enabled():
 
     :return: True or False
     """
-    if flags.automatedInstall or not conf.target.is_hardware:
+    if flags.automatedInstall \
+            or not conf.target.is_hardware \
+            or not conf.system.can_detect_enabled_smt:
         log.info("Skipping detection of SMT.")
         return False
 

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1510,3 +1510,19 @@ def get_anaconda_version_string(build_time_version=False):
         # there is a slight chance version.py might be generated incorrectly
         # during build, so don't crash in that case
         return "unknown"
+
+
+def is_smt_enabled():
+    """Is Simultaneous Multithreading (SMT) enabled?
+
+    :return: True or False
+    """
+    if flags.automatedInstall or not conf.target.is_hardware:
+        log.info("Skipping detection of SMT.")
+        return False
+
+    try:
+        return int(open("/sys/devices/system/cpu/smt/active").read()) == 1
+    except (IOError, ValueError):
+        log.warning("Failed to detect SMT.")
+        return False

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -254,7 +254,8 @@ class Hub(GUIObject, common.Hub):
         if update_continue:
             self._updateContinue()
 
-    def _updateContinue(self):
+    def _get_warning(self):
+        """Get the warning message for the hub."""
         warning = None
         if len(self._incompleteSpokes) == 0:
             if self._checker and not self._checker.check():
@@ -269,8 +270,13 @@ class Hub(GUIObject, common.Hub):
         else:
             warning = _("Please complete items marked with this icon before continuing to the next step.")
 
+        return warning
+
+    def _updateContinue(self):
         # Check that this warning isn't already set to avoid spamming the
         # info bar with incomplete spoke messages when the hub starts
+        warning = self._get_warning()
+
         if warning != self._warningMsg:
             self.clear_info()
             self._warningMsg = warning

--- a/pyanaconda/ui/tui/spokes/kernel_warning.py
+++ b/pyanaconda/ui/tui/spokes/kernel_warning.py
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2019  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from simpleline.render.widgets import TextWidget
+
+from pyanaconda.core.constants import WARNING_SMT_ENABLED_TUI
+from pyanaconda.core.i18n import N_, _
+from pyanaconda.core.util import is_smt_enabled
+from pyanaconda.ui.tui.spokes import StandaloneTUISpoke
+from pyanaconda.ui.tui.hubs.summary import SummaryHub
+
+__all__ = ["KernelWarningSpoke"]
+
+
+class KernelWarningSpoke(StandaloneTUISpoke):
+    """Spoke for kernel-related warnings."""
+    preForHub = SummaryHub
+    priority = 0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.title = N_("Warning: Processor has Simultaneous Multithreading (SMT) enabled")
+        self.input_required = False
+
+    @property
+    def completed(self):
+        """Show this spoke if SMT is enabled."""
+        return not is_smt_enabled()
+
+    def refresh(self, args=None):
+        """Refresh the window."""
+        super().refresh(args)
+        self.window.add(TextWidget(_(WARNING_SMT_ENABLED_TUI)))
+
+    def show_all(self):
+        """Show the warning and close the screen."""
+        super().show_all()
+        self.close()
+
+    def apply(self):
+        """Nothing to apply."""
+        pass

--- a/tests/nosetests/pyanaconda_tests/simple_ui_test.py
+++ b/tests/nosetests/pyanaconda_tests/simple_ui_test.py
@@ -83,6 +83,7 @@ class SimpleUITestCase(unittest.TestCase):
         # Check the actions classes.
         self.assertEqual(self._get_action_class_names(), [
             "UnsupportedHardwareSpoke",
+            "KernelWarningSpoke",
             "SummaryHub",
             "ProgressSpoke"
         ])


### PR DESCRIPTION
Detect whether hyperthreading (SMT) is enabled on a system. If so,
we should display a warning in the info bar of the summary hub.

(cherry-picked from commits 30fdc00, 0fb8e42, 9a8485a, a4b7e1f)

Resolves: rhbz#1684056