### PR TITLE
Static analyzer fixes - shell scripts

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -18,19 +18,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-LIVE_INSTALL=0
 IMAGE_INSTALL=0
 
-if [ -z "$LIVECMD" ]; then
-    LIVE_INSTALL=1
-fi
-
-if [[ "$LIVECMD $*" =~ "--image" ]]; then
+if [[ "$LIVECMD $@" =~ "--image" ]]; then
     IMAGE_INSTALL=1
-fi
-
-if [[ "$LIVECMD $*" =~ "--liveinst" ]]; then
-    LIVE_INSTALL=1
 fi
 
 # Allow running another command in the place of anaconda, but in this same
@@ -42,8 +33,10 @@ ANACONDA="${LIVECMD:=anaconda --liveinst --graphical}"
 for i in raid0 raid1 raid5 raid6 raid456 raid10 dm-mod dm-zero dm-mirror dm-snapshot dm-multipath dm-round-robin vfat dm-crypt cbc sha256 lrw xts iscsi_tcp iscsi_ibft; do /sbin/modprobe $i 2>/dev/null ; done
 
 if [ -f /etc/system-release ]; then
-    export ANACONDA_PRODUCTNAME=$( cat /etc/system-release | sed -r -e 's/ *release.*//' )
-    export ANACONDA_PRODUCTVERSION=$( cat /etc/system-release | sed -r -e 's/^.* ([0-9\.]+).*$/\1/' )
+    ANACONDA_PRODUCTNAME=$( cat /etc/system-release | sed -r -e 's/ *release.*//' )
+    export ANACONDA_PRODUCTNAME
+    ANACONDA_PRODUCTVERSION=$( cat /etc/system-release | sed -r -e 's/^.* ([0-9\.]+).*$/\1/' )
+    export ANACONDA_PRODUCTVERSION
 fi
 
 # set PRODUCTVARIANT if this is a Fedora Workstation live image
@@ -58,7 +51,8 @@ if [ -f /etc/os-release ]; then
 fi
 
 if [ $IMAGE_INSTALL = 1 ]; then
-    export ANACONDA_PRODUCTVERSION=$(rpmquery -q --qf '%{VERSION}' anaconda | cut -d. -f1)
+    ANACONDA_PRODUCTVERSION=$(rpmquery -q --qf '%{VERSION}' anaconda | cut -d. -f1)
+    export ANACONDA_PRODUCTVERSION
 fi
 
 export ANACONDA_BUGURL=${ANACONDA_BUGURL:="https://bugzilla.redhat.com/bugzilla/"}
@@ -82,7 +76,7 @@ if [ -z "$(sestatus | grep enabled)" ]; then
 fi
 
 # Process cmdline args
-for opt in `cat /proc/cmdline` $*; do
+for opt in `cat /proc/cmdline` "$@"; do
     case $opt in
     xdriver=*)
         ANACONDA="$ANACONDA --$opt"
@@ -135,7 +129,7 @@ for opt in `cat /proc/cmdline` $*; do
 done
 
 # unmount anything that shouldn't be mounted prior to install
-anaconda-cleanup $ANACONDA $*
+anaconda-cleanup $ANACONDA "$@"
 
 # Set up the updates, if provided.
 if [ ! -z "$UPDATES" ]; then
@@ -165,9 +159,9 @@ fi
 export GDK_BACKEND=x11
 
 if [ -x /usr/bin/udisks ]; then
-    /usr/bin/udisks --inhibit -- $ANACONDA $*
+    /usr/bin/udisks --inhibit -- $ANACONDA "$@"
 else
-    $ANACONDA $*
+    $ANACONDA "$@"
 fi
 
 if [ -e /tmp/updates.img ]; then rm /tmp/updates.img; fi

--- a/data/liveinst/liveinst-setup.sh
+++ b/data/liveinst/liveinst-setup.sh
@@ -2,7 +2,7 @@
 # Set up a launcher on the desktop for the live installer if we're on
 # a live CD
 
-if [ ! \( -b /dev/mapper/live-base -o -b /dev/mapper/live-osimg-min \) ]; then
+if [ ! \( -b /dev/mapper/live-base ] || [ -b /dev/mapper/live-osimg-min \) ]; then
     exit 0
 fi
 

--- a/dracut/anaconda-copy-prefixdevname.sh
+++ b/dracut/anaconda-copy-prefixdevname.sh
@@ -2,7 +2,7 @@
 # Copy over persistent network device names to anaconda environment
 
 CMDLINE=$(cat /proc/cmdline)
