### PR TITLE
Use Linux HOST_NAME_MAX hostname length limit

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -109,8 +109,8 @@ def is_valid_hostname(hostname, local=False):
     if not hostname:
         return (False, _("Host name cannot be None or an empty string."))
 
-    if len(hostname) > 255:
-        return (False, _("Host name must be 255 or fewer characters in length."))
+    if len(hostname) > 64:
+        return (False, _("Host name must be 64 or fewer characters in length."))
 
     if local and hostname[-1] == ".":
         return (False, _("Local host name must not end with period '.'."))

--- a/tests/nosetests/pyanaconda_tests/network_test.py
+++ b/tests/nosetests/pyanaconda_tests/network_test.py
@@ -32,10 +32,6 @@ class NetworkTests(unittest.TestCase):
         self.assertTrue(network.is_valid_hostname("h"*63)[0])
         self.assertFalse(network.is_valid_hostname("h"*64)[0])
 
-        # length < 256
-        self.assertTrue(network.is_valid_hostname("section." * 31+"section")[0])
-        self.assertFalse(network.is_valid_hostname("section." * 31+"sectionx")[0])
-
         self.assertFalse(network.is_valid_hostname(
             "section.must.be..nonempty.")[0])
         self.assertFalse(network.is_valid_hostname(


### PR DESCRIPTION
Linux defines HOST_NAME_MAX is 64, so an error was reported when hostname was set more than 64 characters in anaconda.