### PR TITLE
Use LUKSDevice.raw_device instead of LUKSDevice.slave

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -610,12 +610,12 @@ def change_encryption(storage, device, encrypted, luks_version):
     :param device: a device to change
     :param encrypted: should we encrypt the device?
     :param luks_version: a version of LUKS
-    :return: a LUKS device or a device slave
+    :return: a LUKS device or a LUKS device parent device
     """
     if not encrypted:
         log.info("Removing encryption from %s.", device.name)
         storage.destroy_device(device)
-        return device.slave
+        return device.raw_device
     else:
         log.info("Applying encryption to %s.", device.name)
         new_fmt = get_format("luks", device=device.path, luks_version=luks_version)


### PR DESCRIPTION
Blivet is going to remove the LUKSDevice.slave property, see
https://github.com/storaged-project/blivet/pull/863

-----

Note: the `raw_device` property is not new so there is no need to wait for a new blivet release before merging this.