### PR TITLE
Run and fix master tests on Fedora ELN

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,17 @@ on: [push, pull_request_target]
 jobs:
   unit-tests:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        # empty = release that corresponds to current branch name
+        release: ['', 'eln']
+        include:
+          - release: eln
+            build-args: '--build-arg=eln=1'
+    env:
+      CI_TAG: '${{ matrix.release }}'
+      CONTAINER_BUILD_ARGS: '${{ matrix.build-args }}'
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -21,7 +32,8 @@ jobs:
 
       # build container if files for dockerfile changed in the PR
       - name: Build anaconda-ci container
-        if: steps.check-dockerfile-changed.outputs.changed
+        # FIXME: always build ELN container, until we publish it to quay.io
+        if: steps.check-dockerfile-changed.outputs.changed || matrix.release == 'eln'
         run: make -f Makefile.am anaconda-ci-build
 
       - name: Run tests in anaconda-ci container
@@ -33,7 +45,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs
+          name: 'logs${{ matrix.release }}'
           path: test-logs/*
 
   rpm-tests:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,7 +25,6 @@ jobs:
         run: make -f Makefile.am anaconda-ci-build
 
       - name: Run tests in anaconda-ci container
-        id: run-unit-tests
         run: |
           # put the log in the output, where it's easy to read and link to
           make -f Makefile.am container-ci || { cat test-logs/test-suite.log; exit 1; }

--- a/Makefile.am
+++ b/Makefile.am
@@ -89,7 +89,7 @@ CONTAINER_REGISTRY ?= quay.io
 # anaconda-ci container
 CI_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-ci
 CI_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-ci
-CI_TAG ?= $(GIT_BRANCH)
+CI_TAG := $(or $(CI_TAG),$(GIT_BRANCH))
 CI_TEST_ARGS ?= --rm -v $(srcdir):/anaconda:Z
 CI_CMD ?= make ci
 

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -1,8 +1,23 @@
 FROM fedora:rawhide
+ARG eln=
 LABEL maintainer=anaconda-list@redhat.com
 
+# HACK: there is no official fedora-eln container image yet, so cross-grade from rawhide
+COPY ["eln.repo", "/etc/yum.repos.d"]
+
 # Prepare environment and install build dependencies
-RUN dnf update -y && \
+RUN set -e; \
+  if [ -n "$eln" ]; then \
+      sed -i 's/enabled=0/enabled=1/' /etc/yum.repos.d/eln.repo; \
+      dnf install -y --allowerasing fedora-release-eln; \
+  fi; \
+  dnf distro-sync -y; \
+  if [ -n "$eln" ]; then \
+      rm -f /etc/yum.repos.d/fedora*; \
+      if noneln=$(rpm -qa | grep -Ev '\.eln|^gpg-pubkey'); then \
+          echo "ERROR: Non-ELN packages: $noneln" >&2; exit 1; \
+      fi; \
+  fi; \
   dnf install -y \
   'dnf-command(copr)' \
   curl \
@@ -20,12 +35,11 @@ RUN dnf update -y && \
   python3-lxml \
   policycoreutils \
   python3-gobject-base \
-  python3-pip && \
-  dnf copr enable -y @rhinstaller/Anaconda && \
-  dnf copr enable -y @storage/blivet-daily && \
-  curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/master/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec && \
-  rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y && \
-  rpmspec -q --requires /tmp/anaconda.spec | grep -v anaconda | xargs -d '\n' dnf install -y && \
+  python3-pip; \
+  if [ -z "$eln" ]; then dnf copr enable -y @rhinstaller/Anaconda; dnf copr enable -y @storage/blivet-daily; fi; \
+  curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/master/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
+  rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
+  rpmspec -q --requires /tmp/anaconda.spec | grep -v anaconda | xargs -d '\n' dnf install -y; \
   dnf clean all
 
 RUN pip install \

--- a/dockerfile/anaconda-ci/eln.repo
+++ b/dockerfile/anaconda-ci/eln.repo
@@ -1,0 +1,10 @@
+[fedora-eln-baseos]
+name=Fedora ELN - $basearch
+baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/Everything/$basearch/os/
+enabled=0
+countme=1
+priority=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+skip_if_unavailable=False

--- a/tests/nosetests/pyanaconda_tests/ui/simple_ui_test.py
+++ b/tests/nosetests/pyanaconda_tests/ui/simple_ui_test.py
@@ -17,6 +17,7 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
+import os
 import sys
 import unittest
 
@@ -24,6 +25,10 @@ from unittest.mock import Mock, patch, create_autospec
 from pyanaconda.ui import UserInterface
 from pyanaconda.ui.common import StandaloneSpoke, Hub
 from tests.nosetests.pyanaconda_tests import patch_dbus_get_proxy
+
+
+# blivet-gui is supported on Fedora, but not ELN/CentOS/RHEL
+HAVE_BLIVET_GUI = os.path.exists("/usr/bin/blivet-gui")
 
 
 class SimpleUITestCase(unittest.TestCase):
@@ -165,6 +170,16 @@ class SimpleUITestCase(unittest.TestCase):
         ])
 
         # Check the Summary hub.
+        cat_system = [
+                'BlivetGuiSpoke',
+                'CustomPartitioningSpoke',
+                'FilterSpoke',
+                'NetworkSpoke',
+                'StorageSpoke'
+                ]
+        if not HAVE_BLIVET_GUI:
+            cat_system.remove('BlivetGuiSpoke')
+
         self.assertEqual(self._get_category_names(SummaryHub), {
             'CustomizationCategory': [],
             'LocalizationCategory': [
@@ -177,13 +192,7 @@ class SimpleUITestCase(unittest.TestCase):
                 'SourceSpoke',
                 'SubscriptionSpoke'
             ],
-            'SystemCategory': [
-                'BlivetGuiSpoke',
-                'CustomPartitioningSpoke',
-                'FilterSpoke',
-                'NetworkSpoke',
-                'StorageSpoke'
-            ],
+            'SystemCategory': cat_system,
             'UserSettingsCategory': [
                 'PasswordSpoke',
                 'UserSpoke'


### PR DESCRIPTION
Let's make sure that Anaconda keeps building/working on ELN, to avoid breakage in RHEL 9.

This requires adjusting the unit tests to not require blivet-gui on ELN.

 - [x] Builds on top of PR #2991
 - [x] Enable [Everything compose](https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/Everything) to replace rawhide packages