### PR TITLE
Add resolv.conf to log-capture

### DIFF
--- a/scripts/log-capture
+++ b/scripts/log-capture
@@ -52,6 +52,7 @@ _to_log ip a
 _to_log ip r
 _to_log journalctl
 
+cp /etc/resolv.conf ${OUTDIR}
 cp /tmp/*.log ${OUTDIR}
 cp /root/lorax-packages.log ${OUTDIR}
 


### PR DESCRIPTION
For troubleshooting install issues, it is also handy to see what state resolv.conf holds.