### PR TITLE
Use "raise from" to link exceptions

### DIFF
--- a/pyanaconda/core/configuration/base.py
+++ b/pyanaconda/core/configuration/base.py
@@ -71,7 +71,7 @@ def read_config(parser, path):
             parser.read_file(f, path)
 
     except (configparser.Error, IOError) as e:
-        raise ConfigurationFileError(str(e), path)
+        raise ConfigurationFileError(str(e), path) from e
 
 
 def write_config(parser, path):
@@ -86,7 +86,7 @@ def write_config(parser, path):
             parser.write(f)
 
     except (configparser.Error, IOError) as e:
-        raise ConfigurationFileError(str(e), path)
+        raise ConfigurationFileError(str(e), path) from e
 
 
 def get_option(parser, section_name, option_name, converter=None):
@@ -115,7 +115,7 @@ def get_option(parser, section_name, option_name, converter=None):
         return converter(parser.get(section_name, option_name))
 
     except (configparser.Error, ValueError) as e:
-        raise ConfigurationDataError(str(e), section_name, option_name)
+        raise ConfigurationDataError(str(e), section_name, option_name) from e
 
 
 def set_option(parser, section_name, option_name, value):
@@ -135,7 +135,7 @@ def set_option(parser, section_name, option_name, value):
         parser[section_name][option_name] = str(value)
 
     except (configparser.Error, ValueError) as e:
-        raise ConfigurationDataError(str(e), section_name, option_name)
+        raise ConfigurationDataError(str(e), section_name, option_name) from e
 
 
 class Section(ABC):

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -481,7 +481,7 @@ def execConsole():
         proc = startProgram(["/bin/bash"], stdout=None, stderr=None, reset_lang=False)
         proc.wait()
     except OSError as e:
-        raise RuntimeError("Error running /bin/bash: " + e.strerror)
+        raise RuntimeError("Error running /bin/bash: " + e.strerror) from e
 
 
 ## Create a directory path.  Don't fail if the directory already exists.

--- a/pyanaconda/isys/__init__.py
+++ b/pyanaconda/isys/__init__.py
@@ -165,9 +165,10 @@ def total_memory():
 
             try:
                 memsize = int(fields[1])
-            except ValueError:
-                log.error("ivalid value of MemTotal /proc/meminfo: %s", fields[1])
-                raise RuntimeError("ivalid value of MemTotal /proc/meminfo: %s" % fields[1])
+            except ValueError as err:
+                log.error("invalid value of MemTotal /proc/meminfo: %s", fields[1])
+                raise RuntimeError("invalid value of MemTotal /proc/meminfo: %s" % fields[1]) \
+                    from err
 
             # Because /proc/meminfo only gives us the MemTotal (total physical
             # RAM minus the kernel binary code), we need to round this

--- a/pyanaconda/kexec.py
+++ b/pyanaconda/kexec.py
@@ -67,7 +67,7 @@ def run_grubby(args=None):
                 break
     except OSError as e:
         log.error("run_grubby failed: %s", e)
-        raise GrubbyInfoError(e)
+        raise GrubbyInfoError(e) from e
 
     if boot_info_fields:
         raise GrubbyInfoError("Missing values: %s" % ", ".join(boot_info_fields))

--- a/pyanaconda/modules/localization/installation.py
+++ b/pyanaconda/modules/localization/installation.py
@@ -68,7 +68,7 @@ class LanguageInstallationTask(Task):
 
         except IOError as ioerr:
             msg = "Cannot write language configuration file: {}".format(ioerr.strerror)
-            raise LanguageInstallationError(msg)
+            raise LanguageInstallationError(msg) from ioerr
 
 
 class KeyboardInstallationTask(Task):
@@ -203,4 +203,4 @@ def write_vc_configuration(vc_keymap, root):
 
     except IOError as ioerr:
         msg = "Cannot write vconsole configuration file: {}".format(ioerr.strerror)
-        raise KeyboardInstallationError(msg)
+        raise KeyboardInstallationError(msg) from ioerr

