### PR TITLE
Add ParseOrganizationData runtime DBus task

### DIFF
--- a/pyanaconda/modules/common/structures/subscription.py
+++ b/pyanaconda/modules/common/structures/subscription.py
@@ -535,3 +535,59 @@ class AttachedSubscription(DBusData):
     @consumed_entitlement_count.setter
     def consumed_entitlement_count(self, consumed_entitlement_count: Int):
         self._consumed_entitlement_count = consumed_entitlement_count
+
+
+class OrganizationData(DBusData):
+    """Data about a single organization in the Red Hat account system.
+
+    A Red Hat account is expected to be member of an organization,
+    with some accounts being members of more than one organization.
+    """
+
+    def __init__(self):
+        self._organization_id = ""
+        self._name = ""
+        self._simple_content_access_enabled = ""
+
+    @property
+    def organization_id(self) -> Str:
+        """Id of the organization.
+
+        Example: "abc123efg456"
+
+        :return: organization id
+        :rtype: str
+        """
+        return self._organization_id
+
+    @organization_id.setter
+    def organization_id(self, organization_id: Str):
+        self._organization_id = organization_id
+
+    @property
+    def name(self) -> Str:
+        """Name of the organization.
+
+        Example: "Foo Organization"
+
+        :return: organization name
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name: Str):
+        self._name = name
+
+    @property
+    def simple_content_access_enabled(self) -> Bool:
+        """Is Simple Content Access is enabled for this organization ?
+
+        :return: if Simple Content Access is enabled
+        :rtype: bool
+        """
+        return self._simple_content_access_enabled
+
+    @simple_content_access_enabled.setter
+    def simple_content_access_enabled(self, enabled: Str):
+        self._simple_content_access_enabled = enabled

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -50,7 +50,7 @@ from pyanaconda.modules.subscription.initialization import StartRHSMTask
 from pyanaconda.modules.subscription.runtime import SetRHSMConfigurationTask, \
     RegisterWithUsernamePasswordTask, RegisterWithOrganizationKeyTask, \
     UnregisterTask, AttachSubscriptionTask, SystemPurposeConfigurationTask, \
-    ParseAttachedSubscriptionsTask
+    ParseAttachedSubscriptionsTask, ParseOrganizationDataTask
 from pyanaconda.modules.subscription.rhsm_observer import RHSMObserver
 
 
@@ -722,6 +722,26 @@ class SubscriptionService(KickstartService):
         task.succeeded_signal.connect(
             lambda: self._set_system_subscription_data(task.get_result())
         )
+        return task
+
+    def parse_organization_data_with_task(self):
+        """Parse organization data with task.
+
+        Parse data about organizations the currently used Red Hat account is a member of.
+        This data is available as JSON strings via the RHSM DBus API.
+
+        :return: a DBus path of a runtime task
+        """
+
+        # NOTE: we access self._subscription_request directly
+        #       to avoid the sensitive data clearing happening
+        #       in the subscription_request property getter
+        username = self._subscription_request.account_username
+        password = self._subscription_request.account_password.value
+        register_server_proxy = self.rhsm_observer.get_proxy(RHSM_REGISTER_SERVER)
+        task = ParseOrganizationDataTask(rhsm_register_server_proxy=register_server_proxy,
+                                         username=username,
+                                         password=password)
         return task
 
     def collect_requirements(self):

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -20,11 +20,30 @@
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.modules.common.structures.subscription import SystemPurposeData, \
-    SubscriptionRequest, AttachedSubscription
+    SubscriptionRequest, AttachedSubscription, OrganizationData
 from pyanaconda.modules.common.containers import TaskContainer
-from dasbus.server.interface import dbus_interface
+from pyanaconda.modules.common.task import TaskInterface
+from dasbus.server.interface import dbus_interface, dbus_class
 from dasbus.server.property import emits_properties_changed
 from dasbus.typing import *  # pylint: disable=wildcard-import
+
+
+@dbus_class
+class ParseOrganizationDataTaskInterface(TaskInterface):
+    """The interface for a organization data parsing task
+
+    Such a task returns a list of organization data objects.
+    """
+    @staticmethod
+    def convert_result(values) -> Variant:
+        """Convert the list of org data DBus structs.
+
+        Convert list of org data DBus structs to variant.
+
+        :param value: a validation report
+        :return: a variant with the structure
+        """
+        return get_variant(List[Structure], OrganizationData.to_structure_list(values))
 
 
 @dbus_interface(SUBSCRIPTION.interface_name)
@@ -201,4 +220,13 @@ class SubscriptionInterface(KickstartModuleInterface):
         """
         return TaskContainer.to_object_path(
             self.implementation.parse_attached_subscriptions_with_task()
+        )
+
+    def ParseOrganizationDataWithTask(self) -> ObjPath:
+        """Parse organization data using a runtime DBus task.
+
+        :return: a DBus path of an installation task
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.parse_organization_data_with_task()
         )


### PR DESCRIPTION
Add a new runtime DBus task that can query information about the
organizations of a Red Hat account.

Integrate the task with the runtime subscription logic to skip auto-attach if the current organization appears to be in the SCA mode.

~TODO:~
- ~task integration~
- ~unit tests for task integrationa~

Test coverage is in place and manual testing in VM on RHEL 8.4 indicates the change works correctly under real circumstances as well.