### PR TITLE
Unify module source test variable names

### DIFF
--- a/tests/nosetests/pyanaconda_tests/module_source_cdrom_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_cdrom_test.py
@@ -34,25 +34,25 @@ from tests.nosetests.pyanaconda_tests import patch_dbus_get_proxy, PropertiesCha
 class CdromSourceInterfaceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.cdrom_source_module = CdromSourceModule()
-        self.cdrom_source_interface = CdromSourceInterface(self.cdrom_source_module)
+        self.module = CdromSourceModule()
+        self.interface = CdromSourceInterface(self.module)
 
         self.callback = PropertiesChangedCallback()
-        self.cdrom_source_interface.PropertiesChanged.connect(self.callback)
+        self.interface.PropertiesChanged.connect(self.callback)
 
     def type_test(self):
         """Test CD-ROM source has a correct type specified."""
-        self.assertEqual(SOURCE_TYPE_CDROM, self.cdrom_source_interface.Type)
+        self.assertEqual(SOURCE_TYPE_CDROM, self.interface.Type)
 
 
 class CdromSourceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.cdrom_source_module = CdromSourceModule()
+        self.module = CdromSourceModule()
 
     def type_test(self):
         """Test CD-ROM source module has a correct type."""
-        self.assertEqual(SourceType.CDROM, self.cdrom_source_module.type)
+        self.assertEqual(SourceType.CDROM, self.module.type)
 
     def set_up_with_tasks_test(self):
         """Test CD-ROM Source set up call."""
@@ -61,7 +61,7 @@ class CdromSourceTestCase(unittest.TestCase):
         ]
 
         # task will not be public so it won't be published
-        tasks = self.cdrom_source_module.set_up_with_tasks()
+        tasks = self.module.set_up_with_tasks()
 
         # Check the number of the tasks
         task_number = len(task_classes)
@@ -77,7 +77,7 @@ class CdromSourceTestCase(unittest.TestCase):
         ]
 
         # task will not be public so it won't be published
-        tasks = self.cdrom_source_module.tear_down_with_tasks()
+        tasks = self.module.tear_down_with_tasks()
 
         # check the number of tasks
         task_number = len(task_classes)

--- a/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
@@ -50,20 +50,20 @@ def _create_setup_task():
 class HardDriveSourceInterfaceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.source_module = HardDriveSourceModule()
-        self.source_interface = HardDriveSourceInterface(self.source_module)
+        self.module = HardDriveSourceModule()
+        self.interface = HardDriveSourceInterface(self.module)
 
         self.callback = PropertiesChangedCallback()
-        self.source_interface.PropertiesChanged.connect(self.callback)
+        self.interface.PropertiesChanged.connect(self.callback)
 
     def type_test(self):
         """Hard drive source has a correct type specified."""
-        self.assertEqual(SOURCE_TYPE_HDD, self.source_interface.Type)
+        self.assertEqual(SOURCE_TYPE_HDD, self.interface.Type)
 
     def empty_properties_test(self):
         """Hard drive source properties are empty when not set."""
-        self.assertEqual(self.source_interface.Partition, "")
-        self.assertEqual(self.source_interface.Directory, "")
+        self.assertEqual(self.interface.Partition, "")
+        self.assertEqual(self.interface.Directory, "")
 
     def setting_properties_test(self):
         """Hard drive source properties are correctly set."""
@@ -74,7 +74,7 @@ class HardDriveSourceInterfaceTestCase(unittest.TestCase):
         check_dbus_property(
             self,
             PAYLOAD_SOURCE_HARDDRIVE,
-            self.source_interface,
+            self.interface,
             *args, **kwargs
         )
 
@@ -82,11 +82,11 @@ class HardDriveSourceInterfaceTestCase(unittest.TestCase):
 class HardDriveSourceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.source_module = HardDriveSourceModule()
+        self.module = HardDriveSourceModule()
 
     def type_test(self):
         """Hard drive source module has a correct type."""
