### PR TITLE
Fix the priority of the ostreesetup kickstart command (#1896761)

### DIFF
--- a/pyanaconda/modules/payloads/payload/factory.py
+++ b/pyanaconda/modules/payloads/payload/factory.py
@@ -58,6 +58,9 @@ class PayloadFactory(object):
         :param data: a kickstart data
         :return: a payload type
         """
+        if data.ostreesetup.seen:
+            return PayloadType.RPM_OSTREE
+
         if data.liveimg.seen:
             return PayloadType.LIVE_IMAGE
 
@@ -68,8 +71,5 @@ class PayloadFactory(object):
            data.url.seen or \
            data.packages.seen:
             return PayloadType.DNF
-
-        if data.ostreesetup.seen:
-            return PayloadType.RPM_OSTREE
 
         return None

--- a/tests/nosetests/pyanaconda_tests/module_payload_rpm_ostree_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_rpm_ostree_test.py
@@ -86,3 +86,15 @@ class RPMOSTreeKickstartTestCase(unittest.TestCase):
         """
         self.shared_ks_tests.check_kickstart(ks_in, ks_out)
         self._check_properties(SOURCE_TYPE_RPM_OSTREE)
+
+    def priority_kickstart_test(self):
+        ks_in = """
+        ostreesetup --osname="fedora-iot" --url="https://compose/iot/" --ref="fedora/iot"
+        url --url="https://compose/Everything"
+        """
+        ks_out = """
+        # OSTree setup
+        ostreesetup --osname="fedora-iot" --remote="fedora-iot" --url="https://compose/iot/" --ref="fedora/iot"
+        """
+        self.shared_ks_tests.check_kickstart(ks_in, ks_out)
+        self._check_properties(SOURCE_TYPE_RPM_OSTREE)


### PR DESCRIPTION
Keep the same priorities as in the payload property of the Anaconda class.
If ostreesetup is in the kickstart file, always create the RPM OSTree module.

Resolves: rhbz#1896761