### PR TITLE
Install test dependencies from pip when possible

### DIFF
--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -40,12 +40,7 @@ TEST_DEPENDENCIES = [
     "rpm-ostree",
     "pykickstart",
     "python3-mock",
-    "python3-nose-testconfig",
-    "python3-sphinx_rtd_theme",
-    "python3-lxml",
     "python3-pip",
-    "python3-coverage",
-    "python-pycodestyle",  # pep8 check
     "policycoreutils",  # contains restorecon which was removed in Fedora 28 mock
 ]
 
@@ -53,6 +48,11 @@ PIP_DEPENDENCIES = [
     "rpmfluff",
     "dogtail",
     "pocketlint",
+    "nose-testconfig",
+    "sphinx_rtd_theme",
+    "lxml",
+    "coverage",
+    "pycodestyle",  # pep8 check
 ]
 
 RELEASE_DEPENDENCIES = []

--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -39,7 +39,6 @@ TEST_DEPENDENCIES = [
     "cppcheck",
     "rpm-ostree",
     "pykickstart",
-    "python3-mock",
     "python3-pip",
     "policycoreutils",  # contains restorecon which was removed in Fedora 28 mock
 ]

--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -32,21 +32,28 @@ from argparse import ArgumentParser
 
 ANACONDA_SPEC_NAME = "anaconda.spec.in"
 
-TEST_DEPENDENCIES = ["e2fsprogs", "git", "bzip2", "cppcheck", "rpm-ostree", "pykickstart",
-                     "python3-mock", "python3-nose-testconfig", "python3-sphinx_rtd_theme",
-                     "python3-lxml", "python3-pip", "python3-coverage",
-
-                     # pep8 check
-                     "python-pycodestyle",
-
-                     # contains restorecon which was removed in Fedora 28 mock
-                     "policycoreutils"
-                     # "python3-pocketlint"
-                     ]
+TEST_DEPENDENCIES = [
+    "e2fsprogs",
+    "git",
+    "bzip2",
+    "cppcheck",
+    "rpm-ostree",
+    "pykickstart",
+    "python3-mock",
+    "python3-nose-testconfig",
+    "python3-sphinx_rtd_theme",
+    "python3-lxml",
+    "python3-pip",
+    "python3-coverage",
+    "python-pycodestyle",  # pep8 check
+    "policycoreutils",  # contains restorecon which was removed in Fedora 28 mock
+]
 
 PIP_DEPENDENCIES = [
-                    "rpmfluff", "dogtail", "pocketlint"
-                   ]
+    "rpmfluff",
+    "dogtail",
+    "pocketlint",
+]
 
 RELEASE_DEPENDENCIES = []
 

--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -370,7 +370,7 @@ def install_pip_packages_to_mock(mock_command, packages):
     cmd = _prepare_command(mock_command)
 
     cmd = _run_cmd_in_chroot(cmd)
-    cmd.append('pip3 install {}'.format(packages))
+    cmd.append('pip3 install --install-option="--install-scripts=/usr/bin" {}'.format(packages))
 
     _check_subprocess(cmd, "Can't install packages via pip to mock.")
 


### PR DESCRIPTION
We should prefer to install test dependencies via pip. The required RPMs might
not be available for all products. It should also help to reduce the number of
packages that we maintain.