### PR TITLE
Add rpm-tests support for external contributors

### DIFF
--- a/.github/workflows/validate-rhel-8.yml
+++ b/.github/workflows/validate-rhel-8.yml
@@ -46,6 +46,8 @@ jobs:
     if: needs.pr-info.outputs.base_ref == 'rhel-8' && needs.pr-info.outputs.allowed_user == 'true'
     runs-on: [self-hosted, ci-tasks, rhel-8]
     timeout-minutes: 30
+    env:
+      TARGET_BRANCH_NAME: origin/rhel-8
     steps:
       # we post statuses manually as this does not run from a pull_request event
       # https://developer.github.com/v3/repos/statuses/#create-a-status
@@ -69,8 +71,8 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git log --oneline -1 origin/rhel-8
-          git rebase origin/rhel-8
+          git log --oneline -1 ${{ env.TARGET_BRANCH_NAME }}
+          git rebase ${{ env.TARGET_BRANCH_NAME }}
 
       - name: Run test
         run: |
@@ -93,6 +95,61 @@ jobs:
         with:
           route: 'POST /repos/${{ github.repository }}/statuses/${{ needs.pr-info.outputs.sha }}'
           context: unit-tests
+          state: ${{ job.status }}
+          target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  rpm-tests:
+    needs: pr-info
+    if: needs.pr-info.outputs.base_ref == 'rhel-8' && needs.pr-info.outputs.allowed_user == 'true'
+    runs-on: [self-hosted, kstest]
+    timeout-minutes: 30
+    env:
+      TARGET_BRANCH_NAME: origin/rhel-8
+    steps:
+      - name: Create in-progress status
+        uses: octokit/request-action@v2.x
+        with:
+          route: 'POST /repos/${{ github.repository }}/statuses/${{ needs.pr-info.outputs.sha }}'
+          context: rpm-tests
+          state: pending
+          target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.pr-info.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Rebase to current ${{ env.TARGET_BRANCH_NAME }}
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git log --oneline -1 ${{ env.TARGET_BRANCH_NAME }}
+          git rebase ${{ env.TARGET_BRANCH_NAME }}
+
+      - name: Build RPM test container
+        run: make -f Makefile.am anaconda-rpm-build
+
+      - name: Run RPM tests in container
+        run: make -f Makefile.am container-rpm-test
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'logs-rpm-test'
+          path: test-logs/*
+
+      - name: Set result status
+        if: always()
+        uses: octokit/request-action@v2.x
+        with:
+          route: 'POST /repos/${{ github.repository }}/statuses/${{ needs.pr-info.outputs.sha }}'
+          context: rpm-tests
           state: ${{ job.status }}
           target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         env:


### PR DESCRIPTION
After this is merged, owners can start ``rpm-tests`` with a ``unit-tests`` by comment ``/test`` comment in Pull request.

Tested [here](https://github.com/Test-anaconda-org/anaconda/pull/9).