### PR TITLE
Change payload source ready state

### DIFF
--- a/pyanaconda/modules/payloads/base/installation.py
+++ b/pyanaconda/modules/payloads/base/installation.py
@@ -50,7 +50,7 @@ class InstallFromImageTask(Task):
         """Run installation of the payload from image."""
         # TODO: remove this check for None when Live Image payload will support sources
         # The None check is just a temporary hack that Live OS has source but Live Image don't
-        if self._source is not None and not self._source.is_ready():
+        if self._source is not None and not self._source.get_state():
             raise InstallError("Source is not set up!")
 
         cmd = "rsync"

--- a/pyanaconda/modules/payloads/constants.py
+++ b/pyanaconda/modules/payloads/constants.py
@@ -56,9 +56,9 @@ class SourceState(Enum):
 
     These will be used only internally. Not with a DBus API.
     """
+    NOT_APPLICABLE = auto()
     READY = auto()
     UNREADY = auto()
-    NOT_SUPPORTED = auto()
 
     @staticmethod
     def from_bool(value):

--- a/pyanaconda/modules/payloads/constants.py
+++ b/pyanaconda/modules/payloads/constants.py
@@ -16,7 +16,7 @@
 # source code or documentation are not subject to the GNU General Public
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
-from enum import Enum, unique
+from enum import Enum, unique, auto
 
 from pyanaconda.core.constants import URL_TYPE_BASEURL, URL_TYPE_MIRRORLIST, \
     URL_TYPE_METALINK, PAYLOAD_TYPE_DNF, PAYLOAD_TYPE_LIVE_OS, PAYLOAD_TYPE_LIVE_IMAGE
@@ -48,3 +48,28 @@ class URLType(Enum):
     BASEURL = URL_TYPE_BASEURL
     MIRRORLIST = URL_TYPE_MIRRORLIST
     METALINK = URL_TYPE_METALINK
+
+
+@unique
+class SourceState(Enum):
+    """States in which the source modules could be.
+
+    These will be used only internally. Not with a DBus API.
+    """
+    READY = auto()
+    UNREADY = auto()
+    NOT_SUPPORTED = auto()
+
+    @staticmethod
+    def from_bool(value):
+        """Get state from a bool value.
+
+        This way we can't return NONE state but that is not a problem. NONE state is specific
+        for sources which do not have a state, so they don't have to convert it from bool.
+
+        :param value: input boolean value
+        :type value: bool
+
+        :return: READY if value is True or UNREADY
+        """
+        return SourceState.READY if value else SourceState.UNREADY

--- a/pyanaconda/modules/payloads/payload/payload_base.py
+++ b/pyanaconda/modules/payloads/payload/payload_base.py
@@ -129,7 +129,7 @@ class PayloadBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
                 raise IncompatibleSourceError("Source type {} is not supported by this payload."
                                               .format(source.type.value))
 
-        if any(source.is_ready() for source in self.sources):
+        if any(source.get_state() for source in self.sources):
             raise SourceSetupError("Can't change list of sources if there is at least one source "
                                    "initialized! Please tear down the sources first.")
 

--- a/pyanaconda/modules/payloads/payload/payload_base.py
+++ b/pyanaconda/modules/payloads/payload/payload_base.py
@@ -24,6 +24,7 @@ from dasbus.server.publishable import Publishable
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.errors.payload import IncompatibleSourceError, SourceSetupError
 from pyanaconda.modules.common.base import KickstartBaseModule
+from pyanaconda.modules.payloads.constants import SourceState
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -129,7 +130,7 @@ class PayloadBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
                 raise IncompatibleSourceError("Source type {} is not supported by this payload."
                                               .format(source.type.value))
 
-        if any(source.get_state() for source in self.sources):
+        if any(source.get_state() == SourceState.READY for source in self.sources):
             raise SourceSetupError("Can't change list of sources if there is at least one source "
                                    "initialized! Please tear down the sources first.")
 

--- a/pyanaconda/modules/payloads/payload/payload_base.py
+++ b/pyanaconda/modules/payloads/payload/payload_base.py
@@ -128,7 +128,7 @@ class PayloadBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         for source in sources:
             if source.type not in self.supported_source_types:
                 raise IncompatibleSourceError("Source type {} is not supported by this payload."
-                                              .format(source.type))
+                                              .format(source.type.value))
 
         if any(source.is_ready() for source in self.sources):
             raise SourceSetupError("Can't change list of sources if there is at least one source "

--- a/pyanaconda/modules/payloads/payload/payload_base.py
+++ b/pyanaconda/modules/payloads/payload/payload_base.py
@@ -124,7 +124,6 @@ class PayloadBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         :raise: IncompatibleSourceError when source is not a supported type
                 SourceSetupError when attached sources are initialized
         """
