### PR TITLE
rhbz#1888697 list important major languages

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -27,7 +27,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define gtk3ver 3.22.17
 %define helpver 22.1-1
 %define isomd5sumver 1.0.10
-%define langtablever 0.0.53
+%define langtablever 0.0.54
 %define libarchivever 3.0.4
 %define libblockdevver 2.1
 %define libreportanacondaver 2.0.21-1

--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -72,6 +72,11 @@ def get_language_id(locale):
     return langtable.parse_locale(locale).language
 
 
+def get_common_languages():
+    """Return common languages to prioritize them"""
+    return langtable.list_common_languages()
+
+
 def is_supported_locale(locale):
     """Function that tells if the given locale is supported by the Anaconda or
     not. We consider locales supported by the langtable as supported by the

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -162,7 +162,12 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
         # get language codes for the locales
         langs = [localization.get_language_id(locale) for locale in locales]
 
-        # check which of the geolocated languages have translations
+        # get common languages and append them here
+        common_langs = localization.get_common_languages()
+        common_langs_len = len(set(common_langs).difference(set(langs)))
+        langs += common_langs
+
+        # check which of the geolocated or common languages have translations
         # and store the iterators for those languages in a dictionary
         langs_with_translations = {}
         itr = store.get_iter_first()
@@ -181,7 +186,7 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
             langs_with_translations[DEFAULT_LANG] = lang_itr
             locales = [DEFAULT_LANG]
 
-        # go over all geolocated languages in reverse order
+        # go over all geolocated and common languages in reverse order
         # and move those we have translation for to the top of the
         # list, above the separator
         for lang in reversed(langs):
@@ -195,8 +200,13 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
 
         # And then we add a separator after the selected best language
         # and any additional languages (that have translations) from geoip
-        newItr = store.insert(len(langs_with_translations))
+        langs_with_translations_len = len(langs_with_translations)
+        newItr = store.insert(langs_with_translations_len)
         store.set(newItr, 0, "", 1, "", 2, "", 3, True)
+
+        # add a separator before common languages as well
+        commonLangsItr = store.insert(langs_with_translations_len - common_langs_len)
+        store.set(commonLangsItr, 0, "", 1, "", 2, "", 3, True)
 
         # setup the "best" locale
         locale = localization.setup_locale(locales[0], self._l12_module)


### PR DESCRIPTION
Listing the most important major languages make them super-easy to find for international users. (_lesser scroll_)
Identification of those languages is a challenge, however we may refer [gnome-control-center](https://gitlab.gnome.org/GNOME/gnome-control-center/-/blob/master/panels/common/cc-common-language.c#L222).

#### Implementation

- One option is to join (_prepend_) those identified languages to `locales` in `pyanaconda/ui/gui/spokes/welcome.py`. Here, we may have separators to avoid confusion: separate local/national languages to common/major ones. So, `major languages | national languages | other languages`. However, in a many cases the count of national languages remain less than 4 which may leave the separators very close! And may not look nice.

- Another option could be `major languages + national languages | other languages`. I feel this may create confusion.

- As we are identifying local/national languages already to help ease user's search (_for their languages_), it makes sense to populate the first list with identified common languages in the event when `territory lookup` fails instead of just `en_US`.

Should we try moving `get_common_languages` to **langtable** instead?

Please feel free, to suggest better implementation way.
