### PR TITLE
GH workflow: do not fail all matrix jobs on failure of one

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -12,6 +12,7 @@ jobs:
     # we need to have matrix to cover all branches because schedule is run only on default branch
     # we can add here fedora branches (e.g. f33-devel) to cover their support when needed
     strategy:
+      fail-fast: false
       matrix:
         branch:
           - master

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         # empty = release that corresponds to current branch name
         release: ['', 'eln']


### PR DESCRIPTION
The fail-fast configuration value is used to kill all jobs in a matrix when first fails. However, we don't want to do that. These jobs are not dependent and we want to know if one arch is able to run when other is not.

Change this for validate and container-refresh workflows.

You can see the difference on my test [PR](https://github.com/Test-anaconda-org/anaconda/pull/11/checks?check_run_id=1733977768). The `master` part failed but `eln` went well. Compare to [existing PR on Anaconda](https://github.com/rhinstaller/anaconda/pull/3100/checks?check_run_id=1733731194) where `ELN` part was killed because `master` failed.