### PR TITLE
Don't mount DBus sources at /run/install/source (#1851037)

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -53,6 +53,7 @@ DRACUT_ISODIR = "/run/install/source"
 ISO_DIR = MOUNT_DIR + "/isodir"
 IMAGE_DIR = MOUNT_DIR + "/image"
 INSTALL_TREE = MOUNT_DIR + "/source"
+SOURCES_DIR = MOUNT_DIR + "/sources"
 BASE_REPO_NAME = "anaconda"
 
 # Get list of repo names witch should be used as base repo

--- a/pyanaconda/modules/payloads/source/cdrom/initialization.py
+++ b/pyanaconda/modules/payloads/source/cdrom/initialization.py
@@ -47,7 +47,8 @@ class SetUpCdromSourceTask(SetUpMountTask):
             try:
                 device_data = DeviceData.from_structure(device_tree.GetDeviceData(dev_name))
                 mount(device_data.path, self._target_mount, "iso9660", "ro")
-            except PayloadSetupError:
+            except PayloadSetupError as e:
+                log.debug("Failed to mount %s: %s", dev_name, str(e))
                 continue
 
             if is_valid_install_disk(self._target_mount):

--- a/pyanaconda/modules/payloads/source/utils.py
+++ b/pyanaconda/modules/payloads/source/utils.py
@@ -20,7 +20,7 @@ import os.path
 from blivet.arch import get_arch
 from blivet.util import mount
 
-from pyanaconda.core.constants import INSTALL_TREE
+from pyanaconda.core.constants import SOURCES_DIR
 from pyanaconda.core.storage import device_matches
 from pyanaconda.core.util import join_paths
 from pyanaconda.payload.image import find_first_iso_image
@@ -177,7 +177,7 @@ class MountPointGenerator:
         :rtype: str
         """
         path = "{}/mount-{:0>4}-{}".format(
-            INSTALL_TREE,
+            SOURCES_DIR,
             cls._counter,
             suffix
         )

--- a/tests/nosetests/pyanaconda_tests/module_source_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_base_test.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.modules.common.errors.payload import SourceSetupError, SourceTearDownError
 from pyanaconda.modules.payloads.constants import SourceType
 from pyanaconda.modules.payloads.source.mount_tasks import SetUpMountTask, TearDownMountTask
@@ -55,7 +54,7 @@ class MountingSourceMixinTestCase(unittest.TestCase):
     def counter_test(self):
         """Mount path in mount source base gets incremental numbers."""
         module = DummyMountingSourceSubclass()
-        self.assertTrue(module.mount_point.startswith(INSTALL_TREE + "/mount-"))
+        self.assertTrue(module.mount_point.startswith("/run/install/sources/mount-"))
         first_counter = int(module.mount_point.split("-")[1])
 
         module = DummyMountingSourceSubclass()


### PR DESCRIPTION
Dracut can use this mount point to mount a disk with the stage2 image. If it
is a CD-Rom device, then the mount point is read-only. Anaconda will fail to
mount a DBus source at a mount point generated from /run/install/source, for
example /run/install/source/mount-0000-cdrom, because it cannot create the
directory mount-0000-cdrom on a read-only filesystem.

Let's use /run/install/sources for DBus sources instead.

Resolves: rhbz#1851037