### PR TITLE
Fix spokes ordering and add tests for priority uniqueness

### DIFF
--- a/pyanaconda/ui/__init__.py
+++ b/pyanaconda/ui/__init__.py
@@ -136,7 +136,8 @@ class UserInterface(object):
         """
         raise NotImplementedError
 
-    def _collectActionClasses(self, module_pattern_w_path, standalone_class):
+    @staticmethod
+    def _collectActionClasses(module_pattern_w_path, standalone_class):
         """Collect all the Hub and Spoke classes which should be enqueued for processing.
 
         :param module_pattern_w_path: the full name patterns (pyanaconda.ui.gui.spokes.%s)
@@ -165,7 +166,8 @@ class UserInterface(object):
 
         return standalones
 
-    def _orderActionClasses(self, spokes, hubs):
+    @staticmethod
+    def _orderActionClasses(spokes, hubs):
         """Order all the Hub and Spoke classes.
 
         These should be enqueued for processing according to their pre/post dependencies.
@@ -183,13 +185,13 @@ class UserInterface(object):
         for hub in hubs:
             action_classes.extend(
                 sorted(
-                    self._filter_spokes_by_pre_for_hub_reference(spokes, hub),
+                    UserInterface._filter_spokes_by_pre_for_hub_reference(spokes, hub),
                     key=lambda obj: obj.priority)
             )
             action_classes.append(hub)
             action_classes.extend(
                 sorted(
-                    self._filter_spokes_by_post_for_hub_reference(spokes, hub),
+                    UserInterface._filter_spokes_by_post_for_hub_reference(spokes, hub),
                     key=lambda obj: obj.priority)
             )
 

--- a/pyanaconda/ui/__init__.py
+++ b/pyanaconda/ui/__init__.py
@@ -180,18 +180,19 @@ class UserInterface(object):
                      attribute of Spokes to pick up
         :type hubs: common.Hub based types
         """
+        ordered_spokes = sorted(spokes, key=lambda x: x.__name__)
         action_classes = []
 
         for hub in hubs:
             action_classes.extend(
                 sorted(
-                    UserInterface._filter_spokes_by_pre_for_hub_reference(spokes, hub),
+                    UserInterface._filter_spokes_by_pre_for_hub_reference(ordered_spokes, hub),
                     key=lambda obj: obj.priority)
             )
             action_classes.append(hub)
             action_classes.extend(
                 sorted(
-                    UserInterface._filter_spokes_by_post_for_hub_reference(spokes, hub),
+                    UserInterface._filter_spokes_by_post_for_hub_reference(ordered_spokes, hub),
                     key=lambda obj: obj.priority)
             )
 

--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -480,6 +480,8 @@ class StandaloneSpoke(Spoke):
     preForHub = None
     postForHub = None
 
+    priority = 0
+
     def __init__(self, storage, payload):
         """Create a StandaloneSpoke instance."""
         if self.preForHub and self.postForHub:

--- a/pyanaconda/ui/gui/spokes/installation_progress.py
+++ b/pyanaconda/ui/gui/spokes/installation_progress.py
@@ -47,7 +47,6 @@ class ProgressSpoke(StandaloneSpoke):
     helpFile = "ProgressHub.xml"
 
     postForHub = SummaryHub
-    priority = 0
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)

--- a/pyanaconda/ui/tui/spokes/installation_progress.py
+++ b/pyanaconda/ui/tui/spokes/installation_progress.py
@@ -43,7 +43,6 @@ class ProgressSpoke(StandaloneTUISpoke):
           :parts: 3
     """
     postForHub = SummaryHub
-    priority = 0
 
     def __init__(self, ksdata, storage, payload):
         self.initialize_start()

--- a/pyanaconda/ui/tui/spokes/kernel_warning.py
+++ b/pyanaconda/ui/tui/spokes/kernel_warning.py
@@ -29,7 +29,6 @@ __all__ = ["KernelWarningSpoke"]
 class KernelWarningSpoke(StandaloneTUISpoke):
     """Spoke for kernel-related warnings."""
     preForHub = SummaryHub
-    priority = 0
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pyanaconda/ui/tui/spokes/unsupported_hardware.py
+++ b/pyanaconda/ui/tui/spokes/unsupported_hardware.py
@@ -31,7 +31,6 @@ class UnsupportedHardwareSpoke(StandaloneTUISpoke):
     Show this spoke if the unsupported hardware was detected.
     """
     preForHub = SummaryHub
-    priority = 0
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pyanaconda/ui/tui/spokes/unsupported_hardware.py
+++ b/pyanaconda/ui/tui/spokes/unsupported_hardware.py
@@ -31,6 +31,7 @@ class UnsupportedHardwareSpoke(StandaloneTUISpoke):
     Show this spoke if the unsupported hardware was detected.
     """
     preForHub = SummaryHub
+    priority = -10
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
~The "KernelWarningSpoke" and "UnsupportedHardwareSpoke" seems to be switched. Not sure if this is happening only sometimes or all the time but sorting the spokes in the test should solve this for good.~

~Probably introduced by: 0aa6f1507a8b4bacebca7dcccf7bda4b873e6fba~

~**EDIT:**~
~If two standalone spokes have the same priority then we depending on implementation of sorted algorithm which can differ between architectures.~

**EDIT2:**
See https://github.com/rhinstaller/anaconda/pull/2435#issuecomment-614684320 for explanation.

This already happened in the past see:
https://bugzilla.redhat.com/show_bug.cgi?id=929177