### PR TITLE
Grab GitHub notifications for periodic workflows

### DIFF
--- a/.github/workflows/daily-rhel-copr.yml
+++ b/.github/workflows/daily-rhel-copr.yml
@@ -1,3 +1,4 @@
+# Do a build of the rhel-8 branch to RH internal COPR
 name: Build current anaconda rhel-8 branch in RHEL COPR
 on:
   schedule:


### PR DESCRIPTION
Unfortunately, GitHub will sent notifications about failures for on:schedule workflows just to the last person who did some changes to the workflow. :(

So let's go and steal it from pitti!