### PR TITLE
Print warning for boot args without `inst.` prefix

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -303,11 +303,11 @@ if __name__ == "__main__":
     if os.path.exists("/tmp/updates"):
         log.info("Using updates in /tmp/updates/ from %s", opts.updateSrc)
 
-    # TODO: uncomment this when we're sure that we're doing the right thing
-    # with kernel_arguments *everywhere* it appears...
-    #for arg in depr:
-    #    stdout_log.warn("Boot argument '%s' is deprecated. "
-    #                   "In the future, use 'inst.%s'.", arg, arg)
+    # warn users that they should use inst. prefix all the time
+    for arg in depr:
+        stdout_log.warning("Boot argument '%s' is deprecated and will be removed in the future. "
+                           "Please use 'inst.%s' instead.",
+                           arg, arg)
 
     from pyanaconda import isys
 

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -30,8 +30,7 @@ Anaconda bootup is handled by dracut, so most of the kernel arguments handled
 by dracut are also valid. See |dracutkernel|_ for details on those options.
 
 Throughout this guide, installer-specific options are prefixed with
-``inst`` (e.g. ``inst.ks``). Options specified without the ``inst`` prefix are
-recognized, but the prefix may be required in a future release.
+``inst`` (e.g. ``inst.ks``).
 
 .. _repo:
 

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -44,10 +44,9 @@ set_http_header "X-Anaconda-System-Release" "$product"
 # convenience function to warn the user about old argument names.
 warn_renamed_arg() {
     local arg=""
-    arg="$(getarg $1)" && warn "'$1=$arg'" && warn "$1 has been renamed to $2"
+    arg="$(getarg $1)" && warn "'$1=$arg'" && \
+        warn "$1 has been deprecated and will be removed. Please use $2 instead."
 }
-
-warn_renamed_arg() { :; } # XXX REMOVE WHEN WE'RE READY FOR THE NEW NAMES.
 
 # check for deprecated arg, warn user, and write new arg to /etc/cmdline
 check_depr_arg() {

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -92,9 +92,15 @@ check_removed_arg asknetwork "Use an appropriate 'ip=' argument instead."
 warn_renamed_arg "lang" "inst.lang"
 warn_renamed_arg "keymap" "inst.keymap"
 
+# debug
+warn_renamed_arg "debug" "inst.debug"
+
 # repo
 check_depr_arg "method=" "repo=%s"
 warn_renamed_arg "repo" "inst.repo"
+
+# stage2
+warn_renamed_arg "stage2" "inst.stage2"
 
 # kickstart
 warn_renamed_arg "ks" "inst.ks"
@@ -125,6 +131,7 @@ if updates=$(getarg updates inst.updates); then
 fi
 
 # for vnc bring network up in initramfs so that cmdline configuration is used
+warn_renamed_arg "vnc" "inst.vnc"
 getargbool 0 vnc inst.vnc && warn "anaconda requiring network for vnc" && set_neednet
 
 # Driver Update Disk


### PR DESCRIPTION
Deprecate use of Anaconda boot arguments without `inst.` prefix. Our intention is to disable these completely in the future. 