-if [[ ${CMDLINE} =~ "net.ifnames.prefix=" ]]; then
+if echo "${CMDLINE}" | grep -q "net.ifnames.prefix="; then
   mkdir -p /run/initramfs/state/etc/systemd/network
   cp /etc/systemd/network/*-net-ifnames-prefix* /run/initramfs/state/etc/systemd/network
 fi

--- a/dracut/anaconda-depmod.sh
+++ b/dracut/anaconda-depmod.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-[ -e /run/install/DD-1 -o -e /tmp/DD-net ] || return 0
+[ -e /run/install/DD-1 ] || [ -e /tmp/DD-net ] || return 0
 
 # regenerate modules.* files
 depmod -b $NEWROOT

--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -10,7 +10,7 @@ run_checkisomd5() {
     livedev=$1
     if getargbool 0 rd.live.check -d check; then
         [ -b $livedev ] && fs=$(blkid -s TYPE -o value $livedev)
-        if [ "$fs" = "iso9660" -o "$fs" = "udf" ]; then
+        if [ "$fs" = "iso9660" ] || [ "$fs" = "udf" ]; then
             [ -x /bin/plymouth ] && /bin/plymouth --hide-splash
             if [ -n "$DRACUT_SYSTEMD" ]; then
                 p=$(dev_unit_name "$livedev")
@@ -24,7 +24,7 @@ run_checkisomd5() {
                 rc=$?
                 state="inactive"
             fi
-            if [ "$rc" == "1" ]; then
+            if [ "$rc" = "1" ]; then
                 die "CD check failed!"
                 exit 1
             fi
@@ -64,21 +64,26 @@ fi
 # retrigger this script, and we'll mount the disk as normal.
 if str_starts "$kickstart" "cdrom" && [ ! -e /tmp/ks.cfg.done ]; then
     if dev_is_cdrom "$dev"; then
-        > /tmp/anaconda-on-cdrom
+        # create empty marker file
+        true > /tmp/anaconda-on-cdrom
         exit 0
     fi
 fi
 
 # If interactive dd has been requested and this is a cdrom, wait to mount it
 # later. The user may want to swap in a driver update cdrom first.
-if [ -e /tmp/dd_interactive -a ! -e /tmp/dd.done ]; then
+if [ -e /tmp/dd_interactive ] && [ ! -e /tmp/dd.done ]; then
     if dev_is_cdrom "$dev"; then
-        > /tmp/anaconda-dd-on-cdrom
+        # create empty marker file
+        true > /tmp/anaconda-dd-on-cdrom
         exit 0
     fi
 fi
 
 info "anaconda using disk root at $dev"
+# NOTE: the repodir variable is defined in anaconda-lib.sh
+# shellcheck disable=SC2154
 mount -o ro $dev $repodir || warn "Couldn't mount $dev"
+# shellcheck disable=SC2154
 anaconda_live_root_dir $repodir $path
 run_checkisomd5 $dev

--- a/dracut/anaconda-ks-sendheaders.sh
+++ b/dracut/anaconda-ks-sendheaders.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 # anaconda-ks-sendheaders.sh - set various HTTP headers for kickstarting
 
 [ -f /tmp/.ks_sendheaders ] && return
@@ -30,4 +30,5 @@ if getargbool 0 inst.ks.sendsn; then
     fi
 fi
 
-> /tmp/.ks_sendheaders
+# create marker file
+true > /tmp/.ks_sendheaders

--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -23,7 +23,7 @@ done
 
 shopt -u nullglob
 
-if [ "$ARCH" != "s390" -a "$ARCH" != "s390x" ]; then
+if [ "$ARCH" != "s390" ] && [ "$ARCH" != "s390x" ]; then
     MODULE_LIST+=" floppy edd iscsi_ibft "
 else
     MODULE_LIST+=" hmcdrv "

--- a/dracut/anaconda-netroot.sh
+++ b/dracut/anaconda-netroot.sh
@@ -9,15 +9,21 @@ command -v getarg >/dev/null || . /lib/dracut-lib.sh
 netif="$1"
 
 # get repo info
+# NOTE: the root variable is set by dracut
+# shellcheck disable=SC2154
 splitsep ":" "$root" prefix repo
 
 # repo not set? make sure we are using fresh repo information
 if [ -z "$repo" ]; then
+     # NOTE: the hookdir variable is defined by dracut
+     # shellcheck disable=SC2154
      . $hookdir/cmdline/*parse-anaconda-repo.sh
      splitsep ":" "$root" prefix repo
 fi
 
 # no repo? non-net root? we're not needed here.
+# NOTE: prefix variable is set by splitsep dracut function call
+# shellcheck disable=SC2154
 [ "$prefix" = "anaconda-net" ] && [ -n "$repo" ] || return 0
 # already done? don't run again.
 [ -e /dev/root ] && return 0
@@ -46,7 +52,11 @@ case $repo in
         if str_starts "$repo" "nfs4:"; then
             repo=nfs:${repo#nfs4:}
             nfs_to_var "$repo" $netif
+            # NOTE: options variable is set by dracut nfs-lib.sh
+            # shellcheck disable=SC2154
             if ! strstr "$options" "vers="; then
+                # NOTE: server and path variables are set by dracut nfs-lib.sh
+                # shellcheck disable=SC2154
                 repo="nfs:${options:+$options,}nfsvers=4:$server:$path"
             fi
         else
@@ -59,6 +69,8 @@ case $repo in
             # END HACK. FIXME: Figure out what is up with nfs4, jeez
         fi
         if [ "${repo%.iso}" == "$repo" ]; then
+            # NOTE: repodir variable is set by anaconda-lib.sh
+            # shellcheck disable=SC2154
             mount_nfs "$repo" "$repodir" "$netif" || warn "Couldn't mount $repo"
             anaconda_live_root_dir $repodir
         else

--- a/dracut/anaconda-pre-shutdown.sh
+++ b/dracut/anaconda-pre-shutdown.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Fix mount loops that prevent unmount/eject.
 #
 # During startup, we mount our repo (e.g. the DVD) at $repodir or $isodir.
@@ -14,6 +15,8 @@
 
 . /lib/anaconda-lib.sh
 
+# NOTE: the repodir and isodir variables are defined in anaconda-lib.sh
+# shellcheck disable=SC2154
 for mnt in $repodir $isodir; do
     # systemd-shutdown puts old root at /oldroot
     oldmnt=/oldroot$mnt

--- a/dracut/driver-updates-genrules.sh
+++ b/dracut/driver-updates-genrules.sh
@@ -8,7 +8,7 @@ command -v wait_for_dd >/dev/null || . /lib/anaconda-lib.sh
 DD_OEMDRV=""
 if [ -f /tmp/dd_interactive ]; then
     initqueue --onetime --settled --name zz_dd_interactive \
-        systemctl start driver-updates@$(find_tty).service
+        systemctl start "driver-updates@$(find_tty).service"
 else
     # Only process OEMDRV in non-interactive mode
     DD_OEMDRV="LABEL=OEMDRV"
@@ -36,6 +36,8 @@ for dd in $DD_OEMDRV $DD_DISKS; do
         # this is a disk with path to specific RPM file on it
         if [ "${dd##*.}" = "rpm" ]; then
             splitsep ":" "$dd" dd_type dd_dev dd_path
+            # NOTE: dd_type and dd_dev variables are set by splitsep
+            # shellcheck disable=SC2154
             when_diskdev_appears "$(disk_to_dev_path $dd_type)" \
                 driver-updates --disk $dd_whitespace_fix \$devnode $dd_dev
         else
@@ -46,6 +48,8 @@ for dd in $DD_OEMDRV $DD_DISKS; do
 done
 
 # force us to wait at least until we've settled at least once
+# NOTE: the hookdir variable is defined by dracut
+# shellcheck disable=SC2154
 echo '> /tmp/settle.done' > $hookdir/initqueue/settled/settle_done.sh
 echo '[ -f /tmp/settle.done ]' > $hookdir/initqueue/finished/wait_for_settle.sh
 

--- a/dracut/fetch-driver-net.sh
+++ b/dracut/fetch-driver-net.sh
@@ -2,9 +2,6 @@
 # fetch-driver-net - fetch driver from the network.
 # runs from the "initqueue/online" hook whenever a net interface comes online
 
-# initqueue/online hook passes interface name as $1
-netif="$1"
-
 # No dd_net was requested - exit
 [ -f /tmp/dd_net ] || return 0
 DD_NET=$(cat /tmp/dd_net)
@@ -36,7 +33,8 @@ for dd in $DD_NET; do
             info "Fetching RPM driverdisks from $dd directory"
 
             # Following variables are set by nfs_to_var:
-            local nfs="" server="" path="" options="" mntdir=""
+            # (can't use local here as we are not actually inside a function)
+            nfs="" server="" path="" options="" mntdir=""
             nfs_to_var "$dd"
 
             # Obtain mount directory and mount it

--- a/dracut/fetch-kickstart-net.sh
+++ b/dracut/fetch-kickstart-net.sh
@@ -12,6 +12,8 @@ netif="$1"
 [ -n "$kickstart" ] || return 0
 
 # user requested a specific device, but this isn't it - exit
+# NOTE: the ksdevice special variable holds the network device to use for fetching kickstart/stage2/etc
+# shellcheck disable=SC2154
 [ -n "$ksdevice" ] && [ "$ksdevice" != "$netif" ] && return 0
 
 command -v getarg >/dev/null || . /lib/dracut-lib.sh
@@ -67,6 +69,8 @@ esac
 
 # If we're doing sendmac, we need to run after anaconda-ks-sendheaders.sh
 if getargbool 0 inst.ks.sendmac kssendmac; then
+    # NOTE: the hookdir variable is defined by dracut
+    # shellcheck disable=SC2154
     newjob=$hookdir/initqueue/settled/fetch-ks-${netif}.sh
 else
     newjob=$hookdir/initqueue/fetch-ks-${netif}.sh

--- a/dracut/find-net-intfs-by-driver
+++ b/dracut/find-net-intfs-by-driver
@@ -13,7 +13,7 @@ for i in /sys/class/net/*/device/modalias; do
         exit 0
     fi
     # Get kernel mods on which the interface is dependent
