### PR TITLE
Rhel 8 always recreate unified repos

### DIFF
--- a/pyanaconda/payload/base.py
+++ b/pyanaconda/payload/base.py
@@ -39,8 +39,6 @@ class Payload(metaclass=ABCMeta):
         """
         self.data = data
 
-        self._first_payload_reset = True
-
         # A list of verbose error strings from the subclass
         self.verbose_errors = []
 
@@ -67,10 +65,6 @@ class Payload(metaclass=ABCMeta):
         """The DBus type of the source."""
         return None
 
-    @property
-    def first_payload_reset(self):
-        return self._first_payload_reset
-
     def is_ready(self):
         """Is the payload ready?"""
         return True
@@ -89,7 +83,7 @@ class Payload(metaclass=ABCMeta):
 
         This method could be overriden.
         """
-        self._first_payload_reset = False
+        pass
 
     def release(self):
         """Release any resources in use by this object, but do not do final

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -1931,7 +1931,11 @@ class DNFPayload(Payload):
                     repo.treeinfo_origin = True
                     log.debug("Adding new treeinfo repository: %s enabled: %s",
                               repo_md.name, repo_enabled)
-                    self.add_repo(repo)
+
+                    if repo_enabled:
+                        self.add_repo(repo)
+                    else:
+                        self.add_disabled_repo(repo)
 
     def _cleanup_old_treeinfo_repositories(self):
         """Remove all old treeinfo repositories before loading new ones.

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -1531,7 +1531,7 @@ class DNFPayload(Payload):
         log.info("Configuring the base repo")
         self.reset()
 
-        self._cleanup_old_treeinfo_repositories()
+        disabled_treeinfo_repo_names = self._cleanup_old_treeinfo_repositories()
 
         # Find the source and its type.
         source_proxy = self.get_source_proxy()
@@ -1587,7 +1587,7 @@ class DNFPayload(Payload):
                 base_repo_url = self._get_base_repo_location(install_tree_url)
                 log.debug("releasever from %s is %s", base_repo_url, self._base.conf.releasever)
 
-                self._load_treeinfo_repositories(base_repo_url)
+                self._load_treeinfo_repositories(base_repo_url, disabled_treeinfo_repo_names)
             except configparser.MissingSectionHeaderError as e:
                 log.error("couldn't set releasever from base repo (%s): %s", source_type, e)
 
@@ -1896,11 +1896,13 @@ class DNFPayload(Payload):
         log.debug("No base repository found in treeinfo file. Using installation tree root.")
         return install_tree_url
 
-    def _load_treeinfo_repositories(self, base_repo_url):
+    def _load_treeinfo_repositories(self, base_repo_url, repo_names_to_disable):
         """Load new repositories from treeinfo file.
 
         :param base_repo_url: base repository url. This is not saved anywhere when the function
                               is called. It will be add to the existing urls if not None.
+        :param repo_names_to_disable: list of repository names which should be disabled after load
+        :type repo_names_to_disable: [str]
         """
         if self._install_tree_metadata:
             existing_urls = []
@@ -1917,11 +1919,18 @@ class DNFPayload(Payload):
             for repo_md in self._install_tree_metadata.get_metadata_repos():
                 if repo_md.path not in existing_urls:
                     repo_treeinfo = self._install_tree_metadata.get_treeinfo_for(repo_md.name)
-                    repo_enabled = repo_treeinfo.type in enabled_repositories_from_treeinfo
+
+                    # disable repositories disabled by user manually before
+                    if repo_md.name in repo_names_to_disable:
+                        repo_enabled = False
+                    else:
+                        repo_enabled = repo_treeinfo.type in enabled_repositories_from_treeinfo
+
                     repo = RepoData(name=repo_md.name, baseurl=repo_md.path,
                                     install=False, enabled=repo_enabled)
                     repo.treeinfo_origin = True
-                    log.debug("Adding new treeinfo repository %s", repo_md.name)
+                    log.debug("Adding new treeinfo repository: %s enabled: %s",
+                              repo_md.name, repo_enabled)
                     self.add_repo(repo)
 
     def _cleanup_old_treeinfo_repositories(self):
