### PR TITLE
Fix the pylint warning in the Payloads module

### DIFF
--- a/pyanaconda/modules/payloads/__main__.py
+++ b/pyanaconda/modules/payloads/__main__.py
@@ -22,7 +22,7 @@ init()
 
 import os
 if "LD_PRELOAD" in os.environ:
-    del os.environ["LD_PRELOAD"]
+    del os.environ["LD_PRELOAD"]  # pylint: disable=environment-modify
 
 from pyanaconda.modules.payloads.payloads import PayloadsService
 service = PayloadsService()


### PR DESCRIPTION
Disable the warning about potentially unsafe modification of environment
for the environment variable LD_PRELOAD in the Payloads module.