### PR TITLE
Change the default_partitioning option

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -147,13 +147,20 @@ allow_imperfect_devices = False
 file_system_type =
 
 # Default partitioning.
-# Valid values:
+# Specify a mount point and its attributes on each line.
 #
-#   SERVER          Choose partitioning for servers.
-#   WORKSTATION     Choose partitioning for workstations.
-#   VIRTUALIZATION  Choose partitioning for virtualizations.
+# Valid attributes:
 #
-default_partitioning = WORKSTATION
+#   size <SIZE>    The size of the mount point.
+#   min <MIN_SIZE> The size will grow from MIN_SIZE to MAX_SIZE.
+#   max <MAX_SIZE> The max size is unlimited by default.
+#   free <SIZE>    The required available space.
+#   encrypted      The mount point will be encrypted.
+#
+default_partitioning =
+    /     (min 1 GiB, max 70 GiB, encrypted)
+    /home (min 500 MiB, free 50 GiB, encrypted)
+    swap  (encrypted)
 
 # Default partitioning scheme.
 # Valid values:

--- a/data/product.d/fedora-atomic-host.conf
+++ b/data/product.d/fedora-atomic-host.conf
@@ -13,7 +13,9 @@ check_supported_locales = True
 
 [Storage]
 file_system_type = xfs
-default_partitioning = SERVER
+default_partitioning =
+    /    (min 2 GiB, max 15 GiB, encrypted)
+    swap (encrypted)
 
 [User Interface]
 custom_stylesheet = /usr/share/anaconda/pixmaps/atomic/fedora-atomic.css

--- a/data/product.d/fedora-server.conf
+++ b/data/product.d/fedora-server.conf
@@ -12,7 +12,9 @@ default_environment = server-product-environment
 
 [Storage]
 file_system_type = xfs
-default_partitioning = SERVER
+default_partitioning =
+    /    (min 2 GiB, max 15 GiB, encrypted)
+    swap (encrypted)
 
 [User Interface]
 custom_stylesheet = /usr/share/anaconda/pixmaps/server/fedora-server.css

--- a/data/product.d/ovirt.conf
+++ b/data/product.d/ovirt.conf
@@ -7,8 +7,15 @@ product_name = oVirt Node Next
 product_name = CentOS Linux
 
 [Storage]
-default_partitioning = VIRTUALIZATION
 default_scheme = LVM_THINP
+default_partitioning =
+    /              (min 6 GiB)
+    /home          (size 1 GiB)
+    /tmp           (size 1 GiB)
+    /var           (size 15 GiB)
+    /var/log       (size 8 GiB)
+    /var/log/audit (size 2 GiB)
+    swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP

--- a/data/product.d/rhev.conf
+++ b/data/product.d/rhev.conf
@@ -7,8 +7,15 @@ product_name = Red Hat Virtualization
 product_name = Red Hat Enterprise Linux
 
 [Storage]
-default_partitioning = VIRTUALIZATION
 default_scheme = LVM_THINP
+default_partitioning =
+    /              (min 6 GiB)
+    /home          (size 1 GiB)
+    /tmp           (size 1 GiB)
+    /var           (size 15 GiB)
+    /var/log       (size 8 GiB)
+    /var/log/audit (size 2 GiB)
+    swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP

--- a/pyanaconda/core/configuration/storage.py
+++ b/pyanaconda/core/configuration/storage.py
@@ -19,17 +19,12 @@
 #
 from enum import Enum
 
+from blivet.size import Size
+
 from pykickstart.constants import AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_BTRFS, AUTOPART_TYPE_LVM, \
     AUTOPART_TYPE_LVM_THINP
 
 from pyanaconda.core.configuration.base import Section
-
-
-class PartitioningType(Enum):
-    """Type of the default partitioning."""
-    SERVER = "SERVER"
-    WORKSTATION = "WORKSTATION"
-    VIRTUALIZATION = "VIRTUALIZATION"
 
 
 class PartitioningScheme(Enum):
