### PR TITLE
Remove the encrypted attribute

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -152,11 +152,10 @@ file_system_type =
 #   min <MIN_SIZE> The size will grow from MIN_SIZE to MAX_SIZE.
 #   max <MAX_SIZE> The max size is unlimited by default.
 #   free <SIZE>    The required available space.
-#   encrypted      The mount point will be encrypted.
 #
 default_partitioning =
-    /     (min 1 GiB, max 70 GiB, encrypted)
-    /home (min 500 MiB, free 50 GiB, encrypted)
+    /     (min 1 GiB, max 70 GiB)
+    /home (min 500 MiB, free 50 GiB)
 
 # Default partitioning scheme.
 # Valid values:

--- a/data/product.d/fedora-server.conf
+++ b/data/product.d/fedora-server.conf
@@ -14,7 +14,7 @@ default_environment = server-product-environment
 file_system_type = xfs
 default_scheme = LVM
 default_partitioning =
-    /    (min 2 GiB, max 15 GiB, encrypted)
+    /    (min 2 GiB, max 15 GiB)
 
 [User Interface]
 custom_stylesheet = /usr/share/anaconda/pixmaps/server/fedora-server.css

--- a/pyanaconda/core/configuration/storage.py
+++ b/pyanaconda/core/configuration/storage.py
@@ -139,7 +139,6 @@ class StorageSection(Section):
             min        The size will grow from min size to max size.
             max        The max size is unlimited by default.
             free       The required available space.
-            encrypted  The mount point will be encrypted.
 
         :return: a list of dictionaries with mount point attributes
         """
@@ -164,10 +163,7 @@ class StorageSection(Section):
         attrs = {"name": name}
 
         for name, value in raw_attrs:
-            if not value and name in ("encrypted",):
-                # Handle a boolean attribute.
-                attrs[name] = True
-            elif value and name in ("size", "min", "max", "free"):
+            if value and name in ("size", "min", "max", "free"):
                 # Handle a size attribute.
                 attrs[name] = Size(value)
             else:

--- a/pyanaconda/modules/storage/partitioning/automatic/utils.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/utils.py
@@ -238,7 +238,7 @@ def get_default_partitioning():
             max_size=attrs.get("max"),
             grow="min" in attrs,
             required_space=attrs.get("free") or 0,
-            encrypted=attrs.get("encrypted") or False,
+            encrypted=True,
         )
 
         partitioning.append(spec)

--- a/tests/nosetests/pyanaconda_tests/configuration_test.py
+++ b/tests/nosetests/pyanaconda_tests/configuration_test.py
@@ -324,12 +324,10 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
                 'name': '/',
                 'min': Size("1024 MiB"),
                 'max': Size("70 GiB"),
-                'encrypted': True,
             }, {
                 'name': '/home',
                 'min': Size("500 MiB"),
                 'free': Size("50 GiB"),
-                'encrypted': True
             }
         ])
 
@@ -348,11 +346,6 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
             "size": Size("1 GiB")
         })
 
-        self.assertEqual(convert_line("swap (encrypted)"), {
-            "name": "swap",
-            "encrypted": True
-        })
-
         self.assertEqual(convert_line("swap"), {
             "name": "swap"
         })
@@ -361,10 +354,7 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
             convert_line("")
 
         with self.assertRaises(ValueError):
-            convert_line("(encrypted)")
-
-        with self.assertRaises(ValueError):
-            convert_line("/home (encrypted 1)")
+            convert_line("(size 1 GiB)")
 
         with self.assertRaises(ValueError):
             convert_line("/home (size)")

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -44,7 +44,7 @@ SERVER_PARTITIONING = [
         btr=True,
         lv=True,
         thin=True,
-        encrypted=True
+        encrypted=True,
     )
 ]
 
@@ -57,7 +57,8 @@ WORKSTATION_PARTITIONING = [
         btr=True,
         lv=True,
         thin=True,
-        encrypted=True),
+        encrypted=True,
+    ),
     PartSpec(
         mountpoint="/home",
         size=Size("500MiB"), grow=True,
@@ -65,7 +66,8 @@ WORKSTATION_PARTITIONING = [
         btr=True,
         lv=True,
         thin=True,
-        encrypted=True),
+        encrypted=True
+    ),
 ]
 
 VIRTUALIZATION_PARTITIONING = [
@@ -75,46 +77,53 @@ VIRTUALIZATION_PARTITIONING = [
         grow=True,
         btr=True,
         lv=True,
-        thin=True
+        thin=True,
+        encrypted=True,
     ),
     PartSpec(
         mountpoint="/home",
         size=Size("1GiB"),
         btr=True,
         lv=True,
-        thin=True
+        thin=True,
+        encrypted=True,
     ),
     PartSpec(
         mountpoint="/tmp",
         size=Size("1GiB"),
         btr=True,
         lv=True,
-        thin=True
+        thin=True,
+        encrypted=True,
     ),
     PartSpec(
         mountpoint="/var",
         size=Size("15GiB"),
         btr=True,
         lv=True,
-        thin=True
+        thin=True,
+        encrypted=True,
     ),
     PartSpec(
         mountpoint="/var/log",
         size=Size("8GiB"),
         btr=True,
         lv=True,
-        thin=True
+        thin=True,
+        encrypted=True,
     ),
     PartSpec(
         mountpoint="/var/log/audit",
         size=Size("2GiB"),
         btr=True,
         lv=True,
-        thin=True
+        thin=True,
+        encrypted=True,
     ),
     PartSpec(
         fstype="swap",
-        lv=True
+        lv=True,
+        encrypted=True,
     )
 ]
 


### PR DESCRIPTION
The encrypted attribute of the default_partitioning configuration option
can be removed. It will be allowed to encrypt all mount points specified
in the Anaconda configuration files. It won't affect boot partitions that
are defined somewhere else. It will affect the default partitioning of Red
Hat Virtualization and oVirt Node Next, but we are able to with deal that.