### PR TITLE
Don't translate prompt keys (#1892830)

### DIFF
--- a/pyanaconda/ui/tui/hubs/__init__.py
+++ b/pyanaconda/ui/tui/hubs/__init__.py
@@ -132,13 +132,11 @@ class TUIHub(TUIObject, common.Hub):
         else:
             # If we get a continue, check for unfinished spokes.  If unfinished
             # don't continue
-            # TRANSLATORS: 'c' to continue
             if key == Prompt.CONTINUE:
                 for spoke in self._spokes.values():
                     if not spoke.completed and spoke.mandatory:
                         print(_("Please complete all spokes before continuing"))
                         return InputState.DISCARDED
-            # TRANSLATORS: 'h' to help
             elif key == Prompt.HELP:
                 if self.has_help:
                     help_path = get_help_path(self.helpFile, True)

--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -21,7 +21,7 @@ from pyanaconda.ui.lib.space import FileSystemSpaceChecker, DirInstallSpaceCheck
 from pyanaconda.ui.tui.hubs import TUIHub
 from pyanaconda.flags import flags
 from pyanaconda.errors import CmdlineError
-from pyanaconda.core.i18n import N_, _, C_
+from pyanaconda.core.i18n import N_, _
 from pyanaconda.core.configuration.anaconda import conf
 
 from simpleline import App
@@ -33,6 +33,10 @@ import time
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
+
+# TRANSLATORS: 'b' to begin installation
+PROMPT_BEGIN_DESCRIPTION = N_("to begin installation")
+PROMPT_BEGIN_KEY = 'b'
 
 
 class SummaryHub(TUIHub):
@@ -102,9 +106,7 @@ class SummaryHub(TUIHub):
 
                 # TRANSLATORS: 'b' to begin installation
                 print(_("Enter '%s' to ignore the warning and attempt to install anyway.") %
-                        # TRANSLATORS: 'b' to begin installation
-                        C_("TUI|Spoke Navigation", "b")
-                        )
+                      PROMPT_BEGIN_KEY)
             else:
                 # Space is ok and spokes are complete, continue.
                 self.close()
@@ -124,13 +126,12 @@ class SummaryHub(TUIHub):
         if incomplete_spokes:
             flags.automatedInstall = False
 
-        # override the default prompt since we want to offer the 'b' to begin
-        # installation option here
+        # override the default prompt
         prompt = super().prompt(args)
         # this screen cannot be closed
         prompt.remove_option(Prompt.CONTINUE)
-        # TRANSLATORS: 'b' to begin installation
-        prompt.add_option(C_("TUI|Spoke Navigation", "b"), _("to begin installation"))
+        # offer the 'b' to begin installation option
+        prompt.add_option(PROMPT_BEGIN_KEY, _(PROMPT_BEGIN_DESCRIPTION))
         return prompt
 
     def input(self, args, key):
@@ -141,8 +142,7 @@ class SummaryHub(TUIHub):
         else:
             # If we get a continue, check for unfinished spokes.  If unfinished
             # don't continue
-            # TRANSLATORS: 'b' to begin installation
-            if key == C_('TUI|Spoke Navigation', 'b'):
+            if key == PROMPT_BEGIN_KEY:
                 for spoke in self._spokes.values():
                     if not spoke.completed and spoke.mandatory:
                         print(_("Please complete all spokes before continuing"))
@@ -154,8 +154,7 @@ class SummaryHub(TUIHub):
                     return InputState.DISCARDED
 
                 return InputState.PROCESSED_AND_CLOSE
-            # TRANSLATORS: 'c' to continue
-            elif key == C_('TUI|Spoke Navigation', 'c'):
+            elif key == Prompt.CONTINUE:
                 # Kind of a hack, but we want to ignore if anyone presses 'c'
                 # which is the global TUI key to close the current screen
                 return InputState.DISCARDED

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -98,7 +98,6 @@ class NormalTUISpoke(TUISpoke, NormalSpoke):
 
     def input(self, args, key):
         """Handle the input."""
-        # TRANSLATORS: 'h' to help
         if key.lower() == Prompt.HELP:
             if self.has_help:
                 help_path = get_help_path(self.helpFile, True)

