### PR TITLE
Handle correctly signal from delayed Xorg start(#1918702)

### DIFF
--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -340,6 +340,8 @@ def setup_display(anaconda, options):
             anaconda.display_mode = constants.DisplayModes.TUI
             anaconda.gui_startup_failed = True
             time.sleep(2)
+            if conf.system.can_switch_tty:
+                util.vtActivate(1)
 
         if not anaconda.gui_startup_failed:
             do_extra_x11_actions(options.runres, gui_mode=anaconda.gui_mode)


### PR DESCRIPTION
Handling of the SIGUSR1 signal after Xorg start timed out was wrong. If Xorg eventually started and sent SIGUSR1 to Anaconda, the signal was not handled and Anaconda crashed.

Resolves: rhbz#1918702

link:#3107