### PR TITLE
subscription: Simplified system purpose configuration

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -464,3 +464,6 @@ DEFAULT_SUBSCRIPTION_REQUEST_TYPE = SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD
 # - in seconds
 # - based on the default 90 second systemd service activation timeout
 RHSM_SERVICE_TIMEOUT = 90.0
+
+# Path to the System Purpose configuration file on a system.
+RHSM_SYSPURPOSE_FILE_PATH = "/etc/rhsm/syspurpose/syspurpose.json"

--- a/pyanaconda/core/subscription.py
+++ b/pyanaconda/core/subscription.py
@@ -1,0 +1,40 @@
+#
+# Subscription related helper functions.
+#
+# Copyright (C) 2020  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import os
+
+from pyanaconda.core import util
+from pyanaconda.core.constants import RHSM_SYSPURPOSE_FILE_PATH
+
+
+def check_system_purpose_set(sysroot="/"):
+    """Check if System Purpose has been set for the system.
+
+    By manipulating the sysroot parameter it is possible to
+    check is System Purpose has been set for both the installation
+    environment and the target system.
+
+    For installation environment use "/", for the target system
+    path to the installation root.
+
+    :param str sysroot: system root where to check
+    :return: True if System Purpose has been set, False otherwise
+    """
+    syspurpose_path = util.join_paths(sysroot, RHSM_SYSPURPOSE_FILE_PATH)
+    return os.path.exists(syspurpose_path)

--- a/pyanaconda/modules/common/structures/subscription.py
+++ b/pyanaconda/modules/common/structures/subscription.py
@@ -93,6 +93,31 @@ class SystemPurposeData(DBusData):
         """
         return any((self.role, self.sla, self.usage, self.addons))
 
+    def __eq__(self, other_instance):
+        """Used to determining if other SystemPurposeData instance has the same data.
+
+        Otherwise we would have to compare all the fields each time we want to check if the
+        two SystemPurposeData instances have the same data.
+
+        :param other_instance: another SystemPurposeData to compare with this one
+        :type other_instance: SystemPurposeData instance
+        :return: True if the other structure has the same system purpose data as this one,
+                 False otherwise
+        :rtype: bool
+        """
+        # addon ordering is not important
+        if set(self.addons) != set(other_instance.addons):
+            return False
+        elif(self.role != other_instance.role):
+            return False
+        elif(self.sla != other_instance.sla):
+            return False
+        elif(self.usage != other_instance.usage):
+            return False
+        else:
+            return True
+
+
 class SubscriptionRequest(DBusData):
     """Data for a subscription request.
 

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -45,11 +45,11 @@ from pyanaconda.modules.subscription import system_purpose
 from pyanaconda.modules.subscription.kickstart import SubscriptionKickstartSpecification
 from pyanaconda.modules.subscription.subscription_interface import SubscriptionInterface
 from pyanaconda.modules.subscription.installation import ConnectToInsightsTask, \
-    SystemPurposeConfigurationTask, RestoreRHSMLogLevelTask, TransferSubscriptionTokensTask
+    RestoreRHSMLogLevelTask, TransferSubscriptionTokensTask
 from pyanaconda.modules.subscription.initialization import StartRHSMTask
 from pyanaconda.modules.subscription.runtime import SetRHSMConfigurationTask, \
     RegisterWithUsernamePasswordTask, RegisterWithOrganizationKeyTask, \
-    UnregisterTask, AttachSubscriptionTask
+    UnregisterTask, AttachSubscriptionTask, SystemPurposeConfigurationTask
 from pyanaconda.modules.subscription.rhsm_observer import RHSMObserver
 
 
@@ -75,9 +75,6 @@ class SubscriptionService(KickstartService):
         self.system_purpose_data_changed = Signal()
 
         self._load_valid_system_purpose_values()
-
-        self._is_system_purpose_applied = False
-        self.is_system_purpose_applied_changed = Signal()
 
         # subscription request
 
@@ -306,63 +303,17 @@ class SubscriptionService(KickstartService):
         self.system_purpose_data_changed.emit()
         log.debug("System purpose data set to %s.", system_purpose_data)
 
