### PR TITLE
Move the code for the kernel package selection to new functions

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -35,6 +35,7 @@ import imp
 import types
 import inspect
 import functools
+import blivet.arch
 
 import requests
 from requests_file import FileAdapter
@@ -1457,6 +1458,22 @@ def is_smt_enabled():
     except (IOError, ValueError):
         log.warning("Failed to detect SMT.")
         return False
+
+
+def is_lpae_available():
+    """Is LPAE available?
+
+    :return: True of False
+    """
+    if not blivet.arch.is_arm():
+        return False
+
+    with open("/proc/cpuinfo", "r") as f:
+        for line in f:
+            if line.startswith("Features") and "lpae" in line.split():
+                return True
+
+    return False
 
 
 class LazyObject(object):

--- a/pyanaconda/isys/__init__.py
+++ b/pyanaconda/isys/__init__.py
@@ -63,15 +63,6 @@ def isIsoImage(path):
     return False
 
 
-def isLpaeAvailable():
-    with open("/proc/cpuinfo", "r") as fobj:
-        for line in fobj:
-            if line.startswith("Features") and "lpae" in line.split():
-                return True
-
-    return False
-
-
 def set_system_time(secs):
     """
     Set system time to time given as a number of seconds since the Epoch.

--- a/pyanaconda/isys/__init__.py
+++ b/pyanaconda/isys/__init__.py
@@ -63,30 +63,6 @@ def isIsoImage(path):
     return False
 
 
-isPAE = None
-
-
-def isPaeAvailable():
-    global isPAE
-    if isPAE is not None:
-        return isPAE
-
-    isPAE = False
-    if not blivet.arch.is_x86():
-        return isPAE
-
-    f = open("/proc/cpuinfo", "r")
-    lines = f.readlines()
-    f.close()
-
-    for line in lines:
-        if line.startswith("flags") and line.find("pae") != -1:
-            isPAE = True
-            break
-
-    return isPAE
-
-
 def isLpaeAvailable():
     with open("/proc/cpuinfo", "r") as fobj:
         for line in fobj:

--- a/pyanaconda/modules/payloads/payload/dnf/utils.py
+++ b/pyanaconda/modules/payloads/payload/dnf/utils.py
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import dnf.subject
+
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.util import is_lpae_available
+
+log = get_module_logger(__name__)
+
+
+def get_kernel_package(dnf_base, exclude_list):
+    """Get an installable kernel package.
+
+    :param dnf_base: a DNF base
+    :param exclude_list: a list of excluded packages
+    :return: a package name or None
+    """
+    if "kernel" in exclude_list:
+        return None
+
+    # Get the kernel packages.
+    kernels = ["kernel"]
+
+    # ARM systems use either the standard Multiplatform or LPAE platform.
+    if is_lpae_available():
+        kernels.insert(0, "kernel-lpae")
+
+    # Find an installable one.
+    for kernel_package in kernels:
+        subject = dnf.subject.Subject(kernel_package)
+        installable = bool(subject.get_best_query(dnf_base.sack))
+
+        if installable:
+            log.info("kernel: selected %s", kernel_package)
+            return kernel_package
+
+        log.info("kernel: no such package %s", kernel_package)
+
+    log.error("kernel: failed to select a kernel from %s", kernels)
+    return None

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -608,9 +608,6 @@ class DNFPayload(Payload):
 
         kernels = ["kernel"]
 
-        if payload_utils.arch_is_x86() and isys.isPaeAvailable():
-            kernels.insert(0, "kernel-PAE")
-
         # ARM systems use either the standard Multiplatform or LPAE platform
         if payload_utils.arch_is_arm():
             if isys.isLpaeAvailable():

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -44,13 +44,13 @@ from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.payloads.payload.dnf.requirements import collect_language_requirements, \
     collect_platform_requirements, collect_driver_disk_requirements, collect_remote_requirements, \
     apply_requirements
+from pyanaconda.modules.payloads.payload.dnf.utils import get_kernel_package
 from pyanaconda.payload.source import SourceFactory, PayloadSourceTypeUnrecognized
 from pykickstart.constants import GROUP_ALL, GROUP_DEFAULT, KS_MISSING_IGNORE, KS_BROKEN_IGNORE, \
     GROUP_REQUIRED
 from pykickstart.parser import Group
 
 from pyanaconda import errors as errors
-from pyanaconda import isys
 from pyanaconda.anaconda_loggers import get_dnf_logger, get_packaging_logger
 from pyanaconda.core import constants, util
 from pyanaconda.core.configuration.anaconda import conf
@@ -379,7 +379,8 @@ class DNFPayload(Payload):
             include_list.append(pkg_name)
 
         # add kernel package
-        kernel_package = self._get_kernel_package()
+        kernel_package = get_kernel_package(self._base, exclude_list)
+
         if kernel_package:
             include_list.append(kernel_package)
 
@@ -595,39 +596,6 @@ class DNFPayload(Payload):
                 repo.pkgdir = pkgdir
 
         return pkgdir
-
-    def _package_name_installable(self, package_name):
-        """Check if the given package name looks instalable."""
-        subj = dnf.subject.Subject(package_name)
-        return bool(subj.get_best_query(self._base.sack))
-
-    @property
-    def kernel_packages(self):
-        if "kernel" in self.data.packages.excludedList:
-            return []
-
-        kernels = ["kernel"]
-
-        # ARM systems use either the standard Multiplatform or LPAE platform
-        if payload_utils.arch_is_arm():
-            if isys.isLpaeAvailable():
-                kernels.insert(0, "kernel-lpae")
-
-        return kernels
-
-    def _get_kernel_package(self):
-        kernels = self.kernel_packages
-        selected_kernel_package = None
-        for kernel_package in kernels:
-            if self._package_name_installable(kernel_package):
-                log.info('kernel: selected %s', kernel_package)
-                selected_kernel_package = kernel_package
-                break  # one kernel is good enough
-            else:
-                log.info('kernel: no such package %s', kernel_package)
-        else:
-            log.error('kernel: failed to select a kernel from %s', kernels)
-        return selected_kernel_package
 
     def _sync_metadata(self, dnf_repo):
         try:

--- a/pyanaconda/payload/utils.py
+++ b/pyanaconda/payload/utils.py
@@ -163,11 +163,6 @@ def mount(device_path, mount_point, fstype, options):
         raise PayloadSetupError(str(e)) from e
 
 
-def arch_is_x86():
-    """Does the hardware support X86?"""
-    return blivet.arch.is_x86(32)
-
-
 def arch_is_arm():
     """Does the hardware support ARM?"""
     return blivet.arch.is_arm()

--- a/pyanaconda/payload/utils.py
+++ b/pyanaconda/payload/utils.py
@@ -18,7 +18,6 @@
 #
 import os
 import blivet.util
-import blivet.arch
 
 from distutils.version import LooseVersion
 
@@ -161,11 +160,6 @@ def mount(device_path, mount_point, fstype, options):
         return blivet.util.mount(device_path, mount_point, fstype=fstype, options=options)
     except OSError as e:
         raise PayloadSetupError(str(e)) from e
-
-
-def arch_is_arm():
-    """Does the hardware support ARM?"""
-    return blivet.arch.is_arm()
 
 
 def version_cmp(v1, v2):

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_utils_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_utils_test.py
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+from unittest.mock import patch, Mock
+
+from pyanaconda.modules.payloads.payload.dnf.utils import get_kernel_package
+
+
+class DNFUtilsPackagesTestCase(unittest.TestCase):
+
+    def get_kernel_package_excluded_test(self):
+        """Test the get_kernel_package function with kernel excluded."""
+        kernel = get_kernel_package(dnf_base=Mock(), exclude_list=["kernel"])
+        self.assertEqual(kernel, None)
+
+    @patch("pyanaconda.modules.payloads.payload.dnf.utils.dnf")
+    def get_kernel_package_installable_test(self, mock_dnf):
+        """Test the get_kernel_package function without installable packages."""
+        subject = mock_dnf.subject.Subject.return_value
+        subject.get_best_query.return_value = False
+
+        with self.assertLogs(level="ERROR") as cm:
+            kernel = get_kernel_package(dnf_base=Mock(), exclude_list=[])
+
+        msg = "kernel: failed to select a kernel"
+        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+        self.assertEqual(kernel, None)
+
+    @patch("pyanaconda.modules.payloads.payload.dnf.utils.dnf")
+    @patch("pyanaconda.modules.payloads.payload.dnf.utils.is_lpae_available")
+    def get_kernel_package_lpae_test(self, is_lpae, mock_dnf):
+        """Test the get_kernel_package function with LPAE."""
+        subject = mock_dnf.subject.Subject.return_value
+        subject.get_best_query.return_value = True
+        is_lpae.return_value = True
+
+        kernel = get_kernel_package(dnf_base=Mock(), exclude_list=[])
+        self.assertEqual(kernel, "kernel-lpae")
+
+    @patch("pyanaconda.modules.payloads.payload.dnf.utils.dnf")
+    @patch("pyanaconda.modules.payloads.payload.dnf.utils.is_lpae_available")
+    def get_kernel_package_test(self, is_lpae, mock_dnf):
+        """Test the get_kernel_package function."""
+        subject = mock_dnf.subject.Subject.return_value
+        subject.get_best_query.return_value = True
+        is_lpae.return_value = False
+
+        kernel = get_kernel_package(dnf_base=Mock(), exclude_list=[])
+        self.assertEqual(kernel, "kernel")


### PR DESCRIPTION
Call the function `get_kernel_package` to select the best available kernel.

Remove the support for PAE. The PAE kernels have been discontinued since Fedora 28.
See the [reply](https://lists.fedoraproject.org/archives/list/users@lists.fedoraproject.org/message/5KD4KXXPMR44JPRTP7N3XHJYPSCXS4MF/) in the mailing list.

