### PR TITLE
Fix CDN button visibility (Backport to RHEL to fix CentOS stream)

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.glade
+++ b/pyanaconda/ui/gui/spokes/installation_source.glade
@@ -633,9 +633,9 @@
                             <child>
                               <object class="GtkRadioButton" id="cdnRadioButton">
                                 <property name="label" translatable="yes" context="GUI|Software Source">Red Hat _CDN</property>
-                                <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="no_show_all">True</property>
                                 <property name="margin_left">12</property>
                                 <property name="use_underline">True</property>
                                 <property name="xalign">0</property>

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -854,9 +854,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
     def _initialize(self):
         threadMgr.wait(constants.THREAD_PAYLOAD)
 
-        # If there is no Subscriptiopn DBus module, disable the CDN radio button
+        # If there is the Subscriptiopn DBus module, make the CDN radio button visible
         if is_module_available(SUBSCRIPTION):
-            gtk_call_once(self._cdn_button.set_no_show_all, True)
+            gtk_call_once(self._cdn_button.set_no_show_all, False)
 
         # Get the current source.
         source_proxy = self.payload.get_source_proxy()


### PR DESCRIPTION
Only show the Red Hat CDN button if the Subscription
module appears to be running. To achieve that, we do
the same thing as with the HMC button - the CDN
button invisible by default. And enable it only if it
looks like the Subscription module is running.