### PR TITLE
Run unit tests in a GitHub action

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,35 @@
+name: validate
+on: [push, pull_request]
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/fedora:rawhide
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      # FIXME: the following should be done statically in a custom container image
+      - name: set up dependencies
+        run: |
+          dnf install -y /usr/bin/xargs
+          scripts/testing/dependency_solver.py -brt | xargs -d '\n' dnf install -y
+          scripts/testing/dependency_solver.py --pip | xargs pip install
+
+      - name: build
+        run: |
+          ./autogen.sh
+          ./configure
+          make
+
+      - name: run unit tests
+        run: |
+          make ci
+
+      - name: Upload test and coverage logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: |
+            tests/test-suite.log
+            tests/coverage-*.log


### PR DESCRIPTION
Set up a Fedora rawhide container with
scripts/testing/dependency_solver.py and run the unit tests. Export the 
test log on failure.

This is a bit inefficient (dependency_solver.py setup takes about 2
mintues) and brittle (as rawhide may break at any time), but that is
exactly what happens in Jenkins through setup-mock-test-env.py right
now. It should be improved later by regularly building and publishing a
custom container image.

------

 - [x] Builds on top of PR #2882, land that first
 - [x] Export coverage reports as artifacts

Follow-ups:
 - [ ] Dynamically pick container version based on [target branch](https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions)
 - [ ] Provide a script to locally prepare a podman container and run tests in it

This is supposed to replace the "Anaconda Rawhide tests" on Jenkins. It's a first working PoC that runs the same build/test than that, aside from exporting the coverage logs (which is easy enough to do).

I would also like to replace the hardcoded `:master` container tag name with something that picks `master` vs `33` etc. based on the PR's target branch, so that we can use the exact same workflow file on branches.

But first I'd like to get some review/consensus if that is suitable for you. I recommend it because it's super-simple to set up, and there is not that much magic sauce involved -- e.g. it's fairly straightforward to write a .travis.yml or a Semaphore 2.0 CI. For running on a public OpenShift/k8s instance it's not good enough yet, as they usually don't give you containers with root access -- but that's just [some more well-understood work](https://github.com/rhinstaller/anaconda/pull/2882#issuecomment-702552830) if that ever comes up.

If you generally like the approach, I'll do the remaining work in the above TODO list.