### PR TITLE
Move the package-related code to the DNF module

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -128,6 +128,14 @@ class DNFManager(object):
         if data.packages.excludeWeakdeps:
             base.conf.install_weak_deps = False
 
+    @property
+    def environments(self):
+        """Environments defined in comps.xml file.
+
+        :return: a list of ids
+        """
+        return [env.id for env in self._base.comps.environments]
+
     def configure_proxy(self, url):
         """Configure the proxy of the DNF base.
 

--- a/pyanaconda/modules/payloads/payload/dnf/utils.py
+++ b/pyanaconda/modules/payloads/payload/dnf/utils.py
@@ -25,6 +25,19 @@ from pyanaconda.product import productName, productVersion
 log = get_module_logger(__name__)
 
 
+def get_default_environment(dnf_manager):
+    """Get a default environment.
+
+    :return: an id of an environment or None
+    """
+    environments = dnf_manager.environments
+
+    if environments:
+        return environments[0]
+
+    return None
+
+
 def get_kernel_package(dnf_base, exclude_list):
     """Get an installable kernel package.
 

--- a/pyanaconda/modules/payloads/payload/dnf/utils.py
+++ b/pyanaconda/modules/payloads/payload/dnf/utils.py
@@ -16,6 +16,9 @@
 # Red Hat, Inc.
 #
 import dnf.subject
+import dnf.const
+
+from pykickstart.constants import GROUP_ALL, GROUP_DEFAULT
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.regexes import VERSION_DIGITS
@@ -82,3 +85,88 @@ def get_product_release_version():
 
     log.debug("Release version of %s is %s.", productName, release_version)
     return release_version
+
+
+def get_installation_specs(data, default_environment=None):
+    """Get specifications of packages, groups and modules for installation.
+
+    FIXME: Don't use the kickstart data.
+
+    :param data: a kickstart data
+    :param default_environment: a default environment to install
+    :return: a tuple of specification lists for inclusion and exclusion
+    """
+    # Note about package/group/module spec formatting:
+    # - leading @ signifies a group or module
+    # - no leading @ means a package
+    include_list = []
+    exclude_list = []
+
+    # Handle the environment.
+    if data.packages.default and default_environment:
+        env = default_environment
+        log.info("selecting default environment: %s", env)
+        include_list.append("@{}".format(env))
+    elif data.packages.environment:
+        env = data.packages.environment
+        log.info("selected environment: %s", env)
+        include_list.append("@{}".format(env))
+
+    # Handle the core group.
+    if data.packages.nocore:
+        log.info("skipping core group due to %%packages "
+                 "--nocore; system may not be complete")
+        exclude_list.append("@core")
+    else:
+        log.info("selected group: core")
+        include_list.append("@core")
+
+    # Handle groups.
+    for group in data.packages.excludedGroupList:
+        log.debug("excluding group %s", group.name)
+        exclude_list.append("@{}".format(group.name))
+
+    for group in data.packages.groupList:
+        default = group.include in (GROUP_ALL,
+                                    GROUP_DEFAULT)
+        optional = group.include == GROUP_ALL
+
+        # Packages in groups can have different types
+        # and we provide an option to users to set
+        # which types are going to be installed
+        # via the --nodefaults and --optional options.
+        #
+        # To not clash with module definitions we
+        # only use type specififcations if --nodefault,
+        # --optional or both are used.
+        if not default or optional:
+            type_list = list(dnf.const.GROUP_PACKAGE_TYPES)
+            if not default:
+                type_list.remove("default")
+            if optional:
+                type_list.append("optional")
+
+            types = ",".join(type_list)
+            group_spec = "@{group_name}/{types}".format(
+                group_name=group.name,
+                types=types
+            )
+        else:
+            # If group is a regular group this is equal to
+            # @group/mandatory,default,conditional (current
+            # content of the DNF GROUP_PACKAGE_TYPES constant).
+            group_spec = "@{}".format(group.name)
+
+        log.info("selected group: %s", group.name)
+        include_list.append(group_spec)
+
+    # Handle packages.
+    for pkg_name in data.packages.excludedList:
+        log.info("excluded package: %s", pkg_name)
+        exclude_list.append(pkg_name)
+
+    for pkg_name in data.packages.packageList:
+        log.info("selected package: %s", pkg_name)
+        include_list.append(pkg_name)
+
+    return include_list, exclude_list

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -532,7 +532,7 @@ class DNFPayload(Payload):
 
     @property
     def environments(self):
