### PR TITLE
Do not create a flat file /etc/resolv.conf during installation

### DIFF
--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -230,7 +230,7 @@ def copy_resolv_conf_to_root(root="/"):
     dst_dir = os.path.dirname(dst)
     if not os.path.isdir(dst_dir):
         util.mkdirChain(dst_dir)
-    shutil.copyfile(src, dst)
+    shutil.copyfile(src, dst, follow_symlinks=False)
 
 
 def run_network_initialization_task(task_path):


### PR DESCRIPTION
We want a symlink, as in the live image, not a file with static contents
which will get out of date. (Right now, /mnt/sysroot/etc/resolv.conf during
installation from live image has:
```
  # This is /run/systemd/resolve/stub-resolv.conf managed by man:systemd-resolved(8).
  # Do not edit.
```
which is not suitable for being stored permanently in a config file in /etc.)

https://bugzilla.redhat.com/show_bug.cgi?id=1933454