### PR TITLE
drop workarounds for the TLS exhaustion issue on aarch64 and ppc64le

### DIFF
--- a/data/dbus/org.fedoraproject.Anaconda.Modules.Payloads.service
+++ b/data/dbus/org.fedoraproject.Anaconda.Modules.Payloads.service
@@ -1,4 +1,4 @@
 [D-BUS Service]
 Name=org.fedoraproject.Anaconda.Modules.Payloads
-Exec=/usr/libexec/anaconda/start-module --env LD_PRELOAD=libgomp.so.1 pyanaconda.modules.payloads
+Exec=/usr/libexec/anaconda/start-module pyanaconda.modules.payloads
 User=root

--- a/data/tmux.conf
+++ b/data/tmux.conf
@@ -18,12 +18,7 @@ set-option -g history-limit 10000
 
 # The idea here is to detach the client started here via anaconda.service, and
 # then re-attach to it in the tmux service run on the console tty.
-
-# FIXME: Temporary hot fix added to make Fedora installable on aarch64 and ppc64le.
-# For more infromation see:
-# rhbz#1764666
-# rhbz#1722181
-new-session -d -s anaconda -n main "LD_PRELOAD=libgomp.so.1 anaconda"
+new-session -d -s anaconda -n main anaconda
 
 set-option status-right '#[fg=blue]#(echo -n "Switch tab: Alt+Tab | Help: F1 ")'
 


### PR DESCRIPTION
This reverts the workaround from commits ff06b13c273bcabd538eec2095d480867166f0fd and
cd9d85adbdbc637090926f6c5459b9c1faee4323.

Related: rhbz#1764666, rhbz#1722181