### PR TITLE
Create the substitute method

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -24,6 +24,7 @@ import traceback
 import dnf
 import dnf.exceptions
 import dnf.module.module_base
+import libdnf.conf
 
 from blivet.size import Size
 
@@ -182,6 +183,21 @@ class DNFManager(object):
     def dump_configuration(self):
         """Log the state of the DNF configuration."""
         log.debug("DNF configuration:\n%s", self._base.conf.dump())
+
+    def substitute(self, text):
+        """Replace variables with their values.
+
+        Currently supports $releasever and $basearch.
+
+        :param str text: a string to do replacement on
+        :return str: a string with substituted variables
+        """
+        if not text:
+            return ""
+
+        return libdnf.conf.ConfigParser.substitute(
+            text, self._base.conf.substitutions
+        )
 
     def get_installation_size(self):
         """Calculate the installation size.

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -22,7 +22,6 @@ import sys
 import threading
 import dnf.exceptions
 import dnf.repo
-import libdnf.conf
 
 from glob import glob
 
@@ -265,21 +264,6 @@ class DNFPayload(Payload):
         log.debug("Source doesn't require network for installation")
         return False
 
-    def _replace_vars(self, url):
-        """Replace url variables with their values.
-
-        :param url: url string to do replacement on
-        :type url:  string
-        :returns:   string with variables substituted
-        :rtype:     string or None
-
-        Currently supports $releasever and $basearch.
-        """
-        if url:
-            return libdnf.conf.ConfigParser.substitute(url, self._base.conf.substitutions)
-
-        return None
-
     def _process_module_command(self):
         """Enable/disable modules (if any)."""
         # Get the packages configuration data.
@@ -488,9 +472,9 @@ class DNFPayload(Payload):
         :returns: None
         """
         repo = dnf.repo.Repo(ksrepo.name, self._base.conf)
-        url = self._replace_vars(ksrepo.baseurl)
-        mirrorlist = self._replace_vars(ksrepo.mirrorlist)
-        metalink = self._replace_vars(ksrepo.metalink)
+        url = self._dnf_manager.substitute(ksrepo.baseurl)
+        mirrorlist = self._dnf_manager.substitute(ksrepo.mirrorlist)
+        metalink = self._dnf_manager.substitute(ksrepo.metalink)
 
         if url and url.startswith("nfs://"):
             (server, path) = url[6:].split(":", 1)

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
@@ -553,3 +553,18 @@ class DNFMangerTestCase(unittest.TestCase):
 
         self.dnf_manager.reset_base()
         self.assertEqual(self.dnf_manager.download_location, None)
+
+    def substitute_test(self):
+        """Test the substitute method."""
+        # No variables.
+        self.assertEqual(self.dnf_manager.substitute(None), "")
+        self.assertEqual(self.dnf_manager.substitute(""), "")
+        self.assertEqual(self.dnf_manager.substitute("/"), "/")
+        self.assertEqual(self.dnf_manager.substitute("/text"), "/text")
+
+        # Unknown variables.
+        self.assertEqual(self.dnf_manager.substitute("/$unknown"), "/$unknown")
+
+        # Supported variables.
+        self.assertNotEqual(self.dnf_manager.substitute("/$basearch"), "/$basearch")
+        self.assertNotEqual(self.dnf_manager.substitute("/$releasever"), "/$releasever")


### PR DESCRIPTION
Call the `substitute` method of the DNF manager to substitute variables
with their values. Remove the `_replace_vars` method of the DNF payload.