### PR TITLE
Fixes in the Installation Source spoke

### DIFF
--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -958,13 +958,6 @@ class DNFPayload(Payload):
         return [r.name for r in self.data.repo.dataList()]
 
     @property
-    def mirrors_available(self):
-        """Is the closest/fastest mirror option enabled?  This does not make
-        sense for those payloads that do not support this concept.
-        """
-        return conf.payload.enable_closest_mirror
-
-    @property
     def disabled_repos(self):
         """A list of names of the disabled repos."""
         disabled = []

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -844,7 +844,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         # provided a URL.
         # FIXME
 
-        self._reset_repo_store()
+        gtk_call_once(self._reset_repo_store)
 
         self._ready = True
         # Wait to make sure the other threads are done before sending ready, otherwise

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -799,7 +799,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
 
         # If there's no fallback mirror to use, we should just disable that option
         # in the UI.
-        if not self.payload.mirrors_available:
+        if not conf.payload.enable_closest_mirror:
             model = self._protocol_combo_box.get_model()
             itr = model.get_iter_first()
             while itr and model[itr][self._protocol_combo_box.get_id_column()] != PROTOCOL_MIRROR:

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -720,6 +720,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         self.initialize_start()
 
         self._grab_objects()
+        self._initialize_closest_mirror()
 
         # I shouldn't have to do this outside GtkBuilder, but it really doesn't
         # want to let me pass in user data.
@@ -794,9 +795,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         self._ready = True
         hubQ.send_ready(self.__class__.__name__, False)
 
-    def _initialize(self):
-        threadMgr.wait(constants.THREAD_PAYLOAD)
-
+    def _initialize_closest_mirror(self):
         # If there's no fallback mirror to use, we should just disable that option
         # in the UI.
         if not conf.payload.enable_closest_mirror:
@@ -807,6 +806,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
 
             if itr:
                 model.remove(itr)
+
+    def _initialize(self):
+        threadMgr.wait(constants.THREAD_PAYLOAD)
 
         # Get the current source.
         source_proxy = self.payload.get_source_proxy()

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -16,6 +16,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.payload import parse_nfs_url
 from pyanaconda.flags import flags
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
@@ -128,7 +129,7 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
         self._container = ListColumnContainer(1, columns_width=78, spacing=1)
 
         if args == self.SET_NETWORK_INSTALL_MODE:
-            if self.payload.mirrors_available:
+            if conf.payload.enable_closest_mirror:
                 self._container.add(TextWidget(_("Closest mirror")),
                                     self._set_network_close_mirror)
 


### PR DESCRIPTION
Remove the mirrors_available property. Use the configuration option
enable_closest_mirror instead.

Disable the option for the closest mirror from the main thread in GUI.

Reset the store of repositories from the main thread in GUI.
