### PR TITLE
Use podman for pushing the nightly container update

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -42,13 +42,13 @@ jobs:
             tests/coverage-*.log
 
       - name: Login to container registry
-        run: docker login -u ${{ secrets.QUAY_USERNAME }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
+        run: podman login -u ${{ secrets.QUAY_USERNAME }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
 
         # we can hardcode the path to the image here because this will be executed only for master image
       - name: Add latest tag for master branch
         if: ${{ matrix.branch == 'master' }}
         run: |
-          docker tag quay.io/rhinstaller/anaconda-ci:master quay.io/rhinstaller/anaconda-ci:latest
+          podman tag quay.io/rhinstaller/anaconda-ci:master quay.io/rhinstaller/anaconda-ci:latest
           CI_TAG=latest make -f Makefile.am anaconda-ci-push
 
       - name: Push container to registry


### PR DESCRIPTION
Commit 00e9066afef switched the workflows from docker to podman, but
forgot to update the login/push commmands.

---

See  [this failed workflow](https://github.com/rhinstaller/anaconda/runs/1390112340?check_suite_focus=true).