### PR TITLE
post-scripts need to be sorted and anaconda log files relabeled

### DIFF
--- a/data/post-scripts/99-copy-logs.ks
+++ b/data/post-scripts/99-copy-logs.ks
@@ -28,3 +28,12 @@ elif [ -e /run/install/ks.cfg ]; then
 fi
 
 %end
+
+%post
+# Relabel the anaconda logs we've just coppied, since they could be incorrectly labeled, like
+# hawkey.log: https://bugzilla.redhat.com/show_bug.cgi?id=1885772.
+# Execution of this %post script will not be logged in the log files on the installed system.
+
+restorecon -ir /var/log/anaconda/
+
+%end

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -562,7 +562,7 @@ def appendPostScripts(ksdata):
     scripts = ""
 
     # Read in all the post script snippets to a single big string.
-    for fn in glob.glob("/usr/share/anaconda/post-scripts/*ks"):
+    for fn in sorted(glob.glob("/usr/share/anaconda/post-scripts/*ks")):
         f = open(fn, "r")
         scripts += f.read()
         f.close()


### PR DESCRIPTION
Sort the order of execution of post-scripts, since glob.glob() doesn't return a sorted list.
Relabel the copied anaconda log files - they could be labeled incorrectly, like in case of hawkey.log, see bug [1885772](https://bugzilla.redhat.com/show_bug.cgi?id=1885772).

Resolves: rhbz#[1870493](https://bugzilla.redhat.com/show_bug.cgi?id=1870493)