### PR TITLE
Extend the DBus API of the Payloads service

### DIFF
--- a/pyanaconda/modules/payloads/base/initialization.py
+++ b/pyanaconda/modules/payloads/base/initialization.py
@@ -15,95 +15,15 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-import os
-import shutil
 import traceback
-from glob import glob
-
-from pyanaconda.modules.common.errors.payload import SourceSetupError, SourceTearDownError
-from pyanaconda.modules.common.task import Task
-from pyanaconda.modules.payloads.base.utils import create_root_dir, write_module_denylist
 
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.modules.common.errors.payload import SourceSetupError, SourceTearDownError
+from pyanaconda.modules.common.task import Task
+
 log = get_module_logger(__name__)
 
-
-class PrepareSystemForInstallationTask(Task):
-    """Prepare system for the installation process.
-
-    Steps to prepare the installation root:
-    * Create a root directory
-    * Create a module denylist from the boot cmdline
-    """
-
-    def __init__(self, sysroot):
-        """Create prepare system for installation task.
-
-        :param sysroot: path to the installation root
-        :type sysroot: str
-        """
-        super().__init__()
-        self._sysroot = sysroot
-
-    @property
-    def name(self):
-        return "Prepare System for Installation"
-
-    def run(self):
-        """Create a root and write module denylist."""
-        create_root_dir(self._sysroot)
-        write_module_denylist(self._sysroot)
-
-
-# TODO: Can we remove this really old code which probably even doesn't work now?
-# The tmpfs is mounted above Dracut /tmp where the below files are created so we never copy
-# anything because we don't see those files.
-# This code was introduced by commit 13f58e367f918320ce7f5be2e08c6a02ff90a087 with no bz number.
-# It looks that the functionality is not required anymore on the newer implementation.
-class CopyDriverDisksFilesTask(Task):
-    """Copy driver disks files after installation to the installed system."""
-
-    DD_DIR = "/tmp/DD"
-    DD_FIRMWARE_DIR = "/tmp/DD/lib/firmware"
-    DD_RPMS_DIR = "/tmp"
-    DD_RPMS_GLOB = "DD-*"
-
-    def __init__(self, sysroot):
-        """Create copy driver disks files task.
-
-        :param sysroot: path to the installation root
-        :type sysroot: str
-        """
-        super().__init__()
-        self._sysroot = sysroot
-
-    @property
-    def name(self):
-        return "Copy Driver Disks Files"
-
-    def run(self):
-        """Copy files from the driver disks to the installed system."""
-        # Multiple driver disks may be loaded, so we need to glob for all
-        # the firmware files in the common DD firmware directory
-        for f in glob(self.DD_FIRMWARE_DIR + "/*"):
-            try:
-                shutil.copyfile(f, os.path.join(self._sysroot, "lib/firmware/"))
-            except IOError as e:
-                log.error("Could not copy firmware file %s: %s", f, e.strerror)
-
-        # copy RPMS
-        for d in glob(os.path.join(self.DD_RPMS_DIR, self.DD_RPMS_GLOB)):
-            dest_dir = os.path.join(self._sysroot, "root/", os.path.basename(d))
-            shutil.copytree(d, dest_dir)
-
-        # copy modules and firmware into root's home directory
-        if os.path.exists(self.DD_DIR):
-            try:
-                shutil.copytree(self.DD_DIR, os.path.join(self._sysroot, "root/DD"))
-            except IOError as e:
-                log.error("failed to copy driver disk files: %s", e.strerror)
-                # XXX TODO: real error handling, as this is probably going to
-                #           prevent boot on some systems
+__all__ = ["SetUpSourcesTask", "TearDownSourcesTask"]
 
 
 class SetUpSourcesTask(Task):

--- a/pyanaconda/modules/payloads/base/utils.py
+++ b/pyanaconda/modules/payloads/base/utils.py
@@ -23,33 +23,8 @@ import stat
 
 from distutils.version import LooseVersion
 
-from pyanaconda.core.kernel import kernel_arguments
-from pyanaconda.core.util import mkdirChain
-
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
-
-
-def create_root_dir(sysroot):
-    """Create root directory on the installed system."""
-    mkdirChain(os.path.join(sysroot, "root"))
-
-
-def write_module_denylist(sysroot):
-    """Create module denylist based on the user preference.
-
-    Copy modules from modprobe.blacklist=<module> on cmdline to
-    /etc/modprobe.d/anaconda-denylist.conf so that modules will
-    continue to be added to a denylist when the system boots.
-    """
-    if "modprobe.blacklist" not in kernel_arguments:
-        return
-
-    mkdirChain(os.path.join(sysroot, "etc/modprobe.d"))
-    with open(os.path.join(sysroot, "etc/modprobe.d/anaconda-denylist.conf"), "w") as f:
-        f.write("# Module denylist written by anaconda\n")
-        for module in kernel_arguments.get("modprobe.blacklist").split():
-            f.write("blacklist %s\n" % module)
 
 
 def get_dir_size(directory):

