### PR TITLE
Fix error in initrd: shift count out of range

### DIFF
--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -68,7 +68,7 @@ rulesfile="/etc/udev/rules.d/90-anaconda.rules"
 # try to find a usable runtime image from the repo mounted at $mnt.
 # if successful, move the mount(s) to $repodir/$isodir.
 anaconda_live_root_dir() {
-    local img="" iso="" srcdir="" mnt="$1" path="$2"; shift 2
+    local img="" iso="" srcdir="" mnt="$1" path="$2"
     img=$(find_runtime $mnt/$path)
     if [ -n "$img" ]; then
         info "anaconda: found $img"


### PR DESCRIPTION
anaconda_live_root_dir() can be called with just one argument (for example
when booting boot.iso) and the following error is reported:

20:26:12,641 INFO dracut-initqueue:anaconda using disk root at /dev/sr0
20:26:12,650 DEBUG kernel:ISO 9660 Extensions: Microsoft Joliet Level 3
20:26:12,654 DEBUG kernel:ISO 9660 Extensions: RRIP_1991A
20:26:12,654 INFO dracut-initqueue:/lib/anaconda-lib.sh: line 71: shift: 2: shift count out of range
20:26:12,656 INFO dracut-initqueue:anaconda: found /run/install/repo//images/install.img

Remove the shift call, since it has no use.