### PR TITLE
Make failure in generating of dracut arguments for iSCSI device non-f…

### DIFF
--- a/pyanaconda/modules/storage/iscsi/iscsi.py
+++ b/pyanaconda/modules/storage/iscsi/iscsi.py
@@ -220,6 +220,10 @@ class ISCSIModule(KickstartBaseModule):
 
         blivet_node = iscsi.get_node(node.name, node.address, node.port, node.iface)
 
+        if not blivet_node:
+            log.error("No iSCSI node %s found for device", node)
+            return []
+
         address = blivet_node.address
         # surround ipv6 addresses with []
         if ":" in address:


### PR DESCRIPTION
…atal.

The failure indicates a serious problem / inconsistncy.
It can be caused also eg by attaching an iSCSI device outside anaconda.
We should not crash on it.
We might want to ignore it because missing dracut boot option can be
worked around.