### PR TITLE
Reorganize the error handler

### DIFF
--- a/pyanaconda/core/users.py
+++ b/pyanaconda/core/users.py
@@ -25,7 +25,6 @@ from contextlib import contextmanager
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.util import strip_accents
-from pyanaconda.errors import errorHandler, PasswordCryptError, ERROR_RAISE
 from pyanaconda.core.regexes import GROUPLIST_FANCY_PARSE, NAME_VALID, PORTABLE_FS_CHARS, GROUPLIST_SIMPLE_VALID
 import crypt
 from pyanaconda.core.i18n import _
@@ -45,10 +44,12 @@ def crypt_password(password):
     :rtype: str
     """
     cryptpw = crypt.crypt(password, crypt.METHOD_SHA512)
+
     if cryptpw is None:
-        exn = PasswordCryptError(algo=crypt.METHOD_SHA512)
-        if errorHandler.cb(exn) == ERROR_RAISE:
-            raise exn
+        raise RuntimeError(_(
+            "Unable to encrypt password: unsupported "
+            "algorithm {}").format(crypt.METHOD_SHA512)
+        )
 
     return cryptpw
 

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1056,6 +1056,8 @@ _supports_ipmi = None
 
 
 def ipmi_report(event):
+    log.info("Reporting the IPMI event: %s", event)
+
     global _supports_ipmi
     if _supports_ipmi is None:
         _supports_ipmi = os.path.exists("/dev/ipmi0") and os.path.exists("/usr/bin/ipmitool")

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -23,12 +23,6 @@ from pyanaconda.modules.common.errors.installation import BootloaderInstallation
 from pyanaconda.modules.common.errors.storage import UnusableStorageError
 
 
-class InvalidImageSizeError(Exception):
-    def __init__(self, message, filename):
-        Exception.__init__(self, message)
-        self.filename = filename
-
-
 class ScriptError(Exception):
     def __init__(self, lineno, details):
         Exception.__init__(self)
@@ -116,20 +110,6 @@ class ErrorHandler(object):
                    C_("GUI|Storage Detailed Error Dialog", "_Retry"))
         if self.ui.showDetailedError(message, details, buttons=buttons):
             return ERROR_RETRY
-        else:
-            return ERROR_RAISE
-
-    def _invalidImageSizeHandler(self, exn):
-        message = _("The ISO image %s has a size which is not "
-                    "a multiple of 2048 bytes.  This may mean "
-                    "it was corrupted on transfer to this computer."
-                    "\n\n"
-                    "It is recommended that you exit and abort your "
-                    "installation, but you can choose to continue if "
-                    "you think this is in error. Would you like to "
-                    "continue using this image?") % exn.filename
-        if self.ui.showYesNoQuestion(message):
-            return ERROR_CONTINUE
         else:
             return ERROR_RAISE
 
@@ -252,7 +232,6 @@ class ErrorHandler(object):
         _map = {
             StorageInstallationError.__name__: self._storage_install_handler,
             UnusableStorageError.__name__: self._storage_reset_handler,
-            "InvalidImageSizeError": self._invalidImageSizeHandler,
             "NoSuchGroup": self._noSuchGroupHandler,
             "NoStreamSpecifiedException": self._no_module_stream_specified,
             "InstallMoreStreamsException": self._multiple_module_streams_specified,

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -113,29 +113,6 @@ class ErrorHandler(object):
         else:
             return ERROR_RAISE
 
-    def _noSuchGroupHandler(self, exn):
-        if exn.required:
-            message = _("The group '%s' is required for this installation. "
-                        "This group does not exist. This is a fatal error and "
-                        "installation will be aborted.") % exn.group
-            self.ui.showError(message)
-            return ERROR_RAISE
-        elif exn.adding:
-            message = _("You have specified that the group '%s' should be "
-                        "installed.  This group does not exist.  Would you like "
-                        "to ignore this group and continue with "
-                        "installation?") % exn.group
-        else:
-            message = _("You have specified that the group '%s' should be "
-                        "excluded from installation.  This group does not exist.  "
-                        "Would you like to ignore this group and continue with "
-                        "installation?") % exn.group
-
-        if self.ui.showYesNoQuestion(message):
-            return ERROR_CONTINUE
-        else:
-            return ERROR_RAISE
-
     def _install_specs_handler(self, exn):
         broken_packages = exn.error_pkg_specs
         broken_groups_modules = exn.error_group_specs
@@ -232,7 +209,6 @@ class ErrorHandler(object):
         _map = {
             StorageInstallationError.__name__: self._storage_install_handler,
             UnusableStorageError.__name__: self._storage_reset_handler,
-            "NoSuchGroup": self._noSuchGroupHandler,
             "NoStreamSpecifiedException": self._no_module_stream_specified,
             "InstallMoreStreamsException": self._multiple_module_streams_specified,
             "MarkingErrors": self._install_specs_handler,

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -22,18 +22,11 @@ from pyanaconda.modules.common.errors.installation import BootloaderInstallation
     StorageInstallationError
 from pyanaconda.modules.common.errors.storage import UnusableStorageError
 
-__all__ = ["ERROR_RAISE", "ERROR_CONTINUE", "ERROR_RETRY", "errorHandler", "InvalidImageSizeError",
-           "MissingImageError", "ScriptError", "NonInteractiveError", "CmdlineError", "ExitError"]
-
 
 class InvalidImageSizeError(Exception):
     def __init__(self, message, filename):
         Exception.__init__(self, message)
         self.filename = filename
-
-
-class MissingImageError(Exception):
-    pass
 
 
 class ScriptError(Exception):
@@ -137,16 +130,6 @@ class ErrorHandler(object):
                     "continue using this image?") % exn.filename
         if self.ui.showYesNoQuestion(message):
             return ERROR_CONTINUE
-        else:
-            return ERROR_RAISE
-
-    def _missingImageHandler(self, exn):
-        message = _("The installer has tried to mount the "
-                    "installation image, but cannot find it on "
-                    "the hard drive.\n\n"
-                    "Should I try again to locate the image?")
-        if self.ui.showYesNoQuestion(message):
-            return ERROR_RETRY
         else:
             return ERROR_RAISE
 
@@ -270,7 +253,6 @@ class ErrorHandler(object):
             StorageInstallationError.__name__: self._storage_install_handler,
             UnusableStorageError.__name__: self._storage_reset_handler,
             "InvalidImageSizeError": self._invalidImageSizeHandler,
-            "MissingImageError": self._missingImageHandler,
             "NoSuchGroup": self._noSuchGroupHandler,
             "NoStreamSpecifiedException": self._no_module_stream_specified,
             "InstallMoreStreamsException": self._multiple_module_streams_specified,

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -55,12 +55,6 @@ class RemovedModuleError(ImportError):
     pass
 
 
-class PasswordCryptError(Exception):
-    def __init__(self, algo):
-        Exception.__init__(self)
-        self.algo = algo
-
-
 class ExitError(RuntimeError):
     pass
 
@@ -254,12 +248,6 @@ class ErrorHandler(object):
         else:
             return ERROR_RAISE
 
-    def _passwordCryptErrorHandler(self, exn):
-        message = _("Unable to encrypt password: unsupported algorithm %s") % exn.algo
-
-        self.ui.showError(message)
-        return ERROR_RAISE
-
     def cb(self, exn):
         """This method is the callback that all error handling should pass
            through.  The return value is one of the ERROR_* constants defined