@@ -98,20 +93,6 @@ class StorageSection(Section):
         return self._get_option("file_system_type", str)
 
     @property
-    def default_partitioning(self):
-        """Default partitioning.
-
-        Valid values:
-
-          SERVER          Choose partitioning for servers.
-          WORKSTATION     Choose partitioning for workstations.
-          VIRTUALIZATION  Choose partitioning for virtualizations.
-
-        :return: an instance of PartitioningType
-        """
-        return self._get_option("default_partitioning", PartitioningType)
-
-    @property
     def default_scheme(self):
         """Default partitioning scheme.
 
@@ -142,3 +123,83 @@ class StorageSection(Section):
             raise ValueError("Invalid value: {}".format(value))
 
         return value
+
+    @property
+    def default_partitioning(self):
+        """Default partitioning.
+
+        Returns a list of dictionaries with mount point attributes.
+        The name of the mount point is represented by the attribute
+        'name' in the dictionary representation.
+
+        Valid attributes:
+
+            name       The name of the mount point.
+            size       The size of the mount point.
+            min        The size will grow from min size to max size.
+            max        The max size is unlimited by default.
+            free       The required available space.
+            encrypted  The mount point will be encrypted.
+
+        :return: a list of dictionaries with mount point attributes
+        """
+        return self._get_option("default_partitioning", self._convert_partitioning)
+
+    def _convert_partitioning(self, value):
+        """Convert a partitioning string into a list of dictionaries."""
+        return list(map(self._convert_partitioning_line, value.strip().split("\n")))
+
+    @classmethod
+    def _convert_partitioning_line(cls, line):
+        """Convert a partitioning line into a dictionary."""
+        # Parse the line.
+        name, raw_attrs = cls._split_string(line)
+
+        # Split the attributes and skip empty strings (split
+        # always returns at least one item, an empty string).
+        raw_attrs = raw_attrs.strip("()").split(",")
+        raw_attrs = map(cls._split_string, filter(None, raw_attrs))
+
+        # Generate the dictionary.
+        attrs = {"name": name}
+
+        for name, value in raw_attrs:
+            if not value and name in ("encrypted",):
+                # Handle a boolean attribute.
+                attrs[name] = True
+            elif value and name in ("size", "min", "max", "free"):
+                # Handle a size attribute.
+                attrs[name] = Size(value)
+            else:
+                # Handle an invalid attribute.
+                raise ValueError("Invalid attribute: " + name)
+
+        # Validate the dictionary.
+        cls._validate_mount_point_attributes(attrs)
+
+        return attrs
+
+    @staticmethod
+    def _validate_mount_point_attributes(attrs):
+        """Validate the dictionary with mount point attributes."""
+        if not attrs.get("name"):
+            raise ValueError("The mount point is not specified.")
+
+        if attrs.get("name") != "swap" and not attrs.get("name").startswith("/"):
+            raise ValueError("The mount point is not valid.")
+
+        if attrs.get("size") and attrs.get("min"):
+            raise ValueError("Only one of the attributes 'size' and 'min' can be set.")
+
+        if attrs.get("max") and not attrs.get("min"):
+            raise ValueError("The attribute 'max' cannot be set without 'min'.")
+
+    @staticmethod
+    def _split_string(value):
+        """Split the given value into two strings."""
+        items = value.strip().split(maxsplit=1)
+
+        while len(items) < 2:
+            items.append("")
+
+        return items

--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
@@ -16,137 +16,20 @@
 # Red Hat, Inc.
 #
 from blivet.partitioning import do_partitioning, grow_lvm
-from blivet.size import Size
 from blivet.static_data import luks_data
 
 from pyanaconda.anaconda_loggers import get_module_logger
-from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.configuration.storage import PartitioningType
 from pyanaconda.modules.common.structures.partitioning import PartitioningRequest
 from pyanaconda.modules.storage.partitioning.automatic.noninteractive_partitioning import \
     NonInteractivePartitioningTask
 from pyanaconda.modules.storage.partitioning.automatic.utils import get_candidate_disks, \
-    schedule_implicit_partitions, schedule_volumes, schedule_partitions, get_pbkdf_args
-from pyanaconda.modules.storage.platform import platform
-from pyanaconda.modules.storage.partitioning.specification import PartSpec
+    schedule_implicit_partitions, schedule_volumes, schedule_partitions, get_pbkdf_args, \
+    get_default_partitioning
 from pyanaconda.core.storage import suggest_swap_size
 
 log = get_module_logger(__name__)
 
 __all__ = ["AutomaticPartitioningTask"]
-
-
-SERVER_PARTITIONING = [
-    PartSpec(
-        mountpoint="/",
-        size=Size("2GiB"),
-        max_size=Size("15GiB"),
-        grow=True,
-        btr=True,
-        lv=True,
-        thin=True,
-        encrypted=True
-    ),
-    PartSpec(
-        fstype="swap",
-        grow=False,
-        lv=True,
-        encrypted=True
-    )
-]
-
-WORKSTATION_PARTITIONING = [
-    PartSpec(
-        mountpoint="/",
-        size=Size("1GiB"),
-        max_size=Size("70GiB"),
-        grow=True,
-        btr=True,
-        lv=True,
-        thin=True,
-        encrypted=True),
-    PartSpec(
-        mountpoint="/home",
-        size=Size("500MiB"), grow=True,
-        required_space=Size("50GiB"),
-        btr=True,
-        lv=True,
-        thin=True,
-        encrypted=True),
-    PartSpec(
-        fstype="swap",
-        grow=False,
-        lv=True,
-        encrypted=True
-    )
-]
-
-VIRTUALIZATION_PARTITIONING = [
-    PartSpec(
-        mountpoint="/",
-        size=Size("6GiB"),
-        grow=True,
-        lv=True,
-        thin=True
-    ),
-    PartSpec(
-        mountpoint="/home",
-        size=Size("1GiB"),
-        lv=True,
-        thin=True
-    ),
-    PartSpec(
-        mountpoint="/tmp",
-        size=Size("1GiB"),
-        lv=True,
-        thin=True
-    ),
-    PartSpec(
-        mountpoint="/var",
-        size=Size("15GiB"),
-        lv=True,
-        thin=True
-    ),
-    PartSpec(
-        mountpoint="/var/log",
-        size=Size("8GiB"),
-        lv=True,
-        thin=True
-    ),
-    PartSpec(
-        mountpoint="/var/log/audit",
-        size=Size("2GiB"),
-        lv=True,
-        thin=True
-    ),
-    PartSpec(
-        fstype="swap",
-        grow=False,
-        lv=True,
-        encrypted=True
-    )
-]
-
-
-def get_default_partitioning(partitioning_type=None):
-    """Get the default partitioning requests.
-
-    :param partitioning_type: a type of the partitioning
-    :return: a list of partitioning specs
-    """
-    if not partitioning_type:
-        partitioning_type = conf.storage.default_partitioning
-
-    if partitioning_type is PartitioningType.SERVER:
-        return platform.set_default_partitioning() + SERVER_PARTITIONING
-
-    if partitioning_type is PartitioningType.WORKSTATION:
-        return platform.set_default_partitioning() + WORKSTATION_PARTITIONING
-
-    if partitioning_type is PartitioningType.VIRTUALIZATION:
-        return platform.set_default_partitioning() + VIRTUALIZATION_PARTITIONING
-
-    raise ValueError("Invalid partitioning type: {}".format(conf.storage.default_partitioning))
 
 
 class AutomaticPartitioningTask(NonInteractivePartitioningTask):

--- a/pyanaconda/modules/storage/partitioning/automatic/utils.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/utils.py
@@ -32,8 +32,11 @@ from pykickstart.constants import AUTOPART_TYPE_BTRFS, AUTOPART_TYPE_LVM, \
     AUTOPART_TYPE_LVM_THINP, AUTOPART_TYPE_PLAIN
 
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.errors.storage import ProtectedDeviceError
+from pyanaconda.modules.storage.partitioning.specification import PartSpec
+from pyanaconda.modules.storage.platform import platform
 
 log = get_module_logger(__name__)
 
@@ -211,6 +214,36 @@ def schedule_implicit_partitions(storage, disks, scheme, encrypted=False, luks_f
         devs.append(part)
 
     return devs
+
+
+def get_default_partitioning():
+    """Get the default partitioning requests.
+
+    :return: a list of partitioning specs
+    """
+    # Get the platform-specific partitioning.
+    partitioning = list(platform.set_default_partitioning())
+
+    # Get the product-specific partitioning.
+    for attrs in conf.storage.default_partitioning:
+        name = attrs.get("name")
+        swap = name == "swap"
+        spec = PartSpec(
+            mountpoint=name if not swap else None,
+            fstype=None if not swap else "swap",
+            lv=True,
+            thin=not swap,
+            btr=not swap,
+            size=attrs.get("min") or attrs.get("size"),
+            max_size=attrs.get("max"),
+            grow="min" in attrs,
+            required_space=attrs.get("free") or 0,
+            encrypted=attrs.get("encrypted") or False,
+        )
+
+        partitioning.append(spec)
+
+    return partitioning
 
 
 def schedule_partitions(storage, disks, implicit_devices, scheme, requests, encrypted=False,

--- a/pyanaconda/modules/storage/partitioning/specification.py
+++ b/pyanaconda/modules/storage/partitioning/specification.py
@@ -87,3 +87,6 @@ class PartSpec(object):
 
     def __unicode__(self):
         return unicodeize(self._to_string())
+
+    def __eq__(self, other):
+        return isinstance(other, PartSpec) and vars(self) == vars(other)

--- a/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
@@ -23,7 +23,6 @@ from unittest.mock import Mock, patch
 from blivet.formats.luks import LUKS2PBKDFArgs
 from blivet.size import Size
 
-from pyanaconda.core.configuration.storage import PartitioningType
 from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.modules.storage.partitioning.automatic.resizable_module import \
     ResizableDeviceTreeModule
@@ -42,7 +41,8 @@ from pyanaconda.modules.storage.partitioning.automatic.automatic_module import \
 from pyanaconda.modules.storage.partitioning.automatic.automatic_interface import \
     AutoPartitioningInterface
 from pyanaconda.modules.storage.partitioning.automatic.automatic_partitioning import \
-    AutomaticPartitioningTask, get_default_partitioning
+    AutomaticPartitioningTask
+from pyanaconda.modules.storage.partitioning.automatic.utils import get_default_partitioning
 from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 from pyanaconda.modules.storage.devicetree import create_storage
 
@@ -243,18 +243,15 @@ class AutomaticPartitioningTaskTestCase(unittest.TestCase):
         self.assertEqual(pbkdf_args.iterations, 1000)
         self.assertEqual(pbkdf_args.time_ms, 100)
 
-    @patch('pyanaconda.modules.storage.partitioning.automatic.automatic_partitioning.platform')
+    @patch('pyanaconda.modules.storage.partitioning.automatic.utils.platform')
     def get_default_partitioning_test(self, platform):
         platform.set_default_partitioning.return_value = [PartSpec("/boot")]
+        requests = get_default_partitioning()
 
-        requests = get_default_partitioning(PartitioningType.WORKSTATION)
         self.assertEqual(["/boot", "/", "/home", None], [spec.mountpoint for spec in requests])
 
-        requests = get_default_partitioning(PartitioningType.SERVER)
-        self.assertEqual(["/boot", "/", None], [spec.mountpoint for spec in requests])
-
     @patch('pyanaconda.modules.storage.partitioning.automatic.automatic_partitioning.suggest_swap_size')
-    @patch('pyanaconda.modules.storage.partitioning.automatic.automatic_partitioning.platform')
+    @patch('pyanaconda.modules.storage.partitioning.automatic.utils.platform')
     def get_partitioning_test(self, platform, suggest_swap_size):
         storage = create_storage()
 

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -21,6 +21,12 @@ import os
 import tempfile
 import unittest
 from textwrap import dedent
+from unittest.mock import patch
+
+from blivet.size import Size
+
+from pyanaconda.modules.storage.partitioning.automatic.utils import get_default_partitioning
+from pyanaconda.modules.storage.partitioning.specification import PartSpec
 
 from pyanaconda.core.configuration.anaconda import AnacondaConfiguration
 from pyanaconda.core.configuration.base import ConfigurationError, create_parser, read_config
@@ -29,12 +35,106 @@ from pyanaconda.product import trim_product_version_for_ui
 
 PRODUCT_DIR = os.path.join(os.environ.get("ANACONDA_DATA"), "product.d")
 
+SERVER_PARTITIONING = [
+    PartSpec(
+        mountpoint="/",
+        size=Size("2GiB"),
+        max_size=Size("15GiB"),
+        grow=True,
+        btr=True,
+        lv=True,
+        thin=True,
+        encrypted=True
+    ),
+    PartSpec(
+        fstype="swap",
+        lv=True,
+        encrypted=True
+    )
+]
+
+WORKSTATION_PARTITIONING = [
+    PartSpec(
+        mountpoint="/",
+        size=Size("1GiB"),
+        max_size=Size("70GiB"),
+        grow=True,
+        btr=True,
+        lv=True,
+        thin=True,
+        encrypted=True),
+    PartSpec(
+        mountpoint="/home",
+        size=Size("500MiB"), grow=True,
+        required_space=Size("50GiB"),
+        btr=True,
+        lv=True,
+        thin=True,
+        encrypted=True),
+    PartSpec(
+        fstype="swap",
+        lv=True,
+        encrypted=True
+    )
+]
+
+VIRTUALIZATION_PARTITIONING = [
+    PartSpec(
+        mountpoint="/",
+        size=Size("6GiB"),
+        grow=True,
+        btr=True,
+        lv=True,
+        thin=True
+    ),
+    PartSpec(
+        mountpoint="/home",
+        size=Size("1GiB"),
+        btr=True,
+        lv=True,
+        thin=True
+    ),
+    PartSpec(
+        mountpoint="/tmp",
+        size=Size("1GiB"),
+        btr=True,
+        lv=True,
+        thin=True
+    ),
+    PartSpec(
+        mountpoint="/var",
+        size=Size("15GiB"),
+        btr=True,
+        lv=True,
+        thin=True
+    ),
+    PartSpec(
+        mountpoint="/var/log",
+        size=Size("8GiB"),
+        btr=True,
+        lv=True,
+        thin=True
+    ),
+    PartSpec(
+        mountpoint="/var/log/audit",
+        size=Size("2GiB"),
+        btr=True,
+        lv=True,
+        thin=True
+    ),
+    PartSpec(
+        fstype="swap",
+        lv=True
+    )
+]
+
 
 class ProductConfigurationTestCase(unittest.TestCase):
     """Test the default product configurations."""
 
     def setUp(self):
         """Set up the default loader."""
+        self.maxDiff = None
         self._loader = ProductLoader()
         self._loader.load_products(PRODUCT_DIR)
 
@@ -54,7 +154,14 @@ class ProductConfigurationTestCase(unittest.TestCase):
         config_paths = self._loader.collect_configurations(product_name, variant_name)
         self.assertEqual(file_paths, config_paths)
 
-    def _check_default_product(self, product_name, variant_name, file_names):
+    def _check_partitioning(self, config, partitioning):
+        with patch("pyanaconda.modules.storage.partitioning.automatic.utils.platform") as platform:
+            platform.set_default_partitioning.return_value = []
+
+            with patch("pyanaconda.modules.storage.partitioning.automatic.utils.conf", new=config):
+                self.assertEqual(get_default_partitioning(), partitioning)
+
+    def _check_default_product(self, product_name, variant_name, file_names, partitioning):
         """Check a default product."""
         self._check_product(
             product_name, variant_name,
@@ -68,6 +175,8 @@ class ProductConfigurationTestCase(unittest.TestCase):
             config.read(path)
 
         config.validate()
+
+        self._check_partitioning(config, partitioning)
 
     def _get_config(self, product_name, variant_name=""):
         """Get parsed config file."""
@@ -84,51 +193,62 @@ class ProductConfigurationTestCase(unittest.TestCase):
     def fedora_products_test(self):
         self._check_default_product(
             "Fedora", "",
-            ["fedora.conf"]
+            ["fedora.conf"],
+            WORKSTATION_PARTITIONING
         )
         self._check_default_product(
             "Fedora", "Server",
-            ["fedora.conf", "fedora-server.conf"]
+            ["fedora.conf", "fedora-server.conf"],
+            SERVER_PARTITIONING
         )
         self._check_default_product(
             "Fedora", "Workstation",
-            ["fedora.conf", "fedora-workstation.conf"]
+            ["fedora.conf", "fedora-workstation.conf"],
+            WORKSTATION_PARTITIONING
         )
         self._check_default_product(
             "Fedora", "Workstation Live",
-            ["fedora.conf", "fedora-workstation.conf", "fedora-workstation-live.conf"]
+            ["fedora.conf", "fedora-workstation.conf", "fedora-workstation-live.conf"],
+            WORKSTATION_PARTITIONING
         )
         self._check_default_product(
             "Fedora", "AtomicHost",
-            ["fedora.conf", "fedora-atomic-host.conf"]
+            ["fedora.conf", "fedora-atomic-host.conf"],
+            SERVER_PARTITIONING
 
         )
         self._check_default_product(
             "Fedora", "Silverblue",
             ["fedora.conf", "fedora-workstation.conf", "fedora-workstation-live.conf",
-             "fedora-silverblue.conf"]
+             "fedora-silverblue.conf"],
+            WORKSTATION_PARTITIONING
         )
 
     def rhel_products_test(self):
         self._check_default_product(
             "Red Hat Enterprise Linux", "",
-            ["rhel.conf"]
+            ["rhel.conf"],
+            WORKSTATION_PARTITIONING
         )
         self._check_default_product(
             "CentOS Linux", "",
-            ["rhel.conf", "centos.conf"]
+            ["rhel.conf", "centos.conf"],
+            WORKSTATION_PARTITIONING
         )
         self._check_default_product(
             "Red Hat Virtualization", "",
-            ["rhel.conf", "rhev.conf"]
+            ["rhel.conf", "rhev.conf"],
+            VIRTUALIZATION_PARTITIONING
         )
         self._check_default_product(
             "oVirt Node Next", "",
-            ["rhel.conf", "centos.conf", "ovirt.conf"]
+            ["rhel.conf", "centos.conf", "ovirt.conf"],
+            VIRTUALIZATION_PARTITIONING
         )
         self._check_default_product(
             "Scientific Linux", "",
-            ["rhel.conf", "scientific-linux.conf"]
+            ["rhel.conf", "scientific-linux.conf"],
+            WORKSTATION_PARTITIONING
         )
 
     def product_module_list_difference_fedora_rhel_test(self):


### PR DESCRIPTION
Change the default_partitioning option of the Storage section in the Anaconda
configuration file. Instead of the identifier, specify a mount point and its
attributes on each line.