### PR TITLE
Add workflow for daily RHEL COPR build

### DIFF
--- a/.github/workflows/daily-rhel-copr.yml
+++ b/.github/workflows/daily-rhel-copr.yml
@@ -1,0 +1,32 @@
+name: Build current anaconda rhel-8 branch in RHEL COPR
+on:
+  schedule:
+    - cron: 0 2 * * *
+  # be able to start this action manually from a actions tab when needed
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: copr-builder
+    runs-on: [self-hosted, ci-tasks, rhel-8]
+    steps:
+      - name: Checkout copr-builder repository
+        uses: actions/checkout@v2
+        with:
+          repository: vojtechtrefny/copr-builder
+
+      - name: Create copr-builder configuration
+        run: |
+          cat <<EOF > copr-builder-rhel.conf
+          [anaconda]
+          copr_user = rhinstaller-group
+          copr_repo = Anaconda
+          package = anaconda
+          git_url = https://github.com/rhinstaller/anaconda
+          git_branch = rhel-8
+          pre_archive_cmd = ./autogen.sh && ./configure
+          archive_cmd = make po-pull && make dist
+          EOF
+
+      - name: Run copr-builder
+        run: ./copr-builder -v -c copr-builder-rhel.conf -C /copr-rhel


### PR DESCRIPTION
Generate the configuration right in the workflow, so that it is easy to
change and obvious where it comes from.

 - [x] Install python-copr into anaconda-ci container: PR #3001 
 - [x] Make RHEL COPR token available in self-hosted github runners: builders PR 29
 - [x] Disable anaconda_daily_rhel_copr Jenkins job