### PR TITLE
Enable our and blivet COPR repositories for rpm tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -183,6 +183,7 @@ anaconda-rpm-build:
 	$(CONTAINER_BUILD_ARGS) \
 	--build-arg=git_branch=$(GIT_BRANCH) \
 	--build-arg=image=$(BASE_CONTAINER) \
+	--build-arg=copr_repo=$(COPR_REPO) \
 	-t $(RPM_NAME):$(CI_TAG) \
 	$(RPM_DOCKERFILE)
 

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -3,6 +3,7 @@ FROM ${image}
 # FROM starts a new build stage with new ARGs. Put any ARGs after FROM unless required by the FROM itself.
 # see https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG git_branch=master
+ARG copr_repo=@rhinstaller/Anaconda
 LABEL maintainer=anaconda-list@redhat.com
 
 # On ELN, BaseOS+AppStream don't have all our build dependencies; this provides the "Everything" compose
@@ -13,10 +14,12 @@ RUN set -e; \
   if grep -q VARIANT.*eln /etc/os-release; then sed -i 's/enabled=0/enabled=1/' /etc/yum.repos.d/eln.repo; fi; \
   dnf update -y; \
   dnf install -y \
+  'dnf-command(copr)' \
   curl \
   python3-pip \
   /usr/bin/xargs \
   rpm-build; \
+  if ! grep -q VARIANT.*eln /etc/os-release; then dnf copr enable -y ${copr_repo}; dnf copr enable -y @storage/blivet-daily; fi; \
   curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/${git_branch}/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   mkdir /anaconda


### PR DESCRIPTION
This will solve the situation when rpm tests are failing because we depend on blivet which is not yet released.