### PR TITLE
Use podman in GitHub workflows

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   refresh-container:
     name: Refresh anaconda-ci container
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # we need to have matrix to cover all branches because schedule is run only on default branch
     # we can add here fedora branches (e.g. f33-devel) to cover their support when needed
     strategy:
@@ -22,11 +22,11 @@ jobs:
           ref: ${{ matrix.branch }}
 
       - name: Build anaconda-ci container
-        run: CONTAINER_ENGINE=docker make -f Makefile.am anaconda-ci-build
+        run: make -f Makefile.am anaconda-ci-build
 
       - name: Run tests in anaconda-ci container
         id: run-tests
-        run: CONTAINER_ENGINE=docker make -f Makefile.am container-ci
+        run: make -f Makefile.am container-ci
         continue-on-error: true
 
       - name: Upload test and coverage logs from local testing
@@ -53,7 +53,7 @@ jobs:
         if: ${{ matrix.branch == 'master' }}
         run: |
           docker tag quay.io/rhinstaller/anaconda-ci:master quay.io/rhinstaller/anaconda-ci:latest
-          CONTAINER_ENGINE=docker CI_TAG=latest make -f Makefile.am anaconda-ci-push
+          CI_TAG=latest make -f Makefile.am anaconda-ci-push
 
       - name: Push container to registry
-        run: CONTAINER_ENGINE=docker make -f Makefile.am anaconda-ci-push
+        run: make -f Makefile.am anaconda-ci-push

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,7 @@ name: validate
 on: [push, pull_request_target]
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -22,13 +22,13 @@ jobs:
       # build container if files for dockerfile changed in the PR
       - name: Build anaconda-ci container
         if: steps.check-dockerfile-changed.outputs.changed
-        run: CONTAINER_ENGINE=docker make -f Makefile.am anaconda-ci-build
+        run: make -f Makefile.am anaconda-ci-build
 
       - name: Run tests in anaconda-ci container
         id: run-unit-tests
         run: |
           # put the log in the output, where it's easy to read and link to
-          CONTAINER_ENGINE=docker make -f Makefile.am container-ci || { cat test-logs/test-suite.log; exit 1; }
+          make -f Makefile.am container-ci || { cat test-logs/test-suite.log; exit 1; }
 
       - name: Upload test and coverage logs
         if: always()
@@ -38,7 +38,7 @@ jobs:
           path: test-logs/*
 
   rpm-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # start from a minimal container and install only our build deps; mock does
     # not work in an unprivileged container (no CAP_SYS_ADMIN for mount), and
     # dnf --installroot is too broken (rhbz#1885103, #1885101, #1738233)


### PR DESCRIPTION
This is closer to what developers use locally.

Also run the workflows on Ubuntu 20.04 instead of 18.04, to use the
latest LTS version.

---

Note that this is totally unrelated to the `test -r` / `access()` trouble that I had with ELN. It's just some nice little improvement/housekeeping.