-        # TODO: Add test for this when there will be unsupported source implemented
         for source in sources:
             if source.type not in self.supported_source_types:
                 raise IncompatibleSourceError("Source type {} is not supported by this payload."

--- a/pyanaconda/modules/payloads/source/harddrive/harddrive.py
+++ b/pyanaconda/modules/payloads/source/harddrive/harddrive.py
@@ -51,8 +51,8 @@ class HardDriveSourceModule(PayloadSourceBase):
         """Get type of this source."""
         return SourceType.HDD
 
-    def is_ready(self):
-        """This source is ready for the installation to start."""
+    def get_state(self):
+        """Get state of this source."""
         # TODO: this should be check on a special directory for every source
         res = os.path.ismount(self._device_mount) and bool(self._install_tree_path)
         log.debug("Source is set to %s ready state", res)

--- a/pyanaconda/modules/payloads/source/harddrive/harddrive.py
+++ b/pyanaconda/modules/payloads/source/harddrive/harddrive.py
@@ -22,7 +22,7 @@ import os
 from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.core.signal import Signal
 
-from pyanaconda.modules.payloads.constants import SourceType
+from pyanaconda.modules.payloads.constants import SourceType, SourceState
 from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase
 from pyanaconda.modules.payloads.source.harddrive.harddrive_interface import \
     HardDriveSourceInterface
@@ -56,7 +56,7 @@ class HardDriveSourceModule(PayloadSourceBase):
         # TODO: this should be check on a special directory for every source
         res = os.path.ismount(self._device_mount) and bool(self._install_tree_path)
         log.debug("Source is set to %s ready state", res)
-        return res
+        return SourceState.from_bool(res)
 
     def for_publication(self):
         """Get the interface used to publish this source."""

--- a/pyanaconda/modules/payloads/source/repo_files/repo_files.py
+++ b/pyanaconda/modules/payloads/source/repo_files/repo_files.py
@@ -40,7 +40,7 @@ class RepoFilesSourceModule(PayloadSourceBase):
 
     def get_state(self):
         """Get state of this source."""
-        return SourceState.NOT_SUPPORTED
+        return SourceState.NOT_APPLICABLE
 
     def for_publication(self):
         """Get the interface used to publish this source."""

--- a/pyanaconda/modules/payloads/source/repo_files/repo_files.py
+++ b/pyanaconda/modules/payloads/source/repo_files/repo_files.py
@@ -19,7 +19,7 @@
 #
 from pyanaconda.payload.dnf.utils import REPO_DIRS
 
-from pyanaconda.modules.payloads.constants import SourceType
+from pyanaconda.modules.payloads.constants import SourceType, SourceState
 from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase
 from pyanaconda.modules.payloads.source.repo_files.repo_files_interface import \
     RepoFilesSourceInterface
@@ -40,9 +40,7 @@ class RepoFilesSourceModule(PayloadSourceBase):
 
     def get_state(self):
         """Get state of this source."""
-        # FIXME: Returning True is correct here but it will prevent payload from setting sources.
-        # Find better solution.
-        return True
+        return SourceState.NOT_SUPPORTED
 
     def for_publication(self):
         """Get the interface used to publish this source."""

--- a/pyanaconda/modules/payloads/source/repo_files/repo_files.py
+++ b/pyanaconda/modules/payloads/source/repo_files/repo_files.py
@@ -38,8 +38,8 @@ class RepoFilesSourceModule(PayloadSourceBase):
         """Get type of this source."""
         return SourceType.REPO_FILES
 
-    def is_ready(self):
-        """This source is ready for the installation to start."""
+    def get_state(self):
+        """Get state of this source."""
         # FIXME: Returning True is correct here but it will prevent payload from setting sources.
         # Find better solution.
         return True

--- a/pyanaconda/modules/payloads/source/source_base.py
+++ b/pyanaconda/modules/payloads/source/source_base.py
@@ -48,8 +48,8 @@ class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def is_ready(self):
-        """This source is ready for the installation to start.
+    def get_state(self):
+        """Get state of this source.
 
         This method will not be part of the public API. There is no need for others than the
         payload owner to see the status of the source. It is also not really useful, in time when
@@ -104,7 +104,7 @@ class MountingSourceBase(PayloadSourceBase, ABC):
         super().__init__()
         self._mount_point = MountPointGenerator.generate_mount_point(self.type.value.lower())
 
-    def is_ready(self):
+    def get_state(self):
         """This source is ready for the installation to start.
 
         :return: ready or not

--- a/pyanaconda/modules/payloads/source/source_base.py
+++ b/pyanaconda/modules/payloads/source/source_base.py
@@ -23,6 +23,7 @@ from abc import ABC, ABCMeta, abstractmethod
 from dasbus.server.publishable import Publishable
 
 from pyanaconda.modules.common.base import KickstartBaseModule
+from pyanaconda.modules.payloads.constants import SourceState
 from pyanaconda.modules.payloads.source.mount_tasks import TearDownMountTask
 from pyanaconda.modules.payloads.source.utils import MountPointGenerator
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -56,7 +57,8 @@ class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         user gets the ready state the state could be different because of the DBus parallelism.
         In general we should not share state.
 
-        :rtype: bool
+        :return: one of the supported state of SourceState enum
+        :rtype: pyanaconda.modules.payloads.constants.SourceState enum value
         """
         # TODO: Add needs_teardown property which will tell us if the source has to be cleaned up
         # before removing the source from a payload. The is_ready will work for now but it
@@ -107,10 +109,11 @@ class MountingSourceBase(PayloadSourceBase, ABC):
     def get_state(self):
         """This source is ready for the installation to start.
 
-        :return: ready or not
-        :rtype: bool
+        :return: one of the supported state of SourceState enum
+        :rtype: pyanaconda.modules.payloads.constants.SourceState enum value
         """
-        return os.path.ismount(self._mount_point)
+        res = os.path.ismount(self._mount_point)
+        return SourceState.from_bool(res)
 
     @property
     def mount_point(self):

--- a/pyanaconda/modules/payloads/source/url/url.py
+++ b/pyanaconda/modules/payloads/source/url/url.py
@@ -22,7 +22,7 @@ from pyanaconda.core.signal import Signal
 from pyanaconda.core.util import ProxyString, ProxyStringError
 from pyanaconda.modules.common.errors.general import InvalidValueError
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
-from pyanaconda.modules.payloads.constants import SourceType, URLType
+from pyanaconda.modules.payloads.constants import SourceType, URLType, SourceState
 from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase
 from pyanaconda.modules.payloads.source.url.url_interface import URLSourceInterface
 
@@ -56,8 +56,7 @@ class URLSourceModule(PayloadSourceBase):
 
     def get_state(self):
         """Get state of this source."""
-        # FIXME: always true is correct but it will block change of payload source. Find solution!
-        return True
+        return SourceState.NOT_SUPPORTED
 
     @property
     def type(self):

--- a/pyanaconda/modules/payloads/source/url/url.py
+++ b/pyanaconda/modules/payloads/source/url/url.py
@@ -54,8 +54,8 @@ class URLSourceModule(PayloadSourceBase):
 
         self._url_source_name = "{}-{}".format(BASE_REPO_NAME, source_id)
 
-    def is_ready(self):
-        """This source is ready for the installation to start."""
+    def get_state(self):
+        """Get state of this source."""
         # FIXME: always true is correct but it will block change of payload source. Find solution!
         return True
 

--- a/pyanaconda/modules/payloads/source/url/url.py
+++ b/pyanaconda/modules/payloads/source/url/url.py
@@ -56,7 +56,7 @@ class URLSourceModule(PayloadSourceBase):
 
     def get_state(self):
         """Get state of this source."""
-        return SourceState.NOT_SUPPORTED
+        return SourceState.NOT_APPLICABLE
 
     @property
     def type(self):

--- a/tests/nosetests/pyanaconda_tests/module_payload_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_base_test.py
@@ -113,7 +113,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         self.shared_tests.check_set_sources([source1])
 
         # Can't switch source if attached source is ready
-        source1.is_ready.return_value = True
+        source1.get_state.return_value = True
         self.shared_tests.check_set_sources([source2],
                                             exception=SourceSetupError,
                                             expected_sources=[source1])

--- a/tests/nosetests/pyanaconda_tests/module_payload_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_base_test.py
@@ -108,7 +108,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
     def set_when_initialized_source_fail_test(self, publisher):
         """Test payload can't set new sources if the old ones are initialized."""
         source1 = self.shared_tests.prepare_source(SourceType.NFS)
-        source2 = self.shared_tests.prepare_source(SourceType.URL, state=SourceState.NOT_SUPPORTED)
+        source2 = self.shared_tests.prepare_source(SourceType.URL, state=SourceState.NOT_APPLICABLE)
 
         self.shared_tests.check_set_sources([source1])
 
@@ -122,5 +122,5 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         source1.get_state.return_value = SourceState.UNREADY
         self.shared_tests.check_set_sources([source2])
 
-        # can change back anytime because source2 has state NOT_SUPPORTED
+        # can change back anytime because source2 has state NOT_APPLICABLE
         self.shared_tests.check_set_sources([source1])

--- a/tests/nosetests/pyanaconda_tests/module_payload_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_base_test.py
@@ -1,0 +1,119 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
+#
+# This test will test PayloadBase with interface but it's much easier to test
+# this with an existing payload so use DNF just as dummy test payload.
+#
+import unittest
+from unittest.mock import patch
+
+from tests.nosetests.pyanaconda_tests import patch_dbus_publish_object
+from tests.nosetests.pyanaconda_tests.module_payload_shared import PayloadSharedTest
+
+from pyanaconda.modules.common.errors.payload import IncompatibleSourceError, SourceSetupError
+from pyanaconda.modules.payloads.constants import PayloadType, SourceType
+from pyanaconda.modules.payloads.payload.dnf.dnf import DNFModule
+from pyanaconda.modules.payloads.payload.dnf.dnf_interface import DNFInterface
+
+
+class PayloadBaseInterfaceTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.module = DNFModule()
+        self.interface = DNFInterface(self.module)
+
+        self.shared_tests = PayloadSharedTest(self,
+                                              payload=self.module,
+                                              payload_intf=self.interface)
+
+    def type_test(self):
+        self.shared_tests.check_type(PayloadType.DNF)
+
+    def required_space_test(self):
+        """Test required space."""
+        self.module._required_space = 100
+
+        self.assertEqual(self.interface.RequiredSpace, 100)
+
+    def required_default_space_test(self):
+        """Test default value for required space.
+
+        This is used when space is not known.
+        """
+        self.module._required_space = None
+
+        self.assertEqual(self.interface.RequiredSpace, self.module.default_required_space)
+
+    @patch.object(DNFModule, "supported_source_types", [SourceType.URL])
+    def supported_sources_test(self):
+        """Test supported sources API."""
+        self.assertEqual(
+            [SourceType.URL.value],
+            self.interface.SupportedSourceTypes)
+
+    def sources_empty_test(self):
+        """Test sources API for emptiness."""
+        self.shared_tests.check_empty_sources()
+
+    @patch.object(DNFModule, "supported_source_types", [SourceType.URL])
+    @patch_dbus_publish_object
+    def set_source_test(self, publisher):
+        """Test if set source API payload."""
+        sources = [self.shared_tests.prepare_source(SourceType.URL)]
+
+        self.shared_tests.check_set_sources(sources)
+
+    @patch.object(DNFModule, "supported_source_types", [SourceType.URL, SourceType.NFS])
+    @patch_dbus_publish_object
+    def set_multiple_source_test(self, publisher):
+        """Test payload setting multiple compatible sources."""
+        sources = [
+            self.shared_tests.prepare_source(SourceType.NFS),
+            self.shared_tests.prepare_source(SourceType.URL),
+            self.shared_tests.prepare_source(SourceType.URL),
+        ]
+
+        self.shared_tests.check_set_sources(sources)
+
+    @patch.object(DNFModule, "supported_source_types", [SourceType.URL])
+    @patch_dbus_publish_object
+    def set_incompatible_source_test(self, publisher):
+        """Test payload setting incompatible sources."""
+        sources = [self.shared_tests.prepare_source(SourceType.LIVE_OS_IMAGE)]
+
+        cm = self.shared_tests.check_set_sources(sources, exception=IncompatibleSourceError)
+
+        msg = "Source type {} is not supported by this payload.".format(
+            SourceType.LIVE_OS_IMAGE.value)
+        self.assertEqual(str(cm.exception), msg)
+
+    @patch.object(DNFModule, "supported_source_types", [SourceType.NFS])
+    @patch_dbus_publish_object
+    def set_when_initialized_source_fail_test(self, publisher):
+        """Test payload can't set new sources if the old ones are initialized."""
+        source1 = self.shared_tests.prepare_source(SourceType.NFS)
+        source2 = self.shared_tests.prepare_source(SourceType.NFS)
+
+        self.shared_tests.check_set_sources([source1])
+
+        # Can't switch source if attached source is ready
+        source1.is_ready.return_value = True
+        self.shared_tests.check_set_sources([source2],
+                                            exception=SourceSetupError,
+                                            expected_sources=[source1])

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_image_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_image_test.py
@@ -151,10 +151,6 @@ class LiveImageInterfaceTestCase(unittest.TestCase):
 
     # TODO: Add set_source and supported_sources like in Live OS payload when source is available
 
-    def sources_empty_test(self):
-        """Test sources Live Image API for emptiness."""
-        self.shared_tests.check_empty_sources()
-
     def default_url_test(self):
         self.assertEqual(self.live_image_interface.Url, "")
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -27,10 +27,9 @@ from tests.nosetests.pyanaconda_tests.module_payload_shared import PayloadShared
 
 from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.modules.common.constants.interfaces import PAYLOAD
-from pyanaconda.modules.common.containers import PayloadSourceContainer
 from pyanaconda.modules.common.errors.payload import SourceSetupError, IncompatibleSourceError
 from pyanaconda.modules.common.task.task_interface import TaskInterface
-from pyanaconda.modules.payloads.constants import SourceType, PayloadType
+from pyanaconda.modules.payloads.constants import SourceType, PayloadType, SourceState
 from pyanaconda.modules.payloads.base.initialization import PrepareSystemForInstallationTask, \
     CopyDriverDisksFilesTask, SetUpSourcesTask, TearDownSourcesTask
 from pyanaconda.modules.payloads.base.initialization import UpdateBLSConfigurationTask
@@ -97,14 +96,16 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
         source1 = self._prepare_source()
         source2 = self._prepare_source()
 
-        path = PayloadSourceContainer.to_object_path(source1)
-        path2 = PayloadSourceContainer.to_object_path(source2)
+        self.shared_tests.check_set_sources([source1])
 
-        self.live_os_interface.SetSources([path])
-        source1.get_state.return_value = True
+        # can't switch source if attached source is ready
+        source1.get_state.return_value = SourceState.READY
+        self.shared_tests.check_set_sources([source2],
+                                            exception=SourceSetupError,
+                                            expected_sources=[source1])
 
-        with self.assertRaises(SourceSetupError):
-            self.live_os_interface.SetSources([path2])
+        source1.get_state.return_value = SourceState.UNREADY
+        self.shared_tests.check_set_sources([source1])
 
     @patch("pyanaconda.modules.payloads.payload.live_os.live_os.get_dir_size")
     @patch_dbus_publish_object

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -101,7 +101,7 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
         path2 = PayloadSourceContainer.to_object_path(source2)
 
         self.live_os_interface.SetSources([path])
-        source1.is_ready.return_value = True
+        source1.get_state.return_value = True
 
         with self.assertRaises(SourceSetupError):
             self.live_os_interface.SetSources([path2])

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -69,10 +69,6 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
             [SourceType.LIVE_OS_IMAGE.value],
             self.live_os_interface.SupportedSourceTypes)
 
