### PR TITLE
Reset the RAID level of the device request (#1828092)

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -1729,7 +1729,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         # this has to be done before calling populate_raid since it will need
         # the raid level combo to contain the relevant raid levels for the new
         # device type
-        self._populate_raid()
+        self._request.device_raid_level = get_default_raid_level(new_type)
+        self._populate_raid(self._request.device_raid_level)
 
         # Generate a new container configuration for the new type.
         self._request = DeviceFactoryRequest.from_structure(


### PR DESCRIPTION
In the custom partitioning spoke, always reset the RAID level of the
device request when the device type changes. Otherwise, the new type
doesn't have to support the old RAID level.

Resolves: rhbz#1828092