### PR TITLE
Add get_repo_configuration() for DNF payload

### DIFF
--- a/pyanaconda/modules/common/structures/payload.py
+++ b/pyanaconda/modules/common/structures/payload.py
@@ -20,6 +20,8 @@
 
 from dasbus.structure import DBusData
 from dasbus.typing import *  # pylint: disable=wildcard-import
+
+from pyanaconda.core.util import join_paths
 from pyanaconda.core.constants import URL_TYPE_BASEURL, DNF_DEFAULT_REPO_COST
 
 __all__ = ["RepoConfigurationData", "SSLConfigurationData"]
@@ -81,6 +83,21 @@ class RepoConfigurationData(DBusData):
         self._cost = DNF_DEFAULT_REPO_COST
         self._exclude_packages = []
         self._included_packages = []
+
+    @classmethod
+    def from_directory(cls, directory_path):
+        """Generate RepoConfigurationData url from directory path.
+
+        This will basically add file:/// to the directory and set it to url with a proper type.
+
+        :param str directory_path: directory which will be used to create url
+        :return: RepoConfigurationData instance
+        """
+        data = RepoConfigurationData()
+
+        data.url = join_paths("file:///", directory_path)
+
+        return data
 
     @property
     def name(self) -> Str:

--- a/pyanaconda/modules/payloads/payload/dnf/dnf.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf.py
@@ -69,6 +69,23 @@ class DNFModule(PayloadBase):
         for source in self.sources:
             source.setup_kickstart(data)
 
+    def get_repo_configurations(self):
+        """Get RepoConfiguration structures for all sources.
+
+        These structures will be used by DNF payload in the main process.
+
+        FIXME: This is a temporary solution. Will be removed after DNF payload logic is moved.
+
+        :return: RepoConfiguration structures for attached sources.
+        :rtype: RepoConfigurationData instances
+        """
+        structures = []
+
+        for source in self.sources:
+            structures.append(source.generate_repo_configuration())
+
+        return structures
+
     def pre_install_with_tasks(self):
         """Execute preparation steps.
 

--- a/pyanaconda/modules/payloads/payload/dnf/dnf_interface.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_interface.py
@@ -18,11 +18,22 @@
 # Red Hat, Inc.
 #
 from dasbus.server.interface import dbus_interface
+from dasbus.typing import *  # pylint: disable=wildcard-import
 
 from pyanaconda.modules.common.constants.interfaces import PAYLOAD_DNF
+from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.payloads.payload.payload_base_interface import PayloadBaseInterface
 
 
 @dbus_interface(PAYLOAD_DNF.interface_name)
 class DNFInterface(PayloadBaseInterface):
     """DBus interface for DNF payload module."""
+
+    def GetRepoConfigurations(self) -> List[Structure]:
+        """Get RepoConfigurationData structures for all attached sources.
+
+        FIXME: This is a temporary solution. Will be removed after DNF payload logic is moved.
+        """
+        return RepoConfigurationData.to_structure_list(
+            self.implementation.get_repo_configurations()
+        )

--- a/pyanaconda/modules/payloads/source/cdrom/cdrom.py
+++ b/pyanaconda/modules/payloads/source/cdrom/cdrom.py
@@ -18,8 +18,9 @@
 # Red Hat, Inc.
 #
 from pyanaconda.core.i18n import _
+from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.payloads.constants import SourceType
-from pyanaconda.modules.payloads.source.source_base import MountingSourceBase
+from pyanaconda.modules.payloads.source.source_base import MountingSourceBase, RPMSourceMixin
 from pyanaconda.modules.payloads.source.cdrom.cdrom_interface import CdromSourceInterface
 from pyanaconda.modules.payloads.source.cdrom.initialization import SetUpCdromSourceTask
 
@@ -27,7 +28,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class CdromSourceModule(MountingSourceBase):
+class CdromSourceModule(MountingSourceBase, RPMSourceMixin):
     """The CD-ROM source payload module."""
 
     @property
@@ -43,6 +44,10 @@ class CdromSourceModule(MountingSourceBase):
     def for_publication(self):
         """Get the interface used to publish this source."""
         return CdromSourceInterface(self)
+
+    def generate_repo_configuration(self):
+        """Generate RepoConfigurationData structure."""
+        return RepoConfigurationData.from_directory(self.mount_point)
 
     def set_up_with_tasks(self):
         """Set up the installation source.

