### PR TITLE
Allow to disable the Localization module

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -110,9 +110,10 @@ def _prepare_configuration(payload, ksdata):
     os_config.append_dbus_tasks(SERVICES, services_dbus_tasks)
 
     # add installation tasks for the Localization DBus module
-    localization_proxy = LOCALIZATION.get_proxy()
-    localization_dbus_tasks = localization_proxy.InstallWithTasks()
-    os_config.append_dbus_tasks(LOCALIZATION, localization_dbus_tasks)
+    if is_module_available(LOCALIZATION):
+        localization_proxy = LOCALIZATION.get_proxy()
+        localization_dbus_tasks = localization_proxy.InstallWithTasks()
+        os_config.append_dbus_tasks(LOCALIZATION, localization_dbus_tasks)
 
     # add the Firewall configuration task
     firewall_proxy = NETWORK.get_proxy(FIREWALL)

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -790,6 +790,9 @@ class DNFPayload(Payload):
         return selected_kernel_package
 
     def langpacks(self):
+        if not is_module_available(LOCALIZATION):
+            return []
+
         # get all available languages in repos
         available_langpacks = self._base.sack.query().available() \
             .filter(name__glob="langpacks-*")
@@ -1471,6 +1474,9 @@ class DNFPayload(Payload):
         return True
 
     def language_groups(self):
+        if not is_module_available(LOCALIZATION):
+            return []
+
         localization_proxy = LOCALIZATION.get_proxy()
         locales = [localization_proxy.Language] + localization_proxy.LanguageSupport
         match_fn = pyanaconda.localization.langcode_matches_locale

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -38,7 +38,7 @@ from pyanaconda import safe_dbus
 from pyanaconda import kickstart
 from pyanaconda.flags import flags
 from pyanaconda.screensaver import inhibit_screensaver
-from pyanaconda.modules.common.constants.services import TIMEZONE
+from pyanaconda.modules.common.constants.services import TIMEZONE, LOCALIZATION
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.threading import AnacondaThread, threadMgr
 
@@ -399,3 +399,74 @@ def start_chronyd():
 
     if timezone_proxy.NTPEnabled:
         util.start_service("chronyd")
+
+
+def activate_keyboard(opts):
+    """Activate keyboard.
+
+    Set up keyboard layout from the command line option and
+    let it override from kickstart if/when X is initialized.
+
+    :param opts: the command line/boot options
+    """
+    if not is_module_available(LOCALIZATION):
+        return
+
+    from pyanaconda import keyboard
+    localization_proxy = LOCALIZATION.get_proxy()
+
+    if opts.keymap and not localization_proxy.KeyboardKickstarted:
+        localization_proxy.SetKeyboard(opts.keymap)
+        localization_proxy.SetKeyboardKickstarted(True)
+
+    if localization_proxy.KeyboardKickstarted:
+        if conf.system.can_activate_keyboard:
+            keyboard.activate_keyboard(localization_proxy)
+        else:
+            # at least make sure we have all the values
+            keyboard.populate_missing_items(localization_proxy)
+
+
+def initialize_locale(opts, text_mode):
+    """Initialize locale.
+
+    :param opts: the command line/boot options
+    :param text_mode: is the locale being set up for the text mode?
+    """
+    from pyanaconda import localization
+
+    locale_option = None
+    localization_proxy = None
+
+    if is_module_available(LOCALIZATION):
+        localization_proxy = LOCALIZATION.get_proxy()
+
+        # If the language was set on the command line, copy that to kickstart
+        if opts.lang:
+            localization_proxy.SetLanguage(opts.lang)
+            localization_proxy.SetLanguageKickstarted(True)
+
+        # Setup the locale environment
+        if localization_proxy.LanguageKickstarted:
+            locale_option = localization_proxy.Language
+
+    localization.setup_locale_environment(locale_option, text_mode=text_mode)
+
+    # Now that LANG is set, do something with it
+    localization.setup_locale(os.environ["LANG"], localization_proxy, text_mode=text_mode)
+
+
+def reinitialize_locale(opts, text_mode):
+    """Reinitialize locale.
+
+    :param opts: the command line/boot options
+    :param text_mode: is the locale being set up for the text mode?
+    """
+    from pyanaconda import localization
+    localization_proxy = None
+
+    if is_module_available(LOCALIZATION):
+        localization_proxy = LOCALIZATION.get_proxy()
+
+    log.warning("reinitializing locale due to failed attempt to start the GUI")
+    localization.setup_locale(os.environ["LANG"], localization_proxy, text_mode=text_mode)

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -781,6 +781,11 @@ class GraphicalUserInterface(UserInterface):
         from pyanaconda.ui.gui.spokes import StandaloneSpoke
         return isinstance(obj, StandaloneSpoke)
 
