### PR TITLE
Unify GRUB configuration file location across all platforms

### DIFF
--- a/pyanaconda/modules/storage/bootloader/utils.py
+++ b/pyanaconda/modules/storage/bootloader/utils.py
@@ -19,7 +19,6 @@ import os
 from glob import glob
 
 from pyanaconda.modules.common.errors.installation import BootloaderInstallationError
-from pyanaconda.modules.storage.bootloader.efi import EFIBase
 from pyanaconda.modules.storage.bootloader.image import LinuxBootLoaderImage
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.util import decode_bytes, execWithRedirect
@@ -246,14 +245,9 @@ def create_bls_entries(sysroot, storage, kernel_versions):
     # Update the bootloader configuration to make sure that the BLS
     # entries will have the correct kernel cmdline and not the value
     # taken from /proc/cmdline, that is used to boot the live image.
-    if isinstance(storage.bootloader, EFIBase):
-        grub_cfg_path = "/etc/grub2-efi.cfg"
-    else:
-        grub_cfg_path = "/etc/grub2.cfg"
-
     rc = execWithRedirect(
         "grub2-mkconfig",
-        ["-o", grub_cfg_path],
+        ["-o", "/etc/grub2.cfg"],
         root=sysroot
     )
 

--- a/tests/nosetests/pyanaconda_tests/modules/storage/module_bootloader_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/storage/module_bootloader_test.py
@@ -467,7 +467,7 @@ class BootloaderTasksTestCase(unittest.TestCase):
                 ),
                 mock.call(
                     "grub2-mkconfig", [
-                        "-o", "/etc/grub2-efi.cfg"
+                        "-o", "/etc/grub2.cfg"
                     ], root=root
                 )
             ])


### PR DESCRIPTION
The GRUB configuration files layout on EFI platforms isn't consistent with
other non-EFI platforms (e.g: legacy BIOS x86 and Open Firmware ppc64le).

On platforms using EFI, the GRUB config file (grub.cfg) and environment
variables block (grubenv) are stored in the EFI System Partition (ESP),
while for non-EFI platforms these are stored in the boot partition (or
/boot directory if not boot partition is used).

The reason for this is that the path where the GRUB bootloader searches
for its configuration file varies depending on the firmware interface.

For EFI the GRUB binary is located in the ESP and it expects to find its
config file in that location as well. But this creates the mentioned
inconsistency, because the GRUB configuration file has to be stored in
/boot/efi/EFI/fedora/grub.cfg while for non-EFI platforms it has to be
stored in /boot/grub2/grub.cfg.

To allow all platforms to have the GRUB config file in the same location,
only a minimal config file could be stored in the ESP and this will load
the one that is stored in /boot/grub2.

Resolves: rhbz#1918817

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>