### PR TITLE
Introduce the PayloadInstallationError exception

### DIFF
--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -19,7 +19,7 @@
 from pyanaconda.core.i18n import _, C_
 from pyanaconda.flags import flags
 from pyanaconda.modules.common.errors.installation import BootloaderInstallationError, \
-    StorageInstallationError, NonCriticalInstallationError
+    StorageInstallationError, NonCriticalInstallationError, PayloadInstallationError
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.errors.storage import UnusableStorageError
 from pyanaconda.payload.errors import PayloadInstallError, DependencyError, PayloadSetupError
@@ -109,6 +109,7 @@ class ErrorHandler(object):
 
             # Payload DBus errors
             SourceSetupError.__name__: self._payload_setup_handler,
+            PayloadInstallationError.__name__: self._payload_install_handler,
 
             # General installation errors.
             NonCriticalInstallationError.__name__: self._non_critical_error_handler,

--- a/pyanaconda/modules/common/errors/installation.py
+++ b/pyanaconda/modules/common/errors/installation.py
@@ -81,6 +81,12 @@ class StorageInstallationError(InstallationError):
     pass
 
 
+@dbus_error("PayloadInstallationError", namespace=ANACONDA_NAMESPACE)
+class PayloadInstallationError(InstallationError):
+    """Exception for the payload installation errors."""
+    pass
+
+
 @dbus_error("InsightsClientMissingError", namespace=ANACONDA_NAMESPACE)
 class InsightsClientMissingError(InstallationError):
     """Exception for missing Red Hat Insights utility."""

--- a/pyanaconda/modules/common/errors/payload.py
+++ b/pyanaconda/modules/common/errors/payload.py
@@ -42,9 +42,3 @@ class SourceTearDownError(AnacondaError):
 class IncompatibleSourceError(AnacondaError):
     """Error raised when payload does not support given source."""
     pass
-
-
-@dbus_error("InstallError", namespace=PAYLOADS_NAMESPACE)
-class InstallError(AnacondaError):
-    """Error raised during payload installation."""
-    pass

--- a/pyanaconda/modules/payloads/base/installation.py
+++ b/pyanaconda/modules/payloads/base/installation.py
@@ -16,7 +16,7 @@
 # Red Hat, Inc.
 #
 from pyanaconda.modules.common.task import Task
-from pyanaconda.modules.common.errors.payload import InstallError
+from pyanaconda.modules.common.errors.installation import PayloadInstallationError
 from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.core.util import execWithRedirect
 
@@ -46,7 +46,7 @@ class InstallFromImageTask(Task):
         # TODO: remove this check for None when Live Image payload will support sources
         # The None check is just a temporary hack that Live OS has source but Live Image don't
         if self._source is not None and not self._source.get_state():
-            raise InstallError("Source is not set up!")
+            raise PayloadInstallationError("Source is not set up!")
 
         cmd = "rsync"
         # preserve: permissions, owners, groups, ACL's, xattrs, times,
@@ -70,4 +70,4 @@ class InstallFromImageTask(Task):
             log.info(msg)
 
         if err or rc == 11:
-            raise InstallError(err or msg)
+            raise PayloadInstallationError(err or msg)

--- a/pyanaconda/modules/payloads/payload/live_image/installation.py
+++ b/pyanaconda/modules/payloads/payload/live_image/installation.py
@@ -16,7 +16,7 @@
 # Red Hat, Inc.
 #
 from pyanaconda.modules.common.task import Task
-from pyanaconda.modules.common.errors.payload import InstallError
+from pyanaconda.modules.common.errors.installation import PayloadInstallationError
 from pyanaconda.core.util import execWithRedirect
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -56,4 +56,4 @@ class InstallFromTarTask(Task):
             log.info(msg)
 
         if err:
-            raise InstallError(err or msg)
+            raise PayloadInstallationError(err or msg)

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_installation.py
@@ -16,8 +16,9 @@
 # Red Hat, Inc.
 #
 from pyanaconda.core.i18n import _
+from pyanaconda.modules.common.errors.installation import PayloadInstallationError
 from pyanaconda.modules.common.task import Task
-from pyanaconda.payload.errors import PayloadInstallError, FlatpakInstallError
+from pyanaconda.payload.errors import FlatpakInstallError
 from pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_manager import FlatpakManager
 
 
@@ -47,7 +48,7 @@ class InstallFlatpaksTask(Task):
         try:
             flatpak_manager.install_all()
         except FlatpakInstallError as e:
-            raise PayloadInstallError("Failed to install flatpaks: {}".format(e)) from e
+            raise PayloadInstallationError("Failed to install flatpaks: {}".format(e)) from e
 
         self.report_progress(_("Post-installation flatpak tasks"))
 

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_installation.py
@@ -16,10 +16,10 @@
 # Red Hat, Inc.
 #
 from pyanaconda.core.i18n import _
-from pyanaconda.modules.common.errors.installation import PayloadInstallationError
 from pyanaconda.modules.common.task import Task
