### PR TITLE
Select disks for implicit partitions (#1642391)

### DIFF
--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
@@ -26,7 +26,8 @@ from pyanaconda.modules.common.structures.partitioning import PartitioningReques
 from pyanaconda.modules.storage.partitioning.automatic.noninteractive_partitioning import \
     NonInteractivePartitioningTask
 from pyanaconda.modules.storage.partitioning.automatic.utils import get_candidate_disks, \
-    schedule_implicit_partitions, schedule_volumes, schedule_partitions, get_pbkdf_args
+    schedule_implicit_partitions, schedule_volumes, schedule_partitions, get_pbkdf_args, \
+    get_disks_for_implicit_partitions
 from pyanaconda.modules.storage.platform import platform
 from pyanaconda.modules.storage.partitioning.specification import PartSpec
 from pyanaconda.core.storage import suggest_swap_size
@@ -288,7 +289,11 @@ class AutomaticPartitioningTask(NonInteractivePartitioningTask):
         disks = get_candidate_disks(storage)
         log.debug("candidate disks: %s", [d.name for d in disks])
 
-        devs = schedule_implicit_partitions(storage, disks, scheme, encrypted, luks_fmt_args)
+        # Schedule implicit partitions.
+        extra_disks = get_disks_for_implicit_partitions(disks, scheme, requests)
+        devs = schedule_implicit_partitions(storage, extra_disks, scheme, encrypted, luks_fmt_args)
+
+        # Schedule requested partitions.
         devs = schedule_partitions(storage, disks, devs, scheme, requests, encrypted, luks_fmt_args)
 
         # run the autopart function to allocate and grow partitions

--- a/pyanaconda/modules/storage/partitioning/specification.py
+++ b/pyanaconda/modules/storage/partitioning/specification.py
@@ -19,6 +19,8 @@
 #
 
 from blivet.util import stringize, unicodeize
+from pykickstart.constants import AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_BTRFS, AUTOPART_TYPE_LVM, \
+    AUTOPART_TYPE_LVM_THINP
 
 
 class PartSpec(object):
@@ -81,6 +83,52 @@ class PartSpec(object):
               "thin": self.thin})
 
         return s
+
+    def is_partition(self, scheme):
+        """Is the specified device a partition in the given scheme?
+
+        :param scheme: a partitioning scheme
+        :return: True or False
+        """
+        return not self.is_volume(scheme)
+
+    def is_volume(self, scheme):
+        """Is the specified device a volume in the given scheme?
+
+        :param scheme: a partitioning scheme
+        :return: True or False
+        """
+        if scheme == AUTOPART_TYPE_PLAIN:
+            return False
+
+        return self.is_lvm_volume(scheme) or self.is_btrfs_subvolume(scheme)
+
+    def is_lvm_volume(self, scheme):
+        """Is the specified device an LVM volume in the given scheme?
+
+        :param scheme: a partitioning scheme
+        :return: True or False
+        """
+        return scheme in (AUTOPART_TYPE_LVM, AUTOPART_TYPE_LVM_THINP) and self.lv
+
+    def is_lvm_thin_volume(self, scheme):
+        """Is the specified device an LVM thin volume in the given scheme?
+
+        :param scheme: a partitioning scheme
+        :return: True or False
+        """
+        if not self.is_lvm_volume(scheme):
+            return False
+
+        return scheme == AUTOPART_TYPE_LVM_THINP and self.thin
+
+    def is_btrfs_subvolume(self, scheme):
+        """Is the specified device a Btrfs subvolume in the given scheme?
+
+        :param scheme: a partitioning scheme
+        :return: True or False
+        """
+        return scheme == AUTOPART_TYPE_BTRFS and self.btr
 
     def __str__(self):
         return stringize(self._to_string())

--- a/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
@@ -27,11 +27,13 @@ from pyanaconda.core.configuration.storage import PartitioningType
 from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.modules.storage.partitioning.automatic.resizable_module import \
     ResizableDeviceTreeModule
+from pyanaconda.modules.storage.partitioning.automatic.utils import \
+    get_disks_for_implicit_partitions
 from pyanaconda.modules.storage.partitioning.specification import PartSpec
 from tests.nosetests.pyanaconda_tests import patch_dbus_publish_object, check_dbus_property, \
     check_task_creation, check_dbus_object_creation
 
-from pykickstart.constants import AUTOPART_TYPE_LVM_THINP
+from pykickstart.constants import AUTOPART_TYPE_LVM_THINP, AUTOPART_TYPE_PLAIN
 
 from dasbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.constants.objects import AUTO_PARTITIONING
