### PR TITLE
Add DeviceName API to CDrom source

### DIFF
--- a/pyanaconda/modules/payloads/source/cdrom/cdrom_interface.py
+++ b/pyanaconda/modules/payloads/source/cdrom/cdrom_interface.py
@@ -18,6 +18,7 @@
 # Red Hat, Inc.
 #
 from dasbus.server.interface import dbus_interface
+from dasbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.constants.interfaces import PAYLOAD_SOURCE_CDROM
 from pyanaconda.modules.payloads.source.source_base_interface import PayloadSourceBaseInterface
 
@@ -25,4 +26,12 @@ from pyanaconda.modules.payloads.source.source_base_interface import PayloadSour
 @dbus_interface(PAYLOAD_SOURCE_CDROM.interface_name)
 class CdromSourceInterface(PayloadSourceBaseInterface):
     """Interface for the payload CD-ROM image source."""
-    pass
+
+    def connect_signals(self):
+        super().connect_signals()
+        self.watch_property("DeviceName", self.implementation.device_name_changed)
+
+    @property
+    def DeviceName(self) -> Str:
+        """Get device name of the cdrom found."""
+        return self.implementation.device_name

--- a/pyanaconda/modules/payloads/source/cdrom/initialization.py
+++ b/pyanaconda/modules/payloads/source/cdrom/initialization.py
@@ -59,3 +59,5 @@ class SetUpCdromSourceTask(SetUpMountTask):
 
         if not device_name:
             raise SourceSetupError("Found no CD-ROM")
+
+        return device_name

--- a/tests/nosetests/pyanaconda_tests/module_source_cdrom_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_cdrom_test.py
@@ -188,7 +188,7 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
         valid_mock.side_effect = [False, True, False]
 
         task = SetUpCdromSourceTask(self.mount_location)
-        task.run()
+        result = task.run()
 
         # 3/4 devices tried, 1/4 untried
         self.assert_resolve_and_mount_calls(device_tree, mount_mock, 3, 1)
@@ -200,6 +200,9 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
 
         #  #1 died earlier, #2 was unmounted, #3 was left mounted, #4 never got mounted
         unmount_mock.assert_called_once_with(self.mount_location)
+
+        # Test device name returned
+        self.assertEqual(result, "test2")
 
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.is_valid_install_disk")
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.unmount")

--- a/tests/nosetests/pyanaconda_tests/module_source_cdrom_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_cdrom_test.py
@@ -44,6 +44,16 @@ class CdromSourceInterfaceTestCase(unittest.TestCase):
         """Test CD-ROM source has a correct type specified."""
         self.assertEqual(SOURCE_TYPE_CDROM, self.interface.Type)
 
+    def device_test(self):
+        """Test CD-ROM source Device API."""
+        self.assertEqual(self.interface.DeviceName, "")
+
+        task = self.module.set_up_with_tasks()[0]
+        task.get_result = Mock(return_value="top_secret")
+        task.succeeded_signal.emit()
+
+        self.assertEqual(self.interface.DeviceName, "top_secret")
+
 
 class CdromSourceTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Add `DeviceName` API to the CDrom source which will provide name of the device for the GUI.