### PR TITLE
Recognize systemd.unit=anaconda.target in anaconda-generator

### DIFF
--- a/data/systemd/anaconda-generator
+++ b/data/systemd/anaconda-generator
@@ -5,7 +5,7 @@
 ANACONDA_TARGET="/lib/systemd/system/anaconda.target"
 CURRENT_DEFAULT_TARGET=$(readlink /etc/systemd/system/default.target)
 
-if [ "$ANACONDA_TARGET" != "$CURRENT_DEFAULT_TARGET" ]; then
+if ! { [ "$ANACONDA_TARGET" = "$CURRENT_DEFAULT_TARGET" ] || grep -q 'systemd.unit=anaconda.target' /proc/cmdline ;} ; then
     exit 0
 fi
 


### PR DESCRIPTION
anaconda.target may be activated not only by symlinking /etc/systemd/systemd/default.target,
this symlink may even not exist, but by e.g. adding "systemd.unit=anaconda.target"
to kernel cmdline (see kernel-command-line(7) from systemd)

`systemctl is-active -q anaconda.target` could be used here, but systemctl is not available from systemd generators.

P.S. See https://www.redhat.com/archives/anaconda-devel-list/2012-August/msg00118.html for description why generator is needed.