### PR TITLE
Do not use cache for container build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,7 +81,7 @@ TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
 
 CONTAINER_ENGINE ?= podman
 # build/run tweaks for all containers, such as --cap-add
-CONTAINER_BUILD_ARGS ?=
+CONTAINER_BUILD_ARGS ?= --no-cache
 # HACK: bash's builtin `test -r` fails when running on Ubuntu host (GitHub) due to incompatible seccomp profile
 CONTAINER_TEST_ARGS ?= $(shell grep -q ID=ubuntu /etc/os-release && echo --security-opt=seccomp=unconfined)
 CONTAINER_REGISTRY ?= quay.io


### PR DESCRIPTION
Cache will not take dnf calls into account so no Anaconda dependencies are checked for a cache invalidation check. Let's just ignore the cache and build the container always.