--- a/pyanaconda/modules/payloads/installation.py
+++ b/pyanaconda/modules/payloads/installation.py
@@ -1,0 +1,135 @@
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import os
+import shutil
+from glob import glob
+
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.kernel import kernel_arguments
+from pyanaconda.core.util import mkdirChain
+from pyanaconda.modules.common.task import Task
+
+log = get_module_logger(__name__)
+
+__all__ = ["PrepareSystemForInstallationTask", "CopyDriverDisksFilesTask"]
+
+
+class PrepareSystemForInstallationTask(Task):
+    """Prepare system for the installation process.
+
+    Steps to prepare the installation root:
+    * Create a root directory
+    * Create a module denylist from the boot cmdline
+    """
+
+    def __init__(self, sysroot):
+        """Create prepare system for installation task.
+
+        :param sysroot: path to the installation root
+        :type sysroot: str
+        """
+        super().__init__()
+        self._sysroot = sysroot
+
+    @property
+    def name(self):
+        return "Prepare System for Installation"
+
+    def run(self):
+        """Create a root and write module denylist."""
+        self._create_root_dir(self._sysroot)
+        self._write_module_denylist(self._sysroot)
+
+    @staticmethod
+    def _create_root_dir(sysroot):
+        """Create root directory on the installed system."""
+        mkdirChain(os.path.join(sysroot, "root"))
+
+    @staticmethod
+    def _write_module_denylist(sysroot):
+        """Create module denylist based on the user preference.
+
+        Copy modules from modprobe.blacklist=<module> on cmdline to
+        /etc/modprobe.d/anaconda-denylist.conf so that modules will
+        continue to be added to a denylist when the system boots.
+        """
+        if "modprobe.blacklist" not in kernel_arguments:
+            return
+
+        mkdirChain(os.path.join(sysroot, "etc/modprobe.d"))
+        with open(os.path.join(sysroot, "etc/modprobe.d/anaconda-denylist.conf"), "w") as f:
+            f.write("# Module denylist written by anaconda\n")
+            for module in kernel_arguments.get("modprobe.blacklist").split():
+                f.write("blacklist %s\n" % module)
+
+
+class CopyDriverDisksFilesTask(Task):
+    """Copy driver disks files after installation to the installed system.
+
+    TODO: Can we remove this really old code?
+
+    The tmpfs is mounted above Dracut /tmp where the below files are created
+    so we never copy anything because we don't see those files.
+
+    This code was introduced by commit 13f58e3 with no bz number.
+
+    It looks that the functionality is not required anymore on the newer
+    implementation.
+    """
+
+    DD_DIR = "/tmp/DD"
+    DD_FIRMWARE_DIR = "/tmp/DD/lib/firmware"
+    DD_RPMS_DIR = "/tmp"
+    DD_RPMS_GLOB = "DD-*"
+
+    def __init__(self, sysroot):
+        """Create copy driver disks files task.
+
+        :param sysroot: path to the installation root
+        :type sysroot: str
+        """
+        super().__init__()
+        self._sysroot = sysroot
+
+    @property
+    def name(self):
+        return "Copy Driver Disks Files"
+
+    def run(self):
+        """Copy files from the driver disks to the installed system."""
+        # Multiple driver disks may be loaded, so we need to glob for all
+        # the firmware files in the common DD firmware directory
+        for f in glob(self.DD_FIRMWARE_DIR + "/*"):
+            try:
+                shutil.copyfile(f, os.path.join(self._sysroot, "lib/firmware/"))
+            except IOError as e:
+                log.error("Could not copy firmware file %s: %s", f, e.strerror)
+
+        # copy RPMS
+        for d in glob(os.path.join(self.DD_RPMS_DIR, self.DD_RPMS_GLOB)):
+            dest_dir = os.path.join(self._sysroot, "root/", os.path.basename(d))
+            shutil.copytree(d, dest_dir)
+
+        # copy modules and firmware into root's home directory
+        if os.path.exists(self.DD_DIR):
+            try:
+                shutil.copytree(self.DD_DIR, os.path.join(self._sysroot, "root/DD"))
+            except IOError as e:
+                log.error("failed to copy driver disk files: %s", e.strerror)
+                # XXX TODO: real error handling, as this is probably going to
+                #           prevent boot on some systems

--- a/pyanaconda/modules/payloads/payload/dnf/dnf.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf.py
@@ -255,21 +255,13 @@ class DNFModule(PayloadBase):
 
         return structures
 
-    def pre_install_with_tasks(self):
-        """Execute preparation steps.
-
-        :return: list of tasks
-        """
-        # TODO: Implement this method
-        pass
-
     def install_with_tasks(self):
         """Install the payload.
 
         :return: list of tasks
         """
         # TODO: Implement this method
-        pass
+        return []
 
     def post_install_with_tasks(self):
         """Execute post installation steps.
@@ -277,4 +269,4 @@ class DNFModule(PayloadBase):
         :return: list of tasks
         """
         # TODO: Implement this method
-        pass
+        return []

--- a/pyanaconda/modules/payloads/payload/live_image/live_image.py
+++ b/pyanaconda/modules/payloads/payload/live_image/live_image.py
@@ -67,12 +67,13 @@ class LiveImageModule(PayloadBase):
         for source in self.sources:
             source.setup_kickstart(data)
 
