### PR TITLE
Allow to disable the Localization module

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -325,7 +325,6 @@ if __name__ == "__main__":
 
     from pyanaconda import vnc
     from pyanaconda import kickstart
-    from pyanaconda import keyboard
     # we are past the --version and --help shortcut so we can import display &
     # startup_utils, which import Blivet, without slowing down anything critical
     from pyanaconda import display
@@ -479,20 +478,7 @@ if __name__ == "__main__":
 
     # setup keyboard layout from the command line option and let
     # it override from kickstart if/when X is initialized
-
-    from pyanaconda.modules.common.constants.services import LOCALIZATION
-    localization_proxy = LOCALIZATION.get_proxy()
-
-    if opts.keymap and not localization_proxy.KeyboardKickstarted:
-        localization_proxy.SetKeyboard(opts.keymap)
-        localization_proxy.SetKeyboardKickstarted(True)
-
-    if localization_proxy.KeyboardKickstarted:
-        if conf.system.can_activate_keyboard:
-            keyboard.activate_keyboard(localization_proxy)
-        else:
-            # at least make sure we have all the values
-            keyboard.populate_missing_items(localization_proxy)
+    startup_utils.activate_keyboard(opts)
 
     # Some post-install parts of anaconda are implemented as kickstart
     # scripts.  Add those to the ksdata now.
@@ -510,26 +496,8 @@ if __name__ == "__main__":
     if not flags.automatedInstall:
         security_proxy.SetFingerprintAuthEnabled(True)
 
-    from pyanaconda import localization
     # Set the language before loading an interface, when it may be too late.
-
-    from pyanaconda.modules.common.constants.services import LOCALIZATION
-    localization_proxy = LOCALIZATION.get_proxy()
-
-    # If the language was set on the command line, copy that to kickstart
-    if opts.lang:
-        localization_proxy.SetLanguage(opts.lang)
-        localization_proxy.SetLanguageKickstarted(True)
-
-    # Setup the locale environment
-    if localization_proxy.LanguageKickstarted:
-        locale_option = localization_proxy.Language
-    else:
-        locale_option = None
-    localization.setup_locale_environment(locale_option, text_mode=anaconda.tui_mode)
-
-    # Now that LANG is set, do something with it
-    localization.setup_locale(os.environ["LANG"], localization_proxy, text_mode=anaconda.tui_mode)
+    startup_utils.initialize_locale(opts, text_mode=anaconda.tui_mode)
 
     # Initialize the network now, in case the display needs it
     from pyanaconda.network import initialize_network, wait_for_connecting_NM_thread, wait_for_connected_NM
@@ -550,8 +518,7 @@ if __name__ == "__main__":
         # we need to reinitialize the locale if GUI startup failed,
         # as we might now be in text mode, which might not be able to display
         # the characters from our current locale
-        log.warning("reinitializing locale due to failed attempt to start the GUI")
-        localization.setup_locale(os.environ["LANG"], localization_proxy, text_mode=anaconda.tui_mode)
+        startup_utils.reinitialize_locale(opts, text_mode=anaconda.tui_mode)
 
     # we now know in which mode we are going to run so store the information
     from pykickstart import constants as pykickstart_constants

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -109,9 +109,10 @@ def _prepare_configuration(payload, ksdata):
     os_config.append_dbus_tasks(SERVICES, services_dbus_tasks)
 
     # add installation tasks for the Localization DBus module
-    localization_proxy = LOCALIZATION.get_proxy()
-    localization_dbus_tasks = localization_proxy.InstallWithTasks()
-    os_config.append_dbus_tasks(LOCALIZATION, localization_dbus_tasks)
+    if is_module_available(LOCALIZATION):
+        localization_proxy = LOCALIZATION.get_proxy()
+        localization_dbus_tasks = localization_proxy.InstallWithTasks()
+        os_config.append_dbus_tasks(LOCALIZATION, localization_dbus_tasks)
 
     # add the Firewall configuration task
     if conf.target.can_configure_network:

--- a/pyanaconda/modules/payloads/payload/dnf/requirements.py
+++ b/pyanaconda/modules/payloads/payload/dnf/requirements.py
@@ -26,6 +26,7 @@ from pyanaconda.core.util import detect_virtualized_platform
 from pyanaconda.localization import find_best_locale_match, is_valid_langcode
 from pyanaconda.modules.common.constants.services import LOCALIZATION, BOSS
 from pyanaconda.modules.common.structures.requirement import Requirement
+from pyanaconda.modules.common.util import is_module_available
 
 log = get_module_logger(__name__)
 
