### PR TITLE
Setup RHEL rebuilds to exclude subscription-manager

### DIFF
--- a/data/product.d/centos.conf
+++ b/data/product.d/centos.conf
@@ -6,6 +6,19 @@ product_name = CentOS Linux
 [Base Product]
 product_name = Red Hat Enterprise Linux
 
+[Anaconda]
+# List of enabled Anaconda DBus modules for RHEL.
+#  but without org.fedoraproject.Anaconda.Modules.Subscription
+kickstart_modules =
+     org.fedoraproject.Anaconda.Modules.Timezone
+     org.fedoraproject.Anaconda.Modules.Network
+     org.fedoraproject.Anaconda.Modules.Localization
+     org.fedoraproject.Anaconda.Modules.Security
+     org.fedoraproject.Anaconda.Modules.Users
+     org.fedoraproject.Anaconda.Modules.Payloads
+     org.fedoraproject.Anaconda.Modules.Storage
+     org.fedoraproject.Anaconda.Modules.Services
+
 [Bootloader]
 efi_dir = centos
 

--- a/data/product.d/scientific-linux.conf
+++ b/data/product.d/scientific-linux.conf
@@ -6,6 +6,19 @@ product_name = Scientific Linux
 [Base Product]
 product_name = Red Hat Enterprise Linux
 
+[Anaconda]
+# List of enabled Anaconda DBus modules for RHEL.
+#  but without org.fedoraproject.Anaconda.Modules.Subscription
+kickstart_modules =
+     org.fedoraproject.Anaconda.Modules.Timezone
+     org.fedoraproject.Anaconda.Modules.Network
+     org.fedoraproject.Anaconda.Modules.Localization
+     org.fedoraproject.Anaconda.Modules.Security
+     org.fedoraproject.Anaconda.Modules.Users
+     org.fedoraproject.Anaconda.Modules.Payloads
+     org.fedoraproject.Anaconda.Modules.Storage
+     org.fedoraproject.Anaconda.Modules.Services
+
 [Payload]
 enable_updates = True
 

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -131,7 +131,7 @@ class ProductConfigurationTestCase(unittest.TestCase):
             ["rhel.conf", "scientific-linux.conf"]
         )
 
-    def product_module_list_difference_test(self):
+    def product_module_list_difference_fedora_rhel_test(self):
         """Test for expected Fedora & RHEL module list differences."""
         fedora_config = self._get_config("Fedora")
         fedora_modules = fedora_config.anaconda.kickstart_modules
@@ -140,6 +140,19 @@ class ProductConfigurationTestCase(unittest.TestCase):
         rhel_modules = rhel_config.anaconda.kickstart_modules
 
         difference = list(set(rhel_modules) - set(fedora_modules))
+        expected_difference = ["org.fedoraproject.Anaconda.Modules.Subscription"]
+
+        self.assertListEqual(difference, expected_difference)
+
+    def product_module_difference_centos_rhel_test(self):
+        """Test for expected CentOS & RHEL module list differences."""
+        centos_config = self._get_config("CentOS Linux")
+        centos_modules = centos_config.anaconda.kickstart_modules
+
+        rhel_config = self._get_config("Red Hat Enterprise Linux")
+        rhel_modules = rhel_config.anaconda.kickstart_modules
+
+        difference = list(set(rhel_modules) - set(centos_modules))
         expected_difference = ["org.fedoraproject.Anaconda.Modules.Subscription"]
 
         self.assertListEqual(difference, expected_difference)


### PR DESCRIPTION
This PR clones the DBUS list from RHEL minus org.fedoraproject.Anaconda.Modules.Subscription for the RHEL Rebuilds.

A unit test is added to ensure anaconda in CentOS maintains compatibility with RHEL (minus subscription-manager).