### PR TITLE
Use a custom stylesheet to define Fedora-specific stylesheet data

### DIFF
--- a/data/product.d/fedora.conf
+++ b/data/product.d/fedora.conf
@@ -19,6 +19,8 @@ default_help_pages =
     FedoraPlaceholder.html
     FedoraPlaceholderWithLinks.html
 
+custom_stylesheet = /usr/share/anaconda/pixmaps/fedora.css
+
 [Payload]
 default_source = CLOSEST_MIRROR
 


### PR DESCRIPTION
Use a stylesheet provided by the `fedora-logos` package.

**Related to:** https://github.com/rhinstaller/anaconda/pull/3161