### PR TITLE
Pin version of astroid

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -32,6 +32,7 @@ RUN echo dnf update -y && \
 
 RUN pip-3.6 install \
   "pylint==2.5.3" \
+  "astroid==2.4.2" \
   pocketlint \
   copr \
   coverage \


### PR DESCRIPTION
The astroid library is used by pylint and can change its behavior by changing the parse tree. Pinning astroid version prevents all new detections since the pinning of pylint (in September 2020).