### PR TITLE
Determine GRUB directory relative path to use in config file

### DIFF
--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -173,10 +173,11 @@ class EFIGRUB(EFIBase, GRUB2):
         with open(config_path, "w") as fd:
             grub_dir = self.config_dir
             fs_uuid = self.stage2_device.format.uuid
-            mountpoint = self.stage2_device.format.mountpoint
 
-            if mountpoint != "/" and grub_dir.startswith(mountpoint):
-                grub_dir = grub_dir[len(mountpoint):]
+            grub_dir = util.execWithCapture("grub2-mkrelpath", [grub_dir],
+                                            root=conf.target.system_root)
+            if not grub_dir:
+                raise BootLoaderError("Could not get GRUB directory path")
 
             fd.write("search --no-floppy --fs-uuid --set=dev %s\n" % fs_uuid)
             fd.write("set prefix=($dev)%s\n" % grub_dir)


### PR DESCRIPTION
Currently Anaconda is only checking whether /boot/ is a mount point or not
to use the proper relative path to the GRUB directory. But there are more
cases than this, for example /boot/grub2 could be a symlink or a subvolume
in a btrfs filesystem.

Use the grub2-mkrelpath tool to figure out the actual relative path that
has to be used in the GRUB config file.

Resolves: rhbz#1928588

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>