### PR TITLE
subscription: Assure payload restart on DVD install after registration

### DIFF
--- a/pyanaconda/ui/lib/subscription.py
+++ b/pyanaconda/ui/lib/subscription.py
@@ -315,6 +315,10 @@ def register_and_subscribe(payload, progress_callback=None, error_callback=None,
             switch_source(payload, SOURCE_TYPE_CDN)
         # If requested, also restart the payload if CDN is the installation source
         # The CDN either already was the installation source or we just switched to it.
+        #
+        # Make sure to get fresh source proxy as the old one might be stale after
+        # after a source switch.
+        source_proxy = payload.get_source_proxy()
         if restart_payload and source_proxy.Type == SOURCE_TYPE_CDN:
             log.debug("subscription thread: restarting payload after registration")
             _do_payload_restart(payload)

--- a/pyanaconda/ui/lib/subscription.py
+++ b/pyanaconda/ui/lib/subscription.py
@@ -186,6 +186,20 @@ def register_and_subscribe(payload, progress_callback=None, error_callback=None,
     :type progress_callback: callable(subscription_phase)
     :param error_callback: error callback function, takes one argument, the error message
     :type error_callback: callable(error_message)
+    :param bool restart_payload: should payload restart be attempted if it appears necessary ?
+
+    NOTE: The restart_payload attribute controls if the subscription helper function should
+          attempt to restart the payload thread if it deems it necessary (DVD -> CDN switch,
+          registration with CDN source, etc.). If restart_payload is True, it might restart
+          the payload. If it is False, it well never try to do that.
+
+          The main usecase of this at the moment is when the subscription helper function
+          is invoked during early Anaconda kickstart installation. At this stage the initial
+          payload restart has not yet been run and starting it too early could lead to various
+          issues. At this stage we don't want the helper function to restart payload, so we keep
+          restart_payload at default value (False). Later on during manual user interaction we
+          definitely want payload to be restarted as needed (the initial restart long done)
+          and so we pass restart_payload=True.
     """
 
     # assign dummy callback functions if none were provided by caller
@@ -325,6 +339,10 @@ def unregister(payload, overridden_source_type, progress_callback=None, error_ca
     :type progress_callback: callable(subscription_phase)
     :param error_callback: error callback function, takes one argument, the error message
     :type error_callback: callable(error_message)
+    :param bool restart_payload: should payload restart be attempted if it appears necessary ?
+
+    NOTE: For more information about the restart_payload attribute, see the
+          register_and_subscribe() function doc string.
     """
 
     # assign dummy callback functions if none were provided by caller

--- a/tests/nosetests/pyanaconda_tests/subscription_helpers_test.py
+++ b/tests/nosetests/pyanaconda_tests/subscription_helpers_test.py
@@ -517,19 +517,25 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         # when we were not able to attach a subscription
         switch_source.assert_not_called()
 
+    @patch("pyanaconda.payload.manager.payloadMgr.restart_thread")
     @patch("pyanaconda.ui.lib.subscription.switch_source")
     @patch("pyanaconda.modules.common.task.sync_run_task")
     @patch("pyanaconda.threading.threadMgr.wait")
     @patch("pyanaconda.modules.common.constants.services.SUBSCRIPTION.get_proxy")
-    def register_override_cdrom_test(self, get_proxy, thread_mgr_wait, run_task, switch_source):
+    def register_override_cdrom_test(self, get_proxy, thread_mgr_wait, run_task, switch_source,
+                                     restart_thread):
         """Test the register_and_subscribe() helper method - override CDROM source."""
         payload = Mock()
         payload.type = PAYLOAD_TYPE_DNF
         payload.data.repo.dataList = MagicMock(return_value=[])
-        #repo_data_list = payload.data.return_value.repo.return_value.dataList
-        #repo_data_list.return_value = []
-        source_proxy = payload.get_source_proxy.return_value
-        source_proxy.Type = SOURCE_TYPE_CDROM
+        source_proxy_1 = Mock()
+        source_proxy_1.Type = SOURCE_TYPE_CDROM
+        source_proxy_2 = Mock()
+        source_proxy_2.Type = SOURCE_TYPE_CDN
+        payload.get_source_proxy.side_effect = [
+            source_proxy_1,
+            source_proxy_2
+        ]
         progress_callback = Mock()
         error_callback = Mock()
         subscription_proxy = get_proxy.return_value
@@ -540,7 +546,8 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         # run the function
         register_and_subscribe(payload=payload,
                                progress_callback=progress_callback,
-                               error_callback=error_callback)
+                               error_callback=error_callback,
+                               restart_payload=True)
         # we should have waited on network
         thread_mgr_wait.assert_called_once_with(THREAD_WAIT_FOR_CONNECTING_NM)
         # system was no registered, so no unregistration phase
@@ -561,6 +568,63 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         switch_source.assert_called_once_with(payload, SOURCE_TYPE_CDN)
         # and tried to run them
         run_task.assert_called()
+        # tried to restart the payload as CDN is set and we need to restart
+        # the payload to make it usable
+        restart_thread.assert_called_once()
+
+    @patch("pyanaconda.payload.manager.payloadMgr.restart_thread")
+    @patch("pyanaconda.ui.lib.subscription.switch_source")
+    @patch("pyanaconda.modules.common.task.sync_run_task")
+    @patch("pyanaconda.threading.threadMgr.wait")
+    @patch("pyanaconda.modules.common.constants.services.SUBSCRIPTION.get_proxy")
+    def register_override_cdrom_no_restart_test(self, get_proxy, thread_mgr_wait, run_task,
+                                                switch_source, restart_thread):
+        """Test the register_and_subscribe() helper method - override CDROM source, no restart."""
+        payload = Mock()
+        payload.type = PAYLOAD_TYPE_DNF
+        payload.data.repo.dataList = MagicMock(return_value=[])
+        source_proxy_1 = Mock()
+        source_proxy_1.Type = SOURCE_TYPE_CDROM
+        source_proxy_2 = Mock()
+        source_proxy_2.Type = SOURCE_TYPE_CDN
+        payload.get_source_proxy.side_effect = [
+            source_proxy_1,
+            source_proxy_2
+        ]
+        progress_callback = Mock()
+        error_callback = Mock()
+        subscription_proxy = get_proxy.return_value
+        # simulate the system not being registered
+        subscription_proxy.IsRegistered = False
+        # simulate subscription request
+        subscription_proxy.SubscriptionRequest = self.KEY_REQUEST
+        # run the function & tell it not to restart payload
+        register_and_subscribe(payload=payload,
+                               progress_callback=progress_callback,
+                               error_callback=error_callback,
+                               restart_payload=False)
+        # we should have waited on network
+        thread_mgr_wait.assert_called_once_with(THREAD_WAIT_FOR_CONNECTING_NM)
+        # system was no registered, so no unregistration phase
+        progress_callback.assert_has_calls(
+            [call(SubscriptionPhase.REGISTER),
+             call(SubscriptionPhase.ATTACH_SUBSCRIPTION),
+             call(SubscriptionPhase.DONE)]
+        )
+        # we were successful, so no error callback calls
+        error_callback.assert_not_called()
+        # we should have requested the appropriate tasks
+        subscription_proxy.SetRHSMConfigWithTask.assert_called_once()
+        subscription_proxy.RegisterOrganizationKeyWithTask.assert_called_once()
+        subscription_proxy.AttachSubscriptionWithTask.assert_called_once()
+        subscription_proxy.ParseAttachedSubscriptionsWithTask.assert_called_once()
+        # and tried to override the CDROM source, as it is on a list of sources
+        # that are appropriate to be overriden by the CDN source
+        switch_source.assert_called_once_with(payload, SOURCE_TYPE_CDN)
+        # and tried to run them
+        run_task.assert_called()
+        # we told the payload not to restart
+        restart_thread.assert_not_called()
 
     @patch("pyanaconda.ui.lib.subscription.switch_source")
     @patch("pyanaconda.modules.common.task.sync_run_task")
@@ -690,8 +754,14 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         """Test the unregister() helper method - roll back to CDROM source."""
         payload = Mock()
         payload.type = PAYLOAD_TYPE_DNF
-        source_proxy = payload.get_source_proxy.return_value
-        source_proxy.Type = SOURCE_TYPE_CDN
+        source_proxy_1 = Mock()
+        source_proxy_1.Type = SOURCE_TYPE_CDN
+        source_proxy_2 = Mock()
+        source_proxy_2.Type = SOURCE_TYPE_CDROM
+        payload.get_source_proxy.side_effect = [
+            source_proxy_1,
+            source_proxy_2
+        ]
         progress_callback = Mock()
         error_callback = Mock()
         subscription_proxy = get_proxy.return_value
@@ -849,13 +919,56 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         subscription_proxy.RegisterUsernamePasswordWithTask.assert_called_once()
         subscription_proxy.AttachSubscriptionWithTask.assert_called_once()
         subscription_proxy.ParseAttachedSubscriptionsWithTask.assert_called_once()
-        # not tried to set the CDN source
-        switch_source.assert_not_called()
         # and tried to run them
         run_task.assert_called()
         # tried to restart the payload as CDN is set and we need to restart
         # the payload to make it usable
         restart_thread.assert_called_once()
+
+    @patch("pyanaconda.payload.manager.payloadMgr.restart_thread")
+    @patch("pyanaconda.ui.lib.subscription.switch_source")
+    @patch("pyanaconda.modules.common.task.sync_run_task")
+    @patch("pyanaconda.threading.threadMgr.wait")
+    @patch("pyanaconda.modules.common.constants.services.SUBSCRIPTION.get_proxy")
+    def register_payload_no_restart_test(self, get_proxy, thread_mgr_wait, run_task, switch_source,
+                                         restart_thread):
+        """Test payload no restart at registration if not requested."""
+        payload = Mock()
+        payload.type = PAYLOAD_TYPE_DNF
+        source_proxy = payload.get_source_proxy.return_value
+        source_proxy.Type = SOURCE_TYPE_CDN
+        progress_callback = Mock()
+        error_callback = Mock()
+        subscription_proxy = get_proxy.return_value
+        # simulate the system not being registered
+        subscription_proxy.IsRegistered = False
+        # simulate subscription request
+        subscription_proxy.SubscriptionRequest = self.PASSWORD_REQUEST
+        # run the function
+        register_and_subscribe(payload=payload,
+                               progress_callback=progress_callback,
+                               error_callback=error_callback,
+                               restart_payload=False)
+        # we should have waited on network
+        thread_mgr_wait.assert_called_once_with(THREAD_WAIT_FOR_CONNECTING_NM)
+        # system was no registered, so no unregistration phase
+        print(error_callback.mock_calls)
+        progress_callback.assert_has_calls(
+            [call(SubscriptionPhase.REGISTER),
+             call(SubscriptionPhase.ATTACH_SUBSCRIPTION),
+             call(SubscriptionPhase.DONE)]
+        )
+        # we were successful, so no error callback calls
+        error_callback.assert_not_called()
+        # we should have requested the appropriate tasks
+        subscription_proxy.SetRHSMConfigWithTask.assert_called_once()
+        subscription_proxy.RegisterUsernamePasswordWithTask.assert_called_once()
+        subscription_proxy.AttachSubscriptionWithTask.assert_called_once()
+        subscription_proxy.ParseAttachedSubscriptionsWithTask.assert_called_once()
+        # and tried to run them
+        run_task.assert_called()
+        # told the helper method not to restart
+        restart_thread.assert_not_called()
 
     @patch("pyanaconda.payload.manager.payloadMgr.restart_thread")
     @patch("pyanaconda.ui.lib.subscription.switch_source")


### PR DESCRIPTION
Make sure that after successful registration on an install from a DVD image
Anaconda does not just switch the installation source to the CDN (as it
has more up to date and secure packages than the on media repos), but
also restarts the payload. Otherwise we can end in an in-between state
with CDN source being assumed, yet most things still pointing to the
on media repo, resulting in an install-time crash.

To fix this, make sure to get a new source proxy - the previously used
one is no longer valid after a source switch.
    
Also fix unit tests accordingly.

Resolves: rhbz#1873164