### PR TITLE
Fix RHEL-8 tests on the rebase branch

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -19,7 +19,6 @@ Source0: %{name}-%{version}.tar.bz2
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).
 
-%define blivetguiver 2.1.12-1
 %define dbusver 1.2.3
 %define dnfver 3.6.0
 %define dracutver 034-7
@@ -168,12 +167,6 @@ Requires: isomd5sum >= %{isomd5sum}
 %ifarch %{ix86} x86_64
 Requires: fcoe-utils >= %{fcoeutilsver}
 %endif
-# likely HFS+ resize support
-%ifarch %{ix86} x86_64
-%if ! 0%{?rhel}
-Requires: hfsplus-tools
-%endif
-%endif
 # kexec support
 Requires: kexec-tools
 Requires: createrepo_c
@@ -205,7 +198,6 @@ Requires: NetworkManager-wifi
 %endif
 Requires: anaconda-user-help >= %{helpver}
 Requires: yelp
-Requires: blivet-gui-runtime >= %{blivetguiver}
 Requires: system-logos
 
 # Needed to compile the gsettings files


### PR DESCRIPTION
These changes should not be problem for Rawhide tests. However, it will fail until blivet-gui is removed from the code base and tests which is correct failure.

Tests are still blocked by https://github.com/rhinstaller/anaconda/pull/2520 which should be merged first.