### PR TITLE
Remove crun version abort for container refresh workflow

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -55,6 +55,10 @@ jobs:
           make
           sudo make install
 
+          # remove crun folder because otherwise pylint will start the check there
+          cd ..
+          rm -rf crun
+
           echo "New crun version:"
           crun --version
 

--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   refresh-containers:
     name: Refresh anaconda containers
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # we need to have matrix to cover all branches because schedule is run only on default branch
     # we can add here fedora branches (e.g. f33-devel) to cover their support when needed
     strategy:
@@ -42,11 +42,6 @@ jobs:
           set -eux
           echo "Currently installed crun version:"
           crun --version
-
-          # abort this step if crun was updated already on the host
-          CRUN_VERSION=$(crun --version | grep "^crun version 0.17")
-          echo "$CRUN_VERSION"
-          [ -z "$CRUN_VERSION" ] && exit 17
 
           echo "Build newer crun version:"
           git clone https://github.com/containers/crun.git


### PR DESCRIPTION
This abort logic works great, however, GitHub runners are not updated immediately. That means that this check will abort the workflow for some runners but and the others will work.

Lets remove this and just remove the workaround as whole when we see that the old runners are not available anymore.

Also switch to ubuntu explicit version because latest tag depends on runner you will get. It could be 18.04 or 20.04 based on documentation.

Test run is [here](https://github.com/Test-anaconda-org/anaconda/actions/runs/625003188). 