### PR TITLE
Add back NFS ISO support (ups)

### DIFF
--- a/pyanaconda/modules/payloads/source/harddrive/initialization.py
+++ b/pyanaconda/modules/payloads/source/harddrive/initialization.py
@@ -19,11 +19,10 @@ import os.path
 
 from collections import namedtuple
 
-from pyanaconda.core.util import join_paths
-from pyanaconda.payload.image import find_first_iso_image
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.task import Task
-from pyanaconda.modules.payloads.source.utils import find_and_mount_device, mount_iso_image
+from pyanaconda.modules.payloads.source.utils import find_and_mount_device, \
+    find_and_mount_iso_image
 from pyanaconda.payload.image import verify_valid_installtree
 from pyanaconda.anaconda_loggers import get_module_logger
 
@@ -77,14 +76,11 @@ class SetUpHardDriveSourceTask(Task):
             "{}/{}".format(self._device_mount, self._directory)
         )
 
-        iso_name = find_first_iso_image(full_path_on_mounted_device)
+        iso_name = find_and_mount_iso_image(full_path_on_mounted_device, self._iso_mount)
 
         if iso_name:
-            full_path_to_iso = self._create_iso_path(full_path_on_mounted_device, iso_name)
-
-            if mount_iso_image(full_path_to_iso, self._iso_mount):
-                log.debug("Using the ISO '%s' mounted at '%s'.", iso_name, self._iso_mount)
-                return SetupHardDriveResult(self._iso_mount, iso_name)
+            log.debug("Using the ISO '%s' mounted at '%s'.", iso_name, self._iso_mount)
+            return SetupHardDriveResult(self._iso_mount, iso_name)
 
         if verify_valid_installtree(full_path_on_mounted_device):
             log.debug("Using the directory at '%s'.", full_path_on_mounted_device)
@@ -93,12 +89,3 @@ class SetUpHardDriveSourceTask(Task):
         raise SourceSetupError(
             "Nothing useful found for Hard drive ISO source at partition={} directory={}".format(
                 self._partition, self._directory))
-
-    @staticmethod
-    def _create_iso_path(full_path_on_mounted_device, iso_name):
-        # The directory parameter is not pointing directly to ISO
-        if not full_path_on_mounted_device.endswith(iso_name):
-            return os.path.normpath(join_paths(full_path_on_mounted_device, iso_name))
-
-        # The directory parameter is pointing directly to ISO
-        return full_path_on_mounted_device

--- a/pyanaconda/modules/payloads/source/harddrive/initialization.py
+++ b/pyanaconda/modules/payloads/source/harddrive/initialization.py
@@ -24,6 +24,7 @@ from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.payloads.source.utils import find_and_mount_device, \
     find_and_mount_iso_image
 from pyanaconda.payload.image import verify_valid_installtree
+from pyanaconda.payload.utils import unmount
 from pyanaconda.anaconda_loggers import get_module_logger
 
 log = get_module_logger(__name__)
@@ -86,6 +87,8 @@ class SetUpHardDriveSourceTask(Task):
             log.debug("Using the directory at '%s'.", full_path_on_mounted_device)
             return SetupHardDriveResult(full_path_on_mounted_device, "")
 
+        # nothing found unmount the existing device
+        unmount(self._device_mount)
         raise SourceSetupError(
             "Nothing useful found for Hard drive ISO source at partition={} directory={}".format(
                 self._partition, self._directory))

--- a/pyanaconda/modules/payloads/source/nfs/nfs.py
+++ b/pyanaconda/modules/payloads/source/nfs/nfs.py
@@ -17,6 +17,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import os.path
+
 from pyanaconda.core.i18n import _
 from pyanaconda.core.payload import create_nfs_url, parse_nfs_url
 from pyanaconda.core.signal import Signal
@@ -25,8 +27,8 @@ from pyanaconda.modules.payloads.constants import SourceType, SourceState
 from pyanaconda.modules.payloads.source.nfs.nfs_interface import NFSSourceInterface
 from pyanaconda.modules.payloads.source.nfs.initialization import SetUpNFSSourceTask
 from pyanaconda.modules.payloads.source.mount_tasks import TearDownMountTask
