### PR TITLE
Define container for running rpm-tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -58,11 +58,6 @@ jobs:
 
   rpm-tests:
     runs-on: ubuntu-20.04
-    # start from a minimal container and install only our build deps; anaconda-ci container has too many other packages
-    container:
-      image: docker.io/fedora:rawhide
-      # HACK: bash's builtin `test -r` fails due to incompatible seccomp profile
-      options: --security-opt=seccomp=unconfined
     timeout-minutes: 30
     steps:
       - name: Clone repository
@@ -70,20 +65,24 @@ jobs:
         with:
           # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
-      - name: install build dependencies
-        run: ./scripts/testing/install_dependencies.sh -y
-
-      - name: build RPMs
+      - name: Rebase to current master
         run: |
-          ./autogen.sh
-          ./configure
-          make rpms
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git log --oneline -1 origin/master
+          git rebase origin/master
 
-      - name: run RPM tests
-        run: |
-          make run-rpm-tests-only || { cat tests/rpm_tests.log; exit 1; }
+      - name: Build RPM test container
+        run: make -f Makefile.am anaconda-rpm-build
 
-      - name: test installability
-        run: |
-          dnf install -y result/build/01-rpm-build/*.rpm
+      - name: Run RPM tests in container
+        run: make -f Makefile.am container-rpm-test
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'logs-rpm-test'
+          path: test-logs/*

--- a/Makefile.am
+++ b/Makefile.am
@@ -88,7 +88,9 @@ CONTAINER_REGISTRY ?= quay.io
 
 # anaconda-ci container
 CI_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-ci
+RPM_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-rpm
 CI_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-ci
+RPM_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-rpm
 CI_TAG := $(or $(CI_TAG),$(GIT_BRANCH))
 CI_TEST_ARGS ?= --rm -v $(srcdir):/anaconda:Z
 CI_CMD ?= make ci
@@ -178,6 +180,9 @@ anaconda-ci-build:
 anaconda-ci-push:
 	$(CONTAINER_ENGINE) push $(CI_NAME):$(CI_TAG)
 
+anaconda-rpm-build:
+	$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_ARGS) -t $(RPM_NAME):$(CI_TAG) $(RPM_DOCKERFILE)
+
 bumpver: po-pull
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \
 	if [ ! -z "$(IGNORE)" ]; then \
@@ -232,6 +237,13 @@ container-ci:
 
 container-shell:
 	$(CONTAINER_ENGINE) run -it $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) $(CI_NAME):$(CI_TAG)
+
+container-rpm-test:
+	$(CONTAINER_ENGINE) run -it $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) -v $(CI_DOCKERFILE)/run-build-and-arg:/run-build-and-arg $(RPM_NAME):$(CI_TAG) sh -exc ' \
+	    /run-build-and-arg make rpms; \
+	    cd /tmp/anaconda; \
+	    make run-rpm-tests-only; \
+	    dnf install -y result/build/01-rpm-build/*.rpm'
 
 check-branching:
 # checking if branching can be finished and all the pieces are in place

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -1,0 +1,20 @@
+ARG image=docker.io/fedora:rawhide
+FROM ${image}
+LABEL maintainer=anaconda-list@redhat.com
+
+# On ELN, BaseOS+AppStream don't have all our build dependencies; this provides the "Everything" compose
+COPY ["eln.repo", "/etc/yum.repos.d"]
+
+# Prepare environment and install build dependencies
+RUN set -e; \
+  if grep -q VARIANT.*eln /etc/os-release; then sed -i 's/enabled=0/enabled=1/' /etc/yum.repos.d/eln.repo; fi; \
+  dnf update -y; \
+  dnf install -y \
+  curl \
+  /usr/bin/xargs \
+  rpm-build; \
+  curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/master/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
+  rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
+  mkdir /anaconda
+
+WORKDIR /anaconda

--- a/dockerfile/anaconda-rpm/eln.repo
+++ b/dockerfile/anaconda-rpm/eln.repo
@@ -1,0 +1,10 @@
+[fedora-eln-baseos]
+name=Fedora ELN - $basearch
+baseurl=https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/Everything/$basearch/os/
+enabled=0
+countme=1
+priority=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=0
+skip_if_unavailable=False

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -6,8 +6,8 @@ such as unit tests, rpm tests and translation tests.  All the tests will be run
 together if you follow the steps below.  For integration tests there is a
 separate repository kickstart-tests_ containing also tooling for running the tests.
 
-Run tests inside of container
------------------------------
+Run unit tests inside of container
+----------------------------------
 This is the primary and recommended way to run the tests.
 
 Right now only unit tests are supported by the container, not rpm-tests.
@@ -79,6 +79,17 @@ Please update your container from time to time to have newest dependencies.
 To do that, run `podman pull quay.io/rhinstaller/anaconda-ci:master` or build
 it locally again.
 
+Run rpm tests inside of container
+---------------------------------
+
+First, build the container image for running the test, as it does not yet get
+published to any registry::
+
+    make -f Makefile.am anaconda-rpm-build
+
+Then run the test in that container::
+
+    make -f Makefile.am container-rpm-test
 
 GitHub workflows
 ----------------


### PR DESCRIPTION
Define and document the  "anaconda-rpm" container similar to the
"anaconda-ci" one for running the RPM tests. We don't want to use the
anaconda-ci one as that has too many packages pre-installed, and thus we
would not detect missing dependencies.

Fix the workflow to rebase the branch to current master just as the
unit tests do.

-----

This is *prepared* for running for ELN, but the workflow does not yet enable it. I'd first like to get @jkonecny12 's and others opinion whether you like this direction. I think it's better than PR #3050 as it uses a smaller environment, which is quite important for this particular test. It should also port well to the rhel8 branch (I'll do that once this lands).

Note that for ELN it already uses the official image, like I do in PR #3053 .

Successfully [tested on my fork](https://github.com/martinpitt/anaconda/runs/1536764299?check_suite_focus=true).