### PR TITLE
Improve the support for NTP servers

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -325,7 +325,6 @@ if __name__ == "__main__":
 
     from pyanaconda import vnc
     from pyanaconda import kickstart
-    from pyanaconda import ntp
     from pyanaconda import keyboard
     # we are past the --version and --help shortcut so we can import display &
     # startup_utils, which import Blivet, without slowing down anything critical
@@ -714,15 +713,7 @@ if __name__ == "__main__":
         geoloc.geoloc.refresh()
 
     # setup ntp servers and start NTP daemon if not requested otherwise
-    if conf.system.can_set_time_synchronization:
-        kickstart_ntpservers = timezone_proxy.NTPServers
-
-        if kickstart_ntpservers:
-            pools, servers = ntp.internal_to_pools_and_servers(kickstart_ntpservers)
-            ntp.save_servers_to_config(pools, servers)
-
-        if timezone_proxy.NTPEnabled:
-            util.start_service("chronyd")
+    startup_utils.start_chronyd()
 
     # Finish the initialization of the setup on boot action.
     # This should be done sooner and somewhere else once it is possible.

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -33,7 +33,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.25-1
+%define pykickstartver 3.27-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 1.1-1

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -306,6 +306,10 @@ PAYLOAD_STATUS_GROUP_MD = N_("Downloading group metadata...")
 # Window title text
 WINDOW_TITLE_TEXT = N_("Anaconda Installer")
 
+# Types of time sources.
+TIME_SOURCE_SERVER = "SERVER"
+TIME_SOURCE_POOL = "POOL"
+
 # NTP server checking
 NTP_SERVER_OK = 0
 NTP_SERVER_NOK = 1

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -76,7 +76,8 @@ from pykickstart.commands.snapshot import F26_Snapshot as Snapshot
 from pykickstart.commands.sshpw import F24_SshPw as SshPw
 from pykickstart.commands.sshkey import F22_SshKey as SshKey
 from pykickstart.commands.syspurpose import RHEL8_Syspurpose as Syspurpose
-from pykickstart.commands.timezone import F32_Timezone as Timezone
+from pykickstart.commands.timezone import F33_Timezone as Timezone
+from pykickstart.commands.timesource import F33_Timesource as Timesource
 from pykickstart.commands.updates import F7_Updates as Updates
 from pykickstart.commands.url import F30_Url as Url
 from pykickstart.commands.user import F24_User as User
@@ -107,6 +108,7 @@ from pykickstart.commands.repo import F30_RepoData as RepoData
 from pykickstart.commands.snapshot import F26_SnapshotData as SnapshotData
 from pykickstart.commands.sshpw import F24_SshPwData as SshPwData
 from pykickstart.commands.sshkey import F22_SshKeyData as SshKeyData
+from pykickstart.commands.timesource import F33_TimesourceData as TimesourceData
 from pykickstart.commands.user import F19_UserData as UserData
 from pykickstart.commands.volgroup import F21_VolGroupData as VolGroupData
 from pykickstart.commands.zfcp import F14_ZFCPData as ZFCPData

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -372,6 +372,7 @@ commandMap = {
     "sshkey" : UselessCommand,
     "skipx": UselessCommand,
     "snapshot": UselessCommand,
+    "timesource": UselessCommand,
     "timezone": UselessCommand,
     "url": UselessCommand,
     "user": UselessCommand,

--- a/pyanaconda/modules/common/structures/timezone.py
+++ b/pyanaconda/modules/common/structures/timezone.py
@@ -1,0 +1,84 @@
+#
+# DBus structures for the timezone data.
+#
+# Copyright (C) 2020  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from dasbus.structure import DBusData
+from dasbus.typing import *  # pylint: disable=wildcard-import
+
+from pyanaconda.core.constants import TIME_SOURCE_SERVER
+
+__all__ = ["TimeSourceData"]
+
+
+class TimeSourceData(DBusData):
+    """Data for a time source."""
+
+    def __init__(self):
+        self._type = TIME_SOURCE_SERVER
+        self._hostname = ""
+        self._options = []
+
+    @property
+    def type(self) -> Str:
+        """Type of the time source.
+
+        Supported values:
+
+            SERVER  A single NTP server
+            POOL    A pool of NTP servers
+
+        :return: a type of the time source
+        """
+        return self._type
+
+    @type.setter
+    def type(self, value: Str):
+        self._type = value
+
+    @property
+    def hostname(self) -> Str:
+        """Name of the time server.
+
+        For example:
+
+            ntp.cesnet.cz
+
+        :return: a host name
+        """
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, value: Str):
+        self._hostname = value
+
+    @property
+    def options(self) -> List[Str]:
+        """Options of the time source.
+
+        For example:
+
+            nts, ntsport 1234, iburst
+
+        See ``man chrony.conf``.
+
+        :return: a list of options
+        """
+        return self._options
+
+    @options.setter
+    def options(self, value):
+        self._options = value

