### PR TITLE
Use Btrfs for all Fedora variants installed by Anaconda except Server

### DIFF
--- a/data/product.d/fedora-server.conf
+++ b/data/product.d/fedora-server.conf
@@ -12,6 +12,7 @@ default_environment = server-product-environment
 
 [Storage]
 file_system_type = xfs
+default_scheme = LVM
 default_partitioning =
     /    (min 2 GiB, max 15 GiB, encrypted)
     swap (encrypted)

--- a/data/product.d/fedora.conf
+++ b/data/product.d/fedora.conf
@@ -9,6 +9,9 @@ default_on_boot = FIRST_WIRED_WITH_LINK
 [Bootloader]
 efi_dir = fedora
 
+[Storage]
+default_scheme = BTRFS
+
 [User Interface]
 default_help_pages =
     FedoraPlaceholder.txt


### PR DESCRIPTION
All variants of Fedora that install using Anaconda are changing to use Btrfs
as the default filesystem and partitioning scheme. At this time, Fedora Server
is not making the same change, so set it to LVM+XFS.

Reference: https://fedoraproject.org/wiki/Changes/BtrfsByDefault

Resolves: [rhbz#1851166](https://bugzilla.redhat.com/1851166)