### PR TITLE
Create real updates images

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -103,72 +103,12 @@ def exitHandler(rebootData):
 
 def setup_python_updates():
     """Setup updates to Anaconda Python files."""
-    from distutils.sysconfig import get_python_lib
     import gi.overrides
 
     if "ANACONDA_WIDGETS_OVERRIDES" in os.environ:
         for p in os.environ["ANACONDA_WIDGETS_OVERRIDES"].split(":"):
             gi.overrides.__path__.insert(0, os.path.abspath(p))
 
-    # Temporary hack for F18 alpha to symlink updates and product directories
-    # into tmpfs.  To be removed after beta in order to directly use content
-    # from /run/install/ -- JLK
-    for dirname in ("updates", "product"):
-        if os.path.exists("/run/install/%s" % dirname):
-            if os.path.islink("/tmp/%s" % dirname):
-                # Assume updates have already been setup
-                return
-            os.symlink("/run/install/%s" % dirname,
-                       "/tmp/%s" % dirname)
-
-    if not os.path.exists("/tmp/updates"):
-        return
-
-    for pkg in os.listdir("/tmp/updates"):
-        d = "/tmp/updates/%s" % pkg
-
-        if not os.path.isdir(d):
-            continue
-
-        # See if the package exists in /usr/lib{64,}/python/?.?/site-packages.
-        # If it does, we can set it up as an update.  If not, the pkg is
-        # likely a completely new directory and should not be looked at.
-        dest = "%s/%s" % (get_python_lib(), pkg)
-        if not os.access(dest, os.R_OK):
-            dest = "%s/%s" % (get_python_lib(1), pkg)
-            if not os.access(dest, os.R_OK):
-                continue
-        # Symlink over everything that's in the python libdir but not in
-        # the updates directory.
-        symlink_updates(dest, d)
-
-    gi.overrides.__path__.insert(0, "/run/install/updates")
-
-    import glob
-    import shutil
-    for rule in glob.glob("/tmp/updates/*.rules"):
-        target = "/etc/udev/rules.d/" + rule.split('/')[-1]
-        shutil.copyfile(rule, target)
-
-def symlink_updates(dest_dir, update_dir):
-    """Setup symlinks for the updates from the updates image.
-
-    :param str dest_dir: symlink target
-    :param str update_dir: symlink source (updates image content)
-    """
-    contents = os.listdir(update_dir)
-
-    for f in os.listdir(dest_dir):
-        dest_path = os.path.join(dest_dir, f)
-        update_path = os.path.join(update_dir, f)
-        if f in contents:
-            # recurse into directories, there might be files missing in updates
-            if os.path.isdir(dest_path) and os.path.isdir(update_path):
-                symlink_updates(dest_path, update_path)
-        else:
-            if f.endswith(".pyc") or f.endswith(".pyo"):
-                continue
-            os.symlink(dest_path, update_path)
 
 def parse_arguments(argv=None, boot_cmdline=None):
     """Parse command line/boot options and arguments.
@@ -188,9 +128,6 @@ def parse_arguments(argv=None, boot_cmdline=None):
 
 def setup_python_path():
     """Add items Anaconda needs to sys.path."""
-    # First add our updates path
-    sys.path.insert(0, '/tmp/updates/')
-
     from pyanaconda.core.constants import ADDON_PATHS
     # append ADDON_PATHS dirs at the end
     sys.path.extend(ADDON_PATHS)
@@ -300,8 +237,9 @@ if __name__ == "__main__":
         sys.exit(0)
 
     log.info("%s %s", sys.argv[0], util.get_anaconda_version_string(build_time_version=True))
-    if os.path.exists("/tmp/updates"):
-        log.info("Using updates in /tmp/updates/ from %s", opts.updateSrc)
+
+    if opts.updates_url:
+        log.info("Using updates from: %s", opts.updates_url)
 
     # warn users that they should use inst. prefix all the time
     for arg in removed_no_inst_args:

--- a/anaconda.py
+++ b/anaconda.py
@@ -101,14 +101,6 @@ def exitHandler(rebootData):
         else:  # reboot action is KS_REBOOT or None
             util.execWithRedirect("systemctl", ["--no-wall", "reboot"])
 
-def setup_python_updates():
-    """Setup updates to Anaconda Python files."""
-    import gi.overrides
-
-    if "ANACONDA_WIDGETS_OVERRIDES" in os.environ:
-        for p in os.environ["ANACONDA_WIDGETS_OVERRIDES"].split(":"):
-            gi.overrides.__path__.insert(0, os.path.abspath(p))
-
 
 def parse_arguments(argv=None, boot_cmdline=None):
     """Parse command line/boot options and arguments.
