### PR TITLE
Remove sphinx test dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -316,7 +316,7 @@ intersphinx_mapping = {'https://docs.python.org/3': None}
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
+    import sphinx_rtd_theme  # pylint: disable=import-error
     html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 

--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -48,7 +48,6 @@ PIP_DEPENDENCIES = [
     "dogtail",
     "pocketlint",
     "nose-testconfig",
-    "sphinx_rtd_theme",
     "lxml",
     "coverage",
     "pycodestyle",  # pep8 check


### PR DESCRIPTION
We can remove the whole package as test dependency with just one line of pylint disable. This will also help switching to RHEL where are not all dependencies for sphinx in the build root.