### PR TITLE
Don't automatically execute the default partitioning

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -113,6 +113,9 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         self._selected_disks = []
         self._last_selected_disks = []
 
+        # Is the partitioning already configured?
+        self._is_preconfigured = bool(self._storage_module.CreatedPartitioning)
+
         # Find a partitioning to use.
         self._partitioning = find_partitioning()
         self._last_partitioning_method = self._partitioning.PartitioningMethod
@@ -483,9 +486,10 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         # Update the selected disks.
         select_default_disks()
 
-        # Apply the partitioning. Do not set ready in the automated
-        # installation before the execute method is run.
-        if flags.automatedInstall:
+        # Automatically apply the preconfigured partitioning.
+        # Do not set ready in the automated installation before
+        # the execute method is run.
+        if flags.automatedInstall and self._is_preconfigured:
             self.execute()
         else:
             self._ready = True

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -103,6 +103,11 @@ class StorageSpoke(NormalTUISpoke):
 
         self._available_disks = []
         self._selected_disks = []
+
+        # Is the partitioning already configured?
+        self._is_preconfigured = bool(self._storage_module.CreatedPartitioning)
+
+        # Find a partitioning to use.
         self._partitioning = find_partitioning()
 
         self.errors = []
@@ -414,8 +419,8 @@ class StorageSpoke(NormalTUISpoke):
         # Update the selected disks.
         select_default_disks()
 
-        # Apply the partitioning in the automated installation.
-        if flags.automatedInstall:
+        # Automatically apply the preconfigured partitioning.
+        if flags.automatedInstall and self._is_preconfigured:
             self.execute()
 
         # Storage is ready.


### PR DESCRIPTION
We should automatically execute only a partitioning that was already
configured by the user, for example with a kickstart file.