### PR TITLE
Add the "Encrypt my data" checkbox to the custom partitioning spoke

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -114,6 +114,8 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._accordion = None
 
         self._partitioning_scheme = conf.storage.default_scheme
+        self._partitioning_encrypted = False
+
         self._default_file_system = ""
         self._selected_disks = []
         self._passphrase = ""
@@ -316,7 +318,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         model = self._fsCombo.get_model()
         return model[itr][1]
 
-    def _change_autopart_type(self, autopart_type_combo):
+    def _on_autopart_type_changed(self, autopart_type_combo):
         """
         This is called when the autopart type combo on the left hand side of
         custom partitioning is changed.  We already know how to handle the case
@@ -331,6 +333,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         model = autopart_type_combo.get_model()
         self._partitioning_scheme = model[itr][1]
+
+    def _on_autopart_encrypted_toggled(self, checkbox):
+        """The callback for the autopart encryption checkbox."""
+        self._partitioning_encrypted = checkbox.get_active()
 
     def _set_page_label_text(self):
         if self._accordion.is_multiselection:
@@ -408,8 +414,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         page = CreateNewPage(
             self._os_name,
             self.on_create_clicked,
-            self._change_autopart_type,
+            self._on_autopart_type_changed,
+            self._on_autopart_encrypted_toggled,
             default_scheme=self._partitioning_scheme,
+            default_encryption=self._partitioning_encrypted,
             partitions_to_reuse=reuse_existing
         )
 
@@ -1436,7 +1444,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         else:
             self._removeButton.set_sensitive(True)
 
-    def _do_autopart(self, scheme):
+    def _do_autopart(self, scheme, encrypted):
         """Helper function for on_create_clicked.
            Assumes a non-final context in which at least some errors
            discovered by storage checker are not considered fatal because they
@@ -1449,6 +1457,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         # Create the partitioning request.
         request = PartitioningRequest()
         request.partitioning_scheme = scheme
+        request.encrypted = encrypted
 
         try:
             # Schedule the partitioning.
@@ -1466,7 +1475,10 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     def on_create_clicked(self, button, autopart_type_combo):
         # Then do autopartitioning.  We do not do any clearpart first.  This is
         # custom partitioning, so you have to make your own room.
-        self._do_autopart(self._partitioning_scheme)
+        self._do_autopart(
+            scheme=self._partitioning_scheme,
+            encrypted=self._partitioning_encrypted
+        )
 
         # Refresh the spoke to make the new partitions appear.
         self._do_refresh()

--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -456,7 +456,8 @@ class CreateNewPage(BasePage):
         is created, it will be removed and replaced with a Page for it.
     """
     def __init__(self, title, create_clicked_cb, autopart_type_changed_cb,
-                 default_scheme, partitions_to_reuse=True):
+                 encrypted_changed_cb, default_scheme, default_encryption,
+                 partitions_to_reuse=True):
         super().__init__(title)
 
         # Create a box where we store the "Here's how you create a new blah" info.
@@ -530,4 +531,27 @@ class CreateNewPage(BasePage):
         combo.set_hexpand(False)
         combo.set_active_iter(default or store.get_iter_first())
         self._createBox.attach(combo, 0, 5, 2, 1)
+
+        label = Gtk.Label(
+            label=C_(
+                "GUI|Custom Partitioning|Autopart Page",
+                "_Automatically created mount points can be encrypted by default:"
+            ),
+            xalign=0,
+            yalign=0.5,
+            wrap=True,
+            use_underline=True
+        )
+        self._createBox.attach(label, 0, 6, 2, 1)
+
+        checkbox = Gtk.CheckButton(label="Encrypt my data.")
+        checkbox.connect("toggled", encrypted_changed_cb)
+        checkbox.set_active(default_encryption)
+        checkbox.set_margin_start(18)
+        checkbox.set_margin_end(18)
+        checkbox.set_hexpand(False)
+
+        label.set_mnemonic_widget(checkbox)
+        self._createBox.attach(checkbox, 0, 7, 2, 1)
+
         self.add(self._createBox)


### PR DESCRIPTION
Allow users to generate encrypted default partitioning to have the same
experience as with the automatic partitioning in the storage spoke.

Related: rhbz#1903786