### PR TITLE
subscription: Attach subscription task

### DIFF
--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -139,3 +139,8 @@ RHSM_UNREGISTER = DBusObjectIdentifier(
     namespace=RHSM_NAMESPACE,
     basename="Unregister"
 )
+
+RHSM_ATTACH = DBusObjectIdentifier(
+    namespace=RHSM_NAMESPACE,
+    basename="Attach"
+)

--- a/pyanaconda/modules/common/errors/subscription.py
+++ b/pyanaconda/modules/common/errors/subscription.py
@@ -31,3 +31,9 @@ class RegistrationError(AnacondaError):
 class UnregistrationError(AnacondaError):
     """Unregistration attempt failed."""
     pass
+
+
+@dbus_error("SubscriptionError", namespace=ANACONDA_NAMESPACE)
+class SubscriptionError(AnacondaError):
+    """Subscription attempt failed."""
+    pass

--- a/pyanaconda/modules/subscription/runtime.py
+++ b/pyanaconda/modules/subscription/runtime.py
@@ -28,7 +28,7 @@ from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.common.constants.services import RHSM
 from pyanaconda.modules.common.constants.objects import RHSM_REGISTER
 from pyanaconda.modules.common.errors.subscription import RegistrationError, \
-    UnregistrationError
+    UnregistrationError, SubscriptionError
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -289,3 +289,43 @@ class UnregisterTask(Task):
             # is missing
             message = exception_dict.get("message", _("Unregistration failed."))
             raise UnregistrationError(message) from None
+
+
+class AttachSubscriptionTask(Task):
+    """Attach a subscription."""
+
+    def __init__(self, rhsm_attach_proxy, sla):
+        """Create a new subscription task.
+
+        :param rhsm_attach_proxy: DBus proxy for the RHSM Attach object
+        :param str sla: organization name for subscription purposes
+        """
+        super().__init__()
+        self._rhsm_attach_proxy = rhsm_attach_proxy
+        self._sla = sla
+
+    @property
+    def name(self):
+        return "Attach a subscription"
+
+    def run(self):
+        """Attach a subscription to the installation environment.
+
+        This subscription will be used for CDN access during the
+        installation and then transferred to the target system
+        via separate DBus task.
+
+        :raises: SubscriptionError if RHSM API DBus call fails
+        """
+        log.debug("subscription: auto-attaching a subscription")
+        try:
+            locale = os.environ.get("LANG", "")
+            result = self._rhsm_attach_proxy.AutoAttach(self._sla, {}, locale)
+            log.debug("subscription: auto-attached a subscription")
+        except DBusError as e:
+            log.debug("subscription: auto-attach failed: %s", str(e))
+            exception_dict = json.loads(str(e))
+            # return a generic error message in case the RHSM provided error message
+            # is missing
+            message = exception_dict.get("message", _("Failed to attach subscription."))
+            raise SubscriptionError(message) from None

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -37,7 +37,7 @@ from pyanaconda.core.dbus import DBus
 
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.modules.common.constants.objects import RHSM_CONFIG, RHSM_REGISTER_SERVER, \
-    RHSM_UNREGISTER
+    RHSM_UNREGISTER, RHSM_ATTACH
 from pyanaconda.modules.common.containers import TaskContainer
 from pyanaconda.modules.common.structures.requirement import Requirement
 
@@ -49,7 +49,7 @@ from pyanaconda.modules.subscription.installation import ConnectToInsightsTask, 
 from pyanaconda.modules.subscription.initialization import StartRHSMTask
 from pyanaconda.modules.subscription.runtime import SetRHSMConfigurationTask, \
     RegisterWithUsernamePasswordTask, RegisterWithOrganizationKeyTask, \
-    UnregisterTask
+    UnregisterTask, AttachSubscriptionTask
 from pyanaconda.modules.subscription.rhsm_observer import RHSMObserver
 
 
@@ -621,6 +621,24 @@ class SubscriptionService(KickstartService):
         # so set the corresponding property appropriately
         task.succeeded_signal.connect(
             lambda: self.set_subscription_attached(False))
