### PR TITLE
Drop the dependency on python3-ntplib

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -119,7 +119,6 @@ Requires: NetworkManager-libnm >= %{nmver}
 Requires: NetworkManager-team
 Requires: kbd
 Requires: chrony
-Requires: python3-ntplib
 Requires: systemd
 Requires: python3-pid
 Requires: python3-ordered-set >= 2.0.0

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -117,7 +117,6 @@ THREAD_STORAGE_WATCHER = "AnaStorageWatcher"
 THREAD_WAIT_FOR_CONNECTING_NM = "AnaWaitForConnectingNMThread"
 THREAD_PAYLOAD = "AnaPayloadThread"
 THREAD_PAYLOAD_RESTART = "AnaPayloadRestartThread"
-THREAD_SYNC_TIME_BASENAME = "AnaSyncTime"
 THREAD_EXCEPTION_HANDLING_TEST = "AnaExceptionHandlingTest"
 THREAD_LIVE_PROGRESS = "AnaLiveProgressThread"
 THREAD_SOFTWARE_WATCHER = "AnaSoftwareWatcher"
@@ -314,6 +313,9 @@ TIME_SOURCE_POOL = "POOL"
 NTP_SERVER_OK = 0
 NTP_SERVER_NOK = 1
 NTP_SERVER_QUERY = 2
+
+# Timeout for the NTP server check
+NTP_SERVER_TIMEOUT = 5
 
 # Storage checker constraints
 STORAGE_MIN_RAM = "min_ram"

--- a/pyanaconda/ntp.py
+++ b/pyanaconda/ntp.py
@@ -25,14 +25,12 @@ import re
 import os
 import tempfile
 import shutil
-import ntplib
-import socket
 
-from pyanaconda import isys
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import N_, _
-from pyanaconda.core.constants import THREAD_SYNC_TIME_BASENAME, NTP_SERVER_QUERY, \
+from pyanaconda.core.constants import NTP_SERVER_TIMEOUT, NTP_SERVER_QUERY, \
     THREAD_NTP_SERVER_CHECK, NTP_SERVER_OK, NTP_SERVER_NOK
+from pyanaconda.core.util import execWithRedirect
 from pyanaconda.modules.common.structures.timezone import TimeSourceData
 from pyanaconda.threading import threadMgr, AnacondaThread
 
@@ -107,25 +105,13 @@ def ntp_server_working(server_hostname, nts_enabled):
     :return: True if the given server is reachable and working, False otherwise
     :rtype: bool
     """
-    try:
-        # ntplib doesn't support NTS
-        if nts_enabled:
-            s = socket.create_connection((server_hostname, 4460), 2)
-            s.close()
-        else:
-            client = ntplib.NTPClient()
-            client.request(server_hostname)
-    except ntplib.NTPException:
-        return False
-    # address related error
-    except socket.gaierror:
-        return False
-    # socket related error
-    # (including "Network is unreachable")
-    except socket.error:
-        return False
+    directive = ["server", server_hostname, "iburst", "maxsamples", "1"]
 
-    return True
+    if nts_enabled:
+        directive.append("nts")
+
+    arguments = ["-Q", " ".join(directive), "-t", str(NTP_SERVER_TIMEOUT)]
+    return execWithRedirect("chronyd", arguments) == 0
 
 
 def get_servers_from_config(conf_file_path=NTP_CONFIG_FILE):
@@ -241,62 +227,6 @@ def save_servers_to_config(servers, conf_file_path=NTP_CONFIG_FILE, out_file_pat
         except OSError as oserr:
             msg = "Cannot replace the old config with the new one ({})."
             raise NTPconfigError(msg.format(oserr.strerror))
-
-
-def _one_time_sync(server, callback=None):
-    """Synchronize the system time with a given NTP server.
-
-    Synchronize the system time with a given NTP server. Note that this
-    function is blocking and will not return until the time gets synced or
-    querying server fails (may take some time before timeouting).
-
-    :param server: an NTP server
-    :type server: an instance of TimeSourceData
-    :param callback: callback function to run after sync or failure
-    :type callback: a function taking one boolean argument (success)
-    :return: True if the sync was successful, False otherwise
-    """
-
-    client = ntplib.NTPClient()
-    try:
-        results = client.request(server.hostname)
-        isys.set_system_time(int(results.tx_time))
-        success = True
-    except ntplib.NTPException:
-        success = False
-    except socket.gaierror:
-        success = False
-
-    if callback is not None:
-        callback(success)
-
-    return success
-
-
-def one_time_sync_async(server, callback=None):
-    """Asynchronously synchronize the system time with a given NTP server.
-
-    Asynchronously synchronize the system time with a given NTP server. This
-    function is non-blocking it starts a new thread for synchronization and
-    returns. Use callback argument to specify the function called when the
-    new thread finishes if needed.
-
-    :param server: an NTP server
-    :type server: an instance of TimeSourceData
-    :param callback: callback function to run after sync or failure
-    :type callback: a function taking one boolean argument (success)
-    """
-    thread_name = "%s_%s" % (THREAD_SYNC_TIME_BASENAME, server.hostname)
-
-    # syncing with the same server running
-    if threadMgr.get(thread_name):
-        return
-
-    threadMgr.add(AnacondaThread(
-        name=thread_name,
-        target=_one_time_sync,
-        args=(server, callback)
-    ))
 
 
 class NTPServerStatusCache(object):

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -1124,10 +1124,6 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
                 if working_server is None:
                     self._show_no_ntp_server_warning()
-                else:
-                    # We need a one-time sync here, because chronyd would
-                    # not change the time as drastically as we need.
-                    ntp.one_time_sync_async(working_server)
 
             ret = util.start_service(NTP_SERVICE)
             self._set_date_time_setting_sensitive(False)


### PR DESCRIPTION
* Use `chronyd -Q` to check the status of an NTP server.
* Don't synchronize the system time with a working NTP server.
* Let the chronyd service to synchronize the time.