### PR TITLE
RHEL8 help content compatibility

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -234,7 +234,7 @@ reformat_blacklist = /home /usr/local /opt /var/www
 custom_stylesheet =
 
 # The path to a directory with help files.
-help_directory = /usr/share/anaconda/help
+help_directory =
 
 # Default help pages for TUI, GUI and Live OS.
 default_help_pages =

--- a/data/product.d/centos.conf
+++ b/data/product.d/centos.conf
@@ -23,7 +23,8 @@ kickstart_modules =
 efi_dir = centos
 
 [User Interface]
+help_directory = /usr/share/anaconda/help/centos
 default_help_pages =
-    CentOSPlaceholder.txt
-    CentOSPlaceholder.html
-    CentOSPlaceholder.html
+    centos_help_placeholder.txt
+    centos_help_placeholder.xml
+    centos_help_placeholder.xml

--- a/data/product.d/fedora.conf
+++ b/data/product.d/fedora.conf
@@ -10,7 +10,8 @@ default_on_boot = FIRST_WIRED_WITH_LINK
 efi_dir = fedora
 
 [User Interface]
+help_directory = /usr/share/anaconda/help/fedora
 default_help_pages =
-    FedoraPlaceholder.txt
-    FedoraPlaceholder.html
-    FedoraPlaceholderWithLinks.html
+    fedora_help_placeholder.txt
+    fedora_help_placeholder.xml
+    fedora_help_placeholder.xml

--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -43,6 +43,7 @@ efi_dir = redhat
 file_system_type = xfs
 
 [User Interface]
+help_directory = /usr/share/anaconda/help/rhel
 default_help_pages =
     rhel_help_placeholder.txt
     rhel_help_placeholder.xml

--- a/data/product.d/scientific-linux.conf
+++ b/data/product.d/scientific-linux.conf
@@ -23,7 +23,9 @@ kickstart_modules =
 enable_updates = True
 
 [User Interface]
+help_directory = /usr/share/anaconda/help/sl
 default_help_pages =
-    SLPlaceholder.txt
-    SLPlaceholder.html
-    SLPlaceholder.html
+    sl_help_placeholder.txt
+    sl_help_placeholder.xml
+    sl_help_placeholder.xml
+

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -83,10 +83,6 @@ DEFAULT_KEYBOARD = "us"
 
 DRACUT_SHUTDOWN_EJECT = "/run/initramfs/usr/lib/dracut/hooks/shutdown/99anaconda-eject.sh"
 
-# Help.
-HELP_MAIN_PAGE_GUI = "Installation_Guide.xml"
-HELP_MAIN_PAGE_TUI = "Installation_Guide.txt"
-
 # VNC questions
 USEVNC = N_("Start VNC")
 USETEXT = N_("Use text mode")

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -45,7 +45,7 @@ from pyanaconda.ui.gui.utils import gtk_call_once, unbusyCursor
 from pyanaconda.core.async_utils import async_action_wait
 from pyanaconda.ui.gui.utils import watch_children, unwatch_children
 from pyanaconda.ui.gui.helpers import autoinstall_stopped
-from pyanaconda.ui.lib.help import start_yelp, get_help_path
+from pyanaconda.ui.lib.help import start_yelp
 import os.path
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -101,10 +101,11 @@ class GUIObject(common.UIObject):
                            that use GUI elements (Hubs & Spokes) from Anaconda
                            can override the translation domain with their own,
                            so that their subclasses are properly translated.
-       helpFile         -- The location of the yelp-compatible help file for the
-                           given GUI object. The default value of "" indicates
+
+       help_id          -- The id of of the documentation corresponding to the
+                           given GUI object. The default value of None indicates
                            that the object has not specific help file assigned
