### PR TITLE
Build real boot.iso for /kickstart-tests runs

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -113,7 +113,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: 'logs-${{ matrix.scenario }}'
+          name: 'logs'
           # skip the /anaconda subdirectories, too large
           path: |
             kickstart-tests/data/logs/kstest.log

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -88,12 +88,6 @@ jobs:
           git log --oneline -1 origin/master
           git rebase origin/master
 
-      # FIXME: build a complete boot.iso with lorax/osbuild
-      - name: Build updates.img
-        run: |
-          scripts/makeupdates
-          gzip -cd updates.img | cpio -tv
-
       - name: Check out kickstart-tests
         uses: actions/checkout@v2
         with:
@@ -101,13 +95,51 @@ jobs:
           path: kickstart-tests
 
       - name: Ensure http proxy is running
+        run: sudo kickstart-tests/containers/squid.sh start
+
+      # This is really fast, but does not catch file removals or dracut changes
+      # maybe this becomes opt-in via a magic comment for efficiency reasons?
+      # if you use this, add `--updates ../updates.img` to the launch command line below
+      #- name: Build updates.img
+      #  run: |
+      #    scripts/makeupdates
+      #    gzip -cd updates.img | cpio -tv
+
+      - name: Build boot.iso from Rawhide and this branch
         run: |
-          [ -n "$(sudo podman ps -q -f 'name=^squid$')" ] || sudo kickstart-tests/containers/squid.sh start
+          mkdir -p kickstart-tests/data/images
+          # HACK: lorax and podman overlayfs really hate each other: https://bugzilla.redhat.com/show_bug.cgi?id=1906364
+          sudo podman run -i --rm --privileged --storage-driver=vfs --root /tmp/podman-vfs -v `pwd`:/source:ro -v `pwd`/kickstart-tests/data/images:/images:z fedora:rawhide <<EOF
+          set -eux
+          # /source from host is read-only, build in a copy
+          cp -a /source/ /tmp/
+          cd /tmp/source
+
+          # install build dependencies and lorax
+          ./scripts/testing/install_dependencies.sh -y
+          dnf install -y createrepo_c lorax
+
+          # build RPMs and repo for it; bump version so that it's higher than rawhide's
+          sed -ri '/AC_INIT/ s/\[[0-9.]+\]/[999999999]/' configure.ac
+          ./autogen.sh
+          ./configure
+          make rpms
+          createrepo_c result/build/01-rpm-build/
+
+          # build boot.iso with our rpms
+          . /etc/os-release
+          lorax -p Fedora -v \$VERSION_ID -r \$VERSION_ID -s http://pubmirror2.math.uh.edu/fedora-buffet/fedora/linux/development/rawhide/Everything/x86_64/os/ -s file://\$PWD/result/build/01-rpm-build/ lorax
+          cp lorax/images/boot.iso /images/
+          EOF
+
+      - name: Clean up after podman/lorax hack
+        if: always()
+        run: sudo rm -rf /tmp/podman-vfs
 
       - name: Run kickstart tests with ${{ needs.pr-info.outputs.launch_args }} in container
         working-directory: kickstart-tests
         run: |
-          sudo TEST_JOBS=16 containers/runner/launch --skip-testtypes 'rhel-only,knownfailure' --updates ../updates.img ${{ needs.pr-info.outputs.launch_args }}
+          sudo TEST_JOBS=16 containers/runner/launch --skip-testtypes 'rhel-only,knownfailure' ${{ needs.pr-info.outputs.launch_args }}
 
       - name: Collect logs
         if: always()


### PR DESCRIPTION
Using an updates.img is really fast, but does not catch changes to
dracut or file removals. So move to building a boot.iso from Rawhide and
locally built anaconda RPMs, and using that.

Do the lorax build *after* checking out kickstart-tests and starting the
squid container, so that lorax already benefits from the HTTP caching
and seeds the cache for the subsequent kickstart tests.

Keep the old updates.img build in a comment, as that may come in handy
in the future -- we may want to control that via the magic comment to
select between fast and thorough?

-----

As before, I tested this on my test org on a [deliberate failure](https://github.com/mpitt-test-org/anaconda/pull/2), which proves that it's really using the new code; and on a [successful run](https://github.com/mpitt-test-org/anaconda/pull/1) which proves that all the boot.iso/kickstart-tests plumbing is working.

This adds 8 minutes to the test run to build boot.iso. This is certainly not a small price compared to the 15 mins that an average set of kicktart-tests needs, but it may be worth the trouble. Also, as explained in the commit message, there's always the option to select between the two approaches if we want that.