### PR TITLE
Drop old WiFi & geocoding based geolocation support

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -135,12 +135,8 @@ THREAD_SUBSCRIPTION_SPOKE_INIT = "AnaSubscriptionSpokeInitThread"
 # - values are used by the geoloc CLI/boot option
 GEOLOC_PROVIDER_FEDORA_GEOIP = "provider_fedora_geoip"
 GEOLOC_PROVIDER_HOSTIP = "provider_hostip"
-GEOLOC_PROVIDER_GOOGLE_WIFI = "provider_google_wifi"
-# geocoding provider
-GEOLOC_GEOCODER_NOMINATIM = "geocoder_nominatim"
-# default providers
+# default provider
 GEOLOC_DEFAULT_PROVIDER = GEOLOC_PROVIDER_FEDORA_GEOIP
-GEOLOC_DEFAULT_GEOCODER = GEOLOC_GEOCODER_NOMINATIM
 # how long should the GUI wait for the geolocation thread to finish (in seconds)
 # - GUI starts this count once it finishes its initialization
 # - the geoloc thread is started early and in most cases will be already done

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -26,7 +26,6 @@ class AnacondaLintConfig(CensorshipConfig):
             FalsePositive(r"^E1101.*: Instance of 'KickstartSpecificationHandler' has no '.*' member$"),
             FalsePositive(r"^E1101.*: FedoraGeoIPProvider._refresh: Instance of 'LookupDict' has no 'ok' member"),
             FalsePositive(r"^E1101.*: HostipGeoIPProvider._refresh: Instance of 'LookupDict' has no 'ok' member"),
-            FalsePositive(r"^E1101.*: Geocoder._reverse_geocode_nominatim: Instance of 'LookupDict' has no 'ok' member"),
 
             # TODO: BlockDev introspection needs to be added to pylint to handle these
             FalsePositive(r"E1101.*: Instance of 'int' has no 'dasd_is_fba' member"),


### PR DESCRIPTION
This code was developed in the initial stages of geolocation
support in Anaconda with the aim of providing an alternative
to purely IP based territory & timezone determination.

In was considered a prototype back then and was never documented as
something you can enable via the inst.geoloc boot option.

In the end we never did get to making the code production ready
while the IP based geolocation worked fine. Also all the WiFi
location and geocoding API URLs no longer work anyway.

So lets drop that old code & cleanup the docstrings a bit when we are at it.