### PR TITLE
Simplify container make calls

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,6 +45,10 @@ install-exec-hook:
 uninstall-hook:
 	-cd $(DESTDIR)$(sbindir) && rm -f anaconda
 
+
+# Set environment if 'make -f Makefile.am' is called to avoid autotools
+srcdir ?= .
+
 ARCHIVE_TAG   = $(PACKAGE_NAME)-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE)
 
 # LOCALIZATION SETTINGS

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -49,6 +49,10 @@ produce a human readable report.
 Run tests inside of container
 -----------------------------
 
+Feel free to avoid installation of dependencies required for
+`autogen.sh && ./configure` execution by replacing `make` calls below
+with `make -f Makefile.am` in the Anaconda repository root directory.
+
 Right now only unit tests are supported by the container, not rpm-tests.
 Before being able to run the tests you have to build the container.
 To build the container run::


### PR DESCRIPTION
It's not really required to run `./autogen.sh && ./configure` to run containers so let's skip that part and just support `make -f` call instead.