### PR TITLE
Add support for anaconda-rpm containers to refresh workflow

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  refresh-container:
-    name: Refresh anaconda-ci container
+  refresh-containers:
+    name: Refresh anaconda containers
     runs-on: ubuntu-20.04
     # we need to have matrix to cover all branches because schedule is run only on default branch
     # we can add here fedora branches (e.g. f33-devel) to cover their support when needed
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         container-tag: ['master', 'eln', 'f34-devel', 'f34-release']
+        container-type: ['ci', 'rpm']
         include:
           - container-tag: master
             branch: master
@@ -34,16 +35,22 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      - name: Build anaconda-ci container
+      - name: Build anaconda-${{ matrix.container-type }} container
         run: |
           BASE_CONTAINER=${{ matrix.base-container }}
-          make -f Makefile.am anaconda-ci-build ${BASE_CONTAINER:+BASE_CONTAINER=}${BASE_CONTAINER:-}
+          make -f Makefile.am anaconda-${{ matrix.container-type }}-build ${BASE_CONTAINER:+BASE_CONTAINER=}${BASE_CONTAINER:-}
 
       - name: Run tests in anaconda-ci container
-        id: run-tests
+        if: matrix.container-type == 'ci'
         run: |
           # put the log in the output, where it's easy to read and link to
           make -f Makefile.am container-ci || { cat test-logs/test-suite.log; exit 1; }
+
+      - name: Run tests in anaconda-rpm container
+        if: matrix.container-type == 'rpm'
+        run: |
+          # put the log in the output, where it's easy to read and link to
+          make -f Makefile.am container-rpm-test || { cat test-logs/test-suite.log; exit 1; }
 
       - name: Upload test and coverage logs from local testing
         if: always()
@@ -60,11 +67,11 @@ jobs:
         run: podman login -u ${{ secrets.QUAY_USERNAME }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
 
         # we can hardcode the path to the image here because this will be executed only for master image
-      - name: Add latest tag for master branch
+      - name: Add latest tag for master container
         if: ${{ matrix.container-tag == 'master' }}
         run: |
-          podman tag quay.io/rhinstaller/anaconda-ci:master quay.io/rhinstaller/anaconda-ci:latest
-          CI_TAG=latest make -f Makefile.am anaconda-ci-push
+          podman tag quay.io/rhinstaller/anaconda-${{ matrix.container-type }}:master quay.io/rhinstaller/anaconda-${{ matrix.container-type }}:latest
+          CI_TAG=latest make -f Makefile.am anaconda-${{ matrix.container-type }}-push
 
       - name: Push container to registry
-        run: make -f Makefile.am anaconda-ci-push
+        run: make -f Makefile.am anaconda-${{ matrix.container-type }}-push

--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -20,14 +20,13 @@ jobs:
             branch: master
           - container-tag: eln
             branch: master
-            build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
+            base-container: 'quay.io/fedoraci/fedora:eln-x86_64'
           - container-tag: f34-devel
             branch: f34-devel
           - container-tag: f34-release
             branch: f34-release
     env:
       CI_TAG: '${{ matrix.container-tag }}'
-      CONTAINER_BUILD_ARGS: '${{ matrix.build-args }}'
     timeout-minutes: 60
     steps:
       - name: Checkout anaconda repository
@@ -36,7 +35,9 @@ jobs:
           ref: ${{ matrix.branch }}
 
       - name: Build anaconda-ci container
-        run: make -f Makefile.am anaconda-ci-build
+        run: |
+          BASE_CONTAINER=${{ matrix.base-container }}
+          make -f Makefile.am anaconda-ci-build ${BASE_CONTAINER:+BASE_CONTAINER=}${BASE_CONTAINER:-}
 
       - name: Run tests in anaconda-ci container
         id: run-tests

--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -48,7 +48,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs
+          name: ${{ matrix.container-tag }}-${{ matrix.container-type }}-logs
           path: |
             test-logs/test-suite.log
             test-logs/nosetests.log


### PR DESCRIPTION
We will use power of combinations of matrix. That will create all the combinations between container-tag and container-type variables for us and we don't have to define new job for this.