### PR TITLE
Fix issue when ns_info cannot be retrieved for NVDimm namespace

### DIFF
--- a/pyanaconda/modules/storage/nvdimm/nvdimm.py
+++ b/pyanaconda/modules/storage/nvdimm/nvdimm.py
@@ -101,6 +101,12 @@ class NVDIMMModule(KickstartBaseModule):
         devices_to_ignore = set()
 
         for ns_name, ns_info in nvdimm.namespaces.items():
+            # this is happening when namespace is set to DEVDAX mode - block device is not present
+            if ns_info.blockdev is None:
+                log.debug("%s will be skipped - NVDIMM namespace block device information "
+                          "can't be retrieved", ns_name)
+                continue
+
             info = udev.get_device(device_node="/dev/" + ns_info.blockdev)
 
             if info and udev.device_get_format(info) == "iso9660":
@@ -116,8 +122,7 @@ class NVDIMMModule(KickstartBaseModule):
             else:
                 continue
 
-            if ns_info.blockdev:
-                devices_to_ignore.add(ns_info.blockdev)
+            devices_to_ignore.add(ns_info.blockdev)
 
         return devices_to_ignore
 

--- a/tests/nosetests/pyanaconda_tests/module_nvdimm_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_nvdimm_test.py
@@ -145,6 +145,7 @@ class NVDIMMKickstartTestCase(unittest.TestCase):
                 "namespace0.0": Mock(blockdev="pmem0", mode=blockdev.NVDIMMNamespaceMode.SECTOR),
                 "namespace1.0": Mock(blockdev="pmem1", mode=blockdev.NVDIMMNamespaceMode.SECTOR),
                 "namespace2.0": Mock(blockdev="pmem2", mode=blockdev.NVDIMMNamespaceMode.MEMORY),
+                "namespace3.0": Mock(blockdev=None, mode=blockdev.NVDIMMNamespaceMode.DEVDAX),
             }
 
             ignored_devices = self.nvdimm_module.get_devices_to_ignore()


### PR DESCRIPTION
If we don't skip this part the uncaught exception will raise because we are
trying to concatenate string and None types.

*Resolves: rhbz#1891827*