### PR TITLE
Translate spoke category title directly at runtime

### DIFF
--- a/pyanaconda/ui/categories/__init__.py
+++ b/pyanaconda/ui/categories/__init__.py
@@ -17,12 +17,12 @@
 # Red Hat, Inc.
 #
 
-from pyanaconda.core.i18n import N_
+from abc import ABC, abstractmethod
 
 __all__ = ["SpokeCategory"]
 
 
-class SpokeCategory(object):
+class SpokeCategory(ABC):
     """A SpokeCategory is an object used to group multiple related Spokes
        together on a hub.  It consists of a title displayed above, and then
        a two-column grid of SpokeSelectors.  Each SpokeSelector is associated
@@ -31,11 +31,26 @@ class SpokeCategory(object):
 
        Class attributes:
 
-       sortOrder     -- A number indicating the order in which this Category
-                        will be displayed.  A lower number indicates display
-                        higher up in the Hub.
-       title         -- The title of this SpokeCategory, to be displayed above
-                        the grid.
     """
-    sortOrder = 1000
-    title = N_("DEFAULT TITLE")
+
+    @staticmethod
+    @abstractmethod
+    def get_title():
+        """The translated title of this category, to be displayed above the grid.
+
+        :return: translated category title
+        :rtype: str
+        """
+        return ""
+
+    @staticmethod
+    @abstractmethod
+    def get_sort_order():
+        """A number indicating the order in which this Category will be displayed.
+
+        A lower number indicates display higher up in the Hub.
+
+        :return: sort order number
+        :rtype: int
+        """
+        return 0

--- a/pyanaconda/ui/categories/localization.py
+++ b/pyanaconda/ui/categories/localization.py
@@ -17,12 +17,18 @@
 # Red Hat, Inc.
 #
 
-from pyanaconda.core.i18n import N_
+from pyanaconda.core.i18n import _
 from pyanaconda.ui.categories import SpokeCategory
 
 __all__ = ["LocalizationCategory"]
 
 
 class LocalizationCategory(SpokeCategory):
-    sortOrder = 100
-    title = N_("LOCALIZATION")
+
+    @staticmethod
+    def get_title():
+        return _("LOCALIZATION")
+
+    @staticmethod
+    def get_sort_order():
+        return 100

--- a/pyanaconda/ui/categories/software.py
+++ b/pyanaconda/ui/categories/software.py
@@ -17,12 +17,18 @@
 # Red Hat, Inc.
 #
 
-from pyanaconda.core.i18n import N_
+from pyanaconda.core.i18n import _
 from pyanaconda.ui.categories import SpokeCategory
 
 __all__ = ["SoftwareCategory"]
 
 
 class SoftwareCategory(SpokeCategory):
-    sortOrder = 200
-    title = N_("SOFTWARE")
+
+    @staticmethod
+    def get_title():
+        return _("SOFTWARE")
+
+    @staticmethod
+    def get_sort_order():
+        return 200

--- a/pyanaconda/ui/categories/system.py
+++ b/pyanaconda/ui/categories/system.py
@@ -17,12 +17,18 @@
 # Red Hat, Inc.
 #
 
-from pyanaconda.core.i18n import N_
+from pyanaconda.core.i18n import _
 from pyanaconda.ui.categories import SpokeCategory
 
 __all__ = ["SystemCategory"]
 
 
 class SystemCategory(SpokeCategory):
-    sortOrder = 300
-    title = N_("SYSTEM")
+
+    @staticmethod
+    def get_title():
+        return _("SYSTEM")
+
+    @staticmethod
+    def get_sort_order():
+        return 300

--- a/pyanaconda/ui/categories/user_settings.py
+++ b/pyanaconda/ui/categories/user_settings.py
@@ -17,12 +17,18 @@
 # Red Hat, Inc.
 #
 
-from pyanaconda.core.i18n import N_
+from pyanaconda.core.i18n import _
 from pyanaconda.ui.categories import SpokeCategory
 
 __all__ = ["UserSettingsCategory"]
 
 
 class UserSettingsCategory(SpokeCategory):
-    sortOrder = 400
-    title = N_("USER SETTINGS")
+
+    @staticmethod
+    def get_title():
+        return _("USER SETTINGS")
+
+    @staticmethod
+    def get_sort_order():
+        return 400

--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -665,7 +665,7 @@ def collectCategoriesAndSpokes(paths, klass):
     ret = {}
     # Collect all the categories this hub displays, then collect all the
     # spokes belonging to all those categories.
-    categories = sorted(collect_categories(paths["categories"]), key=lambda c: c.sortOrder)
+    categories = sorted(collect_categories(paths["categories"]), key=lambda c: c.get_sort_order())
 
     for c in categories:
         ret[c] = collect_spokes(paths["spokes"], c.__name__)
@@ -683,3 +683,22 @@ def collectCategoriesAndSpokes(paths, klass):
     lifecycle.add_controller(klass.__name__, category_names)
 
     return ret
