### PR TITLE
CI tasks cleanup

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,11 +9,11 @@ jobs:
 
       # FIXME: this should only be done if a PR touches dockerfile/ci-tasks, otherwise take the current one from registry
       - name: Build ci-tasks container
-        run: docker build -t anaconda/ci-tasks:latest dockerfile/ci-tasks
+        run: CONTAINER_ENGINE=docker make -f Makefile.am ci-tasks-build
 
       - name: Run tests in ci-tasks container
         id: run-unit-tests
-        run: docker run -v $(pwd):/anaconda:Z anaconda/ci-tasks
+        run: CONTAINER_ENGINE=docker make -f Makefile.am container-ci
         continue-on-error: true
 
       - name: Upload test and coverage logs

--- a/Makefile.am
+++ b/Makefile.am
@@ -79,17 +79,15 @@ SRPM_BUILD_DIR = $(BUILD_RESULT_DIR)/00-srpm-build
 RPM_BUILD_DIR = $(BUILD_RESULT_DIR)/01-rpm-build
 TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
 
-# Default variables for container build call
-DOCKERFILE_PATH ?= $(srcdir)/dockerfile/ci-tasks
-CONTAINER_BUILD_NAME ?= anaconda/ci-tasks
-CONTAINER_BUILD_TAG ?= latest
+# build/run tweaks for all containers, such as --cap-add
 CONTAINER_BUILD_ARGS ?=
-
-# Default argument to execute tests in the container
-CONTAINER_TEST_NAME ?= anaconda/ci-tasks
-CONTAINER_TEST_TAG ?= latest
-CONTAINER_RUNNER_TEST_ARGS ?= --rm -v .:/anaconda:Z
 CONTAINER_TEST_ARGS ?=
+
+# ci-tasks container
+CI_TASKS_DOCKERFILE ?= $(srcdir)/dockerfile/ci-tasks
+CI_TASKS_NAME ?= anaconda/ci-tasks
+CI_TASKS_TAG ?= $(GIT_BRANCH)
+CI_TASKS_TEST_ARGS ?= --rm -v .:/anaconda:Z
 
 SKIP_BRANCHING_CHECK ?= "false"
 
@@ -168,8 +166,8 @@ release-and-tag:
 	$(MAKE) dist
 	$(MAKE) tag
 
-container-build:
-	podman build $(CONTAINER_BUILD_ARGS) -t $(CONTAINER_BUILD_NAME):$(CONTAINER_BUILD_TAG) $(DOCKERFILE_PATH)
+ci-tasks-build:
+	podman build $(CONTAINER_BUILD_ARGS) -t $(CI_TASKS_NAME):$(CI_TASKS_TAG) $(CI_TASKS_DOCKERFILE)
 
 bumpver: po-pull
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \
@@ -228,7 +226,7 @@ ci:
 	fi
 
 container-ci:
-	podman run $(CONTAINER_RUNNER_TEST_ARGS) $(CONTAINER_TEST_NAME):$(CONTAINER_TEST_TAG) $(CONTAINER_TEST_ARGS)
+	podman run $(CONTAINER_TEST_ARGS) $(CI_TASKS_TEST_ARGS) $(CI_TASKS_NAME):$(CI_TASKS_TAG)
 
 check-branching:
 # checking if branching can be finished and all the pieces are in place

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,7 +47,7 @@ uninstall-hook:
 
 
 # Set environment if 'make -f Makefile.am' is called to avoid autotools
-srcdir ?= .
+srcdir ?= $(CURDIR)
 
 ARCHIVE_TAG   = $(PACKAGE_NAME)-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE)
 
@@ -80,6 +80,7 @@ RPM_BUILD_DIR = $(BUILD_RESULT_DIR)/01-rpm-build
 TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
 
 # build/run tweaks for all containers, such as --cap-add
+CONTAINER_ENGINE ?= podman
 CONTAINER_BUILD_ARGS ?=
 CONTAINER_TEST_ARGS ?=
 
@@ -87,7 +88,7 @@ CONTAINER_TEST_ARGS ?=
 CI_TASKS_DOCKERFILE ?= $(srcdir)/dockerfile/ci-tasks
 CI_TASKS_NAME ?= anaconda/ci-tasks
 CI_TASKS_TAG ?= $(GIT_BRANCH)
-CI_TASKS_TEST_ARGS ?= --rm -v .:/anaconda:Z
+CI_TASKS_TEST_ARGS ?= --rm -v $(srcdir):/anaconda:Z
 
 SKIP_BRANCHING_CHECK ?= "false"
 
@@ -167,7 +168,7 @@ release-and-tag:
 	$(MAKE) tag
 
 ci-tasks-build:
-	podman build $(CONTAINER_BUILD_ARGS) -t $(CI_TASKS_NAME):$(CI_TASKS_TAG) $(CI_TASKS_DOCKERFILE)
+	$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_ARGS) -t $(CI_TASKS_NAME):$(CI_TASKS_TAG) $(CI_TASKS_DOCKERFILE)
 
 bumpver: po-pull
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \
@@ -226,7 +227,7 @@ ci:
 	fi
 
 container-ci:
-	podman run $(CONTAINER_TEST_ARGS) $(CI_TASKS_TEST_ARGS) $(CI_TASKS_NAME):$(CI_TASKS_TAG)
+	$(CONTAINER_ENGINE) run $(CONTAINER_TEST_ARGS) $(CI_TASKS_TEST_ARGS) $(CI_TASKS_NAME):$(CI_TASKS_TAG)
 
 check-branching:
 # checking if branching can be finished and all the pieces are in place

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -57,7 +57,7 @@ Right now only unit tests are supported by the container, not rpm-tests.
 Before being able to run the tests you have to build the container.
 To build the container run::
 
-    make container-build
+    make ci-tasks-build
 
 Then you are free to run the tests without dependency installation by
 running::
@@ -68,7 +68,7 @@ This will run all the tests. To run just some tests you can pass parameters
 which will replace the current one. For example to run just some nose-tests
 please do this::
 
-    make container-ci CONTAINER_TEST_ARGS="make tests-nose-only NOSE_TESTS_ARGS=nosetests/pyanaconda_tests/kernel_test.py"
+    make container-ci CI_TASKS_TEST_ARGS="make tests-nose-only NOSE_TESTS_ARGS=nosetests/pyanaconda_tests/kernel_test.py"
 
 WARNING:
 
@@ -79,7 +79,7 @@ Logs from the run are stored in the ``tests`` folder.
 
 For debugging of the container please run the container as::
 
-    make container-ci CONTAINER_RUNNER_TEST_ARGS="--rm -ti -v .:/anaconda:Z --entrypoint /bin/bash"
+    make container-ci CONTAINER_TEST_ARGS="--rm -ti -v .:/anaconda:Z --entrypoint /bin/bash"
 
 This command will open bash inside the container for you with mounted
 current folder at the `/anaconda` path. This could be even convenient way


### PR DESCRIPTION
With this we can re-use the same make rules for the rhel-8 and other branches, and they become extensible for other containers.