@@ -291,7 +279,6 @@ class ErrorHandler(object):
             "PayloadInstallError": self._payloadInstallHandler,
             "DependencyError": self._dependencyErrorHandler,
             BootloaderInstallationError.__name__: self._bootLoaderErrorHandler,
-            "PasswordCryptError": self._passwordCryptErrorHandler,
         }
 
         if exn.__class__.__name__ in _map:

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -106,8 +106,6 @@ class ErrorHandler(object):
             PayloadInstallError.__name__: self._payload_install_handler,
 
             # DNF errors
-            "NoStreamSpecifiedException": self._no_module_stream_specified,
-            "InstallMoreStreamsException": self._multiple_module_streams_specified,
             "MarkingErrors": self._install_specs_handler,
         }
 
@@ -157,22 +155,6 @@ class ErrorHandler(object):
                 return ERROR_CONTINUE
             else:
                 return ERROR_RAISE
-
-    def _no_module_stream_specified(self, exn):
-        message = _("Stream was not specified for a module without a default stream. This is "
-                    "a fatal error and installation will be aborted. The details "
-                    "of this error are:\n\n%(exception)s") % \
-                            {"exception": exn}
-        self.ui.showError(message)
-        return ERROR_RAISE
-
-    def _multiple_module_streams_specified(self, exn):
-        message = _("Multiple streams have been specified for a single module. This is "
-                    "a fatal error and installation will be aborted. The details "
-                    "of this error are:\n\n%(exception)s") % \
-                            {"exception": exn}
-        self.ui.showError(message)
-        return ERROR_RAISE
 
     def _script_error_handler(self, exn):
         message = _("There was an error running the kickstart script at line "

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -20,8 +20,9 @@ from pyanaconda.core.i18n import _, C_
 from pyanaconda.flags import flags
 from pyanaconda.modules.common.errors.installation import BootloaderInstallationError, \
     StorageInstallationError
+from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.errors.storage import UnusableStorageError
-from pyanaconda.payload.errors import PayloadInstallError, DependencyError
+from pyanaconda.payload.errors import PayloadInstallError, DependencyError, PayloadSetupError
 
 
 class ScriptError(Exception):
@@ -103,7 +104,11 @@ class ErrorHandler(object):
 
             # Payload errors
             DependencyError.__name__: self._dependency_error_handler,
+            PayloadSetupError.__name__: self._payload_setup_handler,
             PayloadInstallError.__name__: self._payload_install_handler,
+
+            # Payload DBus errors
+            SourceSetupError.__name__: self._payload_setup_handler,
 
             # DNF errors
             "MarkingErrors": self._install_specs_handler,
@@ -164,9 +169,17 @@ class ErrorHandler(object):
         self.ui.showError(message)
         return ERROR_RAISE
 
+    def _payload_setup_handler(self, exn):
+        message = _("The following error occurred while setting up the payload. "
+                    "This is a fatal error and installation will be aborted.")
+        message += "\n\n" + str(exn)
+
+        self.ui.showError(message)
+        return ERROR_RAISE
+
     def _payload_install_handler(self, exn):
-        message = _("The following error occurred while installing.  This is "
-                    "a fatal error and installation will be aborted.")
+        message = _("The following error occurred while installing the payload. "
+                    "This is a fatal error and installation will be aborted.")
         message += "\n\n" + str(exn)
 
         self.ui.showError(message)

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -112,13 +112,16 @@ class AnacondaExceptionHandler(ExceptionHandler):
                              "The installer will now terminate.") % str(value)
             self.intf.messageWindow(_("Hardware error occurred"), hw_error_msg)
             self._run_kickstart_scripts(dump_info)
