### PR TITLE
Fix hiding of network device activation switch (#1847493)

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1019,8 +1019,9 @@ class NetworkControlBox(GObject.GObject):
 
         switch = self.builder.get_object("device_%s_off_switch" % dev_type_str)
         if dev_type_str == "wired":
-            switch.set_visible(state not in (NM.DeviceState.UNAVAILABLE,
-                                             NM.DeviceState.UNMANAGED))
+            visible = state not in (NM.DeviceState.UNAVAILABLE, NM.DeviceState.UNMANAGED)
+            switch.set_visible(visible)
+            switch.set_no_show_all(not visible)
             self._updating_device = True
             switch.set_active(state not in (NM.DeviceState.UNMANAGED,
                                             NM.DeviceState.UNAVAILABLE,


### PR DESCRIPTION
Sometimes we need to call set_no_show_all(True) to make sure that
the widget disappears.