### PR TITLE
Add the ConnectToInsightsTask and related machinery

### DIFF
--- a/pyanaconda/modules/common/errors/installation.py
+++ b/pyanaconda/modules/common/errors/installation.py
@@ -73,3 +73,15 @@ class BootloaderInstallationError(InstallationError):
 class StorageInstallationError(InstallationError):
     """Exception for the storage installation errors."""
     pass
+
+
+@dbus_error("InsightsClientMissingError", namespace=ANACONDA_NAMESPACE)
+class InsightsClientMissingError(InstallationError):
+    """Exception for missing Red Hat Insights utility."""
+    pass
+
+
+@dbus_error("InsightsConnectError", namespace=ANACONDA_NAMESPACE)
+class InsightsConnectError(InstallationError):
+    """Exception for error when connecting to Red Hat Insights."""
+    pass

--- a/pyanaconda/modules/subscription/installation.py
+++ b/pyanaconda/modules/subscription/installation.py
@@ -1,0 +1,75 @@
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import os
+
+from pyanaconda.core import util
+
+from pyanaconda.modules.common.task import Task
+from pyanaconda.modules.common.errors.installation import InsightsConnectError, \
+    InsightsClientMissingError
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+
+class ConnectToInsightsTask(Task):
+    """Connect the target system to Red Hat Insights."""
+
+    INSIGHTS_TOOL_PATH = "/usr/bin/insights-client"
+
+    def __init__(self, sysroot, subscription_attached, connect_to_insights):
+        """Create a new task.
+
+        :param str sysroot: target system root path
+        :param bool subscription_attached: if True then the system has been subscribed,
+                                           False otherwise
+        :param bool connect_to_insights: if True then connect the system to Insights,
+                                         if False do nothing
+        """
+        super().__init__()
+        self._sysroot = sysroot
+        self._subscription_attached = subscription_attached
+        self._connect_to_insights = connect_to_insights
+
+    @property
+    def name(self):
+        return "Connect the target system to Red Hat Insights"
+
+    def run(self):
+        """Connect the target system to Red Hat Insights."""
+        # check if we should connect to Red Hat Insights
+        if not self._connect_to_insights:
+            log.debug("insights-connect-task: Insights not requested, skipping")
+            return
+        elif not self._subscription_attached:
+            log.debug("insights-connect-task: "
+                      "Insights requested but target system is not subscribed, skipping")
+            return
+
+        insights_path = util.join_paths(self._sysroot, self.INSIGHTS_TOOL_PATH)
+        # check the insights client utility is available
+        if not os.path.isfile(insights_path):
+            raise InsightsClientMissingError(
+                "The insight-client tool ({}) is not available.".format(self.INSIGHTS_TOOL_PATH)
+            )
+
+        # tell the insights client to connect to insights
+        log.debug("insights-connect-task: connecting to insights")
+        rc = util.execWithRedirect(self.INSIGHTS_TOOL_PATH, ["--register"], root=self._sysroot)
+        if rc:
+            raise InsightsConnectError("Connecting to Red Hat Insights failed.")

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -81,6 +81,10 @@ class SubscriptionService(KickstartService):
         self._connect_to_insights = False
         self.connect_to_insights_changed = Signal()
 
+        # subscription status
+        self.subscription_attached_changed = Signal()
+        self._subscription_attached = False
+
         # FIXME: handle rhsm.service startup in a safe manner
 
     def publish(self):
@@ -364,3 +368,26 @@ class SubscriptionService(KickstartService):
         self._connect_to_insights = connect
         self.connect_to_insights_changed.emit()
         log.debug("Connect target system to Insights set to: %s", self._connect_to_insights)
+
+    # subscription status
+
+    @property
+    def subscription_attached(self):
+        """Return True if a subscription has been attached to the system.
+
+        :return: True if a subscription has been attached to the system, False otherwise
+        :rtype: bool
+        """
+        return self._subscription_attached
+
+    def set_subscription_attached(self, system_subscription_attached):
+        """Set a subscription has been attached to the system.
+
+        :param bool system_registered: True if subscription has been attached, False otherwise
+        """
+        self._subscription_attached = system_subscription_attached
+        self.subscription_attached_changed.emit()
+        # as there is no public setter in the DBus API, we need to emit
+        # the properties changed signal here manually
+        self.module_properties_changed.emit()
+        log.debug("Subscription attached set to: %s", system_subscription_attached)

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -24,6 +24,7 @@ from pyanaconda.core import util
 from pyanaconda.core.signal import Signal
 from pyanaconda.core.constants import SECRET_TYPE_HIDDEN, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY, \
     SUBSCRIPTION_REQUEST_VALID_TYPES
+from pyanaconda.core.configuration.anaconda import conf
 
 from pyanaconda.modules.common.errors.general import InvalidValueError
 from pyanaconda.modules.common.base import KickstartService