-    d=$(modprobe -R $(cat "$i"))
+    d="$(modprobe -R $(cat "$i"))"
 
     # Test if this is the mod we are looking for. If so return name of the interface.
     if [[ " $d " == *\ $driver\ * ]]; then

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -2,6 +2,8 @@
 # module-setup.sh for anaconda
 
 check() {
+    # NOTE: the hostonly variable is set by dracut
+    # shellcheck disable=SC2154
     [[ $hostonly ]] && return 1
     return 255 # this module is optional
 }
@@ -30,6 +32,8 @@ install() {
     inst_binary /usr/libexec/anaconda/dd_extract /bin/dd_extract
 
     # anaconda
+    # NOTE: the moddir variable is set by dracut
+    # shellcheck disable=SC2154
     inst "$moddir/anaconda-lib.sh" "/lib/anaconda-lib.sh"
     inst_hook cmdline 25 "$moddir/parse-anaconda-options.sh"
     inst_hook cmdline 26 "$moddir/parse-anaconda-kickstart.sh"

--- a/dracut/parse-anaconda-kickstart.sh
+++ b/dracut/parse-anaconda-kickstart.sh
@@ -29,12 +29,14 @@ case "${kickstart%%:*}" in
     ;;
     file|path) # "file:<path>" - "path:<path>" is accepted but deprecated
         splitsep ":" "$kickstart" kstype kspath
