### PR TITLE
Separate the "Reset All" button from the edge of the screen

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom_storage.glade
+++ b/pyanaconda/ui/gui/spokes/custom_storage.glade
@@ -118,6 +118,7 @@
             <property name="vexpand">True</property>
             <property name="yalign">0</property>
             <property name="left_padding">24</property>
+            <property name="right_padding">6</property>
             <child internal-child="action_area">
               <object class="GtkBox" id="customStorageWindow-actionArea">
                 <property name="can_focus">False</property>


### PR DESCRIPTION
This change makes the "Reset All" button on the custom partitioning screen aligned with the "Help!" button and increases the user experience by 2%.
It is worth mentioning that this change slightly reduces the usable area of the screen, compare the attached screenshots.

Before:
![before](https://user-images.githubusercontent.com/3199786/80418620-0071e880-88d8-11ea-8b04-0de5b801b182.png)
After:
![after](https://user-images.githubusercontent.com/3199786/80418651-08318d00-88d8-11ea-9503-41b59314feab.png)

