### PR TITLE
1/2 DNF kickstart support

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -35,7 +35,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.23-1
+%define pykickstartver 3.25-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 1.1-1

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -64,7 +64,7 @@ from pykickstart.commands.partition import F29_Partition as Partition
 from pykickstart.commands.raid import F29_Raid as Raid
 from pykickstart.commands.realm import F19_Realm as Realm
 from pykickstart.commands.reboot import F23_Reboot as Reboot
-from pykickstart.commands.repo import F30_Repo as Repo
+from pykickstart.commands.repo import F33_Repo as Repo
 from pykickstart.commands.reqpart import F23_ReqPart as ReqPart
 from pykickstart.commands.rescue import F10_Rescue as Rescue
 from pykickstart.commands.rhsm import RHEL8_RHSM as RHSM

--- a/pyanaconda/modules/payloads/kickstart.py
+++ b/pyanaconda/modules/payloads/kickstart.py
@@ -19,7 +19,6 @@
 #
 from pykickstart.errors import KickstartParseError
 from pykickstart.sections import PackageSection
-from pykickstart.parser import Packages
 from pykickstart.constants import KS_BROKEN_IGNORE
 
 from pyanaconda.core.configuration.anaconda import conf
@@ -53,12 +52,4 @@ class PayloadKickstartSpecification(KickstartSpecification):
         "liveimg": COMMANDS.Liveimg,
         "nfs": COMMANDS.NFS,
         "url": COMMANDS.Url
-    }
-
-    sections = {
-        "packages": AnacondaPackageSection
-    }
-
-    sections_data = {
-        "packages": Packages
     }

--- a/pyanaconda/modules/payloads/kickstart.py
+++ b/pyanaconda/modules/payloads/kickstart.py
@@ -47,7 +47,12 @@ class AnacondaPackageSection(PackageSection):
 class PayloadKickstartSpecification(KickstartSpecification):
 
     commands = {
-        "liveimg": COMMANDS.Liveimg
+        "cdrom": COMMANDS.Cdrom,
+        "harddrive": COMMANDS.HardDrive,
+        "hmc": COMMANDS.Hmc,
+        "liveimg": COMMANDS.Liveimg,
+        "nfs": COMMANDS.NFS,
+        "url": COMMANDS.Url
     }
 
     sections = {

--- a/pyanaconda/modules/payloads/payload/dnf/dnf.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf.py
@@ -17,7 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.modules.payloads.constants import PayloadType
+from pyanaconda.modules.payloads.constants import PayloadType, SourceType
 from pyanaconda.modules.payloads.payload.payload_base import PayloadBase
 from pyanaconda.modules.payloads.payload.dnf.dnf_interface import DNFInterface
 
@@ -43,8 +43,14 @@ class DNFModule(PayloadBase):
     @property
     def supported_source_types(self):
         """Get list of sources supported by DNF module."""
-        # TODO: Add supported sources when implemented
-        return None
+        return [
+            SourceType.CDROM,
+            SourceType.HDD,
+            SourceType.HMC,
+            SourceType.NFS,
+            SourceType.REPO_FILES,
+            SourceType.URL
+        ]
 
     def process_kickstart(self, data):
         """Process the kickstart data."""

--- a/pyanaconda/modules/payloads/payload/factory.py
+++ b/pyanaconda/modules/payloads/payload/factory.py
@@ -57,4 +57,11 @@ class PayloadFactory(object):
         if data.liveimg.seen:
             return PayloadType.LIVE_IMAGE
 
+        if data.cdrom.seen or \
+           data.harddrive.seen or \
+           data.hmc.seen or \
+           data.nfs.seen or \
+           data.url.seen:
+            return PayloadType.DNF
+
         return None

--- a/pyanaconda/modules/payloads/payload/factory.py
+++ b/pyanaconda/modules/payloads/payload/factory.py
@@ -57,7 +57,4 @@ class PayloadFactory(object):
         if data.liveimg.seen:
             return PayloadType.LIVE_IMAGE
 
-        if data.packages.seen:
-            return PayloadType.DNF
-
         return None

--- a/pyanaconda/modules/payloads/payload/payload_base.py
+++ b/pyanaconda/modules/payloads/payload/payload_base.py
@@ -146,6 +146,15 @@ class PayloadBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         """
         return bool(self.sources)
 
+    def add_source(self, source):
+        """Module scope API for easier adding of sources.
+
+        :param source: Source we want to add.
+        """
+        sources = list(self.sources)
+        sources.append(source)
+        self.set_sources(sources)
+
     @abstractmethod
     def pre_install_with_tasks(self):
         """Execute preparation steps.

--- a/pyanaconda/modules/payloads/payload/payload_base.py
+++ b/pyanaconda/modules/payloads/payload/payload_base.py
@@ -135,7 +135,7 @@ class PayloadBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
                                    "initialized! Please tear down the sources first.")
 
         self._sources = sources