--- a/pyanaconda/modules/timezone/installation.py
+++ b/pyanaconda/modules/timezone/installation.py
@@ -145,12 +145,14 @@ class ConfigureNTPTask(Task):
             return
 
         chronyd_conf_path = os.path.normpath(self._sysroot + ntp.NTP_CONFIG_FILE)
-        pools, servers = ntp.internal_to_pools_and_servers(self._ntp_servers)
 
         if os.path.exists(chronyd_conf_path):
             log.debug("Modifying installed chrony configuration")
             try:
-                ntp.save_servers_to_config(pools, servers, conf_file_path=chronyd_conf_path)
+                ntp.save_servers_to_config(
+                    self._ntp_servers,
+                    conf_file_path=chronyd_conf_path
+                )
             except ntp.NTPconfigError as ntperr:
                 log.warning("Failed to save NTP configuration: %s", ntperr)
 
@@ -160,9 +162,11 @@ class ConfigureNTPTask(Task):
             log.debug("Creating chrony configuration based on the "
                       "configuration from installation environment")
             try:
-                ntp.save_servers_to_config(pools, servers,
-                                           conf_file_path=ntp.NTP_CONFIG_FILE,
-                                           out_file_path=chronyd_conf_path)
+                ntp.save_servers_to_config(
+                    self._ntp_servers,
+                    conf_file_path=ntp.NTP_CONFIG_FILE,
+                    out_file_path=chronyd_conf_path
+                )
             except ntp.NTPconfigError as ntperr:
                 log.warning("Failed to save NTP configuration without chrony package: %s",
                             ntperr)

--- a/pyanaconda/modules/timezone/kickstart.py
+++ b/pyanaconda/modules/timezone/kickstart.py
@@ -24,4 +24,9 @@ class TimezoneKickstartSpecification(KickstartSpecification):
 
     commands = {
         "timezone": COMMANDS.Timezone,
+        "timesource": COMMANDS.Timesource,
+    }
+
+    commands_data = {
+        "TimesourceData": COMMANDS.TimesourceData,
     }

--- a/pyanaconda/modules/timezone/timezone_interface.py
+++ b/pyanaconda/modules/timezone/timezone_interface.py
@@ -17,12 +17,14 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.modules.common.constants.services import TIMEZONE
-from pyanaconda.modules.common.containers import TaskContainer
 from dasbus.server.property import emits_properties_changed
 from dasbus.typing import *  # pylint: disable=wildcard-import
-from pyanaconda.modules.common.base import KickstartModuleInterface
 from dasbus.server.interface import dbus_interface
+
+from pyanaconda.modules.common.base import KickstartModuleInterface
+from pyanaconda.modules.common.constants.services import TIMEZONE
+from pyanaconda.modules.common.containers import TaskContainer
+from pyanaconda.modules.common.structures.timezone import TimeSourceData
 
 
 @dbus_interface(TIMEZONE.interface_name)
@@ -34,7 +36,7 @@ class TimezoneInterface(KickstartModuleInterface):
         self.watch_property("Timezone", self.implementation.timezone_changed)
         self.watch_property("IsUTC", self.implementation.is_utc_changed)
         self.watch_property("NTPEnabled", self.implementation.ntp_enabled_changed)
