### PR TITLE
subscription: Add the ParseAttachedSubscriptionsTask

### DIFF
--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -144,3 +144,13 @@ RHSM_ATTACH = DBusObjectIdentifier(
     namespace=RHSM_NAMESPACE,
     basename="Attach"
 )
+
+RHSM_ENTITLEMENT = DBusObjectIdentifier(
+    namespace=RHSM_NAMESPACE,
+    basename="Entitlement"
+)
+
+RHSM_SYSPURPOSE = DBusObjectIdentifier(
+    namespace=RHSM_NAMESPACE,
+    basename="Syspurpose"
+)

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -20,7 +20,7 @@
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.modules.common.structures.subscription import SystemPurposeData, \
-    SubscriptionRequest
+    SubscriptionRequest, AttachedSubscription
 from pyanaconda.modules.common.containers import TaskContainer
 from dasbus.server.interface import dbus_interface
 from dasbus.server.property import emits_properties_changed
@@ -37,6 +37,8 @@ class SubscriptionInterface(KickstartModuleInterface):
                             self.implementation.system_purpose_data_changed)
         self.watch_property("SubscriptionRequest",
                             self.implementation.subscription_request_changed)
+        self.watch_property("AttachedSubscriptions",
+                            self.implementation.attached_subscriptions_changed)
         self.watch_property("InsightsEnabled",
                             self.implementation.connect_to_insights_changed)
         self.watch_property("IsSubscriptionAttached",
@@ -116,6 +118,13 @@ class SubscriptionInterface(KickstartModuleInterface):
         self.implementation.set_subscription_request(converted_data)
 
     @property
+    def AttachedSubscriptions(self) -> List[Structure]:
+        """Return a list of DBus structures holding data about attached subscriptions."""
+        return AttachedSubscription.to_structure_list(
+            self.implementation.attached_subscriptions
+        )
+
+    @property
     def InsightsEnabled(self) -> Int:
         """Connect the target system to Red Hat Insights."""
         return self.implementation.connect_to_insights
@@ -176,4 +185,13 @@ class SubscriptionInterface(KickstartModuleInterface):
         """
         return TaskContainer.to_object_path(
             self.implementation.attach_subscription_with_task()
+        )
+
+    def ParseAttachedSubscritionsWithTask(self) -> ObjPath:
+        """Parse attached subscriptions using a runtime DBus task.
+
+        :return: a DBus path of an installation task
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.parse_attached_subscriptions_with_task()
         )


### PR DESCRIPTION
The task parses attached subscriptions as well as final
system purpose data from the installation environment
after a successful subscription.

(System purpose data can change if an activation key
with attached system purpose data is used. Due to this we
need to parse system purpose data after subscription has
been attached to avoid the Subscription spoke showing stale
system purpose data after a subscription has been attached.)

We connect to the completed signal of the task to automatically
set attached subscriptions and system purpose data when the task
succeeds. And we do the same in reverse for the unregister task.