### PR TITLE
Adjust rhel-8 log retrieval for changed container volume handling

### DIFF
--- a/.github/workflows/validate-rhel-8.yml
+++ b/.github/workflows/validate-rhel-8.yml
@@ -52,17 +52,14 @@ jobs:
           ./configure
           make
           # put the log in the output, where it's easy to read and link to
-          make ci || { cat tests/test-suite.log; exit 1; }
+          make ci || { cat test-logs/test-suite.log; exit 1; }
 
       - name: Upload test and coverage logs
         if: always()
         uses: actions/upload-artifact@v2
         with:
           name: logs
-          path: |
-            tests/test-suite.log
-            tests/pylint/runpylint*.log
-            tests/coverage-*.log
+          path: test-logs/*
 
       - name: Set result status
         if: always()


### PR DESCRIPTION
Commit 96d9d40490 and the rhel-8 backport [1] changed how unit test logs
appear on the host. Adjust the workflow for rhel-8 PRs accordingly.

[1] https://github.com/rhinstaller/anaconda/pull/2970

 - [ ] Land this in lockstep with #2970