### PR TITLE
Restore RHEL-specific stylesheet data (#1865882)

### DIFF
--- a/data/anaconda-gtk.css
+++ b/data/anaconda-gtk.css
@@ -95,7 +95,7 @@ infobar.error {
 
 /* theme colors/images */
 
-@define-color product_bg_color @fedora;
+@define-color product_bg_color @redhat;
 
 /* logo and sidebar classes */
 
@@ -126,7 +126,7 @@ infobar.error {
 AnacondaSpokeWindow #nav-box {
     background-color: @product_bg_color;
     background-image: url('/usr/share/anaconda/pixmaps/topbar-bg.png');
-    background-repeat: repeat;
+    background-repeat: no-repeat;
     color: white;
 }
 


### PR DESCRIPTION
* Change the product background color to `@redhat`.
* Don't repeat the background image of the navigation bar.

(based on commits a7fa66a and abb73fa)

Resolves: rhbz#1865882