### PR TITLE
subscription: Initial subscription GUI bits

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/subscription.py
+++ b/pyanaconda/ui/gui/spokes/lib/subscription.py
@@ -1,0 +1,102 @@
+# Helper methods for the Subscription spoke.
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from collections import namedtuple
+
+from pyanaconda.core.i18n import _
+
+TextComboBoxItem = namedtuple("TextComboBoxItem", ["value", "display_string", "is_preselected"])
+
+
+def handle_user_provided_value(user_provided_value, valid_values):
+    """Handle user provided value (if any) based on list of valid values.
+
+    There are three possible outcomes:
+    - the value matches one of the valid values, so we preselect the valid value
+    - the value does not match a valid value, so we append a custom value
+      to the list and preselect it
+    - the user provided value is not available (empty string), no matching will be done
+      and no value will be preselected
+
+    :param str user_provided_value: a value provided by user
+    :param list valid_values: a list of valid values
+    :returns: list of values with one value preselected
+    :rtype: list of TextComboBoxItem tuples
+    """
+    preselected_value_list = []
+    value_matched = False
+    for valid_value in valid_values:
+        preselect = False
+        if user_provided_value and not value_matched:
+            if user_provided_value == valid_value:
+                preselect = True
+                value_matched = True
+        item = TextComboBoxItem(value=valid_value,
+                                display_string=valid_value,
+                                is_preselected=preselect)
+        preselected_value_list.append(item)
+    # check if the user provided value matched a valid value
+    if user_provided_value and not value_matched:
+        # user provided value did not match any valid value,
+        # add it as a custom value to the list and preselect it
+        other_value_string = _("Other ({})").format(user_provided_value)
+        item = TextComboBoxItem(value=user_provided_value,
+                                display_string=other_value_string,
+                                is_preselected=True)
+        preselected_value_list.append(item)
+    return preselected_value_list
+
+
+def fill_combobox(combobox, user_provided_value, valid_values):
+    """Fill the given ComboBoxText instance with data based on current value & valid values.
+
+    Please note that it is possible that the list box will be empty if no
+    list of valid values are available and the user has not supplied any value
+    via kickstart or the DBUS API.
+
+    NOTE: Removes any existing values from the GTK ComboBoxText instance before
+          filling it.
+
+    :param combobox: the combobox to fill
+    :param user_provided_value: the value provided by the user (if any)
+    :type user_provided_value: str or None
+    :param list valid_values: list of known valid values
+    """
+    preselected_value_list = handle_user_provided_value(user_provided_value,
+                                                        valid_values)
+    # make sure the combo box is empty
+    combobox.remove_all()
+
+    # add the "Not Specified" option as the first item
+    # - otherwise the user would not be able to unselect option clicked previously
+    #   or selected via kickstart
+    # - set the active id to this value by default
+
+    active_id = ""
+    combobox.append("", _("Not Specified"))
+
+    if preselected_value_list:
+        for value, display_string, preselected in preselected_value_list:
+            combobox.append(value, display_string)
+            # the value has been preselected, set the active id accordingly
+            if preselected:
+                active_id = value
+
+    # set the active id (what item should be selected in the combobox)
+    combobox.set_active_id(active_id)

