### PR TITLE
Create /tmp with the right permissions (#1937626)

### DIFF
--- a/pyanaconda/modules/storage/devicetree/fsset.py
+++ b/pyanaconda/modules/storage/devicetree/fsset.py
@@ -591,6 +591,16 @@ class FSSet(object):
             if read_only:
                 options = "%s,%s" % (options, read_only)
 
+            # Create /tmp with the right permissions (rhbz#1937626).
+            # It needs to be created right before we mount anything.
+            # Call chmod to enforce the mode.
+            if device.format.mountpoint == "/tmp":
+                path = os.path.join(root_path, "tmp")
+
+                if not os.path.exists(path):
+                    os.makedirs(path)
+                    os.chmod(path, 0o1777)
+
             device.setup()
             device.format.setup(
                 options=options,


### PR DESCRIPTION
The `/tmp` directory of the target system could be created with wrong permissions,
so we need to create this directory and set up its permission right before it is
used to mount a device.

Resolves: rhbz#1937626