### PR TITLE
Do not require treeinfo

### DIFF
--- a/pyanaconda/modules/payloads/source/harddrive/initialization.py
+++ b/pyanaconda/modules/payloads/source/harddrive/initialization.py
@@ -22,8 +22,7 @@ from collections import namedtuple
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.payloads.source.utils import find_and_mount_device, \
-    find_and_mount_iso_image
-from pyanaconda.payload.image import verify_valid_installtree
+    find_and_mount_iso_image, verify_valid_installtree
 from pyanaconda.payload.utils import unmount
 from pyanaconda.anaconda_loggers import get_module_logger
 

--- a/pyanaconda/modules/payloads/source/harddrive/initialization.py
+++ b/pyanaconda/modules/payloads/source/harddrive/initialization.py
@@ -22,7 +22,7 @@ from collections import namedtuple
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.payloads.source.utils import find_and_mount_device, \
-    find_and_mount_iso_image, verify_valid_installtree
+    find_and_mount_iso_image, verify_valid_repository
 from pyanaconda.payload.utils import unmount
 from pyanaconda.anaconda_loggers import get_module_logger
 
@@ -82,7 +82,7 @@ class SetUpHardDriveSourceTask(Task):
             log.debug("Using the ISO '%s' mounted at '%s'.", iso_name, self._iso_mount)
             return SetupHardDriveResult(self._iso_mount, iso_name)
 
-        if verify_valid_installtree(full_path_on_mounted_device):
+        if verify_valid_repository(full_path_on_mounted_device):
             log.debug("Using the directory at '%s'.", full_path_on_mounted_device)
             return SetupHardDriveResult(full_path_on_mounted_device, "")
 

--- a/pyanaconda/modules/payloads/source/nfs/initialization.py
+++ b/pyanaconda/modules/payloads/source/nfs/initialization.py
@@ -21,9 +21,9 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.payload import parse_nfs_url
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.task import Task
-from pyanaconda.modules.payloads.source.utils import find_and_mount_iso_image
+from pyanaconda.modules.payloads.source.utils import find_and_mount_iso_image, \
+    verify_valid_installtree
 from pyanaconda.payload.errors import PayloadSetupError
-from pyanaconda.payload.image import verify_valid_installtree
 from pyanaconda.payload.utils import mount, unmount
 
 log = get_module_logger(__name__)

--- a/pyanaconda/modules/payloads/source/nfs/initialization.py
+++ b/pyanaconda/modules/payloads/source/nfs/initialization.py
@@ -22,7 +22,7 @@ from pyanaconda.core.payload import parse_nfs_url
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.payloads.source.utils import find_and_mount_iso_image, \
-    verify_valid_installtree
+    verify_valid_repository
 from pyanaconda.payload.errors import PayloadSetupError
 from pyanaconda.payload.utils import mount, unmount
 
@@ -65,7 +65,7 @@ class SetUpNFSSourceTask(Task):
             log.debug("Using the ISO '%s' mounted at '%s'.", iso_name, self._iso_mount)
             return self._iso_mount
 
-        if verify_valid_installtree(self._device_mount):
+        if verify_valid_repository(self._device_mount):
             log.debug("Using the directory at '%s'.", self._device_mount)
             return self._device_mount
 

--- a/pyanaconda/modules/payloads/source/utils.py
+++ b/pyanaconda/modules/payloads/source/utils.py
@@ -148,10 +148,10 @@ def _create_iso_path(path, iso_name):
     return path
 
 
-def verify_valid_installtree(path):
-    """Check if the given path is a valid installtree repository.
+def verify_valid_repository(path):
+    """Check if the given path is a valid repository.
 
