### PR TITLE
Fix localization context issues in GUI

### DIFF
--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -26,7 +26,7 @@ from pyanaconda.modules.common.structures.storage import OSData, DeviceFormatDat
 from pyanaconda.modules.common.task import sync_run_task
 from pyanaconda.threading import threadMgr
 from pyanaconda.flags import flags
-from pyanaconda.core.i18n import _, N_
+from pyanaconda.core.i18n import _
 from pyanaconda.kickstart import runPostScripts
 from pyanaconda.ui.tui import tui_quit_callback
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
@@ -293,6 +293,15 @@ class RescueModeSpoke(NormalTUISpoke):
     def title(self):
         return _("Rescue")
 
+    @staticmethod
+    def get_category():
+        return None
+
+    @staticmethod
+    def get_sort_order():
+        # not actually displayed on a hub, so sort order 0
+        return 0
+
     def refresh(self, args=None):
         super().refresh(args)
 
@@ -414,6 +423,15 @@ class RescueStatusAndShellSpoke(NormalTUISpoke):
     def title(self):
         return _("Rescue Shell")
 
+    @staticmethod
+    def get_category():
+        return None
+
+    @staticmethod
+    def get_sort_order():
+        # not actually displayed on a hub, so sort order 0
+        return 0
+
     @property
     def indirect(self):
         return True
@@ -501,6 +519,15 @@ class RootSelectionSpoke(NormalTUISpoke):
     @property
     def title(self):
         return _("Root Selection")
+
+    @staticmethod
+    def get_category():
+        return None
+
+    @staticmethod
+    def get_sort_order():
+        # not actually displayed on a hub, so sort order 0
+        return 0
 
     @property
     def selection(self):

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -286,9 +286,12 @@ class RescueModeSpoke(NormalTUISpoke):
     # always. This is independent of any hub(s), so pass in some fake data
     def __init__(self, rescue):
         super().__init__(data=None, storage=None, payload=None)
-        self.title = N_("Rescue")
         self._container = None
         self._rescue = rescue
+
+    @property
+    def title(self):
+        return _("Rescue")
 
     def refresh(self, args=None):
         super().refresh(args)
@@ -405,8 +408,11 @@ class RescueStatusAndShellSpoke(NormalTUISpoke):
 
     def __init__(self, rescue):
         super().__init__(data=None, storage=None, payload=None)
-        self.title = N_("Rescue Shell")
         self._rescue = rescue
+
+    @property
+    def title(self):
+        return _("Rescue Shell")
 
     @property
     def indirect(self):
@@ -488,10 +494,13 @@ class RootSelectionSpoke(NormalTUISpoke):
 
     def __init__(self, roots):
         super().__init__(data=None, storage=None, payload=None)
-        self.title = N_("Root Selection")
         self._roots = roots
         self._selection = roots[0]
         self._container = None
+
+    @property
+    def title(self):
+        return _("Root Selection")
 
     @property
     def selection(self):

--- a/pyanaconda/ui/__init__.py
+++ b/pyanaconda/ui/__init__.py
@@ -154,8 +154,8 @@ class UserInterface(object):
 
         def check_standalone_spokes(obj):
             return issubclass(obj, standalone_class) and \