--- a/pyanaconda/modules/localization/runtime.py
+++ b/pyanaconda/modules/localization/runtime.py
@@ -192,5 +192,5 @@ def try_to_load_keymap(keymap):
         ret = execWithRedirect("loadkeys", [keymap])
     except OSError as oserr:
         msg = "'loadkeys' command not available (%s)" % oserr.strerror
-        raise KeyboardConfigurationError(msg)
+        raise KeyboardConfigurationError(msg) from oserr
     return ret == 0

--- a/pyanaconda/modules/network/installation.py
+++ b/pyanaconda/modules/network/installation.py
@@ -89,7 +89,7 @@ def _write_config_file(root, path, content, error_msg, overwrite):
             fobj.write(content)
     except IOError as ioerr:
         msg = "{}: {}".format(error_msg, ioerr.strerror)
-        raise NetworkInstallationError(msg)
+        raise NetworkInstallationError(msg) from ioerr
 
 
 class NetworkInstallationTask(Task):
@@ -214,7 +214,7 @@ Name={}
 
         except IOError as ioerr:
             msg = "Cannot disable ipv6 on the system: {}".format(ioerr.strerror)
-            raise NetworkInstallationError(msg)
+            raise NetworkInstallationError(msg) from ioerr
 
     def _copy_resolv_conf(self, root, overwrite):
         """Copy resolf.conf file to target system.

--- a/pyanaconda/modules/payloads/payload/live_image/initialization.py
+++ b/pyanaconda/modules/payloads/payload/live_image/initialization.py
@@ -76,7 +76,7 @@ class CheckInstallationSourceImageTask(Task):
             if response.headers.get('content-length'):
                 size = int(response.headers.get('content-length')) * 4
         except IOError as e:
-            raise SourceSetupError("Error opening liveimg: {}".format(e))
+            raise SourceSetupError("Error opening liveimg: {}".format(e)) from e
         else:
             if response.status_code != 200:
                 raise SourceSetupError("http request returned: {}".format(response.status_code))
@@ -176,7 +176,7 @@ class SetupInstallationSourceImageTask(Task):
         except RequestException as e:
             error = "Error downloading liveimg: {}".format(e)
             log.error(error)
-            raise SourceSetupError(error)
+            raise SourceSetupError(error) from e
         else:
             if not os.path.exists(image_path):
                 error = "Failed to download {}, file doesn't exist".format(self._url)

--- a/pyanaconda/modules/payloads/source/nfs/initialization.py
+++ b/pyanaconda/modules/payloads/source/nfs/initialization.py
@@ -59,8 +59,8 @@ class SetUpNFSSourceTask(Task):
         path, image = self._split_iso_from_path(path)
         try:
             self._mount_nfs(host, options, path)
-        except PayloadSetupError:
-            raise SourceSetupError("Could not mount NFS url '{}'".format(self._url))
+        except PayloadSetupError as exn:
+            raise SourceSetupError("Could not mount NFS url '{}'".format(self._url)) from exn
 
         iso_source_path = join_paths(self._device_mount, image) if image else self._device_mount
 

--- a/pyanaconda/modules/payloads/source/url/url.py
+++ b/pyanaconda/modules/payloads/source/url/url.py
@@ -177,13 +177,14 @@ class URLSourceModule(PayloadSourceBase, RPMSourceMixin):
         try:
             ProxyString(url=proxy)
         except ProxyStringError as e:
-            raise InvalidValueError("Proxy URL does not have valid format: {}".format(str(e)))
+            raise InvalidValueError("Proxy URL does not have valid format: {}".format(str(e))) \
+                from e
 
     def _validate_url(self, url_type):
         try:
             URLType(url_type)
-        except ValueError:
-            raise InvalidValueError("Invalid source type set '{}'".format(url_type))
+        except ValueError as e:
+            raise InvalidValueError("Invalid source type set '{}'".format(url_type)) from e
 
     @property
     def install_repo_enabled(self):

--- a/pyanaconda/modules/storage/dasd/discover.py
+++ b/pyanaconda/modules/storage/dasd/discover.py
@@ -54,7 +54,7 @@ class DASDDiscoverTask(Task):
         try:
             self._device_number = blockdev.s390.sanitize_dev_input(self._device_number)
         except blockdev.S390Error as e:
-            raise StorageDiscoveryError(str(e))
+            raise StorageDiscoveryError(str(e)) from e
 
     def _discover_device(self):
         """Discover the device."""
@@ -62,4 +62,4 @@ class DASDDiscoverTask(Task):
         try:
             blockdev.s390.dasd_online(self._device_number)
         except blockdev.S390Error as e:
-            raise StorageDiscoveryError(str(e))
+            raise StorageDiscoveryError(str(e)) from e

--- a/pyanaconda/modules/storage/devicetree/utils.py
+++ b/pyanaconda/modules/storage/devicetree/utils.py
@@ -73,10 +73,11 @@ def download_escrow_certificate(url):
     try:
         request = util.requests_session().get(url, verify=True)
     except requests.exceptions.SSLError as e:
-        raise KickstartError(_("SSL error while downloading the escrow certificate:\n\n%s") % e)
+        raise KickstartError(_("SSL error while downloading the escrow certificate:\n\n%s") % e) \
+            from e
     except requests.exceptions.RequestException as e:
         raise KickstartError(_("The following error was encountered while downloading the "
-                               "escrow certificate:\n\n%s") % e)
+                               "escrow certificate:\n\n%s") % e) from e
 
     try:
         certificate = request.content

--- a/pyanaconda/modules/storage/fcoe/discover.py
+++ b/pyanaconda/modules/storage/fcoe/discover.py
@@ -44,7 +44,7 @@ class FCOEDiscoverTask(Task):
         try:
             error_message = fcoe.add_san(self._nic, self._dcb, self._auto_vlan)
         except (IOError, OSError) as e:
-            raise StorageDiscoveryError(str(e))
+            raise StorageDiscoveryError(str(e)) from e
 
         if error_message:
             raise StorageDiscoveryError(error_message)

--- a/pyanaconda/modules/storage/iscsi/discover.py
+++ b/pyanaconda/modules/storage/iscsi/discover.py
@@ -107,7 +107,7 @@ class ISCSIDiscoverTask(Task):
                 r_password=credentials.reverse_password
             )
         except SafeDBusError as e:
-            raise StorageDiscoveryError(str(e).split(':')[-1])
+            raise StorageDiscoveryError(str(e).split(':')[-1]) from e
 
         if not nodes:
             raise StorageDiscoveryError("No nodes discovered.")

--- a/pyanaconda/modules/storage/kickstart.py
+++ b/pyanaconda/modules/storage/kickstart.py
@@ -204,7 +204,7 @@ class Iscsi(COMMANDS.Iscsi):
                              target=tg.target,
                              iface=tg.iface)
         except (IOError, ValueError) as e:
-            raise KickstartParseError(lineno=self.lineno, msg=str(e))
+            raise KickstartParseError(lineno=self.lineno, msg=str(e)) from e
 
         return tg
 

--- a/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
@@ -248,11 +248,11 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
         if not size and partition_data.size:
             try:
                 size = Size("%d MiB" % partition_data.size)
-            except ValueError:
+            except ValueError as e:
                 raise KickstartParseError(
                     _("The size \"%s\" is invalid.") % partition_data.size,
                     lineno=partition_data.lineno
-                )
+                ) from e
 
         # If this specified an existing request that we should not format,
         # quit here after setting up enough information to mount it later.
@@ -277,23 +277,23 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
                     try:
                         devicetree.actions.add(ActionResizeFormat(dev, size))
                         devicetree.actions.add(ActionResizeDevice(dev, size))
-                    except ValueError:
+                    except ValueError as e:
                         raise KickstartParseError(
                             _("Target size \"%(size)s\" for device \"%(device)s\" is invalid.") %
                             {"size": partition_data.size, "device": dev.name},
                             lineno=partition_data.lineno
-                        )
+                        ) from e
                 else:
                     # grow
                     try:
                         devicetree.actions.add(ActionResizeDevice(dev, size))
                         devicetree.actions.add(ActionResizeFormat(dev, size))
-                    except ValueError:
+                    except ValueError as e:
                         raise KickstartParseError(
                             _("Target size \"%(size)s\" for device \"%(device)s\" is invalid.") %
                             {"size": partition_data.size, "device": dev.name},
                             lineno=partition_data.lineno
-                        )
+                        ) from e
 
             dev.format.mountpoint = partition_data.mountpoint
             dev.format.mountopts = partition_data.fsopts
@@ -355,11 +355,11 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
         if partition_data.maxSizeMB:
             try:
                 maxsize = Size("%d MiB" % partition_data.maxSizeMB)
-            except ValueError:
+            except ValueError as e:
                 raise KickstartParseError(
                     _("The maximum size \"%s\" is invalid.") % partition_data.maxSizeMB,
                     lineno=partition_data.lineno
-                )
+                ) from e
         else:
             maxsize = None
 
@@ -385,12 +385,12 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
                 size = device.raw_device.align_target_size(size)
                 try:
                     devicetree.actions.add(ActionResizeDevice(device, size))
-                except ValueError:
+                except ValueError as e:
                     raise KickstartParseError(
                         _("Target size \"%(size)s\" for device \"%(device)s\" is invalid.")
                         % {"size": partition_data.size, "device": device.name},
                         lineno=partition_data.lineno
-                    )
+                    ) from e
 
             devicetree.actions.add(ActionCreateFormat(device, kwargs["fmt"]))
             if ty == "swap":
@@ -401,7 +401,7 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
             try:
                 request = storage.new_tmp_fs(**kwargs)
             except (StorageError, ValueError) as e:
-                raise KickstartParseError(lineno=partition_data.lineno, msg=str(e))
+                raise KickstartParseError(lineno=partition_data.lineno, msg=str(e)) from e
             storage.create_device(request)
         else:
             # If a previous device has claimed this mount point, delete the
@@ -416,7 +416,7 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
             try:
                 request = storage.new_partition(**kwargs)
             except (StorageError, ValueError) as e:
-                raise KickstartParseError(lineno=partition_data.lineno, msg=str(e))
+                raise KickstartParseError(lineno=partition_data.lineno, msg=str(e)) from e
 
             storage.create_device(request)
             if ty == "swap":
@@ -663,7 +663,7 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
             try:
                 request = storage.new_mdarray(**kwargs)
             except (StorageError, ValueError) as e:
-                raise KickstartParseError(str(e), lineno=raid_data.lineno)
+                raise KickstartParseError(str(e), lineno=raid_data.lineno) from e
 
             storage.create_device(request)
             if ty == "swap":
@@ -828,7 +828,7 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
                     pe_size=pesize
                 )
             except (StorageError, ValueError) as e:
-                raise KickstartParseError(lineno=volgroup_data.lineno, msg=str(e))
+                raise KickstartParseError(lineno=volgroup_data.lineno, msg=str(e)) from e
 
             storage.create_device(request)
             if volgroup_data.reserved_space:
@@ -910,11 +910,11 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
                 )
             try:
                 size = Size("%d MiB" % logvol_data.size)
-            except ValueError:
+            except ValueError as e:
                 raise KickstartParseError(
                     "The size \"%s\" is invalid." % logvol_data.size,
                     lineno=logvol_data.lineno
-                )
+                ) from e
 
         if logvol_data.thin_pool:
             logvol_data.mountpoint = ""
@@ -976,23 +976,23 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
                     try:
                         devicetree.actions.add(ActionResizeFormat(dev, size))
                         devicetree.actions.add(ActionResizeDevice(dev, size))
-                    except ValueError:
+                    except ValueError as e:
                         raise KickstartParseError(
                             _("Target size \"%(size)s\" for device \"%(device)s\" is invalid.")
                             % {"size": logvol_data.size, "device": dev.name},
                             lineno=logvol_data.lineno
-                        )
+                        ) from e
                 else:
                     # grow
                     try:
                         devicetree.actions.add(ActionResizeDevice(dev, size))
                         devicetree.actions.add(ActionResizeFormat(dev, size))
-                    except ValueError:
+                    except ValueError as e:
                         raise KickstartParseError(
                             _("Target size \"%(size)s\" for device \"%(device)s\" is invalid.")
                             % {"size": logvol_data.size, "device": dev.name},
                             lineno=logvol_data.lineno
-                        )
+                        ) from e
 
             dev.format.mountpoint = logvol_data.mountpoint
             dev.format.mountopts = logvol_data.fsopts
@@ -1052,12 +1052,12 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
                 size = device.raw_device.align_target_size(size)
                 try:
                     devicetree.actions.add(ActionResizeDevice(device, size))
-                except ValueError:
+                except ValueError as e:
                     raise KickstartParseError(
                         _("Target size \"%(size)s\" for device \"%(device)s\" is invalid.") %
                         {"size": logvol_data.size, "device": device.name},
                         lineno=logvol_data.lineno
-                    )
+                    ) from e
 
             devicetree.actions.add(ActionCreateFormat(device, fmt))
             if ty == "swap":
@@ -1097,11 +1097,11 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
             if logvol_data.maxSizeMB:
                 try:
                     maxsize = Size("%d MiB" % logvol_data.maxSizeMB)
-                except ValueError:
+                except ValueError as e:
                     raise KickstartParseError(
                         _("The maximum size \"%s\" is invalid.") % logvol_data.maxSizeMB,
                         lineno=logvol_data.lineno
-                    )
+                    ) from e
             else:
                 maxsize = None
 
@@ -1128,7 +1128,7 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
                     **pool_args
                 )
             except (StorageError, ValueError) as e:
-                raise KickstartParseError(str(e), lineno=logvol_data.lineno)
+                raise KickstartParseError(str(e), lineno=logvol_data.lineno) from e
 
             storage.create_device(request)
             if ty == "swap":
@@ -1303,6 +1303,6 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
                     create_options=btrfs_data.mkfsopts
                 )
             except BTRFSValueError as e:
-                raise KickstartParseError(lineno=btrfs_data.lineno, msg=str(e))
+                raise KickstartParseError(lineno=btrfs_data.lineno, msg=str(e)) from e
 
             storage.create_device(request)

--- a/pyanaconda/modules/storage/partitioning/interactive/change_device.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/change_device.py
@@ -105,7 +105,7 @@ class ChangeDeviceTask(Task):
             rename_container(self._storage, container, container_name)
         except StorageError as e:
             log.error("Invalid container name: %s", e)
-            raise StorageError(str(e))
+            raise StorageError(str(e)) from e
 
     def _replace_device(self):
         """Replace the nonexistent device with a new one.
