### PR TITLE
Remove leftover bootloader-related code from the Payloads service

### DIFF
--- a/pyanaconda/modules/payloads/base/initialization.py
+++ b/pyanaconda/modules/payloads/base/initialization.py
@@ -20,7 +20,6 @@ import shutil
 import traceback
 from glob import glob
 
-from pyanaconda.core.util import execWithRedirect
 from pyanaconda.modules.common.errors.payload import SourceSetupError, SourceTearDownError
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.payloads.base.utils import create_root_dir, write_module_blacklist
@@ -54,49 +53,6 @@ class PrepareSystemForInstallationTask(Task):
         """Create a root and write module blacklist."""
         create_root_dir(self._sysroot)
         write_module_blacklist(self._sysroot)
-
-
-class UpdateBLSConfigurationTask(Task):
-    """Task to update BLS configuration."""
-
-    def __init__(self, sysroot, kernel_version_list):
-        """Create a new task.
-
-        :param sysroot: a path to the root of the installed system
-        :type sysroot: str
-        :param kernel_version_list: list of kernel versions for updating of BLS configuration
-        :type kernel_version_list: list(str)
-        """
-        super().__init__()
-        self._sysroot = sysroot
-        self._kernel_version_list = kernel_version_list
-
-    @property
-    def name(self):
-        return "Update BLS configuration."""
-
-    def run(self):
-        """Run update of bls configuration."""
-        # Not using BLS configuration, skip it
-        if os.path.exists(self._sysroot + "/usr/sbin/new-kernel-pkg"):
-            return
-
-        # TODO: test if this is not a dir install
-
-        # Remove any existing BLS entries, they will not match the new system's
-        # machine-id or /boot mountpoint.
-        for file in glob(self._sysroot + "/boot/loader/entries/*.conf"):
-            log.info("Removing old BLS entry: %s", file)
-            os.unlink(file)
-
-        # Create new BLS entries for this system
-        for kernel in self._kernel_version_list:
-            log.info("Regenerating BLS info for %s", kernel)
-            execWithRedirect(
-                "kernel-install",
-                ["add", kernel, "/lib/modules/{0}/vmlinuz".format(kernel)],
-                root=self._sysroot
-            )
 
 
 # TODO: Can we remove this really old code which probably even doesn't work now?

--- a/pyanaconda/modules/payloads/base/installation.py
+++ b/pyanaconda/modules/payloads/base/installation.py
@@ -19,7 +19,6 @@ from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.common.errors.payload import InstallError
 from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.core.util import execWithRedirect
-from pyanaconda.modules.payloads.base.utils import create_rescue_image
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -28,19 +27,15 @@ log = get_module_logger(__name__)
 class InstallFromImageTask(Task):
     """Task to install the payload from image."""
 
-    def __init__(self, dest_path, kernel_version_list, source=None):
+    def __init__(self, dest_path, source=None):
         """Create a new task.
 
         :param dest_path: installation destination root path
         :type dest_path: str
-        :param kernel_version_list: list of kernel versions for rescue initrd images
-                                    to be created
-        :type kernel_version_list: list(str)
         """
         super().__init__()
         self._source = source
         self._dest_path = dest_path
-        self._kernel_version_list = kernel_version_list
 
     @property
     def name(self):
@@ -76,5 +71,3 @@ class InstallFromImageTask(Task):
 
         if err or rc == 11:
             raise InstallError(err or msg)
-
-        create_rescue_image(self._dest_path, self._kernel_version_list)

--- a/pyanaconda/modules/payloads/base/utils.py
+++ b/pyanaconda/modules/payloads/base/utils.py
@@ -23,7 +23,7 @@ import os
 import stat
 
 from pyanaconda.core.kernel import kernel_arguments
-from pyanaconda.core.util import mkdirChain, execWithRedirect
+from pyanaconda.core.util import mkdirChain
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.payload.utils import version_cmp
 
@@ -104,30 +104,3 @@ def get_kernel_version_list(root_path):
                                   if os.path.isfile(f) and "-rescue-" not in f),
                                  key=functools.cmp_to_key(version_cmp))
     return kernel_version_list