-        log.debug("New sources %s was added.", sources)
+        log.debug("New sources %s were added.", sources)
         self.sources_changed.emit()
 
     def has_source(self):

--- a/pyanaconda/modules/payloads/payloads.py
+++ b/pyanaconda/modules/payloads/payloads.py
@@ -121,6 +121,7 @@ class PayloadsService(KickstartService):
             self.payload.setup_kickstart(data)
         except PayloadNotSetError:
             log.warning("Generating kickstart data without payload set - data will be empty!")
+            return ""
 
         return str(data)
 

--- a/pyanaconda/modules/payloads/payloads.py
+++ b/pyanaconda/modules/payloads/payloads.py
@@ -27,7 +27,6 @@ from pyanaconda.modules.payloads.payload.factory import PayloadFactory
 from pyanaconda.modules.payloads.kickstart import PayloadKickstartSpecification
 from pyanaconda.modules.payloads.packages.packages import PackagesModule
 from pyanaconda.modules.payloads.payloads_interface import PayloadsInterface
-from pyanaconda.modules.payloads.payload.dnf.dnf import DNFModule
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -106,10 +105,6 @@ class PayloadsService(KickstartService):
             # FIXME: This is a temporary workaround.
             PayloadContainer.to_object_path(payload_module)
 
-        # FIXME: Process packages in the DNF module.
-        # The packages module should be replaces with a DBus structure.
-        self._packages.process_kickstart(data)
-
     def setup_kickstart(self, data):
         """Set up the kickstart data."""
         pass
@@ -126,10 +121,6 @@ class PayloadsService(KickstartService):
             self.payload.setup_kickstart(data)
         except PayloadNotSetError:
             log.warning("Generating kickstart data without payload set - data will be empty!")
-
-        # generate packages section only for DNF module
-        if isinstance(self.payload, DNFModule):
-            self._packages.setup_kickstart(data)
 
         return str(data)
 

