### PR TITLE
Fix instructions for unit tests

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -49,8 +49,8 @@ produce a human readable report.
 Run tests inside Mock
 ---------------------
 
-When using the `ci' target in a mock you need to use a regular user account which
-is a member of the `mock' group. You can update your account by running
+When using the `ci` target in a mock you need to use a regular user account which
+is a member of the `mock` group. You can update your account by running
 the command::
 
     # usermod -a -G mock <username>

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -35,7 +35,7 @@ Executing the tests can be done with::
 
 To run a single test do::
 
-    make TESTS=install/nosetests.sh check
+    make TESTS=nosetests.sh check
 
 See `tests/Makefile.am` for possible values. Alternatively you can try::
 

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -57,14 +57,17 @@ the command::
 
 To prepare testing mock environment call::
 
-    ./scripts/testing/setup-mock-test-env.py [mock-configuration]
+    ./scripts/testing/setup-mock-test-env.py --init [mock-configuration]
 
 Mock configuration can be path to a file or name of file in `/etc/mock/*.cfg`
 without suffix. For detail configuration look on the script help output.
 
 Then you can run tests by::
 
-    mock -r [mock_configuration] --chroot -- "cd /anaconda && ./autogen.sh && ./configure && make ci"
+    ./scripts/testing/setup-mock-test-env.py -ut [mock-configuration]
+
+See `./scripts/testing/setup-mock-test-env.py --help` for additional options
+like running individual tests.
 
 Or you can just attach to shell inside of the prepared mock environment::
 


### PR DESCRIPTION
With these I am able to set up a mock and successfully run unit tests. On Fedora 33 one first needs to manually install the 
[latest pykickstart](https://koji.fedoraproject.org/koji/buildinfo?buildID=1617300), as the one in current 33 isn't sufficient.