### PR TITLE
network: commit changes synchronously when dumping autoconnections

### DIFF
--- a/pyanaconda/modules/network/initialization.py
+++ b/pyanaconda/modules/network/initialization.py
@@ -503,7 +503,7 @@ class DumpMissingConfigFilesTask(Task):
                     )
                 log.debug("%s: dumping connection %s to config file for %s",
                           self.name, con.get_uuid(), iface)
-                con.commit_changes(True, None)
+                commit_changes_with_autoconnection_blocked(con)
             else:
                 log.debug("%s: none of the connections can be dumped as persistent",
                           self.name)


### PR DESCRIPTION
We should make sure they are complete when creating device configuraitons in
next step.