### PR TITLE
Add container image build badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,10 @@ Anaconda is the OS installer used by Fedora, RHEL, CentOS and other Linux distri
     :alt: Build status
     :target: https://copr.fedorainfracloud.org/coprs/g/rhinstaller/Anaconda/package/anaconda/
 
+.. image:: https://github.com/rhinstaller/anaconda/workflows/Refresh%20container%20images/badge.svg
+    :alt: Refresh container images
+    :target: https://github.com/rhinstaller/anaconda/actions?query=workflow%3A%22Refresh%2C+container+images%22
+
 .. image:: https://readthedocs.org/projects/anaconda-installer/badge/?version=latest
     :alt: Documentation Status
     :target: https://anaconda-installer.readthedocs.io/en/latest/?badge=latest


### PR DESCRIPTION
This would be super helpful to get info that our image build is failing!

And it looks cool too ;).

Blocked by https://github.com/rhinstaller/anaconda/pull/2954 . I want to be sure that the links here are fine and they will work after first run with the new name.

----------------------
Adding badge is not a notable change but having automatic container builds for testing is ;).