### PR TITLE
Add workaround to fix support for installtree without repo

### DIFF
--- a/pyanaconda/modules/payloads/source/utils.py
+++ b/pyanaconda/modules/payloads/source/utils.py
@@ -160,6 +160,17 @@ def verify_valid_repository(path):
     if os.path.exists(repomd_path) and os.path.isfile(repomd_path):
         return True
 
+    # FIXME: Remove this temporary solution when payload source migration will be finished.
+    #
+    # Source should not point to an installation tree but only to a repository, however, right now
+    # we are in state that sources are only for base repository and just reflecting data from
+    # user. With the unified feature the above check won't work because repository is a sub-folder
+    # redirected by .treeinfo file. Add this check back to fix this issue.
+    if os.path.exists(join_paths(path, ".treeinfo")):
+        return True
+    if os.path.exists(join_paths(path, "treeinfo")):
+        return True
+
     return False
 
 

--- a/tests/nosetests/pyanaconda_tests/module_source_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_source_base_test.py
@@ -187,13 +187,27 @@ class UtilitiesTestCase(unittest.TestCase):
 
         self.assertEqual(iso_name, "")
 
-    def verify_valid_repository_success_test(self):
+    def verify_valid_repository_repo_success_test(self):
         """Test verify_valid_repository functionality success."""
         with TemporaryDirectory() as tmp:
             repodir_path = Path(tmp, "repodata")
             repodir_path.mkdir()
             repomd_path = Path(repodir_path, "repomd.xml")
             repomd_path.write_text("This is a cool repomd file!")
+
+            self.assertTrue(verify_valid_repository(tmp))
+
+    def verify_valid_repository_installtree_success_test(self):
+        """Test verify_valid_repository functionality for installation tree success."""
+        with TemporaryDirectory() as tmp:
+            treeinfo_path = Path(tmp, ".treeinfo")
+            treeinfo_path.write_text("This is a cool .treeinfo file!")
+
+            self.assertTrue(verify_valid_repository(tmp))
+
+        with TemporaryDirectory() as tmp:
+            treeinfo_path = Path(tmp, "treeinfo")
+            treeinfo_path.write_text("This is a cool treeinfo file!")
 
             self.assertTrue(verify_valid_repository(tmp))
 


### PR DESCRIPTION
Sources should always point to the repository, however, right now we are in
middle of the migration process to Payloads sources so only base
repositories are migrated and they are more or less only reflecting user data.
To solve this for now we are adding back support for .treeinfo file and not
just repodata. This should be removed when payload source migration will be
finished.

Resolves: rhbz#1854825
(cherry picked from commit 4db89b9be8007b093042f94b18a73042f3526bc9)

Backport of https://github.com/rhinstaller/anaconda/pull/2717.