### PR TITLE
Fix order of spokes in TUI test

### DIFF
--- a/tests/nosetests/pyanaconda_tests/simple_ui_test.py
+++ b/tests/nosetests/pyanaconda_tests/simple_ui_test.py
@@ -82,8 +82,8 @@ class SimpleUITestCase(unittest.TestCase):
 
         # Check the actions classes.
         self.assertEqual(self._get_action_class_names(), [
-            "UnsupportedHardwareSpoke",
             "KernelWarningSpoke",
+            "UnsupportedHardwareSpoke",
             "SummaryHub",
             "ProgressSpoke"
         ])


### PR DESCRIPTION
Something was broken, some time ago, somewhere. Not sure about any of that. But this fixes the test.