### PR TITLE
Revert "Do not build Anaconda on i686"

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -148,11 +148,6 @@ Obsoletes: anaconda-runtime < %{version}-%{release}
 Provides: anaconda-runtime = %{version}-%{release}
 Obsoletes: booty <= 0.107-1
 
-# native i686 installations are not supported on RHEL8 and Anaconda
-# is not a i686 compatibility library, so building it for i686 does not
-# make sense
-ExcludeArch: i686
-
 %description core
 The anaconda-core package contains the program which was used to install your
 system.


### PR DESCRIPTION
This reverts commit 63f85f6226bcdca800129d2ed311c37736a3b6d7.

Turns out that anaconda-widgets.i686 has been shipped to customers
so there is a slight chance that dropping the i686 might cause issues.

So revert the commit that disables the i686 Anaconda build.

Resolves: rhbz#1857180