### PR TITLE
Allow to disable the network installation

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -46,6 +46,10 @@ physical_root = /mnt/sysimage
 # A path to the system root of the target.
 system_root = /mnt/sysroot
 
+# Should we install the network configuration?
+can_configure_network = True
+
+
 [Network]
 # Network device to be activated on boot if none was configured so.
 # Valid values:

--- a/pyanaconda/core/configuration/target.py
+++ b/pyanaconda/core/configuration/target.py
@@ -61,3 +61,11 @@ class TargetSection(Section):
     def is_directory(self):
         """Are we installing to a directory?"""
         return self.type is TargetType.DIRECTORY
+
+    @property
+    def can_configure_network(self):
+        """Should we install the network configuration?
+
+        :return: True or False
+        """
+        return self._get_option("can_configure_network", bool)

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -113,14 +113,15 @@ def _prepare_configuration(payload, ksdata):
     os_config.append_dbus_tasks(LOCALIZATION, localization_dbus_tasks)
 
     # add the Firewall configuration task
-    firewall_proxy = NETWORK.get_proxy(FIREWALL)
-    firewall_dbus_task = firewall_proxy.InstallWithTask()
-    os_config.append_dbus_tasks(NETWORK, [firewall_dbus_task])
+    if conf.target.can_configure_network:
+        firewall_proxy = NETWORK.get_proxy(FIREWALL)
+        firewall_dbus_task = firewall_proxy.InstallWithTask()
+        os_config.append_dbus_tasks(NETWORK, [firewall_dbus_task])
 
     configuration_queue.append(os_config)
 
     # schedule network configuration (if required)
-    if conf.system.provides_network_config:
+    if conf.target.can_configure_network and conf.system.provides_network_config:
         overwrite = payload.type in PAYLOAD_LIVE_TYPES
         network_config = TaskQueue("Network configuration", N_("Writing network configuration"))
         network_config.append(Task("Network configuration",


### PR DESCRIPTION
Check the `can_configure_network` configuration option of the `Installation Target`
section before the installation of the network configuration on the target
system.

(cherry-picked from a commit 76d52f2)

Related: rhbz#1834535