### PR TITLE
Fix regression reading kernel list when collecting configurations

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -159,9 +159,12 @@ def _prepare_configuration(payload, ksdata):
     # been created, fixing the kernel root and subvol args and adding the missing initrd entry.
     bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
 
-    if payload.type in PAYLOAD_LIVE_TYPES:
+    def fix_btrfs_bootloader():
         btrfs_task = bootloader_proxy.FixBTRFSWithTask(payload.kernel_version_list)
-        generate_initramfs.append_dbus_tasks(STORAGE, [btrfs_task])
+        sync_run_task(STORAGE.get_proxy(btrfs_task))
+
+    if payload.type in PAYLOAD_LIVE_TYPES:
+        generate_initramfs.append(Task("Fix bootloader on BTRFS", fix_btrfs_bootloader))
 
     # Invoking zipl should be the last thing done on a s390x installation (see #1652727).
     zipl_task = bootloader_proxy.FixZIPLWithTask()


### PR DESCRIPTION


We have to have payload prepared to be able to read list of kernels from the installation source. However, during transitioning to storage module we moved reading list of kernels to place where the installation tasks are collected instead of where they are executed.

Create a function which will read this list and execute everything later during the installation tasks execution.

*Resolves: rhbz#1846156*