### PR TITLE
Move code from payload classes to the Bootloader module

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -331,15 +331,16 @@ def _prepare_installation(payload, ksdata):
     bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
     bootloader_install = TaskQueue("Bootloader installation", N_("Installing boot loader"))
 
-    def configure_bootloader():
-        boot_task = bootloader_proxy.ConfigureWithTask(payload.kernel_version_list)
-        sync_run_task(STORAGE.get_proxy(boot_task))
+    def run_install_bootloader():
+        tasks = bootloader_proxy.InstallBootloaderWithTasks(
+            payload.type,
+            payload.kernel_version_list
+        )
 
-    if not payload.handles_bootloader_configuration:
-        # FIXME: This is a temporary workaround, run the DBus task directly.
-        bootloader_install.append(Task("Configure the bootloader", configure_bootloader))
+        for task in tasks:
+            sync_run_task(STORAGE.get_proxy(task))
 
-    bootloader_install.append_dbus_tasks(STORAGE, [bootloader_proxy.InstallWithTask()])
+    bootloader_install.append(Task("Install bootloader", run_install_bootloader))
     installation_queue.append(bootloader_install)
 
     post_install = TaskQueue("Post-installation setup tasks", (N_("Performing post-installation setup tasks")))

--- a/pyanaconda/modules/storage/bootloader/bootloader.py
+++ b/pyanaconda/modules/storage/bootloader/bootloader.py
@@ -38,7 +38,7 @@ from pyanaconda.modules.common.structures.requirement import Requirement
 from pyanaconda.modules.storage.bootloader.bootloader_interface import BootloaderInterface
 from pyanaconda.modules.storage.bootloader.installation import ConfigureBootloaderTask, \
     InstallBootloaderTask, FixZIPLBootloaderTask, FixBTRFSBootloaderTask, RecreateInitrdsTask, \
-    CreateRescueImagesTask
+    CreateRescueImagesTask, CreateBLSEntriesTask
 from pyanaconda.modules.storage.constants import BootloaderMode, ZIPLSecureBoot
 
 log = get_module_logger(__name__)
@@ -483,6 +483,12 @@ class BootloaderModule(KickstartBaseModule):
             InstallBootloaderTask(
                 storage=self.storage,
                 mode=self.bootloader_mode
+            ),
+            CreateBLSEntriesTask(
+                storage=self.storage,
+                payload_type=payload_type,
+                kernel_versions=kernel_versions,
+                sysroot=conf.target.system_root
             )
         ]
 

--- a/pyanaconda/modules/storage/bootloader/bootloader_interface.py
+++ b/pyanaconda/modules/storage/bootloader/bootloader_interface.py
@@ -273,28 +273,21 @@ class BootloaderInterface(KickstartModuleInterfaceTemplate):
         """
         return self.implementation.detect_windows()
 
-    def ConfigureWithTask(self, kernel_versions: List[Str]) -> ObjPath:
-        """Configure the bootloader.
+    def InstallBootloaderWithTasks(self, payload_type: Str, kernel_versions: List[Str]) \
+            -> List[ObjPath]:
+        """Install the bootloader with a list of tasks.
 
         FIXME: This is just a temporary method.
 
+        :param payload_type: a string with the payload type
         :param kernel_versions: a list of kernel versions
-        :return: a path to a DBus task
+        :return: a list of paths to DBus tasks
         """
-        return TaskContainer.to_object_path(
-            self.implementation.configure_with_task(kernel_versions)
+        tasks = self.implementation.install_bootloader_with_tasks(
+            payload_type,
+            kernel_versions
         )
-
-    def InstallWithTask(self) -> ObjPath:
-        """Install the bootloader.
-
-        FIXME: This is just a temporary method.
-
-        :return: a path to a DBus task
-        """
-        return TaskContainer.to_object_path(
-            self.implementation.install_with_task()
-        )
+        return TaskContainer.to_object_path_list(tasks)
 
     def GenerateInitramfsWithTasks(self, payload_type: Str, kernel_versions: List[Str]) \
             -> List[ObjPath]:

--- a/pyanaconda/modules/storage/bootloader/bootloader_interface.py
+++ b/pyanaconda/modules/storage/bootloader/bootloader_interface.py
@@ -296,25 +296,18 @@ class BootloaderInterface(KickstartModuleInterfaceTemplate):
             self.implementation.install_with_task()
         )
 
-    def FixBTRFSWithTask(self, kernel_versions: List[Str]) -> ObjPath:
-        """Configure the bootloader.
+    def GenerateInitramfsWithTasks(self, payload_type: Str, kernel_versions: List[Str]) \
+            -> List[ObjPath]:
+        """Generate initramfs with a list of tasks.
 
         FIXME: This is just a temporary method.
 
