### PR TITLE
Rebase branches to current master before testing

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,6 +22,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Rebase to current master
+        run: git rebase origin/master
+
       - name: Check if container changed in this PR
         id: check-dockerfile-changed
         run: |


### PR DESCRIPTION
This makes sure that we test what we will actually land: The PR's
commits will be rebased on top of master. It also avoids rebuilding the
anaconda-ci container when the proposed branch is older, and doesn't
include recent container changes.