### PR TITLE
2/2 DNF kickstart support

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -336,7 +336,7 @@ if __name__ == "__main__":
     from pyanaconda import startup_utils
     from pyanaconda import rescue
     from pyanaconda import geoloc
-    from pyanaconda.core.util import ProxyString, ProxyStringError
+    from pyanaconda.core.payload import ProxyString, ProxyStringError
 
     # Print the usual "startup note" that contains Anaconda version
     # and short usage & bug reporting instructions.

--- a/pyanaconda/core/payload.py
+++ b/pyanaconda/core/payload.py
@@ -15,6 +15,11 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from urllib.parse import quote, unquote
+
+from pyanaconda.core.i18n import _
+from pyanaconda.core.regexes import URL_PARSE
+from pyanaconda.core.util import ensure_str
 
 
 def parse_nfs_url(nfs_url):
@@ -38,3 +43,94 @@ def parse_nfs_url(nfs_url):
             host = s[0]
 
     return options, host, path
+
+
+class ProxyStringError(Exception):
+    pass
+
+
+# TODO: Add tests
+class ProxyString(object):
+    """ Handle a proxy url."""
+    def __init__(self, url=None, protocol="http://", host=None, port="3128",
+                 username=None, password=None):
+        """ Initialize with either url
+        ([protocol://][username[:password]@]host[:port]) or pass host and
+        optionally:
+
+        protocol    http, https, ftp
+        host        hostname without protocol
+        port        port number (defaults to 3128)
+        username    username
+        password    password
+
+        The str() of the object is the full proxy url
+
+        ProxyString.url is the full url including username:password@
+        ProxyString.noauth_url is the url without username:password@
+        """
+        self.url = ensure_str(url, keep_none=True)
+        self.protocol = ensure_str(protocol, keep_none=True)
+        self.host = ensure_str(host, keep_none=True)
+        self.port = str(port)
+        self.username = ensure_str(username, keep_none=True)
+        self.password = ensure_str(password, keep_none=True)
+        self.proxy_auth = ""
+        self.noauth_url = None
+
+        if url:
+            self.parse_url()
+        elif not host:
+            raise ProxyStringError(_("No host url"))
+        else:
+            self.parse_components()
+
+    def parse_url(self):
+        """ Parse the proxy url into its component pieces
+        """
+        # NOTE: If this changes, update tests/regex/proxy.py
+        #
+        # proxy=[protocol://][username[:password]@]host[:port][path][?query][#fragment]
+        # groups (both named and numbered)
+        # 1 = protocol
+        # 2 = username
+        # 3 = password
+        # 4 = host
+        # 5 = port
+        # 6 = path
+        # 7 = query
+        # 8 = fragment
+        m = URL_PARSE.match(self.url)
+        if not m:
+            raise ProxyStringError(_("malformed URL, cannot parse it."))
+
+        # If no protocol was given default to http.
+        self.protocol = m.group("protocol") or "http://"
+
+        if m.group("username"):
+            self.username = ensure_str(unquote(m.group("username")))
+
+        if m.group("password"):
+            self.password = ensure_str(unquote(m.group("password")))
+
+        if m.group("host"):
+            self.host = m.group("host")
+            if m.group("port"):
+                self.port = m.group("port")
+        else:
+            raise ProxyStringError(_("URL has no host component"))
+
+        self.parse_components()
+
+    def parse_components(self):
+        """ Parse the components of a proxy url into url and noauth_url
+        """
+        if self.username or self.password:
+            self.proxy_auth = "%s:%s@" % (quote(self.username or ""),
+                                          quote(self.password or ""))
+
+        self.url = self.protocol + self.proxy_auth + self.host + ":" + self.port
+        self.noauth_url = self.protocol + self.host + ":" + self.port
+
+    def __str__(self):
+        return self.url

--- a/pyanaconda/core/payload.py
+++ b/pyanaconda/core/payload.py
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+
+def parse_nfs_url(nfs_url):
+    """Parse NFS URL into components.
+
+    :param str nfs_url: The raw URL, including "nfs:"
+    :return: Tuple with options, host, and path
+    :rtype: (str, str, str) or None
+    """
+    options = ''
+    host = ''
+    path = ''
+    if nfs_url:
+        s = nfs_url.split(":")
+        s.pop(0)
+        if len(s) >= 3:
+            (options, host, path) = s[:3]
+        elif len(s) == 2:
+            (host, path) = s
+        else:
+            host = s[0]
+
+    return options, host, path

--- a/pyanaconda/core/payload.py
+++ b/pyanaconda/core/payload.py
@@ -45,6 +45,25 @@ def parse_nfs_url(nfs_url):
     return options, host, path
 
 
