### PR TITLE
Remove the DBus method ConfigureNTPServiceEnablementWithTask

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -608,6 +608,28 @@ def service_running(service):
     return ret == 0
 
 
+def is_service_installed(service, root=None):
+    """Is a systemd service installed in the sysroot?
+
+    :param str service: name of the service to check
+    :param str root: path to the sysroot or None to use default sysroot path
+    """
+    if root is None:
+        root = conf.target.system_root
+
+    if not service.endswith(".service"):
+        service += ".service"
+
+    args = ["list-unit-files", service, "--no-legend"]
+
+    if root != "/":
+        args += ["--root", root]
+
+    unit_file = execWithCapture("systemctl", args)
+
+    return bool(unit_file)
+
+
 def enable_service(service, root=None):
     """ Enable a systemd service in the sysroot.
 

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -97,15 +97,16 @@ def _prepare_configuration(payload, ksdata):
     security_dbus_tasks = security_proxy.InstallWithTasks()
     os_config.append_dbus_tasks(SECURITY, security_dbus_tasks)
 
+    # add installation tasks for the Timezone DBus module
+    # run these tasks before tasks of the Services module
+    timezone_proxy = TIMEZONE.get_proxy()
+    timezone_dbus_tasks = timezone_proxy.InstallWithTasks()
+    os_config.append_dbus_tasks(TIMEZONE, timezone_dbus_tasks)
+
     # add installation tasks for the Services DBus module
     services_proxy = SERVICES.get_proxy()
     services_dbus_tasks = services_proxy.InstallWithTasks()
     os_config.append_dbus_tasks(SERVICES, services_dbus_tasks)
-
-    # add installation tasks for the Timezone DBus module
-    timezone_proxy = TIMEZONE.get_proxy()
-    timezone_dbus_tasks = timezone_proxy.InstallWithTasks()
-    os_config.append_dbus_tasks(TIMEZONE, timezone_dbus_tasks)
 
     # add installation tasks for the Localization DBus module
     localization_proxy = LOCALIZATION.get_proxy()
@@ -278,13 +279,6 @@ def _prepare_installation(payload, ksdata):
     # - try to discover a realm (if any)
     # - check for possibly needed additional packages.
     pre_install = TaskQueue("Pre install tasks", N_("Running pre-installation tasks"))
-    # Setup timezone and add chrony as package if timezone was set in KS
-    # and "-chrony" wasn't in packages section and/or --nontp wasn't set.
-    timezone_proxy = TIMEZONE.get_proxy()
-    ntp_excluded = timezone.NTP_PACKAGE in ksdata.packages.excludedList
-    pre_install.append_dbus_tasks(
-        TIMEZONE, [timezone_proxy.ConfigureNTPServiceEnablementWithTask(ntp_excluded)]
-    )
 
     # make name resolution work for rpm scripts in chroot
     if conf.system.provides_resolver_config:

--- a/pyanaconda/modules/timezone/timezone.py
+++ b/pyanaconda/modules/timezone/timezone.py
@@ -30,8 +30,7 @@ from pyanaconda.modules.common.structures.timezone import TimeSourceData
 from pyanaconda.timezone import NTP_PACKAGE
 from pyanaconda.modules.common.containers import TaskContainer
 from pyanaconda.modules.common.structures.requirement import Requirement
-from pyanaconda.modules.timezone.installation import ConfigureNTPTask, ConfigureTimezoneTask, \
-    ConfigureNTPServiceEnablementTask
+from pyanaconda.modules.timezone.installation import ConfigureNTPTask, ConfigureTimezoneTask
 from pyanaconda.modules.timezone.kickstart import TimezoneKickstartSpecification
 from pyanaconda.modules.timezone.timezone_interface import TimezoneInterface
 
@@ -55,9 +54,6 @@ class TimezoneService(KickstartService):
 
         self.time_sources_changed = Signal()
         self._time_sources = []
-
-        # FIXME: temporary workaround until PAYLOAD module is available
-        self._ntp_excluded = False
 
     def publish(self):
         """Publish the module."""
@@ -192,26 +188,12 @@ class TimezoneService(KickstartService):
         requirements = []
 
         # Add ntp service requirements.
-        if self._ntp_enabled and not self._ntp_excluded:
+        if self._ntp_enabled:
             requirements.append(
                 Requirement.for_package(NTP_PACKAGE, reason="Needed to run NTP service.")
             )
 
         return requirements
-
-    def configure_ntp_service_enablement_with_task(self, ntp_excluded):
-        """Enable or disable NTP service.
-
-        FIXME: replace with asking PAYLOAD module when available
-        :param ntp_excluded: the NTP service package was explicitly excluded
-
-        return: task for ntp service enablement
-        """
-        self._ntp_excluded = ntp_excluded
-        return ConfigureNTPServiceEnablementTask(
-            ntp_excluded=ntp_excluded,
-            ntp_enabled=self.ntp_enabled
-        )
 
     def install_with_tasks(self):
         """Return the installation tasks of this module.

