### PR TITLE
subscription: Run install time subscription tasks

### DIFF
--- a/pyanaconda/modules/common/util.py
+++ b/pyanaconda/modules/common/util.py
@@ -1,0 +1,32 @@
+#
+# Shared module related utility functions.
+#
+# Copyright (C) 2020  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from pyanaconda.modules.common.constants.services import BOSS
+
+
+def is_module_available(module_service_identifier):
+    """Check if the module appears to be running.
+
+    :param module_service_identifier: module service identifier to check
+    :type module_service_identifier: DBusServiceIdentifier instance
+    :return: True if module is running, False otherwise
+    :rtype: bool
+    """
+    boss_proxy = BOSS.get_proxy()
+    return module_service_identifier.service_name in boss_proxy.GetModules()

--- a/tests/nosetests/pyanaconda_tests/module_util_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_util_test.py
@@ -1,0 +1,70 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
+
+import unittest
+from unittest.mock import patch
+
+from pyanaconda.modules.common.constants.services import SUBSCRIPTION
+from pyanaconda.modules.common.util import is_module_available
+
+
+class IsModuleAvailableTestCase(unittest.TestCase):
+    """Test the is_module_available() utility function."""
+
+    @patch("pyanaconda.modules.common.constants.services.BOSS.get_proxy")
+    def is_module_available_test(self, get_proxy):
+        """Test the is_module_available() function - module available."""
+        # mock the Boss proxy
+        boss_proxy = get_proxy.return_value
+        # make sure it returns a list containing the Subscription module
+        running_modules = [
+            "org.fedoraproject.Anaconda.Modules.Timezone",
+            "org.fedoraproject.Anaconda.Modules.Network",
+            "org.fedoraproject.Anaconda.Modules.Localization",
+            "org.fedoraproject.Anaconda.Modules.Security",
+            "org.fedoraproject.Anaconda.Modules.Users",
+            "org.fedoraproject.Anaconda.Modules.Payloads",
+            "org.fedoraproject.Anaconda.Modules.Storage",
+            "org.fedoraproject.Anaconda.Modules.Services",
+            "org.fedoraproject.Anaconda.Modules.Subscription",
+         ]
+        boss_proxy.GetModules.return_value = running_modules
+        # call the function
+        self.assertTrue(is_module_available(SUBSCRIPTION))
+
+    @patch("pyanaconda.modules.common.constants.services.BOSS.get_proxy")
+    def is_module_not_available_test(self, get_proxy):
+        """Test the is_module_available() function - module not available."""
+        # mock the Boss proxy
+        boss_proxy = get_proxy.return_value
+        # make sure it returns a list not containing the Subscription module
+        running_modules = [
+            "org.fedoraproject.Anaconda.Modules.Timezone",
+            "org.fedoraproject.Anaconda.Modules.Network",
+            "org.fedoraproject.Anaconda.Modules.Localization",
+            "org.fedoraproject.Anaconda.Modules.Security",
+            "org.fedoraproject.Anaconda.Modules.Users",
+            "org.fedoraproject.Anaconda.Modules.Payloads",
+            "org.fedoraproject.Anaconda.Modules.Storage",
+            "org.fedoraproject.Anaconda.Modules.Services",
+         ]
+        boss_proxy.GetModules.return_value = running_modules
+        # call the function
+        self.assertFalse(is_module_available(SUBSCRIPTION))


### PR DESCRIPTION
The first commit introduces a helper function for easy checking if the Subscription module is running (due to this the PR is temporarily based on top of #2486). The second commit adds the Subscription module provided installation tasks to the installation task queue, provided the Subscription module is running.

~**NOTE:** When working on this I've realized there is no longer a reason to handle the System Purpose configuration task separately & there will be a followup PR that drops it's `with_task()`/`WithTask()` methods and rolls it to the list of regular installation tasks.~
See PR #2496.