### PR TITLE
Allow to disable the Services module

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -546,19 +546,8 @@ if __name__ == "__main__":
     ksdata.displaymode.displayMode = display_mode_coversion_table[anaconda.display_mode]
     ksdata.displaymode.nonInteractive = not anaconda.interactive_mode
 
-    # If we're in text mode, the resulting system should be too
-    # ...unless the kickstart specified otherwise
-    # NOTE: Installation controlled via VNC is considered to be
-    #       a text mode installation, as the installation run itself
-    #       is effectively headless.
-    from pyanaconda.modules.common.constants.services import SERVICES
-    from pyanaconda.core.constants import TEXT_ONLY_TARGET
-
-    services_proxy = SERVICES.get_proxy()
-
-    if not services_proxy.DefaultTarget and (anaconda.tui_mode or flags.usevnc):
-        log.debug("no default systemd target set & in text/vnc mode - setting multi-user.target.")
-        services_proxy.SetDefaultTarget(TEXT_ONLY_TARGET)
+    # Initialize the default systemd target.
+    startup_utils.initialize_default_systemd_target(text_mode=anaconda.tui_mode)
 
     # Set flag to prompt for missing ks data
     if not anaconda.interactive_mode:
@@ -674,14 +663,7 @@ if __name__ == "__main__":
 
     # Finish the initialization of the setup on boot action.
     # This should be done sooner and somewhere else once it is possible.
-    from pyanaconda.core.constants import SETUP_ON_BOOT_DEFAULT, SETUP_ON_BOOT_ENABLED
-    from pyanaconda.modules.common.constants.services import SERVICES
-    services_proxy = SERVICES.get_proxy()
-
-    if services_proxy.SetupOnBoot == SETUP_ON_BOOT_DEFAULT:
-        if  not flags.automatedInstall:
-            # Enable by default for interactive installations.
-            services_proxy.SetSetupOnBoot(SETUP_ON_BOOT_ENABLED)
+    startup_utils.initialize_first_boot_action()
 
     # Create pre-install snapshots
     from pykickstart.constants import SNAPSHOT_WHEN_PRE_INSTALL

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -105,9 +105,10 @@ def _prepare_configuration(payload, ksdata):
         os_config.append_dbus_tasks(TIMEZONE, timezone_dbus_tasks)
 
     # add installation tasks for the Services DBus module
-    services_proxy = SERVICES.get_proxy()
-    services_dbus_tasks = services_proxy.InstallWithTasks()
-    os_config.append_dbus_tasks(SERVICES, services_dbus_tasks)
+    if is_module_available(SERVICES):
+        services_proxy = SERVICES.get_proxy()
+        services_dbus_tasks = services_proxy.InstallWithTasks()
+        os_config.append_dbus_tasks(SERVICES, services_dbus_tasks)
 
     # add installation tasks for the Localization DBus module
     if is_module_available(LOCALIZATION):

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -36,9 +36,11 @@ from pyanaconda import anaconda_logging
 from pyanaconda import network
 from pyanaconda import safe_dbus
 from pyanaconda import kickstart
+from pyanaconda.core.constants import TEXT_ONLY_TARGET, SETUP_ON_BOOT_DEFAULT, \
+    SETUP_ON_BOOT_ENABLED
 from pyanaconda.flags import flags
 from pyanaconda.screensaver import inhibit_screensaver
-from pyanaconda.modules.common.constants.services import TIMEZONE, LOCALIZATION
+from pyanaconda.modules.common.constants.services import TIMEZONE, LOCALIZATION, SERVICES
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.threading import AnacondaThread, threadMgr
 
@@ -470,3 +472,40 @@ def reinitialize_locale(opts, text_mode):
 
     log.warning("reinitializing locale due to failed attempt to start the GUI")
     localization.setup_locale(os.environ["LANG"], localization_proxy, text_mode=text_mode)
+
+
+def initialize_default_systemd_target(text_mode):
+    """Initialize the default systemd target.
+
+    If we're in text mode, the resulting system should be too
+    unless the kickstart specified otherwise.
+
+    NOTE:
+
+        Installation controlled via VNC is considered to be
+        a text mode installation, as the installation run itself
+        is effectively headless.
+
+    :param text_mode: does the installer run in the text mode?
+    """
+    if not is_module_available(SERVICES):
+        return
+
+    services_proxy = SERVICES.get_proxy()
+
+    if not services_proxy.DefaultTarget and (text_mode or flags.usevnc):
+        log.debug("no default systemd target set & in text/vnc mode - setting multi-user.target.")
+        services_proxy.SetDefaultTarget(TEXT_ONLY_TARGET)
+
+
+def initialize_first_boot_action():
+    """Initialize the setup on boot action."""
+    if not is_module_available(SERVICES):
+        return
+
+    services_proxy = SERVICES.get_proxy()
+
+    if services_proxy.SetupOnBoot == SETUP_ON_BOOT_DEFAULT:
+        if not flags.automatedInstall:
+            # Enable by default for interactive installations.
+            services_proxy.SetSetupOnBoot(SETUP_ON_BOOT_ENABLED)

