### PR TITLE
Fix the permission for changing a mount point (#1818500)

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -865,7 +865,7 @@ def generate_device_factory_permissions(storage, request: DeviceFactoryRequest):
 
     permissions.device_type = not device.raw_device.exists
     permissions.device_raid_level = not device.raw_device.exists
-    permissions.mount_point = device.format.mountable
+    permissions.mount_point = get_format(request.format_type).mountable
     permissions.label = True
 
     permissions.reformat = \

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -526,8 +526,6 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
             This method must never trigger a call to self._do_refresh.
         """
-        self.clear_errors()
-
         # check if initialized and have something to operate on
         if not self._initialized or not selector:
             return
@@ -543,6 +541,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             # just-removed device
             return
 
+        self.clear_errors()
         self._back_already_clicked = False
 
         log.debug("Saving the right side for device: %s", device_name)
@@ -573,8 +572,6 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             return
 
         # Apply the changes.
-        self.clear_errors()
-
         try:
             self._device_tree.ChangeDevice(
                 DeviceFactoryRequest.to_structure(new_request),
@@ -934,7 +931,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         # Clear any existing errors
         self.clear_errors()
 
-        # Save anything from the currently displayed mountpoint.
+        # Save anything from the currently displayed mount point.
         self._save_right_side(self._accordion.current_selector)
         self._applyButton.set_sensitive(False)
 
@@ -970,6 +967,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         NormalSpoke.on_back_clicked(self, button)
 
     def on_add_clicked(self, button):
+        # Clear any existing errors
+        self.clear_errors()
+
+        # Save anything from the currently displayed mount point.
         self._save_right_side(self._accordion.current_selector)
 
         # Initialize and run the AddDialog.
@@ -1358,12 +1359,6 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._modifyContainerButton.set_sensitive(self._permissions.can_modify_container())
         self.on_value_changed()
 
-    def _save_current_page(self, selector=None):
-        if selector is None:
-            selector = self._accordion.current_selector
-
-        self._save_right_side(selector)
-
     def on_selector_clicked(self, old_selector, selector):
         if not self._initialized:
             return
@@ -1375,7 +1370,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         # Take care of the previously chosen selector.
         if old_selector:
-            self._save_current_page(old_selector)
+            self._save_right_side(old_selector)
 
         # There is no device to show.
         if self._accordion.is_multiselection or not self._accordion.current_selector:
@@ -1416,7 +1411,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             return
 
         if self._accordion.is_current_selected:
-            self._save_current_page()
+            self._save_right_side(self._accordion.current_selector)
 
         self._show_mountpoint(page=page, mountpoint=mountpoint_to_show)
 
@@ -1836,6 +1831,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     @timed_action(delay=50, threshold=100)
     def on_update_settings_clicked(self, button):
         """ call _save_right_side, then, perhaps, populate_right_side. """
+        # Clear any existing errors
+        self.clear_errors()
+
+        # Save anything from the currently displayed mount point.
         self._save_right_side(self._accordion.current_selector)
         self._applyButton.set_sensitive(False)
 

--- a/tests/nosetests/pyanaconda_tests/module_scheduler_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_scheduler_test.py
@@ -27,7 +27,7 @@ from blivet.devices import StorageDevice, DiskDevice, PartitionDevice, LUKSDevic
     BTRFSVolumeDevice, MDRaidArrayDevice, LVMVolumeGroupDevice, LVMLogicalVolumeDevice
 from blivet.errors import StorageError
 from blivet.formats import get_format
-from blivet.formats.fs import FS
+from blivet.formats.fs import FS, BTRFS
 from blivet.size import Size
 from dasbus.structure import compare_data
 from dasbus.typing import get_native
@@ -562,10 +562,10 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(dev2)
 
         # Make the btrfs format not mountable.
-        dev2.format._mount = Mock(available=False)
+        with patch.object(BTRFS, "_mount_class", return_value=Mock(available=False)):
+            request = self.interface.GenerateDeviceFactoryRequest(dev2.name)
+            permissions = self.interface.GenerateDeviceFactoryPermissions(request)
 
-        request = self.interface.GenerateDeviceFactoryRequest(dev2.name)
-        permissions = self.interface.GenerateDeviceFactoryPermissions(request)
         self.assertEqual(get_native(permissions), {
             'mount-point': False,
             'reformat': False,


### PR DESCRIPTION
We shouldn't check whether the current format of a device is mountable, but
whether the requested format type is mountable. Otherwise, it might not be
possible to reformat a device.

We shouldn't clear errors in the callbacks on_page_clicked and
on_selector_clicked of the custom spoke. Otherwise, we might
clear the errors before the user sees them.

Resolves: rhbz#1818500