### PR TITLE
Fix traceback when removing additional repository

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1686,7 +1686,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         :param repo_model_path: repo_model_path of what we can remove or None
         :type repo_model_path: repo_store repo_model_path
         """
-        if repo_model_path is None:
+        if repo_model_path is not None:
             itr = self._repo_store[repo_model_path].iter
         else:
             itr = self._repo_selection.get_selected()[1]


### PR DESCRIPTION
I made a mistake by missing `not` in the condition. That way the repo removal as user action crashed Anaconda because variable which was not set was immediately used.

Unfortunately, I tested this just on the failing use-case and in that case it looked like it is working correctly (but didn't really).

*Resolves: rhbz#1871037*