### PR TITLE
subscription: Fix rhsm --proxy kickstart command usage with no userna…

### DIFF
--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -211,7 +211,10 @@ class SubscriptionService(KickstartService):
 
                     subscription_request.server_proxy_hostname = proxy.host
                     subscription_request.server_proxy_port = port
-                    subscription_request.server_proxy_user = proxy.username
+
+                    # ensure no username translates to the expected ""
+                    # instead of the None returned by the ProxyString class
+                    subscription_request.server_proxy_user = proxy.username or ""
                     subscription_request.server_proxy_password.set_secret(proxy.password)
             except ProxyStringError as e:
                 # should not be fatal, but definitely logged as error


### PR DESCRIPTION
…me specified

The ProxyString class used for parsing proxy definitions in Anaconda
set's it's username property to None if the proxy definition does not
have any username specified.

This is a problem if the None get's forwarded to the SubscriptionRequest
DBus structure, which expects an empty string instead, leading to
a crash once such incorrectly filled structure is first serialized.

To prevent that always check if ProxyString returned something for
the username and use "" if not, preventing the serialization crash.

Resolves: rhbz#1849792