### PR TITLE
subscription: Convert the RHSM default config values to expected format

### DIFF
--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -556,6 +556,26 @@ class SubscriptionService(KickstartService):
         """
         return self._rhsm_observer
 
+    def _flatten_rhsm_nested_dict(self, nested_dict):
+        """Convert the GetAll() returned nested dict into a flat one.
+
+        RHSM returns a nested dict with categories on top
+        and category keys & values inside. This is not convenient
+        for setting keys based on original values, so
+        let's normalize the dict to the flat key based
+        structure similar to what's used by SetAll().
+
+        :param dict nested_dict: the nested dict returned by GetAll()
+        :return: flat key/value dictionary, similar to format used by SetAll()
+        :rtype: dict
+        """
+        flat_dict = {}
+        for category_key, category_dict in nested_dict.items():
+            for key, value in category_dict.items():
+                flat_key = "{}.{}".format(category_key, key)
+                flat_dict[flat_key] = value
+        return flat_dict
+
     def get_rhsm_config_defaults(self):
         """Return RHSM config default values.
 
@@ -572,6 +592,10 @@ class SubscriptionService(KickstartService):
         or else the method might return non-default (Anaconda overwritten)
         data.
 
+        NOTE: While RHSM GetAll() DBus call returns a nested dictionary,
+              we turn it into a flat key/value dict, in the same format SetAll()
+              uses.
+
         :return : dictionary of default RHSM configuration values
         :rtype: dict
         """
@@ -579,7 +603,10 @@ class SubscriptionService(KickstartService):
             # config defaults cache not yet populated, do it now
             proxy = self.rhsm_observer.get_proxy(RHSM_CONFIG)
             # turn the variant into a dict with get_native()
-            self._rhsm_config_defaults = get_native(proxy.GetAll(""))
+            nested_dict = get_native(proxy.GetAll(""))
+            # flatten the nested dict
+            flat_dict = self._flatten_rhsm_nested_dict(nested_dict)
+            self._rhsm_config_defaults = flat_dict
         return self._rhsm_config_defaults
 
     def set_rhsm_config_with_task(self):

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
@@ -1050,17 +1050,36 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         # create a default config
         default_config = {
+            "server":
+                {
+                    "hostname": "server.example.com",
+                    "proxy_hostname": "proxy.example.com",
+                    "proxy_port": "1000",
+                    "proxy_user": "foo_user",
+                    "proxy_password": "foo_password",
+                },
+            "rhsm":
+                {
+                    "baseurl": "cdn.example.com",
+                    "key_anaconda_does_not_use_1": "foo1",
+                    "key_anaconda_does_not_use_2": "foo2"
+                }
+        }
+
+        # create expected output - flat version of the nested default config
+        flat_default_config = {
             SetRHSMConfigurationTask.CONFIG_KEY_SERVER_HOSTNAME: "server.example.com",
             SetRHSMConfigurationTask.CONFIG_KEY_SERVER_PROXY_HOSTNAME: "proxy.example.com",
             SetRHSMConfigurationTask.CONFIG_KEY_SERVER_PROXY_PORT: "1000",
             SetRHSMConfigurationTask.CONFIG_KEY_SERVER_PROXY_USER: "foo_user",
             SetRHSMConfigurationTask.CONFIG_KEY_SERVER_PROXY_PASSWORD: "foo_password",
             SetRHSMConfigurationTask.CONFIG_KEY_RHSM_BASEURL: "cdn.example.com",
-            "key_anaconda_does_not_use_1": "foo1",
-            "key_anaconda_does_not_use_2": "foo2"
+            "rhsm.key_anaconda_does_not_use_1": "foo1",
+            "rhsm.key_anaconda_does_not_use_2": "foo2"
         }
+
         # turn it to variant, which is what RHSM DBus API will return
-        default_variant = get_variant(Dict[Str, Str], default_config)
+        default_variant = get_variant(Dict[Str, Dict[Str, Str]], default_config)
 
         # mock the rhsm config proxy
         observer = Mock()
@@ -1082,8 +1101,8 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         # - even though GetAll() returns a variant, the
         #   get_rhsm_config_default() should convert it
         #   to a native Python dict
-        self.assertEqual(result1, default_config)
-        self.assertEqual(result2, default_config)
+        self.assertEqual(result1, flat_default_config)
+        self.assertEqual(result2, flat_default_config)
 
         # check the property requested the correct DBus object
         observer.get_proxy.assert_called_once_with(RHSM_CONFIG)
@@ -1116,14 +1135,32 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         """Test SetRHSMConfigurationTask creation."""
         # prepare the module with dummy data
         default_config = {
+            "server":
+                {
+                    "hostname": "server.example.com",
+                    "proxy_hostname": "proxy.example.com",
+                    "proxy_port": "1000",
+                    "proxy_user": "foo_user",
+                    "proxy_password": "foo_password",
+                },
+            "rhsm":
+                {
+                    "baseurl": "cdn.example.com",
+                    "key_anaconda_does_not_use_1": "foo1",
+                    "key_anaconda_does_not_use_2": "foo2"
+                }
+        }
+
+        # create expected output - flat version of the nested default config
+        flat_default_config = {
             SetRHSMConfigurationTask.CONFIG_KEY_SERVER_HOSTNAME: "server.example.com",
             SetRHSMConfigurationTask.CONFIG_KEY_SERVER_PROXY_HOSTNAME: "proxy.example.com",
             SetRHSMConfigurationTask.CONFIG_KEY_SERVER_PROXY_PORT: "1000",
             SetRHSMConfigurationTask.CONFIG_KEY_SERVER_PROXY_USER: "foo_user",
             SetRHSMConfigurationTask.CONFIG_KEY_SERVER_PROXY_PASSWORD: "foo_password",
             SetRHSMConfigurationTask.CONFIG_KEY_RHSM_BASEURL: "cdn.example.com",
-            "key_anaconda_does_not_use_1": "foo1",
-            "key_anaconda_does_not_use_2": "foo2"
+            "rhsm.key_anaconda_does_not_use_1": "foo1",
+            "rhsm.key_anaconda_does_not_use_2": "foo2"
         }
 
         full_request = SubscriptionRequest()
@@ -1173,7 +1210,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         self.assertEqual(
                 get_native(SubscriptionRequest.to_structure(task_request)),
                 expected_full_dict)
-        self.assertEqual(obj.implementation._rhsm_config_defaults, default_config)
+        self.assertEqual(obj.implementation._rhsm_config_defaults, flat_default_config)
 
     @patch_dbus_publish_object
     def register_with_username_password_test(self, publisher):


### PR DESCRIPTION
Turns out the RHSM config DBus API GetAll() returns a nested
distionary instead of a flat dict we were expecting, as SetAll()
uses such a flat dict.

Due to this empty values from GUI would be written to the RHSM
config file as no original values would be found due to the
unexpected format of the GetAll() returned dict.

To fix this, convert the nested dict to the flat one we expect &
which is much easier to work with in our use case.

This way the Candlepin URL & CDN URL should no longer be overwritten
by empty values from the GUI.

Resolves: rhbz#1862116