@@ -304,4 +304,4 @@ class ChangeDeviceTask(Task):
             self._device.raw_device.name = name
         except ValueError as e:
             log.error("Invalid device name: %s", e)
-            raise StorageError(str(e))
+            raise StorageError(str(e)) from e

--- a/pyanaconda/modules/storage/snapshot/device.py
+++ b/pyanaconda/modules/storage/snapshot/device.py
@@ -60,4 +60,4 @@ def get_snapshot_device(request, devicetree):
             origin=origin_dev
         )
     except ValueError as e:
-        raise KickstartParseError(str(e), lineno=request.lineno)
+        raise KickstartParseError(str(e), lineno=request.lineno) from e

--- a/pyanaconda/modules/storage/zfcp/discover.py
+++ b/pyanaconda/modules/storage/zfcp/discover.py
@@ -64,11 +64,11 @@ class ZFCPDiscoverTask(Task):
             self._wwpn = blockdev.s390.zfcp_sanitize_wwpn_input(self._wwpn)
             self._lun = blockdev.s390.zfcp_sanitize_lun_input(self._lun)
         except (blockdev.S390Error, ValueError) as err:
-            raise StorageDiscoveryError(str(err))
+            raise StorageDiscoveryError(str(err)) from err
 
     def _discover_device(self):
         """Discover the device."""
         try:
             zfcp.add_fcp(self._device_number, self._wwpn, self._lun)
         except ValueError as e:
