### PR TITLE
Initialize librepo logger (#1908286)

### DIFF
--- a/pyanaconda/anaconda_logging.py
+++ b/pyanaconda/anaconda_logging.py
@@ -40,6 +40,7 @@ ANACONDA_SYSLOG_FORMAT = "anaconda: %(log_prefix)s: %(message)s"
 MAIN_LOG_FILE = "/tmp/anaconda.log"
 PROGRAM_LOG_FILE = "/tmp/program.log"
 PACKAGING_LOG_FILE = "/tmp/packaging.log"
+LIBREPO_LOG_FILE = "/tmp/dnf.librepo.log"
 SENSITIVE_INFO_LOG_FILE = "/tmp/sensitive-info.log"
 ANACONDA_SYSLOG_FACILITY = SysLogHandler.LOG_LOCAL1
 ANACONDA_SYSLOG_IDENTIFIER = "anaconda"
@@ -215,6 +216,13 @@ class AnacondaLog(object):
         self.addFileHandler(PACKAGING_LOG_FILE, dnf_logger,
                             minLevel=logging.NOTSET)
         self.forwardToJournal(dnf_logger)
+
+        # Create the librepo logger.
+        librepo_logger = logging.getLogger(constants.LOGGER_LIBREPO)
+        librepo_logger.setLevel(logging.DEBUG)
+        self.addFileHandler(LIBREPO_LOG_FILE, librepo_logger,
+                            minLevel=logging.NOTSET)
+        self.forwardToJournal(librepo_logger)
 
         # Create the simpleline logger and link it to anaconda
         simpleline_logger = logging.getLogger(constants.LOGGER_SIMPLELINE)

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -346,6 +346,7 @@ LOGGER_PROGRAM = "program"
 LOGGER_STORAGE = "storage"
 LOGGER_PACKAGING = "packaging"
 LOGGER_DNF = "dnf"
+LOGGER_LIBREPO = "librepo" # second DNF logger for librepo
 LOGGER_BLIVET = "blivet"
 LOGGER_SIMPLELINE = "simpleline"
 LOGGER_SENSITIVE_INFO = "sensitive_info"

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -696,6 +696,9 @@ class DNFPayload(Payload):
             config.install_weak_deps = False
 
         # Setup librepo logging
+        # This is still required even when the librepo has a separate logger because
+        # DNF needs to have callbacks that the librepo log is written to be able to
+        # process that log.
         libdnf.repo.LibrepoLog.removeAllHandlers()
         libdnf.repo.LibrepoLog.addHandler(DNF_LIBREPO_LOG)
 


### PR DESCRIPTION
Due to a change in dnf and libdnf, librepo logs are now redirected to "librepo" logger in python, so a handler needs to be added.

Resolves: rhbz#1908286