### PR TITLE
Handle exceptions from threads without new instances

### DIFF
--- a/pyanaconda/threading.py
+++ b/pyanaconda/threading.py
@@ -168,7 +168,7 @@ class ThreadManager(object):
         with self._errors_lock:
             exc_info = self._errors.pop(name)
         if exc_info:
-            raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])
+            raise exc_info[1]
 
     def in_main_thread(self):
         """Return True if it is run in the main thread."""


### PR DESCRIPTION
It is not possible to instantiate some exceptions with just an instance as the only argument, for example `UnicodeError` and descendants. However, these days it is possible to raise directly with the provided instance, no need to instantiate the class. The original came to be so due to incrementally rewriting the python2 3-argument form of `raise`. See previous commits affecting this line, in chronological order: 07b7034, d16512e, a6085b8.

Resolves: [rhbz#1835027](https://bugzilla.redhat.com/show_bug.cgi?id=1835027)