### PR TITLE
Add selinux=0 boot parameter when SELinux is set to disabled (#1882464)

### DIFF
--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -35,8 +35,9 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.modules.common.constants.objects import FCOE, ISCSI, BOOTLOADER
 from pyanaconda.modules.common.structures.iscsi import Node
-from pyanaconda.modules.common.constants.services import STORAGE, NETWORK
+from pyanaconda.modules.common.constants.services import STORAGE, NETWORK, SECURITY
 from pyanaconda.modules.common.structures.network import NetworkDeviceInfo
+from pykickstart.constants import SELINUX_DISABLED
 
 log = get_module_logger(__name__)
 
@@ -729,6 +730,7 @@ class BootLoader(object):
         self._set_storage_boot_args(storage)
         self._preserve_some_boot_args()
         self._set_graphical_boot_args()
+        self._set_security_boot_args()
 
     def _set_extra_boot_args(self):
         """Set the extra boot args."""
@@ -884,6 +886,12 @@ class BootLoader(object):
 
         self.boot_args.update(args)
         self.dracut_args.update(args)
+
+    def _set_security_boot_args(self):
+        """Set LSM-related boot args."""
+        proxy = SECURITY.get_proxy()
+        if proxy.SELinux == SELINUX_DISABLED:
+            self.boot_args.add('selinux=0')
 
     #
     # configuration


### PR DESCRIPTION
We are trying to eliminate the reliance on disabling SELinux via
/etc/selinux/config in Fedora [1], since this functionality is being
deprecated upstream.

Even though only setting SELINUX=disabled in /etc/selinux/config will
still lead to a similar result as if SELinux would be disabled
completely, users might complain that Anaconda didn't actually do the
right thing, so let's make sure it is done properly by adding selinux=0
to the target system's kernel command line when the user requests
SELinux to be disabled via anaconda command line or kickstart.

[1] https://fedoraproject.org/wiki/Changes/Remove_Support_For_SELinux_Runtime_Disable

---
BTW, I didn't actually test if this code path is actually taken in the kickstart case. I just hope it uses the same code :) If my assumption is wrong, I'll be thankful for any pointers on where to make additional changes (and how to test them easily).