### PR TITLE
Use RHEL help content for RHV/Ovirt

### DIFF
--- a/data/product.d/ovirt.conf
+++ b/data/product.d/ovirt.conf
@@ -26,7 +26,7 @@ req_partition_sizes =
     /boot  1  GiB
 
 [User Interface]
-help_directory = /usr/share/anaconda/help/rhv
+help_directory = /usr/share/anaconda/help/rhel
 
 [Payload]
 default_source = CLOSEST_MIRROR

--- a/data/product.d/rhev.conf
+++ b/data/product.d/rhev.conf
@@ -26,7 +26,7 @@ req_partition_sizes =
     /boot  1  GiB
 
 [User Interface]
-help_directory = /usr/share/anaconda/help/rhv
+help_directory = /usr/share/anaconda/help/rhel
 
 [Payload]
 default_source = CLOSEST_MIRROR


### PR DESCRIPTION
As we don't have any RHV/Ovirt specific help content, the
RHEL help content should be the most suitable.