### PR TITLE
Permit blacklisting modules from inherited parent product

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -20,6 +20,8 @@ kickstart_modules =
      org.fedoraproject.Anaconda.Modules.Storage
      org.fedoraproject.Anaconda.Modules.Services
 
+# List of disabled Anaconda DBus modules.
+blacklist_kickstart_modules =
 
 [Installation System]
 # Type of the installation system.

--- a/data/product.d/centos.conf
+++ b/data/product.d/centos.conf
@@ -6,6 +6,10 @@ product_name = CentOS Linux
 [Base Product]
 product_name = Red Hat Enterprise Linux
 
+[Anaconda]
+blacklist_kickstart_modules =
+     org.fedoraproject.Anaconda.Modules.Subscription
+
 [Bootloader]
 efi_dir = centos
 

--- a/data/product.d/scientific-linux.conf
+++ b/data/product.d/scientific-linux.conf
@@ -6,6 +6,10 @@ product_name = Scientific Linux
 [Base Product]
 product_name = Red Hat Enterprise Linux
 
+[Anaconda]
+blacklist_kickstart_modules =
+     org.fedoraproject.Anaconda.Modules.Subscription
+
 [Payload]
 enable_updates = True
 

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -54,7 +54,13 @@ class AnacondaSection(Section):
     @property
     def kickstart_modules(self):
         """List of enabled kickstart modules."""
-        return self._get_option("kickstart_modules").split()
+        return [i for i in self._get_option("kickstart_modules").split()
+                if i not in self.blacklist_kickstart_modules]
+
+    @property
+    def blacklist_kickstart_modules(self):
+        """List of disabled kickstart modules."""
+        return self._get_option("blacklist_kickstart_modules").split()
 
 
 class AnacondaConfiguration(Configuration):

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -144,6 +144,19 @@ class ProductConfigurationTestCase(unittest.TestCase):
 
         self.assertListEqual(difference, expected_difference)
 
+    def product_module_blacklist_test(self):
+        """Test for expected CentOS & RHEL module list differences."""
+        centos_config = self._get_config("CentOS Linux")
+        centos_modules = centos_config.anaconda.kickstart_modules
+
+        rhel_config = self._get_config("Red Hat Enterprise Linux")
+        rhel_modules = rhel_config.anaconda.kickstart_modules
+
+        difference = list(set(rhel_modules) - set(centos_modules))
+        expected_difference = ["org.fedoraproject.Anaconda.Modules.Subscription"]
+
+        self.assertListEqual(difference, expected_difference)
+
     def _compare_product_files(self, file_name, other_file_name):
         parser = create_parser()
         read_config(parser, os.path.join(PRODUCT_DIR, file_name))


### PR DESCRIPTION
This patch will make it easy for CentOS and SL to inherit RHEL, but not subscription-manager.