### PR TITLE
Run RHEL8 contributor tests on kstest runners

### DIFF
--- a/.github/workflows/tests-contributors.yml
+++ b/.github/workflows/tests-contributors.yml
@@ -244,7 +244,7 @@ jobs:
   unit-tests-rhel-8:
     needs: pr-info
     if: needs.pr-info.outputs.base_ref == 'rhel-8' && needs.pr-info.outputs.allowed_user == 'true'
-    runs-on: [self-hosted, ci-tasks, rhel-8]
+    runs-on: [self-hosted, kstest]
     timeout-minutes: 30
     env:
       TARGET_BRANCH_NAME: origin/rhel-8
@@ -275,13 +275,14 @@ jobs:
           git log --oneline -1 ${{ env.TARGET_BRANCH_NAME }}
           git rebase ${{ env.TARGET_BRANCH_NAME }}
 
-      - name: Run test
+      - name: Build CI test container
         run: |
-          ./autogen.sh
-          ./configure
-          make
+          make -f Makefile.am anaconda-ci-build
+
+      - name: Run tests in container
+        run: |
           # put the log in the output, where it's easy to read and link to
-          make ci || { cat test-logs/test-suite.log; exit 1; }
+          make -f Makefile.am container-ci || { cat test-logs/test-suite.log; exit 1; }
 
       - name: Upload test and coverage logs
         if: always()


### PR DESCRIPTION
Uses same code as owner tests, mostly.

With this, we should be able to get rid of the rhel-specific runner, this time for real.

~~TODO: Still testing. Ongoing PSI networking instability incident = downloading packages in the runner times out before the job can succeed. See here: https://github.com/vslavik-test-org/anaconda/pull/6~~

It works fine, see here: https://github.com/vslavik-test-org/anaconda/actions/runs/725452092