### PR TITLE
Create a DBus proxy of the DNF module

### DIFF
--- a/pyanaconda/modules/common/errors/payload.py
+++ b/pyanaconda/modules/common/errors/payload.py
@@ -48,9 +48,3 @@ class IncompatibleSourceError(AnacondaError):
 class InstallError(AnacondaError):
     """Error raised during payload installation."""
     pass
-
-
-@dbus_error("PayloadNotSetError", namespace=PAYLOADS_NAMESPACE)
-class PayloadNotSetError(AnacondaError):
-    """Payload is not set."""
-    pass

--- a/pyanaconda/modules/payloads/payloads.py
+++ b/pyanaconda/modules/payloads/payloads.py
@@ -85,11 +85,11 @@ class PayloadsService(KickstartService):
         """
         return self._active_payload
 
-    def set_payload(self, payload):
-        """Set payload."""
+    def activate_payload(self, payload):
+        """Activate the payload."""
         self._active_payload = payload
         self.active_payload_changed.emit()
-        log.debug("Payload %s used.", payload.__class__.__name__)
+        log.debug("Activated the payload %s.", payload.type)
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
@@ -99,6 +99,7 @@ class PayloadsService(KickstartService):
         if payload_type:
             payload_module = self.create_payload(payload_type)
             payload_module.process_kickstart(data)
+            self.activate_payload(payload_module)
 
     def setup_kickstart(self, data):
         """Set up the kickstart data."""
@@ -125,7 +126,6 @@ class PayloadsService(KickstartService):
         """
         payload = PayloadFactory.create_payload(payload_type)
         self._add_created_payload(payload)
-        self.set_payload(payload)
         return payload
 
     def create_source(self, source_type):

--- a/pyanaconda/modules/payloads/payloads.py
+++ b/pyanaconda/modules/payloads/payloads.py
@@ -76,13 +76,6 @@ class PayloadsService(KickstartService):
         self._payload = payload
         log.debug("Payload %s used.", payload.__class__.__name__)
 
-    def is_payload_set(self):
-        """Test if any payload is created and used.
-
-        :rtype: bool
-        """
-        return self._payload is not None
-
     def get_active_payload(self):
         """Get active payload.
 

--- a/pyanaconda/modules/payloads/payloads.py
+++ b/pyanaconda/modules/payloads/payloads.py
@@ -37,6 +37,9 @@ class PayloadsService(KickstartService):
 
     def __init__(self):
         super().__init__()
+        self._created_payloads = []
+        self.created_payloads_changed = Signal()
+
         self._active_payload = None
         self.active_payload_changed = Signal()
 
@@ -55,6 +58,17 @@ class PayloadsService(KickstartService):
     def kickstart_specification(self):
         """Return the kickstart specification."""
         return PayloadKickstartSpecification
+
+    @property
+    def created_payloads(self):
+        """List of all created payload modules."""
+        return self._created_payloads
+
+    def _add_created_payload(self, module):
+        """Add a created payload module."""
+        self._created_payloads.append(module)
+        self.created_payloads_changed.emit(module)
+        log.debug("Created the payload %s.", module.type)
 
     @property
     def active_payload(self):
@@ -110,6 +124,7 @@ class PayloadsService(KickstartService):
         :type payload_type: value of the payload.base.constants.PayloadType enum
         """
         payload = PayloadFactory.create_payload(payload_type)
+        self._add_created_payload(payload)
         self.set_payload(payload)
         return payload
 

--- a/pyanaconda/modules/payloads/payloads_interface.py
+++ b/pyanaconda/modules/payloads/payloads_interface.py
@@ -41,13 +41,6 @@ class PayloadsInterface(KickstartModuleInterface):
             self.implementation.get_active_payload()
         )
 
