### PR TITLE
Prevent shell injection from a /kickstart-test comment

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -37,9 +37,13 @@ jobs:
 
       - name: Parse launch arguments
         id: parse_launch_args
+        # Do not use comment body directly in the shell command to avoid possible code injection.
+        env:
+          BODY: ${{ github.event.comment.body }}
         run: |
           # extract first line and cut out the "/kickstart-tests" first word
-          LAUNCH_ARGS=$(echo '${{ github.event.comment.body }}' | sed -n '1 s/^[^ ]* *//p')
+          LAUNCH_ARGS=$(echo "$BODY" | sed -n '1 s/^[^ ]* *//p')
+          echo "launch arguments are: $LAUNCH_ARGS"
           echo "::set-output name=launch_args::${LAUNCH_ARGS}"
 
     outputs:


### PR DESCRIPTION
Users could inject shell code in the command of the /kickstart-test comment.
This code will prevent that.

Tested on [PR](https://github.com/Test-anaconda-org/anaconda/runs/1750151768?check_suite_focus=true). The failure is not important, parsing is happening before the failure.