### PR TITLE
Set up FIPS during the installation

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -124,6 +124,9 @@ Requires: systemd
 Requires: python3-pid
 Requires: python3-ordered-set >= 2.0.0
 
+# Required by the systemd service anaconda-fips.
+Requires: crypto-policies
+
 # required because of the rescue mode and VNC question
 Requires: anaconda-tui = %{version}-%{release}
 

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -28,6 +28,7 @@ dist_systemd_DATA = anaconda.service \
                     anaconda-sshd.service \
                     anaconda-nm-config.service \
                     anaconda-pre.service \
+                    anaconda-fips.service \
                     zram.service
 
 dist_generator_SCRIPTS = anaconda-generator

--- a/data/systemd/anaconda-fips.service
+++ b/data/systemd/anaconda-fips.service
@@ -1,0 +1,10 @@
+[Unit]
+# This service sets up the FIPS mode in the installation environment.
+Description=Anaconda FIPS service
+ConditionKernelCommandLine=fips=1
+Before=network.target
+Before=NetworkManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/update-crypto-policies --set FIPS

--- a/data/systemd/anaconda-sshd.service
+++ b/data/systemd/anaconda-sshd.service
@@ -11,7 +11,8 @@ ConditionKernelCommandLine=!sshd=0
 ConditionPathIsDirectory=|/sys/hypervisor/s390
 
 [Service]
-EnvironmentFile=/etc/sysconfig/sshd
+EnvironmentFile=-/etc/crypto-policies/back-ends/opensshserver.config
+EnvironmentFile=-/etc/sysconfig/sshd
 ExecStartPre=/usr/sbin/handle-sshpw
-ExecStart=/usr/sbin/sshd -D $OPTIONS -f /etc/ssh/sshd_config.anaconda
+ExecStart=/usr/sbin/sshd -D $OPTIONS $CRYPTO_POLICY -f /etc/ssh/sshd_config.anaconda
 ExecReload=/bin/kill -HUP $MAINPID

--- a/data/systemd/anaconda.target
+++ b/data/systemd/anaconda.target
@@ -11,6 +11,7 @@ Wants=plymouth-quit.service plymouth-quit-wait.service
 Wants=anaconda-direct.service anaconda.service
 Wants=anaconda-sshd.service
 Wants=anaconda-pre.service
+Wants=anaconda-fips.service
 Wants=zram.service
 Wants=systemd-logind.service
 Wants=rhsm.service

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -55,14 +55,16 @@ from pyanaconda.core.constants import INSTALL_TREE, ISO_DIR, PAYLOAD_TYPE_DNF, \
     DNF_DEFAULT_SOURCE_TYPE, SOURCE_TYPE_HMC, SOURCE_TYPE_URL, SOURCE_TYPE_CDN, \
     URL_TYPE_BASEURL, URL_TYPE_MIRRORLIST, URL_TYPE_METALINK, SOURCE_REPO_FILE_TYPES
 from pyanaconda.core.i18n import N_, _
+from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.core.regexes import VERSION_DIGITS
-from pyanaconda.core.util import decode_bytes
+from pyanaconda.core.util import decode_bytes, join_paths
 from pyanaconda.flags import flags
 from pyanaconda.kickstart import RepoData
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import LOCALIZATION, STORAGE, SUBSCRIPTION
 from pyanaconda.modules.payloads.source.utils import has_network_protocol
+from pyanaconda.modules.common.errors.installation import SecurityInstallationError
 from pyanaconda.modules.common.errors.storage import DeviceSetupError, MountFilesystemError
 from pyanaconda.payload import utils as payload_utils
 from pyanaconda.payload.base import Payload
@@ -1238,6 +1240,10 @@ class DNFPayload(Payload):
     def pre_install(self):
         super().pre_install()
 
+        # Set up FIPS in the target system before package installation.
+        if kernel_arguments.get("fips") == "1":
+            self._set_up_fips()
+
         # Set rpm-specific options
 
         # nofsync speeds things up at the risk of rpmdb data loss in a crash.
@@ -1269,6 +1275,69 @@ class DNFPayload(Payload):
             self.requirements.add_groups([groupid], reason="platform")
         elif groupid:
             log.warning("Platform group %s not available.", groupid)
+
+    def _set_up_fips(self):
+        """Set up FIPS in the target system.
+
+        Copy the crypto policy from the installation environment
+        to the target system before package installation. The RPM
+        scriptlets need to be executed in the FIPS mode if there
+        is fips=1 on the kernel cmdline.
+
+        FIXME: Move the FIPS support to the Security module.
+         """
+        log.debug("Copying the crypto policy.")
+
+        if not self._check_fips():
+            raise SecurityInstallationError(
+                "FIPS is not correctly set up "
+                "in the installation environment."
+            )
+
+        # Create /etc/crypto-policies.
+        src = "/etc/crypto-policies/"
+        dst = join_paths(conf.target.system_root, src)
+        util.mkdirChain(dst)
+
+        # Copy the config file.
+        src = "/etc/crypto-policies/config"
+        dst = join_paths(conf.target.system_root, src)
+        shutil.copyfile(src, dst)
+
+        # Log the file content on the target system.
+        util.execWithRedirect("/bin/cat", [dst])
+
+        # Copy the back-ends.
+        src = "/etc/crypto-policies/back-ends/"
+        dst = join_paths(conf.target.system_root, src)
+        shutil.copytree(src, dst, symlinks=True)
+
+        # Log the directory content on the target system.
+        util.execWithRedirect("/bin/ls", ["-l", dst])
+
+    def _check_fips(self):
+        """Check FIPS in the installation environment."""
+
+        # Check the config file.
+        config_path = "/etc/crypto-policies/config"
+
+        if not os.path.exists(config_path):
+            log.error("File '%s' doesn't exist.", config_path)
+            return False
+
+        with open(config_path) as f:
+            if f.read().strip() != "FIPS":
+                log.error("The crypto policy is not set to FIPS.")
+                return False
+
+        # Check one of the back-end symlinks.
+        symlink_path = "/etc/crypto-policies/back-ends/opensshserver.config"
+
+        if "FIPS" not in os.path.realpath(symlink_path):
+            log.error("The back ends are not set to FIPS.")
+            return False
+
+        return True
 
     def install(self):
         progress_message(N_('Starting package installation process'))


### PR DESCRIPTION
Add the systemd service anaconda-fips that will set up the FIPS mode in stage2
if there is fips=1 on the kernel cmdline. It should run before network.target.

Bring the service anaconda-sshd unit closer to sshd.service and respect
the crypto policy of the installation environment.

Copy the crypto policy from the installation environment to target system
the before the package installation. The RPM scriptlets needs to be executed
in the FIPS mode if there is fips=1 on the kernel cmdline.

Resolves: rhbz#1800697