### PR TITLE
Add ISOPath API to Hard drive payload source

### DIFF
--- a/pyanaconda/modules/payloads/source/harddrive/harddrive.py
+++ b/pyanaconda/modules/payloads/source/harddrive/harddrive.py
@@ -52,7 +52,7 @@ class HardDriveSourceModule(PayloadSourceBase, RPMSourceMixin):
         self._iso_mount = MountPointGenerator.generate_mount_point(
             self.type.value.lower() + "-iso"
         )
-        self._uses_iso_mount = False
+        self._iso_name = ""
 
     @property
     def type(self):
@@ -160,12 +160,13 @@ class HardDriveSourceModule(PayloadSourceBase, RPMSourceMixin):
         :rtype: [Task]
         """
         tasks = []
-        if self._uses_iso_mount:
+        if self._iso_name:
             tasks.append(TearDownMountTask(self._iso_mount))
         tasks.append(TearDownMountTask(self._device_mount))
         return tasks
 
     def _handle_setup_task_result(self, task):
         result = task.get_result()
-        self._install_tree_path, self._uses_iso_mount = result
+        self._install_tree_path = result.install_tree_path
+        self._iso_name = result.iso_name
         log.debug("Hard drive install tree path is set to '%s'", self._install_tree_path)

--- a/pyanaconda/modules/payloads/source/harddrive/harddrive.py
+++ b/pyanaconda/modules/payloads/source/harddrive/harddrive.py
@@ -55,6 +55,11 @@ class HardDriveSourceModule(PayloadSourceBase, RPMSourceMixin):
         self._iso_name = ""
 
     @property
+    def is_iso_mounted(self):
+        """Is ISO file mounted from set up task?"""
+        return bool(self._iso_name)
+
+    @property
     def type(self):
         """Get type of this source."""
         return SourceType.HDD
@@ -160,7 +165,7 @@ class HardDriveSourceModule(PayloadSourceBase, RPMSourceMixin):
         :rtype: [Task]
         """
         tasks = []
-        if self._iso_name:
+        if self.is_iso_mounted:
             tasks.append(TearDownMountTask(self._iso_mount))
         tasks.append(TearDownMountTask(self._device_mount))
         return tasks

--- a/pyanaconda/modules/payloads/source/harddrive/harddrive.py
+++ b/pyanaconda/modules/payloads/source/harddrive/harddrive.py
@@ -24,6 +24,7 @@ from pykickstart.errors import KickstartParseError
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
 from pyanaconda.core.signal import Signal
+from pyanaconda.core.util import join_paths
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.payloads.constants import SourceType, SourceState
 from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase, RPMSourceMixin
@@ -169,6 +170,20 @@ class HardDriveSourceModule(PayloadSourceBase, RPMSourceMixin):
             tasks.append(TearDownMountTask(self._iso_mount))
         tasks.append(TearDownMountTask(self._device_mount))
         return tasks
+
+    def get_iso_path(self):
+        """Get path to the ISO from the partition root.
+
+        This could be an empty string if the source is pointing to
+        installation tree instead of ISO.
+
+        :return: path to the ISO or empty string if no ISO is involved
+        :rtype: str
+        """
+        if not self._iso_name:
+            return ""
+
+        return join_paths(self.directory, self._iso_name)
 
     def _handle_setup_task_result(self, task):
         result = task.get_result()

--- a/pyanaconda/modules/payloads/source/harddrive/harddrive_interface.py
+++ b/pyanaconda/modules/payloads/source/harddrive/harddrive_interface.py
@@ -52,3 +52,11 @@ class HardDriveSourceInterface(PayloadSourceBaseInterface):
     def SetPartition(self, partition: Str):
         """Set the partition containing the repository."""
         self.implementation.set_device(partition)
+
+    def GetIsoPath(self) -> Str:
+        """Get path to the ISO from the partition root.
+
+        This could be an empty string if the source is pointing to
+        installation tree instead of ISO.
+        """
+        return self.implementation.get_iso_path()

--- a/pyanaconda/modules/payloads/source/harddrive/initialization.py
+++ b/pyanaconda/modules/payloads/source/harddrive/initialization.py
@@ -17,10 +17,11 @@
 #
 import os.path
 
+from pyanaconda.core.util import join_paths
+from pyanaconda.payload.image import find_first_iso_image
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.task import Task
-from pyanaconda.modules.payloads.source.utils import find_and_mount_device, \
-    find_and_mount_iso_image
+from pyanaconda.modules.payloads.source.utils import find_and_mount_device, mount_iso_image
 from pyanaconda.payload.image import verify_valid_installtree
 from pyanaconda.anaconda_loggers import get_module_logger
 
