### PR TITLE
Don't run the execute method in the kickstart installation in GUI by default

### DIFF
--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -215,8 +215,6 @@ class Spoke(object, metaclass=ABCMeta):
         self._payload = payload
         self.applyOnSkip = False
 
-        self.visitedSinceApplied = True
-
         # entry and exit signals
         # - get the hub instance as a single argument
         self.entered = Signal()

--- a/pyanaconda/ui/communication.py
+++ b/pyanaconda/ui/communication.py
@@ -33,6 +33,4 @@ hubQ = QueueFactory("hub")
 hubQ.addMessage("ready", 1)             # spoke_name
 hubQ.addMessage("not_ready", 1)         # spoke_name
 hubQ.addMessage("message", 2)           # spoke_name, string
-hubQ.addMessage("input", 1)             # string
 hubQ.addMessage("exception", 1)         # exception
-hubQ.addMessage("show_message", 3)      # show_message_function, args, result_queue

--- a/pyanaconda/ui/communication.py
+++ b/pyanaconda/ui/communication.py
@@ -30,7 +30,7 @@ from pyanaconda.queuefactory import QueueFactory
 # details.
 hubQ = QueueFactory("hub")
 
-hubQ.addMessage("ready", 2)             # spoke_name, justUpdate
+hubQ.addMessage("ready", 1)             # spoke_name
 hubQ.addMessage("not_ready", 1)         # spoke_name
 hubQ.addMessage("message", 2)           # spoke_name, string
 hubQ.addMessage("input", 1)             # string

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -182,13 +182,6 @@ class Hub(GUIObject, common.Hub):
                 self._updateCompleteness(spoke, update_continue=False)
                 spoke.selector.connect("button-press-event", self._on_spoke_clicked, spoke)
                 spoke.selector.connect("key-release-event", self._on_spoke_clicked, spoke)
-
-                # If this is a kickstart install, attempt to execute any provided ksdata now.
-                if flags.automatedInstall and spoke.ready and spoke.changed and \
-                   spoke.visitedSinceApplied:
-                    spoke.execute()
-                    spoke.visitedSinceApplied = False
-
                 selectors.append(spoke.selector)
 
             if not selectors:
@@ -346,15 +339,6 @@ class Hub(GUIObject, common.Hub):
                     else:
                         log.debug("kickstart installation, spoke %s is ready", spoke_title)
 
-                    # Spokes that were not initially ready got the execute call in
-                    # _createBox skipped.  Now that it's become ready, do it.  Note
-                    # that we also provide a way to skip this processing (see comments
-                    # communication.py) to prevent getting caught in a loop.
-                    if not args[1] and spoke.changed and spoke.visitedSinceApplied:
-                        log.debug("execute spoke from event loop %s", spoke.title.replace("_", ""))
-                        spoke.execute()
-                        spoke.visitedSinceApplied = False
-
                     if self.continuePossible:
                         if self._inSpoke:
                             self._autoContinue = False
@@ -431,14 +415,9 @@ class Hub(GUIObject, common.Hub):
         if not self._inSpoke:
             return
 
-        spoke.visitedSinceApplied = True
-
-        # Don't take visitedSinceApplied into account here.  It will always be
-        # True from the line above.
         if spoke.changed and (not spoke.skipTo or (spoke.skipTo and spoke.applyOnSkip)):
             spoke.apply()
             spoke.execute()
-            spoke.visitedSinceApplied = False
 
         spoke.exited.emit(spoke)
 

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -132,7 +132,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
     def apply(self):
         self.clear_errors()
-        hubQ.send_ready("StorageSpoke", True)
+        hubQ.send_ready("StorageSpoke")
 
     @property
     def indirect(self):

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -535,7 +535,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
                              _("Restoring hardware time..."))
             threadMgr.wait(constants.THREAD_TIME_INIT)
 
-        hubQ.send_ready(self.__class__.__name__, False)
+        hubQ.send_ready(self.__class__.__name__)
 
         # report that we are done
         self.initialize_done()

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -821,9 +821,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         hubQ.send_message(self.__class__.__name__, _(constants.PAYLOAD_STATUS_GROUP_MD))
 
     def _payload_finished(self):
-        hubQ.send_ready("SoftwareSelectionSpoke", False)
+        hubQ.send_ready("SoftwareSelectionSpoke")
         self._ready = True
-        hubQ.send_ready(self.__class__.__name__, False)
+        hubQ.send_ready(self.__class__.__name__)
 
     def _payload_error(self):
         self._error = True
@@ -836,7 +836,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
             self._error_msg += _(CLICK_FOR_DETAILS)
 
         self._ready = True
-        hubQ.send_ready(self.__class__.__name__, False)
+        hubQ.send_ready(self.__class__.__name__)
 
     def _initialize_closest_mirror(self):
         # If there's no fallback mirror to use, we should just disable that option
