### PR TITLE
Move lxml test dependency from pip to RPM

### DIFF
--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -40,6 +40,7 @@ TEST_DEPENDENCIES = [
     "rpm-ostree",
     "pykickstart",
     "python3-pip",
+    "python3-lxml",
     "policycoreutils",  # contains restorecon which was removed in Fedora 28 mock
 ]
 
@@ -54,7 +55,6 @@ PIP_DEPENDENCIES = [
     "dogtail",
     "pocketlint",
     "nose-testconfig",
-    "lxml",
     "coverage",
     "pycodestyle",  # pep8 check
 ]


### PR DESCRIPTION
The lxml on pip is just a wrapper so it needs the package installed in the system during the installation. There is no real benefit in having it from pip.

Also it is not installed by default in RHEL-8 build root.