### PR TITLE
Allow to remove incomplete devices (#1823232)

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/scheduler_interface.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/scheduler_interface.py
@@ -35,6 +35,16 @@ __all__ = ["DeviceTreeSchedulerInterface"]
 class DeviceTreeSchedulerInterface(DeviceTreeInterface):
     """DBus interface for the device tree scheduler."""
 
+    def IsDevice(self, device_name: Str) -> Bool:
+        """Is the specified device in the device tree?
+
+        It can recognize also hidden and incomplete devices.
+
+        :param device_name: a name of the device
+        :return: True or False
+        """
+        return self.implementation.is_device(device_name)
+
     def IsDeviceLocked(self, device_name: Str) -> Bool:
         """Is the specified device locked?
 

--- a/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
@@ -43,6 +43,20 @@ class DeviceTreeSchedulerModule(DeviceTreeModule):
         """Return a DBus representation."""
         return DeviceTreeSchedulerInterface(self)
 
+    def is_device(self, device_name):
+        """Is the specified device in the device tree?
+
+        It can recognize also hidden and incomplete devices.
+
+        :param device_name: a name of the device
+        :return: True or False
+        """
+        device = self.storage.devicetree.get_device_by_name(
+            device_name, hidden=True, incomplete=True
+        )
+
+        return device is not None
+
     def is_device_locked(self, device_name):
         """Is the specified device locked?
 

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -1079,7 +1079,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             log.debug("Removing device %s from page %s.", device_name, root_name)
 
             # Skip if the device isn't in the device tree.
-            if device_name not in self._device_tree.GetDevices():
+            if not self._device_tree.IsDevice(device_name):
                 log.debug("Device %s isn't in the device tree.", device_name)
                 continue
 
@@ -1116,7 +1116,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                 # remove it in other pages when Delete all option is checked.
                 for other_name in self._find_unshared_devices(page):
                     # Skip if the device isn't in the device tree.
-                    if other_name not in self._device_tree.GetDevices():
+                    if not self._device_tree.IsDevice(other_name):
                         log.debug("Device %s isn't in the device tree.", other_name)
                         continue
 

--- a/tests/nosetests/pyanaconda_tests/module_scheduler_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_scheduler_test.py
@@ -961,3 +961,23 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self.assertEqual(request.container_raid_level, "")
         self.assertEqual(request.container_size_policy, Size("1.5 GiB").get_bytes())
         self.assertEqual(request.disks, [])
+
+    def is_device_test(self):
+        """Test IsDevice."""
+        dev1 = StorageDevice(
+            "dev1",
+            fmt=get_format("ext4"),
+            size=Size("10 GiB"),
+            exists=True
+        )
+
+        self.assertEqual(self.interface.IsDevice("dev1"), False)
+
+        self._add_device(dev1)
+        self.assertEqual(self.interface.IsDevice("dev1"), True)
+
+        dev1.complete = False
+        self.assertEqual(self.interface.IsDevice("dev1"), True)
+
+        self.storage.devicetree.hide(dev1)
+        self.assertEqual(self.interface.IsDevice("dev1"), True)


### PR DESCRIPTION
The custom partitioning spoke should allow to remove incomplete devices. Use
the DBus method IsDevice of DeviceTreeSchedulerInterface to check whether the
specified device is in the device tree. The method will check also incomplete
and hidden devices.

Resolves: rhbz#1823232