### PR TITLE
subscription: Use SetAll to set RHSM log level

### DIFF
--- a/pyanaconda/modules/subscription/initialization.py
+++ b/pyanaconda/modules/subscription/initialization.py
@@ -65,7 +65,8 @@ class StartRHSMTask(Task):
         # set RHSM log levels to debug
         # - otherwise the RHSM log output is not usable for debugging subscription issues
         log.debug("subscription: setting RHSM log level to DEBUG")
-        rhsm_config_proxy.Set("logging.default_log_level", get_variant(Str, "DEBUG"), "")
+        config_dict = {"logging.default_log_level": get_variant(Str, "DEBUG")}
+        rhsm_config_proxy.SetAll(config_dict, "")
         # all seems fine
         log.debug("subscription: RHSM service start successfully.")
         return True


### PR DESCRIPTION
The Set() RHSM DBus API method unfortunately does clash with default
DBus Set() method, resulting in a type conflict. So at least until
this is fixed, let's use the SetAll() method that is unaffected by this.