### PR TITLE
Do not offer disk selection when encrypting existing partition

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -959,6 +959,7 @@ def generate_device_factory_permissions(storage, request: DeviceFactoryRequest):
 
     permissions.disks = \
         not device.exists \
+        and not device.raw_device.exists \
         and request.device_type not in CONTAINER_DEVICE_TYPES
 
     can_change_container = \


### PR DESCRIPTION
Anaconda allowed to enter the "Configure mount point" window when
re-using an existing partition and making it encrypted.