### PR TITLE
Fixes in the Source spoke in GUI

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -433,10 +433,17 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         self._treeinfo_repos_already_disabled = False
 
     def apply(self):
-        payloadMgr.restart_thread(self.payload, checkmount=False)
+        source_changed = self._update_payload_source()
+        repo_changed = self._update_payload_repos()
+
+        if source_changed or repo_changed or self._error:
+            payloadMgr.restart_thread(self.payload, checkmount=False)
+        else:
+            log.debug("Nothing has changed - skipping payload restart.")
+
         self.clear_info()
 
-    def _method_changed(self):
+    def _update_payload_source(self):
         """ Check to see if the install method has changed.
 
             :returns: True if it changed, False if not
@@ -592,12 +599,6 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
                 return row
 
         return None
-
-    @property
-    def changed(self):
-        method_changed = self._method_changed()
-        update_payload_repos = self._update_payload_repos()
-        return method_changed or update_payload_repos or self._error
 
     @property
     def completed(self):

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -463,6 +463,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
 
             self.set_source_cdrom()
         elif self._hmc_button.get_active():
+            if source_type == SOURCE_TYPE_HMC:
+                return False
+
             self.set_source_hmc()
         elif self._iso_button.get_active():
             # If the user didn't select a partition (not sure how that would


### PR DESCRIPTION
Use the default property that always returns True and move the code to the
method apply. The method apply will reset the payload if anything has changed.

Otherwise, the property could cause tearing down of the source without setting
it up again in the apply method. Then the installation started with unmounted
sources.

If the current source is SE/HMC, don't replace it with a new SE/HMC source.