-    def pre_install_with_tasks(self):
-        """Execute preparation steps.
+    def install_with_tasks(self):
+        """Execute preparation and installation steps.
 
         * Download the image
         * Check the checksum
         * Mount the image
+        * Install the image
         """
         # task = SetupInstallationSourceImageTask(
         #     self.url,
@@ -85,20 +86,7 @@ class LiveImageModule(PayloadBase):
         # )
         # task.succeeded_signal.connect(lambda: self.set_image_path(task.get_result()))
         # return [task]
-        return []
 
-    def post_install_with_tasks(self):
-        """Execute post installation steps.
-
-        * Copy Driver Disk files to the resulting system
-        """
-        # return [
-        #     CopyDriverDisksFilesTask(conf.target.system_root)
-        # ]
-        return []
-
-    def install_with_tasks(self):
-        """Install the payload."""
         # if url_target_is_tarfile(self._url):
         #     task = InstallFromTarTask(
         #         self.image_path,
@@ -118,4 +106,14 @@ class LiveImageModule(PayloadBase):
         # )
         #
         # return [task, task2]
+        return []
+
+    def post_install_with_tasks(self):
+        """Execute post installation steps.
+
+        * Copy Driver Disk files to the resulting system
+        """
+        # return [
+        #     CopyDriverDisksFilesTask(conf.target.system_root)
+        # ]
         return []

--- a/pyanaconda/modules/payloads/payload/live_image/live_image.py
+++ b/pyanaconda/modules/payloads/payload/live_image/live_image.py
@@ -113,7 +113,4 @@ class LiveImageModule(PayloadBase):
 
         * Copy Driver Disk files to the resulting system
         """
-        # return [
-        #     CopyDriverDisksFilesTask(conf.target.system_root)
-        # ]
         return []

--- a/pyanaconda/modules/payloads/payload/live_os/live_os.py
+++ b/pyanaconda/modules/payloads/payload/live_os/live_os.py
@@ -129,20 +129,19 @@ class LiveOSModule(PayloadBase):
 
         return task
 
-    def pre_install_with_tasks(self):
-        """Execute preparation steps."""
-        self._check_source_availability("Pre install task failed - source is not available!")
-
-        return [PrepareSystemForInstallationTask(conf.target.system_root)]
-
     def install_with_tasks(self):
         """Install the payload."""
         self._check_source_availability("Installation task failed - source is not available!")
 
-        return [InstallFromImageTask(
-            self._image_source,
-            conf.target.system_root
-        )]
+        return [
+            PrepareSystemForInstallationTask(
+                conf.target.system_root
+            ),
+            InstallFromImageTask(
+                self._image_source,
+                conf.target.system_root
+            )
+        ]
 
     def post_install_with_tasks(self):
         """Execute post installation steps.
@@ -151,5 +150,7 @@ class LiveOSModule(PayloadBase):
         :rtype: List
         """
         return [
-            CopyDriverDisksFilesTask(conf.target.system_root)
+            CopyDriverDisksFilesTask(
+                conf.target.system_root
+            )
         ]

--- a/pyanaconda/modules/payloads/payload/live_os/live_os.py
+++ b/pyanaconda/modules/payloads/payload/live_os/live_os.py
@@ -23,8 +23,7 @@ from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.modules.common.errors.payload import SourceSetupError, IncompatibleSourceError
 from pyanaconda.modules.payloads.constants import SourceType, PayloadType
 from pyanaconda.modules.payloads.payload.payload_base import PayloadBase
-from pyanaconda.modules.payloads.base.initialization import PrepareSystemForInstallationTask, \
-    CopyDriverDisksFilesTask, SetUpSourcesTask, TearDownSourcesTask
+from pyanaconda.modules.payloads.base.initialization import SetUpSourcesTask, TearDownSourcesTask
 from pyanaconda.modules.payloads.base.installation import InstallFromImageTask
 from pyanaconda.modules.payloads.payload.live_os.utils import get_kernel_version_list
 from pyanaconda.modules.payloads.payload.live_os.live_os_interface import LiveOSInterface
@@ -134,9 +133,6 @@ class LiveOSModule(PayloadBase):
         self._check_source_availability("Installation task failed - source is not available!")
 
         return [
-            PrepareSystemForInstallationTask(
-                conf.target.system_root
-            ),
             InstallFromImageTask(
                 self._image_source,
                 conf.target.system_root
@@ -149,8 +145,4 @@ class LiveOSModule(PayloadBase):
         :returns: list of paths.
         :rtype: List
         """
-        return [
-            CopyDriverDisksFilesTask(
-                conf.target.system_root
-            )
-        ]
+        return []

--- a/pyanaconda/modules/payloads/payload/payload_base.py
+++ b/pyanaconda/modules/payloads/payload/payload_base.py
@@ -160,14 +160,6 @@ class PayloadBase(KickstartBaseModule, Publishable, metaclass=ABCMeta):
         log.debug("The kernel version list is set to: %s", kernels)
 
     @abstractmethod
-    def pre_install_with_tasks(self):
-        """Execute preparation steps.
-
-        :return: list of tasks
-        """
-        pass
-
-    @abstractmethod
     def install_with_tasks(self):
         """Install the payload.
 

--- a/pyanaconda/modules/payloads/payload/payload_base_interface.py
+++ b/pyanaconda/modules/payloads/payload/payload_base_interface.py
@@ -79,59 +79,6 @@ class PayloadBaseInterface(ModuleInterfaceTemplate, metaclass=ABCMeta):
             )
         )
 
