### PR TITLE
Remove kickstart sources from the class DNFPayload (2/5)

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -503,13 +503,13 @@ if __name__ == "__main__":
     # scripts.  Add those to the ksdata now.
     kickstart.appendPostScripts(ksdata)
 
-    if anaconda.proxy:
+    if opts.proxy:
         # Setup proxy environmental variables so that pre/post scripts use it
         # as well as libreport
         try:
-            proxy = ProxyString(anaconda.proxy)
+            proxy = ProxyString(opts.proxy)
         except ProxyStringError as e:
-            log.info("Failed to parse proxy \"%s\": %s", anaconda.proxy, e)
+            log.info("Failed to parse proxy \"%s\": %s", opts.proxy, e)
         else:
             # Set environmental variables to be used by pre/post scripts
             util.setenv("PROXY", proxy.noauth_url)

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -44,11 +44,9 @@ class Anaconda(object):
         self.gui_startup_failed = False
         self._intf = None
         self.ksdata = None
-        self.methodstr = None
         self.additional_repos = None
         self.opts = None
         self._payload = None
-        self.proxy = None
         self.mehConfig = None
 
         # Data for inhibiting the screensaver
@@ -66,8 +64,6 @@ class Anaconda(object):
     def set_from_opts(self, opts):
         """Load argument to variables from self.opts."""
         self.opts = opts
-        self.proxy = opts.proxy
-        self.methodstr = opts.method
         self.additional_repos = opts.addRepo
 
     @property

--- a/pyanaconda/payload/base.py
+++ b/pyanaconda/payload/base.py
@@ -49,6 +49,13 @@ class Payload(metaclass=ABCMeta):
         # Additional packages required by installer based on used features
         self.requirements = PayloadRequirements()
 
+    def set_from_opts(self, opts):
+        """Set the payload from the Anaconda cmdline options.
+
+        :param opts: a namespace of options
+        """
+        pass
+
     @property
     @abstractmethod
     def type(self):

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -54,7 +54,7 @@ from pyanaconda.core import constants, util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import INSTALL_TREE, ISO_DIR, PAYLOAD_TYPE_DNF, \
     SOURCE_TYPE_REPO_FILES, SOURCE_TYPE_HMC, SOURCE_TYPE_HDD, URL_TYPE_BASEURL, \
-    URL_TYPE_MIRRORLIST, SOURCE_TYPE_URL
+    URL_TYPE_MIRRORLIST, URL_TYPE_METALINK, SOURCE_TYPE_URL
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.core.regexes import VERSION_DIGITS
@@ -1489,7 +1489,7 @@ class DNFPayload(Payload):
             # Get the URL.
             install_tree_url = data.url if data.type == URL_TYPE_BASEURL else ""
             mirrorlist = data.url if data.type == URL_TYPE_MIRRORLIST else ""
-            metalink = data.url if data.type == URL_TYPE_MIRRORLIST else ""
+            metalink = data.url if data.type == URL_TYPE_METALINK else ""
 
             # Fallback to the installation root.
             base_repo_url = install_tree_url

--- a/pyanaconda/payload/live/payload_liveimg.py
+++ b/pyanaconda/payload/live/payload_liveimg.py
@@ -52,6 +52,17 @@ class LiveImagePayload(BaseLivePayload):
         self._proxies = {}
         self.image_path = conf.target.system_root + "/disk.img"
 
+    def set_from_opts(self, opts):
+        """Set the payload from the Anaconda cmdline options.
+
+        :param opts: a namespace of options
+        """
+        if opts.proxy:
+            self.data.liveimg.proxy = opts.proxy
+
+        if not conf.payload.verify_ssl:
+            self.data.liveimg.noverifyssl = not conf.payload.verify_ssl
+
     @property
     def type(self):
         """The DBus type of the payload."""

--- a/pyanaconda/payload/manager.py
+++ b/pyanaconda/payload/manager.py
@@ -20,6 +20,7 @@
 import threading
 from enum import IntEnum
 
