### PR TITLE
Improve Packit configuration to use fedora-development

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -13,19 +13,13 @@ jobs:
     trigger: pull_request
     metadata:
       targets:
-        - fedora-34
+        - fedora-development
 
   - job: copr_build
-    trigger: commit
+    trigger: pull_request
     metadata:
       targets:
-        - fedora-34
-      branch: f34-devel
-      owner: "@rhinstaller"
-      project: Anaconda-devel
-      preserve_project: True
-      additional_repos:
-        - "copr://@storage/blivet-daily"
+        - fedora-eln
 
   - job: copr_build
     trigger: commit
@@ -36,6 +30,18 @@ jobs:
       branch: master
       owner: "@rhinstaller"
       project: Anaconda
+      preserve_project: True
+      additional_repos:
+        - "copr://@storage/blivet-daily"
+
+  - job: copr_build
+    trigger: commit
+    metadata:
+      targets:
+        - fedora-34
+      branch: f34-devel
+      owner: "@rhinstaller"
+      project: Anaconda-devel
       preserve_project: True
       additional_repos:
         - "copr://@storage/blivet-daily"


### PR DESCRIPTION
This will build to Rawhide and newest Fedora in development. Thanks to this change it should be pretty easy to adapt the configuration on master branch just by switching fedora-development to fedora-rawhide.