### PR TITLE
Deprecate the level option of the logging kickstart command

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -35,7 +35,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.28-1
+%define pykickstartver 3.31-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.2.2-1
 %define rpmver 4.10.0

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -48,7 +48,7 @@ from pykickstart.commands.iscsiname import FC6_IscsiName as IscsiName
 from pykickstart.commands.keyboard import F18_Keyboard as Keyboard
 from pykickstart.commands.lang import F19_Lang as Lang
 from pykickstart.commands.liveimg import F19_Liveimg as Liveimg
-from pykickstart.commands.logging import FC6_Logging as Logging
+from pykickstart.commands.logging import F34_Logging as Logging
 from pykickstart.commands.logvol import F29_LogVol as LogVol
 from pykickstart.commands.mediacheck import FC4_MediaCheck as MediaCheck
 from pykickstart.commands.method import F28_Method as Method


### PR DESCRIPTION
Use the new version of the logging command with a deprecated option.
The support for this command was removed in https://github.com/rhinstaller/anaconda/pull/2864.

**Depends on:** pykickstart/pykickstart#341