### PR TITLE
Add support for tear-down of the payload modules

### DIFF
--- a/pyanaconda/modules/payloads/payload/payload_base.py
+++ b/pyanaconda/modules/payloads/payload/payload_base.py
@@ -164,3 +164,17 @@ class PayloadBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
     def tear_down_sources_with_task(self):
         """Tear down installation sources."""
         return TearDownSourcesTask(self.sources)
+
+    def tear_down_with_tasks(self):
+        """Returns teardown tasks for this payload.
+
+        Clean up everything after this payload.
+
+        :return: a list of tasks
+        """
+        tasks = []
+
+        if self.sources:
+            tasks.append(self.tear_down_sources_with_task())
+
+        return tasks

--- a/pyanaconda/modules/payloads/payloads.py
+++ b/pyanaconda/modules/payloads/payloads.py
@@ -141,3 +141,15 @@ class PayloadsService(KickstartService):
         :type source_type: value of the payload.base.constants.SourceType enum
         """
         return SourceFactory.create_source(source_type)
+
+    def teardown_with_tasks(self):
+        """Returns teardown tasks for this module.
+
+        :return: a list of tasks
+        """
+        tasks = []
+
+        if self.active_payload:
+            tasks.extend(self.active_payload.tear_down_with_tasks())
+
+        return tasks


### PR DESCRIPTION
Call the `TeardownWithTasks` DBus method of the Payloads service
to tear down active payloads and sources.

**Blocked by:** Beta Freeze