### PR TITLE
Handle the module command in the Payloads module

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -321,7 +321,6 @@ class AnacondaKickstartSpecification(KickstartSpecification):
         "autostep": COMMANDS.AutoStep,
         "cmdline": COMMANDS.DisplayMode,
         "driverdisk": COMMANDS.DriverDisk,
-        "module": COMMANDS.Module,
         "eula": COMMANDS.Eula,
         "graphical": COMMANDS.DisplayMode,
         "halt": COMMANDS.Reboot,
@@ -342,7 +341,6 @@ class AnacondaKickstartSpecification(KickstartSpecification):
 
     commands_data = {
         "DriverDiskData": COMMANDS.DriverDiskData,
-        "ModuleData": COMMANDS.ModuleData,
         "RepoData": RepoData,
         "SshPwData": COMMANDS.SshPwData,
     }

--- a/pyanaconda/modules/common/structures/packages.py
+++ b/pyanaconda/modules/common/structures/packages.py
@@ -38,6 +38,8 @@ class PackagesSelectionData(DBusData):
         self._excluded_groups = []
         self._packages = []
         self._excluded_packages = []
+        self._modules = []
+        self._disabled_modules = []
 
     @property
     def core_group_enabled(self) -> Bool:
@@ -169,6 +171,42 @@ class PackagesSelectionData(DBusData):
     @excluded_packages.setter
     def excluded_packages(self, value: List[Str]):
         self._excluded_packages = value
+
+    @property
+    def modules(self) -> List[Str]:
+        """A list of modules to enable.
+
+        Supported format of values:
+
+            NAME         Specify the module name.
+            NAME:STREAM  Specify the module and stream names.
+
+        :return: a list of modules
+        :rtype: [str]
+        """
+        return self._modules
+
+    @modules.setter
+    def modules(self, value: List[Str]):
+        self._modules = value
+
+    @property
+    def disabled_modules(self) -> List[Str]:
+        """A list of modules to disable.
+
+        Supported format of values:
+
+            NAME         Specify the module name.
+            NAME:STREAM  Specify the module and stream names.
+
+        :return: a list of modules
+        :rtype: [str]
+        """
+        return self._disabled_modules
+
+    @disabled_modules.setter
+    def disabled_modules(self, value: List[Str]):
+        self._disabled_modules = value
 
 
 class PackagesConfigurationData(DBusData):

--- a/pyanaconda/modules/payloads/kickstart.py
+++ b/pyanaconda/modules/payloads/kickstart.py
@@ -65,9 +65,14 @@ class PayloadKickstartSpecification(KickstartSpecification):
         "harddrive": COMMANDS.HardDrive,
         "hmc": COMMANDS.Hmc,
         "liveimg": COMMANDS.Liveimg,
+        "module": COMMANDS.Module,
         "nfs": COMMANDS.NFS,
         "ostreesetup": COMMANDS.OSTreeSetup,
         "url": COMMANDS.Url
+    }
+
+    commands_data = {
+        "ModuleData": COMMANDS.ModuleData
     }
 
     sections = {

--- a/pyanaconda/modules/payloads/payload/dnf/dnf.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf.py
@@ -164,6 +164,17 @@ class DNFModule(PayloadBase):
         for group in data.packages.excludedGroupList:
             selection.excluded_groups.append(group.name)
 
+        for module in data.module.dataList():
+            name = module.name
+
+            if module.stream:
+                name += ":" + module.stream
+
+            if module.enable:
+                selection.modules.append(name)
+            else:
+                selection.disabled_modules.append(name)
+
         self.set_packages_selection(selection)
         self.set_packages_kickstarted(data.packages.seen)
 
@@ -244,6 +255,24 @@ class DNFModule(PayloadBase):
                 name=group_name
             )
             data.packages.excludedGroupList.append(group)
+
+        for name in selection.modules:
+            self._set_up_kickstart_module_data(data, name)
+
+        for name in selection.disabled_modules:
+            self._set_up_kickstart_module_data(data, name, False)
+
+    @staticmethod
+    def _set_up_kickstart_module_data(data, name, enabled=True):
+        """Set up the kickstart data for the module command."""
+        names = name.split(":", maxsplit=1) + [""]
+
+        module = data.ModuleData()
+        module.name = names[0]
+        module.stream = names[1]
+        module.enable = enabled
+
+        data.module.dataList().append(module)
 
     def _set_up_kickstart_packages_configuration(self, data):
         """Set up the kickstart packages configuration."""