-    :param str path: install tree path
+    :param str path: path to the repository
     :returns: True if repository is valid false otherwise
     :rtype: bool
     """

--- a/pyanaconda/modules/payloads/source/utils.py
+++ b/pyanaconda/modules/payloads/source/utils.py
@@ -148,6 +148,21 @@ def _create_iso_path(path, iso_name):
     return path
 
 
+def verify_valid_installtree(path):
+    """Check if the given path is a valid installtree repository.
+
+    :param str path: install tree path
+    :returns: True if repository is valid false otherwise
+    :rtype: bool
+    """
+    repomd_path = join_paths(path, "repodata/repomd.xml")
+
+    if os.path.exists(repomd_path) and os.path.isfile(repomd_path):
+        return True
+
+    return False
+
+
 class MountPointGenerator:
     _counter = 0
 

--- a/pyanaconda/payload/image.py
+++ b/pyanaconda/payload/image.py
@@ -28,7 +28,6 @@ import blivet.arch
 from blivet.size import Size
 
 from pyanaconda import isys
-from pyanaconda.core.util import join_paths
 from pyanaconda.errors import errorHandler, ERROR_RAISE, InvalidImageSizeError, MissingImageError
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
@@ -127,21 +126,6 @@ def find_first_iso_image(path, mount_path="/mnt/install/cdimage"):
         return fn
 
     return None
-
-
-def verify_valid_installtree(path):
-    """Check if the given path is a valid installtree repository.
-
-    :param str path: install tree path
-    :returns: True if repository is valid false otherwise
-    :rtype: bool
-    """
-    repomd_path = join_paths(path, "repodata/repomd.xml")
-
-    if os.path.exists(repomd_path) and os.path.isfile(repomd_path):
-        return True
-
-    return False
 
 
 def _check_repodata(mount_path):

--- a/pyanaconda/payload/image.py
+++ b/pyanaconda/payload/image.py
@@ -28,6 +28,7 @@ import blivet.arch
 from blivet.size import Size
 
 from pyanaconda import isys
+from pyanaconda.core.util import join_paths
 from pyanaconda.errors import errorHandler, ERROR_RAISE, InvalidImageSizeError, MissingImageError
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
@@ -129,16 +130,15 @@ def find_first_iso_image(path, mount_path="/mnt/install/cdimage"):
 
 
 def verify_valid_installtree(path):
-    """Check if the given path is a valid installtree repository
+    """Check if the given path is a valid installtree repository.
 
     :param str path: install tree path
     :returns: True if repository is valid false otherwise
     :rtype: bool
     """
-    # TODO: This can be enhanced to check for repodata folder.
-    if os.path.exists(os.path.join(path, ".treeinfo")):
-        return True
-    elif os.path.exists(os.path.join(path, "treeinfo")):
+    repomd_path = join_paths(path, "repodata/repomd.xml")
+
+    if os.path.exists(repomd_path) and os.path.isfile(repomd_path):
         return True
 
     return False

--- a/tests/nosetests/pyanaconda_tests/module_source_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_base_test.py
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from pyanaconda.core.constants import INSTALL_TREE
@@ -23,7 +25,8 @@ from pyanaconda.modules.common.errors.payload import SourceSetupError, SourceTea
 from pyanaconda.modules.payloads.constants import SourceType
 from pyanaconda.modules.payloads.source.mount_tasks import SetUpMountTask, TearDownMountTask
 from pyanaconda.modules.payloads.source.source_base import MountingSourceMixin
-from pyanaconda.modules.payloads.source.utils import find_and_mount_iso_image
+from pyanaconda.modules.payloads.source.utils import find_and_mount_iso_image, \
+    verify_valid_installtree
 
 mount_location = "/some/dir"
 
@@ -184,3 +187,21 @@ class UtilitiesTestCase(unittest.TestCase):
         )
 
         self.assertEqual(iso_name, "")
+
+    def verify_valid_installtree_success_test(self):
+        """Test verify_valid_installtree functionality success."""
+        with TemporaryDirectory() as tmp:
+            repodir_path = Path(tmp, "repodata")
+            repodir_path.mkdir()
+            repomd_path = Path(repodir_path, "repomd.xml")
+            repomd_path.write_text("This is a cool repomd file!")
+
+            self.assertTrue(verify_valid_installtree(tmp))
+
+    def verify_valid_installtree_failed_test(self):
+        """Test verify_valid_installtree functionality failed."""
+        with TemporaryDirectory() as tmp:
+            repodir_path = Path(tmp, "repodata")
+            repodir_path.mkdir()
+
+            self.assertFalse(verify_valid_installtree(tmp))

--- a/tests/nosetests/pyanaconda_tests/module_source_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_base_test.py
@@ -26,7 +26,7 @@ from pyanaconda.modules.payloads.constants import SourceType
 from pyanaconda.modules.payloads.source.mount_tasks import SetUpMountTask, TearDownMountTask
 from pyanaconda.modules.payloads.source.source_base import MountingSourceMixin
 from pyanaconda.modules.payloads.source.utils import find_and_mount_iso_image, \
-    verify_valid_installtree
+    verify_valid_repository
 
 mount_location = "/some/dir"
 
@@ -188,20 +188,20 @@ class UtilitiesTestCase(unittest.TestCase):
 
         self.assertEqual(iso_name, "")
 
-    def verify_valid_installtree_success_test(self):
-        """Test verify_valid_installtree functionality success."""
+    def verify_valid_repository_success_test(self):
+        """Test verify_valid_repository functionality success."""
         with TemporaryDirectory() as tmp:
             repodir_path = Path(tmp, "repodata")
             repodir_path.mkdir()
             repomd_path = Path(repodir_path, "repomd.xml")
             repomd_path.write_text("This is a cool repomd file!")
 
-            self.assertTrue(verify_valid_installtree(tmp))
+            self.assertTrue(verify_valid_repository(tmp))
 
-    def verify_valid_installtree_failed_test(self):
-        """Test verify_valid_installtree functionality failed."""
+    def verify_valid_repository_failed_test(self):
+        """Test verify_valid_repository functionality failed."""
         with TemporaryDirectory() as tmp:
             repodir_path = Path(tmp, "repodata")
             repodir_path.mkdir()
 
