### PR TITLE
Do not exclude English from available languages

### DIFF
--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -342,9 +342,15 @@ def locale_has_translation(locale):
     locale has a translation, or because there is another translation to fall back onto. In
     reality, the fallback is mostly of the type "ja_JP" -> "ja".
 
+    For English, always return true, because that is the "untranslated" state which does not need
+    translation files present to work.
+
     :param str locale: locale to check
     :return bool: is there a translation
     """
+    if get_language_id(locale) == "en":
+        return True
+
     files = gettext.find("anaconda", None, [locale], True)
     return bool(files)
 


### PR DESCRIPTION
English is the untranslated state, so it needs no translation files.
All its locales are always "available".

Resolves: [rhbz#1890340](https://bugzilla.redhat.com/show_bug.cgi?id=1890340)
Resolves: [rhbz#1890342](https://bugzilla.redhat.com/show_bug.cgi?id=1890342)