### PR TITLE
ovirt: rebase on CentOS Stream

### DIFF
--- a/data/product.d/ovirt.conf
+++ b/data/product.d/ovirt.conf
@@ -4,7 +4,7 @@
 product_name = oVirt Node Next
 
 [Base Product]
-product_name = CentOS Linux
+product_name = CentOS Stream
 
 [Storage]
 default_scheme = LVM_THINP

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -285,7 +285,7 @@ class ProductConfigurationTestCase(unittest.TestCase):
         )
         self._check_default_product(
             "oVirt Node Next", "",
-            ["rhel.conf", "centos-stream.conf", "centos.conf", "ovirt.conf"],
+            ["rhel.conf", "centos-stream.conf", "ovirt.conf"],
             VIRTUALIZATION_PARTITIONING
         )
         self._check_default_product(


### PR DESCRIPTION
oVirt 4.4.5 is moving to CentOS Stream
See: https://gerrit.ovirt.org/#/c/ovirt-node-ng-image/+/109123/18/data/ovirt.conf