### PR TITLE
Fix SECTION headers in docstrings

### DIFF
--- a/widgets/src/BaseStandalone.c
+++ b/widgets/src/BaseStandalone.c
@@ -22,7 +22,7 @@
 #include "intl.h"
 
 /**
- * SECTION: BaseStandalone
+ * SECTION: AnacondaBaseStandalone
  * @title: AnacondaBaseStandalone
  * @short_description: Abstract base class for standalone Anaconda windows.
  *

--- a/widgets/src/BaseWindow.c
+++ b/widgets/src/BaseWindow.c
@@ -30,7 +30,7 @@
  #include <atk/atk.h>
 
 /**
- * SECTION: BaseWindow
+ * SECTION: AnacondaBaseWindow
  * @title: AnacondaBaseWindow
  * @short_description: Top-level, non-resizeable window
  *

--- a/widgets/src/DiskOverview.c
+++ b/widgets/src/DiskOverview.c
@@ -27,7 +27,7 @@
 #include "widgets-common.h"
 
 /**
- * SECTION: DiskOverview
+ * SECTION: AnacondaDiskOverview
  * @title: AnacondaDiskOverview
  * @short_description: A widget that displays basic information about a disk
  *

--- a/widgets/src/HubWindow.c
+++ b/widgets/src/HubWindow.c
@@ -22,7 +22,7 @@
 #include "intl.h"
 
 /**
- * SECTION: HubWindow
+ * SECTION: AnacondaHubWindow
  * @title: AnacondaHubWindow
  * @short_description: Window for displaying a Hub
  *

--- a/widgets/src/LayoutIndicator.c
+++ b/widgets/src/LayoutIndicator.c
@@ -36,7 +36,7 @@
 #define DEFAULT_LABEL_MAX_CHAR_WIDTH 8
 
 /**
- * SECTION: LayoutIndicator
+ * SECTION: AnacondaLayoutIndicator
  * @title: AnacondaLayoutIndicator
  * @short_description: An indicator of currently activated X layout
  *

--- a/widgets/src/MountpointSelector.c
+++ b/widgets/src/MountpointSelector.c
@@ -29,7 +29,7 @@
 #include "widgets-common.h"
 
 /**
- * SECTION: MountpointSelector
+ * SECTION: AnacondaMountpointSelector
  * @title: AnacondaMountpointSelector
  * @short_description: A graphical way to select a mount point.
  *

--- a/widgets/src/SpokeSelector.c
+++ b/widgets/src/SpokeSelector.c
@@ -28,7 +28,7 @@
 #include "widgets-common.h"
 
 /**
- * SECTION: SpokeSelector
+ * SECTION: AnacondaSpokeSelector
  * @title: AnacondaSpokeSelector
  * @short_description: A graphical way to enter a configuration spoke
  *

--- a/widgets/src/SpokeWindow.c
+++ b/widgets/src/SpokeWindow.c
@@ -25,7 +25,7 @@
 #include <gdk/gdkkeysyms.h>
 
 /**
- * SECTION: SpokeWindow
+ * SECTION: AnacondaSpokeWindow
  * @title: AnacondaSpokeWindow
  * @short_description: Window for displaying single spokes
  *

--- a/widgets/src/StandaloneWindow.c
+++ b/widgets/src/StandaloneWindow.c
@@ -25,7 +25,7 @@
 #include <gdk/gdkkeysyms.h>
 
 /**
- * SECTION: StandaloneWindow
+ * SECTION: AnacondaStandaloneWindow
  * @title: AnacondaStandaloneWindow
  * @short_description: Window for displaying standalone spokes
  *


### PR DESCRIPTION
Make them coincide with the class names. The missing "Anaconda" prefix
causes a build failure with gobject-introspection ≥ 1.61.1 due to [1]:

    Namespace conflict: DocSection('BaseWindow')

See https://bugzilla.redhat.com/show_bug.cgi?id=1885825 for some
details.

[1] https://gitlab.gnome.org/GNOME/gobject-introspection/-/commit/346c0690fe62f614ecb1f55857ea72939d9c0f83