-                           and the default help file should be used.
+                           and the default help placeholder should be used.
     """
     builderObjects = []
     mainWidgetName = None
@@ -115,7 +116,7 @@ class GUIObject(common.UIObject):
     focusWidgetName = None
 
     uiFile = ""
-    helpFile = None
+    help_id = None
     translationDomain = "anaconda"
 
     handles_autostep = False
@@ -1028,7 +1029,7 @@ class GraphicalUserInterface(UserInterface):
     def _on_help_clicked(self, window, obj):
         # the help button has been clicked, start the yelp viewer with
         # content for the current screen
-        start_yelp(get_help_path(obj.helpFile))
+        start_yelp(obj.help_id)
 
     def _on_quit_clicked(self, win, userData=None):
         if not win.get_quit_button():

--- a/pyanaconda/ui/gui/hubs/summary.py
+++ b/pyanaconda/ui/gui/hubs/summary.py
@@ -35,7 +35,7 @@ class SummaryHub(Hub):
     builderObjects = ["summaryWindow"]
     mainWidgetName = "summaryWindow"
     uiFile = "hubs/summary.glade"
-    helpFile = "SummaryHub.xml"
+    help_id = "SummaryHub"
 
     def __init__(self, data, storage, payload):
         """Create a new Hub instance.

--- a/pyanaconda/ui/gui/spokes/__init__.py
+++ b/pyanaconda/ui/gui/spokes/__init__.py
@@ -19,7 +19,7 @@
 from pyanaconda.ui import common
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.utils import gtk_call_once
-from pyanaconda.ui.lib.help import start_yelp, get_help_path
+from pyanaconda.ui.lib.help import start_yelp
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -73,7 +73,7 @@ class NormalSpoke(GUIObject, common.NormalSpoke):
     def _on_help_clicked(self, window):
         # the help button has been clicked, start the yelp viewer with
         # content for the current spoke
-        start_yelp(get_help_path(self.helpFile))
+        start_yelp(self.help_id)
 
     def on_back_clicked(self, button):
         # Notify the hub that we're finished.

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -503,7 +503,7 @@ class FilterSpoke(NormalSpoke):
                       "searchModel", "multipathModel", "otherModel", "zModel", "nvdimmModel"]
     mainWidgetName = "filterWindow"
     uiFile = "spokes/advanced_storage.glade"
-    helpFile = "FilterSpoke.xml"
+    help_id = "AdvancedStorageSpoke"
 
     category = SystemCategory
 

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -102,8 +102,6 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
     # title of the spoke (will be displayed on the hub)
     title = CN_("GUI|Spoke", "_Blivet-GUI Partitioning")
 