--- a/pyanaconda/ui/tui/spokes/askvnc.py
+++ b/pyanaconda/ui/tui/spokes/askvnc.py
@@ -16,19 +16,19 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
 import sys
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.core.constants import USEVNC, USETEXT, QUIT_MESSAGE
-from pyanaconda.core.i18n import N_, _, C_
+from pyanaconda.core.i18n import N_, _
 from pyanaconda.ui.tui import exception_msg_handler
 from pyanaconda.core.util import execWithRedirect, ipmi_abort
 
 from simpleline import App
 from simpleline.event_loop.signals import ExceptionSignal
 from simpleline.render.containers import ListColumnContainer
+from simpleline.render.prompt import Prompt
 from simpleline.render.screen import InputState
 from simpleline.render.screen_handler import ScreenHandler
 from simpleline.render.adv_widgets import YesNoDialog
@@ -98,8 +98,7 @@ class AskVNCSpoke(NormalTUISpoke):
             self.apply()
             return InputState.PROCESSED_AND_CLOSE
         else:
-            # TRANSLATORS: 'q' to quit
-            if key.lower() == C_('TUI|Spoke Navigation', 'q'):
+            if key.lower() == Prompt.QUIT:
                 d = YesNoDialog(_(QUIT_MESSAGE))
                 ScreenHandler.push_screen_modal(d)
                 if d.answer:

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -30,7 +30,7 @@ from pyanaconda.ui.tui.tuiobject import Dialog
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload import utils as payload_utils
 from pyanaconda.payload.manager import payloadMgr, PayloadState
-from pyanaconda.core.i18n import N_, _, C_
+from pyanaconda.core.i18n import N_, _
 from pyanaconda.payload.image import find_potential_hdiso_sources, \
     get_hdiso_source_info, get_hdiso_source_description
 
@@ -43,6 +43,7 @@ from pyanaconda.core.constants import PAYLOAD_STATUS_PROBING_STORAGE
 from pyanaconda.ui.helpers import SourceSwitchHandler
 
 from simpleline.render.containers import ListColumnContainer
+from simpleline.render.prompt import Prompt
 from simpleline.render.screen import InputState
 from simpleline.render.screen_handler import ScreenHandler
 from simpleline.render.widgets import TextWidget, EntryWidget
@@ -479,8 +480,7 @@ class SelectISOSpoke(NormalTUISpoke, SourceSwitchHandler):
     def input(self, args, key):
         if self._container is not None and self._container.process_user_input(key):
             return InputState.PROCESSED
-        # TRANSLATORS: 'c' to continue
-        elif key.lower() == C_('TUI|Spoke Navigation', 'c'):
+        elif key.lower() == Prompt.CONTINUE:
             self.apply()
             return InputState.PROCESSED_AND_CLOSE
         else:

--- a/pyanaconda/ui/tui/spokes/language_support.py
+++ b/pyanaconda/ui/tui/spokes/language_support.py
@@ -23,12 +23,16 @@ from pyanaconda.ui.categories.localization import LocalizationCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda import localization
-from pyanaconda.core.i18n import N_, _, C_
+from pyanaconda.core.i18n import N_, _
 
 from simpleline.render.containers import ListColumnContainer
 from simpleline.render.screen import InputState
 from simpleline.render.screen_handler import ScreenHandler
 from simpleline.render.widgets import TextWidget
+
+# TRANSLATORS: 'b' to go back to language list
+PROMPT_BACK_DESCRIPTION = N_("to return to language list")
+PROMPT_BACK_KEY = 'b'
 
 
 class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
@@ -125,8 +129,8 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         if self._container.process_user_input(key):
             return InputState.PROCESSED
         else:
-            # TRANSLATORS: 'b' to go back
-            if key.lower() == C_("TUI|Spoke Navigation|Language Support", "b"):
+
+            if key.lower() == PROMPT_BACK_KEY:
                 ScreenHandler.replace_screen(self)
                 return InputState.PROCESSED
             else:
@@ -136,8 +140,7 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         """ Customize default prompt. """
         prompt = NormalTUISpoke.prompt(self, args)
         prompt.set_message(_("Please select language support to install"))
-        # TRANSLATORS: 'b' to go back
-        prompt.add_option(C_("TUI|Spoke Navigation|Language Support", "b"), _("to return to language list"))
+        prompt.add_option(PROMPT_BACK_KEY, _(PROMPT_BACK_DESCRIPTION))
         return prompt
 
     def apply(self):

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -16,7 +16,6 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
 import gi
 gi.require_version("NM", "1.0")
 from gi.repository import NM
@@ -32,14 +31,13 @@ from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog, report_if_failed
 from pyanaconda.ui.common import FirstbootSpokeMixIn
