### PR TITLE
Use the source proxy to get the device name

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -814,7 +814,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         # again.  So just use what we already know to create the selector.
         # Otherwise, check to see if there's anything available.
         if source_type == SOURCE_TYPE_CDROM:
-            self._cdrom = source_type.DeviceName
+            self._cdrom = source_proxy.DeviceName
         elif not flags.automatedInstall:
             self._cdrom = find_optical_install_media()
 


### PR DESCRIPTION
In GUI, we should use the source proxy and not the source type to get
the device name of the CDROM source.