@@ -126,11 +118,6 @@ def parse_arguments(argv=None, boot_cmdline=None):
     namespace = ap.parse_args(argv, boot_cmdline=boot_cmdline)
     return (namespace, ap.removed_no_inst_bootargs)
 
-def setup_python_path():
-    """Add items Anaconda needs to sys.path."""
-    from pyanaconda.core.constants import ADDON_PATHS
-    # append ADDON_PATHS dirs at the end
-    sys.path.extend(ADDON_PATHS)
 
 def setup_environment():
     """Setup contents of os.environ according to Anaconda needs.
@@ -186,9 +173,9 @@ if __name__ == "__main__":
     except ImportError:
         pass
 
-    # this handles setting up updates for pypackages to minimize the set needed
-    setup_python_updates()
-    setup_python_path()
+    # Append Python paths to Anaconda addons at the end.
+    from pyanaconda.core.constants import ADDON_PATHS
+    sys.path.extend(ADDON_PATHS)
 
     # init threading before Gtk can do anything and before we start using threads
     from pyanaconda.threading import AnacondaThread, threadMgr

--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -139,18 +139,6 @@ anaconda-cleanup $ANACONDA $*
 
 # Set up the updates, if provided.
 if [ ! -z "$UPDATES" ]; then
-    if [ -e /tmp/updates.img -o -e /tmp/updates ]; then
-        title="Updates already exist"
-        text="updates= was provided, but an updates image already exists.  Please remove /tmp/updates.img and /tmp/updates and try again."
-        if which zenity &> /dev/null; then
-            zenity --error --title="$title" --text="$text"
-        else
-            echo "$title" >&2
-            echo "$text" >&2
-        fi
-        exit 1
-    fi
-
     curl -o /tmp/updates.img $UPDATES
 
     # We officially support two updates.img formats:  a filesystem image, and
@@ -165,9 +153,6 @@ if [ ! -z "$UPDATES" ]; then
         rmdir /tmp/updates.disk
     fi
 
-    export PYTHONPATH=/tmp/updates:$PYTHONPATH
-    export LD_LIBRARY_PATH=/tmp/updates:$LD_LIBRARY_PATH
-    export PATH=/tmp/updates:$PATH
 fi
 
 if [ -z $LC_ALL ]; then
@@ -185,7 +170,6 @@ else
     $ANACONDA $*
 fi
 
-if [ -e /tmp/updates ]; then rm -r /tmp/updates; fi
 if [ -e /tmp/updates.img ]; then rm /tmp/updates.img; fi
 
 # try to teardown the filesystems if this was an image install

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -566,7 +566,7 @@ def getArgumentParser(version_string, boot_cmdline=None):
     # Miscellaneous
     ap.add_argument("--nomount", dest="rescue_nomount", action="store_true", default=False,
                     help=help_parser.help_text("nomount"))
-    ap.add_argument("--updates", dest="updateSrc", action="store", type=str,
+    ap.add_argument("--updates", dest="updates_url", action="store", type=str,
                     metavar="UPDATES_URL", help=help_parser.help_text("updates"))
     ap.add_argument("--image", action="append", dest="images", default=[],
                     metavar="IMAGE_SPEC", help=help_parser.help_text("image"))

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -41,8 +41,6 @@ shortProductName = productName.lower()          # pylint: disable=no-member
 if productName.count(" "):                      # pylint: disable=no-member
     shortProductName = ''.join(s[0] for s in shortProductName.split())
 
-TRANSLATIONS_UPDATE_DIR = "/tmp/updates/po"
-
 # The default virtio port.
 VIRTIO_PORT = "/dev/virtio-ports/org.fedoraproject.anaconda.log.0"
 

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -42,7 +42,7 @@ from requests_ftp import FTPAdapter
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.flags import flags
 from pyanaconda.core.process_watchers import WatchProcesses
-from pyanaconda.core.constants import DRACUT_SHUTDOWN_EJECT, TRANSLATIONS_UPDATE_DIR, \
+from pyanaconda.core.constants import DRACUT_SHUTDOWN_EJECT, \
     IPMI_ABORTED, X_TIMEOUT, TAINT_HARDWARE_UNSUPPORTED, TAINT_SUPPORT_REMOVED, \
     WARNING_HARDWARE_UNSUPPORTED, WARNING_SUPPORT_REMOVED
 from pyanaconda.errors import RemovedModuleError, ExitError
@@ -533,24 +533,7 @@ def resetRpmDb():
             log.debug("error %s removing file: %s", e, rpmfile)
 
 
-def add_po_path(directory):
-    """ Looks to see what translations are under a given path and tells
-    the gettext module to use that path as the base dir """
-    for d in os.listdir(directory):
-        if not os.path.isdir("%s/%s" % (directory, d)):
-            continue
-        if not os.path.exists("%s/%s/LC_MESSAGES" % (directory, d)):
-            continue
-        for basename in os.listdir("%s/%s/LC_MESSAGES" % (directory, d)):
-            if not basename.endswith(".mo"):
-                continue
-            log.info("setting %s as translation source for %s", directory, basename[:-3])
-            gettext.bindtextdomain(basename[:-3], directory)
-
-
 def setup_translations():
-    if os.path.isdir(TRANSLATIONS_UPDATE_DIR):
-        add_po_path(TRANSLATIONS_UPDATE_DIR)
     gettext.textdomain("anaconda")
 
 

--- a/pyanaconda/modules/payloads/constants.py
+++ b/pyanaconda/modules/payloads/constants.py
@@ -29,9 +29,7 @@ from pyanaconda.core.constants import \
 # Locations of repo files.
 DNF_REPO_DIRS = [
     '/etc/yum.repos.d',
-    '/etc/anaconda.repos.d',
-    '/tmp/updates/anaconda.repos.d',
-    '/tmp/product/anaconda.repos.d'
+    '/etc/anaconda.repos.d'
 ]
 
 

--- a/pyanaconda/modules/payloads/payload/dnf/installation.py
+++ b/pyanaconda/modules/payloads/payload/dnf/installation.py
@@ -67,8 +67,7 @@ class SetRPMMacrosTask(Task):
             macros.append(('_install_langs', data.languages))
 
         if conf.security.selinux:
-            for d in ["/tmp/updates",
-                      "/etc/selinux/targeted/contexts/files",
+            for d in ["/etc/selinux/targeted/contexts/files",
                       "/etc/security/selinux/src/policy",
                       "/etc/security/selinux"]:
                 f = d + "/file_contexts"

--- a/pyanaconda/product.py
+++ b/pyanaconda/product.py
@@ -35,7 +35,7 @@ config.set("Main", "UUID", "")
 config.set("Main", "Version", os.environ.get("ANACONDA_PRODUCTVERSION", "bluesky"))
 
 # Now read in the .buildstamp file, wherever it may be.
-config.read(["/.buildstamp", "/tmp/product/.buildstamp", os.environ.get("PRODBUILDPATH", "")])
+config.read(["/.buildstamp", os.environ.get("PRODBUILDPATH", "")])
 
 # Set up some variables we import throughout, applying a couple transforms as necessary.
 bugUrl = config.get("Main", "BugURL")

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -371,8 +371,7 @@ def find_kickstart(options):
         flags.eject = False
         ks_files = ["/run/install/ks.cfg"]
     else:
-        ks_files = ["/tmp/updates/interactive-defaults.ks",
-                    "/usr/share/anaconda/interactive-defaults.ks"]
+        ks_files = ["/usr/share/anaconda/interactive-defaults.ks"]
 
     for ks in ks_files:
         if not os.path.exists(ks):

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -160,7 +160,7 @@ class GUIObject(common.UIObject):
         self.builder.connect_signals(self)
 
     def _findUIFile(self):
-        path = os.environ.get("UIPATH", "./:/tmp/updates/:/tmp/updates/ui/:/usr/share/anaconda/ui/")
+        path = os.environ.get("UIPATH", "./:/usr/share/anaconda/ui/")
         dirs = path.split(":")
 
         # append the directory where this UIObject is defined
@@ -563,10 +563,9 @@ class GraphicalUserInterface(UserInterface):
 
     basemask = "pyanaconda.ui"
     basepath = os.path.dirname(os.path.dirname(__file__))
-    updatepath = "/tmp/updates/pyanaconda/ui"
     sitepackages = [os.path.join(dir, "pyanaconda", "ui")
                     for dir in site.getsitepackages()]
-    pathlist = set([updatepath, basepath] + sitepackages)
+    pathlist = set([basepath] + sitepackages)
 
     _categories = []
     _spokes = []

--- a/pyanaconda/ui/tui/__init__.py
+++ b/pyanaconda/ui/tui/__init__.py
@@ -121,10 +121,9 @@ class TextUserInterface(ui.UserInterface):
 
     basemask = "pyanaconda.ui"
     basepath = os.path.dirname(os.path.dirname(__file__))
-    updatepath = "/tmp/updates/pyanaconda/ui"
     sitepackages = [os.path.join(dir, "pyanaconda", "ui")
                     for dir in site.getsitepackages()]
-    pathlist = set([updatepath, basepath] + sitepackages)
+    pathlist = set([basepath] + sitepackages)
 
     _categories = []
     _spokes = []

--- a/scripts/apply-updates
+++ b/scripts/apply-updates
@@ -36,8 +36,5 @@ if [[ "$EUID" -ne 0 ]]; then
     exit 1
 fi
 
-# Clear /tmp/updates, so Anaconda can set it up again.
-rm -rf /tmp/updates
-
 # Download and extract the updates image.
 (cd / ; curl -f "${URL}" | gzip -dc  | cpio -idu )

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -32,6 +32,9 @@ import tempfile
 RPM_FOLDER_NAME = os.path.expanduser("~/.anaconda_updates_rpm_cache")
 RPM_RELEASE_DIR_TEMPLATE = "for_%s"
 
+# The Python site-packages path for pyanaconda.
+SITE_PACKAGES_PATH = "./usr/lib64/python3.9/site-packages/"
+
 # Anaconda scripts that should be installed into the libexec folder
 LIBEXEC_SCRIPTS = ["log-capture", "start-module", "apply-updates"]
 
@@ -174,15 +177,6 @@ def copy_updated_files(tag, updates, cwd, builddir):
         finally:
             shutil.rmtree(tmpdir)
 
-
-
-    # Updates get overlaid onto the runtime filesystem. Anaconda expects them
-    # to be in /run/install/updates, so put them in
-    # $updatedir/run/install/updates.
-    tmpupdates = updates.rstrip('/')
-    if not tmpupdates.endswith("/run/install/updates"):
-        tmpupdates = os.path.join(tmpupdates, "run/install/updates")
-
     try:
         lines = do_git_diff(tag)
     except RuntimeError as e:
@@ -201,10 +195,12 @@ def copy_updated_files(tag, updates, cwd, builddir):
         # R is followed by a number that doesn't matter to us.
         if status == "D" or status[0] == "R":
             if gitfile.startswith('pyanaconda/') and gitfile.endswith(".py"):
-                # deleted python module, write out a stub raising RemovedModuleError
-                file_path = os.path.join(tmpupdates, gitfile)
+                sys.stdout.write("Replacing %s\n" % gitfile)
+                file_path = os.path.join(updates, SITE_PACKAGES_PATH, gitfile)
+
                 if not os.path.exists(os.path.dirname(file_path)):
                     os.makedirs(os.path.dirname(file_path))
+
                 with open(file_path, "w") as fobj:
                     fobj.write('from pyanaconda.errors import RemovedModuleError\n')
                     fobj.write('raise RemovedModuleError("This module no longer exists!")\n')
@@ -225,13 +221,9 @@ def copy_updated_files(tag, updates, cwd, builddir):
             dir_parts = os.path.dirname(gitfile).split(os.path.sep)
             g_idx = dir_parts.index("gui")
             uidir = os.path.sep.join(dir_parts[g_idx+1:])
-            path_comps = [tmpupdates, "ui"]
-            if uidir:
-                path_comps.append(uidir)
-            install_to_dir(gitfile, os.path.join(*path_comps))
+            install_to_dir(gitfile, os.path.join("usr/share/anaconda/ui/", uidir))
         elif gitfile.startswith('pyanaconda/'):
-            # pyanaconda stuff goes into /tmp/updates/[path]
-            dirname = os.path.join(tmpupdates, os.path.dirname(gitfile))
+            dirname = os.path.join(SITE_PACKAGES_PATH, os.path.dirname(gitfile))
             install_to_dir(gitfile, dirname)
         elif gitfile == 'anaconda.py':
             # Install it as /usr/sbin/anaconda
@@ -343,20 +335,15 @@ def copy_updated_isys(updates, srcdir, builddir):
 
     os.system('make -C %s -j %d' % (builddir, multiprocessing.cpu_count()))
 
-    # Updates get overlaid onto the runtime filesystem. Anaconda expects them
-    # to be in /run/install/updates, so put them in
-    # $updatedir/run/install/updates.
-    tmpupdates = updates.rstrip('/')
-    if not tmpupdates.endswith("/run/install/updates/pyanaconda"):
-        tmpupdates = os.path.join(tmpupdates, "run/install/updates/pyanaconda")
+    outdir = os.path.join(updates, SITE_PACKAGES_PATH, "pyanaconda")
+    if not os.path.isdir(outdir):
+        os.makedirs(outdir)
 
-    if not os.path.isdir(tmpupdates):
-        os.makedirs(tmpupdates)
-
-    isysmodule = os.path.realpath(os.path.join(builddir,'pyanaconda/isys/.libs/_isys.so'))
+    isysmodule = os.path.realpath(os.path.join(builddir, 'pyanaconda/isys/.libs/_isys.so'))
 
     if os.path.isfile(isysmodule):
-        shutil.copy2(isysmodule, tmpupdates)
+        sys.stdout.write("Including %s\n" % isysmodule)
+        shutil.copy2(isysmodule, outdir)
 
 def copy_updated_auditd(updates, srcdir, builddir):
     os.chdir(srcdir)
@@ -519,7 +506,8 @@ def main():
             builddir = os.path.join(cwd, args.builddir)
     else:
         builddir = cwd
-    print("BUILDDIR %s" % builddir)
+
+    print("Using site-packages path: %s\n" % SITE_PACKAGES_PATH)
 
     if not os.path.isdir(updates):
         os.makedirs(updates)

--- a/scripts/restart-anaconda
+++ b/scripts/restart-anaconda
@@ -19,8 +19,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-rm -rf /tmp/updates || echo "Error removing /tmp/updates. Updates won't be re-downloaded." >&2
-
 if [[ -f /var/run/iscsid.pid ]]; then
     # iscsid must die else it will cause us troubles on the next run
     # log out of all nodes

--- a/scripts/start-module
+++ b/scripts/start-module
@@ -25,12 +25,6 @@ done
 # Add Anaconda addons to the PYTHONPATH.
 PYTHONPATH="$PYTHONPATH:/usr/share/anaconda/addons"
 
-# Add updates & product image directories to PYTHONPATH if
-# it looks like we are in the installation environment.
-if [ -d "/run/install" ]; then
-  PYTHONPATH="/run/install/updates:/run/install/product:/tmp/updates:/tmp/product:$PYTHONPATH"
-fi
-
 # Export the modified PYTHONPATH.
 export PYTHONPATH
 

--- a/tests/nosetests/__init__.py
+++ b/tests/nosetests/__init__.py
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import os
+import locale
+import gi.overrides
+
+# Apply overrides for the anaconda widgets.
+if "ANACONDA_WIDGETS_OVERRIDES" in os.environ:
+    for p in os.environ["ANACONDA_WIDGETS_OVERRIDES"].split(":"):
+        gi.overrides.__path__.insert(0, os.path.abspath(p))
+
+
+# Set the default locale.
+locale.setlocale(locale.LC_ALL, "en_US.UTF-8")

--- a/tests/nosetests/pyanaconda_tests/__init__.py
+++ b/tests/nosetests/pyanaconda_tests/__init__.py
@@ -23,22 +23,15 @@ import gi
 gi.require_version("GLib", "2.0")
 from gi.repository import GLib
 
-import locale
-
 from contextlib import ContextDecorator
 from textwrap import dedent
 from unittest.mock import Mock, patch
 
-from pyanaconda.core.constants import DEFAULT_LANG
 from dasbus.server.template import BasicInterfaceTemplate
 from pyanaconda.modules.common.constants.interfaces import KICKSTART_MODULE
 from pyanaconda.modules.common.structures.kickstart import KickstartReport
 from pyanaconda.modules.common.task import TaskInterface
 from dasbus.typing import get_native
-
-
-# Set the default locale.
-locale.setlocale(locale.LC_ALL, DEFAULT_LANG)
 
 
 class run_in_glib(object):

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_installation_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_installation_test.py
@@ -102,7 +102,7 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
 
         macros = [
             ('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}'),
-            ('__file_context_path', '/tmp/updates/file_contexts'),
+            ('__file_context_path', '/etc/selinux/targeted/contexts/files/file_contexts'),
         ]
 
         task = self._run_task(data)

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
@@ -77,9 +77,7 @@ class DNFMangerTestCase(unittest.TestCase):
         self._check_configuration(
             "reposdir = "
             "/etc/yum.repos.d, "
-            "/etc/anaconda.repos.d, "
-            "/tmp/updates/anaconda.repos.d, "
-            "/tmp/product/anaconda.repos.d",
+            "/etc/anaconda.repos.d"
         )
         self._check_substitutions({
             "arch": "x86_64",


### PR DESCRIPTION
Don't use `/run/install/updates` and `/tmp/updates` for updates. Use the real paths.
It will allow to use updates images for the initial setup testing and debugging.

Some notes:

* Addons are installed at `/usr/share/anaconda/addons`, so they shouldn't use this support.
* So far, I haven't found any documentation that would suggest to use `/run/install/updates` in the updates image.