-            raise StorageDiscoveryError(str(e))
+            raise StorageDiscoveryError(str(e)) from e

--- a/pyanaconda/modules/timezone/installation.py
+++ b/pyanaconda/modules/timezone/installation.py
@@ -116,7 +116,7 @@ class ConfigureTimezoneTask(Task):
                     fobj.write("LOCAL\n")
         except IOError as ioerr:
             msg = "Error while writing /etc/adjtime file: {}".format(ioerr.strerror)
-            raise TimezoneConfigurationError(msg)
+            raise TimezoneConfigurationError(msg) from ioerr
 
 
 class ConfigureNTPTask(Task):

--- a/pyanaconda/ntp.py
+++ b/pyanaconda/ntp.py
@@ -158,7 +158,7 @@ def get_servers_from_config(conf_file_path=NTP_CONFIG_FILE):
 
     except IOError as ioerr:
         msg = "Cannot open config file {} for reading ({})."
-        raise NTPconfigError(msg.format(conf_file_path, ioerr.strerror))
+        raise NTPconfigError(msg.format(conf_file_path, ioerr.strerror)) from ioerr
 
     return servers
 
@@ -181,21 +181,21 @@ def save_servers_to_config(servers, conf_file_path=NTP_CONFIG_FILE, out_file_pat
         old_conf_file = open(conf_file_path, "r")
     except IOError as ioerr:
         msg = "Cannot open config file {} for reading ({})."
-        raise NTPconfigError(msg.format(conf_file_path, ioerr.strerror))
+        raise NTPconfigError(msg.format(conf_file_path, ioerr.strerror)) from ioerr
 
     if out_file_path:
         try:
             new_conf_file = open(out_file_path, "w")
         except IOError as ioerr:
             msg = "Cannot open new config file {} for writing ({})."
-            raise NTPconfigError(msg.format(out_file_path, ioerr.strerror))
+            raise NTPconfigError(msg.format(out_file_path, ioerr.strerror)) from ioerr
     else:
         try:
             (fields, temp_path) = tempfile.mkstemp()
             new_conf_file = os.fdopen(fields, "w")
         except IOError as ioerr:
             msg = "Cannot open temporary file {} for writing ({})."
-            raise NTPconfigError(msg.format(temp_path, ioerr.strerror))
+            raise NTPconfigError(msg.format(temp_path, ioerr.strerror)) from ioerr
 
     heading = "# These servers were defined in the installation:\n"
 
@@ -226,7 +226,7 @@ def save_servers_to_config(servers, conf_file_path=NTP_CONFIG_FILE, out_file_pat
 
         except OSError as oserr:
             msg = "Cannot replace the old config with the new one ({})."
-            raise NTPconfigError(msg.format(oserr.strerror))
+            raise NTPconfigError(msg.format(oserr.strerror)) from oserr
 
 
 class NTPServerStatusCache(object):

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -782,11 +782,12 @@ class DNFPayload(Payload):
                 ret.append(self.group_id(grp))
             return ret
         # Translation feature is not implemented for this payload.
-        except NotImplementedError:
+        except NotImplementedError as ex:
             raise PayloadError(("Can't translate group names to group ID - "
-                                "Group translation is not implemented for %s payload." % self))
+                                "Group translation is not implemented for %s payload." % self)) \
+                from ex
         except PayloadError as ex:
