### PR TITLE
Remove the dasbus workarounds

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -38,7 +38,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define rpmver 4.10.0
 %define simplelinever 1.1-1
 %define utillinuxver 2.15.1
-%define dasbusver 0.4
+%define dasbusver 1.3
 
 BuildRequires: audit-libs-devel
 BuildRequires: libtool

--- a/pyanaconda/modules/subscription/initialization.py
+++ b/pyanaconda/modules/subscription/initialization.py
@@ -24,10 +24,11 @@ from dasbus.typing import get_variant, Str
 
 from pyanaconda.core import util
 from pyanaconda.core.constants import RHSM_SERVICE_TIMEOUT
+from pyanaconda.modules.common.constants.objects import RHSM_CONFIG
+from pyanaconda.modules.common.constants.services import RHSM
 from pyanaconda.threading import threadMgr
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.common.errors.task import NoResultError
-from pyanaconda.modules.subscription.rhsm_observer import get_rhsm_configuration_proxy
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -65,8 +66,9 @@ class StartRHSMTask(Task):
                 rc
             )
             return False
+
         # create a temporary proxy to set the log levels
-        rhsm_config_proxy = get_rhsm_configuration_proxy()
+        rhsm_config_proxy = RHSM.get_proxy(RHSM_CONFIG, interface_name=RHSM_CONFIG)
 
         # set RHSM log levels to debug
         # - otherwise the RHSM log output is not usable for debugging subscription issues

--- a/pyanaconda/modules/subscription/rhsm_observer.py
+++ b/pyanaconda/modules/subscription/rhsm_observer.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from dasbus.client.proxy import InterfaceProxy
-from pyanaconda.modules.common.constants.objects import RHSM_CONFIG
 from pyanaconda.modules.common.constants.services import RHSM
 from pyanaconda.core.constants import RHSM_SERVICE_TIMEOUT
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -23,25 +21,6 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from dasbus.client.observer import DBusObserver, DBusObserverError
 
 log = get_module_logger(__name__)
-
-
-def get_rhsm_configuration_proxy():
-    """Get the RHSM configuration proxy.
-
-    The DBus object Config re-defines methods of the standard
-    interface org.freedesktop.DBus.Properties, so create a proxy
-    only with the Config's interface.
-
-    FIXME: Dasbus should prioritize the custom interfaces.
-
-    :return: a DBus proxy
-    """
-    return InterfaceProxy(
-        RHSM.message_bus,
-        RHSM.service_name,
-        RHSM_CONFIG.object_path,
-        RHSM_CONFIG.interface_name
-    )
 
 
 class RHSMObserver(DBusObserver):
@@ -78,7 +57,5 @@ class RHSMObserver(DBusObserver):
         if not self.is_service_available and not self._startup_check_method(self._timeout):
             raise DBusObserverError("The RHSM DBus API is not available.")
 
-        if object_identifier == RHSM_CONFIG:
-            return get_rhsm_configuration_proxy()
-
-        return RHSM.get_proxy(object_identifier)
+        # get a proxy of a specific DBus interface
+        return RHSM.get_proxy(object_identifier, interface_name=object_identifier)

--- a/pyanaconda/modules/subscription/rhsm_observer.py
+++ b/pyanaconda/modules/subscription/rhsm_observer.py
@@ -37,7 +37,7 @@ def get_rhsm_configuration_proxy():
     :return: a DBus proxy
     """
     return InterfaceProxy(
-        RHSM._message_bus,
+        RHSM.message_bus,
         RHSM.service_name,
         RHSM_CONFIG.object_path,
         RHSM_CONFIG.interface_name
@@ -63,7 +63,7 @@ class RHSMObserver(DBusObserver):
                                      otherwise
         :param float timeout: how long to wait for RHSM service to start in seconds
         """
-        super().__init__(RHSM._message_bus, RHSM.service_name)
+        super().__init__(RHSM.message_bus, RHSM.service_name)
         self._startup_check_method = startup_check_method
         self._timeout = timeout
 

--- a/tests/nosetests/pyanaconda_tests/__init__.py
+++ b/tests/nosetests/pyanaconda_tests/__init__.py
@@ -280,7 +280,7 @@ def patch_dbus_get_proxy_with_cache(func):
     """
     proxies = defaultdict(Mock)
 
-    def mock_get(service_name, object_path):
+    def mock_get(service_name, object_path, *args, **kwargs):
         return proxies[(service_name, object_path)]
 
     return patch('pyanaconda.core.dbus.DBus.get_proxy', side_effect=mock_get)(func)

--- a/tests/nosetests/pyanaconda_tests/__init__.py
+++ b/tests/nosetests/pyanaconda_tests/__init__.py
@@ -248,6 +248,14 @@ def patch_dbus_get_proxy(func):
     return patch('pyanaconda.core.dbus.DBus.get_proxy')(func)
 
 
+def patch_system_dbus_get_proxy(func):
+    """Patch DBus proxies on the system message bus.
+
+    This is a shortcut to avoid creating of DBus proxies using DBus.
+    """
+    return patch('pyanaconda.core.dbus.SystemBus.get_proxy')(func)
+
+
 def patch_dbus_get_proxy_with_cache(func):
     """Patch DBus proxies with a cache.
 


### PR DESCRIPTION
Don't use the private attribute for a message bus. The class
DBusServiceIdentifier has the message_bus property now.

Use the service identifier to create a proxy for a specific interface.
Always create this type of a proxy for the RHSM objects.

**Depends on:** https://github.com/rhinstaller/dasbus/pull/36