### PR TITLE
Specify version 3 of GTK+ and GDK for fedora-welcome

### DIFF
--- a/data/liveinst/gnome/fedora-welcome.js
+++ b/data/liveinst/gnome/fedora-welcome.js
@@ -18,6 +18,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+imports.gi.versions.Gdk = "3.0";
+imports.gi.versions.Gtk = "3.0";
+
 const Gdk = imports.gi.Gdk;
 const GdkPixbuf = imports.gi.GdkPixbuf;
 const Gio = imports.gi.Gio;


### PR DESCRIPTION
Now version 4 exists and is on the live image, if we don't specify
a version, we get 4. And the code doesn't work with 4.

Resolves: rhbz#1918940