-    def sources_empty_test(self):
-        """Test sources LiveOS API for emptiness."""
-        self.shared_tests.check_empty_sources()
-
     @patch_dbus_publish_object
     def set_source_test(self, publisher):
         """Test if set source API of LiveOS payload."""

--- a/tests/nosetests/pyanaconda_tests/module_payload_shared.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_shared.py
@@ -93,7 +93,7 @@ class PayloadSharedTest(object):
         :param SourceType source: Enum describing the source type
         """
         source = SourceFactory.create_source(source_type)
-        source.is_ready = Mock(return_value=True)
+        source.get_state = Mock(return_value=True)
 
         return source
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_shared.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_shared.py
@@ -17,12 +17,11 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 #
-from unittest.mock import patch, create_autospec
+from unittest.mock import patch, Mock
 
 from tests.nosetests.pyanaconda_tests import check_kickstart_interface
 from pyanaconda.modules.common.containers import PayloadSourceContainer
-from pyanaconda.modules.payloads.constants import SourceType
-from pyanaconda.modules.payloads.source.live_os.live_os import LiveOSSourceModule
+from pyanaconda.modules.payloads.source.factory import SourceFactory
 
 
 class PayloadKickstartSharedTest(object):
@@ -93,12 +92,8 @@ class PayloadSharedTest(object):
 
         :param SourceType source: Enum describing the source type
         """