-    helpFile = "blivet-gui/index.page"
-
     ### methods defined by API ###
     def __init__(self, data, storage, payload):
         """

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -93,7 +93,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                       "luksVersionStore"]
     mainWidgetName = "customStorageWindow"
     uiFile = "spokes/custom_storage.glade"
-    helpFile = "CustomSpoke.xml"
+    help_id = "ManualPartitioningSpoke"
 
     category = SystemCategory
     title = N_("MANUAL PARTITIONING")

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -414,7 +414,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
     mainWidgetName = "datetimeWindow"
     uiFile = "spokes/datetime_spoke.glade"
-    helpFile = "DateTimeSpoke.xml"
+    help_id = "DateTimeSpoke"
 
     category = LocalizationCategory
 

--- a/pyanaconda/ui/gui/spokes/installation_progress.py
+++ b/pyanaconda/ui/gui/spokes/installation_progress.py
@@ -44,7 +44,7 @@ class ProgressSpoke(StandaloneSpoke):
     builderObjects = ["progressWindow"]
     mainWidgetName = "progressWindow"
     uiFile = "spokes/installation_progress.glade"
-    helpFile = "ProgressHub.xml"
+    help_id = "ProgressHub"
 
     postForHub = SummaryHub
 

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -402,7 +402,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
                       "dirImage", "repoStore"]
     mainWidgetName = "sourceWindow"
     uiFile = "spokes/installation_source.glade"
-    helpFile = "SourceSpoke.xml"
+    help_id = "InstallationSourceSpoke"
 
     category = SoftwareCategory
 

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -271,7 +271,7 @@ class KeyboardSpoke(NormalSpoke):
                       "layoutTestBuffer"]
     mainWidgetName = "keyboardWindow"
     uiFile = "spokes/keyboard.glade"
-    helpFile = "KeyboardSpoke.xml"
+    help_id = "KeyboardSpoke"
 
     category = LocalizationCategory
 

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -55,7 +55,7 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
     mainWidgetName = "langsupportWindow"
     focusWidgetName = "languageEntry"
     uiFile = "spokes/language_support.glade"
-    helpFile = "LangSupportSpoke.xml"
+    help_id = "LanguageSupportSpoke"
 
     category = LocalizationCategory
 

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1427,7 +1427,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
     builderObjects = ["networkWindow", "liststore_wireless_network", "liststore_devices", "add_device_dialog", "liststore_add_device"]
     mainWidgetName = "networkWindow"
     uiFile = "spokes/network.glade"
-    helpFile = "NetworkSpoke.xml"
+    help_id = "NetworkSpoke"
 
     title = CN_("GUI|Spoke", "_Network & Host Name")
     icon = "network-transmit-receive-symbolic"

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -47,7 +47,8 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     mainWidgetName = "passwordWindow"
     focusWidgetName = "password_entry"
     uiFile = "spokes/root_password.glade"
-    helpFile = "PasswordSpoke.xml"
+    help_id = "RootPasswordSpoke"
+
 
     category = UserSettingsCategory
 

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -56,7 +56,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
     builderObjects = ["addonStore", "environmentStore", "softwareWindow"]
     mainWidgetName = "softwareWindow"
     uiFile = "spokes/software_selection.glade"
-    helpFile = "SoftwareSpoke.xml"
+    help_id = "SoftwareSelectionSpoke"
 
     category = SoftwareCategory
 

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -229,7 +229,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
     builderObjects = ["storageWindow", "addSpecializedImage"]
     mainWidgetName = "storageWindow"
     uiFile = "spokes/storage.glade"
-    helpFile = "StorageSpoke.xml"
+    help_id = "StorageSpoke"
 
     category = SystemCategory
 

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -223,7 +223,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
     mainWidgetName = "userCreationWindow"
     focusWidgetName = "fullname_entry"
     uiFile = "spokes/user.glade"
-    helpFile = "UserSpoke.xml"
+    help_id = "UserConfigurationSpoke"
 
     category = UserSettingsCategory
 

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -56,7 +56,7 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
     mainWidgetName = "welcomeWindow"
     focusWidgetName = "languageEntry"
     uiFile = "spokes/welcome.glade"
-    helpFile = "WelcomeSpoke.xml"
+    help_id = "WelcomeSpoke"
     builderObjects = ["languageStore", "languageStoreFilter", "localeStore",
                       "welcomeWindow", "betaWarnDialog"]
 

--- a/pyanaconda/ui/lib/help.py
+++ b/pyanaconda/ui/lib/help.py
@@ -19,54 +19,102 @@
 Anaconda built-in help module
 """
 import os
+import json
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.localization import find_best_locale_match
-from pyanaconda.core.constants import DEFAULT_LANG, HELP_MAIN_PAGE_GUI, HELP_MAIN_PAGE_TUI
+from pyanaconda.core.constants import DEFAULT_LANG
 from pyanaconda.core.util import startProgram
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
+# Help structure
+#
+# There is a docbook file called anaconda-help.xml with sections that have anchors.
+# We expect yelp to be able to show the sections when we specify them when launching
+# yelp via CLI.
+#
+# Anaconda screens that should have documentation each have a unique help id,
+# which is converted into an anchor via a dictionary loaded from the
+# anaconda-help-anchors.json file.
+#
+# There are also placeholders (docbook & plain text) that are shown:
+# - when screen has no help id set (None)
+# - no anchor is found for a help id
+# - anaconda-help.xml is missing
+#
+# Help in TUI
+#
+# The help system is disabled in TUI as we don't have any plain text help content
+# suitable for TUI at the moment.
+
+MAIN_HELP_FILE = "anaconda-help.xml"
+HELP_ID_MAPPING_FILE_NAME = "anaconda-help-anchors.json"
+
 yelp_process = None
 
 
-def _get_best_help_file(help_file):
-    """
-    Return the path to the best help file for the current language and available
-    help content
+def get_help_id_mapping(help_directory):
+    """Parse the json file containing the help id -> document anchor mapping.
 
