### PR TITLE
gui: specify unit in which disk capacity is measured in traditional partitioning module

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
@@ -510,6 +510,30 @@ use.  Try something else?</property>
               </packing>
             </child>
             <child>
+              <object class="GtkLabel" id="desired_capacity_units">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">MiB</property>
+                <property name="track_visited_links">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">4</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
               <placeholder/>
             </child>
           </object>


### PR DESCRIPTION
GUI requests to specify size of a new partition, but it was not clear if it is in MiB, GiB etc.

Thanks to Mikhail Mosolov <m.mosolov@rosalinux.ru> for help.

Screenshot:

![DeepinScreenshot_выберите-область_20201029174337](https://user-images.githubusercontent.com/15802528/97590042-45a1df00-1a0f-11eb-8270-10af7cd9da37.png)
