### PR TITLE
Rhel 8 disable some modules based on configuration

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -97,21 +97,23 @@ def _prepare_configuration(payload, ksdata):
     security_dbus_tasks = security_proxy.InstallWithTasks()
     os_config.append_dbus_tasks(SECURITY, security_dbus_tasks)
 
-    # add installation tasks for the Timezone DBus module
-    # run these tasks before tasks of the Services module
-    timezone_proxy = TIMEZONE.get_proxy()
-    timezone_dbus_tasks = timezone_proxy.InstallWithTasks()
-    os_config.append_dbus_tasks(TIMEZONE, timezone_dbus_tasks)
+    if is_module_available(TIMEZONE):
+        # add installation tasks for the Timezone DBus module
+        # run these tasks before tasks of the Services module
+        timezone_proxy = TIMEZONE.get_proxy()
+        timezone_dbus_tasks = timezone_proxy.InstallWithTasks()
+        os_config.append_dbus_tasks(TIMEZONE, timezone_dbus_tasks)
 
     # add installation tasks for the Services DBus module
     services_proxy = SERVICES.get_proxy()
     services_dbus_tasks = services_proxy.InstallWithTasks()
     os_config.append_dbus_tasks(SERVICES, services_dbus_tasks)
 
-    # add installation tasks for the Localization DBus module
-    localization_proxy = LOCALIZATION.get_proxy()
-    localization_dbus_tasks = localization_proxy.InstallWithTasks()
-    os_config.append_dbus_tasks(LOCALIZATION, localization_dbus_tasks)
+    if is_module_available(LOCALIZATION):
+        # add installation tasks for the Localization DBus module
+        localization_proxy = LOCALIZATION.get_proxy()
+        localization_dbus_tasks = localization_proxy.InstallWithTasks()
+        os_config.append_dbus_tasks(LOCALIZATION, localization_dbus_tasks)
 
     # add the Firewall configuration task
     firewall_proxy = NETWORK.get_proxy(FIREWALL)
@@ -128,12 +130,13 @@ def _prepare_configuration(payload, ksdata):
                                    network.write_configuration, (overwrite, )))
         configuration_queue.append(network_config)
 
-    # add installation tasks for the Users DBus module
-    user_config = TaskQueue("User creation", N_("Creating users"))
-    users_proxy = USERS.get_proxy()
-    users_dbus_tasks = users_proxy.InstallWithTasks()
-    os_config.append_dbus_tasks(USERS, users_dbus_tasks)
-    configuration_queue.append(user_config)
+    if is_module_available(USERS):
+        # add installation tasks for the Users DBus module
+        user_config = TaskQueue("User creation", N_("Creating users"))
+        users_proxy = USERS.get_proxy()
+        users_dbus_tasks = users_proxy.InstallWithTasks()
+        os_config.append_dbus_tasks(USERS, users_dbus_tasks)
+        configuration_queue.append(user_config)
 
     # Anaconda addon configuration
     addon_config = TaskQueue("Anaconda addon configuration", N_("Configuring addons"))

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -44,6 +44,7 @@ from pyanaconda import network
 from pyanaconda import ntp
 from pyanaconda import flags
 from pyanaconda.modules.common.constants.services import TIMEZONE, NETWORK
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core.i18n import _, CN_
 from pyanaconda.core.async_utils import async_action_wait, async_action_nowait
@@ -563,6 +564,10 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
         # report that we are done
         self.initialize_done()
+
+    @property
+    def showable(self):
+        return is_module_available(TIMEZONE)
 
     @property
     def status(self):

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -37,6 +37,7 @@ from pyanaconda.core.constants import DEFAULT_KEYBOARD, THREAD_KEYBOARD_INIT, TH
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.core.util import strip_accents, have_word_match
 from pyanaconda.modules.common.constants.services import LOCALIZATION
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.threading import threadMgr, AnacondaThread
 
 import locale as locale_mod
@@ -316,6 +317,10 @@ class KeyboardSpoke(NormalSpoke):
             return False
 
         return True
+
+    @property
+    def showable(self):
+        return is_module_available(LOCALIZATION)
 
     @property
     def status(self):

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -25,6 +25,7 @@ from gi.repository import Pango, Gdk
 
 from pyanaconda.core.constants import PAYLOAD_LIVE_TYPES
 from pyanaconda.modules.common.constants.services import LOCALIZATION
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import CN_
 from pyanaconda.ui.gui.spokes import NormalSpoke
@@ -130,7 +131,9 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
     @property
     def showable(self):
         # don't show the language support spoke on live media and in single language mode
-        return self.payload.type not in PAYLOAD_LIVE_TYPES and not flags.singlelang
+        return is_module_available(LOCALIZATION) \
+            and self.payload.type not in PAYLOAD_LIVE_TYPES \
+            and not flags.singlelang
 
     @property
     def status(self):

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -23,6 +23,7 @@ from pyanaconda.core.users import crypt_password
 from pyanaconda import input_checking
 from pyanaconda.core import constants
 from pyanaconda.modules.common.constants.services import USERS, SERVICES
+from pyanaconda.modules.common.util import is_module_available
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
@@ -140,6 +141,10 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
         # rerun checks so that we have a correct status message, if any
         self.checker.run_checks()
+
+    @property
+    def showable(self):
+        return is_module_available(USERS)
 
     @property
     def status(self):

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -24,6 +24,7 @@ from pyanaconda.core.users import crypt_password, guess_username, check_groupnam
 from pyanaconda import input_checking
 from pyanaconda.core import constants
 from pyanaconda.modules.common.constants.services import USERS
+from pyanaconda.modules.common.util import is_module_available
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui import GUIObject
@@ -436,6 +437,10 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
 
         # rerun checks so that we have a correct status message, if any
         self.checker.run_checks()
+
+    @property
+    def showable(self):
+        return is_module_available(USERS)
 
     @property
     def status(self):

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -41,6 +41,7 @@ from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.util import ipmi_abort
 from pyanaconda.core.constants import DEFAULT_LANG, WINDOW_TITLE_TEXT
 from pyanaconda.modules.common.constants.services import TIMEZONE, LOCALIZATION
+from pyanaconda.modules.common.util import is_module_available
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -112,9 +113,10 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
     @property
     def completed(self):
         # Skip the welcome screen if we are in single language mode
+        # or module is not available.
         # If language has not been set the default language (en_US)
         # will be used for the installation and for the installed system.
-        if flags.flags.singlelang:
+        if flags.flags.singlelang or not is_module_available(LOCALIZATION):
             return True
 
         if flags.flags.automatedInstall and self._l12_module.LanguageKickstarted:


### PR DESCRIPTION
Example of configuration disabling the modules:
`data/conf.d/09-rhel-image-disable-modules.conf`:
```
# Anaconda configuration file ISOs generated by ImageBuilder for Bare Metal Image Deployment
  
[Anaconda]
# List of enabled Anaconda DBus modules for RHEL.
#  but without org.fedoraproject.Anaconda.Modules.Subscription
kickstart_modules =
#     org.fedoraproject.Anaconda.Modules.Timezone
     # TODO turn off but allow to configure with kickstart
     org.fedoraproject.Anaconda.Modules.Network
#     org.fedoraproject.Anaconda.Modules.Localization
     org.fedoraproject.Anaconda.Modules.Security
#     org.fedoraproject.Anaconda.Modules.Users
     org.fedoraproject.Anaconda.Modules.Payloads
     org.fedoraproject.Anaconda.Modules.Storage
     # TODO possibly turn off
     org.fedoraproject.Anaconda.Modules.Services
#     org.fedoraproject.Anaconda.Modules.Subscription

```