### PR TITLE
 Select disks for implicit partitions

### DIFF
--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
@@ -24,7 +24,7 @@ from pyanaconda.modules.storage.partitioning.automatic.noninteractive_partitioni
     NonInteractivePartitioningTask
 from pyanaconda.modules.storage.partitioning.automatic.utils import get_candidate_disks, \
     schedule_implicit_partitions, schedule_volumes, schedule_partitions, get_pbkdf_args, \
-    get_default_partitioning
+    get_default_partitioning, get_disks_for_implicit_partitions
 from pyanaconda.core.storage import suggest_swap_size
 
 log = get_module_logger(__name__)
@@ -171,7 +171,11 @@ class AutomaticPartitioningTask(NonInteractivePartitioningTask):
         disks = get_candidate_disks(storage)
         log.debug("candidate disks: %s", [d.name for d in disks])
 
-        devs = schedule_implicit_partitions(storage, disks, scheme, encrypted, luks_fmt_args)
+        # Schedule implicit partitions.
+        extra_disks = get_disks_for_implicit_partitions(disks, scheme, requests)
+        devs = schedule_implicit_partitions(storage, extra_disks, scheme, encrypted, luks_fmt_args)
+
+        # Schedule requested partitions.
         devs = schedule_partitions(storage, disks, devs, scheme, requests, encrypted, luks_fmt_args)
 
         # run the autopart function to allocate and grow partitions

--- a/pyanaconda/modules/storage/partitioning/automatic/utils.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/utils.py
@@ -170,6 +170,45 @@ def get_candidate_disks(storage):
     return free_disks
 
 
