### PR TITLE
Handle disabled and failing add-ons

### DIFF
--- a/scripts/start-module
+++ b/scripts/start-module
@@ -36,3 +36,12 @@ export PYTHONPATH
 
 # Start a Python module in the detached mode.
 python3 -m $1 &
+module_pid="$!"
+
+# Wait for a minute in the detached mode.
+sleep 60 &
+timeout_pid="$!"
+
+# If the Python module fails before the timeout, return its exit status.
+# Otherwise, return 0.
+wait -n "${timeout_pid}" "${module_pid}"


### PR DESCRIPTION
If the add-on started by the `start-module` script fails before the
timeout of sixty seconds, return its exit status. Otherwise, return zero.

If the add-on fails to start, just remove it from the list of available modules
and continue. Don't abort the whole installation because of that.

This will allow the kdump add-on to refuse to run its DBus module if it is
not enabled via the `inst.kdump_addon` boot option.