### PR TITLE
Rhel 8 enable rpm tests

### DIFF
--- a/.github/workflows/owner-validate-rhel-8.yml
+++ b/.github/workflows/owner-validate-rhel-8.yml
@@ -53,3 +53,38 @@ jobs:
         with:
           name: logs
           path: test-logs/*
+
+  # Run rpm tests only if user have write or admin rights
+  rpm-tests:
+    needs: pr-info
+    if: needs.pr-info.outputs.allowed_user == 'true'
+    runs-on: [self-hosted, kstest]
+    timeout-minutes: 30
+    env:
+      TARGET_BRANCH_NAME: origin/rhel-8
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Rebase to current master
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git log --oneline -1 ${{ env.TARGET_BRANCH_NAME }}
+          git rebase ${{ env.TARGET_BRANCH_NAME }}
+
+      - name: Build RPM test container
+        run: make -f Makefile.am anaconda-rpm-build
+
+      - name: Run RPM tests in container
+        run: make -f Makefile.am container-rpm-test
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'logs-rpm-test'
+          path: test-logs/*

--- a/Makefile.am
+++ b/Makefile.am
@@ -86,7 +86,9 @@ CONTAINER_TEST_ARGS ?=
 
 # anaconda-ci container
 CI_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-ci
+RPM_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-rpm
 CI_NAME ?= rhinstaller/anaconda-ci
+RPM_NAME ?= rhinstaller/anaconda-rpm
 CI_TAG ?= $(GIT_BRANCH)
 CI_TEST_ARGS ?= --rm -v $(srcdir):/anaconda:Z
 CI_CMD ?= make ci
@@ -178,6 +180,9 @@ release-and-tag:
 anaconda-ci-build:
 	$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_ARGS) -t $(CI_NAME):$(CI_TAG) $(CI_DOCKERFILE)
 
+anaconda-rpm-build:
+	$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_ARGS) -t $(RPM_NAME):$(CI_TAG) $(RPM_DOCKERFILE)
+
 bumpver: po-pull
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \
 	if [ ! -z "$(IGNORE)" ]; then \
@@ -239,6 +244,11 @@ container-ci:
 
 container-shell:
 	$(CONTAINER_ENGINE) run -it $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) $(CI_NAME):$(CI_TAG)
+
+container-rpm-test:
+	$(CONTAINER_ENGINE) run -it $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) -v $(CI_DOCKERFILE)/run-build-and-arg:/run-build-and-arg $(RPM_NAME):$(CI_TAG) sh -exc ' \
+		/run-build-and-arg make run-rpm-tests-only; \
+		dnf install -y /tmp/anaconda/result/build/01-rpm-build/*.rpm'
 
 check-branching:
 # checking if branching can be finished and all the pieces are in place
@@ -340,7 +350,7 @@ test-rpm: mock-rpms run-rpm-tests-only
 	mock -r $(MOCKCHROOT) $(MOCK_EXTRA_ARGS) --install $(RPM_BUILD_DIR)/*[0-9].rpm
 	$(MAKE) grab-logs
 
-run-rpm-tests-only:
+run-rpm-tests-only: rpms
 	$(MAKE) TEST_SUITE_LOG=test-suite.log RPM_PATH=$(RPM_BUILD_DIR) \
 			ROOT_ANACONDA_PATH=$(abs_srcdir) TESTS=rpm_tests.sh check
 

--- a/dockerfile/anaconda-ci/rhel-8.repo
+++ b/dockerfile/anaconda-ci/rhel-8.repo
@@ -1,6 +1,6 @@
 [RHEL-8-BuildRoot]
 name=buildroot
-baseurl=http://download.devel.redhat.com/brewroot/repos/rhel-8.3.0-build/latest/$basearch
+baseurl=http://download.devel.redhat.com/brewroot/repos/rhel-8-build/latest/$basearch
 enabled=1
 gpgcheck=0
 install_weak_deps=0

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -1,0 +1,19 @@
+FROM registry.access.redhat.com/ubi8:latest
+LABEL maintainer=anaconda-list@redhat.com
+
+# Enable our repositories (RHEL 8 and overlays)
+RUN rm /etc/yum.repos.d/*.repo
+COPY *.repo /etc/yum.repos.d/
+
+# Prepare environment and install build dependencies
+RUN set -e; \
+  dnf update -y; \
+  dnf install -y \
+  curl \
+  /usr/bin/xargs \
+  rpm-build; \
+  curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/rhel-8/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
+  rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
+  mkdir /anaconda
+
+WORKDIR /anaconda

--- a/dockerfile/anaconda-rpm/overlays.repo
+++ b/dockerfile/anaconda-rpm/overlays.repo
@@ -1,0 +1,11 @@
+[rhinstaller]
+name=Copr repo for rhinstaller daily builds for RHEL 8
+baseurl=http://coprbe.devel.redhat.com/results/rhinstaller-group/Anaconda/rhel-8.dev-$basearch/
+enabled=1
+
+[cobra2-rhel-fallback]
+name=Cobra02 custom repository used to solve temporary missing new versions
+baseurl=http://cobra02.anaconda.englab.brq.redhat.com/trees/tests_fallback_repos/rhel8/
+enabled=1
+priority=50
+skip_if_unavailable=True

--- a/dockerfile/anaconda-rpm/rhel-8.repo
+++ b/dockerfile/anaconda-rpm/rhel-8.repo
@@ -1,0 +1,7 @@
+[RHEL-8-BuildRoot]
+name=buildroot
+baseurl=http://download.devel.redhat.com/brewroot/repos/rhel-8.3.0-build/latest/$basearch
+enabled=1
+gpgcheck=0
+install_weak_deps=0
+module_hotfixes=1

--- a/dockerfile/anaconda-rpm/rhel-8.repo
+++ b/dockerfile/anaconda-rpm/rhel-8.repo
@@ -1,6 +1,6 @@
 [RHEL-8-BuildRoot]
 name=buildroot
-baseurl=http://download.devel.redhat.com/brewroot/repos/rhel-8.3.0-build/latest/$basearch
+baseurl=http://download.devel.redhat.com/brewroot/repos/rhel-8-build/latest/$basearch
 enabled=1
 gpgcheck=0
 install_weak_deps=0

--- a/tests/rpm_tests.sh
+++ b/tests/rpm_tests.sh
@@ -5,4 +5,4 @@ if [ $# -eq 0 ] && [ -z $RPM_TESTS_ARGS ]; then
     set -- "${top_srcdir}"/tests/rpm_tests
 fi
 
-exec nosetests-3 -v --exclude=logpicker -a \!acceptance,\!slow $RPM_TESTS_ARGS "$@"
+exec python3 -m nose -v --exclude=logpicker -a \!acceptance,\!slow $RPM_TESTS_ARGS "$@"


### PR DESCRIPTION
Add RPM test support for owners of this repository.

This PR is mostly backport of the rpm testing in a container solution from master.

- Adding anaconda-rpm container
- Adding Makefile targets to build and start tests in a container 
- Extend existing workflow to run these container rpm tests on existing kstests runner 

Tested [here](https://github.com/Test-anaconda-org/anaconda/runs/1651531355?check_suite_focus=true). The unit-test failure is expected because I did not connected runner for that :).