+        # NOTE: kspath is filled by splitsep
+        # shellcheck disable=SC2154
         if [ -f "$kspath" ]; then
             info "anaconda: parsing kickstart $kspath"
             cp $kspath /tmp/ks.cfg
             parse_kickstart /tmp/ks.cfg
             [ "$root" = "anaconda-kickstart" ] && root=""
-            > /tmp/ks.cfg.done
+            true > /tmp/ks.cfg.done
         else
             warn "inst.ks='$kickstart'"
             warn "can't find $kspath!"

--- a/dracut/parse-anaconda-net.sh
+++ b/dracut/parse-anaconda-net.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # parse-anaconda-net.sh - parse old deprecated anaconda network setup args
 
 net_conf=/etc/cmdline.d/75-anaconda-network-options.conf

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -5,6 +5,8 @@
 . /lib/url-lib.sh
 
 # create the repodir and isodir that anaconda will look for
+# NOTE: the repodir and isodir variables are defined in anaconda-lib.sh
+# shellcheck disable=SC2154
 mkdir -p $repodir $isodir
 
 # add some modules

--- a/dracut/parse-anaconda-repo.sh
+++ b/dracut/parse-anaconda-repo.sh
@@ -19,6 +19,8 @@ getargbool 0 inst.stage2.all && repo="urls"
 
 if [ -n "$repo" ]; then
     splitsep ":" "$repo" repotype rest