-                getattr(obj, "preForHub", False) or \
-                getattr(obj, "postForHub", False)
+                getattr(obj, "pre_action_for_hub", False) or \
+                getattr(obj, "post_action_for_hub", False)
 
         for module_pattern, path in module_pattern_w_path:
             standalones.extend(
@@ -176,7 +176,7 @@ class UserInterface(object):
                        to the hub dependencies
         :type spokes: list of Spoke instances
 
-        :param hubs: the list of Hub classes we check to be in pre/postForHub
+        :param hubs: the list of Hub classes we check to be in pre/post_action_for_hub
                      attribute of Spokes to pick up
         :type hubs: common.Hub based types
         """
@@ -200,8 +200,8 @@ class UserInterface(object):
 
     @staticmethod
     def _filter_spokes_by_pre_for_hub_reference(spokes, hub):
-        return filter(lambda obj, h=hub: getattr(obj, "preForHub", None) == h, spokes)
+        return filter(lambda obj, h=hub: getattr(obj, "pre_action_for_hub", None) == h, spokes)
 
     @staticmethod
     def _filter_spokes_by_post_for_hub_reference(spokes, hub):
-        return filter(lambda obj, h=hub: getattr(obj, "postForHub", None) == h, spokes)
+        return filter(lambda obj, h=hub: getattr(obj, "post_action_for_hub", None) == h, spokes)

--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -497,39 +497,43 @@ class StandaloneSpoke(Spoke, metaclass=ABCMeta):
 
     def __init__(self, storage, payload):
         """Create a StandaloneSpoke instance."""
-        if self.pre_action_for_hub and self.post_action_for_hub:
+        if self.get_pre_action_for_hub() and self.get_post_action_for_hub():
             raise AttributeError(
-                "StandaloneSpoke instance %{} may not have both pre_action_for_hub"
-                "and post_action_for_hub set".format(self)
+                "StandaloneSpoke instance %{} may not have both get_pre_action_for_hub"
+                "and get_post_action_for_hub returning an action".format(self)
             )
 
         super().__init__(storage, payload)
 
-    @property
+    @staticmethod
     @abstractmethod
-    def pre_action_for_hub(self):
+    def get_pre_action_for_hub():
         """A reference to a Hub subclass this Spoke is a pre action for.
 
-        Only one of pre_for_hub/post_for_hub may be set at a time.
+        Only one of get_pre_action_for_hub()/get_post_action_for_hub()
+        may return an action at a time.
+
         Note that all post actions will be run for one hub before any
         pre actions for the next.
         """
         return None
 
-    @property
+    @staticmethod
     @abstractmethod
-    def post_action_for_hub(self):
+    def get_post_action_for_hub():
         """A reference to a Hub subclass this Spoke is a post action for.
 
-        Only one of pre_action_for_hub/post_action_for_hub may be set at a time.
+        Only one of get_pre_action_for_hub()/get_post_action_for_hub()
+        may return an action at a time.
+
         Note that all post actions will be run for one hub before any
         pre actions for the next.
         """
         return None
 
-    @property
+    @staticmethod
     @abstractmethod
-    def action_priority(self):
+    def get_action_priority():
         """Used to sort pre and post actions.
 
         The lower a value, the earlier it will be run.

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -18,7 +18,7 @@
 #
 
 from pyanaconda.flags import flags
-from pyanaconda.core.i18n import _, C_
+from pyanaconda.core.i18n import _
 from pyanaconda.product import distributionText
 from pyanaconda import lifecycle
 from pyanaconda.core.timer import Timer
@@ -133,7 +133,7 @@ class Hub(GUIObject, common.Hub):
 
         for category in common.sort_categories(categories):
             selectors = []
-            for spokeClass in sorted(cats_and_spokes[c], key=lambda s: s.get_sort_order()):
+            for spokeClass in sorted(cats_and_spokes[category], key=lambda s: s.get_sort_order()):
                 # Check if this spoke is to be shown in the supported environments
                 if not any(spokeClass.should_run(environ, self.data) for environ in flags.environs):
                     continue

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -133,7 +133,7 @@ class Hub(GUIObject, common.Hub):
 
         for category in common.sort_categories(categories):
             selectors = []
-            for spokeClass in sorted(cats_and_spokes[category], key=lambda s: s.title):
+            for spokeClass in sorted(cats_and_spokes[c], key=lambda s: s.get_sort_order()):
                 # Check if this spoke is to be shown in the supported environments
                 if not any(spokeClass.should_run(environ, self.data) for environ in flags.environs):
                     continue
@@ -167,7 +167,7 @@ class Hub(GUIObject, common.Hub):
                     spoke.initialize()
                     continue
 
-                spoke.selector = AnacondaWidgets.SpokeSelector(C_("GUI|Spoke", spoke.title),
+                spoke.selector = AnacondaWidgets.SpokeSelector(spoke.title,
                                                                spoke.icon)
 
                 # Set all selectors to insensitive before initialize runs.  The call to

--- a/pyanaconda/ui/gui/spokes/__init__.py
+++ b/pyanaconda/ui/gui/spokes/__init__.py
@@ -16,6 +16,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 
+from abc import ABCMeta, abstractmethod
+
 from pyanaconda.ui import common
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.lib.help import start_yelp, get_help_path
@@ -47,7 +49,7 @@ class StandaloneSpoke(GUIObject, common.StandaloneSpoke):
 
 # Inherit abstract methods from common.NormalSpoke
 # pylint: disable=abstract-method
-class NormalSpoke(GUIObject, common.NormalSpoke):
+class NormalSpoke(GUIObject, common.NormalSpoke, metaclass=ABCMeta):
     """
        .. inheritance-diagram:: NormalSpoke
           :parts: 3
@@ -61,6 +63,21 @@ class NormalSpoke(GUIObject, common.NormalSpoke):
 
         # warning message
         self._current_warning_message = ""
+
+    @property
+    @abstractmethod
+    def icon(self):
+        """The name of the icon to be displayed.
+
+        The name of the icon to be displayed in the SpokeSelector
+        widget corresponding to this Spoke instance.  If no icon
+        is given, the default from SpokeSelector will be used.
+
+        NOTE: As standalone spokes are not displayed on a hub,
+              they don't need a spoke icon to be defined for them.
+        """
+        return None
+
 
     def _on_help_clicked(self, window):
         # the help button has been clicked, start the yelp viewer with

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -22,7 +22,7 @@ from blivet.size import Size
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.flags import flags
-from pyanaconda.core.i18n import CN_, CP_
+from pyanaconda.core.i18n import _, CP_, C_
 from pyanaconda.modules.common.structures.storage import DeviceData
 from pyanaconda.ui.lib.storage import apply_disk_selection, try_populate_devicetree, \
     filter_disks_by_names
@@ -505,10 +505,6 @@ class FilterSpoke(NormalSpoke):
     uiFile = "spokes/advanced_storage.glade"
     helpFile = "FilterSpoke.xml"
 
-    category = SystemCategory
-
-    title = CN_("GUI|Spoke", "_Installation Destination")
-
     def __init__(self, *args):
         super().__init__(*args)
         self.applyOnSkip = True
@@ -526,6 +522,23 @@ class FilterSpoke(NormalSpoke):
         self._notebook = self.builder.get_object("advancedNotebook")
         self._store = self.builder.get_object("diskStore")
         self._reconfigure_nvdimm_button = self.builder.get_object("reconfigureNVDIMMButton")
+
+    @staticmethod
+    def get_category():
+        return SystemCategory
+
+    @property
+    def icon(self):
+        return "drive-harddisk-symbolic"
+
+    @property
+    def title(self):
+        return C_("GUI|Spoke", "_Installation Destination")
+
+    @staticmethod
+    def get_sort_order():
+        # not actually displayed on a hub, so sort order 0
+        return 0
 
     @property
     def indirect(self):

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -22,7 +22,7 @@ from blivet.size import Size
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.flags import flags
-from pyanaconda.core.i18n import _, CP_, C_
+from pyanaconda.core.i18n import CP_, C_
 from pyanaconda.modules.common.structures.storage import DeviceData
 from pyanaconda.ui.lib.storage import apply_disk_selection, try_populate_devicetree, \
     filter_disks_by_names

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -41,7 +41,7 @@ from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.gui.spokes.lib.summary import ActionSummaryDialog
 from pyanaconda.core.constants import THREAD_EXECUTE_STORAGE, THREAD_STORAGE, \
     PARTITIONING_METHOD_BLIVET
-from pyanaconda.core.i18n import _, CN_, C_
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.ui.lib.storage import reset_bootloader, create_partitioning
 from pyanaconda.threading import threadMgr
 from pyanaconda.modules.common.constants.services import STORAGE
@@ -96,12 +96,6 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
     # name of the .glade file in the same directory as this source
     uiFile = "spokes/blivet_gui.glade"
 
-    # category this spoke belongs to
-    category = SystemCategory
-
-    # title of the spoke (will be displayed on the hub)
-    title = CN_("GUI|Spoke", "_Blivet-GUI Partitioning")
-
     helpFile = "blivet-gui/index.page"
 
     ### methods defined by API ###
@@ -132,6 +126,25 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
 
         StorageCheckHandler.__init__(self)
         NormalSpoke.__init__(self, data, storage, payload)
+
+    @staticmethod
+    def get_category():
+        """Category this spoke belongs to."""
+        return SystemCategory
+
+    @property
+    def icon(self):
+        return "drive-harddisk-symbolic"
+
+    @property
+    def title(self):
+        """Title of the spoke (will be displayed on the hub)."""
+        return C_("GUI|Spoke", "_Blivet-GUI Partitioning")
+
+    @staticmethod
+    def get_sort_order():
+        # not actually displayed on a hub, so sort order 0
+        return 0
 
     @property
     def label_actions(self):

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -35,7 +35,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import THREAD_EXECUTE_STORAGE, THREAD_STORAGE, \
     SIZE_UNITS_DEFAULT, PARTITIONING_METHOD_INTERACTIVE
-from pyanaconda.core.i18n import _, N_, CP_, C_
+from pyanaconda.core.i18n import _, CP_, C_
 from pyanaconda.modules.common.constants.objects import BOOTLOADER, DISK_SELECTION
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.structures.storage import OSData, DeviceFormatData, DeviceData
@@ -96,9 +96,6 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     uiFile = "spokes/custom_storage.glade"
     helpFile = "CustomSpoke.xml"
 
-    category = SystemCategory
-    title = N_("MANUAL PARTITIONING")
-
     # The maximum number of places to show when displaying a size
     MAX_SIZE_PLACES = 2
 
@@ -129,6 +126,23 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._storage_module = STORAGE.get_proxy()
         self._boot_loader = STORAGE.get_proxy(BOOTLOADER)
         self._disk_selection = STORAGE.get_proxy(DISK_SELECTION)
+
+    @staticmethod
+    def get_category():
+        return SystemCategory
+
+    @property
+    def icon(self):
+        return "drive-harddisk-symbolic"
+
+    @property
+    def title(self):
+        return C_("GUI|Spoke", "Manual Partitioning")
+
+    @staticmethod
+    def get_sort_order():
+        # not actually displayed on a hub, so sort order 0
+        return 0
 
     def apply(self):
         self.clear_errors()

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -32,7 +32,7 @@ from pyanaconda.core import util, constants
 from pyanaconda.core.async_utils import async_action_wait, async_action_nowait
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import TIME_SOURCE_POOL, TIME_SOURCE_SERVER
-from pyanaconda.core.i18n import _, CN_
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.timer import Timer
 from pyanaconda.localization import get_xlated_timezone, resolve_date_format
 from pyanaconda.modules.common.structures.timezone import TimeSourceData
@@ -392,11 +392,6 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
     uiFile = "spokes/datetime_spoke.glade"
     helpFile = "DateTimeSpoke.xml"
 
-    category = LocalizationCategory
-
-    icon = "preferences-system-time-symbolic"
-    title = CN_("GUI|Spoke", "_Time & Date")
-
     # Hack to get libtimezonemap loaded for GtkBuilder
     # see https://bugzilla.gnome.org/show_bug.cgi?id=712184
     _hack = TimezoneMap.TimezoneMap()
@@ -418,6 +413,22 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
         self._ntp_servers = []
         self._ntp_servers_states = NTPServerStatusCache()
+
+    @staticmethod
+    def get_category():
+        return LocalizationCategory
+
+    @property
+    def icon(self):
+        return "preferences-system-time-symbolic"
+
+    @property
+    def title(self):
+        return C_("GUI|Spoke", "_Time & Date")
+
+    @staticmethod
+    def get_sort_order():
+        return 300
 
     def initialize(self):
         NormalSpoke.initialize(self)

--- a/pyanaconda/ui/gui/spokes/installation_progress.py
+++ b/pyanaconda/ui/gui/spokes/installation_progress.py
@@ -46,8 +46,6 @@ class ProgressSpoke(StandaloneSpoke):
     uiFile = "spokes/installation_progress.glade"
     helpFile = "ProgressHub.xml"
 
-    postForHub = SummaryHub
-
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
         self._totalSteps = 0
@@ -58,6 +56,10 @@ class ProgressSpoke(StandaloneSpoke):
         self._progressLabel = self.builder.get_object("progressLabel")
         self._progressNotebook = self.builder.get_object("progressNotebook")
         self._spinner = self.builder.get_object("progressSpinner")
+
+    @property
+    def post_action_for_hub(self):
+        return SummaryHub
 
     @property
     def completed(self):

--- a/pyanaconda/ui/gui/spokes/installation_progress.py
+++ b/pyanaconda/ui/gui/spokes/installation_progress.py
@@ -57,8 +57,12 @@ class ProgressSpoke(StandaloneSpoke):
         self._progressNotebook = self.builder.get_object("progressNotebook")
         self._spinner = self.builder.get_object("progressSpinner")
 
-    @property
-    def post_action_for_hub(self):
+    @staticmethod
+    def get_pre_action_for_hub():
+        return None
+
+    @staticmethod
+    def get_post_action_for_hub():
         return SummaryHub
 
     @property

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -32,7 +32,7 @@ from pyanaconda.core.constants import PAYLOAD_TYPE_DNF, SOURCE_TYPE_HDD, SOURCE_
     URL_TYPE_METALINK, SOURCE_TYPE_CLOSEST_MIRROR, SOURCE_TYPE_CDN
 from pyanaconda.core.process_watchers import PidWatcher
 from pyanaconda.flags import flags
-from pyanaconda.core.i18n import _, N_, CN_
+from pyanaconda.core.i18n import _, N_, C_
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.payload.image import find_optical_install_media, find_potential_hdiso_sources, \
@@ -401,11 +401,6 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
     uiFile = "spokes/installation_source.glade"
     helpFile = "SourceSpoke.xml"
 
-    category = SoftwareCategory
-
-    icon = "media-optical-symbolic"
-    title = CN_("GUI|Spoke", "_Installation Source")
-
     def __init__(self, *args, **kwargs):
         NormalSpoke.__init__(self, *args, **kwargs)
         GUISpokeInputCheckHandler.__init__(self)
@@ -426,6 +421,22 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
 
         self._network_module = NETWORK.get_proxy()
         self._device_tree = STORAGE.get_proxy(DEVICE_TREE)
+
+    @staticmethod
+    def get_category():
+        return SoftwareCategory
+
+    @property
+    def icon(self):
+        return "media-optical-symbolic"
+
+    @property
+    def title(self):
+        return C_("GUI|Spoke", "_Installation Source")
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     def apply(self):
         source_changed = self._update_payload_source()
@@ -702,6 +713,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         self._url_entry = self.builder.get_object("urlEntry")
         self._protocol_combo_box = self.builder.get_object("protocolComboBox")
         self._iso_chooser_button = self.builder.get_object("isoChooserButton")
+        self._orig_iso_chooser_button = self._iso_chooser_button.get_label()
 
         # Attach a validator to the URL entry. Start it as disabled, and it will be
         # enabled/disabled as entry sensitivity is enabled/disabled.
@@ -1082,6 +1094,11 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         self._updates_box.set_sensitive(self._mirror_active())
         active = self._mirror_active() and self.payload.is_repo_enabled("updates")
         self._updates_radio_button.set_active(active)
+
+    def _update_CDN_usage(self):
+        """Notify Payload module and Subscription spoke about possible CDN usage change."""
+        # notify Subscription spoke about possible change
+        hubQ.send_ready("SubscriptionSpoke", False)
 
     @property
     def showable(self):

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -32,7 +32,7 @@ from pyanaconda.ui.gui.utils import override_cell_property
 from pyanaconda.ui.gui.xkl_wrapper import XklWrapper, XklWrapperError
 from pyanaconda import keyboard
 from pyanaconda import flags
-from pyanaconda.core.i18n import _, N_, CN_
+from pyanaconda.core.i18n import _, N_, C_
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import DEFAULT_KEYBOARD, THREAD_KEYBOARD_INIT, THREAD_ADD_LAYOUTS_INIT
 from pyanaconda.ui.communication import hubQ
@@ -285,11 +285,6 @@ class KeyboardSpoke(NormalSpoke):
     uiFile = "spokes/keyboard.glade"
     helpFile = "KeyboardSpoke.xml"
 
-    category = LocalizationCategory
-
-    icon = "input-keyboard-symbolic"
-    title = CN_("GUI|Spoke", "_Keyboard")
-
     def __init__(self, *args):
         super().__init__(*args)
         self._remove_last_attempt = False
@@ -305,6 +300,22 @@ class KeyboardSpoke(NormalSpoke):
 
         self._l12_module = LOCALIZATION.get_proxy()
         self._seen = self._l12_module.KeyboardKickstarted
+
+    @staticmethod
+    def get_category():
+        return LocalizationCategory
+
+    @property
+    def icon(self):
+        return "input-keyboard-symbolic"
+
+    @property
+    def title(self):
+        return C_("GUI|Spoke", "_Keyboard")
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     def apply(self):
         # the user has confirmed (seen) the configuration

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -25,7 +25,7 @@ from gi.repository import Pango, Gdk
 
 from pyanaconda.core.constants import PAYLOAD_LIVE_TYPES
 from pyanaconda.modules.common.constants.services import LOCALIZATION
-from pyanaconda.core.i18n import CN_
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.utils import escape_markup, override_cell_property
 from pyanaconda.ui.categories.localization import LocalizationCategory
@@ -56,17 +56,28 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
     uiFile = "spokes/language_support.glade"
     helpFile = "LangSupportSpoke.xml"
 
-    category = LocalizationCategory
-
-    icon = "accessories-character-map-symbolic"
-    title = CN_("GUI|Spoke", "_Language Support")
-
     def __init__(self, *args, **kwargs):
         NormalSpoke.__init__(self, *args, **kwargs)
         LangLocaleHandler.__init__(self)
         self._selected_locales = set()
 
         self._l12_module = LOCALIZATION.get_proxy()
+
+    @staticmethod
+    def get_category():
+        LocalizationCategory
+
+    @property
+    def icon(self):
+        return "accessories-character-map-symbolic"
+
+    @property
+    def title(self):
+        return C_("GUI|Spoke", "_Language Support")
+
+    @staticmethod
+    def get_sort_order():
+        return 200
 
     def initialize(self):
         self.initialize_start()

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -25,7 +25,7 @@ from gi.repository import Pango, Gdk
 
 from pyanaconda.core.constants import PAYLOAD_LIVE_TYPES
 from pyanaconda.modules.common.constants.services import LOCALIZATION
-from pyanaconda.core.i18n import _, C_
+from pyanaconda.core.i18n import C_
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.utils import escape_markup, override_cell_property
 from pyanaconda.ui.categories.localization import LocalizationCategory
@@ -65,7 +65,7 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
 
     @staticmethod
     def get_category():
-        LocalizationCategory
+        return LocalizationCategory
 
     @property
     def icon(self):

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1622,13 +1622,28 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
         self._now_available = False
 
     @property
-    def pre_action_for_hub(self):
-        return SummaryHub
+    def title(self):
+        return C_("GUI|Spoke", "_Network & Host Name")
 
     @property
-    def action_priority(self):
-        return 10
+    def icon(self):
+        return "network-transmit-receive-symbolic"
 
+    @staticmethod
+    def get_category():
+        return SystemCategory
+
+    @staticmethod
+    def get_pre_action_for_hub():
+        return SummaryHub
+
+    @staticmethod
+    def get_post_action_for_hub():
+        return None
+
+    @staticmethod
+    def get_action_priority():
+        return 10
 
     def _hostname_changed(self, hostname):
         gtk_call_once(self._update_hostname)

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -27,7 +27,7 @@ gi.require_version("NM", "1.0")
 from gi.repository import Gtk
 from gi.repository import GObject, Pango, Gio, NM
 
-from pyanaconda.core.i18n import _, N_, CN_
+from pyanaconda.core.i18n import _, N_, C_
 from pyanaconda.flags import flags as anaconda_flags
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.ui.gui import GUIObject
@@ -1439,11 +1439,6 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
     uiFile = "spokes/network.glade"
     helpFile = "NetworkSpoke.xml"
 
-    title = CN_("GUI|Spoke", "_Network & Host Name")
-    icon = "network-transmit-receive-symbolic"
-
-    category = SystemCategory
-
     def __init__(self, *args, **kwargs):
         NormalSpoke.__init__(self, *args, **kwargs)
         self.networking_changed = False
@@ -1459,6 +1454,22 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
                                          self.on_device_state_changed)
         self.network_control_box.connect("apply-hostname",
                                          self.on_apply_hostname)
+
+    @property
+    def title(self):
+        return C_("GUI|Spoke", "_Network & Host Name")
+
+    @property
+    def icon(self):
+        return "network-transmit-receive-symbolic"
+
+    @staticmethod
+    def get_category():
+        return SystemCategory
+
+    @staticmethod
+    def get_sort_order():
+        return 200
 
     def _hostname_changed(self, hostname):
         gtk_call_once(self._update_hostname)
@@ -1588,9 +1599,6 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
     mainWidgetName = "networkStandaloneWindow"
     uiFile = "spokes/network.glade"
 
-    preForHub = SummaryHub
-    priority = 10
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._network_module = NETWORK.get_proxy()
@@ -1612,6 +1620,15 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
         self._initially_available = self.completed
         log.debug("network standalone spoke (init): completed: %s", self._initially_available)
         self._now_available = False
+
+    @property
+    def pre_action_for_hub(self):
+        return SummaryHub
+
+    @property
+    def action_priority(self):
+        return 10
+
 
     def _hostname_changed(self, hostname):
         gtk_call_once(self._update_hostname)

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -18,7 +18,7 @@
 #
 
 from pyanaconda.flags import flags
-from pyanaconda.core.i18n import _, CN_
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.users import crypt_password
 from pyanaconda import input_checking
 from pyanaconda.core import constants
@@ -49,11 +49,6 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     uiFile = "spokes/root_password.glade"
     helpFile = "PasswordSpoke.xml"
 
-    category = UserSettingsCategory
-
-    icon = "dialog-password-symbolic"
-    title = CN_("GUI|Spoke", "_Root Password")
-
     def __init__(self, *args):
         NormalSpoke.__init__(self, *args)
         GUISpokeInputCheckHandler.__init__(self)
@@ -61,6 +56,22 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self._services_module = SERVICES.get_proxy()
         self._refresh_running = False
         self._manually_locked = False
+
+    @staticmethod
+    def get_category():
+        return UserSettingsCategory
+
+    @property
+    def icon(self):
+        return "dialog-password-symbolic"
+
+    @property
+    def title(self):
+        return C_("GUI|Spoke", "_Root Password")
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     def initialize(self):
         NormalSpoke.initialize(self)

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -21,7 +21,7 @@ import copy
 import gi
 
 from pyanaconda.flags import flags
-from pyanaconda.core.i18n import _, C_, CN_
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.constants import PAYLOAD_TYPE_DNF
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.payload.manager import payloadMgr, PayloadState
@@ -60,11 +60,6 @@ class SoftwareSelectionSpoke(NormalSpoke):
     mainWidgetName = "softwareWindow"
     uiFile = "spokes/software_selection.glade"
     helpFile = "SoftwareSpoke.xml"
-
-    category = SoftwareCategory
-
-    icon = "package-x-generic-symbolic"
-    title = CN_("GUI|Spoke", "_Software Selection")
 
     # Add-on selection states
     # no user interaction with this add-on
@@ -116,6 +111,22 @@ class SoftwareSelectionSpoke(NormalSpoke):
         # list with no radio buttons ticked
         self._fake_radio = Gtk.RadioButton(group=None)
         self._fake_radio.set_active(True)
+
+    @staticmethod
+    def get_category():
+        return SoftwareCategory
+
+    @property
+    def icon(self):
+        return "package-x-generic-symbolic"
+
+    @property
+    def title(self):
+        return C_("GUI|Spoke", "_Software Selection")
+
+    @staticmethod
+    def get_sort_order():
+        return 200
 
     # Payload event handlers
     def _downloading_package_md(self):

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -26,7 +26,7 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import CLEAR_PARTITIONS_NONE, BOOTLOADER_ENABLED, \
     STORAGE_METADATA_RATIO, WARNING_NO_DISKS_SELECTED, WARNING_NO_DISKS_DETECTED, \
     PARTITIONING_METHOD_AUTOMATIC, PARTITIONING_METHOD_INTERACTIVE, PARTITIONING_METHOD_BLIVET
-from pyanaconda.core.i18n import _, C_, CN_
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.flags import flags
 from pyanaconda.modules.common.constants.objects import DISK_SELECTION, DISK_INITIALIZATION, \
     BOOTLOADER, DEVICE_TREE
@@ -75,12 +75,6 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
     mainWidgetName = "storageWindow"
     uiFile = "spokes/storage.glade"
     helpFile = "StorageSpoke.xml"
-
-    category = SystemCategory
-
-    # other candidates: computer-symbolic, folder-symbolic
-    icon = "drive-harddisk-symbolic"
-    title = CN_("GUI|Spoke", "Installation _Destination")
 
     def __init__(self, *args, **kwargs):
         StorageCheckHandler.__init__(self)
@@ -133,6 +127,23 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
 
         # Configure the partitioning methods.
         self._configure_partitioning_methods()
+
+    @staticmethod
+    def get_category():
+        return SystemCategory
+
+    @property
+    def icon(self):
+        # other candidates: computer-symbolic, folder-symbolic
+        return "drive-harddisk-symbolic"
+
+    @property
+    def title(self):
+        return C_("GUI|Spoke", "Installation _Destination")
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     def _configure_partitioning_methods(self):
         if "CustomPartitioningSpoke" in conf.ui.hidden_spokes:

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -22,7 +22,7 @@ from enum import IntEnum
 from pyanaconda.flags import flags
 from pyanaconda.threading import threadMgr, AnacondaThread
 
-from pyanaconda.core.i18n import _
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.constants import SECRET_TYPE_HIDDEN, \
     SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY, \
     THREAD_SUBSCRIPTION, THREAD_PAYLOAD, SOURCE_TYPES_OVERRIDEN_BY_CDN, \

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -22,7 +22,7 @@ from enum import IntEnum
 from pyanaconda.flags import flags
 from pyanaconda.threading import threadMgr, AnacondaThread
 
-from pyanaconda.core.i18n import _, CN_
+from pyanaconda.core.i18n import _
 from pyanaconda.core.constants import SECRET_TYPE_HIDDEN, \
     SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY, \
     THREAD_SUBSCRIPTION, THREAD_PAYLOAD, SOURCE_TYPES_OVERRIDEN_BY_CDN, \
@@ -66,10 +66,21 @@ class SubscriptionSpoke(NormalSpoke):
     mainWidgetName = "subscription_window"
     uiFile = "spokes/subscription.glade"
 
-    category = SoftwareCategory
+    @staticmethod
+    def get_category():
+        return SoftwareCategory
 
-    icon = "application-certificate-symbolic"
-    title = CN_("GUI|Spoke", "_Connect to Red Hat")
+    @property
+    def icon(self):
+        return "application-certificate-symbolic"
+
+    @property
+    def title(self):
+        return C_("GUI|Spoke", "_Connect to Red Hat")
+
+    @staticmethod
+    def get_sort_order():
+        return 300
 
     # main notebook pages
     REGISTRATION_PAGE = 0

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -19,7 +19,7 @@
 
 import os
 from pyanaconda.flags import flags
-from pyanaconda.core.i18n import _, CN_
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.users import crypt_password, guess_username, check_groupname
 from pyanaconda import input_checking
 from pyanaconda.core import constants
@@ -225,11 +225,6 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
     uiFile = "spokes/user.glade"
     helpFile = "UserSpoke.xml"
 
-    category = UserSettingsCategory
-
-    icon = "avatar-default-symbolic"
-    title = CN_("GUI|Spoke", "_User Creation")
-
     @classmethod
     def should_run(cls, environment, data):
         # the user spoke should run always in the anaconda and in firstboot only
@@ -255,6 +250,22 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
 
         self._users_module = USERS.get_proxy()
         self._password_is_required = True
+
+    @staticmethod
+    def get_category():
+        return UserSettingsCategory
+
+    @property
+    def icon(self):
+        return "avatar-default-symbolic"
+
+    @property
+    def title(self):
+        return C_("GUI|Spoke", "_User Creation")
+
+    @staticmethod
+    def get_sort_order():
+        return 200
 
     def initialize(self):
         NormalSpoke.initialize(self)

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -60,9 +60,6 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
     builderObjects = ["languageStore", "languageStoreFilter", "localeStore",
                       "welcomeWindow", "betaWarnDialog"]
 
-    preForHub = SummaryHub
-    priority = 0
-
     def __init__(self, *args, **kwargs):
         StandaloneSpoke.__init__(self, *args, **kwargs)
         LangLocaleHandler.__init__(self)
@@ -71,6 +68,14 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
         self._l12_module = LOCALIZATION.get_proxy()
 
         self._only_existing_locales = True
+
+    @property
+    def pre_action_for_hub(self):
+        return SummaryHub
+
+    @property
+    def action_priority(self):
+        return 0
 
     def apply(self):
         (store, itr) = self._localeSelection.get_selected()

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -69,12 +69,16 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
 
         self._only_existing_locales = True
 
-    @property
-    def pre_action_for_hub(self):
+    @staticmethod
+    def get_pre_action_for_hub():
         return SummaryHub
 
-    @property
-    def action_priority(self):
+    @staticmethod
+    def get_post_action_for_hub():
+        return None
+
+    @staticmethod
+    def get_action_priority():
         return 0
 
     def apply(self):

--- a/pyanaconda/ui/tui/hubs/__init__.py
+++ b/pyanaconda/ui/tui/hubs/__init__.py
@@ -16,6 +16,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from abc import ABCMeta, abstractmethod
+
 from pyanaconda import lifecycle
 from pyanaconda.ui.tui.tuiobject import TUIObject
 from pyanaconda.ui.lib.help import get_help_path
@@ -27,12 +29,12 @@ from simpleline.render.prompt import Prompt
 from simpleline.render.screen import InputState
 from simpleline.render.screen_handler import ScreenHandler
 
-from pyanaconda.core.i18n import _, N_
+from pyanaconda.core.i18n import _
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class TUIHub(TUIObject, common.Hub):
+class TUIHub(TUIObject, common.Hub, metaclass=ABCMeta):
     """Base Hub class implementing the pyanaconda.ui.common.Hub interface.
        It uses text based categories to look for relevant Spokes and manages
        all the spokes it finds to have the proper category.
@@ -51,7 +53,6 @@ class TUIHub(TUIObject, common.Hub):
     def __init__(self, data, storage, payload):
         TUIObject.__init__(self, data)
         common.Hub.__init__(self, storage, payload)
-        self.title = N_("Default HUB title")
         self._container = None
 
         self._spokes_map = []  # hold all the spokes in the right ordering
@@ -60,6 +61,11 @@ class TUIHub(TUIObject, common.Hub):
 
         # we want user input
         self.input_required = True
+
+    @property
+    @abstractmethod
+    def title(self):
+        return None
 
     def setup(self, args="anaconda"):
         TUIObject.setup(self, args)
@@ -90,7 +96,7 @@ class TUIHub(TUIObject, common.Hub):
                     hub_spokes.append(spoke)
 
             # sort created spokes and add them to result structures
-            for spoke in sorted(hub_spokes, key=lambda s: s.title):
+            for spoke in sorted(hub_spokes, key=lambda s: s.get_sort_order()):
 
                 self._spoke_count += 1
                 self._spokes_map.append(spoke)

--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -21,7 +21,7 @@ from pyanaconda.ui.lib.space import FileSystemSpaceChecker, DirInstallSpaceCheck
 from pyanaconda.ui.tui.hubs import TUIHub
 from pyanaconda.flags import flags
 from pyanaconda.errors import CmdlineError
-from pyanaconda.core.i18n import N_, _, C_
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.configuration.anaconda import conf
 
 from simpleline import App
@@ -44,12 +44,15 @@ class SummaryHub(TUIHub):
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
-        self.title = N_("Installation")
 
         if not conf.target.is_directory:
             self._checker = FileSystemSpaceChecker(payload)
         else:
             self._checker = DirInstallSpaceChecker(payload)
+
+    @property
+    def title(self):
+        return C_("TUI|Hub", "Installation")
 
     def setup(self, args="anaconda"):
         environment = args

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -54,7 +54,10 @@ class TUISpoke(TUIObject, Widget, Spoke):
         Spoke.__init__(self, storage, payload)
 
         self.input_required = True
-        self.title = N_("Default spoke title")
+
+    @property
+    def title(self):
+        return None
 
     @property
     def status(self):
@@ -85,7 +88,7 @@ class TUISpoke(TUIObject, Widget, Spoke):
         # always set completed = True here; otherwise key value won't be
         # displayed if completed (spoke value from above) is False
         c = CheckboxWidget(key=key, completed=True,
-                           title=_(self.title), text=self.status)
+                           title=self.title, text=self.status)
         c.render(width)
         self.draw(c)
 

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -20,7 +20,7 @@
 from pyanaconda.ui.common import Spoke, StandaloneSpoke, NormalSpoke
 from pyanaconda.ui.tui.tuiobject import TUIObject
 from pyanaconda.ui.lib.help import get_help_path
-from pyanaconda.core.i18n import N_, _
+from pyanaconda.core.i18n import _
 
 from simpleline.render.adv_widgets import HelpScreen
 from simpleline.render.screen import InputState

--- a/pyanaconda/ui/tui/spokes/askvnc.py
+++ b/pyanaconda/ui/tui/spokes/askvnc.py
@@ -65,10 +65,6 @@ class AskVNCSpoke(NormalTUISpoke):
         self.initialize_done()
 
     @staticmethod
-    def get_category():
-        return None
-
-    @staticmethod
     def get_sort_order():
         # standalone spoke -> sort order 0
         return 0
@@ -77,9 +73,18 @@ class AskVNCSpoke(NormalTUISpoke):
     def title(self):
         return C_("TUI|Spoke", "VNC")
 
+    @staticmethod
+    def get_category():
+        return None
+
     @property
     def indirect(self):
         return True
+
+    @property
+    def icon(self):
+        # no icon needed since spoke is indirect
+        return None
 
     def refresh(self, args=None):
         super().refresh(args)
@@ -145,6 +150,15 @@ class VNCPassSpoke(NormalTUISpoke):
     @property
     def title(self):
         return C_("TUI|Spoke", "VNC Password")
+
+    @staticmethod
+    def get_category():
+        return None
+
+    @staticmethod
+    def get_sort_order():
+        # not actually displayed on a hub, so sort order 0
+        return 0
 
     @property
     def indirect(self):

--- a/pyanaconda/ui/tui/spokes/askvnc.py
+++ b/pyanaconda/ui/tui/spokes/askvnc.py
@@ -22,7 +22,7 @@ import sys
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.core.constants import USEVNC, USETEXT, QUIT_MESSAGE
-from pyanaconda.core.i18n import N_, _, C_
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.ui.tui import exception_msg_handler
 from pyanaconda.core.util import execWithRedirect, ipmi_abort
 
@@ -46,7 +46,6 @@ class AskVNCSpoke(NormalTUISpoke):
        .. inheritance-diagram:: AskVNCSpoke
           :parts: 3
     """
-    title = N_("VNC")
 
     # This spoke is kinda standalone, not meant to be used with a hub
     # We pass in some fake data just to make our parents happy
@@ -64,6 +63,19 @@ class AskVNCSpoke(NormalTUISpoke):
         self._message = message
         self._usevnc = False
         self.initialize_done()
+
+    @staticmethod
+    def get_category():
+        return None
+
+    @staticmethod
+    def get_sort_order():
+        # standalone spoke -> sort order 0
+        return 0
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "VNC")
 
     @property
     def indirect(self):
@@ -123,13 +135,16 @@ class VNCPassSpoke(NormalTUISpoke):
 
     def __init__(self, data, storage, payload, message=None):
         super().__init__(data, storage, payload)
-        self.title = N_("VNC Password")
         self._password = ""
         if message:
             self._message = message
         else:
             self._message = _("Please provide VNC password (must be six to eight characters long).\n"
                               "You will have to type it twice. Leave blank for no password")
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "VNC Password")
 
     @property
     def indirect(self):

--- a/pyanaconda/ui/tui/spokes/installation_progress.py
+++ b/pyanaconda/ui/tui/spokes/installation_progress.py
@@ -62,8 +62,12 @@ class ProgressSpoke(StandaloneTUISpoke):
     def title(self):
         return C_("TUI|Spoke", "Progress")
 
-    @property
-    def post_action_for_hub(self):
+    @staticmethod
+    def get_pre_action_for_hub():
+        return None
+
+    @staticmethod
+    def get_post_action_for_hub():
         return SummaryHub
 
     @property

--- a/pyanaconda/ui/tui/spokes/installation_progress.py
+++ b/pyanaconda/ui/tui/spokes/installation_progress.py
@@ -20,7 +20,7 @@
 import sys
 
 from pyanaconda.flags import flags
-from pyanaconda.core.i18n import N_, _
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.core import util
 from pyanaconda.core.constants import THREAD_INSTALL, IPMI_FINISHED
 from pyanaconda.core.configuration.anaconda import conf
@@ -42,14 +42,29 @@ class ProgressSpoke(StandaloneTUISpoke):
        .. inheritance-diagram:: ProgressSpoke
           :parts: 3
     """
-    postForHub = SummaryHub
 
     def __init__(self, ksdata, storage, payload):
         self.initialize_start()
         super().__init__(ksdata, storage, payload)
-        self.title = N_("Progress")
         self._stepped = False
         self.initialize_done()
+
+    @staticmethod
+    def get_category():
+        return None
+
+    @staticmethod
+    def get_sort_order():
+        # standalone spoke -> sort order 0
+        return 0
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Progress")
+
+    @property
+    def post_action_for_hub(self):
+        return SummaryHub
 
     @property
     def completed(self):

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -29,7 +29,7 @@ from pyanaconda.ui.tui.tuiobject import Dialog
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload import utils as payload_utils
 from pyanaconda.payload.manager import payloadMgr, PayloadState
-from pyanaconda.core.i18n import N_, _, C_
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.payload.image import find_potential_hdiso_sources, \
     get_hdiso_source_info, get_hdiso_source_description
 
@@ -69,11 +69,22 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)
         SourceSwitchHandler.__init__(self)
