### PR TITLE
Fix spelling/name of OSTree

### DIFF
--- a/pyanaconda/modules/payloads/source/rpm_ostree/rpm_ostree.py
+++ b/pyanaconda/modules/payloads/source/rpm_ostree/rpm_ostree.py
@@ -47,7 +47,7 @@ class RPMOSTreeSourceModule(PayloadSourceBase):
     @property
     def description(self):
         """Get description of this source."""
-        return _("RPM OS Tree")
+        return _("RPM OSTree")
 
     def for_publication(self):
         """Return a DBus representation."""

--- a/tests/gettext_tests/style_guide.py
+++ b/tests/gettext_tests/style_guide.py
@@ -31,6 +31,7 @@ bad_strings = {'(?i)bootloader': 'boot loader',
                '[Cc]an not':     'cannot',
                '(?i)mountpoint': 'mount point',
                'Ok':             'OK',
+               '(?i)os tree ':   'OSTree',
                # Find instances of "return" that are referring to a keyboard key
                '(?i)<return>':   '[Enter]',
                '(?i)press return': 'press Enter',

--- a/tests/nosetests/pyanaconda_tests/module_source_rpm_ostree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_rpm_ostree_test.py
@@ -50,7 +50,7 @@ class OSTreeSourceInterfaceTestCase(unittest.TestCase):
 
     def description_test(self):
         """Test the Description property."""
-        self.assertEqual("RPM OS Tree", self.interface.Description)
+        self.assertEqual("RPM OSTree", self.interface.Description)
 
     def configuration_test(self):
         """Test the configuration property."""


### PR DESCRIPTION
It's spelled that way everywhere. I think it might be better to stick to that?

See https://translate.fedoraproject.org/translate/anaconda/master/en/?checksum=e440ad521e7a3ffe