### PR TITLE
Small changes in the HDD source

### DIFF
--- a/pyanaconda/modules/payloads/source/harddrive/harddrive.py
+++ b/pyanaconda/modules/payloads/source/harddrive/harddrive.py
@@ -180,10 +180,10 @@ class HardDriveSourceModule(PayloadSourceBase, RPMSourceMixin):
         :return: list of tasks required for the source clean-up
         :rtype: [Task]
         """
-        tasks = []
-        if self.is_iso_mounted:
-            tasks.append(TearDownMountTask(self._iso_mount))
-        tasks.append(TearDownMountTask(self._device_mount))
+        tasks = [
+            TearDownMountTask(self._iso_mount),
+            TearDownMountTask(self._device_mount),
+        ]
         return tasks
 
     def get_iso_path(self):

--- a/pyanaconda/modules/payloads/source/harddrive/harddrive.py
+++ b/pyanaconda/modules/payloads/source/harddrive/harddrive.py
@@ -67,11 +67,6 @@ class HardDriveSourceModule(PayloadSourceBase, RPMSourceMixin):
         return HardDriveSourceInterface(self)
 
     @property
-    def is_iso_mounted(self):
-        """Is ISO file mounted from set up task?"""
-        return bool(self._iso_name)
-
-    @property
     def type(self):
         """Get type of this source."""
         return SourceType.HDD

--- a/pyanaconda/modules/payloads/source/harddrive/initialization.py
+++ b/pyanaconda/modules/payloads/source/harddrive/initialization.py
@@ -83,9 +83,11 @@ class SetUpHardDriveSourceTask(Task):
 
         if iso_name:
             if mount_iso_image(full_path_to_iso, self._iso_mount):
+                log.debug("Using the ISO '%s' mounted at '%s'.", iso_name, self._iso_mount)
                 return SetupHardDriveResult(self._iso_mount, iso_name)
 
         if verify_valid_installtree(full_path_on_mounted_device):
+            log.debug("Using the directory at '%s'.", full_path_on_mounted_device)
             return SetupHardDriveResult(full_path_on_mounted_device, "")
 
         raise SourceSetupError(

--- a/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
@@ -344,7 +344,6 @@ class HardDriveSourceTearDownTestCase(unittest.TestCase):
 
     def tear_down_task_order_test(self):
         """Hard drive source tear down task order."""
-        self.source_module._iso_name = "my-cool.iso"
         tasks = self.source_module.tear_down_with_tasks()
         self.assertEqual(len(tasks), 2)
         self.assertIsInstance(tasks[0], TearDownMountTask)
@@ -352,11 +351,3 @@ class HardDriveSourceTearDownTestCase(unittest.TestCase):
         name_suffixes = ["-iso", "-device"]
         for task, fragment in zip(tasks, name_suffixes):
             self.assertTrue(task._target_mount.endswith(fragment))
-
-    def single_tear_down_task_test(self):
-        """Hard drive source single tear down task."""
-        self.source_module._uses_iso_mount = False
-        tasks = self.source_module.tear_down_with_tasks()
-        self.assertEqual(len(tasks), 1)
-        self.assertIsInstance(tasks[0], TearDownMountTask)
-        self.assertTrue(tasks[0]._target_mount.endswith("-device"))

--- a/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
@@ -154,7 +154,7 @@ class HardDriveSourceTestCase(unittest.TestCase):
         task.succeeded_signal.emit()
 
         self.assertEqual(self.module.install_tree_path, iso_mount_location)
-        self.assertEqual(self.module.is_iso_mounted, True)
+        self.assertEqual(self.module._iso_name, "iso_name.iso")
 
     def return_handler_without_iso_test(self):
         """Hard drive source setup result propagates back when no ISO is involved.
@@ -168,7 +168,7 @@ class HardDriveSourceTestCase(unittest.TestCase):
         task.succeeded_signal.emit()
 
         self.assertEqual(self.module.install_tree_path, iso_mount_location)
-        self.assertEqual(self.module.is_iso_mounted, False)
+        self.assertEqual(self.module._iso_name, "")
 
     def repr_test(self):
         self.module.set_device("device")


### PR DESCRIPTION
The indicator of a mounted ISO is not really reliable outside the task, so
always try to unmount the HDD ISO. The task will log an error message, but
it will not fail if the mount point doesn't exist or it is not mounted.

There are two possible results of the task, so make sure the result
is readable from the logs.