### PR TITLE
Use should_run instead of showable

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -338,8 +338,8 @@ if __name__ == "__main__":
     # The note should in most cases end on TTY1.
     startup_utils.print_startup_note(options=opts)
 
-    from pyanaconda.anaconda import Anaconda
-    anaconda = Anaconda()
+    from pyanaconda.ui.context import context
+    anaconda = context.anaconda
     util.setup_translations()
 
     # reset python's default SIGINT handler

--- a/pyanaconda/ui/context.py
+++ b/pyanaconda/ui/context.py
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+__all__ = ["context"]
+
+from pyanaconda.anaconda import Anaconda
+
+
+class UserInterfaceContext(object):
+    """The context of the user interface.
+
+    The context provides access to persistent objects
+    of the user interface. The goal is to replace all
+    these objects with this one.
+
+    We might replace this object with a DBus module in
+    the future.
+    """
+
+    def __init__(self):
+        self._anaconda = Anaconda()
+
+    @property
+    def anaconda(self) -> Anaconda:
+        """The Anaconda object."""
+        return self._anaconda
+
+    @property
+    def data(self):
+        """The kickstart data."""
+        return self._anaconda.ksdata
+
+    @property
+    def payload(self):
+        """The payload object."""
+        return self._anaconda.payload
+
+
+context = UserInterfaceContext()

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -40,6 +40,7 @@ from pyanaconda.payload.image import find_optical_install_media, find_potential_
 from pyanaconda.core.payload import ProxyString, ProxyStringError, parse_nfs_url, create_nfs_url
 from pyanaconda.core.util import cmp_obj_attrs, id_generator
 from pyanaconda.ui.communication import hubQ
+from pyanaconda.ui.context import context
 from pyanaconda.ui.helpers import InputCheck, InputCheckHandler, SourceSwitchHandler
 from pyanaconda.ui.lib.subscription import switch_source
 from pyanaconda.ui.gui import GUIObject
@@ -405,6 +406,11 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
 
     icon = "media-optical-symbolic"
     title = CN_("GUI|Spoke", "_Installation Source")
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Don't run for any non-package payload."""
+        return context.payload.type == PAYLOAD_TYPE_DNF
 
     def __init__(self, *args, **kwargs):
         NormalSpoke.__init__(self, *args, **kwargs)
@@ -1082,10 +1088,6 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         self._updates_box.set_sensitive(self._mirror_active())
         active = self._mirror_active() and self.payload.is_repo_enabled("updates")
         self._updates_radio_button.set_active(active)
-
-    @property
-    def showable(self):
-        return self.payload.type == PAYLOAD_TYPE_DNF
 
     def _mirror_active(self):
         return self._protocol_combo_box.get_active_id() == PROTOCOL_MIRROR and \

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -26,6 +26,7 @@ from gi.repository import Pango, Gdk
 from pyanaconda.core.constants import PAYLOAD_LIVE_TYPES
 from pyanaconda.modules.common.constants.services import LOCALIZATION
 from pyanaconda.core.i18n import CN_
+from pyanaconda.ui.context import context
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.utils import escape_markup, override_cell_property
 from pyanaconda.ui.categories.localization import LocalizationCategory
@@ -60,6 +61,11 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
 
     icon = "accessories-character-map-symbolic"
     title = CN_("GUI|Spoke", "_Language Support")
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Don't show the language support spoke on live media."""
+        return context.payload.type not in PAYLOAD_LIVE_TYPES
 
     def __init__(self, *args, **kwargs):
         NormalSpoke.__init__(self, *args, **kwargs)
@@ -125,11 +131,6 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
     @property
     def _installed_langsupports(self):
         return [self._l12_module.Language] + sorted(self._l12_module.LanguageSupport)
-
-    @property
-    def showable(self):
-        # don't show the language support spoke on live media
-        return self.payload.type not in PAYLOAD_LIVE_TYPES
 
     @property
     def status(self):

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -30,6 +30,7 @@ from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core import util, constants
 
 from pyanaconda.ui.communication import hubQ
+from pyanaconda.ui.context import context
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.spokes.lib.detailederror import DetailedErrorDialog
 from pyanaconda.ui.gui.utils import blockedHandler, escape_markup
