### PR TITLE
Allow to interrupt media verification (#1349152)

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.glade
+++ b/pyanaconda/ui/gui/spokes/installation_source.glade
@@ -91,14 +91,14 @@
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton" id="doneButton">
-                <property name="label" translatable="yes" context="GUI|Software Source|Media Check Dialog">_Done</property>
+              <object class="GtkButton" id="cancelButton">
+                <property name="label" translatable="yes" context="GUI|Software Source|Media Check Dialog">_Cancel</property>
                 <property name="visible">True</property>
-                <property name="sensitive">False</property>
+                <property name="sensitive">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_underline">True</property>
-                <signal name="clicked" handler="on_done_clicked" swapped="no"/>
+                <signal name="clicked" handler="on_close" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -191,7 +191,7 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="0">doneButton</action-widget>
+      <action-widget response="0">cancelButton</action-widget>
     </action-widgets>
   </object>
   <object class="GtkListStore" id="partitionStore">

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -259,7 +259,6 @@ class MediaCheckDialog(GUIObject):
         self._pid = None
 
     def _check_iso_ends_cb(self, pid, status):
-        done_button = self.builder.get_object("doneButton")
         verify_label = self.builder.get_object("verifyLabel")
 
         if os.WIFSIGNALED(status):
@@ -270,7 +269,6 @@ class MediaCheckDialog(GUIObject):
             verify_label.set_text(_("This media is not good to install from."))
 
         self.progressBar.set_fraction(1.0)
-        done_button.set_sensitive(True)
         glib.spawn_close_pid(pid)
         self._pid = None
 
@@ -314,9 +312,6 @@ class MediaCheckDialog(GUIObject):
         if self._pid:
             os.kill(self._pid, signal.SIGKILL)
 
-        self.window.destroy()
-
-    def on_done_clicked(self, *args):
         self.window.destroy()
 
 


### PR DESCRIPTION
There is no button to stop media verification, for example when the progress is very slow.
Change the current "Done" button (usable only when the verification completes) to "Close" button, allowing to cancel the verification and closing the dialog window any time.

Related: rhbz#1349152