@@ -898,7 +898,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         # the spoke may not be set sensitive by _handleCompleteness in the hub.
         while not self.ready:
             time.sleep(1)
-        hubQ.send_ready(self.__class__.__name__, False)
+        hubQ.send_ready(self.__class__.__name__)
 
         # report that the source spoke has been initialized
         self.initialize_done()

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -401,7 +401,7 @@ class KeyboardSpoke(NormalSpoke):
     def _wait_ready(self):
         self._add_dialog.wait_initialize()
         self._ready = True
-        hubQ.send_ready(self.__class__.__name__, False)
+        hubQ.send_ready(self.__class__.__name__)
 
         # report that the keyboard spoke initialization has been completed
         self.initialize_done()

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -134,7 +134,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self._password_bar.add_offset_value("high", 4)
 
         # Send ready signal to main event loop
-        hubQ.send_ready(self.__class__.__name__, False)
+        hubQ.send_ready(self.__class__.__name__)
 
         # report that we are done
         self.initialize_done()
@@ -203,7 +203,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self.remove_placeholder_texts()
 
         # Send ready signal to main event loop
-        hubQ.send_ready(self.__class__.__name__, False)
+        hubQ.send_ready(self.__class__.__name__)
 
     @property
     def completed(self):

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -235,8 +235,8 @@ class SoftwareSelectionSpoke(NormalSpoke):
             self._error_msgs = None
             self._tx_id = self.payload.tx_id
         finally:
-            hubQ.send_ready(self.__class__.__name__, False)
-            hubQ.send_ready("SourceSpoke", False)
+            hubQ.send_ready(self.__class__.__name__)
+            hubQ.send_ready("SourceSpoke")
 
     @property
     def completed(self):
@@ -372,7 +372,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
             if not self._first_refresh():
                 return
 
-        hubQ.send_ready(self.__class__.__name__, False)
+        hubQ.send_ready(self.__class__.__name__)
 
         # If packages were provided by an input kickstart file (or some other means),
         # we should do dependency solving here.

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -235,7 +235,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         StorageCheckHandler.warnings = list(report.warning_messages)
 
         self._ready = True
-        hubQ.send_ready(self.__class__.__name__, True)
+        hubQ.send_ready(self.__class__.__name__)
 
     def _show_execute_message(self, msg):
         hubQ.send_message(self.__class__.__name__, msg)
@@ -485,7 +485,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             self.execute()
         else:
             self._ready = True
-            hubQ.send_ready(self.__class__.__name__, False)
+            hubQ.send_ready(self.__class__.__name__)
 
         # Report that the storage spoke has been initialized.
         self.initialize_done()

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -636,7 +636,7 @@ class SubscriptionSpoke(NormalSpoke):
         self._update_subscription_state()
 
         # Send ready signal to main event loop
-        hubQ.send_ready(self.__class__.__name__, False)
+        hubQ.send_ready(self.__class__.__name__)
 
         # report that we are done
         self.initialize_done()
@@ -924,12 +924,12 @@ class SubscriptionSpoke(NormalSpoke):
             # enable controls
             self.set_registration_controls_sensitive(True)
             # notify hub
-            hubQ.send_ready(self.__class__.__name__, False)
+            hubQ.send_ready(self.__class__.__name__)
         else:
             # processing still ongoing, set the phase
             self.registration_phase = phase
             # notify hub
-            hubQ.send_ready(self.__class__.__name__, False)
+            hubQ.send_ready(self.__class__.__name__)
         # update spoke state
         self._update_registration_state()
 
@@ -947,7 +947,7 @@ class SubscriptionSpoke(NormalSpoke):
         # re-enable controls, so user can try again
         self.set_registration_controls_sensitive(True)
         # notify hub
-        hubQ.send_ready(self.__class__.__name__, False)
+        hubQ.send_ready(self.__class__.__name__)
 
     def _get_status_message(self):
         """Get status message describing current spoke state.

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -100,7 +100,7 @@ class AdvancedUserDialog(GUIObject, GUIDialogInputCheckHandler):
         # Validate the group input box
         self.add_check(self._tGroups, self._validateGroups)
         # Send ready signal to main event loop
-        hubQ.send_ready(self.__class__.__name__, False)
+        hubQ.send_ready(self.__class__.__name__)
 
     @property
     def user(self):
@@ -159,7 +159,7 @@ class AdvancedUserDialog(GUIObject, GUIDialogInputCheckHandler):
         self.user.groups = [''.join(g.split()) for g in self._tGroups.get_text().split(",") if g]
 
         # Send ready signal to main event loop
-        hubQ.send_ready(self.__class__.__name__, False)
+        hubQ.send_ready(self.__class__.__name__)
 
     def run(self):
         self.window.show()


### PR DESCRIPTION
We always run the `execute` method from the `initialize` method of the spoke when
it is required. The `execute` method will be still called when we leave a spoke.

Call `hubQ.send_ready` without the `justUpdate` argument.
Remove unused `hubQ` messages.