### PR TITLE
network: clone connections from intramfs to persistent config

### DIFF
--- a/pyanaconda/modules/network/nm_client.py
+++ b/pyanaconda/modules/network/nm_client.py
@@ -974,6 +974,39 @@ def activate_connection_sync(nm_client, connection, device):
     return ret
 
 
+def clone_connection_sync(nm_client, connection, con_id=None, uuid=None):
+    sync_queue = Queue()
+
+    def finish_callback(nm_client, result, sync_queue):
+        con, result = nm_client.add_connection2_finish(result)
+        log.debug("connection %s cloned:\n%s", con.get_uuid(),
+                  con.to_dbus(NM.ConnectionSerializationFlags.NO_SECRETS))
+        sync_queue.put(con)
+
+    cloned_connection = NM.SimpleConnection.new_clone(connection)
+    s_con = cloned_connection.get_setting_connection()
+    s_con.props.uuid = uuid or NM.utils_uuid_generate()
+    s_con.props.id = con_id or "{}-clone".format(connection.get_id())
+    nm_client.add_connection2(
+        cloned_connection.to_dbus(NM.ConnectionSerializationFlags.ALL),
+        (NM.SettingsAddConnection2Flags.TO_DISK |
+         NM.SettingsAddConnection2Flags.BLOCK_AUTOCONNECT),
+        None,
+        False,
+        None,
+        finish_callback,
+        sync_queue
+    )
+
+    try:
+        ret = sync_queue.get(timeout=CONNECTION_ACTIVATION_TIMEOUT)
+    except Empty:
+        log.error("Cloning of a connection timed out.")
+        ret = None
+
+    return ret
+
+
 def get_dracut_arguments_from_connection(nm_client, connection, iface, target_ip,
                                          hostname, ibft=False):
     """Get dracut arguments for the iface and SAN target from NM connection.


### PR DESCRIPTION
In case of common connection ("Wired connection") being used for multiple
devices in initramfs (which happens in case of ip=dhcp or no ip= specified) the
connection was not used for persistent configuration of the devices and instead
a default connection created by Anaconda was used.  Let's clone the "Wired
connection" into the default connection created by Anaconda so that its
properties (like default ipv6.addr-gen-mode or
ipv4.dhcp-vendor-class-identifier) are preserved.

Related: rhbz#1870692