### PR TITLE
Remove the workaround with LD_PRELOAD (#1843533)

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -216,11 +216,6 @@ def setup_environment():
     # make sure we have /sbin and /usr/sbin in our path
     os.environ["PATH"] += ":/sbin:/usr/sbin"
 
-    # we can't let the LD_PRELOAD hang around because it will leak into
-    # rpm %post and the like.  ick :/
-    if "LD_PRELOAD" in os.environ:
-        del os.environ["LD_PRELOAD"]
-
     # Go ahead and set $DISPLAY whether we're going to use X or not
     if "DISPLAY" in os.environ:
         flags.preexisting_x11 = True

--- a/data/tmux.conf
+++ b/data/tmux.conf
@@ -18,12 +18,7 @@ set-option -g history-limit 10000
 
 # The idea here is to detach the client started here via anaconda.service, and
 # then re-attach to it in the tmux service run on the console tty.
-
-# FIXME: Temporary hot fix added to make Fedora installable on aarch64 and ppc64le.
-# For more infromation see:
-# rhbz#1764666
-# rhbz#1722181
-new-session -d -s anaconda -n main "LD_PRELOAD=libgomp.so.1 anaconda"
+new-session -d -s anaconda -n main "anaconda"
 
 set-option status-right '#[fg=blue]#(echo -n "Switch tab: Alt+Tab | Help: F1 ")'
 


### PR DESCRIPTION
The temporary fix, that adds LD_PRELOAD=libgomp.so.1 to make Fedora installable
on aarch64 and ppc64le, is not required in RHEL 8.

Resolves: rhbz#1843533