### PR TITLE
Make the user interface context safe for the initial setup

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -273,8 +273,8 @@ if __name__ == "__main__":
     # The note should in most cases end on TTY1.
     startup_utils.print_startup_note(options=opts)
 
-    from pyanaconda.ui.context import context
-    anaconda = context.anaconda
+    from pyanaconda.anaconda import Anaconda
+    anaconda = Anaconda()
     util.setup_translations()
 
     # reset python's default SIGINT handler
@@ -419,6 +419,10 @@ if __name__ == "__main__":
     # Some post-install parts of anaconda are implemented as kickstart
     # scripts.  Add those to the ksdata now.
     kickstart.appendPostScripts(ksdata)
+
+    # Set up the UI context.
+    from pyanaconda.ui.context import context
+    context.payload_type = anaconda.payload.type
 
     # Set up the payload from the cmdline options.
     anaconda.payload.set_from_opts(opts)

--- a/pyanaconda/ui/context.py
+++ b/pyanaconda/ui/context.py
@@ -18,8 +18,6 @@
 
 __all__ = ["context"]
 
-from pyanaconda.anaconda import Anaconda
-
 
 class UserInterfaceContext(object):
     """The context of the user interface.
@@ -28,27 +26,27 @@ class UserInterfaceContext(object):
     of the user interface. The goal is to replace all
     these objects with this one.
 
+    WARNING: This class is also used by the Initial Setup tool.
+    Please keep that in mind when doing any API breaking changes.
+
     We might replace this object with a DBus module in
     the future.
     """
 
     def __init__(self):
-        self._anaconda = Anaconda()
+        self._payload_type = None
 
     @property
-    def anaconda(self) -> Anaconda:
-        """The Anaconda object."""
-        return self._anaconda
+    def payload_type(self):
+        """The type of the payload.
 
-    @property
-    def data(self):
-        """The kickstart data."""
-        return self._anaconda.ksdata
+        :return: a string or None
+        """
+        return self._payload_type
 
-    @property
-    def payload(self):
-        """The payload object."""
-        return self._anaconda.payload
+    @payload_type.setter
+    def payload_type(self, value):
+        self._payload_type = value
 
 
 context = UserInterfaceContext()

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -413,7 +413,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         if not NormalSpoke.should_run(environment, data):
             return False
 
-        return context.payload.type == PAYLOAD_TYPE_DNF
+        return context.payload_type == PAYLOAD_TYPE_DNF
 
     def __init__(self, *args, **kwargs):
         NormalSpoke.__init__(self, *args, **kwargs)

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -73,7 +73,7 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
             return False
 
         # Don't show the language support spoke on live media.
-        return context.payload.type not in PAYLOAD_LIVE_TYPES
+        return context.payload_type not in PAYLOAD_LIVE_TYPES
 
     def __init__(self, *args, **kwargs):
         NormalSpoke.__init__(self, *args, **kwargs)

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -82,7 +82,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
         if not NormalSpoke.should_run(environment, data):
             return False
 
-        return context.payload.type == PAYLOAD_TYPE_DNF
+        return context.payload_type == PAYLOAD_TYPE_DNF
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -74,7 +74,7 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
         if not NormalTUISpoke.should_run(environment, data):
             return False
 
-        return context.payload.type == PAYLOAD_TYPE_DNF
+        return context.payload_type == PAYLOAD_TYPE_DNF
 
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -56,7 +56,7 @@ class SoftwareSpoke(NormalTUISpoke):
         if not NormalTUISpoke.should_run(environment, data):
             return False
 
-        return context.payload.type == PAYLOAD_TYPE_DNF
+        return context.payload_type == PAYLOAD_TYPE_DNF
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)


### PR DESCRIPTION
The context needs to be safe to use for the initial setup, so provide
a very limited specific API that will work in both projects.