### PR TITLE
The network spoke should be visible in live spins (#1932961)

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1472,7 +1472,8 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         if not FirstbootSpokeMixIn.should_run(environment, data):
             return False
 
-        return conf.system.can_configure_network
+        # Always allow to configure the hostname for the target system.
+        return True
 
     def __init__(self, *args, **kwargs):
         NormalSpoke.__init__(self, *args, **kwargs)


### PR DESCRIPTION
It should be always possible to configure the hostname for the target system
in the graphical network spoke, unless the spoke was specifically disabled in
the Anaconda configuration files.

This regression was caused by the commit 6b80b7b.

Resolves: rhbz#1932961