### PR TITLE
Fix call to super() with missing parameters

### DIFF
--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -78,7 +78,7 @@ class SubscriptionSpoke(NormalSpoke):
         return is_module_available(SUBSCRIPTION)
 
     def __init__(self, *args):
-        super().__init__()
+        super().__init__(*args)
 
         # connect to the Subscription DBus module API
         self._subscription_module = SUBSCRIPTION.get_proxy()


### PR DESCRIPTION
Not sure if this is needed as such, but pylint does not like it.

What could go wrong?