### PR TITLE
Set up LANG for tests

### DIFF
--- a/tests/testenv.sh
+++ b/tests/testenv.sh
@@ -30,6 +30,9 @@ export PYTHONPATH
 export top_srcdir
 export top_builddir
 
+# Set up the locale.
+export LANG=en_US.UTF-8
+
 # This must be added to gi.overrides.__path__ by any test requiring the
 # AnacondaWidgets gi-overrides
 export ANACONDA_WIDGETS_OVERRIDES="${top_srcdir}/widgets/python"


### PR DESCRIPTION
Set the environment variable LANG to en_US.UTF-8 in the testing environment.