### PR TITLE
Always clear treeinfo metadata (#1872056)

### DIFF
--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -1477,6 +1477,7 @@ class DNFPayload(Payload):
     def reset(self):
         tear_down_sources(self.proxy)
         self.reset_additional_repos()
+        self._install_tree_metadata = None
 
         shutil.rmtree(DNF_CACHE_DIR, ignore_errors=True)
         shutil.rmtree(DNF_PLUGINCONF_DIR, ignore_errors=True)


### PR DESCRIPTION
Metadata from the treeinfo were loaded only during the load of new metadata. However, this does not work if we have source without metadata (e.g. mirrorlist). In that case we are loading additional repositories from the old metadata (not mounted anymore) and not the new ones which may have unexpected results.

*Resolves: rhbz#1872056*