### PR TITLE
Remove 'firstboot --enable' from interactive defaults

### DIFF
--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -1,6 +1,5 @@
 # Kickstart defaults file for an interative install.
 # This is not loaded if a kickstart file is provided on the command line.
-firstboot --enable
 
 %anaconda
 # Default password policies


### PR DESCRIPTION
The first boot is enabled in anaconda.py for interactive installations,
so remove the redundant kickstart command 'firstboot --enable' from
the interactive-defaults.ks file.