### PR TITLE
Drop astroid hotfix patch

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -40,10 +40,6 @@ RUN pip-3.6 install \
   nose-testconfig \
   rpmfluff
 
-# HACK: Apply fix from https://github.com/PyCQA/astroid/pull/847 to avoid
-# excessive memory usage, until astroid > 2.4.2 gets released
-RUN curl https://github.com/PyCQA/astroid/commit/d62349a424c549b4634c90e471c9f876b99edfeb.patch | patch /usr/local/lib/python3*/site-packages/astroid/manager.py
-
 # see https://github.com/martinpitt/anaconda/settings/actions/add-new-runner
 RUN mkdir actions-runner && cd actions-runner && \
   URL_BASE=https://github.com/actions/runner/releases && \


### PR DESCRIPTION
Port of #3174 & #3175. All work by @jkonecny12 who debugged the problem and pointed out the existing fix.

This fixes the container build, which in turn enables the rhel-8 unit tests to work. Probably.