### PR TITLE
Fix getting kernel version list for liveimg

### DIFF
--- a/pyanaconda/modules/payloads/payload/live_image/utils.py
+++ b/pyanaconda/modules/payloads/payload/live_image/utils.py
@@ -32,7 +32,7 @@ def get_kernel_version_list_from_tar(tarfile_path):
 
         # Strip out vmlinuz- from the names
         kernel_version_list = sorted((n.split("/")[-1][8:] for n in names
-                                      if "boot/vmlinuz-" in n),
+                                      if "boot/vmlinuz-" in n and "-rescue-" not in n),
                                      key=functools.cmp_to_key(version_cmp))
     return kernel_version_list
 

--- a/pyanaconda/payload/live/payload_liveimg.py
+++ b/pyanaconda/payload/live/payload_liveimg.py
@@ -376,6 +376,6 @@ class LiveImagePayload(BaseLivePayload):
 
             # Strip out vmlinuz- from the names
             self._kernel_version_list = sorted((n.split("/")[-1][8:] for n in names
-                                               if "boot/vmlinuz-" in n),
+                                               if "boot/vmlinuz-" in n and "-rescue-" not in n),
                                                key=functools.cmp_to_key(payload_utils.version_cmp))
         return self._kernel_version_list


### PR DESCRIPTION
Ignore rescue kernels same as in base live payload class and liveos payload.

Resolves: rhbz#1919463