### PR TITLE
Allow to use an existing unlocked LUKS in one special case (#1772902)

### DIFF
--- a/pyanaconda/storage/checker.py
+++ b/pyanaconda/storage/checker.py
@@ -336,6 +336,7 @@ def verify_unlocked_devices_have_key(storage, constraints, report_error, report_
         and d.format.exists
         and not d.format.has_key
         and d.children
+        and any(c.name == d.format.map_name for c in d.children)
     ]
 
     for dev in devices:


### PR DESCRIPTION
In general, we don't allow to use an existing unlocked LUKS for the installation,
because Blivet is not able to set it up without a key and the whole installation
fails with an exception.

However, when the LUKS is unlocked with a different name than the standard
`luks-<UUID>`, Blivet will keep it open due to a bug in its code and the
installation will be successful. Let's allow this use case again and later
figure out how to allow unlocked LUKS devices in general.

Resolves: rhbz#1772902