### PR TITLE
change the grub2 user.cfg permission from 0700 to 0600

### DIFF
--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -310,7 +310,7 @@ class GRUB2(BootLoader):
             return
 
         users_file = "%s%s/%s" % (conf.target.system_root, self.config_dir, self._passwd_file)
-        header = util.open_with_perm(users_file, "w", 0o700)
+        header = util.open_with_perm(users_file, "w", 0o600)
         # XXX FIXME: document somewhere that the username is "root"
         self._encrypt_password()
         password_line = "GRUB2_PASSWORD=" + self.encrypted_password


### PR DESCRIPTION
The file user. cfg permission set in the grub2-set-password script is 0600, and Anaconda should be consistent with GRUB2

the grub2-set-password script:

    # on the ESP, these will fail to set the permissions, but it's okay because
    # the directory is protected.
    install -m 0600 /dev/null "${OUTPUT_PATH}/user.cfg" 2>/dev/null || :
    chmod 0600 "${OUTPUT_PATH}/user.cfg" 2>/dev/null || :
    echo "GRUB2_PASSWORD=${MYPASS}" > "${OUTPUT_PATH}/user.cfg"`