-        self.title = N_("Installation source")
         self._container = None
         self._ready = False
         self._error = False
         self._hmc = False
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Installation source")
+
+    @staticmethod
+    def get_category():
+        return SoftwareCategory
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     def initialize(self):
         NormalTUISpoke.initialize(self)
@@ -229,10 +240,13 @@ class SpecifyRepoSpoke(NormalTUISpoke, SourceSwitchHandler):
     def __init__(self, data, storage, payload, protocol):
         NormalTUISpoke.__init__(self, data, storage, payload)
         SourceSwitchHandler.__init__(self)
-        self.title = N_("Specify Repo Options")
         self.protocol = protocol
         self._container = None
         self._url = self._get_url()
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Specify Repo Options")
 
     def _get_url(self):
         """Get the URL of the current source."""
@@ -289,18 +303,27 @@ class SpecifyRepoSpoke(NormalTUISpoke, SourceSwitchHandler):
 
 class SpecifyNFSRepoSpoke(NormalTUISpoke, SourceSwitchHandler):
     """ Specify server and mount opts here if NFS selected. """
-    category = SoftwareCategory
 
     def __init__(self, data, storage, payload, error):
         NormalTUISpoke.__init__(self, data, storage, payload)
         SourceSwitchHandler.__init__(self)
-        self.title = N_("Specify Repo Options")
         self._container = None
         self._error = error