--- a/pyanaconda/ui/gui/spokes/subscription.glade
+++ b/pyanaconda/ui/gui/spokes/subscription.glade
@@ -1,0 +1,992 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <requires lib="AnacondaWidgets" version="1.0"/>
+  <object class="AnacondaSpokeWindow" id="subscription_window">
+    <property name="can_focus">False</property>
+    <property name="window_name" translatable="yes">CONNECT TO RED HAT</property>
+    <signal name="button-clicked" handler="on_back_clicked" swapped="no"/>
+    <child internal-child="main_box">
+      <object class="GtkBox" id="AnacondaSpokeWindow-main_box1">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+        <child internal-child="nav_box">
+          <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
+            <property name="can_focus">False</property>
+            <child internal-child="nav_area">
+              <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">
+                <property name="can_focus">False</property>
+                <property name="margin_left">6</property>
+                <property name="margin_right">6</property>
+                <property name="margin_top">6</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child internal-child="alignment">
+          <object class="GtkAlignment" id="AnacondaSpokeWindow-alignment1">
+            <property name="can_focus">False</property>
+            <property name="yalign">0</property>
+            <property name="top_padding">12</property>
+            <property name="bottom_padding">48</property>
+            <property name="left_padding">48</property>
+            <property name="right_padding">48</property>
+            <child internal-child="action_area">
+              <object class="GtkBox" id="AnacondaSpokeWindow-action_area1">
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">8</property>
+                <child>
+                  <object class="GtkNotebook" id="main_notebook">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="vexpand">True</property>
+                    <property name="show_tabs">False</property>
+                    <property name="show_border">False</property>
+                    <child>
+                      <object class="GtkScrolledWindow" id="registration_scrolled_window">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <child>
+                          <object class="GtkViewport" id="registration_viewport">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">center</property>
+                            <property name="shadow_type">none</property>
+                            <child>
+                              <object class="GtkBox" id="registration_box">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">center</property>
+                                <property name="orientation">vertical</property>
+                                <property name="spacing">4</property>
+                                <child>
+                                  <object class="GtkGrid" id="registration_grid">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">center</property>
+                                    <property name="valign">center</property>
+                                    <property name="row_spacing">4</property>
+                                    <property name="column_spacing">4</property>
+                                    <child>
+                                      <object class="GtkLabel" id="authentication_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">Authentication</property>
+                                        <property name="justify">right</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="authetication_method_hbox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <child>
+                                          <object class="GtkRadioButton" id="account_radio_button">
+                                            <property name="label" translatable="yes" context="GUI|Subscription|Authentication|Account">_Account</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="active">True</property>
+                                            <property name="draw_indicator">True</property>
+                                            <signal name="toggled" handler="on_account_radio_button_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkRadioButton" id="activation_key_radio_button">
+                                            <property name="label" translatable="yes" context="GUI|Subscription|Authetication|Activation Key">Activation _Key</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="draw_indicator">True</property>
+                                            <property name="group">account_radio_button</property>
+                                            <signal name="toggled" handler="on_activation_key_radio_button_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkRevealer" id="account_revealer">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="transition_type">none</property>
+                                        <property name="reveal_child">True</property>
+                                        <child>
+                                          <object class="GtkGrid" id="account_grid">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="row_spacing">4</property>
+                                            <property name="column_spacing">4</property>
+                                            <child>
+                                              <object class="GtkLabel" id="username_label">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="label" translatable="yes">User name</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="username_entry">
+                                                <property name="width_request">250</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="hexpand">True</property>
+                                                <signal name="changed" handler="on_username_entry_changed" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="password_label">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="label" translatable="yes">Password</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="password_entry">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="hexpand">True</property>
+                                                <property name="visibility">False</property>
+                                                <property name="invisible_char">●</property>
+                                                <signal name="changed" handler="on_password_entry_changed" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkRevealer" id="activation_key_revealer">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="transition_type">none</property>
+                                        <child>
+                                          <object class="GtkGrid" id="activation_key_grid">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="row_spacing">4</property>
+                                            <property name="column_spacing">4</property>
+                                            <child>
+                                              <object class="GtkLabel" id="organization_label">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="label" translatable="yes">Organization</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="activation_key_label">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="label" translatable="yes">Activation Key</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="organization_entry">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="hexpand">True</property>
+                                                <signal name="changed" handler="on_organization_entry_changed" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkEntry" id="activation_key_entry">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="hexpand">True</property>
+                                                <property name="placeholder_text" translatable="yes">key1,key2,...</property>
+                                                <signal name="changed" handler="on_activation_key_entry_changed" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="purpose_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">Purpose</property>
+                                        <property name="justify">right</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkRevealer" id="system_purpose_revealer">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <child>
+                                          <object class="GtkGrid" id="system_purpose_grid">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="row_spacing">4</property>
+                                            <property name="column_spacing">4</property>
+                                            <child>
+                                              <object class="GtkLabel" id="usage_label">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="label" translatable="yes">Usage</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="role_label">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="label" translatable="yes">Role</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="sla_label">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="label" translatable="yes">SLA</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">0</property>
+                                                <property name="top_attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="system_purpose_role_combobox">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <signal name="changed" handler="on_system_purpose_role_combobox_changed" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="system_purpose_sla_combobox">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <signal name="changed" handler="on_system_purpose_sla_combobox_changed" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkComboBoxText" id="system_purpose_usage_combobox">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <signal name="changed" handler="on_system_purpose_usage_combobox_changed" swapped="no"/>
+                                              </object>
+                                              <packing>
+                                                <property name="left_attach">1</property>
+                                                <property name="top_attach">2</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="system_purpose_checkbox">
+                                        <property name="label" translatable="yes" context="GUI|Subscription|Set System Purpose">Set System Purpose</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">True</property>
+                                        <signal name="toggled" handler="on_system_purpose_checkbox_toggled" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="insights_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">Insights</property>
+                                        <property name="justify">right</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">5</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="insights_checkbox">
+                                        <property name="label" translatable="yes" context="GUI|Subscription|Red Hat Insights">Connect to Red Hat _Insights</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="use_underline">True</property>
+                                        <property name="active">True</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">5</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkExpander" id="options_expander">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <child>
+                                      <object class="GtkGrid" id="options_grid">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="row_spacing">4</property>
+                                        <property name="column_spacing">4</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="custom_rhsm_baseurl_checkbox">
+                                            <property name="label" translatable="yes">Custom base URL</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
+                                            <signal name="toggled" handler="on_custom_rhsm_baseurl_checkbox_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">4</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkRevealer" id="custom_rhsm_baseurl_revealer">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <child>
+                                              <object class="GtkEntry" id="custom_rhsm_baseurl_entry">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <signal name="changed" handler="on_custom_rhsm_baseurl_entry_changed" swapped="no"/>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">5</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkRevealer" id="custom_server_hostname_revealer">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <child>
+                                              <object class="GtkEntry" id="custom_server_hostname_entry">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <signal name="changed" handler="on_custom_server_hostname_entry_changed" swapped="no"/>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="custom_server_hostname_checkbox">
+                                            <property name="label" translatable="yes">Custom server URL</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
+                                            <signal name="toggled" handler="on_custom_server_hostname_checkbox_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="http_proxy_checkbox">
+                                            <property name="label" translatable="yes">Use HTTP proxy</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
+                                            <signal name="toggled" handler="on_http_proxy_checkbox_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkRevealer" id="http_proxy_revealer">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <child>
+                                              <object class="GtkGrid" id="http_proxy_grid">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="row_spacing">4</property>
+                                                <property name="column_spacing">4</property>
+                                                <child>
+                                                  <object class="GtkLabel" id="http_proxy_location_label">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="halign">start</property>
+                                                    <property name="label" translatable="yes">Location</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left_attach">0</property>
+                                                    <property name="top_attach">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkLabel" id="http_proxy_username_label">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="halign">start</property>
+                                                    <property name="label" translatable="yes">User name</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left_attach">0</property>
+                                                    <property name="top_attach">1</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkLabel" id="http_proxy_password_label">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="halign">start</property>
+                                                    <property name="label" translatable="yes">Password</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left_attach">0</property>
+                                                    <property name="top_attach">2</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkEntry" id="http_proxy_location_entry">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="hexpand">True</property>
+                                                    <property name="placeholder_text" translatable="yes">hostname:port</property>
+                                                    <signal name="changed" handler="on_http_proxy_location_entry_changed" swapped="no"/>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left_attach">1</property>
+                                                    <property name="top_attach">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkEntry" id="http_proxy_username_entry">
+                                                    <property name="width_request">250</property>
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <signal name="changed" handler="on_http_proxy_username_entry_changed" swapped="no"/>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left_attach">1</property>
+                                                    <property name="top_attach">1</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkEntry" id="http_proxy_password_entry">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="visibility">False</property>
+                                                    <property name="invisible_char">●</property>
+                                                    <signal name="changed" handler="on_http_proxy_password_entry_changed" swapped="no"/>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left_attach">1</property>
+                                                    <property name="top_attach">2</property>
+                                                  </packing>
+                                                </child>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child type="label">
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Options</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="registration_status_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_top">8</property>
+                                    <property name="margin_bottom">8</property>
+                                    <property name="label" translatable="yes">The system is currently not registered.</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkButton" id="register_button">
+                                    <property name="label" translatable="yes" context="GUI|Subscription|Register">_Register</property>
+                                    <property name="visible">True</property>
+                                    <property name="sensitive">False</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">True</property>
+                                    <property name="halign">center</property>
+                                    <property name="use_underline">True</property>
+                                    <signal name="clicked" handler="on_register_button_clicked" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">3</property>
+                                  </packing>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="tab">
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="subscription_status_box">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">8</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">4</property>
+                        <child>
+                          <object class="GtkBox" id="status_box">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">4</property>
+                            <child>
+                              <object class="GtkBox" id="top_level_status_box">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="spacing">4</property>
+                                <child>
+                                  <object class="GtkLabel" id="properly_subscribed_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">The system has been properly subscribed</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                      <attribute name="scale" value="1.2"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkButton" id="unregister_button">
+                                    <property name="label" translatable="yes" context="GUI|Subscription|Unregister">_Unregister</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">True</property>
+                                    <property name="halign">center</property>
+                                    <property name="use_underline">True</property>
+                                    <signal name="clicked" handler="on_unregister_button_clicked" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">8</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkGrid" id="status_grid">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin_top">8</property>
+                                <property name="row_spacing">4</property>
+                                <property name="column_spacing">8</property>
+                                <child>
+                                  <object class="GtkLabel" id="method_label">
+                                    <property name="name">method_label</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">end</property>
+                                    <property name="label" translatable="yes">Method</property>
+                                    <property name="justify">right</property>
+                                    <attributes>
+                                      <attribute name="weight" value="semibold"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="system_purpose_label">
+                                    <property name="name">system_purpose_label</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">end</property>
+                                    <property name="label" translatable="yes">System Purpose</property>
+                                    <property name="justify">right</property>
+                                    <attributes>
+                                      <attribute name="weight" value="semibold"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="method_status_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label">lorem ipsum</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="role_status_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label">lorem ipsum</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="sla_status_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label">lorem ipsum</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="another_insights_label">
+                                    <property name="name">insights_label</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">end</property>
+                                    <property name="label" translatable="yes">Insights</property>
+                                    <property name="justify">right</property>
+                                    <attributes>
+                                      <attribute name="weight" value="semibold"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">4</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="insights_status_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label">lorem ipsum</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">4</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="usage_status_label">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label">lorem ipsum</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="attached_subscriptions_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin_top">16</property>
+                            <property name="margin_bottom">4</property>
+                            <property name="label" translatable="yes">No subscriptions have been attached to the system</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                              <attribute name="scale" value="1.2"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkScrolledWindow" id="subscriptions_scrolled_window">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="vexpand">True</property>
+                            <child>
+                              <object class="GtkViewport" id="subscriptions_viewport">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="shadow_type">none</property>
+                                <child>
+                                  <object class="GtkListBox" id="subscriptions_listbox">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="selection_mode">none</property>
+                                    <style>
+                                      <class name="subscriptions_listbox"/>
+                                    </style>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child type="tab">
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child type="tab">
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child internal-child="accessible">
+      <object class="AtkObject" id="subscription_window-atkobject">
+        <property name="AtkObject::accessible-name" translatable="yes">SYSTEM PURPOSE</property>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -1,0 +1,830 @@
+# Subscription spoke class
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from enum import IntEnum
+
+from pyanaconda.flags import flags
+
+
+from pyanaconda.core.i18n import _, CN_
+from pyanaconda.core.constants import SECRET_TYPE_HIDDEN, \
+    SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY
+from pyanaconda.core.payload import ProxyString
+
+from pyanaconda.modules.common.constants.services import SUBSCRIPTION, NETWORK
+from pyanaconda.modules.common.structures.subscription import SystemPurposeData, \
+    SubscriptionRequest
+from pyanaconda.modules.common.util import is_module_available
+from pyanaconda.modules.common.task import sync_run_task
+
+from pyanaconda.ui.gui.spokes import NormalSpoke
+from pyanaconda.ui.gui.spokes.lib.subscription import fill_combobox
+from pyanaconda.ui.categories.system import SystemCategory
+from pyanaconda.ui.communication import hubQ
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+__all__ = ["SubscriptionSpoke"]
+
+
+# the integers correspond to the order of options
+# in the authentication mode combo box
+class AuthenticationMethod(IntEnum):
+    USERNAME_PASSWORD = 0
+    ORG_KEY = 1
+
+
+class SubscriptionSpoke(NormalSpoke):
+    """Subscription spoke provides the Connect to Red Hat screen."""
+    builderObjects = ["subscription_window"]
+
+    mainWidgetName = "subscription_window"
+    uiFile = "spokes/subscription.glade"
+    help_id = "SubscriptionSpoke"
+
+    category = SystemCategory
+
+    icon = "application-certificate-symbolic"
+    title = CN_("GUI|Spoke", "_Connect to Red Hat")
+
+    # main notebook pages
+    REGISTRATION_PAGE = 0
+    SUBSCRIPTION_STATUS_PAGE = 1
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """The Subscription spoke should run only if the Subscription module is available."""
+        return is_module_available(SUBSCRIPTION)
+
+    def __init__(self, *args):
+        super().__init__()
+
+        # connect to the Subscription DBus module API
+        self._subscription_module = SUBSCRIPTION.get_proxy()
+
+        # connect to the Network DBus module API
+        self._network_module = NETWORK.get_proxy()
+
+        # get initial data from the Subscription module
+        self._subscription_request = self._get_subscription_request()
+        self._system_purpose_data = self._get_system_purpose_data()
+        # Keep a copy of system purpose data that has been last applied to
+        # the installation environment.
+        # That way we can check if the main copy of the system purposed data
+        # changed since it was applied (for example due to user input)
+        # and needs to be reapplied.
+        # By default this variable is None and will only be set to a
+        # SystemPurposeData instance when first system purpose data is
+        # applied to the installation environment.
+        self._last_applied_system_purpose_data = None
+
+        self._authentication_method = AuthenticationMethod.USERNAME_PASSWORD
+
+        self._registration_error = ""
+        self._registration_phase = None
+        self._registration_controls_enabled = True
+
+        # Red Hat Insights should be enabled by default for non-kickstart installs.
+        #
+        # For kickstart installations we will use the value from the module, which
+        # False by default & can be set to True via the rhsm kickstart command.
+        if not flags.automatedInstall:
+            self._subscription_module.SetInsightsEnabled(True)
+
+    # common spoke properties
+
+    @property
+    def ready(self):
+        """The subscription spoke is always ready."""
+        return True
+
+    @property
+    def status(self):
+        # TODO: status message depends on registration/unregistration handling
+        # - shows registration phases when registration + subscription is ongoing
+        # - otherwise shows not-registered/registered/error
+        return ""
+
+    @property
+    def mandatory(self):
+        """The subscription spoke is mandatory if Red Hat CDN is set as installation source."""
+        # TODO: depends on source switching, mandatory if Red Hat CDN is set as installation source
+        return True
+
+    @property
+    def completed(self):
+        return self.subscription_attached
+
+    @property
+    def sensitive(self):
+        # the Subscription spoke should be always accessible
+        return True
+
+    # common spoke methods
+
+    def apply(self):
+        log.debug("Subscription GUI: apply() running")
+        self._set_data_to_module()
+
+    def refresh(self):
+        log.debug("Subscription GUI: refresh() running")
+        # update spoke state based on up-to-date data from the Subscription module
+        # (this also takes care of updating the two properties holding subscription
+        #  request as well as system purpose data)
+        self._update_spoke_state()
+
+    # DBus structure mirrors
+
+    @property
+    def subscription_request(self):
+        """A mirror of the subscription request from the Subscription DBus module.
+
+        Should be always set and is periodically updated on refresh().
+
+        :return: up to date subscription request
+        :rtype: SubscriptionRequest instance
+        """
+        return self._subscription_request
+
+    @property
+    def system_purpose_data(self):
+        """A mirror of system purpose data from the Subscription DBus module.
+
+        Should be always set and is periodically updated on refresh().
+
+        :return: up to date system purpose data
+        :rtype: SystemPurposeData instance
+        """
+        return self._system_purpose_data
+
+    # placeholder control
+
+    def enable_http_proxy_password_placeholder(self, show_placeholder):
+        """Show a placeholder on the HTTP proxy password field.
+
+        The placeholder notifies the user about HTTP proxy password
+        being set in the DBus module.
+
+        The placeholder will be only shown if there is no
+        actual text in the entry field.
+        """
+        if show_placeholder:
+            self._http_proxy_password_entry.set_placeholder_text(_("Password set."))
+        else:
+            self._http_proxy_password_entry.set_placeholder_text("")
+
+    def enable_password_placeholder(self, show_placeholder):
+        """Show a placeholder on the red hat account password field.
+
+        The placeholder notifies the user about activation
+        key being set in the DBus module.
+
+        The placeholder will be only shown if there is no
+        actual text in the entry field.
+        """
+        if show_placeholder:
+            self._password_entry.set_placeholder_text(_("Password set."))
+        else:
+            self._password_entry.set_placeholder_text("")
+
+    def enable_activation_key_placeholder(self, show_placeholder):
+        """Show a placeholder on the activation key field.
+
+        The placeholder notifies the user about activation
+        key being set in the DBus module.
+
+        The placeholder will be only shown if there is no
+        actual text in the entry field.
+        """
+        if show_placeholder:
+            self._activation_key_entry.set_placeholder_text(_("Activation key set."))
+        else:
+            self._activation_key_entry.set_placeholder_text("")
+
+    # properties controlling visibility of options that can be hidden
+
+    @property
+    def custom_server_hostname_visible(self):
+        return self._custom_server_hostname_checkbox.get_active()
+
+    @custom_server_hostname_visible.setter
+    def custom_server_hostname_visible(self, visible):
+        self._custom_server_hostname_checkbox.set_active(visible)
+
+    @property
+    def http_proxy_visible(self):
+        return self._http_proxy_checkbox.get_active()
+
+    @http_proxy_visible.setter
+    def http_proxy_visible(self, visible):
+        self._http_proxy_checkbox.set_active(visible)
+
+    @property
+    def custom_rhsm_baseurl_visible(self):
+        return self._custom_rhsm_baseurl_checkbox.get_active()
+
+    @custom_rhsm_baseurl_visible.setter
+    def custom_rhsm_baseurl_visible(self, visible):
+        self._custom_rhsm_baseurl_checkbox.set_active(visible)
+
+    @property
+    def account_visible(self):
+        return self._account_radio_button.get_active()
+
+    @account_visible.setter
+    def account_visible(self, visible):
+        self._account_radio_button.set_active(visible)
+
+    @property
+    def activation_key_visible(self):
+        return self._activation_key_radio_button.get_active()
+
+    @activation_key_visible.setter
+    def activation_key_visible(self, visible):
+        self._activation_key_radio_button.set_active(visible)
+
+    @property
+    def system_purpose_visible(self):
+        return self._system_purpose_checkbox.get_active()
+
+    @system_purpose_visible.setter
+    def system_purpose_visible(self, visible):
+        self._system_purpose_checkbox.set_active(visible)
+
+    @property
+    def options_visible(self):
+        return self._options_expander.get_expanded()
+
+    @options_visible.setter
+    def options_visible(self, visible):
+        self._options_expander.set_expanded(visible)
+
+    # properties - element sensitivity
+
+    def set_registration_controls_sensitive(self, sensitive, include_register_button=True):
+        """Set sensitivity of the registration controls.
+
+        We set these value individually so that the registration status label
+        that is between the controls will not become grayed out due to setting
+        the top level container insensitive.
+        """
+        self._registration_grid.set_sensitive(sensitive)
+        self._options_expander.set_sensitive(sensitive)
+        self._registration_controls_enabled = sensitive
+        self._update_registration_state()
+
+    # authentication related signals
+
+    def on_account_radio_button_toggled(self, radio):
+        if radio.get_active():
+            self.authentication_method = AuthenticationMethod.USERNAME_PASSWORD
+
+    def on_activation_key_radio_button_toggled(self, radio):
+        if radio.get_active():
+            self.authentication_method = AuthenticationMethod.ORG_KEY
+
+    def on_username_entry_changed(self, editable):
+        self.subscription_request.username = editable.get_text()
+
+    def on_password_entry_changed(self, editable):
+        entered_text = editable.get_text()
+        if entered_text:
+            self.enable_password_placeholder(False)
+        self.subscription_request.account_password.set_secret(entered_text)
+
+    def on_organization_entry_changed(self, editable):
+        self.subscription_request.organization = editable.get_text()
+
+    def on_activation_key_entry_changed(self, editable):
+        entered_text = editable.get_text()
+        keys = None
+        if entered_text:
+            self.enable_activation_key_placeholder(False)
+            keys = entered_text.split(',')
+        # keys == None clears keys in the module, so deleting keys
+        # in the keys field will also clear module data on apply()
+        self.subscription_request.activation_keys.set_secret(keys)
+
+    # system purpose related signals
+
+    def on_system_purpose_checkbox_toggled(self, checkbox):
+        active = checkbox.get_active()
+        self._system_purpose_revealer.set_reveal_child(active)
+        if active:
+            # make sure data in the system purpose comboboxes
+            # are forwarded to the system purpose data structure
+            # in case something was set before they were hidden
+            self.on_system_purpose_role_combobox_changed(self._system_purpose_role_combobox)
+            self.on_system_purpose_sla_combobox_changed(self._system_purpose_sla_combobox)
+            self.on_system_purpose_usage_combobox_changed(self._system_purpose_usage_combobox)
+        else:
+            # system purpose combo boxes have been hidden, clear the corresponding
+            # data from the system purpose data structure, but keep it in the combo boxes
+            # in case the user tries to show them again before next spoke entry clears them
+            self.system_purpose_data.role = ""
+            self.system_purpose_data.sla = ""
+            self.system_purpose_data.usage = ""
+
+    def on_system_purpose_role_combobox_changed(self, combobox):
+        self.system_purpose_data.role = combobox.get_active_id()
+
+    def on_system_purpose_sla_combobox_changed(self, combobox):
+        self.system_purpose_data.sla = combobox.get_active_id()
+
+    def on_system_purpose_usage_combobox_changed(self, combobox):
+        self.system_purpose_data.usage = combobox.get_active_id()
+
+    # HTTP proxy signals
+
+    def on_http_proxy_checkbox_toggled(self, checkbox):
+        active = checkbox.get_active()
+        self._http_proxy_revealer.set_reveal_child(active)
+        if active:
+            # make sure data in the HTTP proxy entries
+            # are forwarded to the subscription request structure
+            # in case something was entered before they were hidden
+            self.on_http_proxy_location_entry_changed(self._http_proxy_location_entry)
+            self.on_http_proxy_username_entry_changed(self._http_proxy_username_entry)
+            self.on_http_proxy_password_entry_changed(self._http_proxy_password_entry)
+        else:
+            # HTTP proxy entries have been hidden, clear the corresponding data from
+            # the subscription request structure, but keep it in the entries in case
+            # the user tries to show them again before next spoke entry clears them
+            self._subscription_request.server_proxy_hostname = ""
+            self._subscription_request.server_proxy_posr = -1
+            self._subscription_request.server_proxy_user = ""
+            self._subscription_request.server_proxy_password = ""
+
+    def on_http_proxy_location_entry_changed(self, editable):
+        hostname = ""
+        port = -1  # not set == -1
+        entered_text = editable.get_text()
+        if entered_text:
+            proxy_obj = ProxyString(url=entered_text)
+            hostname = proxy_obj.host
+            if proxy_obj.port:
+                # the DBus API expects an integer
+                port = int(proxy_obj.port)
+        self.subscription_request.server_proxy_hostname = hostname
+        self.subscription_request.server_proxy_port = port
+
+    def on_http_proxy_username_entry_changed(self, editable):
+        self.subscription_request.server_proxy_user = editable.get_text()
+
+    def on_http_proxy_password_entry_changed(self, editable):
+        self.subscription_request.server_proxy_password = editable.get_text()
+
+    # custom server hostname and rhsm baseurl signals
+
+    def on_custom_server_hostname_checkbox_toggled(self, checkbox):
+        active = checkbox.get_active()
+        self._custom_server_hostname_revealer.set_reveal_child(active)
+        if active:
+            # make sure data in the server hostname entry
+            # is forwarded to the subscription request structure
+            # in case something was entered before the entry was
+            # hidden
+            self.on_custom_server_hostname_entry_changed(self._custom_server_hostname_entry)
+        else:
+            # the entry was hidden, clear the data from subscription request but
+            # keep it in the entry in case user decides to show the entry again
+            # before next spoke entry clears it
+            self.subscription_request.server_hostname = ""
+
+    def on_custom_server_hostname_entry_changed(self, editable):
+        self.subscription_request.server_hostname = editable.get_text()
+
+    def on_custom_rhsm_baseurl_checkbox_toggled(self, checkbox):
+        active = checkbox.get_active()
+        self._custom_rhsm_baseurl_revealer.set_reveal_child(active)
+        if active:
+            # make sure data in the rhsm baseurl entry
+            # is forwarded to the subscription request structure
+            # in case something was entered before the entry was
+            # hidden
+            self.on_custom_rhsm_baseurl_entry_changed(self._custom_rhsm_baseurl_entry)
+        else:
+            # the entry was hidden, clear the data from subscription request but
+            # keep it in the entry in case user decides to show the entry again
+            # before next spoke entry clears it
+            self.subscription_request.rhsm_baseurl = ""
+
+    def on_custom_rhsm_baseurl_entry_changed(self, editable):
+        self.subscription_request.rhsm_baseurl = editable.get_text()
+
+    # button signals
+
+    def on_register_button_clicked(self, button):
+        log.debug("Subscription GUI: register button clicked")
+        self._register()
+
+    def on_unregister_button_clicked(self, button):
+        """Handle registration related tasks."""
+        log.debug("Subscription GUI: unregister button clicked")
+        self._unregister()
+
+    # properties - general properties
+
+    @property
+    def registration_phase(self):
+        """Reports what phase the registration procedure is in.
+
+        Only valid if a registration thread is running.
+        """
+        return self._registration_phase
+
+    @registration_phase.setter
+    def registration_phase(self, phase):
+        self._registration_phase = phase
+
+    @property
+    def subscription_attached(self):
+        """Was a subscription entitlement successfully attached ?"""
+        return self._subscription_module.IsSubscriptionAttached
+
+    @property
+    def network_connected(self):
+        """Does it look like that we have network connectivity ?
+
+        Network connectivity is required for subscribing a system.
+        """
+        return self._network_module.Connected
+
+    @property
+    def authentication_method(self):
+        """Report which authentication method is in use."""
+        return self._authentication_method
+
+    @authentication_method.setter
+    def authentication_method(self, method):
+        self._authentication_method = method
+        if method == AuthenticationMethod.USERNAME_PASSWORD:
+            self.activation_key_visible = False
+            self.account_visible = True
+            self.subscription_request.type = SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD
+        elif method == AuthenticationMethod.ORG_KEY:
+            self.activation_key_visible = True
+            self.account_visible = False
+            self.subscription_request.type = SUBSCRIPTION_REQUEST_TYPE_ORG_KEY
+
+    @property
+    def options_set(self):
+        """Report if at least one option in the Options section has been set."""
+        return self.http_proxy_visible or self.custom_server_hostname_visible or \
+            self.custom_rhsm_baseurl_visible
+
+    @property
+    def registration_error(self):
+        return self._registration_error
+
+    @registration_error.setter
+    def registration_error(self, error_message):
+        self._registration_error = error_message
+        # also set the spoke warning banner
+        self.show_warning_message(error_message)
+
+    def initialize(self):
+        NormalSpoke.initialize(self)
+        self.initialize_start()
+
+        # get object references from the builders
+        self._main_notebook = self.builder.get_object("main_notebook")
+
+        # * the registration tab  * #
+
+        # container for the main registration controls
+        self._registration_grid = self.builder.get_object("registration_grid")
+
+        # authentication
+        self._account_radio_button = self.builder.get_object("account_radio_button")
+        self._activation_key_radio_button = self.builder.get_object("activation_key_radio_button")
+
+        # authentication - account
+        self._account_revealer = self.builder.get_object("account_revealer")
+        self._username_entry = self.builder.get_object("username_entry")
+        self._password_entry = self.builder.get_object("password_entry")
+
+        # authentication - activation key
+        self._activation_key_revealer = self.builder.get_object("activation_key_revealer")
+        self._organization_entry = self.builder.get_object("organization_entry")
+        self._activation_key_entry = self.builder.get_object("activation_key_entry")
+
+        # system purpose
+        self._system_purpose_checkbox = self.builder.get_object("system_purpose_checkbox")
+        self._system_purpose_revealer = self.builder.get_object("system_purpose_revealer")
+        self._system_purpose_role_combobox = self.builder.get_object(
+            "system_purpose_role_combobox"
+        )
+        self._system_purpose_sla_combobox = self.builder.get_object(
+            "system_purpose_sla_combobox"
+        )
+        self._system_purpose_usage_combobox = self.builder.get_object(
+            "system_purpose_usage_combobox"
+        )
+
+        # insights
+        self._insights_checkbox = self.builder.get_object("insights_checkbox")
+
+        # options expander
+        self._options_expander = self.builder.get_object("options_expander")
+
+        # HTTP proxy
+        self._http_proxy_checkbox = self.builder.get_object("http_proxy_checkbox")
+        self._http_proxy_revealer = self.builder.get_object("http_proxy_revealer")
+        self._http_proxy_location_entry = self.builder.get_object("http_proxy_location_entry")
+        self._http_proxy_username_entry = self.builder.get_object("http_proxy_username_entry")
+        self._http_proxy_password_entry = self.builder.get_object("http_proxy_password_entry")
+
+        # RHSM baseurl
+        self._custom_rhsm_baseurl_checkbox = self.builder.get_object(
+            "custom_rhsm_baseurl_checkbox"
+        )
+        self._custom_rhsm_baseurl_revealer = self.builder.get_object(
+            "custom_rhsm_baseurl_revealer"
+        )
+        self._custom_rhsm_baseurl_entry = self.builder.get_object(
+            "custom_rhsm_baseurl_entry"
+        )
+
+        # server hostname
+        self._custom_server_hostname_checkbox = self.builder.get_object(
+            "custom_server_hostname_checkbox"
+        )
+        self._custom_server_hostname_revealer = self.builder.get_object(
+            "custom_server_hostname_revealer"
+        )
+        self._custom_server_hostname_entry = self.builder.get_object(
+            "custom_server_hostname_entry"
+        )
+
+        # status label
+        self._registration_status_label = self.builder.get_object("registration_status_label")
+
+        # register button
+        self._register_button = self.builder.get_object("register_button")
+
+        # * the subscription status tab * #
+
+        # general status
+        self._method_status_label = self.builder.get_object("method_status_label")
+        self._role_status_label = self.builder.get_object("role_status_label")
+        self._sla_status_label = self.builder.get_object("sla_status_label")
+        self._usage_status_label = self.builder.get_object("usage_status_label")
+        self._insights_status_label = self.builder.get_object("insights_status_label")
+
+        # attached subscriptions
+        self._attached_subscriptions_label = self.builder.get_object(
+            "attached_subscriptions_label"
+        )
+        self._subscriptions_listbox = self.builder.get_object("subscriptions_listbox")
+
+        # unregister button
+        self._unregister_revealer = self.builder.get_object("unregister_revealer")
+        self._unregister_button = self.builder.get_object("unregister_button")
+
+        # setup spoke state based on data from the Subscription DBus module
+        self._update_spoke_state()
+
+        # wait for subscription thread to finish (if any)
+        # TODO - synchronization with subscription thread
+
+        # update overall state
+        self._update_registration_state()
+        self._update_subscription_state()
+
+        # Send ready signal to main event loop
+        hubQ.send_ready(self.__class__.__name__, False)
+
+        # report that we are done
+        self.initialize_done()
+
+    # private methods
+
+    def _update_spoke_state(self):
+        """Setup spoke state based on Subscription DBus module state.
+
+        Subscription DBus module state is represented by the SubscriptionRequest and
+        SystemPurposeData DBus structures. We first update their local mirrors from
+        the DBus module and then set all the controls in the spoke to values
+        represented in the DBus structures.
+
+        NOTE: There are a couple special cases where we need to do some special precessing,
+              such as for fields holding sensitive data. If we blindly set those based
+              on DBus structure data, we would effectively clear them as the Subscription
+              DBus module never returns previously set sensitive data in plain text.
+
+        """
+        # start by pulling in fresh data from the Subscription DBus module
+        self._subscription_request = self._get_subscription_request()
+        self._system_purpose_data = self._get_system_purpose_data()
+
+        # next update the authentication part of the UI
+        self._update_authetication_ui()
+
+        # check if system purpose part of the spoke should be visible
+        self.system_purpose_visible = self.system_purpose_data.check_data_available()
+
+        # NOTE: the fill_combobox() function makes sure to remove old data from the
+        #       combo box before filling it
+
+        # role
+        fill_combobox(self._system_purpose_role_combobox,
+                      self.system_purpose_data.role,
+                      self._subscription_module.proxy.GetValidRoles())
+        # SLA
+        fill_combobox(self._system_purpose_sla_combobox,
+                      self.system_purpose_data.sla,
+                      self._subscription_module.proxy.GetValidSLAs())
+        # usage
+        fill_combobox(self._system_purpose_usage_combobox,
+                      self.system_purpose_data.usage,
+                      self._subscription_module.GetValidUsageTypes())
+
+        # Insights
+        self._insights_checkbox.set_active(self._subscription_module.InsightsEnabled)
+
+        # update the HTTP proxy part of the UI
+        self._update_http_proxy_ui()
+
+        # set custom server hostname
+        self.custom_server_hostname_visible = bool(self.subscription_request.server_hostname)
+        self._custom_server_hostname_entry.set_text(self.subscription_request.server_hostname)
+
+        # set custom rhsm baseurl
+        self.custom_rhsm_baseurl_visible = bool(self.subscription_request.rhsm_baseurl)
+        self._custom_rhsm_baseurl_entry.set_text(self.subscription_request.rhsm_baseurl)
+
+        # if there is something set in the Options section, expand the expander
+        # - this needs to go last, after all the values in option section are set/not set
+        if self.options_set:
+            self.options_visible = True
+
+    def _update_authetication_ui(self):
+        """Update the authentication part of the spoke.
+
+        - SubscriptionRequest always has type set
+        - username + password is the default
+        For the related password and activation keys entry holding sensitive data
+        we need to reconcile the data held in the spoke from previous entry with
+        data set in the DBus module previously:
+        - data in module and entry empty -> set placeholder
+        - data in module and entry populated -> keep text in entry,
+          we assume it is the same as what is in module
+        - no data in module and entry populated -> clear entry & any placeholders
+          (data cleared over DBus API)
+        - no data in module and entry empty -> do nothing
+        """
+        if self.subscription_request.type == SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD:
+            self.authentication_method = AuthenticationMethod.USERNAME_PASSWORD
+            self._username_entry.set_text(self.subscription_request.account_username)
+            set_in_entry = bool(self._password_entry.get_text())
+            set_in_module = self.subscription_request.account_password.type == SECRET_TYPE_HIDDEN
+            if set_in_module:
+                if not set_in_entry:
+                    self.enable_password_placeholder(True)
+            else:
+                self._password_entry.set_text("")
+                self.enable_password_placeholder(False)
+        elif self.subscription_request.type == SUBSCRIPTION_REQUEST_TYPE_ORG_KEY:
+            self.authentication_method = AuthenticationMethod.ORG_KEY
+            self._organization_entry.set_text(self.subscription_request.organization)
+            set_in_entry = bool(self._activation_key_entry.get_text())
+            set_in_module = self.subscription_request.activation_keys.type == SECRET_TYPE_HIDDEN
+            if set_in_module:
+                if not set_in_entry:
+                    self.enable_activation_key_placeholder(True)
+            else:
+                self._activation_key_entry.set_text("")
+                self.enable_activation_key_placeholder(False)
+
+    def _update_http_proxy_ui(self):
+        """Update the HTTP proxy configuration part of the spoke."""
+        proxy_hostname = self.subscription_request.server_proxy_hostname
+        proxy_port = self.subscription_request.server_proxy_port
+        proxy_port_set = proxy_port >= 0
+        proxy_username = self.subscription_request.server_proxy_user
+        proxy_password_secret = self.subscription_request.server_proxy_password
+        proxy_password_set = proxy_password_secret.type == SECRET_TYPE_HIDDEN
+        self.http_proxy_visible = proxy_hostname or proxy_username or proxy_password_set
+        if proxy_hostname:
+            proxy_url = proxy_hostname
+            if proxy_port_set:
+                proxy_url = "{}:{}".format(proxy_url, proxy_port)
+            self._http_proxy_location_entry.set_text(proxy_url)
+        # HTTP proxy username
+        self._http_proxy_username_entry.set_text(proxy_username)
+        # HTTP proxy password
+        set_in_entry = bool(self._http_proxy_password_entry.get_text())
+        secret_type = self.subscription_request.server_proxy_password.type
+        set_in_module = secret_type == SECRET_TYPE_HIDDEN
+        if set_in_module:
+            if not set_in_entry:
+                self.enable_http_proxy_password_placeholder(True)
+        else:
+            self._http_proxy_password_entry.set_text("")
+            self.enable_http_proxy_password_placeholder(False)
+
+    def _set_data_to_module(self):
+        """Set system purpose data to the DBus module.
+
+        Called either on apply() or right before a subscription
+        attempt.
+        """
+        self._set_system_purpose_data()
+        # Set data about Insights to the DBus module.
+        self._set_insights()
+        # Set subscription request to the DBus module.
+        self._set_subscription_request()
+
+    def _get_system_purpose_data(self):
+        """Get SystemPurposeData from the Subscription module."""
+        struct = self._subscription_module.SystemPurposeData
+        return SystemPurposeData.from_structure(struct)
+
+    def _set_system_purpose_data(self):
+        """Set system purpose data to the Subscription DBus module."""
+        self._subscription_module.SetSystemPurposeData(
+            SystemPurposeData.to_structure(self.system_purpose_data)
+        )
+        # also apply the data (only applies when needed)
+        self._apply_system_purpose_data()
+
+    def _apply_system_purpose_data(self):
+        """Apply system purpose data to the installation environment.
+
+        Apply system purpose data to the installation environment, provided that:
+        - system purpose data has not yet been applied to the system
+        or
+        - current system purpose data is different from the data last applied to the system
+
+        Due to that we keep a copy of the last applied system purpose data so that we can
+        check for difference.
+
+        If the last applied data is the same as current system purpose data, nothing is done.
+        """
+        if self._last_applied_system_purpose_data != self.system_purpose_data:
+            log.debug("Subscription GUI: applying system purpose data to installation environment")
+            task_path = self._subscription_module.SetSystemPurposeWithTask()
+            task_proxy = SUBSCRIPTION.get_proxy(task_path)
+            sync_run_task(task_proxy)
+            self._last_applied_system_purpose_data = self.system_purpose_data
+
+    def _get_subscription_request(self):
+        """Get SubscriptionRequest from the Subscription module."""
+        struct = self._subscription_module.SubscriptionRequest
+        return SubscriptionRequest.from_structure(struct)
+
+    def _set_subscription_request(self):
+        """Set subscription request to the Subscription DBus module."""
+        self._subscription_module.SetSubscriptionRequest(
+            SubscriptionRequest.to_structure(self.subscription_request)
+        )
+
+    def _set_insights(self):
+        """Configure Insights in DBus module based on GUI state."""
+        self._subscription_module.InsightsEnabled(self._insights_checkbox.get_active())
+
+    def _register(self):
+        """Try to register a system."""
+        # TODO
+
+    def _unregister(self):
+        """Try to unregister a system."""
+        # TODO
+
+    def _update_registration_state(self):
+        """Update state of the registration related part of the spoke."""
+        # TODO
+
+    def _update_subscription_state(self):
+        """Update state of the subscription related part of the spoke.
+
+        Update state of the part of the spoke, that shows data about the
+        currently attached subscriptions.
+        """
+        # TODO
+
+    def _check_connectivity(self):
+        """Check network connectivity is available."""
+        # TODO
+
+    def _update_register_button_state(self):
+        """Update register button state."""
+        # TODO

