### PR TITLE
Fixes for the CDROM source

### DIFF
--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -53,7 +53,7 @@ from pyanaconda.anaconda_loggers import get_dnf_logger, get_packaging_logger
 from pyanaconda.core import constants, util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import INSTALL_TREE, ISO_DIR, PAYLOAD_TYPE_DNF, \
-    DNF_DEFAULT_SOURCE_TYPE, SOURCE_TYPE_HMC, SOURCE_TYPE_URL, \
+    DNF_DEFAULT_SOURCE_TYPE, SOURCE_TYPE_HMC, SOURCE_TYPE_URL, SOURCE_TYPE_CDROM, \
     URL_TYPE_BASEURL, URL_TYPE_MIRRORLIST, URL_TYPE_METALINK, SOURCE_REPO_FILE_TYPES
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.core.payload import ProxyString, ProxyStringError
@@ -74,7 +74,7 @@ from pyanaconda.payload.dnf.download_progress import DownloadProgress
 from pyanaconda.payload.dnf.repomd import RepoMDMetaHash
 from pyanaconda.payload.errors import MetadataError, PayloadError, NoSuchGroup, DependencyError, \
     PayloadInstallError, PayloadSetupError
-from pyanaconda.payload.image import find_first_iso_image, mountImage
+from pyanaconda.payload.image import find_first_iso_image, mountImage, find_optical_install_media
 from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
 from pyanaconda.product import productName, productVersion
 from pyanaconda.progress import progressQ, progress_message
@@ -1442,12 +1442,19 @@ class DNFPayload(Payload):
         log.info("Configuring the base repo")
         self.reset()
 
-        # Set up the source.
-        set_up_sources(self.proxy)
-
         # Find the source and its type.
         source_proxy = self.get_source_proxy()
         source_type = source_proxy.Type
+
+        # Change the default source to CDROM if there is a valid install media.
+        # FIXME: Set up the default source earlier.
+        if checkmount and source_type == DNF_DEFAULT_SOURCE_TYPE and find_optical_install_media():
+            source_type = SOURCE_TYPE_CDROM
+            source_proxy = create_source(source_type)
+            set_source(self.proxy, source_proxy)
+
+        # Set up the source.
+        set_up_sources(self.proxy)
 
         # Read in all the repos from the installation environment, make a note of which
         # are enabled, and then disable them all.  If the user gave us a method, we want

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -55,7 +55,6 @@ from pyanaconda.modules.common.constants.services import NETWORK, STORAGE
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.structures.storage import DeviceData
 from pyanaconda.core.storage import device_matches
-from pyanaconda.ui.lib.payload import set_source, tear_down_sources, create_source
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -973,20 +972,17 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
                 self._iso_chooser_button.set_use_underline(False)
         elif source_type == SOURCE_TYPE_HMC:
             self._hmc_button.set_active(True)
-        else:
-            # No method was given in advance, so now we need to make a sensible
-            # guess.  Go with autodetected media if that was provided, and then
-            # fall back to closest mirror.
+        elif source_type == SOURCE_TYPE_CDROM:
+            # Go with autodetected media if that was provided,
+            # otherwise fall back to the closest mirror.
             if not self._autodetect_button.get_no_show_all():
                 self._autodetect_button.set_active(True)
-                source_type = SOURCE_TYPE_CDROM
             else:
                 self._network_button.set_active(True)
-                source_type = SOURCE_TYPE_CLOSEST_MIRROR
-
-            tear_down_sources(self.payload.proxy)
-            source_proxy = create_source(source_type)
-            set_source(self.payload.proxy, source_proxy)
+        elif source_type == SOURCE_TYPE_CLOSEST_MIRROR:
+            self._network_button.set_active(True)
+        else:
+            ValueError("Unsupported source type: '{}'".format(source_type))
 
         self._setup_updates()
 


### PR DESCRIPTION
Use the current source to set up the GUI elements in the refresh method of
the Source spoke, but don't change it. The source should be changed only in
the apply method.

Set up the spoke for all supported types of sources and raise an exception
if the current type is unsupported.

When we restart the payload thread for the first time, we should change
the default source to CDROM if there is a valid install media.

Anaconda uses the argument checkmount to control this behavior, but we
should try to find a better way how to handle this case.