### PR TITLE
IOError cleanup

### DIFF
--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -257,7 +257,7 @@ def read_lines(filename):
     """return a list containing each line in filename, with newlines removed."""
     try:
         return [line.rstrip('\n') for line in open(filename)]
-    except IOError:
+    except OSError:
         return []
 
 def save_repo(repo, target="/run/install"):
@@ -455,7 +455,7 @@ def load_drivers(moddict):
 def process_driver_disk(dev, interactive=False):
     try:
         return _process_driver_disk(dev, interactive=interactive)
-    except (subprocess.CalledProcessError, IOError) as e:
+    except (subprocess.CalledProcessError, OSError) as e:
         log.error("ERROR: %s", e)
         return {}
 
@@ -503,7 +503,7 @@ def process_driver_rpm(rpm, dev=None):
             return _process_driver_rpm_from_device(rpm, dev)
         else:
             return _process_driver_rpm(rpm)
-    except (subprocess.CalledProcessError, IOError) as e:
+    except (subprocess.CalledProcessError, OSError) as e:
         log.error("ERROR: %s", e)
         return {}
 

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -71,7 +71,7 @@ def readsysfile(f):
     '''Return the contents of f, or "" if missing.'''
     try:
         val = open(f).readline().strip()
-    except IOError:
+    except OSError:
         val = ""
     return val
 
@@ -81,7 +81,7 @@ def read_cmdline(f):
     args = OrderedDict()
     try:
         lines = open(f).readlines()
-    except IOError:
+    except OSError:
         lines = []
     # pylint: disable=redefined-outer-name
     for line in lines:
@@ -102,7 +102,7 @@ def first_device_with_link():
             with open(dev_dir+"/carrier") as f:
                 if f.read().strip() == ARPHRD_ETHER:
                     return os.path.basename(dev_dir)
-        except IOError:
+        except OSError:
             pass
 
     return ""

--- a/pyanaconda/anaconda_logging.py
+++ b/pyanaconda/anaconda_logging.py
@@ -253,7 +253,7 @@ class AnacondaLog(object):
             logfile_handler.setLevel(minLevel)
             logfile_handler.setFormatter(logging.Formatter(fmtStr, DATE_FORMAT))
             addToLogger.addHandler(logfile_handler)
-        except IOError:
+        except OSError:
             pass
 
     def forwardToJournal(self, logr, log_formatter=None, log_filter=None):

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -64,7 +64,7 @@ def get_help_width():
     try:
         data = fcntl.ioctl(sys.stdout, termios.TIOCGWINSZ, '1234')
         columns = int(struct.unpack('hh', data)[1])
-    except (IOError, ValueError) as e:
+    except (OSError, ValueError) as e:
         log.info("Unable to determine terminal width: %s", e)
         print("terminal size detection failed, using default width")
         return DEFAULT_HELP_WIDTH
@@ -367,7 +367,7 @@ class HelpTextParser(object):
                 with open(self._path) as lines:
                     for parsed_option, parsed_text in self.read(lines):
                         self._help_text[parsed_option] = parsed_text
-            except IOError as e:
+            except OSError as e:
                 log.error("error reading help text file %s: %s", self._path, e)
 
         return self._help_text.get(option, "")

--- a/pyanaconda/core/configuration/base.py
+++ b/pyanaconda/core/configuration/base.py
@@ -70,7 +70,7 @@ def read_config(parser, path):
         with open(path, "r") as f:
             parser.read_file(f, path)
 
-    except (configparser.Error, IOError) as e:
+    except (configparser.Error, OSError) as e:
         raise ConfigurationFileError(str(e), path) from e
 
 
@@ -85,7 +85,7 @@ def write_config(parser, path):
         with open(path, "w") as f:
             parser.write(f)
 
-    except (configparser.Error, IOError) as e:
+    except (configparser.Error, OSError) as e:
         raise ConfigurationFileError(str(e), path) from e
 
 

--- a/pyanaconda/core/kernel.py
+++ b/pyanaconda/core/kernel.py
@@ -80,7 +80,7 @@ class KernelArguments():
             try:
                 self.read_string(open(f).read())
                 readfiles.append(f)