-
-
-def create_rescue_image(root, kernel_version_list):
-    """Create the rescue initrd images for each kernel."""
-    # Always make sure the new system has a new machine-id, it won't boot without it
-    # (and nor will some of the subsequent commands like grub2-mkconfig and kernel-install)
-    log.info("Generating machine ID")
-    if os.path.exists(root + "/etc/machine-id"):
-        os.unlink(root + "/etc/machine-id")
-    execWithRedirect("systemd-machine-id-setup", [], root=root)
-
-    if os.path.exists(root + "/usr/sbin/new-kernel-pkg"):
-        use_nkp = True
-    else:
-        log.warning("new-kernel-pkg does not exist - grubby wasn't installed?")
-        use_nkp = False
-
-    for kernel in kernel_version_list:
-        log.info("Generating rescue image for %s", kernel)
-        if use_nkp:
-            execWithRedirect("new-kernel-pkg", ["--rpmposttrans", kernel], root=root)
-        else:
-            files = glob.glob(root + "/etc/kernel/postinst.d/*")
-            srlen = len(root)
-            files = sorted([f[srlen:] for f in files if os.access(f, os.X_OK)])
-            for file in files:
-                execWithRedirect(file, [kernel, "/boot/vmlinuz-%s" % kernel], root=root)

--- a/pyanaconda/modules/payloads/payload/live_image/installation.py
+++ b/pyanaconda/modules/payloads/payload/live_image/installation.py
@@ -18,7 +18,6 @@
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.common.errors.payload import InstallError
 from pyanaconda.core.util import execWithRedirect
-from pyanaconda.modules.payloads.base.utils import create_rescue_image
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -27,11 +26,10 @@ log = get_module_logger(__name__)
 class InstallFromTarTask(Task):
     """Task to install the payload from tarball."""
 
-    def __init__(self, tarfile_path, dest_path, kernel_version_list):
+    def __init__(self, tarfile_path, dest_path):
         super().__init__()
         self._tarfile_path = tarfile_path
         self._dest_path = dest_path
-        self._kernel_version_list = kernel_version_list
 
     @property
     def name(self):
@@ -59,5 +57,3 @@ class InstallFromTarTask(Task):
 
         if err:
             raise InstallError(err or msg)
-
-        create_rescue_image(self._dest_path, self._kernel_version_list)

--- a/pyanaconda/modules/payloads/payload/live_image/live_image.py
+++ b/pyanaconda/modules/payloads/payload/live_image/live_image.py
@@ -90,14 +90,9 @@ class LiveImageModule(PayloadBase):
     def post_install_with_tasks(self):
         """Execute post installation steps.
 
-        * Update bootloader BLS configuration
         * Copy Driver Disk files to the resulting system
         """
         # return [
-        #     UpdateBLSConfigurationTask(
-        #         conf.target.system_root,
-        #         self.kernel_version_list
-        #     ),
         #     CopyDriverDisksFilesTask(conf.target.system_root)
         # ]
         return []

--- a/pyanaconda/modules/payloads/payload/live_os/live_os.py
+++ b/pyanaconda/modules/payloads/payload/live_os/live_os.py
@@ -25,7 +25,7 @@ from pyanaconda.modules.common.errors.payload import SourceSetupError, Incompati
 from pyanaconda.modules.payloads.constants import SourceType, PayloadType
 from pyanaconda.modules.payloads.payload.payload_base import PayloadBase
 from pyanaconda.modules.payloads.base.initialization import PrepareSystemForInstallationTask, \
-    CopyDriverDisksFilesTask, SetUpSourcesTask, TearDownSourcesTask, UpdateBLSConfigurationTask
+    CopyDriverDisksFilesTask, SetUpSourcesTask, TearDownSourcesTask
 from pyanaconda.modules.payloads.base.installation import InstallFromImageTask
 from pyanaconda.modules.payloads.base.utils import get_kernel_version_list
 from pyanaconda.modules.payloads.payload.live_os.live_os_interface import LiveOSInterface