--- a/pyanaconda/modules/payloads/source/source_base.py
+++ b/pyanaconda/modules/payloads/source/source_base.py
@@ -38,6 +38,12 @@ class PayloadSourceBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
     to be implemented by a source to be used.
     """
 
+    def __repr__(self):
+        """Print sources in a nicer way."""
+        # FIXME: Every source should implement it's repr and this should be removed.
+        # See https://docs.python.org/3/library/functions.html#repr for reasons why.
+        return "Source({})".format(self.type.value)
+
     @property
     @abstractmethod
     def type(self):

--- a/tests/nosetests/pyanaconda_tests/module_payload_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_base_test.py
@@ -159,9 +159,8 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
 
         # can't switch source if attached source is ready
         source1.get_state.return_value = SourceState.READY
-        self.shared_tests.check_set_sources([source2],
-                                            exception=SourceSetupError,
-                                            expected_sources=[source1])
+        self.shared_tests.set_sources([source2], SourceSetupError)
+        self.shared_tests.check_sources([source1])
 
         # change to source2 when attached source state is UNREADY
         source1.get_state.return_value = SourceState.UNREADY

--- a/tests/nosetests/pyanaconda_tests/module_payload_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_base_test.py
@@ -77,7 +77,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         """Test if set source API payload."""
         sources = [self.shared_tests.prepare_source(SourceType.URL)]
 
-        self.shared_tests.check_set_sources(sources)
+        self.shared_tests.set_and_check_sources(sources)
 
     @patch.object(DNFModule, "supported_source_types", [SourceType.URL])
     @patch_dbus_publish_object
@@ -86,7 +86,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         source1 = self.shared_tests.prepare_source(SourceType.URL, SourceState.NOT_APPLICABLE)
 
         sources = [source1]
-        self.shared_tests.check_set_sources(sources)
+        self.shared_tests.set_and_check_sources(sources)
 
         source2 = self.shared_tests.prepare_source(SourceType.URL)
         self.module.add_source(source2)
@@ -101,7 +101,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         source1 = self.shared_tests.prepare_source(SourceType.URL, SourceState.NOT_APPLICABLE)
 
         sources = [source1]
-        self.shared_tests.check_set_sources(sources)
+        self.shared_tests.set_and_check_sources(sources)
 
         source2 = self.shared_tests.prepare_source(SourceType.NFS)
         with self.assertRaises(IncompatibleSourceError):
@@ -116,7 +116,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         source1 = self.shared_tests.prepare_source(SourceType.URL, SourceState.READY)
 
         sources = [source1]
-        self.shared_tests.check_set_sources(sources)
+        self.shared_tests.set_and_check_sources(sources)
 
         source2 = self.shared_tests.prepare_source(SourceType.URL)
         with self.assertRaises(SourceSetupError):
@@ -134,7 +134,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
             self.shared_tests.prepare_source(SourceType.URL),
         ]
 
-        self.shared_tests.check_set_sources(sources)
+        self.shared_tests.set_and_check_sources(sources)
 
     @patch.object(DNFModule, "supported_source_types", [SourceType.URL])
     @patch_dbus_publish_object
@@ -142,7 +142,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         """Test payload setting incompatible sources."""
         sources = [self.shared_tests.prepare_source(SourceType.LIVE_OS_IMAGE)]
 
-        cm = self.shared_tests.check_set_sources(sources, exception=IncompatibleSourceError)
+        cm = self.shared_tests.set_and_check_sources(sources, exception=IncompatibleSourceError)
 
         msg = "Source type {} is not supported by this payload.".format(
             SourceType.LIVE_OS_IMAGE.value)
@@ -155,7 +155,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         source1 = self.shared_tests.prepare_source(SourceType.NFS)
         source2 = self.shared_tests.prepare_source(SourceType.URL, state=SourceState.NOT_APPLICABLE)
 
-        self.shared_tests.check_set_sources([source1])
+        self.shared_tests.set_and_check_sources([source1])
 
         # can't switch source if attached source is ready
         source1.get_state.return_value = SourceState.READY
@@ -164,7 +164,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
 
         # change to source2 when attached source state is UNREADY
         source1.get_state.return_value = SourceState.UNREADY
-        self.shared_tests.check_set_sources([source2])
+        self.shared_tests.set_and_check_sources([source2])
 
         # can change back anytime because source2 has state NOT_APPLICABLE
-        self.shared_tests.check_set_sources([source1])
+        self.shared_tests.set_and_check_sources([source1])

--- a/tests/nosetests/pyanaconda_tests/module_payload_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_base_test.py
@@ -79,6 +79,51 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
 
         self.shared_tests.check_set_sources(sources)
 
+    @patch.object(DNFModule, "supported_source_types", [SourceType.URL])
+    @patch_dbus_publish_object
+    def add_source_test(self, publisher):
+        """Test module API to add source."""
+        source1 = self.shared_tests.prepare_source(SourceType.URL, SourceState.NOT_APPLICABLE)
+
+        sources = [source1]
+        self.shared_tests.check_set_sources(sources)
+
+        source2 = self.shared_tests.prepare_source(SourceType.URL)
+        self.module.add_source(source2)
+
+        sources.append(source2)
+        self.shared_tests.check_sources(sources)
+
+    @patch.object(DNFModule, "supported_source_types", [SourceType.URL])
+    @patch_dbus_publish_object
+    def add_source_incompatible_source_failed_test(self, publisher):
+        """Test module API to add source failed with incompatible source."""
+        source1 = self.shared_tests.prepare_source(SourceType.URL, SourceState.NOT_APPLICABLE)
+
+        sources = [source1]
+        self.shared_tests.check_set_sources(sources)
+
+        source2 = self.shared_tests.prepare_source(SourceType.NFS)
+        with self.assertRaises(IncompatibleSourceError):
+            self.module.add_source(source2)
+
+        self.shared_tests.check_sources(sources)
+
+    @patch.object(DNFModule, "supported_source_types", [SourceType.URL])
+    @patch_dbus_publish_object
+    def add_source_ready_failed_test(self, publisher):
+        """Test module API to add source failed with ready source."""
+        source1 = self.shared_tests.prepare_source(SourceType.URL, SourceState.READY)
+
+        sources = [source1]
+        self.shared_tests.check_set_sources(sources)
+
+        source2 = self.shared_tests.prepare_source(SourceType.URL)
+        with self.assertRaises(SourceSetupError):
+            self.module.add_source(source2)
+
+        self.shared_tests.check_sources(sources)
+
     @patch.object(DNFModule, "supported_source_types", [SourceType.URL, SourceType.NFS])
     @patch_dbus_publish_object
     def set_multiple_source_test(self, publisher):

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
@@ -21,6 +21,8 @@ import unittest
 
 from tests.nosetests.pyanaconda_tests.module_payload_shared import PayloadSharedTest
 
+from pyanaconda.core.constants import SOURCE_TYPE_CDROM, SOURCE_TYPE_HDD, SOURCE_TYPE_HMC, \
+    SOURCE_TYPE_NFS, SOURCE_TYPE_REPO_FILES, SOURCE_TYPE_URL
 from pyanaconda.modules.payloads.constants import PayloadType
 from pyanaconda.modules.payloads.payload.dnf.dnf import DNFModule
 from pyanaconda.modules.payloads.payload.dnf.dnf_interface import DNFInterface
@@ -29,12 +31,23 @@ from pyanaconda.modules.payloads.payload.dnf.dnf_interface import DNFInterface
 class DNFInterfaceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.dnf_module = DNFModule()
-        self.dnf_interface = DNFInterface(self.dnf_module)
+        self.module = DNFModule()
+        self.interface = DNFInterface(self.module)
 
         self.shared_tests = PayloadSharedTest(self,
-                                              payload=self.dnf_module,
-                                              payload_intf=self.dnf_interface)
+                                              payload=self.module,
+                                              payload_intf=self.interface)
 
     def type_test(self):
         self.shared_tests.check_type(PayloadType.DNF)
+
+    def supported_sources_test(self):
+        """Test DNF supported sources API."""
+        self.assertEqual(
+            [SOURCE_TYPE_CDROM,
+             SOURCE_TYPE_HDD,
+             SOURCE_TYPE_HMC,
+             SOURCE_TYPE_NFS,
+             SOURCE_TYPE_REPO_FILES,
+             SOURCE_TYPE_URL],
+            self.interface.SupportedSourceTypes)

--- a/tests/nosetests/pyanaconda_tests/module_payload_factory_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_factory_test.py
@@ -48,6 +48,32 @@ class PayloadFactoryTestCase(TestCase):
             PayloadType.LIVE_IMAGE,
             "liveimg --url http://my/path"
         )
+
+        self._check_payload_type(
+            PayloadType.DNF,
+            "cdrom"
+        )
+
+        self._check_payload_type(
+            PayloadType.DNF,
+            "hmc"
+        )
+
+        self._check_payload_type(
+            PayloadType.DNF,
+            "harddrive --partition=Glum1 --dir=something/precious"
+        )
+
+        self._check_payload_type(
+            PayloadType.DNF,
+            "nfs --server=ring.com --dir=Moria"
+        )
+
+        self._check_payload_type(
+            PayloadType.DNF,
+            "url --url=lonely_mountain.erebor/GOLD!"
+        )
+
         self._check_payload_type(
             None,
             ""

--- a/tests/nosetests/pyanaconda_tests/module_payload_factory_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_factory_test.py
@@ -49,10 +49,6 @@ class PayloadFactoryTestCase(TestCase):
             "liveimg --url http://my/path"
         )
         self._check_payload_type(
-            PayloadType.DNF,
-            "%packages\na\nb\nc\n%end"
-        )
-        self._check_payload_type(
             None,
             ""
         )

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -56,7 +56,7 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
 
     def _prepare_and_use_source(self):
         source = self._prepare_source()
-        self.shared_tests.set_sources([source])
+        self.live_os_module.set_sources([source])
 
         return source
 
@@ -96,9 +96,8 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
 
         # can't switch source if attached source is ready
         source1.get_state.return_value = SourceState.READY
-        self.shared_tests.check_set_sources([source2],
-                                            exception=SourceSetupError,
-                                            expected_sources=[source1])
+        self.shared_tests.set_sources([source2], SourceSetupError)
+        self.shared_tests.check_sources([source1])
 
         source1.get_state.return_value = SourceState.UNREADY
         self.shared_tests.check_set_sources([source1])

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -74,7 +74,7 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
         """Test if set source API of LiveOS payload."""
         sources = [self._prepare_source()]
 
-        self.shared_tests.check_set_sources(sources)
+        self.shared_tests.set_and_check_sources(sources)
 
     @patch_dbus_publish_object
     def set_multiple_sources_fail_test(self, publisher):
@@ -84,7 +84,7 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
             self._prepare_source()
         ]
 
-        self.shared_tests.check_set_sources(paths, exception=IncompatibleSourceError)
+        self.shared_tests.set_and_check_sources(paths, exception=IncompatibleSourceError)
 
     @patch_dbus_publish_object
     def set_when_initialized_source_fail_test(self, publisher):
@@ -92,7 +92,7 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
         source1 = self._prepare_source()
         source2 = self._prepare_source()
 
-        self.shared_tests.check_set_sources([source1])
+        self.shared_tests.set_and_check_sources([source1])
 
         # can't switch source if attached source is ready
         source1.get_state.return_value = SourceState.READY
@@ -100,7 +100,7 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
         self.shared_tests.check_sources([source1])
 
         source1.get_state.return_value = SourceState.UNREADY
-        self.shared_tests.check_set_sources([source1])
+        self.shared_tests.set_and_check_sources([source1])
 
     @patch("pyanaconda.modules.payloads.payload.live_os.live_os.get_dir_size")
     @patch_dbus_publish_object

--- a/tests/nosetests/pyanaconda_tests/module_payload_packages_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_packages_test.py
@@ -38,6 +38,8 @@ from pyanaconda.modules.payloads.packages.constants import TIMEOUT_UNSET, RETRIE
     LANGUAGES_DEFAULT, LANGUAGES_NONE
 
 
+# TODO: Add this back when packages section is supported by DNF module.
+@unittest.skip("Skipping until %packages are supported by payloads service")
 class PackagesKSTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/tests/nosetests/pyanaconda_tests/module_payload_shared.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_shared.py
@@ -100,55 +100,45 @@ class PayloadSharedTest(object):
 
         return source
 
-    def set_sources(self, sources):
-        """Set sources list to payload object.
-
-        This will not call DBus API.
-
-        :param sources: list of source objects to be set
-        """
-        self.payload.set_sources(sources)
-
     def check_empty_sources(self):
         """Default check for payload with no sources set."""
         self._test.assertEqual([], self.payload_interface.Sources)
         self._test.assertFalse(self.payload_interface.HasSource())
 
-    def check_set_sources(self, test_sources, exception=None, expected_sources=None):
+    def check_set_sources(self, test_sources, exception=None):
         """Default check to set sources.
 
         :param test_sources: list of sources for emptiness failed check
         :type test_sources: list of source instances
         :param exception: exception class which will be raised for the given sources
