### PR TITLE
network: match also connections named by MAC created by NM in initramfs

### DIFF
--- a/pyanaconda/core/regexes.py
+++ b/pyanaconda/core/regexes.py
@@ -194,3 +194,6 @@ IPV6_ADDRESS_IN_DRACUT_IP_OPTION = re.compile(r'\[[^\]]+\]')
 
 # Octet of MAC address
 MAC_OCTET = re.compile(r'[a-fA-F0-9][a-fA-F0-9]')
+
+# Name of initramfs connection created by NM based on MAC
+NM_MAC_INITRAMFS_CONNECTION = re.compile(r'^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$')

--- a/pyanaconda/modules/network/initialization.py
+++ b/pyanaconda/modules/network/initialization.py
@@ -16,7 +16,9 @@
 # Red Hat, Inc.
 #
 import copy
+import re
 
+from pyanaconda.core.regexes import NM_MAC_INITRAMFS_CONNECTION
 from pyanaconda.modules.common.task import Task
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.network.network_interface import NetworkInitializationTaskInterface
@@ -506,4 +508,6 @@ class DumpMissingIfcfgFilesTask(Task):
         return new_ifcfgs
 
     def _is_initramfs_connection(self, con, iface):
-        return con.get_id() in ["Wired Connection", iface]
+        con_id = con.get_id()
+        return con_id in ["Wired Connection", iface] \
+            or re.match(NM_MAC_INITRAMFS_CONNECTION, con_id)


### PR DESCRIPTION
Related: rhbz#1910438

For example connection created by configuration:
ip=10.43.136.52::10.43.136.254:255.255.255.0:testhost.example.com:52-54-00-8e-57-91:none

Same as in case of specification by BOOTIF= boot option, the connection is
bound to interface name and renamed to the interface name.