@@ -1929,11 +1938,23 @@ class DNFPayload(Payload):
 
         Find all repositories added from treeinfo file and remove them. After this step new
         repositories will be loaded from the new link.
+
+        :return: list of repository names which were disabled before removal
+        :rtype: [str]
         """
+        disabled_repo_names = []
+
         for ks_repo_name in self.addons:
-            if self.get_addon_repo(ks_repo_name).treeinfo_origin:
+            repo = self.get_addon_repo(ks_repo_name)
+            if repo.treeinfo_origin:
                 log.debug("Removing old treeinfo repository %s", ks_repo_name)
+
+                if not repo.enabled:
+                    disabled_repo_names.append(ks_repo_name)
+
                 self.remove_repo(ks_repo_name)
+
+        return disabled_repo_names
 
     def _write_dnf_repo(self, repo, repo_path):
         """Write a repo object to a DNF repo.conf file.

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -763,6 +763,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         self.initialize_start()
 
         self._grab_objects()
+        self._initialize_closest_mirror()
 
         # I shouldn't have to do this outside GtkBuilder, but it really doesn't
         # want to let me pass in user data.
@@ -838,9 +839,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         self._ready = True
         hubQ.send_ready(self.__class__.__name__, False)
 
-    def _initialize(self):
-        threadMgr.wait(constants.THREAD_PAYLOAD)
-
+    def _initialize_closest_mirror(self):
         # If there's no fallback mirror to use, we should just disable that option
         # in the UI.
         if not self.payload.mirrors_available:
@@ -851,6 +850,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
 
             if itr:
                 model.remove(itr)
+
+    def _initialize(self):
+        threadMgr.wait(constants.THREAD_PAYLOAD)
 
         # If there is no Subscriptiopn DBus module, disable the CDN radio button
         if is_module_available(SUBSCRIPTION):

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1694,10 +1694,12 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
 
         # Remove the input validation checks for this repo
         repo = self._repo_store[itr][REPO_OBJ]
-        self.remove_check(self._repo_checks[repo.repo_id].name_check)
-        self.remove_check(self._repo_checks[repo.repo_id].url_check)
-        self.remove_check(self._repo_checks[repo.repo_id].proxy_check)
-        del self._repo_checks[repo.repo_id]
+        # avoid crash when the source is changed because of initialization
+        if repo.repo_id in self._repo_checks:
+            self.remove_check(self._repo_checks[repo.repo_id].name_check)
+            self.remove_check(self._repo_checks[repo.repo_id].url_check)
+            self.remove_check(self._repo_checks[repo.repo_id].proxy_check)
+            del self._repo_checks[repo.repo_id]
 
         self._repo_store.remove(itr)
         if len(self._repo_store) == 0:

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -892,7 +892,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         # provided a URL.
         # FIXME
 
-        self._reset_repo_store()
+        gtk_call_once(self._reset_repo_store)
 
         self._ready = True
         # Wait to make sure the other threads are done before sending ready, otherwise

--- a/pyanaconda/ui/lib/subscription.py
+++ b/pyanaconda/ui/lib/subscription.py
@@ -275,11 +275,6 @@ def register_and_subscribe(payload, progress_callback=None, error_callback=None)
     if source_proxy.Type in SOURCE_TYPES_OVERRIDEN_BY_CDN:
         log.debug("subscription thread: overriding current installation source by CDN")
         switch_source(payload, SOURCE_TYPE_CDN)
-        # disable automatically added treeinfo repos so that
-        # they do not interfere with the CDN
-        for repo in payload.data.repo.dataList():
-            if repo.treeinfo_origin:
-                repo.enabled = False
 
     # and done, report attaching subscription was successful
     log.debug("subscription thread: auto attach succeeded")


### PR DESCRIPTION
This will solve problem that additional repositories pointing to an invalid path. This is happening because we moved source mounting to a different folders for each source. By this patch we will always reload new treeinfo repository if user change the base source repository.

Also this changed behavior of Source spoke. The Source spoke does not disable repository on base repo switch but instead it will remove this repository and the repository will be reloaded when user re-enter the spoke. It's not ideal solution but doable with avoiding great amount of changes everywhere.

Resolves: rhbz#1851207