### PR TITLE
anaconda should add only s390utils-core

### DIFF
--- a/pyanaconda/modules/storage/bootloader/zipl.py
+++ b/pyanaconda/modules/storage/bootloader/zipl.py
@@ -35,7 +35,7 @@ class ZIPL(BootLoader):
 
     name = "ZIPL"
     config_file = "/etc/zipl.conf"
-    packages = ["s390utils-base"]
+    packages = ["s390utils-core"]
 
     # stage2 device requirements
     stage2_device_types = ["partition"]

--- a/pyanaconda/modules/storage/platform.py
+++ b/pyanaconda/modules/storage/platform.py
@@ -398,11 +398,6 @@ class PS3(PPC):
 class S390(Platform):
 
     @property
-    def packages(self):
-        """Packages required for this platform."""
-        return ["s390utils"]
-
-    @property
     def stage1_suggestion(self):
         """The platform-specific suggestion about the stage1 device."""
         return _(

--- a/tests/nosetests/pyanaconda_tests/modules/storage/module_storage_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/storage/module_storage_test.py
@@ -290,11 +290,6 @@ class StorageInterfaceTestCase(unittest.TestCase):
         self.assertEqual(self.storage_interface.CollectRequirements(), [
             {
                 "type": get_variant(Str, "package"),
-                "name": get_variant(Str, "s390utils"),
-                "reason": get_variant(Str, "Required for the platform.")
-            },
-            {
-                "type": get_variant(Str, "package"),
                 "name": get_variant(Str, "lvm2"),
                 "reason": get_variant(Str, "Required to manage storage devices.")
             },

--- a/tests/nosetests/pyanaconda_tests/modules/storage/platform_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/storage/platform_test.py
@@ -116,8 +116,7 @@ class PlatformTestCase(unittest.TestCase):
         arch.is_s390.return_value = True
 
         self._check_platform(
-            platform_cls=S390,
-            packages=["s390utils"]
+            platform_cls=S390
         )
 
         self._check_partitions(


### PR DESCRIPTION
The s390utils-core is the sufficient part of s390utils that's required for a s390x
system to be functional. Thus add only s390utils-core to the package set instead of
the complete s390utils.

Fixes: #1918642