-        self.assertEqual(SourceType.HDD, self.source_module.type)
+        self.assertEqual(SourceType.HDD, self.module.type)
 
     def set_up_with_tasks_test(self):
         """Hard drive source set up task type and amount."""
@@ -95,7 +95,7 @@ class HardDriveSourceTestCase(unittest.TestCase):
         ]
 
         # task will not be public so it won't be published
-        tasks = self.source_module.set_up_with_tasks()
+        tasks = self.module.set_up_with_tasks()
 
         # Check the number of the tasks
         task_number = len(task_classes)
@@ -109,18 +109,19 @@ class HardDriveSourceTestCase(unittest.TestCase):
         """Hard drive source ready state for set up."""
         ismount.return_value = False
 
-        self.assertEqual(self.source_module.get_state(), SourceState.UNREADY)
-        ismount.assert_called_once_with(self.source_module._device_mount)
+        self.assertEqual(self.module.get_state(), SourceState.UNREADY)
+        ismount.assert_called_once_with(self.module._device_mount)
 
         ismount.reset_mock()
         ismount.return_value = True
 
-        task = self.source_module.set_up_with_tasks()[0]
+        task = self.module.set_up_with_tasks()[0]
         task.get_result = Mock(return_value=("/my/path", False))
         task.succeeded_signal.emit()
 
-        self.assertEqual(self.source_module.get_state(), SourceState.READY)
-        ismount.assert_called_once_with(self.source_module._device_mount)
+        self.assertEqual(self.module.get_state(), SourceState.READY)
+        ismount.assert_called_once_with(self.module._device_mount)
+
 
     def return_handler_test(self):
         """Hard drive source setup result propagates back."""
@@ -128,10 +129,10 @@ class HardDriveSourceTestCase(unittest.TestCase):
         # Test only the returning. To do that, fake what the magic in start() does.
         # Do not run() the task at all, less mocking needed that way.
         task._set_result((iso_mount_location, True))
-        self.source_module._handle_setup_task_result(task)
+        self.module._handle_setup_task_result(task)
 
-        self.assertEqual(iso_mount_location, self.source_module.install_tree_path)
-        self.assertEqual(True, self.source_module._uses_iso_mount)
+        self.assertEqual(iso_mount_location, self.module.install_tree_path)
+        self.assertEqual(True, self.module._uses_iso_mount)
 
 
 class HardDriveSourceSetupTaskTestCase(unittest.TestCase):

--- a/tests/nosetests/pyanaconda_tests/module_source_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_live_os_test.py
@@ -36,24 +36,24 @@ from tests.nosetests.pyanaconda_tests import patch_dbus_get_proxy, PropertiesCha
 class LiveOSSourceInterfaceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.live_os_source_module = LiveOSSourceModule()
-        self.live_os_source_interface = LiveOSSourceInterface(self.live_os_source_module)
+        self.module = LiveOSSourceModule()
+        self.interface = LiveOSSourceInterface(self.module)
 
         self.callback = PropertiesChangedCallback()
-        self.live_os_source_interface.PropertiesChanged.connect(self.callback)
+        self.interface.PropertiesChanged.connect(self.callback)
 
     def type_test(self):
         """Test Live OS source has a correct type specified."""
-        self.assertEqual(SOURCE_TYPE_LIVE_OS_IMAGE, self.live_os_source_interface.Type)
+        self.assertEqual(SOURCE_TYPE_LIVE_OS_IMAGE, self.interface.Type)
 
     def image_path_empty_properties_test(self):
         """Test Live OS payload image path property when not set."""
-        self.assertEqual(self.live_os_source_interface.ImagePath, "")
+        self.assertEqual(self.interface.ImagePath, "")
 
     def image_path_properties_test(self):
         """Test Live OS payload image path property is correctly set."""
