### PR TITLE
Don't run the execute method in the kickstart installation in TUI by default

### DIFF
--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -61,6 +61,7 @@ class SummaryHub(TUIHub):
             sys.stdout.write(_("Starting automated install"))
             sys.stdout.flush()
             spokes = self._spokes.values()
+
             while not all(spoke.ready for spoke in spokes):
                 # Catch any asynchronous events (like storage crashing)
                 loop = App.get_event_loop()
@@ -70,9 +71,6 @@ class SummaryHub(TUIHub):
                 time.sleep(1)
 
             print('')
-            for spoke in spokes:
-                if spoke.changed:
-                    spoke.execute()
 
         return True
 

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -407,6 +407,10 @@ class StorageSpoke(NormalTUISpoke):
         # Update the selected disks.
         select_default_disks()
 
+        # Apply the partitioning in the automated installation.
+        if flags.automatedInstall:
+            self.execute()
+
         # Storage is ready.
         self._ready = True
 


### PR DESCRIPTION
We should run the `execute` method from the `initialize` method of the spoke when it
is required. In GUI, we have removed this functionality in the commit 31d35e9.

This patch will fix the broken dir installation.