### PR TITLE
Fix the GetContainerFreeSpace method

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
@@ -107,11 +107,15 @@ class DeviceTreeSchedulerModule(DeviceTreeModule):
     def get_container_free_space(self, container_name):
         """Get total free space in the specified container.
 
+        If Blivet returns a negative size, return zero.
+
         :param container_name: a name of the container
         :return: a size in bytes
         """
         container = self._get_device(container_name)
-        return Size(getattr(container, "free_space", 0)).get_bytes()
+        free_space = getattr(container, "free_space", 0)
+        free_space = max(0, free_space)
+        return Size(free_space).get_bytes()
 
     def generate_system_name(self):
         """Generate a name of the new installation.

--- a/tests/nosetests/pyanaconda_tests/modules/storage/partitioning/module_scheduler_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/storage/partitioning/module_scheduler_test.py
@@ -785,6 +785,12 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self.assertGreater(free_space, Size("9 GiB").get_bytes())
         self.assertLess(free_space, Size("10 GiB").get_bytes())
 
+        dev2.reserved_space = Size("15 GiB")
+        self.assertLess(dev2.free_space, 0)
+
+        free_space = self.interface.GetContainerFreeSpace("dev2")
+        self.assertEqual(free_space, 0)
+
     @patch_dbus_get_proxy
     def generate_container_name_test(self, proxy_getter):
         """Test GenerateContainerName."""


### PR DESCRIPTION
If Blivet returns a negative size of the container free space, return zero.

Resolves: rhbz#1937593