### PR TITLE
Always recreate unified repos

### DIFF
--- a/pyanaconda/payload/base.py
+++ b/pyanaconda/payload/base.py
@@ -39,8 +39,6 @@ class Payload(metaclass=ABCMeta):
         """
         self.data = data
 
-        self._first_payload_reset = True
-
         # A list of verbose error strings from the subclass
         self.verbose_errors = []
 
@@ -67,10 +65,6 @@ class Payload(metaclass=ABCMeta):
         """The DBus type of the source."""
         return None
 
-    @property
-    def first_payload_reset(self):
-        return self._first_payload_reset
-
     def is_ready(self):
         """Is the payload ready?"""
         return True
@@ -89,7 +83,7 @@ class Payload(metaclass=ABCMeta):
 
         This method could be overriden.
         """
-        self._first_payload_reset = False
+        pass
 
     def release(self):
         """Release any resources in use by this object, but do not do final

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -1852,7 +1852,11 @@ class DNFPayload(Payload):
                     repo.treeinfo_origin = True
                     log.debug("Adding new treeinfo repository: %s enabled: %s",
                               repo_md.name, repo_enabled)
-                    self.add_repo(repo)
+
+                    if repo_enabled:
+                        self.add_repo(repo)
+                    else:
+                        self.add_disabled_repo(repo)
 
     def _cleanup_old_treeinfo_repositories(self):
         """Remove all old treeinfo repositories before loading new ones.

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -1455,6 +1455,8 @@ class DNFPayload(Payload):
         log.info("Configuring the base repo")
         self.reset()
 
+        self._cleanup_old_treeinfo_repositories()
+
         # Find the source and its type.
         source_proxy = self.get_source_proxy()
         source_type = source_proxy.Type
@@ -1507,11 +1509,9 @@ class DNFPayload(Payload):
                 self._refresh_install_tree(data)
                 self._base.conf.releasever = self._get_release_version(install_tree_url)
                 base_repo_url = self._get_base_repo_location(install_tree_url)
-
-                if self.first_payload_reset:
-                    self._add_treeinfo_repositories(install_tree_url, base_repo_url)
-
                 log.debug("releasever from %s is %s", base_repo_url, self._base.conf.releasever)
+
+                self._load_treeinfo_repositories(base_repo_url)
             except configparser.MissingSectionHeaderError as e:
                 log.error("couldn't set releasever from base repo (%s): %s", source_type, e)
 
@@ -1817,12 +1817,11 @@ class DNFPayload(Payload):
         log.debug("No base repository found in treeinfo file. Using installation tree root.")
         return install_tree_url
 
-    def _add_treeinfo_repositories(self, install_tree_url, base_repo_url=None):
-        """Add all repositories from treeinfo file which are not already loaded.
+    def _load_treeinfo_repositories(self, base_repo_url):
+        """Load new repositories from treeinfo file.
 
-        :param install_tree_url: Url to the installation tree root.
-        :param base_repo_url: Base repository url. This is not saved anywhere when the function
-        is called. It will be add to the existing urls if not None.
+        :param base_repo_url: base repository url. This is not saved anywhere when the function
+                              is called. It will be add to the existing urls if not None.
         """
         if self._install_tree_metadata:
             existing_urls = []
@@ -1843,9 +1842,19 @@ class DNFPayload(Payload):
                     repo = RepoData(name=repo_md.name, baseurl=repo_md.path,
                                     install=False, enabled=repo_enabled)
                     repo.treeinfo_origin = True
+                    log.debug("Adding new treeinfo repository %s", repo_md.name)
                     self.add_repo(repo)
 
-        return install_tree_url
+    def _cleanup_old_treeinfo_repositories(self):
+        """Remove all old treeinfo repositories before loading new ones.
+
+        Find all repositories added from treeinfo file and remove them. After this step new
+        repositories will be loaded from the new link.
+        """
+        for ks_repo_name in self.addons:
+            if self.get_addon_repo(ks_repo_name).treeinfo_origin:
+                log.debug("Removing old treeinfo repository %s", ks_repo_name)
+                self.remove_repo(ks_repo_name)
 
     def _write_dnf_repo(self, repo, repo_path):
         """Write a repo object to a DNF repo.conf file.

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -872,8 +872,7 @@ class DNFPayload(Payload):
         """Add an enabled repo to dnf and kickstart repo lists.
 
         Add the repo given by the pykickstart Repo object ksrepo to the
-        system.  The repo will be automatically enabled and its metadata
-        fetched.
+        system.
 
         Duplicate repos will not raise an error.  They should just silently
         take the place of the previous value.
@@ -882,11 +881,11 @@ class DNFPayload(Payload):
         :type ksrepo: Kickstart RepoData object.
         :returns: None
         """
-        self._add_repo(ksrepo)
-        self._fetch_md(ksrepo.name)
+        if ksrepo.enabled:
+            self._add_repo(ksrepo)
+            self._fetch_md(ksrepo.name)
 
         # Add the repo to the ksdata so it'll appear in the output ks file.
