### PR TITLE
Fix testing target branch instead of PR branch

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,9 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
+        with:
+          # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run tests
         id: run-unit-tests


### PR DESCRIPTION
Hardening done in the commit baafcef39acbf0df181dd4b87176308c07a261e8 work more
than expected. Right now we are testing target branch instead of the PR ref
which means that we are not testing commits on the PR at all.
Ups...

We have to change what we are checking out to fix this.

(cherry picked from commit b7f77fc018a89e6757f46490ae4d799b8258fdb1)

Related: rhbz#1885635