### PR TITLE
Set up LD_PRELOAD for the Payloads module

### DIFF
--- a/data/dbus/org.fedoraproject.Anaconda.Modules.Payloads.service
+++ b/data/dbus/org.fedoraproject.Anaconda.Modules.Payloads.service
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=org.fedoraproject.Anaconda.Modules.Payloads
-Exec=/usr/libexec/anaconda/start-module pyanaconda.modules.payloads
+Exec=/usr/libexec/anaconda/start-module --env LD_PRELOAD=libgomp.so.1 pyanaconda.modules.payloads
 User=root

--- a/pyanaconda/modules/payloads/__main__.py
+++ b/pyanaconda/modules/payloads/__main__.py
@@ -20,6 +20,10 @@
 from pyanaconda.modules.common import init
 init()
 
+import os
+if "LD_PRELOAD" in os.environ:
+    del os.environ["LD_PRELOAD"]
+
 from pyanaconda.modules.payloads.payloads import PayloadsService
 service = PayloadsService()
 service.run()

--- a/scripts/start-module
+++ b/scripts/start-module
@@ -1,6 +1,26 @@
 #!/bin/bash
 # Start the Anaconda's Python module $1.
-# For example: ./start-module pyanaconda.modules.boss
+#
+# Examples:
+#   ./start-module pyanaconda.modules.boss
+#   ./start-module --env LD_PRELOAD=libgomp.so.1 pyanaconda.modules.payloads
+#
+
+# Process the arguments.
+while true
+do
+  case $1 in
+    # Set up the environment.
+    --env)
+      export $2
+      shift 2
+    ;;
+    # Nothing else to do.
+    *)
+      break
+    ;;
+  esac
+done
 
 # Add Anaconda addons to the PYTHONPATH.
 PYTHONPATH="$PYTHONPATH:/usr/share/anaconda/addons"


### PR DESCRIPTION
The environment variable LD_PRELOAD needs to be set up during the start of
the Payloads module, but it needs to be dropped after that.

After the modularization, only the Payloads module should require LD_PRELOAD.