### PR TITLE
subscription: Replace helpFile property with help_id

### DIFF
--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -45,7 +45,7 @@ from pyanaconda.ui.gui.utils import gtk_call_once, unbusyCursor
 from pyanaconda.core.async_utils import async_action_wait
 from pyanaconda.ui.gui.utils import watch_children, unwatch_children
 from pyanaconda.ui.gui.helpers import autoinstall_stopped
-from pyanaconda.ui.lib.help import start_yelp, get_help_path
+from pyanaconda.ui.lib.help import start_yelp
 import os.path
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -101,10 +101,11 @@ class GUIObject(common.UIObject):
                            that use GUI elements (Hubs & Spokes) from Anaconda
                            can override the translation domain with their own,
                            so that their subclasses are properly translated.
-       helpFile         -- The location of the yelp-compatible help file for the
-                           given GUI object. The default value of "" indicates
+
+       help_id          -- The id of of the documentation corresponding to the
+                           given GUI object. The default value of None indicates
                            that the object has not specific help file assigned
-                           and the default help file should be used.
+                           and the default help placeholder should be used.
     """
     builderObjects = []
     mainWidgetName = None
@@ -115,7 +116,7 @@ class GUIObject(common.UIObject):
     focusWidgetName = None
 
     uiFile = ""
-    helpFile = None
+    help_id = None
     translationDomain = "anaconda"
 
     handles_autostep = False
@@ -1028,7 +1029,7 @@ class GraphicalUserInterface(UserInterface):
     def _on_help_clicked(self, window, obj):
         # the help button has been clicked, start the yelp viewer with
         # content for the current screen
-        start_yelp(get_help_path(obj.helpFile))
+        start_yelp(obj.help_id)
 
     def _on_quit_clicked(self, win, userData=None):
         if not win.get_quit_button():

--- a/pyanaconda/ui/gui/hubs/summary.py
+++ b/pyanaconda/ui/gui/hubs/summary.py
@@ -35,7 +35,7 @@ class SummaryHub(Hub):
     builderObjects = ["summaryWindow"]
     mainWidgetName = "summaryWindow"
     uiFile = "hubs/summary.glade"
-    helpFile = "SummaryHub.xml"
+    help_id = "SummaryHub"
 
     def __init__(self, data, storage, payload):
         """Create a new Hub instance.

--- a/pyanaconda/ui/gui/spokes/__init__.py
+++ b/pyanaconda/ui/gui/spokes/__init__.py
@@ -19,7 +19,7 @@
 from pyanaconda.ui import common
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.utils import gtk_call_once
-from pyanaconda.ui.lib.help import start_yelp, get_help_path
+from pyanaconda.ui.lib.help import start_yelp
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -73,7 +73,7 @@ class NormalSpoke(GUIObject, common.NormalSpoke):
     def _on_help_clicked(self, window):
         # the help button has been clicked, start the yelp viewer with
         # content for the current spoke
-        start_yelp(get_help_path(self.helpFile))
+        start_yelp(self.help_id)
 
     def on_back_clicked(self, button):
         # Notify the hub that we're finished.

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -503,7 +503,7 @@ class FilterSpoke(NormalSpoke):
                       "searchModel", "multipathModel", "otherModel", "zModel", "nvdimmModel"]
     mainWidgetName = "filterWindow"
     uiFile = "spokes/advanced_storage.glade"
-    helpFile = "FilterSpoke.xml"
+    help_id = "AdvancedStorageSpoke"
 
     category = SystemCategory
 

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -102,8 +102,6 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
     # title of the spoke (will be displayed on the hub)
     title = CN_("GUI|Spoke", "_Blivet-GUI Partitioning")
 
