### PR TITLE
Rhel 8 rebase root policy

### DIFF
--- a/pyanaconda/modules/users/users.py
+++ b/pyanaconda/modules/users/users.py
@@ -51,7 +51,7 @@ class UsersService(KickstartService):
         self.root_account_locked_changed = Signal()
         self._root_account_locked = True
 
-        self._root_password_ssh_login_allowed = False
+        self._root_password_ssh_login_allowed = True
         self.root_password_ssh_login_allowed_changed = Signal()
 
         self.users_changed = Signal()

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -72,6 +72,8 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self._password_label = self.builder.get_object("password_label")
         self._lock = self.builder.get_object("lock")
         self._root_password_ssh_login_override = self.builder.get_object("root_password_ssh_login_override")
+        # Do not expose root account options in RHEL, #1819844
+        self._hide_root_account_options()
 
         # Install the password checks:
         # - Has a password been specified?
@@ -138,6 +140,12 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
         # report that we are done
         self.initialize_done()
+
+    def _hide_root_account_options(self):
+        self._lock.set_visible(False)
+        self._lock.set_no_show_all(True)
+        self._root_password_ssh_login_override.set_visible(False)
+        self._root_password_ssh_login_override.set_no_show_all(True)
 
     def refresh(self):
         # report refresh is running


### PR DESCRIPTION
The first two commits are fixes applied also to master.
The third commit changes the defaults of root account options from these:
![root_opts_original](https://user-images.githubusercontent.com/1220237/82537449-55f18c00-9b4a-11ea-99ce-d353675c9e80.png)

to current rhel behaviour:
![root_opts_rhel_policy](https://user-images.githubusercontent.com/1220237/82537472-60138a80-9b4a-11ea-8a01-edf827ef337d.png)

The fourth commit hides the options from the GUI:
![root_opts_rhel_hidden](https://user-images.githubusercontent.com/1220237/82537491-66a20200-9b4a-11ea-8099-17fc8293be66.png)

