### PR TITLE
Add link to metacity enums schema

### DIFF
--- a/data/window-manager/config/Makefile.am
+++ b/data/window-manager/config/Makefile.am
@@ -31,6 +31,7 @@ install-data-hook:
 	$(LN_S) -f /usr/share/glib-2.0/schemas/org.gnome.desktop.wm.keybindings.gschema.xml $(DESTDIR)$(schemadir)
 	$(LN_S) -f /usr/share/glib-2.0/schemas/org.gnome.desktop.wm.preferences.gschema.xml $(DESTDIR)$(schemadir)
 	$(LN_S) -f /usr/share/glib-2.0/schemas/org.gnome.metacity.gschema.xml $(DESTDIR)$(schemadir)
+	$(LN_S) -f /usr/share/glib-2.0/schemas/org.gnome.metacity.enums.xml $(DESTDIR)$(schemadir)
 	$(LN_S) -f /usr/share/glib-2.0/schemas/org.gnome.desktop.enums.xml $(DESTDIR)$(schemadir)
 	glib-compile-schemas --strict $(DESTDIR)$(schemadir)
 


### PR DESCRIPTION
Metacity recently started to use `MetaEnumPreference` [1], so make the
schema available.

[1] https://gitlab.gnome.org/GNOME/metacity/-/commit/676fea75b

https://bugzilla.redhat.com/show_bug.cgi?id=1887969