-    helpFile = "blivet-gui/index.page"
-
     ### methods defined by API ###
     def __init__(self, data, storage, payload):
         """

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -93,7 +93,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                       "luksVersionStore"]
     mainWidgetName = "customStorageWindow"
     uiFile = "spokes/custom_storage.glade"
-    helpFile = "CustomSpoke.xml"
+    help_id = "ManualPartitioningSpoke"
 
     category = SystemCategory
     title = N_("MANUAL PARTITIONING")

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -414,7 +414,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
     mainWidgetName = "datetimeWindow"
     uiFile = "spokes/datetime_spoke.glade"
-    helpFile = "DateTimeSpoke.xml"
+    help_id = "DateTimeSpoke"
 
     category = LocalizationCategory
 

--- a/pyanaconda/ui/gui/spokes/installation_progress.py
+++ b/pyanaconda/ui/gui/spokes/installation_progress.py
@@ -44,7 +44,7 @@ class ProgressSpoke(StandaloneSpoke):
     builderObjects = ["progressWindow"]
     mainWidgetName = "progressWindow"
     uiFile = "spokes/installation_progress.glade"
-    helpFile = "ProgressHub.xml"
+    help_id = "ProgressHub"
 
     postForHub = SummaryHub
 

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -402,7 +402,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
                       "dirImage", "repoStore"]
     mainWidgetName = "sourceWindow"
     uiFile = "spokes/installation_source.glade"
-    helpFile = "SourceSpoke.xml"
+    help_id = "InstallationSourceSpoke"
 
     category = SoftwareCategory
 

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -271,7 +271,7 @@ class KeyboardSpoke(NormalSpoke):
                       "layoutTestBuffer"]
     mainWidgetName = "keyboardWindow"
     uiFile = "spokes/keyboard.glade"
-    helpFile = "KeyboardSpoke.xml"
+    help_id = "KeyboardSpoke"
 
     category = LocalizationCategory
 

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -55,7 +55,7 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
     mainWidgetName = "langsupportWindow"
     focusWidgetName = "languageEntry"
     uiFile = "spokes/language_support.glade"
-    helpFile = "LangSupportSpoke.xml"
+    help_id = "LanguageSupportSpoke"
 
     category = LocalizationCategory
 

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1427,7 +1427,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
     builderObjects = ["networkWindow", "liststore_wireless_network", "liststore_devices", "add_device_dialog", "liststore_add_device"]
     mainWidgetName = "networkWindow"
     uiFile = "spokes/network.glade"
-    helpFile = "NetworkSpoke.xml"
+    help_id = "NetworkSpoke"
 
     title = CN_("GUI|Spoke", "_Network & Host Name")
     icon = "network-transmit-receive-symbolic"

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -47,7 +47,8 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     mainWidgetName = "passwordWindow"
     focusWidgetName = "password_entry"
     uiFile = "spokes/root_password.glade"
-    helpFile = "PasswordSpoke.xml"
+    help_id = "RootPasswordSpoke"
+
 
     category = UserSettingsCategory
 

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -56,7 +56,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
     builderObjects = ["addonStore", "environmentStore", "softwareWindow"]
     mainWidgetName = "softwareWindow"
     uiFile = "spokes/software_selection.glade"
-    helpFile = "SoftwareSpoke.xml"
+    help_id = "SoftwareSelectionSpoke"
 
     category = SoftwareCategory
 

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -229,7 +229,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
     builderObjects = ["storageWindow", "addSpecializedImage"]
     mainWidgetName = "storageWindow"
     uiFile = "spokes/storage.glade"
-    helpFile = "StorageSpoke.xml"
+    help_id = "StorageSpoke"
 
     category = SystemCategory
 

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -223,7 +223,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
     mainWidgetName = "userCreationWindow"
     focusWidgetName = "fullname_entry"
     uiFile = "spokes/user.glade"
-    helpFile = "UserSpoke.xml"
+    help_id = "UserConfigurationSpoke"
 
     category = UserSettingsCategory
 

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -56,7 +56,7 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
     mainWidgetName = "welcomeWindow"
     focusWidgetName = "languageEntry"
     uiFile = "spokes/welcome.glade"
-    helpFile = "WelcomeSpoke.xml"
+    help_id = "WelcomeSpoke"
     builderObjects = ["languageStore", "languageStoreFilter", "localeStore",
                       "welcomeWindow", "betaWarnDialog"]
 

--- a/pyanaconda/ui/tui/hubs/__init__.py
+++ b/pyanaconda/ui/tui/hubs/__init__.py
@@ -18,7 +18,7 @@
 #
 from pyanaconda import lifecycle
 from pyanaconda.ui.tui.tuiobject import TUIObject
-from pyanaconda.ui.lib.help import get_help_path
+from pyanaconda.ui.lib.help import get_placeholder_path
 from pyanaconda.ui import common
 
 from simpleline.render.adv_widgets import HelpScreen
@@ -139,7 +139,7 @@ class TUIHub(TUIObject, common.Hub):
             # TRANSLATORS: 'h' to help
             elif key == Prompt.HELP:
                 if self.has_help:
-                    help_path = get_help_path(self.helpFile, True)
+                    help_path = get_placeholder_path(plain_text=True)
                     ScreenHandler.push_screen_modal(HelpScreen(help_path))
                     return InputState.PROCESSED_AND_REDRAW
             return key

--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -40,7 +40,7 @@ class SummaryHub(TUIHub):
        .. inheritance-diagram:: SummaryHub
           :parts: 3
     """
-    helpFile = "SummaryHub.txt"
+    help_id = "SummaryHub"
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -19,7 +19,7 @@
 
 from pyanaconda.ui.common import Spoke, StandaloneSpoke, NormalSpoke
 from pyanaconda.ui.tui.tuiobject import TUIObject
