### PR TITLE
Change the default_partitioning option (#1887370)

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -152,13 +152,19 @@ allow_imperfect_devices = False
 file_system_type =
 
 # Default partitioning.
-# Valid values:
+# Specify a mount point and its attributes on each line.
 #
-#   SERVER          Choose partitioning for servers.
-#   WORKSTATION     Choose partitioning for workstations.
-#   VIRTUALIZATION  Choose partitioning for virtualizations.
+# Valid attributes:
 #
-default_partitioning = WORKSTATION
+#   size <SIZE>    The size of the mount point.
+#   min <MIN_SIZE> The size will grow from MIN_SIZE to MAX_SIZE.
+#   max <MAX_SIZE> The max size is unlimited by default.
+#   free <SIZE>    The required available space.
+#
+default_partitioning =
+    /     (min 1 GiB, max 70 GiB)
+    /home (min 500 MiB, free 50 GiB)
+    swap
 
 # Default partitioning scheme.
 # Valid values:

--- a/data/product.d/fedora-atomic-host.conf
+++ b/data/product.d/fedora-atomic-host.conf
@@ -13,7 +13,9 @@ check_supported_locales = True
 
 [Storage]
 file_system_type = xfs
-default_partitioning = SERVER
+default_partitioning =
+    /    (min 2 GiB, max 15 GiB)
+    swap
 
 [User Interface]
 custom_stylesheet = /usr/share/anaconda/pixmaps/atomic/fedora-atomic.css

--- a/data/product.d/fedora-server.conf
+++ b/data/product.d/fedora-server.conf
@@ -12,7 +12,9 @@ default_environment = server-product-environment
 
 [Storage]
 file_system_type = xfs
-default_partitioning = SERVER
+default_partitioning =
+    /    (min 2 GiB, max 15 GiB)
+    swap
 
 [User Interface]
 custom_stylesheet = /usr/share/anaconda/pixmaps/server/fedora-server.css

--- a/data/product.d/ovirt.conf
+++ b/data/product.d/ovirt.conf
@@ -7,8 +7,15 @@ product_name = oVirt Node Next
 product_name = CentOS Linux
 
 [Storage]
-default_partitioning = VIRTUALIZATION
 default_scheme = LVM_THINP
+default_partitioning =
+    /              (min 6 GiB)
+    /home          (size 1 GiB)
+    /tmp           (size 1 GiB)
+    /var           (size 15 GiB)
+    /var/log       (size 8 GiB)
+    /var/log/audit (size 2 GiB)
+    swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP

--- a/data/product.d/rhev.conf
+++ b/data/product.d/rhev.conf
@@ -7,8 +7,15 @@ product_name = Red Hat Virtualization
 product_name = Red Hat Enterprise Linux
 
 [Storage]
-default_partitioning = VIRTUALIZATION
 default_scheme = LVM_THINP
+default_partitioning =
+    /              (min 6 GiB)
+    /home          (size 1 GiB)
+    /tmp           (size 1 GiB)
+    /var           (size 15 GiB)
+    /var/log       (size 8 GiB)
+    /var/log/audit (size 2 GiB)
+    swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP

--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
@@ -16,138 +16,20 @@
 # Red Hat, Inc.
 #
 from blivet.partitioning import do_partitioning, grow_lvm
-from blivet.size import Size
 from blivet.static_data import luks_data
 
 from pyanaconda.anaconda_loggers import get_module_logger
-from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.configuration.storage import PartitioningType
 from pyanaconda.modules.common.structures.partitioning import PartitioningRequest
 from pyanaconda.modules.storage.partitioning.automatic.noninteractive_partitioning import \
     NonInteractivePartitioningTask
 from pyanaconda.modules.storage.partitioning.automatic.utils import get_candidate_disks, \
     schedule_implicit_partitions, schedule_volumes, schedule_partitions, get_pbkdf_args, \
-    get_disks_for_implicit_partitions
-from pyanaconda.modules.storage.platform import platform
-from pyanaconda.modules.storage.partitioning.specification import PartSpec
+    get_disks_for_implicit_partitions, get_default_partitioning
 from pyanaconda.core.storage import suggest_swap_size
 
 log = get_module_logger(__name__)
 
 __all__ = ["AutomaticPartitioningTask"]
-
-
-SERVER_PARTITIONING = [
-    PartSpec(
-        mountpoint="/",
-        size=Size("2GiB"),
-        max_size=Size("15GiB"),
-        grow=True,
-        btr=True,
-        lv=True,
-        thin=True,
-        encrypted=True
-    ),
-    PartSpec(
-        fstype="swap",
-        grow=False,
-        lv=True,
-        encrypted=True
-    )
-]
-
-WORKSTATION_PARTITIONING = [
-    PartSpec(
-        mountpoint="/",
-        size=Size("1GiB"),
-        max_size=Size("70GiB"),
-        grow=True,
-        btr=True,
-        lv=True,
-        thin=True,
-        encrypted=True),
-    PartSpec(
-        mountpoint="/home",
-        size=Size("500MiB"), grow=True,
-        required_space=Size("50GiB"),
-        btr=True,
-        lv=True,
-        thin=True,
-        encrypted=True),
-    PartSpec(
-        fstype="swap",
-        grow=False,
-        lv=True,
-        encrypted=True
-    )
-]
-
-VIRTUALIZATION_PARTITIONING = [
-    PartSpec(
-        mountpoint="/",
-        size=Size("6GiB"),
-        grow=True,
-        lv=True,
-        thin=True
-    ),
-    PartSpec(
-        mountpoint="/home",
-        size=Size("1GiB"),
-        lv=True,
-        thin=True
-    ),
-    PartSpec(
-        mountpoint="/tmp",
-        size=Size("1GiB"),
-        lv=True,
-        thin=True
-    ),
-    PartSpec(
-        mountpoint="/var",
-        size=Size("15GiB"),
-        lv=True,
-        thin=True
-    ),
-    PartSpec(
-        mountpoint="/var/log",
-        size=Size("8GiB"),
-        lv=True,
-        thin=True
-    ),
-    PartSpec(
-        mountpoint="/var/log/audit",
-        size=Size("2GiB"),
-        lv=True,
-        thin=True
-    ),
-    PartSpec(
-        fstype="swap",
-        grow=False,
-        lv=True,
-        encrypted=True
-    )
-]
-
-
-def get_default_partitioning(partitioning_type=None):
-    """Get the default partitioning requests.
-
-    :param partitioning_type: a type of the partitioning
-    :return: a list of partitioning specs
-    """
-    if not partitioning_type:
-        partitioning_type = conf.storage.default_partitioning
-
-    if partitioning_type is PartitioningType.SERVER:
-        return platform.set_default_partitioning() + SERVER_PARTITIONING
-
-    if partitioning_type is PartitioningType.WORKSTATION:
-        return platform.set_default_partitioning() + WORKSTATION_PARTITIONING
-
-    if partitioning_type is PartitioningType.VIRTUALIZATION:
-        return platform.set_default_partitioning() + VIRTUALIZATION_PARTITIONING
-
-    raise ValueError("Invalid partitioning type: {}".format(conf.storage.default_partitioning))
 
 
 class AutomaticPartitioningTask(NonInteractivePartitioningTask):

--- a/pyanaconda/modules/storage/partitioning/specification.py
+++ b/pyanaconda/modules/storage/partitioning/specification.py
@@ -135,3 +135,6 @@ class PartSpec(object):
 
     def __unicode__(self):
         return unicodeize(self._to_string())
+
+    def __eq__(self, other):
+        return isinstance(other, PartSpec) and vars(self) == vars(other)

--- a/tests/nosetests/pyanaconda_tests/configuration_test.py
+++ b/tests/nosetests/pyanaconda_tests/configuration_test.py
@@ -22,10 +22,13 @@ import tempfile
 import unittest
 from textwrap import dedent
 
+from blivet.size import Size
+
 from pyanaconda.core.configuration.anaconda import AnacondaConfiguration
 from pyanaconda.core.configuration.base import create_parser, read_config, write_config, \
     get_option, set_option, ConfigurationError, ConfigurationDataError, ConfigurationFileError, \
     Configuration
+from pyanaconda.core.configuration.storage import StorageSection
 from pyanaconda.modules.common.constants import services
 
 
@@ -313,3 +316,56 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
     def bootloader_test(self):
         conf = AnacondaConfiguration.from_defaults()
         self.assertIn("selinux", conf.bootloader.preserved_arguments)
+
+    def default_partitioning_test(self):
+        conf = AnacondaConfiguration.from_defaults()
+        self.assertEqual(conf.storage.default_partitioning, [
+            {
+                'name': '/',
+                'min': Size("1024 MiB"),
+                'max': Size("70 GiB"),
+            }, {
+                'name': '/home',
+                'min': Size("500 MiB"),
+                'free': Size("50 GiB"),
+            }, {
+                'name': 'swap',
+            }
+        ])
+
+    def convert_partitioning_test(self):
+        convert_line = StorageSection._convert_partitioning_line
+
+        self.assertEqual(convert_line("/ (min 1 GiB, max 2 GiB, free 20 GiB)"), {
+            "name": "/",
+            "min": Size("1 GiB"),
+            "max": Size("2 GiB"),
+            "free": Size("20 GiB")
+        })
+
+        self.assertEqual(convert_line("/home (size 1 GiB)"), {
+            "name": "/home",
+            "size": Size("1 GiB")
+        })
+
+        self.assertEqual(convert_line("swap"), {
+            "name": "swap"
+        })
+
+        with self.assertRaises(ValueError):
+            convert_line("")
+
+        with self.assertRaises(ValueError):
+            convert_line("(size 1 GiB)")
+
+        with self.assertRaises(ValueError):
+            convert_line("/home (size)")
+
+        with self.assertRaises(ValueError):
+            convert_line("/home (invalid 1 GiB)")
+
+        with self.assertRaises(ValueError):
+            convert_line("/home  (size 1 GiB, min 2 GiB)")
+
+        with self.assertRaises(ValueError):
+            convert_line("/home  (max 2 GiB)")

--- a/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_automatic_test.py
@@ -23,7 +23,6 @@ from unittest.mock import Mock, patch
 from blivet.formats.luks import LUKS2PBKDFArgs
 from blivet.size import Size
 
-from pyanaconda.core.configuration.storage import PartitioningType
 from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.modules.storage.partitioning.automatic.resizable_module import \
     ResizableDeviceTreeModule
@@ -44,7 +43,8 @@ from pyanaconda.modules.storage.partitioning.automatic.automatic_module import \
 from pyanaconda.modules.storage.partitioning.automatic.automatic_interface import \
     AutoPartitioningInterface
 from pyanaconda.modules.storage.partitioning.automatic.automatic_partitioning import \
-    AutomaticPartitioningTask, get_default_partitioning
+    AutomaticPartitioningTask
+from pyanaconda.modules.storage.partitioning.automatic.utils import get_default_partitioning
 from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
 from pyanaconda.modules.storage.devicetree import create_storage
 
@@ -245,18 +245,15 @@ class AutomaticPartitioningTaskTestCase(unittest.TestCase):
         self.assertEqual(pbkdf_args.iterations, 1000)
         self.assertEqual(pbkdf_args.time_ms, 100)
 
-    @patch('pyanaconda.modules.storage.partitioning.automatic.automatic_partitioning.platform')
+    @patch('pyanaconda.modules.storage.partitioning.automatic.utils.platform')
     def get_default_partitioning_test(self, platform):
         platform.set_default_partitioning.return_value = [PartSpec("/boot")]
+        requests = get_default_partitioning()
 
-        requests = get_default_partitioning(PartitioningType.WORKSTATION)
         self.assertEqual(["/boot", "/", "/home", None], [spec.mountpoint for spec in requests])
 
-        requests = get_default_partitioning(PartitioningType.SERVER)
-        self.assertEqual(["/boot", "/", None], [spec.mountpoint for spec in requests])
-
     @patch('pyanaconda.modules.storage.partitioning.automatic.automatic_partitioning.suggest_swap_size')
-    @patch('pyanaconda.modules.storage.partitioning.automatic.automatic_partitioning.platform')
+    @patch('pyanaconda.modules.storage.partitioning.automatic.utils.platform')
     def get_partitioning_test(self, platform, suggest_swap_size):
         storage = create_storage()
 


### PR DESCRIPTION
Change the default_partitioning option of the Storage section in the Anaconda
configuration file. Instead of the identifier, specify a mount point and its
attributes on each line.

(cherry-picked from commits f6f373f,  b3d59e6, a58afad and 08093ad)

Resolves: rhbz#1887370