-    def IsNetworkRequired(self) -> Bool:
-        """Do the sources require a network?
-
-        :return: True or False
-        """
-        return self.implementation.is_network_required()
-
-    def CalculateRequiredSpace(self) -> UInt64:
-        """Calculate space required for the installation.
-
-        :return: required size in bytes
-        :rtype: int
-        """
-        return self.implementation.calculate_required_space()
-
-    def GetKernelVersionList(self) -> List[Str]:
-        """Get the kernel versions list.
-
-        The kernel version list doesn't have to be available
-        before the payload installation.
-
-        :return: a list of kernel versions
-        :raises UnavailableValueError: if the list is not available
-        """
-        return self.implementation.get_kernel_version_list()
-
-    def PreInstallWithTasks(self) -> List[ObjPath]:
-        """Execute preparation steps.
-
-        FIXME: Temporary -- installation methods will be provided only by the main service
-        """
-        return TaskContainer.to_object_path_list(
-            self.implementation.pre_install_with_tasks()
-        )
-
-    def InstallWithTasks(self) -> List[ObjPath]:
-        """Install the payload.
-
-        FIXME: Temporary -- installation methods will be provided only by the main service
-        """
-        return TaskContainer.to_object_path_list(
-            self.implementation.install_with_tasks()
-        )
-
-    def PostInstallWithTasks(self) -> List[ObjPath]:
-        """Execute post installation steps.
-
-        FIXME: Temporary -- installation methods will be provided only by the main service
-        """
-        return TaskContainer.to_object_path_list(
-            self.implementation.post_install_with_tasks()
-        )
-
     def SetUpSourcesWithTask(self) -> ObjPath:
         """Set up installation sources."""
         return TaskContainer.to_object_path(

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/rpm_ostree.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/rpm_ostree.py
@@ -64,21 +64,13 @@ class RPMOSTreeModule(PayloadBase):
         for source in self.sources:
             source.setup_kickstart(data)
 
-    def pre_install_with_tasks(self):
-        """Execute preparation steps.
-
-        :return: list of tasks
-        """
-        # TODO: Implement this method
-        pass
-
     def install_with_tasks(self):
         """Install the payload.
 
         :return: list of tasks
         """
         # TODO: Implement this method
-        pass
+        return []
 
     def post_install_with_tasks(self):
         """Execute post installation steps.
@@ -86,4 +78,4 @@ class RPMOSTreeModule(PayloadBase):
         :return: list of tasks
         """
         # TODO: Implement this method
-        pass
+        return []

--- a/pyanaconda/modules/payloads/payloads.py
+++ b/pyanaconda/modules/payloads/payloads.py
@@ -142,6 +142,66 @@ class PayloadsService(KickstartService):
         """
         return SourceFactory.create_source(source_type)
 
+    def is_network_required(self):
+        """Do the sources require a network?
+
+        :return: True or False
+        """
+        return bool(self.active_payload) and self.active_payload.is_network_required()
+
+    def calculate_required_space(self):
+        """Calculate space required for the installation.
+
+        :return: required size in bytes
+        :rtype: int
+        """
+        total = 0
+
+        if self.active_payload:
+            total += self.active_payload.calculate_required_space()
+
+        return total
+
+    def get_kernel_version_list(self):
+        """Get the kernel versions list.
+
+        The kernel version list doesn't have to be available
+        before the payload installation.
+
+        :return: a list of kernel versions
+        :raises UnavailableValueError: if the list is not available
+        """
+        kernel_version_list = []
+
+        if self.active_payload:
+            kernel_version_list += self.active_payload.get_kernel_version_list()
+
+        return kernel_version_list
+
+    def install_with_tasks(self):
+        """Return a list of installation tasks.
+
+        :return: list of tasks
+        """
+        tasks = []
+
+        if self.active_payload:
+            tasks += self.active_payload.install_with_tasks()
+
+        return tasks
+
+    def post_install_with_tasks(self):
+        """Return a list of post-installation tasks.
+
+        :return: a list of tasks
+        """
+        tasks = []
+
+        if self.active_payload:
+            tasks += self.active_payload.post_install_with_tasks()
+
+        return tasks
+
     def teardown_with_tasks(self):
         """Returns teardown tasks for this module.
 
@@ -150,6 +210,6 @@ class PayloadsService(KickstartService):
         tasks = []
 
         if self.active_payload:
-            tasks.extend(self.active_payload.tear_down_with_tasks())
+            tasks += self.active_payload.tear_down_with_tasks()
 
         return tasks

--- a/pyanaconda/modules/payloads/payloads_interface.py
+++ b/pyanaconda/modules/payloads/payloads_interface.py
@@ -22,7 +22,8 @@ from dasbus.server.property import emits_properties_changed
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
 from pyanaconda.modules.common.base import KickstartModuleInterface
-from pyanaconda.modules.common.containers import PayloadSourceContainer, PayloadContainer
+from pyanaconda.modules.common.containers import PayloadSourceContainer, PayloadContainer, \
+    TaskContainer
 from pyanaconda.modules.common.constants.services import PAYLOADS
 from pyanaconda.modules.payloads.constants import PayloadType, SourceType
 
@@ -91,4 +92,39 @@ class PayloadsInterface(KickstartModuleInterface):
         """
         return PayloadSourceContainer.to_object_path(
             self.implementation.create_source(SourceType(source_type))
+        )
+
+    def IsNetworkRequired(self) -> Bool:
+        """Do the sources require a network?
+
+        :return: True or False
+        """
+        return self.implementation.is_network_required()
+
+    def CalculateRequiredSpace(self) -> UInt64:
+        """Calculate space required for the installation.
+
+        :return: required size in bytes
+        :rtype: int
+        """
+        return self.implementation.calculate_required_space()
+
+    def GetKernelVersionList(self) -> List[Str]:
+        """Get the kernel versions list.
+
+        The kernel version list doesn't have to be available
+        before the payload installation.
+
+        :return: a list of kernel versions
+        :raises UnavailableValueError: if the list is not available
+        """
+        return self.implementation.get_kernel_version_list()
+
+    def PostInstallWithTasks(self) -> List[ObjPath]:
+        """Return a list of post-installation tasks.
+
+        :return: a list of object paths of installation tasks
+        """
+        return TaskContainer.to_object_path_list(
+            self.implementation.post_install_with_tasks()
         )

--- a/pyanaconda/payload/base.py
+++ b/pyanaconda/payload/base.py
@@ -121,6 +121,7 @@ class Payload(metaclass=ABCMeta):
     ###
     def pre_install(self):
         """Perform pre-installation tasks."""
+        # FIXME: Merge the pre-installation tasks with the installation tasks.
         from pyanaconda.modules.payloads.base.initialization import PrepareSystemForInstallationTask
         PrepareSystemForInstallationTask(conf.target.system_root).run()
 

--- a/pyanaconda/payload/base.py
+++ b/pyanaconda/payload/base.py
@@ -18,8 +18,9 @@
 #
 from abc import ABCMeta, abstractmethod
 
-from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.modules.common.constants.services import PAYLOADS
 
 log = get_module_logger(__name__)
 
@@ -35,7 +36,10 @@ class Payload(metaclass=ABCMeta):
         """
         self.data = data
 
-        # A DBus proxy of the payload.
+        # A DBus proxy of the Payloads service.
+        self._service_proxy = PAYLOADS.get_proxy()
+
+        # A DBus proxy of the active payload.
         self._payload_proxy = None
 
     def set_from_opts(self, opts):
@@ -58,6 +62,14 @@ class Payload(metaclass=ABCMeta):
         :return: a DBus proxy
         """
         return self._payload_proxy
+
+    @property
+    def service_proxy(self):
+        """The DBus proxy of the Payloads service.
+
+        :return: a DBus proxy
+        """
+        return self._service_proxy
 
     def get_source_proxy(self):
         """Get the DBus proxy of the installation source (if any).

--- a/pyanaconda/payload/base.py
+++ b/pyanaconda/payload/base.py
@@ -122,7 +122,7 @@ class Payload(metaclass=ABCMeta):
     def pre_install(self):
         """Perform pre-installation tasks."""
         # FIXME: Merge the pre-installation tasks with the installation tasks.
-        from pyanaconda.modules.payloads.base.initialization import PrepareSystemForInstallationTask
+        from pyanaconda.modules.payloads.installation import PrepareSystemForInstallationTask
         PrepareSystemForInstallationTask(conf.target.system_root).run()
 
     def install(self):
@@ -134,5 +134,5 @@ class Payload(metaclass=ABCMeta):
 
         # write out static config (storage, modprobe, keyboard, ??)
         #   kickstart should handle this before we get here
-        from pyanaconda.modules.payloads.base.initialization import CopyDriverDisksFilesTask
+        from pyanaconda.modules.payloads.installation import CopyDriverDisksFilesTask
         CopyDriverDisksFilesTask(conf.target.system_root).run()

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -235,7 +235,7 @@ class DNFPayload(Payload):
     @property
     def needs_network(self):
         """Test base and additional repositories if they require network."""
-        return (self.proxy.IsNetworkRequired() or
+        return (self.service_proxy.IsNetworkRequired() or
                 any(self._repo_needs_network(repo) for repo in self.data.repo.dataList()))
 
     def _repo_needs_network(self, repo):

--- a/pyanaconda/payload/rpmostreepayload.py
+++ b/pyanaconda/payload/rpmostreepayload.py
@@ -83,7 +83,7 @@ class RPMOSTreePayload(Payload):
     @property
     def needs_network(self):
         """Test ostree repository if it requires network."""
-        return self.proxy.IsNetworkRequired()
+        return self.service_proxy.IsNetworkRequired()
 
     def setup(self):
         """Do any payload-specific setup."""

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/module_payload_base_utils_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/module_payload_base_utils_test.py
@@ -15,57 +15,12 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-import os
-
-from tempfile import TemporaryDirectory
-from textwrap import dedent
 from unittest.case import TestCase
-from unittest.mock import patch
 
-from pyanaconda.modules.payloads.base.utils import create_root_dir, write_module_denylist, \
-    get_dir_size, sort_kernel_version_list
+from pyanaconda.modules.payloads.base.utils import get_dir_size, sort_kernel_version_list
 
 
 class PayloadBaseUtilsTest(TestCase):
-
-    def create_root_test(self):
-        """Test payload create root directory function."""
-        with TemporaryDirectory() as temp:
-            create_root_dir(temp)
-
-            root_dir = os.path.join(temp, "/root")
-
-            self.assertTrue(os.path.isdir(root_dir))
-
-    @patch('pyanaconda.modules.payloads.base.utils.kernel_arguments',
-           {"modprobe.blacklist": "mod1 mod2 nonono_mod"})
-    def write_module_denylist_test(self):
-        """Test write kernel module denylist to the install root."""
-        with TemporaryDirectory() as temp:
-            write_module_denylist(temp)
-
-            denylist_file = os.path.join(temp, "etc/modprobe.d/anaconda-denylist.conf")
-
-            self.assertTrue(os.path.isfile(denylist_file))
-
-            with open(denylist_file, "rt") as f:
-                expected_content = """
-                # Module denylist written by anaconda
-                blacklist mod1
-                blacklist mod2
-                blacklist nonono_mod
-                """
-                self.assertEqual(dedent(expected_content).lstrip(), f.read())
-
-    @patch('pyanaconda.modules.payloads.base.utils.kernel_arguments', {})
-    def write_empty_module_denylist_test(self):
-        """Test write kernel module denylist to the install root -- empty list."""
-        with TemporaryDirectory() as temp:
-            write_module_denylist(temp)
-
-            denylist_file = os.path.join(temp, "etc/modprobe.d/anaconda-denylist.conf")
-
-            self.assertFalse(os.path.isfile(denylist_file))
 
     def get_dir_size_test(self):
         """Test the get_dir_size function."""

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/module_payloads_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/module_payloads_test.py
@@ -27,6 +27,7 @@ from tests.nosetests.pyanaconda_tests.modules.payloads.payload.module_payload_sh
 
 from pyanaconda.core.constants import SOURCE_TYPE_LIVE_OS_IMAGE
 from pyanaconda.modules.common.containers import PayloadContainer
+from pyanaconda.modules.common.errors.general import UnavailableValueError
 from pyanaconda.modules.common.errors.payload import SourceSetupError, SourceTearDownError
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase
@@ -166,6 +167,67 @@ class PayloadsInterfaceTestCase(TestCase):
         """Test creation of the not existing source."""
         with self.assertRaises(ValueError):
             self.payload_interface.CreateSource("NotASource")
+
+    def is_network_required_test(self):
+        """Test the IsNetworkRequired method."""
+        self.assertEqual(self.payload_interface.IsNetworkRequired(), False)
+
+        payload = self.payload_module.create_payload(PayloadType.DNF)
+        self.payload_module.activate_payload(payload)
+
+        self.assertEqual(self.payload_interface.IsNetworkRequired(), False)
+
+        source = self.payload_module.create_source(SourceType.NFS)
+        payload.set_sources([source])
+
+        self.assertEqual(self.payload_interface.IsNetworkRequired(), True)
+
+    def calculate_required_space_test(self):
+        """Test the CalculateRequiredTest method."""
+        self.assertEqual(self.payload_interface.CalculateRequiredSpace(), 0)
+
+        payload = self.payload_module.create_payload(PayloadType.LIVE_IMAGE)
+        self.payload_module.activate_payload(payload)
+
+        self.assertEqual(self.payload_interface.CalculateRequiredSpace(), 0)
+
+        source = self.payload_module.create_source(SourceType.LIVE_IMAGE)
+        payload.set_sources([source])
+
+        self.assertEqual(self.payload_interface.CalculateRequiredSpace(), 1024 * 1024 * 1024)
+
+    def get_kernel_version_list_test(self):
+        """Test the GetKernelVersionList method."""
+        self.assertEqual(self.payload_interface.GetKernelVersionList(), [])
+
+        payload = self.payload_module.create_payload(PayloadType.DNF)
+        self.payload_module.activate_payload(payload)
+
+        with self.assertRaises(UnavailableValueError):
+            self.payload_interface.GetKernelVersionList()
+
+        payload.set_kernel_version_list(["k1", "k2", "k3"])
+        self.assertEqual(self.payload_interface.GetKernelVersionList(), ["k1", "k2", "k3"])
+
+    @patch_dbus_publish_object
+    def install_with_tasks_test(self, publisher):
+        """Test the InstallWithTasks method."""
+        self.assertEqual(self.payload_interface.InstallWithTasks(), [])
+
+        payload = self.payload_module.create_payload(PayloadType.DNF)
+        self.payload_module.activate_payload(payload)
+
+        self.assertEqual(self.payload_interface.InstallWithTasks(), [])
+
+    @patch_dbus_publish_object
+    def post_install_with_tasks_test(self, publisher):
+        """Test the PostInstallWithTasks method."""
+        self.assertEqual(self.payload_interface.PostInstallWithTasks(), [])
+
+        payload = self.payload_module.create_payload(PayloadType.DNF)
+        self.payload_module.activate_payload(payload)
+
+        self.assertEqual(self.payload_interface.PostInstallWithTasks(), [])
 
     @patch_dbus_publish_object
     def tear_down_with_tasks_test(self, publisher):

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_base_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_base_test.py
@@ -23,7 +23,6 @@
 import unittest
 from unittest.mock import patch
 
-from pyanaconda.modules.common.errors.general import UnavailableValueError
 from pyanaconda.modules.payloads.base.initialization import SetUpSourcesTask, TearDownSourcesTask
 from pyanaconda.modules.payloads.source.factory import SourceFactory
 from pyanaconda.modules.common.errors.payload import IncompatibleSourceError, SourceSetupError
@@ -159,31 +158,6 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         self.shared_tests.set_and_check_sources([source1])
 
     @patch_dbus_publish_object
-    def is_network_required_test(self, publisher):
-        """Test IsNetworkRequired."""
-        self.assertEqual(self.interface.IsNetworkRequired(), False)
-
-        source1 = self.shared_tests.prepare_source(SourceType.CDROM, state=SourceState.UNREADY)
-        self.shared_tests.set_sources([source1])
-
-        self.assertEqual(self.interface.IsNetworkRequired(), False)
-
-        source2 = self.shared_tests.prepare_source(SourceType.NFS, state=SourceState.UNREADY)
-        self.shared_tests.set_sources([source1, source2])
-
-        self.assertEqual(self.interface.IsNetworkRequired(), True)
-
-    @patch_dbus_publish_object
-    def calculate_required_space_test(self, publisher):
-        """Test CalculateRequiredTest."""
-        self.assertEqual(self.interface.CalculateRequiredSpace(), 0)
-
-        source1 = self.shared_tests.prepare_source(SourceType.CDROM, state=SourceState.UNREADY)
-        self.shared_tests.set_sources([source1])
-
-        self.assertEqual(self.interface.CalculateRequiredSpace(), 0)
-
-    @patch_dbus_publish_object
     def set_up_sources_with_task_test(self, publisher):
         """Test SetUpSourcesWithTask."""
         source = SourceFactory.create_source(SourceType.CDROM)
@@ -202,11 +176,3 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         task_path = self.interface.TearDownSourcesWithTask()
         obj = check_task_creation(self, task_path, publisher, TearDownSourcesTask)
         self.assertEqual(obj.implementation._sources, [source])
-
-    def get_kernel_version_list_test(self):
-        """Test GetKernelVersionList."""
-        with self.assertRaises(UnavailableValueError):
-            self.interface.GetKernelVersionList()
-
-        self.module.set_kernel_version_list(["k1", "k2", "k3"])
-        self.assertEqual(self.interface.GetKernelVersionList(), ["k1", "k2", "k3"])

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_test.py
@@ -30,7 +30,7 @@ from pyanaconda.core.kickstart.specification import KickstartSpecificationHandle
 from pyanaconda.modules.common.constants.interfaces import PAYLOAD_DNF
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData, \
     PackagesConfigurationData
-from pyanaconda.modules.payloads.constants import PayloadType, SourceType
+from pyanaconda.modules.payloads.constants import PayloadType, SourceType, SourceState
 from pyanaconda.modules.payloads.kickstart import PayloadKickstartSpecification
 from pyanaconda.modules.payloads.payload.dnf.dnf import DNFModule
 from pyanaconda.modules.payloads.payload.dnf.dnf_interface import DNFInterface
@@ -554,3 +554,27 @@ class DNFInterfaceTestCase(unittest.TestCase):
         }]
 
         self.assertEqual(self.interface.GetRepoConfigurations(), expected)
