### PR TITLE
Improve behavior of the boot loader selection window

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/cart.py
+++ b/pyanaconda/ui/gui/spokes/lib/cart.py
@@ -71,6 +71,10 @@ class SelectedDisksDialog(GUIObject):
         if not set_boot:
             self._set_button.hide()
 
+        # no disk is selected by default, inactivate the buttons
+        self._set_button.set_sensitive(False)
+        self._remove_button.set_sensitive(False)
+
     @property
     def disks(self):
         """Selected disks.
@@ -196,6 +200,11 @@ class SelectedDisksDialog(GUIObject):
 
     def on_selection_changed(self, *args):
         itr = self._selection.get_selected()[1]
+
+        # make the buttons (in)active if something/nothing is  selected
+        self._set_button.set_sensitive(bool(itr))
+        self._remove_button.set_sensitive(bool(itr))
+
         if not itr:
             return
 

--- a/pyanaconda/ui/gui/spokes/lib/cart.py
+++ b/pyanaconda/ui/gui/spokes/lib/cart.py
@@ -151,6 +151,8 @@ class SelectedDisksDialog(GUIObject):
 
         if reset_boot_device and len(self._store) > 0:
             self._store[0][IS_BOOT_COL] = True
+            self._previous_boot_device = self._store[0][NAME_COL]
+            self._toggle_button_text(self._store[0])
 
         self._update_summary()
 


### PR DESCRIPTION
The UI in the "Select disks and boot loader" window  was not properly updated after removing the disk marked as a boot device:
* The first disk was correctly marked as a new boot device, but it was possible to set one more disk as a boot device.
* The label of the "set as boot" button was not updated properly.

Activate the set/remove buttons in the "Select disks and boot loader" window only when a disk is selected