### PR TITLE
network: match also connections named by MAC created by NM in initramfs

### DIFF
--- a/pyanaconda/core/regexes.py
+++ b/pyanaconda/core/regexes.py
@@ -194,3 +194,6 @@ IPV6_ADDRESS_IN_DRACUT_IP_OPTION = re.compile(r'\[[^\]]+\]')
 
 # Octet of MAC address
 MAC_OCTET = re.compile(r'[a-fA-F0-9][a-fA-F0-9]')
+
+# Name of initramfs connection created by NM based on MAC
+NM_MAC_INITRAMFS_CONNECTION = re.compile(r'^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$')

--- a/pyanaconda/modules/network/initialization.py
+++ b/pyanaconda/modules/network/initialization.py
@@ -16,7 +16,9 @@
 # Red Hat, Inc.
 #
 import copy
+import re
 
+from pyanaconda.core.regexes import NM_MAC_INITRAMFS_CONNECTION
 from pyanaconda.modules.common.task import Task
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.network.network_interface import NetworkInitializationTaskInterface
@@ -308,4 +310,6 @@ class DumpMissingConfigFilesTask(Task):
         return new_configs
 
     def _is_initramfs_connection(self, con, iface):
-        return con.get_id() in ["Wired Connection", iface]
+        con_id = con.get_id()
+        return con_id in ["Wired Connection", iface] \
+            or re.match(NM_MAC_INITRAMFS_CONNECTION, con_id)

--- a/tests/nosetests/regex_tests/initamfs_con_name_test.py
+++ b/tests/nosetests/regex_tests/initamfs_con_name_test.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+# vim:set fileencoding=utf-8
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from regexcheck import regex_match
+from pyanaconda.core.regexes import NM_MAC_INITRAMFS_CONNECTION
+
+
+class NMMacInitramfsConnectionTestCase(unittest.TestCase):
+    def initramfs_connection_test(self):
+        good_tests = [
+            '12:24:56:78:ab:cd',
+            '12:24:56:78:AB:cd',
+            '12:24:56:78:AB:CD',
+        ]
+
+        bad_tests = [
+            '',
+            '12:24:56:789:ab:cd',
+            '12:24:56:78:AB:cg',
+            '12:24:56:78:ab:cd:ef',
+            '12-24-56-78-ab-cd',
+            '12-24-56-78-AB-CD',
+            '12:24:56:78-ab-cd',
+            '12:24:56:78-AB-CD',
+            '12:24:56:78:ab',
+            # Infiniband MAC address
+            '80:00:02:00:fe:80:00:00:00:00:00:00:f4:52:14:03:00:7b:cb:a3',
+        ]
+
+        self.assertTrue(regex_match(NM_MAC_INITRAMFS_CONNECTION, good_tests, bad_tests))


### PR DESCRIPTION
This is port from rhel-8 branch.

Related: rhbz#1910438

For example connection created by configuration:
ip=10.43.136.52::10.43.136.254:255.255.255.0:testhost.example.com:52-54-00-8e-57-91:none

Same as in case of specification by BOOTIF= boot option, the connection is
bound to interface name and renamed to the interface name.