### PR TITLE
Create a proxy of the RHSM Config object for a specific interface

### DIFF
--- a/pyanaconda/modules/subscription/initialization.py
+++ b/pyanaconda/modules/subscription/initialization.py
@@ -22,13 +22,10 @@ from dasbus.typing import get_variant, Str
 
 from pyanaconda.core import util
 from pyanaconda.core.constants import RHSM_SERVICE_TIMEOUT
-
 from pyanaconda.threading import threadMgr
-
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.common.errors.task import NoResultError
-from pyanaconda.modules.common.constants.services import RHSM
-from pyanaconda.modules.common.constants.objects import RHSM_CONFIG
+from pyanaconda.modules.subscription.rhsm_observer import get_rhsm_configuration_proxy
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -60,7 +57,7 @@ class StartRHSMTask(Task):
             )
             return False
         # create a temporary proxy to set the log levels
-        rhsm_config_proxy = RHSM.get_proxy(RHSM_CONFIG)
+        rhsm_config_proxy = get_rhsm_configuration_proxy()
 
         # set RHSM log levels to debug
         # - otherwise the RHSM log output is not usable for debugging subscription issues

--- a/pyanaconda/modules/subscription/rhsm_observer.py
+++ b/pyanaconda/modules/subscription/rhsm_observer.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from dasbus.client.proxy import InterfaceProxy
+from pyanaconda.modules.common.constants.objects import RHSM_CONFIG
 from pyanaconda.modules.common.constants.services import RHSM
 from pyanaconda.core.constants import RHSM_SERVICE_TIMEOUT
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -21,6 +23,25 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from dasbus.client.observer import DBusObserver, DBusObserverError
 
 log = get_module_logger(__name__)
+
+
+def get_rhsm_configuration_proxy():
+    """Get the RHSM configuration proxy.
+
+    The DBus object Config re-defines methods of the standard
+    interface org.freedesktop.DBus.Properties, so create a proxy
+    only with the Config's interface.
+
+    FIXME: Dasbus should prioritize the custom interfaces.
+
+    :return: a DBus proxy
+    """
+    return InterfaceProxy(
+        RHSM._message_bus,
+        RHSM.service_name,
+        RHSM_CONFIG.object_path,
+        RHSM_CONFIG.interface_name
+    )
 
 
 class RHSMObserver(DBusObserver):
@@ -56,5 +77,8 @@ class RHSMObserver(DBusObserver):
         # first check if the DBus API seems to be up
         if not self.is_service_available and not self._startup_check_method(self._timeout):
             raise DBusObserverError("The RHSM DBus API is not available.")
-        else:
-            return RHSM.get_proxy(object_identifier)
+
+        if object_identifier == RHSM_CONFIG:
+            return get_rhsm_configuration_proxy()
+
+        return RHSM.get_proxy(object_identifier)

--- a/tests/nosetests/pyanaconda_tests/rhsm_observer_test.py
+++ b/tests/nosetests/pyanaconda_tests/rhsm_observer_test.py
@@ -25,9 +25,6 @@ from dasbus.typing import get_variant, Str
 from dasbus.client.observer import DBusObserverError
 
 from pyanaconda.core.constants import RHSM_SERVICE_TIMEOUT
-
-from pyanaconda.modules.common.constants.objects import RHSM_CONFIG
-
 from pyanaconda.modules.subscription.initialization import StartRHSMTask
 from pyanaconda.modules.subscription.rhsm_observer import RHSMObserver
 
@@ -39,7 +36,7 @@ class StartRHSMTaskTestCase(unittest.TestCase):
     so lets test it here.
     """
 
-    @patch("pyanaconda.modules.common.constants.services.RHSM.get_proxy")
+    @patch("pyanaconda.modules.subscription.initialization.get_rhsm_configuration_proxy")
     @patch("pyanaconda.core.util.start_service")
     def success_test(self, start_service, get_proxy):
         """Test StartRHSMTask - successful task."""
@@ -56,7 +53,7 @@ class StartRHSMTaskTestCase(unittest.TestCase):
         # check service was started correctly
         start_service.assert_called_once_with("rhsm.service")
         # check proxy was requested
-        get_proxy.assert_called_once_with(RHSM_CONFIG)
+        get_proxy.assert_called_once_with()
         # check expected values were set on the RHSM config proxy
         config_proxy.Set.assert_called_once_with(
             'logging.default_log_level',


### PR DESCRIPTION
The DBus object Config re-defines methods of the standard interface
org.freedesktop.DBus.Properties, so create a proxy only with the
Config's interface.