### PR TITLE
Do not use disabled --install-scripts command of pip

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,7 +63,8 @@ RC_RELEASE ?= $(shell date -u +0.1.%Y%m%d%H%M%S)
 MOCKCHROOT ?= fedora-$(DIST_NAME)-$(ARCH_NAME)
 MOCK_EXTRA_ARGS ?=
 
-COVERAGE ?= coverage3
+PYTHON ?= python3
+COVERAGE ?= $(PYTHON) -m coverage
 USER_SITE_BASE ?= $(abs_top_builddir)/python-site
 USER_SITE_PACKAGES ?= $(shell PYTHONUSERBASE=$(USER_SITE_BASE) $(PYTHON) -m site --user-site)
 
@@ -83,7 +84,7 @@ SKIP_BRANCHING_CHECK ?= "false"
 dist-hook:
 	for p in $(distdir)/po/*.po ; do \
 	    if [ -e "$$p" ]; then \
-		PYTHONPATH=$(srcdir)/translation-canary python3 -m translation_canary.translated \
+		PYTHONPATH=$(srcdir)/translation-canary $(PYTHON) -m translation_canary.translated \
 		    --release $(distdir)/po ; \
 	    fi ; \
 	    break ; \

--- a/scripts/testing/setup-mock-test-env.py
+++ b/scripts/testing/setup-mock-test-env.py
@@ -371,7 +371,7 @@ def install_pip_packages_to_mock(mock_command, packages):
 
     cmd = _run_cmd_in_chroot(cmd)
     cmd.append(
-        'python3 -m pip install --install-option="--install-scripts=/usr/bin" {}'.format(packages)
+        'python3 -m pip install {}'.format(packages)
     )
 
     _check_subprocess(cmd, "Can't install packages via pip to mock.")


### PR DESCRIPTION
This command will raise an error from pip 20.2.2.

https://github.com/pypa/pip/issues/7309

Without this command we can't call coverage3 directly so we had to change our Makefile a bit.