### PR TITLE
Use black color for errors in bottom bar (#1823004)

### DIFF
--- a/data/anaconda-gtk.css
+++ b/data/anaconda-gtk.css
@@ -43,7 +43,7 @@ levelbar.discrete trough block.filled.high {
 @define-color warning_bg_color rgb (250, 173, 61);
 @define-color question_fg_color white;
 @define-color question_bg_color rgb (138, 173, 212);
-@define-color error_fg_color white;
+@define-color error_fg_color black;
 @define-color error_bg_color rgb (237, 54, 54);
 
 infobar.info {


### PR DESCRIPTION
Make errors in the bottom bar easier to read.