-        if source_type == SourceType.LIVE_OS_IMAGE:
-            source = create_autospec(LiveOSSourceModule)
-            source.image_path = "/test/path"
-
-        source.type = source_type
-        source.is_ready.return_value = True
+        source = SourceFactory.create_source(source_type)
+        source.is_ready = Mock(return_value=True)
 
         return source
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_shared.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_shared.py
@@ -20,8 +20,10 @@
 from unittest.mock import patch, Mock
 
 from tests.nosetests.pyanaconda_tests import check_kickstart_interface
+
 from pyanaconda.modules.common.containers import PayloadSourceContainer
 from pyanaconda.modules.payloads.source.factory import SourceFactory
+from pyanaconda.modules.payloads.constants import SourceState
 
 
 class PayloadKickstartSharedTest(object):
@@ -87,13 +89,14 @@ class PayloadSharedTest(object):
         self._test.assertEqual(t, payload_type.value)
 
     @staticmethod
-    def prepare_source(source_type):
+    def prepare_source(source_type, state=SourceState.READY):
         """Prepare mock objects which will present given source.
 
         :param SourceType source: Enum describing the source type
+        :param SourceState state: mock state of the created source
         """
         source = SourceFactory.create_source(source_type)
-        source.get_state = Mock(return_value=True)
+        source.get_state = Mock(return_value=state)
 
         return source
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_shared.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_shared.py
@@ -111,22 +111,37 @@ class PayloadSharedTest(object):
         self._test.assertEqual([], self.payload_interface.Sources)
         self._test.assertFalse(self.payload_interface.HasSource())
 
