### PR TITLE
Move the password policy into the configuration files and on DBus

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -452,6 +452,10 @@ if __name__ == "__main__":
     # Parse the kickstart file.
     ksdata = startup_utils.parse_kickstart(kspath, addon_paths, strict_mode=opts.ksstrict)
 
+    # Set up the password policy.
+    from pyanaconda.pwpolicy import apply_password_policy_from_kickstart
+    apply_password_policy_from_kickstart(ksdata)
+
     # Pick up any changes from interactive-defaults.ks that would
     # otherwise be covered by the dracut KS parser.
     from pyanaconda.modules.common.constants.services import STORAGE

--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,7 @@ AC_CONFIG_FILES([Makefile
                  pyanaconda/modules/boss/install_manager/Makefile
                  pyanaconda/modules/boss/kickstart_manager/Makefile
                  pyanaconda/modules/boss/module_manager/Makefile
+                 pyanaconda/modules/boss/user_interface/Makefile
                  pyanaconda/modules/security/Makefile
                  pyanaconda/modules/timezone/Makefile
                  pyanaconda/modules/network/Makefile

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -270,6 +270,12 @@ hidden_spokes =
 # Run GUI installer in a decorated window.
 decorated_window = False
 
+# Should the UI allow to change the configured root account?
+can_change_root = False
+
+# Should the UI allow to change the configured user accounts?
+can_change_users = False
+
 
 [License]
 # A path to EULA (if any)

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -276,6 +276,21 @@ can_change_root = False
 # Should the UI allow to change the configured user accounts?
 can_change_users = False
 
+# Define the default password policies.
+# Specify a policy name and its attributes on each line.
+#
+# Valid attributes:
+#
+#   quality <NUMBER>  The minimum quality score (see libpwquality).
+#   length <NUMBER>   The minimum length of the password.
+#   empty             Allow an empty password.
+#   strict            Require the minimum quality.
+#
+password_policies =
+    root (quality 1, length 6)
+    user (quality 1, length 6, empty)
+    luks (quality 1, length 6)
+
 
 [License]
 # A path to EULA (if any)

--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -1,2 +1,8 @@
-# Kickstart defaults file for an interative install.
+# Kickstart defaults file for an interactive install.
 # This is not loaded if a kickstart file is provided on the command line.
+#
+# WARNING:
+#
+#   This file is deprecated and will be removed in in the future.
+#   Use the Anaconda configuration files instead.
+#

--- a/data/interactive-defaults.ks
+++ b/data/interactive-defaults.ks
@@ -1,13 +1,2 @@
 # Kickstart defaults file for an interative install.
 # This is not loaded if a kickstart file is provided on the command line.
-
-%anaconda
-# Default password policies
-pwpolicy root --notstrict --minlen=6 --minquality=1 --nochanges --notempty
-pwpolicy user --notstrict --minlen=6 --minquality=1 --nochanges --emptyok
-pwpolicy luks --notstrict --minlen=6 --minquality=1 --nochanges --notempty
-# NOTE: This applies only to *fully* interactive installations, partial kickstart
-#       installations use defaults specified in pyanaconda/pwpolicy.py.
-#       Automated kickstart installs simply ignore the password policy as the policy
-#       only applies to the UI, not for passwords specified in kickstart.
-%end

--- a/docs/kickstart.rst
+++ b/docs/kickstart.rst
@@ -10,6 +10,7 @@ commands `documented here <https://pykickstart.readthedocs.io/>`_
 by adding a new kickstart section named ``%anaconda`` where commands to control the behavior
 of Anaconda will be defined.
 
+*Deprecated since Fedora 34.*
 
 pwpolicy
 --------
@@ -61,6 +62,11 @@ the kickstart, like this::
     %end
 
 .. note:: The commit message for pwpolicy included some incorrect examples.
+
+*Deprecated since Fedora 34.*
+
+.. note:: You can use the configuration option ``password_policies``.
+
 
 installclass
 ------------

--- a/pyanaconda/core/configuration/storage.py
+++ b/pyanaconda/core/configuration/storage.py
@@ -25,6 +25,7 @@ from pykickstart.constants import AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_BTRFS, AUTO
     AUTOPART_TYPE_LVM_THINP
 
 from pyanaconda.core.configuration.base import Section
+from pyanaconda.core.configuration.utils import split_name_and_attributes
 
 
 class PartitioningScheme(Enum):
@@ -152,17 +153,12 @@ class StorageSection(Section):
     def _convert_partitioning_line(cls, line):
         """Convert a partitioning line into a dictionary."""
         # Parse the line.
-        name, raw_attrs = cls._split_string(line)
-
-        # Split the attributes and skip empty strings (split
-        # always returns at least one item, an empty string).
-        raw_attrs = raw_attrs.strip("()").split(",")
-        raw_attrs = map(cls._split_string, filter(None, raw_attrs))
+        name, raw_attrs = split_name_and_attributes(line)
 
         # Generate the dictionary.
         attrs = {"name": name}
 
-        for name, value in raw_attrs:
+        for name, value in raw_attrs.items():
             if value and name in ("size", "min", "max", "free"):
                 # Handle a size attribute.
                 attrs[name] = Size(value)
@@ -189,13 +185,3 @@ class StorageSection(Section):
 
         if attrs.get("max") and not attrs.get("min"):
             raise ValueError("The attribute 'max' cannot be set without 'min'.")
-
-    @staticmethod
-    def _split_string(value):
-        """Split the given value into two strings."""
-        items = value.strip().split(maxsplit=1)
-
-        while len(items) < 2:
-            items.append("")
-
-        return items

--- a/pyanaconda/core/configuration/ui.py
+++ b/pyanaconda/core/configuration/ui.py
@@ -18,6 +18,7 @@
 #  Author(s):  Vendula Poncova <vponcova@redhat.com>
 #
 from pyanaconda.core.configuration.base import Section
+from pyanaconda.core.configuration.utils import split_name_and_attributes
 
 
 class UserInterfaceSection(Section):
@@ -93,3 +94,64 @@ class UserInterfaceSection(Section):
         :return: True or False
         """
         return self._get_option("can_change_users", bool)
+
+    @property
+    def password_policies(self):
+        """The password policies.
+
+        Returns a list of dictionaries with password policy attributes.
+        The name of the policy is represented by the attribute 'name'
+        in the dictionary representation.
+
+        Valid attributes:
+
+            name        The name of the policy.
+            quality     The minimum quality score (see libpwquality).
+            length      The minimum length of the password.
+            empty       Allow an empty password.
+            strict      Require the minimum quality.
+
+        :return: a list of dictionaries with policy attributes
+        """
+        return self._get_option("password_policies", self._convert_policies)
+
+    def _convert_policies(self, value):
+        """Convert a policies string into a list of dictionaries."""
+        return list(map(self._convert_policy_line, value.strip().split("\n")))
+
+    @classmethod
+    def _convert_policy_line(cls, line):
+        """Convert a policy line into a dictionary."""
+        # Parse the line.
+        name, raw_attrs = split_name_and_attributes(line)
+
+        # Generate the dictionary.
+        attrs = {"name": name}
+
+        for name, value in raw_attrs.items():
+            if not value and name in ("strict", "empty"):
+                # Handle a boolean attribute.
+                attrs[name] = True
+            elif value and name in ("length", "quality"):
+                # Handle an integer attribute.
+                attrs[name] = int(value)
+            else:
+                # Handle an invalid attribute.
+                raise ValueError("Invalid attribute: " + name)
+
+        # Validate the dictionary.
+        cls._validate_policy_attributes(attrs)
+
+        return attrs
+
+    @staticmethod
+    def _validate_policy_attributes(attrs):
+        """Validate the dictionary with policy attributes."""
+        if not attrs.get("name"):
+            raise ValueError("The name of the policy is not specified.")
+
+        if "length" not in attrs:
+            raise ValueError("The minimal length is not specified.")
+
+        if "quality" not in attrs:
+            raise ValueError("The minimal quality is not specified.")

--- a/pyanaconda/core/configuration/ui.py
+++ b/pyanaconda/core/configuration/ui.py
@@ -69,3 +69,27 @@ class UserInterfaceSection(Section):
         :return: True or False
         """
         return self._get_option("decorated_window", bool)
+
+    @property
+    def can_change_root(self):
+        """Should the UI allow to change the configured root account?
+
+        If the root account is already set up by a kickstart file or
+        via the DBus API, should we allow to change it via the user
+        interface?
+
+        :return: True or False
+        """
+        return self._get_option("can_change_root", bool)
+
+    @property
+    def can_change_users(self):
+        """Should the UI allow to change the configured user accounts?
+
+        If the user accounts are already set up by a kickstart file or
+        via the DBus API, should we allow to change them via the user
+        interface?
+
+        :return: True or False
+        """
+        return self._get_option("can_change_users", bool)

--- a/pyanaconda/core/configuration/utils.py
+++ b/pyanaconda/core/configuration/utils.py
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+def split_name_and_attributes(value):
+    """Split the given string into a name and a dictionary of attributes.
+
+    :param value: a string of the type 'name (attr1 val1, attr2, ...)'
+    :return: a name and a dictionary of attributes
+    """
+    # Parse the line.
+    name, raw_attrs = _split_string(value)
+
+    # Split the attributes and skip empty strings (split
+    # always returns at least one item, an empty string).
+    raw_attrs = raw_attrs.strip("()").split(",")
+    raw_attrs = dict(map(_split_string, filter(None, raw_attrs)))
+
+    return name, raw_attrs
+
+
+def _split_string(value, delimiter=None):
+    """Split the given value into two strings.
+
+    :param value: a string to split
+    :param delimiter: a delimiter for splitting
+    :return: a list of exactly two strings
+    """
+    # There might be up to two items in the list.
+    items = value.strip().split(sep=delimiter, maxsplit=1)
+
+    # Return exactly two items. Add empty strings if necessary.
+    return (items + [""] * 2)[:2]

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -250,6 +250,11 @@ PASSWORD_SHOW = N_("Show password.")
 PASSWORD_HIDE_ICON = "anaconda-password-show-off"
 PASSWORD_SHOW_ICON = "anaconda-password-show-on"
 
+# The default types of password policies.
+PASSWORD_POLICY_ROOT = "root"
+PASSWORD_POLICY_USER = "user"
+PASSWORD_POLICY_LUKS = "luks"
+
 # the number of seconds we consider a noticeable freeze of the UI
 NOTICEABLE_FREEZE = 0.1
 

--- a/pyanaconda/input_checking.py
+++ b/pyanaconda/input_checking.py
@@ -24,8 +24,9 @@ from pyanaconda.core.signal import Signal
 from pyanaconda.core.i18n import _
 from pyanaconda.core import constants, regexes
 from pyanaconda.core import users
-
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.modules.common.constants.objects import USER_INTERFACE
+from pyanaconda.modules.common.constants.services import BOSS
 from pyanaconda.modules.common.structures.policy import PasswordPolicy
 
 log = get_module_logger(__name__)
@@ -37,7 +38,12 @@ def get_policy(policy_name) -> PasswordPolicy:
     :param policy_name: a name of the policy
     :return: a password policy data
     """
-    # FIXME: Get the policy from the UI DBus module.
+    proxy = BOSS.get_proxy(USER_INTERFACE)
+    policies = PasswordPolicy.from_structure_dict(proxy.PasswordPolicies)
+
+    if policy_name in policies:
+        return policies[policy_name]
+
     return PasswordPolicy.from_defaults(policy_name)
 
 

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -40,11 +40,11 @@ from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.constants.services import BOSS
 from pyanaconda.modules.common.structures.kickstart import KickstartReport
-from pyanaconda.pwpolicy import F22_PwPolicy, F22_PwPolicyData
+from pyanaconda.pwpolicy import F34_PwPolicy, F34_PwPolicyData
 
 from pykickstart.base import BaseHandler, KickstartCommand
 from pykickstart.constants import KS_SCRIPT_POST, KS_SCRIPT_PRE, KS_SCRIPT_TRACEBACK, KS_SCRIPT_PREINSTALL
-from pykickstart.errors import KickstartError, KickstartParseWarning
+from pykickstart.errors import KickstartError, KickstartParseWarning, KickstartDeprecationWarning
 from pykickstart.ko import KickstartObject
 from pykickstart.parser import KickstartParser
 from pykickstart.parser import Script as KSScript
@@ -248,11 +248,11 @@ class RepoData(COMMANDS.RepoData):
 class AnacondaSectionHandler(BaseHandler):
     """A handler for only the anaconda section's commands."""
     commandMap = {
-        "pwpolicy": F22_PwPolicy
+        "pwpolicy": F34_PwPolicy
     }
 
     dataMap = {
-        "PwPolicyData": F22_PwPolicyData
+        "PwPolicyData": F34_PwPolicyData
     }
 
     def __init__(self):
@@ -294,6 +294,14 @@ class AnacondaSection(Section):
     def handleHeader(self, lineno, args):
         """Process the arguments to the %anaconda header."""
         Section.handleHeader(self, lineno, args)
+
+        warnings.warn(_(
+            "The %%anaconda section has been deprecated. It "
+            "may be removed from future releases, which will "
+            "result in a fatal error when it is encountered. "
+            "Please modify your kickstart file to remove this "
+            "section."
+        ), KickstartDeprecationWarning)
 
     def finalize(self):
         """Let %anaconda know no additional data will come."""

--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -23,6 +23,7 @@ from pyanaconda.modules.boss.boss_interface import BossInterface
 from pyanaconda.modules.boss.module_manager import ModuleManager
 from pyanaconda.modules.boss.install_manager import InstallManager
 from pyanaconda.modules.boss.kickstart_manager import KickstartManager
+from pyanaconda.modules.boss.user_interface import UIModule
 from pyanaconda.modules.common.base import Service
 from pyanaconda.modules.common.constants.services import BOSS
 from pyanaconda.modules.common.containers import TaskContainer
@@ -40,6 +41,7 @@ class Boss(Service):
         self._module_manager = ModuleManager()
         self._kickstart_manager = KickstartManager()
         self._install_manager = InstallManager()
+        self._ui_module = UIModule()
 
         self._module_manager.module_observers_changed.connect(
             self._kickstart_manager.on_module_observers_changed
@@ -52,6 +54,10 @@ class Boss(Service):
     def publish(self):
         """Publish the boss."""
         TaskContainer.set_namespace(BOSS.namespace)
+
+        # Publish submodules.
+        self._ui_module.publish()
+
         DBus.publish_object(BOSS.object_path, BossInterface(self))
         DBus.register_service(BOSS.service_name)
 

--- a/pyanaconda/modules/boss/user_interface/Makefile.am
+++ b/pyanaconda/modules/boss/user_interface/Makefile.am
@@ -1,6 +1,5 @@
-# modules/boss/Makefile.am for anaconda
 #
-# Copyright (C) 2017  Red Hat, Inc.
+# Copyright (C) 2021  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published
@@ -15,10 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = install_manager kickstart_manager module_manager user_interface
-
 pkgpyexecdir = $(pyexecdir)/py$(PACKAGE_NAME)
-bossdir = $(pkgpyexecdir)/modules/boss
-boss_PYTHON = $(srcdir)/*.py
+user_interfacedir = $(pkgpyexecdir)/modules/boss/user_interface
+user_interface_PYTHON = $(srcdir)/*.py
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/pyanaconda/modules/boss/user_interface/__init__.py
+++ b/pyanaconda/modules/boss/user_interface/__init__.py
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.modules.boss.user_interface.ui import UIModule
+
+__all__ = ["UIModule"]

--- a/pyanaconda/modules/boss/user_interface/ui.py
+++ b/pyanaconda/modules/boss/user_interface/ui.py
@@ -1,0 +1,76 @@
+#
+# The user interface module
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.constants import PASSWORD_POLICY_LUKS, PASSWORD_POLICY_ROOT, \
+    PASSWORD_POLICY_USER
+from pyanaconda.core.dbus import DBus
+from pyanaconda.core.signal import Signal
+from pyanaconda.modules.boss.user_interface.ui_interface import UIInterface
+from pyanaconda.modules.common.base import KickstartBaseModule
+from pyanaconda.modules.common.constants.objects import USER_INTERFACE
+from pyanaconda.modules.common.structures.policy import PasswordPolicy
+
+log = get_module_logger(__name__)
+
+__all__ = ["UIModule"]
+
+
+class UIModule(KickstartBaseModule):
+    """The user interface module."""
+
+    def __init__(self):
+        super().__init__()
+        self._password_policies = self.get_default_password_policies()
+        self.password_policies_changed = Signal()
+
+    def publish(self):
+        """Publish the module."""
+        DBus.publish_object(USER_INTERFACE.object_path, UIInterface(self))
+
+    @property
+    def password_policies(self):
+        """The password policies."""
+        return self._password_policies
+
+    def set_password_policies(self, policies):
+        """Set the password policies.
+
+        Default policy names:
+
+            root  The policy for the root password.
+            user  The policy for the user password.
+            luks  The policy for the LUKS passphrase.
+
+        :param policies: a dictionary of policy names and policy data
+        """
+        self._password_policies = policies
+        self.password_policies_changed.emit()
+        log.debug("Password policies are set to '%s'.", policies)
+
+    def get_default_password_policies(self):
+        """Get the default password policies.
+
+        :return: a dictionary of policy names and policy data
+        """
+        return {
+            PASSWORD_POLICY_ROOT: PasswordPolicy.from_defaults(PASSWORD_POLICY_ROOT),
+            PASSWORD_POLICY_USER: PasswordPolicy.from_defaults(PASSWORD_POLICY_USER),
+            PASSWORD_POLICY_LUKS: PasswordPolicy.from_defaults(PASSWORD_POLICY_LUKS),
+        }

--- a/pyanaconda/modules/boss/user_interface/ui_interface.py
+++ b/pyanaconda/modules/boss/user_interface/ui_interface.py
@@ -1,0 +1,61 @@
+#
+# DBus interface for the user interface module
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from dasbus.server.interface import dbus_interface
+from dasbus.server.property import emits_properties_changed
+from dasbus.typing import *  # pylint: disable=wildcard-import
+
+from pyanaconda.modules.common.base import KickstartModuleInterfaceTemplate
+from pyanaconda.modules.common.constants.objects import USER_INTERFACE
+from pyanaconda.modules.common.structures.policy import PasswordPolicy
+
+__all__ = ["UIInterface"]
+
+
+@dbus_interface(USER_INTERFACE.interface_name)
+class UIInterface(KickstartModuleInterfaceTemplate):
+    """DBus interface for the user interface module."""
+
+    def connect_signals(self):
+        """Connect the signals."""
+        super().connect_signals()
+        self.watch_property("PasswordPolicies", self.implementation.password_policies_changed)
+
+    @property
+    def PasswordPolicies(self) -> Dict[Str, Structure]:
+        """The password policies."""
+        return PasswordPolicy.to_structure_dict(
+            self.implementation.password_policies
+        )
+
+    @emits_properties_changed
+    def SetPasswordPolicies(self, policies: Dict[Str, Structure]):
+        """Set the password policies.
+
+        Default policy names:
+
+            root  The policy for the root password.
+            user  The policy for the user password.
+            luks  The policy for the LUKS passphrase.
+
+        :param policies: a dictionary of policy names and policy data
+        """
+        self.implementation.set_password_policies(
+            PasswordPolicy.from_structure_dict(policies)
+        )

--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -19,7 +19,14 @@
 from dasbus.identifier import DBusObjectIdentifier
 from pyanaconda.modules.common.constants.namespaces import STORAGE_NAMESPACE, NETWORK_NAMESPACE, \
     PARTITIONING_NAMESPACE, DEVICE_TREE_NAMESPACE, \
-    RHSM_NAMESPACE
+    RHSM_NAMESPACE, BOSS_NAMESPACE
+
+# Boss objects.
+
+USER_INTERFACE = DBusObjectIdentifier(
+    namespace=BOSS_NAMESPACE,
+    basename="UserInterface"
+)
 
 # Storage objects.
 

--- a/pyanaconda/modules/common/structures/policy.py
+++ b/pyanaconda/modules/common/structures/policy.py
@@ -1,0 +1,139 @@
+#
+# DBus structures for the password policy.
+#
+# Copyright (C) 2020  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from dasbus.structure import DBusData
+from dasbus.typing import *  # pylint: disable=wildcard-import
+
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.configuration.anaconda import conf
+
+log = get_module_logger(__name__)
+
+__all__ = ["PasswordPolicy"]
+
+
+class PasswordPolicy(DBusData):
+    """The password policy data."""
+
+    def __init__(self):
+        self._min_quality = UInt16(0)
+        self._min_length = UInt16(0)
+        self._allow_empty = True
+        self._is_strict = False
+
+    @property
+    def min_quality(self) -> UInt16:
+        """The minimum quality score (see libpwquality).
+
+        :return: a number from 0 to 100
+        """
+        return self._min_quality
+
+    @min_quality.setter
+    def min_quality(self, value):
+        self._min_quality = UInt16(value)
+
+    @property
+    def min_length(self) -> UInt16:
+        """The minimum length of the password..
+
+        :return: a number of characters
+        """
+        return self._min_length
+
+    @min_length.setter
+    def min_length(self, value):
+        self._min_length = UInt16(value)
+
+    @property
+    def allow_empty(self) -> Bool:
+        """Should an empty password be allowed?
+
+        :return: True or False
+        """
+        return self._allow_empty
+
+    @allow_empty.setter
+    def allow_empty(self, value: Bool):
+        self._allow_empty = value
+
+    @property
+    def is_strict(self) -> Bool:
+        """Should the minimal quality be required?
+
+        :return: True or False
+        """
+        return self._is_strict
+
+    @is_strict.setter
+    def is_strict(self, value: Bool):
+        self._is_strict = value
+
+    @classmethod
+    def from_defaults(cls, policy_name):
+        """Create a default policy.
+
+        :param policy_name: a name of the policy
+        :return: a new instance of PasswordPolicy
+        """
+        policy = cls()
+
+        for attrs in conf.ui.password_policies:
+            if policy_name != attrs.get("name"):
+                continue
+
+            policy.min_quality = attrs.get("quality")
+            policy.min_length = attrs.get("length")
+            policy.allow_empty = attrs.get("empty", False)
+            policy.is_strict = attrs.get("strict", False)
+            break
+        else:
+            log.debug(
+                "No default %s password policy is "
+                "configured.", policy_name
+            )
+
+        return policy
+
+    @classmethod
+    def to_structure_dict(cls, objects) -> Dict[Str, Structure]:
+        """Convert password policies to DBus structures.
+
+        :param objects: a dictionary of policy names and policy data objects
+        :return: a dictionary of policy names and DBus structures
+        """
+        if not isinstance(objects, dict):
+            raise TypeError(
+                "Invalid type '{}'.".format(type(objects).__name__)
+            )
+
+        return {k: PasswordPolicy.to_structure(v) for k, v in objects.items()}
+
+    @classmethod
+    def from_structure_dict(cls, structures: Dict[Str, Structure]):
+        """Convert DBus structures to password policies.
+
+        :param structures: a dictionary of policy names and DBus structures
+        :return: a dictionary of policy names and policy data objects
+        """
+        if not isinstance(structures, dict):
+            raise TypeError(
+                "Invalid type '{}'.".format(type(structures).__name__)
+            )
+
+        return {k: PasswordPolicy.from_structure(v) for k, v in structures.items()}

--- a/pyanaconda/pwpolicy.py
+++ b/pyanaconda/pwpolicy.py
@@ -20,7 +20,7 @@
 import warnings
 
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartDeprecationWarning
 from pykickstart.options import KSOptionParser
 from pykickstart.version import F22
 
@@ -221,3 +221,25 @@ class F22_PwPolicy(KickstartCommand):
             return self.handler.PwPolicyData()
         else:
             return None
+
+
+class F34_PwPolicyData(F22_PwPolicyData):
+    """ Kickstart Data object to hold information about pwpolicy. """
+    pass
+
+
+class F34_PwPolicy(F22_PwPolicy):
+    """ Kickstart command implementing password policy. """
+
+    def parse(self, args):
+        data = super().parse(args)
+
+        warnings.warn(_(
+            "The pwpolicy command has been deprecated. It "
+            "may be removed from future releases, which will "
+            "result in a fatal error when it is encountered. "
+            "Please modify your kickstart file to remove this "
+            "command."
+        ), KickstartDeprecationWarning)
+
+        return data

--- a/pyanaconda/ui/gui/spokes/lib/passphrase.py
+++ b/pyanaconda/ui/gui/spokes/lib/passphrase.py
@@ -26,6 +26,7 @@ from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.utils import really_hide, really_show, set_password_visibility
 from pyanaconda import input_checking
 from pyanaconda.core import constants
+from pyanaconda.core.constants import PASSWORD_POLICY_LUKS
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -58,9 +59,12 @@ class PassphraseDialog(GUIObject):
         self._strength_bar.add_offset_value("high", 4)
 
         # Setup the password checker for passphrase checking
-        self._checker = input_checking.PasswordChecker(initial_password_content = self._passphrase_entry.get_text(),
-                                                       initial_password_confirmation_content = self._confirm_entry.get_text(),
-                                                       policy = input_checking.get_policy(self.data, "luks"))
+        self._checker = input_checking.PasswordChecker(
+            initial_password_content=self._passphrase_entry.get_text(),
+            initial_password_confirmation_content=self._confirm_entry.get_text(),
+            policy_name=PASSWORD_POLICY_LUKS
+        )
+
         # configure the checker for passphrase checking
         self._checker.secret_type = constants.SecretType.PASSPHRASE
         # connect UI updates to check results
@@ -164,7 +168,7 @@ class PassphraseDialog(GUIObject):
             self._passphrase_good_enough = True
         elif len(self._checker.failed_checks) == 1 and self._validity_check in self._checker._failed_checks:
             # only the password validity check failed
-            if self._checker.policy.strict:
+            if self._checker.policy.is_strict:
                 # this is not fine for the strict password policy
                 self._passphrase_good_enough = False
             else:

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -16,15 +16,14 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
 from pyanaconda.flags import flags
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.i18n import _, CN_
 from pyanaconda.core.users import crypt_password
 from pyanaconda import input_checking
 from pyanaconda.core import constants
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.modules.common.constants.services import USERS
-
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
 from pyanaconda.ui.gui.helpers import GUISpokeInputCheckHandler
@@ -226,8 +225,9 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     def sensitive(self):
         # A password set in kickstart can be changed in the GUI
         # if the changesok password policy is set for the root password.
-        kickstarted_password_can_be_changed = self._users_module.CanChangeRootPassword \
-            or self.checker.policy.changesok
+        kickstarted_password_can_be_changed = conf.ui.can_change_root or \
+            self._users_module.CanChangeRootPassword
+
         return not (self.completed and flags.automatedInstall
                     and not kickstarted_password_can_be_changed)
 

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -16,6 +16,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.core.constants import PASSWORD_POLICY_ROOT
 from pyanaconda.flags import flags
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.i18n import _, CN_
@@ -89,9 +90,9 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
         # Setup the password checker for password checking
         self._checker = input_checking.PasswordChecker(
-                initial_password_content = self.password,
-                initial_password_confirmation_content = self.password_confirmation,
-                policy = input_checking.get_policy(self.data, "root")
+                initial_password_content=self.password,
+                initial_password_confirmation_content=self.password_confirmation,
+                policy_name=PASSWORD_POLICY_ROOT
         )
         # configure the checker for password checking
         self.checker.secret_type = constants.SecretType.PASSWORD
@@ -253,7 +254,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
             # empty string is not set as the root password.
             self.clear_info()
         else:
-            if self.checker.policy.strict or unwaivable_check_failed:
+            if self.checker.policy.is_strict or unwaivable_check_failed:
                 # just forward the error message
                 self.show_warning_message(error_message)
             else:
@@ -289,7 +290,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         elif unwaivable_check_failed:
             self.can_go_back = False
         else:
-            if self.checker.policy.strict:
+            if self.checker.policy.is_strict:
                 if not self._validity_check.result.success:
                     # failing validity check in strict
                     # mode prevents us from going back

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -16,16 +16,16 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
 import os
+
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _, CN_
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.users import crypt_password, guess_username, check_groupname
 from pyanaconda import input_checking
 from pyanaconda.core import constants
 from pyanaconda.modules.common.constants.services import USERS
 from pyanaconda.modules.common.util import is_module_available
-
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
@@ -35,7 +35,6 @@ from pyanaconda.ui.gui.helpers import GUISpokeInputCheckHandler, GUIDialogInputC
 from pyanaconda.ui.gui.utils import blockedHandler, set_password_visibility
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.ui.lib.users import get_user_list, set_user_list
-
 from pyanaconda.core.regexes import GROUPLIST_FANCY_PARSE
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -499,7 +498,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         # Spoke cannot be entered if a user was set in the kickstart and the user
         # policy doesn't allow changes.
         return not (self.completed and flags.automatedInstall
-                    and self._user_requested and not self.checker.policy.changesok)
+                    and self._user_requested and not conf.ui.can_change_users)
 
     @property
     def completed(self):

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -25,6 +25,7 @@ from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.modules.common.constants.services import USERS
+from pyanaconda.core.constants import PASSWORD_POLICY_ROOT
 from pyanaconda.core.configuration.anaconda import conf
 
 from simpleline.render.widgets import TextWidget
@@ -52,7 +53,6 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         self.title = N_("Root password")
         self.input_required = False
 
-        self._policy = self.data.anaconda.pwpolicy.get_policy("root", fallback_to_default=True)
         self._password = None
 
         self._users_module = USERS.get_proxy()
@@ -95,9 +95,11 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     def show_all(self):
         super().show_all()
 
-        password_dialog = PasswordDialog(_("Password"), policy=self._policy)
+        password_dialog = PasswordDialog(
+            title=_("Password"),
+            policy_name=PASSWORD_POLICY_ROOT
+        )
         password_dialog.no_separator = True
-
         self._password = password_dialog.run()
 
         if self._password is None:

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -25,6 +25,7 @@ from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.modules.common.constants.services import USERS
+from pyanaconda.core.configuration.anaconda import conf
 
 from simpleline.render.widgets import TextWidget
 
@@ -63,7 +64,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     @property
     def showable(self):
-        return not (self.completed and flags.automatedInstall and not self._policy.changesok)
+        return not (self.completed and flags.automatedInstall and not conf.ui.can_change_root)
 
     @property
     def mandatory(self):

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -19,7 +19,6 @@
 
 from collections import OrderedDict
 
-from pyanaconda.input_checking import get_policy
 from pyanaconda.modules.common.constants.objects import DISK_SELECTION, DISK_INITIALIZATION, \
     BOOTLOADER, DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
@@ -44,7 +43,8 @@ from pyanaconda.core.constants import THREAD_STORAGE, THREAD_STORAGE_WATCHER, \
     PAYLOAD_STATUS_PROBING_STORAGE, CLEAR_PARTITIONS_ALL, \
     CLEAR_PARTITIONS_LINUX, CLEAR_PARTITIONS_NONE, CLEAR_PARTITIONS_DEFAULT, \
     BOOTLOADER_LOCATION_MBR, SecretType, WARNING_NO_DISKS_DETECTED, WARNING_NO_DISKS_SELECTED, \
-    PARTITIONING_METHOD_AUTOMATIC, PARTITIONING_METHOD_CUSTOM, PARTITIONING_METHOD_MANUAL
+    PARTITIONING_METHOD_AUTOMATIC, PARTITIONING_METHOD_CUSTOM, PARTITIONING_METHOD_MANUAL, \
+    PASSWORD_POLICY_LUKS
 from pyanaconda.core.i18n import _, N_, C_
 
 from simpleline.render.containers import ListColumnContainer
@@ -346,7 +346,7 @@ class StorageSpoke(NormalTUISpoke):
             message=_("Please provide a default LUKS passphrase for all devices "
                       "you want to encrypt. You will have to type it twice."),
             secret_type=SecretType.PASSPHRASE,
-            policy=get_policy(self.data, "luks"),
+            policy_name=PASSWORD_POLICY_LUKS,
             process_func=lambda x: x
         )
 

--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -17,7 +17,7 @@
 # Red Hat, Inc.
 #
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.constants import FIRSTBOOT_ENVIRON, PASSWORD_SET
+from pyanaconda.core.constants import FIRSTBOOT_ENVIRON, PASSWORD_SET, PASSWORD_POLICY_USER
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.core.regexes import GECOS_VALID
@@ -99,8 +99,6 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         self._use_password = self.user.is_crypted or self.user.password
         self._groups = ""
         self._is_admin = False
-        self._policy = self.data.anaconda.pwpolicy.get_policy("user", fallback_to_default=True)
-
         self.errors = []
 
         self._users_module = USERS.get_proxy()
@@ -142,7 +140,10 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
             self._container.add(w, self._set_use_password)
 
             if self._use_password:
-                password_dialog = PasswordDialog(title=_("Password"), policy=self._policy)
+                password_dialog = PasswordDialog(
+                    title=_("Password"),
+                    policy_name=PASSWORD_POLICY_USER
+                )
                 if self.user.password:
                     entry = EntryWidget(password_dialog.title, _(PASSWORD_SET))
                 else:

--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -16,13 +16,13 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import FIRSTBOOT_ENVIRON, PASSWORD_SET
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.core.regexes import GECOS_VALID
 from pyanaconda.modules.common.constants.services import USERS
 from pyanaconda.modules.common.util import is_module_available
-
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
 from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
@@ -218,7 +218,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     @property
     def showable(self):
         return not (self.completed and flags.automatedInstall
-                    and self._user_requested and not self._policy.changesok)
+                    and self._user_requested and not conf.ui.can_change_users)
 
     @property
     def mandatory(self):

--- a/pyanaconda/ui/tui/tuiobject.py
+++ b/pyanaconda/ui/tui/tuiobject.py
@@ -202,14 +202,14 @@ class Dialog(object):
 class PasswordDialog(Dialog):
     """Ask for user password and process it."""
 
-    def __init__(self, title, policy,
+    def __init__(self, title, policy_name,
                  report_func=reporting_callback,
                  process_func=crypt_password,
                  secret_type=constants.SecretType.PASSWORD,
                  message=None):
         super().__init__(title, report_func=report_func)
         self._no_separator = False
-        self._policy = policy
+        self._policy = input_checking.get_policy(policy_name)
         self._secret_type = secret_type
         self._process_password = process_func
         self._dialog_message = message
@@ -264,8 +264,8 @@ class PasswordDialog(Dialog):
             self._report(password_check.result.error_message)
             return None
 
-        if password_check.result.password_quality < self._policy.minquality:
-            if self._policy.strict:
+        if password_check.result.password_quality < self._policy.min_quality:
+            if self._policy.is_strict:
                 done_msg = ""
             else:
                 done_msg = _("\nWould you like to use it anyway?")
@@ -277,7 +277,7 @@ class PasswordDialog(Dialog):
                 weak_prefix = _(constants.SECRET_WEAK[self._secret_type])
                 error = "{} {}".format(weak_prefix, done_msg)
 
-            if not self._policy.strict:
+            if not self._policy.is_strict:
                 question_window = YesNoDialog(error)
                 ScreenHandler.push_screen_modal(question_window)
                 if not question_window.answer:

--- a/tests/nosetests/pyanaconda_tests/modules/boss/module_ui_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/boss/module_ui_test.py
@@ -1,0 +1,71 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+
+from dasbus.structure import compare_data
+from dasbus.typing import get_variant, Bool, UInt16
+
+from pyanaconda.modules.boss.user_interface import UIModule
+from pyanaconda.modules.boss.user_interface.ui_interface import UIInterface
+from pyanaconda.modules.common.constants.objects import USER_INTERFACE
+from pyanaconda.modules.common.structures.policy import PasswordPolicy
+from tests.nosetests.pyanaconda_tests import check_dbus_property
+
+
+class UIInterfaceTestCase(unittest.TestCase):
+    """Test DBus interface of the user interface module."""
+
+    def setUp(self):
+        """Set up the module."""
+        self.module = UIModule()
+        self.interface = UIInterface(self.module)
+
+    def _check_dbus_property(self, *args, **kwargs):
+        check_dbus_property(
+            self,
+            USER_INTERFACE,
+            self.interface,
+            *args, **kwargs
+        )
+
+    def default_password_policies_test(self):
+        """Test the password policies property."""
+        policies = PasswordPolicy.from_structure_dict(
+            self.interface.PasswordPolicies)
+
+        expected_names = {"root", "user", "luks"}
+        self.assertEqual(policies.keys(), expected_names)
+
+        for name in expected_names:
+            policy = policies[name]
+            expected_policy = PasswordPolicy.from_defaults(name)
+            self.assertTrue(compare_data(policy, expected_policy))
+
+    def password_policies_property_test(self):
+        """Test the password policies property."""
+        policy = {
+            "min-quality": get_variant(UInt16, 10),
+            "min-length": get_variant(UInt16, 20),
+            "allow-empty": get_variant(Bool, True),
+            "is-strict": get_variant(Bool, False)
+        }
+
+        self._check_dbus_property(
+            "PasswordPolicies",
+            {"luks": policy}
+        )

--- a/tests/nosetests/pyanaconda_tests/modules/common/policy_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/common/policy_test.py
@@ -1,0 +1,86 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+from dasbus.typing import get_variant, Int
+from pyanaconda.modules.common.structures.policy import PasswordPolicy
+
+
+class PasswordPolicyTestCase(unittest.TestCase):
+    """Test the module requirements."""
+
+    def default_known_policy_test(self):
+        """Test the default policy data."""
+        policy = PasswordPolicy.from_defaults("root")
+        self.assertEqual(policy.min_quality, 1)
+        self.assertEqual(policy.min_length, 6)
+        self.assertEqual(policy.allow_empty, False)
+        self.assertEqual(policy.is_strict, False)
+
+    def default_unknown_policy_test(self):
+        """Test the default policy data for unknown policy."""
+        policy = PasswordPolicy.from_defaults("test")
+        self.assertEqual(policy.min_quality, 0)
+        self.assertEqual(policy.min_length, 0)
+        self.assertEqual(policy.allow_empty, True)
+        self.assertEqual(policy.is_strict, False)
+
+    def to_structure_dict_test(self):
+        """Test the to_structure_dict method."""
+        p1 = PasswordPolicy()
+        p1.quality = 1
+
+        p2 = PasswordPolicy()
+        p2.quality = 2
+
+        p3 = PasswordPolicy()
+        p3.quality = 3
+
+        # Test an invalid argument.
+        with self.assertRaises(TypeError):
+            PasswordPolicy.to_structure_dict([])
+
+        # Test a valid argument.
+        structures = PasswordPolicy.to_structure_dict({
+            "p1": p1, "p2": p2, "p3": p3
+        })
+
+        self.assertEqual(structures, {
+            "p1": PasswordPolicy.to_structure(p1),
+            "p2": PasswordPolicy.to_structure(p2),
+            "p3": PasswordPolicy.to_structure(p3),
+        })
+
+    def from_structure_dict_test(self):
+        """Test the from_structure_dict method."""
+        s1 = {"min-quality": get_variant(Int, 1)}
+        s2 = {"min-quality": get_variant(Int, 2)}
+        s3 = {"min-quality": get_variant(Int, 3)}
+
+        # Test an invalid argument.
+        with self.assertRaises(TypeError):
+            PasswordPolicy.from_structure_dict([])
+
+        # Test a valid argument.
+        objects = PasswordPolicy.from_structure_dict({
+            "s1": s1, "s2": s2, "s3": s3
+        })
+
+        self.assertEqual(objects.keys(), {"s1", "s2", "s3"})
+        self.assertEqual(objects["s1"].min_quality, 1)
+        self.assertEqual(objects["s2"].min_quality, 2)
+        self.assertEqual(objects["s3"].min_quality, 3)

--- a/tests/nosetests/pyanaconda_tests/password_quality_test.py
+++ b/tests/nosetests/pyanaconda_tests/password_quality_test.py
@@ -17,15 +17,18 @@
 #
 # Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
 #
-
-from pyanaconda import input_checking
-from pyanaconda.pwpolicy import F22_PwPolicyData
-from pyanaconda.core import constants
-from pyanaconda.core.i18n import _
 import unittest
 
+from pyanaconda import input_checking
+from pyanaconda.core import constants
+from pyanaconda.core.constants import PASSWORD_POLICY_USER
+from pyanaconda.core.i18n import _
+from pyanaconda.modules.common.structures.policy import PasswordPolicy
+
+
 def get_policy():
-    return F22_PwPolicyData()
+    return PasswordPolicy.from_defaults(PASSWORD_POLICY_USER)
+
 
 class PasswordQuality(unittest.TestCase):
     def password_empty_test(self):
@@ -42,7 +45,7 @@ class PasswordQuality(unittest.TestCase):
         # empty password should override password-too-short messages
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
-        request.policy.minlen = 10
+        request.policy.min_length = 10
         request.password = ""
         check = input_checking.PasswordValidityCheck()
         check.run(request)
@@ -55,7 +58,7 @@ class PasswordQuality(unittest.TestCase):
         """Check if the empty_ok flag works correctly."""
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
-        request.policy.emptyok = True
+        request.policy.allow_empty = True
         request.password = ""
         check = input_checking.PasswordValidityCheck()
         check.run(request)
@@ -66,8 +69,8 @@ class PasswordQuality(unittest.TestCase):
         # empty_ok with password length
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
-        request.policy.emptyok = True
-        request.policy.minlen = 10
+        request.policy.allow_empty = True
+        request.policy.min_length = 10
         request.password = ""
         check = input_checking.PasswordValidityCheck()
         check.run(request)
@@ -78,8 +81,8 @@ class PasswordQuality(unittest.TestCase):
         # non-empty passwords that are too short should still get a score of 0 & the "too short" message
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
-        request.policy.emptyok = True
-        request.policy.minlen = 10
+        request.policy.allow_empty = True
+        request.policy.min_length = 10
         request.password = "123"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
@@ -90,8 +93,8 @@ class PasswordQuality(unittest.TestCase):
         # also check a long-enough password, just in case
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
-        request.policy.emptyok = True
-        request.policy.minlen = 10
+        request.policy.allow_empty = True
+        request.policy.min_length = 10
         request.password = "1234567891"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
@@ -124,7 +127,7 @@ class PasswordQuality(unittest.TestCase):
         # check if setting password length works correctly
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
-        request.policy.minlen = 10
+        request.policy.min_length = 10
         request.password = "12345"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
@@ -132,7 +135,7 @@ class PasswordQuality(unittest.TestCase):
         self.assertEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
-        request.policy.minlen = 10
+        request.policy.min_length = 10
         request.password = "1234567891"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
@@ -216,7 +219,7 @@ class PasswordQuality(unittest.TestCase):
         # a long enough strong password with minlen set
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
-        request.policy.minlen = 10
+        request.policy.min_length = 10
         request.password = "!?----4naconda----?!"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
@@ -229,7 +232,7 @@ class PasswordQuality(unittest.TestCase):
         # minimum password length overrides strong passwords for score and status
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
-        request.policy.minlen = 30
+        request.policy.min_length = 30
         request.password = "?----4naconda----?"
         check = input_checking.PasswordValidityCheck()
         check.run(request)

--- a/tests/nosetests/pyanaconda_tests/pwpolicy_test.py
+++ b/tests/nosetests/pyanaconda_tests/pwpolicy_test.py
@@ -18,7 +18,17 @@
 # with the express permission of Red Hat, Inc.
 #
 import unittest
+from textwrap import dedent
+from unittest.mock import Mock, patch
+
 from pyanaconda import kickstart
+from pyanaconda.core.configuration.anaconda import AnacondaConfiguration
+from pyanaconda.core.constants import PASSWORD_POLICY_ROOT, PASSWORD_POLICY_USER, \
+    PASSWORD_POLICY_LUKS
+from pyanaconda.modules.common.structures.policy import PasswordPolicy
+from pyanaconda.pwpolicy import apply_password_policy_from_kickstart
+
+from tests.nosetests.pyanaconda_tests import patch_dbus_get_proxy
 
 
 class PwPolicyTestCase(unittest.TestCase):
@@ -43,3 +53,105 @@ pwpolicy luks --strict --minlen=8 --minquality=50 --nochanges --emptyok
         eq_template = "pwpolicy %s --minlen=8 --minquality=50 --strict --nochanges --emptyok\n"
         for name in ["root", "user", "luks"]:
             self.assertEqual(str(self.handler.anaconda.pwpolicy.get_policy(name)), eq_template % name)    # pylint: disable=no-member
+
+    @patch_dbus_get_proxy
+    def apply_none_to_module_test(self, proxy_getter):
+        ui_module = Mock()
+        proxy_getter.return_value = ui_module
+
+        apply_password_policy_from_kickstart(self.handler)
+        ui_module.SetPasswordPolicies.assert_not_called()
+
+    @patch_dbus_get_proxy
+    def apply_policies_to_module_test(self, proxy_getter):
+        ui_module = Mock()
+        proxy_getter.return_value = ui_module
+
+        ks_in = """
+        %anaconda
+        pwpolicy root --minlen=1 --minquality=10 --notempty --strict
+        pwpolicy user --minlen=2 --minquality=20 --emptyok --notstrict
+        pwpolicy luks --minlen=3 --minquality=30 --emptyok --strict
+        %end
+        """
+
+        self.ksparser.readKickstartFromString(dedent(ks_in))
+        apply_password_policy_from_kickstart(self.handler)
+
+        root_policy = PasswordPolicy()
+        root_policy.min_length = 1
+        root_policy.min_quality = 10
+        root_policy.is_strict = True
+        root_policy.allow_empty = False
+
+        user_policy = PasswordPolicy()
+        user_policy.min_length = 2
+        user_policy.min_quality = 20
+        user_policy.is_strict = False
+        user_policy.allow_empty = True
+
+        luks_policy = PasswordPolicy()
+        luks_policy.min_length = 3
+        luks_policy.min_quality = 30
+        luks_policy.is_strict = True
+        luks_policy.allow_empty = True
+
+        policies = {
+            PASSWORD_POLICY_ROOT: root_policy,
+            PASSWORD_POLICY_USER: user_policy,
+            PASSWORD_POLICY_LUKS: luks_policy
+        }
+
+        ui_module.SetPasswordPolicies.assert_called_once_with(
+            PasswordPolicy.to_structure_dict(policies)
+        )
+
+    @patch_dbus_get_proxy
+    def apply_none_to_configuration_test(self, proxy_getter):
+        anaconda_conf = AnacondaConfiguration.from_defaults()
+
+        with patch("pyanaconda.pwpolicy.conf", anaconda_conf):
+            apply_password_policy_from_kickstart(self.handler)
+
+        self.assertEqual(anaconda_conf.ui.can_change_root, False)
+        self.assertEqual(anaconda_conf.ui.can_change_users, False)
+
+    @patch_dbus_get_proxy
+    def apply_changesok_to_configuration_test(self, proxy_getter):
+        anaconda_conf = AnacondaConfiguration.from_defaults()
+
+        ks_in = """
+        %anaconda
+        pwpolicy root --changesok
+        pwpolicy user --changesok
+        pwpolicy luks --changesok
+        %end
+        """
+
+        self.ksparser.readKickstartFromString(dedent(ks_in))
+
+        with patch("pyanaconda.pwpolicy.conf", anaconda_conf):
+            apply_password_policy_from_kickstart(self.handler)
+
+        self.assertEqual(anaconda_conf.ui.can_change_root, True)
+        self.assertEqual(anaconda_conf.ui.can_change_users, True)
+
+    @patch_dbus_get_proxy
+    def apply_nochanges_to_configuration_test(self, proxy_getter):
+        anaconda_conf = AnacondaConfiguration.from_defaults()
+
+        ks_in = """
+        %anaconda
+        pwpolicy root --nochanges
+        pwpolicy user --nochanges
+        pwpolicy luks --nochanges
+        %end
+        """
+
+        self.ksparser.readKickstartFromString(dedent(ks_in))
+
+        with patch("pyanaconda.pwpolicy.conf", anaconda_conf):
+            apply_password_policy_from_kickstart(self.handler)
+
+        self.assertEqual(anaconda_conf.ui.can_change_root, False)
+        self.assertEqual(anaconda_conf.ui.can_change_users, False)

--- a/tests/nosetests/pyanaconda_tests/pwpolicy_test.py
+++ b/tests/nosetests/pyanaconda_tests/pwpolicy_test.py
@@ -21,6 +21,8 @@ import unittest
 from textwrap import dedent
 from unittest.mock import Mock, patch
 
+from pykickstart.errors import KickstartDeprecationWarning
+
 from pyanaconda import kickstart
 from pyanaconda.core.configuration.anaconda import AnacondaConfiguration
 from pyanaconda.core.constants import PASSWORD_POLICY_ROOT, PASSWORD_POLICY_USER, \
@@ -45,7 +47,8 @@ pwpolicy luks --strict --minlen=8 --minquality=50 --nochanges --emptyok
         self.ksparser = kickstart.AnacondaKSParser(self.handler)
 
     def pwpolicy_test(self):
-        self.ksparser.readKickstartFromString(self.ks)
+        with self.assertWarns(KickstartDeprecationWarning):
+            self.ksparser.readKickstartFromString(self.ks)
 
         self.assertIsInstance(self.handler, kickstart.AnacondaKSHandler)
         self.assertIsInstance(self.handler.anaconda, kickstart.AnacondaSectionHandler)


### PR DESCRIPTION
Use the configuration options `can_change_root` and `can_change_users` 
from the `User Interface` section instead of the `changesok` attribute of the
`pwpolicy` kickstart command.

Use the `password_policies` configuration option of the `User Interface` section to
define the default password policies.

Use the User Interface module of the Boss service to get and set password policies
during the runtime. This support is required for the OSCAP addon.

Apply the password policy specified in the kickstart file if there is any
and set up the UI DBus module and the Anaconda configuration options.

Deprecate the `%anaconda` kickstart section and its `pwpolicy` kickstart command.
The section specified in a kickstart file will generate a deprecation warning.

The `interactive-defaults.ks` file is deprecated and will be removed in in the future.
Use the Anaconda configuration files instead. Anaconda no longer uses this file for
the configuration of the interactive defaults, but some of the products do. Make sure
that the products use the configuration files before the removal of this support.

