### PR TITLE
Exclude stderr from returned output when executing powerpc-utils tools

### DIFF
--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -570,7 +570,8 @@ class IPSeriesGRUB2(GRUB2):
         log.debug("updateNVRAMBootList: self.stage1_device.path = %s", self.stage1_device.path)
 
         buf = util.execWithCapture("nvram",
-                                   ["--print-config=boot-device"])
+                                   ["--print-config=boot-device"],
+                                   filter_stderr=True)
 
         if len(buf) == 0:
             log.error("Failed to determine nvram boot device")
@@ -580,7 +581,8 @@ class IPSeriesGRUB2(GRUB2):
         log.debug("updateNVRAMBootList: boot_list = %s", boot_list)
 
         buf = util.execWithCapture("ofpathname",
-                                   [self.stage1_device.path])
+                                   [self.stage1_device.path],
+                                   filter_stderr=True)
 
         if len(buf) > 0:
             boot_disk = buf.strip()


### PR DESCRIPTION
The GRUB2 class updateNVRAMBootList() method calls to some tools to update
ppc64le's boot device order list but it doesn't exclude the error messages
which leads to an error message being stored in the NVRAM instead of the
boot list.

To prevent this to happen, exclude the standard error messages from the
output when calling the tools.

Related: rhbz#1847604

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>