### PR TITLE
Destroy the disk selection dialog on escape

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -1201,6 +1201,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         )
         with self.main_window.enlightbox(dialog.window):
             rc = dialog.run()
+            dialog.window.destroy()
 
         if rc != 1:
             return


### PR DESCRIPTION
The "Configure mount point" dialog window for selecting disk devices for standard partitions doesn't close after pressing Esc (it's necessary to press Esc twice).