### PR TITLE
Use the DNF manager instead of the DNF base

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -419,6 +419,19 @@ class DNFManager(object):
         subject = dnf.subject.Subject(package_spec)
         return bool(subject.get_best_query(self._base.sack))
 
+    def match_available_packages(self, pattern):
+        """Find available packages that match the specified pattern.
+
+        :param pattern: a pattern for package names
+        :return: a list of matched package names
+        """
+        if not self._base.sack:
+            log.warning("There is no metadata about packages!")
+            return []
+
+        packages = self._base.sack.query().available().filter(name__glob=pattern)
+        return [p.name for p in packages]
+
     def enable_modules(self, module_specs):
         """Mark module streams for enabling.
 

--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -24,6 +24,7 @@ import traceback
 import dnf
 import dnf.exceptions
 import dnf.module.module_base
+import dnf.subject
 import libdnf.conf
 
 from blivet.size import Size
@@ -404,6 +405,19 @@ class DNFManager(object):
         shutil.rmtree(DNF_PLUGINCONF_DIR, ignore_errors=True)
         self._base.reset(sack=True, repos=True)
         log.debug("The DNF cache has been cleared.")
+
+    def is_package_available(self, package_spec):
+        """Is the specified package available for the installation?
+
+        :param package_spec: a package spec
+        :return: True if the package can be installed, otherwise False
+        """
+        if not self._base.sack:
+            log.warning("There is no metadata about packages!")
+            return False
+
+        subject = dnf.subject.Subject(package_spec)
+        return bool(subject.get_best_query(self._base.sack))
 
     def enable_modules(self, module_specs):
         """Mark module streams for enabling.

--- a/pyanaconda/modules/payloads/payload/dnf/requirements.py
+++ b/pyanaconda/modules/payloads/payload/dnf/requirements.py
@@ -80,10 +80,10 @@ def collect_language_requirements(dnf_manager):
     return requirements
 
 
-def collect_platform_requirements(dnf_base):
+def collect_platform_requirements(dnf_manager):
     """Collect the requirements for the current platform.
 
-    :param dnf_base: a DNF base
+    :param dnf_manager: a DNF manager
     :return: a list of requirements
     """
     # Detect the current platform.
@@ -92,13 +92,10 @@ def collect_platform_requirements(dnf_base):
     if not platform:
         return []
 
-    # Get all available groups.
-    available_groups = [g.id for g in dnf_base.comps.groups_iter()]
-
     # Add a platform specific group.
     group = "platform-" + platform.lower()
 
-    if group not in available_groups:
+    if group not in dnf_manager.groups:
         log.warning("Platform group %s not available.", group)
         return []
 

--- a/pyanaconda/modules/payloads/payload/dnf/requirements.py
+++ b/pyanaconda/modules/payloads/payload/dnf/requirements.py
@@ -42,10 +42,10 @@ def collect_remote_requirements():
     )
 
 
-def collect_language_requirements(dnf_base):
+def collect_language_requirements(dnf_manager):
     """Collect requirements for supported languages.
 
-    :param dnf_base: a DNF base
+    :param dnf_manager: a DNF manager
     :return: a list of requirements
     """
     requirements = []
@@ -57,10 +57,10 @@ def collect_language_requirements(dnf_base):
     locales = [localization_proxy.Language] + localization_proxy.LanguageSupport
 
     # Find all available langpacks.
-    packages = dnf_base.sack.query().available().filter(name__glob="langpacks-*")
+    packages = dnf_manager.match_available_packages("langpacks-*")
 
     # Get all valid langcodes.
-    codes = [p.name.split('-', 1)[1] for p in packages]
+    codes = [p.split('-', 1)[1] for p in packages]
     codes = list(filter(is_valid_langcode, codes))
 
     # Find the best langpacks to install.

--- a/pyanaconda/modules/payloads/payload/dnf/utils.py
+++ b/pyanaconda/modules/payloads/payload/dnf/utils.py
@@ -15,8 +15,6 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-import dnf.subject
-import dnf.const
 import fnmatch
 import os
 import rpm
