### PR TITLE
gui: updating current_hostname lable when clicking apply button in network spoke

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -663,6 +663,7 @@ class NetworkControlBox(GObject.GObject):
             con.delete()
 
     def on_apply_hostname(self, *args):
+        self.label_current_hostname.set_text(self.hostname)
         self.emit("apply-hostname")
 
     def add_device(self, ty):


### PR DESCRIPTION
When you click on the "Apply" button the current_hostname label does't change, while the hostname itself changes. This may mislead users.
![](https://i.ibb.co/5rDVwvR/screenshoot.png)