@@ -73,6 +74,11 @@ class SoftwareSelectionSpoke(NormalSpoke):
     _ADDON_SELECTED = 1
     # user de-selected
     _ADDON_DESELECTED = 2
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Don't run for any non-package payload."""
+        return context.payload.type == PAYLOAD_TYPE_DNF
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -247,10 +253,6 @@ class SoftwareSelectionSpoke(NormalSpoke):
                     not threadMgr.get(constants.THREAD_PAYLOAD) and
                     not threadMgr.get(constants.THREAD_CHECK_SOFTWARE) and
                     self.payload.base_repo is not None)
-
-    @property
-    def showable(self):
-        return self.payload.type == PAYLOAD_TYPE_DNF
 
     @property
     def status(self):

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -82,6 +82,11 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
     icon = "drive-harddisk-symbolic"
     title = CN_("GUI|Spoke", "Installation _Destination")
 
+    @classmethod
+    def should_run(cls, environment, data):
+        """Don't run the storage spoke on dir installations."""
+        return not conf.target.is_directory
+
     def __init__(self, *args, **kwargs):
         StorageCheckHandler.__init__(self)
         NormalSpoke.__init__(self, *args, **kwargs)
@@ -253,10 +258,6 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             and not threadMgr.get(constants.THREAD_STORAGE) \
             and not threadMgr.get(constants.THREAD_DASDFMT) \
             and not threadMgr.get(constants.THREAD_EXECUTE_STORAGE)
-
-    @property
-    def showable(self):
-        return not conf.target.is_directory
 
     @property
     def status(self):

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -24,6 +24,7 @@ from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.payload.utils import get_device_path
 from pyanaconda.ui.categories.software import SoftwareCategory
+from pyanaconda.ui.context import context
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog
 from pyanaconda.threading import threadMgr, AnacondaThread
@@ -66,6 +67,11 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
 
     SET_NETWORK_INSTALL_MODE = "network_install"
 
+    @classmethod
+    def should_run(cls, environment, data):
+        """Don't run for any non-package payload."""
+        return context.payload.type == PAYLOAD_TYPE_DNF
+
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)
         SourceSwitchHandler.__init__(self)
@@ -98,10 +104,6 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
 
     def _payload_error(self):
         self._error = True
-
-    @property
-    def showable(self):
-        return self.payload.type == PAYLOAD_TYPE_DNF
 
     @property
     def status(self):

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -18,6 +18,7 @@
 #
 from pyanaconda.flags import flags
 from pyanaconda.ui.categories.software import SoftwareCategory
+from pyanaconda.ui.context import context
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload.manager import payloadMgr, PayloadState
@@ -47,6 +48,11 @@ class SoftwareSpoke(NormalTUISpoke):
     """
     helpFile = "SoftwareSpoke.txt"
     category = SoftwareCategory
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Don't run for any non-package payload."""
+        return context.payload.type == PAYLOAD_TYPE_DNF
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
@@ -133,10 +139,6 @@ class SoftwareSpoke(NormalTUISpoke):
                 addons.extend(addons_list)
 
         return addons
-
-    @property
-    def showable(self):
-        return self.payload.type == PAYLOAD_TYPE_DNF
 
     @property
     def status(self):

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -76,6 +76,11 @@ class StorageSpoke(NormalTUISpoke):
     helpFile = "StorageSpoke.txt"
     category = SystemCategory
 
+    @classmethod
+    def should_run(cls, environment, data):
+        """Don't run the storage spoke on dir installations."""
+        return not conf.target.is_directory
+
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
         self.title = N_("Installation Destination")
@@ -111,10 +116,6 @@ class StorageSpoke(NormalTUISpoke):
     @property
     def mandatory(self):
         return True
-
-    @property
-    def showable(self):
-        return not conf.target.is_directory
 
     @property
     def status(self):


### PR DESCRIPTION
Create a new object that will provide access to all persistent objects of the
user interface. The goal is to replace all these objects with this one. In the
future, the context might be replaced with a DBus module.

Define the `should_run` method instead of the `showable` property to prevent
the initialization of spokes that shouldn't run at all.