### PR TITLE
Allow to disable the Timezone module

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -626,7 +626,6 @@ if __name__ == "__main__":
     disk_select_proxy.SetProtectedDevices(protected_devices)
 
     from pyanaconda.payload.manager import payloadMgr
-    from pyanaconda.timezone import time_initialize
 
     if not conf.target.is_directory:
         from pyanaconda.ui.lib.storage import reset_storage
@@ -634,13 +633,8 @@ if __name__ == "__main__":
         threadMgr.add(AnacondaThread(name=constants.THREAD_STORAGE,
                                      target=reset_storage))
 
-    from pyanaconda.modules.common.constants.services import TIMEZONE
-    timezone_proxy = TIMEZONE.get_proxy()
-
-    if conf.system.can_initialize_system_clock:
-        threadMgr.add(AnacondaThread(name=constants.THREAD_TIME_INIT,
-                                     target=time_initialize,
-                                     args=(timezone_proxy, )))
+    # Initialize the system clock.
+    startup_utils.initialize_system_clock()
 
     if flags.rescue_mode:
         rescue.start_rescue_mode_ui(anaconda)

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -98,9 +98,10 @@ def _prepare_configuration(payload, ksdata):
 
     # add installation tasks for the Timezone DBus module
     # run these tasks before tasks of the Services module
-    timezone_proxy = TIMEZONE.get_proxy()
-    timezone_dbus_tasks = timezone_proxy.InstallWithTasks()
-    os_config.append_dbus_tasks(TIMEZONE, timezone_dbus_tasks)
+    if is_module_available(TIMEZONE):
+        timezone_proxy = TIMEZONE.get_proxy()
+        timezone_dbus_tasks = timezone_proxy.InstallWithTasks()
+        os_config.append_dbus_tasks(TIMEZONE, timezone_dbus_tasks)
 
     # add installation tasks for the Services DBus module
     services_proxy = SERVICES.get_proxy()

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -40,6 +40,7 @@ from pyanaconda.modules.common.constants.objects import FCOE
 from pyanaconda.modules.common.task import sync_run_task
 from pyanaconda.modules.common.structures.network import NetworkDeviceInfo
 from pyanaconda.modules.common.structures.timezone import TimeSourceData
+from pyanaconda.modules.common.util import is_module_available
 
 import gi
 gi.require_version("NM", "1.0")
@@ -304,6 +305,9 @@ def write_configuration(overwrite=False):
 def _set_ntp_servers_from_dhcp():
     """Set NTP servers of timezone module from dhcp if not set by kickstart."""
     # FIXME - do it only if they will be applied (the guard at the end of the function)
+    if not is_module_available(TIMEZONE):
+        return
+
     timezone_proxy = TIMEZONE.get_proxy()
     ntp_servers = get_ntp_servers_from_dhcp(get_nm_client())
     log.info("got %d NTP servers from DHCP", len(ntp_servers))

--- a/pyanaconda/timezone.py
+++ b/pyanaconda/timezone.py
@@ -31,6 +31,7 @@ from pyanaconda.core.constants import THREAD_STORAGE
 from pyanaconda.flags import flags
 from pyanaconda.modules.common.constants.objects import BOOTLOADER
 from pyanaconda.modules.common.constants.services import TIMEZONE, STORAGE
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.threading import threadMgr
 from blivet import arch
 
@@ -87,6 +88,9 @@ def save_hw_clock(timezone_proxy=None):
 
     """
     if arch.is_s390():
+        return
+
+    if not is_module_available(TIMEZONE):
         return
 
     if not timezone_proxy:

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -37,6 +37,7 @@ from pyanaconda.core.timer import Timer
 from pyanaconda.localization import get_xlated_timezone, resolve_date_format
 from pyanaconda.modules.common.structures.timezone import TimeSourceData
 from pyanaconda.modules.common.constants.services import TIMEZONE, NETWORK
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.ntp import NTPServerStatusCache
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.ui.common import FirstbootSpokeMixIn
@@ -401,6 +402,14 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
     # see https://bugzilla.gnome.org/show_bug.cgi?id=712184
     _hack = TimezoneMap.TimezoneMap()
     del(_hack)
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(TIMEZONE):
+            return False
+
+        return FirstbootSpokeMixIn.should_run(environment, data)
 
     def __init__(self, *args):
         NormalSpoke.__init__(self, *args)

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -41,8 +41,9 @@ from pyanaconda.core.i18n import _, C_
 from pyanaconda.core.util import ipmi_abort
 from pyanaconda.core.constants import DEFAULT_LANG, WINDOW_TITLE_TEXT
 from pyanaconda.modules.common.constants.services import TIMEZONE, LOCALIZATION
-
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.anaconda_loggers import get_module_logger
+
 log = get_module_logger(__name__)
 
 __all__ = ["WelcomeLanguageSpoke"]
@@ -80,15 +81,25 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
             return
 
         locale = store[itr][1]
+
+        self._apply_selected_locale(locale)
+        self._apply_geolocation_results()
+
+    def _apply_selected_locale(self, locale):
+        """Apply the selected locale."""
         locale = localization.setup_locale(locale, self._l12_module, text_mode=False)
         self._set_lang(locale)
 
+    def _apply_geolocation_results(self):
+        """Apply the geolocation results if any."""
         # Skip timezone and keyboard default setting for kickstart installs.
         # The user may have provided these values via kickstart and if not, we
         # need to prompt for them. But do continue if geolocation-with-kickstart
         # is enabled.
-
         if flags.flags.automatedInstall and not geoloc.geoloc.enabled:
+            return
+
+        if not is_module_available(TIMEZONE):
             return
 
         timezone_proxy = TIMEZONE.get_proxy()

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -19,6 +19,7 @@
 from pyanaconda.core.constants import TIME_SOURCE_SERVER
 from pyanaconda.modules.common.constants.services import TIMEZONE
 from pyanaconda.modules.common.structures.timezone import TimeSourceData
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.ntp import NTPServerStatusCache
 from pyanaconda.ui.categories.localization import LocalizationCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
@@ -49,6 +50,14 @@ CallbackTimezoneArgs = namedtuple("CallbackTimezoneArgs", ["region", "timezone"]
 class TimeSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     helpFile = "DateTimeSpoke.txt"
     category = LocalizationCategory
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(TIMEZONE):
+            return False
+
+        return FirstbootSpokeMixIn.should_run(environment, data)
 
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)


### PR DESCRIPTION
Check whether the Timezone DBus module is enabled before it is used.
It might be disabled in the Anaconda configuration file.

(cherry-picked from a commit e579de3)

Related: rhbz#1834535