-            raise PayloadError("Can't translate group names to group ID - {}".format(ex))
+            raise PayloadError("Can't translate group names to group ID - {}".format(ex)) from ex
 
     def group_selected(self, groupid):
         return Group(groupid) in self.data.packages.groupList
@@ -983,7 +984,7 @@ class DNFPayload(Payload):
             repo.disable()
             log.debug("repo: '%s' - %s failed to load repomd", repo.id,
                       repo.baseurl or repo.mirrorlist or repo.metalink)
-            raise MetadataError(e)
+            raise MetadataError(e) from e
 
         log.info("enabled repo: '%s' - %s and got repomd", repo.id,
                  repo.baseurl or repo.mirrorlist or repo.metalink)
@@ -1105,7 +1106,7 @@ class DNFPayload(Payload):
         except dnf.exceptions.DepsolveError as e:
             msg = str(e)
             log.warning(msg)
-            raise DependencyError(msg)
+            raise DependencyError(msg) from e
 
         log.info("%d packages selected totalling %s",
                  len(self._base.transaction), self.space_required)
@@ -1733,7 +1734,7 @@ class DNFPayload(Payload):
         except (DeviceSetupError, MountFilesystemError) as e:
             log.error("mount failed: %s", e)
             payload_utils.teardown_device(device)