-        self.live_os_source_interface.SetImagePath("/my/supper/image/path")
-        self.assertEqual(self.live_os_source_interface.ImagePath, "/my/supper/image/path")
+        self.interface.SetImagePath("/my/supper/image/path")
+        self.assertEqual(self.interface.ImagePath, "/my/supper/image/path")
         self.callback.assert_called_once_with(
             PAYLOAD_SOURCE_LIVE_OS.interface_name, {"ImagePath": "/my/supper/image/path"}, [])
 
@@ -69,7 +69,7 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
         stat_mock.S_ISBLK = Mock()
         stat_mock.S_ISBLK.return_value = False
 
-        self.assertEqual(self.live_os_source_interface.DetectLiveOSImage(), "")
+        self.assertEqual(self.interface.DetectLiveOSImage(), "")
 
     @patch("pyanaconda.modules.payloads.source.live_os.live_os.os.stat")
     def detect_live_os_image_failed_nothing_found_test(self, os_stat_mock):
@@ -78,7 +78,7 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
         # otherwise we will skip the whole sequence
         os_stat_mock.side_effect = FileNotFoundError()
 
-        self.assertEqual(self.live_os_source_interface.DetectLiveOSImage(), "")
+        self.assertEqual(self.interface.DetectLiveOSImage(), "")
 
     @patch("pyanaconda.modules.payloads.source.live_os.live_os.stat")
     @patch("pyanaconda.modules.payloads.source.live_os.live_os.os.stat")
@@ -88,7 +88,7 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
         # otherwise we will skip the whole sequence
         stat_mock.S_ISBLK = Mock(return_value=True)
 
-        detected_image = self.live_os_source_interface.DetectLiveOSImage()
+        detected_image = self.interface.DetectLiveOSImage()
         stat_mock.S_ISBLK.assert_called_once()
 
         self.assertEqual(detected_image, "/dev/mapper/live-base")
@@ -97,7 +97,7 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
 class LiveOSSourceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.live_os_source_module = LiveOSSourceModule()
+        self.module = LiveOSSourceModule()
 
     def set_up_with_tasks_test(self):
         """Test Live OS Source set up call."""
@@ -106,7 +106,7 @@ class LiveOSSourceTestCase(unittest.TestCase):
         ]
 
         # task will not be public so it won't be published
-        tasks = self.live_os_source_module.set_up_with_tasks()
+        tasks = self.module.set_up_with_tasks()
 
         # Check the number of the tasks
         task_number = len(task_classes)
@@ -122,7 +122,7 @@ class LiveOSSourceTestCase(unittest.TestCase):
         ]
 
         # task will not be public so it won't be published
-        tasks = self.live_os_source_module.tear_down_with_tasks()
+        tasks = self.module.tear_down_with_tasks()
 
         # check the number of tasks
         task_number = len(task_classes)

--- a/tests/nosetests/pyanaconda_tests/module_source_nfs_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_nfs_test.py
@@ -38,26 +38,26 @@ mount_location = "/mnt/put-nfs-here"
 class NFSSourceInterfaceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.source_module = NFSSourceModule()
-        self.source_interface = NFSSourceInterface(self.source_module)
+        self.module = NFSSourceModule()
+        self.interface = NFSSourceInterface(self.module)
 
         self.callback = PropertiesChangedCallback()
-        self.source_interface.PropertiesChanged.connect(self.callback)
+        self.interface.PropertiesChanged.connect(self.callback)
 
     def type_test(self):
         """Test NFS source has a correct type specified."""
-        self.assertEqual(SOURCE_TYPE_NFS, self.source_interface.Type)
+        self.assertEqual(SOURCE_TYPE_NFS, self.interface.Type)
 
     def url_empty_properties_test(self):
         """Test NFS source URL property when not set."""
-        self.assertEqual(self.source_interface.URL, "")
+        self.assertEqual(self.interface.URL, "")
 
     def url_properties_test(self):
         """Test NFS source URL property is correctly set."""
         check_dbus_property(
             self,
             PAYLOAD_SOURCE_NFS,
-            self.source_interface,
+            self.interface,
             "URL",
             nfs_url
         )
