### PR TITLE
Don't return negative container free space

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
@@ -111,7 +111,12 @@ class DeviceTreeSchedulerModule(DeviceTreeModule):
         :return: a size in bytes
         """
         container = self._get_device(container_name)
-        return Size(getattr(container, "free_space", 0)).get_bytes()
+        free_space = getattr(container, "free_space", 0)
+
+        if free_space < 0:
+            free_space = 0
+
+        return Size(free_space).get_bytes()
 
     def generate_system_name(self):
         """Generate a name of the new installation.

--- a/tests/nosetests/pyanaconda_tests/module_scheduler_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_scheduler_test.py
@@ -807,6 +807,10 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self.assertGreater(free_space, Size("9 GiB").get_bytes())
         self.assertLess(free_space, Size("10 GiB").get_bytes())
 
+        dev2.reserved_percent = 110
+        free_space = self.interface.GetContainerFreeSpace("dev2")
+        self.assertEqual(free_space, Size("0 GiB").get_bytes())
+
     @patch_dbus_get_proxy
     def generate_container_name_test(self, proxy_getter):
         """Test GenerateContainerName."""


### PR DESCRIPTION
The DBus method GetContainerFreeSpace is supposed to return an unsigned integer,
so adjust the return value in case that Blivet returned a negative value.

Resolves: rhbz#1853071