### PR TITLE
Fix kickstart tests failure when loop device is not yet created

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -54,6 +54,8 @@ jobs:
     if: needs.pr-info.outputs.base_ref == 'master' && needs.pr-info.outputs.allowed_user == 'true' && needs.pr-info.outputs.launch_args != ''
     runs-on: [self-hosted, kstest]
     timeout-minutes: 300
+    env:
+       LORAX_BUILD_CONTAINER: fedora:rawhide
     steps:
       # self-hosted runners don't do this automatically; also useful to keep stuff around for debugging
       # need to run sudo as the launch script and the container create root/other user owned files
@@ -62,6 +64,11 @@ jobs:
           sudo podman ps -q --all --filter='ancestor=kstest-runner' | xargs -tr sudo podman rm -f
           sudo podman volume rm --all || true
           sudo rm -rf * .git
+
+      - name: Update container images used here
+        run: |
+          sudo podman pull ${{ env.LORAX_BUILD_CONTAINER }}
+          sudo podman pull quay.io/rhinstaller/kstest-runner:latest
 
       # we post statuses manually as this does not run from a pull_request event
       # https://developer.github.com/v3/repos/statuses/#create-a-status
@@ -114,7 +121,7 @@ jobs:
           sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
           sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
-          sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`:/source:ro -v `pwd`/kickstart-tests/data/images:/images:z fedora:rawhide <<EOF
+          sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`:/source:ro -v `pwd`/kickstart-tests/data/images:/images:z ${{ env.LORAX_BUILD_CONTAINER }} <<EOF
           set -eux
           # /source from host is read-only, build in a copy
           cp -a /source/ /tmp/

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -108,8 +108,13 @@ jobs:
       - name: Build boot.iso from Rawhide and this branch
         run: |
           mkdir -p kickstart-tests/data/images
-          # HACK: lorax and podman overlayfs really hate each other: https://bugzilla.redhat.com/show_bug.cgi?id=1906364
-          sudo podman run -i --rm --privileged --storage-driver=vfs --root /tmp/podman-vfs -v `pwd`:/source:ro -v `pwd`/kickstart-tests/data/images:/images:z fedora:rawhide <<EOF
+          # We have to pre-create loop devices because they are not namespaced in kernel so
+          # podman can't access newly created ones. That caused failures of tests when runners
+          # were rebooted.
+          sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
+          sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
+          # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
+          sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`:/source:ro -v `pwd`/kickstart-tests/data/images:/images:z fedora:rawhide <<EOF
           set -eux
           # /source from host is read-only, build in a copy
           cp -a /source/ /tmp/
@@ -132,9 +137,11 @@ jobs:
           cp lorax/images/boot.iso /images/
           EOF
 
-      - name: Clean up after podman/lorax hack
+      - name: Clean up after lorax
         if: always()
-        run: sudo rm -rf /tmp/podman-vfs
+        run: |
+          sudo losetup -d /dev/loop0 2> /dev/null || true
+          sudo losetup -d /dev/loop1 2> /dev/null || true
 
       - name: Run kickstart tests with ${{ needs.pr-info.outputs.launch_args }} in container
         working-directory: kickstart-tests

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -57,6 +57,18 @@ jobs:
     env:
        LORAX_BUILD_CONTAINER: fedora:rawhide
     steps:
+      # we post statuses manually as this does not run from a pull_request event
+      # https://developer.github.com/v3/repos/statuses/#create-a-status
+      - name: Create in-progress status
+        uses: octokit/request-action@v2.x
+        with:
+          route: 'POST /repos/${{ github.repository }}/statuses/${{ needs.pr-info.outputs.sha }}'
+          context: 'kickstart ${{ needs.pr-info.outputs.launch_args }}'
+          state: pending
+          target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # self-hosted runners don't do this automatically; also useful to keep stuff around for debugging
       # need to run sudo as the launch script and the container create root/other user owned files
       - name: Clean up previous run
@@ -69,18 +81,6 @@ jobs:
         run: |
           sudo podman pull ${{ env.LORAX_BUILD_CONTAINER }}
           sudo podman pull quay.io/rhinstaller/kstest-runner:latest
-
-      # we post statuses manually as this does not run from a pull_request event
-      # https://developer.github.com/v3/repos/statuses/#create-a-status
-      - name: Create in-progress status
-        uses: octokit/request-action@v2.x
-        with:
-          route: 'POST /repos/${{ github.repository }}/statuses/${{ needs.pr-info.outputs.sha }}'
-          context: 'kickstart ${{ needs.pr-info.outputs.launch_args }}'
-          state: pending
-          target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clone repository
         uses: actions/checkout@v2


### PR DESCRIPTION
The loop device is not in the container automatically it has to be created first. Let's pre-create the loop 0 and 1 devices always before podman run.

Also add update of container images used by this workflow.

Tested [here](https://github.com/Test-anaconda-org/anaconda/runs/1663957864?check_suite_focus=true).