### PR TITLE
Set shorter workflow timeouts

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         branch:
           - master
+    timeout-minutes: 60
     steps:
       - name: Checkout anaconda repository
         uses: actions/checkout@v2

--- a/.github/workflows/validate-rhel-8.yml
+++ b/.github/workflows/validate-rhel-8.yml
@@ -45,6 +45,7 @@ jobs:
     needs: pr-info
     if: needs.pr-info.outputs.base_ref == 'rhel-8' && needs.pr-info.outputs.allowed_user == 'true'
     runs-on: [self-hosted, ci-tasks, rhel-8]
+    timeout-minutes: 30
     steps:
       # we post statuses manually as this does not run from a pull_request event
       # https://developer.github.com/v3/repos/statuses/#create-a-status

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       CI_TAG: '${{ matrix.release }}'
       CONTAINER_BUILD_ARGS: '${{ matrix.build-args }}'
+    timeout-minutes: 30
 
     steps:
       - name: Clone repository
@@ -58,6 +59,7 @@ jobs:
       image: docker.io/fedora:rawhide
       # HACK: bash's builtin `test -r` fails due to incompatible seccomp profile
       options: --security-opt=seccomp=unconfined
+    timeout-minutes: 30
     steps:
       - name: Clone repository
         uses: actions/checkout@v2


### PR DESCRIPTION
The default timeout is 6 hours, which just causes unnecessary hangs,
delays, and blocked self-hosted runners if anything goes wrong (such as
https://github.com/PyCQA/pylint/issues/3899).

A normal run takes about 10 minutes, so set a timeout of 30 minutes.
Use one hour for the full container rebuild+validation+upload to be on
the safe side (it usually takes between 15 and 18 minutes).