### PR TITLE
Use a custom stylesheet to define RHEL-specific stylesheet data

### DIFF
--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -61,6 +61,7 @@ default_help_pages =
     rhel_help_placeholder.xml
     rhel_help_placeholder.xml
 
+custom_stylesheet = /usr/share/anaconda/pixmaps/redhat.css
 blivet_gui_supported = False
 
 [License]


### PR DESCRIPTION
Use a stylesheet provided by the rhel-logos package.

**Based on:** https://github.com/rhinstaller/anaconda/pull/3161