### PR TITLE
Add the DBus method IsDeviceShrinkable (#1875677)

### DIFF
--- a/pyanaconda/modules/storage/partitioning/automatic/resizable_interface.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/resizable_interface.py
@@ -37,13 +37,13 @@ class ResizableDeviceTreeInterface(DeviceTreeInterface):
         """
         return self.implementation.is_device_partitioned(device_name)
 
-    def IsDeviceResizable(self, device_name: Str) -> Bool:
-        """Is the specified device resizable?
+    def IsDeviceShrinkable(self, device_name: Str) -> Bool:
+        """Is the specified device shrinkable?
 
         :param device_name: a name of the device
         :return: True or False
         """
-        return self.implementation.is_device_resizable(device_name)
+        return self.implementation.is_device_shrinkable(device_name)
 
     def GetDevicePartitions(self, device_name: Str) -> List[Str]:
         """Get partitions of the specified device.

--- a/pyanaconda/modules/storage/partitioning/automatic/resizable_module.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/resizable_module.py
@@ -52,14 +52,14 @@ class ResizableDeviceTreeModule(DeviceTreeModule):
         """Is the specified device partitioned?"""
         return device.is_disk and device.partitioned and device.format.supported
 
-    def is_device_resizable(self, device_name):
-        """Is the specified device resizable?
+    def is_device_shrinkable(self, device_name):
+        """Is the specified device shrinkable?
 
         :param device_name: a name of the device
         :return: True or False
         """
         device = self._get_device(device_name)
-        return device.resizable
+        return device.resizable and device.min_size < device.size
 
     def get_device_partitions(self, device_name):
         """Get partitions of the specified device.

--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -228,13 +228,13 @@ class ResizeDialog(GUIObject):
 
         # Calculate the free size.
         # Devices that are not resizable are still deletable.
-        is_resizable = self._device_tree.IsDeviceResizable(device_name)
+        is_shrinkable = self._device_tree.IsDeviceShrinkable(device_name)
         size_limits = self._device_tree.GetDeviceSizeLimits(device_name)
 
         min_size = Size(size_limits[0])
         device_size = Size(device_data.size)
 
-        if is_resizable:
+        if is_shrinkable:
             free_size = device_size - min_size
             resize_string = _("%(freeSize)s of %(devSize)s") % {
                 "freeSize": free_size.human_readable(max_places=1),
@@ -394,10 +394,10 @@ class ResizeDialog(GUIObject):
 
         # If the selected filesystem does not support shrinking, make that
         # button insensitive.
-        is_resizable = self._device_tree.IsDeviceResizable(device_name)
-        self._shrink_button.set_sensitive(is_resizable)
+        is_shrinkable = self._device_tree.IsDeviceShrinkable(device_name)
+        self._shrink_button.set_sensitive(is_shrinkable)
 
-        if is_resizable:
+        if is_shrinkable:
             min_size = self._device_tree.GetDeviceSizeLimits(device_name)[0]
             self._setup_slider(min_size, device_data.size, Size(obj.target))
 


### PR DESCRIPTION
Replace the DBus method IsDeviceResizable with IsDeviceShrinkable and fix its
implementation. A shrinkable device has to be resizable and its minimal size
has to be lower then the current size. This should fix the issue with XFS, that
is resizable, but not shrinkable.

Resolves: rhbz#1875677