-        ksrepo.enabled = True
         self.data.repo.dataList().append(ksrepo)
 
     def _add_repo(self, ksrepo):
@@ -986,16 +985,6 @@ class DNFPayload(Payload):
 
         log.info("enabled repo: '%s' - %s and got repomd", repo.id,
                  repo.baseurl or repo.mirrorlist or repo.metalink)
-
-    def add_disabled_repo(self, ksrepo):
-        """Add the repo given by the pykickstart Repo object ksrepo to the
-        list of known repos.  The repo will be automatically disabled.
-
-        Duplicate repos will not raise an error.  They should just silently
-        take the place of the previous value.
-        """
-        ksrepo.enabled = False
-        self.data.repo.dataList().append(ksrepo)
 
     def remove_repo(self, repo_id):
         repos = self.data.repo.dataList()
@@ -1853,10 +1842,7 @@ class DNFPayload(Payload):
                     log.debug("Adding new treeinfo repository: %s enabled: %s",
                               repo_md.name, repo_enabled)
 
-                    if repo_enabled:
-                        self.add_repo(repo)
-                    else:
-                        self.add_disabled_repo(repo)
+                    self.add_repo(repo)
 
     def _cleanup_old_treeinfo_repositories(self):
         """Remove all old treeinfo repositories before loading new ones.

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -1455,7 +1455,7 @@ class DNFPayload(Payload):
         log.info("Configuring the base repo")
         self.reset()
 
-        self._cleanup_old_treeinfo_repositories()
+        disabled_treeinfo_repo_names = self._cleanup_old_treeinfo_repositories()
 
         # Find the source and its type.
         source_proxy = self.get_source_proxy()
@@ -1511,7 +1511,7 @@ class DNFPayload(Payload):
                 base_repo_url = self._get_base_repo_location(install_tree_url)
                 log.debug("releasever from %s is %s", base_repo_url, self._base.conf.releasever)
 
-                self._load_treeinfo_repositories(base_repo_url)
+                self._load_treeinfo_repositories(base_repo_url, disabled_treeinfo_repo_names)
             except configparser.MissingSectionHeaderError as e:
                 log.error("couldn't set releasever from base repo (%s): %s", source_type, e)
 
@@ -1817,11 +1817,13 @@ class DNFPayload(Payload):
         log.debug("No base repository found in treeinfo file. Using installation tree root.")
         return install_tree_url
 
-    def _load_treeinfo_repositories(self, base_repo_url):
+    def _load_treeinfo_repositories(self, base_repo_url, repo_names_to_disable):
         """Load new repositories from treeinfo file.
 
         :param base_repo_url: base repository url. This is not saved anywhere when the function
                               is called. It will be add to the existing urls if not None.
+        :param repo_names_to_disable: list of repository names which should be disabled after load
+        :type repo_names_to_disable: [str]
         """
         if self._install_tree_metadata:
             existing_urls = []
@@ -1838,11 +1840,18 @@ class DNFPayload(Payload):
             for repo_md in self._install_tree_metadata.get_metadata_repos():
                 if repo_md.path not in existing_urls:
                     repo_treeinfo = self._install_tree_metadata.get_treeinfo_for(repo_md.name)
-                    repo_enabled = repo_treeinfo.type in enabled_repositories_from_treeinfo
+
+                    # disable repositories disabled by user manually before
+                    if repo_md.name in repo_names_to_disable:
+                        repo_enabled = False
+                    else:
+                        repo_enabled = repo_treeinfo.type in enabled_repositories_from_treeinfo
+
                     repo = RepoData(name=repo_md.name, baseurl=repo_md.path,
                                     install=False, enabled=repo_enabled)
                     repo.treeinfo_origin = True
-                    log.debug("Adding new treeinfo repository %s", repo_md.name)
+                    log.debug("Adding new treeinfo repository: %s enabled: %s",
+                              repo_md.name, repo_enabled)
                     self.add_repo(repo)
 
     def _cleanup_old_treeinfo_repositories(self):
@@ -1850,11 +1859,23 @@ class DNFPayload(Payload):
 
         Find all repositories added from treeinfo file and remove them. After this step new
         repositories will be loaded from the new link.
+
+        :return: list of repository names which were disabled before removal
+        :rtype: [str]
         """
+        disabled_repo_names = []
+
         for ks_repo_name in self.addons:
-            if self.get_addon_repo(ks_repo_name).treeinfo_origin:
+            repo = self.get_addon_repo(ks_repo_name)
+            if repo.treeinfo_origin:
                 log.debug("Removing old treeinfo repository %s", ks_repo_name)
+
+                if not repo.enabled:
+                    disabled_repo_names.append(ks_repo_name)
+
                 self.remove_repo(ks_repo_name)
