### PR TITLE
Fix crash on nonexisting network config directories

### DIFF
--- a/pyanaconda/modules/network/config_file.py
+++ b/pyanaconda/modules/network/config_file.py
@@ -44,6 +44,10 @@ def get_config_files_paths(root_path=""):
     paths = []
     for directory in (os.path.normpath(root_path + IFCFG_DIR),
                       os.path.normpath(root_path + KEYFILE_DIR)):
+        if not os.path.exists(directory):
+            log.info("network device config directory %s does not exist, skipping", directory)
+            continue
+
         for filename in os.listdir(directory):
             if not (_has_keyfile_basename(filename) or _has_ifcfg_basename(filename)):
                 continue


### PR DESCRIPTION
In the network config module, don't crash on nonexisting
/etc/sysconfig/network-scripts/ directory. This is owned by
NetworkManager, which is not present in a minimal installation. Just
return an empty file list in this case.

Detected by the "container" kickstart test.