### PR TITLE
Allow to disable the Security module

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -487,14 +487,8 @@ if __name__ == "__main__":
     # Set up the payload from the cmdline options.
     anaconda.payload.set_from_opts(opts)
 
-    from pyanaconda.modules.common.constants.services import SECURITY
-    security_proxy = SECURITY.get_proxy()
-    # Override the selinux state from kickstart if set on the command line
-    if conf.security.selinux != constants.SELINUX_DEFAULT:
-        security_proxy.SetSELinux(conf.security.selinux)
-    # Enable fingerprint option by default (#481273).
-    if not flags.automatedInstall:
-        security_proxy.SetFingerprintAuthEnabled(True)
+    # Initialize the security configuration.
+    startup_utils.initialize_security()
 
     # Set the language before loading an interface, when it may be too late.
     startup_utils.initialize_locale(opts, text_mode=anaconda.tui_mode)

--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -25,6 +25,7 @@ from blivet.formats.disklabel import DiskLabel
 from blivet.iscsi import iscsi
 from blivet.size import Size
 
+from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.network import iface_for_host_ip
 from pyanaconda.modules.storage.platform import platform, PLATFORM_DEVICE_TYPES, \
     PLATFORM_FORMAT_TYPES, PLATFORM_MOUNT_POINTS, PLATFORM_MAX_END, PLATFORM_RAID_LEVELS, \
@@ -882,6 +883,9 @@ class BootLoader(object):
 
     def _set_security_boot_args(self):
         """Set LSM-related boot args."""
+        if not is_module_available(SECURITY):
+            return
+
         proxy = SECURITY.get_proxy()
         if proxy.SELinux == SELINUX_DISABLED:
             self.boot_args.add('selinux=0')

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -37,7 +37,8 @@ from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.flags import flags
 from pyanaconda.screensaver import inhibit_screensaver
 from pyanaconda.modules.common.structures.timezone import TimeSourceData
-from pyanaconda.modules.common.constants.services import TIMEZONE, LOCALIZATION, SERVICES
+from pyanaconda.modules.common.constants.services import TIMEZONE, LOCALIZATION, SERVICES, \
+    SECURITY
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.threading import AnacondaThread, threadMgr
 
@@ -563,3 +564,19 @@ def initialize_first_boot_action():
         if not flags.automatedInstall:
             # Enable by default for interactive installations.
             services_proxy.SetSetupOnBoot(SETUP_ON_BOOT_ENABLED)
+
+
+def initialize_security():
+    """Initialize the security configuration."""
+    if not is_module_available(SECURITY):
+        return
+
+    security_proxy = SECURITY.get_proxy()
+
+    # Override the selinux state from kickstart if set on the command line
+    if conf.security.selinux != constants.SELINUX_DEFAULT:
+        security_proxy.SetSELinux(conf.security.selinux)
+
+    # Enable fingerprint option by default (#481273).
+    if not flags.automatedInstall:
+        security_proxy.SetFingerprintAuthEnabled(True)


### PR DESCRIPTION
Check whether the Security DBus module is enabled before it is used.
It might be disabled in the Anaconda configuration file.

(cherry-picked from a commit f19f39d)

Related: rhbz#1834535