### PR TITLE
Fix exclude arguments of tar payload extracting.

### DIFF
--- a/pyanaconda/modules/payloads/payload/live_image/installation.py
+++ b/pyanaconda/modules/payloads/payload/live_image/installation.py
@@ -42,10 +42,10 @@ class InstallFromTarTask(Task):
         cmd = "tar"
         # preserve: ACL's, xattrs, and SELinux context
         args = ["--numeric-owner", "--selinux", "--acls", "--xattrs", "--xattrs-include", "*",
-                "--exclude", "dev/*", "--exclude", "proc/*", "--exclude", "tmp/*",
-                "--exclude", "sys/*", "--exclude", "run/*", "--exclude", "boot/*rescue*",
-                "--exclude", "boot/loader", "--exclude", "boot/efi/loader",
-                "--exclude", "etc/machine-id", "-xaf", self._tarfile_path, "-C", self._dest_path]
+                "--exclude", "./dev/*", "--exclude", "./proc/*", "--exclude", "./tmp/*",
+                "--exclude", "./sys/*", "--exclude", "./run/*", "--exclude", "./boot/*rescue*",
+                "--exclude", "./boot/loader", "--exclude", "./boot/efi/loader",
+                "--exclude", "./etc/machine-id", "-xaf", self._tarfile_path, "-C", self._dest_path]
         try:
             rc = execWithRedirect(cmd, args)
         except (OSError, RuntimeError) as e:

--- a/pyanaconda/payload/live/payload_liveimg.py
+++ b/pyanaconda/payload/live/payload_liveimg.py
@@ -303,10 +303,10 @@ class LiveImagePayload(BaseLivePayload):
         cmd = "tar"
         # preserve: ACL's, xattrs, and SELinux context
         args = ["--numeric-owner", "--selinux", "--acls", "--xattrs", "--xattrs-include", "*",
-                "--exclude", "dev/*", "--exclude", "proc/*", "--exclude", "tmp/*",
-                "--exclude", "sys/*", "--exclude", "run/*", "--exclude", "boot/*rescue*",
-                "--exclude", "boot/loader", "--exclude", "boot/efi/loader",
-                "--exclude", "etc/machine-id", "-xaf", self.image_path, "-C", conf.target.system_root]
+                "--exclude", "./dev/*", "--exclude", "./proc/*", "--exclude", "./tmp/*",
+                "--exclude", "./sys/*", "--exclude", "./run/*", "--exclude", "./boot/*rescue*",
+                "--exclude", "./boot/loader", "--exclude", "./boot/efi/loader",
+                "--exclude", "./etc/machine-id", "-xaf", self.image_path, "-C", conf.target.system_root]
         try:
             rc = util.execWithRedirect(cmd, args)
         except (OSError, RuntimeError) as e:


### PR DESCRIPTION
The intention is to exclude subdirectories of the root directory.  --exclude
"sys/*" would exclude also /usr/include/sys/*.

Resolves: rhbz#1924118