### PR TITLE
Fix GitHub container failure with latest Fedora Rawhide

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -26,10 +26,12 @@ jobs:
 
       - name: Run tests in anaconda-ci container
         id: run-tests
-        run: make -f Makefile.am container-ci
-        continue-on-error: true
+        run: |
+          # put the log in the output, where it's easy to read and link to
+          make -f Makefile.am container-ci || { cat test-logs/test-suite.log; exit 1; }
 
       - name: Upload test and coverage logs from local testing
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: logs
@@ -38,12 +40,6 @@ jobs:
             tests/nosetests.log
             tests/pylint/runpylint*.log
             tests/coverage-*.log
-
-      - name: Fail if local test did not worked
-        if: ${{ steps.run-tests.outcome == 'failure' }}
-        run: |
-          cat tests/test-suite.log
-          exit 1
 
       - name: Login to container registry
         run: docker login -u ${{ secrets.QUAY_USERNAME }} -p ${{ secrets.QUAY_PASSWORD }} quay.io

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,11 +39,11 @@ jobs:
 
   rpm-tests:
     runs-on: ubuntu-20.04
-    # start from a minimal container and install only our build deps; mock does
-    # not work in an unprivileged container (no CAP_SYS_ADMIN for mount), and
-    # dnf --installroot is too broken (rhbz#1885103, #1885101, #1738233)
+    # start from a minimal container and install only our build deps; anaconda-ci container has too many other packages
     container:
       image: docker.io/fedora:rawhide
+      # HACK: bash's builtin `test -r` fails due to incompatible seccomp profile
+      options: --security-opt=seccomp=unconfined
     steps:
       - name: Clone repository
         uses: actions/checkout@v2

--- a/Makefile.am
+++ b/Makefile.am
@@ -79,10 +79,11 @@ SRPM_BUILD_DIR = $(BUILD_RESULT_DIR)/00-srpm-build
 RPM_BUILD_DIR = $(BUILD_RESULT_DIR)/01-rpm-build
 TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
 
-# build/run tweaks for all containers, such as --cap-add
 CONTAINER_ENGINE ?= podman
+# build/run tweaks for all containers, such as --cap-add
 CONTAINER_BUILD_ARGS ?=
-CONTAINER_TEST_ARGS ?=
+# HACK: bash's builtin `test -r` fails when running on Ubuntu host (GitHub) due to incompatible seccomp profile
+CONTAINER_TEST_ARGS ?= $(shell grep -q ID=ubuntu /etc/os-release && echo --security-opt=seccomp=unconfined)
 CONTAINER_REGISTRY ?= quay.io
 
 # anaconda-ci container


### PR DESCRIPTION
Turns out that the weird "m4 not found" error that I was brooding over yesterday was in fact not specific to Fedora ELN, but affects Rawhide as well. [Last night's container refresh broke due to this](https://github.com/rhinstaller/anaconda/actions/runs/358720903), and the RPM tests (which don't use a static container) now [fail as well](https://github.com/rhinstaller/anaconda/pull/2990/checks?check_run_id=1386774946).

This PR avoids the error in a more generic fashion than I did in #2987 (and I'll rebase/adjust that PR on top of this).

This is a bit urgent, as currently our CI is broken, so I'd like to skip the 24 hour thing for this. @jkonecny12 , @poncovka , can you please review this quickly?