### PR TITLE
subscription: Add unregistration task

### DIFF
--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -134,3 +134,8 @@ RHSM_REGISTER = DBusObjectIdentifier(
     namespace=RHSM_NAMESPACE,
     basename="Register"
 )
+
+RHSM_UNREGISTER = DBusObjectIdentifier(
+    namespace=RHSM_NAMESPACE,
+    basename="Unregister"
+)

--- a/pyanaconda/modules/common/errors/subscription.py
+++ b/pyanaconda/modules/common/errors/subscription.py
@@ -25,3 +25,9 @@ from pyanaconda.modules.common.errors.general import AnacondaError
 class RegistrationError(AnacondaError):
     """Registration attempt failed."""
     pass
+
+
+@dbus_error("UnregistrationError", namespace=ANACONDA_NAMESPACE)
+class UnregistrationError(AnacondaError):
+    """Unregistration attempt failed."""
+    pass

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -171,3 +171,12 @@ class SubscriptionInterface(KickstartModuleInterface):
         return TaskContainer.to_object_path(
             self.implementation.register_organization_key_with_task()
         )
+
+    def UnregisterWithTask(self) -> ObjPath:
+        """Unregister using a runtime DBus task.
+
+        :return: a DBus path of an installation task
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.unregister_with_task()
+        )

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tasks_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tasks_tests.py
@@ -41,7 +41,9 @@ from pyanaconda.modules.subscription.installation import ConnectToInsightsTask, 
     SystemPurposeConfigurationTask, RestoreRHSMLogLevelTask, \
     TransferSubscriptionTokensTask
 from pyanaconda.modules.subscription.runtime import SetRHSMConfigurationTask, \
-    RHSMPrivateBus, RegisterWithUsernamePasswordTask, RegisterWithOrganizationKeyTask
+    RHSMPrivateBus, RegisterWithUsernamePasswordTask, RegisterWithOrganizationKeyTask, \
+    UnregisterTask
+
 
 
 class ConnectToInsightsTaskTestCase(unittest.TestCase):
@@ -642,3 +644,33 @@ class RegistrationTasksTestCase(unittest.TestCase):
             {},
             'en_US.UTF-8'
         )
+
+
+class UnregisterTaskTestCase(unittest.TestCase):
+    """Test the unregister task."""
+
+    @patch("os.environ.get", return_value="en_US.UTF-8")
+    def unregister_success_test(self, environ_get):
+        """Test the UnregisterTask - success."""
+        # register server proxy
+        rhsm_unregister_proxy = Mock()
+        # instantiate the task and run it
+        task = UnregisterTask(rhsm_unregister_proxy=rhsm_unregister_proxy)
+        task.run()
+        # check the unregister proxy Unregister method was called correctly
+        rhsm_unregister_proxy.Unregister.assert_called_once_with({}, "en_US.UTF-8")
+
+    @patch("os.environ.get", return_value="en_US.UTF-8")
+    def unregister_failure_test(self, environ_get):
+        """Test the UnregisterTask - failure."""
+        # register server proxy
+        rhsm_unregister_proxy = Mock()
+        # raise DBusError with error message in JSON
+        json_error = '{"message": "Unregistration failed."}'
+        rhsm_unregister_proxy.Unregister.side_effect = DBusError(json_error)
+        # instantiate the task and run it
+        task = UnregisterTask(rhsm_unregister_proxy=rhsm_unregister_proxy)
+        with self.assertRaises(DBusError):
+            task.run()
+        # check the unregister proxy Unregister method was called correctly
+        rhsm_unregister_proxy.Unregister.assert_called_once_with({}, "en_US.UTF-8")


### PR DESCRIPTION
Add the UnregistrationTask that takes care of unregistering a system.

~NOTE: Currently rebased on top of the Registration tasks PR, which adds the subscription DBus error file to avoid conflicts.~
Rebased on top of master after the Registration tasks PR has been merged.