@@ -48,6 +49,9 @@ def collect_language_requirements(dnf_base):
     :return: a list of requirements
     """
     requirements = []
+
+    if not is_module_available(LOCALIZATION):
+        return requirements
 
     localization_proxy = LOCALIZATION.get_proxy()
     locales = [localization_proxy.Language] + localization_proxy.LanguageSupport

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -651,6 +651,11 @@ class GraphicalUserInterface(UserInterface):
         from pyanaconda.ui.gui.spokes import StandaloneSpoke
         return isinstance(obj, StandaloneSpoke)
 
+    def _is_standalone_class(self, cls):
+        """Is the class passed as cls standalone?"""
+        from pyanaconda.ui.gui.spokes import StandaloneSpoke
+        return issubclass(cls, StandaloneSpoke)
+
     def setup(self, data):
         self._actions = self.getActionClasses(self._list_hubs())
         self.data = data
@@ -668,6 +673,11 @@ class GraphicalUserInterface(UserInterface):
         return self._orderActionClasses(standalones, hubs)
 
     def _instantiateAction(self, actionClass):
+        # Check if this action is to be shown in the supported environments.
+        if self._is_standalone_class(actionClass):
+            if not any(actionClass.should_run(environ, self.data) for environ in flags.environs):
+                return None
+
         # Instantiate an action on-demand, passing the arguments defining our
         # spoke API and setting up continue/quit signal handlers.
         obj = actionClass(self.data, self.storage, self.payload)

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -38,6 +38,7 @@ from pyanaconda.core.constants import DEFAULT_KEYBOARD, THREAD_KEYBOARD_INIT, TH
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.core.util import strip_accents, have_word_match
 from pyanaconda.modules.common.constants.services import LOCALIZATION
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.threading import threadMgr, AnacondaThread
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -289,6 +290,14 @@ class KeyboardSpoke(NormalSpoke):
 
     icon = "input-keyboard-symbolic"
     title = CN_("GUI|Spoke", "_Keyboard")
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(LOCALIZATION):
+            return False
+
+        return NormalSpoke.should_run(environment, data)
 
     def __init__(self, *args):
         super().__init__(*args)

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -25,6 +25,7 @@ from gi.repository import Pango, Gdk
 
 from pyanaconda.core.constants import PAYLOAD_LIVE_TYPES
 from pyanaconda.modules.common.constants.services import LOCALIZATION
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.core.i18n import CN_
 from pyanaconda.ui.context import context
 from pyanaconda.ui.gui.spokes import NormalSpoke
@@ -64,10 +65,14 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
 
     @classmethod
     def should_run(cls, environment, data):
-        """Don't show the language support spoke on live media."""
+        """Should the spoke run?"""
+        if not is_module_available(LOCALIZATION):
+            return False
+
         if not NormalSpoke.should_run(environment, data):
             return False
 
+        # Don't show the language support spoke on live media.
         return context.payload.type not in PAYLOAD_LIVE_TYPES
 
     def __init__(self, *args, **kwargs):

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -64,6 +64,14 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
     preForHub = SummaryHub
     priority = 0
 
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(LOCALIZATION):
+            return False
+
+        return StandaloneSpoke.should_run(environment, data)
+
     def __init__(self, *args, **kwargs):
         StandaloneSpoke.__init__(self, *args, **kwargs)
         LangLocaleHandler.__init__(self)

--- a/pyanaconda/ui/tui/spokes/language_support.py
+++ b/pyanaconda/ui/tui/spokes/language_support.py
@@ -18,6 +18,7 @@
 #
 
 from pyanaconda.modules.common.constants.services import LOCALIZATION
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.ui.categories.localization import LocalizationCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
@@ -44,6 +45,14 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     """
     helpFile = "LangSupportSpoke.txt"
     category = LocalizationCategory
+
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not is_module_available(LOCALIZATION):
+            return False
+
+        return FirstbootSpokeMixIn.should_run(environment, data)
 
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)

--- a/tests/nosetests/pyanaconda_tests/module_payload_dnf_requirements_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_payload_dnf_requirements_test.py
@@ -57,6 +57,9 @@ class DNFRequirementsTestCase(unittest.TestCase):
     @patch_dbus_get_proxy_with_cache
     def collect_language_requirements_test(self, proxy_getter):
         """Test the function collect_language_requirements."""
+        boss = BOSS.get_proxy()
+        boss.GetModules.return_value = [LOCALIZATION.service_name]
+
         proxy = LOCALIZATION.get_proxy()
         proxy.Language = "cs_CZ.UTF-8"
         proxy.LanguageSupport = ["en_GB.UTF-8", "sr_RS@cyrilic"]


### PR DESCRIPTION
Check whether the Localization DBus module is enabled before it is used.
It might be disabled in the Anaconda configuration file.

The installer should skip standalone GUI spokes that return False from their
`should_run` method. There are no standalone TUI spokes.

(cherry-picked from commits efc6278 and 1df4c77)

Related: rhbz#1834535