### PR TITLE
Provide a hint for the desired capacity

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
@@ -482,7 +482,7 @@ use.  Try something else?</property>
               <object class="GtkEntry" id="addSizeEntry">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="tooltip_text" translatable="yes">eg: "20 GB", "500mb" (minus the quotation marks)</property>
+                <property name="placeholder_text" translatable="yes">Enter size and unit.</property>
                 <property name="activates_default">True</property>
               </object>
               <packing>

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -49,7 +49,7 @@ CONTAINER_TOOLTIP = N_("Create or select %(container_type)s")
 CONTAINER_DIALOG_TITLE = N_("CONFIGURE %(container_type)s")
 CONTAINER_DIALOG_TEXT = N_("Please create a name for this %(container_type)s "
                            "and select at least one disk below.")
-DESIRED_CAPACITY_ERROR = N_(
+DESIRED_CAPACITY_HINT = N_(
     "Specify the Desired Capacity in whole or decimal numbers, with an appropriate unit.\n\n"
     "Spaces separating digit groups are not allowed. Units consist of a decimal or binary "
     "prefix, and optionally the letter B. Letter case does not matter for units. The default "
@@ -59,6 +59,8 @@ DESIRED_CAPACITY_ERROR = N_(
     "'512m' = 512 megabytes\n"
     "'123456789' = 123 terabytes and a bit less than a half\n"
 )
+
+DESIRED_CAPACITY_ERROR = DESIRED_CAPACITY_HINT
 
 ContainerType = namedtuple("ContainerType", ["name", "label"])
 
@@ -231,7 +233,12 @@ class AddDialog(GUIObject):
         self._size = Size(0)
         self._mount_point = ""
         self._error = ""
+
         self._warning_label = self.builder.get_object("mountPointWarningLabel")
+
+        self._size_entry = self.builder.get_object("addSizeEntry")
+        self._size_entry.set_tooltip_text(DESIRED_CAPACITY_HINT)
+
         self._populate_mount_points()
 
     @property


### PR DESCRIPTION
Clarify that it is possible to enter the size with a unit or that we will use
MiB if the unit is not specified.

Suggested-by: Mikhail Novosyolov <m.novosyolov@rosalinux.ru>

There is a new placeholder in the Desired Capacity entry:
![desired_capacity_01](https://user-images.githubusercontent.com/7396092/103645107-c6251480-4f57-11eb-91f1-898d6634d47e.png)

A new tooltip appears when you keep the mouse above the Desired Capacity entry:
![desired-capacity-03](https://user-images.githubusercontent.com/7396092/103645112-c1f8f700-4f57-11eb-9bf8-4a60c1c18d32.png)
