### PR TITLE
Switch call of pip3 to python3 -m pip

### DIFF
--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -370,7 +370,9 @@ def install_pip_packages_to_mock(mock_command, packages):
     cmd = _prepare_command(mock_command)
 
     cmd = _run_cmd_in_chroot(cmd)
-    cmd.append('pip3 install --install-option="--install-scripts=/usr/bin" {}'.format(packages))
+    cmd.append(
+        'python3 -m pip install --install-option="--install-scripts=/usr/bin" {}'.format(packages)
+    )
 
     _check_subprocess(cmd, "Can't install packages via pip to mock.")
 


### PR DESCRIPTION
This is the best way how to avoid problem with different naming on different distributions.