### PR TITLE
Remove the DBus method ConfigureNTPServiceEnablementWithTask

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -608,6 +608,28 @@ def service_running(service):
     return ret == 0
 
 
+def is_service_installed(service, root=None):
+    """Is a systemd service installed in the sysroot?
+
+    :param str service: name of the service to check
+    :param str root: path to the sysroot or None to use default sysroot path
+    """
+    if root is None:
+        root = conf.target.system_root
+
+    if not service.endswith(".service"):
+        service += ".service"
+
+    args = ["list-unit-files", service, "--no-legend"]
+
+    if root != "/":
+        args += ["--root", root]
+
+    unit_file = execWithCapture("systemctl", args)
+
+    return bool(unit_file)
+
+
 def enable_service(service, root=None):
     """ Enable a systemd service in the sysroot.
 

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -97,15 +97,16 @@ def _prepare_configuration(payload, ksdata):
     security_dbus_tasks = security_proxy.InstallWithTasks()
     os_config.append_dbus_tasks(SECURITY, security_dbus_tasks)
 
+    # add installation tasks for the Timezone DBus module
+    # run these tasks before tasks of the Services module
+    timezone_proxy = TIMEZONE.get_proxy()
+    timezone_dbus_tasks = timezone_proxy.InstallWithTasks()
+    os_config.append_dbus_tasks(TIMEZONE, timezone_dbus_tasks)
+
     # add installation tasks for the Services DBus module
     services_proxy = SERVICES.get_proxy()
     services_dbus_tasks = services_proxy.InstallWithTasks()
     os_config.append_dbus_tasks(SERVICES, services_dbus_tasks)
-
-    # add installation tasks for the Timezone DBus module
-    timezone_proxy = TIMEZONE.get_proxy()
-    timezone_dbus_tasks = timezone_proxy.InstallWithTasks()
-    os_config.append_dbus_tasks(TIMEZONE, timezone_dbus_tasks)
 
     # add installation tasks for the Localization DBus module
     localization_proxy = LOCALIZATION.get_proxy()
@@ -278,13 +279,6 @@ def _prepare_installation(payload, ksdata):
     # - try to discover a realm (if any)
     # - check for possibly needed additional packages.
     pre_install = TaskQueue("Pre install tasks", N_("Running pre-installation tasks"))
-    # Setup timezone and add chrony as package if timezone was set in KS
-    # and "-chrony" wasn't in packages section and/or --nontp wasn't set.
-    timezone_proxy = TIMEZONE.get_proxy()
-    ntp_excluded = timezone.NTP_PACKAGE in ksdata.packages.excludedList
-    pre_install.append_dbus_tasks(
-        TIMEZONE, [timezone_proxy.ConfigureNTPServiceEnablementWithTask(ntp_excluded)]
-    )
 
     # make name resolution work for rpm scripts in chroot
     if conf.system.provides_resolver_config:

--- a/pyanaconda/modules/timezone/installation.py
+++ b/pyanaconda/modules/timezone/installation.py
@@ -19,7 +19,7 @@ import os
 import os.path
 
 from pyanaconda import ntp
-from pyanaconda.modules.common.constants.services import SERVICES
+from pyanaconda.core import util
 from pyanaconda.timezone import NTP_SERVICE
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.common.errors.installation import TimezoneConfigurationError
@@ -28,7 +28,7 @@ from pyanaconda.timezone import is_valid_timezone
 
 from blivet import arch
 
-__all__ = ["ConfigureNTPTask", "ConfigureTimezoneTask", "ConfigureNTPServiceEnablementTask"]
+__all__ = ["ConfigureNTPTask", "ConfigureTimezoneTask"]
 
 log = get_module_logger(__name__)
 
@@ -141,7 +141,24 @@ class ConfigureNTPTask(Task):
 
     def run(self):
         """Perform the actual work of setting up NTP."""
+        self._enable_service()
+        self._write_configuration()
+
+    def _enable_service(self):
+        """Enable or disable the chrony service."""
+        if not util.is_service_installed(NTP_SERVICE, root=self._sysroot):
+            log.debug("The NTP service is not installed.")
+            return
+
+        if self._ntp_enabled:
+            util.enable_service(NTP_SERVICE, root=self._sysroot)
+        else:
+            util.disable_service(NTP_SERVICE, root=self._sysroot)
+
+    def _write_configuration(self):
+        """Write the chrony configuration."""
         if not (self._ntp_enabled and self._ntp_servers):
+            log.debug("The NTP service is not enabled or configured.")
             return
 
         chronyd_conf_path = os.path.normpath(self._sysroot + ntp.NTP_CONFIG_FILE)
@@ -166,36 +183,3 @@ class ConfigureNTPTask(Task):
             except ntp.NTPconfigError as ntperr:
                 log.warning("Failed to save NTP configuration without chrony package: %s",
                             ntperr)
-
-
-class ConfigureNTPServiceEnablementTask(Task):
-    """Installation task for NTP service enablement."""
-
-    def __init__(self, ntp_enabled, ntp_excluded):
-        """Create a new task.
-
-        :param bool ntp_enabled: is NTP enabled or not
-        # FIXME replace with asking PAYLOAD when available
-        :param bool ntp_excluded: is NTP service package explicitly excluded?
-        """
-        super().__init__()
-        self._ntp_enabled = ntp_enabled
-        self._ntp_excluded = ntp_excluded
-
-    @property
-    def name(self):
-        return "Configure NTP service enablement"
-
-    def run(self):
-        services_proxy = SERVICES.get_proxy()
-        enabled_services = services_proxy.EnabledServices
-        disabled_services = services_proxy.DisabledServices
-
-        if self._ntp_enabled and not self._ntp_excluded:
-            if NTP_SERVICE not in enabled_services and NTP_SERVICE not in disabled_services:
-                enabled_services.append(NTP_SERVICE)
-                services_proxy.SetEnabledServices(enabled_services)
-        else:
-            if NTP_SERVICE not in disabled_services:
-                disabled_services.append(NTP_SERVICE)
-                services_proxy.SetDisabledServices(disabled_services)

--- a/pyanaconda/modules/timezone/timezone.py
+++ b/pyanaconda/modules/timezone/timezone.py
@@ -25,8 +25,7 @@ from pyanaconda.modules.common.constants.services import TIMEZONE
 from pyanaconda.timezone import NTP_PACKAGE
 from pyanaconda.modules.common.containers import TaskContainer
 from pyanaconda.modules.common.structures.requirement import Requirement
-from pyanaconda.modules.timezone.installation import ConfigureNTPTask, ConfigureTimezoneTask, \
-    ConfigureNTPServiceEnablementTask
+from pyanaconda.modules.timezone.installation import ConfigureNTPTask, ConfigureTimezoneTask
 from pyanaconda.modules.timezone.kickstart import TimezoneKickstartSpecification
 from pyanaconda.modules.timezone.timezone_interface import TimezoneInterface
 
@@ -50,9 +49,6 @@ class TimezoneService(KickstartService):
 
         self.ntp_servers_changed = Signal()
         self._ntp_servers = []
-
-        # FIXME: temporary workaround until PAYLOAD module is available
-        self._ntp_excluded = False
 
     def publish(self):
         """Publish the module."""
@@ -133,26 +129,12 @@ class TimezoneService(KickstartService):
         requirements = []
 
         # Add ntp service requirements.
-        if self._ntp_enabled and not self._ntp_excluded:
+        if self._ntp_enabled:
             requirements.append(
                 Requirement.for_package(NTP_PACKAGE, reason="Needed to run NTP service.")
             )
 
         return requirements
-
-    def configure_ntp_service_enablement_with_task(self, ntp_excluded):
-        """Enable or disable NTP service.
-
-        FIXME: replace with asking PAYLOAD module when available
-        :param ntp_excluded: the NTP service package was explicitly excluded
-
-        return: task for ntp service enablement
-        """
-        self._ntp_excluded = ntp_excluded
-        return ConfigureNTPServiceEnablementTask(
-            ntp_excluded=ntp_excluded,
-            ntp_enabled=self.ntp_enabled
-        )
 
     def install_with_tasks(self):
         """Return the installation tasks of this module.

