### PR TITLE
Names of signal handlers should have the on_ prefix

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -153,6 +153,7 @@ In general we are trying to be as close as possible to `PEP8 <https://www.python
 * Methods that return a task should have the suffix ‘_with_task’ (for example discover_with_task and DiscoverWithTask).
 * Prefer to use ``pyanaconda.util.join_paths`` over ``os.path.join``. See documentation for more info.
 * Never call ``upper()`` on translated strings. See the bug `1619530 <https://bugzilla.redhat.com/show_bug.cgi?id=1619530>`_
+* Names of signal handlers defined in ``.glade`` files should have the ``on_`` prefix.
 
 Merging examples
 ----------------

--- a/pyanaconda/ui/gui/spokes/lib/dasdfmt.glade
+++ b/pyanaconda/ui/gui/spokes/lib/dasdfmt.glade
@@ -210,7 +210,7 @@
                     <property name="use_markup">True</property>
                     <property name="wrap">True</property>
                     <property name="track_visited_links">False</property>
-                    <signal name="activate-link" handler="return_to_hub_link_clicked" swapped="no"/>
+                    <signal name="activate-link" handler="on_return_to_hub_link_clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>

--- a/pyanaconda/ui/gui/spokes/lib/dasdfmt.py
+++ b/pyanaconda/ui/gui/spokes/lib/dasdfmt.py
@@ -65,7 +65,7 @@ class DasdFormatDialog(GUIObject):
                 self._epoch += 1
         return rc
 
-    def return_to_hub_link_clicked(self, label, uri):
+    def on_return_to_hub_link_clicked(self, label, uri):
         """
         The user clicked on the link that takes them back to the hub.  We need
         to kill the _check_format watcher and then emit a special response ID

--- a/pyanaconda/ui/gui/spokes/lib/refresh.glade
+++ b/pyanaconda/ui/gui/spokes/lib/refresh.glade
@@ -225,7 +225,7 @@ installation options while this scan completes.</property>
                         <property name="use_markup">True</property>
                         <property name="wrap">True</property>
                         <property name="track_visited_links">False</property>
-                        <signal name="activate-link" handler="return_to_hub_link_clicked" swapped="no"/>
+                        <signal name="activate-link" handler="on_return_to_hub_link_clicked" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>

--- a/pyanaconda/ui/gui/spokes/lib/refresh.py
+++ b/pyanaconda/ui/gui/spokes/lib/refresh.py
@@ -65,7 +65,7 @@ class RefreshDialog(GUIObject):
         self._notebook.set_current_page(3)
         return False
 
-    def return_to_hub_link_clicked(self, label, uri):
+    def on_return_to_hub_link_clicked(self, label, uri):
         # The user clicked on the link that takes them back to the hub.  We need
         # to kill the _check_rescan watcher and then emit a special response ID
         # indicating the user did not press OK.

--- a/pyanaconda/ui/gui/spokes/lib/resize.glade
+++ b/pyanaconda/ui/gui/spokes/lib/resize.glade
@@ -293,7 +293,7 @@
                 <property name="adjustment">resizeAdjustment</property>
                 <property name="round_digits">0</property>
                 <property name="digits">0</property>
-                <signal name="format-value" handler="resize_slider_format" swapped="no"/>
+                <signal name="format-value" handler="on_resize_slider_format" swapped="no"/>
                 <signal name="value-changed" handler="on_resize_value_changed" swapped="no"/>
               </object>
               <packing>

--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -620,7 +620,7 @@ class ResizeDialog(GUIObject):
         # And then the reclaim button, in case they've made enough space.
         self._update_reclaim_button(self._selected_reclaimable_space)
 
-    def resize_slider_format(self, scale, value):
+    def on_resize_slider_format(self, scale, value):
         # This makes the value displayed under the slider prettier than just a
         # single number.
         return str(Size(value))

--- a/pyanaconda/ui/gui/spokes/user.glade
+++ b/pyanaconda/ui/gui/spokes/user.glade
@@ -208,7 +208,7 @@
                         <property name="xalign">0</property>
                         <property name="active">True</property>
                         <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="password_required_toggled" swapped="no"/>
+                        <signal name="toggled" handler="on_password_required_toggled" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -500,7 +500,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
     def completed(self):
         return bool(get_user_list(self._users_module))
 
-    def password_required_toggled(self, togglebutton=None, data=None):
+    def on_password_required_toggled(self, togglebutton=None, data=None):
         """Called by Gtk callback when the "Use password" check
         button is toggled. It will make password entries in/sensitive."""
         password_is_required = togglebutton.get_active()


### PR DESCRIPTION
Add a new rule to the code conventions and rename signal handles that break it.
These handles are reported as unused code and it is easier to filter them out
when they use the same prefix.