### PR TITLE
Remove container refresh workaround for ELN

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -35,33 +35,6 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      # FIXME: Remove when crun 0.18 will be available by default, see issue https://github.com/containers/podman/issues/9442
-      - name: Install newest crun from source (workaround for ELN)
-        if: matrix.container-tag == 'eln'
-        run: |
-          set -eux
-          echo "Currently installed crun version:"
-          crun --version
-
-          echo "Build newer crun version:"
-          git clone https://github.com/containers/crun.git
-          sudo apt-get install -y make git gcc build-essential pkgconf libtool \
-              libsystemd-dev libcap-dev libseccomp-dev libyajl-dev \
-              go-md2man libtool autoconf python3 automake
-          cd crun
-          git checkout 0.18
-          ./autogen.sh
-          ./configure --prefix=/usr/
-          make
-          sudo make install
-
-          # remove crun folder because otherwise pylint will start the check there
-          cd ..
-          rm -rf crun
-
-          echo "New crun version:"
-          crun --version
-
       - name: Build anaconda-${{ matrix.container-type }} container
         run: |
           BASE_CONTAINER=${{ matrix.base-container }}


### PR DESCRIPTION
They updated runners day before I merged this PR. So let's remove this, sight :(.

Unfortunately, not all runners have the new version but I don't think we want to solve that on our side. Just wait until they will update everything.