### PR TITLE
multiple fixes for packit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -2,10 +2,9 @@ specfile_path: anaconda.spec
 upstream_package_name: anaconda
 upstream_tag_template: anaconda-{version}-1
 actions:
-  post-upstream-clone:
+  create-archive:
     - ./autogen.sh
     - ./configure
-  create-archive:
     - "make release"
     - 'bash -c "ls -1 anaconda-*.tar.bz2"'
 jobs:

--- a/.packit.yml
+++ b/.packit.yml
@@ -12,12 +12,15 @@ jobs:
     trigger: pull_request
     metadata:
       targets:
-        - fedora-development
+        - fedora-34
+        - fedora-rawhide
 
   - job: copr_build
     trigger: pull_request
     metadata:
       targets:
+        - fedora-34
+        - fedora-rawhide
         - fedora-eln
 
   - job: copr_build

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # configure.ac for anaconda
 #
-# Copyright (C) 2009  Red Hat, Inc.
+# Copyright (C) 2021  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published


### PR DESCRIPTION
commits:
```
packit: make tests ⊂ builds for the chroot set
```

```
packit: run all actions in a single action

to make sure that generated files from autotools have correct paths

since create-archive and post-upstream-clone are running in different
environments, paths in Makefiles written from autogen.sh and configure
are no longer valid in the create-archive action

this mainly affected the config.h in widgets
```

```
configure.ac: make the Copyright up to date

I hope this will trigger regeneration of config.h in CI
```