### PR TITLE
Reload NTP server list in dialog on every run

### DIFF
--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -261,6 +261,7 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
             return InputCheck.CHECK_OK
 
     def refresh(self):
+        self._initialize_store_from_config()
         self._serverEntry.grab_focus()
 
     def refresh_servers_state(self):
@@ -287,8 +288,6 @@ class NTPconfigDialog(GUIObject, GUIDialogInputCheckHandler):
             self._epoch_lock.acquire()
             self._epoch += 1
             self._epoch_lock.release()
-
-            self._initialize_store_from_config()
 
         return rc
 


### PR DESCRIPTION
Fixes weird behavior of removals and changes. Basically the dialog was reloaded only on cancel, but needs it on every show.
    
See also: rhbz#1823129