-from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase, \
-    MountingSourceMixin, RPMSourceMixin
+from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase, RPMSourceMixin
+from pyanaconda.modules.payloads.source.utils import MountPointGenerator
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -34,13 +36,24 @@ log = get_module_logger(__name__)
 __all__ = ["NFSSourceModule"]
 
 
-class NFSSourceModule(PayloadSourceBase, MountingSourceMixin, RPMSourceMixin):
-    """The NFS source module."""
+class NFSSourceModule(PayloadSourceBase, RPMSourceMixin):
+    """The NFS source module.
+
+    TODO: Merge code from HardDriveSourceModule and this one.
+    TODO: Add install_tree_path property.
+    """
 
     def __init__(self):
         super().__init__()
         self._url = ""
         self.url_changed = Signal()
+        self._install_tree_path = ""
+        self._device_mount = MountPointGenerator.generate_mount_point(
+            self.type.value.lower() + "-device"
+        )
+        self._iso_mount = MountPointGenerator.generate_mount_point(
+            self.type.value.lower() + "-iso"
+        )
 
     def __repr__(self):
         return "Source(type='NFS', url='{}')".format(self.url)
@@ -69,7 +82,8 @@ class NFSSourceModule(PayloadSourceBase, MountingSourceMixin, RPMSourceMixin):
 
     def get_state(self):
         """Get state of this source."""
-        return SourceState.from_bool(self.get_mount_state())
+        res = os.path.ismount(self._device_mount) and bool(self._install_tree_path)
+        return SourceState.from_bool(res)
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
@@ -87,7 +101,7 @@ class NFSSourceModule(PayloadSourceBase, MountingSourceMixin, RPMSourceMixin):
 
     def generate_repo_configuration(self):
         """Generate RepoConfigurationData structure."""
-        return RepoConfigurationData.from_directory(self.mount_point)
+        return RepoConfigurationData.from_directory(self.install_tree_path)
 
     @property
     def url(self):
@@ -111,13 +125,25 @@ class NFSSourceModule(PayloadSourceBase, MountingSourceMixin, RPMSourceMixin):
         self.url_changed.emit()
         log.debug("NFS URL is set to %s", self._url)
 
+    @property
+    def install_tree_path(self):
+        """Path to the install tree.
+
+        Read only, and available only after the setup task finishes successfully.
+
+        :rtype: str
+        """
+        return self._install_tree_path
+
     def set_up_with_tasks(self):
         """Set up the installation source for installation.
 
         :return: list of tasks required for the source setup
         :rtype: [Task]
         """
-        return [SetUpNFSSourceTask(self.mount_point, self._url)]
+        task = SetUpNFSSourceTask(self._device_mount, self._url)
+        task.succeeded_signal.connect(lambda: self._handle_setup_task_result(task))
+        return [task]
 
     def tear_down_with_tasks(self):
         """Tear down the installation source.
@@ -125,5 +151,13 @@ class NFSSourceModule(PayloadSourceBase, MountingSourceMixin, RPMSourceMixin):
         :return: list of tasks required for the source clean-up
         :rtype: [TearDownMountTask]
         """
-        task = TearDownMountTask(self._mount_point)
-        return [task]
+        tasks = [
+            TearDownMountTask(self._iso_mount),
+            TearDownMountTask(self._device_mount),
+        ]
+        return tasks
+
+    def _handle_setup_task_result(self, task):
+        result = task.get_result()
+        self._install_tree_path = result
+        log.debug("NFS install tree path is set to '%s'", self._install_tree_path)

