### PR TITLE
Fix testing target branch instead of PR branch

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,9 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
+        with:
+          # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # FIXME: this should only be done if a PR touches dockerfile/ci-tasks, otherwise take the current one from registry
       - name: Build ci-tasks container
@@ -42,6 +45,9 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
+        with:
+          # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: install build dependencies
         run: |


### PR DESCRIPTION
Hardening done in the commit baafcef39acbf0df181dd4b87176308c07a261e8 work more than expected. Right now we are testing target branch instead of the PR ref which means that we are not testing commits on the PR at all.
Ups...

We have to change what we are checking out to fix this.

We have to merge this ASAP.