### PR TITLE
gui: fix window width with long product titles

### DIFF
--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -249,6 +249,11 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
         welcomeLabel.set_text(_("WELCOME TO %(name)s %(version)s.") %
                 {"name" : productName.upper(), "version" : productVersion})         # pylint: disable=no-member
 
+        # Product title may be long and make the window of Anaconda so wide
+        # that it will not fit into not big resolutions of VMs and some screens;
+        # avoid this by wrapping long lines.
+        welcomeLabel.set_line_wrap(True)
+
         # Retranslate the language (filtering) entry's placeholder text
         languageEntry = self.builder.get_object("languageEntry")
         if languageEntry not in self._origStrings:


### PR DESCRIPTION
It was:
![image](https://user-images.githubusercontent.com/15802528/99876554-70dfae80-2c08-11eb-82eb-17a7966439dd.png)

It is now:
![image](https://user-images.githubusercontent.com/15802528/99876574-a5ec0100-2c08-11eb-98d0-cfcbd7e10268.png)


Also, by the way, a similar fix may be done in the dashboard of available spokes
![image](https://user-images.githubusercontent.com/15802528/99876566-8c4ab980-2c08-11eb-85de-db00ebdb82ea.png)
by adding something like `<property name="wrap">True</property>` into `*.glade`.