### PR TITLE
Make the kickstart support for the btrfs command optional

### DIFF
--- a/pyanaconda/modules/storage/kickstart.py
+++ b/pyanaconda/modules/storage/kickstart.py
@@ -67,6 +67,23 @@ class AutoPart(COMMANDS.AutoPart):
         return retval
 
 
+class BTRFS(COMMANDS.BTRFS):
+    """The btrfs kickstart command."""
+
+    def parse(self, args):
+        """Parse the command."""
+        retval = super().parse(args)
+
+        # Check the file system type.
+        fmt = get_format("btrfs")
+
+        if not fmt.supported or not fmt.formattable:
+            msg = _("Btrfs file system is not supported.")
+            raise KickstartParseError(msg, lineno=self.lineno)
+
+        return retval
+
+
 class ClearPart(COMMANDS.ClearPart):
     """The clearpart kickstart command."""
 
@@ -266,7 +283,7 @@ class StorageKickstartSpecification(KickstartSpecification):
     commands = {
         "autopart": AutoPart,
         "bootloader": COMMANDS.Bootloader,
-        "btrfs": COMMANDS.BTRFS,
+        "btrfs": BTRFS,
         "clearpart": ClearPart,
         "fcoe": Fcoe,
         "ignoredisk": IgnoreDisk,

--- a/tests/nosetests/pyanaconda_tests/module_part_factory_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_factory_test.py
@@ -18,7 +18,9 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+from unittest.mock import patch, PropertyMock
 
+from blivet.formats.fs import BTRFS
 from pyanaconda.core.kickstart.specification import KickstartSpecificationHandler, \
     KickstartSpecificationParser
 from pyanaconda.modules.storage.kickstart import StorageKickstartSpecification
@@ -44,8 +46,13 @@ class PartitioningFactoryTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             PartitioningFactory.create_partitioning("INVALID")
 
-    def get_method_for_kickstart_test(self):
+    @patch.object(BTRFS, "formattable", new_callable=PropertyMock)
+    @patch.object(BTRFS, "supported", new_callable=PropertyMock)
+    def get_method_for_kickstart_test(self, supported, formattable):
         """Test get_method_for_kickstart."""
+        supported.return_value = True
+        formattable.return_value = True
+
         self._check_method(
             PartitioningMethod.AUTOMATIC,
             "autopart"

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -19,7 +19,9 @@
 #
 import logging
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, PropertyMock
+
+from blivet.formats.fs import BTRFS
 
 from pyanaconda.bootloader import BootLoaderFactory
 from pyanaconda.bootloader.extlinux import EXTLINUX
@@ -1345,15 +1347,28 @@ class StorageInterfaceTestCase(unittest.TestCase):
         self._check_dbus_partitioning(publisher, PartitioningMethod.CUSTOM)
 
     @patch_dbus_publish_object
-    def btrfs_kickstart_test(self, publisher):
+    @patch.object(BTRFS, "supported", new_callable=PropertyMock)
+    @patch.object(BTRFS, "formattable", new_callable=PropertyMock)
+    def btrfs_kickstart_test(self, supported, formattable, publisher):
         """Test the btrfs command."""
         ks_in = """
         btrfs / --subvol --name=root fedora-btrfs
         """
         ks_out = ""
+
+        supported.return_value = True
+        formattable.return_value = True
         self._apply_partitioning_when_created()
         self._test_kickstart(ks_in, ks_out)
         self._check_dbus_partitioning(publisher, PartitioningMethod.CUSTOM)
+
+        supported.return_value = False
+        formattable.return_value = True
+        self._test_kickstart(ks_in, ks_out, ks_valid=False)
+
+        supported.return_value = True
+        formattable.return_value = False
+        self._test_kickstart(ks_in, ks_out, ks_valid=False)
 
 
 class StorageModuleTestCase(unittest.TestCase):


### PR DESCRIPTION
Raise the exception KickstartParseError if the btrfs command is specified
in a kickstart file, but btrfs is not a supported file system type.

(based on a commit 3b28b3e)