--- a/pyanaconda/modules/timezone/timezone_interface.py
+++ b/pyanaconda/modules/timezone/timezone_interface.py
@@ -18,7 +18,6 @@
 # Red Hat, Inc.
 #
 from pyanaconda.modules.common.constants.services import TIMEZONE
-from pyanaconda.modules.common.containers import TaskContainer
 from dasbus.server.property import emits_properties_changed
 from dasbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterface
@@ -107,13 +106,3 @@ class TimezoneInterface(KickstartModuleInterface):
         :param servers: a list of servers
         """
         self.implementation.set_ntp_servers(servers)
-
-    def ConfigureNTPServiceEnablementWithTask(self, ntp_excluded: Bool) -> ObjPath:
-        """Enable or disable NTP service.
-
-        FIXME: replace with asking PAYLOAD module when available
-        :param ntp_excluded: the NTP service package was explicitly excluded
-        """
-        return TaskContainer.to_object_path(
-            self.implementation.configure_ntp_service_enablement_with_task(ntp_excluded)
-        )

--- a/tests/nosetests/pyanaconda_tests/util_test.py
+++ b/tests/nosetests/pyanaconda_tests/util_test.py
@@ -67,6 +67,32 @@ class UpcaseFirstLetterTests(unittest.TestCase):
                          "Czech Republic")
 
 
+class RunSystemctlTests(unittest.TestCase):
+
+    def is_service_installed_test(self):
+        """Test the is_service_installed function."""
+        with patch('pyanaconda.core.util.execWithCapture') as execute:
+            execute.return_value = "fake.service enabled enabled"
+            self.assertEqual(util.is_service_installed("fake"), True)
+            execute.assert_called_once_with("systemctl", [
+                "list-unit-files", "fake.service", "--no-legend", "--root", "/mnt/sysroot"
+            ])
+
+        with patch('pyanaconda.core.util.execWithCapture') as execute:
+            execute.return_value = "fake.service enabled enabled"
+            self.assertEqual(util.is_service_installed("fake.service", root="/"), True)
+            execute.assert_called_once_with("systemctl", [
+                "list-unit-files", "fake.service", "--no-legend"
+            ])
+
+        with patch('pyanaconda.core.util.execWithCapture') as execute:
+            execute.return_value = ""
+            self.assertEqual(util.is_service_installed("fake", root="/"), False)
+            execute.assert_called_once_with("systemctl", [
+                "list-unit-files", "fake.service", "--no-legend"
+            ])
+
+
 class RunProgramTests(unittest.TestCase):
     def run_program_test(self):
         """Test the _run_program method."""


### PR DESCRIPTION
Don't enable or disable the NTP service via the Services DBus module. Extend
the installation task ConfigureNTPTask of the Timezone module and configure
the NTP service there.

Change the order of the installation tasks of the Services and Timezone module,
so the NTP service can be always disabled with 'services --disabled=chronyd'.

It is not necessary to skip the requirement of the Timezone module if the
chrony package is excluded from the installation package set, because we do
that automatically for all collected requirements.

Resolves: rhbz#1862492