### PR TITLE
Fix software spoke message when source changes

### DIFF
--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -313,12 +313,12 @@ class SoftwareSelectionSpoke(NormalSpoke):
                     return _("Invalid environment specified in kickstart")
             # we have no packages section in the kickstart and no environment has been set
             elif not self.environment:
-                return _("Nothing selected")
+                return _("Please confirm software selection")
 
         if not flags.automatedInstall:
             if not self.environment:
                 # No environment yet set
-                return _("Nothing selected")
+                return _("Please confirm software selection")
             elif not self.environment_valid:
                 # selected environment is not valid, this can happen when a valid environment
                 # is selected (by default, manually or from kickstart) and then the installation


### PR DESCRIPTION
With the Red Hat CDN now easily available the users will now
trigger the software spoke message that tells them to re-enter
the software spoke and confirm the software selection.

Unfortunately the current message - "Nothing selected" is
rather confusing. It does not tell what is not selected and
might actually be incorrect, as in some cases the previous
selection might transfer over when the installation source
changes.

So change the confusing message to "Please confirm software
selection" which is also more in line with our other spoke
status messages.

Thanks a lot to Jan Stodola for coming up with the text of
the new message. :)

Resolves: rhbz#1788458