### PR TITLE
Stop trying to set the default hostname

### DIFF
--- a/pyanaconda/modules/network/installation.py
+++ b/pyanaconda/modules/network/installation.py
@@ -62,7 +62,7 @@ class HostnameConfigurationTask(Task):
     def run(self):
         _write_config_file(
             self._sysroot, self.HOSTNAME_CONF_FILE_PATH,
-            "{}\n".format(self._hostname),
+            "{}\n".format(self._hostname or ""),
             "Cannot write hostname configuration file",
             self._overwrite
         )

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -61,7 +61,7 @@ class NetworkService(KickstartService):
         self._firewall_module = FirewallModule()
 
         self.hostname_changed = Signal()
-        self._hostname = "localhost.localdomain"
+        self._hostname = None
 
         self.current_hostname_changed = Signal()
         self._hostname_service_proxy = None

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -250,7 +250,7 @@ def prompt_for_ssh(options):
         hinfo = socket.gethostbyaddr(ipstr)
     except socket.herror as e:
         stdout_log.debug("Exception caught trying to get host name of %s: %s", ipstr, e)
-        name = network.get_hostname()
+        name = socket.gethostname()
     else:
         if len(hinfo) == 3:
             name = hinfo[0]


### PR DESCRIPTION
Not tested. I'd like to make a change along the following lines:

If the user configured a hostname, then great, let's use it. If not,
let's just do nothing. This is totally appropriate, we know that
systemd sets some hostname when the machine is booted and we can just
keep using it.

In https://github.com/rhinstaller/anaconda/pull/643:
> To prevent fallouts from changed behaviour, we keep writing out
> /etc/hostname even when static hostname is not configured - using
> value "localhost.localdomain". In this case target system still
> applies transient hostname (same as if we didn't write
> /etc/hostname). I bet there is something relying on /etc/hostname
> existing after installation.

I want to drop this behaviour from systemd since it's just pointless
complicated. All the layers of guesswork mean that the whole system is
frozen in place. Instead of trying to second-guess the user and figure
out if the hostname was configured by the user or not based on the
specific string used, let's just write the config file only when the
user specifies a hostname.