### PR TITLE
Allow hiding the help button selectively

### DIFF
--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -106,6 +106,8 @@ class GUIObject(common.UIObject):
                            given GUI object. The default value of None indicates
                            that the object has not specific help file assigned
                            and the default help placeholder should be used.
+
+       hide_help_button -- Hide the button for showing help.
     """
     builderObjects = []
     mainWidgetName = None
@@ -117,6 +119,7 @@ class GUIObject(common.UIObject):
 
     uiFile = ""
     help_id = None
+    hide_help_button = False
     translationDomain = "anaconda"
 
     handles_autostep = False
@@ -169,6 +172,22 @@ class GUIObject(common.UIObject):
 
         # this indicates if the screen is the last spoke to be processed for a hub
         self.lastAutostepSpoke = False
+
+    def initialize(self):
+        """Initialize the GUI of this instance. Runs once.
+
+        Hide the help button, if applicable.
+
+        Descendants will override this method to do more.
+        """
+        super().initialize()
+
+        if self.hide_help_button:
+            help_button = self.window.get_help_button()
+            if not help_button:
+                return  # GUIObject descendants might be also dialogs which don't have the button
+            help_button.set_visible(False)
+            help_button.set_no_show_all(True)
 
     def _findUIFile(self):
         path = os.environ.get("UIPATH", "./:/tmp/updates/:/tmp/updates/ui/:/usr/share/anaconda/ui/")

--- a/pyanaconda/ui/gui/spokes/installation_progress.py
+++ b/pyanaconda/ui/gui/spokes/installation_progress.py
@@ -45,6 +45,7 @@ class ProgressSpoke(StandaloneSpoke):
     mainWidgetName = "progressWindow"
     uiFile = "spokes/installation_progress.glade"
     help_id = "ProgressHub"
+    hide_help_button = True
 
     postForHub = SummaryHub
 


### PR DESCRIPTION
Resolves: [rhbz#1890092](https://bugzilla.redhat.com/show_bug.cgi?id=1890092)


Before & after - see "help" button absence in top right corner:
![Screenshot_vs_main_2020-10-21_15:56:07](https://user-images.githubusercontent.com/15903878/96731087-312e6880-13b7-11eb-92da-a831ae5ec272.png)
![Screenshot_vs_main_2020-10-21_15:51:36](https://user-images.githubusercontent.com/15903878/96731106-34295900-13b7-11eb-852d-7073edad1164.png)



~~Blocked since we don't have the bug (yet).~~

~~There does not seem to be a good place to put this, since spokes generally inherit from `NormalSpoke` and `StandaloneSpoke` which then are based on the GUI/TUI-agnostic classes of the same name before a common ancestor comes up. I tried a mixin, but it seemed pretty weird to have it depend on unknown attributes, and making it inherit from `GUIObject` meant introducing another diamond. Additionally it would mean the calls to `super()...` would need to be specified. So in the end I just made it a helper function. This needs the smallest amount of changes, both in structural sense and LoC.~~