-            raise PayloadSetupError(str(e))
+            raise PayloadSetupError(str(e)) from e
 
     @staticmethod
     def _setup_NFS(mountpoint, server, path, options):

--- a/pyanaconda/payload/flatpak.py
+++ b/pyanaconda/payload/flatpak.py
@@ -176,7 +176,7 @@ class FlatpakPayload(object):
         try:
             self._transaction.run()
         except GError as exn:
-            raise FlatpakInstallError(str(exn))
+            raise FlatpakInstallError(str(exn)) from exn
 
     def _stuff_refs_to_transaction(self):
         for ref in self._remote_refs_list.get_refs_full_format():

--- a/pyanaconda/payload/image.py
+++ b/pyanaconda/payload/image.py
@@ -176,10 +176,10 @@ def mountImage(isodir, tree):
 
         try:
             blivet.util.mount(image, tree, fstype='iso9660', options="ro")
-        except OSError:
+        except OSError as oserr:
             exn = MissingImageError()
             if errorHandler.cb(exn) == ERROR_RAISE:
-                raise exn
+                raise exn from oserr
             else:
                 continue
         else:

--- a/pyanaconda/payload/utils.py
+++ b/pyanaconda/payload/utils.py
@@ -160,7 +160,7 @@ def mount(device_path, mount_point, fstype, options):
     try:
         return blivet.util.mount(device_path, mount_point, fstype=fstype, options=options)
     except OSError as e:
