### PR TITLE
Fix user permission checking for rhel-8 validate task

### DIFF
--- a/.github/workflows/validate-rhel-8.yml
+++ b/.github/workflows/validate-rhel-8.yml
@@ -7,11 +7,25 @@ on:
 
 jobs:
   pr-info:
-    # restrict running of tests to trusted organization members
-    # see https://developer.github.com/v4/enum/commentauthorassociation/
-    if: startsWith(github.event.comment.body, '/test') && contains('OWNER MEMBER', github.event.comment.author_association)
+    if: startsWith(github.event.comment.body, '/test')
     runs-on: ubuntu-latest
     steps:
+      - name: Query comment author repository permissions
+        uses: octokit/request-action@v2.x
+        id: user_permission
+        with:
+          route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # restrict running of tests to users with admin or write permission for the repository
+      # see https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-repository-permissions-for-a-user
+      - name: Fail because user does not have correct permissions
+        if: ${{ ! contains('admin write', fromJson(steps.user_permission.outputs.data).permission) }}
+        run: |
+          echo "User '${{ github.event.sender.login }}' has permission '${{ fromJson(steps.user_permission.outputs.data).permission }}' only 'admin' or 'write' is allowed"
+          exit 1
+
       - name: Get information for pull request
         uses: octokit/request-action@v2.x
         id: pr_api


### PR DESCRIPTION
It does not work correctly for users with private visibility on the organization. However, this is problem because the private visibility is default on GitHub and it can't be changed globally.

Use GH API to check user permissions on the repository. This does not require special privileges on token. Allow only admin or write access to start the tests.

This was tested on my test organization with help of our bot. Should work as expected.
https://github.com/Test-anaconda-org/anaconda/actions?query=workflow%3Aunit-tests-rhel-8
Last failure is because I removed the bot from the organization.