### PR TITLE
Add upstream tag hint for Packit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,11 +1,10 @@
 specfile_path: anaconda.spec
 upstream_package_name: anaconda
+upstream_tag_template: anaconda-{version}-1
 actions:
   post-upstream-clone:
     - ./autogen.sh
     - ./configure
-  get-current-version:
-    - bash -c "git describe --tags --match '*.*' | awk -F '-' '{ print $2}' "
   create-archive:
     - "make release"
     - 'bash -c "ls -1 anaconda-*.tar.bz2"'


### PR DESCRIPTION
Without this Packit is not able to detect Anaconda version correctly.


This is now doable thanks to this fix on Packit side:
https://github.com/packit/packit/issues/867#event-3791693297