### PR TITLE
Remove support for no inst prefix

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -184,7 +184,7 @@ def parse_arguments(argv=None, boot_cmdline=None):
     ap = getArgumentParser(get_anaconda_version_string(), boot_cmdline)
 
     namespace = ap.parse_args(argv, boot_cmdline=boot_cmdline)
-    return (namespace, ap.deprecated_bootargs)
+    return (namespace, ap.removed_no_inst_bootargs)
 
 def setup_python_path():
     """Add items Anaconda needs to sys.path."""
@@ -262,7 +262,7 @@ if __name__ == "__main__":
     # do this early so we can set flags before initializing logging
     from pyanaconda.flags import flags
     from pyanaconda.core.kernel import kernel_arguments
-    (opts, depr) = parse_arguments(boot_cmdline=kernel_arguments)
+    (opts, removed_no_inst_args) = parse_arguments(boot_cmdline=kernel_arguments)
 
     from pyanaconda.core.configuration.anaconda import conf
     conf.set_from_opts(opts)
@@ -304,10 +304,13 @@ if __name__ == "__main__":
         log.info("Using updates in /tmp/updates/ from %s", opts.updateSrc)
 
     # warn users that they should use inst. prefix all the time
-    for arg in depr:
-        stdout_log.warning("Boot argument '%s' is deprecated and will be removed in the future. "
-                           "Please use 'inst.%s' instead.",
+    for arg in removed_no_inst_args:
+        stdout_log.warning("Kernel boot argument '%s' detected. "
+                           "Did you want to use 'inst.%s' for the installer instead?",
                            arg, arg)
+    if removed_no_inst_args:
+        stdout_log.warning("All Anaconda kernel boot arguments are now required to use "
+                           "'inst.' prefix!")
 
     from pyanaconda import isys
 

--- a/data/systemd/anaconda-noshell.service
+++ b/data/systemd/anaconda-noshell.service
@@ -3,7 +3,6 @@ Description=Restrict Anaconda Text Console
 After=anaconda.service
 Before=anaconda-tmux@.service
 ConditionKernelCommandLine=|inst.noshell
-ConditionKernelCommandLine=|noshell
 
 [Service]
 Type=oneshot

--- a/data/systemd/anaconda-shell@.service
+++ b/data/systemd/anaconda-shell@.service
@@ -3,7 +3,6 @@
 [Unit]
 Description=Shell on %I
 After=systemd-user-sessions.service plymouth-quit-wait.service
-ConditionKernelCommandLine=!noshell
 ConditionKernelCommandLine=!inst.noshell
 
 [Service]

--- a/data/systemd/anaconda-sshd.service
+++ b/data/systemd/anaconda-sshd.service
@@ -3,10 +3,8 @@ Description=OpenSSH server daemon
 Before=anaconda.target
 After=syslog.target network.target sshd-keygen.target
 Wants=sshd-keygen.target
-ConditionKernelCommandLine=|sshd
 ConditionKernelCommandLine=|inst.sshd
 ConditionKernelCommandLine=!inst.sshd=0
-ConditionKernelCommandLine=!sshd=0
 # TODO: use ConditionArchitecture in systemd v210 or later
 ConditionPathIsDirectory=|/sys/hypervisor/s390
 

--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -39,7 +39,7 @@ run_checkisomd5() {
 
 dev="$1"
 path="$2" # optional, could be empty
-kickstart="$(getarg ks= inst.ks=)"
+kickstart="$(getarg inst.ks=)"
 
 # Log the device that triggered this job.
 debug_msg "Trying to find a root image on the device $dev."

--- a/dracut/anaconda-ks-sendheaders.sh
+++ b/dracut/anaconda-ks-sendheaders.sh
@@ -5,7 +5,7 @@
 command -v set_http_header >/dev/null || . /lib/url-lib.sh
 
 # inst.ks.sendmac: send MAC addresses in HTTP headers
-if getargbool 0 kssendmac inst.ks.sendmac; then
+if getargbool 0 inst.ks.sendmac; then
     ifnum=0
     for ifname in /sys/class/net/*; do
         [ -e "$ifname/address" ] || continue
@@ -21,7 +21,7 @@ if getargbool 0 kssendmac inst.ks.sendmac; then
 fi
 
 # inst.ks.sendsn: send system serial number in HTTP headers
-if getargbool 0 kssendsn inst.ks.sendsn; then
+if getargbool 0 inst.ks.sendsn; then
     system_serial=$(cat /sys/class/dmi/id/product_serial 2>/dev/null)
     if [ -z "$system_serial" ]; then
         warn "inst.ks.sendsn: can't find system serial number"

--- a/dracut/fetch-kickstart-disk
+++ b/dracut/fetch-kickstart-disk
@@ -6,7 +6,7 @@ command -v getarg >/dev/null || . /lib/dracut-lib.sh
 
 dev="$1"
 path="${2:-/ks.cfg}"
-kickstart="$(getarg ks= inst.ks=)"
+kickstart="$(getarg inst.ks=)"
 
 [ -e /tmp/ks.cfg.done ] && exit 1
 [ -b "$dev" ] || exit 1

--- a/dracut/kickstart-genrules.sh
+++ b/dracut/kickstart-genrules.sh
@@ -28,7 +28,7 @@ case "${kickstart%%:*}" in
         wait_for_kickstart
     ;;
     "")
-        if [ -z "$kickstart" -a -z "$(getarg ks= inst.ks=)" ]; then
+        if [ -z "$kickstart" -a -z "$(getarg inst.ks=)" ]; then
             when_diskdev_appears $(disk_to_dev_path LABEL=OEMDRV) \
                 fetch-kickstart-disk \$env{DEVNAME} "/ks.cfg"
         fi

--- a/dracut/parse-anaconda-dd.sh
+++ b/dracut/parse-anaconda-dd.sh
@@ -11,7 +11,7 @@
 rm -f /tmp/dd_interactive /tmp/dd_net /tmp/dd_disk /tmp/dd_todo
 
 # parse any dd/inst.dd args found
-for dd in $(getargs dd= inst.dd=); do
+for dd in $(getargs inst.dd=); do
     case "$dd" in
         # plain 'dd'/'inst.dd': Engage interactive mode!
         dd|inst.dd) echo menu > /tmp/dd_interactive ;;

--- a/dracut/parse-anaconda-kickstart.sh
+++ b/dracut/parse-anaconda-kickstart.sh
@@ -5,9 +5,9 @@
 [ -f /tmp/ks.cfg.done ] && return
 
 # inst.ks: provide a "URI" for the kickstart file
-kickstart="$(getarg ks= inst.ks=)"
+kickstart="$(getarg inst.ks=)"
 if [ -z "$kickstart" ]; then
-    getargbool 0 ks inst.ks && kickstart='nfs:auto'
+    getargbool 0 inst.ks && kickstart='nfs:auto'
 fi
 # no root? the kickstart will probably tell us what our root device is.
 [ "$kickstart" ] && [ -z "$root" ] && root="anaconda-kickstart"
@@ -23,7 +23,7 @@ case "${kickstart%%:*}" in
         set_neednet
     ;;
     urls) # multiple network kickstarts?
-        locations="$(getargs ks= inst.ks=)"
+        locations="$(getargs inst.ks=)"
         get_urls "$locations" >/tmp/ks_urls
         set_neednet
     ;;

--- a/dracut/parse-anaconda-net.sh
+++ b/dracut/parse-anaconda-net.sh
@@ -16,6 +16,9 @@ mac_to_bootif() {
 
 # handle ksdevice (tell us which device to use for ip= stuff later)
 export ksdevice=""
+# TODO: Remove support for ksdevice. It's deprecated a long time already
+# this should be inst.ksdevice however, this is deprecated a long time so we don't have
+# any inst.ksdevice. Let's just ignore this for now.
 ksdev_val=$(getarg ksdevice=)
 if [ -n "$ksdev_val" ]; then
     case "$ksdev_val" in

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -58,6 +58,12 @@ check_removed_arg() {
     fi
 }
 
+check_removed_no_inst_arg() {
+    local removed_arg="$1" new_arg="$2"
+    check_removed_arg "$removed_arg" "All usage of Anaconda boot arguments without 'inst.' prefix \
+was removed. Please use $new_arg instead."
+}
+
 check_depr_args "blacklist=" "inst.blacklist=%s"
 check_depr_arg "nofirewire" "inst.blacklist=firewire_ohci"
 
@@ -77,35 +83,32 @@ check_removed_arg askmethod "Use an appropriate 'inst.repo=' argument instead."
 check_removed_arg asknetwork "Use an appropriate 'ip=' argument instead."
 
 # lang & keymap
-warn_renamed_arg "lang" "inst.lang"
-warn_renamed_arg "keymap" "inst.keymap"
-
-# debug
-warn_renamed_arg "debug" "inst.debug"
+check_removed_no_inst_arg "lang" "inst.lang"
+check_removed_no_inst_arg "keymap" "inst.keymap"
 
 # repo
 check_depr_arg "method=" "repo=%s"
-warn_renamed_arg "repo" "inst.repo"
+check_removed_no_inst_arg "repo" "inst.repo"
 
 # stage2
-warn_renamed_arg "stage2" "inst.stage2"
+check_removed_no_inst_arg "stage2" "inst.stage2"
 
 # kickstart
-warn_renamed_arg "ks" "inst.ks"
-warn_renamed_arg "ksdevice" "inst.ks.device"
-warn_renamed_arg "kssendmac" "inst.ks.sendmac"
-warn_renamed_arg "kssendsn" "inst.ks.sendsn"
+check_removed_no_inst_arg "ks" "inst.ks"
+check_removed_no_inst_arg "ksdevice" "inst.ks.device"
+check_removed_no_inst_arg "kssendmac" "inst.ks.sendmac"
+check_removed_no_inst_arg "kssendsn" "inst.ks.sendsn"
 
 # Ignore self-signed SSL certs
-warn_renamed_arg "noverifyssl" "inst.noverifyssl"
-if getargbool 0 noverifyssl inst.noverifyssl; then
+check_removed_no_inst_arg "noverifyssl" "inst.noverifyssl"
+if getargbool 0 inst.noverifyssl; then
     # Tell dracut to use curl --insecure
     echo "rd.noverifyssl" >> /etc/cmdline.d/75-anaconda-options.conf
 fi
 
 # updates
-warn_renamed_arg "updates=" "inst.updates"
-if updates=$(getarg updates inst.updates); then
+check_removed_no_inst_arg "updates" "inst.updates"
+if updates=$(getarg inst.updates); then
     if [ -n "$updates" ]; then
         export anac_updates=$updates
         case $updates in
@@ -119,11 +122,11 @@ if updates=$(getarg updates inst.updates); then
 fi
 
 # for vnc bring network up in initramfs so that cmdline configuration is used
-warn_renamed_arg "vnc" "inst.vnc"
-getargbool 0 vnc inst.vnc && warn "anaconda requiring network for vnc" && set_neednet
+check_removed_no_inst_arg "vnc" "inst.vnc"
+getargbool 0 inst.vnc && warn "anaconda requiring network for vnc" && set_neednet
 
 # Driver Update Disk
-warn_renamed_arg "dd" "inst.dd"
+check_removed_no_inst_arg "dd" "inst.dd"
 
 # re-read the commandline args
 unset CMDLINE

--- a/dracut/parse-anaconda-repo.sh
+++ b/dracut/parse-anaconda-repo.sh
@@ -4,8 +4,8 @@
 # If there's a root= arg, we'll just use that
 getarg root= >/dev/null && return
 
-repo="$(getarg repo= inst.repo=)"
-stage2="$(getarg stage2= inst.stage2=)"
+repo="$(getarg inst.repo=)"
+stage2="$(getarg inst.stage2=)"
 
 arg="repo"
 # default to using repo, but if we have stage2=, use that
@@ -26,7 +26,7 @@ if [ -n "$repo" ]; then
         ;;
         urls)
             root="anaconda-net:urls"
-            locations="$(getargs stage2= inst.stage2=)"
+            locations="$(getargs inst.stage2=)"
             get_urls "$locations" >/tmp/stage2_urls
             set_neednet
         ;;

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -144,9 +144,6 @@ class AnacondaArgumentParser(ArgumentParser):
         :returns: argparse option object or None if no suitable option is found
         :rtype argparse option or None
         """
-        if arg == "version" or arg == "help":
-            return None
-
         prefixed_option = False
 
         if self.bootarg_prefix and arg.startswith(self.bootarg_prefix):

--- a/tests/nosetests/pyanaconda_tests/argparse_test.py
+++ b/tests/nosetests/pyanaconda_tests/argparse_test.py
@@ -28,7 +28,7 @@ class ArgparseTest(unittest.TestCase):
     def _parseCmdline(self, argv, version="", boot_cmdline=None):
         ap = argument_parsing.getArgumentParser(version, boot_cmdline)
         opts = ap.parse_args(argv, boot_cmdline=boot_cmdline)
-        return (opts, ap.deprecated_bootargs)
+        return (opts, ap.removed_no_inst_bootargs)
 
     def display_mode_test(self):
         opts, _deprecated = self._parseCmdline(['--cmdline'])


### PR DESCRIPTION
Anaconda kernel boot arguments without `inst.` prefix won't be accepted and used. Only warning will be printed that these were removed and you should use the `inst.` variant.

This will happen in Dracut and also in Anaconda.

This is implementation of [Fedora system wide change](https://fedoraproject.org/wiki/Changes/Ignore_Anaconda_kernel_boot_parameters_without_inst_prefix).