### PR TITLE
Add GitHub actions runner to ci-tasks container

### DIFF
--- a/dockerfile/ci-tasks/Dockerfile
+++ b/dockerfile/ci-tasks/Dockerfile
@@ -12,6 +12,8 @@ RUN dnf update -y && \
   git \
   bzip2 \
   cppcheck \
+  libicu \
+  lttng-ust \
   rpm-ostree \
   pykickstart \
   python3-pip \
@@ -34,11 +36,19 @@ RUN pip install \
   nose-testconfig \
   rpmfluff
 
+# see https://github.com/martinpitt/anaconda/settings/actions/add-new-runner
+RUN mkdir actions-runner && cd actions-runner && \
+  URL=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | \
+        sed -n '/browser_download_url.*linux-x64/ { s/^.*https:/https:/; s/"$//; p }') && \
+  curl -O -L "$URL" && \
+  tar xzf actions-runner-*.tar.gz && \
+  rm actions-runner-*.tar.gz
+
 RUN mkdir /anaconda
 
 WORKDIR /anaconda
 
-COPY entrypoint.sh /root/entrypoint.sh
+COPY ["entrypoint.sh", "github-action-run-once", "/"]
 
 CMD ["make ci"]
-ENTRYPOINT ["/root/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dockerfile/ci-tasks/github-action-run-once
+++ b/dockerfile/ci-tasks/github-action-run-once
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Register a self-hosted runner on GitHub, wait for and run one request, and stop again.
+# This ensures that broken/malicious PRs cannot leave anything permanent behind on the host machine.
+# Inputs:
+#   $GITHUB_TOKEN: must have "public_repo" scope
+#   $GITHUB_REPOSITORY: owner/name
+#   $RUNNER_NAME: string, optional (defaults to container host name)
+#
+# Example invocation:
+# podman run -h local-runner-1 --rm -e GITHUB_TOKEN=$(< ~/.config/github-token) -e GITHUB_REPOSITORY=rhinstaller/anaconda \
+#        --entrypoint /github-action-run-once anaconda/ci-tasks
+#
+# Documentation:
+# https://docs.github.com/en/free-pro-team@latest/actions/hosting-your-own-runners/about-self-hosted-runners
+# https://developer.github.com/v3/actions/self-hosted-runners/
+
+set -eu
+
+export RUNNER_ALLOW_RUNASROOT=1
+cd /actions-runner
+
+# get the runner registration token
+RUNNER_TOKEN=$(curl --silent --show-error -X POST -u "token:$GITHUB_TOKEN" \
+    "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runners/registration-token" | \
+    sed -n '/"token"/ { s/.*: "//; s/".*$//; p }')
+if [ -z "$RUNNER_TOKEN" ]; then
+    echo "Failed to acquire runner token" >&2
+    exit 1
+fi
+
+# register runner
+./config.sh --labels 'ci-tasks' ${RUNNER_NAME:+--name} ${RUNNER_NAME:-} --replace --token "$RUNNER_TOKEN" --unattended --url "https://github.com/$GITHUB_REPOSITORY"
+
+# run one job
+./run.sh  --once
+
+# unregister the runner; this is ok to fail (token timed out, or runner crashed), the --replace on registration will clean it up the next time
+./config.sh remove --token "$RUNNER_TOKEN" || true


### PR DESCRIPTION
This allows us to start a self-hosted runner pretty much anywhere,
including locally (for debugging) or on internal infrastructure (for
RHEL tests).

Include a `github-action-run-once` script that does everything that's
required for this, so that the container invocation becomes fairly
simple (see comment at the top of the file).

 - [x] Builds on top of PR #2899, which changes the entrypoint; land that first