+    # NOTE: repodir is filled by splitsep
+    # shellcheck disable=SC2154
     case "$repotype" in
         http|https|ftp|nfs|nfs4)
             root="anaconda-net:$repo"
@@ -58,4 +60,6 @@ esac
 
 # We've got *some* root variable set.
 # Set rootok so we can move on to anaconda-genrules.sh.
+# NOTE: rootok is a special variable managed by dracut
+# shellcheck disable=SC2304
 rootok=1

--- a/dracut/repo-genrules.sh
+++ b/dracut/repo-genrules.sh
@@ -4,23 +4,25 @@
 
 . /lib/anaconda-lib.sh
 
+# NOTE: the root variable appears to be a special variable set by either dracut or Anaconda
+# shellcheck disable=SC2154
 case "$root" in
   anaconda-disk:*)
     # anaconda-disk:<device>[:<path>]
     splitsep ":" "$root" f diskdev diskpath
     diskdev=$(disk_to_dev_path $diskdev)
     when_diskdev_appears $diskdev \
-        anaconda-diskroot \$env{DEVNAME} $diskpath
+        anaconda-diskroot "\$env{DEVNAME}" $diskpath
   ;;
   anaconda-auto-cd)
     # special catch-all rule for CDROMs
     when_any_cdrom_appears \
-        anaconda-diskroot \$env{DEVNAME}
+        anaconda-diskroot "\$env{DEVNAME}"
     # HACK: anaconda demands that CDROMs be mounted at /mnt/install/source
     ln -s repo /run/install/source
   ;;
   anaconda-hmc)
     when_any_hmcdrv_appears \
-        anaconda-hmcroot \$env{DEVNAME}
+        anaconda-hmcroot "\$env{DEVNAME}"
   ;;
 esac

--- a/dracut/save-initramfs.sh
+++ b/dracut/save-initramfs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # save-initramfs - save a copy of initramfs for shutdown/eject, if needed
 
 command -v config_get >/dev/null || . /lib/anaconda-lib.sh
@@ -6,6 +6,8 @@ initramfs=""
 
 # First, check to see if we can find a copy of initramfs laying around
 for i in images/pxeboot/initrd.img ppc/ppc64/initrd.img images/initrd.img; do
+    # NOTE: the repodir variable is defined in anaconda-lib.sh
+    # shellcheck disable=SC2154
     [ -f $repodir/$i ] && initramfs=$repodir/$i && break
 done
 
@@ -23,5 +25,5 @@ fi
 
 # Make sure dracut-shutdown.service can find the initramfs later.
 mkdir -p $NEWROOT/boot
-ln -s $initramfs $NEWROOT/boot/initramfs-$(uname -r).img
+ln -s $initramfs "$NEWROOT/boot/initramfs-$(uname -r).img"
 # NOTE: $repodir must also be somewhere under /run for this to work correctly

--- a/dracut/updates-genrules.sh
+++ b/dracut/updates-genrules.sh
@@ -3,6 +3,8 @@
 
 . /lib/anaconda-lib.sh
 
+# NOTE: anac_updates is a special variable holding Anaconda-style URL for updates.img
+# shellcheck disable=SC2154
 updates=$anac_updates
 [ -n "$updates" ] || return
 case $updates in
@@ -17,8 +19,10 @@ case $updates in
         # accept hd:<dev>:<path> (or cdrom:<dev>:<path>)
         updates=${updates#hd:}; updates=${updates#cdrom:}
         splitsep ":" "$updates" dev path
+        # NOTE: the path variable is set by splitsep
+        # shellcheck disable=SC2154
         dev=$(disk_to_dev_path $dev)
-        when_diskdev_appears $dev fetch-updates-disk \$env{DEVNAME} $path
+        when_diskdev_appears $dev fetch-updates-disk "\$env{DEVNAME}" $path
         wait_for_updates
     ;;
 esac

--- a/scripts/log-capture
+++ b/scripts/log-capture
@@ -4,10 +4,14 @@ date=$(date +%F_%H%M%S)
 OUTDIR=/tmp/log-capture-${date}
 ARCHIVE=${1-/tmp/log-capture.tar.bz2}
 
-_to_log() { local OutputFile=$(tr ' /' '_' <<<"$@"); $@ >${OUTDIR}/${OutputFile}; }
+_to_log() {
+    local OutputFile
+    OutputFile=$(tr ' /' '_' <<<"$@")
+    "$@" >${OUTDIR}/${OutputFile}
+}
 
 mkdir -p ${OUTDIR}
-cd ${OUTDIR}
+cd ${OUTDIR} || { echo "log-capture script failed to cd to outputdir"; exit 1; }
 
 if [[ ! -f /tmp/ks.cfg ]];then
   echo "# No /tmp/ks.cfg present" > ${OUTDIR}/ks.cfg

--- a/scripts/start-module
+++ b/scripts/start-module
@@ -12,6 +12,8 @@ do
   case $1 in
     # Set up the environment.
     --env)
