### PR TITLE
Take spoke refresh after enter it (#1847493)

### DIFF
--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -424,8 +424,8 @@ class Hub(GUIObject, common.Hub):
 
         # Enter the spoke
         self._inSpoke = True
-        spoke.refresh()
         self.main_window.enterSpoke(spoke)
+        spoke.refresh()
         # the new spoke should be now visible, trigger the entered signal
         spoke.entered.emit(spoke)
 


### PR DESCRIPTION
If firset netdev is unplugged, and when we click Network in summary page, the switch which is used to turn device on/off is default visible.
How to reproduce:
- Environmental constraints：The First netdev is unplugged！
- In anaconda summary page, click Network & HostName,you cloud find a switch to turn on/off (even the device is unplugged)
- turn the unplugged device on, and turn the unplugged device off.

View [bugzilla 1847493](https://bugzilla.redhat.com/show_bug.cgi?id=1847493) for detials.

To fix this, i change the refresh order when we click the Network Spoke in Summary Hub. 