### PR TITLE
Robustify GitHub actions runner download in ci-tasks container

### DIFF
--- a/dockerfile/ci-tasks/Dockerfile
+++ b/dockerfile/ci-tasks/Dockerfile
@@ -38,11 +38,9 @@ RUN pip install \
 
 # see https://github.com/martinpitt/anaconda/settings/actions/add-new-runner
 RUN mkdir actions-runner && cd actions-runner && \
-  URL=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | \
-        sed -n '/browser_download_url.*linux-x64/ { s/^.*https:/https:/; s/"$//; p }') && \
-  curl -O -L "$URL" && \
-  tar xzf actions-runner-*.tar.gz && \
-  rm actions-runner-*.tar.gz
+  URL_BASE=https://github.com/actions/runner/releases && \
+  LATEST_VER=$(basename $(curl -Ls -o /dev/null -w '%{url_effective}' $URL_BASE/latest)) && \
+  curl -L "$URL_BASE/download/$LATEST_VER/actions-runner-linux-x64-${LATEST_VER#v}.tar.gz" | tar xvz
 
 RUN mkdir /anaconda
 


### PR DESCRIPTION
- Don't use the API, as that is very prone to running into rate
  limiting, especially behind large NATed environments such as the Red
  Hat VPN. Parse the releases HTML page instead, which is just as
  simple.

- Skip the intermediate writing and deletion of the tarball, just
  pipeline it.

- Enable verbosity for tar, for easier debugging.