### PR TITLE
Add product data for CentOS Stream

### DIFF
--- a/data/product.d/centos-stream.conf
+++ b/data/product.d/centos-stream.conf
@@ -1,0 +1,29 @@
+# Anaconda configuration file for CentOS Stream.
+
+[Product]
+product_name = CentOS Stream
+
+[Base Product]
+product_name = Red Hat Enterprise Linux
+
+[Anaconda]
+# List of enabled Anaconda DBus modules for RHEL.
+#  but without org.fedoraproject.Anaconda.Modules.Subscription
+kickstart_modules =
+     org.fedoraproject.Anaconda.Modules.Timezone
+     org.fedoraproject.Anaconda.Modules.Network
+     org.fedoraproject.Anaconda.Modules.Localization
+     org.fedoraproject.Anaconda.Modules.Security
+     org.fedoraproject.Anaconda.Modules.Users
+     org.fedoraproject.Anaconda.Modules.Payloads
+     org.fedoraproject.Anaconda.Modules.Storage
+     org.fedoraproject.Anaconda.Modules.Services
+
+[Bootloader]
+efi_dir = centos
+
+[User Interface]
+default_help_pages =
+    CentOSPlaceholder.txt
+    CentOSPlaceholder.html
+    CentOSPlaceholder.html

--- a/data/product.d/centos-stream.conf
+++ b/data/product.d/centos-stream.conf
@@ -4,26 +4,4 @@
 product_name = CentOS Stream
 
 [Base Product]
-product_name = Red Hat Enterprise Linux
-
-[Anaconda]
-# List of enabled Anaconda DBus modules for RHEL.
-#  but without org.fedoraproject.Anaconda.Modules.Subscription
-kickstart_modules =
-     org.fedoraproject.Anaconda.Modules.Timezone
-     org.fedoraproject.Anaconda.Modules.Network
-     org.fedoraproject.Anaconda.Modules.Localization
-     org.fedoraproject.Anaconda.Modules.Security
-     org.fedoraproject.Anaconda.Modules.Users
-     org.fedoraproject.Anaconda.Modules.Payloads
-     org.fedoraproject.Anaconda.Modules.Storage
-     org.fedoraproject.Anaconda.Modules.Services
-
-[Bootloader]
-efi_dir = centos
-
-[User Interface]
-default_help_pages =
-    CentOSPlaceholder.txt
-    CentOSPlaceholder.html
-    CentOSPlaceholder.html
+product_name = CentOS Linux

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -236,6 +236,11 @@ class ProductConfigurationTestCase(unittest.TestCase):
             WORKSTATION_PARTITIONING
         )
         self._check_default_product(
+            "CentOS Stream", "",
+            ["rhel.conf", "centos.conf", "centos-stream.conf"],
+            WORKSTATION_PARTITIONING
+        )
+        self._check_default_product(
             "Red Hat Virtualization", "",
             ["rhel.conf", "rhev.conf"],
             VIRTUALIZATION_PARTITIONING


### PR DESCRIPTION
We need product data for CentOS Stream in addition to CentOS Linux. This is just a copy of the CentOS Linux data with the product_name changed.

Can we be sure this also makes it into a RHEL build of anaconda?