+        :param payload_type: a string with the payload type
         :param kernel_versions: a list of kernel versions
-        :return: a path to a DBus task
+        :return: a list of paths to DBus tasks
         """
-        return TaskContainer.to_object_path(
-            self.implementation.fix_btrfs_with_task(kernel_versions)
+        tasks = self.implementation.generate_initramfs_with_tasks(
+            payload_type,
+            kernel_versions
         )
-
-    def FixZIPLWithTask(self) -> ObjPath:
-        """Fix the ZIPL bootloader.
-
-        FIXME: This is just a temporary method.
-
-        :return: a path to a DBus task
-        """
-        return TaskContainer.to_object_path(
-            self.implementation.fix_zipl_with_task()
-        )
+        return TaskContainer.to_object_path_list(tasks)

--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -28,7 +28,7 @@ from pyanaconda.modules.storage.constants import BootloaderMode
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.storage.bootloader.utils import configure_boot_loader, \
-    install_boot_loader, recreate_initrds
+    install_boot_loader, recreate_initrds, create_rescue_images
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.modules.common.task import Task
 
@@ -36,7 +36,35 @@ log = get_module_logger(__name__)
 
 
 __all__ = ["ConfigureBootloaderTask", "InstallBootloaderTask", "FixBTRFSBootloaderTask",
-           "FixZIPLBootloaderTask", "RecreateInitrdsTask"]
+           "FixZIPLBootloaderTask", "RecreateInitrdsTask", "CreateRescueImagesTask"]
+
+
+class CreateRescueImagesTask(Task):
+    """Installation task that creates rescue images."""
+
+    def __init__(self, payload_type, kernel_versions, sysroot):
+        """Create a new task."""
+        super().__init__()
+        self._payload_type = payload_type
+        self._versions = kernel_versions
+        self._sysroot = sysroot
+
+    @property
+    def name(self):
+        return "Create rescue images"
+
+    def run(self):
+        """Run the task."""
+        #  Live payloads need to create rescue images
+        #  before the bootloader is written on the system.
+        if self._payload_type not in PAYLOAD_LIVE_TYPES:
+            log.debug("Only live payloads require this fix.")
+            return
+
+        create_rescue_images(
+            sysroot=self._sysroot,
+            kernel_versions=self._versions
+        )
 
 
 class ConfigureBootloaderTask(Task):

--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -70,11 +70,12 @@ class CreateRescueImagesTask(Task):
 class ConfigureBootloaderTask(Task):
     """Installation task for the bootloader configuration."""
 
-    def __init__(self, storage, mode, kernel_versions, sysroot):
+    def __init__(self, storage, mode, payload_type, kernel_versions, sysroot):
         """Create a new task."""
         super().__init__()
         self._storage = storage
         self._mode = mode
+        self._payload_type = payload_type
         self._versions = kernel_versions
         self._sysroot = sysroot
 
@@ -84,6 +85,10 @@ class ConfigureBootloaderTask(Task):
 
     def run(self):
         """Run the task."""
+        if self._payload_type == PAYLOAD_TYPE_RPM_OSTREE:
+            log.debug("Don't configure bootloader on rpm-ostree systems.")
+            return
+
         if conf.target.is_directory:
             log.debug("The bootloader configuration is disabled for dir installations.")
             return
@@ -208,6 +213,7 @@ class FixBTRFSBootloaderTask(Task):
         ConfigureBootloaderTask(
             self._storage,
             self._mode,
+            self._payload_type,
             self._versions,
             self._sysroot
         ).run()

--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -19,7 +19,7 @@
 #
 from blivet import arch
 from blivet.devices import BTRFSDevice
-from pyanaconda.core.constants import PAYLOAD_TYPE_RPM_OSTREE
+from pyanaconda.core.constants import PAYLOAD_TYPE_RPM_OSTREE, PAYLOAD_LIVE_TYPES
 from pyanaconda.modules.storage.bootloader import BootLoaderError
 
 from pyanaconda.core.util import execInSysroot
@@ -146,11 +146,12 @@ class FixBTRFSBootloaderTask(Task):
     kernel root and subvol args and adding the missing initrd entry.
     """
 
-    def __init__(self, storage, mode, kernel_versions, sysroot):
+    def __init__(self, storage, mode, payload_type, kernel_versions, sysroot):
         """Create a new task."""
         super().__init__()
         self._storage = storage
         self._mode = mode
+        self._payload_type = payload_type
         self._versions = kernel_versions
         self._sysroot = sysroot
 
@@ -160,6 +161,10 @@ class FixBTRFSBootloaderTask(Task):
 
     def run(self):
         """Run the task."""
+        if self._payload_type not in PAYLOAD_LIVE_TYPES:
+            log.debug("Only live payloads require this fix.")
+            return
+
         if conf.target.is_directory:
             log.debug("The bootloader installation is disabled for dir installations.")
             return

