### PR TITLE
Remove biospart support

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -33,7 +33,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.27-1
+%define pykickstartver 3.28-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 1.1-1

--- a/dracut/kickstart-genrules.sh
+++ b/dracut/kickstart-genrules.sh
@@ -27,9 +27,6 @@ case "${kickstart%%:*}" in
         fi
         wait_for_kickstart
     ;;
-    bd) # bd:<dev>:<path> - biospart (TODO... if anyone uses this anymore)
-        warn "inst.ks: can't get kickstart - biospart (bd:) isn't supported yet"
-    ;;
     "")
         if [ -z "$kickstart" -a -z "$(getarg ks= inst.ks=)" ]; then
             when_diskdev_appears $(disk_to_dev_path LABEL=OEMDRV) \

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -47,7 +47,7 @@ from pykickstart.version import DEVEL as VERSION
 
 # Import all kickstart commands as version-less.
 from pykickstart.commands.cdrom import FC3_Cdrom as Cdrom
-from pykickstart.commands.harddrive import FC3_HardDrive as HardDrive
+from pykickstart.commands.harddrive import F33_HardDrive as HardDrive
 from pykickstart.commands.hmc import F28_Hmc as Hmc
 from pykickstart.commands.nfs import FC6_NFS as NFS
 from pykickstart.commands.url import F30_Url as Url

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -192,6 +192,7 @@ class DracutDriverDisk(DriverDisk, DracutArgsMixin):
                 dd_args.append("inst.dd=hd:%s" % dd.partition)
             elif dd.source:
                 dd_args.append("inst.dd=%s" % dd.source)
+            # TODO: find out if biospart is support is required for DD and remove this code if not
             elif dd.biospart:
                 dd_args.append("inst.dd=bd:%s" % dd.biospart)
 

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -136,12 +136,9 @@ class DracutCdrom(Cdrom, DracutArgsMixin):
 
 class DracutHardDrive(HardDrive, DracutArgsMixin):
     def dracut_args(self, args, lineno, obj):
-        if self.biospart:
-            return "inst.repo=bd:%s:%s" % (self.partition, self.dir)
-        else:
-            args = "inst.repo=hd:%s:%s" % (self.partition, self.dir)
-            # Escape spaces
-            return args.replace(" ", "\\x20")
+        args = "inst.repo=hd:%s:%s" % (self.partition, self.dir)
+        # Escape spaces
+        return args.replace(" ", "\\x20")
 
 class DracutHmc(Hmc, DracutArgsMixin):
     def dracut_args(self, args, lineno, obj):

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -41,7 +41,7 @@ from pykickstart.commands.fcoe import F28_Fcoe as Fcoe
 from pykickstart.commands.firewall import F28_Firewall as Firewall
 from pykickstart.commands.firstboot import FC3_Firstboot as Firstboot
 from pykickstart.commands.group import F12_Group as Group
-from pykickstart.commands.harddrive import FC3_HardDrive as HardDrive
+from pykickstart.commands.harddrive import F33_HardDrive as HardDrive
 from pykickstart.commands.hmc import F28_Hmc as Hmc
 from pykickstart.commands.ignoredisk import F29_IgnoreDisk as IgnoreDisk
 from pykickstart.commands.install import F29_Install as Install

--- a/pyanaconda/modules/payloads/source/harddrive/harddrive.py
+++ b/pyanaconda/modules/payloads/source/harddrive/harddrive.py
@@ -19,10 +19,7 @@
 #
 import os
 
-from pykickstart.errors import KickstartParseError
-
 from pyanaconda.anaconda_loggers import get_module_logger
-from pyanaconda.core.i18n import _
 from pyanaconda.core.signal import Signal
 from pyanaconda.core.util import join_paths
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
@@ -91,10 +88,6 @@ class HardDriveSourceModule(PayloadSourceBase, RPMSourceMixin):
 
     def process_kickstart(self, data):
         """Process the kickstart data."""
-        if data.harddrive.biospart:
-            msg = _("The --biospart parameter of harddrive command is not supported!")
-            raise KickstartParseError(msg, lineno=data.harddrive.lineno)
-
         self.set_device(data.harddrive.partition)
         self.set_directory(data.harddrive.dir)
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_test.py
@@ -99,16 +99,6 @@ class DNFKSTestCase(unittest.TestCase):
         self.shared_ks_tests.check_kickstart(ks_in, ks_valid=False, expected_publish_calls=0)
         self.assertEqual(self.interface.ActivePayload, "")
 
-    def harddrive_biospart_kickstart_failed_test(self):
-        # The biospart parameter is not implemented since 2012 and it won't
-        # really work. Make it obvious for user.
-        ks_in = """
-        harddrive --biospart=007 --dir=cool/store
-        """
-        # One publisher call because the biospart support is decided in the harddrive source
-        self.shared_ks_tests.check_kickstart(ks_in, ks_valid=False, expected_publish_calls=1)
-        self.assertEqual(self.interface.ActivePayload, "")
-
     def nfs_kickstart_test(self):
         ks_in = """
         nfs --server=gotham.city --dir=/secret/underground/base --opts=nomount


### PR DESCRIPTION
Remove ``biospart`` support from KS and HDD installation source. These were not implemented and I would be surprised if we would ever add the support.

Blocked by https://github.com/pykickstart/pykickstart/pull/333.