### PR TITLE
Conscious language blacklist 1

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -881,10 +881,10 @@ Instead, use `inst.repo`_ or specify appropriate `Network Options`_.
 blacklist, nofirewire
 ^^^^^^^^^^^^^^^^^^^^^
 
-``modprobe`` handles blacklisting kernel modules on its own; try
+``modprobe`` handles adding kernel modules to a denylist on its own; try
 ``modprobe.blacklist=<mod1>,<mod2>...``
 
-You can blacklist the firewire module with ``modprobe.blacklist=firewire_ohci``.
+You can add the firewire module to a denylist with ``modprobe.blacklist=firewire_ohci``.
 
 serial
 ^^^^^^

--- a/docs/rescue.rst
+++ b/docs/rescue.rst
@@ -48,7 +48,7 @@ Examples of use
 
 - adding driver using ``inst.dd`` boot option (or ``driverdisk`` kickstart
   command)
-- blacklisting a driver with ``modprobe.blacklist`` boot option
+- adding a driver to a denylist with ``modprobe.blacklist`` boot option
 - examining and repairing storage using partitioning or lvm tools present in
   the installer image
 - repairing or reinstalling the bootloader

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -64,9 +64,6 @@ check_removed_no_inst_arg() {
 was removed. Please use $new_arg instead."
 }
 
-check_depr_args "blacklist=" "inst.blacklist=%s"
-check_depr_arg "nofirewire" "inst.blacklist=firewire_ohci"
-
 # ssh
 check_depr_arg "sshd" "inst.sshd"
 

--- a/pyanaconda/modules/payloads/base/initialization.py
+++ b/pyanaconda/modules/payloads/base/initialization.py
@@ -22,7 +22,7 @@ from glob import glob
 
 from pyanaconda.modules.common.errors.payload import SourceSetupError, SourceTearDownError
 from pyanaconda.modules.common.task import Task
-from pyanaconda.modules.payloads.base.utils import create_root_dir, write_module_blacklist
+from pyanaconda.modules.payloads.base.utils import create_root_dir, write_module_denylist
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -33,7 +33,7 @@ class PrepareSystemForInstallationTask(Task):
 
     Steps to prepare the installation root:
     * Create a root directory
-    * Create a module blacklist from the boot cmdline
+    * Create a module denylist from the boot cmdline
     """
 
     def __init__(self, sysroot):
@@ -50,9 +50,9 @@ class PrepareSystemForInstallationTask(Task):
         return "Prepare System for Installation"
 
     def run(self):
-        """Create a root and write module blacklist."""
+        """Create a root and write module denylist."""
         create_root_dir(self._sysroot)
-        write_module_blacklist(self._sysroot)
+        write_module_denylist(self._sysroot)
 
 
 # TODO: Can we remove this really old code which probably even doesn't work now?

--- a/pyanaconda/modules/payloads/base/utils.py
+++ b/pyanaconda/modules/payloads/base/utils.py
@@ -35,19 +35,19 @@ def create_root_dir(sysroot):
     mkdirChain(os.path.join(sysroot, "root"))
 
 
-def write_module_blacklist(sysroot):
-    """Create module blacklist based on the user preference.
+def write_module_denylist(sysroot):
+    """Create module denylist based on the user preference.
 
     Copy modules from modprobe.blacklist=<module> on cmdline to
     /etc/modprobe.d/anaconda-blacklist.conf so that modules will
-    continue to be blacklisted when the system boots.
+    continue to be added to a denylist when the system boots.
     """
     if "modprobe.blacklist" not in kernel_arguments:
         return
 
     mkdirChain(os.path.join(sysroot, "etc/modprobe.d"))
     with open(os.path.join(sysroot, "etc/modprobe.d/anaconda-blacklist.conf"), "w") as f:
-        f.write("# Module blacklists written by anaconda\n")
+        f.write("# Module denylist written by anaconda\n")
         for module in kernel_arguments.get("modprobe.blacklist").split():
             f.write("blacklist %s\n" % module)
 

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/module_payload_base_utils_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/module_payload_base_utils_test.py
@@ -22,7 +22,7 @@ from textwrap import dedent
 from unittest.case import TestCase
 from unittest.mock import patch
 
