### PR TITLE
Fix source tear down

### DIFF
--- a/pyanaconda/modules/payloads/source/mount_tasks.py
+++ b/pyanaconda/modules/payloads/source/mount_tasks.py
@@ -21,7 +21,7 @@ import os.path
 from abc import ABC, abstractmethod
 
 from pyanaconda.modules.common.task import Task
-from pyanaconda.modules.common.errors.payload import SourceSetupError
+from pyanaconda.modules.common.errors.payload import SourceSetupError, SourceTearDownError
 
 from pyanaconda.payload.utils import unmount
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -46,7 +46,19 @@ class TearDownMountTask(Task):
     def run(self):
         """Run source un-setup."""
         log.debug("Unmounting installation source")
+        self._do_unmount()
+        self._check_mount()
+
+    def _do_unmount(self):
+        """Unmount the source."""
         unmount(self._target_mount)
+
+    def _check_mount(self):
+        """Check if the source is unmounted."""
+        if os.path.ismount(self._target_mount):
+            raise SourceTearDownError("The mount point {} is still in use.".format(
+                self._target_mount
+            ))
 
 
 class SetUpMountTask(Task, ABC):

--- a/pyanaconda/modules/payloads/source/mount_tasks.py
+++ b/pyanaconda/modules/payloads/source/mount_tasks.py
@@ -69,10 +69,13 @@ class SetUpMountTask(Task, ABC):
         self._target_mount = target_mount
 
     def run(self):
+        """Run source setup."""
+        log.debug("Mounting installation source")
         self._check_mount()
         return self._do_mount()
 
     def _check_mount(self):
+        """Check if the source is unmounted."""
         if os.path.ismount(self._target_mount):
             raise SourceSetupError("The mount point {} is already in use.".format(
                 self._target_mount
@@ -80,7 +83,9 @@ class SetUpMountTask(Task, ABC):
 
     @abstractmethod
     def _do_mount(self):
-        """Override this method in descendants to do the actual work of mounting.
+        """Mount the source.
 
-        Return the result you want returned from the task."""
+        Override this method in descendants to do the actual work of mounting.
+        Return the result you want returned from the task.
+        """
         pass

--- a/pyanaconda/payload/dnf/repomd.py
+++ b/pyanaconda/payload/dnf/repomd.py
@@ -90,10 +90,12 @@ class RepoMDMetaHash(object):
                                      timeout=constants.NETWORK_CONNECTION_TIMEOUT)
                 if result.ok:
                     repomd = result.text
+                    result.close()
                     break
                 else:
                     log.debug("Server returned %i code when downloading repomd",
                               result.status_code)
+                    result.close()
                     continue
             except RequestException as e:
                 log.debug("Can't download new repomd.xml from %s with proxy: %s. Error: %s",


### PR DESCRIPTION
The tear-down task of a mountable source should raise the SourceTearDownError
exception if the mount point is still in use after the unmounting.

We should always close a response returned by session.get. Otherwise, we might
be unable to tear down a source because there is an opened file that blocks the
unmount operation.