-            except IOError:
+            except OSError:
                 continue
 
         return readfiles

--- a/pyanaconda/core/startup/dbus_launcher.py
+++ b/pyanaconda/core/startup/dbus_launcher.py
@@ -113,12 +113,12 @@ class AnacondaDBusLauncher(object):
         self._dbus_daemon_process = startProgram(command, stderr=self._log_file, reset_lang=False)
 
         if self._dbus_daemon_process.poll() is not None:
-            raise IOError("DBus wasn't properly started!")
+            raise RuntimeError("DBus wasn't properly started!")
 
         address = self._dbus_daemon_process.stdout.readline().decode('utf-8').strip()
 
         if not address:
-            raise IOError("Unable to start DBus session!")
+            raise RuntimeError("Unable to start DBus session!")
 
         self._bus_address = address
 

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -647,7 +647,7 @@ def dracut_eject(device):
         f.write("eject %s\n" % (device,))
         f.close()
         log.info("Wrote dracut shutdown eject hook for %s", device)
-    except (IOError, OSError) as e:
+    except OSError as e:
         log.error("Error writing dracut shutdown eject hook for %s: %s", device, e)
 
 
@@ -797,7 +797,7 @@ def get_kernel_taint(flag):
     """
     try:
         tainted = int(open("/proc/sys/kernel/tainted").read())
-    except (IOError, ValueError):
+    except (OSError, ValueError):
         tainted = 0
 
     return bool(tainted & (1 << flag))
@@ -1012,7 +1012,7 @@ def detect_virtualized_platform():
     """
     try:
         platform = execWithCapture("systemd-detect-virt", []).strip()
-    except (IOError, AttributeError):
+    except (OSError, AttributeError):
         return None
 
     if platform == "none":
@@ -1402,7 +1402,7 @@ def is_smt_enabled():
 
     try:
         return int(open("/sys/devices/system/cpu/smt/active").read()) == 1
-    except (IOError, ValueError):
+    except (OSError, ValueError):
         log.warning("Failed to detect SMT.")
         return False
 

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -224,7 +224,7 @@ class AnacondaExceptionHandler(ExceptionHandler):
             try:
                 dest = conf.target.system_root + "/root/%s" % os.path.basename(self.exnFile)
                 shutil.copyfile(self.exnFile, dest)
-            except (shutil.Error, IOError):
+            except (shutil.Error, OSError):
                 log.error("Failed to copy %s to %s/root", self.exnFile, conf.target.system_root)
 
         # run kickstart traceback scripts (if necessary)

--- a/pyanaconda/isys/__init__.py
+++ b/pyanaconda/isys/__init__.py
@@ -57,7 +57,7 @@ def isIsoImage(path):
                 isoFile.seek(blockNum * ISO_BLOCK_SIZE + 1)
                 if isoFile.read(5) == b"CD001":
                     return True
-    except IOError:
+    except OSError:
         pass
 
     return False

--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -450,7 +450,7 @@ def get_firmware_language(text_mode=False):
         n = "/sys/firmware/efi/efivars/PlatformLang-8be4df61-93ca-11d2-aa0d-00e098032b8c"
         with open(n, 'r') as f:
             d = f.read()
-    except IOError:
+    except OSError:
         return None
 
     # the contents of the file are:

--- a/pyanaconda/modules/localization/installation.py
+++ b/pyanaconda/modules/localization/installation.py
@@ -67,9 +67,9 @@ class LanguageInstallationTask(Task):
             with open(fpath, "w") as fobj:
                 fobj.write('LANG="{}"\n'.format(lang))
 
-        except IOError as ioerr:
-            msg = "Cannot write language configuration file: {}".format(ioerr.strerror)
-            raise LanguageInstallationError(msg) from ioerr
+        except OSError as e:
+            msg = "Cannot write language configuration file: {}".format(e.strerror)
+            raise LanguageInstallationError(msg) from e
 
 
 class KeyboardInstallationTask(Task):