-    def IsPayloadSet(self) -> Bool:
-        """Test if any payload is set and used.
-
-        FIXME: This is potentially dangerous and replaceable by GetActivePayload.
-        """
-        return self.implementation.is_payload_set()
-
     def CreatePayload(self, payload_type: Str) -> ObjPath:
         """Create payload and publish it on DBus.
 

--- a/pyanaconda/modules/payloads/payloads_interface.py
+++ b/pyanaconda/modules/payloads/payloads_interface.py
@@ -30,16 +30,10 @@ from pyanaconda.modules.payloads.constants import PayloadType, SourceType
 class PayloadsInterface(KickstartModuleInterface):
     """DBus interface for Payload module."""
 
-    def GetActivePayload(self) -> ObjPath:
-        """Get active payload.
-
-        TODO: Do we need to think about ActivePayload? It would be easier to remove this concept.
-
-        :raise: PayloadNotSetError if payload is not set
-        """
-        return PayloadContainer.to_object_path(
-            self.implementation.get_active_payload()
-        )
+    def connect_signals(self):
+        """Connect the signals."""
+        super().connect_signals()
+        self.watch_property("ActivePayload", self.implementation.active_payload_changed)
 
     def CreatePayload(self, payload_type: Str) -> ObjPath:
         """Create payload and publish it on DBus.
@@ -52,6 +46,19 @@ class PayloadsInterface(KickstartModuleInterface):
         return PayloadContainer.to_object_path(
             self.implementation.create_payload(PayloadType(payload_type))
         )
+
+    @property
+    def ActivePayload(self) -> Str:
+        """The active payload.
+
+        :return: a DBus path or an empty string
+        """
+        payload = self.implementation.active_payload
+
+        if not payload:
+            return ""
+
+        return PayloadContainer.to_object_path(payload)
 
     def CreateSource(self, source_type: Str) -> ObjPath:
         """Create payload source and publish it on DBus.

--- a/pyanaconda/modules/payloads/payloads_interface.py
+++ b/pyanaconda/modules/payloads/payloads_interface.py
@@ -18,6 +18,7 @@
 # Red Hat, Inc.
 #
 from dasbus.server.interface import dbus_interface
+from dasbus.server.property import emits_properties_changed
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
 from pyanaconda.modules.common.base import KickstartModuleInterface
@@ -33,8 +34,10 @@ class PayloadsInterface(KickstartModuleInterface):
     def connect_signals(self):
         """Connect the signals."""
         super().connect_signals()
+        self.watch_property("CreatedPayloads", self.implementation.created_payloads_changed)
         self.watch_property("ActivePayload", self.implementation.active_payload_changed)
 
+    @emits_properties_changed
     def CreatePayload(self, payload_type: Str) -> ObjPath:
         """Create payload and publish it on DBus.
 
@@ -45,6 +48,16 @@ class PayloadsInterface(KickstartModuleInterface):
         """
         return PayloadContainer.to_object_path(
             self.implementation.create_payload(PayloadType(payload_type))
+        )
+
+    @property
+    def CreatedPayloads(self) -> List[ObjPath]:
+        """List of all created payload modules.
+
+        :return: a list of DBus paths
+        """
+        return PayloadContainer.to_object_path_list(
+            self.implementation.created_payloads
         )
 
     @property

--- a/pyanaconda/modules/payloads/payloads_interface.py
+++ b/pyanaconda/modules/payloads/payloads_interface.py
@@ -60,6 +60,16 @@ class PayloadsInterface(KickstartModuleInterface):
             self.implementation.created_payloads
         )
 
+    @emits_properties_changed
+    def ActivatePayload(self, payload: ObjPath):
+        """Activate the payload.
+
+        :param payload: a path to a payload
+        """
+        self.implementation.activate_payload(
+            PayloadContainer.from_object_path(payload)
+        )
+
     @property
     def ActivePayload(self) -> Str:
         """The active payload.

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -77,6 +77,7 @@ from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
 from pyanaconda.product import productName, productVersion
 from pyanaconda.progress import progressQ, progress_message
 from pyanaconda.simpleconfig import SimpleConfigFile
+from pyanaconda.ui.lib.payload import get_payload
 
 log = get_packaging_logger()
 
@@ -89,6 +90,9 @@ class DNFPayload(Payload):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Get a DBus payload to use.
+        self._dnf_proxy = get_payload(self.type)
+
         self.install_device = None
         self.tx_id = None
 
@@ -124,6 +128,16 @@ class DNFPayload(Payload):
     def type(self):
         """The DBus type of the payload."""
         return PAYLOAD_TYPE_DNF
+
+    @property
+    def proxy(self):
+        """The DBus proxy of the DNF module.
+
+        FIXME: Move the property to the class Payload.
+
+        :return: a DBus proxy
+        """
+        return self._dnf_proxy
 
     @property
     def is_hmc_enabled(self):