+    The mappings file is located in the root of the current help folder.
+    For example for RHEL it is expected to be in:
+    /usr/share/anaconda/help/rhel/anaconda-help-anchors.json
+
+    :param str help_directory: path to directory containing help content
+    """
+    mapping = {}
+    anchors_file_path = os.path.join(help_directory, HELP_ID_MAPPING_FILE_NAME)
+    if os.path.exists(anchors_file_path):
+        try:
+            with open(anchors_file_path, "rt") as f:
+                mapping = json.load(f)
+        except (IOError, json.JSONDecodeError):
+            log.exception("failed to parse the help id -> anchors mapping file %s",
+                          anchors_file_path)
+    else:
+        log.error("help id -> anchors mapping file not found in %s", anchors_file_path)
+
+    return mapping
+
+
+def get_best_help_file(help_directory, help_file):
+    """Return the path to the best help file for current language and help content.
+
+    :param str help_directory: a path to directory where we should look for the help files
     :param str help_file: name of the requested help file
-    :return: path to the best help file or ``None`` is no match is found
+    :return: path to the best help file or None if no match is found
     :rtype: str or NoneType
-
     """
-    help_folder = conf.ui.help_directory
-    current_lang = os.environ["LANG"]
+    current_locale = os.environ.get("LANG", "")
     # list all available languages for the Anaconda help
     # * content is stored in folders named after the given language code
     #   (en-US, cs-CZ, jp-JP, etc.)
     # * we check if the given folder contains the currently needed help file
     #   and only consider it fit to use if it does have the file
-    if not os.path.exists(help_folder):
-        log.warning("help folder %s for help file %s does not exist", help_folder, help_file)
+    if not os.path.exists(help_directory):
+        log.warning("help folder %s for help file %s does not exist", help_directory,
+                    help_file)
         return None
 
     # Collect languages and files that provide the help content.
     help_langs = {}
 
-    for lang in os.listdir(help_folder):
+    for lang in os.listdir(help_directory):
         # Does the help file exist for this language?
-        path = os.path.join(help_folder, lang, help_file)
+        path = os.path.join(help_directory, lang, help_file)
         if not os.path.isfile(path):
             continue
 
-        # Create a valid langcode. For example, use en_US instead of en-US.
-        code = lang.replace('-', '_')
-        help_langs[code] = path
+        # Create a locale for each language code as unfortunately
+        # that is the only thing our matching function can work with.
+        # For example, en_US instead of en-US.
+        locale = lang.replace('-', '_')
+        help_langs[locale] = path
 
     # Find the best help file.
-    for locale in (current_lang, DEFAULT_LANG):
+    for locale in (current_locale, DEFAULT_LANG):
         best_lang = find_best_locale_match(locale, help_langs.keys())
         best_path = help_langs.get(best_lang, None)
 
@@ -78,75 +126,68 @@ def _get_best_help_file(help_file):
     return None
 
 
-def get_help_path(help_file, plain_text=False):
+def get_default_help_file(plain_text=False):
+    """Get path to appropriate placeholder for given install class.
+
+    :param str plain_text: point to plain text version of the placeholder
+    :returns: path to placeholder or None if no placeholder is found
+    :rtype: str or None
     """
-    Return the full path for the given help file name,
-    if the help file path does not exist a fallback path is returned.
-    There are actually two possible fallback paths that might be returned:
-
-    * first we try to return path to the main page of the installation guide
-      (if it exists)
-    * if we can't find the main page of the installation page, path to a
-      "no help found" placeholder bundled with Anaconda is returned
-
-    Regarding help l10n, we try to respect the current locale as defined by the
-    "LANG" environmental variable, but fallback to English if localized content
-    is not available.
-
-    :param help_file: help file name
-    :type help_file: str or NoneType
-
-    :param plain_text: should we find the help in plain text?
-    :type plain_text: bool
-
-    :return str: full path to the help file requested or to a placeholder
-    """
-    # help l10n handling
-
-    if help_file:
-        help_path = _get_best_help_file(help_file)
-        if help_path is not None:
-            return help_path
-
-    # setup the fallback files
     if plain_text:
-        main_page = HELP_MAIN_PAGE_TUI
         placeholder = conf.ui.default_help_pages[0]
     elif not conf.system.provides_web_browser:
