### PR TITLE
network: fix inst.dhcpclass boot option

### DIFF
--- a/dracut/parse-anaconda-net.sh
+++ b/dracut/parse-anaconda-net.sh
@@ -65,6 +65,6 @@ fi
 
 # set dhcp vendor class
 dhcpclass=$(getarg inst.dhcpclass) || dhcpclass="anaconda-$(uname -srm)"
-echo "send vendor-class-identifier \"$dhcpclass\";" >> /etc/dhclient.conf
+echo "rd.net.dhcp.vendor-class=\"$dhcpclass\"" >> $net_conf
 
 unset CMDLINE


### PR DESCRIPTION
Transform it to dracut configuration option for NM initramfs generator so that
internal NM dhcp client can be used.

Resolves: rhbz#1870692