+
+
+class DNFModuleTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.module = DNFModule()
+
+    def _create_source(self, source_type, state=SourceState.UNREADY):
+        """Create a new source with a mocked state."""
+        return PayloadSharedTest.prepare_source(source_type, state)
+
+    def is_network_required_test(self):
+        """Test the is_network_required method."""
+        self.assertEqual(self.module.is_network_required(), False)
+
+        source1 = self._create_source(SourceType.CDROM)
+        self.module.set_sources([source1])
+
+        self.assertEqual(self.module.is_network_required(), False)
+
+        source2 = self._create_source(SourceType.NFS)
+        self.module.set_sources([source1, source2])
+
+        self.assertEqual(self.module.is_network_required(), True)

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_live_image_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_live_image_test.py
@@ -111,37 +111,39 @@ class LiveImageInterfaceTestCase(unittest.TestCase):
     def type_test(self):
         self.shared_tests.check_type(PayloadType.LIVE_IMAGE)
 
+
+class LiveImageModuleTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.module = LiveImageModule()
+
     def calculate_required_space_test(self):
-        """Test CalculateRequiredTest."""
-        self.assertEqual(self.live_image_interface.CalculateRequiredSpace(), 0)
+        """Test the calculate_required_space method."""
+        self.assertEqual(self.module.calculate_required_space(), 0)
 
         source = SourceFactory.create_source(SourceType.LIVE_IMAGE)
