### PR TITLE
Fix the should_run methods of the network spoke

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1466,6 +1466,14 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
     category = SystemCategory
 
+    @classmethod
+    def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not FirstbootSpokeMixIn.should_run(environment, data):
+            return False
+
+        return conf.system.can_configure_network
+
     def __init__(self, *args, **kwargs):
         NormalSpoke.__init__(self, *args, **kwargs)
         self.networking_changed = False

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -224,6 +224,10 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     @classmethod
     def should_run(cls, environment, data):
+        """Should the spoke run?"""
+        if not FirstbootSpokeMixIn.should_run(environment, data):
+            return False
+
         return conf.system.can_configure_network
 
     def initialize(self):


### PR DESCRIPTION
The network spoke should use the same logic for its visibility in TUI and GUI.
This might finally fix the initial setup tests in https://github.com/rhinstaller/kickstart-tests/pull/464.