### PR TITLE
Dracut do not mount source as rw

### DIFF
--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -64,6 +64,6 @@ if [ -e /tmp/dd_interactive -a ! -e /tmp/dd.done ]; then
 fi
 
 info "anaconda using disk root at $dev"
-mount $dev $repodir || warn "Couldn't mount $dev"
+mount -o ro $dev $repodir || warn "Couldn't mount $dev"
 anaconda_live_root_dir $repodir $path
 run_checkisomd5 $dev


### PR DESCRIPTION
Dracut do not have reason to mount sources as RW it's more that it wasn't specified and until recently we just did not bother. However, we changed the logic that installation sources in stage2 environment does not re-using mounts from the Dracut so this will now fail to set the environment because you can't mount one thing as RW and RO at once.


**DEV NOTE:**
When backporting to Fedora add test that there is no RW mount in Dracut code. Just scan the code for mount without ``-o ro`` should be enough for now.

*Resolves: rhbz#1871049*