### PR TITLE
fix remove unkown partition in sda failed

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -1072,8 +1072,10 @@ def _destroy_device(storage, device):
     :param device: an instance of a device
     """
     # Remove the device.
-    if device.is_disk and device.partitioned and not device.format.supported:
-        storage.recursive_remove(device)
+    if device.is_disk:
+        if device.partitioned and not device.format.supported:
+            storage.recursive_remove(device)
+        storage.initialize_disk(device)
     elif device.direct and not device.isleaf:
         # We shouldn't call this method for with non-leaf devices
         # except for those which are also directly accessible like
@@ -1082,10 +1084,6 @@ def _destroy_device(storage, device):
         storage.recursive_remove(device)
     else:
         storage.destroy_device(device)
-
-    # Initialize the disk.
-    if device.is_disk:
-        storage.initialize_disk(device)
 
     # Remove empty extended partitions.
     if getattr(device, "is_logical", False):


### PR DESCRIPTION
fix: cannot create partition when sda exists a ext4 filesystem.
When you remove unkown partition in sda, only the format in sda should be destroyed without removing sda from the device tree, but sda is also destroyed. As a result, sda cannot be found during disk initialization and an error is reported. 
Resolves: rhbz#1878661