### PR TITLE
network: fix double-free using libnm function filter_connections()

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -485,10 +485,16 @@ class NetworkControlBox(GObject.GObject):
             dialog.refresh(device_name)
             dialog.run()
 
+    def _device_filter_connections(self, device, connections):
+        return [c for c in connections if device.connection_valid(c)]
+
+    def _ap_filter_connections(self, ap, connections):
+        return [c for c in connections if ap.connection_valid(c)]
+
     def _get_the_only_wireless_connection(self, device):
         con_uuid = con_ssid = ""
         if device:
-            cons = device.filter_connections(self.client.get_connections())
+            cons = self._device_filter_connections(device, self.client.get_connections())
             if len(cons) == 1:
                 connection = cons[0]
                 con_uuid = connection.get_setting_connection().get_uuid()
@@ -1185,7 +1191,7 @@ class ConfigureWirelessNetworksDialog(GUIObject):
             log.warnig("device for interface %s not found", device)
             return
 
-        cons = device.filter_connections(self._nm_client.get_connections())
+        cons = self._device_filter_connections(device, self._nm_client.get_connections())
 
         # Update model
         self._store.clear()
@@ -1384,7 +1390,8 @@ class SelectWirelessNetworksDialog(GUIObject):
         if not ap:
             return
 
-        cons = ap.filter_connections(device.filter_connections(self._nm_client.get_connections()))
+        cons = self._device_filter_connections(device, self._nm_client.get_connections())
+        cons = self._ap_filter_connections(ap, cons)
         if cons:
             con = cons[0]
             self._nm_client.activate_connection_async(con, device, ap.get_path(), None)


### PR DESCRIPTION
The libnm functions `nm_{device,access_pointer}_filter_connections()`
return ownership of a newly create GPtrArray, which also owns the
content by having the `g_ptr_array_set_free_func()` function set to
`g_object_unref()`.

Consequently, this functions should be annotate with "(transfer
container)" or "(transfer full)", but various bindings treat that
differently. To make pygobject happy, it would require "(transfer
container)", but that breaks vala (and vice versa).

This leads to a double-free and a crash in anaconda.

This is not really fixable in libnm. But the workaround is simple.
Let's just not use these functions.

See-also: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/b012877445bddd772eec79e3ce38f93cc40de720
See-also: https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/305

https://bugzilla.redhat.com/show_bug.cgi?id=1847868
https://bugzilla.redhat.com/show_bug.cgi?id=1873561


---

it was easy to reproduce the crash, especially when using https://copr.fedorainfracloud.org/coprs/networkmanager/NetworkManager-CI-master/, which has more assertions enabled. With this patch, I couldn't reproduce the crash anymore... but I still ran into other issues. So it is not clear to me whether this patch completely fixes all libnm related issues. What is also strange, is that this problem should exist at least since NetworkManager 1.16.0 (March 2019). Dunno why this was not discovered earlier...