### PR TITLE
Small fixes in unit tests

### DIFF
--- a/tests/nosetests/pyanaconda_tests/kickstart_specification_test.py
+++ b/tests/nosetests/pyanaconda_tests/kickstart_specification_test.py
@@ -398,7 +398,6 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
 
     # Names of the kickstart commands and data that should be temporarily ignored.
     IGNORED_NAMES = {
-        "timezone",
     }
 
     def setUp(self):


### PR DESCRIPTION
Partially revert the commit ca07d04 that allowed to temporarily ignore the new
`timezone` kickstart command. We use the latest version of this command now.