-from pyanaconda.payload.errors import FlatpakInstallError
 from pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_manager import FlatpakManager
+
+__all__ = ["InstallFlatpaksTask"]
 
 
 class InstallFlatpaksTask(Task):
@@ -39,19 +39,13 @@ class InstallFlatpaksTask(Task):
 
     def run(self):
         self.report_progress(_("Starting Flatpak installation"))
-
         flatpak_manager = FlatpakManager(self._sysroot)
 
         # Initialize new repo on the installed system
         flatpak_manager.initialize_with_system_path()
-
-        try:
-            flatpak_manager.install_all()
-        except FlatpakInstallError as e:
-            raise PayloadInstallationError("Failed to install flatpaks: {}".format(e)) from e
+        flatpak_manager.install_all()
 
         self.report_progress(_("Post-installation flatpak tasks"))
-
         flatpak_manager.add_remote("fedora", "oci+https://registry.fedoraproject.org")
         flatpak_manager.replace_installed_refs_remote("fedora")
         flatpak_manager.remove_remote(FlatpakManager.LOCAL_REMOTE_NAME)

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_manager.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_manager.py
@@ -26,8 +26,8 @@ from abc import ABC, abstractmethod
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
 from pyanaconda.core.glib import GError, VariantType, Variant, Bytes
+from pyanaconda.modules.common.errors.installation import PayloadInstallationError
 from pyanaconda.progress import progressQ
-from pyanaconda.payload.errors import FlatpakInstallError
 
 gi.require_version("Flatpak", "1.0")
 gi.require_version("Gio", "2.0")
@@ -175,8 +175,8 @@ class FlatpakManager(object):
 
         try:
             self._transaction.run()
-        except GError as exn:
-            raise FlatpakInstallError(str(exn)) from exn
+        except GError as e:
+            raise PayloadInstallationError("Failed to install flatpaks: {}".format(e)) from e
 
     def _stuff_refs_to_transaction(self):
         for ref in self._remote_refs_list.get_refs_full_format():

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -20,12 +20,12 @@ import blivet.util
 
 from subprocess import CalledProcessError
 
-from pyanaconda.payload.errors import PayloadInstallError
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.glib import format_size_full, create_new_context, Variant, GError
 from pyanaconda.core.i18n import _
 from pyanaconda.core.util import execWithRedirect, mkdirChain, set_system_root
+from pyanaconda.modules.common.errors.installation import PayloadInstallationError
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE, BOOTLOADER
 from pyanaconda.modules.common.constants.services import STORAGE
@@ -43,11 +43,11 @@ log = get_module_logger(__name__)
 def safe_exec_with_redirect(cmd, argv, **kwargs):
     """Like util.execWithRedirect, but treat errors as fatal.
 
-    :raise: PayloadInstallError if the call fails for any reason
+    :raise: PayloadInstallationError if the call fails for any reason
     """
     rc = execWithRedirect(cmd, argv, **kwargs)
     if rc != 0:
-        raise PayloadInstallError("{} {} exited with code {}".format(cmd, argv, rc))
+        raise PayloadInstallationError("{} {} exited with code {}".format(cmd, argv, rc))
 
 
 class PrepareOSTreeMountTargetsTask(Task):
@@ -231,12 +231,12 @@ class CopyBootloaderDataTask(Task):
     def run(self):
         """Run the installation task.
 
-        :raise PayloadInstallError: if the installation fails
+        :raise PayloadInstallationError: if the installation fails
         """
         try:
             self._run()
         except (OSError, RuntimeError) as e:
-            raise PayloadInstallError("Failed to copy bootloader data: {}".format(e)) from e
+            raise PayloadInstallationError("Failed to copy bootloader data: {}".format(e)) from e
 
     def _run(self):
         """Copy bootloader data files from the deployment checkout to the target root.
@@ -460,7 +460,7 @@ class PullRemoteAndDeleteTask(Task):
 
         All pulls in our code follow the pattern pull + delete.
 
-        :raise: PayloadInstallError if the pull fails
+        :raise: PayloadInstallationError if the pull fails
         """
         # pull requires this for some reason
         mainctx = create_new_context()
@@ -504,7 +504,7 @@ class PullRemoteAndDeleteTask(Task):
                                    Variant('a{sv}', pull_opts),
                                    progress, cancellable)
         except GError as e:
-            raise PayloadInstallError("Failed to pull from repository: %s" % e) from e
+            raise PayloadInstallationError("Failed to pull from repository: %s" % e) from e
 
         log.info("ostree pull: %s", progress.get_status() or "")
         self.report_progress(_("Preparing deployment of {}").format(ref))

--- a/pyanaconda/payload/errors.py
+++ b/pyanaconda/payload/errors.py
@@ -47,7 +47,3 @@ class DependencyError(PayloadError):
 # installation
 class PayloadInstallError(PayloadError):
     pass
