### PR TITLE
Warn users that commands without `inst.` prefix will be removed

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -301,11 +301,11 @@ if __name__ == "__main__":
     if os.path.exists("/tmp/updates"):
         log.info("Using updates in /tmp/updates/ from %s", opts.updateSrc)
 
-    # TODO: uncomment this when we're sure that we're doing the right thing
-    # with kernel_arguments *everywhere* it appears...
-    #for arg in depr:
-    #    stdout_log.warn("Boot argument '%s' is deprecated. "
-    #                   "In the future, use 'inst.%s'.", arg, arg)
+    # warn users that they should use inst. prefix all the time
+    for arg in depr:
+        stdout_log.warning("Boot argument '%s' is deprecated and will be removed in the future. "
+                           "Please use 'inst.%s' instead.",
+                           arg, arg)
 
     from pyanaconda import isys
 

--- a/anaconda.py
+++ b/anaconda.py
@@ -303,9 +303,12 @@ if __name__ == "__main__":
 
     # warn users that they should use inst. prefix all the time
     for arg in depr:
-        stdout_log.warning("Boot argument '%s' is deprecated and will be removed in the future. "
+        stdout_log.warning("Deprecated boot argument '%s' must be used with the 'inst.' prefix. "
                            "Please use 'inst.%s' instead.",
                            arg, arg)
+    if depr:
+        stdout_log.warning("Anaconda boot arguments without 'inst.' prefix have been deprecated "
+                           "and will be removed in a future major release.")
 
     from pyanaconda import isys
 

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -30,8 +30,7 @@ Anaconda bootup is handled by dracut, so most of the kernel arguments handled
 by dracut are also valid. See |dracutkernel|_ for details on those options.
 
 Throughout this guide, installer-specific options are prefixed with
-``inst`` (e.g. ``inst.ks``). Options specified without the ``inst`` prefix are
-recognized, but the prefix may be required in a future release.
+``inst`` (e.g. ``inst.ks``).
 
 .. _repo:
 

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -668,19 +668,19 @@ Forces/disables (on/off) usage of zRAM swap for the installation process.
 Boot loader options
 -------------------
 
-.. extlinux:
+.. inst.extlinux:
 
-extlinux
-^^^^^^^^
+inst.extlinux
+^^^^^^^^^^^^^
 
 Use extlinux as the bootloader. Note that there's no attempt to validate that
 this will work for your platform or anything; it assumes that if you ask for it,
 you want to try.
 
-.. leavebootorder:
+.. inst.leavebootorder:
 
-leavebootorder
-^^^^^^^^^^^^^^
+inst.leavebootorder
+^^^^^^^^^^^^^^^^^^^
 
 Boot the drives in their existing order, to override the default of booting into
 the newly installed drive on Power Systems servers and EFI systems. This is

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -45,7 +45,8 @@ set_http_header "X-Anaconda-System-Release" "$product"
 warn_renamed_arg() {
     local arg=""
     arg="$(getarg $1)" && warn "'$1=$arg'" && \
-        warn "$1 has been deprecated and will be removed. Please use $2 instead."
+        warn "$1 has been deprecated. All usage of Anaconda boot arguments without 'inst.' prefix \
+have been deprecated and will be removed in a future major release. Please use $2 instead."
 }
 
 # check for deprecated arg, warn user, and write new arg to /etc/cmdline

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -44,10 +44,9 @@ set_http_header "X-Anaconda-System-Release" "$product"
 # convenience function to warn the user about old argument names.
 warn_renamed_arg() {
     local arg=""
-    arg="$(getarg $1)" && warn "'$1=$arg'" && warn "$1 has been renamed to $2"
+    arg="$(getarg $1)" && warn "'$1=$arg'" && \
+        warn "$1 has been deprecated and will be removed. Please use $2 instead."
 }
-
-warn_renamed_arg() { :; } # XXX REMOVE WHEN WE'RE READY FOR THE NEW NAMES.
 
 # check for deprecated arg, warn user, and write new arg to /etc/cmdline
 check_depr_arg() {

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -92,9 +92,15 @@ check_removed_arg asknetwork "Use an appropriate 'ip=' argument instead."
 warn_renamed_arg "lang" "inst.lang"
 warn_renamed_arg "keymap" "inst.keymap"
 
+# debug
+warn_renamed_arg "debug" "inst.debug"
+
 # repo
 check_depr_arg "method=" "repo=%s"
 warn_renamed_arg "repo" "inst.repo"
+
+# stage2
+warn_renamed_arg "stage2" "inst.stage2"
 
 # kickstart
 warn_renamed_arg "ks" "inst.ks"
@@ -125,6 +131,7 @@ if updates=$(getarg updates inst.updates); then
 fi
 
 # for vnc bring network up in initramfs so that cmdline configuration is used
+warn_renamed_arg "vnc" "inst.vnc"
 getargbool 0 vnc inst.vnc && warn "anaconda requiring network for vnc" && set_neednet
 
 # Driver Update Disk

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -194,7 +194,7 @@ class AnacondaArgumentParser(ArgumentParser):
         # go over all options corresponding to current boot cmdline
         # and do any modifications necessary
         # NOTE: program cmdline overrides boot cmdline
-        for arg, val in bootargs.items():
+        for arg, val in bootargs.items_raw():
             option = self._get_bootarg_option(arg)
             if option is None:
                 # this boot option is unknown to Anaconda, skip it

--- a/tests/nosetests/pyanaconda_tests/kernel_test.py
+++ b/tests/nosetests/pyanaconda_tests/kernel_test.py
@@ -27,7 +27,8 @@ class KernelArgumentsTests(unittest.TestCase):
         """KernelArguments value retrieval test."""
 
         ka = KernelArguments.from_string(
-            "blah foo=anything bar=1 baz=0 nowhere nothing=indeed beep=off derp=no nobody=0")
+            "inst.blah foo=anything inst.bar=1 baz=0 nowhere inst.nothing=indeed beep=off "
+            "derp=no nobody=0")
 
         # test using "in" operator on the class
         self.assertTrue("blah" in ka)
@@ -82,6 +83,25 @@ class KernelArgumentsTests(unittest.TestCase):
             if k == "root":
                 root_seen = True
         self.assertTrue(root_seen)
+
+    def items_raw_test(self):
+        """Test KernelArguments access to raw contents with iterator."""
+
+        ka = KernelArguments.from_string(
+            "blah inst.foo=anything inst.nothing=indeed")
+        it = ka.items_raw()
+
+        self.assertIsInstance(it, collections.Iterable)
+
+        res = dict()
+        for k, v in it:
+            res[k] = v
+
+        self.assertIn("inst.foo", res)
+        self.assertIn("blah", res)
+        self.assertIn("inst.nothing", res)
+
+        self.assertEqual(res["inst.nothing"], "indeed")
 
     def shared_instance_test(self):
         """Test the kernel.kernel_arguments instance."""


### PR DESCRIPTION
This is the backport of warnings on master. I've adjusted the message a bit for users on RHEL.

I've tried my best to create a message for users that these won't be removed on the existing RHEL. If you have any suggestions for improvement of the message please write your ideas here.

This is a best effort solution. I don't want to change the code much just for the warnings. In general users will receive this warning on every deprecated argument not just for the ones with missing `inst.` prefix.

*Resolves: rhbz#1897657*