+from dasbus.error import DBusError
 from pyanaconda.core.constants import THREAD_STORAGE, THREAD_PAYLOAD, THREAD_PAYLOAD_RESTART, \
     THREAD_WAIT_FOR_CONNECTING_NM, PAYLOAD_TYPE_DNF
 from pyanaconda.core.i18n import _, N_
@@ -204,7 +205,7 @@ class PayloadManager(object):
         try:
             payload.update_base_repo(fallback=fallback, checkmount=checkmount)
             payload.add_driver_repos()
-        except (OSError, PayloadError) as e:
+        except (OSError, DBusError, PayloadError) as e:
             log.error("PayloadError: %s", e)
             self._error = self.ERROR_SETUP
             self._set_state(PayloadState.ERROR)

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -39,8 +39,6 @@ from pyanaconda import kickstart
 from pyanaconda.flags import flags
 from pyanaconda.screensaver import inhibit_screensaver
 
-from pyanaconda.payload.source import SourceFactory, PayloadSourceTypeUnrecognized
-
 import blivet
 
 
@@ -289,41 +287,6 @@ def live_startup(anaconda):
         log.info("Unable to connect to DBus session bus: %s", e)
     else:
         anaconda.dbus_inhibit_id = inhibit_screensaver(anaconda.dbus_session_connection)
-
-
-def set_installation_method_from_anaconda_options(anaconda, ksdata):
-    """Set the installation method from Anaconda options.
-
-    This basically means to set the installation method from options provided
-    to Anaconda via command line/boot options.
-
-    :param anaconda: instance of the Anaconda class
-    :param ksdata: data model corresponding to the installation kickstart
-    """
-    try:
-        source = SourceFactory.parse_repo_cmdline_string(anaconda.methodstr)
-    except PayloadSourceTypeUnrecognized:
-        log.error("Unknown method: %s", anaconda.methodstr)
-        return
-
-    ksdata.method.method = source.method_type
-
-    if source.is_nfs:
-        ksdata.method.server = source.server
-        ksdata.method.dir = source.path
-        ksdata.method.opts = source.options
-    elif source.is_harddrive:
-        ksdata.method.partition = source.partition
-        ksdata.method.dir = source.path
-    elif source.is_http or source.is_https or source.is_ftp:
-        ksdata.method.url = source.url
-        ksdata.method.mirrorlist = None
-        ksdata.method.metalink = None
-    # file is not url based but it is stored same way
-    elif source.is_file:
-        ksdata.method.url = source.path
-        ksdata.method.mirrorlist = None
-        ksdata.method.metalink = None
 
 
 def find_kickstart(options):

--- a/tests/nosetests/pyanaconda_tests/payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/payload_test.py
@@ -105,19 +105,6 @@ class DummyRepo(object):
         self.sslverify = True
 
 
-class DummyPayload(object):
-    def __init__(self):
-        class DummyMethod(object):
-            def __init__(self):
-                self.method = None
-
-        class DummyData(object):
-            def __init__(self):
-                self.method = DummyMethod()
-
-        self.data = DummyData()
-
-
 class DNFPayloadMDCheckTests(unittest.TestCase):
     def setUp(self):
         self._content_repomd = """
@@ -143,14 +130,14 @@ or it should be. Nah it's just a test!
         m.update(self._content_repomd.encode('ascii', 'backslashreplace'))
         reference_digest = m.digest()
 
-        r = RepoMDMetaHash(DummyPayload(), self._dummyRepo)
+        r = RepoMDMetaHash(self._dummyRepo, None)
         r.store_repoMD_hash()
 
         self.assertEqual(r.repoMD_hash, reference_digest)
 
     def verify_repo_test(self):
         """Test verification method."""
-        r = RepoMDMetaHash(DummyPayload(), self._dummyRepo)
+        r = RepoMDMetaHash(self._dummyRepo, None)
         r.store_repoMD_hash()
 
         # test if repomd comparision works properly


### PR DESCRIPTION
This is the second part of the code that will replace RPM sources in UI with
the DBus sources of the Payloads module. All parts have to be tested
and merged together.

Remove kickstart sources from the class DNFPayload.  Use the DBus sources
instead.

**DO NOT MERGE!**