--- a/pyanaconda/modules/payloads/source/harddrive/harddrive.py
+++ b/pyanaconda/modules/payloads/source/harddrive/harddrive.py
@@ -24,8 +24,9 @@ from pykickstart.errors import KickstartParseError
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
 from pyanaconda.core.signal import Signal
+from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.payloads.constants import SourceType, SourceState
-from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase
+from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase, RPMSourceMixin
 from pyanaconda.modules.payloads.source.utils import MountPointGenerator
 from pyanaconda.modules.payloads.source.harddrive.harddrive_interface import \
     HardDriveSourceInterface
@@ -35,7 +36,7 @@ from pyanaconda.modules.payloads.source.mount_tasks import TearDownMountTask
 log = get_module_logger(__name__)
 
 
-class HardDriveSourceModule(PayloadSourceBase):
+class HardDriveSourceModule(PayloadSourceBase, RPMSourceMixin):
     """The Hard drive source payload module."""
 
     def __init__(self):
@@ -86,6 +87,10 @@ class HardDriveSourceModule(PayloadSourceBase):
     def for_publication(self):
         """Get the interface used to publish this source."""
         return HardDriveSourceInterface(self)
+
+    def generate_repo_configuration(self):
+        """Generate RepoConfigurationData structure."""
+        return RepoConfigurationData.from_directory(self.install_tree_path)
 
     @property
     def directory(self):

--- a/pyanaconda/modules/payloads/source/hmc/hmc.py
+++ b/pyanaconda/modules/payloads/source/hmc/hmc.py
@@ -18,10 +18,11 @@
 # Red Hat, Inc.
 #
 from pyanaconda.core.i18n import _
+from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.payloads.constants import SourceType
 from pyanaconda.modules.payloads.source.hmc.hmc_interface import HMCSourceInterface
 from pyanaconda.modules.payloads.source.hmc.initialization import SetUpHMCSourceTask
-from pyanaconda.modules.payloads.source.source_base import MountingSourceBase
+from pyanaconda.modules.payloads.source.source_base import MountingSourceBase, RPMSourceMixin
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -29,7 +30,7 @@ log = get_module_logger(__name__)
 __all__ = ["HMCSourceModule"]
 
 
-class HMCSourceModule(MountingSourceBase):
+class HMCSourceModule(MountingSourceBase, RPMSourceMixin):
     """The SE/HMC source module."""
 
     @property
@@ -45,6 +46,10 @@ class HMCSourceModule(MountingSourceBase):
     def for_publication(self):
         """Return a DBus representation."""
         return HMCSourceInterface(self)
