### PR TITLE
Enable Packit for smoke testing

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,11 @@
+specfile_path: anaconda.spec
+upstream_package_name: anaconda
+actions:
+  post-upstream-clone:
+    - ./autogen.sh
+    - ./configure
+  get-current-version:
+    - bash -c "git describe --tags --match '*.*' | awk -F '-' '{ print $2}' "
+  create-archive:
+    - "make release"
+    - "bash -c 'ls | grep tar.bz2'"

--- a/.packit.yml
+++ b/.packit.yml
@@ -9,3 +9,9 @@ actions:
   create-archive:
     - "make release"
     - "bash -c 'ls | grep tar.bz2'"
+jobs:
+  - job: tests
+    trigger: pull_request
+    metadata:
+      targets:
+        - fedora-rawhide

--- a/.packit.yml
+++ b/.packit.yml
@@ -8,7 +8,7 @@ actions:
     - bash -c "git describe --tags --match '*.*' | awk -F '-' '{ print $2}' "
   create-archive:
     - "make release"
-    - "bash -c 'ls | grep tar.bz2'"
+    - 'bash -c "ls -1 anaconda-*.tar.bz2"'
 jobs:
   - job: tests
     trigger: pull_request

--- a/configure.ac
+++ b/configure.ac
@@ -33,7 +33,10 @@ AS_IF([test $ANACONDA_RELEASE],
 # This needs to be set before initializing automake
 AC_DISABLE_STATIC
 
-AM_INIT_AUTOMAKE([foreign no-dist-gzip dist-bzip2 tar-ustar])
+# UIDs in an openshift pod are bigger than what tar-ustar can handle
+# tar-pax can deal with it though
+# https://github.com/hpcng/singularity/issues/670#issuecomment-346104684
+AM_INIT_AUTOMAKE([foreign no-dist-gzip dist-bzip2 tar-pax])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
This is a first step to support Packit. In the future we would like to run our tests and make releases by Packit.

**Ready for review.**