### PR TITLE
Use modinfo to check ko before modprobe

### DIFF
--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -38,6 +38,10 @@ MODULE_LIST+=" raid0 raid1 raid5 raid6 raid456 raid10 linear dm-mod dm-zero  \
               sha256 lrw xts "
 
 for m in $MODULE_LIST; do
+    if ! modinfo $m >/dev/null 2>&1 ; then
+        echo "anaconda-modprobe: Module $m not found" >&2
+        continue
+    fi
     if modprobe $m ; then
         debug_msg "$m was loaded"
     else


### PR DESCRIPTION
Hello, everyone:
I install CentOS8  recently, and i found some ERROR info during dracut-pre-udev. such as:
`
dracut-pre-udev[534]: modprobe: FATAL: Module floppy not found in directory /lib/modules/4.18.0-80.el8.x86_64
`
when i finish the installer and reboot os, i check the kernel config for floppy: _CONFIG_BLK_DEV_FD_ is not set.

so, would it be better if we use modinfo to check it exists before we probe it? And, we can still got what ko not loaded if we add inst.debug in cmdline.
