### PR TITLE
Rebase test pull request also for rhel-8 contributors

### DIFF
--- a/.github/workflows/validate-rhel-8.yml
+++ b/.github/workflows/validate-rhel-8.yml
@@ -65,7 +65,11 @@ jobs:
           fetch-depth: 0
 
       - name: Rebase to current rhel-8
-        run: git rebase origin/rhel-8
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git log --oneline -1 origin/rhel-8
+          git rebase origin/rhel-8
 
       - name: Run test
         run: |

--- a/.github/workflows/validate-rhel-8.yml
+++ b/.github/workflows/validate-rhel-8.yml
@@ -62,6 +62,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ needs.pr-info.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Rebase to current rhel-8
+        run: git rebase origin/rhel-8
 
       - name: Run test
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,11 @@ jobs:
           fetch-depth: 0
 
       - name: Rebase to current master
-        run: git rebase origin/master
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git log --oneline -1 origin/master
+          git rebase origin/master
 
       - name: Check if container changed in this PR
         id: check-dockerfile-changed


### PR DESCRIPTION
By this change the tests will run always on top of the rhel-8 branch.