### PR TITLE
Propagate a lazy proxy of the storage model

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1453,3 +1453,40 @@ def is_smt_enabled():
     except (IOError, ValueError):
         log.warning("Failed to detect SMT.")
         return False
+
+
+class LazyObject(object):
+    """The lazy object."""
+
+    def __init__(self, getter):
+        """Create a proxy of an object.
+
+        The object might not exist until we call the given
+        function. The function is called only when we try
+        to access the attributes of the object.
+
+        The returned object is not cached in this class.
+        We call the function every time.
+
+        :param getter: a function that returns the object
+        """
+        self._getter = getter
+
+    @property
+    def _object(self):
+        return self._getter()
+
+    def __eq__(self, other):
+        return self._object == other
+
+    def __hash__(self):
+        return self._object.__hash__()
+
+    def __getattr__(self, name):
+        return getattr(self._object, name)
+
+    def __setattr__(self, name, value):
+        if name in ("_getter", ):
+            return super().__setattr__(name, value)
+
+        return setattr(self._object, name, value)

--- a/tests/nosetests/pyanaconda_tests/module_part_interactive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_interactive_test.py
@@ -72,6 +72,24 @@ class InteractivePartitioningInterfaceTestCase(unittest.TestCase):
         self.assertEqual(self.interface.PartitioningMethod, PARTITIONING_METHOD_INTERACTIVE)
 
     @patch_dbus_publish_object
+    def lazy_storage_test(self, publisher):
+        """Make sure that the storage playground is created lazily."""
+        self.module.on_storage_changed(create_storage())
+
+        device_tree_module = self.module.get_device_tree()
+        self.assertIsNone(self.module._storage_playground)
+
+        device_tree_module.get_disks()
+        self.assertIsNotNone(self.module._storage_playground)
+
+        self.module.on_partitioning_reset()
+        self.module.on_storage_changed(create_storage())
+        self.assertIsNone(self.module._storage_playground)
+
+        device_tree_module.get_actions()
+        self.assertIsNotNone(self.module._storage_playground)
+
+    @patch_dbus_publish_object
     def get_device_tree_test(self, publisher):
         """Test GetDeviceTree."""
         DeviceTreeContainer._counter = 0

--- a/tests/nosetests/pyanaconda_tests/util_test.py
+++ b/tests/nosetests/pyanaconda_tests/util_test.py
@@ -29,7 +29,7 @@ from unittest.mock import Mock, patch
 from pyanaconda.errors import ExitError
 from pyanaconda.core.process_watchers import WatchProcesses
 from pyanaconda.core import util
-from pyanaconda.core.util import synchronized
+from pyanaconda.core.util import synchronized, LazyObject
 from pyanaconda.core.configuration.anaconda import conf
 
 from timer import timer
@@ -855,3 +855,98 @@ class MiscTests(unittest.TestCase):
         )
         self.assertEqual(get_anaconda_version_string(), "1.0")
         self.assertEqual(get_anaconda_version_string(build_time_version=True), "1.0-1")
+
+
+class LazyObjectTestCase(unittest.TestCase):
+
+    class Object(object):
+
+        def __init__(self):
+            self._x = 0
+
+        @property
+        def x(self):
+            return self._x
+
+        @x.setter
+        def x(self, value):
+            self._x = value
+
+        def f(self, value):
+            self._x += value
+
+    def setUp(self):
+        self._obj = None
+
+    @property
+    def obj(self):
+        if not self._obj:
+            self._obj = self.Object()
+
+        return self._obj
+
+    @property
+    def lazy_obj(self):
+        return LazyObject(lambda: self.obj)
+
+    def get_set_test(self):
+        self.assertIsNotNone(self.lazy_obj)
+        self.assertIsNone(self._obj)
+
+        self.assertEqual(self.lazy_obj.x, 0)
+        self.assertIsNotNone(self._obj)
+
+        self.obj.x = -10
+        self.assertEqual(self.obj.x, -10)
+        self.assertEqual(self.lazy_obj.x, -10)
+
+        self.lazy_obj.x = 10
+        self.assertEqual(self.obj.x, 10)
+        self.assertEqual(self.lazy_obj.x, 10)
+
+        self.lazy_obj.f(90)
+        self.assertEqual(self.obj.x, 100)
+        self.assertEqual(self.lazy_obj.x, 100)
+
+    def eq_test(self):
+        a = object()
+        lazy_a1 = LazyObject(lambda: a)
+        lazy_a2 = LazyObject(lambda: a)
+
+        self.assertEqual(a, lazy_a1)
+        self.assertEqual(lazy_a1, a)
+
+        self.assertEqual(a, lazy_a2)
+        self.assertEqual(lazy_a2, a)
+
+        self.assertEqual(lazy_a1, lazy_a2)
+        self.assertEqual(lazy_a2, lazy_a1)
+
+        self.assertEqual(lazy_a1, lazy_a1)
+        self.assertEqual(lazy_a2, lazy_a2)
+
+    def neq_test(self):
+        a = object()
+        lazy_a = LazyObject(lambda: a)
+
+        b = object()
+        lazy_b = LazyObject(lambda: b)
+
+        self.assertNotEqual(b, lazy_a)
+        self.assertNotEqual(lazy_a, b)
+
+        self.assertNotEqual(lazy_a, lazy_b)
+        self.assertNotEqual(lazy_b, lazy_a)
+
+    def hash_test(self):
+        a = object()
+        lazy_a1 = LazyObject(lambda: a)
+        lazy_a2 = LazyObject(lambda: a)
+
+        b = object()
+        lazy_b1 = LazyObject(lambda: b)
+        lazy_b2 = LazyObject(lambda: b)
+
+        self.assertEqual({a, lazy_a1, lazy_a2}, {a})
+        self.assertEqual({b, lazy_b1, lazy_b2}, {b})
+        self.assertEqual({lazy_a1, lazy_b2}, {a, b})


### PR DESCRIPTION
The storage model for the partitioning modules should be always created lazily.
When we reset the partitioning, the new model shouldn't be created until we try
to work with it. Then we create a new copy of the storage model, hide disks that
are not selected and possibly initialize empty disks.

There is a problem with modules that need to be able to work with the same copy
of the storage model as the partitioning modules. At this moment, it is only the
device tree module. The suggested solution is to propagate a lazy proxy of the
storage model. It will not trigger the creation of the copy until we try to
access the attributes of the storage model.

Basically, the device tree module always gets the storage model on demand from
the storage property of the partitioning module.

Related: rhbz#1868577