-
         options, host, path = self._get_nfs()
         self._nfs_opts = options
         self._nfs_server = "{}:{}".format(host, path) if host else ""
+
+    @staticmethod
+    def get_category():
+        return SoftwareCategory
+
+    @staticmethod
+    def get_sort_order():
+        return 100
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Specify Repo Options")
 
     def _get_nfs(self):
         """Get the NFS options, host and path of the current source."""
@@ -375,11 +398,14 @@ class SelectDeviceSpoke(NormalTUISpoke):
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
-        self.title = N_("Select device containing the ISO file")
         self._container = None
         self._device_tree = STORAGE.get_proxy(DEVICE_TREE)
         self._mountable_devices = self._get_mountable_devices()
         self._device = None
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Select device containing the ISO file")
 
     @property
     def indirect(self):
@@ -447,10 +473,13 @@ class SelectISOSpoke(NormalTUISpoke, SourceSwitchHandler):
     def __init__(self, data, storage, payload, device):
         NormalTUISpoke.__init__(self, data, storage, payload)
         SourceSwitchHandler.__init__(self)
-        self.title = N_("Select an ISO to use as install source")
         self._container = None
         self._device = device
         self._isos = self._collect_iso_files()
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Select an ISO to use as install source")
 
     def refresh(self, args=None):
         NormalTUISpoke.refresh(self, args)

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -62,7 +62,6 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
           :parts: 3
     """
     helpFile = "SourceSpoke.txt"
-    category = SoftwareCategory
 
     SET_NETWORK_INSTALL_MODE = "network_install"
 
@@ -231,7 +230,6 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
 
 class SpecifyRepoSpoke(NormalTUISpoke, SourceSwitchHandler):
     """ Specify the repo URL here if closest mirror not selected. """
-    category = SoftwareCategory
 
     HTTP = 1
     HTTPS = 2
@@ -247,6 +245,14 @@ class SpecifyRepoSpoke(NormalTUISpoke, SourceSwitchHandler):
     @property
     def title(self):
         return C_("TUI|Spoke", "Specify Repo Options")
+
+    @staticmethod
+    def get_category():
+        return SoftwareCategory
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     def _get_url(self):
         """Get the URL of the current source."""
@@ -313,6 +319,10 @@ class SpecifyNFSRepoSpoke(NormalTUISpoke, SourceSwitchHandler):
         self._nfs_opts = options
         self._nfs_server = "{}:{}".format(host, path) if host else ""
 
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Specify Repo Options")
+
     @staticmethod
     def get_category():
         return SoftwareCategory
@@ -320,10 +330,6 @@ class SpecifyNFSRepoSpoke(NormalTUISpoke, SourceSwitchHandler):
     @staticmethod
     def get_sort_order():
         return 100
-
-    @property
-    def title(self):
-        return C_("TUI|Spoke", "Specify Repo Options")
 
     def _get_nfs(self):
         """Get the NFS options, host and path of the current source."""
@@ -394,7 +400,6 @@ class SpecifyNFSRepoSpoke(NormalTUISpoke, SourceSwitchHandler):
 
 class SelectDeviceSpoke(NormalTUISpoke):
     """ Select device containing the install source ISO file. """
-    category = SoftwareCategory
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
@@ -406,6 +411,14 @@ class SelectDeviceSpoke(NormalTUISpoke):
     @property
     def title(self):
         return C_("TUI|Spoke", "Select device containing the ISO file")
+
+    @staticmethod
+    def get_category():
+        return SoftwareCategory
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     @property
     def indirect(self):
@@ -468,7 +481,6 @@ class SelectDeviceSpoke(NormalTUISpoke):
 
 class SelectISOSpoke(NormalTUISpoke, SourceSwitchHandler):
     """ Select an ISO to use as install source. """
-    category = SoftwareCategory
 
     def __init__(self, data, storage, payload, device):
         NormalTUISpoke.__init__(self, data, storage, payload)
@@ -480,6 +492,14 @@ class SelectISOSpoke(NormalTUISpoke, SourceSwitchHandler):
     @property
     def title(self):
         return C_("TUI|Spoke", "Select an ISO to use as install source")
+
+    @staticmethod
+    def get_category():
+        return SoftwareCategory
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     def refresh(self, args=None):
         NormalTUISpoke.refresh(self, args)

--- a/pyanaconda/ui/tui/spokes/kernel_warning.py
+++ b/pyanaconda/ui/tui/spokes/kernel_warning.py
@@ -18,7 +18,7 @@
 from simpleline.render.widgets import TextWidget
 
 from pyanaconda.core.constants import WARNING_SMT_ENABLED_TUI
-from pyanaconda.core.i18n import N_, _
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.util import is_smt_enabled
 from pyanaconda.ui.tui.spokes import StandaloneTUISpoke
 from pyanaconda.ui.tui.hubs.summary import SummaryHub
@@ -28,12 +28,27 @@ __all__ = ["KernelWarningSpoke"]
 
 class KernelWarningSpoke(StandaloneTUISpoke):
     """Spoke for kernel-related warnings."""
-    preForHub = SummaryHub
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.title = N_("Warning: Processor has Simultaneous Multithreading (SMT) enabled")
         self.input_required = False
+
+    @staticmethod
+    def get_category():
+        return None
+
+    @staticmethod
+    def get_sort_order():
+        # standalone spoke -> sort order 0
+        return 0
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Warning: Processor has Simultaneous Multithreading (SMT) enabled")
+
+    @property
+    def pre_action_for_hub(self):
+        return SummaryHub
 
     @property
     def completed(self):

--- a/pyanaconda/ui/tui/spokes/kernel_warning.py
+++ b/pyanaconda/ui/tui/spokes/kernel_warning.py
@@ -46,9 +46,13 @@ class KernelWarningSpoke(StandaloneTUISpoke):
     def title(self):
         return C_("TUI|Spoke", "Warning: Processor has Simultaneous Multithreading (SMT) enabled")
 
-    @property
-    def pre_action_for_hub(self):
+    @staticmethod
+    def get_pre_action_for_hub():
         return SummaryHub
+
+    @staticmethod
+    def get_post_action_for_hub():
+        return None
 
     @property
     def completed(self):

--- a/pyanaconda/ui/tui/spokes/language_support.py
+++ b/pyanaconda/ui/tui/spokes/language_support.py
@@ -22,7 +22,7 @@ from pyanaconda.ui.categories.localization import LocalizationCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda import localization
-from pyanaconda.core.i18n import N_, _, C_
+from pyanaconda.core.i18n import _, C_
 
 from simpleline.render.containers import ListColumnContainer
 from simpleline.render.screen import InputState
@@ -43,11 +43,9 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
           :parts: 3
     """
     helpFile = "LangSupportSpoke.txt"
