### PR TITLE
Add the DBus method GetModules to the Boss service

### DIFF
--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -53,6 +53,16 @@ class Boss(Service):
         DBus.publish_object(BOSS.object_path, BossInterface(self))
         DBus.register_service(BOSS.service_name)
 
+    def get_modules(self):
+        """Get service names of running modules.
+
+        Get a list of all running DBus modules (including addons)
+        that were discovered and started by the boss.
+
+        :return: a list of service names
+        """
+        return self._module_manager.get_service_names()
+
     def start_modules_with_task(self):
         """Start the modules with the task."""
         return self._module_manager.start_modules_with_task()

--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -29,6 +29,16 @@ from pyanaconda.modules.common.structures.kickstart import KickstartReport
 class BossInterface(InterfaceTemplate):
     """DBus interface for the Boss."""
 
+    def GetModules(self) -> List[Str]:
+        """Get service names of running modules.
+
+        Get a list of all running DBus modules (including addons)
+        that were discovered and started by the boss.
+
+        :return: a list of service names
+        """
+        return self.implementation.get_modules()
+
     def StartModulesWithTask(self) -> ObjPath:
         """Start modules with the task.
 

--- a/pyanaconda/modules/boss/module_manager/module_manager.py
+++ b/pyanaconda/modules/boss/module_manager/module_manager.py
@@ -54,6 +54,21 @@ class ModuleManager(object):
         )
         return task
 
+    def get_service_names(self):
+        """Get service names of running modules.
+
+        :return: a list of service names
+        """
+        names = []
+
+        for observer in self.module_observers:
+            if not observer.is_service_available:
+                continue
+
+            names.append(observer.service_name)
+
+        return names
+
     def set_modules_locale(self, locale):
         """Set locale of all modules.
 

--- a/tests/nosetests/pyanaconda_tests/module_boss_modules_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_boss_modules_test.py
@@ -132,3 +132,20 @@ class ModuleManagerTestCase(unittest.TestCase):
 
         expected = "Service org.fedoraproject.Anaconda.Modules.A has failed to start: Fake error!"
         self.assertEqual(str(cm.exception), expected)
+
+    @patch("dasbus.client.observer.Gio")
+    def get_service_names_test(self, gio):
+        """Get service names of running modules."""
+        self.assertEqual(self._manager.get_service_names(), [])
+
+        service_names = [
+            "org.fedoraproject.Anaconda.Modules.A",
+            "org.fedoraproject.Anaconda.Modules.B",
+            "org.fedoraproject.Anaconda.Modules.C",
+        ]
+
+        task = StartModulesTask(self._message_bus, service_names, addons_enabled=False)
+        observers = self._check_started_modules(task, service_names)
+
+        self._manager.set_module_observers(observers)
+        self.assertEqual(self._manager.get_service_names(), service_names)

--- a/tests/nosetests/pyanaconda_tests/module_boss_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_boss_test.py
@@ -36,6 +36,35 @@ class BossInterfaceTestCase(unittest.TestCase):
         self.module = Boss()
         self.interface = BossInterface(self.module)
 
+    def _add_module(self, service_name, available=True):
+        """Add a DBus module."""
+        observer = Mock(
+            service_name=service_name,
+            is_service_available=available
+        )
+
+        module_manager = self.module._module_manager
+        observers = list(module_manager.module_observers)
+        observers.append(observer)
+
+        module_manager.set_module_observers(observers)
+        return observer
+
+    def get_modules_test(self):
+        """Test GetModules."""
+        self.assertEqual(self.interface.GetModules(), [])
+
+        self._add_module("org.fedoraproject.Anaconda.Modules.A")
+        self._add_module("org.fedoraproject.Anaconda.Modules.B")
+        self._add_module("org.fedoraproject.Anaconda.Addons.C", available=False)
+        self._add_module("org.fedoraproject.Anaconda.Addons.D")
+
+        self.assertEqual(self.interface.GetModules(), [
+            "org.fedoraproject.Anaconda.Modules.A",
+            "org.fedoraproject.Anaconda.Modules.B",
+            "org.fedoraproject.Anaconda.Addons.D"
+        ])
+
     @patch_dbus_publish_object
     def start_modules_with_task_test(self, publisher):
         """Test StartModulesWithTask."""


### PR DESCRIPTION
Call the DBus method `GetModules` to get service names of all running DBus modules
(including addons) that were discovered and started by the boss.