### PR TITLE
network: apply kickstart network --nodefroute also from stage2

### DIFF
--- a/pyanaconda/modules/network/nm_client.py
+++ b/pyanaconda/modules/network/nm_client.py
@@ -614,6 +614,8 @@ def update_connection_ip_settings_from_ksdata(connection, network_data):
         s_ip4.add_address(addr4)
         if network_data.gateway:
             s_ip4.props.gateway = network_data.gateway
+    if network_data.nodefroute:
+        s_ip4.props.never_default = True
     connection.add_setting(s_ip4)
 
     # ipv6 settings


### PR DESCRIPTION
Apply the option also when kikcstart is applied in stage2, for example when
defining commands via %pre section.