-        return [env.id for env in self._base.comps.environments]
+        return self._dnf_manager.environments
 
     def select_environment(self, environment_id):
         if environment_id not in self.environments:

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -45,7 +45,7 @@ from pyanaconda.modules.payloads.payload.dnf.requirements import collect_languag
     collect_platform_requirements, collect_driver_disk_requirements, collect_remote_requirements, \
     apply_requirements
 from pyanaconda.modules.payloads.payload.dnf.utils import get_kernel_package, \
-    get_product_release_version
+    get_product_release_version, get_default_environment
 from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager
 from pyanaconda.payload.source import SourceFactory, PayloadSourceTypeUnrecognized
 from pykickstart.constants import GROUP_ALL, GROUP_DEFAULT, KS_MISSING_IGNORE, GROUP_REQUIRED
@@ -313,6 +313,8 @@ class DNFPayload(Payload):
     def _apply_selections(self):
         log.debug("applying DNF package/group/module selection")
 
+        default_environment = get_default_environment(self._dnf_manager)
+
         # note about package/group/module spec formatting:
         # - leading @ signifies a group or module
         # - no leading @ means a package
@@ -336,8 +338,8 @@ class DNFPayload(Payload):
 
         # environment
         env = None
-        if self.data.packages.default and self.environments:
-            env = self.environments[0]
+        if self.data.packages.default and default_environment:
+            env = default_environment
             log.info("selecting default environment: %s", env)
         elif self.data.packages.environment:
             env = self.data.packages.environment

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_manager_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_manager_test.py
@@ -203,3 +203,22 @@ class DNFMangerTestCase(unittest.TestCase):
         size = self.dnf_manager.get_download_size()
 
         self.assertEqual(size, Size("450 MiB"))
+
+    def environments_test(self):
+        """Test the environments property."""
+        self.assertEqual(self.dnf_manager.environments, [])
+
+        # Fake environments.
+        env_1 = Mock(id="environment-1")
+        env_2 = Mock(id="environment-2")
+        env_3 = Mock(id="environment-3")
+
+        # Fake comps.
+        comps = Mock(environments=[env_1, env_2, env_3])
+
+        self.dnf_manager._base._comps = comps
+        self.assertEqual(self.dnf_manager.environments, [
+            "environment-1",
+            "environment-2",
+            "environment-3",
+        ])

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_utils_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_utils_test.py
@@ -16,10 +16,11 @@
 # Red Hat, Inc.
 #
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, PropertyMock
 
+from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager
 from pyanaconda.modules.payloads.payload.dnf.utils import get_kernel_package, \
-    get_product_release_version
+    get_product_release_version, get_default_environment
 
 
 class DNFUtilsPackagesTestCase(unittest.TestCase):
@@ -78,3 +79,16 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
     def get_product_release_version_dot_test(self):
         """Test the get_product_release_version function with a dot."""
         self.assertEqual(get_product_release_version(), "7.4")
+
+    @patch.object(DNFManager, 'environments', new_callable=PropertyMock)
+    def get_default_environment_test(self, mock_environments):
+        """Test the get_default_environment function"""
+        mock_environments.return_value = []
+        self.assertEqual(get_default_environment(DNFManager()), None)
+
+        mock_environments.return_value = [
+            "environment-1",
+            "environment-2",
+            "environment-3",
+        ]
+        self.assertEqual(get_default_environment(DNFManager()), "environment-1")


### PR DESCRIPTION
Move code that works with the `%packages` section to the DNF module.

It will simplify the removal of the `%packages` section from UI, because
it can be tested with unit tests now.