@@ -143,8 +143,7 @@ class LiveOSModule(PayloadBase):
 
         return [InstallFromImageTask(
             self._image_source,
-            conf.target.system_root,
-            self.kernel_version_list
+            conf.target.system_root
         )]
 
     def post_install_with_tasks(self):
@@ -154,10 +153,6 @@ class LiveOSModule(PayloadBase):
         :rtype: List
         """
         return [
-            UpdateBLSConfigurationTask(
-                conf.target.system_root,
-                self.kernel_version_list
-            ),
             CopyDriverDisksFilesTask(conf.target.system_root)
         ]
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_image_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_image_test.py
@@ -147,7 +147,6 @@ class LiveImageInterfaceTestCase(unittest.TestCase):
     def post_install_with_tasks_test(self, publisher):
         """Test Live Image post installation configuration task."""
         # task_classes = [
-        #     UpdateBLSConfigurationTask,
         #     CopyDriverDisksFilesTask,
         #     TeardownInstallationSourceImageTask
         # ]

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_os_test.py
@@ -31,7 +31,6 @@ from pyanaconda.modules.common.task.task_interface import TaskInterface
 from pyanaconda.modules.payloads.constants import SourceType, PayloadType, SourceState
 from pyanaconda.modules.payloads.base.initialization import PrepareSystemForInstallationTask, \
     CopyDriverDisksFilesTask, SetUpSourcesTask, TearDownSourcesTask
-from pyanaconda.modules.payloads.base.initialization import UpdateBLSConfigurationTask
 from pyanaconda.modules.payloads.base.installation import InstallFromImageTask
 from pyanaconda.modules.payloads.payload.live_os.live_os import LiveOSModule
 from pyanaconda.modules.payloads.payload.live_os.live_os_interface import LiveOSInterface
@@ -186,7 +185,6 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
     def post_install_with_tasks_test(self, publisher):
         """Test Live OS post installation configuration task."""
         task_classes = [
-            UpdateBLSConfigurationTask,
             CopyDriverDisksFilesTask
         ]
 

--- a/tests/nosetests/pyanaconda_tests/module_payload_live_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_live_test.py
@@ -18,18 +18,16 @@
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 #
 import os
-import stat
 import unittest
 
-from unittest.mock import patch, call, Mock
+from unittest.mock import patch, Mock
 from tempfile import TemporaryDirectory
 
 from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.modules.common.errors.payload import InstallError
-from pyanaconda.modules.payloads.base.initialization import UpdateBLSConfigurationTask
 from pyanaconda.modules.payloads.base.installation import InstallFromImageTask
-from pyanaconda.modules.payloads.base.utils import create_rescue_image, get_kernel_version_list
+from pyanaconda.modules.payloads.base.utils import get_kernel_version_list
 
 
 class LiveUtilsTestCase(unittest.TestCase):
@@ -48,30 +46,6 @@ class LiveUtilsTestCase(unittest.TestCase):
         self._kernel_test_files_list.append(name[8:])
         if is_valid:
             self._kernel_test_valid_list.append(name[8:])
-
-    def _prepare_rescue_test_dirs(self, temp_dir,
-                                  fake_machine_id,
-                                  fake_new_kernel_pkg,
-                                  fake_postinst_scripts_list):
-        etc_path = os.path.join(temp_dir, "etc")
-        postinst_path = os.path.join(etc_path, "kernel/postinst.d")
-        sbin_path = os.path.join(temp_dir, "usr/sbin")
-
-        os.makedirs(etc_path)
-
-        if fake_machine_id:
-            open(os.path.join(etc_path, "machine-id"), "wt").close()
-
-        if fake_new_kernel_pkg:
-            os.makedirs(sbin_path)
-            open(os.path.join(sbin_path, "new-kernel-pkg"), "wb").close()
-
-        if fake_postinst_scripts_list:
-            os.makedirs(postinst_path)
-            for path in fake_postinst_scripts_list:
-                path = os.path.join(postinst_path, path)
-                open(path, "wt").close()
-                os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
     def kernel_list_empty_test(self):
         """Test empty get kernel list function."""
@@ -99,97 +73,17 @@ class LiveUtilsTestCase(unittest.TestCase):
 
             self.assertListEqual(kernel_list, self._kernel_test_valid_list)
 
-    @patch("pyanaconda.modules.payloads.base.utils.execWithRedirect")
-    def create_rescue_image_with_new_kernel_pkg_test(self, exec_with_redirect):
-        """Test creation of rescue image with kernel pkg."""
-        kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
-        with TemporaryDirectory() as temp:
-            self._prepare_rescue_test_dirs(temp,
-                                           fake_machine_id=True,
-                                           fake_new_kernel_pkg=True,
-                                           fake_postinst_scripts_list=[])
-
-            create_rescue_image(temp, kernel_version_list)
-
-            calls = [call("systemd-machine-id-setup", [], root=temp)]
-            for kernel in kernel_version_list:
-                calls.append(call("new-kernel-pkg", ["--rpmposttrans", kernel], root=temp))
-
-            exec_with_redirect.assert_has_calls(calls)
-
-    @patch("pyanaconda.modules.payloads.base.utils.execWithRedirect")
-    def create_rescue_image_without_machine_id_test(self, exec_with_redirect):
-        """Test creation of rescue image without machine-id file."""
-        kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
-        with TemporaryDirectory() as temp:
-            self._prepare_rescue_test_dirs(temp,
-                                           fake_machine_id=False,
-                                           fake_new_kernel_pkg=True,
-                                           fake_postinst_scripts_list=[])
-
-            create_rescue_image(temp, kernel_version_list)
-
-            calls = [call("systemd-machine-id-setup", [], root=temp)]
-            for kernel in kernel_version_list:
-                calls.append(call("new-kernel-pkg", ["--rpmposttrans", kernel], root=temp))
-
-            exec_with_redirect.assert_has_calls(calls)
-
-    @patch("pyanaconda.modules.payloads.base.utils.execWithRedirect")
-    def create_rescue_image_with_postinst_scripts_test(self, exec_with_redirect):
-        """Test creation of rescue image with postinst scripts."""
-        kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
-        postinst_scripts = ["01-create", "02-rule", "03-aaaand-we-lost"]
-        with TemporaryDirectory() as temp:
-            self._prepare_rescue_test_dirs(temp,
-                                           fake_machine_id=True,
-                                           fake_new_kernel_pkg=False,
-                                           fake_postinst_scripts_list=postinst_scripts)
-
-            with self.assertLogs(level="WARNING") as cm:
-                create_rescue_image(temp, kernel_version_list)
-
-                self.assertTrue(any(map(lambda x: "new-kernel-pkg does not exist" in x,
-                                        cm.output)))
-
-            calls = [call("systemd-machine-id-setup", [], root=temp)]
-            for kernel in kernel_version_list:
-                for script in sorted(postinst_scripts):
-                    script = os.path.join("/etc/kernel/postinst.d", script)
-                    kernel_path = "/boot/vmlinuz-{}".format(kernel)
-                    calls.append(call(script, [kernel, kernel_path], root=temp))
-
-            exec_with_redirect.assert_has_calls(calls)
-
 
 class LiveTasksTestCase(unittest.TestCase):
 
-    def _prepare_bls_test_env(self, temp_dir, fake_kernel_pkg, bls_entries):
-        sbin_path = os.path.join(temp_dir, "usr/sbin")
-        entries_path = os.path.join(temp_dir, "boot/loader/entries")
-        lib_modules_path = os.path.join(temp_dir, "lib/modules")
-
-        if fake_kernel_pkg:
-            os.makedirs(sbin_path)
-            open(os.path.join(sbin_path, "new-kernel-pkg"), "wb").close()
-            return
-
-        os.makedirs(entries_path)
-        os.makedirs(lib_modules_path)
-
-        for entry in bls_entries:
-            open(os.path.join(entries_path, entry), "wt").close()
-
-    @patch("pyanaconda.modules.payloads.base.installation.create_rescue_image")
     @patch("pyanaconda.modules.payloads.base.installation.execWithRedirect")
-    def install_image_task_test(self, exec_with_redirect, create_rescue_image_mock):
+    def install_image_task_test(self, exec_with_redirect, ):
         """Test installation from an image task."""
         dest_path = "/destination/path"
-        kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
         source = Mock()
         exec_with_redirect.return_value = 0
 
-        InstallFromImageTask(dest_path, kernel_version_list, source).run()
+        InstallFromImageTask(dest_path, source).run()
 
         expected_rsync_args = ["-pogAXtlHrDx", "--exclude", "/dev/", "--exclude", "/proc/",
                                "--exclude", "/tmp/*", "--exclude", "/sys/", "--exclude", "/run/",
@@ -198,18 +92,15 @@ class LiveTasksTestCase(unittest.TestCase):
                                "--exclude", "/etc/machine-id", INSTALL_TREE + "/", dest_path]
 
         exec_with_redirect.assert_called_once_with("rsync", expected_rsync_args)
-        create_rescue_image_mock.assert_called_once_with(dest_path, kernel_version_list)
 
-    @patch("pyanaconda.modules.payloads.base.installation.create_rescue_image")
     @patch("pyanaconda.modules.payloads.base.installation.execWithRedirect")
-    def install_image_task_source_unready_test(self, exec_with_redirect, create_rescue_image_mock):
+    def install_image_task_source_unready_test(self, exec_with_redirect):
         """Test installation from an image task when source is not ready."""
         dest_path = "/destination/path"
-        kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
         source = Mock()
         exec_with_redirect.return_value = 0
 
-        InstallFromImageTask(dest_path, kernel_version_list, source).run()
+        InstallFromImageTask(dest_path, source).run()
 
         expected_rsync_args = ["-pogAXtlHrDx", "--exclude", "/dev/", "--exclude", "/proc/",
                                "--exclude", "/tmp/*", "--exclude", "/sys/", "--exclude", "/run/",
@@ -218,21 +109,17 @@ class LiveTasksTestCase(unittest.TestCase):
                                "--exclude", "/etc/machine-id", INSTALL_TREE + "/", dest_path]
 
         exec_with_redirect.assert_called_once_with("rsync", expected_rsync_args)
-        create_rescue_image_mock.assert_called_once_with(dest_path, kernel_version_list)
 
-    @patch("pyanaconda.modules.payloads.base.installation.create_rescue_image")
     @patch("pyanaconda.modules.payloads.base.installation.execWithRedirect")
-    def install_image_task_failed_exception_test(self, exec_with_redirect,
-                                                 create_rescue_image_mock):
+    def install_image_task_failed_exception_test(self, exec_with_redirect):
         """Test installation from an image task with exception."""
         dest_path = "/destination/path"
-        kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
         source = Mock()
         exec_with_redirect.side_effect = OSError("mock exception")
 
         with self.assertLogs(level="ERROR") as cm:
             with self.assertRaises(InstallError):
-                InstallFromImageTask(dest_path, kernel_version_list, source).run()
+                InstallFromImageTask(dest_path, source).run()
 
             self.assertTrue(any(map(lambda x: "mock exception" in x, cm.output)))
 
@@ -243,21 +130,17 @@ class LiveTasksTestCase(unittest.TestCase):
                                "--exclude", "/etc/machine-id", INSTALL_TREE + "/", dest_path]
 
         exec_with_redirect.assert_called_once_with("rsync", expected_rsync_args)
-        create_rescue_image_mock.assert_not_called()
 
-    @patch("pyanaconda.modules.payloads.base.installation.create_rescue_image")
     @patch("pyanaconda.modules.payloads.base.installation.execWithRedirect")
-    def install_image_task_failed_return_code_test(self, exec_with_redirect,
-                                                   create_rescue_image_mock):
+    def install_image_task_failed_return_code_test(self, exec_with_redirect):
         """Test installation from an image task with bad return code."""
         dest_path = "/destination/path"
-        kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
         source = Mock()
         exec_with_redirect.return_value = 11
 
         with self.assertLogs(level="INFO") as cm:
             with self.assertRaises(InstallError):
-                InstallFromImageTask(dest_path, kernel_version_list, source).run()
+                InstallFromImageTask(dest_path, source).run()
 
             self.assertTrue(any(map(lambda x: "exited with code 11" in x, cm.output)))
 
@@ -268,74 +151,3 @@ class LiveTasksTestCase(unittest.TestCase):
                                "--exclude", "/etc/machine-id", INSTALL_TREE + "/", dest_path]
 
         exec_with_redirect.assert_called_once_with("rsync", expected_rsync_args)
-        create_rescue_image_mock.assert_not_called()
-
-    @patch("pyanaconda.modules.payloads.base.initialization.execWithRedirect")
-    def update_bls_configuration_task_no_bls_system_test(self, exec_with_redirect):
-        """Test update bls configuration task on no BLS system."""
-        kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
-
-        with TemporaryDirectory() as temp:
-            self._prepare_bls_test_env(temp, fake_kernel_pkg=True, bls_entries=[])
-
-            UpdateBLSConfigurationTask(temp, kernel_version_list).run()
-
-            # nothing should be done when new-kernel-pkg is present
-            exec_with_redirect.assert_not_called()
-
-    @patch("pyanaconda.modules.payloads.base.initialization.execWithRedirect")
-    def update_bls_configuration_task_old_entries_test(self, exec_with_redirect):
-        """Test update bls configuration task with old bls entries."""
-        kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
-        bls_entries = ["one.conf", "two.conf", "three_trillions_twenty_two.noconf"]
-
-        with TemporaryDirectory() as temp:
-            self._prepare_bls_test_env(temp, fake_kernel_pkg=False, bls_entries=bls_entries)
-
-            UpdateBLSConfigurationTask(temp, kernel_version_list).run()
-
-            entries_path = os.path.join(temp, "boot/loader/entries")
-            for entry in bls_entries:
-                entry = os.path.join(entries_path, entry)
-                if entry[-7:] != ".noconf":
-                    self.assertFalse(os.path.exists(entry),
-                                     msg="File {} should be removed".format(entry))
-                else:
-                    self.assertTrue(os.path.exists(entry),
-                                    msg="File {} shouldn't be removed".format(entry))
-
-            calls = []
-            for kernel in kernel_version_list:
-                calls.append(
-                    call("kernel-install",
-                         ["add", kernel, "/lib/modules/{0}/vmlinuz".format(kernel)],
-                         root=temp),
-                )
-
-            exec_with_redirect.assert_has_calls(calls)
-
-    @patch("pyanaconda.modules.payloads.base.initialization.execWithRedirect")
-    def update_bls_configuration_task_no_old_entries_test(self, exec_with_redirect):
-        """Test update bls configuration task without old bls entries."""
-        kernel_version_list = ["kernel-v1.fc2000.x86_64", "kernel-sad-kernel"]
-        bls_entries = ["three_trillions_twenty_two.noconf"]
-
-        with TemporaryDirectory() as temp:
-            self._prepare_bls_test_env(temp, fake_kernel_pkg=False, bls_entries=bls_entries)
-
-            UpdateBLSConfigurationTask(temp, kernel_version_list).run()
-
-            entries_path = os.path.join(temp, "boot/loader/entries")
-            entry = os.path.join(entries_path, bls_entries[0])
-            self.assertTrue(os.path.exists(entry),
-                            msg="File {} shouldn't be removed".format(entry))
-
-            calls = []
-            for kernel in kernel_version_list:
-                calls.append(
-                    call("kernel-install",
-                         ["add", kernel, "/lib/modules/{0}/vmlinuz".format(kernel)],
-                         root=temp),
-                )
-
-            exec_with_redirect.assert_has_calls(calls)


### PR DESCRIPTION
All bootloader-related code was already migrated to the Storage service.