### PR TITLE
Avoid imports from blivet.devicefactory

### DIFF
--- a/pyanaconda/core/configuration/storage_constraints.py
+++ b/pyanaconda/core/configuration/storage_constraints.py
@@ -18,11 +18,9 @@
 #
 from enum import Enum
 
-from blivet.devicefactory import DEVICE_TYPE_LVM, DEVICE_TYPE_MD, DEVICE_TYPE_PARTITION, \
-    DEVICE_TYPE_BTRFS, DEVICE_TYPE_DISK, DEVICE_TYPE_LVM_THINP
-from blivet.size import Size
-
 from pyanaconda.core.configuration.base import Section
+from pyanaconda.core.storage import DEVICE_TYPE_LVM, DEVICE_TYPE_MD, DEVICE_TYPE_PARTITION, \
+    DEVICE_TYPE_BTRFS, DEVICE_TYPE_DISK, DEVICE_TYPE_LVM_THINP, Size
 
 
 class DeviceType(Enum):

--- a/pyanaconda/core/storage.py
+++ b/pyanaconda/core/storage.py
@@ -20,8 +20,6 @@ import os
 from decimal import Decimal
 
 from blivet import udev
-from blivet.devicefactory import DEVICE_TYPE_LVM, DEVICE_TYPE_MD, DEVICE_TYPE_PARTITION, \
-    DEVICE_TYPE_BTRFS, DEVICE_TYPE_LVM_THINP, DEVICE_TYPE_DISK, is_supported_device_type
 from blivet.size import Size
 from blivet.util import total_memory
 
@@ -34,6 +32,16 @@ log = get_module_logger(__name__)
 
 # Maximum ratio of swap size to disk size (10 %).
 MAX_SWAP_DISK_RATIO = Decimal('0.1')
+
+SIZE_POLICY_MAX = -1
+SIZE_POLICY_AUTO = 0
+
+DEVICE_TYPE_LVM = 0
+DEVICE_TYPE_MD = 1
+DEVICE_TYPE_PARTITION = 2
+DEVICE_TYPE_BTRFS = 3
+DEVICE_TYPE_DISK = 4
+DEVICE_TYPE_LVM_THINP = 5
 
 NAMED_DEVICE_TYPES = (
     DEVICE_TYPE_BTRFS,
@@ -121,7 +129,11 @@ def device_type_from_autopart(autopart_type):
 
 
 def get_supported_autopart_choices():
-    """Get the supported autopart choices."""
+    """Get the supported autopart choices.
+
+    # FIXME: Move this function to the Storage module.
+    """
+    from blivet.devicefactory import is_supported_device_type
     return [c for c in AUTOPART_CHOICES if is_supported_device_type(AUTOPART_DEVICE_TYPES[c[1]])]
 
 

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -27,9 +27,6 @@
 # - Activating reformat should always enable resize for existing devices.
 import copy
 
-from blivet.devicefactory import DEVICE_TYPE_BTRFS, DEVICE_TYPE_MD
-from blivet.size import Size
-
 from dasbus.client.proxy import get_object_path
 from dasbus.structure import compare_data
 from dasbus.typing import unwrap_variant
@@ -53,7 +50,8 @@ from pyanaconda.product import productName, productVersion
 from pyanaconda.ui.lib.storage import reset_bootloader, create_partitioning, filter_disks_by_names
 from pyanaconda.core.storage import DEVICE_TYPE_UNSUPPORTED, DEVICE_TEXT_MAP, \
     MOUNTPOINT_DESCRIPTIONS, NAMED_DEVICE_TYPES, CONTAINER_DEVICE_TYPES, device_type_from_autopart, \
-    PROTECTED_FORMAT_TYPES
+    PROTECTED_FORMAT_TYPES, DEVICE_TYPE_BTRFS, DEVICE_TYPE_MD, Size
+
 from pyanaconda.threading import threadMgr
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.communication import hubQ

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -18,15 +18,13 @@
 #
 from collections import namedtuple
 
-from blivet.devicefactory import SIZE_POLICY_AUTO, SIZE_POLICY_MAX, DEVICE_TYPE_LVM, \
-    DEVICE_TYPE_BTRFS, DEVICE_TYPE_LVM_THINP, DEVICE_TYPE_MD
-from blivet.size import Size
 from dasbus.structure import get_fields
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.constants import SIZE_UNITS_DEFAULT
 from pyanaconda.core.i18n import _, N_, CN_, C_
-from pyanaconda.core.storage import PROTECTED_FORMAT_TYPES
+from pyanaconda.core.storage import PROTECTED_FORMAT_TYPES, SIZE_POLICY_AUTO, SIZE_POLICY_MAX, \
+    DEVICE_TYPE_LVM, DEVICE_TYPE_BTRFS, DEVICE_TYPE_LVM_THINP, DEVICE_TYPE_MD, Size
 from pyanaconda.core.util import lowerASCII
 from pyanaconda.modules.common.structures.device_factory import DeviceFactoryRequest, \
     DeviceFactoryPermissions


### PR DESCRIPTION
The module blivet.devicefactory imports blivet.formats that will import and
register all available device formats. That is not necessary when we need to
import only a few constants, so let's copy these constants to pyanaconda.