### PR TITLE
Add important files for container build to rebuild check

### DIFF
--- a/.github/workflows/tests-contributors.yml
+++ b/.github/workflows/tests-contributors.yml
@@ -89,10 +89,10 @@ jobs:
           git log --oneline -1 ${{ env.TARGET_BRANCH_NAME }}
           git rebase ${{ env.TARGET_BRANCH_NAME }}
 
-      - name: Check if container changed in this PR
+      - name: Check if rebuild of the container image is required
         id: check-dockerfile-changed
         run: |
-          changes=$(git diff ${{ env.TARGET_BRANCH_NAME }}..HEAD -- dockerfile/anaconda-ci/)
+          changes=$(git diff ${{ env.TARGET_BRANCH_NAME }}..HEAD -- dockerfile/anaconda-ci/ anaconda.spec.in scripts/testing/install_dependencies.sh)
           # print for debugging
           echo "$changes"
           [ -z "$changes" ] || echo "::set-output name=changed::true"

--- a/.github/workflows/tests-owners.yml
+++ b/.github/workflows/tests-owners.yml
@@ -60,10 +60,10 @@ jobs:
           git log --oneline -1 ${{ env.TARGET_BRANCH_NAME }}
           git rebase ${{ env.TARGET_BRANCH_NAME }}
 
-      - name: Check if container changed in this PR
+      - name: Check if rebuild of the container image is required
         id: check-dockerfile-changed
         run: |
-          changes=$(git diff origin/master..HEAD -- dockerfile/anaconda-ci/)
+          changes=$(git diff origin/master..HEAD -- dockerfile/anaconda-ci/ anaconda.spec.in scripts/testing/install_dependencies.sh)
           # print for debugging
           echo "$changes"
           [ -z "$changes" ] || echo "::set-output name=changed::true"


### PR DESCRIPTION
When we did rebuild check we just looked if dockerfile and files in that directory has changed. However, these are not the only ones giving us dependencies for container image build.

Check also:
* spec file
* script file used during the build

This PR should prevent issue similar to what happened with `nose` dependency removal.

Tested by [owners PR](https://github.com/Test-anaconda-org/anaconda/pull/13), [contributors spec change](https://github.com/Test-anaconda-org/anaconda/pull/19), [contributors scripts change](https://github.com/Test-anaconda-org/anaconda/pull/18), [contributors dockerfile change](https://github.com/Test-anaconda-org/anaconda/pull/20).