+def create_nfs_url(host, path, options=None):
+    """Compose NFS url from components.
+
+    :param str host: NFS server
+    :param str path: path on the NFS server to the shared folder
+    :param options: NFS mount options
+    :type options: str or None if not set
+    :return: NFS url created from the components given
+    :rtype: str
+    """
+    if host == "":
+        return ""
+
+    if options:
+        return "nfs:{opts}:{server}:{path}".format(opts=options, server=host, path=path)
+
+    return "nfs:{server}:{path}".format(server=host, path=path)
+
+
 class ProxyStringError(Exception):
     pass
 

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -28,7 +28,6 @@ import string  # pylint: disable=deprecated-module
 import shutil
 import tempfile
 import re
-from urllib.parse import quote, unquote
 import gettext
 import signal
 import sys
@@ -48,10 +47,7 @@ from pyanaconda.core.constants import DRACUT_SHUTDOWN_EJECT, TRANSLATIONS_UPDATE
     IPMI_ABORTED, X_TIMEOUT, TAINT_HARDWARE_UNSUPPORTED, TAINT_SUPPORT_REMOVED, \
     WARNING_HARDWARE_UNSUPPORTED, WARNING_SUPPORT_REMOVED
 from pyanaconda.core.constants import SCREENSHOTS_DIRECTORY, SCREENSHOTS_TARGET_DIRECTORY
-from pyanaconda.core.regexes import URL_PARSE
 from pyanaconda.errors import RemovedModuleError, ExitError
-
-from pyanaconda.core.i18n import _
 
 from pyanaconda.anaconda_logging import program_log_lock
 from pyanaconda.anaconda_loggers import get_module_logger, get_program_logger
@@ -689,97 +685,6 @@ def vtActivate(num):
         log.error("Failed to switch to tty%d", num)
 
     return ret == 0
-
-
-class ProxyStringError(Exception):
-    pass
-
-
-class ProxyString(object):
-    """ Handle a proxy url
-    """
-    def __init__(self, url=None, protocol="http://", host=None, port="3128",
-                 username=None, password=None):
-        """ Initialize with either url
-        ([protocol://][username[:password]@]host[:port]) or pass host and
-        optionally:
-
-        protocol    http, https, ftp
-        host        hostname without protocol
-        port        port number (defaults to 3128)
-        username    username
-        password    password
-
-        The str() of the object is the full proxy url
-
-        ProxyString.url is the full url including username:password@
-        ProxyString.noauth_url is the url without username:password@
-        """
-        self.url = ensure_str(url, keep_none=True)
-        self.protocol = ensure_str(protocol, keep_none=True)
-        self.host = ensure_str(host, keep_none=True)
-        self.port = str(port)
-        self.username = ensure_str(username, keep_none=True)
-        self.password = ensure_str(password, keep_none=True)
-        self.proxy_auth = ""
-        self.noauth_url = None
-
-        if url:
-            self.parse_url()
-        elif not host:
-            raise ProxyStringError(_("No host url"))
-        else:
-            self.parse_components()
-
-    def parse_url(self):
-        """ Parse the proxy url into its component pieces
-        """
-        # NOTE: If this changes, update tests/regex/proxy.py
-        #
-        # proxy=[protocol://][username[:password]@]host[:port][path][?query][#fragment]
-        # groups (both named and numbered)
-        # 1 = protocol
-        # 2 = username
-        # 3 = password
-        # 4 = host
-        # 5 = port
-        # 6 = path
-        # 7 = query
-        # 8 = fragment
-        m = URL_PARSE.match(self.url)
-        if not m:
-            raise ProxyStringError(_("malformed URL, cannot parse it."))
-
-        # If no protocol was given default to http.
-        self.protocol = m.group("protocol") or "http://"
-
-        if m.group("username"):
-            self.username = ensure_str(unquote(m.group("username")))
-
-        if m.group("password"):
-            self.password = ensure_str(unquote(m.group("password")))
-
-        if m.group("host"):
-            self.host = m.group("host")
-            if m.group("port"):
-                self.port = m.group("port")
-        else:
-            raise ProxyStringError(_("URL has no host component"))
-
-        self.parse_components()
-
-    def parse_components(self):
-        """ Parse the components of a proxy url into url and noauth_url
-        """
-        if self.username or self.password:
-            self.proxy_auth = "%s:%s@" % (quote(self.username or ""),
-                                          quote(self.password or ""))
-
-        self.url = self.protocol + self.proxy_auth + self.host + ":" + self.port
-        self.noauth_url = self.protocol + self.host + ":" + self.port
-
-    def __str__(self):
-        return self.url
 
 
 def strip_accents(s):

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -556,29 +556,6 @@ def resetRpmDb():
             log.debug("error %s removing file: %s", e, rpmfile)
 
 
-def parse_nfs_url(nfs_url):
-    """Parse NFS URL into components.
-
-    :param str nfs_url: The raw URL, including "nfs:"
-    :return: Tuple with options, host, and path
-    :rtype: (str, str, str) or None
-    """
-    options = ''
-    host = ''
-    path = ''
-    if nfs_url:
-        s = nfs_url.split(":")
-        s.pop(0)
-        if len(s) >= 3:
-            (options, host, path) = s[:3]
-        elif len(s) == 2:
-            (host, path) = s
-        else:
-            host = s[0]
-
-    return options, host, path
-
-
 def add_po_path(directory):
     """ Looks to see what translations are under a given path and tells
     the gettext module to use that path as the base dir """