-from pyanaconda.core.i18n import N_, _, C_
-
+from pyanaconda.core.i18n import N_, _
 from pyanaconda.core.regexes import IPV4_PATTERN_WITH_ANCHORS, IPV4_NETMASK_WITH_ANCHORS, IPV4_OR_DHCP_PATTERN_WITH_ANCHORS
 from pyanaconda.core.constants import ANACONDA_ENVIRON
-
 from pyanaconda.anaconda_loggers import get_module_logger
 
 from simpleline.render.containers import ListColumnContainer
+from simpleline.render.prompt import Prompt
 from simpleline.render.screen import InputState
 from simpleline.render.screen_handler import ScreenHandler
 from simpleline.render.widgets import TextWidget, CheckboxWidget, EntryWidget
@@ -571,8 +569,7 @@ class ConfigureDeviceSpoke(NormalTUISpoke):
         if self._container.process_user_input(key):
             return InputState.PROCESSED_AND_REDRAW
         else:
-            # TRANSLATORS: 'c' to continue
-            if key.lower() == C_('TUI|Spoke Navigation', 'c'):
+            if key.lower() == Prompt.CONTINUE:
                 if self._data.ip != "dhcp" and not self._data.netmask:
                     self.errors.append(_("Configuration not saved: netmask missing in static configuration"))
                 else:

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -23,13 +23,14 @@ from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload.manager import payloadMgr, PayloadState
 from pyanaconda.payload.errors import DependencyError, NoSuchGroup
-from pyanaconda.core.i18n import N_, _, C_
+from pyanaconda.core.i18n import N_, _
 from pyanaconda.core.configuration.anaconda import conf
 
 from pyanaconda.core.constants import THREAD_PAYLOAD, THREAD_CHECK_SOFTWARE, \
     THREAD_SOFTWARE_WATCHER, PAYLOAD_TYPE_DNF
 
 from simpleline.render.containers import ListColumnContainer
+from simpleline.render.prompt import Prompt
 from simpleline.render.screen import InputState
 from simpleline.render.screen_handler import ScreenHandler
 from simpleline.render.widgets import TextWidget, CheckboxWidget
@@ -260,8 +261,7 @@ class SoftwareSpoke(NormalTUISpoke):
         if self._container is not None and self._container.process_user_input(key):
             self.redraw()
         else:
-            # TRANSLATORS: 'c' to continue
-            if key.lower() == C_('TUI|Spoke Navigation', 'c'):
+            if key.lower() == Prompt.CONTINUE:
 
                 # No environment was selected, close
                 if not self._selection.environment:

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -16,7 +16,6 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
 from collections import OrderedDict
 
 from pyanaconda.modules.common.constants.objects import DISK_SELECTION, DISK_INITIALIZATION, \
@@ -45,9 +44,10 @@ from pyanaconda.core.constants import THREAD_STORAGE, THREAD_STORAGE_WATCHER, \
     BOOTLOADER_LOCATION_MBR, SecretType, WARNING_NO_DISKS_DETECTED, WARNING_NO_DISKS_SELECTED, \
     PARTITIONING_METHOD_AUTOMATIC, PARTITIONING_METHOD_CUSTOM, PARTITIONING_METHOD_MANUAL, \
     PASSWORD_POLICY_LUKS
-from pyanaconda.core.i18n import _, N_, C_
+from pyanaconda.core.i18n import _, N_
 
 from simpleline.render.containers import ListColumnContainer
+from simpleline.render.prompt import Prompt
 from simpleline.render.screen import InputState
 from simpleline.render.screen_handler import ScreenHandler
 from simpleline.render.widgets import TextWidget, CheckboxWidget, EntryWidget
@@ -57,6 +57,10 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 __all__ = ["StorageSpoke"]
+
+# TRANSLATORS: 's' to rescan devices
+PROMPT_SCAN_DESCRIPTION = N_("to rescan devices")
+PROMPT_SCAN_KEY = 's'
 
 CLEARALL = N_("Use All Space")
 CLEARLINUX = N_("Replace Existing Linux system(s)")
@@ -254,8 +258,7 @@ class StorageSpoke(NormalTUISpoke):
         if self._container.process_user_input(key):
             return InputState.PROCESSED_AND_REDRAW
         else:
