### PR TITLE
Fix imports of Blivet-GUI in unit tests

### DIFF
--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -21,10 +21,14 @@
 
 """Module with the BlivetGuiSpoke class."""
 from threading import Lock
+from pyanaconda.errors import RemovedModuleError
 
-from blivetgui.osinstall import BlivetGUIAnaconda  # pylint: disable=import-error
-from blivetgui.communication.client import BlivetGUIClient  # pylint: disable=import-error
-from blivetgui.config import config  # pylint: disable=import-error
+try:
+    from blivetgui.osinstall import BlivetGUIAnaconda  # pylint: disable=import-error
+    from blivetgui.communication.client import BlivetGUIClient  # pylint: disable=import-error
+    from blivetgui.config import config  # pylint: disable=import-error
+except ImportError:
+    raise RemovedModuleError("This module is not supported!")
 
 from dasbus.client.proxy import get_object_path
 from dasbus.typing import unwrap_variant

--- a/tests/nosetests/pyanaconda_tests/simple_import_test.py
+++ b/tests/nosetests/pyanaconda_tests/simple_import_test.py
@@ -39,7 +39,7 @@ class SimpleImportTestCase(unittest.TestCase):
     def tearDown(self):
         sys.modules.pop("gi.repository.TimezoneMap")
 
-    def _check_package(self, package, expected_imports):
+    def _check_package(self, package, expected_imports, skipped_imports):
         """Check if all submodules of the package can be imported."""
         failed = set()
         missing = set(expected_imports)
@@ -48,6 +48,9 @@ class SimpleImportTestCase(unittest.TestCase):
 
         for _, name, _ in walk_packages(path, prefix, failed.add):
             if name.endswith(".__main__"):
+                continue
+
+            if name in skipped_imports:
                 continue
 
             print(name)
@@ -77,4 +80,7 @@ class SimpleImportTestCase(unittest.TestCase):
             "pyanaconda.ui.gui.spokes.lib.cart",
             "pyanaconda.ui.tui.spokes.askvnc",
             "pyanaconda.rescue"
+        ], [
+            "pyanaconda.modules.storage.partitioning.blivet.blivet_handler",
+            "pyanaconda.ui.gui.spokes.blivet_gui"
         ])


### PR DESCRIPTION
Skip imports of pyanaconda modules that depend on blivetgui.

(cherry-picked from a commit f102257)

**Ported from:** https://github.com/rhinstaller/anaconda/pull/2607