### PR TITLE
Fix root password and LUKS passphrase visibility toggle (#1911360)

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/passphrase.py
+++ b/pyanaconda/ui/gui/spokes/lib/passphrase.py
@@ -90,6 +90,12 @@ class PassphraseDialog(GUIObject):
         self._checker.add_check(self._ascii_check)
         self._checker.add_check(self._empty_check)
 
+        # set the visibility of the password entries
+        # - without this the password visibility toggle icon will
+        #   not be shown
+        set_password_visibility(self._passphrase_entry, False)
+        set_password_visibility(self._confirm_entry, False)
+
     def refresh(self):
         super().refresh()
 

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -142,6 +142,12 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self._password_bar.add_offset_value("medium", 3)
         self._password_bar.add_offset_value("high", 4)
 
+        # set visibility of the password entries
+        # - without this the password visibility toggle icon will
+        #   not be shown
+        set_password_visibility(self.password_entry, False)
+        set_password_visibility(self.password_confirmation_entry, False)
+
         # Send ready signal to main event loop
         hubQ.send_ready(self.__class__.__name__)
 

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -376,6 +376,8 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         self._advanced_user_dialog.initialize()
 
         # set the visibility of the password entries
+        # - without this the password visibility toggle icon will
+        #   not be shown
         set_password_visibility(self.password_entry, False)
         set_password_visibility(self.password_confirmation_entry, False)
 


### PR DESCRIPTION
Anaconda supports showing a little "eye" icon in the password/passphrase
entry field that can be used to make the entered text visible in
plaintext during entry.

For this to work correctly entry text visibility state needs to be
set correctly. This has been broken by some of the password/passphrase
entry related refactorings in the recent past, resulting in the "eye"
icon not being visible.

So put the initialization back for the root password and LUKS passphrase
entries and also extend the docstring in the user configuration spoke
to note how password visibility influences the toggle icon.

Resolves: rhbz#1911360