### PR TITLE
Match names from ignoredisk after setting up all devices

### DIFF
--- a/pyanaconda/modules/storage/kickstart.py
+++ b/pyanaconda/modules/storage/kickstart.py
@@ -144,7 +144,7 @@ class StorageKickstartSpecification(KickstartSpecification):
         "autopart": AutoPart,
         "bootloader": COMMANDS.Bootloader,
         "clearpart": ClearPart,
-        "ignoredisk": IgnoreDisk,
+        "ignoredisk": COMMANDS.IgnoreDisk,
         "logvol": COMMANDS.LogVol,
         "mount": COMMANDS.Mount,
         "part": COMMANDS.Partition,


### PR DESCRIPTION
We should match names specified by the ignoredisk kickstart command after
we set up devices defined by iscsi, fcoe and other kickstart commands. Parse
the ignoredisk command in UI and update the Disk Selection module to fix it.