### PR TITLE
Show in the first screen only translated locales

### DIFF
--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -24,6 +24,7 @@ import langtable
 import locale as locale_mod
 import glob
 from collections import namedtuple
+import functools
 
 from pyanaconda.core import constants
 from pyanaconda.core.util import upcase_first_letter, setenv, execWithRedirect
@@ -331,6 +332,21 @@ def get_available_translations(localedir=None):
                 continue
 
             yield lang
+
+
+@functools.lru_cache(2048)
+def locale_has_translation(locale):
+    """Does the locale have a translation available?
+
+    Checks if a given locale will receive a gettext translation. That could be either because the
+    locale has a translation, or because there is another translation to fall back onto. In
+    reality, the fallback is mostly of the type "ja_JP" -> "ja".
+
+    :param str locale: locale to check
+    :return bool: is there a translation
+    """
+    files = gettext.find("anaconda", None, [locale], True)
+    return bool(files)
 
 
 def get_language_locales(lang):

--- a/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
+++ b/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
@@ -59,6 +59,8 @@ class LangLocaleHandler(object):
         self._right_arrow = None
         self._left_arrow = None
 
+        self._only_existing_locales = False
+
     @abstractproperty
     def payload(self):
         """Get payload class."""
@@ -163,6 +165,8 @@ class LangLocaleHandler(object):
         locales = localization.get_language_locales(lang)
 
         for locale in locales:
+            if self._only_existing_locales and not localization.locale_has_translation(locale):
+                continue
             self._add_locale(self._localeStore,
                              localization.get_native_name(locale),
                              locale)

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -70,6 +70,8 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
 
         self._l12_module = LOCALIZATION.get_proxy()
 
+        self._only_existing_locales = True
+
     def apply(self):
         (store, itr) = self._localeSelection.get_selected()
 


### PR DESCRIPTION
This decision is delegated to gettext. The most usual situations are:

- The locale does not have exactly matching translation and falls back to translation for the language.
- The locale has an exactly matching translation.
- The locale has neither a translation nor anything to fall back to.

Languages are already filtered in a similar manner, so there is no danger of having a language with no locale leading to an empty locale list and failing callbacks.

Resolves: [rhbz#1678787](https://bugzilla.redhat.com/show_bug.cgi?id=1678787)