### PR TITLE
Hardening of our GH action event trigger

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,5 @@
 name: validate
-on: [push, pull_request]
+on: [push, pull_request_target]
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have self-hosted runners in our repository for rhel-8 branch. That works
great and it's nicely hardened. Also, we would like to add even better hardening
to start rhel-8 tests only on comment by admin.

However, the above hardening could be easily avoided by creating PR which would
change existing workflow file. To avoid this problem we have set the trigger to
pull_request_target which will start the PR tests on the 'target' branch not on
PR branch (e.g. will not use the modified workflow file).

Unfortunately, because this trigger is used only on rhel-8 and not on other
branches, it's pretty easy to create PR to change this trigger on other branch to
add our self-hosted runners to the customized workflow. To avoid that we have to
use pull_request_target trigger everywhere.