### PR TITLE
Only pass one initrd image to kexec

### DIFF
--- a/pyanaconda/kexec.py
+++ b/pyanaconda/kexec.py
@@ -72,6 +72,11 @@ def run_grubby(args=None):
     if boot_info_fields:
         raise GrubbyInfoError("Missing values: %s" % ", ".join(boot_info_fields))
 
+    # There could be multiple initrd images defined for a boot entry, but
+    # the kexec command line tool only supports passing a single initrd.
+    if "initrd" in boot_info_args:
+        boot_info_args["initrd"] = boot_info_args["initrd"].split(" ")[0]
+
     boot_info = boot_info_class(**boot_info_args)
     log.info("grubby boot info for (%s): %s", args, boot_info)
     return boot_info


### PR DESCRIPTION
The kexec command line tool can only get a single initrd, but a boot entry
can have multiple ones. For example the tuned package adds a variable that
could be set to a second initrd image.

If that's the case, it will lead to the following error:

FileNotFoundError: [Errno 2] No such file or directory:
'/mnt/sysroot/boot/initramfs-4.18.0-223.el8.x86_64.img $tuned_initrd'

Resolves: rhbz#1855290

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>