### PR TITLE
Run unit tests on self-hosted GitHub runner

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,33 @@
+name: validate
+on: [push, pull_request_target]
+jobs:
+  unit-tests:
+    # this already is a ci-tasks:rhel-8 container environment
+    runs-on: [self-hosted, ci-tasks, rhel-8]
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Run tests
+        id: run-unit-tests
+        run: |
+          ./autogen.sh
+          ./configure
+          make
+          make ci
+        continue-on-error: true
+
+      - name: Upload test and coverage logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: |
+            tests/test-suite.log
+            tests/pylint/runpylint*.log
+            tests/coverage-*.log
+
+      - name: Set job result
+        if: ${{ steps.run-unit-tests.outcome == 'failure' }}
+        run: |
+          cat tests/test-suite.log
+          exit 1

--- a/Makefile.am
+++ b/Makefile.am
@@ -89,6 +89,7 @@ CI_TASKS_DOCKERFILE ?= $(srcdir)/dockerfile/ci-tasks
 CI_TASKS_NAME ?= anaconda/ci-tasks
 CI_TASKS_TAG ?= $(GIT_BRANCH)
 CI_TASKS_TEST_ARGS ?= --rm -v $(srcdir):/anaconda:Z
+CI_TASKS_CMD ?=
 
 SKIP_BRANCHING_CHECK ?= "false"
 
@@ -234,7 +235,7 @@ ci:
 	fi
 
 container-ci:
-	$(CONTAINER_ENGINE) run $(CONTAINER_TEST_ARGS) $(CI_TASKS_TEST_ARGS) $(CI_TASKS_NAME):$(CI_TASKS_TAG)
+	$(CONTAINER_ENGINE) run $(CONTAINER_TEST_ARGS) $(CI_TASKS_TEST_ARGS) $(CI_TASKS_NAME):$(CI_TASKS_TAG) $(CI_TASKS_CMD)
 
 check-branching:
 # checking if branching can be finished and all the pieces are in place

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -65,7 +65,7 @@ This will run all the tests. To run just some tests you can pass parameters
 which will replace the current one. For example to run just some nose-tests
 please do this::
 
-    make container-ci CI_TASKS_TEST_ARGS="make tests-nose-only NOSE_TESTS_ARGS=nosetests/pyanaconda_tests/kernel_test.py"
+    make container-ci CI_TASKS_CMD="make tests-nose-only NOSE_TESTS_ARGS=nosetests/pyanaconda_tests/kernel_test.py"
 
 WARNING:
 

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -76,7 +76,7 @@ Logs from the run are stored in the ``tests`` folder.
 
 For debugging of the container please run the container as::
 
-    make container-ci CONTAINER_TEST_ARGS="--rm -ti -v .:/anaconda:Z --entrypoint /bin/bash"
+    make container-ci CONTAINER_TEST_ARGS="-it --entrypoint /bin/bash"
 
 This command will open bash inside the container for you with mounted
 current folder at the `/anaconda` path. This could be even convenient way

--- a/tests/pylint/censorship.py
+++ b/tests/pylint/censorship.py
@@ -125,8 +125,8 @@ class CensorshipLinter():
                     avail_mem_kb = int(line.split()[1])
                     break
         num_cpus = multiprocessing.cpu_count()
-        # each process uses ~ 1.5 GiB RAM, leave some breathing space
-        jobs = max(1, avail_mem_kb // 2000000)
+        # each process uses ~ 2 GiB RAM, leave some breathing space
+        jobs = max(1, avail_mem_kb // 3000000)
         # but also clip to nproc
         jobs = min(jobs, num_cpus)
         print("Using", jobs, "parallel jobs based on", avail_mem_kb, "kB available RAM and",

--- a/tests/pylint/censorship.py
+++ b/tests/pylint/censorship.py
@@ -126,9 +126,9 @@ class CensorshipLinter():
                     break
         num_cpus = multiprocessing.cpu_count()
         # each process uses ~ 1.5 GiB RAM, leave some breathing space
-        jobs = min(1, avail_mem_kb // 2000000)
+        jobs = max(1, avail_mem_kb // 2000000)
         # but also clip to nproc
-        jobs = max(jobs, num_cpus)
+        jobs = min(jobs, num_cpus)
         print("Using", jobs, "parallel jobs based on", avail_mem_kb, "kB available RAM and",
               num_cpus, "CPUs")
         args.append("-j%i" % jobs)


### PR DESCRIPTION
Adapted the workflow from master, but skip the `container:` bits -- our
registered runners are already one-time throwaway container
environments for security reasons.

Related: rhbz#1885635

 - [x] Wait for and include PR #2925