@@ -39,10 +37,10 @@ log = get_module_logger(__name__)
 DNF_PACKAGE_CACHE_DIR_SUFFIX = 'dnf.package.cache'
 
 
-def get_kernel_package(dnf_base, exclude_list):
+def get_kernel_package(dnf_manager, exclude_list):
     """Get an installable kernel package.
 
-    :param dnf_base: a DNF base
+    :param dnf_manager: a DNF manager
     :param exclude_list: a list of excluded packages
     :return: a package name or None
     """
@@ -62,14 +60,12 @@ def get_kernel_package(dnf_base, exclude_list):
             log.info("kernel: excluded %s", kernel_package)
             continue
 
-        subject = dnf.subject.Subject(kernel_package)
-        installable = bool(subject.get_best_query(dnf_base.sack))
+        if not dnf_manager.is_package_available(kernel_package):
+            log.info("kernel: no such package %s", kernel_package)
+            continue
 
-        if installable:
-            log.info("kernel: selected %s", kernel_package)
-            return kernel_package
-
-        log.info("kernel: no such package %s", kernel_package)
+        log.info("kernel: selected %s", kernel_package)
+        return kernel_package
 
     log.error("kernel: failed to select a kernel from %s", kernels)
     return None

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -766,7 +766,7 @@ class DNFPayload(Payload):
         self._requirements.extend(
             collect_remote_requirements()
             + collect_language_requirements(self._dnf_manager)
-            + collect_platform_requirements(self._base)
+            + collect_platform_requirements(self._dnf_manager)
             + collect_driver_disk_requirements()
         )
 

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -765,7 +765,7 @@ class DNFPayload(Payload):
     def _collect_requirements(self):
         self._requirements.extend(
             collect_remote_requirements()
-            + collect_language_requirements(self._base)
+            + collect_language_requirements(self._dnf_manager)
             + collect_platform_requirements(self._base)
             + collect_driver_disk_requirements()
         )

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -299,7 +299,7 @@ class DNFPayload(Payload):
         )
 
         # Add the kernel package.
-        kernel_package = get_kernel_package(self._base, exclude_list)
+        kernel_package = get_kernel_package(self._dnf_manager, exclude_list)
 
         if kernel_package:
             include_list.append(kernel_package)

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
@@ -555,6 +555,25 @@ class DNFManagerTestCase(unittest.TestCase):
         self.assertNotEqual(self.dnf_manager.substitute("/$basearch"), "/$basearch")
         self.assertNotEqual(self.dnf_manager.substitute("/$releasever"), "/$releasever")
 
+    @patch("dnf.subject.Subject.get_best_query")
+    def is_package_available_test(self, get_best_query):
+        """Test the is_package_available method."""
+        self.dnf_manager._base._sack = Mock()
+        self.assertEqual(self.dnf_manager.is_package_available("kernel"), True)
+
+        # No package.
+        get_best_query.return_value = None
+        self.assertEqual(self.dnf_manager.is_package_available("kernel"), False)
+
+        # No metadata.
+        self.dnf_manager._base._sack = None
+
+        with self.assertLogs(level="WARNING") as cm:
+            self.assertEqual(self.dnf_manager.is_package_available("kernel"), False)
+
+        msg = "There is no metadata about packages!"
+        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+
 
 class DNFManagerCompsTestCase(unittest.TestCase):
     """Test the comps abstraction of the DNF base."""

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
@@ -574,6 +574,34 @@ class DNFManagerTestCase(unittest.TestCase):
         msg = "There is no metadata about packages!"
         self.assertTrue(any(map(lambda x: msg in x, cm.output)))
 
