### PR TITLE
Avoid using DockerHub because of limits

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -1,4 +1,4 @@
-ARG image=docker.io/fedora:rawhide
+ARG image=registry.fedoraproject.org/fedora:rawhide
 FROM ${image}
 LABEL maintainer=anaconda-list@redhat.com
 

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -1,4 +1,4 @@
-ARG image=docker.io/fedora:rawhide
+ARG image=registry.fedoraproject.org/fedora:rawhide
 FROM ${image}
 LABEL maintainer=anaconda-list@redhat.com
 


### PR DESCRIPTION
DockerHub has a limit on number of pulls which is not great for our CI solution.
Instead use official fedora registry for the container image download.