### PR TITLE
Automatically break lines in labels in software selection spoke

### DIFF
--- a/pyanaconda/ui/gui/spokes/software_selection.glade
+++ b/pyanaconda/ui/gui/spokes/software_selection.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.1 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <requires lib="AnacondaWidgets" version="1.0"/>
@@ -60,10 +60,12 @@
                       <object class="GtkLabel" id="label1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="valign">end</property>
                         <property name="margin_bottom">6</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Base Environment</property>
+                        <property name="wrap">True</property>
+                        <property name="xalign">0</property>
                         <attributes>
                           <attribute name="font-desc" value="Cantarell 12"/>
                           <attribute name="weight" value="normal"/>
@@ -78,10 +80,12 @@
                       <object class="GtkLabel" id="label2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="valign">end</property>
                         <property name="margin_bottom">6</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Additional software for Selected Environment</property>
+                        <property name="wrap">True</property>
+                        <property name="xalign">0</property>
                         <attributes>
                           <attribute name="font-desc" value="Cantarell 12"/>
                           <attribute name="weight" value="normal"/>


### PR DESCRIPTION
Resolves: rhbz#1822787

Before and after - observe labels above the lists:
![Screenshot_vs_main_2020-08-11_17:43:09](https://user-images.githubusercontent.com/15903878/89918430-4db16600-dbfa-11ea-8ee4-1579bbefeae5.png)
![Screenshot_vs_main_2020-08-11_17:39:29](https://user-images.githubusercontent.com/15903878/89918446-5144ed00-dbfa-11ea-8cd5-89a25bee766a.png)
