### PR TITLE
repair  password entry box conflicts with  root lock button when enter root_password spoke

### DIFF
--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -165,6 +165,8 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self._root_password_ssh_login_override.set_active(
             self._users_module.RootPasswordSSHLoginAllowed
         )
+        self.password_entry.set_sensitive(not self._lock.get_active())
+        self.password_confirmation_entry.set_sensitive(not self._lock.get_active())
         if not self._lock.get_active():
             # rerun checks so that we have a correct status message, if any
             self.checker.run_checks()


### PR DESCRIPTION
 The logic of the password entry box conflicts with that of the root lock button when enter the root_password spoke
Root is locked but the password_entry box can still be entered when enter the root password spoke
It's a confusing situation