--- a/pyanaconda/ui/lib/payload.py
+++ b/pyanaconda/ui/lib/payload.py
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.constants import PAYLOAD_TYPE_DNF
+from pyanaconda.modules.common.constants.services import PAYLOADS
+
+log = get_module_logger(__name__)
+
+
+def create_payload(payload_type=PAYLOAD_TYPE_DNF, activate=True):
+    """Create a payload module.
+
+    :param payload_type: a payload type
+    :param activate: True to activate the payload, otherwise False
+    :return: a proxy of a payload module
+    """
+    payloads_proxy = PAYLOADS.get_proxy()
+    object_path = payloads_proxy.CreatePayload(payload_type)
+
+    if activate:
+        payloads_proxy.ActivatePayload(object_path)
+
+    return PAYLOADS.get_proxy(object_path)
+
+
+def get_payload(payload_type=PAYLOAD_TYPE_DNF):
+    """Get a payload of the specified type.
+
+    If there is no active payload of the specified type,
+    we will create and activate a new payload.
+
+    :return: a proxy of a payload module
+    """
+    payloads_proxy = PAYLOADS.get_proxy()
+    object_path = payloads_proxy.ActivePayload
+
+    # Choose the active payload.
+    if object_path:
+        object_proxy = PAYLOADS.get_proxy(object_path)
+
+        # Check the type of the active payload.
+        if object_proxy.Type == payload_type:
+            return object_proxy
+
+    # Or create a new payload.
+    return create_payload(payload_type)

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
@@ -48,7 +48,6 @@ class DNFKSTestCase(unittest.TestCase):
 
     def _check_properties(self, expected_source_type):
         payload = self.shared_ks_tests.get_payload()
-
         self.assertIsInstance(payload, DNFModule)
 
         # verify sources set
@@ -107,7 +106,7 @@ class DNFKSTestCase(unittest.TestCase):
         """
         # One publisher call because the biospart support is decided in the harddrive source
         self.shared_ks_tests.check_kickstart(ks_in, ks_valid=False, expected_publish_calls=1)
-        self._check_properties(None)
+        self.assertEqual(self.interface.ActivePayload, "")
 
     def nfs_kickstart_test(self):
         ks_in = """

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
@@ -28,7 +28,6 @@ from dasbus.typing import *  # pylint: disable=wildcard-import
 
 from pyanaconda.core.constants import SOURCE_TYPE_CDROM, SOURCE_TYPE_HDD, SOURCE_TYPE_HMC, \
     SOURCE_TYPE_NFS, SOURCE_TYPE_REPO_FILES, SOURCE_TYPE_URL, URL_TYPE_BASEURL
-from pyanaconda.modules.common.errors.payload import PayloadNotSetError
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.payloads.constants import PayloadType, SourceType
 from pyanaconda.modules.payloads.payload.dnf.dnf import DNFModule
