### PR TITLE
Remove support for the nfsiso: pseudo-protocol

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -814,12 +814,6 @@ method
 
 This is an alias for `inst.repo`_.
 
-repo=nfsiso:...
-^^^^^^^^^^^^^^^
-
-The difference between an installable tree and a dir with an ``.iso`` file is
-autodetected, so this is the same as ``inst.repo=nfs:``...
-
 .. dns:
 
 dns
@@ -997,3 +991,10 @@ inst.singlelang
 ^^^^^^^^^^^^^^^
 
 Anaconda does not support single language mode anymore.
+
+repo=nfsiso:...
+^^^^^^^^^^^^^^^
+
+Anaconda no longer needs explicit specification that a NFS location is an ISO image.
+The difference between an installable tree and a dir with an ``.iso`` file is now
+automatically detected, so this is the same as ``inst.repo=nfs:``...

--- a/dracut/anaconda-netroot.sh
+++ b/dracut/anaconda-netroot.sh
@@ -33,7 +33,6 @@ case $repo in
     nfs*)
         . /lib/nfs-lib.sh
         info "anaconda mounting NFS repo at $repo"
-        str_starts "$repo" "nfsiso:" && repo=nfs:${repo#nfsiso:}
 
         # Replace hex space with a real one. All uses of repo need to be quoted
         # after this point.

--- a/dracut/parse-anaconda-repo.sh
+++ b/dracut/parse-anaconda-repo.sh
@@ -20,7 +20,7 @@ getargbool 0 inst.stage2.all && repo="urls"
 if [ -n "$repo" ]; then
     splitsep ":" "$repo" repotype rest
     case "$repotype" in
-        http|https|ftp|nfs|nfs4|nfsiso)
+        http|https|ftp|nfs|nfs4)
             root="anaconda-net:$repo"
             set_neednet
         ;;

--- a/pyanaconda/modules/payloads/source/utils.py
+++ b/pyanaconda/modules/payloads/source/utils.py
@@ -38,7 +38,7 @@ def has_network_protocol(url):
     if not url:
         return False
 
-    network_protocols = ["http:", "https:", "ftp:", "nfs:", "nfsiso:"]
+    network_protocols = ["http:", "https:", "ftp:", "nfs:"]
     return any(url.startswith(p) for p in network_protocols)
 
 


### PR DESCRIPTION
It was already deprecated, because Anaconda can automatically detect that an NFS location is an ISO image.

TODO:
- [x] test it