### PR TITLE
Add Fedora IoT product override

### DIFF
--- a/data/product.d/fedora-iot.conf
+++ b/data/product.d/fedora-iot.conf
@@ -1,0 +1,11 @@
+# Anaconda configuration file for Fedora IoT.
+
+[Product]
+product_name = Fedora
+variant_name = IoT
+
+[Base Product]
+product_name = Fedora
+
+[Storage]
+default_scheme = LVM

--- a/data/product.d/fedora-iot.conf
+++ b/data/product.d/fedora-iot.conf
@@ -1,7 +1,7 @@
 # Anaconda configuration file for Fedora IoT.
 
 [Product]
-product_name = Fedora
+product_name = Fedora-IoT
 variant_name = IoT
 
 [Base Product]

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -218,7 +218,7 @@ class ProductConfigurationTestCase(unittest.TestCase):
             WORKSTATION_PARTITIONING
         )
         self._check_default_product(
-            "Fedora", "IoT",
+            "Fedora-IoT", "IoT",
             ["fedora.conf", "fedora-iot.conf"],
             WORKSTATION_PARTITIONING
         )

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -217,6 +217,11 @@ class ProductConfigurationTestCase(unittest.TestCase):
              "fedora-silverblue.conf"],
             WORKSTATION_PARTITIONING
         )
+        self._check_default_product(
+            "Fedora", "IoT",
+            ["fedora.conf", "fedora-iot.conf"],
+            WORKSTATION_PARTITIONING
+        )
 
     def rhel_products_test(self):
         self._check_default_product(


### PR DESCRIPTION
Fedora IoT was previously relying on the base Fedora product definition,
but it should not, since it should be using the classic storage configuration.

Fixes https://pagure.io/fedora-iot/issue/31

(cc: @AdamWill, @nullr0ute)

Signed-off-by: Neal Gompa <ngompa13@gmail.com>