### PR TITLE
Allow to detect devices with the iso9660 file system as optical media

### DIFF
--- a/pyanaconda/modules/storage/devicetree/model.py
+++ b/pyanaconda/modules/storage/devicetree/model.py
@@ -303,6 +303,11 @@ class InstallerStorage(Blivet):
         # cdroms, involves unmounting which is undesirable (see bug #1671713).
         protected.extend(dev for dev in self.devicetree.devices if dev.type == "cdrom")
 
+        # Protect also all devices with an iso9660 file system. It will protect
+        # NVDIMM devices that can be used only as an installation source anyway
+        # (see the bug #1856264).
+        protected.extend(dev for dev in self.devicetree.devices if dev.format.type == "iso9660")
+
         # Mark the collected devices as protected.
         for dev in protected:
             log.debug("Marking device %s as protected.", dev.name)


### PR DESCRIPTION
Test that the DBus method FindOpticalMedia identifies devices with the iso9660 file
system as optical media, so it is able to find NVDIMM devices with iso9660.

The DBus method GetDevicesToIgnore of the NVDIMM module shouldn't return NVDIMM
devices with the iso9660 file system. They can be used as an installation source.

Protect all devices with the iso9660 file system. It will protect, for example, NVDIMM
devices with the iso9660 file system that can be used only as an installation source
anyway.

Backport of https://github.com/rhinstaller/anaconda/pull/2746.

Should be merged together with https://github.com/rhinstaller/anaconda/pull/2749.