### PR TITLE
Ignore the required package dmraid in RHEL

### DIFF
--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -31,6 +31,7 @@ default_on_boot = DEFAULT_ROUTE_DEVICE
 ignored_packages =
     ntfsprogs
     btrfs-progs
+    dmraid
 
 enable_updates = False
 enable_closest_mirror = False


### PR DESCRIPTION
The package dmraid is not available in RHEL 8, so ignore this requirement.

Resolves: rhbz#1831790