### PR TITLE
Work around pylint 2.5.0 issue with _ in warning id

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -376,7 +376,8 @@ if __name__ == "__main__":
             # The module-level _() calls are ok here because the language may
             # be set from the live environment in this case, and anaconda's
             # language setup hasn't happened yet.
-            # pylint: disable=found-_-in-module-class
+            # FIXME: change the line below back to found-_-in-module-class once it works in pylint
+            # pylint: disable=W9902
             util.execWithRedirect("zenity",
                                   ["--error", "--title", _("Unable to create PID file"), "--text",
                                    _("Anaconda is unable to create %s because the file"


### PR DESCRIPTION
Pylint 2.5.0 chokes on disable pragmas that contain `_`. See https://github.com/PyCQA/pylint/issues/3604

*This does NOT fix all errors after upgrading to pylint 2.5.0, only one of them.*