+
+
+def sort_categories(categories):
+    """Sort categories based on sort order & calls name.
+
+    While sort order is the primarily sorting key, we can't always
+    assure all categories have unique sort order values.
+    So make the class name part of the sorting key, to at least
+    make the resulting category sort order deterministic.
+
+    To do this we concatenate we create a tuple as the sorting key,
+    with the sort order integer being followed by the by the class
+    name. This way the categories will be sorted by the sort order
+    first and then by class name if sort order happens to be the same.
+
+    :param categories: list of categories
+    :type categories: SpokeCategory sub classes
+    """
+    return sorted(categories, key=lambda i: (i.get_sort_order(), i.__class__))

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -130,11 +130,9 @@ class Hub(GUIObject, common.Hub):
 
         row_in_column = [-1] * self._gridColumns
 
-        for c in sorted(categories, key=lambda c: c.sortOrder):
-            obj = c()
-
+        for category in common.sort_categories(categories):
             selectors = []
-            for spokeClass in sorted(cats_and_spokes[c], key=lambda s: s.title):
+            for spokeClass in sorted(cats_and_spokes[category], key=lambda s: s.title):
                 # Check if this spoke is to be shown in the supported environments
                 if not any(spokeClass.should_run(environ, self.data) for environ in flags.environs):
                     continue
@@ -196,7 +194,14 @@ class Hub(GUIObject, common.Hub):
             if not selectors:
                 continue
 
-            label = Gtk.Label(label="<span size=\"larger\" weight=\"bold\">%s</span>" % escape_markup(_(obj.title)),
+            # category handling
+
+            # excape unwanted markup
+            cat_title = escape_markup(category.get_title())
+            # generate pango markup
+            cat_label = '<span size="larger" weight="bold">{}</span>'.format(cat_title)
+            # setup the category label
+            label = Gtk.Label(label=cat_label,
                               use_markup=True, halign=Gtk.Align.START, valign=Gtk.Align.END,
                               margin_bottom=6, wrap=True, xalign=0.0)
 

--- a/pyanaconda/ui/tui/hubs/__init__.py
+++ b/pyanaconda/ui/tui/hubs/__init__.py
@@ -67,7 +67,9 @@ class TUIHub(TUIObject, common.Hub):
         cats_and_spokes = self._collectCategoriesAndSpokes()
         categories = cats_and_spokes.keys()
 
-        for c in sorted(categories, key=lambda i: i.title):
+        # display categories by sort order or class name if their
+        # sort order is the same
+        for c in common.sort_categories(categories):
 
             hub_spokes = []
             for spoke_class in cats_and_spokes[c]:

--- a/tests/nosetests/pyanaconda_tests/common_ui_code_tests.py
+++ b/tests/nosetests/pyanaconda_tests/common_ui_code_tests.py
@@ -1,6 +1,5 @@
-# Localization category classes
 #
-# Copyright (C) 2011, 2013  Red Hat, Inc.
+# Copyright (C) 2020  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -16,19 +15,57 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
 
+import unittest
 from pyanaconda.core.i18n import _
+from pyanaconda.ui.common import sort_categories
 from pyanaconda.ui.categories import SpokeCategory
 
-__all__ = ["CustomizationCategory"]
 
-
-class CustomizationCategory(SpokeCategory):
+class AaaCategory(SpokeCategory):
 
     @staticmethod
     def get_title():
-        return _("CUSTOMIZATION")
+        return _("FOO")
 
     @staticmethod
     def get_sort_order():
         return 100
+
+
+class BbbCategory(SpokeCategory):
+
+    @staticmethod
+    def get_title():
+        return _("BAR")
+
+    @staticmethod
+    def get_sort_order():
+        return 100
+
+
+class CccCategory(SpokeCategory):
+
+    @staticmethod
+    def get_title():
+        return _("BAZ")
+
+    @staticmethod
+    def get_sort_order():
+        return 50
+
+
+class CommonCodeTestCase(unittest.TestCase):
+    """Test common UI code."""
+
+    def category_sorting_test(self):
+        """Test category sorting works as expected."""
+
+        category_list = [AaaCategory, BbbCategory, CccCategory]
+        # We expect the C category to be dorted first due to sort order and
+        # then A & B as they have the same sort order but A comes before B
+        # on the alphabet.
+        expected_category_list = [CccCategory, AaaCategory, BbbCategory]
+        self.assertEqual(sort_categories(category_list), expected_category_list)


### PR DESCRIPTION
At the moment we mark spoke category title stored in class attribute for
translation and then translate it when hub sets up the category widget.

This had to be done as the class attribute is evaluated on code parsing
time and Anaconda might have a different locale (due to user selecting
installation language) by the tame the string is being displayed &
We would then translate the string at runtime.

This is unfortunately problematic for Initial Setup and addons as there
the category title will be marked for translation in the IS/addon
context and then the translation will be attempted in the Anaconda
context, which of course does not have the translated string.

So lets drop this split and instead translate the category title always
at runtime by providing it via a static class method. IS/addons can then
do the same, making sure the category title will be always translated at
the appropriate time & in their translation context.

Also clean up and document the category widget handling code a bit.