### PR TITLE
Mark kickstart commands of RPM sources as useless (1/5)

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -216,20 +216,6 @@ class Logging(COMMANDS.Logging):
             anaconda_logging.logger.updateRemote(remote_server)
 
 
-def is_dnf_method(name):
-    """Is it a method of the DNF installation?
-
-    :param name: a name of a kickstart command
-    :return: True or False
-    """
-    return name != "liveimg"
-
-
-class Method(COMMANDS.Method):
-    """Proxy to the actual method of the DNF installation."""
-    _methods = list(filter(is_dnf_method, COMMANDS.Method._methods))
-
-
 class RepoData(COMMANDS.RepoData):
 
     __mount_counter = 0
@@ -359,12 +345,15 @@ commandMap = {
     "autopart": UselessCommand,
     "btrfs": UselessCommand,
     "bootloader": UselessCommand,
+    "cdrom": UselessCommand,
     "clearpart": UselessCommand,
     "eula": Eula,
     "fcoe": UselessCommand,
     "firewall": UselessCommand,
     "firstboot": UselessCommand,
     "group" : UselessCommand,
+    "harddrive": UselessCommand,
+    "hmc": UselessCommand,
     "ignoredisk": UselessCommand,
     "iscsi": UselessCommand,
     "iscsiname": UselessCommand,
@@ -372,9 +361,10 @@ commandMap = {
     "lang": UselessCommand,
     "logging": Logging,
     "logvol": UselessCommand,
-    "method": Method,
+    "method": UselessCommand,
     "mount": UselessCommand,
     "network": UselessCommand,
+    "nfs": UselessCommand,
     "nvdimm": UselessCommand,
     "part": UselessCommand,
     "partition": UselessCommand,
@@ -388,6 +378,7 @@ commandMap = {
     "skipx": UselessCommand,
     "snapshot": UselessCommand,
     "timezone": UselessCommand,
+    "url": UselessCommand,
     "user": UselessCommand,
     "volgroup": UselessCommand,
     "xconfig": UselessCommand,

--- a/pyanaconda/modules/payloads/payloads.py
+++ b/pyanaconda/modules/payloads/payloads.py
@@ -22,6 +22,7 @@ from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.base import KickstartService
 from pyanaconda.modules.common.constants.services import PAYLOADS
 from pyanaconda.modules.common.containers import TaskContainer
+from pyanaconda.modules.payloads.constants import PayloadType
 from pyanaconda.modules.payloads.source.factory import SourceFactory
 from pyanaconda.modules.payloads.payload.factory import PayloadFactory
 from pyanaconda.modules.payloads.kickstart import PayloadKickstartSpecification
@@ -103,20 +104,22 @@ class PayloadsService(KickstartService):
 
     def setup_kickstart(self, data):
         """Set up the kickstart data."""
-        pass
-
-    def generate_temporary_kickstart(self):
-        """Return the temporary kickstart string.
-
-        FIXME: This is a temporary workaround.
-        """
-        log.debug("Generating temporary kickstart data...")
-        data = self.get_kickstart_handler()
-
         if self.active_payload:
             self.active_payload.setup_kickstart(data)
 
-        return str(data)
+    def generate_kickstart(self):
+        """Return a kickstart string."""
+        # FIXME: This is a temporary workaround for RPM sources.
+        if self.active_payload and self.active_payload.type != PayloadType.DNF:
+            log.debug("Generating kickstart... (skip)")
+            return ""
+
+        return super().generate_kickstart()
+
+    def generate_temporary_kickstart(self):
+        """Return the temporary kickstart string."""
+        # FIXME: This is a temporary workaround for testing.
+        return super().generate_kickstart()
 
     def create_payload(self, payload_type):
         """Create payload based on the passed type.

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_image_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_image_test.py
@@ -74,7 +74,7 @@ class LiveImageKSTestCase(unittest.TestCase):
         # Use live disk image installation
         liveimg --url="http://my/super/path"
         """
-        self.shared_tests.check_kickstart(ks_in, ks_out)
+        self.shared_tests.check_kickstart(ks_in, ks_out="", ks_tmp=ks_out)
         self._check_properties(url="http://my/super/path")
 
     def liveimg_proxy_kickstart_test(self):
@@ -86,7 +86,7 @@ class LiveImageKSTestCase(unittest.TestCase):
         # Use live disk image installation
         liveimg --url="http://my/super/path" --proxy="http://ultimate/proxy"
         """
-        self.shared_tests.check_kickstart(ks_in, ks_out)
+        self.shared_tests.check_kickstart(ks_in, ks_out="", ks_tmp=ks_out)
         self._check_properties(url="http://my/super/path", proxy="http://ultimate/proxy")
 
     def liveimg_checksum_kickstart_test(self):
@@ -98,7 +98,7 @@ class LiveImageKSTestCase(unittest.TestCase):
         # Use live disk image installation
         liveimg --url="http://my/super/path" --checksum="BATBATBATMAN!"
         """
-        self.shared_tests.check_kickstart(ks_in, ks_out)
+        self.shared_tests.check_kickstart(ks_in, ks_out="", ks_tmp=ks_out)
         self._check_properties(url="http://my/super/path", checksum="BATBATBATMAN!")
 
     def liveimg_noverifyssl_kickstart_test(self):
@@ -110,7 +110,7 @@ class LiveImageKSTestCase(unittest.TestCase):
         # Use live disk image installation
         liveimg --url="http://my/super/path" --noverifyssl
         """
-        self.shared_tests.check_kickstart(ks_in, ks_out)
+        self.shared_tests.check_kickstart(ks_in, ks_out="", ks_tmp=ks_out)
         self._check_properties(url="http://my/super/path", verifyssl=False)
 
     def liveimg_complex_kickstart_test(self):
@@ -122,7 +122,7 @@ class LiveImageKSTestCase(unittest.TestCase):
         # Use live disk image installation
         liveimg --url="http://my/super/path" --proxy="http://NO!!!!!" --noverifyssl --checksum="ABCDEFG"
         """
-        self.shared_tests.check_kickstart(ks_in, ks_out)
+        self.shared_tests.check_kickstart(ks_in, ks_out="", ks_tmp=ks_out)
         self._check_properties(url="http://my/super/path",
                                proxy="http://NO!!!!!",
                                verifyssl=False,

--- a/tests/nosetests/pyanaconda_tests/module_payload_shared.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_shared.py
@@ -39,19 +39,21 @@ class PayloadKickstartSharedTest(object):
         self.payload_service = payload_service
         self.payload_service_interface = payload_service_intf
 
-    def check_kickstart(self, ks_in, ks_out=None, ks_valid=True, expected_publish_calls=1):
+    def check_kickstart(self, ks_in, ks_out=None, ks_valid=True, ks_tmp=None,
+                        expected_publish_calls=1):
         """Test kickstart processing.
 
-        :param test_obj: TestCase object (probably self)
         :param ks_in: input kickstart for testing
         :param ks_out: expected output kickstart
+        :param ks_valid: True if the input kickstart is valid, otherwise False
+        :param ks_tmp: string with the temporary output kickstart
         :param expected_publish_calls: how many times times the publisher should be called
         :type expected_publish_calls: int
         """
         with patch('pyanaconda.core.dbus.DBus.publish_object') as publisher:
             result = check_kickstart_interface(self._test,
                                                self.payload_service_interface,
-                                               ks_in, "", ks_valid, ks_tmp=ks_out)
+                                               ks_in, ks_out, ks_valid, ks_tmp)
 
             if ks_valid and expected_publish_calls != 0:
                 publisher.assert_called()


### PR DESCRIPTION
This is the first part of the code that will replace RPM sources in UI with
the DBus sources of the Payloads module. All parts have to be tested
and merged together.

If the active payload of the Payloads module is DNF, generate the output
kickstart string with the RPM sources. Otherwise, generate an empty string.

Mark kickstart commands of RPM sources as useless. We should use the
Payloads module to work with RPM sources now.

**DO NOT MERGE!** 