### PR TITLE
Correctly set up the LUKS version when we click on a mount point

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -1520,8 +1520,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     def on_encrypt_toggled(self, widget):
         self._encryptCheckbox.set_inconsistent(False)
         self._request.device_encrypted = self._encryptCheckbox.get_active()
-        self.on_luks_version_changed(self._luksCombo)
-        self._update_luks_combo()
+        self._populate_luks(self._request.luks_version)
         self.on_value_changed()
 
     def _update_luks_combo(self):


### PR DESCRIPTION
When the encryption is changed, set the LUKS version to the current version of
the device factory request or use a default one. Don't use the LUKS version
selected in UI. It might be a version of the previously selected mount point.

Resolves: rhbz#1689699