### PR TITLE
Do not use cache for container build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -81,7 +81,7 @@ TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
 
 # build/run tweaks for all containers, such as --cap-add
 CONTAINER_ENGINE ?= podman
-CONTAINER_BUILD_ARGS ?=
+CONTAINER_BUILD_ARGS ?= --no-cache
 CONTAINER_TEST_ARGS ?=
 
 # anaconda-ci container


### PR DESCRIPTION
Cache will not take dnf calls into account so no Anaconda dependencies are checked for a cache invalidation check. Let's just ignore the cache and build the container always.

(cherry picked from commit c644627a3131c92807e8a52b724f491dbd80d09e)

Related: rhbz#1885635

Backport of https://github.com/rhinstaller/anaconda/pull/3124.