-    @property
-    def is_system_purpose_applied(self):
-        """Report if system purpose has been applied to the system.
-
-        Note that we don't differentiate between the installation environment
-        and the target system, as the token transfer installation task will
-        make sure any system purpose configuration file created in the installation
-        environment will be transferred to the target system.
-
-        We also need to avoid running system purpose configuration again after
-        a successful subscription attempt, as subscription can actually change
-        the system purpose attached to the system via system purpose values
-        attached to an activation key. If we re-run the system purpose task
-        on the installed system, we would basically overwrite these changes.
-        """
-        return self._is_system_purpose_applied
-
-    def set_is_system_purpose_applied(self, system_purpose_applied):
-        """Set if system purpose is applied.
-
-        :param bool system_purpose_applied: True if applied, False otherwise
-
-        NOTE: We keep this as a private method, called by the completed signal of the
-              task that applies system purpose information on the system.
-        """
-        self._is_system_purpose_applied = system_purpose_applied
-        self.is_system_purpose_applied_changed.emit()
-        # as there is no public setter in the DBus API, we need to emit
-        # the properties changed signal here manually
-        self.module_properties_changed.emit()
-        log.debug("System purpose is applied set to: %s", system_purpose_applied)
-
     def _apply_syspurpose(self):
-        """Apply system purpose information to the installation environment.
-
-        If this method is called, then the token transfer installation task will
-        make sure to transfer the result, so the system purpose installation task
-        does not have to run afterwards.
-        For this reason we record if this method has run via the
-        set_is_system_purpose_applied() method.
-        """
+        """Apply system purpose information to the installation environment."""
         log.debug("subscription: Applying system purpose data")
-        task = SystemPurposeConfigurationTask(sysroot="/",
-                                              system_purpose_data=self.system_purpose_data)
-        # set system purpose as applied/not applied based on True/False returned by run()
-        self.set_is_system_purpose_applied(task.run())
+        task = SystemPurposeConfigurationTask(system_purpose_data=self.system_purpose_data)
+        task.run()
 
     def set_system_purpose_with_task(self):
         """Set system purpose for the installed system with an installation task.
-
         :return: a DBus path of an installation task
         """
-        task = SystemPurposeConfigurationTask(sysroot=conf.target.system_root,
-                                              system_purpose_data=self.system_purpose_data)
-        # set system purpose as applied once the task successfully finishes running
-        task.succeeded_signal.connect(
-            lambda: self.set_is_system_purpose_applied(task.get_result()))
+        task = SystemPurposeConfigurationTask(system_purpose_data=self.system_purpose_data)
         return task
 
     # subscription request
@@ -647,22 +598,6 @@ class SubscriptionService(KickstartService):
         :return: a list of requirements
         """
         requirements = []
-
-        # check if we need the syspurpose package needed for system purpose configuration
-        if self.system_purpose_data.check_data_available() and not self.is_system_purpose_applied:
-            # The system purpose installation task (which needs the syspurpose utility
-            # to be installed) runs:
-            # - if system purpose configuration has been requested
-            # - but system purpose has not been applied during the installation
-            # Only in such a case it will run on the target system and needs the
-            # syspurpose utility to be available on the target system.
-            requirements.append(
-                Requirement.for_package(
-                    "python3-syspurpose",
-                    reason="Needed for System Purpose configuration."
-                )
-            )
-
         # check if we need the insights-client package, which is needed to connect the
         # target system to Red Hat Insights
         if self.connect_to_insights:

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -35,8 +35,6 @@ class SubscriptionInterface(KickstartModuleInterface):
         super().connect_signals()
         self.watch_property("SystemPurposeData",
                             self.implementation.system_purpose_data_changed)
-        self.watch_property("IsSystemPurposeApplied",
-                            self.implementation.is_system_purpose_applied_changed)
         self.watch_property("SubscriptionRequest",
                             self.implementation.subscription_request_changed)
         self.watch_property("InsightsEnabled",
@@ -90,16 +88,6 @@ class SubscriptionInterface(KickstartModuleInterface):
         """
         converted_data = SystemPurposeData.from_structure(system_purpose_data)
         self.implementation.set_system_purpose_data(converted_data)
