### PR TITLE
subscription: Show data about attached subscriptions

### DIFF
--- a/data/anaconda-gtk.css
+++ b/data/anaconda-gtk.css
@@ -158,3 +158,26 @@ animation have only N discrete states with no interpolation, so there are effect
 where the look is constant. This reduces redraws significantly and saves the CPU. See rhbz#1204242
 for measurements. */
 spinner { animation-timing-function: steps(24); }
+
+/* Set colors for the subscriptions listbox:
+ * - disable background color, so that the
+ *   list box looks good even if half empty
+ * - disable border color as well
+ * - only rows should have a distinct background
+ */
+.subscriptions_listbox {
+    background-color: transparent;
+    background-image: none;
+    border-color: transparent;
+    border-image: none;
+}
+
+#subscriptions_listbox_row {
+    background-color: white;
+    border-color: gray;
+}
+
+#subscriptions_listbox_row_spacer {
+    background-color: transparent;
+    border-color: transparent;
+}

--- a/pyanaconda/ui/gui/spokes/lib/subscription.py
+++ b/pyanaconda/ui/gui/spokes/lib/subscription.py
@@ -17,12 +17,20 @@
 # Red Hat, Inc.
 #
 
+import gi
+gi.require_version("Gtk", "3.0")
+gi.require_version("Pango", "1.0")
+from gi.repository import Gtk, Pango
+
 from collections import namedtuple
 
 from pyanaconda.core.i18n import _
 
-TextComboBoxItem = namedtuple("TextComboBoxItem", ["value", "display_string", "is_preselected"])
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
 