-        raise PayloadSetupError(str(e))
+        raise PayloadSetupError(str(e)) from e
 
 
 def arch_is_x86():

--- a/pyanaconda/safe_dbus.py
+++ b/pyanaconda/safe_dbus.py
@@ -71,7 +71,7 @@ def get_new_session_connection():
             Gio.DBusConnectionFlags.MESSAGE_BUS_CONNECTION,
             None, None)
     except GError as gerr:
-        raise DBusCallError("Unable to connect to session bus: {}".format(gerr))
+        raise DBusCallError("Unable to connect to session bus: {}".format(gerr)) from gerr
     finally:
         if old_euid is not None:
             os.seteuid(old_euid)
@@ -116,7 +116,7 @@ def call_sync(service, obj_path, iface, method, args, connection):
     except GError as gerr:
         msg = "Failed to call %s method on %s with %s arguments: %s" % (method, obj_path,
                                                                         args, str(gerr))
-        raise DBusCallError(msg)
+        raise DBusCallError(msg) from gerr
 
     if ret is None:
         msg = "No return from %s method on %s with %s arguments" % (method, obj_path, args)

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -28,7 +28,7 @@ try:
     from blivetgui.communication.client import BlivetGUIClient  # pylint: disable=import-error
     from blivetgui.config import config  # pylint: disable=import-error
 except ImportError:
-    raise RemovedModuleError("This module is not supported!")
+    raise RemovedModuleError("This module is not supported!") from None
 
 from dasbus.client.proxy import get_object_path
 from dasbus.typing import unwrap_variant