-from pyanaconda.modules.payloads.base.utils import create_root_dir, write_module_blacklist, \
+from pyanaconda.modules.payloads.base.utils import create_root_dir, write_module_denylist, \
     get_dir_size, sort_kernel_version_list
 
 
@@ -39,18 +39,18 @@ class PayloadBaseUtilsTest(TestCase):
 
     @patch('pyanaconda.modules.payloads.base.utils.kernel_arguments',
            {"modprobe.blacklist": "mod1 mod2 nonono_mod"})
-    def write_module_blacklist_test(self):
-        """Test write kernel module blacklist to the install root."""
+    def write_module_denylist_test(self):
+        """Test write kernel module denylist to the install root."""
         with TemporaryDirectory() as temp:
-            write_module_blacklist(temp)
+            write_module_denylist(temp)
 
-            blacklist_file = os.path.join(temp, "etc/modprobe.d/anaconda-blacklist.conf")
+            denylist_file = os.path.join(temp, "etc/modprobe.d/anaconda-blacklist.conf")
 
-            self.assertTrue(os.path.isfile(blacklist_file))
+            self.assertTrue(os.path.isfile(denylist_file))
 
-            with open(blacklist_file, "rt") as f:
+            with open(denylist_file, "rt") as f:
                 expected_content = """
-                # Module blacklists written by anaconda
+                # Module denylist written by anaconda
                 blacklist mod1
                 blacklist mod2
                 blacklist nonono_mod
@@ -58,14 +58,14 @@ class PayloadBaseUtilsTest(TestCase):
                 self.assertEqual(dedent(expected_content).lstrip(), f.read())
 
     @patch('pyanaconda.modules.payloads.base.utils.kernel_arguments', {})
-    def write_empty_module_blacklist_test(self):
-        """Test write kernel module blacklist to the install root -- empty list."""
+    def write_empty_module_denylist_test(self):
+        """Test write kernel module denylist to the install root -- empty list."""
         with TemporaryDirectory() as temp:
-            write_module_blacklist(temp)
+            write_module_denylist(temp)
 
-            blacklist_file = os.path.join(temp, "etc/modprobe.d/anaconda-blacklist.conf")
+            denylist_file = os.path.join(temp, "etc/modprobe.d/anaconda-blacklist.conf")
 
-            self.assertFalse(os.path.isfile(blacklist_file))
+            self.assertFalse(os.path.isfile(denylist_file))
 
     def get_dir_size_test(self):
         """Test the get_dir_size function."""

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/module_payloads_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/module_payloads_test.py
@@ -168,10 +168,10 @@ class PayloadsInterfaceTestCase(TestCase):
 
 class PayloadSharedTasksTest(TestCase):
 
-    @patch('pyanaconda.modules.payloads.base.initialization.write_module_blacklist')
+    @patch('pyanaconda.modules.payloads.base.initialization.write_module_denylist')
     @patch('pyanaconda.modules.payloads.base.initialization.create_root_dir')
     def prepare_system_for_install_task_test(self, create_root_dir_mock,
-                                             write_module_blacklist_mock):
+                                             write_module_denylist_mock):
         """Test task prepare system for installation."""
         # the dir won't be used because of mock
         task = PrepareSystemForInstallationTask("/some/dir")
@@ -179,7 +179,7 @@ class PayloadSharedTasksTest(TestCase):
         task.run()
 
         create_root_dir_mock.assert_called_once()
-        write_module_blacklist_mock.assert_called_once()
+        write_module_denylist_mock.assert_called_once()
 
     def set_up_sources_task_test(self):
         """Test task to set up installation sources."""

--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -5,11 +5,11 @@
 # run arbitrary code.
 extension-pkg-whitelist=
 
-# Add files or directories to the blacklist. They should be base names, not
+# Add files or directories to the denylist. They should be base names, not
 # paths.
 ignore=
 
-# Add files or directories matching the regex patterns to the blacklist. The
+# Add files or directories matching the regex patterns to the denylist. The
 # regex matches against base names, not paths.
 ignore-patterns=
 


### PR DESCRIPTION
Note: the main reason for picking blocklist/passlist (not denylist/allowlist) was consistency with RHEL 8 installation documentation where it is already used.