### PR TITLE
Fix local tests run inside of container

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -89,6 +89,7 @@ CI_TASKS_DOCKERFILE ?= $(srcdir)/dockerfile/ci-tasks
 CI_TASKS_NAME ?= anaconda/ci-tasks
 CI_TASKS_TAG ?= $(GIT_BRANCH)
 CI_TASKS_TEST_ARGS ?= --rm -v $(srcdir):/anaconda:Z
+CI_TASKS_CMD ?=
 
 SKIP_BRANCHING_CHECK ?= "false"
 
@@ -227,7 +228,7 @@ ci:
 	fi
 
 container-ci:
-	$(CONTAINER_ENGINE) run $(CONTAINER_TEST_ARGS) $(CI_TASKS_TEST_ARGS) $(CI_TASKS_NAME):$(CI_TASKS_TAG)
+	$(CONTAINER_ENGINE) run $(CONTAINER_TEST_ARGS) $(CI_TASKS_TEST_ARGS) $(CI_TASKS_NAME):$(CI_TASKS_TAG) $(CI_TASKS_CMD)
 
 check-branching:
 # checking if branching can be finished and all the pieces are in place

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -68,7 +68,7 @@ This will run all the tests. To run just some tests you can pass parameters
 which will replace the current one. For example to run just some nose-tests
 please do this::
 
-    make container-ci CI_TASKS_TEST_ARGS="make tests-nose-only NOSE_TESTS_ARGS=nosetests/pyanaconda_tests/kernel_test.py"
+    make container-ci CI_TASKS_CMD="make tests-nose-only NOSE_TESTS_ARGS=nosetests/pyanaconda_tests/kernel_test.py"
 
 WARNING:
 


### PR DESCRIPTION
Following the documentation to run single test will not work for two reasons.

- it will remove --rm -v ... from the podman call
- it will try to download image from the $(CI_TASKS_TEST_ARGS) variable so this
  have to be last parameter