+
+    def generate_repo_configuration(self):
+        """Generate RepoConfigurationData structure."""
+        return RepoConfigurationData.from_directory(self.mount_point)
 
     def set_up_with_tasks(self):
         """Set up the installation source for installation.

--- a/pyanaconda/modules/payloads/source/nfs/nfs.py
+++ b/pyanaconda/modules/payloads/source/nfs/nfs.py
@@ -20,10 +20,11 @@
 from pyanaconda.core.i18n import _
 from pyanaconda.core.payload import create_nfs_url, parse_nfs_url
 from pyanaconda.core.signal import Signal
+from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.payloads.constants import SourceType
 from pyanaconda.modules.payloads.source.nfs.nfs_interface import NFSSourceInterface
 from pyanaconda.modules.payloads.source.nfs.initialization import SetUpNFSSourceTask
-from pyanaconda.modules.payloads.source.source_base import MountingSourceBase
+from pyanaconda.modules.payloads.source.source_base import MountingSourceBase, RPMSourceMixin
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -31,7 +32,7 @@ log = get_module_logger(__name__)
 __all__ = ["NFSSourceModule"]
 
 
-class NFSSourceModule(MountingSourceBase):
+class NFSSourceModule(MountingSourceBase, RPMSourceMixin):
     """The NFS source module."""
 
     def __init__(self):
@@ -66,6 +67,10 @@ class NFSSourceModule(MountingSourceBase):
         data.nfs.dir = path
         data.nfs.opts = opts
         data.nfs.seen = True
+
+    def generate_repo_configuration(self):
+        """Generate RepoConfigurationData structure."""
+        return RepoConfigurationData.from_directory(self.mount_point)
 
     @property
     def url(self):

--- a/pyanaconda/modules/payloads/source/source_base.py
+++ b/pyanaconda/modules/payloads/source/source_base.py
@@ -144,3 +144,17 @@ class MountingSourceBase(PayloadSourceBase, ABC):
         """
         task = TearDownMountTask(self._mount_point)
         return [task]
+
+
+class RPMSourceMixin(ABC):
+    """Interface class which has to be implemented by all sources used by DNF payload."""
+
+    @abstractmethod
+    def generate_repo_configuration(self):
+        """Generate RepoConfigurationData structure.
+
+        This structure will be used by DNF payload in the main process.
+
+        FIXME: This is a temporary solution. Will be removed after DNF payload logic is moved.
+        """
+        pass

--- a/pyanaconda/modules/payloads/source/url/url.py
+++ b/pyanaconda/modules/payloads/source/url/url.py
@@ -24,14 +24,14 @@ from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.modules.common.errors.general import InvalidValueError
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.payloads.constants import SourceType, URLType, SourceState
-from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase
+from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase, RPMSourceMixin
 from pyanaconda.modules.payloads.source.url.url_interface import URLSourceInterface
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class URLSourceModule(PayloadSourceBase):
+class URLSourceModule(PayloadSourceBase, RPMSourceMixin):
     """The URL source payload module."""
 
     REPO_NAME_ID = 0
@@ -112,6 +112,10 @@ class URLSourceModule(PayloadSourceBase):
         data.url.sslclientkey = self.repo_configuration.ssl_configuration.client_key_path
 
         data.url.seen = True
