### PR TITLE
Use docker as container engine for time required

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -28,6 +28,8 @@ jobs:
             branch: f34-release
     env:
       CI_TAG: '${{ matrix.container-tag }}'
+      # FIXME: Remove this when issue https://github.com/containers/podman/issues/9442 is resolved
+      CONTAINER_ENGINE: docker
     timeout-minutes: 60
     steps:
       - name: Checkout anaconda repository


### PR DESCRIPTION
We encountered issue that ELN images can't be used in podman. Until that is fixed fall back to docker which doesn't have this problem

https://github.com/containers/podman/issues/9442