### PR TITLE
Prevent crash on unregistration

### DIFF
--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -837,6 +837,9 @@ class SubscriptionSpoke(NormalSpoke):
         # disable controls
         self.set_registration_controls_sensitive(False)
 
+        # wait for the previous subscription thread to finish
+        threadMgr.wait(THREAD_SUBSCRIPTION)
+
         # try to register
         log.debug("Subscription GUI: attempting to register")
         threadMgr.add(
@@ -858,6 +861,9 @@ class SubscriptionSpoke(NormalSpoke):
 
         # disable controls
         self.set_registration_controls_sensitive(False)
+
+        # wait for the previous subscription thread to finish
+        threadMgr.wait(THREAD_SUBSCRIPTION)
 
         # try to unregister
         log.debug("Subscription GUI: attempting to unregister")


### PR DESCRIPTION
Previously it was possible that the registration thread was still
running when the user clicks the "Unregister" button.

To prevent that, we now wait for the previous subscription thread to
finish before starting the next registration/unregistration thread.

Resolves: rhbz#1845962