### PR TITLE
Add Dockerfile for anaconda unit-tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,12 @@ CONTAINER_BUILD_NAME ?= anaconda/ci-tasks
 CONTAINER_BUILD_TAG ?= latest
 CONTAINER_BUILD_ARGS ?=
 
+# Default argument to execute tests in the container
+CONTAINER_TEST_NAME ?= anaconda/ci-tasks
+CONTAINER_TEST_TAG ?= latest
+CONTAINER_RUNNER_TEST_ARGS ?=--rm -v .:/anaconda:Z
+CONTAINER_TEST_ARGS ?=
+
 SKIP_BRANCHING_CHECK ?= "false"
 
 # If translations are present, run tests on the .po files before tarring them
@@ -216,6 +222,9 @@ ci:
 		rm $(srcdir)/tests/error_occured; \
 		exit $$status; \
 	fi
+
+container-ci:
+	podman run $(CONTAINER_RUNNER_TEST_ARGS) $(CONTAINER_TEST_NAME):$(CONTAINER_TEST_TAG) $(CONTAINER_TEST_ARGS)
 
 check-branching:
 # checking if branching can be finished and all the pieces are in place

--- a/Makefile.am
+++ b/Makefile.am
@@ -75,6 +75,12 @@ SRPM_BUILD_DIR = $(BUILD_RESULT_DIR)/00-srpm-build
 RPM_BUILD_DIR = $(BUILD_RESULT_DIR)/01-rpm-build
 TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
 
+# Default variables for container build call
+DOCKERFILE_PATH ?= $(srcdir)/dockerfile/ci-tasks
+CONTAINER_BUILD_NAME ?= anaconda/ci-tasks
+CONTAINER_BUILD_TAG ?= latest
+CONTAINER_BUILD_ARGS ?=
+
 SKIP_BRANCHING_CHECK ?= "false"
 
 # If translations are present, run tests on the .po files before tarring them
@@ -151,6 +157,9 @@ release:
 release-and-tag:
 	$(MAKE) dist
 	$(MAKE) tag
+
+container-build:
+	podman build $(CONTAINER_BUILD_ARGS) -t $(CONTAINER_BUILD_NAME):$(CONTAINER_BUILD_TAG) $(DOCKERFILE_PATH)
 
 bumpver: po-pull
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \

--- a/dockerfile/ci-tasks/Dockerfile
+++ b/dockerfile/ci-tasks/Dockerfile
@@ -1,0 +1,40 @@
+FROM fedora:rawhide
+LABEL maintainer=anaconda-list@redhat.com
+
+# Prepare environment and install build dependencies
+RUN dnf update -y && \
+  dnf install -y \
+  'dnf-command(copr)' \
+  curl \
+  /usr/bin/xargs \
+  rpm-build \
+  e2fsprogs \
+  git \
+  bzip2 \
+  cppcheck \
+  rpm-ostree \
+  pykickstart \
+  python3-pip \
+  python3-lxml \
+  policycoreutils \
+  python3-gobject-base \
+  python3-pip && \
+  dnf copr enable -y @rhinstaller/Anaconda && \
+  dnf copr enable -y @storage/blivet-daily && \
+  curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/master/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec && \
+  rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y && \
+  rpmspec -q --requires /tmp/anaconda.spec | grep -v anaconda | xargs -d '\n' dnf install -y && \
+  dnf clean all
+
+RUN pip install \
+  pocketlint \
+  coverage \
+  pycodestyle \
+  dogtail \
+  nose-testconfig \
+  rpmfluff
+
+RUN mkdir /anaconda
+
+WORKDIR /anaconda
+CMD ./autogen.sh && ./configure && make && make ci

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -46,6 +46,29 @@ In case the *ci* target fails there is also a *coverage-report* target
 which can be used to combine the multiple `.coverage` files into one and
 produce a human readable report.
 
+Run tests inside of container
+-----------------------------
+
+Right now only unit tests are supported by the container, not rpm-tests.
+Before being able to run the tests you have to build the container.
+To build the container run::
+
+    make container-build
+
+Then you are free to run the tests without dependency installation by
+running::
+
+    make container-ci
+
+This will run all the tests.
+
+Logs from the run are stored in the `tests` folder.
+
+Note:
+
+Please update your container from time to time to have newest dependencies.
+To do that just run the build again.
+
 Run tests inside Mock
 ---------------------
 


### PR DESCRIPTION
This will install all dependencies to run the tests and add simple script to run tests by default or anything in the Anaconda directory.

Thanks to replacing the dependency_solver.py here we should be able to drop the script completely.

TODO:
- [x] Change README file in tests folder to explain container workflow.