### PR TITLE
subscription: Add AttachedSubscription DBus structure

### DIFF
--- a/pyanaconda/modules/common/structures/subscription.py
+++ b/pyanaconda/modules/common/structures/subscription.py
@@ -362,3 +362,147 @@ class SubscriptionRequest(DBusData):
     @server_proxy_password.setter
     def server_proxy_password(self, password: SecretData):
         self._server_proxy_password = password
+
+
+class AttachedSubscription(DBusData):
+    """Data for a single attached subscription."""
+
+    def __init__(self):
+        self._name = ""
+        self._service_level = ""
+        self._sku = ""
+        self._contract = ""
+        self._start_date = ""
+        self._end_date = ""
+        # we can expect at least one entitlement
+        # to be consumed per attached subscription
+        self._consumed_entitlement_count = 1
+
+    @property
+    def name(self) -> Str:
+        """Name of the attached subscription.
+
+        Example: "Red Hat Beta Access"
+
+        :return: subscription name
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name: Str):
+        self._name = name
+
+    @property
+    def service_level(self) -> Str:
+        """Service level of the attached subscription.
+
+        Example: "Premium"
+
+        :return: service level
+        :rtype: str
+        """
+        return self._service_level
+
+    @service_level.setter
+    def service_level(self, service_level: Str):
+        self._service_level = service_level
+
+    @property
+    def sku(self) -> Str:
+        """SKU id of the attached subscription.
+
+        Example: "MBT8547"
+
+        :return: SKU id
+        :rtype: str
+        """
+        return self._sku
+
+    @sku.setter
+    def sku(self, sku: Str):
+        self._sku = sku
+
+    @property
+    def contract(self) -> Str:
+        """Contract identifier.
+
+        Example: "32754658"
+
+        :return: contract identifier
+        :rtype: str
+        """
+        return self._contract
+
+    @contract.setter
+    def contract(self, contract: Str):
+        self._contract = contract
+
+    @property
+    def start_date(self) -> Str:
+        """Subscription start date.
+
+        We do not guarantee fixed date format,
+        but we aim for the date to look good
+        when displayed in a GUI and be human
+        readable.
+
+        For context see the following bug, that
+        illustrates the issues we are having with
+        the source date for this property, that
+        prevent us from providing a consistent
+        date format:
+        https://bugzilla.redhat.com/show_bug.cgi?id=1793501
+
+        Example: "Nov 04, 2019"
+
+        :return: start date of the subscription
+        :rtype: str
+        """
+        return self._start_date
+
+    @start_date.setter
+    def start_date(self, start_date: Str):
+        self._start_date = start_date
+
+    @property
+    def end_date(self) -> Str:
+        """Subscription end date.
+
+        We do not guarantee fixed date format,
+        but we aim for the date to look good
+        when displayed in a GUI and be human
+        readable.
+
+        For context see the following bug, that
+        illustrates the issues we are having with
+        the source date for this property, that
+        prevent us from providing a consistent
+        date format:
+        https://bugzilla.redhat.com/show_bug.cgi?id=1793501
+
+        Example: "Nov 04, 2020"
+
+        :return: end date of the subscription
+        :rtype: str
+        """
+        return self._end_date
+
+    @end_date.setter
+    def end_date(self, end_date: Str):
+        self._end_date = end_date
+
+    @property
+    def consumed_entitlement_count(self) -> Int:
+        """Number of consumed entitlements for this subscription.
+
+        Example: "1"
+
+        :return: consumed entitlement number
+        :rtype: int
+        """
+        return self._consumed_entitlement_count
+
+    @consumed_entitlement_count.setter
+    def consumed_entitlement_count(self, consumed_entitlement_count: Int):
+        self._consumed_entitlement_count = consumed_entitlement_count

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
@@ -32,7 +32,7 @@ from pyanaconda.core.constants import SECRET_TYPE_NONE, SECRET_TYPE_HIDDEN, SECR
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.modules.common.constants.objects import RHSM_CONFIG
 from pyanaconda.modules.common.structures.subscription import SystemPurposeData, \
-    SubscriptionRequest
+    SubscriptionRequest, AttachedSubscription
 
 from pyanaconda.modules.subscription.subscription import SubscriptionService
 from pyanaconda.modules.subscription.subscription_interface import SubscriptionInterface
@@ -797,6 +797,57 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
                          ["key_foo", "key_bar", "key_baz"])
         self.assertEqual(internal_request.server_proxy_password.value,
                          "foo_proxy_password")
+
+    def attached_subscription_defaults_test(self):
+        """Test the AttachedSubscription DBus structure defaults."""
+
+        # create empty AttachedSubscription structure
+        empty_request = AttachedSubscription()
+
+        # compare with expected default values
+        expected_default_dict = {
+            "name": get_variant(Str, ""),
+            "service-level": get_variant(Str, ""),
+            "sku": get_variant(Str, ""),
+            "contract": get_variant(Str, ""),
+            "start-date": get_variant(Str, ""),
+            "end-date": get_variant(Str, ""),
+            "consumed-entitlement-count": get_variant(Int, 1)
+        }
+        # compare the empty structure with expected default values
+        self.assertEqual(
+            AttachedSubscription.to_structure(empty_request),
+            expected_default_dict
+        )
+
+    def attached_subscription_full_test(self):
+        """Test the AttachedSubscription DBus structure that is fully populated."""
+
+        # create empty AttachedSubscription structure
+        full_request = AttachedSubscription()
+        full_request.name = "Foo Bar Beta"
+        full_request.service_level = "really good"
+        full_request.sku = "ABCD1234"
+        full_request.contract = "87654321"
+        full_request.start_date = "Jan 01, 1970"
+        full_request.end_date = "Jan 19, 2038"
+        full_request.consumed_entitlement_count = 9001
+
+        # compare with expected values
+        expected_default_dict = {
+            "name": get_variant(Str, "Foo Bar Beta"),
+            "service-level": get_variant(Str, "really good"),
+            "sku": get_variant(Str, "ABCD1234"),
+            "contract": get_variant(Str, "87654321"),
+            "start-date": get_variant(Str, "Jan 01, 1970"),
+            "end-date": get_variant(Str, "Jan 19, 2038"),
+            "consumed-entitlement-count": get_variant(Int, 9001)
+        }
+        # compare the full structure with expected values
+        self.assertEqual(
+            AttachedSubscription.to_structure(full_request),
+            expected_default_dict
+        )
 
     def insights_property_test(self):
         """Test the InsightsEnabled property."""


### PR DESCRIPTION
The AttachedSubscription DBus structure describes a single subscription
that has been attached to the target system.

A list of AttachedSubscription instances together with the InsightsEnabled property
and SystemPurposeData property describe the system state post registration and subscription.

Note that all the fields are effectively string "blobs" we are getting
from a JSON file returned by RHSM DBus API.