-            # TRANSLATORS: 'c' to continue
-            if key.lower() == C_('TUI|Spoke Navigation', 'c'):
+            if key.lower() == Prompt.CONTINUE:
                 if self._selected_disks:
                     # Is DASD formatting supported?
                     if DasdFormatting.is_supported():
@@ -530,8 +533,7 @@ class PartTypeSpoke(NormalTUISpoke):
     def input(self, args, key):
         """Grab the choice and update things"""
         if not self._container.process_user_input(key):
-            # TRANSLATORS: 'c' to continue
-            if key.lower() == C_('TUI|Spoke Navigation', 'c'):
+            if key.lower() == Prompt.CONTINUE:
                 self.apply()
                 self._ensure_init_storage()
                 if self._part_method == PARTITIONING_METHOD_MANUAL:
@@ -602,8 +604,7 @@ class PartitionSchemeSpoke(NormalTUISpoke):
     def input(self, args, key):
         """ Grab the choice and update things. """
         if not self._container.process_user_input(key):
-            # TRANSLATORS: 'c' to continue
-            if key.lower() == C_('TUI|Spoke Navigation', 'c'):
+            if key.lower() == Prompt.CONTINUE:
                 self.apply()
                 return InputState.PROCESSED_AND_CLOSE
             else:
@@ -654,10 +655,7 @@ class MountPointAssignSpoke(NormalTUISpoke):
 
     def prompt(self, args=None):
         prompt = super().prompt(args)
-
-        # TRANSLATORS: 's' to rescan devices
-        prompt.add_option(C_('TUI|Spoke Navigation|Partitioning', 's'), _("rescan devices"))
-
+        prompt.add_option(PROMPT_SCAN_KEY, _(PROMPT_SCAN_DESCRIPTION))
         return prompt
 
     def input(self, args, key):
@@ -665,13 +663,11 @@ class MountPointAssignSpoke(NormalTUISpoke):
         if self._container.process_user_input(key):
             return InputState.PROCESSED
 
-        # TRANSLATORS: 's' to rescan devices
-        if key.lower() == C_('TUI|Spoke Navigation|Partitioning', 's'):
+        if key.lower() == PROMPT_SCAN_KEY:
             self._rescan_devices()
             return InputState.PROCESSED_AND_REDRAW
 
-        # TRANSLATORS: 'c' to continue
-        elif key.lower() == C_('TUI|Spoke Navigation', 'c'):
+        elif key.lower() == Prompt.CONTINUE:
             self.apply()
 
         return super().input(args, key)

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -27,7 +27,7 @@ from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda import timezone
 from pyanaconda import ntp
 from pyanaconda.core import constants
-from pyanaconda.core.i18n import N_, _, C_
+from pyanaconda.core.i18n import N_, _
 from pyanaconda.flags import flags
 
 from collections import namedtuple
@@ -43,6 +43,9 @@ log = get_module_logger(__name__)
 
 __all__ = ["TimeSpoke"]
 
+# TRANSLATORS: 'b' to go back to region list
+PROMPT_BACK_DESCRIPTION = N_("to go back to region list")
+PROMPT_BACK_KEY = 'b'
 
 CallbackTimezoneArgs = namedtuple("CallbackTimezoneArgs", ["region", "timezone"])
 
@@ -283,8 +286,7 @@ class TimeZoneSpoke(NormalTUISpoke):
                 else:
                     ScreenHandler.replace_screen(self, self._regions[index])
                 return InputState.PROCESSED
-            # TRANSLATORS: 'b' to go back
-            elif key.lower() == C_('TUI|Spoke Navigation|Time Settings', 'b'):
+            elif key.lower() == PROMPT_BACK_KEY:
                 ScreenHandler.replace_screen(self)
                 return InputState.PROCESSED
             else:
@@ -294,8 +296,7 @@ class TimeZoneSpoke(NormalTUISpoke):
         """ Customize default prompt. """
         prompt = NormalTUISpoke.prompt(self, args)
         prompt.set_message(_("Please select the timezone. Use numbers or type names directly"))
-        # TRANSLATORS: 'b' to go back
-        prompt.add_option(C_('TUI|Spoke Navigation|Time Settings', 'b'), _("back to region list"))
+        prompt.add_option(PROMPT_BACK_KEY, _(PROMPT_BACK_DESCRIPTION))
         return prompt
 
     def apply(self):


### PR DESCRIPTION
Translated prompt keys are not supported by the simpleline library, so
anaconda shouldn't translate them neither. Use constants when possible.

Resolves: rhbz#1892830