-        self.watch_property("NTPServers", self.implementation.ntp_servers_changed)
+        self.watch_property("TimeSources", self.implementation.time_sources_changed)
 
     @property
     def Timezone(self) -> Str:
@@ -91,22 +93,26 @@ class TimezoneInterface(KickstartModuleInterface):
         self.implementation.set_ntp_enabled(ntp_enabled)
 
     @property
-    def NTPServers(self) -> List[Str]:
-        """A list of NTP servers.
+    def TimeSources(self) -> List[Structure]:
+        """A list of time sources.
 
-        :return: a list of servers
+        :return: a list of time source data
+        :rtype: a list of structures of the type TimeSourceData
         """
-        return self.implementation.ntp_servers
+        return TimeSourceData.to_structure_list(
+            self.implementation.time_sources
+        )
 
     @emits_properties_changed
-    def SetNTPServers(self, servers: List[Str]):
-        """Set the NTP servers.
+    def SetTimeSources(self, sources: List[Structure]):
+        """Set the time sources.
 
-        Example: [ntp.cesnet.cz]
-
-        :param servers: a list of servers
+        :param sources: a list of time sources
+        :type sources: a list of structures of the type TimeSourceData
         """
-        self.implementation.set_ntp_servers(servers)
+        self.implementation.set_time_sources(
+            TimeSourceData.from_structure_list(sources)
+        )
 
     def ConfigureNTPServiceEnablementWithTask(self, ntp_excluded: Bool) -> ObjPath:
         """Enable or disable NTP service.

--- a/pyanaconda/ntp.py
+++ b/pyanaconda/ntp.py
@@ -60,6 +60,41 @@ class NTPconfigError(Exception):
     pass
 
 
+def get_ntp_server_summary(server, states):
+    """Generate a summary of an NTP server and its status.
+
+    :param server: an NTP server
+    :type server: an instance of TimeSourceData
+    :param states: a cache of NTP server states
+    :type states: an instance of NTPServerStatusCache
+    :return: a string with a summary
+    """
+    return "{} ({})".format(
+        server.hostname,
+        states.get_status_description(server)
+    )
+
+
+def get_ntp_servers_summary(servers, states):
+    """Generate a summary of NTP servers and their states.
+
+    :param servers: a list of NTP servers
+    :type servers: a list of TimeSourceData
+    :param states: a cache of NTP server states
+    :type states: an instance of NTPServerStatusCache
+    :return: a string with a summary
+    """
+    summary = _("NTP servers:")
+
+    for server in servers:
+        summary += "\n" + get_ntp_server_summary(server, states)
+
+    if not servers:
+        summary += " " + _("not configured")
+
+    return summary
+
+
 def ntp_server_working(server_hostname):
     """Tries to do an NTP request to the server (timeout may take some time).
 

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.glade
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.glade
@@ -87,6 +87,8 @@
       <column type="gint"/>
       <!-- column-name use -->
       <column type="gboolean"/>
+      <!-- column-name object -->
+      <column type="PyObject"/>
     </columns>
   </object>
   <object class="GtkDialog" id="ntpConfigDialog">
@@ -242,6 +244,8 @@
                       <object class="GtkCellRendererText" id="hostnameRenderer">
                         <property name="editable">True</property>
                         <signal name="edited" handler="on_server_edited" swapped="no"/>
+                        <signal name="editing-started" handler="on_server_editing_started" swapped="no"/>
+                        <signal name="editing-canceled" handler="on_server_editing_canceled" swapped="no"/>
                       </object>
                       <attributes>
                         <attribute name="text">0</attribute>

--- a/tests/nosetests/pyanaconda_tests/module_timezone_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_timezone_test.py
@@ -65,7 +65,7 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
 
     def kickstart_properties_test(self):
         """Test kickstart properties."""
