### PR TITLE
list major common keyboard layouts first

### DIFF
--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -375,6 +375,15 @@ def get_locale_keyboards(locale):
     return langtable.list_keyboards(languageId=locale)
 
 
+def get_common_keyboard_layouts():
+    """Function returning common keyboard layouts carrying high ranks.
+
+    :return: list of common keyboard layouts
+    :rtype: list of strings
+    """
+    return langtable.list_common_keyboards()
+
+
 def get_locale_timezones(locale):
     """Function returning preferred timezones for the given locale.
 

--- a/pyanaconda/ui/gui/spokes/keyboard.glade
+++ b/pyanaconda/ui/gui/spokes/keyboard.glade
@@ -393,13 +393,12 @@
     <columns>
       <!-- column-name name -->
       <column type="gchararray"/>
+      <!-- column-name separator -->
+      <column type="gboolean"/>
     </columns>
   </object>
   <object class="GtkTreeModelFilter" id="newLayoutStoreFilter">
     <property name="child_model">newLayoutStore</property>
-  </object>
-  <object class="GtkTreeModelSort" id="newLayoutStoreSort">
-    <property name="model">newLayoutStoreFilter</property>
   </object>
   <object class="GtkDialog" id="addLayoutDialog">
     <property name="can_focus">False</property>
@@ -503,7 +502,7 @@
                   <object class="GtkTreeView" id="newLayoutView">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="model">newLayoutStoreSort</property>
+                    <property name="model">newLayoutStoreFilter</property>
                     <property name="headers_visible">False</property>
                     <property name="headers_clickable">False</property>
                     <property name="enable_search">False</property>
@@ -532,6 +531,9 @@
                         <property name="AtkObject::accessible-name" translatable="yes">Available Layouts</property>
                       </object>
                     </child>
+                    <style>
+                      <class name="solid-separator"/>
+                    </style>
                   </object>
                 </child>
               </object>

--- a/pyanaconda/ui/gui/xkl_wrapper.py
+++ b/pyanaconda/ui/gui/xkl_wrapper.py
@@ -40,8 +40,10 @@ from collections import namedtuple
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import DEFAULT_KEYBOARD
-from pyanaconda.keyboard import join_layout_variant, parse_layout_variant, KeyboardConfigError, InvalidLayoutVariantSpec
+from pyanaconda.keyboard import join_layout_variant, parse_layout_variant, \
+    KeyboardConfigError, InvalidLayoutVariantSpec, normalize_layout_variant
 from pyanaconda.core.async_utils import async_action_wait
+from pyanaconda import localization
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -209,6 +211,13 @@ class XklWrapper(object):
 
         with self._layout_infos_lock:
             return list(self._layout_infos.keys())
+
+    def get_common_layouts(self):
+        """A list of common layouts"""
+
+        return list(set(map(
+            normalize_layout_variant, localization.get_common_keyboard_layouts()
+        )).intersection(set(self.get_available_layouts())))
 
     def get_switching_options(self):
         """Method returning list of available layout switching options"""

--- a/tests/nosetests/pyanaconda_tests/localization_test.py
+++ b/tests/nosetests/pyanaconda_tests/localization_test.py
@@ -77,6 +77,12 @@ class LangcodeLocaleParsingTests(unittest.TestCase):
         self.assertEqual(localization.get_locale_keyboards("en_US"), ["us"])
         self.assertEqual(localization.get_locale_keyboards("en_GB"), ["gb"])
 
+    def common_keyboard_layouts_test(self):
+        layouts = localization.get_common_keyboard_layouts()
+        self.assertIn("us", layouts)
+        self.assertIn("fr(oss)", layouts)
+        self.assertIn("de(nodeadkeys)", layouts)
+
     def locale_timezones_test(self):
         self.assertIn("Europe/Oslo", localization.get_locale_timezones("no"))
 


### PR DESCRIPTION
Refer: rhbz#[1158370](https://bugzilla.redhat.com/show_bug.cgi?id=1158370)
Depends: https://github.com/mike-fabian/langtable/pull/11

This is an attempt to determine major keyboard layouts and place them first in the keyboard layouts selection list.
Hence lesser scroll for users.

To Do:
- [x] determine better approach, if any
- [x] few UI changes: include a separator
- [x] code cleanups