### PR TITLE
Skip storage-related spokes in the initial setup (#1918048)

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -85,6 +85,9 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
     @classmethod
     def should_run(cls, environment, data):
         """Don't run the storage spoke on dir installations."""
+        if not NormalSpoke.should_run(environment, data):
+            return False
+
         return not conf.target.is_directory
 
     def __init__(self, *args, **kwargs):

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -79,6 +79,9 @@ class StorageSpoke(NormalTUISpoke):
     @classmethod
     def should_run(cls, environment, data):
         """Don't run the storage spoke on dir installations."""
+        if not NormalTUISpoke.should_run(environment, data):
+            return False
+
         return not conf.target.is_directory
 
     def __init__(self, data, storage, payload):


### PR DESCRIPTION
The initial setup doesn't configure storage. It was broken by the commit 2e305f8.

Resolves: rhbz#1918048