### PR TITLE
Fix dependency_solver failure with spec file boolean logic syntax

### DIFF
--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -102,13 +102,25 @@ def parse_args():
 
 def runtime_dependencies(spec_content):
     """Find all Requires from spec file."""
-    packages = re.findall(r"\n *Requires: *([^ \n]*)", spec_content)
+    # find all Requires: statements
+    # take first word from these statements to avoid these problems:
+    # - Requires: (take_package or not_taken)             # take first from the boolean is the
+    #                                                       best what we can do
+    # - Requires: ( taken_package or not_taken_package )  # work even with space after bracket
+    # - Requires: taken_package >= 3.2.1                  # not taking the version
+    packages = re.findall(r"\n *Requires:[ (]*([^ \n]*)", spec_content)
     result = set()
 
     for pkg in packages:
-        # remove anaconda packages and packages with special autoconf variables
-        if "anaconda" not in pkg and "%{" not in pkg:
-            result.add(pkg.strip())
+        # remove anaconda packages
+        if "anaconda" in pkg:
+            continue
+
+        # remove packages with special autoconf variables (rpm macros)
+        if "%{" in pkg:
+            continue
+
+        result.add(pkg.strip())
 
     result = _filter_out_excludes(result)
 


### PR DESCRIPTION
There is proposed change to have requires in spec file like

``Requires: (... or ...)``

Problem with this is that we take package name with '('. To avoid this problem, remove the brackets before processing and take the first item. Taking the first is not the best solution but we don't have all the info to decide so go with first and hope is our way now. It really should be fine in most of the cases.

This is blocking: https://github.com/rhinstaller/anaconda/pull/2793