-        self.live_image_module.add_source(source)
+        self.module.add_source(source)
 
-        self.assertEqual(self.live_image_interface.CalculateRequiredSpace(), 1024 * 1024 * 1024)
+        self.assertEqual(self.module.calculate_required_space(), 1024 * 1024 * 1024)
 
-    # TODO: Add set_source and supported_sources like in Live OS payload when source is available
-
-    @patch_dbus_publish_object
-    def prepare_system_for_installation_task_test(self, publisher):
-        """Test Live Image is able to create a prepare installation task."""
+    def install_with_task_from_tar_test(self):
+        """Test Live Image install with tasks from tarfile."""
         # task_path = self.live_image_interface.PreInstallWithTasks()
         # check_task_creation_list(self, task_path, publisher, [SetupInstallationSourceImageTask])
-        self.assertEqual(self.live_image_interface.PreInstallWithTasks(), [])
 
-    @patch_dbus_publish_object
-    def install_with_task_from_tar_test(self, publisher):
-        """Test Live Image install with tasks from tarfile."""
         # task_path = self.live_image_interface.InstallWithTasks()
         # check_task_creation_list(self, task_path, publisher, [InstallFromTarTask])
-        self.assertEqual(self.live_image_interface.InstallWithTasks(), [])
+        self.assertEqual(self.module.install_with_tasks(), [])
 
     @patch_dbus_publish_object
     def install_with_task_from_image_test(self, publisher):
         """Test Live Image install with tasks from image."""
