### PR TITLE
Install python-copr and RedHat CA into anaconda-ci container

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -45,6 +45,9 @@ RUN mkdir actions-runner && cd actions-runner && \
   LATEST_VER=$(basename $(curl -Ls -o /dev/null -w '%{url_effective}' $URL_BASE/latest)) && \
   curl -L "$URL_BASE/download/$LATEST_VER/actions-runner-linux-x64-${LATEST_VER#v}.tar.gz" | tar xvz
 
+RUN curl https://password.corp.redhat.com/RH-IT-Root-CA.crt -o /etc/pki/ca-trust/source/anchors/Red_Hat_IT_Root_CA.crt && \
+  update-ca-trust
+
 RUN mkdir /anaconda
 
 WORKDIR /anaconda

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -32,6 +32,7 @@ RUN echo dnf update -y && \
 RUN pip-3.6 install \
   "pylint==2.5.3" \
   pocketlint \
+  copr \
   coverage \
   pycodestyle \
   dogtail \


### PR DESCRIPTION
This is a dependency of https://github.com/vojtechtrefny/copr-builder

Related: rhbz#1885635

----

This is a prerequisite for replacing the anaconda_daily_rhel_copr Jenkins job.