### PR TITLE
Disable the debug solver debugging

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -71,7 +71,6 @@ class DNFManager(object):
         base.conf.cachedir = DNF_CACHE_DIR
         base.conf.pluginconfpath = DNF_PLUGINCONF_DIR
         base.conf.logdir = '/tmp/'
-        base.conf.debug_solver = conf.anaconda.debug
         base.conf.releasever = get_product_release_version()
         base.conf.installroot = conf.target.system_root
         base.conf.prepend_installroot('persistdir')

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_manager_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_manager_test.py
@@ -70,7 +70,6 @@ class DNFMangerTestCase(unittest.TestCase):
             "cachedir = /tmp/dnf.cache",
             "pluginconfpath = /tmp/dnf.pluginconf",
             "logdir = /tmp/",
-            "debug_solver = 0",
         )
         self._check_configuration(
             "installroot = /mnt/sysroot",


### PR DESCRIPTION
Never automatically enable the DNF debug solver debugging. It slows down the
installation and blocks the main thread, so the UI freezes for tens of seconds.
The debugging can be easily enabled with an updates image or we can introduce
a new option for that.