### PR TITLE
Log the information about the original exception

### DIFF
--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -102,7 +102,7 @@ class InstallBootloaderTask(Task):
         try:
             install_boot_loader(storage=self._storage)
         except BootLoaderError as e:
-            log.error("Bootloader installation has failed: %s", e)
+            log.exception("Bootloader installation has failed: %s", e)
             raise BootloaderInstallationError(str(e)) from None
 
 

--- a/pyanaconda/modules/storage/installation.py
+++ b/pyanaconda/modules/storage/installation.py
@@ -84,13 +84,13 @@ class ActivateFilesystemsTask(Task):
                 callbacks=register
             )
         except (FSResizeError, FormatResizeError) as e:
-            log.error("Failed to resize device %s: %s", e.details, str(e))
+            log.exception("Failed to resize device %s: %s", e.details, str(e))
             message = _("An error occurred while resizing the device {}: {}").format(
                 e.details, str(e)
             )
             raise StorageInstallationError(message) from None
         except StorageError as e:
-            log.error("Failed to activate filesystems: %s", str(e))
+            log.exception("Failed to activate filesystems: %s", str(e))
             raise StorageInstallationError(str(e)) from None
 
     def _report_message(self, data):

--- a/pyanaconda/modules/storage/partitioning/interactive/add_device.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/add_device.py
@@ -161,5 +161,5 @@ class AddDeviceTask(Task):
             log.error("The device creation has failed: %s", e)
             raise
         except OverflowError as e:
-            log.error("Invalid partition size set: %s", str(e))
+            log.exception("Invalid partition size set: %s", str(e))
             raise StorageError("Invalid partition size set. Use a valid integer.") from None

--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -545,7 +545,7 @@ def resize_device(storage, device, new_size, old_size):
         try:
             storage.resize_device(device.raw_device, use_size)
         except (StorageError, ValueError) as e:
-            log.error("Failed to schedule device resize: %s", e)
+            log.exception("Failed to schedule device resize: %s", e)
             device.raw_device.size = use_old_size
             raise StorageError(str(e)) from None
 
@@ -648,7 +648,7 @@ def reformat_device(storage, device, fstype, mountpoint, label):
     try:
         storage.format_device(device, new_format)
     except (StorageError, ValueError) as e:
-        log.error("Failed to register device format action: %s", e)
+        log.exception("Failed to register device format action: %s", e)
         device.format = old_format
         raise StorageError(str(e)) from None
 
@@ -1019,7 +1019,7 @@ def reset_device(storage, device):
             # Destroy a non-existing device.
             _destroy_device(storage, device)
     except (StorageError, ValueError) as e:
-        log.error("Failed to reset a device: %s", e)
+        log.exception("Failed to reset a device: %s", e)
         raise StorageConfigurationError(str(e)) from None
 
 
@@ -1035,7 +1035,7 @@ def destroy_device(storage, device):
     try:
         _destroy_device(storage, device)
     except (StorageError, ValueError) as e:
-        log.error("Failed to destroy a device: %s", e)
+        log.exception("Failed to destroy a device: %s", e)
         raise StorageConfigurationError(str(e)) from None
 
 
@@ -1120,6 +1120,7 @@ def rename_container(storage, container, name):
     try:
         container.name = name
     except ValueError as e:
+        log.exception("Failed to rename container: %s", str(e))
         raise StorageError(str(e)) from None
 
     # Fix the btrfs label.

--- a/pyanaconda/modules/storage/reset.py
+++ b/pyanaconda/modules/storage/reset.py
@@ -62,7 +62,7 @@ class ScanDevicesTask(Task):
             self._reload_modules()
             self._reset_storage(self._storage)
         except UnusableConfigurationError as e:
-            log.error("Failed to scan devices: %s", e)
+            log.exception("Failed to scan devices: %s", e)
             message = "\n\n".join([str(e), _(e.suggestion)])
             raise UnusableStorageError(message) from None
 


### PR DESCRIPTION
When we re-raise an exception from None, log the information about the original
exception. Otherwise, we might not be able to find the cause of the error.