+        # task_path = self.live_image_interface.PreInstallWithTasks()
+        # check_task_creation_list(self, task_path, publisher, [SetupInstallationSourceImageTask])
+
         # task_path = self.live_image_interface.InstallWithTasks()
         # check_task_creation_list(self, task_path, publisher, [InstallFromImageTask])
-        self.assertEqual(self.live_image_interface.InstallWithTasks(), [])
+        self.assertEqual(self.module.install_with_tasks(), [])
 
     @patch_dbus_publish_object
     def post_install_with_tasks_test(self, publisher):
@@ -164,4 +166,4 @@ class LiveImageInterfaceTestCase(unittest.TestCase):
         #     self.assertEqual(object_path, task_paths[i])
         #     self.assertIsInstance(obj, TaskInterface)
         #     self.assertIsInstance(obj.implementation, task_classes[i])
-        self.assertEqual(self.live_image_interface.PostInstallWithTasks(), [])
+        self.assertEqual(self.module.post_install_with_tasks(), [])

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_live_image_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_live_image_test.py
@@ -149,7 +149,6 @@ class LiveImageModuleTestCase(unittest.TestCase):
     def post_install_with_tasks_test(self, publisher):
         """Test Live Image post installation configuration task."""
         # task_classes = [
-        #     CopyDriverDisksFilesTask,
         #     TeardownInstallationSourceImageTask
         # ]
         #

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_live_os_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_live_os_test.py
@@ -27,8 +27,7 @@ from tests.nosetests.pyanaconda_tests.modules.payloads.payload.module_payload_sh
 from pyanaconda.core.constants import SOURCE_TYPE_LIVE_OS_IMAGE
 from pyanaconda.modules.common.errors.payload import SourceSetupError, IncompatibleSourceError
 from pyanaconda.modules.payloads.constants import SourceType, PayloadType, SourceState
