### PR TITLE
KS test workflow groups

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -153,22 +153,28 @@ jobs:
           cd /tmp/source
 
           # install build dependencies and lorax
+          echo "::group::Install build dependencies and lorax"
           ./scripts/testing/install_dependencies.sh -y
           dnf install -y createrepo_c lorax
+          echo "::endgroup::"
 
           # build RPMs and repo for it; bump version so that it's higher than rawhide's
+          echo "::group::Build Anaconda RPMs and make a repository"
           sed -ri '/AC_INIT/ s/\[[0-9.]+\]/[999999999]/' configure.ac
           ./autogen.sh
           ./configure
           make rpms
           createrepo_c result/build/01-rpm-build/
+          echo "::endgroup::"
 
           # build boot.iso with our rpms
+          echo "::group::Build boot.iso with the RPMs"
           . /etc/os-release
           # The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; use a mirror
           # The --volid argument can cause different network interface naming: https://github.com/rhinstaller/kickstart-tests/issues/448
           lorax -p Fedora -v \$VERSION_ID -r \$VERSION_ID --volid Fedora-S-dvd-x86_64-rawh -s http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/ -s file://\$PWD/result/build/01-rpm-build/ lorax
           cp lorax/images/boot.iso /images/
+          echo "::endgroup::"
           EOF
 
       - name: Clean up after lorax


### PR DESCRIPTION
Let's make the ISO build in kickstart tests easier to read and debug.

See https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#grouping-log-lines