--- a/pyanaconda/modules/payloads/source/nfs/nfs.py
+++ b/pyanaconda/modules/payloads/source/nfs/nfs.py
@@ -141,7 +141,7 @@ class NFSSourceModule(PayloadSourceBase, RPMSourceMixin):
         :return: list of tasks required for the source setup
         :rtype: [Task]
         """
-        task = SetUpNFSSourceTask(self._device_mount, self._url)
+        task = SetUpNFSSourceTask(self._device_mount, self._iso_mount, self._url)
         task.succeeded_signal.connect(lambda: self._handle_setup_task_result(task))
         return [task]
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
@@ -229,12 +229,12 @@ class DNFInterfaceTestCase(unittest.TestCase):
 
         self.assertEqual(self.interface.GetRepoConfigurations(), expected)
 
-    @patch("pyanaconda.modules.payloads.source.nfs.nfs.NFSSourceModule.mount_point",
+    @patch("pyanaconda.modules.payloads.source.nfs.nfs.NFSSourceModule.install_tree_path",
            new_callable=PropertyMock)
     @patch_dbus_publish_object
-    def nfs_get_repo_configurations_test(self, publisher, mount_point):
+    def nfs_get_repo_configurations_test(self, publisher, install_tree_path_mock):
         """Test DNF GetRepoConfigurations for NFS source."""
-        mount_point.return_value = "/install_source/nfs"
+        install_tree_path_mock.return_value = "/install_source/nfs"
         source = self.shared_tests.prepare_source(SourceType.NFS)
 
         self.shared_tests.set_sources([source])
@@ -246,9 +246,9 @@ class DNFInterfaceTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.payloads.source.harddrive.harddrive.HardDriveSourceModule.install_tree_path",
            new_callable=PropertyMock)
     @patch_dbus_publish_object
-    def harddrive_get_repo_configurations_test(self, publisher, mount_point):
+    def harddrive_get_repo_configurations_test(self, publisher, install_tree_path_mock):
         """Test DNF GetRepoConfigurations for HARDDRIVE source."""
-        mount_point.return_value = "/install_source/harddrive"
+        install_tree_path_mock.return_value = "/install_source/harddrive"
         source = self.shared_tests.prepare_source(SourceType.HDD)
 
         self.shared_tests.set_sources([source])

--- a/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
@@ -189,12 +189,10 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
 
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
            return_value=True)
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_first_iso_image",
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_iso_image",
            return_value="skynet.iso")
-    @patch("pyanaconda.modules.payloads.source.utils.mount")
     def success_find_iso_test(self,
-                              mount_mock,
-                              find_first_iso_image_mock,
+                              find_and_mount_iso_image_mock,
                               find_and_mount_device_mock):
         """Hard drive source setup iso found."""
         task = _create_setup_task()
@@ -204,26 +202,20 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
             device_spec,
             device_mount_location
         )
-        find_first_iso_image_mock.assert_called_once_with(
-            device_mount_location + path_on_device
-        )
-        mount_mock.assert_called_once_with(
-            device_mount_location + path_on_device + "/skynet.iso",
-            iso_mount_location,
-            fstype="iso9660",
-            options="ro"
+        find_and_mount_iso_image_mock.assert_called_once_with(
+            device_mount_location + path_on_device, iso_mount_location
         )
         self.assertEqual(result, SetupHardDriveResult(iso_mount_location, "skynet.iso"))
 
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
            return_value=True)
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_first_iso_image",
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_iso_image",
            return_value="")
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.verify_valid_installtree",
            return_value=True)
     def success_find_dir_test(self,
                               verify_valid_installtree_mock,
-                              find_first_iso_image_mock,
+                              find_and_mount_iso_image_mock,
                               find_and_mount_device_mock):
         """Hard drive source setup dir found."""
         task = _create_setup_task()
@@ -233,8 +225,8 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
             device_spec,
             device_mount_location
         )
-        find_first_iso_image_mock.assert_called_once_with(
-            device_mount_location + path_on_device
+        find_and_mount_iso_image_mock.assert_called_once_with(
+            device_mount_location + path_on_device, iso_mount_location
         )
         verify_valid_installtree_mock.assert_called_once_with(
             device_mount_location + path_on_device
@@ -243,13 +235,13 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
 
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
            return_value=True)
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_first_iso_image",
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_iso_image",
            return_value="")
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.verify_valid_installtree",
            return_value=False)
     def failure_to_find_anything_test(self,
                                       verify_valid_installtree_mock,
-                                      find_first_iso_image_mock,
+                                      find_and_mount_iso_image_mock,
                                       find_and_mount_device_mock):
         """Hard drive source setup failure to find anything."""
         task = _create_setup_task()
@@ -260,45 +252,8 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
             device_spec,
             device_mount_location
         )
-        find_first_iso_image_mock.assert_called_once_with(
-            device_mount_location + path_on_device
-        )
-        verify_valid_installtree_mock.assert_called_once_with(
-            device_mount_location + path_on_device
-        )
-        self.assertTrue(str(cm.exception).startswith(
-            "Nothing useful found for Hard drive ISO source"
-        ))
-
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.verify_valid_installtree",
-           return_value=False)
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
-           return_value=True)
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_first_iso_image",
-           return_value="skynet.iso")
-    @patch("pyanaconda.modules.payloads.source.utils.mount", side_effect=OSError())
-    def failure_to_mount_iso_test(self,
-                                  mount_mock,
-                                  find_first_iso_image_mock,
-                                  find_and_mount_device_mock,
-                                  verify_valid_installtree_mock):
-        """Hard drive source setup iso found."""
-        task = _create_setup_task()
-        with self.assertRaises(SourceSetupError) as cm:
-            task.run()
-
-        find_and_mount_device_mock.assert_called_once_with(
-            device_spec,
-            device_mount_location
-        )
-        find_first_iso_image_mock.assert_called_once_with(
-            device_mount_location + path_on_device
-        )
-        mount_mock.assert_called_once_with(
-            device_mount_location + path_on_device + "/skynet.iso",
-            iso_mount_location,
-            fstype="iso9660",
-            options="ro"
+        find_and_mount_iso_image_mock.assert_called_once_with(
+            device_mount_location + path_on_device, iso_mount_location
         )
         verify_valid_installtree_mock.assert_called_once_with(
             device_mount_location + path_on_device
@@ -310,7 +265,7 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
            return_value=False)
     def failure_to_find_mount_device_test(self, find_and_mount_device_mock):
-        """Hard drive source setup failure to find or mount partition device."""
+        """Hard drive source setup failure to find partition device."""
         task = _create_setup_task()
         with self.assertRaises(SourceSetupError) as cm:
             task.run()
@@ -326,7 +281,7 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.os.path.ismount",
            return_value=True)
     def failure_mount_already_used_test(self, ismount_mock):
-        """Hard drive source setup failure to find or mount partition device."""
+        """Hard drive source setup failure to mount partition device."""
         task = _create_setup_task()
         with self.assertRaises(SourceSetupError) as cm:
             task.run()

--- a/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
@@ -239,7 +239,9 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
            return_value="")
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.verify_valid_installtree",
            return_value=False)
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.unmount")
     def failure_to_find_anything_test(self,
+                                      unmount_mock,
                                       verify_valid_installtree_mock,
                                       find_and_mount_iso_image_mock,
                                       find_and_mount_device_mock):
@@ -257,6 +259,9 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
         )
         verify_valid_installtree_mock.assert_called_once_with(
             device_mount_location + path_on_device
+        )
+        unmount_mock.assert_called_once_with(
+            device_mount_location
         )
         self.assertTrue(str(cm.exception).startswith(
             "Nothing useful found for Hard drive ISO source"

--- a/tests/nosetests/pyanaconda_tests/module_source_nfs_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_nfs_test.py
@@ -113,6 +113,7 @@ class NFSSourceTestCase(unittest.TestCase):
     def tear_down_with_tasks_test(self):
         """Test NFS Source ready state for tear down."""
         task_classes = [
+            TearDownMountTask,
             TearDownMountTask
         ]
 


### PR DESCRIPTION
We missed support for ISO in the NFS payload source.

This will implement it back in a reasonable manner. It has plenty of duplicate code with HardDriveSourceModule but merging those would mean changing almost all the hard drive tests and nfs tests also designing completely new solution (probably mixin class). This is good enough solution for now and I'll try to make next PR with better solution soon to get it to RHEL-8 when we have time.

Backport of https://github.com/rhinstaller/anaconda/pull/2615