### PR TITLE
Skip payload-related spokes in the initial setup (#1915541)

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -410,6 +410,9 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
     @classmethod
     def should_run(cls, environment, data):
         """Don't run for any non-package payload."""
+        if not NormalSpoke.should_run(environment, data):
+            return False
+
         return context.payload.type == PAYLOAD_TYPE_DNF
 
     def __init__(self, *args, **kwargs):

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -65,6 +65,9 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
     @classmethod
     def should_run(cls, environment, data):
         """Don't show the language support spoke on live media."""
+        if not NormalSpoke.should_run(environment, data):
+            return False
+
         return context.payload.type not in PAYLOAD_LIVE_TYPES
 
     def __init__(self, *args, **kwargs):

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -78,6 +78,9 @@ class SoftwareSelectionSpoke(NormalSpoke):
     @classmethod
     def should_run(cls, environment, data):
         """Don't run for any non-package payload."""
+        if not NormalSpoke.should_run(environment, data):
+            return False
+
         return context.payload.type == PAYLOAD_TYPE_DNF
 
     def __init__(self, *args, **kwargs):

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -70,6 +70,9 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
     @classmethod
     def should_run(cls, environment, data):
         """Don't run for any non-package payload."""
+        if not NormalTUISpoke.should_run(environment, data):
+            return False
+
         return context.payload.type == PAYLOAD_TYPE_DNF
 
     def __init__(self, data, storage, payload):

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -52,6 +52,9 @@ class SoftwareSpoke(NormalTUISpoke):
     @classmethod
     def should_run(cls, environment, data):
         """Don't run for any non-package payload."""
+        if not NormalTUISpoke.should_run(environment, data):
+            return False
+
         return context.payload.type == PAYLOAD_TYPE_DNF
 
     def __init__(self, data, storage, payload):


### PR DESCRIPTION
The initial setup doesn't install payload. It was broken by the commit ef0b5e9.

Resolves: rhbz#1915541