### PR TITLE
[r8] Apply pylint excessive memory usage fix

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -18,6 +18,7 @@ RUN echo dnf update -y && \
   libicu \
   lttng-ust \
   rpm-ostree \
+  patch \
   pykickstart \
   python3-pip \
   python3-lxml \
@@ -38,6 +39,10 @@ RUN pip-3.6 install \
   dogtail \
   nose-testconfig \
   rpmfluff
+
+# HACK: Apply fix from https://github.com/PyCQA/astroid/pull/847 to avoid
+# excessive memory usage, until astroid > 2.4.2 gets released
+RUN curl https://github.com/PyCQA/astroid/commit/d62349a424c549b4634c90e471c9f876b99edfeb.patch | patch /usr/local/lib/python3*/site-packages/astroid/manager.py
 
 # see https://github.com/martinpitt/anaconda/settings/actions/add-new-runner
 RUN mkdir actions-runner && cd actions-runner && \

--- a/tests/pylint/censorship.py
+++ b/tests/pylint/censorship.py
@@ -116,23 +116,6 @@ class CensorshipLinter():
     def _prepare_args(self):
         args = []
 
-        # pylint uses a lot of memory and doesn't handle ENOMEM well, so set --jobs based on memory
-        # do this early so that command_line_args can override -j
-        avail_mem_kb = 0
-        with open("/proc/meminfo") as f:
-            for line in f:
-                if line.startswith("MemAvailable:"):
-                    avail_mem_kb = int(line.split()[1])
-                    break
-        num_cpus = multiprocessing.cpu_count()
-        # each process uses ~ 2 GiB RAM, leave some breathing space
-        jobs = max(1, avail_mem_kb // 3000000)
-        # but also clip to nproc
-        jobs = min(jobs, num_cpus)
-        print("Using", jobs, "parallel jobs based on", avail_mem_kb, "kB available RAM and",
-              num_cpus, "CPUs")
-        args.append("-j%i" % jobs)
-
         if self._config.command_line_args:
             args = self._config.command_line_args
 

--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -17,6 +17,10 @@ ignore-patterns=
 # pygtk.require().
 init-hook='import gi.overrides, os; gi.overrides.__path__[0:0] = (os.environ["ANACONDA_WIDGETS_OVERRIDES"].split(":") if "ANACONDA_WIDGETS_OVERRIDES" in os.environ else [])'
 
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=0
+
 # Control the amount of potential inferred values when inferring a single
 # object. This can help the performance when dealing with large functions or
 # complex, nested conditions.


### PR DESCRIPTION
With current astroid 2.4.2, pylint requires a ginormous amount of
memory. Apply the recent fix during container build, until a newer
version gets released.

Revert the hack from commit 283561559b0 and go back to pylint
auto-selecting the number of jobs based on number of CPUs.

Backported from master PR #3018
    
Related: rhbz#1885635