### PR TITLE
Don't stop unit tests when the tests failed

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,9 @@ jobs:
         run: docker build -t anaconda/ci-tasks:latest dockerfile/ci-tasks
 
       - name: Run tests in ci-tasks container
+        id: run-unit-tests
         run: docker run -v $(pwd):/anaconda:Z anaconda/ci-tasks
+        continue-on-error: true
 
       - name: Upload test and coverage logs
         uses: actions/upload-artifact@v2
@@ -21,6 +23,10 @@ jobs:
           path: |
             tests/test-suite.log
             tests/coverage-*.log
+
+      - name: Set job result
+        if: ${{ steps.run-unit-tests.outcome == 'failure' }}
+        run: exit 1
 
   rpm-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Otherwise we would be missing logs which are uploaded as next step.