-        main_page = HELP_MAIN_PAGE_GUI
         placeholder = conf.ui.default_help_pages[1]
     else:
-        main_page = HELP_MAIN_PAGE_GUI
         placeholder = conf.ui.default_help_pages[2]
 
-    # the screen did not have a helpFile defined or the defined help file
-    # does not exist, so next try to check if we can find the main page
-    # of the installation guide and use it instead
-    help_path = _get_best_help_file(main_page)
-    if help_path is not None:
-        return help_path
-
-    # looks like the installation guide is not available, so just return
-    # a placeholder page, which should be always present
-    return _get_best_help_file(placeholder)
+    placeholder_path = get_best_help_file(conf.ui.help_directory, placeholder)
+    if placeholder_path:
+        return placeholder_path
+    else:
+        log.error("placeholder %s not found in %s",
+                  placeholder,
+                  conf.ui.help_directory)
+        return None
 
 
-def start_yelp(help_path):
+def start_yelp(help_id):
+    """Start a new yelp process and make sure to kill any existing ones.
+
+    We will try to resolve the help id to appropriate content and show it to the user.
+
+    :param str help_id: help id to be shown to the user
     """
-    Start a new yelp process and make sure to kill any existing ones
-
-    :param help_path: path to the help file yelp should load
-    :type help_path: str or NoneType
-    """
-
     kill_yelp()
-    log.debug("starting yelp")
-    global yelp_process
-    # under some extreme circumstances (placeholders missing)
-    # the help path can be None and we need to prevent Popen
-    # receiving None as an argument instead of a string
-    yelp_process = startProgram(["yelp", help_path or ""], reset_lang=False)
+    log.info("help requested for help id %s", help_id)
 
+    # get the help id -> mapping
+    help_id_mapping = get_help_id_mapping(conf.ui.help_directory)
+
+    # we initially set the yelp string to the placeholder path, just in case
+    yelp_string = get_default_help_file()
+
+    # resolve the help id to docbook document anchor (if there is one for the help id)
+    help_anchor = help_id_mapping.get(help_id, None)
+    main_help_file_path = get_best_help_file(conf.ui.help_directory, MAIN_HELP_FILE)
+    if help_anchor and main_help_file_path:
+        log.info("help id %s was resolved to anchor %s", help_id, help_anchor)
+        log.info("starting yelp with anchor %s for help id %s", help_anchor, help_id)
+        # construct string for yelp with anchor based document section access
+        yelp_string = "ghelp:{path_to_file}?{anchor}".format(path_to_file=main_help_file_path,
+                                                             anchor=help_anchor)
+        log.debug("starting yelp with args: %s", yelp_string)
+        global yelp_process
+        yelp_process = startProgram(["yelp", yelp_string], reset_lang=False)
+    else:
+        # find what went wrong
+        if help_anchor is None:
+            # anchor not found
+            log.error("no anchor found for help id %s, yelp started with placeholder", help_id)
+        else:
+            # help file not available
+            log.error("main help file %s not found in %s, yelp started with placeholder",
+                      MAIN_HELP_FILE,
+                      conf.ui.help_directory)
 
 def kill_yelp():
     """Try to kill any existing yelp processes"""

--- a/pyanaconda/ui/tui/hubs/__init__.py
+++ b/pyanaconda/ui/tui/hubs/__init__.py
@@ -18,10 +18,8 @@
 #
 from pyanaconda import lifecycle
 from pyanaconda.ui.tui.tuiobject import TUIObject
-from pyanaconda.ui.lib.help import get_help_path
 from pyanaconda.ui import common
 
-from simpleline.render.adv_widgets import HelpScreen
 from simpleline.render.containers import ListRowContainer
 from simpleline.render.prompt import Prompt
 from simpleline.render.screen import InputState
@@ -139,9 +137,7 @@ class TUIHub(TUIObject, common.Hub):
             # TRANSLATORS: 'h' to help
             elif key == Prompt.HELP:
                 if self.has_help:
-                    help_path = get_help_path(self.helpFile, True)
-                    ScreenHandler.push_screen_modal(HelpScreen(help_path))
-                    return InputState.PROCESSED_AND_REDRAW
+                    raise NotImplementedError("Help system currently not available in TUI")
             return key
 
     def prompt(self, args=None):

--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -40,7 +40,7 @@ class SummaryHub(TUIHub):
        .. inheritance-diagram:: SummaryHub
           :parts: 3
     """