-    category = LocalizationCategory
 
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)
-        self.title = N_("Language settings")
         self.initialize_start()
         self._container = None
 
@@ -62,6 +60,18 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
         self._selected = self._l12_module.Language
         self.initialize_done()
+
+    @staticmethod
+    def get_category():
+        return LocalizationCategory
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Language settings")
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     @property
     def completed(self):

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -468,13 +468,13 @@ class ConfigureDeviceSpoke(NormalTUISpoke):
         log.debug("Configure iface %s: connection %s -> %s", self._iface, self._connection_uuid,
                   self._data)
 
-    @staticmethod
-    def get_category():
-        return "network"
-
     @property
     def title(self):
         return C_("TUI|Spoke", "Device configuration")
+
+    @staticmethod
+    def get_category():
+        return SystemCategory
 
     @staticmethod
     def get_sort_order():

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -201,7 +201,6 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
           :parts: 3
     """
     helpFile = "NetworkSpoke.txt"
-    category = SystemCategory
     configurable_device_types = [
         NM.DeviceType.ETHERNET,
         NM.DeviceType.INFINIBAND,
@@ -209,7 +208,6 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)
-        self.title = N_("Network configuration")
         self._network_module = NETWORK.get_proxy()
 
         self.nm_client = network.get_nm_client()
@@ -221,6 +219,18 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         self.editable_configurations = []
         self.errors = []
         self._apply = False
+
+    @staticmethod
+    def get_category():
+        return SystemCategory
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Network configuration")
+
+    @staticmethod
+    def get_sort_order():
+        return 200
 
     @classmethod
     def should_run(cls, environment, data):
@@ -440,11 +450,9 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
 class ConfigureDeviceSpoke(NormalTUISpoke):
     """ Spoke to set various configuration options for net devices. """
-    category = "network"
 
     def __init__(self, data, storage, payload, network_module, iface, connection):
         super().__init__(data, storage, payload)
-        self.title = N_("Device configuration")
 
         self._network_module = network_module
         self._container = None
@@ -459,6 +467,18 @@ class ConfigureDeviceSpoke(NormalTUISpoke):
 
         log.debug("Configure iface %s: connection %s -> %s", self._iface, self._connection_uuid,
                   self._data)
+
+    @staticmethod
+    def get_category():
+        return "network"
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Device configuration")
+
+    @staticmethod
+    def get_sort_order():
+        return 200
 
     def refresh(self, args=None):
         """ Refresh window. """

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -22,7 +22,7 @@ from pyanaconda.ui.tui.tuiobject import PasswordDialog
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.flags import flags
-from pyanaconda.core.i18n import N_, _
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.constants import SETUP_ON_BOOT_RECONFIG
 from pyanaconda.modules.common.constants.services import USERS, SERVICES
 
@@ -35,12 +35,10 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
           :parts: 3
     """
     helpFile = "PasswordSpoke.txt"