--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -20,14 +20,14 @@
 from abc import ABCMeta, abstractproperty
 
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.constants import ANACONDA_ENVIRON, FIRSTBOOT_ENVIRON, SETUP_ON_BOOT_RECONFIG
-from pyanaconda.modules.common.constants.services import SERVICES
+from pyanaconda.core.constants import ANACONDA_ENVIRON, FIRSTBOOT_ENVIRON
 from pyanaconda.core.util import collect
 from pyanaconda.core.signal import Signal
 from pyanaconda.ui.categories import SpokeCategory
+from pyanaconda.ui.lib.services import is_reconfiguration_mode
 from pyanaconda import lifecycle
-
 from pyanaconda.anaconda_loggers import get_module_logger
+
 log = get_module_logger(__name__)
 
 
@@ -130,8 +130,7 @@ class FirstbootSpokeMixIn(object):
             # generally run spokes in firstboot only if doing reconfig, spokes
             # that should run even if not doing reconfig should override this
             # method
-            services_proxy = SERVICES.get_proxy()
-            return services_proxy.SetupOnBoot == SETUP_ON_BOOT_RECONFIG
+            return is_reconfiguration_mode()
 
         return False
 

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -22,8 +22,8 @@ from pyanaconda.core.i18n import _, CN_
 from pyanaconda.core.users import crypt_password
 from pyanaconda import input_checking
 from pyanaconda.core import constants
-from pyanaconda.modules.common.constants.services import USERS, SERVICES
 from pyanaconda.modules.common.util import is_module_available
+from pyanaconda.modules.common.constants.services import USERS
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
@@ -31,6 +31,7 @@ from pyanaconda.ui.gui.helpers import GUISpokeInputCheckHandler
 from pyanaconda.ui.gui.utils import set_password_visibility
 from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.ui.communication import hubQ
+from pyanaconda.ui.lib.services import is_reconfiguration_mode
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -67,7 +68,6 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         NormalSpoke.__init__(self, *args)
         GUISpokeInputCheckHandler.__init__(self)
         self._users_module = USERS.get_proxy()
-        self._services_module = SERVICES.get_proxy()
 
     def initialize(self):
         NormalSpoke.initialize(self)
@@ -153,11 +153,9 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     @property
     def status(self):
         if self._users_module.IsRootAccountLocked:
-            # check if we are running in Initial Setup reconfig mode
-            reconfig_mode = self._services_module.SetupOnBoot == constants.SETUP_ON_BOOT_RECONFIG
             # reconfig mode currently allows re-enabling a locked root account if
             # user sets a new root password
-            if reconfig_mode:
+            if is_reconfiguration_mode():
                 return _("Disabled, set password to enable.")
             else:
                 return _("Root account is disabled.")

--- a/pyanaconda/ui/lib/services.py
+++ b/pyanaconda/ui/lib/services.py
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.constants import SETUP_ON_BOOT_RECONFIG
+from pyanaconda.modules.common.constants.services import SERVICES
+from pyanaconda.modules.common.util import is_module_available
+
+log = get_module_logger(__name__)
+
+
+def is_reconfiguration_mode():
+    """Check if we are running in Initial Setup reconfig mode.
+
+    :return: True or False
+    """
+    if not is_module_available(SERVICES):
+        return False
+
+    services_module = SERVICES.get_proxy()
+    return services_module.SetupOnBoot == SETUP_ON_BOOT_RECONFIG

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -18,13 +18,13 @@
 #
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
+from pyanaconda.ui.lib.services import is_reconfiguration_mode
 from pyanaconda.ui.tui.tuiobject import PasswordDialog
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import N_, _
-from pyanaconda.core.constants import SETUP_ON_BOOT_RECONFIG
-from pyanaconda.modules.common.constants.services import USERS, SERVICES
+from pyanaconda.modules.common.constants.services import USERS
 
 from simpleline.render.widgets import TextWidget
 
@@ -55,8 +55,6 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         self._password = None
 
         self._users_module = USERS.get_proxy()
-        self._services_module = SERVICES.get_proxy()
-
         self.initialize_done()
 
     @property
@@ -78,11 +76,9 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     @property
     def status(self):
         if self._users_module.IsRootAccountLocked:
-            # check if we are running in Initial Setup reconfig mode
-            reconfig_mode = self._services_module.SetupOnBoot == SETUP_ON_BOOT_RECONFIG
             # reconfig mode currently allows re-enabling a locked root account if
             # user sets a new root password
-            if reconfig_mode:
+            if is_reconfiguration_mode():
                 return _("Disabled. Set password to enable root account.")
             else:
                 return _("Root account is disabled.")


### PR DESCRIPTION
Check whether the Services DBus module is enabled before it is used.
It might be disabled in the Anaconda configuration file.

Related: rhbz#1834535