### PR TITLE
Call nose python module instead of nosetests binary

### DIFF
--- a/tests/nosetests.sh
+++ b/tests/nosetests.sh
@@ -11,4 +11,4 @@ if [ $# -eq 0 ] && [ -z $NOSE_TESTS_ARGS ]; then
     set -- "${top_srcdir}"/tests/nosetests/*_tests
 fi
 
-exec nosetests-3 -v --exclude=logpicker -a \!acceptance,\!slow $NOSE_TESTS_ARGS "$@"
+exec python3 -m nose -v --exclude=logpicker -a \!acceptance,\!slow $NOSE_TESTS_ARGS "$@"


### PR DESCRIPTION
The binary name could change based on the distribution.

Rhel 8 don't have original nosetests-3.