### PR TITLE
Fix MountData UnboundLocalError when no reformat specified

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -1194,7 +1194,7 @@ class MountData(commands.mount.RHEL7_MountData):
         dev.format.options = self.mount_opts
 
         # make sure swaps end up in /etc/fstab
-        if fmt.type == "swap":
+        if dev.format.type == "swap":
             storage.addFstabSwap(dev)
 
 class Network(commands.network.RHEL7_Network):


### PR DESCRIPTION
This patch attempts to make `--reformat` actually optional by using a defined
local variable.

When `mount` directive is present in a Kickstart file, it's parsed and
validated. The docs for RHEL 7 say that `--reformat` is optional, and
specifying it will re-format the specified block device:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/installation_guide/sect-kickstart-syntax

However, due to `fmt` being undefined _unless_ `--reformat` happens to be 
specified, Anaconda crashes, as captured in the `anaconda-tb-*` file:

```
anaconda 21.48.22.158-1 exception report
Traceback (most recent call first):
  File "/usr/lib64/python2.7/site-packages/pyanaconda/kickstart.py", line 1197, in execute
    if fmt.type == "swap":
  File "/usr/lib64/python2.7/site-packages/pyanaconda/kickstart.py", line 1166, in execute
    md.execute(storage, ksdata, instClass)
  File "/usr/lib64/python2.7/site-packages/pyanaconda/kickstart.py", line 2534, in doKickstartStorage
    ksdata.mount.execute(storage, ksdata, instClass)
  File "/usr/lib64/python2.7/site-packages/pyanaconda/ui/tui/spokes/storage.py", line 439, in execute
    doKickstartStorage(self.storage, self.data, self.instclass)
  File "/usr/lib64/python2.7/site-packages/pyanaconda/ui/tui/hubs/summary.py", line 64, in setup
    spoke.execute()
  File "/usr/lib64/python2.7/site-packages/pyanaconda/ui/tui/__init__.py", line 171, in setup
    should_schedule = obj.setup(self.ENVIRONMENT)
  File "/sbin/anaconda", line 1374, in <module>
    anaconda._intf.setup(ksdata)
UnboundLocalError: local variable 'fmt' referenced before assignment

Local variables in innermost frame:
instClass: <centos.RHELBaseInstallClass object at 0x7fbe695fe710>
self: mount /dev/sda3 none
```

You can reproduce this in VirtualBox using this in your `ks.cfg`:

```cfg
# Partition clearing information
clearpart --none --initlabel
# Disk partitioning information
mount /dev/sda4 / --mountoptions="defaults" --reformat="xfs"
mount /dev/sda2 /boot --mountoptions="defaults" --reformat="vfat"
mount /dev/sda1 /boot/efi --mountoptions="umask=0077,shortname=winnt" --reformat="efi"
# THIS CAUSES THE CRASH because there's no --reformat
mount /dev/sda3 none
```