+        return task
+
+    def attach_subscription_with_task(self):
+        """Attach a subscription.
+
+        This should only be run on a system that has been successfully registered.
+        Attached subscription depends on system type, system purpose data
+        and entitlements available for the account that has been used for registration.
+
+        :return: a DBus path of an installation task
+        """
+        sla = self.system_purpose_data.sla
+        rhsm_attach_proxy = self.rhsm_observer.get_proxy(RHSM_ATTACH)
+        task = AttachSubscriptionTask(rhsm_attach_proxy=rhsm_attach_proxy,
+                                      sla=sla)
+        # if the task succeeds, it means a subscription has been attached
+        task.succeeded_signal.connect(
+            lambda: self.set_subscription_attached(True))
         return task
 
     def collect_requirements(self):

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -180,3 +180,12 @@ class SubscriptionInterface(KickstartModuleInterface):
         return TaskContainer.to_object_path(
             self.implementation.unregister_with_task()
         )
+
+    def AttachSubscriptionWithTask(self) -> ObjPath:
+        """Attach subscription using a runtime DBus task.
+
+        :return: a DBus path of an installation task
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.attach_subscription_with_task()
+        )

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
@@ -42,7 +42,7 @@ from pyanaconda.modules.subscription.installation import ConnectToInsightsTask, 
     SystemPurposeConfigurationTask, RestoreRHSMLogLevelTask, TransferSubscriptionTokensTask
 from pyanaconda.modules.subscription.runtime import SetRHSMConfigurationTask, \
     RegisterWithUsernamePasswordTask, RegisterWithOrganizationKeyTask, \
-    UnregisterTask
+    UnregisterTask, AttachSubscriptionTask
 
 from tests.nosetests.pyanaconda_tests import check_kickstart_interface, check_dbus_property, \
     PropertiesChangedCallback, patch_dbus_publish_object, check_task_creation_list, \
@@ -1219,6 +1219,36 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         obj.implementation.succeeded_signal.emit()
         # check this set subscription_attached to False
         self.assertFalse(self.subscription_interface.IsSubscriptionAttached)
+
+    @patch_dbus_publish_object
+    def attach_subscription_test(self, publisher):
+        """Test AttachSubscriptionTask creation."""
+        # create the SystemPurposeData structure
+        system_purpose_data = SystemPurposeData()
+        system_purpose_data.role = "foo"
+        system_purpose_data.sla = "bar"
+        system_purpose_data.usage = "baz"
+        system_purpose_data.addons = ["a", "b", "c"]
+        # feed it to the DBus interface
+        self.subscription_interface.SetSystemPurposeData(
+            SystemPurposeData.to_structure(system_purpose_data)
+        )
+        # make sure system is not subscribed
+        self.assertFalse(self.subscription_interface.IsSubscriptionAttached)
+        # make sure the task gets dummy rhsm attach proxy
+        observer = Mock()
+        self.subscription_module._rhsm_observer = observer
+        rhsm_attach_proxy = observer.get_proxy.return_value
+        # check the task is created correctly
+        task_path = self.subscription_interface.AttachSubscriptionWithTask()
+        obj = check_task_creation(self, task_path, publisher, AttachSubscriptionTask)
+        # check all the data got propagated to the module correctly
+        self.assertEqual(obj.implementation._rhsm_attach_proxy, rhsm_attach_proxy)
+        self.assertEqual(obj.implementation._sla, "bar")
+        # trigger the succeeded signal
+        obj.implementation.succeeded_signal.emit()
+        # check this set subscription_attached to True
+        self.assertTrue(self.subscription_interface.IsSubscriptionAttached)
 
     @patch_dbus_publish_object
     def install_with_tasks_default_test(self, publisher):


### PR DESCRIPTION
The AttachSubscription task should be run after the system
has been successfully registered. It makes sure that appropriate
subscriptions are attached to the system based on system architecture,
account used for registration and system purpose data.

Note that this effectively subscribes the running installation
environment, so that it can communicate with the CDN and install
packages from it. Separate TransferSubscriptionTokens install time
task then makes sure the subscription tokens and configuration
files are transferred to the target system.