### PR TITLE
Change absolute shebangs to /usr/bin/env equivalents

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # anaconda: The Red Hat Linux Installation program
 #

--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (C) 2015 by Red Hat, Inc.  All rights reserved.
 #

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #vim: set fileencoding=utf8
 # parse-kickstart - read a kickstart file and emit equivalent dracut boot args
 #

--- a/dracut/python-deps
+++ b/dracut/python-deps
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # python-deps - find the dependencies of a given python script.
 #
 # Copyright (C) 2012-2015 by Red Hat, Inc.  All rights reserved.

--- a/scripts/anaconda-cleanup
+++ b/scripts/anaconda-cleanup
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
     always:
         - unmount everything under /mnt/sysimage

--- a/scripts/anaconda-read-journal
+++ b/scripts/anaconda-read-journal
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from systemd import journal
 import argparse

--- a/scripts/analog
+++ b/scripts/analog
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # analog: Remote logging manager for the Red Hat Installer
 #

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """ Run the Anaconda pylint tests on the files changed in this commit
 
     Set NOPYLINT env variable to skip this. eg. NOPYLINT= git commit
@@ -17,7 +17,7 @@ def is_python(filename):
 
     try:
         with open(filename) as testfile:
-            if testfile.readline().startswith("#!/usr/bin/python"):
+            if testfile.readline().startswith("#!/usr/bin/env python"):
                 return True
     except IOError:
         pass

--- a/scripts/instperf
+++ b/scripts/instperf
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import logging
 from subprocess import Popen, PIPE

--- a/scripts/list-screens
+++ b/scripts/list-screens
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # list_screens - list Anaconda screen names relevant for the
 #                user interaction config file

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # makebumpver - Increment version number and add in RPM spec file changelog
 #               block.  Ensures rhel*-branch commits reference RHEL bugs.

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # makeupdates - Generate an updates.img containing changes since the last
 #               tag, but only changes to the main anaconda runtime.

--- a/scripts/merge-pr
+++ b/scripts/merge-pr
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # merge-pr - Rebase, merge, and close a github pull request
 #

--- a/scripts/run-anaconda
+++ b/scripts/run-anaconda
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 #
 # Quick script to attach to tmux where anaconda is running
 #

--- a/scripts/run_boss_locally.py
+++ b/scripts/run_boss_locally.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Run Anaconda DBus services locally in separate DBus session.
 #

--- a/scripts/testing/install_dependencies.sh
+++ b/scripts/testing/install_dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Anaconda has plenty of dependencies and because of that it's hard to set
 # environment to with Anaconda properly.

--- a/tests/gettext_tests/click.py
+++ b/tests/gettext_tests/click.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (C) 2015  Red Hat, Inc.
 #

--- a/tests/gettext_tests/contexts.py
+++ b/tests/gettext_tests/contexts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (C) 2015  Red Hat, Inc.
 #

--- a/tests/gettext_tests/style_guide.py
+++ b/tests/gettext_tests/style_guide.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (C) 2014  Red Hat, Inc.
 #

--- a/tests/glade/check_markup.py
+++ b/tests/glade/check_markup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (C) 2014  Red Hat, Inc.
 #

--- a/tests/glade/run_glade_tests.py
+++ b/tests/glade/run_glade_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import nose
 import os

--- a/tests/nosetests/pyanaconda_tests/ks_version_test.py
+++ b/tests/nosetests/pyanaconda_tests/ks_version_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (C) 2013  Red Hat, Inc.
 #

--- a/tests/nosetests/regex_tests/dasd_name_test.py
+++ b/tests/nosetests/regex_tests/dasd_name_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (C) 2016  Red Hat, Inc.
 #

--- a/tests/nosetests/regex_tests/groupparse_test.py
+++ b/tests/nosetests/regex_tests/groupparse_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (C) 2010-2013  Red Hat, Inc.
 #

--- a/tests/nosetests/regex_tests/hostname_test.py
+++ b/tests/nosetests/regex_tests/hostname_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:set fileencoding=utf-8
 #
 # Copyright (C) 2014  Red Hat, Inc.

--- a/tests/nosetests/regex_tests/ibft_device_name_test.py
+++ b/tests/nosetests/regex_tests/ibft_device_name_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim:set fileencoding=utf-8
 #
 # Copyright (C) 2016  Red Hat, Inc.

--- a/tests/nosetests/regex_tests/iscsi_name_test.py
+++ b/tests/nosetests/regex_tests/iscsi_name_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim:set fileencoding=utf-8
 #
 # This program is free software; you can redistribute it and/or modify

--- a/tests/nosetests/regex_tests/netmask_test.py
+++ b/tests/nosetests/regex_tests/netmask_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim:set fileencoding=utf-8
 #
 # Copyright (C) 2016  Red Hat, Inc.

--- a/tests/nosetests/regex_tests/repo_name_test.py
+++ b/tests/nosetests/regex_tests/repo_name_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:set fileencoding=utf-8
 #
 # Copyright (C) 2014  Red Hat, Inc.

--- a/tests/nosetests/regex_tests/username_test.py
+++ b/tests/nosetests/regex_tests/username_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:set fileencoding=utf-8
 #
 # Copyright (C) 2010-2013  Red Hat, Inc.

--- a/tests/nosetests/regex_tests/zfcp_name_test.py
+++ b/tests/nosetests/regex_tests/zfcp_name_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (C) 2016  Red Hat, Inc.
 #

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -77,7 +77,8 @@ class AnacondaLintConfig(CensorshipConfig):
 
                 # Test any file that either ends in .py or contains #!/usr/bin/env python
                 # in the first line.
-                if f.endswith(".py") or (lines and str(lines[0]).startswith("#!/usr/bin/env python")):
+                if f.endswith(".py") or 
+                (lines and str(lines[0]).startswith("#!/usr/bin/env python")):
                     retval.append(root + "/" + f)
 
         return retval

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import atexit
 import shutil
@@ -75,9 +75,9 @@ class AnacondaLintConfig(CensorshipConfig):
                     # going to be valid python anyway.
                     continue
 
-                # Test any file that either ends in .py or contains #!/usr/bin/python
+                # Test any file that either ends in .py or contains #!/usr/bin/env python
                 # in the first line.
-                if f.endswith(".py") or (lines and str(lines[0]).startswith("#!/usr/bin/python")):
+                if f.endswith(".py") or (lines and str(lines[0]).startswith("#!/usr/bin/env python")):
                     retval.append(root + "/" + f)
 
         return retval

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -77,7 +77,7 @@ class AnacondaLintConfig(CensorshipConfig):
 
                 # Test any file that either ends in .py or contains #!/usr/bin/env python
                 # in the first line.
-                if f.endswith(".py") or 
+                if f.endswith(".py") or
                 (lines and str(lines[0]).startswith("#!/usr/bin/env python")):
                     retval.append(root + "/" + f)
 

--- a/translation-canary/tests/pylint/runpylint.py
+++ b/translation-canary/tests/pylint/runpylint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 from pocketlint import PocketLintConfig, PocketLinter

--- a/utils/handle-sshpw
+++ b/utils/handle-sshpw
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # handle-sshpw:  Code processing sshpw lines in kickstart files for the
 #                install environment.


### PR DESCRIPTION
Current shebangs for executed files gave a direct path to where they would be located on most systems. With the current official Anaconda targets, this is not an issue. Some distributions however place their installations of Bourne, BASH, and Python at other locations. They may not have /bin symlinked to /usr/bin or may install in an entirely different location. /usr/bin/env is more consistent as it can support wherever an interpreter is located no matter the target system, and env is found at /usr/bin/env on almost every distribution.