### PR TITLE
Handle exceptions inside the CopyBootloaderDataTask class

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -207,6 +207,16 @@ class CopyBootloaderDataTask(Task):
         return "Copy OSTree bootloader data"
 
     def run(self):
+        """Run the installation task.
+
+        :raise PayloadInstallError: if the installation fails
+        """
+        try:
+            self._run()
+        except (OSError, RuntimeError) as e:
+            raise PayloadInstallError("Failed to copy bootloader data: {}".format(e)) from e
+
+    def _run(self):
         """Copy bootloader data files from the deployment checkout to the target root.
 
         See https://bugzilla.gnome.org/show_bug.cgi?id=726757 This happens once, at installation

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -25,7 +25,6 @@ from pyanaconda.modules.common.structures.rpm_ostree import RPMOSTreeConfigurati
 from pyanaconda.progress import progressQ
 from pyanaconda.payload.base import Payload
 from pyanaconda.payload import utils as payload_utils
-from pyanaconda.payload.errors import PayloadInstallError
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.ui.lib.payload import get_payload, get_source, set_up_sources, tear_down_sources
 
@@ -140,16 +139,13 @@ class RPMOSTreePayload(Payload):
         task = SetSystemRootTask(conf.target.physical_root)
         task.run()
 
-        try:
-            from pyanaconda.modules.payloads.payload.rpm_ostree.installation import \
-                CopyBootloaderDataTask
-            task = CopyBootloaderDataTask(
-                sysroot=conf.target.system_root,
-                physroot=conf.target.physical_root
-            )
-            task.run()
-        except (OSError, RuntimeError) as e:
-            raise PayloadInstallError("Failed to copy bootloader data: %s" % e) from e
+        from pyanaconda.modules.payloads.payload.rpm_ostree.installation import \
+            CopyBootloaderDataTask
+        task = CopyBootloaderDataTask(
+            sysroot=conf.target.system_root,
+            physroot=conf.target.physical_root
+        )
+        task.run()
 
     def _prepare_mount_targets(self, data):
         """ Prepare the ostree root """

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/rpm_ostree_tasks_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/rpm_ostree_tasks_test.py
@@ -209,6 +209,24 @@ class CopyBootloaderDataTaskTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.path.isdir")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.listdir")
+    def run_failed_test(self, listdir_mock, isdir_mock, storage_mock):
+        """Test OSTree bootloader copy task run() with an exception."""
+        bootloader_mock = storage_mock.get_proxy()
+        bootloader_mock.IsEFI.return_value = False
+
+        isdir_mock.return_value = False
+        listdir_mock.side_effect = OSError("Fake!")
+
+        task = CopyBootloaderDataTask("/sysroot", "/physroot")
+
+        with self.assertRaises(PayloadInstallError) as cm:
+            task.run()
+
+        self.assertEqual(str(cm.exception), "Failed to copy bootloader data: Fake!")
+
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.path.isdir")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.listdir")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.safe_exec_with_redirect")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.path.islink")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.unlink")


### PR DESCRIPTION
Move the code for exception handling into the `CopyBootloaderDataTask` class.