### PR TITLE
Run the user instance of systemd

### DIFF
--- a/pyanaconda/core/configuration/system.py
+++ b/pyanaconda/core/configuration/system.py
@@ -69,6 +69,11 @@ class SystemSection(Section):
         return self._is_boot_iso or self._is_booted_os
 
     @property
+    def can_start_user_systemd(self):
+        """Can we start the user instance of systemd?"""
+        return self._is_boot_iso
+
+    @property
     def can_switch_tty(self):
         """Can we change the foreground virtual terminal?"""
         return self._is_boot_iso

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -50,6 +50,20 @@ log = get_module_logger(__name__)
 stdout_log = get_stdout_logger()
 
 
+def start_user_systemd():
+    """Start the user instance of systemd.
+
+    The service org.a11y.Bus runs the dbus-broker-launch in
+    the user scope that requires the user instance of systemd.
+    """
+    if not conf.system.can_start_user_systemd:
+        log.debug("Don't start the user instance of systemd.")
+        return
+
+    childproc = util.startProgram(["/usr/lib/systemd/systemd", "--user"])
+    WatchProcesses.watch_process(childproc, "systemd")
+
+
 # Spice
 
 def start_spice_vd_agent():
@@ -193,6 +207,7 @@ def do_extra_x11_actions(runres, gui_mode):
     # Load the system-wide Xresources
     util.execWithRedirect("xrdb", ["-nocpp", "-merge", "/etc/X11/Xresources"])
 
+    start_user_systemd()
     start_spice_vd_agent()
 
 


### PR DESCRIPTION
The service org.a11y.Bus runs the dbus-broker-launch in the user scope that
requires the user instance of systemd.

Resolves: rhbz#1832362