### PR TITLE
Allow to disable the Timezone module

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -99,9 +99,10 @@ def _prepare_configuration(payload, ksdata):
 
     # add installation tasks for the Timezone DBus module
     # run these tasks before tasks of the Services module
-    timezone_proxy = TIMEZONE.get_proxy()
-    timezone_dbus_tasks = timezone_proxy.InstallWithTasks()
-    os_config.append_dbus_tasks(TIMEZONE, timezone_dbus_tasks)
+    if is_module_available(TIMEZONE):
+        timezone_proxy = TIMEZONE.get_proxy()
+        timezone_dbus_tasks = timezone_proxy.InstallWithTasks()
+        os_config.append_dbus_tasks(TIMEZONE, timezone_dbus_tasks)
 
     # add installation tasks for the Services DBus module
     services_proxy = SERVICES.get_proxy()

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -43,8 +43,9 @@ from pyanaconda.modules.common.constants.services import NETWORK, TIMEZONE, STOR
 from pyanaconda.modules.common.constants.objects import FCOE
 from pyanaconda.modules.common.task import sync_run_task
 from pyanaconda.modules.common.structures.network import NetworkDeviceInfo
-
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.anaconda_loggers import get_module_logger
+
 log = get_module_logger(__name__)
 
 DEFAULT_HOSTNAME = "localhost.localdomain"
@@ -335,6 +336,9 @@ def write_configuration(overwrite=False):
 def _set_ntp_servers_from_dhcp():
     """Set NTP servers of timezone module from dhcp if not set by kickstart."""
     # FIXME - do it only if they will be applied (the guard at the end of the function)
+    if not is_module_available(TIMEZONE):
+        return
+
     timezone_proxy = TIMEZONE.get_proxy()
     ntp_servers = get_ntp_servers_from_dhcp(get_nm_client())
     log.info("got %d NTP servers from DHCP", len(ntp_servers))

--- a/pyanaconda/timezone.py
+++ b/pyanaconda/timezone.py
@@ -31,6 +31,7 @@ from pyanaconda.core.constants import THREAD_STORAGE
 from pyanaconda.flags import flags
 from pyanaconda.modules.common.constants.objects import BOOTLOADER
 from pyanaconda.modules.common.constants.services import TIMEZONE, STORAGE
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.threading import threadMgr
 from blivet import arch
 
@@ -87,6 +88,9 @@ def save_hw_clock(timezone_proxy=None):
 
     """
     if arch.is_s390():
+        return
+
+    if not is_module_available(TIMEZONE):
         return
 
     if not timezone_proxy:

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -44,6 +44,7 @@ from pyanaconda import network
 from pyanaconda import ntp
 from pyanaconda import flags
 from pyanaconda.modules.common.constants.services import TIMEZONE, NETWORK
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.core.i18n import _, CN_
 from pyanaconda.core.async_utils import async_action_wait, async_action_nowait
@@ -425,6 +426,14 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
     # see https://bugzilla.gnome.org/show_bug.cgi?id=712184
     _hack = TimezoneMap.TimezoneMap()
     del(_hack)
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(TIMEZONE):
+            return False
+
+        return FirstbootSpokeMixIn.should_run(environment, data)
 
     def __init__(self, *args):
         NormalSpoke.__init__(self, *args)

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -41,8 +41,9 @@ from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.util import ipmi_abort
 from pyanaconda.core.constants import DEFAULT_LANG, WINDOW_TITLE_TEXT
 from pyanaconda.modules.common.constants.services import TIMEZONE, LOCALIZATION
-
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.anaconda_loggers import get_module_logger
+
 log = get_module_logger(__name__)
 
 __all__ = ["WelcomeLanguageSpoke"]
@@ -87,6 +88,9 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
         # is enabled.
 
         if flags.flags.automatedInstall and not geoloc.geoloc.enabled:
+            return
+
+        if not is_module_available(TIMEZONE):
             return
 
         timezone_proxy = TIMEZONE.get_proxy()

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -17,6 +17,7 @@
 # Red Hat, Inc.
 #
 from pyanaconda.modules.common.constants.services import TIMEZONE
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.ui.categories.localization import LocalizationCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
@@ -60,6 +61,14 @@ __all__ = ["TimeSpoke"]
 class TimeSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     help_id = "DateTimeSpoke"
     category = LocalizationCategory
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(TIMEZONE):
+            return False
+
+        return FirstbootSpokeMixIn.should_run(environment, data)
 
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)


### PR DESCRIPTION
Check whether the Timezone DBus module is enabled before it is used.
It might be disabled in the Anaconda configuration file.

Related: rhbz#1834535