### PR TITLE
network: do not crash when updating a connection without wired settings

### DIFF
--- a/pyanaconda/modules/network/initialization.py
+++ b/pyanaconda/modules/network/initialization.py
@@ -411,13 +411,14 @@ class DumpMissingIfcfgFilesTask(Task):
         s_con.set_property(NM.SETTING_CONNECTION_ID, iface)
         s_con.set_property(NM.SETTING_CONNECTION_INTERFACE_NAME, iface)
         s_wired = con.get_setting_wired()
-        # By default connections are bound to interface name
-        s_wired.set_property(NM.SETTING_WIRED_MAC_ADDRESS, None)
-        bound_mac = bound_hwaddr_of_device(self._nm_client, iface, self._ifname_option_values)
-        if bound_mac:
-            s_wired.set_property(NM.SETTING_WIRED_MAC_ADDRESS, bound_mac)
-            log.debug("%s: iface %s bound to mac address %s by ifname boot option",
-                      self.name, iface, bound_mac)
+        if s_wired:
+            # By default connections are bound to interface name
+            s_wired.set_property(NM.SETTING_WIRED_MAC_ADDRESS, None)
+            bound_mac = bound_hwaddr_of_device(self._nm_client, iface, self._ifname_option_values)
+            if bound_mac:
+                s_wired.set_property(NM.SETTING_WIRED_MAC_ADDRESS, bound_mac)
+                log.debug("%s: iface %s bound to mac address %s by ifname boot option",
+                          self.name, iface, bound_mac)
 
     @guard_by_system_configuration(return_value=[])
     def run(self):


### PR DESCRIPTION
One of the Anaconda fallouts of NM defaulting to keyfiles.
Hit by team-pre and five other -pre kickstart tests.