### PR TITLE
Fix failing tests after nose dependency was removed from the spec

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -40,6 +40,7 @@ RUN pip install \
   pycodestyle \
   dogtail \
   nose-testconfig \
+  nose \
   rpmfluff
 
 # HACK: Apply fix from https://github.com/PyCQA/astroid/pull/847 to avoid

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -11,10 +11,13 @@ RUN set -e; \
   dnf update -y; \
   dnf install -y \
   curl \
+  python3-pip \
   /usr/bin/xargs \
   rpm-build; \
   curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/master/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   mkdir /anaconda
+
+RUN pip install nose
 
 WORKDIR /anaconda

--- a/tests/rpm_tests.sh
+++ b/tests/rpm_tests.sh
@@ -5,4 +5,4 @@ if [ $# -eq 0 ] && [ -z $RPM_TESTS_ARGS ]; then
     set -- "${top_srcdir}"/tests/rpm_tests
 fi
 
-exec nosetests-3 -v --exclude=logpicker -a \!acceptance,\!slow $RPM_TESTS_ARGS "$@"
+exec python3 -m nose -v --exclude=logpicker -a \!acceptance,\!slow $RPM_TESTS_ARGS "$@"


### PR DESCRIPTION
We removed this dependency from spec file in commit
2be2374

However, we missed that these dependencies are not yet installed by pip. Fix this issue now.

Also apply a small fix on the rpm tests execution which is required now.