--- a/pyanaconda/modules/payloads/payload/dnf/dnf.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf.py
@@ -20,6 +20,7 @@
 from pyanaconda.modules.payloads.constants import PayloadType, SourceType
 from pyanaconda.modules.payloads.payload.payload_base import PayloadBase
 from pyanaconda.modules.payloads.payload.dnf.dnf_interface import DNFInterface
+from pyanaconda.modules.payloads.source.factory import SourceFactory
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -54,11 +55,19 @@ class DNFModule(PayloadBase):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
-        pass
+        source_type = SourceFactory.get_rpm_type_for_kickstart(data)
+
+        if source_type is None:
+            return
+
+        source = SourceFactory.create_source(source_type)
+        source.process_kickstart(data)
+        self.add_source(source)
 
     def setup_kickstart(self, data):
         """Setup the kickstart data."""
-        pass
+        for source in self.sources:
+            source.setup_kickstart(data)
 
     def pre_install_with_tasks(self):
         """Execute preparation steps.

--- a/pyanaconda/modules/payloads/payload/live_image/utils.py
+++ b/pyanaconda/modules/payloads/payload/live_image/utils.py
@@ -19,7 +19,7 @@ import functools
 import tarfile
 
 from pyanaconda.payload.utils import version_cmp
-from pyanaconda.core.util import ProxyString, ProxyStringError
+from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.core.constants import TAR_SUFFIX
 
 from pyanaconda.anaconda_loggers import get_module_logger

--- a/pyanaconda/modules/payloads/source/cdrom/cdrom.py
+++ b/pyanaconda/modules/payloads/source/cdrom/cdrom.py
@@ -46,3 +46,14 @@ class CdromSourceModule(MountingSourceBase):
         """
         task = SetUpCdromSourceTask(self.mount_point)
         return [task]
+
+    def process_kickstart(self, data):
+        """Process the kickstart data.
+
+        This will be empty because cdrom KS command does not have any arguments.
+        """
+        pass
+
+    def setup_kickstart(self, data):
+        """Setup the kickstart data."""
+        data.cdrom.seen = True

--- a/pyanaconda/modules/payloads/source/factory.py
+++ b/pyanaconda/modules/payloads/source/factory.py
@@ -57,3 +57,27 @@ class SourceFactory(object):
             return HardDriveSourceModule()
 
         raise ValueError("Unknown source type: {}".format(source_type))
+
+    @staticmethod
+    def get_rpm_type_for_kickstart(ks_data):
+        """Generate source type from DNF kickstart data.
+
+        This method will mimic behavior of method command which will take first from the list
+        and ignore rest of the commands. If we want to improve this behavior we should do that
+        in the pykickstart instead.
+
+        :param ks_data: kickstart data from DNF payload
+        :return: SourceType value
+        """
+        if ks_data.cdrom.seen:
+            return SourceType.CDROM
+        if ks_data.harddrive.seen:
+            return SourceType.HDD
+        if ks_data.hmc.seen:
+            return SourceType.HMC
+        if ks_data.nfs.seen:
+            return SourceType.NFS
+        if ks_data.url.seen:
+            return SourceType.URL
+
+        return None

--- a/pyanaconda/modules/payloads/source/factory.py
+++ b/pyanaconda/modules/payloads/source/factory.py
@@ -73,11 +73,11 @@ class SourceFactory(object):
             return SourceType.CDROM
         if ks_data.harddrive.seen:
             return SourceType.HDD
-        if ks_data.hmc.seen:
-            return SourceType.HMC
         if ks_data.nfs.seen:
             return SourceType.NFS
         if ks_data.url.seen:
             return SourceType.URL
+        if ks_data.hmc.seen:
+            return SourceType.HMC
 
         return None

--- a/pyanaconda/modules/payloads/source/harddrive/harddrive.py
+++ b/pyanaconda/modules/payloads/source/harddrive/harddrive.py
@@ -19,7 +19,10 @@
 #
 import os
 
+from pykickstart.errors import KickstartParseError
+
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.i18n import _
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.payloads.constants import SourceType, SourceState
 from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase
@@ -62,6 +65,10 @@ class HardDriveSourceModule(PayloadSourceBase):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
+        if data.harddrive.biospart:
+            msg = _("The --biospart parameter of harddrive command is not supported!")
+            raise KickstartParseError(msg, lineno=data.harddrive.lineno)
+
         self.set_device(data.harddrive.partition)
         self.set_directory(data.harddrive.dir)
 

--- a/pyanaconda/modules/payloads/source/harddrive/harddrive.py
+++ b/pyanaconda/modules/payloads/source/harddrive/harddrive.py
@@ -60,6 +60,17 @@ class HardDriveSourceModule(PayloadSourceBase):
         res = os.path.ismount(self._device_mount) and bool(self._install_tree_path)
         return SourceState.from_bool(res)
 
