### PR TITLE
Avoid unnecessarily pulling in glibc-langpack-en

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -131,7 +131,7 @@ Requires: /usr/bin/update-crypto-policies
 Requires: anaconda-tui = %{version}-%{release}
 
 # Make sure we get the en locale one way or another
-Requires: glibc-langpack-en
+Requires: (glibc-langpack-en or glibc-all-langpacks)
 
 # anaconda literally runs its own dbus-daemon, so it needs this,
 # even though the distro default is dbus-broker in F30+


### PR DESCRIPTION
Back in 2016[1], this was changed to a strict dependency because the
releng tools of the time could not handle boolean dependencies in
spec files. Nowadays, these work just fine, so we should switch
back to ensuring that we only pull it in when glibc-all-langpacks
is not installed.

Related to https://pagure.io/releng/issue/9689

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1323314

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>