### PR TITLE
Lower geolocation connection timeout to 5 seconds (#1774873)

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -141,9 +141,13 @@ GEOLOC_GEOCODER_NOMINATIM = "geocoder_nominatim"
 # default providers
 GEOLOC_DEFAULT_PROVIDER = GEOLOC_PROVIDER_FEDORA_GEOIP
 GEOLOC_DEFAULT_GEOCODER = GEOLOC_GEOCODER_NOMINATIM
-# timeout (in seconds)
+# how long should the GUI wait for the geolocation thread to finish (in seconds)
+# - GUI starts this count once it finishes its initialization
+# - the geoloc thread is started early and in most cases will be already done
+#   when GUI finishes its initialization, so no delays will be introduced
 GEOLOC_TIMEOUT = 3
-
+# timeout for the network connection used for geolocation (in seconds)
+GEOLOC_CONNECTION_TIMEOUT = 5
 
 ANACONDA_ENVIRON = "anaconda"
 FIRSTBOOT_ENVIRON = "firstboot"

--- a/pyanaconda/geoloc.py
+++ b/pyanaconda/geoloc.py
@@ -475,7 +475,7 @@ class FedoraGeoIPProvider(GeolocationBackend):
     def _refresh(self):
         try:
             reply = self._session.get(self.API_URL,
-                                      timeout=constants.NETWORK_CONNECTION_TIMEOUT,
+                                      timeout=constants.GEOLOC_CONNECTION_TIMEOUT,
                                       verify=True)
             if reply.status_code == requests.codes.ok:
                 json_reply = reply.json()
@@ -513,7 +513,7 @@ class HostipGeoIPProvider(GeolocationBackend):
     def _refresh(self):
         try:
             reply = self._session.get(self.API_URL,
-                                      timeout=constants.NETWORK_CONNECTION_TIMEOUT,
+                                      timeout=constants.GEOLOC_CONNECTION_TIMEOUT,
                                       verify=True)
             if reply.status_code == requests.codes.ok:
                 reply_dict = reply.json()


### PR DESCRIPTION
Lower the connection timeout to 5 seconds as the GUI will wait
only up to 3 seconds for the geolocation thread to finish anyway.

Up till now we used the Anaconda default timeout, which is 45 seconds.
Apparently the actual waiting time could be up to 2x the timeout value,
so 45 seconds was far too long.

Resolves: rhbz#1774873