--- a/pyanaconda/ui/gui/xkl_wrapper.py
+++ b/pyanaconda/ui/gui/xkl_wrapper.py
@@ -296,7 +296,7 @@ class XklWrapper(object):
             #we can get 'layout' or 'layout (variant)'
             (layout, variant) = parse_layout_variant(layout)
         except InvalidLayoutVariantSpec as ilverr:
-            raise XklWrapperError("Failed to add layout: %s" % ilverr)
+            raise XklWrapperError("Failed to add layout: %s" % ilverr) from ilverr
 
         #do not add the same layout-variant combinanion multiple times
         if (layout, variant) in list(zip(self._rec.layouts, self._rec.variants)):

--- a/tests/glade/check_markup.py
+++ b/tests/glade/check_markup.py
@@ -64,12 +64,16 @@ class CheckMarkup(GladeTest):
                 self.assertTrue(markup_necessary(pango_tree),
                         msg="Markup %s could be expressed as attributes at %s%s:%d" %
                             (label.text, label.base, lang_str, label.sourceline))
-            except etree.XMLSyntaxError:
-                raise AssertionError("Unable to parse pango markup %s at %s%s:%d" %
-                        (label.text, label.base, lang_str, label.sourceline))
+            except etree.XMLSyntaxError as xx:
+                raise AssertionError(
+                    "Unable to parse pango markup %s at %s%s:%d" %
+                    (label.text, label.base, lang_str, label.sourceline)
+                ) from xx
             except PangoElementException as px:
-                raise AssertionError("Invalid pango element %s at %s%s:%d" %
-                        (px.element, label.base, lang_str, label.sourceline))
+                raise AssertionError(
+                    "Invalid pango element %s at %s%s:%d" %
+                    (px.element, label.base, lang_str, label.sourceline)
+                ) from px
 
             # If this is a translated node, check that the translated markup
             # has the same elements and attributes as the original.

--- a/translation-canary/translation_canary/translated/test_markup.py
+++ b/translation-canary/translation_canary/translated/test_markup.py
@@ -47,15 +47,15 @@ def test_markup(pofile):
                 try:
                     # pylint: disable=unescaped-markup
                     ET.fromstring('<markup>%s</markup>' % msgstr)
-                except ET.ParseError:
+                except ET.ParseError as e:
                     if entry.msgid_plural:
                         raise AssertionError(
                             "Invalid markup translation for {} translation of msgid {}\n{}".
-                            format(plural_id, entry.msgid, msgstr))
+                            format(plural_id, entry.msgid, msgstr)) from e
                     else:
                         raise AssertionError(
                             "Invalid markup translation for msgid {}\n{}".
-                            format(entry.msgid, msgstr))
+                            format(entry.msgid, msgstr)) from e
 
                 # Check if the markup has the same number and kind of tags
                 if not markup_match(entry.msgid, msgstr):

--- a/translation-canary/translation_canary/translated/test_usability.py
+++ b/translation-canary/translation_canary/translated/test_usability.py
@@ -43,4 +43,4 @@ def test_msgfmt(pofile):
             subprocess.check_output(["msgfmt", "-c", "--verbose", "-o", mofile.name, pofile],
                                     stderr=subprocess.STDOUT, universal_newlines=True)
         except subprocess.CalledProcessError as e:
-            raise AssertionError("Unable to compile %s: %s" % (pofile, e.output))
+            raise AssertionError("Unable to compile %s: %s" % (pofile, e.output)) from e


### PR DESCRIPTION
Silences all appearances of Pylint error W0707.

In a nutshell, this means both exceptions are printed. This is always in the `except` clause, which printed the other exception anyway. However, the previous message was "_During handling of the above exception, another exception occurred_", which is sort of meant to be for cases where there is a legitimate error. By explicitly linking the exceptions, they are now described as "_The above exception was the direct cause of the following exception_".

At this point we need a discussion: What do we really want to achieve, besides making pylint shut up? Do we want to mask the original traceback somewhere? (`raise * from None`) Do we want to not care?