### PR TITLE
Correctly work with package boolean logic in our setup scripts

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -25,7 +25,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define gettextver 0.19.8
 %define gtk3ver 3.22.17
 %define helpver 22.1-1
-%define isomd5sum 1.0.10
+%define isomd5sumver 1.0.10
 %define langtablever 0.0.49
 %define libarchivever 3.0.4
 %define libblockdevver 2.1
@@ -168,7 +168,7 @@ Requires: udisks2-iscsi
 Requires: libblockdev-plugins-all >= %{libblockdevver}
 # active directory/freeipa join support
 Requires: realmd
-Requires: isomd5sum >= %{isomd5sum}
+Requires: isomd5sum >= %{isomd5sumver}
 %ifarch %{ix86} x86_64
 Recommends: fcoe-utils >= %{fcoeutilsver}
 %endif

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -18,6 +18,7 @@ Source0: %{name}-%{version}.tar.bz2
 %if ! 0%{?rhel}
 %define blivetguiver 2.1.12-1
 %endif
+%define dasbusver 1.3
 %define dbusver 1.2.3
 %define dnfver 3.6.0
 %define dracutver 034-7
@@ -29,16 +30,18 @@ Source0: %{name}-%{version}.tar.bz2
 %define langtablever 0.0.49
 %define libarchivever 3.0.4
 %define libblockdevver 2.1
+%define libreportanacondaver 2.0.21-1
 %define libtimezonemapver 0.4.1-2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
 %define pykickstartver 3.27-1
 %define pypartedver 2.5-2
+%define pythonblivetver 1:3.2.2-1
 %define rpmver 4.10.0
 %define simplelinever 1.1-1
+%define subscriptionmanagerver 1.26
 %define utillinuxver 2.15.1
-%define dasbusver 1.3
 
 BuildRequires: audit-libs-devel
 BuildRequires: libtool
@@ -80,10 +83,10 @@ The anaconda package is a metapackage for the Anaconda installer.
 Summary: Core of the Anaconda installer
 Requires: python3-libs
 Requires: python3-dnf >= %{dnfver}
-Requires: python3-blivet >= 1:3.2.2-1
+Requires: python3-blivet >= %{pythonblivetver}
 Requires: python3-blockdev >= %{libblockdevver}
 Requires: python3-meh >= %{mehver}
-Requires: libreport-anaconda >= 2.0.21-1
+Requires: libreport-anaconda >= %{libreportanacondaver}
 Requires: libselinux-python3
 Requires: rpm-python3 >= %{rpmver}
 Requires: python3-pyparted >= %{pypartedver}
@@ -102,7 +105,7 @@ Requires: python3-dasbus >= %{dasbusver}
 Requires: flatpak-libs
 %if 0%{?rhel}
 Requires: python3-syspurpose
-Requires: subscription-manager >= 1.26
+Requires: subscription-manager >= %{subscriptionmanagerver}
 %endif
 
 # pwquality only "recommends" the dictionaries it needs to do anything useful,

--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -104,11 +104,9 @@ def runtime_dependencies(spec_content):
     """Find all Requires from spec file."""
     # find all Requires: statements
     # take first word from these statements to avoid these problems:
-    # - Requires: (take_package or not_taken)             # take first from the boolean is the
-    #                                                       best what we can do
-    # - Requires: ( taken_package or not_taken_package )  # work even with space after bracket
+    # - Requires: (take_package or not_taken)             # take the whole (...)
     # - Requires: taken_package >= 3.2.1                  # not taking the version
-    packages = re.findall(r"\n *Requires:[ (]*([^ \n]*)", spec_content)
+    packages = re.findall(r"\n *Requires: +([^#><=\n]*)", spec_content)
     result = set()
 
     for pkg in packages:


### PR DESCRIPTION
There is support in spec file to have (package1 or package2). This was already fixed by taking the first package by 9c500836d595c0c16cb530efc79cbcf7bf89e26f but there is better way by taking whole brackets.

Add logic to take whole brackets and put that to mock directly.