### PR TITLE
Fix dependency_solver to not require spec file to get pip dependencies

### DIFF
--- a/scripts/testing/dependency_solver.py
+++ b/scripts/testing/dependency_solver.py
@@ -167,7 +167,7 @@ if __name__ == "__main__":
     spec = ""
     res_packages = set()
 
-    nothing_specified = not any([args.runtime, args.build, args.release, args.test])
+    nothing_specified = not any([args.runtime, args.build, args.release, args.test, args.pip])
 
     if args.build or args.runtime or nothing_specified:
         spec = _read_spec_file()


### PR DESCRIPTION
We definitely don't need to read spec for pip.