### PR TITLE
Fix the get_os_release_value function

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1506,5 +1506,5 @@ def get_os_release_value(name, sysroot=""):
             pass
 
     # No value found.
-    log.debug("%s not found in os-release files")
+    log.debug("%s not found in os-release files", name[:-1])
     return None

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1475,7 +1475,7 @@ class LazyObject(object):
         return setattr(self._object, name, value)
 
 
-def get_os_release_value(name, sysroot=""):
+def get_os_release_value(name, sysroot="/"):
     """Read os-release files and return a value of the specified parameter.
 
     :param name: a name of the parameter (for example, "VERSION_ID")

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -245,7 +245,7 @@ def iface_for_host_ip(host_ip):
     return route_info[route_info.index("dev") + 1]
 
 
-def copy_resolv_conf_to_root(root=""):
+def copy_resolv_conf_to_root(root="/"):
     """Copy resolv.conf to a system root."""
     src = "/etc/resolv.conf"
     dst = os.path.join(root, src.lstrip('/'))

--- a/tests/nosetests/pyanaconda_tests/core/util_test.py
+++ b/tests/nosetests/pyanaconda_tests/core/util_test.py
@@ -865,6 +865,14 @@ class MiscTests(unittest.TestCase):
             util.mkdirChain(root + "/usr/lib")
             util.mkdirChain(root + "/etc")
 
+            # no file
+            with self.assertLogs(level="DEBUG") as cm:
+                version = util.get_os_release_value("VERSION_ID", root)
+
+            msg = "VERSION_ID not found in os-release files"
+            self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+            self.assertEqual(version, None)
+
             # backup file only
             with open(root + "/usr/lib/os-release", "w") as f:
                 f.write("# blah\nVERSION_ID=foo256bar  \n VERSION_ID = wrong\n\n")


### PR DESCRIPTION
* Log the name of the parameter that wasn't found in the os-release files.
* Don't use an empty string as a system root.