### PR TITLE
Fix the error reporting from ReadKickstart

### DIFF
--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -233,7 +233,8 @@ class KickstartService(Service, KickstartBaseModule):
 
                 for warn in warns:
                     if issubclass(warn.category, KickstartParseWarning):
-                        data = KickstartMessage.for_warning(str(warn))
+                        message = str(warn.message)
+                        data = KickstartMessage.for_warning(message)
                         report.warning_messages.append(data)
 
         except KickstartError as e:

--- a/pyanaconda/modules/common/structures/kickstart.py
+++ b/pyanaconda/modules/common/structures/kickstart.py
@@ -56,15 +56,15 @@ class KickstartMessage(DBusData):
         self._file_name = value
 
     @property
-    def line_number(self) -> Int:
+    def line_number(self) -> UInt32:
         """Number of the line.
 
         :return: a number
         """
-        return self._line_number
+        return UInt32(self._line_number)
 
     @line_number.setter
-    def line_number(self, value: Int):
+    def line_number(self, value: UInt32):
         self._line_number = value
 
     @property
@@ -88,7 +88,7 @@ class KickstartMessage(DBusData):
         """
         data = cls()
         data.message = e.message
-        data.line_number = e.lineno
+        data.line_number = e.lineno or 0
         return data
 
     @classmethod
@@ -100,7 +100,7 @@ class KickstartMessage(DBusData):
         """
         data = cls()
         data.message = warn_msg
-        data.line_number = -1
+        data.line_number = 0
         return data
 
     def __str__(self):

--- a/tests/nosetests/pyanaconda_tests/module_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_base_test.py
@@ -1,0 +1,112 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+import warnings
+
+from dasbus.typing import *  # pylint: disable=wildcard-import
+from pyanaconda.modules.common.base import KickstartService, KickstartModuleInterface
+from pykickstart.errors import KickstartParseError, KickstartParseWarning, \
+    KickstartDeprecationWarning
+
+
+class BaseModuleTestCase(unittest.TestCase):
+    """Test base classes for DBus modules."""
+
+    def setUp(self):
+        self.maxDiff = None
+
+    def read_kickstart_error_test(self):
+        """Test ReadKickstart with a custom error."""
+
+        class Service(KickstartService):
+            def process_kickstart(self, data):
+                raise KickstartParseError("Error!")
+
+        module = Service()
+        interface = KickstartModuleInterface(module)
+
+        error = {
+            'file-name': get_variant(Str, ""),
+            'line-number': get_variant(UInt32, 0),
+            'message': get_variant(Str, 'Error!'),
+            'module-name': get_variant(Str, ""),
+        }
+
+        report = {
+            'error-messages': get_variant(List[Structure], [error]),
+            'warning-messages': get_variant(List[Structure], [])
+        }
+
+        self.assertEqual(interface.ReadKickstart(""), report)
+
+    def read_kickstart_error_line_number_test(self):
+        """Test ReadKickstart with a custom error on a specified line."""
+
+        class Service(KickstartService):
+            def process_kickstart(self, data):
+                raise KickstartParseError("Error!", lineno=10)
+
+        module = Service()
+        interface = KickstartModuleInterface(module)
+
+        error = {
+            'file-name': get_variant(Str, ""),
+            'line-number': get_variant(UInt32, 10),
+            'message': get_variant(Str, 'Error!'),
+            'module-name': get_variant(Str, ""),
+        }
+
+        report = {
+            'error-messages': get_variant(List[Structure], [error]),
+            'warning-messages': get_variant(List[Structure], [])
+        }
+
+        self.assertEqual(interface.ReadKickstart(""), report)
+
+    def read_kickstart_warning_test(self):
+        """Test ReadKickstart with a custom warning."""
+
+        class Service(KickstartService):
+            def process_kickstart(self, data):
+                warnings.warn("First warning!", KickstartParseWarning)
+                warnings.warn("Other warning!", DeprecationWarning)
+                warnings.warn("Second warning!", KickstartDeprecationWarning)
+
+        module = Service()
+        interface = KickstartModuleInterface(module)
+
+        first_warning = {
+            'file-name': get_variant(Str, ""),
+            'line-number': get_variant(UInt32, 0),
+            'message': get_variant(Str, 'First warning!'),
+            'module-name': get_variant(Str, ""),
+        }
+
+        second_warning = {
+            'file-name': get_variant(Str, ""),
+            'line-number': get_variant(UInt32, 0),
+            'message': get_variant(Str, 'Second warning!'),
+            'module-name': get_variant(Str, ""),
+        }
+
+        report = {
+            'error-messages': get_variant(List[Structure], []),
+            'warning-messages': get_variant(List[Structure], [first_warning, second_warning])
+        }
+
+        self.assertEqual(interface.ReadKickstart(""), report)

--- a/tests/nosetests/pyanaconda_tests/module_timezone_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_timezone_test.py
@@ -209,9 +209,13 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
     def deprecated_warnings_test(self):
         response = self.timezone_interface.ReadKickstart("timezone --isUtc Europe/Bratislava")
         report = KickstartReport.from_structure(response)
-        self.assertIn("The option --isUtc will be deprecated in future releases",
-                      str(report.warning_messages[0]))
+
+        warning = "The option --isUtc will be deprecated in future releases. " \
+                  "Please modify your kickstart file to replace this option with " \
+                  "its preferred alias --utc."
+
         self.assertEqual(len(report.warning_messages), 1)
+        self.assertEqual(report.warning_messages[0].message, warning)
 
 
 class TimezoneTasksTestCase(unittest.TestCase):


### PR DESCRIPTION
Change the type of the attribute `line_number` in the class `KickstartMessage` to
`UInt32` and change the default value to zero. Set the line number in the method
`for_error` method to zero if it is not set in the given exception.

Warning messages returned by the DBus method `ReadKickstart` shouldn't contain
meta data about caught warnings.

Test propagation of errors and warnings from the DBus method `ReadKickstart`.

