### PR TITLE
Add support for booting installation media with plain SquashFS (Fedora 33)

### DIFF
--- a/tests/nosetests/dracut_tests/dracut_source_test.py
+++ b/tests/nosetests/dracut_tests/dracut_source_test.py
@@ -34,11 +34,13 @@ REPO_DIR = dirname(os.path.realpath(pyanaconda.__file__))
 class SourcesTestCase(unittest.TestCase):
 
     def find_rw_mounts_test(self):
+        """Test that only RO mounts of install sources are in Dracut."""
         # everything what starts by string in this list will not be tested
         ignore_prefixes = ("Makefile", "README", "python-deps", "module-setup.sh")
         # define false positives
         false_positives = (re.compile(r'\bmount +(--move|--make-rprivate)'),
-                           re.compile(r'\bmount /dev/mapper/live-rw'))
+                           re.compile(r'\bmount /dev/mapper/live-rw'),
+                           re.compile(r'\bmount +-t *overlay'))
 
         # filter not interesting content
         comment_regex = re.compile(r'#[^\n]*')


### PR DESCRIPTION
This patch allows booting the image even if it's SquashFS images/install.img
does not contain the embedded rootfs.img in it.
In dracut documentation, this is called direct compression of the root filesystem.

In case the plain SquashFS is found, the filesystem is mounted as overlay.
Otherwise, the current method of mounting the /dev/mapper/live-rw applies.

An example of a netinstall image with the plain SquashFS:
https://kojipkgs.fedoraproject.org/compose/rawhide/Fedora-Rawhide-20200828.n.0/compose/Server/x86_64/iso/Fedora-Server-netinst-x86_64-Rawhide-20200828.n.0.iso

The following problem is solved by this change:

Starting dracut mount hook...
dracut-mount: mount /sysroot: special device /dev/mapper/live-rw does not exist
Entering emergency mode...
The simplest way you can test this change is by interrupting the boot process,
And editing the /usr/lib/anaconda-lib.sh
You can interrupt the boot process by adding rd.break=pre-udev kernel argument.

The plain SquashFS is already supported if the image is Live. But because non-Live images
use a different code path for mounting the root filesystem, this change is needed.

The following patch relates to the following change proposal:
https://fedoraproject.org/wiki/Changes/OptimizeSquashFS

This change is the same as https://github.com/rhinstaller/anaconda/pull/2820, but targets the f33-devel branch.