### PR TITLE
Always clear kickstarted status for GUI time&date spoke (#1665428)

### DIFF
--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -587,22 +587,15 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
         # Etc/XXXXXX timezone is selected
         region = self._get_active_region()
         city = self._get_active_city()
-        # nothing selected, just leave the spoke and
-        # return to hub without changing anything
+
+        # nothing selected, just leave the spoke and return to hub without changing anything
         if not region or not city:
             return
 
-        old_tz = self._timezone_module.Timezone
-        new_tz = region + "/" + city
-
-        self._timezone_module.SetTimezone(new_tz)
-
-        if old_tz != new_tz:
-            # new values, not from kickstart
-            # TODO: seen should be set from the module
-            self._kickstarted = False
-
+        self._timezone_module.SetTimezone(region + "/" + city)
         self._timezone_module.SetNTPEnabled(self._ntpSwitch.get_active())
+
+        self._kickstarted = False
 
     def execute(self):
         if self._update_datetime_timer is not None:


### PR DESCRIPTION
Clear the (internal) kickstarted status of Time and date GUI spoke on every call to `apply()`, because only human interaction can cause its execution.

This allows setting the default timezone America/New York in a single spoke visit when using kickstart with no timezone specified.

Resolves: rhbz#1665428