-    def check_set_sources(self, test_sources, exception=None):
+    def check_set_sources(self, test_sources, exception=None, expected_sources=None):
         """Default check to set sources.
 
         :param test_sources: list of sources for emptiness failed check
+        :type test_sources: list of source instances
         :param exception: exception class which will be raised for the given sources
+        :param expected_sources: list of expected sources after trying to set;
+                                 including when exception raised
+        :type expected_sources: list of source instances
+        :return: caught exception if exception raised
         """
         paths = PayloadSourceContainer.to_object_path_list(test_sources)
+        ret = None
 
         if exception:
-            with self._test.assertRaises(exception):
+            with self._test.assertRaises(exception) as cm:
                 self.payload_interface.SetSources(paths)
-
-            self._test.assertEqual(self.payload_interface.Sources, [])
-            self._test.assertFalse(self.payload_interface.HasSource())
+            ret = cm
         else:
             self.payload_interface.SetSources(paths)
 
+        if expected_sources:
+            expected_paths = PayloadSourceContainer.to_object_path_list(expected_sources)
+
+            self._test.assertEqual(self.payload_interface.Sources, expected_paths)
+            self._test.assertTrue(self.payload_interface.HasSource())
+        elif exception:
+            self._test.assertEqual(self.payload_interface.Sources, [])
+            self._test.assertFalse(self.payload_interface.HasSource())
+        else:
             self._test.assertEqual(self.payload_interface.Sources, paths)
             self._test.assertTrue(self.payload_interface.HasSource())