@@ -173,7 +173,7 @@ def write_x_configuration(localed_wrapper, x_layouts, switch_options, x_conf_dir
         rooted_xconf_file_path = os.path.normpath(root + "/" + xconf_file_path)
         try:
             shutil.copy2(xconf_file_path, rooted_xconf_file_path)
-        except IOError as ioerr:
+        except OSError as ioerr:
             log.error("Cannot copy X layouts configuration file %s to target system: %s.",
                       xconf_file_path, ioerr.strerror)
 
@@ -209,6 +209,6 @@ def write_vc_configuration(vc_keymap, root):
             # characters, so we have to tell it to use a better one
             fobj.write('FONT="%s"\n' % vc_font)
 
-    except IOError as ioerr:
-        msg = "Cannot write vconsole configuration file: {}".format(ioerr.strerror)
-        raise KeyboardInstallationError(msg) from ioerr
+    except OSError as e:
+        msg = "Cannot write vconsole configuration file: {}".format(e.strerror)
+        raise KeyboardInstallationError(msg) from e

--- a/pyanaconda/modules/network/installation.py
+++ b/pyanaconda/modules/network/installation.py
@@ -88,9 +88,9 @@ def _write_config_file(root, path, content, error_msg, overwrite):
     try:
         with open(fpath, "w") as fobj:
             fobj.write(content)
-    except IOError as ioerr:
-        msg = "{}: {}".format(error_msg, ioerr.strerror)
-        raise NetworkInstallationError(msg) from ioerr
+    except OSError as e:
+        msg = "{}: {}".format(error_msg, e.strerror)
+        raise NetworkInstallationError(msg) from e
 
 
 class NetworkInstallationTask(Task):
@@ -213,9 +213,9 @@ Name={}
                 f.write("net.ipv6.conf.all.disable_ipv6=1\n")
                 f.write("net.ipv6.conf.default.disable_ipv6=1\n")
 
-        except IOError as ioerr:
-            msg = "Cannot disable ipv6 on the system: {}".format(ioerr.strerror)
-            raise NetworkInstallationError(msg) from ioerr
+        except OSError as e:
+            msg = "Cannot disable ipv6 on the system: {}".format(e.strerror)
+            raise NetworkInstallationError(msg) from e
 
     def _copy_resolv_conf(self, root, overwrite):
         """Copy resolf.conf file to target system.

--- a/pyanaconda/modules/payloads/installation.py
+++ b/pyanaconda/modules/payloads/installation.py
@@ -117,7 +117,7 @@ class CopyDriverDisksFilesTask(Task):
         for f in glob(self.DD_FIRMWARE_DIR + "/*"):
             try:
                 shutil.copyfile(f, os.path.join(self._sysroot, "lib/firmware/"))
-            except IOError as e:
+            except OSError as e:
                 log.error("Could not copy firmware file %s: %s", f, e.strerror)
 
         # copy RPMS
@@ -129,7 +129,7 @@ class CopyDriverDisksFilesTask(Task):
         if os.path.exists(self.DD_DIR):
             try:
                 shutil.copytree(self.DD_DIR, os.path.join(self._sysroot, "root/DD"))
-            except IOError as e:
+            except (OSError, shutil.Error) as e:
                 log.error("failed to copy driver disk files: %s", e.strerror)
                 # XXX TODO: real error handling, as this is probably going to
                 #           prevent boot on some systems

--- a/pyanaconda/modules/security/installation.py
+++ b/pyanaconda/modules/security/installation.py
@@ -213,7 +213,7 @@ class ConfigureSELinuxTask(Task):
             selinux_cfg.read()
             selinux_cfg.set(("SELINUX", self.SELINUX_STATES[self._selinux_mode]))
             selinux_cfg.write()
-        except IOError as msg:
+        except OSError as msg:
             log.error("SELinux configuration failed: %s", msg)
 
 

--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -143,7 +143,7 @@ class EFIGRUB(EFIBase, GRUB2):
         try:
             f = open("/sys/firmware/efi/fw_platform_size", "r")
             value = f.readline().strip()
-        except IOError:
+        except OSError:
             log.info("Reading /sys/firmware/efi/fw_platform_size failed, "
                      "defaulting to 64-bit install.")
             value = '64'

--- a/pyanaconda/modules/storage/devicetree/root.py
+++ b/pyanaconda/modules/storage/devicetree/root.py
@@ -196,7 +196,7 @@ def _release_from_redhat_release(fn):
     with open(fn) as f:
         try:
             relstr = f.readline().strip()
-        except (IOError, AttributeError):
+        except (OSError, AttributeError):
             relstr = ""
 
     # get the release name and version

--- a/pyanaconda/modules/storage/installation.py
+++ b/pyanaconda/modules/storage/installation.py
@@ -321,7 +321,7 @@ class WriteConfigurationTask(Task):
                 device.format.escrow(escrow_dir,
                                      backup_passphrase)
 
-        except (IOError, RuntimeError) as e:
+        except (OSError, RuntimeError) as e:
             # TODO: real error handling
             log.error("failed to store encryption key: %s", e)
 

--- a/pyanaconda/modules/subscription/system_purpose.py
+++ b/pyanaconda/modules/subscription/system_purpose.py
@@ -52,7 +52,7 @@ def get_valid_fields(valid_fields_file_path=VALID_FIELDS_FILE_PATH):
                 valid_roles = valid_fields_json.get("role", [])
                 valid_slas = valid_fields_json.get("service_level_agreement", [])
                 valid_usage_types = valid_fields_json.get("usage", [])
-        except (IOError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError):
             log.exception("parsing of syspurpose valid fields file at %s failed",
                           valid_fields_file_path)
     else:

--- a/pyanaconda/modules/timezone/installation.py
+++ b/pyanaconda/modules/timezone/installation.py
@@ -103,7 +103,7 @@ class ConfigureTimezoneTask(Task):
         try:
             with open(os.path.normpath(self._sysroot + "/etc/adjtime"), "r") as fobj:
                 lines = fobj.readlines()
-        except IOError:
+        except OSError:
             lines = ["0.0 0 0.0\n", "0\n"]
 
         try:
@@ -114,9 +114,9 @@ class ConfigureTimezoneTask(Task):
                     fobj.write("UTC\n")
                 else:
                     fobj.write("LOCAL\n")
-        except IOError as ioerr:
-            msg = "Error while writing /etc/adjtime file: {}".format(ioerr.strerror)
-            raise TimezoneConfigurationError(msg) from ioerr
+        except OSError as e:
+            msg = "Error while writing /etc/adjtime file: {}".format(e.strerror)
+            raise TimezoneConfigurationError(msg) from e
 
 
 class ConfigureNTPTask(Task):

--- a/pyanaconda/ntp.py
+++ b/pyanaconda/ntp.py
@@ -153,9 +153,9 @@ def get_servers_from_config(conf_file_path=NTP_CONFIG_FILE):
 
                 servers.append(server)
 
-    except IOError as ioerr:
+    except OSError as e:
         msg = "Cannot open config file {} for reading ({})."
-        raise NTPconfigError(msg.format(conf_file_path, ioerr.strerror)) from ioerr
+        raise NTPconfigError(msg.format(conf_file_path, e.strerror)) from e
 
     return servers
 
@@ -176,23 +176,23 @@ def save_servers_to_config(servers, conf_file_path=NTP_CONFIG_FILE, out_file_pat
 
     try:
         old_conf_file = open(conf_file_path, "r")
-    except IOError as ioerr:
+    except OSError as e:
         msg = "Cannot open config file {} for reading ({})."
-        raise NTPconfigError(msg.format(conf_file_path, ioerr.strerror)) from ioerr
+        raise NTPconfigError(msg.format(conf_file_path, e.strerror)) from e
 
     if out_file_path:
         try:
             new_conf_file = open(out_file_path, "w")
-        except IOError as ioerr:
+        except OSError as e:
             msg = "Cannot open new config file {} for writing ({})."
-            raise NTPconfigError(msg.format(out_file_path, ioerr.strerror)) from ioerr
+            raise NTPconfigError(msg.format(out_file_path, e.strerror)) from e
     else:
         try:
             (fields, temp_path) = tempfile.mkstemp()
             new_conf_file = os.fdopen(fields, "w")
-        except IOError as ioerr:
+        except OSError as e:
             msg = "Cannot open temporary file {} for writing ({})."
-            raise NTPconfigError(msg.format(temp_path, ioerr.strerror)) from ioerr
+            raise NTPconfigError(msg.format(temp_path, e.strerror)) from e
 
     heading = "# These servers were defined in the installation:\n"
 

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -73,7 +73,7 @@ from pyanaconda.payload.dnf.repomd import RepoMDMetaHash
 from pyanaconda.payload.errors import MetadataError, PayloadError, NoSuchGroup, DependencyError, \
     PayloadInstallError, PayloadSetupError
 from pyanaconda.payload.image import find_first_iso_image, find_optical_install_media
-from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
+from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata, FileNotDownloadedError
 from pyanaconda.product import productName, productVersion
 from pyanaconda.progress import progressQ, progress_message
 from pyanaconda.ui.lib.payload import get_payload, get_source, create_source, set_source, \
@@ -1328,7 +1328,7 @@ class DNFPayload(Payload):
         self._install_tree_metadata = InstallTreeMetadata()
         try:
             ret = self._install_tree_metadata.load_url(url, proxies, ssl_verify, ssl_cert, headers)
-        except IOError as e:
+        except FileNotDownloadedError as e:
             self._install_tree_metadata = None
             self.verbose_errors.append(str(e))
             log.warning("Install tree metadata fetching failed: %s", str(e))

--- a/pyanaconda/payload/install_tree_metadata.py
+++ b/pyanaconda/payload/install_tree_metadata.py
@@ -31,6 +31,10 @@ log = get_packaging_logger()
 MAX_TREEINFO_DOWNLOAD_RETRIES = 6
 
 
+class FileNotDownloadedError(Exception):
+    pass
+
+
 class InstallTreeMetadata(object):
     # TODO: Add tests for InstallTreeMetadata class
 
@@ -71,7 +75,7 @@ class InstallTreeMetadata(object):
         :param headers: Additional headers of the request.
         :returns: True if the install tree repo metadata was successfully loaded. False otherwise.
 
-        :raise: IOError is thrown in case of immediate failure.
+        :raise: FileNotDownloadedError is thrown in case of immediate failure.
         """
         # Retry treeinfo downloads with a progressively longer pause,
         # so NetworkManager have a chance setup a network and we have
@@ -120,7 +124,9 @@ class InstallTreeMetadata(object):
                 err_msg = ("Repo info download for %s failed after %d retries" %
                            (url, retry_count))
                 log.error(err_msg)
-                raise IOError("Can't get .treeinfo file from the url {}".format(url))
+                raise FileNotDownloadedError(
+                    "Can't get .treeinfo file from the url {}".format(url)
+                )
 
         if response:
             # get the treeinfo contents

--- a/pyanaconda/payload/live/payload_liveimg.py
+++ b/pyanaconda/payload/live/payload_liveimg.py
@@ -101,6 +101,7 @@ class LiveImagePayload(BaseLivePayload):
             # Enough space for image and image * 3
             if response.headers.get('content-length'):
                 self._min_size = int(response.headers.get('content-length')) * 4
+            # FIXME: look up what is raised by Requests, replace IOError
         except IOError as e:
             log.error("Error opening liveimg: %s", e)
             error = e

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -66,7 +66,7 @@ def makeFStab(instPath=""):
         if buf:
             f.write(buf)
         f.close()
-    except IOError as e:
+    except OSError as e:
         log.info("failed to write /etc/fstab: %s", e)
 
 
@@ -208,7 +208,7 @@ class Rescue(object):
             try:
                 fd = open("%s/.autorelabel" % conf.target.system_root, "w+")
                 fd.close()
-            except IOError as e:
+            except OSError as e:
                 log.warning("Error turning on selinux: %s", e)
 
         # set a libpath to use mounted fs
@@ -227,7 +227,7 @@ class Rescue(object):
         if not self.ro:
             try:
                 makeResolvConf(conf.target.system_root)
-            except(OSError, IOError) as e:
+            except OSError as e:
                 log.error("Error making resolv.conf: %s", e)
 
         # create /etc/fstab in ramdisk so it's easier to work with RO mounted fs

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -171,7 +171,7 @@ class GUIObject(common.UIObject):
             if os.path.isfile(testPath) and os.access(testPath, os.R_OK):
                 return testPath
 
-        raise IOError("Could not load UI file '%s' for object '%s'" % (self.uiFile, self))
+        raise OSError("Could not load UI file '{}' for object '{}'".format(self.uiFile, self))
 
     @property
     def window(self):

--- a/scripts/analog
+++ b/scripts/analog
@@ -201,7 +201,7 @@ def main():
         try:
             with open(options.output, 'w') as f:
                 f.write(config)
-        except IOError:
+        except OSError:
             print("Can't write into file %s" % options.output, file=sys.stderr)
             sys.exit(1)
         if options.stdout:

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -19,7 +19,7 @@ def is_python(filename):
         with open(filename) as testfile:
             if testfile.readline().startswith("#!/usr/bin/python"):
                 return True
-    except IOError:
+    except OSError:
         pass
 
     return False

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -583,7 +583,7 @@ class MakeBumpVer:
                         if job["name"] == targetJob:
                             ret = job["color"] == "blue"
                             break
-        except IOError:
+        except OSError:
             log.exception("Jenkins check failed!")
             return False
 

--- a/scripts/merge-pr
+++ b/scripts/merge-pr
@@ -130,7 +130,7 @@ def main():
         p = subprocess.Popen(['git', 'credential', 'fill'], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         p.stdin.write(github_cred)
         (stdin, _stderr) = p.communicate()
-    except (OSError, IOError) as e:
+    except OSError as e:
         print("Unable to get github credentials: %s" % e)
         sys.exit(1)
 
@@ -164,7 +164,7 @@ def main():
             p = subprocess.Popen(['git', 'credential', 'approve'], stdin=subprocess.PIPE)
             p.stdin.write(stdin)
             p.communicate()
-        except (OSError, IOError) as e:
+        except OSError as e:
             print("Unable to save github credentials: %s" % e)
             sys.exit(1)
 

--- a/tests/nosetests/pyanaconda_tests/core/util_test.py
+++ b/tests/nosetests/pyanaconda_tests/core/util_test.py
@@ -907,7 +907,7 @@ class MiscTests(unittest.TestCase):
     def detect_virtualized_platform_test(self):
         """Test the function detect_virtualized_platform."""
         with patch('pyanaconda.core.util.execWithCapture') as execute:
-            execute.side_effect = IOError
+            execute.side_effect = OSError
             self.assertEqual(util.detect_virtualized_platform(), None)
 
         with patch('pyanaconda.core.util.execWithCapture') as execute:


### PR DESCRIPTION
I tried to eradicate `IOError` which is just an alias for `OSError`.

* Generally, most of the occurrences were to catch problems after calling `open()` or something from `os`, so the replacement was straightforward.
* There were a few more cases where we raised `IOError` in our code, so it could be replaced with a custom exception class.
* In a few cases, it's not us but Blivet raising `IOError`; in that case, I left it in our code as-is. Feel free to disagree. These were:
  * https://github.com/rhinstaller/anaconda/blob/master/pyanaconda/modules/storage/kickstart.py#L206
  * https://github.com/rhinstaller/anaconda/blob/master/pyanaconda/modules/storage/fcoe/discover.py#L46
* In one case, we have `IOError` guarding use of `Requests`, probably as a leftover from 2013 when we used `urllib`, and I have no idea if we want to keep the whole except there: https://github.com/rhinstaller/anaconda/blob/master/pyanaconda/payload/live/payload_liveimg.py#L104