### PR TITLE
[Storage] add btrfs_compression option (#1928857)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -48,7 +48,7 @@ Patch2: 0003-Do-not-require-inst.-prefixes-for-Anaconda-boot-argu.patch
 %define nmver 1.0
 %define pykickstartver 3.32-1
 %define pypartedver 2.5-2
-%define pythonblivetver 1:3.2.2-1
+%define pythonblivetver 1:3.3.3-1
 %define rpmver 4.10.0
 %define simplelinever 1.1-1
 %define subscriptionmanagerver 1.26

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -156,6 +156,9 @@ multipath_friendly_names = True
 # Do you want to allow imperfect devices (for example, degraded mdraid array devices)?
 allow_imperfect_devices = False
 
+# Btrfs compression algorithm and level. e.g. zstd:1
+btrfs_compression =
+
 # Default file system type. Use whatever Blivet uses by default.
 file_system_type =
 

--- a/data/product.d/fedora.conf
+++ b/data/product.d/fedora.conf
@@ -11,6 +11,7 @@ efi_dir = fedora
 
 [Storage]
 default_scheme = BTRFS
+btrfs_compression = zstd:1
 
 [User Interface]
 default_help_pages =

--- a/pyanaconda/core/configuration/storage.py
+++ b/pyanaconda/core/configuration/storage.py
@@ -84,6 +84,17 @@ class StorageSection(Section):
         return self._get_option("allow_imperfect_devices", bool)
 
     @property
+    def btrfs_compression(self):
+        """BTRFS compression setting.
+
+        Specifies the compression algorithm and level used when
+        mounting Btrfs partitions. Defaults to None.
+
+        For example: "zstd:1"
+        """
+        return self._get_option("btrfs_compression", str) or None
+
+    @property
     def file_system_type(self):
         """Default file system type.
 

--- a/pyanaconda/modules/storage/initialization.py
+++ b/pyanaconda/modules/storage/initialization.py
@@ -57,6 +57,7 @@ def enable_installer_mode():
     blivet_flags.ibft = conf.storage.ibft
     blivet_flags.multipath_friendly_names = conf.storage.multipath_friendly_names
     blivet_flags.allow_imperfect_devices = conf.storage.allow_imperfect_devices
+    blivet_flags.btrfs_compression = conf.storage.btrfs_compression
 
     # Platform class setup depends on flags, re-initialize it.
     _set_default_label_type()


### PR DESCRIPTION
This is a new option to allow specifying the compression algorithm and
level for Btrfs filesystems. If set, it will be passed to Blivet and
applied when mounting Btrfs filesystems.

Default this to None, but set it to "zstd:1" for Fedora.

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rhinstaller/anaconda/3177)
<!-- Reviewable:end -->
