### PR TITLE
Differentiate between RAID levels of a device and its container

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/add_device.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/add_device.py
@@ -24,7 +24,7 @@ from pyanaconda.modules.common.errors.configuration import StorageConfigurationE
 from pyanaconda.modules.common.structures.device_factory import DeviceFactoryRequest
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.storage.partitioning.interactive.utils import \
-    get_device_raid_level_name, get_container_size_policy, get_device_factory_arguments
+    get_container_raid_level_name, get_container_size_policy, get_device_factory_arguments
 from pyanaconda.core.storage import PARTITION_ONLY_FORMAT_TYPES
 
 log = get_module_logger(__name__)
@@ -141,7 +141,7 @@ class AddDeviceTask(Task):
             # Don't override user-initiated changes to a defined container.
             request.disks = [d.name for d in container.disks]
             request.container_encrypted = container.encrypted
-            request.container_raid_level = get_device_raid_level_name(container)
+            request.container_raid_level = get_container_raid_level_name(container)
             request.container_size_policy = get_container_size_policy(container)
 
             # The existing container has a name.

--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -808,6 +808,7 @@ def generate_device_factory_request(storage, device) -> DeviceFactoryRequest:
     if device_type is None:
         raise UnsupportedDeviceError("Unsupported type of {}.".format(device.name))
 
+    # Generate the device data.
     request = DeviceFactoryRequest()
     request.device_spec = device.name
     request.device_name = getattr(device.raw_device, "lvname", device.raw_device.name)
@@ -828,6 +829,10 @@ def generate_device_factory_request(storage, device) -> DeviceFactoryRequest:
 
     request.disks = [d.name for d in disks]
 
+    if request.device_type not in CONTAINER_DEVICE_TYPES:
+        return request
+
+    # Generate the container data.
     factory = devicefactory.get_device_factory(
         storage,
         device_type=device_type,


### PR DESCRIPTION
The current logic returned the same RAID level for the device and its container,
but we expect that only one of them will have the RAID level set.

If the current device type is not a container device type, don't generate
container data for the device factory request.