### PR TITLE
Fix adding repository from unified URL source

### DIFF
--- a/pyanaconda/core/payload.py
+++ b/pyanaconda/core/payload.py
@@ -64,6 +64,34 @@ def create_nfs_url(host, path, options=None):
     return "nfs:{server}:{path}".format(server=host, path=path)
 
 
+def split_protocol(url):
+    """Split protocol from url
+
+    The function will look for ://.
+
+    - If found more than once in the url then raising an error.
+    - If found exactly once it will return tuple with [protocol, rest_of_url].
+    - If an empty string is given it will return tuple with empty strings ("", "").
+
+    :param str url: base url we want to split protocol from
+    :return: tuple of (protocol, rest of url)
+    :raise: ValueError if url is invalid
+    """
+    ret = url.split("://")
+
+    if len(ret) > 2:
+        raise ValueError("Invalid url to split protocol '{}'".format(url))
+
+    if len(ret) == 2:
+        # return back part removed when splitting
+        return (ret[0] + "://", ret[1])
+
+    if len(ret) == 1:
+        return ("", ret[0])
+
+    return ("", "")
+
+
 class ProxyStringError(Exception):
     pass
 

--- a/pyanaconda/payload/install_tree_metadata.py
+++ b/pyanaconda/payload/install_tree_metadata.py
@@ -23,6 +23,7 @@ import os
 
 from productmd.treeinfo import TreeInfo
 from pyanaconda.core import util, constants
+from pyanaconda.core.payload import split_protocol
 
 from pyanaconda.anaconda_loggers import get_packaging_logger
 log = get_packaging_logger()
@@ -31,6 +32,7 @@ MAX_TREEINFO_DOWNLOAD_RETRIES = 6
 
 
 class InstallTreeMetadata(object):
+    # TODO: Add tests for InstallTreeMetadata class
 
     def __init__(self):
         self._tree_info = TreeInfo()
@@ -236,7 +238,10 @@ class RepoMetadata(object):
         if self.relative_path == ".":
             return self._root_path
         else:
-            return os.path.normpath(os.path.join(self._root_path, self.relative_path))
+            protocol, url = split_protocol(os.path.join(self._root_path, self.relative_path))
+            # resolve problems with relative path especially useful for NFS (root/path/../new_path)
+            url = os.path.normpath(url)
+            return protocol + url
 
     def is_valid(self):
         """Quick check if the repo is a valid repository.

--- a/tests/nosetests/pyanaconda_tests/payload_test.py
+++ b/tests/nosetests/pyanaconda_tests/payload_test.py
@@ -633,7 +633,7 @@ class PayloadUtilsTests(unittest.TestCase):
                          "nfs:options:host:/path/to/something")
 
     def nfs_combine_test(self):
-        "Test combination of parse and create nfs functions."
+        """Test combination of parse and create nfs functions."""
 
         host = "host"
         path = "/path/to/somewhere"
@@ -645,3 +645,23 @@ class PayloadUtilsTests(unittest.TestCase):
         url = "nfs:options:host:/my/path"
         (options, host, path) = util.parse_nfs_url(url)
         self.assertEqual(util.create_nfs_url(host, path, options), url)
+
+    def split_protocol_test(self):
+        """Test split protocol test."""
+
+        self.assertEqual(util.split_protocol("http://abc/cde"),
+                         ("http://", "abc/cde"))
+        self.assertEqual(util.split_protocol("https://yay/yay"),
+                         ("https://", "yay/yay"))
+        self.assertEqual(util.split_protocol("ftp://ups/spu"),
+                         ("ftp://", "ups/spu"))
+        self.assertEqual(util.split_protocol("file:///test/file"),
+                         ("file://", "/test/file"))
+        self.assertEqual(util.split_protocol("nfs:ups/spu:/abc:opts"),
+                         ("", "nfs:ups/spu:/abc:opts"))
+        self.assertEqual(util.split_protocol("http:/typo/test"),
+                         ("", "http:/typo/test"))
+        self.assertEqual(util.split_protocol(""), ("", ""))
+
+        with self.assertRaises(ValueError):
+            util.split_protocol("http://ftp://ups/this/is/not/correct")


### PR DESCRIPTION
The problem is that we added ``os.path.normpath()`` to clean-up relative paths with NFS mounts (`../../`). However, this also resulted in change of `http://` -> `http:/` issue which resulted in crash of DNF `repo.load()` method.

Add new helper function to split protocol from a url so we can use normpath to just url without the protocol.