-
-    @property
-    def IsSystemPurposeApplied(self) -> Bool:
-        """Report if system purpose data has been applied.
-
-        We don't differentiate between that installation environment and the target system in this
-        case as we will make sure the system purpose data will always end up on the target system
-        if requested by the user, regardless of where it is initially set.
-        """
-        return self.implementation.is_system_purpose_applied
 
     def SetSystemPurposeWithTask(self) -> ObjPath:
         """Set system purpose for the installed system with an installation task.

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
@@ -294,6 +294,39 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         output = self.subscription_interface.SystemPurposeData
         self.assertEqual(output, expected_dict)
 
+    def system_purpose_data_comparison_test(self):
+        """Test SystemPurposeData instance equality comparison."""
+        # This is important as we use the comparison to decide if newly set system purpose data
+        # is different and we should set it to the system or not if it is the same.
+
+        # create the SystemPurposeData structure
+        system_purpose_data = SystemPurposeData()
+        system_purpose_data.role = "foo"
+        system_purpose_data.sla = "bar"
+        system_purpose_data.usage = "baz"
+        system_purpose_data.addons = ["a", "b", "c"]
+
+        # create a clone of the structure - new instance same data
+        system_purpose_data_clone = SystemPurposeData()
+        system_purpose_data_clone.role = "foo"
+        system_purpose_data_clone.sla = "bar"
+        system_purpose_data_clone.usage = "baz"
+        system_purpose_data_clone.addons = ["a", "b", "c"]
+
+        # create the SystemPurposeData structure
+        different_system_purpose_data = SystemPurposeData()
+        different_system_purpose_data.role = "different_foo"
+        different_system_purpose_data.sla = "different_bar"
+        different_system_purpose_data.usage = "different_baz"
+        different_system_purpose_data.addons = ["different_a", "different_b", "different_c"]
+
+        # same content should be considered the same
+        self.assertTrue(system_purpose_data == system_purpose_data_clone)
+
+        # different content should not be considered the same
+        self.assertFalse(system_purpose_data == different_system_purpose_data)
+        self.assertFalse(system_purpose_data_clone == different_system_purpose_data)
+
     def system_purpose_data_helper_test(self):
         """Test the SystemPurposeData DBus structure data availability helper method."""
 

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
@@ -39,10 +39,10 @@ from pyanaconda.modules.subscription.subscription_interface import SubscriptionI
 from pyanaconda.modules.subscription.system_purpose import get_valid_fields, _normalize_field, \
     _match_field, process_field, give_the_system_purpose, SYSPURPOSE_UTILITY_PATH
 from pyanaconda.modules.subscription.installation import ConnectToInsightsTask, \
-    SystemPurposeConfigurationTask, RestoreRHSMLogLevelTask, TransferSubscriptionTokensTask
+    RestoreRHSMLogLevelTask, TransferSubscriptionTokensTask
 from pyanaconda.modules.subscription.runtime import SetRHSMConfigurationTask, \
     RegisterWithUsernamePasswordTask, RegisterWithOrganizationKeyTask, \
-    UnregisterTask, AttachSubscriptionTask
+    UnregisterTask, AttachSubscriptionTask, SystemPurposeConfigurationTask
 
 from tests.nosetests.pyanaconda_tests import check_kickstart_interface, check_dbus_property, \
     PropertiesChangedCallback, patch_dbus_publish_object, check_task_creation_list, \
@@ -920,29 +920,6 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         # at the end the property should be True
         self.assertTrue(self.subscription_interface.IsSubscriptionAttached)
 
-    def system_purpose_applied_property_test(self):
-        """Test the IsSystemPurposeApplied property."""
-        # should be false by default
-        self.assertFalse(self.subscription_interface.IsSystemPurposeApplied)
-
-        # this property can't be set by client as it is set as the result of
-        # system purpose to be applied, so we need to call the internal module interface
-        # via a custom setter
-
-        def custom_setter(value):
-            self.subscription_module.set_is_system_purpose_applied(True)
-
-        # check the property is True and the signal was emitted
-        # - we use fake setter as there is no public setter
-        self._check_dbus_property(
-          "IsSystemPurposeApplied",
-          True,
-          setter=custom_setter
-        )
-
-        # at the end the property should be True
-        self.assertTrue(self.subscription_interface.IsSystemPurposeApplied)
-
     @patch_dbus_publish_object
     def set_system_purpose_with_task_test(self, publisher):
         """Test SystemPurposeConfigurationTask creation."""
@@ -968,50 +945,29 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         }
         self.assertEqual(SystemPurposeData.to_structure(data_from_module), expected_dict)
 
-    @patch("pyanaconda.modules.common.task.task.Task.get_result")
-    @patch("pyanaconda.modules.common.task.task.Task.run")
-    @patch_dbus_publish_object
-    def set_system_purpose_with_task_applied_test(self, publisher, mock_run, get_result):
-        """Test system purpose is applied after SystemPurposeConfigurationTask runs."""
-        # simulate successful task run
-        get_result.return_value = True
-        # should be false before the task runs
-        self.assertFalse(self.subscription_interface.IsSystemPurposeApplied)
-        # run the partially mocked task
-        task = self.subscription_module.set_system_purpose_with_task()
-        task.run()
-        # simulate the task run finishing by triggering the emitted signal manually
-        task.succeeded_signal.emit()
-        # check system purpose is marked as applied
-        self.assertTrue(self.subscription_interface.IsSystemPurposeApplied)
-
-    @patch("pyanaconda.modules.common.task.task.Task.get_result")
-    @patch("pyanaconda.modules.common.task.task.Task.run")
-    @patch_dbus_publish_object
-    def set_system_purpose_with_task_applied_failure_test(self, publisher, mock_run, get_result):
-        """Test system purpose is not applied after SystemPurposeConfigurationTask fails."""
-        # simulate task failure
-        get_result.return_value = False
-        # should be false before the task runs
-        self.assertFalse(self.subscription_interface.IsSystemPurposeApplied)
-        # run the partially mocked task
-        task = self.subscription_module.set_system_purpose_with_task()
-        task.run()
-        # simulate the task run finishing by triggering the emitted signal manually
-        task.succeeded_signal.emit()
-        # check system purpose is not marked as applied due to the failure
-        self.assertFalse(self.subscription_interface.IsSystemPurposeApplied)
-
-    @patch("pyanaconda.modules.subscription.installation.SystemPurposeConfigurationTask")
-    def test_apply_syspurpose(self, task):
+    @patch("pyanaconda.modules.subscription.system_purpose.give_the_system_purpose")
+    def test_apply_syspurpose(self, mock_give_purpose):
         """Test applying of system purpose on the installation environment."""
         # The _apply_syspurpose() method is used the apply system purpose data immediately
-        # on the installation environment and is invoked:
-        # - if system purpose data is found in kickstart
-        # - before installation if system purpose data has been input by the user
-        self.assertFalse(self.subscription_interface.IsSystemPurposeApplied)
+        # on the installation environment.
+        # create some system purpose data
+        system_purpose_data = SystemPurposeData()
+        system_purpose_data.role = "foo"
+        system_purpose_data.sla = "bar"
+        system_purpose_data.usage = "baz"
+        system_purpose_data.addons = ["a", "b", "c"]
+        # feed it to the DBus interface
+        self.subscription_interface.SetSystemPurposeData(
+            SystemPurposeData.to_structure(system_purpose_data)
+        )
         self.subscription_module._apply_syspurpose()
-        self.assertTrue(self.subscription_interface.IsSystemPurposeApplied)
+        mock_give_purpose.assert_called_once_with(
+            sysroot="/",
+            role="foo",
+            sla="bar",
+            usage="baz",
+            addons=["a", "b", "c"]
+        )
 
     def get_rhsm_config_defaults_test(self):
         """Test the get_rhsm_config_defaults() method."""
@@ -1067,49 +1023,6 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         requirements = self.subscription_interface.CollectRequirements()
         self.assertEqual(requirements, [])
 
-    def package_requirements_syspurpose_test(self):
-        """Test package requirements - system purpose data available and not applied."""
-        # prepare system purpose data
-        system_purpose_data = SystemPurposeData()
-        system_purpose_data.role = "foo"
-        system_purpose_data.sla = "bar"
-        system_purpose_data.usage = "baz"
-        system_purpose_data.addons = ["a", "b", "c"]
-        # feed it to the DBus interface
-        self.subscription_interface.SetSystemPurposeData(
-            SystemPurposeData.to_structure(system_purpose_data)
-        )
-        # system purpose is no applied by default
-        self.assertFalse(self.subscription_interface.IsSystemPurposeApplied)
-        # the syspurpose utility should be listed amongst the requirements
-        # as system purpose data is available & not applied
-        requirements = self.subscription_interface.CollectRequirements()
-        expected_requirements = [
-            {"name": "python3-syspurpose",
-             "reason": "Needed for System Purpose configuration.",
-             "type": "package"}
-        ]
-        self.assertEqual(get_native(requirements), expected_requirements)
-
-    def package_requirements_syspurpose_applied_test(self):
-        """Test package requirements - syspurpose data available and but already applied."""
-        # prepare system purpose data
-        system_purpose_data = SystemPurposeData()
-        system_purpose_data.role = "foo"
-        system_purpose_data.sla = "bar"
-        system_purpose_data.usage = "baz"
-        system_purpose_data.addons = ["a", "b", "c"]
-        # feed it to the DBus interface
-        self.subscription_interface.SetSystemPurposeData(
-            SystemPurposeData.to_structure(system_purpose_data)
-        )
-        # mark system purpose as already applied
-        self.subscription_module.set_is_system_purpose_applied(True)
-        # the syspurpose utility should not be listed amongst the requirements
-        # as system purpose data is available & already applied
-        requirements = self.subscription_interface.CollectRequirements()
-        self.assertEqual(requirements, [])
-
     def package_requirements_insights_test(self):
         """Test package requirements - connect to Insights enabled."""
         # enable connect to Insights
@@ -1117,34 +1030,6 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         # check the Insights client package is requested
         requirements = self.subscription_interface.CollectRequirements()
         expected_requirements = [
-            {"name": "insights-client",
-             "reason": "Needed to connect the target system to Red Hat Insights.",
-             "type": "package"}
-        ]
-        self.assertEqual(get_native(requirements), expected_requirements)
-
-    def package_requirements_all_test(self):
-        """Test package requirements - all expected packages."""
-        # prepare system purpose data
-        system_purpose_data = SystemPurposeData()
-        system_purpose_data.role = "foo"
-        system_purpose_data.sla = "bar"
-        system_purpose_data.usage = "baz"
-        system_purpose_data.addons = ["a", "b", "c"]
-        # feed it to the DBus interface
-        self.subscription_interface.SetSystemPurposeData(
-            SystemPurposeData.to_structure(system_purpose_data)
-        )
-        # system purpose is no applied by default
-        self.assertFalse(self.subscription_interface.IsSystemPurposeApplied)
-        # enable connect to Insights
-        self.subscription_interface.SetInsightsEnabled(True)
-        # both syspurpose and Insights client should be requested
-        requirements = self.subscription_interface.CollectRequirements()
-        expected_requirements = [
-            {"name": "python3-syspurpose",
-             "reason": "Needed for System Purpose configuration.",
-             "type": "package"},
             {"name": "insights-client",
              "reason": "Needed to connect the target system to Red Hat Insights.",
              "type": "package"}
@@ -1588,8 +1473,6 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
                                                   usage="BAZ",
                                                   addons=['F Product', 'B Feature'],
                                                   sysroot="/")
-        # also system purpose should be marked as applied
-        self.assertTrue(self.subscription_interface.IsSystemPurposeApplied)
 
     @patch("pyanaconda.modules.subscription.system_purpose.give_the_system_purpose")
     def ks_no_apply_syspurpose_test(self, mock_give_purpose):
@@ -1603,5 +1486,3 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         # the SystemPurposeConfigurationTask should have been called,
         # which calls give_the_system_purpose()
         mock_give_purpose.assert_not_called()
-        # also system purpose should be marked as applied
-        self.assertFalse(self.subscription_interface.IsSystemPurposeApplied)

--- a/tests/nosetests/pyanaconda_tests/subscription_helpers_test.py
+++ b/tests/nosetests/pyanaconda_tests/subscription_helpers_test.py
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
+import os
+import tempfile
+
+import unittest
+
+from pyanaconda.core import util
+from pyanaconda.core.constants import RHSM_SYSPURPOSE_FILE_PATH
+
+from pyanaconda.core.subscription import check_system_purpose_set
+
+
+class CheckSystemPurposeSetTestCase(unittest.TestCase):
+    """Test the check_system_purpose_set helper function."""
+
+    def check_system_purpose_set_test(self):
+        """Test the check_system_purpose_set() helper function."""
+        # system purpose set
+        with tempfile.TemporaryDirectory() as sysroot:
+            # create a dummy syspurpose file
+            syspurpose_path = RHSM_SYSPURPOSE_FILE_PATH
+            directory = os.path.split(syspurpose_path)[0]
+            os.makedirs(util.join_paths(sysroot, directory))
+            os.mknod(util.join_paths(sysroot, syspurpose_path))
+            self.assertTrue(check_system_purpose_set(sysroot))
+
+        # system purpose not set
+        with tempfile.TemporaryDirectory() as sysroot:
+            self.assertFalse(check_system_purpose_set(sysroot))


### PR DESCRIPTION
This PR substantially simplifies system purpose configuration in comparison to what was done back in RHEL 8.0 and 8.2 due to the specific circumstances back then. 

In short, we now simply set system purpose data to the installation environment every time a new system purpose data DBus structure is supplied & a separate installation task will take care of transferring the system purpose configuration file to the target system. Due to this we need just a simple runtime DBus task that des not need to be directly invoked via DBus API. Also we no longer need the `syspurpose` package to be installed to the target system as `syspurpose` is no longer called on the target system anymore.

For more details you can see the commit message of the third commit.

The PR is structured as follows:
- commit 1 adds a simple helper function for checking if system purpose has been set
- commit 2 adds equality checking for SystemPurpose data, that wee need to decide if system purpose data changed and should be re-applied
- commit 3 does the actual simplification of system purpose configuration