-
-
-class FlatpakInstallError(PayloadError):
-    pass

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_live_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_live_test.py
@@ -25,7 +25,7 @@ from tempfile import TemporaryDirectory
 
 from pyanaconda.core.constants import INSTALL_TREE
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.modules.common.errors.payload import InstallError
+from pyanaconda.modules.common.errors.installation import PayloadInstallationError
 from pyanaconda.modules.payloads.base.installation import InstallFromImageTask
 from pyanaconda.modules.payloads.payload.live_os.utils import get_kernel_version_list
 
@@ -118,7 +118,7 @@ class LiveTasksTestCase(unittest.TestCase):
         exec_with_redirect.side_effect = OSError("mock exception")
 
         with self.assertLogs(level="ERROR") as cm:
-            with self.assertRaises(InstallError):
+            with self.assertRaises(PayloadInstallationError):
                 InstallFromImageTask(dest_path, source).run()
 
             self.assertTrue(any(map(lambda x: "mock exception" in x, cm.output)))
@@ -139,7 +139,7 @@ class LiveTasksTestCase(unittest.TestCase):
         exec_with_redirect.return_value = 11
 
         with self.assertLogs(level="INFO") as cm:
-            with self.assertRaises(InstallError):
+            with self.assertRaises(PayloadInstallationError):
                 InstallFromImageTask(dest_path, source).run()
 
             self.assertTrue(any(map(lambda x: "exited with code 11" in x, cm.output)))

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/rpm_ostree_flatpak_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/rpm_ostree_flatpak_test.py
@@ -20,7 +20,6 @@ from unittest.mock import patch
 from tempfile import TemporaryDirectory
 
 from pyanaconda.modules.common.errors.installation import PayloadInstallationError
-from pyanaconda.payload.errors import FlatpakInstallError
 from pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_installation import \
     InstallFlatpaksTask
 
@@ -43,7 +42,7 @@ class InstallFlatpakTaskTest(unittest.TestCase):
     def run_failure_test(self, fm_mock):
         """Test InstallFlatpakTask.run failure"""
         fm_instance = fm_mock.return_value
-        fm_instance.install_all.side_effect = FlatpakInstallError
+        fm_instance.install_all.side_effect = PayloadInstallationError
 
         with TemporaryDirectory() as temp:
             with self.assertRaises(PayloadInstallationError):

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/rpm_ostree_flatpak_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/rpm_ostree_flatpak_test.py
@@ -19,7 +19,8 @@ import unittest
 from unittest.mock import patch
 from tempfile import TemporaryDirectory
 
-from pyanaconda.payload.errors import PayloadInstallError, FlatpakInstallError
+from pyanaconda.modules.common.errors.installation import PayloadInstallationError
+from pyanaconda.payload.errors import FlatpakInstallError
 from pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_installation import \
     InstallFlatpaksTask
 
@@ -45,6 +46,6 @@ class InstallFlatpakTaskTest(unittest.TestCase):
         fm_instance.install_all.side_effect = FlatpakInstallError
 
         with TemporaryDirectory() as temp:
-            with self.assertRaises(PayloadInstallError):
+            with self.assertRaises(PayloadInstallationError):
                 task = InstallFlatpaksTask(temp)
                 task.run()

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/rpm_ostree_tasks_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/rpm_ostree_tasks_test.py
@@ -22,9 +22,8 @@ import unittest
 from unittest.mock import patch, call, MagicMock
 
 from pyanaconda.core.glib import Variant, GError
+from pyanaconda.modules.common.errors.installation import PayloadInstallationError
 from pyanaconda.modules.common.structures.rpm_ostree import RPMOSTreeConfigurationData
-from pyanaconda.payload.errors import PayloadInstallError
-
 from pyanaconda.modules.payloads.payload.rpm_ostree.installation import \
     PrepareOSTreeMountTargetsTask, CopyBootloaderDataTask, InitOSTreeFsAndRepoTask, \
     ChangeOSTreeRemoteTask, ConfigureBootloader, DeployOSTreeTask, PullRemoteAndDeleteTask, \
@@ -263,7 +262,7 @@ class CopyBootloaderDataTaskTestCase(unittest.TestCase):
 
         task = CopyBootloaderDataTask("/sysroot", "/physroot")
 
-        with self.assertRaises(PayloadInstallError) as cm:
+        with self.assertRaises(PayloadInstallationError) as cm:
             task.run()
 
         self.assertEqual(str(cm.exception), "Failed to copy bootloader data: Fake!")
@@ -594,7 +593,7 @@ class PullRemoteAndDeleteTaskTestCase(unittest.TestCase):
         repo_mock.pull_with_options.side_effect = [GError("blah")]
 
         with patch.object(PullRemoteAndDeleteTask, "report_progress") as progress_mock:
-            with self.assertRaises(PayloadInstallError) as ex:
+            with self.assertRaises(PayloadInstallationError) as ex:
                 task = PullRemoteAndDeleteTask(data)
                 task.run()
 


### PR DESCRIPTION
Replace exceptions raised from installation tasks of the Payloads
module with the `PayloadInstallationError` exception.