### PR TITLE
Allow having /boot on a btrfs volume

### DIFF
--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -116,7 +116,7 @@ class GRUB2(BootLoader):
     stage2_must_be_primary = False
 
     # requirements for boot devices
-    stage2_device_types = ["partition", "mdarray", "btrfs subvolume"]
+    stage2_device_types = ["partition", "mdarray", "btrfs volume", "btrfs subvolume"]
     stage2_raid_levels = [raid.RAID0, raid.RAID1, raid.RAID4,
                           raid.RAID5, raid.RAID6, raid.RAID10]
     stage2_raid_member_types = ["partition"]


### PR DESCRIPTION
It works just fine and in case you go with btrfs-on-luks there is no
reason to create a btrfs volume and just one boot subvolume in it.

Signed-off-by: Igor Raits <i.gnatenko.brain@gmail.com>