@@ -71,9 +72,15 @@ class SetUpHardDriveSourceTask(Task):
             "{}/{}".format(self._device_mount, self._directory)
         )
 
-        if find_and_mount_iso_image(full_path_on_mounted_device, self._iso_mount):
-            return self._iso_mount, True
-        elif verify_valid_installtree(full_path_on_mounted_device):
+        iso_name = find_first_iso_image(full_path_on_mounted_device)
+
+        full_path_to_iso = join_paths(full_path_on_mounted_device, iso_name)
+
+        if iso_name:
+            if mount_iso_image(full_path_to_iso, self._iso_mount):
+                return self._iso_mount, True
+
+        if verify_valid_installtree(full_path_on_mounted_device):
             return full_path_on_mounted_device, False
 
         raise SourceSetupError(

--- a/pyanaconda/modules/payloads/source/harddrive/initialization.py
+++ b/pyanaconda/modules/payloads/source/harddrive/initialization.py
@@ -17,6 +17,8 @@
 #
 import os.path
 
+from collections import namedtuple
+
 from pyanaconda.core.util import join_paths
 from pyanaconda.payload.image import find_first_iso_image
 from pyanaconda.modules.common.errors.payload import SourceSetupError
@@ -28,6 +30,9 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 __all__ = ["SetUpHardDriveSourceTask"]
+
+
+SetupHardDriveResult = namedtuple("SetupHardDriveResult", ["install_tree_path", "iso_name"])
 
 
 class SetUpHardDriveSourceTask(Task):
@@ -52,8 +57,8 @@ class SetUpHardDriveSourceTask(Task):
         order again.
 
         :raise: SourceSetupError
-        :return: path to the install tree
-        :rtype: str
+        :return: named tuple with path to the install tree and name of ISO if set or empty string
+        :rtype: SetupHardDriveResult instance
         """
         log.debug("Setting up Hard drive source")
 
@@ -78,10 +83,10 @@ class SetUpHardDriveSourceTask(Task):
 
         if iso_name:
             if mount_iso_image(full_path_to_iso, self._iso_mount):
-                return self._iso_mount, True
+                return SetupHardDriveResult(self._iso_mount, iso_name)
 
         if verify_valid_installtree(full_path_on_mounted_device):
-            return full_path_on_mounted_device, False
+            return SetupHardDriveResult(full_path_on_mounted_device, "")
 
         raise SourceSetupError(
             "Nothing useful found for Hard drive ISO source at partition={} directory={}".format(

--- a/pyanaconda/modules/payloads/source/utils.py
+++ b/pyanaconda/modules/payloads/source/utils.py
@@ -25,7 +25,7 @@ from pyanaconda.core.util import join_paths
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
-__all__ = ["is_valid_install_disk", "find_and_mount_device", "find_and_mount_iso_image",
+__all__ = ["is_valid_install_disk", "find_and_mount_device", "mount_iso_image",
            "MountPointGenerator"]
 
 

--- a/pyanaconda/modules/payloads/source/utils.py
+++ b/pyanaconda/modules/payloads/source/utils.py
@@ -21,7 +21,6 @@ from blivet.util import mount
 from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.core.storage import device_matches
 from pyanaconda.core.util import join_paths
-from pyanaconda.payload.image import find_first_iso_image
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -79,21 +78,17 @@ def find_and_mount_device(device_spec, mount_point):
         return False
 
 
-def find_and_mount_iso_image(image_location, mount_point):
-    """Find a ISO image in a location and mount it.
+def mount_iso_image(image_path, mount_point):
+    """Mount ISO image.
 
-    :param str image_location: where the image ISO file is
+    :param str image_path: where the image ISO file is
     :param str mount_point: where to mount the image
 
     :return: success or not
     :rtype: bool
     """
-    image_filename = find_first_iso_image(image_location)
-    if not image_filename:
-        return False
-    full_image_path = join_paths(image_location, image_filename)
     try:
-        mount(full_image_path, mount_point, fstype='iso9660', options="ro")
+        mount(image_path, mount_point, fstype='iso9660', options="ro")
         return True
     except OSError as e:
         log.error("Mount of ISO file failed: %s", e)

--- a/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
@@ -138,7 +138,7 @@ class HardDriveSourceTestCase(unittest.TestCase):
         self.module._handle_setup_task_result(task)
 
         self.assertEqual(self.module.install_tree_path, iso_mount_location)
-        self.assertEqual(self.module._iso_name, "iso_name.iso")
+        self.assertEqual(self.module.is_iso_mounted, True)
 
 
 class HardDriveSourceSetupTaskTestCase(unittest.TestCase):


### PR DESCRIPTION
This API will return name of the ISO. It's a replacement for `dnf.payload.ISO_image` to get name of the ISO to GUI.