### PR TITLE
packit: generate config.h after cloning the repo

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -5,6 +5,7 @@ actions:
   post-upstream-clone:
     - ./autogen.sh
     - ./configure
+    - "make config.h"
   create-archive:
     - "make release"
     - 'bash -c "ls -1 anaconda-*.tar.bz2"'

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # configure.ac for anaconda
 #
-# Copyright (C) 2009  Red Hat, Inc.
+# Copyright (C) 2021  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published


### PR DESCRIPTION
since create-archive and post-upstream-clone are running in different
environments, paths in Makefiles written from autogen.sh and configure
are no longer valid in the create-archive action

This should resolve: https://prod.packit.dev/srpm-build/13919/logs

Full context: https://blog.tomecek.net/post/automake-in-openshift/ :)