--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -23,6 +23,7 @@ import traceback
 
 import dnf
 import dnf.exceptions
+import dnf.module.module_base
 
 from blivet.size import Size
 
@@ -237,6 +238,40 @@ class DNFManager(object):
         shutil.rmtree(DNF_PLUGINCONF_DIR, ignore_errors=True)
         self._base.reset(sack=True, repos=True)
         log.debug("The DNF cache has been cleared.")
+
+    def enable_modules(self, module_specs):
+        """Mark module streams for enabling.
+
+        Mark module streams matching the module_specs list and also
+        all required modular dependencies for enabling. For specs
+        that do not specify the stream, the default stream is used.
+
+        :param module_specs: a list of specs
+        """
+        log.debug("Enabling modules: %s", module_specs)
+
+        try:
+            module_base = dnf.module.module_base.ModuleBase(self._base)
+            module_base.enable(module_specs)
+        except dnf.exceptions.MarkingErrors as e:
+            log.debug("Some packages, groups or modules are missing or broken:\n%s", e)
+            raise
+
+    def disable_modules(self, module_specs):
+        """Mark modules for disabling.
+
+        Mark modules matching the module_specs list for disabling.
+        Only the name part of the module specification is relevant.
+
+        :param module_specs: a list of specs to disable
+        """
+        log.debug("Disabling modules: %s", module_specs)
+        try:
+            module_base = dnf.module.module_base.ModuleBase(self._base)
+            module_base.disable(module_specs)
+        except dnf.exceptions.MarkingErrors as e:
+            log.debug("Some packages, groups or modules are missing or broken:\n%s", e)
+            raise
 
     def apply_specs(self, include_list, exclude_list):
         """Mark packages, groups and modules for installation.

--- a/pyanaconda/modules/payloads/payload/factory.py
+++ b/pyanaconda/modules/payloads/payload/factory.py
@@ -67,6 +67,7 @@ class PayloadFactory(object):
         if data.cdrom.seen or \
            data.harddrive.seen or \
            data.hmc.seen or \
+           data.module.seen or \
            data.nfs.seen or \
            data.url.seen or \
            data.packages.seen:

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -21,13 +21,8 @@ import os
 import shutil
 import sys
 import threading
-import dnf
-import dnf.logging
 import dnf.exceptions
-import dnf.module
-import dnf.module.module_base
 import dnf.repo
-import dnf.subject
 import libdnf.conf
 
 from glob import glob
@@ -293,30 +288,14 @@ class DNFPayload(Payload):
         # Get the packages configuration data.
         selection = self.get_packages_selection()
 
-        # convert data from kickstart to module specs
-        module_specs_to_enable = selection.modules
-        module_specs_to_disable = selection.disabled_modules
-
-        # forward the module specs to disable to DNF
-        log.debug("disabling modules: %s", module_specs_to_disable)
         try:
-            module_base = dnf.module.module_base.ModuleBase(self._base)
-            module_base.disable(module_specs_to_disable)
+            self._dnf_manager.disable_modules(selection.disabled_modules)
         except dnf.exceptions.MarkingErrors as e:
-            log.debug(
-                "ModuleBase.disable(): some packages, groups "
-                "or modules are missing or broken:\n%s", e
-            )
             self._handle_marking_error(e)
 
-        # forward the module specs to enable to DNF
-        log.debug("enabling modules: %s", module_specs_to_enable)
         try:
-            module_base = dnf.module.module_base.ModuleBase(self._base)
-            module_base.enable(module_specs_to_enable)
+            self._dnf_manager.enable_modules(selection.modules)
         except dnf.exceptions.MarkingErrors as e:
-            log.debug("ModuleBase.enable(): some packages, groups "
-                      "or modules are missing or broken:\n%s", e)
             self._handle_marking_error(e)
 
     def _apply_selections(self):

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -290,23 +290,12 @@ class DNFPayload(Payload):
 
     def _process_module_command(self):
         """Enable/disable modules (if any)."""
-        # convert data from kickstart to module specs
-        module_specs_to_enable = []
-        module_specs_to_disable = []
-        for module in self.data.module.dataList():
-            # stream definition is optional
-            if module.stream:
-                module_spec = "{name}:{stream}".format(
-                    name=module.name,
-                    stream=module.stream
-                )
-            else:
-                module_spec = module.name
+        # Get the packages configuration data.
+        selection = self.get_packages_selection()
 
-            if module.enable:
-                module_specs_to_enable.append(module_spec)
-            else:
-                module_specs_to_disable.append(module_spec)
+        # convert data from kickstart to module specs
+        module_specs_to_enable = selection.modules
+        module_specs_to_disable = selection.disabled_modules
 
         # forward the module specs to disable to DNF
         log.debug("disabling modules: %s", module_specs_to_disable)

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/module_payloads_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/module_payloads_test.py
@@ -64,6 +64,7 @@ class PayloadsInterfaceTestCase(TestCase):
             "harddrive",
             "hmc",
             "liveimg",
+            "module",
             "nfs",
             "ostreesetup",
             "url"

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
@@ -228,6 +228,50 @@ class DNFMangerTestCase(unittest.TestCase):
             "environment-3",
         ])
 
+    @patch("dnf.module.module_base.ModuleBase.enable")
+    def enable_modules_test(self, module_base_enable):
+        """Test the enable_modules method."""
+        self.dnf_manager.enable_modules(
+            module_specs=["m1", "m2:latest"]
+        )
+        module_base_enable.assert_called_once_with(
+            ["m1", "m2:latest"]
+        )
+
+    @patch("dnf.module.module_base.ModuleBase.enable")
+    def enable_modules_error_test(self, module_base_enable):
+        """Test the failed enable_modules method."""
+        module_base_enable.side_effect = MarkingErrors(
+            module_depsolv_errors=["e1", "e2"]
+        )
+
+        with self.assertRaises(MarkingErrors):
+            self.dnf_manager.enable_modules(
+                module_specs=["m1", "m2:latest"]
+            )
+
+    @patch("dnf.module.module_base.ModuleBase.disable")
+    def disable_modules_test(self, module_base_disable):
+        """Test the enable_modules method."""
+        self.dnf_manager.disable_modules(
+            module_specs=["m1", "m2:latest"]
+        )
+        module_base_disable.assert_called_once_with(
+            ["m1", "m2:latest"]
+        )
+
+    @patch("dnf.module.module_base.ModuleBase.disable")
+    def disable_modules_error_test(self, module_base_disable):
+        """Test the failed enable_modules method."""
+        module_base_disable.side_effect = MarkingErrors(
+            module_depsolv_errors=["e1", "e2"]
+        )
+
+        with self.assertRaises(MarkingErrors):
+            self.dnf_manager.disable_modules(
+                module_specs=["m1", "m2:latest"]
+            )
+
     @patch("dnf.base.Base.install_specs")
     def apply_specs_test(self, install_specs):
         """Test the apply_specs method."""

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_test.py
@@ -178,6 +178,25 @@ class DNFKSTestCase(unittest.TestCase):
         self.shared_ks_tests.check_kickstart(ks_in, ks_out)
         self._check_properties(SOURCE_TYPE_URL)
 
+    def module_kickstart_test(self):
+        ks_in = """
+        module --name=nodejs
+        module --name=django --stream=1.6
+        module --name=postgresql --disable
+        module --name=mysql --stream=8.0 --disable
+        """
+        ks_out = """
+        module --name=nodejs
+        module --name=django --stream=1.6
+        module --name=postgresql --disable
+        module --name=mysql --stream=8.0 --disable
+
+        %packages
+
+        %end
+        """
+        self.shared_ks_tests.check_kickstart(ks_in, ks_out)
+
     def packages_section_empty_kickstart_test(self):
         """Test the empty packages section."""
         ks_in = """
@@ -424,6 +443,12 @@ class DNFInterfaceTestCase(unittest.TestCase):
             ]),
             "excluded-packages": get_variant(List[Str], [
                 "p3", "p4"
+            ]),
+            "modules": get_variant(List[Str], [
+                "m1", "m2:latest", "m3:1.01"
+            ]),
+            "disabled-modules": get_variant(List[Str], [
+                "m4", "m5:master", "m6:10"
             ]),
         }
 


### PR DESCRIPTION
Keep the data about enabled and disabled modules in the packages selection.

Call the `enable_modules` and `disable_modules` methods of the DNF manager
to enable and disable the specified modules.

