### PR TITLE
Always specify the boot disk

### DIFF
--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
@@ -175,7 +175,7 @@ class AutomaticPartitioningTask(NonInteractivePartitioningTask):
         devs = schedule_partitions(storage, disks, devs, scheme, requests, encrypted, luks_fmt_args)
 
         # run the autopart function to allocate and grow partitions
-        do_partitioning(storage)
+        do_partitioning(storage, boot_disk=storage.bootloader.stage1_disk)
         schedule_volumes(storage, devs, scheme, requests, encrypted)
 
         # grow LVs

--- a/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
@@ -136,7 +136,7 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
             self._execute_partition_data(storage, data, partition_data)
 
         if data.partition.partitions:
-            do_partitioning(storage)
+            do_partitioning(storage, boot_disk=storage.bootloader.stage1_disk)
 
     def _execute_partition_data(self, storage, data, partition_data):
         """Execute the partition data.


### PR DESCRIPTION
We should always specify the boot disk when we allocate partitions. Otherwise,
Blivet will choose one of the available disks that don't have to be valid.

(cherry-picked from a commit 856e011)

**Ported from:** https://github.com/rhinstaller/anaconda/pull/2680