### PR TITLE
subscription: Do not pass payload to unregister() helper function

### DIFF
--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -864,7 +864,6 @@ class SubscriptionSpoke(NormalSpoke):
                 name=THREAD_SUBSCRIPTION,
                 target=unregister,
                 kwargs={
-                    "payload": self.payload,
                     "progress_callback": self._subscription_progress_callback,
                     "error_callback": self._subscription_error_callback
                 }


### PR DESCRIPTION
The unregister() helper function does not need to work with payload
just yet.