### PR TITLE
subscription: Add registration tasks

### DIFF
--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -124,3 +124,13 @@ RHSM_CONFIG = DBusObjectIdentifier(
     namespace=RHSM_NAMESPACE,
     basename="Config"
 )
+
+RHSM_REGISTER_SERVER = DBusObjectIdentifier(
+    namespace=RHSM_NAMESPACE,
+    basename="RegisterServer"
+)
+
+RHSM_REGISTER = DBusObjectIdentifier(
+    namespace=RHSM_NAMESPACE,
+    basename="Register"
+)

--- a/pyanaconda/modules/common/errors/subscription.py
+++ b/pyanaconda/modules/common/errors/subscription.py
@@ -1,0 +1,27 @@
+#
+# DBus errors related to subscription handling
+#
+# Copyright (C) 2020  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from pyanaconda.core.dbus import dbus_error
+from pyanaconda.modules.common.constants.namespaces import ANACONDA_NAMESPACE
+from pyanaconda.modules.common.errors.general import AnacondaError
+
+
+@dbus_error("RegistrationError", namespace=ANACONDA_NAMESPACE)
+class RegistrationError(AnacondaError):
+    """Registration attempt failed."""
+    pass

--- a/pyanaconda/modules/subscription/runtime.py
+++ b/pyanaconda/modules/subscription/runtime.py
@@ -15,12 +15,56 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import os
+import json
+
 from dasbus.typing import get_variant, Str
+from dasbus.connection import MessageBus
+from dasbus.error import DBusError
+
+from pyanaconda.core.i18n import _
 
 from pyanaconda.modules.common.task import Task
+from pyanaconda.modules.common.constants.services import RHSM
+from pyanaconda.modules.common.constants.objects import RHSM_REGISTER
+from pyanaconda.modules.common.errors.subscription import RegistrationError
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
+
+
+class RHSMPrivateBus(MessageBus):
+    """Representation of RHSM private bus connection that can be used as a context manager."""
+
+    def __init__(self, rhsm_register_server_proxy, *args, **kwargs):
+        """Representation of RHSM private bus connection that can be used as a context manager.
+
+        :param rhsm_register_server_proxy: DBus proxy for the RHSM RegisterServer object
+        """
+        super().__init__(*args, **kwargs)
+        self._rhsm_register_server_proxy = rhsm_register_server_proxy
+        self._private_bus_address = None
+
+    def __enter__(self):
+        log.debug("subscription: starting RHSM private DBus session")
+        locale = os.environ.get("LANG", "")
+        self._private_bus_address = self._rhsm_register_server_proxy.Start(locale)
+        log.debug("subscription: RHSM private DBus session has been started")
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        log.debug("subscription: shutting down the RHSM private DBus session")
+        self.connection.disconnect()
+        locale = os.environ.get("LANG", "")
+        self._rhsm_register_server_proxy.Stop(locale)
+        log.debug("subscription: RHSM private DBus session has been shutdown")
+
+    def _get_connection(self):
+        """Get a connection to RHSM private DBus session."""
+        # the RHSM private bus address is potentially sensitive
+        # so we will not log it
+        log.info("Connecting to the RHSM private DBus session.")
+        return self._provider.get_addressed_bus_connection(self._private_bus_address)
 
 
 class SetRHSMConfigurationTask(Task):
@@ -114,3 +158,106 @@ class SetRHSMConfigurationTask(Task):
 
         # and finally set the dict to RHSM via the DBus API
         self._rhsm_config_proxy.SetAll(config_dict, "")
