### PR TITLE
gui source spoke: fix the key used to check proxy for additional repo

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1750,7 +1750,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler):
 
         # do not update check status if checks are not yet set up
         # (populating/refreshing the spoke)
-        if repo.name in self._repo_checks:
+        if repo.repo_id in self._repo_checks:
             self._repo_checks[repo.repo_id].proxy_check.update_check_status()
 
         try:


### PR DESCRIPTION
This is a small fallout of
commit b3b8808039516bb338749d3340672f0a9c8987a0
I came across when checking if the functionality of
https://github.com/rhinstaller/anaconda/pull/1158
is present / ported to Fedora).