-    helpFile = "SummaryHub.txt"
+    help_id = "SummaryHub"
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -19,12 +19,8 @@
 
 from pyanaconda.ui.common import Spoke, StandaloneSpoke, NormalSpoke
 from pyanaconda.ui.tui.tuiobject import TUIObject
-from pyanaconda.ui.lib.help import get_help_path
 from pyanaconda.core.i18n import N_, _
 
-from simpleline.render.adv_widgets import HelpScreen
-from simpleline.render.screen import InputState
-from simpleline.render.screen_handler import ScreenHandler
 from simpleline.render.prompt import Prompt
 from simpleline.render.widgets import Widget, CheckboxWidget
 
@@ -101,9 +97,7 @@ class NormalTUISpoke(TUISpoke, NormalSpoke):
         # TRANSLATORS: 'h' to help
         if key.lower() == Prompt.HELP:
             if self.has_help:
-                help_path = get_help_path(self.helpFile, True)
-                ScreenHandler.push_screen_modal(HelpScreen(help_path))
-                return InputState.PROCESSED_AND_REDRAW
+                raise NotImplementedError("Help system currently not available in TUI")
 
         return super().input(args, key)
 

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -60,7 +60,7 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
        .. inheritance-diagram:: SourceSpoke
           :parts: 3
     """
-    helpFile = "SourceSpoke.txt"
+    help_id = "SourceSpoke"
     category = SoftwareCategory
 
     SET_NETWORK_INSTALL_MODE = "network_install"

--- a/pyanaconda/ui/tui/spokes/language_support.py
+++ b/pyanaconda/ui/tui/spokes/language_support.py
@@ -43,7 +43,7 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
        .. inheritance-diagram:: LangSpoke
           :parts: 3
     """
-    helpFile = "LangSupportSpoke.txt"
+    help_id = "LangSupportSpoke"
     category = LocalizationCategory
 
     def __init__(self, data, storage, payload):

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -195,7 +195,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
        .. inheritance-diagram:: NetworkSpoke
           :parts: 3
     """
-    helpFile = "NetworkSpoke.txt"
+    help_id = "NetworkSpoke"
     category = SystemCategory
     configurable_device_types = [
         NM.DeviceType.ETHERNET,

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -34,7 +34,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
        .. inheritance-diagram:: PasswordSpoke
           :parts: 3
     """
-    helpFile = "PasswordSpoke.txt"
+    help_id = "RootPasswordSpoke"
     category = UserSettingsCategory
 
     def __init__(self, data, storage, payload):

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -45,7 +45,7 @@ class SoftwareSpoke(NormalTUISpoke):
        .. inheritance-diagram:: SoftwareSpoke
           :parts: 3
     """
-    helpFile = "SoftwareSpoke.txt"
+    help_id = "SoftwareSelectionSpoke"
     category = SoftwareCategory
 
     def __init__(self, data, storage, payload):

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -73,7 +73,7 @@ class StorageSpoke(NormalTUISpoke):
        .. inheritance-diagram:: StorageSpoke
           :parts: 3
     """
-    helpFile = "StorageSpoke.txt"
+    help_id = "StorageSpoke"
     category = SystemCategory
 
     def __init__(self, data, storage, payload):

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -58,7 +58,7 @@ __all__ = ["TimeSpoke"]
 
 
 class TimeSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
-    helpFile = "DateTimeSpoke.txt"
+    help_id = "DateTimeSpoke"
     category = LocalizationCategory
 
     def __init__(self, data, storage, payload):

