### PR TITLE
Make locked root be completed only for kickstart

### DIFF
--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -169,7 +169,6 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         # value from the kickstart changed
         # NOTE: yet again, this stops to be valid once multiple
         #       commands are supported by a single DBUS module
-        #self._users_module.SetRootpwKickstarted(False) # !!!!
         self.password_kickstarted = False
 
         self._users_module.SetRootAccountLocked(False)
@@ -190,7 +189,10 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     @property
     def completed(self):
-        return bool(self._users_module.IsRootPasswordSet or self._users_module.IsRootAccountLocked)
+        return bool(
+            self._users_module.IsRootPasswordSet or
+            (self._users_module.IsRootAccountLocked and flags.automatedInstall)
+        )
 
     @property
     def sensitive(self):

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -53,7 +53,10 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     @property
     def completed(self):
-        return bool(self._users_module.IsRootPasswordSet or self._users_module.IsRootAccountLocked)
+        return bool(
+            self._users_module.IsRootPasswordSet or
+            (self._users_module.IsRootAccountLocked and flags.automatedInstall)
+        )
 
     @property
     def showable(self):


### PR DESCRIPTION
With the rebase and later changes, root will always have a password filled, or stay locked with password "".

Resolves: [rhbz#1876727](https://bugzilla.redhat.com/show_bug.cgi?id=1876727)