-    category = UserSettingsCategory
 
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)
         self.initialize_start()
-        self.title = N_("Root password")
         self.input_required = False
 
         self._policy = self.data.anaconda.pwpolicy.get_policy("root", fallback_to_default=True)
@@ -50,6 +48,18 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         self._services_module = SERVICES.get_proxy()
 
         self.initialize_done()
+
+    @staticmethod
+    def get_category():
+        return UserSettingsCategory
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Root password")
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     @property
     def completed(self):

--- a/pyanaconda/ui/tui/spokes/shell_spoke.py
+++ b/pyanaconda/ui/tui/spokes/shell_spoke.py
@@ -34,9 +34,6 @@ class ShellSpoke(NormalTUISpoke):
           :parts: 3
     """
 
-    def __init__(self, data, storage, payload):
-        super().__init__(data, storage, payload)
-
     @staticmethod
     def get_category():
         return SystemCategory

--- a/pyanaconda/ui/tui/spokes/shell_spoke.py
+++ b/pyanaconda/ui/tui/spokes/shell_spoke.py
@@ -19,7 +19,7 @@
 
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
-from pyanaconda.core.i18n import N_, _
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import ANACONDA_ENVIRON
 from pyanaconda.core.util import execConsole
@@ -33,11 +33,21 @@ class ShellSpoke(NormalTUISpoke):
        .. inheritance-diagram:: ShellSpoke
           :parts: 3
     """
-    category = SystemCategory
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
-        self.title = N_("Shell")
+
+    @staticmethod
+    def get_category():
+        return SystemCategory
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Shell")
+
+    @staticmethod
+    def get_sort_order():
+        return 300
 
     @classmethod
     def should_run(cls, environment, data):

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -22,7 +22,7 @@ from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload.manager import payloadMgr, PayloadState
 from pyanaconda.payload.errors import DependencyError, NoSuchGroup
-from pyanaconda.core.i18n import N_, _, C_
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.configuration.anaconda import conf
 
 from pyanaconda.core.constants import THREAD_PAYLOAD, THREAD_CHECK_SOFTWARE, \
