### PR TITLE
Define the updates repositories in the Anaconda configuration files (#1642513)

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -64,8 +64,8 @@ default_environment =
 # List of ignored packages.
 ignored_packages =
 
-# Enable installation of latest updates.
-enable_updates = True
+# Names of repositories that provide latest updates.
+updates_repositories =
 
 # List of .treeinfo variant types to enable.
 # Valid items:

--- a/data/product.d/fedora.conf
+++ b/data/product.d/fedora.conf
@@ -20,5 +20,10 @@ default_help_pages =
 
 [Payload]
 default_source = CLOSEST_MIRROR
+
 default_rpm_gpg_keys =
     /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+
+updates_repositories =
+    updates
+    updates-modular

--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -33,7 +33,6 @@ ignored_packages =
     btrfs-progs
     dmraid
 
-enable_updates = False
 enable_closest_mirror = False
 default_source = CDN
 

--- a/data/product.d/scientific-linux.conf
+++ b/data/product.d/scientific-linux.conf
@@ -20,8 +20,11 @@ kickstart_modules =
     org.fedoraproject.Anaconda.Modules.Services
 
 [Payload]
-enable_updates = True
 default_source = CLOSEST_MIRROR
+
+updates_repositories =
+    updates
+    updates-modular
 
 [User Interface]
 default_help_pages =

--- a/pyanaconda/core/configuration/payload.py
+++ b/pyanaconda/core/configuration/payload.py
@@ -41,16 +41,17 @@ class PayloadSection(Section):
         return self._get_option("ignored_packages", str).split()
 
     @property
-    def enable_updates(self):
-        """Enable installation of latest updates.
+    def updates_repositories(self):
+        """List of names of repositories that provide latest updates.
 
-        This flag controls whether or not Anaconda should provide an option to
-        install the latest updates during installation source selection.
+        This option also controls whether or not Anaconda should provide
+        an option to install the latest updates during installation source
+        selection.
 
-        The installation of latest updates is selected by default, if the closest
-        mirror is selected, and the "updates" repo is enabled.
+        The installation of latest updates is selected by default, if
+        the closest mirror is selected, and the "updates" repo is enabled.
         """
-        return self._get_option("enable_updates", bool)
+        return self._get_option("updates_repositories", str).split()
 
     @property
     def enabled_repositories_from_treeinfo(self):

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -61,10 +61,6 @@ DEFAULT_REPOS = [productName.split('-')[0].lower(),
                  "rawhide",
                  "BaseOS"]
 
-# Get list of repo names which should be used as updates repos
-DEFAULT_UPDATE_REPOS = ["updates",
-                        "updates-modular"]
-
 DBUS_ANACONDA_SESSION_ADDRESS = "DBUS_ANACONDA_SESSION_BUS_ADDRESS"
 
 ANACONDA_BUS_CONF_FILE = "/usr/share/anaconda/dbus/anaconda-bus.conf"

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -768,10 +768,10 @@ class DNFPayload(Payload):
 
         # Enable or disable updates.
         if self._updates_enabled:
-            for repo in constants.DEFAULT_UPDATE_REPOS:
+            for repo in conf.payload.updates_repositories:
                 self.enable_repo(repo)
         else:
-            for repo in constants.DEFAULT_UPDATE_REPOS:
+            for repo in conf.payload.updates_repositories:
                 self.disable_repo(repo)
 
         # Disable updates-testing.

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1085,7 +1085,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
             uncheck it.
         """
         self._updates_box.set_sensitive(self._mirror_active())
-        active = self._mirror_active() or self.payload.is_repo_enabled("updates")
+        active = self._mirror_active() and self.payload.is_repo_enabled("updates")
         self._updates_radio_button.set_active(active)
 
     @property
@@ -1646,10 +1646,8 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
 
     def on_updatesRadioButton_toggled(self, button):
         """Toggle the enable state of the updates repo."""
-        if self._updates_radio_button.get_active():
-            self.payload.set_updates_enabled(False)
-        else:
-            self.payload.set_updates_enabled(True)
+        active = self._updates_radio_button.get_active()
+        self.payload.set_updates_enabled(active)
 
         # Refresh the metadata using the new set of repos
         self._updates_change = True

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -775,7 +775,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         self._network_button.connect("toggled", self._update_url_entry_check)
 
         # Show or hide the updates option based on the configuration
-        if conf.payload.enable_updates:
+        if conf.payload.updates_repositories:
             really_show(self._updates_box)
         else:
             really_hide(self._updates_box)


### PR DESCRIPTION
Replace the enable_updates configuration option with the updates_repositories
configuration option. Installation of latest updates will be enabled if there
are some updates repositories defined in the configuration files.

Resolves: rhbz#1642513