+
+
+class RegisterWithUsernamePasswordTask(Task):
+    """Register the system via username + password."""
+
+    def __init__(self, rhsm_register_server_proxy, username, password):
+        """Create a new registration task.
+
+        It is assumed the username and password have been
+        validated before this task has been started.
+
+        :param rhsm_register_server_proxy: DBus proxy for the RHSM RegisterServer object
+        :param str username: Red Hat account username
+        :param str password: Red Hat account password
+        """
+        super().__init__()
+        self._rhsm_register_server_proxy = rhsm_register_server_proxy
+        self._username = username
+        self._password = password
+
+    @property
+    def name(self):
+        return "Register with Red Hat account username and password"
+
+    def run(self):
+        """Register the system with Red Hat account username and password.
+
+        :return: True on success, raises RegistrationError on failure
+        :rtype: bool
+        :raises: RegistrationError
+        """
+        log.debug("subscription: registering with username and password")
+        with RHSMPrivateBus(self._rhsm_register_server_proxy) as private_bus:
+            try:
+                locale = os.environ.get("LANG", "")
+                private_register_proxy = private_bus.get_proxy(RHSM.service_name,
+                                                               RHSM_REGISTER.object_path)
+                # We do not yet support setting organization for username & password
+                # registration, so organization is blank for now.
+                organization = ""
+                private_register_proxy.Register(organization,
+                                                self._username,
+                                                self._password,
+                                                {},
+                                                {},
+                                                locale)
+                log.debug("subscription: registered with username and password")
+            except DBusError as e:
+                log.debug("subscription: failed to register with username and password: %s",
+                          str(e))
+                # RHSM exception contain details as JSON due to DBus exception handling limitations
+                exception_dict = json.loads(str(e))
+                # return a generic error message in case the RHSM provided error message is missing
+                message = exception_dict.get("message", _("Registration failed."))
+                raise RegistrationError(message) from None
+
+
+class RegisterWithOrganizationKeyTask(Task):
+    """Register the system via organization and one or more activation keys."""
+
+    def __init__(self, rhsm_register_server_proxy, organization, activation_keys):
+        """Create a new registration task.
+
+        :param rhsm_register_server_proxy: DBus proxy for the RHSM RegisterServer object
+        :param str organization: organization name for subscription purposes
+        :param activation keys: activation keys
+        :type activation_keys: list of str
+        """
+        super().__init__()
+        self._rhsm_register_server_proxy = rhsm_register_server_proxy
+        self._organization = organization
+        self._activation_keys = activation_keys
+
+    @property
+    def name(self):
+        return "Register with organization name and activation key"
+
+    def run(self):
+        """Register the system with organization name and activation key.
+
+        :return: True on success, raises RegistrationError on failure
+        :rtype: bool
+        :raises: RegistrationError
+        """
+        log.debug("subscription: registering with organization and activation key")
+        with RHSMPrivateBus(self._rhsm_register_server_proxy) as private_bus:
+            try:
+                locale = os.environ.get("LANG", "")
+                private_register_proxy = private_bus.get_proxy(RHSM.service_name,
+                                                               RHSM_REGISTER.object_path)
+                private_register_proxy.RegisterWithActivationKeys(self._organization,
+                                                                  self._activation_keys,
+                                                                  {},
+                                                                  {},
+                                                                  locale)
+                log.debug("subscription: registered with organization and activation key")
+            except DBusError as e:
+                log.debug("subscription: failed to register with organization & key: %s", str(e))
+                # RHSM exception contain details as JSON due to DBus exception handling limitations
+                exception_dict = json.loads(str(e))
+                # return a generic error message in case the RHSM provided error message is missing
+                message = exception_dict.get("message", _("Registration failed."))
+                raise RegistrationError(message) from None

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -153,3 +153,21 @@ class SubscriptionInterface(KickstartModuleInterface):
         return TaskContainer.to_object_path(
             self.implementation.set_rhsm_config_with_task()
         )
+
+    def RegisterUsernamePasswordWithTask(self) -> ObjPath:
+        """Register with username & password using a runtime DBus task.
+
+        :return: a DBus path of an installation task
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.register_username_password_with_task()
+        )
+
+    def RegisterOrganizationKeyWithTask(self) -> ObjPath:
+        """Register with organization & keys(s) using a runtime DBus task.
+
+        :return: a DBus path of an installation task
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.register_organization_key_with_task()
+        )


### PR DESCRIPTION
Add the username+password and organization+activation key(s) registration
tasks. Also add helper methods needed to active a private DBus session
that is needed for safe credential passing to RHSM.

For success/error reporting the tasks return to value tuple with the
first value indicating success/failure via a boolean and the second
value contains the error message, which is an empty string for success.