### PR TITLE
Fix stage2 as default sources

### DIFF
--- a/pyanaconda/modules/payloads/source/cdrom/cdrom.py
+++ b/pyanaconda/modules/payloads/source/cdrom/cdrom.py
@@ -32,7 +32,12 @@ log = get_module_logger(__name__)
 
 
 class CdromSourceModule(PayloadSourceBase, MountingSourceMixin, RPMSourceMixin):
-    """The CD-ROM source payload module."""
+    """The CD-ROM source payload module.
+
+    This source will try to automatically detect installation source. First it tries to look only
+    stage2 device used to boot the environment then it will use first valid iso9660 media with a
+    valid structure.
+    """
 
     def __init__(self):
         super().__init__()

--- a/pyanaconda/modules/payloads/source/cdrom/cdrom_interface.py
+++ b/pyanaconda/modules/payloads/source/cdrom/cdrom_interface.py
@@ -25,7 +25,12 @@ from pyanaconda.modules.payloads.source.source_base_interface import PayloadSour
 
 @dbus_interface(PAYLOAD_SOURCE_CDROM.interface_name)
 class CdromSourceInterface(PayloadSourceBaseInterface):
-    """Interface for the payload CD-ROM image source."""
+    """Interface for the payload CD-ROM image source.
+
+    This source will try to automatically detect installation source. First it tries to look only
+    stage2 device used to boot the environment then it will use first valid iso9660 media with a
+    valid structure.
+    """
 
     def connect_signals(self):
         super().connect_signals()

--- a/pyanaconda/modules/payloads/source/cdrom/initialization.py
+++ b/pyanaconda/modules/payloads/source/cdrom/initialization.py
@@ -15,13 +15,15 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.errors.payload import SourceSetupError
-from pyanaconda.modules.payloads.source.mount_tasks import SetUpMountTask
 from pyanaconda.modules.common.structures.storage import DeviceData
-from pyanaconda.payload.utils import mount, unmount, PayloadSetupError
+from pyanaconda.modules.payloads.source.mount_tasks import SetUpMountTask
 from pyanaconda.modules.payloads.source.utils import is_valid_install_disk
+from pyanaconda.payload.source.factory import SourceFactory, PayloadSourceTypeUnrecognized
+from pyanaconda.payload.utils import mount, unmount, PayloadSetupError
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -37,13 +39,62 @@ class SetUpCdromSourceTask(SetUpMountTask):
         return "Set up CD-ROM Installation Source"
 
     def _do_mount(self):
-        """Run CD-ROM installation source setup."""
-        log.debug("Trying to detect CD-ROM automatically")
+        """Run CD-ROM installation source setup.
 
+        Try to discover installation media and mount that. Device used for booting (inst.stage2)
+        has a priority.
+        """
+        log.debug("Trying to detect CD-ROM automatically")
         device_tree = STORAGE.get_proxy(DEVICE_TREE)
+
+        device_candidates = self._get_device_candidate_list(device_tree)
+        device_name = self._choose_installation_device(device_tree, device_candidates)
+
+        if not device_name:
+            raise SourceSetupError("Found no CD-ROM")
+
+        return device_name
+
+    def _get_device_candidate_list(self, device_tree):
+        stage2_device = self._probe_stage2_for_cdrom(device_tree)
+        device_candidates = device_tree.FindOpticalMedia()
+
+        if stage2_device in device_candidates:
+            device_candidates = [stage2_device] + device_candidates
+
+        return device_candidates
+
+    @staticmethod
+    def _probe_stage2_for_cdrom(device_tree):
+        # TODO: This is temporary method which should be moved closer to the inst.repo logic
+        log.debug("Testing if inst.stage2 is a CDROM device")
+        stage2_string = kernel_arguments.get("stage2")
+
+        if not stage2_string:
+            return None
+
+        try:
+            source = SourceFactory.parse_repo_cmdline_string(stage2_string)
+        except PayloadSourceTypeUnrecognized:
+            log.warning("Unknown stage2 method: %s", stage2_string)
+            return None
+
+        # We have HDD here because DVD ISO has inst.stage2=hd:LABEL=....
+        # TODO: Let's return back support of inst.cdrom=<device> which should work based on the
+        # documentation and use that as inst.stage2 parameter for Pungi
+        if not source.is_harddrive:
+            log.debug("Stage2 can't be used as source %s", stage2_string)
+            return None
+
+        # We can ignore source.path here because DVD ISOs are not using that.
+        stage2_device = device_tree.ResolveDevice(source.partition)
+        log.debug("Found possible stage2 default installation source %s", stage2_device)
+        return stage2_device
+
+    def _choose_installation_device(self, device_tree, devices_candidates):
         device_name = ""
 