+    def match_available_packages_test(self):
+        """Test the match_available_packages method"""
+        p1 = self._get_package("langpacks-cs")
+        p2 = self._get_package("langpacks-core-cs")
+        p3 = self._get_package("langpacks-core-font-cs")
+
+        sack = Mock()
+        sack.query.return_value.available.return_value.filter.return_value = [
+            p1, p2, p3
+        ]
+
+        # With metadata.
+        self.dnf_manager._base._sack = sack
+        self.assertEqual(self.dnf_manager.match_available_packages("langpacks-*"), [
+            "langpacks-cs",
+            "langpacks-core-cs",
+            "langpacks-core-font-cs"
+        ])
+
+        # No metadata.
+        self.dnf_manager._base._sack = None
+
+        with self.assertLogs(level="WARNING") as cm:
+            self.assertEqual(self.dnf_manager.match_available_packages("langpacks-*"), [])
+
+        msg = "There is no metadata about packages!"
+        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+
 
 class DNFManagerCompsTestCase(unittest.TestCase):
     """Test the comps abstraction of the DNF base."""

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_requirements_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_requirements_test.py
@@ -22,6 +22,7 @@ from unittest.mock import Mock, patch
 from pyanaconda.core.constants import REQUIREMENT_TYPE_PACKAGE, REQUIREMENT_TYPE_GROUP
 from pyanaconda.modules.common.constants.services import LOCALIZATION, BOSS
 from pyanaconda.modules.common.structures.requirement import Requirement
+from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager
 from pyanaconda.modules.payloads.payload.dnf.requirements import collect_language_requirements, \
     collect_platform_requirements, collect_driver_disk_requirements, collect_remote_requirements, \
     apply_requirements
@@ -29,12 +30,6 @@ from tests.nosetests.pyanaconda_tests import patch_dbus_get_proxy_with_cache
 
 
 class DNFRequirementsTestCase(unittest.TestCase):
-
-    def _create_package(self, name):
-        """Create a mocked package object."""
-        package = Mock()
-        package.name = name
-        return package
 
     def _create_group(self, name):
         """Create a mocked group object."""
@@ -64,22 +59,20 @@ class DNFRequirementsTestCase(unittest.TestCase):
         proxy.Language = "cs_CZ.UTF-8"
         proxy.LanguageSupport = ["en_GB.UTF-8", "sr_RS@cyrilic"]
 
