### PR TITLE
Resolved a user created password verification issue that could not exit

### DIFF
--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -505,7 +505,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         password_is_required = togglebutton.get_active()
         self.password_entry.set_sensitive(password_is_required)
         self.password_confirmation_entry.set_sensitive(password_is_required)
-        self._password_is_required = password_is_required        
+        self._password_is_required = password_is_required
         # also disable/enable corresponding password checks
         self._empty_check.skip = not password_is_required or not self.username
         self._confirm_check.skip = not password_is_required

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -505,8 +505,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         password_is_required = togglebutton.get_active()
         self.password_entry.set_sensitive(password_is_required)
         self.password_confirmation_entry.set_sensitive(password_is_required)
-        self._password_is_required = password_is_required
-        
+        self._password_is_required = password_is_required        
         # also disable/enable corresponding password checks
         self._empty_check.skip = not password_is_required or not self.username
         self._confirm_check.skip = not password_is_required


### PR DESCRIPTION
1.The configure normal user password interface allows the user to exit without any configuration.
2.When normal user password is configured, choose not to require the password, and do not configure the password, allow the user to modify the user name can normally exit.