### PR TITLE
Do not hard-require zram-generator-default on RHEL just yet

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -237,7 +237,10 @@ Requires: gdb
 Requires: rsync
 # only WeakRequires elsewhere and not guaranteed to be present
 Requires: device-mapper-multipath
+# FIXME: do not require on RHEL until the package is ready
+%if ! 0%{?rhel} == 9
 Requires: zram-generator-defaults
+%endif
 
 %description install-img-deps
 The anaconda-install-img-deps metapackage lists all boot.iso installation image dependencies.


### PR DESCRIPTION
Drop the hard Requires on zram-generator-defaults for RHEL builds,
until it's build issues on RHEL are resolved.