### PR TITLE
Fix kickstart file error with user groups

### DIFF
--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -157,7 +157,7 @@ class AdvancedUserDialog(GUIObject, GUIDialogInputCheckHandler):
             self.user.gid = USER_GID_NOT_SET
 
         # ''.split(',') returns [''] instead of [], which is not what we want
-        self.user.groups = [g.strip() for g in self._tGroups.get_text().split(",") if g]
+        self.user.groups = [''.join(g.split()) for g in self._tGroups.get_text().split(",") if g]
 
         # Send ready signal to main event loop
         hubQ.send_ready(self.__class__.__name__, False)


### PR DESCRIPTION
When fill the "Group Membership" in "ADVANCED USER CONFIGURATION"
dialog with the provided example text:

wheel, my-team (1245), project-x (29935)

It keeps the spaces between group name(project-x) and group id('(29935)'),
and then write them to kickstart file. When boot anaconda with the kickstart
file, it fails with:

| unrecognzed arguments: (1245),project-x (29935)

Filter out the spaces between group name and group id to avoid such
issue.

Signed-off-by: Kai Kang <kai.kang@windriver.com>