### PR TITLE
Fix unit test dependency installation for boolean expressions

### DIFF
--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -182,4 +182,4 @@ if __name__ == "__main__":
     if args.pip:
         res_packages = pip_dependencies()
 
-    print(" ".join(res_packages))
+    print("\n".join(res_packages))

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -19,7 +19,9 @@ Run tests locally
 Before you are able to run Anaconda tests you need to install all required dependencies.
 To get list of dependencies you can use::
 
-    [dnf|yum] install -y $(./scripts/testing/dependency_solver.py)
+    ./scripts/testing/dependency_solver.py | xargs -d '\n' sudo dnf install -y
+
+Use `yum` instead of `dnf` on RHEL/CentOS 7.
 
 Prepare the environment and build the sources::
 


### PR DESCRIPTION
Installing test dependencies in the documented way breaks due to boolean
dependencies:

```
$ sudo dnf install (./scripts/testing/dependencyₛolver.py)
Last metadata expiration check: 1:09:39 ago on Wed Sep 30 08:09:56 2020.
Packge kbd-2.3.0-2.fc33.x86_64 is already installed.
[...]
No match for argument: (glibc-langpack-en
No match for argument: or
No match for argument: glibc-all-langpacks)
[...]
Error: Unable to find a match: (glibc-langpack-en or glibc-all-langpacks)
```

There is no way how to quote spaces in package names that makes them
survive correctly through `$()`, so move to a line based format and feed
the list to dnf and setup-mock-test-env.py via `xargs`.