### PR TITLE
virtualization: add missing /var/crash

### DIFF
--- a/data/product.d/ovirt.conf
+++ b/data/product.d/ovirt.conf
@@ -13,6 +13,7 @@ default_partitioning =
     /home          (size 1 GiB)
     /tmp           (size 1 GiB)
     /var           (size 15 GiB)
+    /var/crash     (size 10 GiB)
     /var/log       (size 8 GiB)
     /var/log/audit (size 2 GiB)
     swap

--- a/data/product.d/rhev.conf
+++ b/data/product.d/rhev.conf
@@ -13,6 +13,7 @@ default_partitioning =
     /home          (size 1 GiB)
     /tmp           (size 1 GiB)
     /var           (size 15 GiB)
+    /var/crash     (size 10 GiB)
     /var/log       (size 8 GiB)
     /var/log/audit (size 2 GiB)
     swap

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -105,6 +105,13 @@ VIRTUALIZATION_PARTITIONING = [
         encrypted=True,
     ),
     PartSpec(
+        mountpoint="/var/crash",
+        size=Size("10GiB"),
+        btr=True,
+        lv=True,
+        thin=True,
+        encrypted=True,
+    ),    PartSpec(
         mountpoint="/var/log",
         size=Size("8GiB"),
         btr=True,


### PR DESCRIPTION
/var/crash partition was added to oVirt and RHV-H
with https://bugzilla.redhat.com/show_bug.cgi?id=1433394
and lost with recent changes.
Re-adding to anaconda.