### PR TITLE
Add dependabot support for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Dependabot will check our GitHub actions and if there will be a new version of any action
+# Dependabot will create a pull request to update these.
+
+# Set update schedule for GitHub Actions
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"


### PR DESCRIPTION
Dependabot is GitHub tool to keep your dependencies up to date. In this case it should create a PR when there will be a new version of GitHub action used in one of our workflows to update this workflow.