### PR TITLE
Fix text color on info bars

### DIFF
--- a/data/anaconda-gtk.css
+++ b/data/anaconda-gtk.css
@@ -46,34 +46,45 @@ levelbar.discrete trough block.filled.high {
 @define-color error_fg_color white;
 @define-color error_bg_color rgb (237, 54, 54);
 
-.info {
+infobar.info {
     background-color: @info_bg_color;
-    color: @info_fg_color;
     border-color: darker(@info_bg_color);
 }
 
-.warning {
+infobar.info label {
+    color: @info_fg_color;
+}
+
+infobar.warning {
     background-color: @warning_bg_color;
-    color: @warning_fg_color;
     border-color: darker(@warning_bg_color);
 }
 
-.question {
-    background-color: @question_bg_color;
-    color: @question_fg_color;
-    border-color: darker(@question_bg_color);
+infobar.warning label {
+    color: @warning_fg_color;
 }
 
-.error {
+infobar.question {
+    background-color: @question_bg_color;
+    border-color: darker(@question_bg_color);
+}
+infobar.question label {
+    color: @question_fg_color;
+}
+
+infobar.error {
     background-color: @error_bg_color;
-    color: @error_fg_color;
     border-color: darker(@error_bg_color);
 }
 
-.info,
-.warning,
-.question,
-.error {
+infobar.error label {
+    color: @error_fg_color;
+}
+
+infobar.info,
+infobar.warning,
+infobar.question,
+infobar.error {
     text-shadow: none;
 }
 


### PR DESCRIPTION
Due to some external changes - likely in GTK or the way
it processes CSS styles - our info bar text color overrides
no longer work.

Make the overrides more specific, so they match again and override
the text color on info bars as intended.

This should finally make the warnings Anaconda displays readable
again, as they no longer will be while on orange but black on orange
as intended.

Resolves: rhbz#1782174

(cherry picked from commit 39f8fcd9297b2db82b26546432d4bcee094b445b)

port from RHEL PR #2250