@@ -46,11 +46,9 @@ class SoftwareSpoke(NormalTUISpoke):
           :parts: 3
     """
     helpFile = "SoftwareSpoke.txt"
-    category = SoftwareCategory
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
-        self.title = N_("Software selection")
         self._container = None
         self.errors = []
         self._tx_id = None
@@ -64,6 +62,18 @@ class SoftwareSpoke(NormalTUISpoke):
         # Register event listeners to update our status on payload events
         payloadMgr.add_listener(PayloadState.STARTED, self._payload_start)
         payloadMgr.add_listener(PayloadState.ERROR, self._payload_error)
+
+    @staticmethod
+    def get_category():
+        return SoftwareCategory
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Software selection")
+
+    @staticmethod
+    def get_sort_order():
+        return 200
 
     def initialize(self):
         """Initialize the spoke."""

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -78,7 +78,6 @@ class StorageSpoke(NormalTUISpoke):
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
-        self.title = N_("Installation Destination")
         self._container = None
         self._ready = False
         self._select_all = False
@@ -95,6 +94,18 @@ class StorageSpoke(NormalTUISpoke):
 
         self.errors = []
         self.warnings = []
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Installation Destination")
+
+    @staticmethod
+    def get_category():
+        return SystemCategory
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     @property
     def completed(self):
@@ -420,11 +431,9 @@ class PartTypeSpoke(NormalTUISpoke):
        .. inheritance-diagram:: PartTypeSpoke
           :parts: 3
     """
-    category = SystemCategory
 
     def __init__(self, data, storage, payload, storage_module, partitioning):
         super().__init__(data, storage, payload)
-        self.title = N_("Partitioning Options")
         self._container = None
 
         # Choose the initialization mode.
@@ -444,6 +453,18 @@ class PartTypeSpoke(NormalTUISpoke):
 
         if self._part_method == PARTITIONING_METHOD_MANUAL:
             self._init_mode = CLEAR_PARTITIONS_NONE
+
+    @staticmethod
+    def get_category():
+        return SystemCategory
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Partitioning Options")
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     @property
     def indirect(self):
@@ -548,7 +569,6 @@ class PartitionSchemeSpoke(NormalTUISpoke):
 
     def __init__(self, data, storage, payload, partitioning):
         super().__init__(data, storage, payload)
-        self.title = N_("Partition Scheme Options")
         self._container = None
         self._part_schemes = OrderedDict()
         self._partitioning = partitioning
@@ -568,6 +588,14 @@ class PartitionSchemeSpoke(NormalTUISpoke):
             self._part_schemes[item[0]] = item[1]
             if item[1] == selected_choice:
                 self._selected_scheme_value = item[1]
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Partition Scheme Options")
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     @property
     def indirect(self):
@@ -616,11 +644,18 @@ class MountPointAssignSpoke(NormalTUISpoke):
 
     def __init__(self, data, storage, payload, partitioning):
         super().__init__(data, storage, payload)
-        self.title = N_("Assign mount points")
         self._container = None
         self._partitioning = partitioning
         self._device_tree = STORAGE.get_proxy(self._partitioning.GetDeviceTree())
         self._requests = self._gather_requests()
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Assign mount points")
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     @property
     def indirect(self):
@@ -743,11 +778,18 @@ class ConfigureDeviceSpoke(NormalTUISpoke):
 
     def __init__(self, data, storage, payload, device_tree, request):
         super().__init__(data, storage, payload)
-        self.title = N_("Configure device: %s") % request.device_spec
         self._container = None
         self._device_tree = device_tree
         self._request = request
         self._supported_filesystems = set(device_tree.GetSupportedFileSystems())
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Configure device: %s") % request.device_spec
+
+    @staticmethod
+    def get_sort_order():
+        return 100
 
     @property
     def indirect(self):

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -74,7 +74,6 @@ class StorageSpoke(NormalTUISpoke):
           :parts: 3
     """
     helpFile = "StorageSpoke.txt"
-    category = SystemCategory
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
@@ -454,13 +453,13 @@ class PartTypeSpoke(NormalTUISpoke):
         if self._part_method == PARTITIONING_METHOD_MANUAL:
             self._init_mode = CLEAR_PARTITIONS_NONE
 
-    @staticmethod
-    def get_category():
-        return SystemCategory
-
     @property
     def title(self):
         return C_("TUI|Spoke", "Partitioning Options")
+
+    @staticmethod
+    def get_category():
+        return SystemCategory
 
     @staticmethod
     def get_sort_order():
@@ -565,7 +564,6 @@ class PartTypeSpoke(NormalTUISpoke):
 
 class PartitionSchemeSpoke(NormalTUISpoke):
     """ Spoke to select what partitioning scheme to use on disk(s). """
-    category = SystemCategory
 
     def __init__(self, data, storage, payload, partitioning):
         super().__init__(data, storage, payload)
@@ -592,6 +590,10 @@ class PartitionSchemeSpoke(NormalTUISpoke):
     @property
     def title(self):
         return C_("TUI|Spoke", "Partition Scheme Options")
+
+    @staticmethod
+    def get_category():
+        return SystemCategory
 
     @staticmethod
     def get_sort_order():
@@ -640,7 +642,6 @@ class PartitionSchemeSpoke(NormalTUISpoke):
 
 class MountPointAssignSpoke(NormalTUISpoke):
     """ Assign mount points to block devices. """
-    category = SystemCategory
 
     def __init__(self, data, storage, payload, partitioning):
         super().__init__(data, storage, payload)
@@ -652,6 +653,10 @@ class MountPointAssignSpoke(NormalTUISpoke):
     @property
     def title(self):
         return C_("TUI|Spoke", "Assign mount points")
+
+    @staticmethod
+    def get_category():
+        return SystemCategory
 
     @staticmethod
     def get_sort_order():
@@ -774,7 +779,6 @@ class MountPointAssignSpoke(NormalTUISpoke):
 
 class ConfigureDeviceSpoke(NormalTUISpoke):
     """ Assign mount point to a block device and (optionally) reformat it. """
-    category = SystemCategory
 
     def __init__(self, data, storage, payload, device_tree, request):
         super().__init__(data, storage, payload)
@@ -785,7 +789,11 @@ class ConfigureDeviceSpoke(NormalTUISpoke):
 
     @property
     def title(self):
-        return C_("TUI|Spoke", "Configure device: %s") % request.device_spec
+        return C_("TUI|Spoke", "Configure device: %s") % self._request.device_spec
+
+    @staticmethod
+    def get_category():
+        return SystemCategory
 
     @staticmethod
     def get_sort_order():

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -26,7 +26,7 @@ from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda import timezone
 from pyanaconda import ntp
 from pyanaconda.core import constants
-from pyanaconda.core.i18n import N_, _, C_
+from pyanaconda.core.i18n import _, C_
 from pyanaconda.flags import flags
 
 from collections import namedtuple
@@ -48,16 +48,26 @@ CallbackTimezoneArgs = namedtuple("CallbackTimezoneArgs", ["region", "timezone"]
 
 class TimeSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     helpFile = "DateTimeSpoke.txt"
-    category = LocalizationCategory
 
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)
-        self.title = N_("Time settings")
         self._timezone_spoke = None
         self._container = None
         self._ntp_servers = []
         self._ntp_servers_states = NTPServerStatusCache()
         self._timezone_module = TIMEZONE.get_proxy()
+
+    @staticmethod
+    def get_category():
+        return LocalizationCategory
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Time settings")
+
+    @staticmethod
+    def get_sort_order():
+        return 200
 
     @property
     def indirect(self):
@@ -198,12 +208,10 @@ class TimeZoneSpoke(NormalTUISpoke):
        .. inheritance-diagram:: TimeZoneSpoke
           :parts: 3
     """
-    category = LocalizationCategory
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
 
-        self.title = N_("Timezone settings")
         self._container = None
         # it's stupid to call get_all_regions_and_timezones twice, but regions
         # needs to be unsorted in order to display in the same order as the GUI
@@ -218,6 +226,18 @@ class TimeZoneSpoke(NormalTUISpoke):
         self._selection = ""
 
         self._timezone_module = TIMEZONE.get_proxy()
+
+    @staticmethod
+    def get_category():
+        return LocalizationCategory
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Timezone settings")
+
+    @staticmethod
+    def get_sort_order():
+        return 200
 
     @property
     def indirect(self):
@@ -295,14 +315,24 @@ class TimeZoneSpoke(NormalTUISpoke):
 
 
 class NTPServersSpoke(NormalTUISpoke):
-    category = LocalizationCategory
 
     def __init__(self, data, storage, payload, servers, states):
         super().__init__(data, storage, payload)
-        self.title = N_("NTP configuration")
         self._container = None
         self._servers = servers
         self._states = states
+
+    @staticmethod
+    def get_category():
+        return LocalizationCategory
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "NTP configuration")
+
+    @staticmethod
+    def get_sort_order():
+        return 200
 
     @property
     def indirect(self):
@@ -360,14 +390,24 @@ class NTPServersSpoke(NormalTUISpoke):
 
 
 class AddNTPServerSpoke(NormalTUISpoke):
-    category = LocalizationCategory
 
     def __init__(self, data, storage, payload, servers, states):
         super().__init__(data, storage, payload)
-        self.title = N_("Add NTP server address")
         self._servers = servers
         self._states = states
         self._value = None
+
+    @staticmethod
+    def get_category():
+        return LocalizationCategory
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Add NTP server address")
+
+    @staticmethod
+    def get_sort_order():
+        return 200
 
     @property
     def indirect(self):
@@ -411,14 +451,24 @@ class AddNTPServerSpoke(NormalTUISpoke):
 
 
 class RemoveNTPServerSpoke(NormalTUISpoke):
