### PR TITLE
Use the DBus source for RPM OSTree in UI

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -339,6 +339,7 @@ commandMap = {
     "network": UselessCommand,
     "nfs": UselessCommand,
     "nvdimm": UselessCommand,
+    "ostreesetup": UselessCommand,
     "part": UselessCommand,
     "partition": UselessCommand,
     "raid": UselessCommand,

--- a/pyanaconda/modules/payloads/payload/dnf/dnf.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf.py
@@ -25,7 +25,6 @@ from pyanaconda.core.constants import RPM_LANGUAGES_NONE, MULTILIB_POLICY_ALL, \
     GROUP_PACKAGE_TYPES_REQUIRED, RPM_LANGUAGES_ALL
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.structures.payload import PackagesConfigurationData
-from pyanaconda.modules.payloads.base.initialization import SetUpSourcesTask, TearDownSourcesTask
 from pyanaconda.modules.payloads.constants import PayloadType, SourceType
 from pyanaconda.modules.payloads.payload.payload_base import PayloadBase
 from pyanaconda.modules.payloads.payload.dnf.dnf_interface import DNFInterface
@@ -261,13 +260,3 @@ class DNFModule(PayloadBase):
         """
         # TODO: Implement this method
         pass
-
-    def set_up_sources_with_task(self):
-        """Set up installation sources."""
-        # FIXME: Move the implementation to the base class.
-        return SetUpSourcesTask(self._sources)
-
-    def tear_down_sources_with_task(self):
-        """Tear down installation sources."""
-        # FIXME: Move the implementation to the base class.
-        return TearDownSourcesTask(self._sources)

--- a/pyanaconda/modules/payloads/payload/payload_base.py
+++ b/pyanaconda/modules/payloads/payload/payload_base.py
@@ -24,6 +24,7 @@ from dasbus.server.publishable import Publishable
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.errors.payload import IncompatibleSourceError, SourceSetupError
 from pyanaconda.modules.common.base import KickstartBaseModule
+from pyanaconda.modules.payloads.base.initialization import SetUpSourcesTask, TearDownSourcesTask
 from pyanaconda.modules.payloads.constants import SourceState
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -182,12 +183,10 @@ class PayloadBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         """
         pass
 
-    @abstractmethod
     def set_up_sources_with_task(self):
         """Set up installation sources."""
-        pass
+        return SetUpSourcesTask(self.sources)
 
-    @abstractmethod
     def tear_down_sources_with_task(self):
         """Tear down installation sources."""
-        pass
+        return TearDownSourcesTask(self.sources)

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/rpm_ostree.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/rpm_ostree.py
@@ -87,13 +87,3 @@ class RPMOSTreeModule(PayloadBase):
         """
         # TODO: Implement this method
         pass
-
-    def set_up_sources_with_task(self):
-        """Set up installation sources."""
-        # TODO: Implement this method
-        pass
-
-    def tear_down_sources_with_task(self):
-        """Tear down installation sources."""
-        # TODO: Implement this method
-        pass

--- a/pyanaconda/modules/payloads/payloads.py
+++ b/pyanaconda/modules/payloads/payloads.py
@@ -105,7 +105,12 @@ class PayloadsService(KickstartService):
         """Return a kickstart string."""
         # Generate only the parts of kickstart that were removed from UI.
         # FIXME: This is a temporary workaround for RPM sources.
-        if self.active_payload and self.active_payload.type != PayloadType.DNF:
+        enabled_types = {
+            PayloadType.DNF,
+            PayloadType.RPM_OSTREE
+        }
+
+        if self.active_payload and self.active_payload.type not in enabled_types:
             log.debug("Generating kickstart... (skip)")
             return ""
 

--- a/pyanaconda/modules/payloads/source/rpm_ostree/rpm_ostree.py
+++ b/pyanaconda/modules/payloads/source/rpm_ostree/rpm_ostree.py
@@ -121,4 +121,9 @@ class RPMOSTreeSourceModule(PayloadSourceBase):
         return []
 
     def __repr__(self):
-        return "Source(type='RPM_OSTREE')"
+        """Return a string representation of the source."""
+        return "Source(type='{}', osname='{}', url='{}')".format(
+            self.type.value,
+            self.configuration.osname,
+            self.configuration.url
+        )

--- a/pyanaconda/modules/payloads/source/rpm_ostree/rpm_ostree.py
+++ b/pyanaconda/modules/payloads/source/rpm_ostree/rpm_ostree.py
@@ -81,7 +81,6 @@ class RPMOSTreeSourceModule(PayloadSourceBase):
 
     def get_state(self):
         """Get state of this source."""
-        # TODO: Implement this method
         return SourceState.NOT_APPLICABLE
 
     def process_kickstart(self, data):
@@ -108,7 +107,6 @@ class RPMOSTreeSourceModule(PayloadSourceBase):
         :return: list of tasks required for the source setup
         :rtype: [Task]
         """
-        # TODO: Implement this method
         return []
 
     def tear_down_with_tasks(self):
@@ -117,7 +115,6 @@ class RPMOSTreeSourceModule(PayloadSourceBase):
         :return: list of tasks required for the source clean-up
         :rtype: [Task]
         """
-        # TODO: Implement this method
         return []
 
     def __repr__(self):

--- a/pyanaconda/modules/payloads/source/rpm_ostree/rpm_ostree.py
+++ b/pyanaconda/modules/payloads/source/rpm_ostree/rpm_ostree.py
@@ -25,6 +25,7 @@ from pyanaconda.modules.payloads.constants import SourceType, SourceState
 from pyanaconda.modules.payloads.source.rpm_ostree.rpm_ostree_interface import \
     RPMOSTreeSourceInterface
 from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase
+from pyanaconda.modules.payloads.source.utils import has_network_protocol
 
 log = get_module_logger(__name__)
 
@@ -76,8 +77,7 @@ class RPMOSTreeSourceModule(PayloadSourceBase):
 
         :return: True or False
         """
-        # TODO: Implement this method
-        return False
+        return has_network_protocol(self.configuration.url)
 
     def get_state(self):
         """Get state of this source."""

--- a/tests/nosetests/pyanaconda_tests/module_payload_rpm_ostree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_rpm_ostree_test.py
@@ -84,5 +84,5 @@ class RPMOSTreeKickstartTestCase(unittest.TestCase):
         # OSTree setup
         ostreesetup --osname="fedora-atomic" --remote="fedora-atomic-28" --url="file:///ostree/repo" --ref="fedora/28/x86_64/atomic-host" --nogpg
         """
-        self.shared_ks_tests.check_kickstart(ks_in, ks_out="", ks_tmp=ks_out)
+        self.shared_ks_tests.check_kickstart(ks_in, ks_out)
         self._check_properties(SOURCE_TYPE_RPM_OSTREE)

--- a/tests/nosetests/pyanaconda_tests/module_source_rpm_ostree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_rpm_ostree_test.py
@@ -102,3 +102,24 @@ class OSTreeSourceTestCase(unittest.TestCase):
     def tear_down_with_tasks_test(self):
         """Test the tear-down tasks."""
         self.assertEqual(self.module.tear_down_with_tasks(), [])
+
+    def repr_test(self):
+        """Test the string representation."""
+        self.assertEqual(repr(self.module), str(
+            "Source("
+            "type='RPM_OSTREE', "
+            "osname='', "
+            "url=''"
+            ")"
+        ))
+
+        self.module.configuration.osname = "fedora-atomic"
+        self.module.configuration.url = "https://kojipkgs.fedoraproject.org/atomic/repo"
+
+        self.assertEqual(repr(self.module), str(
+            "Source("
+            "type='RPM_OSTREE', "
+            "osname='fedora-atomic', "
+            "url='https://kojipkgs.fedoraproject.org/atomic/repo'"
+            ")"
+        ))

--- a/tests/nosetests/pyanaconda_tests/module_source_rpm_ostree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_rpm_ostree_test.py
@@ -82,6 +82,15 @@ class OSTreeSourceTestCase(unittest.TestCase):
         """Test the network_required property."""
         self.assertEqual(self.module.network_required, False)
 
+        self.module.configuration.url = "file://my/path"
+        self.assertEqual(self.module.network_required, False)
+
+        self.module.configuration.url = "http://my/path"
+        self.assertEqual(self.module.network_required, True)
+
+        self.module.configuration.url = "https://my/path"
+        self.assertEqual(self.module.network_required, True)
+
     def get_state_test(self):
         """Test the source state."""
         self.assertEqual(SourceState.NOT_APPLICABLE, self.module.get_state())


### PR DESCRIPTION
Use the RPM OSTree DBus module and its source to install the payload.
The `ostreesetup` kickstart command should be handled only by the DBus module now.