### PR TITLE
workflows: Add manual triggering of tests

### DIFF
--- a/.github/workflows/validate-rhel-8.yml
+++ b/.github/workflows/validate-rhel-8.yml
@@ -1,0 +1,76 @@
+# Run rhel-8 unit tests in a PR triggered by a "/test [...]" comment from an organization member.
+# This avoids running untrusted and unreviewed code on self-hosted runners.
+name: unit-tests-rhel-8
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  pr-info:
+    # restrict running of tests to trusted organization members
+    # see https://developer.github.com/v4/enum/commentauthorassociation/
+    if: startsWith(github.event.comment.body, '/test') && contains('OWNER MEMBER', github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get information for pull request
+        uses: octokit/request-action@v2.x
+        id: pr_api
+        with:
+          route: GET /repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    outputs:
+      base_ref: ${{ fromJson(steps.pr_api.outputs.data).base.ref }}
+      sha: ${{ fromJson(steps.pr_api.outputs.data).head.sha }}
+
+  unit-tests:
+    needs: pr-info
+    if: needs.pr-info.outputs.base_ref == 'rhel-8'
+    runs-on: [self-hosted, ci-tasks, rhel-8]
+    steps:
+      # we post statuses manually as this does not run from a pull_request event
+      # https://developer.github.com/v3/repos/statuses/#create-a-status
+      - name: Create in-progress status
+        uses: octokit/request-action@v2.x
+        with:
+          route: 'POST /repos/${{ github.repository }}/statuses/${{ needs.pr-info.outputs.sha }}'
+          context: unit-tests
+          state: pending
+          target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.pr-info.outputs.sha }}
+
+      - name: Run test
+        run: |
+          ./autogen.sh
+          ./configure
+          make
+          # put the log in the output, where it's easy to read and link to
+          make ci || { cat tests/test-suite.log; exit 1; }
+
+      - name: Upload test and coverage logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: |
+            tests/test-suite.log
+            tests/pylint/runpylint*.log
+            tests/coverage-*.log
+
+      - name: Set result status
+        if: always()
+        uses: octokit/request-action@v2.x
+        with:
+          route: 'POST /repos/${{ github.repository }}/statuses/${{ needs.pr-info.outputs.sha }}'
+          context: unit-tests
+          state: ${{ job.status }}
+          target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Run unit tests in a PR triggered by a "/test [...]" comment from an
organization member.  This avoids running untrusted and unreviewed code
on self-hosted runners.

For now this only applies for PRs against the rhel-8 branch, but an
`issue_comment` trigger needs to be on master. (In the future we *could*
support running rhel/ELN tests on master as well, though.)

------

This will go along with dropping the `pull_request` action from the rhel-8 branch. I'll send a PR for that and link it from here.

I tested this pretty thoroughly [on my fork](https://github.com/martinpitt/anaconda/pull/4) and a local github action runner. The "unit-tests" check is "the real thing" (on self-hosted runner), the "demo test" was just some `sleep 10` thing for quickly iterating the workflow mechanics.