### PR TITLE
subscription: Fix SystemPurposeData equality checking

### DIFF
--- a/pyanaconda/modules/common/structures/subscription.py
+++ b/pyanaconda/modules/common/structures/subscription.py
@@ -105,6 +105,10 @@ class SystemPurposeData(DBusData):
                  False otherwise
         :rtype: bool
         """
+        # if the other instance is not instance of SubscriptionRequest,
+        # then it is always considered to be different
+        if not isinstance(other_instance, SystemPurposeData):
+            return False
         # addon ordering is not important
         if set(self.addons) != set(other_instance.addons):
             return False

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
@@ -328,6 +328,12 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         self.assertFalse(system_purpose_data == different_system_purpose_data)
         self.assertFalse(system_purpose_data_clone == different_system_purpose_data)
 
+        # comparing with something else than a SystemPurposeData instance should
+        # not crash & always return False
+        self.assertNotEqual(system_purpose_data, "foo")
+        self.assertNotEqual(system_purpose_data, None)
+        self.assertNotEqual(system_purpose_data, object())
+
     def system_purpose_data_helper_test(self):
         """Test the SystemPurposeData DBus structure data availability helper method."""
 


### PR DESCRIPTION
Prevent the equality check from crashing if the input
is not a SystemPurposeData instance.