-            sys.exit(0)
+            util.ipmi_report(IPMI_FAILED)
+            sys.exit(1)
         elif isinstance(value, UnusableStorageError):
             self._run_kickstart_scripts(dump_info)
-            sys.exit(0)
+            util.ipmi_report(IPMI_FAILED)
+            sys.exit(1)
         elif isinstance(value, NonInteractiveError):
             self._run_kickstart_scripts(dump_info)
-            sys.exit(0)
+            util.ipmi_report(IPMI_FAILED)
+            sys.exit(1)
         else:
             # This will call postWriteHook.
             super().handleException(dump_info)
@@ -190,6 +193,7 @@ class AnacondaExceptionHandler(ExceptionHandler):
                     # for a few seconds before exiting the installer
                     print(cmdline_error_msg)
                     self._run_kickstart_scripts(dump_info)
+                    util.ipmi_report(IPMI_FAILED)
                     time.sleep(180)
                     sys.exit(1)
                 else:

--- a/pyanaconda/installation_tasks.py
+++ b/pyanaconda/installation_tasks.py
@@ -453,7 +453,13 @@ class Task(BaseTask):
         related machinery.
         """
         if self._task:
-            self._task(*self._task_args, **self._task_kwargs)
+            try:
+                # Run the task.
+                self._task(*self._task_args, **self._task_kwargs)
+            except Exception as e:  # pylint: disable=broad-except
+                # Handle an error.
+                if errorHandler.cb(e) == ERROR_RAISE:
+                    raise
         else:
             log.error("Task %s callable not set.", self.name)
 

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -71,7 +71,7 @@ from pyanaconda.payload.dnf.download_progress import DownloadProgress
 from pyanaconda.payload.dnf.repomd import RepoMDMetaHash
 from pyanaconda.payload.errors import MetadataError, PayloadError, NoSuchGroup, DependencyError, \
     PayloadInstallError, PayloadSetupError
-from pyanaconda.payload.image import find_first_iso_image, mountImage, find_optical_install_media
+from pyanaconda.payload.image import find_first_iso_image, find_optical_install_media
 from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
 from pyanaconda.product import productName, productVersion
 from pyanaconda.progress import progressQ, progress_message
@@ -1205,7 +1205,7 @@ class DNFPayload(Payload):
         if not os.path.ismount(iso_mount_dir):
             # mount the ISO on a loop
             image = os.path.normpath("%s/%s" % (path, image))
-            mountImage(image, iso_mount_dir)
+            payload_utils.mount(image, iso_mount_dir, fstype='iso9660', options="ro")
 
         if not iso_path.endswith(".iso"):
             result_path = os.path.normpath("%s/%s" % (iso_path,

--- a/pyanaconda/payload/dnf/utils.py
+++ b/pyanaconda/payload/dnf/utils.py
@@ -17,13 +17,11 @@
 #
 import os
 import operator
-import time
 
 from blivet.size import Size
 
 from pyanaconda.anaconda_loggers import get_packaging_logger
 from pyanaconda.payload.dnf.transaction_progress import TransactionProgress
-from pyanaconda.progress import progressQ
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.product import productName, productVersion
@@ -32,14 +30,7 @@ log = get_packaging_logger()
 
 DNF_PACKAGE_CACHE_DIR_SUFFIX = 'dnf.package.cache'
 YUM_REPOS_DIR = "/etc/yum.repos.d/"
-
 USER_AGENT = "%s (anaconda)/%s" % (productName, productVersion)
-
-
-def go_to_failure_limbo():
-    progressQ.send_quit(1)
-    while True:
-        time.sleep(10000)
 
 
 def get_df_map():

--- a/pyanaconda/payload/errors.py
+++ b/pyanaconda/payload/errors.py
@@ -32,11 +32,9 @@ class PayloadSetupError(PayloadError):
 
 # software selection
 class NoSuchGroup(PayloadError):
-    def __init__(self, group, adding=True, required=False):
+    def __init__(self, group):
         super().__init__(group)
         self.group = group
-        self.adding = adding
-        self.required = required
 
     def __str__(self):
         return "The group '{}' does not exist".format(self.group)

--- a/pyanaconda/payload/image.py
+++ b/pyanaconda/payload/image.py
@@ -28,7 +28,7 @@ import blivet.arch
 from blivet.size import Size
 
 from pyanaconda import isys
-from pyanaconda.errors import errorHandler, ERROR_RAISE, InvalidImageSizeError, MissingImageError
+from pyanaconda.errors import errorHandler, ERROR_RAISE, InvalidImageSizeError
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.errors.storage import MountFilesystemError
@@ -156,34 +156,6 @@ def _search_for_install_root_repository(repos):
             return repo
 
     return None
-
-
-def mountImage(isodir, tree):
-    # FIXME: This is duplicated in SetUpHardDriveSourceTask.run
-    while True:
-        if os.path.isfile(isodir):
-            image = isodir
-        else:
-            image = find_first_iso_image(isodir)
-            if image is None:
-                exn = MissingImageError()
-                if errorHandler.cb(exn) == ERROR_RAISE:
-                    raise exn
-                else:
-                    continue
-
-            image = os.path.normpath("%s/%s" % (isodir, image))
-
-        try:
-            blivet.util.mount(image, tree, fstype='iso9660', options="ro")
-        except OSError as oserr:
-            exn = MissingImageError()
-            if errorHandler.cb(exn) == ERROR_RAISE:
-                raise exn from oserr
-            else:
-                continue
-        else:
-            break
 
 
 def find_optical_install_media():

--- a/pyanaconda/payload/image.py
+++ b/pyanaconda/payload/image.py
@@ -28,7 +28,6 @@ import blivet.arch
 from blivet.size import Size
 
 from pyanaconda import isys
-from pyanaconda.errors import errorHandler, ERROR_RAISE, InvalidImageSizeError
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.errors.storage import MountFilesystemError
@@ -116,10 +115,14 @@ def find_first_iso_image(path, mount_path="/mnt/install/cdimage"):
 
         # warn user if images appears to be wrong size
         if os.stat(what)[stat.ST_SIZE] % 2048:
-            log.warning("%s appears to be corrupted", what)
-            exn = InvalidImageSizeError("size is not a multiple of 2048 bytes", what)
-            if errorHandler.cb(exn) == ERROR_RAISE:
-                raise exn
+            log.warning(
+                "The ISO image %s has a size which is not "
+                "a multiple of 2048 bytes. This may mean it "
+                "was corrupted on transfer to this computer.",
+                what
+            )
+            blivet.util.umount(mount_path)
+            continue
 
         log.info("Found disc at %s", fn)
         blivet.util.umount(mount_path)

--- a/pyanaconda/payload/live/payload_base.py
+++ b/pyanaconda/payload/live/payload_base.py
@@ -24,7 +24,6 @@ from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import INSTALL_TREE, THREAD_LIVE_PROGRESS
 from pyanaconda.core.i18n import _
-from pyanaconda.errors import errorHandler, ERROR_RAISE
 from pyanaconda.modules.payloads.payload.live_os.utils import get_kernel_version_list
 from pyanaconda.payload import utils as payload_utils
 from pyanaconda.payload.base import Payload
@@ -109,9 +108,7 @@ class BaseLivePayload(Payload):
             log.info(msg)
 
         if err or rc == 11:
-            exn = PayloadInstallError(err or msg)
-            if errorHandler.cb(exn) == ERROR_RAISE:
-                raise exn
+            raise PayloadInstallError(err or msg)
 
         # Wait for progress thread to finish
         with self.pct_lock:

--- a/pyanaconda/payload/live/payload_liveimg.py
+++ b/pyanaconda/payload/live/payload_liveimg.py
@@ -30,7 +30,6 @@ from pyanaconda.core.constants import PAYLOAD_TYPE_LIVE_IMAGE, TAR_SUFFIX, \
     NETWORK_CONNECTION_TIMEOUT, INSTALL_TREE, IMAGE_DIR, THREAD_LIVE_PROGRESS
 from pyanaconda.core.i18n import _
 from pyanaconda.core.payload import ProxyString, ProxyStringError
-from pyanaconda.errors import errorHandler, ERROR_RAISE
 from pyanaconda.modules.payloads.payload.live_image.utils import get_kernel_version_list_from_tar
 from pyanaconda.payload import utils as payload_utils
 from pyanaconda.payload.errors import PayloadInstallError
@@ -132,9 +131,7 @@ class LiveImagePayload(BaseLivePayload):
             error = self._setup_url_image()
 
         if error:
-            exn = PayloadInstallError(str(error))
-            if errorHandler.cb(exn) == ERROR_RAISE:
-                raise exn
+            raise PayloadInstallError(str(error))
 
         log.debug("liveimg size is %s", self._min_size)
 
@@ -202,9 +199,7 @@ class LiveImagePayload(BaseLivePayload):
             error = self._pre_install_url_image()
 
         if error:
-            exn = PayloadInstallError(str(error))
-            if errorHandler.cb(exn) == ERROR_RAISE:
-                raise exn
+            raise PayloadInstallError(str(error))
 
         # Used to make install progress % look correct
         self._adj_size = os.stat(self.image_path)[stat.ST_SIZE]
@@ -223,9 +218,7 @@ class LiveImagePayload(BaseLivePayload):
 
             if util.lowerASCII(self.data.liveimg.checksum) != filesum:
                 log.error("%s does not match checksum.", self.data.liveimg.checksum)
-                exn = PayloadInstallError("Checksum of image does not match")
-                if errorHandler.cb(exn) == ERROR_RAISE:
-                    raise exn
+                raise PayloadInstallError("Checksum of image does not match")
 
         # If this looks like a tarfile, skip trying to mount it
         if self.is_tarfile:
@@ -238,9 +231,7 @@ class LiveImagePayload(BaseLivePayload):
                                    ["--make-rprivate", "/"])
         if rc != 0:
             log.error("mount error (%s) making mount of '/' rprivate", rc)
-            exn = PayloadInstallError("mount error %s" % rc)
-            if errorHandler.cb(exn) == ERROR_RAISE:
-                raise exn
+            raise PayloadInstallError("mount error %s" % rc)
 
         # Mount the image and check to see if it is a LiveOS/*.img
         # style squashfs image. If so, move it to IMAGE_DIR and mount the real
@@ -248,9 +239,7 @@ class LiveImagePayload(BaseLivePayload):
         rc = payload_utils.mount(self.image_path, INSTALL_TREE, fstype="auto", options="ro")
         if rc != 0:
             log.error("mount error (%s) with %s", rc, self.image_path)
-            exn = PayloadInstallError("mount error %s" % rc)
-            if errorHandler.cb(exn) == ERROR_RAISE:
-                raise exn
+            raise PayloadInstallError("mount error %s" % rc)
 
         # Nothing more to mount
         if not os.path.exists(INSTALL_TREE + "/LiveOS"):
@@ -266,17 +255,13 @@ class LiveImagePayload(BaseLivePayload):
                                        ["--move", INSTALL_TREE, IMAGE_DIR])
             if rc != 0:
                 log.error("error %s moving mount", rc)
-                exn = PayloadInstallError("mount error %s" % rc)
-                if errorHandler.cb(exn) == ERROR_RAISE:
-                    raise exn
+                raise PayloadInstallError("mount error %s" % rc)
 
             img_file = IMAGE_DIR+"/LiveOS/" + os.path.basename(sorted(img_files)[0])
             rc = payload_utils.mount(img_file, INSTALL_TREE, fstype="auto", options="ro")
             if rc != 0:
                 log.error("mount error (%s) with %s", rc, img_file)
-                exn = PayloadInstallError("mount error %s with %s" % (rc, img_file))
-                if errorHandler.cb(exn) == ERROR_RAISE:
-                    raise exn
+                raise PayloadInstallError("mount error %s with %s" % (rc, img_file))
 
             self._update_kernel_version_list()
 
@@ -320,9 +305,7 @@ class LiveImagePayload(BaseLivePayload):
             log.info(msg)
 
         if err:
-            exn = PayloadInstallError(err or msg)
-            if errorHandler.cb(exn) == ERROR_RAISE:
-                raise exn
+            raise PayloadInstallError(err or msg)
 
         # Wait for progress thread to finish
         with self.pct_lock:

--- a/pyanaconda/payload/live/payload_liveimg.py
+++ b/pyanaconda/payload/live/payload_liveimg.py
@@ -32,7 +32,7 @@ from pyanaconda.core.i18n import _
 from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.modules.payloads.payload.live_image.utils import get_kernel_version_list_from_tar
 from pyanaconda.payload import utils as payload_utils
-from pyanaconda.payload.errors import PayloadInstallError
+from pyanaconda.payload.errors import PayloadInstallError, PayloadSetupError
 from pyanaconda.payload.live.download_progress import DownloadProgress
 from pyanaconda.payload.live.payload_base import BaseLivePayload
 from pyanaconda.progress import progressQ
@@ -131,7 +131,7 @@ class LiveImagePayload(BaseLivePayload):
             error = self._setup_url_image()
 
         if error:
-            raise PayloadInstallError(str(error))
+            raise PayloadSetupError(str(error))
 
         log.debug("liveimg size is %s", self._min_size)
 

--- a/pyanaconda/payload/live/payload_liveos.py
+++ b/pyanaconda/payload/live/payload_liveos.py
@@ -24,7 +24,7 @@ from pyanaconda.core.constants import PAYLOAD_TYPE_LIVE_OS, INSTALL_TREE, SOURCE
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.constants.services import PAYLOADS
 from pyanaconda.payload import utils as payload_utils
-from pyanaconda.payload.errors import PayloadInstallError, PayloadSetupError
+from pyanaconda.payload.errors import PayloadSetupError
 from pyanaconda.payload.live.payload_base import BaseLivePayload
 from pyanaconda.progress import progressQ
 
@@ -65,7 +65,7 @@ class LiveOSPayload(BaseLivePayload):
 
         osimg = payload_utils.resolve_device(osimg_spec)
         if not osimg:
-            raise PayloadInstallError("Unable to find osimg for {}".format(osimg_spec))
+            raise PayloadSetupError("Unable to find osimg for {}".format(osimg_spec))
 
         osimg_path = payload_utils.get_device_path(osimg)
         if not stat.S_ISBLK(os.stat(osimg_path)[stat.ST_MODE]):
@@ -73,7 +73,7 @@ class LiveOSPayload(BaseLivePayload):
 
         rc = payload_utils.mount(osimg_path, INSTALL_TREE, fstype="auto", options="ro")
         if rc != 0:
-            raise PayloadInstallError("Failed to mount the install tree")
+            raise PayloadSetupError("Failed to mount the install tree")
 
         # Grab the kernel version list now so it's available after umount
         self._update_kernel_version_list()

--- a/pyanaconda/payload/live/payload_liveos.py
+++ b/pyanaconda/payload/live/payload_liveos.py
@@ -22,7 +22,6 @@ from blivet.size import Size
 from pyanaconda.anaconda_loggers import get_packaging_logger
 from pyanaconda.core.constants import PAYLOAD_TYPE_LIVE_OS, INSTALL_TREE, SOURCE_TYPE_LIVE_OS_IMAGE
 from pyanaconda.core.i18n import _
-from pyanaconda.errors import errorHandler, ERROR_RAISE
 from pyanaconda.modules.common.constants.services import PAYLOADS
 from pyanaconda.payload import utils as payload_utils
 from pyanaconda.payload.errors import PayloadInstallError, PayloadSetupError
@@ -70,9 +69,7 @@ class LiveOSPayload(BaseLivePayload):
 
         osimg_path = payload_utils.get_device_path(osimg)
         if not stat.S_ISBLK(os.stat(osimg_path)[stat.ST_MODE]):
-            exn = PayloadSetupError("{} is not a valid block device".format(osimg_spec))
-            if errorHandler.cb(exn) == ERROR_RAISE:
-                raise exn
+            raise PayloadSetupError("{} is not a valid block device".format(osimg_spec))
 
         rc = payload_utils.mount(osimg_path, INSTALL_TREE, fstype="auto", options="ro")
         if rc != 0:

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -797,6 +797,7 @@ class GraphicalUserInterface(UserInterface):
             dlg.window.destroy()
 
         # the dialog has the only button -- "Exit installer", so just do so
+        util.ipmi_report(constants.IPMI_ABORTED)
         sys.exit(1)
 
     @async_action_wait


### PR DESCRIPTION
We are not able to use the error handler in the DBus modules, so move
it from the low-level code to the top level if possible, so we don't have to
deal with it during the Anaconda modularization.

Remove error handlers for deprecated or invalid use cases and clean up
the code.