### PR TITLE
Fixup category sorting

### DIFF
--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -665,7 +665,7 @@ def collectCategoriesAndSpokes(paths, klass):
     ret = {}
     # Collect all the categories this hub displays, then collect all the
     # spokes belonging to all those categories.
-    categories = sorted(collect_categories(paths["categories"]), key=lambda c: c.get_sort_order())
+    categories = collect_categories(paths["categories"])
 
     for c in categories:
         ret[c] = collect_spokes(paths["spokes"], c.__name__)
@@ -701,4 +701,4 @@ def sort_categories(categories):
     :param categories: list of categories
     :type categories: SpokeCategory sub classes
     """
-    return sorted(categories, key=lambda i: (i.get_sort_order(), i.__class__))
+    return sorted(categories, key=lambda i: (i.get_sort_order(), i.__name__))

--- a/tests/nosetests/pyanaconda_tests/ui/common_code_tests.py
+++ b/tests/nosetests/pyanaconda_tests/ui/common_code_tests.py
@@ -63,7 +63,7 @@ class CommonCodeTestCase(unittest.TestCase):
     def category_sorting_test(self):
         """Test category sorting works as expected."""
 
-        category_list = [AaaCategory, BbbCategory, CccCategory]
+        category_list = [BbbCategory, CccCategory, AaaCategory]
         # We expect the C category to be dorted first due to sort order and
         # then A & B as they have the same sort order but A comes before B
         # on the alphabet.


### PR DESCRIPTION
Turns out the category sorting code is wrong
(as categories are classes, not class instances :P)
yet it still manages to provide the expected output,
so this incorrect behavior is not readily apparent.

Thanks vponcova for spotting this! :)

Also when we are at it drop apparently unnecessary sorting
of categories in the collect function and fixup the unit test.
Make sure the input is not sorted in the expected order and
move the test to the appropriate sub folder.