### PR TITLE
Handle correctly too slow X11 start

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -271,8 +271,10 @@ def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
         # If X did not make it, stop caring and get rid of it
         if not x11_started[0] and childproc:
             WatchProcesses.unwatch_process(childproc)
-            childproc.terminate()
-            childproc.wait()
+            # Do kill() it with SIGKILL, because terminate() with SIGTERM is only scheduled and
+            # waits until it can be handled which is too late, by then Xorg already sends us the
+            # SIGUSR1 signal of doom.
+            childproc.kill()
 
         # Put back the exception-handler-testing handler
         signal.signal(signal.SIGUSR1, old_sigusr1_handler)

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -155,7 +155,6 @@ def check_vnc_can_be_started(anaconda):
 def start_x11(xtimeout):
     """Start the X server for the Anaconda GUI."""
 
-    # Start Xorg and wait for it become ready
     util.startX(["Xorg", "-br", "-logfile", "/tmp/X.log",
                  ":%s" % constants.X_DISPLAY_NUMBER, "vt6", "-s", "1440", "-ac",
                  "-nolisten", "tcp", "-dpi", "96",
@@ -339,6 +338,8 @@ def setup_display(anaconda, options):
             stdout_log.warning("X startup failed, falling back to text mode")
             anaconda.display_mode = constants.DisplayModes.TUI
             anaconda.gui_startup_failed = True
+            if conf.system.can_switch_tty:
+                util.vtActivate(1)
             time.sleep(2)
 
         if not anaconda.gui_startup_failed:


### PR DESCRIPTION
Yet another episode of the X11 timeout saga :-) This PR mixes ideas by @bitcoffeeiux in #3107 and #3132 and suggestions by @poncovka.

The gist is: If X11 takes too long, kill it, wait until it is dead to ensure signals can't come anymore, then restore the handlers.

Resolves: [rhbz#1918702](https://bugzilla.redhat.com/show_bug.cgi?id=1918702)