+    def process_kickstart(self, data):
+        """Process the kickstart data."""
+        self.set_device(data.harddrive.partition)
+        self.set_directory(data.harddrive.dir)
+
+    def setup_kickstart(self, data):
+        """Setup the kickstart data."""
+        data.harddrive.partition = self.device
+        data.harddrive.dir = self.directory
+        data.harddrive.seen = True
+
     def for_publication(self):
         """Get the interface used to publish this source."""
         return HardDriveSourceInterface(self)

--- a/pyanaconda/modules/payloads/source/hmc/hmc.py
+++ b/pyanaconda/modules/payloads/source/hmc/hmc.py
@@ -47,3 +47,14 @@ class HMCSourceModule(MountingSourceBase):
         :rtype: [Task]
         """
         return [SetUpHMCSourceTask(self.mount_point)]
+
+    def process_kickstart(self, data):
+        """Process the kickstart data.
+
+        This will be empty because cdrom KS command does not have any arguments.
+        """
+        pass
+
+    def setup_kickstart(self, data):
+        """Setup the kickstart data."""
+        data.hmc.seen = True

--- a/pyanaconda/modules/payloads/source/nfs/initialization.py
+++ b/pyanaconda/modules/payloads/source/nfs/initialization.py
@@ -17,7 +17,7 @@
 #
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.payload.utils import mount
-from pyanaconda.core.util import parse_nfs_url
+from pyanaconda.core.payload import parse_nfs_url
 from pyanaconda.modules.payloads.source.mount_tasks import SetUpMountTask
 
 log = get_module_logger(__name__)

--- a/pyanaconda/modules/payloads/source/nfs/nfs.py
+++ b/pyanaconda/modules/payloads/source/nfs/nfs.py
@@ -17,6 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.core.payload import create_nfs_url, parse_nfs_url
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.payloads.constants import SourceType
 from pyanaconda.modules.payloads.source.nfs.nfs_interface import NFSSourceInterface
@@ -45,6 +46,20 @@ class NFSSourceModule(MountingSourceBase):
     def for_publication(self):
         """Return a DBus representation."""
         return NFSSourceInterface(self)
+
+    def process_kickstart(self, data):
+        """Process the kickstart data."""
+        nfs_url = create_nfs_url(data.nfs.server, data.nfs.dir, data.nfs.opts)
+        self.set_url(nfs_url)
+
+    def setup_kickstart(self, data):
+        """Setup the kickstart data."""
+        (opts, host, path) = parse_nfs_url(self.url)
+
+        data.nfs.server = host
+        data.nfs.dir = path
+        data.nfs.opts = opts
+        data.nfs.seen = True
 
     @property
     def url(self):

--- a/pyanaconda/modules/payloads/source/url/url.py
+++ b/pyanaconda/modules/payloads/source/url/url.py
@@ -19,7 +19,7 @@
 #
 from pyanaconda.core.constants import BASE_REPO_NAME
 from pyanaconda.core.signal import Signal
-from pyanaconda.core.util import ProxyString, ProxyStringError
+from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.modules.common.errors.general import InvalidValueError
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.payloads.constants import SourceType, URLType, SourceState

--- a/pyanaconda/modules/payloads/source/url/url.py
+++ b/pyanaconda/modules/payloads/source/url/url.py
@@ -17,7 +17,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.core.constants import BASE_REPO_NAME
+from pyanaconda.core.constants import BASE_REPO_NAME, URL_TYPE_BASEURL, URL_TYPE_METALINK, \
+    URL_TYPE_MIRRORLIST
 from pyanaconda.core.signal import Signal
 from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.modules.common.errors.general import InvalidValueError
@@ -66,6 +67,46 @@ class URLSourceModule(PayloadSourceBase):
     def for_publication(self):
         """Get the interface used to publish this source."""
         return URLSourceInterface(self)
+
+    def process_kickstart(self, data):
+        """Process the kickstart data."""
+        repo_data = RepoConfigurationData()
+        repo_data.name = self._url_source_name
+
+        if data.url.url:
+            repo_data.url = data.url.url
+            repo_data.type = URL_TYPE_BASEURL
+        elif data.url.mirrorlist:
+            repo_data.url = data.url.mirrorlist
+            repo_data.type = URL_TYPE_MIRRORLIST
+        elif data.url.metalink:
+            repo_data.url = data.url.metalink
+            repo_data.type = URL_TYPE_METALINK
+
+        repo_data.proxy = data.url.proxy
+        repo_data.ssl_verification_enabled = not data.url.noverifyssl
+        repo_data.ssl_configuration.ca_cert_path = data.url.sslcacert or ""
+        repo_data.ssl_configuration.client_cert_path = data.url.sslclientcert or ""
+        repo_data.ssl_configuration.client_key_path = data.url.sslclientkey or ""
+
+        self.set_repo_configuration(repo_data)
+
+    def setup_kickstart(self, data):
+        """Setup the kickstart data."""
+        if self.repo_configuration.type == URL_TYPE_BASEURL:
+            data.url.url = self.repo_configuration.url
+        elif self.repo_configuration.type == URL_TYPE_MIRRORLIST:
+            data.url.mirrorlist = self.repo_configuration.url
+        elif self.repo_configuration.type == URL_TYPE_METALINK:
+            data.url.metalink = self.repo_configuration.url
+
+        data.url.proxy = self.repo_configuration.proxy
+        data.url.noverifyssl = not self.repo_configuration.ssl_verification_enabled
+        data.url.sslcacert = self.repo_configuration.ssl_configuration.ca_cert_path
+        data.url.sslclientcert = self.repo_configuration.ssl_configuration.client_cert_path
+        data.url.sslclientkey = self.repo_configuration.ssl_configuration.client_key_path
+
+        data.url.seen = True
 
     def set_up_with_tasks(self):
         """Set up the installation source.

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -22,7 +22,7 @@ import warnings
 
 from dasbus.typing import get_native
 
