### PR TITLE
network: do not enforce network standalone spoke on default source

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1628,10 +1628,10 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
 
     @property
     def completed(self):
-        # If we can't configure network, don't require it
         return (not conf.system.can_configure_network
                 or self._network_module.GetActivatedInterfaces()
-                or not self.payload.needs_network)
+                or not (self.payload.source_type != conf.payload.default_source
+                        and self.payload.needs_network))
 
     def initialize(self):
         register_secret_agent(self)


### PR DESCRIPTION
We used to show standalone network spoke asking for network configuration (not
mandatory) before summary hub only in cases of explicitly set url or nfs
software sources.  We should keep this behaviour in rhel.

On Fedora there are automatic connections created at the beginning of stage2 so
the chances of the standalone spoke being showed are rather small anyway.