+def get_disks_for_implicit_partitions(disks, scheme, requests):
+    """Return a list of disks that can be used for implicit partitions.
+
+    :param disks: a list of candidate disks
+    :param scheme: a type of the partitioning scheme
+    :param requests: a list of partitioning requests
+    :return: a list of disks that can be used for implicit partitions
+    """
+    # There will be no implicit partitions.
+    if scheme == AUTOPART_TYPE_PLAIN:
+        return []
+
+    # Calculate slots for requested partitions.
+    requested_slots = 0
+
+    for request in requests:
+        if request.is_partition(scheme):
+            requested_slots += 1
+
+    # Collect extra disks for implicit partitions.
+    extra_disks = []
+
+    for disk in disks:
+        parted_disk = disk.format.parted_disk
+        supports_extended = parted_disk.supportsFeature(parted.DISK_TYPE_EXTENDED)
+        available_slots = parted_disk.maxPrimaryPartitionCount - parted_disk.primaryPartitionCount
+
+        # Skip disks that will be used for requested partitions.
+        if requested_slots and not supports_extended and available_slots <= requested_slots:
+            requested_slots -= available_slots
+            log.debug("Don't use %s for implicit partitions.", disk.name)
+        else:
+            requested_slots = 0
+            extra_disks.append(disk)
+
+    log.debug("Found disks for implicit partitions: %s", [d.name for d in extra_disks])
+    return extra_disks
+
+
 def schedule_implicit_partitions(storage, disks, scheme, encrypted=False, luks_fmt_args=None):
     """Schedule creation of a lvm/btrfs member partitions for autopart.
 
@@ -212,6 +251,7 @@ def schedule_implicit_partitions(storage, disks, scheme, encrypted=False, luks_f
                                      parents=[disk])
         storage.create_device(part)
         devs.append(part)
+        log.debug("Created the implicit partition %s for %s.", part.name, disk.name)
 
     return devs
 

--- a/pyanaconda/modules/storage/partitioning/specification.py
+++ b/pyanaconda/modules/storage/partitioning/specification.py
@@ -19,6 +19,8 @@
 #
 
 from blivet.util import stringize, unicodeize
+from pykickstart.constants import AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_BTRFS, AUTOPART_TYPE_LVM, \
+    AUTOPART_TYPE_LVM_THINP
 
 
 class PartSpec(object):
@@ -81,6 +83,52 @@ class PartSpec(object):
               "thin": self.thin})
 
         return s
+
+    def is_partition(self, scheme):
+        """Is the specified device a partition in the given scheme?
+
+        :param scheme: a partitioning scheme
+        :return: True or False
+        """
+        return not self.is_volume(scheme)
+
+    def is_volume(self, scheme):
+        """Is the specified device a volume in the given scheme?
+
+        :param scheme: a partitioning scheme
+        :return: True or False
+        """
+        if scheme == AUTOPART_TYPE_PLAIN:
+            return False
+
+        return self.is_lvm_volume(scheme) or self.is_btrfs_subvolume(scheme)
+
+    def is_lvm_volume(self, scheme):
+        """Is the specified device an LVM volume in the given scheme?
+
+        :param scheme: a partitioning scheme
+        :return: True or False
+        """
+        return scheme in (AUTOPART_TYPE_LVM, AUTOPART_TYPE_LVM_THINP) and self.lv
+
+    def is_lvm_thin_volume(self, scheme):
+        """Is the specified device an LVM thin volume in the given scheme?
+
+        :param scheme: a partitioning scheme
+        :return: True or False
+        """
+        if not self.is_lvm_volume(scheme):
+            return False
+
+        return scheme == AUTOPART_TYPE_LVM_THINP and self.thin
+
+    def is_btrfs_subvolume(self, scheme):
+        """Is the specified device a Btrfs subvolume in the given scheme?
+
+        :param scheme: a partitioning scheme
+        :return: True or False
+        """
+        return scheme == AUTOPART_TYPE_BTRFS and self.btr
 
     def __str__(self):
         return stringize(self._to_string())

--- a/tests/nosetests/pyanaconda_tests/module_part_specification_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_specification_test.py
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+
+from pykickstart.constants import AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_LVM, AUTOPART_TYPE_BTRFS, \
+    AUTOPART_TYPE_LVM_THINP
+
+from pyanaconda.modules.storage.partitioning.specification import PartSpec
+
+
+class PartitioningSpecificationTestCase(unittest.TestCase):
+    """Test the PartSpec class."""
+
+    def is_partition_test(self):
+        """Test the is_partition method."""
+        spec = PartSpec("/")
+        self.assertEqual(spec.is_partition(AUTOPART_TYPE_PLAIN), True)
+        self.assertEqual(spec.is_partition(AUTOPART_TYPE_LVM), True)
+        self.assertEqual(spec.is_partition(AUTOPART_TYPE_LVM_THINP), True)
+        self.assertEqual(spec.is_partition(AUTOPART_TYPE_BTRFS), True)
+
+    def is_volume_test(self):
+        """Test the is_volume method."""
+        spec = PartSpec("/", lv=True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_PLAIN), False)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM), True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM_THINP), True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_BTRFS), False)
+
+        spec = PartSpec("/", lv=True, thin=True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_PLAIN), False)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM), True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM_THINP), True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_BTRFS), False)
+
+        spec = PartSpec("/", btr=True)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_PLAIN), False)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM), False)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM_THINP), False)
+        self.assertEqual(spec.is_volume(AUTOPART_TYPE_BTRFS), True)
+
+    def is_lvm_thin_volume_test(self):
+        """Test the is_lvm_thin_volume method."""
+        spec = PartSpec("/", lv=True)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_PLAIN), False)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM), False)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM_THINP), False)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_BTRFS), False)
+
+        spec = PartSpec("/", lv=True, thin=True)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_PLAIN), False)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM), False)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM_THINP), True)
+        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_BTRFS), False)


### PR DESCRIPTION
Don't use disks that will be used for allocation of requested partitions
(for example, the /boot partition). Calculate the number of slots that
will be used by requested partitions and skip disks that will not have
free slots for implicit partitions.

Otherwise, we might schedule implicit partitions, that wouldn't be possible
to allocate on the specified disk, and the partitioning might fail.

Related: rhbz#1642391

**Ported from** https://github.com/rhinstaller/anaconda/pull/2973.