--- a/tests/gettext_tests/style_guide.py
+++ b/tests/gettext_tests/style_guide.py
@@ -61,6 +61,9 @@ expected_badness = {
     },
     'pyanaconda/modules/storage/devicetree/fsset.py': {
         'mountpoint': 1,  # format string specifier mount_point
+    },
+    'pyanaconda/ui/gui/spokes/subscription.glade': {
+       'hostname': 1      # hostname:port placeholder for proxy URL entry
     }
 }
 

--- a/tests/nosetests/pyanaconda_tests/simple_ui_test.py
+++ b/tests/nosetests/pyanaconda_tests/simple_ui_test.py
@@ -181,7 +181,8 @@ class SimpleUITestCase(unittest.TestCase):
                 'CustomPartitioningSpoke',
                 'FilterSpoke',
                 'NetworkSpoke',
-                'StorageSpoke'
+                'StorageSpoke',
+                'SubscriptionSpoke'
             ],
             'UserSettingsCategory': [
                 'PasswordSpoke',

--- a/tests/nosetests/pyanaconda_tests/subscription_spoke_tests.py
+++ b/tests/nosetests/pyanaconda_tests/subscription_spoke_tests.py
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
+
+import unittest
+
+from pyanaconda.ui.gui.spokes.lib.subscription import handle_user_provided_value
+
+
+class SubscriptionSpokeHelpersTestCase(unittest.TestCase):
+    """Test the helper functions of the Subscription spoke."""
+
+    def handle_user_provided_value_test(self):
+        """Test the handle_user_provided_value() helper function."""
+        valid_values = ["Self Support", "Standard", "Premium"]
+        # user provided value matches one of the valid values
+        expected_output = [("Self Support", "Self Support", False),
+                           ("Standard", "Standard", True),
+                           ("Premium", "Premium", False)]
+        output = handle_user_provided_value("Standard", valid_values)
+        self.assertEqual(output, expected_output)
+        # user provided value does not match one of the valid values
+        expected_output = [("Self Support", "Self Support", False),
+                           ("Standard", "Standard", False),
+                           ("Premium", "Premium", False),
+                           ("Custom", "Other (Custom)", True)]
+        output = handle_user_provided_value("Custom", valid_values)
+        self.assertEqual(output, expected_output)
+        # user provided empty string
+        expected_output = [("Self Support", "Self Support", False),
+                           ("Standard", "Standard", False),
+                           ("Premium", "Premium", False)]
+        output = handle_user_provided_value("", valid_values)
+        self.assertEqual(output, expected_output)


### PR DESCRIPTION
The first commit adds the full Glade file "XML blob" providing all the spoke widget layout similar to what is currently in RHEL 8.2.

The second commit adds a couple helper functions in a separate file for easy unit testing. It is expected more will be added there later.

The third commit adds the main Subscription spoke structure. This is mostly boilerplate for interacting with the many controls on the Subscription spoke, with many of the logic methods intentionally left out for now. It is expected followup PRs of much more manageable size will add these parts. See the commit message for list of what has been left out in detail.