+
+TextComboBoxItem = namedtuple("TextComboBoxItem", ["value", "display_string", "is_preselected"])
 
 def handle_user_provided_value(user_provided_value, valid_values):
     """Handle user provided value (if any) based on list of valid values.
@@ -100,3 +108,129 @@ def fill_combobox(combobox, user_provided_value, valid_values):
 
     # set the active id (what item should be selected in the combobox)
     combobox.set_active_id(active_id)
+
+
+def add_attached_subscription_delegate(listbox, subscription, delegate_index):
+    """Add delegate representing an attached subscription to the listbox.
+
+    :param listbox: a listbox to add the delegate to
+    :type listbox: GTK ListBox
+    :param subscription: a subscription attached to the system
+    :type: AttachedSubscription instance
+    :param int delegate_index: index of the delegate in the listbox
+    """
+    log.debug("Subscription GUI: adding subscription to listbox: %s", subscription.name)
+    # if we are not the first delegate, we should pre-pend a spacer, so that the
+    # actual delegates are nicely delimited
+    if delegate_index != 0:
+        row = Gtk.ListBoxRow()
+        row.set_name("subscriptions_listbox_row_spacer")
+        row.set_margin_top(4)
+        listbox.insert(row, -1)
+
+    # construct delegate
+    row = Gtk.ListBoxRow()
+    # set a name so that the ListBoxRow instance can be styled via CSS
+    row.set_name("subscriptions_listbox_row")
+
+    main_vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+    main_vbox.set_margin_top(12)
+    main_vbox.set_margin_bottom(12)
+
+    name_label = Gtk.Label(label='<span size="x-large">{}</span>'.format(subscription.name),
+                           use_markup=True, wrap=True, wrap_mode=Pango.WrapMode.WORD_CHAR,
+                           hexpand=True, xalign=0, yalign=0.5)
+    name_label.set_margin_start(12)
+    name_label.set_margin_bottom(12)
+
+    # create the first details grid
+    details_grid_1 = Gtk.Grid()
+    details_grid_1.set_column_spacing(12)
+    details_grid_1.set_row_spacing(12)
+
+    # first column
+    service_level_label = Gtk.Label(label="<b>{}</b>".format(_("Service level")),
+                                    use_markup=True, xalign=0)
+    service_level_status_label = Gtk.Label(label=subscription.service_level)
+    sku_label = Gtk.Label(label="<b>{}</b>".format(_("SKU")),
+                          use_markup=True, xalign=0)
+    sku_status_label = Gtk.Label(label=subscription.sku, xalign=0)
+    contract_label = Gtk.Label(label="<b>{}</b>".format(_("Contract")),
+                               use_markup=True, xalign=0)
+    contract_status_label = Gtk.Label(label=subscription.contract, xalign=0)
+
+    # add first column to the grid
+    details_grid_1.attach(service_level_label, 0, 0, 1, 1)
+    details_grid_1.attach(service_level_status_label, 1, 0, 1, 1)
+    details_grid_1.attach(sku_label, 0, 1, 1, 1)
+    details_grid_1.attach(sku_status_label, 1, 1, 1, 1)
+    details_grid_1.attach(contract_label, 0, 2, 1, 1)
+    details_grid_1.attach(contract_status_label, 1, 2, 1, 1)
+
+    # second column
+    start_date_label = Gtk.Label(label="<b>{}</b>".format(_("Start date")),
+                                 use_markup=True, xalign=0)
+    start_date_status_label = Gtk.Label(label=subscription.start_date, xalign=0)
+    end_date_label = Gtk.Label(label="<b>{}</b>".format(_("End date")),
+                               use_markup=True, xalign=0)
+    end_date_status_label = Gtk.Label(label=subscription.end_date, xalign=0)
+    entitlements_label = Gtk.Label(label="<b>{}</b>".format(_("Entitlements")),
+                                   use_markup=True, xalign=0)
+    entitlement_string = _("{} consumed").format(subscription.consumed_entitlement_count)
+    entitlements_status_label = Gtk.Label(label=entitlement_string, xalign=0)
+
+    # create the second details grid
+    details_grid_2 = Gtk.Grid()
+    details_grid_2.set_column_spacing(12)
+    details_grid_2.set_row_spacing(12)
+
+    # add second column to the grid
+    details_grid_2.attach(start_date_label, 0, 0, 1, 1)
+    details_grid_2.attach(start_date_status_label, 1, 0, 1, 1)
+    details_grid_2.attach(end_date_label, 0, 1, 1, 1)
+    details_grid_2.attach(end_date_status_label, 1, 1, 1, 1)
+    details_grid_2.attach(entitlements_label, 0, 2, 1, 1)
+    details_grid_2.attach(entitlements_status_label, 1, 2, 1, 1)
+
+    details_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=16)
+    details_hbox.pack_start(details_grid_1, True, True, 12)
+    details_hbox.pack_start(details_grid_2, True, True, 0)
+
+    main_vbox.pack_start(name_label, True, True, 0)
+    main_vbox.pack_start(details_hbox, True, True, 0)
+
+    row.add(main_vbox)
+
+    # append delegate to listbox
+    listbox.insert(row, -1)
+
+
+def populate_attached_subscriptions_listbox(listbox, attached_subscriptions):
+    """Populate the attached subscriptions listbox with delegates.
+
+    Unfortunately it does not seem to be possible to create delegate templates
+    that could be reused for each data item in the listbox via Glade, so
+    we need to construct them imperatively via Python GTK API.
+
+    :param listbox: listbox to populate
+    :type listbox: GTK ListBox
+    :param attached_subscriptions: list of AttachedSubscription instances
+    """
+    log.debug("Subscription GUI: populating attached subscriptions listbox")
+
+    # start by making sure the listbox is empty
+    for child in listbox.get_children():
+        listbox.remove(child)
+        del(child)
+
+    # add one delegate per attached subscription
+    delegate_index = 0
+    for subscription in attached_subscriptions:
+        add_attached_subscription_delegate(listbox, subscription, delegate_index)
+        delegate_index = delegate_index + 1
+
+    # Make sure the delegates are actually visible after the listbox has been cleared.
+    # Without show_all() nothing would be visible past first clear.
+    listbox.show_all()
+
+    log.debug("Subscription GUI: attached subscriptions listbox has been populated")

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -33,12 +33,13 @@ from pyanaconda.core.async_utils import async_action_wait
 
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION, NETWORK
 from pyanaconda.modules.common.structures.subscription import SystemPurposeData, \
-    SubscriptionRequest
+    SubscriptionRequest, AttachedSubscription
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.modules.common.task import sync_run_task
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
-from pyanaconda.ui.gui.spokes.lib.subscription import fill_combobox
+from pyanaconda.ui.gui.spokes.lib.subscription import fill_combobox, \
+    populate_attached_subscriptions_listbox
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.communication import hubQ
 
@@ -970,7 +971,64 @@ class SubscriptionSpoke(NormalSpoke):
         Update state of the part of the spoke, that shows data about the
         currently attached subscriptions.
         """
