### PR TITLE
Fix missing inst. prefixes for bootloader options in documentation

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -648,19 +648,19 @@ See the |anacondalogging|_ for more info on setting up logging via virtio.
 Boot loader options
 -------------------
 
-.. extlinux:
+.. inst.extlinux:
 
-extlinux
-^^^^^^^^
+inst.extlinux
+^^^^^^^^^^^^^
 
 Use extlinux as the bootloader. Note that there's no attempt to validate that
 this will work for your platform or anything; it assumes that if you ask for it,
 you want to try.
 
-.. leavebootorder:
+.. inst.leavebootorder:
 
-leavebootorder
-^^^^^^^^^^^^^^
+inst.leavebootorder
+^^^^^^^^^^^^^^^^^^^
 
 Boot the drives in their existing order, to override the default of booting into
 the newly installed drive on Power Systems servers and EFI systems. This is


### PR DESCRIPTION
We want to disable options without the 'inst.' prefix so our documentation should be correct.