### PR TITLE
Remove kickstart sources from GUI (5/5)

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.glade
+++ b/pyanaconda/ui/gui/spokes/installation_source.glade
@@ -827,9 +827,9 @@
                                         <property name="can_focus">False</property>
                                         <property name="halign">start</property>
                                         <items>
-                                          <item id="url" translatable="yes">repository URL</item>
-                                          <item id="mirrorlist" translatable="yes">mirrorlist</item>
-                                          <item id="metalink" translatable="yes">metalink</item>
+                                          <item id="BASEURL" translatable="yes">repository URL</item>
+                                          <item id="MIRRORLIST" translatable="yes">mirrorlist</item>
+                                          <item id="METALINK" translatable="yes">metalink</item>
                                         </items>
                                       </object>
                                       <packing>

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -915,9 +915,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
             combo = self.builder.get_object("isoPartitionCombo")
             combo.set_active(active_idx)
 
-        # We default to the mirror list, and then if the method tells us
-        # something different later, we can change it.
+        # We defaults and if the method tells us something different later, we can change it.
         self._protocol_combo_box.set_active_id(PROTOCOL_MIRROR)
+        self._url_type_combo_box.set_active_id(URL_TYPE_BASEURL)
 
         if source_type == SOURCE_TYPE_URL:
             self._network_button.set_active(True)

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -46,7 +46,7 @@ __all__ = ["LangsupportSpoke"]
 _HIGHLIGHT_COLOR = Gdk.RGBA(red=0.992157, green=0.984314, blue=0.752941, alpha=1.0)
 
 
-class LangsupportSpoke(LangLocaleHandler, NormalSpoke):
+class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
     """
        .. inheritance-diagram:: LangsupportSpoke
           :parts: 3
@@ -64,7 +64,7 @@ class LangsupportSpoke(LangLocaleHandler, NormalSpoke):
 
     def __init__(self, *args, **kwargs):
         NormalSpoke.__init__(self, *args, **kwargs)
-        LangLocaleHandler.__init__(self, self.payload)
+        LangLocaleHandler.__init__(self)
         self._selected_locales = set()
 
         self._l12_module = LOCALIZATION.get_proxy()

--- a/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
+++ b/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
@@ -27,6 +27,7 @@ gi.require_version("Gtk", "3.0")
 gi.require_version("Pango", "1.0")
 gi.require_version("GdkPixbuf", "2.0")
 
+from abc import abstractproperty
 from gi.repository import Gtk, Pango, GdkPixbuf
 
 from pyanaconda import localization
@@ -41,7 +42,7 @@ class LangLocaleHandler(object):
 
     """
 
-    def __init__(self, payload):
+    def __init__(self):
         # the class inheriting from this class is responsible for populating
         # these items with actual objects
         self._languageStore = None
@@ -58,7 +59,10 @@ class LangLocaleHandler(object):
         self._right_arrow = None
         self._left_arrow = None
 
-        self.payload = payload
+    @abstractproperty
+    def payload(self):
+        """Get payload class."""
+        pass
 
     def initialize(self):
         # Load arrows from resources. Unfortunately, Gtk.Image.new_from_resource does not

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -48,7 +48,7 @@ log = get_module_logger(__name__)
 __all__ = ["WelcomeLanguageSpoke"]
 
 
-class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
+class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
     """
        .. inheritance-diagram:: WelcomeLanguageSpoke
           :parts: 3
@@ -65,7 +65,7 @@ class WelcomeLanguageSpoke(LangLocaleHandler, StandaloneSpoke):
 
     def __init__(self, *args, **kwargs):
         StandaloneSpoke.__init__(self, *args, **kwargs)
-        LangLocaleHandler.__init__(self, self.payload)
+        LangLocaleHandler.__init__(self)
         self._origStrings = {}
 
         self._l12_module = LOCALIZATION.get_proxy()


### PR DESCRIPTION
This is the fifth part of the code that will replace RPM sources in UI with
the DBus sources of the Payloads module. All parts have to be tested
and merged together.

Remove kickstart sources from GUI. Use the DBus sources instead.

**Depends on:** https://github.com/rhinstaller/anaconda/pull/2533

**DO NOT MERGE!**