### PR TITLE
Do not build Anaconda on i686

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -148,6 +148,11 @@ Obsoletes: anaconda-runtime < %{version}-%{release}
 Provides: anaconda-runtime = %{version}-%{release}
 Obsoletes: booty <= 0.107-1
 
+# native i686 installations are not supported on RHEL8 and Anaconda
+# is not a i686 compatibility library, so building it for i686 does not
+# make sense
+ExcludeArch: i686
+
 %description core
 The anaconda-core package contains the program which was used to install your
 system.


### PR DESCRIPTION
As native i686 installations are not supported on RHEL8
and Anaconda is not a i686 compatibility library, it makes
no sense to build it for the i686 architecture.

This also fixes an issue with Anaconda depending on kexec-tools,
which has dropped i686 build. This other packages from being
built due to transitive dependency on i686 kexec-tools package that
no longer exists if those packages have BuildRequires: on anaconda.

Related: rhbz#1691319