-        p1 = self._create_package("langpacks-cs")
-        p2 = self._create_package("langpacks-core-cs")
-        p3 = self._create_package("langpacks-core-font-cs")
-        p4 = self._create_package("langpacks-en")
-        p5 = self._create_package("langpacks-en_GB")
-        p6 = self._create_package("langpacks-core-en")
-        p7 = self._create_package("langpacks-core-en_GB")
-        p8 = self._create_package("langpacks-core-font-en")
-
-        base = Mock()
-        base.sack.query.return_value.available.return_value.filter.return_value = [
-            p1, p2, p3, p4, p5, p6, p7, p8
+        dnf_manager = Mock(spec=DNFManager)
+        dnf_manager.match_available_packages.return_value = [
+            "langpacks-cs",
+            "langpacks-core-cs",
+            "langpacks-core-font-cs",
+            "langpacks-en",
+            "langpacks-en_GB",
+            "langpacks-core-en",
+            "langpacks-core-en_GB",
+            "langpacks-core-font-en"
         ]
 
         with self.assertLogs(level="WARNING") as cm:
-            requirements = collect_language_requirements(base)
+            requirements = collect_language_requirements(dnf_manager)
 
         r1 = self._create_requirement(
             "langpacks-cs", "Required to support the locale 'cs_CZ.UTF-8'."

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_requirements_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_requirements_test.py
@@ -88,29 +88,27 @@ class DNFRequirementsTestCase(unittest.TestCase):
     @patch('pyanaconda.core.util.execWithCapture')
     def collect_platform_requirements_test(self, execute):
         """Test the function collect_platform_requirements."""
-        g1 = self._create_group("platform-vmware")
-        g2 = self._create_group("platform-kvm")
-        g3 = self._create_group("network-server")
-        g4 = self._create_group("virtualization")
-
-        base = Mock()
-        base.comps.groups_iter.return_value = [
-            g1, g2, g3, g4
+        dnf_manager = Mock(spec=DNFManager)
+        dnf_manager.groups = [
+            "platform-vmware",
+            "platform-kvm",
+            "network-server",
+            "virtualization"
         ]
 
         # No platform is detected.
         execute.return_value = None
-        requirements = collect_platform_requirements(base)
+        requirements = collect_platform_requirements(dnf_manager)
         self.assertEqual(requirements, [])
 
         # Unsupported platform is detected.
         execute.return_value = "qemu"
-        requirements = collect_platform_requirements(base)
+        requirements = collect_platform_requirements(dnf_manager)
         self.assertEqual(requirements, [])
 
         # Supported platform is detected.
         execute.return_value = "vmware"
-        requirements = collect_platform_requirements(base)
+        requirements = collect_platform_requirements(dnf_manager)
 
         r1 = self._create_requirement(
             name="platform-vmware",

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_utils_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_utils_test.py
@@ -25,6 +25,7 @@ from pyanaconda.core.constants import GROUP_PACKAGE_TYPES_REQUIRED, GROUP_PACKAG
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.structures.packages import PackagesSelectionData
+from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager
 from pyanaconda.modules.payloads.payload.dnf.utils import get_kernel_package, \
     get_product_release_version, get_installation_specs, get_kernel_version_list, \
     pick_download_location, calculate_required_space, get_free_space_map, _pick_mount_points
@@ -36,45 +37,44 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
 
     def get_kernel_package_excluded_test(self):
         """Test the get_kernel_package function with kernel excluded."""
-        kernel = get_kernel_package(dnf_base=Mock(), exclude_list=["kernel"])
+        kernel = get_kernel_package(Mock(), exclude_list=["kernel"])
         self.assertEqual(kernel, None)
 
-    @patch("pyanaconda.modules.payloads.payload.dnf.utils.dnf")
-    def get_kernel_package_installable_test(self, mock_dnf):
-        """Test the get_kernel_package function without installable packages."""
-        subject = mock_dnf.subject.Subject.return_value
-        subject.get_best_query.return_value = False
+    def get_kernel_package_unavailable_test(self):
+        """Test the get_kernel_package function with unavailable packages."""
+        dnf_manager = Mock(spec=DNFManager)
+        dnf_manager.is_package_available.return_value = False
 
         with self.assertLogs(level="ERROR") as cm:
-            kernel = get_kernel_package(dnf_base=Mock(), exclude_list=[])
+            kernel = get_kernel_package(dnf_manager, exclude_list=[])
 
         msg = "kernel: failed to select a kernel"
         self.assertTrue(any(map(lambda x: msg in x, cm.output)))
         self.assertEqual(kernel, None)
 
-    @patch("pyanaconda.modules.payloads.payload.dnf.utils.dnf")
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.is_lpae_available")
-    def get_kernel_package_lpae_test(self, is_lpae, mock_dnf):
+    def get_kernel_package_lpae_test(self, is_lpae):
         """Test the get_kernel_package function with LPAE."""
-        subject = mock_dnf.subject.Subject.return_value
-        subject.get_best_query.return_value = True
         is_lpae.return_value = True
 
-        kernel = get_kernel_package(dnf_base=Mock(), exclude_list=[])
+        dnf_manager = Mock(spec=DNFManager)
+        dnf_manager.is_package_available.return_value = True
+
+        kernel = get_kernel_package(dnf_manager, exclude_list=[])
         self.assertEqual(kernel, "kernel-lpae")
 
-        kernel = get_kernel_package(dnf_base=Mock(), exclude_list=["kernel-lpae"])
+        kernel = get_kernel_package(dnf_manager, exclude_list=["kernel-lpae"])
         self.assertEqual(kernel, "kernel")
 
-    @patch("pyanaconda.modules.payloads.payload.dnf.utils.dnf")
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.is_lpae_available")
-    def get_kernel_package_test(self, is_lpae, mock_dnf):
+    def get_kernel_package_test(self, is_lpae):
         """Test the get_kernel_package function."""
-        subject = mock_dnf.subject.Subject.return_value
-        subject.get_best_query.return_value = True
         is_lpae.return_value = False
 
-        kernel = get_kernel_package(dnf_base=Mock(), exclude_list=[])
+        dnf_manager = Mock(spec=DNFManager)
+        dnf_manager.is_package_available.return_value = True
+
+        kernel = get_kernel_package(dnf_manager, exclude_list=[])
         self.assertEqual(kernel, "kernel")
 
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.productVersion", "invalid")


### PR DESCRIPTION
Extend the DNF manager, so it can be used instead of the DNF base.