### PR TITLE
Migrate from pytz to zoneinfo, list (close to) all time zones

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -108,7 +108,6 @@ Requires: subscription-manager >= %{subscriptionmanagerver}
 # which is apparently great for containers but unhelpful for the rest of us
 Requires: cracklib-dicts
 
-Requires: python3-pytz
 Requires: teamd
 %ifarch s390 s390x
 Requires: openssh

--- a/pyanaconda/isys/__init__.py
+++ b/pyanaconda/isys/__init__.py
@@ -28,7 +28,7 @@ except ImportError:
 import blivet.arch
 import time
 import datetime
-import pytz
+import zoneinfo
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -88,7 +88,7 @@ def set_system_date_time(year=None, month=None, day=None, hour=None, minute=None
 
     """
 
-    utc = pytz.UTC
+    utc = zoneinfo.ZoneInfo(key='UTC')
     # If no timezone is set, use UTC
     if not tz:
         tz = utc
@@ -104,13 +104,12 @@ def set_system_date_time(year=None, month=None, day=None, hour=None, minute=None
     minute = minute if minute is not None else now.minute
     second = second if second is not None else now.second
 
-    set_date = tz.localize(datetime.datetime(year, month, day, hour, minute, second))
+    set_date = datetime.datetime(year, month, day, hour, minute, second, tzinfo=tz)
 
     # Calculate the number of seconds between this time and timestamp 0
-    # see pytz docs, search for "Converting between timezones"
     # pylint bug here: https://github.com/PyCQA/pylint/issues/1104
     # pylint: disable=no-value-for-parameter
-    epoch = utc.localize(datetime.datetime.utcfromtimestamp(0)).astimezone(tz)
+    epoch = datetime.datetime.fromtimestamp(0, tz=utc).astimezone(tz)
     timestamp = (set_date - epoch).total_seconds()
 
     set_system_time(int(timestamp))


### PR DESCRIPTION
https://listman.redhat.com/archives/anaconda-devel-list/2021-February/msg00020.html

This is very much untested. I've written it and never actually attempted to run it. Not yet anyway.

I found a problem thou. Python's `zoneinfo` does not have any concept of *common timezones*. I can implement my own method to determine whether a timezone is *common* (pytz uses [zone.tab](https://github.com/eggert/tz/blob/master/zone.tab) and a [short list of hardcoded values](https://github.com/stub42/pytz/blob/513450fb7e682d6d828456c661058f0e14a922cd/gen_tzinfo.py#L108)).

With pytz 2021.1, the extra zones effectively added by this PR are:

```pycon
>>> import pytz, zoneinfo
>>> pytz_zones = {tz for tz in pytz.common_timezones if '/' in tz and not tz.startswith('Etc/')}
>>> zoneinfo_zones = {tz for tz in zoneinfo.available_timezones() if '/' in tz and not tz.startswith('Etc/')}
>>> len(zoneinfo_zones) / len(pytz_zones)
1.1762013729977117
>>> zoneinfo_zones - pytz_zones
{'Africa/Asmera',
 'Africa/Timbuktu',
 'America/Argentina/ComodRivadavia',
 'America/Atka',
 'America/Buenos_Aires',
 'America/Catamarca',
 'America/Coral_Harbour',
 'America/Cordoba',
 'America/Ensenada',
 'America/Fort_Wayne',
 'America/Godthab',
 'America/Indianapolis',
 'America/Jujuy',
 'America/Knox_IN',
 'America/Louisville',
 'America/Mendoza',
 'America/Montreal',
 'America/Porto_Acre',
 'America/Rosario',
 'America/Santa_Isabel',
 'America/Shiprock',
 'America/Virgin',
 'Antarctica/South_Pole',
 'Asia/Ashkhabad',
 'Asia/Calcutta',
 'Asia/Chongqing',
 'Asia/Chungking',
 'Asia/Dacca',
 'Asia/Harbin',
 'Asia/Istanbul',
 'Asia/Kashgar',
 'Asia/Katmandu',
 'Asia/Macao',
 'Asia/Rangoon',
 'Asia/Saigon',
 'Asia/Tel_Aviv',
 'Asia/Thimbu',
 'Asia/Ujung_Pandang',
 'Asia/Ulan_Bator',
 'Atlantic/Faeroe',
 'Atlantic/Jan_Mayen',
 'Australia/ACT',
 'Australia/Canberra',
 'Australia/Currie',
 'Australia/LHI',
 'Australia/NSW',
 'Australia/North',
 'Australia/Queensland',
 'Australia/South',
 'Australia/Tasmania',
 'Australia/Victoria',
 'Australia/West',
 'Australia/Yancowinna',
 'Brazil/Acre',
 'Brazil/DeNoronha',
 'Brazil/East',
 'Brazil/West',
 'Canada/Saskatchewan',
 'Canada/Yukon',
 'Chile/Continental',
 'Chile/EasterIsland',
 'Europe/Belfast',
 'Europe/Nicosia',
 'Europe/Tiraspol',
 'Mexico/BajaNorte',
 'Mexico/BajaSur',
 'Mexico/General',
 'Pacific/Johnston',
 'Pacific/Ponape',
 'Pacific/Samoa',
 'Pacific/Truk',
 'Pacific/Yap',
 'US/Aleutian',
 'US/East-Indiana',
 'US/Indiana-Starke',
 'US/Michigan',
 'US/Samoa'}
```

That's 17.6% of extra zones.

Please let me know if this actually matters or not.