-from pyanaconda.ui.lib.help import get_help_path
+from pyanaconda.ui.lib.help import get_placeholder_path
 from pyanaconda.core.i18n import N_, _
 
 from simpleline.render.adv_widgets import HelpScreen
@@ -101,7 +101,7 @@ class NormalTUISpoke(TUISpoke, NormalSpoke):
         # TRANSLATORS: 'h' to help
         if key.lower() == Prompt.HELP:
             if self.has_help:
-                help_path = get_help_path(self.helpFile, True)
+                help_path = get_placeholder_path(plain_text=True)
                 ScreenHandler.push_screen_modal(HelpScreen(help_path))
                 return InputState.PROCESSED_AND_REDRAW
 

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -60,7 +60,7 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
        .. inheritance-diagram:: SourceSpoke
           :parts: 3
     """
-    helpFile = "SourceSpoke.txt"
+    help_id = "SourceSpoke"
     category = SoftwareCategory
 
     SET_NETWORK_INSTALL_MODE = "network_install"

--- a/pyanaconda/ui/tui/spokes/language_support.py
+++ b/pyanaconda/ui/tui/spokes/language_support.py
@@ -43,7 +43,7 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
        .. inheritance-diagram:: LangSpoke
           :parts: 3
     """
-    helpFile = "LangSupportSpoke.txt"
+    help_id = "LangSupportSpoke"
     category = LocalizationCategory
 
     def __init__(self, data, storage, payload):

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -195,7 +195,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
        .. inheritance-diagram:: NetworkSpoke
           :parts: 3
     """
-    helpFile = "NetworkSpoke.txt"
+    help_id = "NetworkSpoke"
     category = SystemCategory
     configurable_device_types = [
         NM.DeviceType.ETHERNET,

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -34,7 +34,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
        .. inheritance-diagram:: PasswordSpoke
           :parts: 3
     """
-    helpFile = "PasswordSpoke.txt"
+    help_id = "RootPasswordSpoke"
     category = UserSettingsCategory
 
     def __init__(self, data, storage, payload):

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -45,7 +45,7 @@ class SoftwareSpoke(NormalTUISpoke):
        .. inheritance-diagram:: SoftwareSpoke
           :parts: 3
     """
-    helpFile = "SoftwareSpoke.txt"
+    help_id = "SoftwareSelectionSpoke"
     category = SoftwareCategory
 
     def __init__(self, data, storage, payload):

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -73,7 +73,7 @@ class StorageSpoke(NormalTUISpoke):
        .. inheritance-diagram:: StorageSpoke
           :parts: 3
     """
-    helpFile = "StorageSpoke.txt"
+    help_id = "StorageSpoke"
     category = SystemCategory
 
     def __init__(self, data, storage, payload):

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -58,7 +58,7 @@ __all__ = ["TimeSpoke"]
 
 
 class TimeSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
-    helpFile = "DateTimeSpoke.txt"
+    help_id = "DateTimeSpoke"
     category = LocalizationCategory
 
     def __init__(self, data, storage, payload):

--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -44,7 +44,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
        .. inheritance-diagram:: UserSpoke
           :parts: 3
     """
-    helpFile = "UserSpoke.txt"
+    help_id = "UserConfigurationSpoke"
     category = UserSettingsCategory
 
     @classmethod

--- a/pyanaconda/ui/tui/tuiobject.py
+++ b/pyanaconda/ui/tui/tuiobject.py
@@ -92,7 +92,7 @@ class TUIObject(UIScreen, common.UIObject):
     """Base class for Anaconda specific TUI screens. Implements the
     common pyanaconda.ui.common.UIObject interface"""
 
-    helpFile = None
+    help_id = None
 
     def __init__(self, data):
         UIScreen.__init__(self)
@@ -105,7 +105,9 @@ class TUIObject(UIScreen, common.UIObject):
 
     @property
     def has_help(self):
-        return self.helpFile is not None
+        # Help content for the TUI is not available at the moment,
+        # so don't show the help option in TUI for the time being.
+        return False
 
     def refresh(self, args=None):
         """Put everything to display into self.window list."""


### PR DESCRIPTION
Previously we used to have one help content file per screen,
which no longer works for the new help content, which is using
a single docbook file with anchors.

So replace the helpFile property with a help_id property, which
holds a unique string id corresponding to one screen needing help.

The help id can then be mapped into an anchor in the main docbook file,
or even something else if needed.

Based on 56777977c9bfbd97b97ef0d72e59d0702f7b725c.

Related: rhbz#1593723
Related: rhbz#1691319