### PR TITLE
Allow to disable the Security module

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -504,14 +504,8 @@ if __name__ == "__main__":
     # Set up the payload from the cmdline options.
     anaconda.payload.set_from_opts(opts)
 
-    from pyanaconda.modules.common.constants.services import SECURITY
-    security_proxy = SECURITY.get_proxy()
-    # Override the selinux state from kickstart if set on the command line
-    if conf.security.selinux != constants.SELINUX_DEFAULT:
-        security_proxy.SetSELinux(conf.security.selinux)
-    # Enable fingerprint option by default (#481273).
-    if not flags.automatedInstall:
-        security_proxy.SetFingerprintAuthEnabled(True)
+    # Initialize the security configuration.
+    startup_utils.initialize_security()
 
     # Set the language before loading an interface, when it may be too late.
     startup_utils.initialize_locale(opts, text_mode=anaconda.tui_mode)

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -93,9 +93,10 @@ def _prepare_configuration(payload, ksdata):
     os_config = TaskQueue("Installed system configuration", N_("Configuring installed system"))
 
     # add installation tasks for the Security DBus module
-    security_proxy = SECURITY.get_proxy()
-    security_dbus_tasks = security_proxy.InstallWithTasks()
-    os_config.append_dbus_tasks(SECURITY, security_dbus_tasks)
+    if is_module_available(SECURITY):
+        security_proxy = SECURITY.get_proxy()
+        security_dbus_tasks = security_proxy.InstallWithTasks()
+        os_config.append_dbus_tasks(SECURITY, security_dbus_tasks)
 
     # add installation tasks for the Timezone DBus module
     # run these tasks before tasks of the Services module
@@ -178,7 +179,9 @@ def _prepare_configuration(payload, ksdata):
 
     # realm join
     # - this can run only after network is configured in the target system chroot
-    configuration_queue.append_dbus_tasks(SECURITY, [security_proxy.JoinRealmWithTask()])
+    if is_module_available(SECURITY):
+        security_proxy = SECURITY.get_proxy()
+        configuration_queue.append_dbus_tasks(SECURITY, [security_proxy.JoinRealmWithTask()])
 
     post_scripts = TaskQueue("Post installation scripts", N_("Running post-installation scripts"))
     post_scripts.append(Task("Run post installation scripts", runPostScripts, (ksdata.scripts,)))
@@ -291,8 +294,9 @@ def _prepare_installation(payload, ksdata):
         pre_install.append(WriteResolvConfTask("Copy resolv.conf to sysroot"))
 
     # realm discovery
-    security_proxy = SECURITY.get_proxy()
-    pre_install.append_dbus_tasks(SECURITY, [security_proxy.DiscoverRealmWithTask()])
+    if is_module_available(SECURITY):
+        security_proxy = SECURITY.get_proxy()
+        pre_install.append_dbus_tasks(SECURITY, [security_proxy.DiscoverRealmWithTask()])
 
     def run_pre_install():
         """This means to gather what additional packages (if any) are needed & executing payload.pre_install()."""

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -40,7 +40,8 @@ from pyanaconda.core.constants import TEXT_ONLY_TARGET, SETUP_ON_BOOT_DEFAULT, \
     SETUP_ON_BOOT_ENABLED
 from pyanaconda.flags import flags
 from pyanaconda.screensaver import inhibit_screensaver
-from pyanaconda.modules.common.constants.services import TIMEZONE, LOCALIZATION, SERVICES
+from pyanaconda.modules.common.constants.services import TIMEZONE, LOCALIZATION, SERVICES, \
+    SECURITY
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.threading import AnacondaThread, threadMgr
 
@@ -509,3 +510,19 @@ def initialize_first_boot_action():
         if not flags.automatedInstall:
             # Enable by default for interactive installations.
             services_proxy.SetSetupOnBoot(SETUP_ON_BOOT_ENABLED)
+
+
+def initialize_security():
+    """Initialize the security configuration."""
+    if not is_module_available(SECURITY):
+        return
+
+    security_proxy = SECURITY.get_proxy()
+
+    # Override the selinux state from kickstart if set on the command line
+    if conf.security.selinux != constants.SELINUX_DEFAULT:
+        security_proxy.SetSELinux(conf.security.selinux)
+
+    # Enable fingerprint option by default (#481273).
+    if not flags.automatedInstall:
+        security_proxy.SetFingerprintAuthEnabled(True)


### PR DESCRIPTION
Check whether the Security DBus module is enabled before it is used.
It might be disabled in the Anaconda configuration file.

Related: rhbz#1834535