### PR TITLE
subscription: Only require Insights package if subscribed

### DIFF
--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -702,7 +702,7 @@ class SubscriptionService(KickstartService):
         requirements = []
         # check if we need the insights-client package, which is needed to connect the
         # target system to Red Hat Insights
-        if self.connect_to_insights:
+        if self.subscription_attached and self.connect_to_insights:
             # establishing a connection to Red Hat Insights has been requested
             # and we need the insights-client package to be present in the
             # target system chroot for that

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
@@ -1099,8 +1099,9 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
     def package_requirements_insights_test(self):
         """Test package requirements - connect to Insights enabled."""
-        # enable connect to Insights
+        # enable connect to Insights & mark system as subscribed
         self.subscription_interface.SetInsightsEnabled(True)
+        self.subscription_module.set_subscription_attached(True)
         # check the Insights client package is requested
         requirements = self.subscription_interface.CollectRequirements()
         expected_requirements = [


### PR DESCRIPTION
Red Hat Insights is enabled by default in the GUI, even if
the user never enters the Connect to Red Hat spoke.

This together with custom repo URL being used will result
in the Insights package being added to the transaction,
even though it can't really be used without the system having
a valid subscription attached.

So before adding the Insights package as a requirement, check
that the system is subscribed.