### PR TITLE
Run rpm tests in a GitHub action

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,3 +33,33 @@ jobs:
           path: |
             tests/test-suite.log
             tests/coverage-*.log
+
+  rpm-tests:
+    runs-on: ubuntu-latest
+    # start from a minimal container and install only our build deps; mock does
+    # not work in an unprivileged container (no CAP_SYS_ADMIN for mount), and
+    # dnf --installroot is too broken (rhbz#1885103, #1885101, #1738233)
+    container:
+      image: docker.io/fedora:rawhide
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: install build dependencies
+        run: |
+          dnf install -y /usr/bin/xargs
+          scripts/testing/dependency_solver.py -b | xargs -d '\n' dnf install -y --setopt=install_weak_deps=False --nodocs rpm-build
+
+      - name: build RPMs
+        run: |
+          ./autogen.sh
+          ./configure
+          make rpms
+
+      - name: run RPM tests
+        run: |
+          make run-rpm-tests-only || { cat tests/rpm_tests.log; exit 1; }
+
+      - name: test installability
+        run: |
+          dnf install -y result/build/01-rpm-build/*.rpm

--- a/Makefile.am
+++ b/Makefile.am
@@ -152,12 +152,6 @@ release-and-tag:
 	$(MAKE) dist
 	$(MAKE) tag
 
-rc-release: scratch
-	-rm -rf $(BUILD_RESULT_DIR)
-	mock -r $(MOCKCHROOT) $(MOCK_EXTRA_ARGS) --clean || exit 1
-	mock -r $(MOCKCHROOT) $(MOCK_EXTRA_ARGS) --buildsrpm  --spec ./$(PACKAGE_NAME).spec --sources . --resultdir $(SRPM_BUILD_DIR) || exit 1
-	mock -r $(MOCKCHROOT) $(MOCK_EXTRA_ARGS) --rebuild $(SRPM_BUILD_DIR)/*src.rpm --resultdir $(RPM_BUILD_DIR) || exit 1
-
 bumpver: po-pull
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \
 	if [ ! -z "$(IGNORE)" ]; then \
@@ -174,6 +168,22 @@ bumpver: po-pull
 	fi ; \
 	( cd $(srcdir) && scripts/makebumpver $${opts} ) || exit 1
 	-$(MAKE) pot-update-check
+
+# (s)rpm builds
+
+srpm: scratch anaconda.spec
+	rpmbuild --define "_sourcedir $(abs_srcdir)" --define "_srcrpmdir $(SRPM_BUILD_DIR)" -bs anaconda.spec
+
+rpms: srpm
+	rpmbuild --rebuild --define "_rpmdir $(RPM_BUILD_DIR)" $(SRPM_BUILD_DIR)/anaconda-*.src.rpm
+	mv "$(RPM_BUILD_DIR)"/*/*.rpm "$(RPM_BUILD_DIR)" # move rpms from per-architecture subdirectory
+
+mock-rpms: scratch
+	-rm -rf $(BUILD_RESULT_DIR)
+	mock -r $(MOCKCHROOT) $(MOCK_EXTRA_ARGS) --clean || exit 1
+	mock -r $(MOCKCHROOT) $(MOCK_EXTRA_ARGS) --buildsrpm  --spec ./$(PACKAGE_NAME).spec --sources . --resultdir $(SRPM_BUILD_DIR) || exit 1
+	mock -r $(MOCKCHROOT) $(MOCK_EXTRA_ARGS) --rebuild $(SRPM_BUILD_DIR)/*src.rpm --resultdir $(RPM_BUILD_DIR) || exit 1
+
 
 # GUI TESTING
 runglade:
@@ -277,7 +287,7 @@ tests-nose-only:
 	@rm -rf $(USER_SITE_BASE)
 	$(MAKE) coverage-report
 
-test-rpm: rc-release run-rpm-tests-only
+test-rpm: mock-rpms run-rpm-tests-only
 	$(MAKE) grab-logs
 
 run-rpm-tests-only:

--- a/Makefile.am
+++ b/Makefile.am
@@ -287,12 +287,14 @@ tests-nose-only:
 	@rm -rf $(USER_SITE_BASE)
 	$(MAKE) coverage-report
 
+# this is the top-level rule called by Jenkins "Anaconda Rawhide test RPM files" job
+# test RPM installability in addition to build and rpm_tests
 test-rpm: mock-rpms run-rpm-tests-only
+	mock -r $(MOCKCHROOT) $(MOCK_EXTRA_ARGS) --install $(RPM_BUILD_DIR)/*[0-9].rpm
 	$(MAKE) grab-logs
 
 run-rpm-tests-only:
-	$(MAKE) TEST_SUITE_LOG=test-suite.log MOCKCHROOT=$(MOCKCHROOT) \
-			MOCK_EXTRA_ARGS=$(MOCK_EXTRA_ARGS) RPM_PATH=$(RPM_BUILD_DIR) \
+	$(MAKE) TEST_SUITE_LOG=test-suite.log RPM_PATH=$(RPM_BUILD_DIR) \
 			ROOT_ANACONDA_PATH=$(abs_srcdir) TESTS=rpm_tests.sh check
 
 coverage-report:

--- a/Makefile.am
+++ b/Makefile.am
@@ -281,7 +281,6 @@ test-rpm: rc-release run-rpm-tests-only
 	$(MAKE) grab-logs
 
 run-rpm-tests-only:
-	$(MAKE)
 	$(MAKE) TEST_SUITE_LOG=test-suite.log MOCKCHROOT=$(MOCKCHROOT) \
 			MOCK_EXTRA_ARGS=$(MOCK_EXTRA_ARGS) RPM_PATH=$(RPM_BUILD_DIR) \
 			ROOT_ANACONDA_PATH=$(abs_srcdir) TESTS=rpm_tests.sh check

--- a/tests/rpm_tests/__init__.py
+++ b/tests/rpm_tests/__init__.py
@@ -6,8 +6,6 @@ import glob
 from unittest import TestCase
 
 
-MOCK_NAME_ENV = "MOCKCHROOT"
-MOCK_EXTRA_ARGS_ENV = "MOCK_EXTRA_ARGS"
 RPM_BUILD_DIR_ENV = "RPM_PATH"
 ROOT_DIR_ENV = "ROOT_ANACONDA_PATH"
 
@@ -38,16 +36,6 @@ class RPMTestCase(TestCase):
         return subprocess.run(cmd, stdout=subprocess.PIPE, cwd=cwd)
 
     @property
-    def mock_name(self):
-        """Name of the mock from Makefile"""
-        return os.environ[MOCK_NAME_ENV]
-
-    @property
-    def mock_extra_args(self):
-        """Extra arguments for mock from Makefile"""
-        return os.environ[MOCK_EXTRA_ARGS_ENV]
-
-    @property
     def anaconda_root_path(self):
         """Root directory of tested anaconda from Makefile"""
         return os.environ[ROOT_DIR_ENV]
@@ -60,24 +48,3 @@ class RPMTestCase(TestCase):
         """
         rpm_path = os.environ[RPM_BUILD_DIR_ENV]
         return glob.glob(rpm_path + os.path.sep + "*[0-9].rpm")
-
-    def run_mock(self, cmd):
-        """Run commands in mock
-
-        Mock name and extra arguments are passed here from Makefile.
-        """
-        mock_command = self._create_mock_command()
-        mock_command.extend(cmd)
-        self.check_subprocess(mock_command)
-
-    def _create_mock_command(self):
-        output_cmd = ["mock", "-r", self.mock_name]
-
-        if self.mock_extra_args:
-            output_cmd.append(self.mock_extra_args)
-
-        return output_cmd
-
-    def init_mock(self):
-        """Init mock before using it for tests."""
-        self.run_mock(["--init"])

--- a/tests/rpm_tests/__init__.py
+++ b/tests/rpm_tests/__init__.py
@@ -56,7 +56,7 @@ class RPMTestCase(TestCase):
     def rpm_paths(self):
         """Paths pointing to RPM files
 
-        This expects files in a place where make rc-release will place them.
+        This expects files in a place where `make rpms` or `make mock-rpms` will place them.
         """
         rpm_path = os.environ[RPM_BUILD_DIR_ENV]
         return glob.glob(rpm_path + os.path.sep + "*[0-9].rpm")

--- a/tests/rpm_tests/create_rpm_test.py
+++ b/tests/rpm_tests/create_rpm_test.py
@@ -27,17 +27,6 @@ from tests.rpm_tests import RPMTestCase
 IGNORED_SOURCE_FILES = []
 
 
-class InstallRPMTestCase(RPMTestCase):
-    """Test if Anaconda rpm files can be installed to the system."""
-
-    def test_install(self):
-        self.init_mock()
-
-        mock_command = ["--install"]
-        mock_command.extend(self.rpm_paths)
-        self.run_mock(mock_command)
-
-
 class InstalledFilesTestCase(RPMTestCase):
     """Test if files in anaconda directory are correctly placed in the rpm files."""
 


### PR DESCRIPTION
This replaces the "Anaconda Rawhide test RPM files" Jenkins job. (When
that gets removed, a lot of Makefile rules can get cleaned up.)

As with the unit tests, use a standard Fedora rawhide container for now,
and install the anaconda build dependencies into it. Like with
unit tests, this should eventually be replaced with a custom container
image that gets refreshed regularly (gated by tests), to increase both
speed and reliability. But the Jenkins job has the exact same problems,
so this is not a regression.