### PR TITLE
Discard current boot list when updating the boot-device variable and use the bootlist tool

### DIFF
--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -569,30 +569,15 @@ class IPSeriesGRUB2(GRUB2):
 
         log.debug("updateNVRAMBootList: self.stage1_device.path = %s", self.stage1_device.path)
 
-        buf = util.execWithCapture("nvram",
-                                   ["--print-config=boot-device"],
-                                   filter_stderr=True)
-
-        if len(buf) == 0:
-            log.error("Failed to determine nvram boot device")
-            return
-
-        boot_list = buf.strip().replace("\"", "").split()
-        log.debug("updateNVRAMBootList: boot_list = %s", boot_list)
-
         buf = util.execWithCapture("ofpathname",
                                    [self.stage1_device.path],
                                    filter_stderr=True)
 
         if len(buf) > 0:
-            boot_disk = buf.strip()
+            boot_list = buf.strip()
         else:
             log.error("Failed to translate boot path into device name")
             return
-
-        # Place the disk containing the PReP partition first.
-        # Remove all other occurances of it.
-        boot_list = [boot_disk] + [x for x in boot_list if x != boot_disk]
 
         # The boot-device NVRAM variable has a maximum number of devices allowed,
         # don't add more than the limit in the ibm,max-boot-devices OF property.

--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -569,27 +569,8 @@ class IPSeriesGRUB2(GRUB2):
 
         log.debug("updateNVRAMBootList: self.stage1_device.path = %s", self.stage1_device.path)
 
-        buf = util.execWithCapture("ofpathname",
-                                   [self.stage1_device.path],
-                                   filter_stderr=True)
-
-        if len(buf) > 0:
-            boot_list = buf.strip()
-        else:
-            log.error("Failed to translate boot path into device name")
-            return
-
-        # The boot-device NVRAM variable has a maximum number of devices allowed,
-        # don't add more than the limit in the ibm,max-boot-devices OF property.
-        max_dev_path = "/sys/firmware/devicetree/base/ibm,max-boot-devices"
-        if os.access(max_dev_path, os.F_OK):
-            with open(max_dev_path, "rb") as f:
-                limit = int.from_bytes(f.read(4), byteorder='big')
-                boot_list = boot_list[:limit]
-
-        update_value = "boot-device=%s" % " ".join(boot_list)
-
-        rc = util.execWithRedirect("nvram", ["--update-config", update_value])
+        rc = util.execWithRedirect("bootlist",
+                                   ["-m", "normal", "-o", self.stage1_device.path])
         if rc:
             log.error("Failed to update new boot device order")
 


### PR DESCRIPTION
This pull-request makes a couple of improvements to the logic that updates the boot-device NVRAM variable in PowerPC 64 machines. These are:

* Discard the current boot device list since the boot-device NVRAM variable can contain wrong values.
* Use the bootlist tool that already supports both logical and OF device paths instead of using the ofpathname tool to convert between from logical device names and the nvram tool to update the boot-device variable.