### PR TITLE
Remove TODO to solve is_ready for payload sources

### DIFF
--- a/pyanaconda/modules/payloads/source/source_base.py
+++ b/pyanaconda/modules/payloads/source/source_base.py
@@ -60,10 +60,6 @@ class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         :return: one of the supported state of SourceState enum
         :rtype: pyanaconda.modules.payloads.constants.SourceState enum value
         """
-        # TODO: Add needs_teardown property which will tell us if the source has to be cleaned up
-        # before removing the source from a payload. The is_ready will work for now but it
-        # will not work for for example HTTP source which is always ready. That source would cause
-        # troubles for the base payload set_sources method ready check.
         pass
 
     @abstractmethod


### PR DESCRIPTION
Payload sources already have 3 states which one is `NOT_APPLICABLE`. This solve the TODO issue.

Solve by: 8e70d426d8af16caf62139f78ec2fdac3d3d8a86