### PR TITLE
F34 devel fix owner tests

### DIFF
--- a/.github/workflows/tests-owners.yml
+++ b/.github/workflows/tests-owners.yml
@@ -34,16 +34,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # empty = release that corresponds to current branch name
-        release: ['', 'eln']
+        # * Don't forget to copypaste also the same matrix below in rpm tests!
+        # * Replace current branch in "release" with empty string. This makes name of the check for
+        #   the current branch always have the same name, so that it can be added to required
+        #   checks.
+        # * For various branches, comment out what does not apply:
+        #     on -devel, run everything
+        #     on -release, only -release
+        #     on master, only master and ELN
+        release: [master, eln, '', f34-release]
         include:
+          - release: master
+            target_branch: 'master'
+            ci_tag: 'master'
           - release: eln
-            name-postfix: ' (eln)'
+            target_branch: 'master'
+            ci_tag: 'eln'
             build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
+          - release: ''
+            target_branch: 'f34-devel'
+            ci_tag: 'f34-devel'
+          - release: f34-release
+            target_branch: 'f34-release'
+            ci_tag: 'f34-devel'
     env:
-      CI_TAG: '${{ matrix.release }}'
+      CI_TAG: '${{ matrix.ci_tag }}'
       CONTAINER_BUILD_ARGS: '${{ matrix.build-args }}'
-      TARGET_BRANCH_NAME: origin/master
+      TARGET_BRANCH_NAME: 'origin/${{ matrix.target_branch }}'
 
     steps:
       - name: Clone repository
@@ -53,7 +70,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Rebase to current master
+      - name: Rebase to current ${{ env.TARGET_BRANCH_NAME }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -63,7 +80,7 @@ jobs:
       - name: Check if rebuild of the container image is required
         id: check-dockerfile-changed
         run: |
-          changes=$(git diff origin/master..HEAD -- dockerfile/anaconda-ci/ anaconda.spec.in scripts/testing/install_dependencies.sh)
+          changes=$(git diff $TARGET_BRANCH_NAME..HEAD -- dockerfile/anaconda-ci/ anaconda.spec.in scripts/testing/install_dependencies.sh)
           # print for debugging
           echo "$changes"
           [ -z "$changes" ] || echo "::set-output name=changed::true"
@@ -83,7 +100,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: 'logs${{ matrix.name-postfix }}'
+          name: 'logs (${{ matrix.ci_tag }})'
           path: test-logs/*
 
   rpm-tests:
@@ -94,16 +111,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # empty = release that corresponds to current branch name
-        release: ['', 'eln']
+        # For matrix details, see comments for the unit tests above.
+        release: [master, eln, '', f34-release]
         include:
+          - release: master
+            target_branch: 'master'
+            ci_tag: 'master'
           - release: eln
-            name-postfix: ' (eln)'
+            target_branch: 'master'
+            ci_tag: 'eln'
             build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
+          - release: ''
+            target_branch: 'f34-devel'
+            ci_tag: 'f34-devel'
+          - release: f34-release
+            target_branch: 'f34-release'
+            ci_tag: 'f34-devel'
     env:
-      CI_TAG: '${{ matrix.release }}'
+      CI_TAG: '${{ matrix.ci_tag }}'
       CONTAINER_BUILD_ARGS: '${{ matrix.build-args }}'
-      TARGET_BRANCH_NAME: origin/master
+      TARGET_BRANCH_NAME: 'origin/${{ matrix.target_branch }}'
 
     steps:
       - name: Clone repository
@@ -113,7 +140,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Rebase to current master
+      - name: Rebase to current ${{ env.TARGET_BRANCH_NAME }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -130,5 +157,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: 'logs-rpm-test${{ matrix.name-postfix }}'
+          name: 'logs-rpm-test (${{ matrix.ci_tag }})'
           path: test-logs/*


### PR DESCRIPTION
This makes tests work. It seems that the best course of action is to take this and comment out stuff on other branches.

Test run here: https://github.com/vslavik-test-org/anaconda/pull/3/checks?check_run_id=2005869646

In an ideal world, we could abstract away the matrix from both jobs, or construct it on demand. But I don't think we can. Oh, the wonders of Github actions black boxes, bugs and workarounds!

Potential TODOs within this PR:
- Drop push runs.
- Make names nicer.