### PR TITLE
conscious lang: rename /etc/modprobe.d/anaconda-blacklist.conf

### DIFF
--- a/pyanaconda/modules/payloads/base/utils.py
+++ b/pyanaconda/modules/payloads/base/utils.py
@@ -39,14 +39,14 @@ def write_module_denylist(sysroot):
     """Create module denylist based on the user preference.
 
     Copy modules from modprobe.blacklist=<module> on cmdline to
-    /etc/modprobe.d/anaconda-blacklist.conf so that modules will
+    /etc/modprobe.d/anaconda-denylist.conf so that modules will
     continue to be added to a denylist when the system boots.
     """
     if "modprobe.blacklist" not in kernel_arguments:
         return
 
     mkdirChain(os.path.join(sysroot, "etc/modprobe.d"))
-    with open(os.path.join(sysroot, "etc/modprobe.d/anaconda-blacklist.conf"), "w") as f:
+    with open(os.path.join(sysroot, "etc/modprobe.d/anaconda-denylist.conf"), "w") as f:
         f.write("# Module denylist written by anaconda\n")
         for module in kernel_arguments.get("modprobe.blacklist").split():
             f.write("blacklist %s\n" % module)

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/module_payload_base_utils_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/module_payload_base_utils_test.py
@@ -44,7 +44,7 @@ class PayloadBaseUtilsTest(TestCase):
         with TemporaryDirectory() as temp:
             write_module_denylist(temp)
 
-            denylist_file = os.path.join(temp, "etc/modprobe.d/anaconda-blacklist.conf")
+            denylist_file = os.path.join(temp, "etc/modprobe.d/anaconda-denylist.conf")
 
             self.assertTrue(os.path.isfile(denylist_file))
 
@@ -63,7 +63,7 @@ class PayloadBaseUtilsTest(TestCase):
         with TemporaryDirectory() as temp:
             write_module_denylist(temp)
 
-            denylist_file = os.path.join(temp, "etc/modprobe.d/anaconda-blacklist.conf")
+            denylist_file = os.path.join(temp, "etc/modprobe.d/anaconda-denylist.conf")
 
             self.assertFalse(os.path.isfile(denylist_file))
 


### PR DESCRIPTION
Follows on https://github.com/rhinstaller/anaconda/pull/3202 but this time changing the name of a configuration file created by Anaconda on target system so proposed in a separate PR.