### PR TITLE
Fix and robustify validate workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,24 +14,24 @@ jobs:
       - name: Check if container changed in this PR
         id: check-dockerfile-changed
         run: |
-          # the SHA is target branch thanks to pull_request_target trigger
-          # add prints for debugging purposes
-          git log -1 --oneline ${{ github.sha }}
-          git diff --name-only ${{ github.sha }}
-          git diff --name-only ${{ github.sha }} | grep -q dockerfile/anaconda-ci/ || exit 2
-        continue-on-error: true
+          changes=$(git diff origin/master..HEAD -- dockerfile/anaconda-ci/)
+          # print for debugging
+          echo "$changes"
+          [ -z "$changes" ] || echo "::set-output name=changed::true"
 
       # build container if files for dockerfile changed in the PR
       - name: Build anaconda-ci container
-        if: ${{ steps.check-dockerfile-changed.outcome == 'success' }}
+        if: steps.check-dockerfile-changed.outputs.changed
         run: CONTAINER_ENGINE=docker make -f Makefile.am anaconda-ci-build
 
       - name: Run tests in anaconda-ci container
         id: run-unit-tests
-        run: CONTAINER_ENGINE=docker make -f Makefile.am container-ci
-        continue-on-error: true
+        run: |
+          # put the log in the output, where it's easy to read and link to
+          CONTAINER_ENGINE=docker make -f Makefile.am container-ci || { cat tests/test-suite.log; exit 1; }
 
       - name: Upload test and coverage logs
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: logs
@@ -40,12 +40,6 @@ jobs:
             tests/nosetests.log
             tests/pylint/runpylint*.log
             tests/coverage-*.log
-
-      - name: Set job result
-        if: ${{ steps.run-unit-tests.outcome == 'failure' }}
-        run: |
-          cat tests/test-suite.log
-          exit 1
 
   rpm-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 - Use `HEAD` instead of `${{ github.sha }}`. The `checkout` step
   fetches the latter, so HEAD will point to that. This makes the shell
   commands easier to reproduce locally, and also easier to read.

 - `git diff HEAD` is a no-op, as it will compare HEAD against itself.
   Thus the container never built even for PRs that changed it. To fix
   this, diff current origin/master against the PR, so that (1) it does
   anything at all, and (2) also checks all commits in the PR instead of
   just the topmost one.

 - Use an output variable instead of an exit code for the
   `check-dockerfile-changed` step, so that we don't hide syntax/command
   errors in the shell script. These would lead to silently not
   refreshing the container when it should be.

 - Don't use `continue-on-error` in the main test run, but instead
   always run the log upload (even on failure). This is more robust, and
   avoids the need for the explicit "Set job result" step.
