### PR TITLE
Never convert translated strings to uppercase

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -132,6 +132,7 @@ In general we are trying to be as close as possible to `PEP8 <https://www.python
 * Use ``raise`` & ``return`` in the doc string. Do not use ``raises`` or ``returns``.
 * Methods that return a task should have the suffix ‘_with_task’ (for example discover_with_task and DiscoverWithTask).
 * Prefer to use ``pyanaconda.util.join_paths`` over ``os.path.join``. See documentation for more info.
+* Never call ``upper()`` on translated strings. See the bug `1619530 <https://bugzilla.redhat.com/show_bug.cgi?id=1619530>`_
 
 Merging examples
 ----------------

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -27,7 +27,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define gtk3ver 3.22.17
 %define helpver 22.1-1
 %define isomd5sumver 1.0.10
-%define langtablever 0.0.49
+%define langtablever 0.0.53
 %define libarchivever 3.0.4
 %define libblockdevver 2.1
 %define libreportanacondaver 2.0.21-1

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -972,6 +972,8 @@ def upcase_first_letter(text):
     lowercases all the others. string.title() capitalizes all words in the
     string.
 
+    Note: Never use on translated strings!
+
     :type text: str
     :return: the given text with the first letter upcased
     :rtype: str

--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -301,8 +301,7 @@ def get_native_name(locale):
     """
     raise_on_invalid_locale(locale)
 
-    name = langtable.language_name(languageId=locale)
-    return upcase_first_letter(name)
+    return langtable.language_name(languageId=locale)
 
 
 def get_available_translations(localedir=None):

--- a/pyanaconda/product.py
+++ b/pyanaconda/product.py
@@ -66,5 +66,7 @@ productVersion = trim_product_version_for_ui(productVersion)
 
 
 def distributionText():
-    return _("%(productName)s %(productVersion)s INSTALLATION") % \
-             {"productName": productName, "productVersion": productVersion}
+    return _("%(productName)s %(productVersion)s INSTALLATION") % {
+        "productName": productName.upper(),
+        "productVersion": productVersion.upper()
+    }

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -839,7 +839,7 @@ class GraphicalUserInterface(UserInterface):
             self._currentAction.refresh()
 
             self._currentAction.window.set_beta(not self._isFinal)
-            self._currentAction.window.set_property("distribution", self._distributionText().upper())
+            self._currentAction.window.set_property("distribution", self._distributionText())
 
             # Set some program-wide settings.
             settings = Gtk.Settings.get_default()
@@ -1005,7 +1005,7 @@ class GraphicalUserInterface(UserInterface):
 
         nextAction.initialize()
         nextAction.window.set_beta(self._currentAction.window.get_beta())
-        nextAction.window.set_property("distribution", self._distributionText().upper())
+        nextAction.window.set_property("distribution", self._distributionText())
 
         if not nextAction.showable:
             self._currentAction.window.hide()

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -147,7 +147,7 @@ class Hub(GUIObject, common.Hub):
                 # From here on, this Spoke will always exist.
                 spoke = spokeClass(self.data, self.storage, self.payload)
                 spoke.window.set_beta(self.window.get_beta())
-                spoke.window.set_property("distribution", distributionText().upper())
+                spoke.window.set_property("distribution", distributionText())
 
                 # If a spoke is not showable, it is unreachable in the UI.  We
                 # might as well get rid of it.

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -251,7 +251,7 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
         languageEntry.set_placeholder_text(_(self._origStrings[languageEntry]))
 
         # And of course, don't forget the underlying window.
-        self.window.set_property("distribution", distributionText().upper())
+        self.window.set_property("distribution", distributionText())
         self.window.retranslate()
 
         # Retranslate the window title text

--- a/pyanaconda/ui/gui/xkl_wrapper.py
+++ b/pyanaconda/ui/gui/xkl_wrapper.py
@@ -237,7 +237,7 @@ class XklWrapper(object):
         # translate language and upcase its first letter, translate the
         # layout-variant description
         if xlated:
-            lang = util.upcase_first_letter(iso_(layout_info.lang))
+            lang = iso_(layout_info.lang)
             description = Xkb_(layout_info.desc)
         else:
             lang = util.upcase_first_letter(layout_info.lang)


### PR DESCRIPTION
The conversion might produce invalid strings in some languages, for example in Georgian.

Resolves: rhbz#1619530