+
+        return ret

--- a/tests/nosetests/pyanaconda_tests/module_source_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_base_test.py
@@ -70,12 +70,12 @@ class MountingSourceBaseTestCase(unittest.TestCase):
         """Mount source base ready state for set up."""
         ismount_mock.return_value = False
         module = DummyMountingSourceSubclass()
-        self.assertFalse(module.is_ready())
+        self.assertFalse(module.get_state())
 
         ismount_mock.reset_mock()
         ismount_mock.return_value = True
 
-        self.assertTrue(module.is_ready())
+        self.assertTrue(module.get_state())
 
         ismount_mock.assert_called_once_with(module.mount_point)
 

--- a/tests/nosetests/pyanaconda_tests/module_source_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_base_test.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.modules.common.errors.payload import SourceSetupError
-from pyanaconda.modules.payloads.constants import SourceType
+from pyanaconda.modules.payloads.constants import SourceType, SourceState
 from pyanaconda.modules.payloads.source.mount_tasks import SetUpMountTask, TearDownMountTask
 from pyanaconda.modules.payloads.source.source_base import MountingSourceBase
 
@@ -70,12 +70,12 @@ class MountingSourceBaseTestCase(unittest.TestCase):
         """Mount source base ready state for set up."""
         ismount_mock.return_value = False
         module = DummyMountingSourceSubclass()