-from pyanaconda.core import util
+from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.core.signal import Signal
 from pyanaconda.core.constants import SECRET_TYPE_HIDDEN, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY, \
     SUBSCRIPTION_REQUEST_VALID_TYPES
@@ -195,7 +195,7 @@ class SubscriptionService(KickstartService):
         if data.rhsm.proxy:
             # first try to parse the proxy string from kickstart
             try:
-                proxy = util.ProxyString(data.rhsm.proxy)
+                proxy = ProxyString(data.rhsm.proxy)
                 if proxy.host:
                     # ensure port is an integer and set to -1 if unknown
                     port = int(proxy.port) if proxy.port else -1
@@ -204,7 +204,7 @@ class SubscriptionService(KickstartService):
                     subscription_request.server_proxy_port = port
                     subscription_request.server_proxy_user = proxy.username
                     subscription_request.server_proxy_password.set_secret(proxy.password)
-            except util.ProxyStringError as e:
+            except ProxyStringError as e:
                 # should not be fatal, but definitely logged as error
                 message = "Failed to parse proxy for the rhsm command: {}".format(str(e))
                 warnings.warn(message, KickstartParseWarning)

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -53,9 +53,9 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import INSTALL_TREE, ISO_DIR, DRACUT_REPODIR, DRACUT_ISODIR, \
     PAYLOAD_TYPE_DNF
 from pyanaconda.core.i18n import N_, _
-from pyanaconda.core.payload import parse_nfs_url
+from pyanaconda.core.payload import parse_nfs_url, ProxyString, ProxyStringError
 from pyanaconda.core.regexes import VERSION_DIGITS
-from pyanaconda.core.util import ProxyString, ProxyStringError, decode_bytes
+from pyanaconda.core.util import decode_bytes
 from pyanaconda.flags import flags
 from pyanaconda.kickstart import RepoData
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -53,6 +53,7 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import INSTALL_TREE, ISO_DIR, DRACUT_REPODIR, DRACUT_ISODIR, \
     PAYLOAD_TYPE_DNF
 from pyanaconda.core.i18n import N_, _
+from pyanaconda.core.payload import parse_nfs_url
 from pyanaconda.core.regexes import VERSION_DIGITS
 from pyanaconda.core.util import ProxyString, ProxyStringError, decode_bytes
 from pyanaconda.flags import flags
@@ -1595,7 +1596,7 @@ class DNFPayload(Payload):
         path = None
 
         if iso_device_path and repo_device_path:
-            path = util.parse_nfs_url('nfs:%s' % iso_device_path)[2]
+            path = parse_nfs_url('nfs:%s' % iso_device_path)[2]
             # See if the dir holding the iso is what we want
             # and also if we have an iso mounted to /run/install/repo
             if path and path in iso_device_path and DRACUT_ISODIR in repo_device_path:
@@ -1605,7 +1606,7 @@ class DNFPayload(Payload):
             # see if the nfs dir is mounted
             need_mount = True
             if repo_device_path:
-                _options, host, path = util.parse_nfs_url('nfs:%s' % repo_device_path)
+                _options, host, path = parse_nfs_url('nfs:%s' % repo_device_path)
                 if method.server and method.server == host and \
                    method.dir and method.dir == path:
                     need_mount = False
@@ -1615,7 +1616,7 @@ class DNFPayload(Payload):
                 # nfs mount have changed. It is already mounted, but on INSTALL_TREE
                 # which is the same as DRACUT_ISODIR, making it hard for _setup_NFS
                 # to detect that it is already mounted.
-                _options, host, path = util.parse_nfs_url('nfs:%s' % iso_device_path)
+                _options, host, path = parse_nfs_url('nfs:%s' % iso_device_path)
                 if path and path in iso_device_path:
                     need_mount = False
                     path = DRACUT_ISODIR
