### PR TITLE
network: do not add superfluous quotes to inst.dhcpclass identifier

### DIFF
--- a/dracut/parse-anaconda-net.sh
+++ b/dracut/parse-anaconda-net.sh
@@ -65,6 +65,6 @@ fi
 
 # set dhcp vendor class
 dhcpclass=$(getarg inst.dhcpclass) || dhcpclass="anaconda-$(uname -srm)"
-echo "rd.net.dhcp.vendor-class=\"$dhcpclass\"" >> $net_conf
+echo "rd.net.dhcp.vendor-class=$dhcpclass" >> $net_conf
 
 unset CMDLINE


### PR DESCRIPTION
They do not help to handle identifiers containing spaces but add quotes to the
identifier instead.

Related: rhbz#1870692