-        # TODO
+        # authentication method
+        if self.authentication_method == AuthenticationMethod.USERNAME_PASSWORD:
+            method_string = _("Registered with account {}").format(
+                self.subscription_request.account_username
+            )
+        else:  # org + key
+            method_string = _("Registered with organization {}").format(
+                self.subscription_request.organization
+            )
+        self._method_status_label.set_text(method_string)
+
+        # final syspurpose data
+
+        # role
+        final_role_string = _("Role: {}").format(self.system_purpose_data.role)
+        self._role_status_label.set_text(final_role_string)
+
+        # SLA
+        final_sla_string = _("SLA: {}").format(self.system_purpose_data.sla)
+        self._sla_status_label.set_text(final_sla_string)
+
+        # usage
+        final_usage_string = _("Usage: {}").format(self.system_purpose_data.usage)
+        self._usage_status_label.set_text(final_usage_string)
+
+        # Insights
+        # - this strings are referring to the desired target system state,
+        #   the installation environment itself is not expected to be
+        #   connected to Insights
+        if self._subscription_module.InsightsEnabled:
+            insights_string = _("Connected to Red Hat Insights")
+        else:
+            insights_string = _("Not connected to Red Hat Insights")
+        self._insights_status_label.set_text(insights_string)
+
+        # get attached subscriptions as a list of structs
+        attached_subscriptions = self._subscription_module.AttachedSubscriptions
+        # turn the structs to more useful AttachedSubscription instances
+        attached_subscriptions = AttachedSubscription.from_structure_list(attached_subscriptions)
+
+        # check how many we have & set the subscription status string accordingly
+        subscription_count = len(attached_subscriptions)
+        if subscription_count == 0:
+            subscription_string = _("No subscriptions are attached to the system")
+        elif subscription_count == 1:
+            subscription_string = _("1 subscription attached to the system")
+        else:
+            subscription_string = _("{} subscriptions attached to the system").format(
+                subscription_count
+            )
+
+        self._attached_subscriptions_label.set_text(subscription_string)
+
+        # populate the attached subscriptions listbox
+        populate_attached_subscriptions_listbox(
+            self._subscriptions_listbox,
+            attached_subscriptions
+        )
 
     def _check_connectivity(self):
         """Check network connectivity is available.


### PR DESCRIPTION
This basically updates the second part of the spoke that
is shown after a successful subscrioption attempt. Type
of authentication used, final system purpose data as
well as information about attached subscriptions is shown.

The code that creates the listbox delegates describing an
attached subscription is not very nice, as it needs to
imperatively construct the rather complex listbox delegate
using the GTK/Pango API.

Ideally this would be done be describing the delegate in
Glade and then just instantiating it per item and filling
it with data. Unfortunately there is zero information
available for dynamically creating widgets with Glade
and I was simply not able to get it working in this way.

I guess this might explain why some of the dynamically
created widgets we have in Anaconda are implemented in C.

Also add a CSS file we use to make the list box background
transparent to make the delegates look better, especially
in case there is just one or two of them.