### PR TITLE
Set up FIPS during the installation

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -123,6 +123,10 @@ Requires: systemd
 Requires: python3-pid
 Requires: python3-ordered-set >= 2.0.0
 
+# Required by the systemd service anaconda-fips.
+Requires: crypto-policies
+Requires: /usr/bin/update-crypto-policies
+
 # required because of the rescue mode and VNC question
 Requires: anaconda-tui = %{version}-%{release}
 

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -27,7 +27,8 @@ dist_systemd_DATA = anaconda.service \
                     instperf.service \
                     anaconda-sshd.service \
                     anaconda-nm-config.service \
-                    anaconda-pre.service
+                    anaconda-pre.service \
+                    anaconda-fips.service
 
 dist_generator_SCRIPTS = anaconda-generator
 

--- a/data/systemd/anaconda-fips.service
+++ b/data/systemd/anaconda-fips.service
@@ -1,0 +1,10 @@
+[Unit]
+# This service sets up the FIPS mode in the installation environment.
+Description=Anaconda FIPS service
+ConditionKernelCommandLine=fips=1
+Before=network.target
+Before=NetworkManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/update-crypto-policies --set FIPS

--- a/data/systemd/anaconda-sshd.service
+++ b/data/systemd/anaconda-sshd.service
@@ -11,7 +11,8 @@ ConditionKernelCommandLine=!sshd=0
 ConditionPathIsDirectory=|/sys/hypervisor/s390
 
 [Service]
-EnvironmentFile=/etc/sysconfig/sshd
+EnvironmentFile=-/etc/crypto-policies/back-ends/opensshserver.config
+EnvironmentFile=-/etc/sysconfig/sshd
 ExecStartPre=/usr/sbin/handle-sshpw
-ExecStart=/usr/sbin/sshd -D $OPTIONS -f /etc/ssh/sshd_config.anaconda
+ExecStart=/usr/sbin/sshd -D $OPTIONS $CRYPTO_POLICY -f /etc/ssh/sshd_config.anaconda
 ExecReload=/bin/kill -HUP $MAINPID

--- a/data/systemd/anaconda.target
+++ b/data/systemd/anaconda.target
@@ -11,4 +11,5 @@ Wants=plymouth-quit.service plymouth-quit-wait.service
 Wants=anaconda-direct.service anaconda.service
 Wants=anaconda-sshd.service
 Wants=anaconda-pre.service
+Wants=anaconda-fips.service
 Wants=systemd-logind.service


### PR DESCRIPTION
Add the systemd service anaconda-fips that will set up the FIPS mode in stage2
if there is fips=1 on the kernel cmdline. It should run before network.target.

Bring the service anaconda-sshd unit closer to sshd.service and respect
the crypto policy of the installation environment.

Copy the crypto policy from the installation environment to target system
the before the package installation. The RPM scriptlets needs to be executed
in the FIPS mode if there is fips=1 on the kernel cmdline.

**Ported from:** https://github.com/rhinstaller/anaconda/pull/2537 https://github.com/rhinstaller/anaconda/pull/2621