-        self.assertFalse(module.get_state())
+        self.assertEqual(SourceState.UNREADY, module.get_state())
 
         ismount_mock.reset_mock()
         ismount_mock.return_value = True
 
-        self.assertTrue(module.get_state())
+        self.assertEqual(SourceState.READY, module.get_state())
 
         ismount_mock.assert_called_once_with(module.mount_point)
 

--- a/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
@@ -125,13 +125,13 @@ class HardDriveSourceTestCase(unittest.TestCase):
         """Hard drive source ready state for set up."""
         ismount.return_value = False
 
-        self.assertFalse(self.source_module.is_ready())
+        self.assertFalse(self.source_module.get_state())
         ismount.assert_called_once_with(INSTALL_TREE + "_device")
 
         ismount.reset_mock()
         ismount.return_value = True
 
-        self.assertFalse(self.source_module.is_ready())
+        self.assertFalse(self.source_module.get_state())
         ismount.assert_called_once_with(INSTALL_TREE + "_device")
 
     def return_handler_test(self):

--- a/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
@@ -16,7 +16,7 @@
 # Red Hat, Inc.
 #
 import unittest
-from unittest.mock import patch, call
+from unittest.mock import patch, call, Mock
 
 from pyanaconda.core.constants import INSTALL_TREE
 
