### PR TITLE
Add logging messages to %post scripts

### DIFF
--- a/data/post-scripts/80-setfilecons.ks
+++ b/data/post-scripts/80-setfilecons.ks
@@ -7,6 +7,7 @@
 # - ostree payloads, where all of the labeling of /var is the installer's
 #   responsibility (see https://github.com/ostreedev/ostree/pull/872 )
 
+echo "Restoring SElinux contexts on directories..."
 restorecon -ir /etc/sysconfig/network-scripts /etc/lvm /etc/X11/xorg.conf.d \
                /etc/iscsi /etc/modprobe.d /etc/sysconfig \
                /var/lib /var/lib/iscsi /var/lock /var/log /var/spool \
@@ -17,6 +18,7 @@ restorecon -ir /etc/sysconfig/network-scripts /etc/lvm /etc/X11/xorg.conf.d \
 # Also relabel the OSTree variants of the traditional mounts if present
 restorecon -ir /var/roothome /var/home /var/opt /var/srv /var/media /var/mnt
 
+echo "Restoring SElinux contexts on files..."
 restorecon -i /etc/rpm/macros /etc/dasd.conf /etc/zfcp.conf /etc/blkid.tab* \
               /etc/mtab /etc/fstab /etc/resolv.conf /etc/modprobe.conf* \
               /etc/crypttab /etc/mdadm.conf /etc/sysconfig/network \
@@ -28,7 +30,10 @@ restorecon -i /etc/rpm/macros /etc/dasd.conf /etc/zfcp.conf /etc/blkid.tab* \
               /root/install.log*
 
 if [ -e /etc/zipl.conf ]; then
+    echo "Restoring SElinux contexts on zipl.conf..."
     restorecon -i /etc/zipl.conf
 fi
+
+echo "Finished."
 
 %end

--- a/data/post-scripts/90-copy-screenshots.ks
+++ b/data/post-scripts/90-copy-screenshots.ks
@@ -1,10 +1,14 @@
 %post --nochroot
 
+echo "Copying screenshots from installation..."
+
 if [ ! -d /tmp/anaconda-screenshots ]; then
+    echo "No screenshots found."
     exit 0
 fi
 
 mkdir -m 0750 -p $ANA_INSTALL_PATH/root/anaconda-screenshots
 cp -a /tmp/anaconda-screenshots/*.png $ANA_INSTALL_PATH/root/anaconda-screenshots/
+echo "Screenshots copied successfully."
 
 %end

--- a/data/post-scripts/99-copy-logs.ks
+++ b/data/post-scripts/99-copy-logs.ks
@@ -1,6 +1,8 @@
 # Note, this script log will not be copied to the installed system.
 %post --nochroot
 
+echo "Copying logs from the installation environment..."
+
 NOSAVE_INPUT_KS_FILE=/tmp/NOSAVE_INPUT_KS
 NOSAVE_LOGS_FILE=/tmp/NOSAVE_LOGS
 PRE_ANA_LOGS=/tmp/pre-anaconda-logs
@@ -21,10 +23,15 @@ else
     chmod 0600 $ANA_INSTALL_PATH/var/log/anaconda/*
 fi
 
+echo "Done."
+echo "Copying generated kickstart file..."
+
 if [ -e ${NOSAVE_INPUT_KS_FILE} ]; then
+    echo "Nosave used, skipping."
     rm -f ${NOSAVE_INPUT_KS_FILE}
 elif [ -e /run/install/ks.cfg ]; then
     cp /run/install/ks.cfg $ANA_INSTALL_PATH/root/original-ks.cfg
+    echo "Done."
 fi
 
 %end


### PR DESCRIPTION
Helps with debugging kickstart tests - the scripts are no longer anonymous. The messages appear in `program.log`.