### PR TITLE
Add support to run RPM tests in a container

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,6 +91,9 @@ CI_TAG ?= $(GIT_BRANCH)
 CI_TEST_ARGS ?= --rm -v $(srcdir):/anaconda:Z
 CI_CMD ?= make ci
 
+# --build-rpm will be processed by run-build-and-arg script to build rpm before command execution
+RPM_TEST_CMD ?= --build-rpms make run-rpm-tests-only
+
 SKIP_BRANCHING_CHECK ?= "false"
 
 # If translations are present, run tests on the .po files before tarring them
@@ -236,6 +239,9 @@ ci:
 
 container-ci:
 	$(CONTAINER_ENGINE) run --entrypoint /anaconda/dockerfile/anaconda-ci/run-build-and-arg $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) $(CI_NAME):$(CI_TAG) $(CI_CMD)
+
+container-rpm-tests:
+	$(CONTAINER_ENGINE) run --entrypoint /anaconda/dockerfile/anaconda-ci/run-build-and-arg $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) $(CI_NAME):$(CI_TAG) $(RPM_TEST_CMD)
 
 container-shell:
 	$(CONTAINER_ENGINE) run -it $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) $(CI_NAME):$(CI_TAG)

--- a/dockerfile/anaconda-ci/run-build-and-arg
+++ b/dockerfile/anaconda-ci/run-build-and-arg
@@ -19,5 +19,11 @@ copy_logs() {
 }
 trap copy_logs EXIT INT QUIT PIPE
 
+if [ $1 == "--build-rpms" ]; then
+    make rpms
+    dnf install -y result/build/01-rpm-build/*.rpm
+    shift 1
+fi
+
 # run user-supplied command (by default, `make ci`)
 $@

--- a/tests/rpm_tests.sh
+++ b/tests/rpm_tests.sh
@@ -5,4 +5,4 @@ if [ $# -eq 0 ] && [ -z $RPM_TESTS_ARGS ]; then
     set -- "${top_srcdir}"/tests/rpm_tests
 fi
 
-exec nosetests-3 -v --exclude=logpicker -a \!acceptance,\!slow $RPM_TESTS_ARGS "$@"
+exec python3 -m nose -v --exclude=logpicker -a \!acceptance,\!slow $RPM_TESTS_ARGS "$@"


### PR DESCRIPTION
This new  make command will do this:

- build RPM files in a container
- run rpm-tests
- test installation of these RPM files

This commit is extending run-build-and-arg script because it's not reasonably
possible to put multiple commands from Makefile in the podman. To avoid this
issue it's adding --build-rpms as first argument which when detected will build
RPM and test installation before the command execution.

Also fix issues that nosetests-3 executable is not available in the container.

*Related: rhbz#1885635*

This is first part of the ``rpm-test`` support for rhel-8. I won't be able to do more this year so more to come ;)