@@ -38,6 +39,7 @@ from pyanaconda.modules.common.containers import TaskContainer
 from pyanaconda.modules.subscription import system_purpose
 from pyanaconda.modules.subscription.kickstart import SubscriptionKickstartSpecification
 from pyanaconda.modules.subscription.subscription_interface import SubscriptionInterface
+from pyanaconda.modules.subscription.installation import ConnectToInsightsTask
 
 from pykickstart.errors import KickstartParseWarning
 
@@ -391,3 +393,18 @@ class SubscriptionService(KickstartService):
         # the properties changed signal here manually
         self.module_properties_changed.emit()
         log.debug("Subscription attached set to: %s", system_subscription_attached)
+
+    # tasks
+
+    def install_with_tasks(self):
+        """Return the installation tasks of this module.
+
+        :returns: list of installation tasks
+        """
+        return [
+            ConnectToInsightsTask(
+                sysroot=conf.target.system_root,
+                subscription_attached=self.subscription_attached,
+                connect_to_insights=self.connect_to_insights
+            )
+        ]

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -38,6 +38,8 @@ class SubscriptionInterface(KickstartModuleInterface):
                             self.implementation.subscription_request_changed)
         self.watch_property("InsightsEnabled",
                             self.implementation.connect_to_insights_changed)
+        self.watch_property("IsSubscriptionAttached",
+                            self.implementation.subscription_attached_changed)
 
     def GetValidRoles(self) -> List[Str]:
         """Return all valid system purpose roles.
@@ -115,3 +117,8 @@ class SubscriptionInterface(KickstartModuleInterface):
         :param bool connect_to_insights: True to connect, False not to connect
         """
         self.implementation.set_connect_to_insights(connect_to_insights)
+
+    @property
+    def IsSubscriptionAttached(self) -> Bool:
+        """Report if an entitlement has been successfully attached."""
+        return self.implementation.subscription_attached

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tasks_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tasks_tests.py
@@ -1,0 +1,115 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
+import os
+import unittest
+from unittest.mock import patch
+
+import tempfile
+
+from pyanaconda.core import util
+
+from pyanaconda.modules.common.errors.installation import InsightsConnectError, \
+    InsightsClientMissingError
+
+from pyanaconda.modules.subscription.installation import ConnectToInsightsTask
+
+
+class ConnectToInsightsTaskTestCase(unittest.TestCase):
+    """Test the ConnectToInsights task."""
+
+    @patch("pyanaconda.core.util.execWithRedirect")
+    def no_connect_test(self, exec_with_redirect):
+        """Test that nothing is done if Insights connection is not requested."""
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            task = ConnectToInsightsTask(sysroot=sysroot,
+                                         subscription_attached=False,
+                                         connect_to_insights=False)
+            task.run()
+            # check that no attempt to call the Insights client has been attempted
+            exec_with_redirect.assert_not_called()
+
+    @patch("pyanaconda.core.util.execWithRedirect")
+    def not_subscribed_test(self, exec_with_redirect):
+        """Test that nothing is done if Insights is requested but system is not subscribed."""
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            task = ConnectToInsightsTask(sysroot=sysroot,
+                                         subscription_attached=False,
+                                         connect_to_insights=True)
+            task.run()
+            # check that no attempt to call the Insights client has been attempted
+            exec_with_redirect.assert_not_called()
+
+    @patch("pyanaconda.core.util.execWithRedirect")
+    def utility_not_available_test(self, exec_with_redirect):
+        """Test that the client-missing exception is raised if Insights client is missing."""
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            task = ConnectToInsightsTask(sysroot=sysroot,
+                                         subscription_attached=True,
+                                         connect_to_insights=True)
+            with self.assertRaises(InsightsClientMissingError):
+                task.run()
+            # check that no attempt to call the Insights client has been attempted
+            exec_with_redirect.assert_not_called()
+
+    @patch("pyanaconda.core.util.execWithRedirect")
+    def connect_error_test(self, exec_with_redirect):
+        """Test that the expected exception is raised if the Insights client fails when called."""
+        with tempfile.TemporaryDirectory() as sysroot:
+            # create a fake insights client tool file
+            utility_path = ConnectToInsightsTask.INSIGHTS_TOOL_PATH
+            directory = os.path.split(utility_path)[0]
+            os.makedirs(util.join_paths(sysroot, directory))
+            os.mknod(util.join_paths(sysroot, utility_path))
+            task = ConnectToInsightsTask(sysroot=sysroot,
+                                         subscription_attached=True,
+                                         connect_to_insights=True)
+            # make sure execWithRedirect has a non zero return code
+            exec_with_redirect.return_value = 1
+            with self.assertRaises(InsightsConnectError):
+                task.run()
+            # check that call to the insights client has been done with the expected parameters
+            exec_with_redirect.assert_called_once_with('/usr/bin/insights-client',
+                                                       ['--register'],
+                                                       root=sysroot)
+
+    @patch("pyanaconda.core.util.execWithRedirect")
+    def connect_test(self, exec_with_redirect):
+        """Test that it is possible to connect to Insights."""
+        with tempfile.TemporaryDirectory() as sysroot:
+            # create a fake insights client tool file
+            utility_path = ConnectToInsightsTask.INSIGHTS_TOOL_PATH
+            directory = os.path.split(utility_path)[0]
+            # we use + here instead of os.path.join() as both paths are absolute and
+            # os.path.join() does not handle that very well
+            os.makedirs(sysroot + directory)
+            os.mknod(sysroot + utility_path)
+            task = ConnectToInsightsTask(sysroot=sysroot,
+                                         subscription_attached=True,
+                                         connect_to_insights=True)
+            # make sure execWithRedirect has a zero return code
+            exec_with_redirect.return_value = 0
+            task.run()
+            # check that call to the insights client has been done with the expected parameters
+            exec_with_redirect.assert_called_once_with('/usr/bin/insights-client',
+                                                       ['--register'],
+                                                       root=sysroot)

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
@@ -714,6 +714,29 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
           False
         )
 