+
+        return disabled_repo_names
 
     def _write_dnf_repo(self, repo, repo_path):
         """Write a repo object to a DNF repo.conf file.

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1639,10 +1639,12 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
 
         # Remove the input validation checks for this repo
         repo = self._repo_store[itr][REPO_OBJ]
-        self.remove_check(self._repo_checks[repo.repo_id].name_check)
-        self.remove_check(self._repo_checks[repo.repo_id].url_check)
-        self.remove_check(self._repo_checks[repo.repo_id].proxy_check)
-        del self._repo_checks[repo.repo_id]
+        # avoid crash when the source is changed because of initialization
+        if repo.repo_id in self._repo_checks:
+            self.remove_check(self._repo_checks[repo.repo_id].name_check)
+            self.remove_check(self._repo_checks[repo.repo_id].url_check)
+            self.remove_check(self._repo_checks[repo.repo_id].proxy_check)
+            del self._repo_checks[repo.repo_id]
 
         self._repo_store.remove(itr)
         if len(self._repo_store) == 0:

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -429,8 +429,6 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         self._network_module = NETWORK.get_proxy()
         self._device_tree = STORAGE.get_proxy(DEVICE_TREE)
 
-        self._treeinfo_repos_already_disabled = False
-
     def apply(self):
         source_changed = self._update_payload_source()
         repo_changed = self._update_payload_repos()
@@ -1205,7 +1203,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         # the newly enabled button as well as the previously enabled (now
         # disabled) button.
         self._on_source_toggled(button, relatedBox)
-        self._disable_treeinfo_repositories()
+        self._remove_treeinfo_repositories()
 
     def _on_source_toggled(self, button, relatedBox):
         enabled = button.get_active()
@@ -1283,7 +1281,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
             button.set_label(os.path.basename(iso_file))
             button.set_use_underline(False)
             self._verify_iso_button.set_sensitive(True)
-            self._disable_treeinfo_repositories()
+            self._remove_treeinfo_repositories()
 
     def on_proxy_clicked(self, button):
         dialog = ProxyDialog(self.data, self._proxy_url)
@@ -1331,7 +1329,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
 
     def on_protocol_changed(self, combo):
         self._on_protocol_changed()
-        self._disable_treeinfo_repositories()
+        self._remove_treeinfo_repositories()
 
     def _on_protocol_changed(self):
         # Only allow the URL entry to be used if we're using an HTTP/FTP
@@ -1431,8 +1429,6 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
             self._clear_repo_info()
             self._repo_entry_box.set_sensitive(False)
 
-        self._treeinfo_repos_already_disabled = False
-
     def _unique_repo_name(self, name):
         """ Return a unique variation of the name if it already
             exists in the repo store.
@@ -1491,13 +1487,16 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         self._repo_store[repo_model_path][REPO_ENABLED_COL] = enabled
         self._repo_store[repo_model_path][REPO_OBJ].enabled = enabled
 
-    def _disable_treeinfo_repositories(self):
+    def _remove_treeinfo_repositories(self):
         """Disable all repositories loaded from the .treeinfo file"""
-        if not self._treeinfo_repos_already_disabled:
-            self._treeinfo_repos_already_disabled = True
-            for repo_item in self._repo_store:
-                if repo_item[REPO_OBJ].treeinfo_origin:
-                    self._set_repo_enabled(repo_item.path, False)
+        removal_repo_list = []
+
+        for repo_item in self._repo_store:
+            if repo_item[REPO_OBJ].treeinfo_origin:
+                removal_repo_list.append(repo_item.path)
+
+        for path in removal_repo_list:
+            self._remove_repository(path)
 
     def _clear_repo_info(self):
         """ Clear the text from the repo entry fields
@@ -1589,7 +1588,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
     def on_urlEntry_changed(self, editable, data=None):
         # Check for and remove a URL prefix that matches the protocol dropdown
         self._on_urlEtry_changed(editable)
-        self._disable_treeinfo_repositories()
+        self._remove_treeinfo_repositories()
 
     def _on_urlEtry_changed(self, editable):
         self._remove_url_prefix(editable, self._protocol_combo_box, self.on_urlEntry_changed)
@@ -1619,9 +1618,22 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         self._repo_entry_box.set_sensitive(True)
 
     def on_removeRepo_clicked(self, button):
-        """ Remove the selected repository
+        """Remove the selected repository"""
+        self._remove_repository()
+
+    def _remove_repository(self, repo_model_path=None):
+        """Remove repository on repo_model_path or current selection.
+
+        If repo_model_path is not specified then current selection will be used.
+
+        :param repo_model_path: repo_model_path of what we can remove or None
+        :type repo_model_path: repo_store repo_model_path
         """
-        itr = self._repo_selection.get_selected()[1]
+        if repo_model_path is None:
+            itr = self._repo_store[repo_model_path].iter
+        else:
+            itr = self._repo_selection.get_selected()[1]
+
         if not itr:
             return
 


### PR DESCRIPTION
This will solve problem that additional repositories pointing to an invalid path. This is happening because we moved source mounting to a different folders for each source. By this patch we will always reload new treeinfo repository if user change the base source repository.

Also this changed behavior of Source spoke. The Source spoke does not disable repository on base repo switch but instead it will remove this repository and the repository will be reloaded when user re-enter the spoke. It's not ideal solution but doable with avoiding great amount of changes everywhere.

Backport of https://github.com/rhinstaller/anaconda/pull/2757 .