### PR TITLE
Fix more SElinux contexts

### DIFF
--- a/data/post-scripts/80-setfilecons.ks
+++ b/data/post-scripts/80-setfilecons.ks
@@ -12,7 +12,9 @@ restorecon -ir /etc/sysconfig/network-scripts /etc/lvm /etc/X11/xorg.conf.d \
                /var/lib /var/lib/iscsi /var/lock /var/log /var/spool \
                /var/cache/yum \
                /dev \
-               /root
+               /root \
+               /boot \
+               /etc/dnf/modules.d
 
 # Also relabel the OSTree variants of the traditional mounts if present
 restorecon -ir /var/roothome /var/home /var/opt /var/srv /var/media /var/mnt


### PR DESCRIPTION
Apparently we have them wrong in `/boot/loader/entries` and `/etc/dnf/modules.d/` See the linked bugs for more details. This is a bit workaroundish, but works.

Resolves: rhbz#1775975
Resolves: rhbz#1834189