### PR TITLE
Fix python3 rpm package name in spec file

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -89,7 +89,7 @@ Requires: python3-blockdev >= %{libblockdevver}
 Requires: python3-meh >= %{mehver}
 Requires: libreport-anaconda >= %{libreportanacondaver}
 Requires: libselinux-python3
-Requires: rpm-python3 >= %{rpmver}
+Requires: python3-rpm >= %{rpmver}
 Requires: python3-pyparted >= %{pypartedver}
 Requires: python3-requests
 Requires: python3-requests-file


### PR DESCRIPTION
Python3 bindings for rpm module are named python3-rpm as all other python packages. However, this package also provides rpm-python3, most probably for backward compatibility.