### PR TITLE
subscription: Add service observer

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -450,3 +450,8 @@ SUBSCRIPTION_REQUEST_VALID_TYPES = {
 # username password - this is basically to avoid the invalid
 # case of request not having a type set.
 DEFAULT_SUBSCRIPTION_REQUEST_TYPE = SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD
+
+# How long to wait for the RHSM service to become available after it is started.
+# - in seconds
+# - based on the default 90 second systemd service activation timeout
+RHSM_SERVICE_TIMEOUT = 90.0

--- a/pyanaconda/modules/common/constants/namespaces.py
+++ b/pyanaconda/modules/common/constants/namespaces.py
@@ -100,3 +100,9 @@ SOURCE_NAMESPACE = (
     *PAYLOADS_NAMESPACE,
     "Source"
 )
+
+# System service namespaces
+
+RHSM_NAMESPACE = (
+    "com", "redhat", "RHSM1"
+)

--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -19,7 +19,7 @@
 from dasbus.identifier import DBusObjectIdentifier
 from pyanaconda.modules.common.constants.namespaces import STORAGE_NAMESPACE, NETWORK_NAMESPACE, \
     PARTITIONING_NAMESPACE, DEVICE_TREE_NAMESPACE, \
-    PAYLOADS_NAMESPACE
+    PAYLOADS_NAMESPACE, RHSM_NAMESPACE
 
 # Storage objects.
 
@@ -114,4 +114,13 @@ FIREWALL = DBusObjectIdentifier(
 PAYLOAD_PACKAGES = DBusObjectIdentifier(
     namespace=PAYLOADS_NAMESPACE,
     basename="Packages"
+)
+
+# System services
+
+# Subscription objects.
+
+RHSM_CONFIG = DBusObjectIdentifier(
+    namespace=RHSM_NAMESPACE,
+    basename="Config"
 )

--- a/pyanaconda/modules/common/constants/services.py
+++ b/pyanaconda/modules/common/constants/services.py
@@ -20,7 +20,8 @@ from pyanaconda.core.dbus import SystemBus, DBus
 from dasbus.identifier import DBusServiceIdentifier
 from pyanaconda.modules.common.constants.namespaces import BOSS_NAMESPACE, TIMEZONE_NAMESPACE, \
     NETWORK_NAMESPACE, LOCALIZATION_NAMESPACE, SECURITY_NAMESPACE, USERS_NAMESPACE, \
-    PAYLOADS_NAMESPACE, STORAGE_NAMESPACE, SERVICES_NAMESPACE, SUBSCRIPTION_NAMESPACE
+    PAYLOADS_NAMESPACE, STORAGE_NAMESPACE, SERVICES_NAMESPACE, SUBSCRIPTION_NAMESPACE, \
+    RHSM_NAMESPACE
 
 # Anaconda services.
 
@@ -89,5 +90,10 @@ LOCALED = DBusServiceIdentifier(
     service_version=1,
     object_version=1,
     interface_version=1,
+    message_bus=SystemBus
+)
+
+RHSM = DBusServiceIdentifier(
+    namespace=RHSM_NAMESPACE,
     message_bus=SystemBus
 )

--- a/pyanaconda/modules/subscription/initialization.py
+++ b/pyanaconda/modules/subscription/initialization.py
@@ -1,0 +1,104 @@
+#
+# Kickstart module for subscription handling.
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from dasbus.typing import get_variant, Str
+
+from pyanaconda.core import util
+from pyanaconda.core.constants import RHSM_SERVICE_TIMEOUT
+
+from pyanaconda.threading import threadMgr
+
+from pyanaconda.modules.common.task import Task
+from pyanaconda.modules.common.errors.task import NoResultError
+from pyanaconda.modules.common.constants.services import RHSM
+from pyanaconda.modules.common.constants.objects import RHSM_CONFIG
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+
+class StartRHSMTask(Task):
+    """Task for starting the RHSM DBus service."""
+
+    RHSM_SYSTEMD_UNIT_NAME = "rhsm.service"
+
+    @property
+    def name(self):
+        return "Start RHSM DBus service"
+
+    def run(self):
+        """Start the RHSM DBus service.
+
+        And also some related tasks, such as setting RHSM log levels.
+        """
+        # start the rhsm.service
+        # - this is blocking, but as we are effectively running in a thread
+        # it should not be an issue
+        # - if the return code is non-zero, return False immediately
+        rc = util.start_service(self.RHSM_SYSTEMD_UNIT_NAME)
+        if rc:
+            log.warning(
+                "subscription: RHSM systemd service failed to start with error code: %s",
+                rc
+            )
+            return False
+        # create a temporary proxy to set the log levels
+        rhsm_config_proxy = RHSM.get_proxy(RHSM_CONFIG)
+
+        # set RHSM log levels to debug
+        # - otherwise the RHSM log output is not usable for debugging subscription issues
+        log.debug("subscription: setting RHSM log level to DEBUG")
+        rhsm_config_proxy.Set("logging.default_log_level", get_variant(Str, "DEBUG"), "")
+        # all seems fine
+        log.debug("subscription: RHSM service start successfully.")
+        return True
+
+    def is_service_available(self, timeout=RHSM_SERVICE_TIMEOUT):
+        """Return if RHSM service is available or wait if startup is ongoing."""
+        if self.is_running:
+            # Wait up to defined timeout for the service to startup
+            # by joining the thread running the task. We specify a timeout when
+            # joining to prevent a deadlocked task blocking this method forever.
+            thread = threadMgr.get(self._thread_name)
+            if thread:
+                log.debug("subscription: waiting for RHSM service to start for up to %f seconds.",
+                          timeout)
+                thread.join(timeout)
+            else:
+                log.error("subscription: RHSM startup task is running but no thread found.")
+                return False
+
+        # now check again if the task is still running
+        if self.is_running:
+            # looks like we timed out
+            log.debug("subscription: RHSM service not available after waiting for %f seconds.",
+                      timeout)
+            return False
+        else:
+            # If we got this far, the task has finished running. If the result is True
+            # it was able to successfully start the systemd unit and connect to the DBus API.
+            # If the result is False, then the service failed to start.
+            try:
+                result = self.get_result()
+            except NoResultError:
+                # if the task fails in weird ways, there could apparently be no result
+                log.error("subscription: got no result from StartRHSMTask")
+                result = False
+            return result

--- a/pyanaconda/modules/subscription/rhsm_observer.py
+++ b/pyanaconda/modules/subscription/rhsm_observer.py
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from pyanaconda.modules.common.constants.services import RHSM
+from pyanaconda.core.constants import RHSM_SERVICE_TIMEOUT
+from pyanaconda.anaconda_loggers import get_module_logger
+
+from dasbus.client.observer import DBusObserver, DBusObserverError
+
+log = get_module_logger(__name__)
+
+
+class RHSMObserver(DBusObserver):
+    """Observer of the systemd unit backed RHSM DBus service."""
+
+    def __init__(self, startup_check_method, timeout=RHSM_SERVICE_TIMEOUT):
+        """Creates a RHSM service observer.
+
+        The observer will wait (up to a timeout) for the task starting the RHSM service
+        to finish and then provide access to the corresponding RHSM DBus API.
+
+        The waiting is only expected to happen at Anaconda startup, once the RHSM
+        startup task has finished running no further waiting is expected.
+
+        :param startup_check_method: a blocking method that waits for RHSM
+                                     startup to finish up to a given timeout
+                                     and then returns a boolean value corresponding
+                                     to True if startup was successful or False
+                                     otherwise
+        :param float timeout: how long to wait for RHSM service to start in seconds
+        """
+        super().__init__(RHSM._message_bus, RHSM.service_name)
+        self._startup_check_method = startup_check_method
+        self._timeout = timeout
+
+    def get_proxy(self, object_identifier):
+        """Returns a proxy of the given RHSM object identifier.
+
+        :param object_identifier: RHSM DBus API object identifier
+        :type object_identifier: DBusObjectIdentifier instance
+        :raises: DBusObserverError if the given proxy can't be returned
+        """
+        # first check if the DBus API seems to be up
+        if not self.is_service_available and not self._startup_check_method(self._timeout):
+            raise DBusObserverError("The RHSM DBus API is not available.")
+        else:
+            return RHSM.get_proxy(object_identifier)

--- a/tests/nosetests/pyanaconda_tests/rhsm_observer_test.py
+++ b/tests/nosetests/pyanaconda_tests/rhsm_observer_test.py
@@ -1,0 +1,253 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
+
+import unittest
+from unittest.mock import patch, Mock, PropertyMock
+
+from dasbus.typing import get_variant, Str
+from dasbus.client.observer import DBusObserverError
+
+from pyanaconda.core.constants import RHSM_SERVICE_TIMEOUT
+
+from pyanaconda.modules.common.constants.objects import RHSM_CONFIG
+
+from pyanaconda.modules.subscription.initialization import StartRHSMTask
+from pyanaconda.modules.subscription.rhsm_observer import RHSMObserver
+
+
+class StartRHSMTaskTestCase(unittest.TestCase):
+    """Test the StartRHSMTask task.
+
+    The StartRHSMTask is pretty closely related to the RHSMObserver,
+    so lets test it here.
+    """
+
+    @patch("pyanaconda.modules.common.constants.services.RHSM.get_proxy")
+    @patch("pyanaconda.core.util.start_service")
+    def success_test(self, start_service, get_proxy):
+        """Test StartRHSMTask - successful task."""
+
+        # create the task
+        task = StartRHSMTask()
+        # simulate successful systemd service start
+        start_service.return_value = 0
+        # return mock proxy
+        config_proxy = Mock()
+        get_proxy.return_value = config_proxy
+        # run the task and expect it to succeed
+        self.assertTrue(task.run())
+        # check service was started correctly
+        start_service.assert_called_once_with("rhsm.service")
+        # check proxy was requested
+        get_proxy.assert_called_once_with(RHSM_CONFIG)
+        # check expected values were set on the RHSM config proxy
+        config_proxy.Set.assert_called_once_with(
+            'logging.default_log_level',
+            get_variant(Str, 'DEBUG'),
+            ''
+        )
+
+    @patch("pyanaconda.modules.common.constants.services.RHSM.get_proxy")
+    @patch("pyanaconda.core.util.start_service")
+    def unit_start_failed_test(self, start_service, get_proxy):
+        """Test StartRHSMTask - systemd unit failed to start."""
+
+        # create the task
+        task = StartRHSMTask()
+        # simulate successful systemd service start
+        start_service.return_value = 1
+        # run the task and expect it to fail
+        self.assertFalse(task.run())
+        # check service was started correctly
+        start_service.assert_called_once_with("rhsm.service")
+        # check proxy was not requested
+        get_proxy.assert_not_called()
+
+    def is_service_available_success_test(self):
+        """Test StartRHSMTask - test is_service_available() - success."""
+
+        # create the task
+        task = StartRHSMTask()
+        # fake get_result()
+        task.get_result = Mock()
+        task.get_result.return_value = True
+        # test the method
+        self.assertTrue(task.is_service_available(1))
+
+    def is_service_available_failure_test(self):
+        """Test StartRHSMTask - test is_service_available() - failure."""
+
+        # create the task
+        task = StartRHSMTask()
+        # fake get_result()
+        task.get_result = Mock()
+        task.get_result.return_value = False
+        # test the method
+        self.assertFalse(task.is_service_available(1))
+
+    @patch("pyanaconda.threading.threadMgr.get")
+    def is_service_available_timeout_test(self, thread_mgr_get):
+        """Test StartRHSMTask - test is_service_available() - timeout."""
+
+        # put this into a variable to fit the patch invocation on single line
+        is_running_import = 'pyanaconda.modules.common.task.task.Task.is_running'
+
+        with patch(is_running_import, new_callable=PropertyMock) as is_running:
+            # fake is_running
+            is_running.return_value = True
+            # create the task
+            task = StartRHSMTask()
+            # fake get_result()
+            task.get_result = Mock()
+            task.get_result.return_value = False
+            # make sure is_running is True
+            self.assertTrue(task.is_running)
+            # us a mock thread, so that it's
+            # join method exists immediately
+            mock_thread = Mock()
+            thread_mgr_get.return_value = mock_thread
+            # test the method times out
+            self.assertFalse(task.is_service_available(timeout=1.0))
+            # check that the mock thread join() was called with expected
+            # timeout
+            mock_thread.join.assert_called_once_with(1.0)
+
+    @patch("pyanaconda.threading.threadMgr.get")
+    def is_service_available_waiting_test(self, thread_mgr_get):
+        """Test StartRHSMTask - test is_service_available() - waiting."""
+
+        # put this into a variable to fit the patch invocation on single line
+        is_running_import = 'pyanaconda.modules.common.task.task.Task.is_running'
+        with patch(is_running_import, new_callable=PropertyMock) as is_running:
+            # fake is_running
+            is_running.return_value = True
+            # create the task
+            task = StartRHSMTask()
+            # fake get_result()
+            task.get_result = Mock()
+            task.get_result.return_value = True
+            # make sure is_running is True
+            self.assertTrue(task.is_running)
+            # assure is_running switches to False before
+            # the method starts waiting on the mock thread
+            mock_thread = Mock()
+
+            def set_running_false(thread):
+                is_running.return_value = False
+                return mock_thread
+
+            thread_mgr_get.side_effect = set_running_false
+            # by replacing the thread by Mock instance,
+            # we can avoid running the method in a thread
+            # as it will join() Mock instance not a real thread
+            self.assertTrue(task.is_service_available(timeout=1.0))
+            # check that the mock thread was joined with the
+            # expected timeout value
+            mock_thread.join.assert_called_once_with(1.0)
+
+
+class RHSMObserverTestCase(unittest.TestCase):
+    """Test the service observer."""
+
+    def _setup_observer(self, observer):
+        """Set up the observer."""
+        observer._service_available = Mock()
+        observer._service_unavailable = Mock()
+        self.assertFalse(observer.is_service_available)
+
+    def _make_service_available(self, observer):
+        """Make the service available."""
+        observer._service_name_appeared_callback()
+        self._test_if_service_available(observer)
+
+    def _test_if_service_available(self, observer):
+        """Test if service is available."""
+        self.assertTrue(observer.is_service_available)
+
+        observer._service_available.emit.assert_called_once_with(observer)
+        observer._service_available.reset_mock()
+
+        observer._service_unavailable.emit.assert_not_called()
+        observer._service_unavailable.reset_mock()
+
+    def _make_service_unavailable(self, observer):
+        """Make the service unavailable."""
+        observer._is_service_available = False
+        self._test_if_service_unavailable(observer)
+
+    def _test_if_service_unavailable(self, observer):
+        """Test if service is unavailable."""
+        self.assertFalse(observer.is_service_available)
+
+        observer._service_available.emit.assert_not_called()
+        observer._service_available.reset_mock()
+
+    @patch("pyanaconda.modules.common.constants.services.RHSM.get_proxy")
+    def service_available_test(self, get_proxy):
+        """Test that RHSMObserver returns proxy if service is available."""
+
+        startup_check_method = Mock()
+        observer = RHSMObserver(startup_check_method)
+
+        self._setup_observer(observer)
+        self._make_service_available(observer)
+
+        # check the observer is returning a reasonably looking proxy
+        observer.get_proxy("BAZ")
+        get_proxy.assert_called_once_with("BAZ")
+
+    @patch("pyanaconda.modules.common.constants.services.RHSM.get_proxy")
+    def service_not_available_success_test(self, get_proxy):
+        """Test that RHSMObserver checks service startup status and succeeds."""
+
+        startup_check_method = Mock()
+        # report that startup was successful
+        startup_check_method.return_value = True
+        observer = RHSMObserver(startup_check_method)
+
+        self._setup_observer(observer)
+        self._make_service_unavailable(observer)
+
+        # check the observer is returning a reasonably looking proxy
+        observer.get_proxy("BAZ")
+        get_proxy.assert_called_once_with("BAZ")
+
+        # check that the startup check method was called
+        startup_check_method.assert_called_once_with(RHSM_SERVICE_TIMEOUT)
+
+    @patch("pyanaconda.modules.common.constants.services.RHSM.get_proxy")
+    def service_not_available_failure_test(self, get_proxy):
+        """Test that RHSMObserver checks service startup status and fails."""
+
+        startup_check_method = Mock()
+        # report that startup failed
+        startup_check_method.return_value = False
+        observer = RHSMObserver(startup_check_method)
+
+        self._setup_observer(observer)
+        self._make_service_unavailable(observer)
+        # DBusObserverError should be raise
+        with self.assertRaises(DBusObserverError):
+            observer.get_proxy("BAZ")
+        # the observer should raise the exception before trying to get a proxy
+        get_proxy.assert_not_called()
+
+        # check that the startup check method was called
+        startup_check_method.assert_called_once_with(RHSM_SERVICE_TIMEOUT)


### PR DESCRIPTION
Add ServiceObserver, which makes it possible to start
systemd unit backed DBus services on demand & to wait for
them to start up to a pre-defined timeout.

The timeout is set to 90 seconds by default, as this is also
the default timeout for systemd unit startup.

If the DBus service has not yet been requested, the corresponding
systemd unit will be started and get_proxy() will block up to
the timeout. If the DBus service becomes available before the timeout
DBus proxy for the service is cached and returned to the caller.

If the DBus service does not start in time a DBusObserverError is raised.

ServiceObserver is thread safe, so multiple threads can call
get_proxy() and safely wait for the DBus service to be available.

Once a proxy has been cached, subsequent get_proxy() calls should
not block ans will return the cached proxy.

On the other hand, if the service failed to start once, all subsequent
calls to get_proxy() will not block but will always raise the
DBusObserverError exception.