### PR TITLE
Force hide CDN button when no CDN sources

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.glade
+++ b/pyanaconda/ui/gui/spokes/installation_source.glade
@@ -636,6 +636,7 @@
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
                                 <property name="no_show_all">True</property>
+                                <property name="visible">False</property>
                                 <property name="margin_left">12</property>
                                 <property name="use_underline">True</property>
                                 <property name="xalign">0</property>

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -853,9 +853,10 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
     def _initialize(self):
         threadMgr.wait(constants.THREAD_PAYLOAD)
 
-        # If there is the Subscriptiopn DBus module, make the CDN radio button visible
+        # If there is the Subscription DBus module, make the CDN radio button visible
         if is_module_available(SUBSCRIPTION):
             gtk_call_once(self._cdn_button.set_no_show_all, False)
+            gtk_call_once(self._cdn_button.set_visible, True)
 
         # Get the current source.
         source_proxy = self.payload.get_source_proxy()


### PR DESCRIPTION
In CentOS Linux and CentOS Stream this patch seems needed to correctly hide the CDN button.