### PR TITLE
network: fix bond confiuration for empty bond options (#1918744)

### DIFF
--- a/pyanaconda/modules/network/nm_client.py
+++ b/pyanaconda/modules/network/nm_client.py
@@ -226,8 +226,10 @@ def _update_bond_connection_from_ksdata(connection, network_data):
     if opts:
         for option in opts.split(';' if ';' in opts else ','):
             key, _sep, value = option.partition("=")
-            if not s_bond.add_option(key, value):
-                log.warning("adding bond option %s failed (invalid?)", key)
+            if s_bond.validate_option(key, value):
+                s_bond.add_option(key, value)
+            else:
+                log.warning("ignoring invalid bond option '%s=%s'", key, value)
     connection.add_setting(s_bond)
 
 

--- a/pyanaconda/modules/network/nm_client.py
+++ b/pyanaconda/modules/network/nm_client.py
@@ -223,10 +223,11 @@ def _update_bond_connection_from_ksdata(connection, network_data):
 
     s_bond = NM.SettingBond.new()
     opts = network_data.bondopts
-    for option in opts.split(';' if ';' in opts else ','):
-        key, _sep, value = option.partition("=")
-        if not s_bond.add_option(key, value):
-            log.warning("adding bond option %s failed (invalid?)", key)
+    if opts:
+        for option in opts.split(';' if ';' in opts else ','):
+            key, _sep, value = option.partition("=")
+            if not s_bond.add_option(key, value):
+                log.warning("adding bond option %s failed (invalid?)", key)
     connection.add_setting(s_bond)
 
 


### PR DESCRIPTION
Add another guard for addin empty ('') option as NM will now allow adding it to
a connection setting and crash later when actually adding the connection.