-        :param expected_sources: list of expected sources after trying to set;
-                                 including when exception raised
-        :type expected_sources: list of source instances
+        :return: caught exception if exception raised
+        """
+        ret = self.set_sources(test_sources, exception)
+
+        if exception:
+            self.check_sources([])
+        else:
+            self.check_sources(test_sources)
+
+        return ret
+
+    def set_sources(self, test_sources, exception=None):
+        """Set sources to payload.
+
+        :param test_sources: list of sources for emptiness failed check
+        :type test_sources: list of source instances
+        :param exception: exception class which will be raised for the given sources
         :return: caught exception if exception raised
         """
         paths = PayloadSourceContainer.to_object_path_list(test_sources)
-        ret = None
 
         if exception:
             with self._test.assertRaises(exception) as cm:
                 self.payload_interface.SetSources(paths)
-            ret = cm
-        else:
-            self.payload_interface.SetSources(paths)
+            return cm
 
-        if expected_sources:
-            expected_paths = PayloadSourceContainer.to_object_path_list(expected_sources)
-
-            self._test.assertEqual(self.payload_interface.Sources, expected_paths)
-            self._test.assertTrue(self.payload_interface.HasSource())
-        elif exception:
-            self._test.assertEqual(self.payload_interface.Sources, [])
-            self._test.assertFalse(self.payload_interface.HasSource())
-        else:
-            self._test.assertEqual(self.payload_interface.Sources, paths)
-            self._test.assertTrue(self.payload_interface.HasSource())
-
-        return ret
-
+        self.payload_interface.SetSources(paths)
+        return None
 
     def check_sources(self, expected_sources=None):
         """Check what sources are set in payload.
