### PR TITLE
Add the default_environment property to the DNF manager

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -143,6 +143,22 @@ class DNFManager(object):
         base.conf.install_weak_deps = not data.weakdeps_excluded
 
     @property
+    def default_environment(self):
+        """Default environment.
+
+        :return: an identifier of an environment or None
+        """
+        environments = self.environments
+
+        if conf.payload.default_environment in environments:
+            return conf.payload.default_environment
+
+        if environments:
+            return environments[0]
+
+        return None
+
+    @property
     def environments(self):
         """Environments defined in comps.xml file.
 

--- a/pyanaconda/modules/payloads/payload/dnf/utils.py
+++ b/pyanaconda/modules/payloads/payload/dnf/utils.py
@@ -39,19 +39,6 @@ log = get_module_logger(__name__)
 DNF_PACKAGE_CACHE_DIR_SUFFIX = 'dnf.package.cache'
 
 
-def get_default_environment(dnf_manager):
-    """Get a default environment.
-
-    :return: an id of an environment or None
-    """
-    environments = dnf_manager.environments
-
-    if environments:
-        return environments[0]
-
-    return None
-
-
 def get_kernel_package(dnf_base, exclude_list):
     """Get an installable kernel package.
 

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -37,8 +37,8 @@ from pyanaconda.modules.payloads.payload.dnf.requirements import collect_languag
     collect_platform_requirements, collect_driver_disk_requirements, collect_remote_requirements, \
     apply_requirements
 from pyanaconda.modules.payloads.payload.dnf.utils import get_kernel_package, \
-    get_product_release_version, get_default_environment, get_installation_specs, \
-    get_kernel_version_list, calculate_required_space
+    get_product_release_version, get_installation_specs, get_kernel_version_list, \
+    calculate_required_space
 from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager
 from pyanaconda.payload.source import SourceFactory, PayloadSourceTypeUnrecognized
 
@@ -302,7 +302,7 @@ class DNFPayload(Payload):
         selection = self.get_packages_selection()
 
         # Get the default environment.
-        default_environment = get_default_environment(self._dnf_manager)
+        default_environment = self._dnf_manager.default_environment
 
         # Get the installation specs.
         include_list, exclude_list = get_installation_specs(

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -120,6 +120,11 @@ class DNFPayload(Payload):
         self._requirements = []
 
     @property
+    def dnf_manager(self):
+        """The DNF manager."""
+        return self._dnf_manager
+
+    @property
     def _base(self):
         """Return a DNF base.
 

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
@@ -211,6 +211,34 @@ class DNFMangerTestCase(unittest.TestCase):
 
         self.assertEqual(size, Size("450 MiB"))
 
+    def no_default_environment_test(self):
+        """Test the default_environment property with no environment."""
+        self.assertEqual(self.dnf_manager.default_environment, None)
+
+    def default_environment_test(self):
+        """Test the default_environment property with environments."""
+        env_1 = Mock(id="environment-1")
+        env_2 = Mock(id="environment-2")
+        env_3 = Mock(id="environment-3")
+
+        comps = Mock(environments=[env_1, env_2, env_3])
+        self.dnf_manager._base._comps = comps
+
+        self.assertEqual(self.dnf_manager.default_environment, "environment-1")
+
+    def default_configured_environment_test(self):
+        """Test the default_environment property with configuration."""
+        env_1 = Mock(id="environment-1")
+        env_2 = Mock(id="environment-2")
+        env_3 = Mock(id="environment-3")
+
+        comps = Mock(environments=[env_1, env_2, env_3])
+        self.dnf_manager._base._comps = comps
+
+        with patch("pyanaconda.modules.payloads.payload.dnf.dnf_manager.conf") as conf:
+            conf.payload.default_environment = "environment-2"
+            self.assertEqual(self.dnf_manager.default_environment, "environment-2")
+
     def environments_test(self):
         """Test the environments property."""
         self.assertEqual(self.dnf_manager.environments, [])

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_utils_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_utils_test.py
@@ -17,7 +17,7 @@
 #
 import unittest
 from textwrap import dedent
-from unittest.mock import patch, Mock, PropertyMock
+from unittest.mock import patch, Mock
 
 from blivet.size import Size
 
@@ -25,11 +25,9 @@ from pyanaconda.core.constants import GROUP_PACKAGE_TYPES_REQUIRED, GROUP_PACKAG
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.structures.packages import PackagesSelectionData
-from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager
 from pyanaconda.modules.payloads.payload.dnf.utils import get_kernel_package, \
-    get_product_release_version, get_default_environment, get_installation_specs, \
-    get_kernel_version_list, pick_download_location, calculate_required_space, \
-    get_free_space_map, _pick_mount_points
+    get_product_release_version, get_installation_specs, get_kernel_version_list, \
+    pick_download_location, calculate_required_space, get_free_space_map, _pick_mount_points
 
 from tests.nosetests.pyanaconda_tests import patch_dbus_get_proxy_with_cache
 
@@ -90,19 +88,6 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
     def get_product_release_version_dot_test(self):
         """Test the get_product_release_version function with a dot."""
         self.assertEqual(get_product_release_version(), "7.4")
-
-    @patch.object(DNFManager, 'environments', new_callable=PropertyMock)
-    def get_default_environment_test(self, mock_environments):
-        """Test the get_default_environment function"""
-        mock_environments.return_value = []
-        self.assertEqual(get_default_environment(DNFManager()), None)
-
-        mock_environments.return_value = [
-            "environment-1",
-            "environment-2",
-            "environment-3",
-        ]
-        self.assertEqual(get_default_environment(DNFManager()), "environment-1")
 
     def get_installation_specs_default_test(self):
         """Test the get_installation_specs function with defaults."""


### PR DESCRIPTION
Choose the environment from the Anaconda configuration file
or the first available one.

Use the DNF manager to select the default environment in UI.