### PR TITLE
Packit shouldn't change changelog for Anaconda

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,5 +1,6 @@
 specfile_path: anaconda.spec
 upstream_package_name: anaconda
+sync_changelog: true
 actions:
   post-upstream-clone:
     - ./autogen.sh


### PR DESCRIPTION
We want our upstream changelog instead. It's rewriting history on the downstream but *SHHH* don't tell anyone.