### PR TITLE
network: remove unneeded line wrap

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.glade
+++ b/pyanaconda/ui/gui/spokes/network.glade
@@ -418,8 +418,7 @@
                   <object class="GtkLabel" id="networkNeedLabel1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">We'll need network access to fetch information about your location and to make software
-updates available for you.</property>
+                    <property name="label" translatable="yes">We'll need network access to fetch information about your location and to make software updates available for you.</property>
                     <attributes>
                       <attribute name="font-desc" value="Cantarell 12"/>
                     </attributes>


### PR DESCRIPTION
The offending line has a line wrap that has no impact in the UI itself, but it raises questions for the translator (e.g. whether this should be 80-char limited line, and where to break the line), resulting in slowing down translation expending little extra-time to investigate a single string.  Besides, there is another big label text a few lines below not wrapped.