+    def _is_standalone_class(self, cls):
+        """Is the class passed as cls standalone?"""
+        from pyanaconda.ui.gui.spokes import StandaloneSpoke
+        return issubclass(cls, StandaloneSpoke)
+
     def setup(self, data):
         self._actions = self.getActionClasses(self._list_hubs())
         self.data = data
@@ -798,6 +803,11 @@ class GraphicalUserInterface(UserInterface):
         return self._orderActionClasses(standalones, hubs)
 
     def _instantiateAction(self, actionClass):
+        # Check if this action is to be shown in the supported environments.
+        if self._is_standalone_class(actionClass):
+            if not any(actionClass.should_run(environ, self.data) for environ in flags.environs):
+                return None
+
         # Instantiate an action on-demand, passing the arguments defining our
         # spoke API and setting up continue/quit signal handlers.
         obj = actionClass(self.data, self.storage, self.payload)

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -37,6 +37,7 @@ from pyanaconda.core.constants import DEFAULT_KEYBOARD, THREAD_KEYBOARD_INIT, TH
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.core.util import strip_accents, have_word_match
 from pyanaconda.modules.common.constants.services import LOCALIZATION
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.threading import threadMgr, AnacondaThread
 
 import locale as locale_mod
@@ -277,6 +278,14 @@ class KeyboardSpoke(NormalSpoke):
 
     icon = "input-keyboard-symbolic"
     title = CN_("GUI|Spoke", "_Keyboard")
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(LOCALIZATION):
+            return False
+
+        return NormalSpoke.should_run(environment, data)
 
     def __init__(self, *args):
         super().__init__(*args)

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -25,6 +25,7 @@ from gi.repository import Pango, Gdk
 
 from pyanaconda.core.constants import PAYLOAD_LIVE_TYPES
 from pyanaconda.modules.common.constants.services import LOCALIZATION
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import CN_
 from pyanaconda.ui.gui.spokes import NormalSpoke
@@ -61,6 +62,14 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
 
     icon = "accessories-character-map-symbolic"
     title = CN_("GUI|Spoke", "_Language Support")
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(LOCALIZATION):
+            return False
+
+        return NormalSpoke.should_run(environment, data)
 
     def __init__(self, *args, **kwargs):
         NormalSpoke.__init__(self, *args, **kwargs)

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -64,6 +64,14 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
     preForHub = SummaryHub
     priority = 0
 
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(LOCALIZATION):
+            return False
+
+        return StandaloneSpoke.should_run(environment, data)
+
     def __init__(self, *args, **kwargs):
         StandaloneSpoke.__init__(self, *args, **kwargs)
         LangLocaleHandler.__init__(self)

--- a/pyanaconda/ui/tui/spokes/language_support.py
+++ b/pyanaconda/ui/tui/spokes/language_support.py
@@ -18,6 +18,7 @@
 #
 
 from pyanaconda.modules.common.constants.services import LOCALIZATION
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.ui.categories.localization import LocalizationCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
@@ -45,6 +46,14 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     """
     help_id = "LangSupportSpoke"
     category = LocalizationCategory
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(LOCALIZATION):
+            return False
+
+        return FirstbootSpokeMixIn.should_run(environment, data)
 
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)


### PR DESCRIPTION
Check whether the Localization DBus module is enabled before it is used.
It might be disabled in the Anaconda configuration file.

The installer should skip standalone GUI spokes that return False from their
`should_run` method. There are no standalone TUI spokes.

Related: rhbz#1834535