### PR TITLE
Clean up the dependencies (#1938132)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -84,7 +84,6 @@ BuildRequires: libxml2
 Requires: anaconda-core = %{version}-%{release}
 Requires: anaconda-gui = %{version}-%{release}
 Requires: anaconda-tui = %{version}-%{release}
-Requires: anaconda-install-env-deps = %{version}-%{release}
 
 %description
 The anaconda package is a metapackage for the Anaconda installer.

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -198,7 +198,6 @@ Requires: tmux
 Requires: gdb
 # support for installation from image and live & live image installations
 Requires: rsync
-Recommends: zram-generator-defaults
 
 %description install-env-deps
 The anaconda-install-env-deps metapackage lists all installation environment dependencies.

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -81,7 +81,6 @@ BuildRequires: libtimezonemap-devel >= %{libtimezonemapver}
 BuildRequires: gdk-pixbuf2-devel
 BuildRequires: libxml2
 
-Requires: anaconda-core = %{version}-%{release}
 Requires: anaconda-gui = %{version}-%{release}
 Requires: anaconda-tui = %{version}-%{release}
 


### PR DESCRIPTION
The `anaconda` package shouldn't depend on `anaconda-install-env-deps`.
It was a temporary workaround when the meta package was created.

The `anaconda-gui` and `anaconda-tui` packages require `anaconda-core`, so
the `anaconda` packages doesn't need to explicitly require it.

The `anaconda-install-img-deps` package shouldn't recommend `zram-generator-defaults`.
It is required only for boot.iso and Live OS and that is handled by the lorax templates
and the `core` group.

Resolves: rhbz#1938132