+      # NOTE: yes, we want to export the contents of $2, not the variable itself
+      # shellcheck disable=SC2163
       export $2
       shift 2
     ;;

--- a/scripts/upd-updates
+++ b/scripts/upd-updates
@@ -25,7 +25,7 @@ isAnacondaGitDir() {
 
 usage() {
 	if [ $1 -ne 0 ]; then
-		>&2
+		true>&2
 	fi
 	echo "upd-updates <updates.img> [<file0> [<file1> [...]]]"
 	exit $1
@@ -48,7 +48,7 @@ if [ ! -f "$1" ]; then
 fi
 
 OK=no
-if [ -e "$TARGET" -a -w "$TARGET" -o -w $(dirname "$TARGET") ] ; then
+if [ -e "$TARGET" ] && [ -w "$TARGET" ] || [ -w "$(dirname "$TARGET")" ] ; then
 	OK=yes
 fi
 
@@ -61,7 +61,7 @@ if [ "$updateAll" == "no" ]; then
 	n=1
 	while [ -n "$(eval echo '${'$n'}')" ]; do
 		arg="$(eval echo '${'$n'}')"
-		[ ${arg} == "--help" -o ${arg} == "-h" ] && usage 0
+		[ ${arg} == "--help" ] || [ ${arg} == "-h" ] && usage 0
 
 		if [ ! -r ${arg} ]; then
 			echo "upd-updates: cannot read ${arg}" 1>&2
@@ -78,29 +78,32 @@ if [ ! -d ${TMPDIR} ]; then
 fi
 
 if [ -e "$TARGET" ]; then
-	zcat "$TARGET" | ( cd $TMPDIR ; cpio -di --quiet -dm --unconditional )
+	zcat "$TARGET" | (cd $TMPDIR || { echo "upd-updates can't cd to tmpdir"; exit 1; } ; cpio -di --quiet -dm --unconditional )
 	[ $? -eq 0 ] || exit 5
 fi
 
 if [ "$updateAll" == "yes" ]; then
 	# this may do the wrong thing if we have two files named the same...
 	# so, uh, don't do that.
+    # also files with spaces in the name could be problematic, so lets
+    # not have those as well, please ?
+    # shellcheck disable=SC2044
 	for oldfile in $(find "$TMPDIR" -type f) ; do
-		for newfile in $(find . -name $(basename $oldfile)) ; do
+		for newfile in $(find . -name "$(basename $oldfile)") ; do
 			if [ "$oldfile" -ot "$newfile" ]; then
 				cp -av "$newfile" "$oldfile"
 			fi
 		done
 	done
 else
-	echo ${@} | tr ' ' '\0' | tr -d '\n' | \
+	echo "${@}" | tr ' ' '\0' | tr -d '\n' | \
 		cpio --null -H newc --quiet -o | \
-		( cd $TMPDIR ; cpio -di --quiet -dm --unconditional )
+		( cd $TMPDIR || { echo "upd-updates can't cd to tmpdir"; exit 1; }; cpio -di --quiet -dm --unconditional )
 
 	[ $? -eq 0 ] || exit 6
 fi
 
-(cd $TMPDIR ; find . -depth -print0 | cpio -H newc --quiet --null -o ) | \
+(cd $TMPDIR || { echo "upd-updates can't cd to tmpdir"; exit 1; }  ; find . -depth -print0 | cpio -H newc --quiet --null -o ) | \
 	gzip -9 > "$TARGET"
 
 [ $? -eq 0 ] || exit 7


### PR DESCRIPTION
Issues identified by the shellcheck scanner in Anaconda
related shell scripts have been either fixed where possible
or documented why the code needs to stay the way it is now
(usually thanks to dracut magic variables) and the given check
has been suppressed.

Related: rhbz#1938677

**NOTE**
- the code qality of the `upd-updates` script seems rather bad and many issues have been found in it by the checker, while the script, at least after a quick look appears old and unused by other code in Anaconda, so maybe we could drop it instead ?