--- a/pyanaconda/payload/base.py
+++ b/pyanaconda/payload/base.py
@@ -149,13 +149,6 @@ class Payload(metaclass=ABCMeta):
         """
         return False
 
-    @property
-    def handles_bootloader_configuration(self):
-        """Whether this payload backend writes the bootloader configuration itself; if
-        False (the default), the generic bootloader configuration code will be used.
-        """
-        return False
-
     def post_install(self):
         """Perform post-installation tasks."""
 

--- a/pyanaconda/payload/live/payload_base.py
+++ b/pyanaconda/payload/live/payload_base.py
@@ -27,9 +27,6 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import INSTALL_TREE, THREAD_LIVE_PROGRESS
 from pyanaconda.core.i18n import _
 from pyanaconda.errors import errorHandler, ERROR_RAISE
-from pyanaconda.modules.common.constants.objects import BOOTLOADER
-from pyanaconda.modules.common.constants.services import STORAGE
-from pyanaconda.modules.common.errors.installation import BootloaderInstallationError
 from pyanaconda.payload import utils as payload_utils
 from pyanaconda.payload.base import Payload
 from pyanaconda.payload.errors import PayloadInstallError
@@ -128,39 +125,6 @@ class BaseLivePayload(Payload):
         payload_utils.unmount(INSTALL_TREE, raise_exc=True)
 
         super().post_install()
-
-        # Not using BLS configuration, skip it
-        if os.path.exists(conf.target.system_root + "/usr/sbin/new-kernel-pkg"):
-            return
-
-        # Remove any existing BLS entries, they will not match the new system's
-        # machine-id or /boot mountpoint.
-        for file in glob.glob(conf.target.system_root + "/boot/loader/entries/*.conf"):
-            log.info("Removing old BLS entry: %s", file)
-            os.unlink(file)
-
-        # Create new BLS entries for this system
-        for kernel in self.kernel_version_list:
-            log.info("Regenerating BLS info for %s", kernel)
-            util.execInSysroot("kernel-install", ["add",
-                                                  kernel,
-                                                  "/lib/modules/{0}/vmlinuz".format(kernel)])
-
-        # Update the bootloader configuration to make sure that the BLS
-        # entries will have the correct kernel cmdline and not the value
-        # taken from /proc/cmdline, that is used to boot the live image.
-        bootloader = STORAGE.get_proxy(BOOTLOADER)
-        if bootloader.IsEFI():
-            grub_cfg_path = "/etc/grub2-efi.cfg"
-        else:
-            grub_cfg_path = "/etc/grub2.cfg"
-
-        # TODO: add a method to the bootloader interface that updates the
-        # configuration and avoid having bootloader specific logic here.
-        rc = util.execInSysroot("grub2-mkconfig",
-                                ["-o", grub_cfg_path])
-        if rc:
-            raise BootloaderInstallationError("failed to write boot loader configuration")
 
     def _update_kernel_version_list(self):
         files = glob.glob(INSTALL_TREE + "/boot/vmlinuz-*")

--- a/pyanaconda/payload/live/payload_liveimg.py
+++ b/pyanaconda/payload/live/payload_liveimg.py
@@ -328,9 +328,6 @@ class LiveImagePayload(BaseLivePayload):
             self.pct = 100
         threadMgr.wait(THREAD_LIVE_PROGRESS)
 
-        # Live needs to create the rescue image before bootloader is written
-        self._create_rescue_image()
-
     def post_install(self):
         """ Unmount and remove image
 

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -61,10 +61,6 @@ class RPMOSTreePayload(Payload):
         return PAYLOAD_TYPE_RPM_OSTREE
 
     @property
-    def handles_bootloader_configuration(self):
-        return True
-
-    @property
     def kernel_version_list(self):
         # OSTree handles bootloader configuration
         return []

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -386,12 +386,6 @@ class RPMOSTreePayload(Payload):
             except CalledProcessError as e:
                 log.debug("unmounting %s failed: %s", mount, str(e))
 
-    def recreate_initrds(self):
-        # For rpmostree payloads, we're replicating an initramfs from
-        # a compose server, and should never be regenerating them
-        # per-machine.
-        pass
-
     def post_install(self):
         super().post_install()
 

--- a/tests/nosetests/pyanaconda_tests/module_bootloader_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_bootloader_test.py
@@ -202,6 +202,7 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
             CreateRescueImagesTask,
             ConfigureBootloaderTask,
             InstallBootloaderTask,
+            CreateBLSEntriesTask
         ]
 
         task_paths = self.bootloader_interface.InstallBootloaderWithTasks(


### PR DESCRIPTION
Move all remaining bootloader-related code from the payload classes
to the Bootloader module and run it as DBus installation tasks.