### PR TITLE
subscription: Registration button sensitivity handling

### DIFF
--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -41,6 +41,7 @@ from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.spokes.lib.subscription import fill_combobox
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.communication import hubQ
+from pyanaconda.ui.lib.subscription import username_password_sufficient, org_keys_sufficient
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -1007,5 +1008,20 @@ class SubscriptionSpoke(NormalSpoke):
         self._network_connected_previously = network_connected
 
     def _update_register_button_state(self):
-        """Update register button state."""
-        # TODO
+        """Update register button state.
+
+        The button is only sensitive if no processing is ongoing
+        and we either have enough authentication data to register
+        or the system is subscribed, so we can unregister it.
+        """
+        button_sensitive = False
+        if self._registration_controls_enabled:
+            # if we are subscribed, we can always unregister
+            if self.subscription_attached:
+                button_sensitive = True
+            # check if credentials are sufficient for registration
+            elif self.authentication_method == AuthenticationMethod.USERNAME_PASSWORD:
+                button_sensitive = username_password_sufficient(self.subscription_request)
+            elif self.authentication_method == AuthenticationMethod.ORG_KEY:
+                button_sensitive = org_keys_sufficient(self.subscription_request)
+        self._register_button.set_sensitive(button_sensitive)

--- a/tests/nosetests/pyanaconda_tests/subscription_helpers_test.py
+++ b/tests/nosetests/pyanaconda_tests/subscription_helpers_test.py
@@ -32,6 +32,7 @@ from pyanaconda.core.constants import RHSM_SYSPURPOSE_FILE_PATH, \
 
 from pyanaconda.modules.common.errors.subscription import UnregistrationError, \
     RegistrationError, SubscriptionError
+from pyanaconda.modules.common.structures.subscription import SubscriptionRequest
 
 from pyanaconda.core.subscription import check_system_purpose_set
 
@@ -123,7 +124,7 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
                          "value": get_variant(Str, "")}),
         "activation-keys":
             get_variant(Structure,
-                        {"type": get_variant(Str, "HIDDEN"),
+                        {"type": get_variant(Str, "TEXT"),
                          "value": get_variant(List[Str], [])}),
         "server-proxy-password":
             get_variant(Structure,
@@ -172,6 +173,16 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         # run the function
         self.assertFalse(org_keys_sufficient())
 
+    def org_keys_sufficient_direct_request_test(self):
+        """Test the org_keys_sufficient() helper method - direct request."""
+        # run the function with sufficient authentication data
+        request = SubscriptionRequest.from_structure(self.KEY_REQUEST)
+        self.assertTrue(org_keys_sufficient(subscription_request=request))
+        # run the function with insufficient authentication data
+        request = SubscriptionRequest.from_structure(self.KEY_MISSING_REQUEST)
+        self.assertFalse(org_keys_sufficient(subscription_request=request))
+
+
     @patch("pyanaconda.modules.common.constants.services.SUBSCRIPTION.get_proxy")
     def username_password_sufficient_test(self, get_proxy):
         """Test the username_password_sufficient() helper method."""
@@ -189,6 +200,15 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         subscription_proxy.SubscriptionRequest = self.PASSWORD_MISSING_REQUEST
         # run the function
         self.assertFalse(username_password_sufficient())
+
+    def username_password_sufficient_direct_request_test(self):
+        """Test the username_password_sufficient() helper method - direct request."""
+        # run the function with sufficient authentication data
+        request = SubscriptionRequest.from_structure(self.PASSWORD_REQUEST)
+        self.assertTrue(username_password_sufficient(subscription_request=request))
+        # run the function with insufficient authentication data
+        request = SubscriptionRequest.from_structure(self.PASSWORD_MISSING_REQUEST)
+        self.assertFalse(username_password_sufficient(subscription_request=request))
 
     @patch("pyanaconda.modules.common.task.sync_run_task")
     @patch("pyanaconda.threading.threadMgr.wait")


### PR DESCRIPTION
The conditions for the Register/Unregister button being sensitive
are as follows:
- no registration/unregistration is currently in progress
- credentials for the currently selected authentication method are
  sufficient (we use the SECRET_TYPE_* constant to detect both locally
  set credentials as well as credentials stored in the module)