### PR TITLE
Don't prompt the user to ssh in VNC installations

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -296,11 +296,8 @@ if __name__ == "__main__":
         util.touch('/tmp/NOSAVE_LOGS')
 
     # see if we're on s390x and if we've got an ssh connection
-    uname = os.uname()
-    if uname[4] == 's390x':
-        if 'TMUX' not in os.environ and 'ks' not in kernel_arguments and conf.target.is_hardware:
-            startup_utils.prompt_for_ssh()
-            sys.exit(0)
+    if startup_utils.prompt_for_ssh(opts):
+        sys.exit(0)
 
     log.info("%s %s", sys.argv[0], util.get_anaconda_version_string(build_time_version=True))
     if os.path.exists("/tmp/updates"):

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -183,8 +183,23 @@ def setup_logging_from_options(options):
             log.error("Could not setup remotelog with %s", options.remotelog)
 
 
-def prompt_for_ssh():
-    """Prompt the user to ssh to the installation environment on the s390."""
+def prompt_for_ssh(options):
+    """Prompt the user to ssh to the installation environment on the s390.
+
+    :param options: Anaconda command line/boot options
+    :return: True if the prompt is printed, otherwise False
+    """
+    if not blivet.arch.is_s390():
+        return False
+
+    if not conf.target.is_hardware:
+        return False
+
+    if 'TMUX' in os.environ:
+        return False
+
+    if options.ksfile:
+        return False
 
     # Do some work here to get the ip addr / hostname to pass
     # to the user.
@@ -222,6 +237,8 @@ def prompt_for_ssh():
         stdout_log.info(_("Please ssh install@%s to begin the install."), connxinfo)
     else:
         stdout_log.info(_("Please ssh install@HOSTNAME to continue installation."))
+
+    return True
 
 
 def clean_pstore():

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -201,6 +201,9 @@ def prompt_for_ssh(options):
     if options.ksfile:
         return False
 
+    if options.vnc:
+        return False
+
     # Do some work here to get the ip addr / hostname to pass
     # to the user.
     import socket


### PR DESCRIPTION
Move the checks for the function prompt_for_ssh from anaconda.py. The function
returns True, if the prompt is printed, otherwise False.

When the installation is started with the boot option inst.vnc, don't ask
the user to ssh to the installation environment. Proceed to establish the
VNC connection.