### PR TITLE
Apply onboot policy even when network was configured in UI.

### DIFF
--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -366,9 +366,6 @@ class NetworkService(KickstartService):
         # Not if any network device was configured via kickstart.
         if self._original_network_data:
             return False
-        # Not if any network device was configured in UI.
-        if self._use_device_configurations:
-            return False
         # Not if there is no configuration to apply the policy to
         if not self._device_configurations or not self._device_configurations.get_all():
             return False


### PR DESCRIPTION
Resolves: rhbz#1856632

Brings back behaviour from RHEL 7 and RHEL 8.2