@@ -293,4 +295,96 @@ class AutomaticPartitioningTaskTestCase(unittest.TestCase):
         self.assertEqual(
             [Size("1GiB"), Size("1GiB"), Size("500MiB"), Size("1024MiB")],
             [spec.size for spec in requests]
+        )
+
+
+class AutomaticPartitioningUtilsTestCase(unittest.TestCase):
+    """Test the automatic partitioning utils."""
+
+    def get_disks_for_implicit_partitions_test(self):
+        """Test the get_disks_for_implicit_partitions function."""
+        # The /boot partition always requires a slot.
+        requests = [
+            PartSpec(
+                mountpoint="/boot",
+                size=Size("1GiB")
+            ),
+            PartSpec(
+                mountpoint="/",
+                size=Size("2GiB"),
+                max_size=Size("15GiB"),
+                grow=True,
+                btr=True,
+                lv=True,
+                thin=True,
+                encrypted=True
+            ),
+            PartSpec(
+                fstype="swap",
+                grow=False,
+                lv=True,
+                encrypted=True
+            )
+        ]
+
+        # No implicit partitions to schedule.
+        disk_1 = Mock()
+        disk_2 = Mock()
+
+        parted_disk_1 = disk_1.format.parted_disk
+        parted_disk_2 = disk_2.format.parted_disk
+
+        self.assertEqual(
+            get_disks_for_implicit_partitions(
+                scheme=AUTOPART_TYPE_PLAIN,
+                disks=[disk_1, disk_2],
+                requests=requests
+            ),
+            []
+        )
+
+        # Extended partitions are supported by the first disk.
+        parted_disk_1.supportsFeature.return_value = True
+        parted_disk_1.maxPrimaryPartitionCount = 3
+        parted_disk_1.primaryPartitionCount = 3
+
+        parted_disk_2.supportsFeature.return_value = False
+        parted_disk_2.maxPrimaryPartitionCount = 3
+        parted_disk_2.primaryPartitionCount = 2
+
+        self.assertEqual(
+            get_disks_for_implicit_partitions(
+                scheme=AUTOPART_TYPE_LVM_THINP,
+                disks=[disk_1, disk_2],
+                requests=requests
+            ),
+            [disk_1, disk_2]
+        )
+
+        # Extended partitions are not supported by the first disk.
+        parted_disk_1.supportsFeature.return_value = False
+        parted_disk_1.maxPrimaryPartitionCount = 3
+        parted_disk_1.primaryPartitionCount = 2
+
+        self.assertEqual(
+            get_disks_for_implicit_partitions(
+                scheme=AUTOPART_TYPE_LVM_THINP,
+                disks=[disk_1, disk_2],
+                requests=requests
+            ),
+            [disk_2]
+        )
+
+        # Not empty slots for implicit partitions.
+        parted_disk_1.supportsFeature.return_value = False
+        parted_disk_1.maxPrimaryPartitionCount = 3
+        parted_disk_1.primaryPartitionCount = 3
+
+        self.assertEqual(
+            get_disks_for_implicit_partitions(
+                scheme=AUTOPART_TYPE_LVM_THINP,
+                disks=[disk_1, disk_2],
+                requests=requests
+            ),
+            []
         )

--- a/tests/nosetests/pyanaconda_tests/module_part_specification_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_specification_test.py
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+
+from pykickstart.constants import AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_LVM, AUTOPART_TYPE_BTRFS, \
+    AUTOPART_TYPE_LVM_THINP
+
+from pyanaconda.modules.storage.partitioning.specification import PartSpec
+
+
+class PartitioningSpecificationTestCase(unittest.TestCase):
+    """Test the PartSpec class."""
+
+    def is_partition_test(self):
+        """Test the is_partition method."""
+        spec = PartSpec("/")
+        self.assertEqual(spec.is_partition(AUTOPART_TYPE_PLAIN), True)
+        self.assertEqual(spec.is_partition(AUTOPART_TYPE_LVM), True)
+        self.assertEqual(spec.is_partition(AUTOPART_TYPE_LVM_THINP), True)
+        self.assertEqual(spec.is_partition(AUTOPART_TYPE_BTRFS), True)
+
+    def is_volume_test(self):
+        """Test the is_volume method."""
+        spec = PartSpec("/", lv=True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_PLAIN), False)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM), True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM_THINP), True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_BTRFS), False)
+
+        spec = PartSpec("/", lv=True, thin=True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_PLAIN), False)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM), True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM_THINP), True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_BTRFS), False)
+
+        spec = PartSpec("/", btr=True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_PLAIN), False)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM), False)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM_THINP), False)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_BTRFS), True)
+
+    def is_lvm_thin_volume_test(self):
+        """Test the is_lvm_thin_volume method."""
+        spec = PartSpec("/", lv=True)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_PLAIN), False)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM), False)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM_THINP), False)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_BTRFS), False)
+
+        spec = PartSpec("/", lv=True, thin=True)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_PLAIN), False)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM), False)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM_THINP), True)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_BTRFS), False)


### PR DESCRIPTION
Don't use disks that will be used for allocation of requested partitions
(for example, the /boot partition). Calculate the number of slots that
will be used by requested partitions and skip disks that will not have
free slots for implicit partitions.

Otherwise, we might schedule implicit partitions, that wouldn't be possible
to allocate on the specified disk, and the partitioning might fail.

Resolves: rhbz#1642391