### PR TITLE
Save logs correctly after container update GH action run

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -37,10 +37,10 @@ jobs:
         with:
           name: logs
           path: |
-            tests/test-suite.log
-            tests/nosetests.log
-            tests/pylint/runpylint*.log
-            tests/coverage-*.log
+            test-logs/test-suite.log
+            test-logs/nosetests.log
+            test-logs/pylint/runpylint*.log
+            test-logs/coverage-*.log
 
       - name: Login to container registry
         run: podman login -u ${{ secrets.QUAY_USERNAME }} -p ${{ secrets.QUAY_PASSWORD }} quay.io


### PR DESCRIPTION
Logs were moved to test-logs folder so we should adapt the workflow to the correct path.

Trying to fix [this](https://github.com/rhinstaller/anaconda/actions/runs/479018492) situation.

Tested [here](https://github.com/Test-anaconda-org/anaconda/actions/runs/479886238). Job has failed which is expected, the point is that logs are stored correctly.