### PR TITLE
[payload]Adds priority and modules_hotfixes params

### DIFF
--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -518,6 +518,12 @@ class DNFPayload(Payload):
         if ksrepo.cost:
             repo.cost = ksrepo.cost
 
+        if ksrepo.priority:
+            repo.priority = ksrepo.priority
+
+        if ksrepo.modules_hotfixes:
+            repo.modules_hotfixes = ksrepo.modules_hotfixes
+
         if ksrepo.includepkgs:
             repo.include = ksrepo.includepkgs
 


### PR DESCRIPTION
This commit follows the PR pykickstart/pykickstart#378

As cost is already part of the supported parameter, this commit just adds the support for priority which could be useful when using repositories that could provide the same packages.

And module_hotfixes may be not as useful but it allows to supports hotfixes repositories.
Thoses repositories could be used in cases of creating images regurlarly in a CI system.

Signed-off-by: Romain Forlot <romain.forlot@iot.bzh>