### PR TITLE
Drop python3-syspurpose dependency

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -114,7 +114,6 @@ Requires: python3-productmd
 Requires: python3-dasbus >= %{dasbusver}
 Requires: flatpak-libs
 %if 0%{?rhel}
-Requires: python3-syspurpose
 Requires: subscription-manager >= %{subscriptionmanagerver}
 %endif
 


### PR DESCRIPTION
The standalone syspurpose CLI utility has been deprecated in favor of
system purpose Dbus API in RHSM and the python3-syspurpose package is
getting dropped.

While the Anaconda subscription module is not yet fully ported to use
the system purpose DBus API, it should still safely survive the missing
syspurpose utility in all the relevant situations, until the porting has
been completed.

And we can't really wait for the porting to be completed as we are already
seeing breakage in Initial Setup builds due to Anaconda depending on the missing
python3-syspurpose package in ELN.