### PR TITLE
Don't try to pass nonexistent fields (#1860058)

### DIFF
--- a/utils/handle-sshpw
+++ b/utils/handle-sshpw
@@ -47,8 +47,8 @@ for ud in userdata:
             users.set_user_password(username=ud.username, password=ud.password,
                                     is_crypted=ud.isCrypted, lock=ud.lock)
     else:
-        users.create_user(username=ud.username, password=ud.password, is_crypted=ud.isCrypted, lock=ud.lock,
-                          homedir=ud.homedir, shell=ud.shell, gecos=ud.gecos, root="/")
+        users.create_user(username=ud.username, password=ud.password, is_crypted=ud.isCrypted,
+                          lock=ud.lock, root="/")
 
     if ud.sshkey:
         # Setup the account so that only the sshkey can be used


### PR DESCRIPTION
This fixes the bug where "homedir" does not exist on F24_SshPwData and no user is created for SSH access to installation environment.

Resolves: [rhbz#1860058](https://bugzilla.redhat.com/show_bug.cgi?id=1860058)