### PR TITLE
Fix our tests with a newer rpmfluff library

### DIFF
--- a/tests/nosetests/dd_tests/dd_test.py
+++ b/tests/nosetests/dd_tests/dd_test.py
@@ -10,7 +10,9 @@ from abc import ABC
 
 from contextlib import contextmanager
 from collections import namedtuple
-from rpmfluff import SourceFile, GeneratedSourceFile, SimpleRpmBuild, expectedArch, make_elf
+from rpmfluff import SourceFile, GeneratedSourceFile, SimpleRpmBuild
+from rpmfluff.utils import expectedArch
+from rpmfluff.make import make_elf
 from shutup import shutup
 
 TOP_SRCDIR = os.environ.get("top_builddir", "../..")


### PR DESCRIPTION
They made breaking changes in the library.

https://pagure.io/rpmfluff/issue/42


This will probably happen even on RHEL branch. I guess we want to pin version there to avoid this issue instead of creating bug to fix tests. :(