### PR TITLE
The underline character should not be displayed

### DIFF
--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -632,6 +632,7 @@ class FilterSpoke(NormalSpoke):
         if count > 0:
             really_show(summary_button)
             label.set_text(summary)
+            label.set_use_underline(True)
         else:
             really_hide(summary_button)
 


### PR DESCRIPTION
Fix anaconda showing "1 _storage device selected" on the advanced storage spoke.
The call was accidentally? removed in 7b7616f