### PR TITLE
Allow to disable the Users module

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -129,11 +129,12 @@ def _prepare_configuration(payload, ksdata):
         configuration_queue.append(network_config)
 
     # add installation tasks for the Users DBus module
-    user_config = TaskQueue("User creation", N_("Creating users"))
-    users_proxy = USERS.get_proxy()
-    users_dbus_tasks = users_proxy.InstallWithTasks()
-    os_config.append_dbus_tasks(USERS, users_dbus_tasks)
-    configuration_queue.append(user_config)
+    if is_module_available(USERS):
+        user_config = TaskQueue("User creation", N_("Creating users"))
+        users_proxy = USERS.get_proxy()
+        users_dbus_tasks = users_proxy.InstallWithTasks()
+        os_config.append_dbus_tasks(USERS, users_dbus_tasks)
+        configuration_queue.append(user_config)
 
     # Anaconda addon configuration
     addon_config = TaskQueue("Anaconda addon configuration", N_("Configuring addons"))

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -23,6 +23,7 @@ from pyanaconda.core.users import crypt_password
 from pyanaconda import input_checking
 from pyanaconda.core import constants
 from pyanaconda.modules.common.constants.services import USERS, SERVICES
+from pyanaconda.modules.common.util import is_module_available
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
@@ -53,6 +54,14 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     icon = "dialog-password-symbolic"
     title = CN_("GUI|Spoke", "_Root Password")
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(USERS):
+            return False
+
+        return FirstbootSpokeMixIn.should_run(environment, data)
 
     def __init__(self, *args):
         NormalSpoke.__init__(self, *args)

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -24,6 +24,7 @@ from pyanaconda.core.users import crypt_password, guess_username, check_groupnam
 from pyanaconda import input_checking
 from pyanaconda.core import constants
 from pyanaconda.modules.common.constants.services import USERS
+from pyanaconda.modules.common.util import is_module_available
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui import GUIObject
@@ -232,9 +233,12 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
 
     @classmethod
     def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(USERS):
+            return False
+
         # the user spoke should run always in the anaconda and in firstboot only
         # when doing reconfig or if no user has been created in the installation
-
         users_module = USERS.get_proxy()
         user_list = get_user_list(users_module)
 

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -16,7 +16,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
 from pyanaconda.ui.tui.tuiobject import PasswordDialog
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
@@ -36,6 +36,14 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     """
     help_id = "RootPasswordSpoke"
     category = UserSettingsCategory
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(USERS):
+            return False
+
+        return FirstbootSpokeMixIn.should_run(environment, data)
 
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)

--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -21,6 +21,7 @@ from pyanaconda.flags import flags
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.core.regexes import GECOS_VALID
 from pyanaconda.modules.common.constants.services import USERS
+from pyanaconda.modules.common.util import is_module_available
 
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
 from pyanaconda.ui.common import FirstbootSpokeMixIn
@@ -49,6 +50,10 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     @classmethod
     def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(USERS):
+            return False
+
         if FirstbootSpokeMixIn.should_run(environment, data):
             return True
 


### PR DESCRIPTION
Check whether the Users DBus module is enabled before it is used.
It might be disabled in the Anaconda configuration file.

Related: rhbz#1834535