### PR TITLE
Add the GetKernelVersionList method

### DIFF
--- a/pyanaconda/modules/common/errors/general.py
+++ b/pyanaconda/modules/common/errors/general.py
@@ -38,3 +38,9 @@ class InvalidValueError(AnacondaError):
 class UnsupportedValueError(AnacondaError):
     """Value passed is not supported."""
     pass
+
+
+@dbus_error("UnavailableValueError", namespace=ANACONDA_NAMESPACE)
+class UnavailableValueError(AnacondaError):
+    """The requested value is not available."""
+    pass

--- a/pyanaconda/modules/payloads/payload/live_os/live_os.py
+++ b/pyanaconda/modules/payloads/payload/live_os/live_os.py
@@ -18,7 +18,6 @@
 # Red Hat, Inc.
 #
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.signal import Signal
 from pyanaconda.core.constants import INSTALL_TREE
 
 from pyanaconda.modules.common.errors.payload import SourceSetupError, IncompatibleSourceError
@@ -39,9 +38,8 @@ class LiveOSModule(PayloadBase):
 
     def __init__(self):
         super().__init__()
-
-        self._kernel_version_list = []
-        self.kernel_version_list_changed = Signal()
+        # FIXME: Set up the kernel version list somewhere else from a task.
+        self.set_kernel_version_list(get_kernel_version_list(INSTALL_TREE))
 
     def for_publication(self):
         """Get the interface used to publish this source."""
@@ -155,24 +153,3 @@ class LiveOSModule(PayloadBase):
         return [
             CopyDriverDisksFilesTask(conf.target.system_root)
         ]
-
-    def update_kernel_version_list(self):
-        """Update list of kernel versions.
-
-        Source have to be set-up first.
-        """
-        self.set_kernel_version_list(get_kernel_version_list(INSTALL_TREE))
-
-    @property
-    def kernel_version_list(self):
-        """Get list of kernel versions.
-
-        :rtype: [str]
-        """
-        return self._kernel_version_list
-
-    def set_kernel_version_list(self, kernel_version_list):
-        """Set list of kernel versions."""
-        self._kernel_version_list = kernel_version_list
-        self.kernel_version_list_changed.emit(self._kernel_version_list)
-        log.debug("List of kernel versions is set to '%s'", self._kernel_version_list)

--- a/pyanaconda/modules/payloads/payload/live_os/live_os_interface.py
+++ b/pyanaconda/modules/payloads/payload/live_os/live_os_interface.py
@@ -17,8 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from dasbus.server.interface import dbus_interface, dbus_signal
-from dasbus.typing import *  # pylint: disable=wildcard-import
+from dasbus.server.interface import dbus_interface
 
 from pyanaconda.modules.common.constants.interfaces import PAYLOAD_LIVE_OS
 from pyanaconda.modules.payloads.payload.payload_base_interface import PayloadBaseInterface
@@ -27,20 +26,3 @@ from pyanaconda.modules.payloads.payload.payload_base_interface import PayloadBa
 @dbus_interface(PAYLOAD_LIVE_OS.interface_name)
 class LiveOSInterface(PayloadBaseInterface):
     """DBus interface for Live OS payload module."""
-
-    def connect_signals(self):
-        super().connect_signals()
-        self.implementation.kernel_version_list_changed.connect(self.KernelVersionListChanged)
-
-    def UpdateKernelVersionList(self):
-        """Update the list of kernel versions."""
-        self.implementation.update_kernel_version_list()
-
-    def GetKernelVersionList(self) -> List[Str]:
-        """Get the kernel versions list."""
-        return self.implementation.kernel_version_list
-
-    @dbus_signal
-    def KernelVersionListChanged(self, kernel_version_list: List[Str]):
-        """Signal kernel version list change."""
-        pass

--- a/pyanaconda/modules/payloads/payload/payload_base.py
+++ b/pyanaconda/modules/payloads/payload/payload_base.py
@@ -22,6 +22,7 @@ from abc import ABCMeta, abstractmethod
 from dasbus.server.publishable import Publishable
 
 from pyanaconda.core.signal import Signal
+from pyanaconda.modules.common.errors.general import UnavailableValueError
 from pyanaconda.modules.common.errors.payload import IncompatibleSourceError, SourceSetupError
 from pyanaconda.modules.common.base import KickstartBaseModule
 from pyanaconda.modules.payloads.base.initialization import SetUpSourcesTask, TearDownSourcesTask
@@ -41,6 +42,7 @@ class PayloadBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         super().__init__()
         self._sources = []
         self.sources_changed = Signal()
+        self._kernel_version_list = None
 
     @property
     @abstractmethod
@@ -132,6 +134,30 @@ class PayloadBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
             total += source.required_space
 
         return total
+
+    def get_kernel_version_list(self):
+        """Get the kernel versions list.
+
+        The kernel version list doesn't have to be available
+        before the payload installation.
+
+        :return: a list of kernel versions
+        :raises UnavailableValueError: if the list is not available
+        """
+        if self._kernel_version_list is None:
+            raise UnavailableValueError("The kernel version list is not available.")
+
+        return self._kernel_version_list
+
+    def set_kernel_version_list(self, kernels):
+        """Set the kernel versions list.
+
+        This function should be called by one of the installation tasks.
+
+        :param kernels: a list of kernel versions
+        """
+        self._kernel_version_list = kernels
+        log.debug("The kernel version list is set to: %s", kernels)
 
     @abstractmethod
     def pre_install_with_tasks(self):