@@ -159,9 +149,9 @@ class PayloadSharedTest(object):
         """
         expected_paths = PayloadSourceContainer.to_object_path_list(expected_sources)
 
+        self._test.assertEqual(self.payload_interface.Sources, expected_paths)
+
         if expected_sources:
-            self._test.assertEqual(self.payload_interface.Sources, expected_paths)
             self._test.assertTrue(self.payload_interface.HasSource())
         else:
-            self._test.assertEqual(self.payload_interface.Sources, [])
             self._test.assertFalse(self.payload_interface.HasSource())

--- a/tests/nosetests/pyanaconda_tests/module_payload_shared.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_shared.py
@@ -148,3 +148,20 @@ class PayloadSharedTest(object):
             self._test.assertTrue(self.payload_interface.HasSource())
 
         return ret
+
+
+    def check_sources(self, expected_sources=None):
+        """Check what sources are set in payload.
+
+        :param expected_sources: list of expected sources after trying to set;
+                                 including when exception raised
+        :type expected_sources: list of source instances
+        """
+        expected_paths = PayloadSourceContainer.to_object_path_list(expected_sources)
+
+        if expected_sources:
+            self._test.assertEqual(self.payload_interface.Sources, expected_paths)
+            self._test.assertTrue(self.payload_interface.HasSource())
+        else:
+            self._test.assertEqual(self.payload_interface.Sources, [])
+            self._test.assertFalse(self.payload_interface.HasSource())

--- a/tests/nosetests/pyanaconda_tests/module_payload_shared.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_shared.py
@@ -39,7 +39,7 @@ class PayloadKickstartSharedTest(object):
         self.payload_service = payload_service
         self.payload_service_interface = payload_service_intf
 
-    def check_kickstart(self, ks_in, ks_out, ks_valid=True, expected_publish_calls=1):
+    def check_kickstart(self, ks_in, ks_out=None, ks_valid=True, expected_publish_calls=1):
         """Test kickstart processing.
 
         :param test_obj: TestCase object (probably self)
