### PR TITLE
Fix unknown error when entering wrong NFS URL address

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1192,6 +1192,10 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
                 else:
                     return _("Remote directory is required")
 
+            if ":" not in url_string or len(url_string.split(":")) != 2:
+                return _("NFS server must be specified as \"SERVER:/PATH\". "
+                         "Only one colon is allowed in the url string.")
+
         return InputCheck.CHECK_OK
 
     def _check_url_entry(self, inputcheck):


### PR DESCRIPTION
enables anaconda to recognize the error when inputting the wrong NFS URL address in GUI instead of throwing an unknown error