+    def subscription_attached_property_test(self):
+        """Test the IsSubscriptionAttached property."""
+        # should be false by default
+        self.assertFalse(self.subscription_interface.IsSubscriptionAttached)
+
+        # this property can't be set by client as it is set as the result of
+        # subscription attempts, so we need to call the internal module interface
+        # via a custom setter
+
+        def custom_setter(value):
+            self.subscription_module.set_subscription_attached(value)
+
+        # check the property is True and the signal was emitted
+        # - we use fake setter as there is no public setter
+        self._check_dbus_property(
+          "IsSubscriptionAttached",
+          True,
+          setter=custom_setter
+        )
+
+        # at the end the property should be True
+        self.assertTrue(self.subscription_interface.IsSubscriptionAttached)
+
     def _test_kickstart(self, ks_in, ks_out):
         check_kickstart_interface(self, self.subscription_interface, ks_in, ks_out)
 

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
@@ -35,9 +35,10 @@ from pyanaconda.modules.subscription.subscription import SubscriptionService
 from pyanaconda.modules.subscription.subscription_interface import SubscriptionInterface
 from pyanaconda.modules.subscription.system_purpose import get_valid_fields, _normalize_field, \
     _match_field, process_field
+from pyanaconda.modules.subscription.installation import ConnectToInsightsTask
 
 from tests.nosetests.pyanaconda_tests import check_kickstart_interface, check_dbus_property, \
-    PropertiesChangedCallback
+    PropertiesChangedCallback, patch_dbus_publish_object, check_task_creation_list
 
 # content of a valid populated valid values json file for system purpose testing
 SYSPURPOSE_VALID_VALUES_JSON = """
@@ -736,6 +737,38 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         # at the end the property should be True
         self.assertTrue(self.subscription_interface.IsSubscriptionAttached)
+
+    @patch_dbus_publish_object
+    def install_with_tasks_default_test(self, publisher):
+        """Test install tasks - Subscription module in default state."""
+        task_classes = [
+            ConnectToInsightsTask
+        ]
+        task_paths = self.subscription_interface.InstallWithTasks()
+        task_objs = check_task_creation_list(self, task_paths, publisher, task_classes)
+
+        # ConnectToInsightsTask
+        obj = task_objs[0]
+        self.assertEqual(obj.implementation._subscription_attached, False)
+        self.assertEqual(obj.implementation._connect_to_insights, False)
+
+    @patch_dbus_publish_object
+    def install_with_tasks_configured_test(self, publisher):
+        """Test install tasks - Subscription module in configured state."""
+
+        self.subscription_interface.SetInsightsEnabled(True)
+        self.subscription_module.set_subscription_attached(True)
+
+        task_classes = [
+            ConnectToInsightsTask
+        ]
+        task_paths = self.subscription_interface.InstallWithTasks()
+        task_objs = check_task_creation_list(self, task_paths, publisher, task_classes)
+
+        # ConnectToInsightsTask
+        obj = task_objs[0]
+        self.assertEqual(obj.implementation._subscription_attached, True)
+        self.assertEqual(obj.implementation._connect_to_insights, True)
 
     def _test_kickstart(self, ks_in, ks_out):
         check_kickstart_interface(self, self.subscription_interface, ks_in, ks_out)


### PR DESCRIPTION
The first commit adds the `ConnectToInsightsTask`, the second commit implements the `IsSubscriptionAttached` property needed by the Insights tasks and the third commit exposes the `ConnectToInsightsTask` via the standard `install_with_tasks()` method.