### PR TITLE
Don't run installation tasks of add-ons in a meta task

### DIFF
--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -104,23 +104,23 @@ class Boss(Service):
         """
         return self._install_manager.collect_requirements()
 
-    def configure_runtime_with_task(self):
-        """Configure the runtime environment.
+    def collect_configure_runtime_tasks(self):
+        """Collect tasks for configuration of the runtime environment.
 
         FIXME: This method temporarily uses only addons.
 
-        :return: a task
+        :return: a list of task proxies
         """
-        return self._install_manager.configure_runtime_with_task()
+        return self._install_manager.collect_configure_runtime_tasks()
 
-    def install_system_with_task(self):
-        """Install the system.
+    def collect_install_system_tasks(self):
+        """Collect tasks for installation of the system.
 
         FIXME: This method temporarily uses only addons.
 
-        :return: a task
+        :return: a list of task proxies
         """
-        return self._install_manager.install_system_with_task()
+        return self._install_manager.collect_install_system_tasks()
 
     def set_locale(self, locale):
         """Set locale of boss and all modules.

--- a/pyanaconda/modules/boss/install_manager/install_manager.py
+++ b/pyanaconda/modules/boss/install_manager/install_manager.py
@@ -18,7 +18,6 @@
 #
 from pyanaconda.core.dbus import DBus
 from pyanaconda.modules.common.structures.requirement import Requirement
-from pyanaconda.modules.common.task import DBusMetaTask
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -62,27 +61,23 @@ class InstallManager(object):
 
         return requirements
 
-    def configure_runtime_with_task(self):
-        """Configure the runtime environment.
+    def collect_configure_runtime_tasks(self):
+        """Collect tasks for configuration of the runtime environment.
 
         FIXME: This is a temporary method for addons.
 
-        :return: an instance of the main configuration task
+        :return: a list of task proxies
         """
-        configuration_tasks = self._collect_tasks(lambda proxy: proxy.ConfigureWithTasks())
-        system_task = DBusMetaTask("Configure the runtime system", configuration_tasks)
-        return system_task
+        return self._collect_tasks(lambda proxy: proxy.ConfigureWithTasks())
 
-    def install_system_with_task(self):
-        """Install the system.
+    def collect_install_system_tasks(self):
+        """Collect tasks for installation of the system.
 
         FIXME: This method temporarily uses only addons.
 
-        :return: an instance of the main installation task
+        :return: a list of task proxies
         """
-        installation_tasks = self._collect_tasks(lambda proxy: proxy.InstallWithTasks())
-        system_task = DBusMetaTask("Install the system", installation_tasks)
-        return system_task
+        return self._collect_tasks(lambda proxy: proxy.InstallWithTasks())
 
     def _collect_tasks(self, collector):
         """Collect installation tasks from modules.

--- a/pyanaconda/modules/common/task/meta.py
+++ b/pyanaconda/modules/common/task/meta.py
@@ -24,7 +24,10 @@ __all__ = ['DBusMetaTask']
 
 
 class DBusMetaTask(AbstractTask):
-    """A task that runs DBus tasks."""
+    """A task that runs DBus tasks.
+
+    FIXME: This class is not used anymore. Do we need it?
+    """
 
     def __init__(self, name, tasks):
         """Create a new meta task.

--- a/pyanaconda/modules/common/typing.py
+++ b/pyanaconda/modules/common/typing.py
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from dasbus.typing import *  # pylint: disable=wildcard-import
+
+__all__ = ["BusName"]
+
+# Type of a DBus service name.
+BusName = Str


### PR DESCRIPTION
The UI needs be able to handle a failure of an installation task and possibly
continue with the installation if the user allows it. That is not possible if
we run all installation tasks in one meta task.