+
+    def generate_repo_configuration(self):
+        """Generate RepoConfigurationData structure."""
+        return self.repo_configuration
 
     def set_up_with_tasks(self):
         """Set up the installation source.

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
@@ -18,14 +18,18 @@
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 #
 import unittest
+from unittest.mock import patch, PropertyMock
 
+from tests.nosetests.pyanaconda_tests import patch_dbus_publish_object
 from tests.nosetests.pyanaconda_tests.module_payload_shared import PayloadSharedTest, \
     PayloadKickstartSharedTest
 
+from dasbus.typing import *  # pylint: disable=wildcard-import
+
 from pyanaconda.core.constants import SOURCE_TYPE_CDROM, SOURCE_TYPE_HDD, SOURCE_TYPE_HMC, \
-    SOURCE_TYPE_NFS, SOURCE_TYPE_REPO_FILES, SOURCE_TYPE_URL
+    SOURCE_TYPE_NFS, SOURCE_TYPE_REPO_FILES, SOURCE_TYPE_URL, URL_TYPE_BASEURL
 from pyanaconda.modules.common.errors.payload import PayloadNotSetError
-from pyanaconda.modules.payloads.constants import PayloadType
+from pyanaconda.modules.payloads.constants import PayloadType, SourceType
 from pyanaconda.modules.payloads.payload.dnf.dnf import DNFModule
 from pyanaconda.modules.payloads.payload.dnf.dnf_interface import DNFInterface
 from pyanaconda.modules.payloads.payloads import PayloadsService
@@ -178,3 +182,77 @@ class DNFInterfaceTestCase(unittest.TestCase):
              SOURCE_TYPE_REPO_FILES,
              SOURCE_TYPE_URL],
             self.interface.SupportedSourceTypes)
+
+    @staticmethod
+    def _generate_expected_repo_configuration_dict(mount_path):
+        return {
+            "name": get_variant(Str, ""),
+            "url": get_variant(Str, mount_path),
+            "type": get_variant(Str, URL_TYPE_BASEURL),
+            "ssl-verification-enabled": get_variant(Bool, True),
+            "ssl-configuration": get_variant(Structure, {
+                "ca-cert-path": get_variant(Str, ""),
+                "client-cert-path": get_variant(Str, ""),
+                "client-key-path": get_variant(Str, "")
+            }),
+            "proxy": get_variant(Str, ""),
+            "cost": get_variant(Int, 1000),
+            "excluded-packages": get_variant(List[Str], []),
+            "included-packages": get_variant(List[Str], [])
+        }
+
+    @patch("pyanaconda.modules.payloads.source.cdrom.cdrom.CdromSourceModule.mount_point",
+           new_callable=PropertyMock)
+    @patch_dbus_publish_object
+    def cdrom_get_repo_configurations_test(self, publisher, mount_point):
+        """Test DNF GetRepoConfigurations for CDROM source."""
+        mount_point.return_value = "/install_source/cdrom"
+        source = self.shared_tests.prepare_source(SourceType.CDROM)
+
+        self.shared_tests.set_sources([source])
+
+        expected = [self._generate_expected_repo_configuration_dict("file:///install_source/cdrom")]
+
+        self.assertEqual(self.interface.GetRepoConfigurations(), expected)
+
+    @patch("pyanaconda.modules.payloads.source.hmc.hmc.HMCSourceModule.mount_point",
+           new_callable=PropertyMock)
+    @patch_dbus_publish_object
+    def hmc_get_repo_configurations_test(self, publisher, mount_point):
+        """Test DNF GetRepoConfigurations for CDROM source."""
+        mount_point.return_value = "/install_source/hmc"
+        source = self.shared_tests.prepare_source(SourceType.HMC)
+
+        self.shared_tests.set_sources([source])
+
+        expected = [self._generate_expected_repo_configuration_dict("file:///install_source/hmc")]
+
+        self.assertEqual(self.interface.GetRepoConfigurations(), expected)
+
+    @patch("pyanaconda.modules.payloads.source.nfs.nfs.NFSSourceModule.mount_point",
+           new_callable=PropertyMock)
+    @patch_dbus_publish_object
+    def nfs_get_repo_configurations_test(self, publisher, mount_point):
+        """Test DNF GetRepoConfigurations for NFS source."""
+        mount_point.return_value = "/install_source/nfs"
+        source = self.shared_tests.prepare_source(SourceType.NFS)
+
+        self.shared_tests.set_sources([source])
+
+        expected = [self._generate_expected_repo_configuration_dict("file:///install_source/nfs")]
+
+        self.assertEqual(self.interface.GetRepoConfigurations(), expected)
+
+    @patch("pyanaconda.modules.payloads.source.harddrive.harddrive.HardDriveSourceModule.install_tree_path",
+           new_callable=PropertyMock)
+    @patch_dbus_publish_object
+    def harddrive_get_repo_configurations_test(self, publisher, mount_point):
+        """Test DNF GetRepoConfigurations for HARDDRIVE source."""
+        mount_point.return_value = "/install_source/harddrive"
+        source = self.shared_tests.prepare_source(SourceType.HDD)
+
+        self.shared_tests.set_sources([source])
+
+        expected = [self._generate_expected_repo_configuration_dict("file:///install_source/harddrive")]
+
+        self.assertEqual(self.interface.GetRepoConfigurations(), expected)


### PR DESCRIPTION
This will provide temporary API which we can use to get sources working in the main process payload. It will provide the necessary data to be able to work with these in the dnf library.

We are re-using the existing `RepoConfigurationData` structure to handle all the sources data.

~This is not finished. I'm waiting for https://github.com/rhinstaller/anaconda/pull/2474 code to finish URL source support.~