@@ -1715,7 +1716,7 @@ class DNFPayload(Payload):
                     # prepend nfs: to the url as that's what the parser
                     # wants.  Note we don't get options from this, but
                     # that's OK for the UI at least.
-                    _options, host, path = util.parse_nfs_url("nfs:%s" % repo_device_path)
+                    _options, host, path = parse_nfs_url("nfs:%s" % repo_device_path)
                     method.method = "nfs"
                     method.server = host
                     method.dir = path

--- a/pyanaconda/payload/dnf/repomd.py
+++ b/pyanaconda/payload/dnf/repomd.py
@@ -21,7 +21,7 @@ from requests import RequestException
 
 from pyanaconda.anaconda_loggers import get_packaging_logger
 from pyanaconda.core import util, constants
-from pyanaconda.core.util import ProxyString, ProxyStringError
+from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.payload.dnf.utils import USER_AGENT
 
 log = get_packaging_logger()

--- a/pyanaconda/payload/live/payload_liveimg.py
+++ b/pyanaconda/payload/live/payload_liveimg.py
@@ -30,7 +30,7 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import PAYLOAD_TYPE_LIVE_IMAGE, TAR_SUFFIX, \
     NETWORK_CONNECTION_TIMEOUT, INSTALL_TREE, IMAGE_DIR, THREAD_LIVE_PROGRESS
 from pyanaconda.core.i18n import _
-from pyanaconda.core.util import ProxyString, ProxyStringError
+from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.errors import errorHandler, ERROR_RAISE
 from pyanaconda.payload import utils as payload_utils
 from pyanaconda.payload.errors import PayloadInstallError

--- a/pyanaconda/payload/source/factory.py
+++ b/pyanaconda/payload/source/factory.py
@@ -16,7 +16,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.core.util import parse_nfs_url
+from pyanaconda.core.payload import parse_nfs_url
 from pyanaconda.payload.source.sources import CDRomSource, HDDSource, NFSSource, HTTPSource, \
     HTTPSSource, FTPSource, FileSource, HMCSource
 

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -33,7 +33,8 @@ from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _, N_, CN_
 from pyanaconda.payload.image import find_optical_install_media, find_potential_hdiso_sources, \
     get_hdiso_source_info, get_hdiso_source_description
-from pyanaconda.core.util import ProxyString, ProxyStringError, cmp_obj_attrs, id_generator
+from pyanaconda.core.payload import ProxyString, ProxyStringError
+from pyanaconda.core.util import cmp_obj_attrs, id_generator
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.ui.helpers import InputCheck, InputCheckHandler
 from pyanaconda.ui.gui import GUIObject

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
@@ -24,6 +24,7 @@ from tests.nosetests.pyanaconda_tests.module_payload_shared import PayloadShared
 
 from pyanaconda.core.constants import SOURCE_TYPE_CDROM, SOURCE_TYPE_HDD, SOURCE_TYPE_HMC, \
     SOURCE_TYPE_NFS, SOURCE_TYPE_REPO_FILES, SOURCE_TYPE_URL
+from pyanaconda.modules.common.errors.payload import PayloadNotSetError
 from pyanaconda.modules.payloads.constants import PayloadType
 from pyanaconda.modules.payloads.payload.dnf.dnf import DNFModule
 from pyanaconda.modules.payloads.payload.dnf.dnf_interface import DNFInterface
