### PR TITLE
Improve the error dialog for storage reset (#1877050)

### DIFF
--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -116,8 +116,8 @@ class ErrorHandler(object):
         return ERROR_RAISE
 
     def _storage_reset_handler(self, exn):
-        message = (_("There is a problem with your existing storage "
-                     "configuration. "
+        message = (_("There is a problem with your existing storage configuration "
+                     "or your initial settings, for example a kickstart file. "
                      "You must resolve this matter before the installation can "
                      "proceed. There is a shell available for use which you "
                      "can access by pressing ctrl-alt-f1 and then ctrl-b 2."


### PR DESCRIPTION
The storage reset might fail because of a problem with the existing storage
configuration or the initial settings (such as a kickstart file). Change the
message in the error dialog for storage reset to cover both cases.

(cherry-picked from a commit e0ccfee)

Resolves: rhbz#1877050