--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -44,7 +44,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
        .. inheritance-diagram:: UserSpoke
           :parts: 3
     """
-    helpFile = "UserSpoke.txt"
+    help_id = "UserConfigurationSpoke"
     category = UserSettingsCategory
 
     @classmethod

--- a/pyanaconda/ui/tui/tuiobject.py
+++ b/pyanaconda/ui/tui/tuiobject.py
@@ -92,7 +92,7 @@ class TUIObject(UIScreen, common.UIObject):
     """Base class for Anaconda specific TUI screens. Implements the
     common pyanaconda.ui.common.UIObject interface"""
 
-    helpFile = None
+    help_id = None
 
     def __init__(self, data):
         UIScreen.__init__(self)
@@ -105,7 +105,9 @@ class TUIObject(UIScreen, common.UIObject):
 
     @property
     def has_help(self):
-        return self.helpFile is not None
+        # Help content for the TUI is not available at the moment,
+        # so don't show the help option in TUI for the time being.
+        return False
 
     def refresh(self, args=None):
         """Put everything to display into self.window list."""

--- a/tests/nosetests/pyanaconda_tests/help_system_tests.py
+++ b/tests/nosetests/pyanaconda_tests/help_system_tests.py
@@ -1,0 +1,149 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
+import os
+import tempfile
+import json
+
+import unittest
+from unittest.mock import patch
+
+from pyanaconda.ui.lib.help import get_help_id_mapping, HELP_ID_MAPPING_FILE_NAME, \
+    get_best_help_file, get_default_help_file
+
+
+class HelpSystemTestCase(unittest.TestCase):
+    """Test the built in help system."""
+
+    def help_id_mapping_no_file_test(self):
+        """Test help id to anchor mapping file loading - no file."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            # check help_id_mapping was parsed correctly
+            # when the mapping file is missing
+            self.assertEqual(get_help_id_mapping(tempdir), {})
+
+    def help_id_mapping_valid_file_test(self):
+        """Test help id to anchor mapping file loading - valid file."""
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            # write an anchors file to the tempdir
+            anchors_mapping_dict = {
+                "SoftwareSelectionSpoke":
+                "configuring-software-selection_configuring-software-settings",
+                "SubscriptionSpoke":
+                "connect-to-red-hat_configuring-system-settings",
+                "ProgressHub":
+                "final-installer-configuration_graphical-installation",
+            }
+            anchors_file_path = os.path.join(tempdir, HELP_ID_MAPPING_FILE_NAME)
+            with open(anchors_file_path, "wt") as f:
+                f.write(json.dumps(anchors_mapping_dict))
+            # check help_id_mapping was parsed correctly
+            self.assertEqual(get_help_id_mapping(tempdir), anchors_mapping_dict)
+
+    def help_id_mapping_file_not_valid_test(self):
+        """Test help id to anchor mapping file loading - file not valid."""
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            # write something that is not valid json to the mapping file
+            anchors_file_path = os.path.join(tempdir, HELP_ID_MAPPING_FILE_NAME)
+            with open(anchors_file_path, "wt") as f:
+                f.write("foo")
+            # check help_id_mapping was not parsed correctly and the dict is empty
+            self.assertEqual(get_help_id_mapping(tempdir), {})
+
+    def get_best_help_file_no_help_file_test(self):
+        """Test get_best_help_file() - no help file."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            # should return None if no help file is found
+            self.assertIsNone(get_best_help_file(tempdir, "foo.xml"))
+
+    @patch("os.environ.get", return_value="cs_CZ")
+    def get_best_help_file_locale_available_help_test(self, environ_get):
+        """Test get_best_help_file() - current(Czech) locale available."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.mkdir(os.path.join(tempdir, "en-US"))
+            os.mknod(os.path.join(tempdir, "en-US", "foo.xml"))
+            os.mkdir(os.path.join(tempdir, "cs-CZ"))
+            os.mknod(os.path.join(tempdir, "cs-CZ", "foo.xml"))
+            self.assertEqual(get_best_help_file(tempdir, "foo.xml"),
+                             os.path.join(tempdir, "cs-CZ", "foo.xml"))
+
+    @patch("os.environ.get", return_value="cs_CZ")
+    def get_best_help_file_english_help_test(self, environ_get):
+        """Test get_best_help_file() - English help available."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.mkdir(os.path.join(tempdir, "en-US"))
+            os.mknod(os.path.join(tempdir, "en-US", "foo.xml"))
+            self.assertEqual(get_best_help_file(tempdir, "foo.xml"),
+                             os.path.join(tempdir, "en-US", "foo.xml"))
+
+    @patch("os.environ.get", return_value="cs_CZ")
+    def get_best_help_file_current_locale_available(self, environ_get):
+        """Test get_best_help_file() - current locale and fallback locale not available."""
+        # content for the current locale (Czech for this test) and fallback
+        # locale (English) not available
+        with tempfile.TemporaryDirectory() as tempdir:
+            os.mkdir(os.path.join(tempdir, "de-DE"))
+            os.mknod(os.path.join(tempdir, "de-DE", "foo.xml"))
+            self.assertEqual(get_best_help_file(tempdir, "foo.xml"), None)
+
+    @patch('pyanaconda.ui.lib.help.conf')
+    @patch("pyanaconda.ui.lib.help.get_best_help_file")
+    def get_default_help_file_test(self, get_best_help_file_mock, conf):
+        """Test get_default_help_file()."""
+        conf.ui.help_directory = "foo_dir"
+        conf.system.provides_web_browser = False
+        conf.ui.default_help_pages = ["foo.txt", "foo.xml", "foo_live.xml"]
+        get_best_help_file_mock.return_value = "foo"
+        self.assertEqual(get_default_help_file(plain_text=False), "foo")
+        get_best_help_file_mock.assert_called_with("foo_dir", "foo.xml")
+
+    @patch('pyanaconda.ui.lib.help.conf')
+    @patch("pyanaconda.ui.lib.help.get_best_help_file")
+    def get_default_help_file_plain_text_test(self, get_best_help_file_mock, conf):
+        """Test get_default_help_file() - plain text."""
+        conf.ui.help_directory = "foo_dir"
+        conf.system.provides_web_browser = False
+        conf.ui.default_help_pages = ["foo.txt", "foo.xml", "foo_live.xml"]
+        get_best_help_file_mock.return_value = "foo"
+        self.assertEqual(get_default_help_file(plain_text=True), "foo")
+        get_best_help_file_mock.assert_called_with("foo_dir", "foo.txt")
+
+    @patch('pyanaconda.ui.lib.help.conf')
+    @patch("pyanaconda.ui.lib.help.get_best_help_file")
+    def get_default_help_file_web_browser_available_test(self, get_best_help_file_mock, conf):
+        """Test get_default_help_file() - web browser available."""
+        conf.ui.help_directory = "foo_dir"
+        conf.system.provides_web_browser = True
+        conf.ui.default_help_pages = ["foo.txt", "foo.xml", "foo_live.xml"]
+        get_best_help_file_mock.return_value = "foo"
+        self.assertEqual(get_default_help_file(plain_text=False), "foo")
+        get_best_help_file_mock.assert_called_with("foo_dir", "foo_live.xml")
+
+    @patch('pyanaconda.ui.lib.help.conf')
+    @patch("pyanaconda.ui.lib.help.get_best_help_file")
+    def get_placeholder_not_found_test(self, get_best_help_file_mock, conf):
+        """Test get_default_help_file() - placeholder not found."""
+        conf.ui.help_directory = "foo_dir"
+        conf.system.provides_web_browser = False
+        conf.ui.default_help_pages = ["foo.txt", "foo.xml", "foo_live.xml"]
+        get_best_help_file_mock.return_value = None
+        self.assertEqual(get_default_help_file(plain_text=False), None)
+        get_best_help_file_mock.assert_called_with("foo_dir", "foo.xml")


### PR DESCRIPTION
Unfortunately Fedora and RHEL use different style of help content. 

Fedora uses per screen docbook files, but the "upstream" for this is effectively dead and nothing has replaced it till now. So the content is pretty much outdated since Fedora ~26. We have help both for GUI and TUI, where the TUI content is basically plaintext dump of the docbook files.

On the other hand the RHEL8 help content is actively maintained & uses a single Docbook file with anchors that we map to help ids assigned to individual Anaconda screens. Due to this we only have help content for the GUI as there is now no easy way to generate text only help content per screen.

**TODO**
- ~finish unit tests~
- ~handle changes in local -> language code matching~