### PR TITLE
Port root changesok from rhel

### DIFF
--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -209,7 +209,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     @property
     def sensitive(self):
         return not (self.completed and flags.automatedInstall
-                    and self._users_module.CanChangeRootPassword)
+                    and not self._users_module.CanChangeRootPassword)
 
     def _checks_done(self, error_message):
         """Update the warning with the input validation error from the first

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -208,8 +208,12 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     @property
     def sensitive(self):
+        # A password set in kickstart can be changed in the GUI
+        # if the changesok password policy is set for the root password.
+        kickstarted_password_can_be_changed = self._users_module.CanChangeRootPassword \
+            or self.checker.policy.changesok
         return not (self.completed and flags.automatedInstall
-                    and not self._users_module.CanChangeRootPassword)
+                    and not kickstarted_password_can_be_changed)
 
     def _checks_done(self, error_message):
         """Update the warning with the input validation error from the first


### PR DESCRIPTION
Port of https://github.com/rhinstaller/anaconda/pull/2034 from rhel-8 branch which also fixes default behaviour (root password is not changeable in GUI if set in kickstart) in the first commit.