### PR TITLE
Root password is mandatory if there is *not* admin user.

### DIFF
--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -64,8 +64,8 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     @property
     def mandatory(self):
-        """Root password spoke is mandatory if no users with admin rights have been requested."""
-        return self._users_module.CheckAdminUserExists()
+        """Only mandatory if no admin user has been requested."""
+        return not self._users_module.CheckAdminUserExists()
 
     @property
     def status(self):


### PR DESCRIPTION
Related: rhbz#1876727

Making the condition the same as in GUI.

Addition to https://github.com/rhinstaller/anaconda/pull/2852