@@ -66,11 +66,11 @@ class NFSSourceInterfaceTestCase(unittest.TestCase):
 class NFSSourceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.source_module = NFSSourceModule()
+        self.module = NFSSourceModule()
 
     def type_test(self):
         """Test NFS source module has a correct type."""
-        self.assertEqual(SourceType.NFS, self.source_module.type)
+        self.assertEqual(SourceType.NFS, self.module.type)
 
     def set_up_with_tasks_test(self):
         """Test NFS Source set up call."""
@@ -79,7 +79,7 @@ class NFSSourceTestCase(unittest.TestCase):
         ]
 
         # task will not be public so it won't be published
-        tasks = self.source_module.set_up_with_tasks()
+        tasks = self.module.set_up_with_tasks()
 
         # Check the number of the tasks
         task_number = len(task_classes)
@@ -95,7 +95,7 @@ class NFSSourceTestCase(unittest.TestCase):
         ]
 
         # task will not be public so it won't be published
-        tasks = self.source_module.tear_down_with_tasks()
+        tasks = self.module.tear_down_with_tasks()
 
         # check the number of tasks
         task_number = len(task_classes)
@@ -106,8 +106,8 @@ class NFSSourceTestCase(unittest.TestCase):
 
     def url_property_test(self):
         """Test NFS source URL property is correctly set."""
-        self.source_module.set_url(nfs_url)
-        self.assertEqual(nfs_url, self.source_module.url)
+        self.module.set_url(nfs_url)
+        self.assertEqual(nfs_url, self.module.url)
 
 
 class NFSSourceSetupTaskTestCase(unittest.TestCase):

--- a/tests/nosetests/pyanaconda_tests/module_source_repo_files_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_repo_files_test.py
@@ -33,38 +33,38 @@ from pyanaconda.modules.payloads.source.repo_files.initialization import \
 class RepoFilesSourceInterfaceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.source_module = RepoFilesSourceModule()
-        self.source_interface = RepoFilesSourceInterface(self.source_module)
+        self.module = RepoFilesSourceModule()
+        self.interface = RepoFilesSourceInterface(self.module)
 
     def type_test(self):
         """Test Repo files source has a correct type specified."""
-        self.assertEqual(SOURCE_TYPE_REPO_FILES, self.source_interface.Type)
+        self.assertEqual(SOURCE_TYPE_REPO_FILES, self.interface.Type)
 
 
 class RepoFilesSourceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.source_module = RepoFilesSourceModule()
-        self.source_interface = RepoFilesSourceInterface(self.source_module)
+        self.module = RepoFilesSourceModule()
+        self.interface = RepoFilesSourceInterface(self.module)
 
     def type_test(self):
         """Test Repo files source module has a correct type."""
-        self.assertEqual(SourceType.REPO_FILES, self.source_module.type)
+        self.assertEqual(SourceType.REPO_FILES, self.module.type)
 
     def set_up_with_tasks_test(self):
         """Test Repo files Source set up call."""
-        tasks = self.source_module.set_up_with_tasks()
+        tasks = self.module.set_up_with_tasks()
         self.assertEqual(len(tasks), 1)
         self.assertIsInstance(tasks[0], SetUpRepoFilesSourceTask)
 
     def tear_down_with_tasks_test(self):
         """Test Repo files Source ready state for tear down."""
-        tasks = self.source_module.tear_down_with_tasks()
+        tasks = self.module.tear_down_with_tasks()
         self.assertEqual([], tasks)
 
     def ready_state_test(self):
         """Test Repo files Source ready state for set up."""
-        self.assertTrue(self.source_module.get_state())
+        self.assertTrue(self.module.get_state())
 
 
 class RepoFilesSourceSetupTaskTestCase(unittest.TestCase):


### PR DESCRIPTION
They are shorter now, and same in all tests.