-        for dev_name in device_tree.FindOpticalMedia():
+        for dev_name in devices_candidates:
             try:
                 device_data = DeviceData.from_structure(device_tree.GetDeviceData(dev_name))
                 mount(device_data.path, self._target_mount, "iso9660", "ro")
@@ -57,8 +108,5 @@ class SetUpCdromSourceTask(SetUpMountTask):
                 break
             else:
                 unmount(self._target_mount)
-
-        if not device_name:
-            raise SourceSetupError("Found no CD-ROM")
 
         return device_name

--- a/pyanaconda/modules/payloads/source/utils.py
+++ b/pyanaconda/modules/payloads/source/utils.py
@@ -84,10 +84,10 @@ def find_and_mount_device(device_spec, mount_point):
     device_path = "/dev/" + matches[0]
 
     try:
-        # FIXME: Add back RO mounting. This was removed because we can't mount one source
-        # RW and RO at the same time. This source is also mounted by IsoChooser dialog in the
-        # SourceSpoke.
-        mount(device_path, mount_point, "auto")
+        mount(device=device_path,
+              mountpoint=mount_point,
+              fstype="auto",
+              options="defaults,ro")
         return True
     except OSError as e:
         log.error("Mount of device failed: %s", e)

--- a/pyanaconda/modules/storage/devicetree/handler.py
+++ b/pyanaconda/modules/storage/devicetree/handler.py
@@ -82,16 +82,17 @@ class DeviceTreeHandler(ABC):
             msg = "Failed to tear down {}: {}".format(device_name, str(e))
             raise DeviceSetupError(msg) from None
 
-    def mount_device(self, device_name, mount_point):
+    def mount_device(self, device_name, mount_point, options):
         """Mount a filesystem on the device.
 
         :param device_name: a name of the device
         :param mount_point: a path to the mount point
+        :param options: a string with mount options or an empty string to use defaults
         :raise: MountFilesystemError if mount fails
         """
         device = self._get_device(device_name)
         try:
-            device.format.mount(mountpoint=mount_point)
+            device.format.mount(mountpoint=mount_point, options=options or None)
         except FSError as e:
             msg = "Failed to mount {} at {}: {}". format(
                 device_name,

--- a/pyanaconda/modules/storage/devicetree/handler_interface.py
+++ b/pyanaconda/modules/storage/devicetree/handler_interface.py
@@ -46,14 +46,15 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
         """
         self.implementation.teardown_device(device_name)
 
-    def MountDevice(self, device_name: Str, mount_point: Str):
+    def MountDevice(self, device_name: Str, mount_point: Str, options: Str):
         """Mount a filesystem on the device.
 
         :param device_name: a name of the device
         :param mount_point: a path to the mount point
+        :param options: a string with mount options or an empty string to use defaults
         :raise: MountFilesystemError if mount fails
         """
-        self.implementation.mount_device(device_name, mount_point)
+        self.implementation.mount_device(device_name, mount_point, options)
 
     def UnmountDevice(self, device_name: Str, mount_point: Str):
         """Unmount a filesystem on the device.

--- a/pyanaconda/payload/utils.py
+++ b/pyanaconda/payload/utils.py
@@ -71,7 +71,7 @@ def mount_device(device_name, mount_point):
     :param str mount_point: a path to the mount point
     """
     device_tree = STORAGE.get_proxy(DEVICE_TREE)
-    device_tree.MountDevice(device_name, mount_point)
+    device_tree.MountDevice(device_name, mount_point, "ro")
 
 
 def unmount_device(device_name, mount_point):


### PR DESCRIPTION
We should prioritize stage2 device as the default source. This is especially needed for DVD ISO because it is booting with inst.stage2 instead and we should use the DVD as the source for the default CDROM. The situation is even worse thanks to the fact that DVD ISOs are using inst.stage2=hd:...

Find stage2 device and test this device first during the auto-discover feature of CDRom source.

Backport of https://github.com/rhinstaller/anaconda/pull/2747.