### PR TITLE
Warn on invalid host name in kickstart (#1897514)

### DIFF
--- a/pyanaconda/modules/network/kickstart.py
+++ b/pyanaconda/modules/network/kickstart.py
@@ -17,7 +17,9 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pykickstart.errors import KickstartParseError
 from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
+from pyanaconda.network import is_valid_hostname
 
 DEFAULT_DEVICE_SPECIFICATION = "link"
 
@@ -30,6 +32,13 @@ class Network(COMMANDS.Network):
 
         if hostname_only_command:
             retval.bootProto = ""
+
+        if retval.hostname:
+            (result, reason) = is_valid_hostname(retval.hostname)
+            if not result:
+                message = "Hostname '{}' given in network kickstart command is invalid: {}"\
+                    .format(retval.hostname, reason)
+                raise KickstartParseError(message, lineno=self.lineno)
 
         return retval
 

--- a/tests/nosetests/pyanaconda_tests/modules/network/module_network_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/network/module_network_test.py
@@ -410,8 +410,8 @@ class NetworkInterfaceTestCase(unittest.TestCase):
             ["ens3", "ens5", "ens7", "bond0", "devA", "devB"]
         )
 
-    def _test_kickstart(self, ks_in, ks_out):
-        check_kickstart_interface(self, self.network_interface, ks_in, ks_out)
+    def _test_kickstart(self, ks_in, ks_out, **kwargs):
+        check_kickstart_interface(self, self.network_interface, ks_in, ks_out, **kwargs)
 
     def no_kickstart_test(self):
         """Test with no kickstart."""
@@ -543,6 +543,12 @@ class NetworkInterfaceTestCase(unittest.TestCase):
                 "reason": get_variant(Str, "Necessary for network team device configuration.")
             }
         ])
+
+    def kickstart_invalid_hostname_test(self):
+        """Test that invalid hostname in kickstart is not accepted"""
+        ks_in = "network --hostname sorry_underscores_banned"
+        ks_out = ""
+        self._test_kickstart(ks_in, ks_out, ks_valid=False)
 
 
 class FirewallInterfaceTestCase(unittest.TestCase):


### PR DESCRIPTION
Do that instead of crashing.

Resolves: [rhbz#1897514](https://bugzilla.redhat.com/show_bug.cgi?id=1897514)

~~I have no idea where to put that warning? Or maybe I could use the stock pykickstart one. Opinions welcome.~~

Pinging @jstodola because it changes behavior, from crashing to... something.