### PR TITLE
Make custom storage summary dialog resizeable (1626555)

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/summary.glade
+++ b/pyanaconda/ui/gui/spokes/lib/summary.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.2"/>
   <object class="GtkListStore" id="actionStore">
@@ -27,7 +27,8 @@
     <property name="window_position">center-on-parent</property>
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">dialog</property>
-    <property name="decorated">False</property>
+    <property name="deletable">False</property>
+    <property name="has_resize_grip">True</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can_focus">False</property>
@@ -82,28 +83,12 @@
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkLabel" id="label1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">SUMMARY OF CHANGES</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkLabel" id="label2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="xalign">0</property>
                 <property name="label" translatable="yes">Your customizations will result in the following changes taking effect after you return to the main menu and begin installation:</property>
                 <property name="wrap">True</property>
+                <property name="xalign">0</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -205,5 +190,8 @@
       <action-widget response="0">summaryCancelButton</action-widget>
       <action-widget response="1">summaryAcceptButton</action-widget>
     </action-widgets>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
   </object>
 </interface>


### PR DESCRIPTION
The dialog that shows the summary of a custom storage spoke session
is rather information dense and not that big by default. So lets enable
decorations, which make it possible for users to grad the window edges
to make it bigger as needed.

Also as we now have the dialog name in the header, drop the label that
was previously holding it.

Resolves: rhbz#1626555