@@ -131,7 +131,11 @@ class HardDriveSourceTestCase(unittest.TestCase):
         ismount.reset_mock()
         ismount.return_value = True
 
-        self.assertEqual(self.source_module.get_state(), SourceState.UNREADY)
+        task = self.source_module.set_up_with_tasks()[0]
+        task.get_result = Mock("/my/path")
+        task.succeeded_signal.emit()
+
+        self.assertEqual(self.source_module.get_state(), SourceState.READY)
         ismount.assert_called_once_with(INSTALL_TREE + "_device")
 
     def return_handler_test(self):

--- a/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
@@ -21,7 +21,7 @@ from unittest.mock import patch, call
 from pyanaconda.core.constants import INSTALL_TREE
 
 from pyanaconda.modules.common.constants.interfaces import PAYLOAD_SOURCE_HARDDRIVE
-from pyanaconda.modules.payloads.constants import SourceType
+from pyanaconda.modules.payloads.constants import SourceType, SourceState
 from pyanaconda.modules.payloads.source.harddrive.harddrive import HardDriveSourceModule
 from pyanaconda.modules.payloads.source.harddrive.harddrive_interface import \
     HardDriveSourceInterface
@@ -125,13 +125,13 @@ class HardDriveSourceTestCase(unittest.TestCase):
         """Hard drive source ready state for set up."""
         ismount.return_value = False
 
-        self.assertFalse(self.source_module.get_state())
+        self.assertEqual(self.source_module.get_state(), SourceState.UNREADY)
         ismount.assert_called_once_with(INSTALL_TREE + "_device")
 
         ismount.reset_mock()
         ismount.return_value = True
 
-        self.assertFalse(self.source_module.get_state())
+        self.assertEqual(self.source_module.get_state(), SourceState.UNREADY)
         ismount.assert_called_once_with(INSTALL_TREE + "_device")
 
     def return_handler_test(self):

--- a/tests/nosetests/pyanaconda_tests/module_source_repo_files_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_repo_files_test.py
@@ -63,7 +63,7 @@ class RepoFilesSourceTestCase(unittest.TestCase):
 
     def ready_state_test(self):
         """Test Repo files Source ready state for set up."""
-        self.assertTrue(self.source_module.is_ready())
+        self.assertTrue(self.source_module.get_state())
 
 
 class RepoFilesSourceSetupTaskTestCase(unittest.TestCase):

--- a/tests/nosetests/pyanaconda_tests/module_source_url_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_url_test.py
@@ -308,7 +308,7 @@ class URLSourceTestCase(unittest.TestCase):
 
         It will be always True there is no state.
         """
-        self.assertTrue(self.module.is_ready())
+        self.assertTrue(self.module.get_state())
 
     def set_up_with_tasks_test(self):
         """Get set up tasks for url source.


### PR DESCRIPTION
Payload ready state is not working for sources like URL which does not have a state. Problem with this is that Payload is not able to switch sources which are ready and on the other hand can't start installation with sources which are not ready.

Make this a 3 state - ready, unready and not implemented. That should be enough to solve any problem.