### PR TITLE
fix text in iscsi loginErrorLabel not wrap

### DIFF
--- a/pyanaconda/ui/gui/spokes/advstorage/iscsi.py
+++ b/pyanaconda/ui/gui/spokes/advstorage/iscsi.py
@@ -417,6 +417,7 @@ class ISCSIDialog(GUIObject):
             task_proxy.Finish()
         except StorageDiscoveryError as e:
             # Login has failed, show the error.
+            self._loginErrorLabel.set_line_wrap(True)
             self._loginErrorLabel.set_text(str(e))
 
             self._set_login_sensitive(True)


### PR DESCRIPTION
In the graphical installation mode, if the login of the iSCSI node fails, the interface will prompt an error message. If the error message text does not wrap automatically, the window will extend to the right, and the Cancel button will extend out of the screen, so that the user cannot click to exit the current interface