-    category = LocalizationCategory
 
     def __init__(self, data, storage, payload, servers, states):
         super().__init__(data, storage, payload)
-        self.title = N_("Select an NTP server to remove")
         self._servers = servers
         self._states = states
         self._container = None
+
+    @staticmethod
+    def get_category():
+        return LocalizationCategory
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Select an NTP server to remove")
+
+    @staticmethod
+    def get_sort_order():
+        return 200
 
     @property
     def indirect(self):

--- a/pyanaconda/ui/tui/spokes/unsupported_hardware.py
+++ b/pyanaconda/ui/tui/spokes/unsupported_hardware.py
@@ -19,8 +19,8 @@ from simpleline.render.widgets import TextWidget
 
 from pyanaconda.ui.tui.spokes import StandaloneTUISpoke
 from pyanaconda.ui.tui.hubs.summary import SummaryHub
-from pyanaconda.core.i18n import N_
 from pyanaconda.core.util import detect_unsupported_hardware
+from pyanaconda.core.i18n import C_
 
 __all__ = ["UnsupportedHardwareSpoke"]
 
@@ -30,13 +30,31 @@ class UnsupportedHardwareSpoke(StandaloneTUISpoke):
 
     Show this spoke if the unsupported hardware was detected.
     """
-    preForHub = SummaryHub
-    priority = -10
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.title = N_("Unsupported Hardware Detected")
         self._warnings = detect_unsupported_hardware()
+
+    @staticmethod
+    def get_category():
+        return None
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "Unsupported Hardware Detected")
+
+    @staticmethod
+    def get_sort_order():
+        # standalone spoke -> sort order 0
+        return 0
+
+    @property
+    def pre_action_for_hub(self):
+        return SummaryHub
+
+    @property
+    def action_priority(self):
+        return -10
 
     @property
     def completed(self):

--- a/pyanaconda/ui/tui/spokes/unsupported_hardware.py
+++ b/pyanaconda/ui/tui/spokes/unsupported_hardware.py
@@ -48,12 +48,16 @@ class UnsupportedHardwareSpoke(StandaloneTUISpoke):
         # standalone spoke -> sort order 0
         return 0
 
-    @property
-    def pre_action_for_hub(self):
+    @staticmethod
+    def get_pre_action_for_hub():
         return SummaryHub
 
-    @property
-    def action_priority(self):
+    @staticmethod
+    def get_post_action_for_hub():
+        return None
+
+    @staticmethod
+    def get_action_priority():
         return -10
 
     @property

--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -18,7 +18,7 @@
 #
 from pyanaconda.core.constants import FIRSTBOOT_ENVIRON, PASSWORD_SET
 from pyanaconda.flags import flags
-from pyanaconda.core.i18n import N_, _
+from pyanaconda.core.i18n import N_, _, C_
 from pyanaconda.core.regexes import GECOS_VALID
 from pyanaconda.modules.common.constants.services import USERS
 
@@ -45,7 +45,6 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
           :parts: 3
     """
     helpFile = "UserSpoke.txt"
-    category = UserSettingsCategory
 
     @classmethod
     def should_run(cls, environment, data):
@@ -70,7 +69,6 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         # connect to the Users DBus module
         self._users_module = USERS.get_proxy()
 
-        self.title = N_("User creation")
         self._container = None
 
         # was user creation requested by the Users DBus module
@@ -101,6 +99,18 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         self._users_module = USERS.get_proxy()
 
         self.initialize_done()
+
+    @staticmethod
+    def get_category():
+        return UserSettingsCategory
+
+    @property
+    def title(self):
+        return C_("TUI|Spoke", "User creation")
+
+    @staticmethod
+    def get_sort_order():
+        return 200
 
     @property
     def user(self):

--- a/pyanaconda/ui/tui/tuiobject.py
+++ b/pyanaconda/ui/tui/tuiobject.py
@@ -16,6 +16,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from abc import ABCMeta, abstractmethod
 
 from pyanaconda.ui import common
 
@@ -88,7 +89,7 @@ class IpmiErrorDialog(ErrorDialog):
         super().input(args, key)
 
 
-class TUIObject(UIScreen, common.UIObject):
+class TUIObject(UIScreen, common.UIObject, metaclass=ABCMeta):
     """Base class for Anaconda specific TUI screens. Implements the
     common pyanaconda.ui.common.UIObject interface"""
 
@@ -97,7 +98,11 @@ class TUIObject(UIScreen, common.UIObject):
     def __init__(self, data):
         UIScreen.__init__(self)
         common.UIObject.__init__(self, data)
-        self.title = u"Default title"
+
+    @property
+    @abstractmethod
+    def title(self):
+        return None
 
     @property
     def showable(self):

--- a/tests/nosetests/pyanaconda_tests/ui/simple_ui_test.py
+++ b/tests/nosetests/pyanaconda_tests/ui/simple_ui_test.py
@@ -95,13 +95,13 @@ class SimpleUITestCase(unittest.TestCase):
         res = dict()
 
         for spoke in spokes:
-            action_priority = spoke.action_priority
+            action_priority = spoke.get_action_priority()
             name = spoke.__name__
 
-            if priority in res:
-                msg = "Spokes {} and {} have the same priority!".format(res[priority], name)
-                self.assertNotIn(priority, res, msg)
-            res[priority] = name
+            if action_priority in res:
+                msg = "Spokes {} and {} have the same priority!".format(res[action_priority], name)
+                self.assertNotIn(action_priority, res, msg)
+            res[action_priority] = name
 
     @patch_dbus_get_proxy
     def tui_test(self, proxy_getter):
@@ -114,6 +114,10 @@ class SimpleUITestCase(unittest.TestCase):
         self.assertEqual(self.hubs, [SummaryHub])
 
         # Check the actions classes.
+        l = self._get_action_class_names()
+        print("BBB GET ACTION CLASS NAMES !!")
+        print(len(l))
+        print(l)
         self.assertEqual(self._get_action_class_names(), [
             "UnsupportedHardwareSpoke",
             "KernelWarningSpoke",
@@ -208,19 +212,29 @@ class SimpleUITestCase(unittest.TestCase):
         hub = create_autospec(Hub)
 
         class SpokeA(StandaloneSpoke):  # pylint: disable=abstract-method
-            pre_action_for_hub = hub
+            @staticmethod
+            def get_pre_action_for_hub():
+                return hub
 
         class SpokeB(StandaloneSpoke):  # pylint: disable=abstract-method
-            pre_action_for_hub = hub
+            @staticmethod
+            def get_pre_action_for_hub():
+                return hub
 
         class SpokeC(StandaloneSpoke):  # pylint: disable=abstract-method
-            pre_action_for_hub = hub
+            @staticmethod
+            def get_pre_action_for_hub():
+                return hub
 
         class SpokeD(StandaloneSpoke):  # pylint: disable=abstract-method
-            post_action_for_hub = hub
+            @staticmethod
+            def get_post_action_for_hub():
+                return hub
 
         class SpokeE(StandaloneSpoke):  # pylint: disable=abstract-method
-            post_action_for_hub = hub
+            @staticmethod
+            def get_post_action_for_hub():
+                return hub
 
         list1 = [SpokeC, SpokeB, SpokeE, SpokeD, SpokeA]
 

--- a/tests/nosetests/pyanaconda_tests/ui/simple_ui_test.py
+++ b/tests/nosetests/pyanaconda_tests/ui/simple_ui_test.py
@@ -95,7 +95,7 @@ class SimpleUITestCase(unittest.TestCase):
         res = dict()
 
         for spoke in spokes:
-            priority = spoke.priority
+            action_priority = spoke.action_priority
             name = spoke.__name__
 
             if priority in res:
@@ -208,19 +208,19 @@ class SimpleUITestCase(unittest.TestCase):
         hub = create_autospec(Hub)
 
         class SpokeA(StandaloneSpoke):  # pylint: disable=abstract-method
-            preForHub = hub
+            pre_action_for_hub = hub
 
         class SpokeB(StandaloneSpoke):  # pylint: disable=abstract-method
-            preForHub = hub
+            pre_action_for_hub = hub
 
         class SpokeC(StandaloneSpoke):  # pylint: disable=abstract-method
-            preForHub = hub
+            pre_action_for_hub = hub
 
         class SpokeD(StandaloneSpoke):  # pylint: disable=abstract-method
-            postForHub = hub
+            post_action_for_hub = hub
 
         class SpokeE(StandaloneSpoke):  # pylint: disable=abstract-method
-            postForHub = hub
+            post_action_for_hub = hub
 
         list1 = [SpokeC, SpokeB, SpokeE, SpokeD, SpokeA]
 


### PR DESCRIPTION
Fix localization context issues in GUI by direct string translations
instead of just marking strings as translatable in spokes and hubs
and translating them before use. This is fragile as strings might
be marked in Initial Setup or Anaconda Addons yet translated and
displayed in Anaconda, with context that does not match.

We can't do this directly in class attributes due to these being
evaluated much to early. Instead, put strings into properties &
make sure these properties are implemented by turning the appropriate
base classes into abstract base classes and the required properties
into abstract properties.

Also when we are at it convert some non-localization class attributes
to properties for better consistency.

**NOTE:**
- still fighting some issues related to the code that collects spokes, so not really tested as working yet

**TODO:**
- adjust Initial Setup
- adjust the Hello World addon
- adjust Kdump addon
- adjust OSCAP addon
- run full kstest suite on this change