### PR TITLE
Save lorax-packages.log to installed system

### DIFF
--- a/data/post-scripts/99-copy-logs.ks
+++ b/data/post-scripts/99-copy-logs.ks
@@ -21,6 +21,7 @@ else
     cp /tmp/ks-script*.log $ANA_INSTALL_PATH/var/log/anaconda/
     journalctl -b > $ANA_INSTALL_PATH/var/log/anaconda/journal.log
     chmod 0600 $ANA_INSTALL_PATH/var/log/anaconda/*
+    [ -e /root/lorax-packages.log ] && cp /root/lorax-packages.log $ANA_INSTALL_PATH/var/log/anaconda/
 fi
 
 echo "Done."


### PR DESCRIPTION
The file contains list of packages used to build the installer image.

The original motivation here is having the log in results of kickstart tests but I think it is useful in general.