-            self.assertFalse(verify_valid_installtree(tmp))
+            self.assertFalse(verify_valid_repository(tmp))

--- a/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_harddrive_test.py
@@ -211,10 +211,10 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
            return_value=True)
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_iso_image",
            return_value="")
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.verify_valid_installtree",
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.verify_valid_repository",
            return_value=True)
     def success_find_dir_test(self,
-                              verify_valid_installtree_mock,
+                              verify_valid_repository_mock,
                               find_and_mount_iso_image_mock,
                               find_and_mount_device_mock):
         """Hard drive source setup dir found."""
@@ -228,7 +228,7 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
         find_and_mount_iso_image_mock.assert_called_once_with(
             device_mount_location + path_on_device, iso_mount_location
         )
-        verify_valid_installtree_mock.assert_called_once_with(
+        verify_valid_repository_mock.assert_called_once_with(
             device_mount_location + path_on_device
         )
         self.assertEqual(result, SetupHardDriveResult(device_mount_location + path_on_device, ""))
@@ -237,12 +237,12 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
            return_value=True)
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_iso_image",
            return_value="")
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.verify_valid_installtree",
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.verify_valid_repository",
            return_value=False)
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.unmount")
     def failure_to_find_anything_test(self,
                                       unmount_mock,
-                                      verify_valid_installtree_mock,
+                                      verify_valid_repository_mock,
                                       find_and_mount_iso_image_mock,
                                       find_and_mount_device_mock):
         """Hard drive source setup failure to find anything."""
@@ -257,7 +257,7 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
         find_and_mount_iso_image_mock.assert_called_once_with(
             device_mount_location + path_on_device, iso_mount_location
         )
-        verify_valid_installtree_mock.assert_called_once_with(
+        verify_valid_repository_mock.assert_called_once_with(
             device_mount_location + path_on_device
         )
         unmount_mock.assert_called_once_with(

--- a/tests/nosetests/pyanaconda_tests/module_source_nfs_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_nfs_test.py
@@ -180,7 +180,7 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
 
         self.assertEqual(result, iso_mount_location)
 
-    @patch("pyanaconda.modules.payloads.source.nfs.initialization.verify_valid_installtree",
+    @patch("pyanaconda.modules.payloads.source.nfs.initialization.verify_valid_repository",
            return_value=True)
     @patch("pyanaconda.modules.payloads.source.nfs.initialization.find_and_mount_iso_image",
            return_value="")
@@ -188,7 +188,7 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
     def success_find_dir_test(self,
                               mount_mock,
                               find_and_mount_iso_image_mock,
-                              verify_valid_installtree_mock):
+                              verify_valid_repository_mock):
         """Test NFS source setup find installation tree success"""
         task = _create_setup_task()
         result = task.run()
@@ -201,7 +201,7 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
         find_and_mount_iso_image_mock.assert_called_once_with(device_mount_location,
                                                               iso_mount_location)
 
-        verify_valid_installtree_mock.assert_called_once_with(device_mount_location)
+        verify_valid_repository_mock.assert_called_once_with(device_mount_location)
 
         self.assertEqual(result, device_mount_location)
 
@@ -252,7 +252,7 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
                                            options="nolock")
 
     @patch("pyanaconda.modules.payloads.source.nfs.initialization.unmount")
-    @patch("pyanaconda.modules.payloads.source.nfs.initialization.verify_valid_installtree",
+    @patch("pyanaconda.modules.payloads.source.nfs.initialization.verify_valid_repository",
            return_value=False)
     @patch("pyanaconda.modules.payloads.source.nfs.initialization.find_and_mount_iso_image",
            return_value="")
@@ -260,7 +260,7 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
     def setup_install_source_task_find_anything_failure_test(self,
                                                              mount_mock,
                                                              find_and_mount_iso_image_mock,
-                                                             verify_valid_installtree_mock,
+                                                             verify_valid_repository_mock,
                                                              unmount_mock):
         """Test NFS can't find anything to install from"""
         task = SetUpNFSSourceTask(device_mount_location, iso_mount_location, nfs_url)
@@ -274,7 +274,7 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
         find_and_mount_iso_image_mock.assert_called_once_with(device_mount_location,
                                                               iso_mount_location)
 
-        verify_valid_installtree_mock.assert_called_once_with(device_mount_location)
+        verify_valid_repository_mock.assert_called_once_with(device_mount_location)
 
         unmount_mock.assert_called_once_with(
             device_mount_location


### PR DESCRIPTION
For mountable sources we want to make stupid check if the folder is a repository. We did that by checking .treeinfo file but that works only for composes and not for repositories created by `createrepo_c` utility.

Instead check if `repodata/repomd.xml` file exists.

*Resolves: rhbz#1844287*
*Resolves: rhbz#1849093 (rhel-8)*