### PR TITLE
Add exclude to the dependency_solver

### DIFF
--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -43,6 +43,10 @@ TEST_DEPENDENCIES = [
     "policycoreutils",  # contains restorecon which was removed in Fedora 28 mock
 ]
 
+# This is useful to remove dependencies from spec file.
+EXCLUDE_SPEC_DEPENDENCIES = [
+]
+
 PIP_DEPENDENCIES = [
     "rpmfluff",
     "dogtail",
@@ -74,6 +78,10 @@ def _read_spec_file():
     return spec_content
 
 
+def _filter_out_excludes(pkgs):
+    return list(filter(lambda x: x not in EXCLUDE_SPEC_DEPENDENCIES, pkgs))
+
+
 def parse_args():
     parser = ArgumentParser(description="Resolve Anaconda all dependencies.",
                             epilog="Without any options the '-b -r -t' options will be used.")
@@ -103,6 +111,8 @@ def runtime_dependencies(spec_content):
         if "anaconda" not in pkg and "%{" not in pkg:
             result.add(pkg.strip())
 
+    result = _filter_out_excludes(result)
+
     return result
 
 
@@ -115,6 +125,8 @@ def build_dependencies(spec_content, is_s390):
         if not is_s390 and "s390utils" in pkg:
             continue
         result.add(pkg.strip())
+
+    result = _filter_out_excludes(result)
 
     return result
 


### PR DESCRIPTION
This is useful to exclude spec dependencies which could be removed by RPM conditionals.

For rebase branch we have to add:

```
    "blivet-gui-runtime",
    "hfsplus-tools",
```