### PR TITLE
Create the initial storage model during the initialization (#1844098)

### DIFF
--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -133,6 +133,10 @@ class StorageService(KickstartService):
             self.on_protected_devices_changed
         )
 
+        # After connecting modules to signals, create the initial
+        # storage model. It will be propagated to all modules.
+        self._set_storage(create_storage())
+
     def _add_module(self, storage_module):
         """Add a base kickstart module."""
         self._modules.append(storage_module)

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -121,6 +121,11 @@ class StorageInterfaceTestCase(unittest.TestCase):
         self.storage_module.partitioning_reset.connect(storage_reset_callback)
 
         self.assertIsNotNone(self.storage_module.storage)
+        storage_changed_callback.assert_not_called()
+        storage_reset_callback.assert_not_called()
+
+        self.storage_module._current_storage = None
+        self.assertIsNotNone(self.storage_module.storage)
         storage_changed_callback.assert_called_once()
         storage_reset_callback.assert_not_called()
 


### PR DESCRIPTION
After connecting all objects of the Storage service to signals, create
the initial storage model. It will be propagated to all these objects.

Otherwise, the objects might raise the UnavailableStorageError exception.

Resolves: rhbz#1844098