--- a/pyanaconda/modules/payloads/payload/payload_base_interface.py
+++ b/pyanaconda/modules/payloads/payload/payload_base_interface.py
@@ -94,6 +94,17 @@ class PayloadBaseInterface(ModuleInterfaceTemplate, metaclass=ABCMeta):
         """
         return self.implementation.calculate_required_space()
 
+    def GetKernelVersionList(self) -> List[Str]:
+        """Get the kernel versions list.
+
+        The kernel version list doesn't have to be available
+        before the payload installation.
+
+        :return: a list of kernel versions
+        :raises UnavailableValueError: if the list is not available
+        """
+        return self.implementation.get_kernel_version_list()
+
     def PreInstallWithTasks(self) -> List[ObjPath]:
         """Execute preparation steps.
 

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_base_test.py
@@ -23,6 +23,7 @@
 import unittest
 from unittest.mock import patch
 
+from pyanaconda.modules.common.errors.general import UnavailableValueError
 from pyanaconda.modules.payloads.base.initialization import SetUpSourcesTask, TearDownSourcesTask
 from pyanaconda.modules.payloads.source.factory import SourceFactory
 from pyanaconda.modules.common.errors.payload import IncompatibleSourceError, SourceSetupError
@@ -201,3 +202,11 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         task_path = self.interface.TearDownSourcesWithTask()
         obj = check_task_creation(self, task_path, publisher, TearDownSourcesTask)
         self.assertEqual(obj.implementation._sources, [source])
+
+    def get_kernel_version_list_test(self):
+        """Test GetKernelVersionList."""
+        with self.assertRaises(UnavailableValueError):
+            self.interface.GetKernelVersionList()
+
+        self.module.set_kernel_version_list(["k1", "k2", "k3"])
+        self.assertEqual(self.interface.GetKernelVersionList(), ["k1", "k2", "k3"])

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_live_os_test.py
@@ -19,14 +19,12 @@
 #
 import unittest
 
-from unittest.mock import Mock, patch
-
 from tests.nosetests.pyanaconda_tests import check_task_creation, check_task_creation_list, \
     patch_dbus_publish_object, PropertiesChangedCallback
 from tests.nosetests.pyanaconda_tests.modules.payloads.payload.module_payload_shared import \
     PayloadSharedTest
 
-from pyanaconda.core.constants import INSTALL_TREE, SOURCE_TYPE_LIVE_OS_IMAGE
+from pyanaconda.core.constants import SOURCE_TYPE_LIVE_OS_IMAGE
 from pyanaconda.modules.common.errors.payload import SourceSetupError, IncompatibleSourceError
 from pyanaconda.modules.common.task.task_interface import TaskInterface
 from pyanaconda.modules.payloads.constants import SourceType, PayloadType, SourceState
@@ -101,38 +99,14 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
         source1.get_state.return_value = SourceState.UNREADY
         self.shared_tests.set_and_check_sources([source1])
 
-    @patch("pyanaconda.modules.payloads.payload.live_os.live_os.get_kernel_version_list")
-    def empty_kernel_version_list_test(self, get_kernel_version_list):
-        """Test Live OS empty get kernel version list."""
-        self.assertEqual(self.live_os_interface.GetKernelVersionList(), [])
-
-        get_kernel_version_list.return_value = []
-        kernel_list_callback = Mock()
-
-        # pylint: disable=no-member
-        self.live_os_interface.KernelVersionListChanged.connect(kernel_list_callback)
-        self.live_os_interface.UpdateKernelVersionList()
-
-        get_kernel_version_list.assert_called_once_with(INSTALL_TREE)
-
-        self.assertEqual(self.live_os_interface.GetKernelVersionList(), [])
-        kernel_list_callback.assert_called_once_with([])
-
-    @patch("pyanaconda.modules.payloads.payload.live_os.live_os.get_kernel_version_list")
-    def kernel_version_list_test(self, get_kernel_version_list):
+    def get_kernel_version_list_test(self):
         """Test Live OS get kernel version list."""
+        self.assertEqual(self.live_os_interface.GetKernelVersionList(), [])
+
         kernel_list = ["kernel-abc", "magic-kernel.fc3000.x86_64", "sad-kernel"]
-        get_kernel_version_list.return_value = kernel_list
-        kernel_list_callback = Mock()
-
-        # pylint: disable=no-member
-        self.live_os_interface.KernelVersionListChanged.connect(kernel_list_callback)
-        self.live_os_interface.UpdateKernelVersionList()
-
-        get_kernel_version_list.assert_called_once_with(INSTALL_TREE)
+        self.live_os_module.set_kernel_version_list(kernel_list)
 
         self.assertListEqual(self.live_os_interface.GetKernelVersionList(), kernel_list)
-        kernel_list_callback.assert_called_once_with(kernel_list)
 
     @patch_dbus_publish_object
     def set_up_installation_sources_task_test(self, publisher):


### PR DESCRIPTION
Call the `GetKernelVersionList` method of a payload module to get a list of kernel
versions. The method might raise the `UnavailableValueError` exception if it is
called before the payload installation.

**Blocked by:** Beta Freeze