### PR TITLE
Drop astroid hotfix patch

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -43,10 +43,6 @@ RUN pip install \
   nose \
   rpmfluff
 
-# HACK: Apply fix from https://github.com/PyCQA/astroid/pull/847 to avoid
-# excessive memory usage, until astroid > 2.4.2 gets released
-RUN curl https://github.com/PyCQA/astroid/commit/d62349a424c549b4634c90e471c9f876b99edfeb.patch | patch /usr/local/lib/python3*/site-packages/astroid/manager.py
-
 # see https://github.com/martinpitt/anaconda/settings/actions/add-new-runner
 RUN mkdir actions-runner && cd actions-runner && \
   URL_BASE=https://github.com/actions/runner/releases && \


### PR DESCRIPTION
New version of astroid (2.5) was released so the build will fail because the patch does nothing. Let's remove it to fix the issue which, as a nice benefit, will improve a build speed of our container!