--- a/pyanaconda/modules/timezone/timezone_interface.py
+++ b/pyanaconda/modules/timezone/timezone_interface.py
@@ -23,7 +23,6 @@ from dasbus.server.interface import dbus_interface
 
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.modules.common.constants.services import TIMEZONE
-from pyanaconda.modules.common.containers import TaskContainer
 from pyanaconda.modules.common.structures.timezone import TimeSourceData
 
 
@@ -112,14 +111,4 @@ class TimezoneInterface(KickstartModuleInterface):
         """
         self.implementation.set_time_sources(
             TimeSourceData.from_structure_list(sources)
-        )
-
-    def ConfigureNTPServiceEnablementWithTask(self, ntp_excluded: Bool) -> ObjPath:
-        """Enable or disable NTP service.
-
-        FIXME: replace with asking PAYLOAD module when available
-        :param ntp_excluded: the NTP service package was explicitly excluded
-        """
-        return TaskContainer.to_object_path(
-            self.implementation.configure_ntp_service_enablement_with_task(ntp_excluded)
         )

--- a/tests/nosetests/pyanaconda_tests/util_test.py
+++ b/tests/nosetests/pyanaconda_tests/util_test.py
@@ -58,6 +58,32 @@ class UpcaseFirstLetterTests(unittest.TestCase):
                          "Czech Republic")
 
 
+class RunSystemctlTests(unittest.TestCase):
+
+    def is_service_installed_test(self):
+        """Test the is_service_installed function."""
+        with patch('pyanaconda.core.util.execWithCapture') as execute:
+            execute.return_value = "fake.service enabled enabled"
+            self.assertEqual(util.is_service_installed("fake"), True)
+            execute.assert_called_once_with("systemctl", [
+                "list-unit-files", "fake.service", "--no-legend", "--root", "/mnt/sysroot"
+            ])
+
+        with patch('pyanaconda.core.util.execWithCapture') as execute:
+            execute.return_value = "fake.service enabled enabled"
+            self.assertEqual(util.is_service_installed("fake.service", root="/"), True)
+            execute.assert_called_once_with("systemctl", [
+                "list-unit-files", "fake.service", "--no-legend"
+            ])
+
+        with patch('pyanaconda.core.util.execWithCapture') as execute:
+            execute.return_value = ""
+            self.assertEqual(util.is_service_installed("fake", root="/"), False)
+            execute.assert_called_once_with("systemctl", [
+                "list-unit-files", "fake.service", "--no-legend"
+            ])
+
+
 class RunProgramTests(unittest.TestCase):
     def run_program_test(self):
         """Test the _run_program method."""


### PR DESCRIPTION
Don't enable or disable the NTP service via the Services DBus module. Extend
the installation task ConfigureNTPTask of the Timezone module and configure
the NTP service there.

Change the order of the installation tasks of the Services and Timezone module,
so the NTP service can be always disabled with 'services --disabled=chronyd'.

It is not necessary to skip the requirement of the Timezone module if the
chrony package is excluded from the installation package set, because we do
that automatically for all collected requirements.

Ported from https://github.com/rhinstaller/anaconda/pull/2764.