### PR TITLE
Run the set-up tasks of sources with signals enabled

### DIFF
--- a/pyanaconda/modules/payloads/base/initialization.py
+++ b/pyanaconda/modules/payloads/base/initialization.py
@@ -181,7 +181,7 @@ class SetUpSourcesTask(Task):
 
             for task in tasks:
                 log.debug("Running task %s", task.name)
-                task.run()
+                task.run_with_signals()
 
 
 class TearDownSourcesTask(Task):

--- a/tests/nosetests/pyanaconda_tests/module_payloads_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payloads_test.py
@@ -196,9 +196,9 @@ class PayloadSharedTasksTest(TestCase):
         set_up_task2 = create_autospec(Task)
         set_up_task3 = create_autospec(Task)
 
-        set_up_task1.run.side_effect = lambda: save_position("task1")
-        set_up_task2.run.side_effect = lambda: save_position("task2")
-        set_up_task3.run.side_effect = lambda: save_position("task3")
+        set_up_task1.run_with_signals.side_effect = lambda: save_position("task1")
+        set_up_task2.run_with_signals.side_effect = lambda: save_position("task2")
+        set_up_task3.run_with_signals.side_effect = lambda: save_position("task3")
 
         source1 = create_autospec(PayloadSourceBase)
         source2 = create_autospec(PayloadSourceBase)
@@ -214,9 +214,9 @@ class PayloadSharedTasksTest(TestCase):
 
         source1.set_up_with_tasks.assert_called_once()
         source2.set_up_with_tasks.assert_called_once()
-        set_up_task1.run.assert_called_once()
-        set_up_task2.run.assert_called_once()
-        set_up_task3.run.assert_called_once()
+        set_up_task1.run_with_signals.assert_called_once()
+        set_up_task2.run_with_signals.assert_called_once()
+        set_up_task3.run_with_signals.assert_called_once()
         self.assertEqual(["source1", "task1", "task2", "source2", "task3"], called_position)
 
     def set_up_sources_task_without_sources_test(self):
@@ -232,7 +232,7 @@ class PayloadSharedTasksTest(TestCase):
         set_up_task2 = create_autospec(Task)
         set_up_task3 = create_autospec(Task)
 
-        set_up_task2.run.side_effect = SourceSetupError("task2 error")
+        set_up_task2.run_with_signals.side_effect = SourceSetupError("task2 error")
 
         source1 = create_autospec(PayloadSourceBase)
         source2 = create_autospec(PayloadSourceBase)
@@ -245,9 +245,9 @@ class PayloadSharedTasksTest(TestCase):
         with self.assertRaises(SourceSetupError):
             task.run()
 
-        set_up_task1.run.assert_called_once()
-        set_up_task2.run.assert_called_once()
-        set_up_task3.run.assert_not_called()
+        set_up_task1.run_with_signals.assert_called_once()
+        set_up_task2.run_with_signals.assert_called_once()
+        set_up_task3.run_with_signals.assert_not_called()
 
     def tear_down_sources_task_test(self):
         """Test task to tear down installation sources."""


### PR DESCRIPTION
The sources are connected to signals of their tasks, so make sure that these
signals are emitted as expected.