@@ -98,9 +97,7 @@ class DNFKSTestCase(unittest.TestCase):
         harddrive --partition=nsa-device
         """
         self.shared_ks_tests.check_kickstart(ks_in, ks_valid=False, expected_publish_calls=0)
-
-        with self.assertRaises(PayloadNotSetError):
-            self.interface.GetActivePayload()
+        self.assertEqual(self.interface.ActivePayload, "")
 
     def harddrive_biospart_kickstart_failed_test(self):
         # The biospart parameter is not implemented since 2012 and it won't

--- a/tests/nosetests/pyanaconda_tests/module_payload_shared.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_shared.py
@@ -61,7 +61,7 @@ class PayloadKickstartSharedTest(object):
 
     def get_payload(self):
         """Get payload created."""
-        return self.payload_service.payload
+        return self.payload_service.active_payload
 
 
 class PayloadSharedTest(object):

--- a/tests/nosetests/pyanaconda_tests/module_payloads_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payloads_test.py
@@ -99,14 +99,6 @@ class PayloadsInterfaceTestCase(TestCase):
             self.payload_interface.GetActivePayload()
 
     @patch_dbus_publish_object
-    def is_payload_set_test(self, publisher):
-        """Test IsPayloadSet API."""
-        self.assertFalse(self.payload_interface.IsPayloadSet())
-
-        self.payload_interface.CreatePayload(PayloadType.DNF.value)
-        self.assertTrue(self.payload_interface.IsPayloadSet())
-
-    @patch_dbus_publish_object
     def create_dnf_payload_test(self, publisher):
         """Test creation and publishing of the DNF payload module."""
         payload_path = self.payload_interface.CreatePayload(PayloadType.DNF.value)

--- a/tests/nosetests/pyanaconda_tests/module_payloads_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payloads_test.py
@@ -99,7 +99,10 @@ class PayloadsInterfaceTestCase(TestCase):
         """Test creation and publishing of the DNF payload module."""
         payload_path = self.payload_interface.CreatePayload(PayloadType.DNF.value)
         self.assertEqual(self.payload_interface.CreatedPayloads, [payload_path])
+
+        self.payload_interface.ActivatePayload(payload_path)
         self.assertEqual(self.payload_interface.ActivePayload, payload_path)
+
         self.assertIsInstance(PayloadContainer.from_object_path(payload_path), DNFModule)
         publisher.assert_called_once()
 
@@ -108,7 +111,10 @@ class PayloadsInterfaceTestCase(TestCase):
         """Test creation and publishing of the Live OS payload module."""
         payload_path = self.payload_interface.CreatePayload(PayloadType.LIVE_OS.value)
         self.assertEqual(self.payload_interface.CreatedPayloads, [payload_path])
+
+        self.payload_interface.ActivatePayload(payload_path)
         self.assertEqual(self.payload_interface.ActivePayload, payload_path)
+
         self.assertIsInstance(PayloadContainer.from_object_path(payload_path), LiveOSModule)
         publisher.assert_called_once()
 
@@ -117,7 +123,10 @@ class PayloadsInterfaceTestCase(TestCase):
         """Test creation and publishing of the Live image payload module."""
         payload_path = self.payload_interface.CreatePayload(PayloadType.LIVE_IMAGE.value)
         self.assertEqual(self.payload_interface.CreatedPayloads, [payload_path])
+
+        self.payload_interface.ActivatePayload(payload_path)
         self.assertEqual(self.payload_interface.ActivePayload, payload_path)
+
         self.assertIsInstance(PayloadContainer.from_object_path(payload_path), LiveImageModule)
         publisher.assert_called_once()
 
@@ -132,12 +141,18 @@ class PayloadsInterfaceTestCase(TestCase):
         """Test creating two payloads."""
         path_1 = self.payload_interface.CreatePayload(PayloadType.DNF.value)
         self.assertEqual(self.payload_interface.CreatedPayloads, [path_1])
+        self.assertEqual(self.payload_interface.ActivePayload, "")
 
         path_2 = self.payload_interface.CreatePayload(PayloadType.LIVE_OS.value)
         self.assertEqual(self.payload_interface.CreatedPayloads, [path_1, path_2])
+        self.assertEqual(self.payload_interface.ActivePayload, "")
 
-        # The last one should win
+        self.payload_interface.ActivatePayload(path_1)
+        self.assertEqual(self.payload_interface.ActivePayload, path_1)
+
+        self.payload_interface.ActivatePayload(path_2)
         self.assertEqual(self.payload_interface.ActivePayload, path_2)
+
         self.assertEqual(publisher.call_count, 2)
 
     @patch_dbus_publish_object

--- a/tests/nosetests/pyanaconda_tests/module_payloads_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payloads_test.py
@@ -29,8 +29,7 @@ from tests.nosetests.pyanaconda_tests import patch_dbus_publish_object, check_db
 from tests.nosetests.pyanaconda_tests.module_payload_shared import PayloadKickstartSharedTest
 
 from pyanaconda.modules.common.containers import PayloadContainer
-from pyanaconda.modules.common.errors.payload import SourceSetupError, SourceTearDownError, \
-    PayloadNotSetError
+from pyanaconda.modules.common.errors.payload import SourceSetupError, SourceTearDownError
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase
 from pyanaconda.modules.payloads.base.utils import create_root_dir, write_module_blacklist, \
@@ -84,8 +83,7 @@ class PayloadsInterfaceTestCase(TestCase):
 
     def no_payload_set_test(self):
         """Test empty string is returned when no payload is set."""
-        with self.assertRaises(PayloadNotSetError):
-            self.payload_interface.GetActivePayload()
+        self.assertEqual(self.payload_interface.ActivePayload, "")
 
     def generate_kickstart_without_payload_test(self):
         """Test kickstart parsing without payload set."""
@@ -94,15 +92,13 @@ class PayloadsInterfaceTestCase(TestCase):
     def process_kickstart_with_no_payload_test(self):
         """Test kickstart processing when no payload set or created based on KS data."""
         self.payload_interface.ReadKickstart("")
-
-        with self.assertRaises(PayloadNotSetError):
-            self.payload_interface.GetActivePayload()
+        self.assertEqual(self.payload_interface.ActivePayload, "")
 
     @patch_dbus_publish_object
     def create_dnf_payload_test(self, publisher):
         """Test creation and publishing of the DNF payload module."""
         payload_path = self.payload_interface.CreatePayload(PayloadType.DNF.value)
-        self.assertEqual(self.payload_interface.GetActivePayload(), payload_path)
+        self.assertEqual(self.payload_interface.ActivePayload, payload_path)
         self.assertIsInstance(PayloadContainer.from_object_path(payload_path), DNFModule)
         publisher.assert_called_once()
 
@@ -110,7 +106,7 @@ class PayloadsInterfaceTestCase(TestCase):
     def create_live_os_payload_test(self, publisher):
         """Test creation and publishing of the Live OS payload module."""
         payload_path = self.payload_interface.CreatePayload(PayloadType.LIVE_OS.value)
-        self.assertEqual(self.payload_interface.GetActivePayload(), payload_path)
+        self.assertEqual(self.payload_interface.ActivePayload, payload_path)
         self.assertIsInstance(PayloadContainer.from_object_path(payload_path), LiveOSModule)
         publisher.assert_called_once()
 
@@ -118,7 +114,7 @@ class PayloadsInterfaceTestCase(TestCase):
     def create_live_image_payload_test(self, publisher):
         """Test creation and publishing of the Live image payload module."""
         payload_path = self.payload_interface.CreatePayload(PayloadType.LIVE_IMAGE.value)
-        self.assertEqual(self.payload_interface.GetActivePayload(), payload_path)
+        self.assertEqual(self.payload_interface.ActivePayload, payload_path)
         self.assertIsInstance(PayloadContainer.from_object_path(payload_path), LiveImageModule)
         publisher.assert_called_once()
 
@@ -135,7 +131,7 @@ class PayloadsInterfaceTestCase(TestCase):
         path = self.payload_interface.CreatePayload(PayloadType.LIVE_OS.value)
 
         # The last one should win
-        self.assertEqual(self.payload_interface.GetActivePayload(), path)
+        self.assertEqual(self.payload_interface.ActivePayload, path)
         self.assertEqual(publisher.call_count, 2)
 
     @patch_dbus_publish_object

--- a/tests/nosetests/pyanaconda_tests/module_payloads_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payloads_test.py
@@ -98,6 +98,7 @@ class PayloadsInterfaceTestCase(TestCase):
     def create_dnf_payload_test(self, publisher):
         """Test creation and publishing of the DNF payload module."""
         payload_path = self.payload_interface.CreatePayload(PayloadType.DNF.value)
+        self.assertEqual(self.payload_interface.CreatedPayloads, [payload_path])
         self.assertEqual(self.payload_interface.ActivePayload, payload_path)
         self.assertIsInstance(PayloadContainer.from_object_path(payload_path), DNFModule)
         publisher.assert_called_once()
@@ -106,6 +107,7 @@ class PayloadsInterfaceTestCase(TestCase):
     def create_live_os_payload_test(self, publisher):
         """Test creation and publishing of the Live OS payload module."""
         payload_path = self.payload_interface.CreatePayload(PayloadType.LIVE_OS.value)
+        self.assertEqual(self.payload_interface.CreatedPayloads, [payload_path])
         self.assertEqual(self.payload_interface.ActivePayload, payload_path)
         self.assertIsInstance(PayloadContainer.from_object_path(payload_path), LiveOSModule)
         publisher.assert_called_once()
@@ -114,6 +116,7 @@ class PayloadsInterfaceTestCase(TestCase):
     def create_live_image_payload_test(self, publisher):
         """Test creation and publishing of the Live image payload module."""
         payload_path = self.payload_interface.CreatePayload(PayloadType.LIVE_IMAGE.value)
+        self.assertEqual(self.payload_interface.CreatedPayloads, [payload_path])
         self.assertEqual(self.payload_interface.ActivePayload, payload_path)
         self.assertIsInstance(PayloadContainer.from_object_path(payload_path), LiveImageModule)
         publisher.assert_called_once()
@@ -127,11 +130,14 @@ class PayloadsInterfaceTestCase(TestCase):
     @patch_dbus_publish_object
     def create_multiple_payloads_test(self, publisher):
         """Test creating two payloads."""
-        self.payload_interface.CreatePayload(PayloadType.DNF.value)
-        path = self.payload_interface.CreatePayload(PayloadType.LIVE_OS.value)
+        path_1 = self.payload_interface.CreatePayload(PayloadType.DNF.value)
+        self.assertEqual(self.payload_interface.CreatedPayloads, [path_1])
+
+        path_2 = self.payload_interface.CreatePayload(PayloadType.LIVE_OS.value)
+        self.assertEqual(self.payload_interface.CreatedPayloads, [path_1, path_2])
 
         # The last one should win
-        self.assertEqual(self.payload_interface.ActivePayload, path)
+        self.assertEqual(self.payload_interface.ActivePayload, path_2)
         self.assertEqual(publisher.call_count, 2)
 
     @patch_dbus_publish_object

--- a/tests/nosetests/pyanaconda_tests/ui_payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/ui_payload_test.py
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+
+from pyanaconda.core.constants import PAYLOAD_TYPE_LIVE_OS, PAYLOAD_TYPE_DNF
+from pyanaconda.modules.common.constants.services import PAYLOADS
+from pyanaconda.ui.lib.payload import create_payload, get_payload
+from tests.nosetests.pyanaconda_tests import patch_dbus_get_proxy_with_cache
+
+
+class PayloadUITestCase(unittest.TestCase):
+    """Test the UI functions and classes of the payload object."""
+
+    @patch_dbus_get_proxy_with_cache
+    def create_payload_test(self, proxy_getter):
+        """Test the create_payload function."""
+        payloads_proxy = PAYLOADS.get_proxy()
+        payloads_proxy.CreatePayload.return_value = "/my/path"
+
+        payload_proxy = PAYLOADS.get_proxy("/my/path")
+        payload_proxy.Type = PAYLOAD_TYPE_LIVE_OS
+
+        self.assertEqual(create_payload(PAYLOAD_TYPE_LIVE_OS), payload_proxy)
+        payloads_proxy.CreatePayload.assert_called_once_with(PAYLOAD_TYPE_LIVE_OS)
+        payloads_proxy.ActivatePayload.assert_called_once_with("/my/path")
+
+    @patch_dbus_get_proxy_with_cache
+    def get_payload_test(self, proxy_getter):
+        """Test the get_payload function."""
+        payloads_proxy = PAYLOADS.get_proxy()
+        payloads_proxy.ActivePayload = "/my/path1"
+        payloads_proxy.CreatePayload.return_value = "/my/path2"
+
+        payload_proxy_1 = PAYLOADS.get_proxy("/my/path1")
+        payload_proxy_1.Type = PAYLOAD_TYPE_LIVE_OS
+
+        payload_proxy_2 = PAYLOADS.get_proxy("/my/path2")
+        payload_proxy_2.Type = PAYLOAD_TYPE_DNF
+
+        # Get the active payload.
+        self.assertEqual(get_payload(PAYLOAD_TYPE_LIVE_OS), payload_proxy_1)
+        self.assertEqual(get_payload(PAYLOAD_TYPE_LIVE_OS), payload_proxy_1)
+        payloads_proxy.ActivatePayload.assert_not_called()
+
+        # Or create a new one.
+        self.assertEqual(get_payload(PAYLOAD_TYPE_DNF), payload_proxy_2)
+        payloads_proxy.ActivatePayload.assert_called_once_with("/my/path2")


### PR DESCRIPTION
An instance of class DNFPayload can access its DBus counterpart via the property
proxy. The property will be eventually moved to the class Payload and created
for each type of the payload.

Refactorize the DBus API for working with payload modules. The current design
is based on the API for the partitioning modules.