### PR TITLE
Remove product-specific data from the Anaconda stylesheet

### DIFF
--- a/data/anaconda-gtk.css
+++ b/data/anaconda-gtk.css
@@ -88,32 +88,22 @@ infobar.error {
     text-shadow: none;
 }
 
-/* vendor-specific colors/images */
-
-@define-color redhat #2d2d2d;
-@define-color fedora #2f4265;
-
-/* theme colors/images */
-
-@define-color product_bg_color @fedora;
-
 /* logo and sidebar classes */
 
 /* The sidebar consists of three parts: a background, a logo, and a product logo,
  * rendered in that order. The product logo is empty by default and is intended
  * to be overridden by a stylesheet in product.img.
  */
+
+@define-color anaconda_bg_color #2f4265;
+
 .logo-sidebar {
-    background-image: url('/usr/share/anaconda/pixmaps/sidebar-bg.png');
-    background-color: @product_bg_color;
-    background-repeat: no-repeat;
+    background-color: @anaconda_bg_color;
 }
 
-/* Add a logo to the sidebar */
+/* This is a placeholder to be filled by a product-specific logo. */
 .logo {
-    background-image: url('/usr/share/anaconda/pixmaps/sidebar-logo.png');
-    background-position: 50% 20px;
-    background-repeat: no-repeat;
+    background-image: none;
     background-color: transparent;
 }
 
@@ -124,9 +114,7 @@ infobar.error {
 }
 
 AnacondaSpokeWindow #nav-box {
-    background-color: @product_bg_color;
-    background-image: url('/usr/share/anaconda/pixmaps/topbar-bg.png');
-    background-repeat: repeat;
+    background-color: @anaconda_bg_color;
     color: white;
 }
 


### PR DESCRIPTION
Anaconda doesn't provide images from the pixmaps directory, so it doesn't make
sense to use them in our stylesheet. Pixmaps are provided by the *-logos
packages, so they should provide these data as well.

**Some notes:**

* Fedora Server and Fedora Workstation already work this way. They use a custom stylesheet that is placed in a subdirectory of `pixmaps` together with their images. Everything is provided by `fedora-logos`.
* Anaconda will use the Fedora background color and no logo by default (for example, if the product configuration doesn't specify the `custom_stylesheet` option).
* Initial Setup will use the product's stylesheet after merging https://github.com/rhinstaller/initial-setup/pull/117.

**TODO:**

- [x] Move `redhat.css` to `redhat-logos` (see https://bugzilla.redhat.com/show_bug.cgi?id=1928711)
- [x] Use the RHEL-specific stylesheet from `redhat-logos` (see https://github.com/rhinstaller/anaconda/pull/3179)
- [x] Move `fedora.css` to `fedora-logos` (see https://pagure.io/fedora-logos/issue/9).
- [x] Drop the commit that adds `fedora.css` and `redhat.css` files.