### PR TITLE
Unit test fixes

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -54,6 +54,7 @@ BuildRequires: gobject-introspection-devel
 BuildRequires: glade-devel
 BuildRequires: libgnomekbd-devel
 BuildRequires: libxklavier-devel >= %{libxklavierver}
+BuildRequires: make
 BuildRequires: pango-devel
 BuildRequires: python3-kickstart >= %{pykickstartver}
 BuildRequires: python3-devel

--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -37,6 +37,7 @@ TEST_DEPENDENCIES = [
     "git",
     "bzip2",
     "cppcheck",
+    "rpm-build",
     "rpm-ostree",
     "pykickstart",
     "python3-pip",

--- a/tests/nosetests/pyanaconda_tests/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_storage_test.py
@@ -1457,13 +1457,26 @@ class StorageTasksTestCase(unittest.TestCase):
         storage.assert_not_called()
 
     @patch("pyanaconda.core.util.mkdirChain")
-    @patch("pyanaconda.core.util.execWithRedirect")
-    def mount_filesystems_test(self, execute, mkdir):
+    @patch("pyanaconda.core.util._run_program")
+    @patch("os.makedirs")
+    @patch("blivet.util._run_program")
+    def mount_filesystems_test(self, blivet_run_program, makedirs, core_run_program, mkdirChain):
         """Test MountFilesystemsTask."""
         storage = create_storage()
         storage._bootloader = Mock()
-        execute.return_value = 0
+        blivet_run_program.return_value = (0, "")
+        core_run_program.return_value = (0, "")
         MountFilesystemsTask(storage).run()
+        # created the mount points
+        makedirs.assert_any_call('/mnt/sysimage/dev', 0o755)
+        # sysimage mounts happened
+        blivet_run_program.assert_any_call(
+                ['mount', '-t', 'bind', '-o', 'bind,defaults', '/dev', '/mnt/sysimage/dev'])
+        # remounted the root filesystem
+        core_run_program.assert_any_call(
+                ['mount', '--rbind', '/mnt/sysimage', '/mnt/sysroot'],
+                stdin=None, stdout=None, root='/', env_prune=None,
+                log_output=True, binary_output=False)
 
     @patch_dbus_get_proxy
     @patch("pyanaconda.modules.storage.installation.conf")


### PR DESCRIPTION
This paves the way for running the unit tests in a container. I will submit a draft PR which does that, but as that may need a little more discussion and fine-tuning, I'm submitting these parts separately.

This can be reproduced with running 

    make tests-nose-only NOSE_TESTS_ARGS='nosetests/pyanaconda_tests/module_storage_test.py'

in mock with a non-root user, in other words

    mock -r fedora-33-x86_64 --shell --unpriv