### PR TITLE
Make the scale visible by default (#1943370)

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/resize.glade
+++ b/pyanaconda/ui/gui/spokes/lib/resize.glade
@@ -289,10 +289,9 @@
               <object class="GtkScale" id="resizeSlider">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="margin_top">12</property>
                 <property name="margin_bottom">12</property>
                 <property name="adjustment">resizeAdjustment</property>
-                <property name="round_digits">0</property>
-                <property name="digits">0</property>
                 <signal name="format-value" handler="on_resize_slider_format" swapped="no"/>
                 <signal name="value-changed" handler="on_resize_value_changed" swapped="no"/>
               </object>

--- a/pyanaconda/ui/gui/spokes/lib/resize.glade
+++ b/pyanaconda/ui/gui/spokes/lib/resize.glade
@@ -287,8 +287,8 @@
             </child>
             <child>
               <object class="GtkScale" id="resizeSlider">
+                <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="no_show_all">True</property>
                 <property name="margin_bottom">12</property>
                 <property name="adjustment">resizeAdjustment</property>
                 <property name="round_digits">0</property>

--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -338,6 +338,10 @@ class ResizeDialog(GUIObject):
         :param default_size: default value to set
         :type default_size: Size
         """
+        # Turn off wrapping of the displayed values.
+        layout = self._resize_slider.get_layout()
+        layout.set_width(-1)
+
         # Convert the Sizes to ints
         min_size = int(min_size)
         max_size = int(max_size)
@@ -623,4 +627,4 @@ class ResizeDialog(GUIObject):
     def on_resize_slider_format(self, scale, value):
         # This makes the value displayed under the slider prettier than just a
         # single number.
-        return str(Size(value))
+        return Size(value).human_readable(max_places=1)


### PR DESCRIPTION
GLib crashes with a segmentation fault if the accessibility
is enabled and a GtkScale widget is not visible by default.
We will hide the widget later if required.

Turn off wrapping of the scale values. There is not enough
space for more than one line above the scale.

Resolves: rhbz#1943370