@@ -76,6 +77,26 @@ class DNFKSTestCase(unittest.TestCase):
         """
         self.shared_ks_tests.check_kickstart(ks_in, ks_out)
         self._check_properties(SOURCE_TYPE_HMC)
+
+    def harddrive_kickstart_test(self):
+        ks_in = """
+        harddrive --partition=nsa-device --dir=top-secret
+        """
+        ks_out = """
+        # Use hard drive installation media
+        harddrive --dir=top-secret --partition=nsa-device
+        """
+        self.shared_ks_tests.check_kickstart(ks_in, ks_out)
+        self._check_properties(SOURCE_TYPE_HDD)
+
+    def harddrive_kickstart_failed_test(self):
+        ks_in = """
+        harddrive --partition=nsa-device
+        """
+        self.shared_ks_tests.check_kickstart(ks_in, ks_valid=False, expected_publish_calls=0)
+
+        with self.assertRaises(PayloadNotSetError):
+            self.interface.GetActivePayload()
 
 
 class DNFInterfaceTestCase(unittest.TestCase):

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
@@ -66,6 +66,17 @@ class DNFKSTestCase(unittest.TestCase):
         self.shared_ks_tests.check_kickstart(ks_in, ks_out)
         self._check_properties(SOURCE_TYPE_CDROM)
 
+    def hmc_kickstart_test(self):
+        ks_in = """
+        hmc
+        """
+        ks_out = """
+        # Use installation media via SE/HMC
+        hmc
+        """
+        self.shared_ks_tests.check_kickstart(ks_in, ks_out)
+        self._check_properties(SOURCE_TYPE_HMC)
+
 
 class DNFInterfaceTestCase(unittest.TestCase):
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
@@ -108,6 +108,17 @@ class DNFKSTestCase(unittest.TestCase):
         self.shared_ks_tests.check_kickstart(ks_in, ks_valid=False, expected_publish_calls=1)
         self._check_properties(None)
 
+    def nfs_kickstart_test(self):
+        ks_in = """
+        nfs --server=gotham.city --dir=/secret/underground/base --opts=nomount
+        """
+        ks_out = """
+        # Use NFS installation media
+        nfs --server=gotham.city --dir=/secret/underground/base --opts="nomount"
+        """
+        self.shared_ks_tests.check_kickstart(ks_in, ks_out)
+        self._check_properties(SOURCE_TYPE_NFS)
+
 
 class DNFInterfaceTestCase(unittest.TestCase):
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
@@ -119,6 +119,42 @@ class DNFKSTestCase(unittest.TestCase):
         self.shared_ks_tests.check_kickstart(ks_in, ks_out)
         self._check_properties(SOURCE_TYPE_NFS)
 
+    def url_kickstart_test(self):
+        self.maxDiff = None
+        ks_in = """
+        url --proxy=https://ClarkKent:suuuperrr@earth:1 --noverifyssl --url http://super/powers --sslcacert wardrobe.cert --sslclientcert private-wardrobe.cert --sslclientkey super-key.key
+        """
+        ks_out = """
+        # Use network installation
+        url --url="http://super/powers" --proxy="https://ClarkKent:suuuperrr@earth:1" --noverifyssl --sslcacert="wardrobe.cert" --sslclientcert="private-wardrobe.cert" --sslclientkey="super-key.key"
+        """
+        self.shared_ks_tests.check_kickstart(ks_in, ks_out)
+        self._check_properties(SOURCE_TYPE_URL)
+
+    def url_mirrorlist_kickstart_test(self):
+        self.maxDiff = None
+        ks_in = """
+        url --mirrorlist http://cool/mirror
+        """
+        ks_out = """
+        # Use network installation
+        url --mirrorlist="http://cool/mirror"
+        """
+        self.shared_ks_tests.check_kickstart(ks_in, ks_out)
+        self._check_properties(SOURCE_TYPE_URL)
+
+    def url_metalink_kickstart_test(self):
+        self.maxDiff = None
+        ks_in = """
+        url --metalink http://itsjustametanotrealstuff --proxy="https://ClarkKent:suuuperrr@earth:1" --sslcacert="wardrobe.cert"
+        """
+        ks_out = """
+        # Use network installation
+        url --metalink="http://itsjustametanotrealstuff" --proxy="https://ClarkKent:suuuperrr@earth:1" --sslcacert="wardrobe.cert"
+        """
+        self.shared_ks_tests.check_kickstart(ks_in, ks_out)
+        self._check_properties(SOURCE_TYPE_URL)
+
 
 class DNFInterfaceTestCase(unittest.TestCase):
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
@@ -98,6 +98,16 @@ class DNFKSTestCase(unittest.TestCase):
         with self.assertRaises(PayloadNotSetError):
             self.interface.GetActivePayload()
 
+    def harddrive_biospart_kickstart_failed_test(self):
+        # The biospart parameter is not implemented since 2012 and it won't
+        # really work. Make it obvious for user.
+        ks_in = """
+        harddrive --biospart=007 --dir=cool/store
+        """
+        # One publisher call because the biospart support is decided in the harddrive source
+        self.shared_ks_tests.check_kickstart(ks_in, ks_valid=False, expected_publish_calls=1)
+        self._check_properties(None)
+
 
 class DNFInterfaceTestCase(unittest.TestCase):
 

--- a/tests/nosetests/pyanaconda_tests/payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/payload_test.py
@@ -626,3 +626,35 @@ class PayloadUtilsTests(unittest.TestCase):
                          ("", "host", ""))
         self.assertEqual(util.parse_nfs_url(":"),
                          ("", "", ""))
+
+    def create_nfs_url_test(self):
+        """Test create_nfs_url."""
+
+        self.assertEqual(util.create_nfs_url("", ""), "")
+        self.assertEqual(util.create_nfs_url("", "", None), "")
+        self.assertEqual(util.create_nfs_url("", "", ""), "")
+
+        self.assertEqual(util.create_nfs_url("host", ""), "nfs:host:")
+        self.assertEqual(util.create_nfs_url("host", "", "options"), "nfs:options:host:")
+
+        self.assertEqual(util.create_nfs_url("host", "path"), "nfs:host:path")
+        self.assertEqual(util.create_nfs_url("host", "/path", "options"), "nfs:options:host:/path")
+
+        self.assertEqual(util.create_nfs_url("host", "/path/to/something"),
+                         "nfs:host:/path/to/something")
+        self.assertEqual(util.create_nfs_url("host", "/path/to/something", "options"),
+                         "nfs:options:host:/path/to/something")
+
+    def nfs_combine_test(self):
+        "Test combination of parse and create nfs functions."
+
+        host = "host"
+        path = "/path/to/somewhere"
+        options = "options"
+
+        url = util.create_nfs_url(host, path, options)
+        self.assertEqual(util.parse_nfs_url(url), (options, host, path))
+
+        url = "nfs:options:host:/my/path"
+        (options, host, path) = util.parse_nfs_url(url)
+        self.assertEqual(util.create_nfs_url(host, path, options), url)

--- a/tests/nosetests/pyanaconda_tests/payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/payload_test.py
@@ -25,6 +25,8 @@ import hashlib
 import shutil
 import gi
 
+import pyanaconda.core.payload as util
+
 from tempfile import TemporaryDirectory
 from unittest.mock import patch, Mock, call
 
@@ -584,3 +586,43 @@ class RefMock(object):
                                     self._name,
                                     self._arch,
                                     self._branch)
+
+
+class PayloadUtilsTests(unittest.TestCase):
+
+    def parse_nfs_url_test(self):
+        """Test parseNfsUrl."""
+
+        # empty NFS url should return 3 blanks
+        self.assertEqual(util.parse_nfs_url(""), ("", "", ""))
+
+        # the string is delimited by :, there is one prefix and 3 parts,
+        # the prefix is discarded and all parts after the 3th part
+        # are also discarded
+        self.assertEqual(util.parse_nfs_url("discard:options:host:path"),
+                         ("options", "host", "path"))
+        self.assertEqual(util.parse_nfs_url("discard:options:host:path:foo:bar"),
+                         ("options", "host", "path"))
+        self.assertEqual(util.parse_nfs_url(":options:host:path::"),
+                         ("options", "host", "path"))
+        self.assertEqual(util.parse_nfs_url(":::::"),
+                         ("", "", ""))
+
+        # if there is only prefix & 2 parts,
+        # the two parts are host and path
+        self.assertEqual(util.parse_nfs_url("prefix:host:path"),
+                         ("", "host", "path"))
+        self.assertEqual(util.parse_nfs_url(":host:path"),
+                         ("", "host", "path"))
+        self.assertEqual(util.parse_nfs_url("::"),
+                         ("", "", ""))
+
+        # if there is only a prefix and single part,
+        # the part is the host
+
+        self.assertEqual(util.parse_nfs_url("prefix:host"),
+                         ("", "host", ""))
+        self.assertEqual(util.parse_nfs_url(":host"),
+                         ("", "host", ""))
+        self.assertEqual(util.parse_nfs_url(":"),
+                         ("", "", ""))

--- a/tests/nosetests/pyanaconda_tests/util_test.py
+++ b/tests/nosetests/pyanaconda_tests/util_test.py
@@ -517,43 +517,6 @@ class MiscTests(unittest.TestCase):
         # at least check if a bool is returned
         self.assertIsInstance(util.isConsoleOnVirtualTerminal(), bool)
 
-    def parse_nfs_url_test(self):
-        """Test parseNfsUrl."""
-
-        # empty NFS url should return 3 blanks
-        self.assertEqual(util.parse_nfs_url(""), ("", "", ""))
-
-        # the string is delimited by :, there is one prefix and 3 parts,
-        # the prefix is discarded and all parts after the 3th part
-        # are also discarded
-        self.assertEqual(util.parse_nfs_url("discard:options:host:path"),
-                         ("options", "host", "path"))
-        self.assertEqual(util.parse_nfs_url("discard:options:host:path:foo:bar"),
-                         ("options", "host", "path"))
-        self.assertEqual(util.parse_nfs_url(":options:host:path::"),
-                         ("options", "host", "path"))
-        self.assertEqual(util.parse_nfs_url(":::::"),
-                         ("", "", ""))
-
-        # if there is only prefix & 2 parts,
-        # the two parts are host and path
-        self.assertEqual(util.parse_nfs_url("prefix:host:path"),
-                         ("", "host", "path"))
-        self.assertEqual(util.parse_nfs_url(":host:path"),
-                         ("", "host", "path"))
-        self.assertEqual(util.parse_nfs_url("::"),
-                         ("", "", ""))
-
-        # if there is only a prefix and single part,
-        # the part is the host
-
-        self.assertEqual(util.parse_nfs_url("prefix:host"),
-                         ("", "host", ""))
-        self.assertEqual(util.parse_nfs_url(":host"),
-                         ("", "host", ""))
-        self.assertEqual(util.parse_nfs_url(":"),
-                         ("", "", ""))
-
     def vt_activate_test(self):
         """Test vtActivate."""
 


### PR DESCRIPTION
Add kickstart support for DNF module.

In this PR I'm disabling `%packages` which will be solved by the main process for the time being. Right now, we have to add support for the base repositories to support subscription spoke.

Will be implemented:
- [x] KS support for HDD
- [x] KS support for NFS
- [x] KS support for URL

Part of this PR was split to https://github.com/rhinstaller/anaconda/pull/2484 to make this smaller.