@@ -53,7 +53,7 @@ class PayloadKickstartSharedTest(object):
                                                self.payload_service_interface,
                                                ks_in, "", ks_valid, ks_tmp=ks_out)
 
-            if ks_valid:
+            if ks_valid and expected_publish_calls != 0:
                 publisher.assert_called()
                 self._test.assertEqual(publisher.call_count, expected_publish_calls)
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_shared.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_shared.py
@@ -105,7 +105,7 @@ class PayloadSharedTest(object):
         self._test.assertEqual([], self.payload_interface.Sources)
         self._test.assertFalse(self.payload_interface.HasSource())
 
-    def check_set_sources(self, test_sources, exception=None):
+    def set_and_check_sources(self, test_sources, exception=None):
         """Default check to set sources.
 
         :param test_sources: list of sources for emptiness failed check

--- a/tests/nosetests/pyanaconda_tests/module_payloads_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payloads_test.py
@@ -61,7 +61,7 @@ class PayloadsInterfaceTestCase(TestCase):
             "nfs",
             "url"
         ])
-        self.assertEqual(self.payload_interface.KickstartSections, ["packages"])
+        self.assertEqual(self.payload_interface.KickstartSections, [])
         self.assertEqual(self.payload_interface.KickstartAddons, [])
 
     def no_payload_set_test(self):

--- a/tests/nosetests/pyanaconda_tests/module_payloads_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payloads_test.py
@@ -53,7 +53,14 @@ class PayloadsInterfaceTestCase(TestCase):
 
     def kickstart_properties_test(self):
         """Test kickstart properties."""
-        self.assertEqual(self.payload_interface.KickstartCommands, ['liveimg'])
+        self.assertEqual(self.payload_interface.KickstartCommands, [
+            "cdrom",
+            "harddrive",
+            "hmc",
+            "liveimg",
+            "nfs",
+            "url"
+        ])
         self.assertEqual(self.payload_interface.KickstartSections, ["packages"])
         self.assertEqual(self.payload_interface.KickstartAddons, [])
 

--- a/tests/nosetests/pyanaconda_tests/module_payloads_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payloads_test.py
@@ -26,6 +26,8 @@ from tempfile import TemporaryDirectory
 
 from pyanaconda.core.constants import SOURCE_TYPE_LIVE_OS_IMAGE
 from tests.nosetests.pyanaconda_tests import patch_dbus_publish_object, check_dbus_object_creation
+from tests.nosetests.pyanaconda_tests.module_payload_shared import PayloadKickstartSharedTest
+
 from pyanaconda.modules.common.containers import PayloadContainer
 from pyanaconda.modules.common.errors.payload import SourceSetupError, SourceTearDownError, \
     PayloadNotSetError
@@ -51,6 +53,10 @@ class PayloadsInterfaceTestCase(TestCase):
         self.payload_module = PayloadsService()
         self.payload_interface = PayloadsInterface(self.payload_module)
 
+        self.shared_ks_tests = PayloadKickstartSharedTest(self,
+                                                          self.payload_module,
+                                                          self.payload_interface)
+
     def kickstart_properties_test(self):
         """Test kickstart properties."""
         self.assertEqual(self.payload_interface.KickstartCommands, [
@@ -63,6 +69,18 @@ class PayloadsInterfaceTestCase(TestCase):
         ])
         self.assertEqual(self.payload_interface.KickstartSections, [])
         self.assertEqual(self.payload_interface.KickstartAddons, [])
+
+    def no_kickstart_test(self):
+        """Test kickstart is not set to the payloads service."""
+        ks_in = None
+        ks_out = ""
+        self.shared_ks_tests.check_kickstart(ks_in, ks_out, expected_publish_calls=0)
+
+    def kickstart_empty_test(self):
+        """Test kickstart is empty for the payloads service."""
+        ks_in = ""
+        ks_out = ""
+        self.shared_ks_tests.check_kickstart(ks_in, ks_out, expected_publish_calls=0)
 
     def no_payload_set_test(self):
         """Test empty string is returned when no payload is set."""

--- a/tests/nosetests/pyanaconda_tests/module_source_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_base_test.py
@@ -52,6 +52,13 @@ class DummySetUpMountTaskSubclass(SetUpMountTask):
         pass
 
 
+class SourceBaseTestCase(unittest.TestCase):
+
+    def source_repr_test(self):
+        module = DummyMountingSourceSubclass()
+        self.assertEqual(repr(module), "Source(URL)")
+
+
 class MountingSourceBaseTestCase(unittest.TestCase):
 
     def counter_test(self):


### PR DESCRIPTION
This is first part of the [DNF kickstart support](https://github.com/rhinstaller/anaconda/pull/2474).

These are separated commits already reviewed in the https://github.com/rhinstaller/anaconda/pull/2474 to make it smaller and easier for review.