-from pyanaconda.modules.payloads.base.initialization import PrepareSystemForInstallationTask, \
-    CopyDriverDisksFilesTask, SetUpSourcesTask, TearDownSourcesTask
+from pyanaconda.modules.payloads.base.initialization import SetUpSourcesTask, TearDownSourcesTask
 from pyanaconda.modules.payloads.base.installation import InstallFromImageTask
 from pyanaconda.modules.payloads.payload.live_os.live_os import LiveOSModule
 from pyanaconda.modules.payloads.payload.live_os.live_os_interface import LiveOSInterface
@@ -136,9 +135,8 @@ class LiveOSModuleTestCase(unittest.TestCase):
         self.module.set_sources([source])
 
         tasks = self.module.install_with_tasks()
-        self.assertEqual(len(tasks), 2)
-        self.assertIsInstance(tasks[0], PrepareSystemForInstallationTask)
-        self.assertIsInstance(tasks[1], InstallFromImageTask)
+        self.assertEqual(len(tasks), 1)
+        self.assertIsInstance(tasks[0], InstallFromImageTask)
 
     def install_with_task_no_source_test(self):
         """Test Live OS install with tasks with no source fail."""
@@ -148,5 +146,4 @@ class LiveOSModuleTestCase(unittest.TestCase):
     def post_install_with_tasks_test(self):
         """Test Live OS post installation configuration task."""
         tasks = self.module.post_install_with_tasks()
-        self.assertEqual(len(tasks), 1)
-        self.assertIsInstance(tasks[0], CopyDriverDisksFilesTask)
+        self.assertEqual(len(tasks), 0)


### PR DESCRIPTION
Move some methods from the payload modules to the main service.
Drop the support for the pre-installation tasks.

Some of the installation tasks don't depend on the type of the payload
module, so include them by default on the service-level.