### PR TITLE
Catch Blivet's exceptions when we reset a device (#1843278)

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
@@ -348,13 +348,7 @@ class DeviceTreeSchedulerModule(DeviceTreeModule):
         :raise: StorageConfigurationError in case of failure
         """
         device = self._get_device(device_name)
-
-        if device.exists:
-            # Revert changes done to an existing device.
-            self.storage.reset_device(device)
-        else:
-            # Destroy a non-existing device.
-            utils.destroy_device(self.storage, device)
+        utils.reset_device(self.storage, device)
 
     def destroy_device(self, device_name):
         """Destroy the specified device in the storage model.

--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -1000,6 +1000,29 @@ def generate_device_factory_permissions(storage, request: DeviceFactoryRequest):
     return permissions
 
 
+def reset_device(storage, device):
+    """Reset the given device in the storage model.
+
+    FIXME: Merge with destroy_device.
+
+    :param storage: an instance of Blivet
+    :param device: an instance of a device
+    :raise: StorageConfigurationError in case of failure
+    """
+    log.debug("Reset device: %s", device.name)
+
+    try:
+        if device.exists:
+            # Revert changes done to an existing device.
+            storage.reset_device(device)
+        else:
+            # Destroy a non-existing device.
+            _destroy_device(storage, device)
+    except (StorageError, ValueError) as e:
+        log.error("Failed to reset a device: %s", e)
+        raise StorageConfigurationError(str(e)) from None
+
+
 def destroy_device(storage, device):
     """Destroy the given device in the storage model.
 


### PR DESCRIPTION
Make sure we catch the Blivet's exceptions and raise the DBus errors instead
when we call the DBus method ResetDevice of the Storage module.

Resolves: rhbz#1843278