-        self.assertEqual(self.timezone_interface.KickstartCommands, ["timezone"])
+        self.assertEqual(self.timezone_interface.KickstartCommands, ["timezone", "timesource"])
         self.assertEqual(self.timezone_interface.KickstartSections, [])
         self.assertEqual(self.timezone_interface.KickstartAddons, [])
         self.callback.assert_not_called()
@@ -143,19 +143,90 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         timezone --utc --nontp Europe/Prague
         """
         ks_out = """
+        timesource --ntp-disable
         # System timezone
-        timezone Europe/Prague --utc --nontp
+        timezone Europe/Prague --utc
         """
         self._test_kickstart(ks_in, ks_out)
 
     def kickstart3_test(self):
-        """Test the timezone command with ntp servers.."""
+        """Test the timezone command with ntp servers."""
         ks_in = """
         timezone --ntpservers ntp.cesnet.cz Europe/Prague
         """
         ks_out = """
+        timesource --ntp-server=ntp.cesnet.cz
         # System timezone
-        timezone Europe/Prague --ntpservers=ntp.cesnet.cz
+        timezone Europe/Prague
+        """
+        self._test_kickstart(ks_in, ks_out)
+
+    def kickstart_timesource_ntp_disabled_test(self):
+        """Test the timesource command with ntp disabled."""
+        ks_in = """
+        timesource --ntp-disable
+        """
+        ks_out = """
+        timesource --ntp-disable
+        """
+        self._test_kickstart(ks_in, ks_out)
+
+    def kickstart_timesource_ntp_server_test(self):
+        """Test the timesource command with ntp servers."""
+        ks_in = """
+        timesource --ntp-server ntp.cesnet.cz
+        """
+        ks_out = """
+        timesource --ntp-server=ntp.cesnet.cz
+        """
+        self._test_kickstart(ks_in, ks_out)
+
+    def kickstart_timesource_ntp_pool_test(self):
+        """Test the timesource command with ntp pools."""
+        ks_in = """
+        timesource --ntp-pool ntp.cesnet.cz
+        """
+        ks_out = """
+        timesource --ntp-pool=ntp.cesnet.cz
+        """
+        self._test_kickstart(ks_in, ks_out)
+
+    def kickstart_timesource_nts_test(self):
+        """Test the timesource command with the nts option."""
+        ks_in = """
+        timesource --ntp-pool ntp.cesnet.cz --nts
+        """
+        ks_out = """
+        timesource --ntp-pool=ntp.cesnet.cz --nts
+        """
+        self._test_kickstart(ks_in, ks_out)
+
+    def kickstart_timesource_all_test(self):
+        """Test the timesource commands."""
+        ks_in = """
+        timesource --ntp-server ntp.cesnet.cz
+        timesource --ntp-pool 0.fedora.pool.ntp.org
+        """
+        ks_out = """
+        timesource --ntp-server=ntp.cesnet.cz
+        timesource --ntp-pool=0.fedora.pool.ntp.org
+        """
+        self._test_kickstart(ks_in, ks_out)
+
+    def kickstart_timezone_timesource_test(self):
+        """Test the combination of timezone and timesource commands."""
+        ks_in = """
+        timezone --ntpservers ntp.cesnet.cz,0.fedora.pool.ntp.org Europe/Prague
+        timesource --ntp-server ntp.cesnet.cz --nts
+        timesource --ntp-pool 0.fedora.pool.ntp.org
+        """
+        ks_out = """
+        timesource --ntp-server=ntp.cesnet.cz
+        timesource --ntp-server=0.fedora.pool.ntp.org
+        timesource --ntp-server=ntp.cesnet.cz --nts
+        timesource --ntp-pool=0.fedora.pool.ntp.org
+        # System timezone
+        timezone Europe/Prague
         """
         self._test_kickstart(ks_in, ks_out)
 


### PR DESCRIPTION
Use the class TimeSourceData to represent a time source.

Modify the Timezone module to work with the DBus structures for time sources
instead of the strings. Rename the DBus property NTPServers to TimeSources.

Clean up the code for the NTP configuration.

The Timezone module should handle the timesource kickstart command.

**Depends on:** https://github.com/pykickstart/pykickstart/pull/322
