### PR TITLE
Allow to exclude the kernel-lpae package

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/utils.py
+++ b/pyanaconda/modules/payloads/payload/dnf/utils.py
@@ -63,6 +63,10 @@ def get_kernel_package(dnf_base, exclude_list):
 
     # Find an installable one.
     for kernel_package in kernels:
+        if kernel_package in exclude_list:
+            log.info("kernel: excluded %s", kernel_package)
+            continue
+
         subject = dnf.subject.Subject(kernel_package)
         installable = bool(subject.get_best_query(dnf_base.sack))
 

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_utils_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_utils_test.py
@@ -57,6 +57,9 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
         kernel = get_kernel_package(dnf_base=Mock(), exclude_list=[])
         self.assertEqual(kernel, "kernel-lpae")
 
+        kernel = get_kernel_package(dnf_base=Mock(), exclude_list=["kernel-lpae"])
+        self.assertEqual(kernel, "kernel")
+
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.dnf")
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.is_lpae_available")
     def get_kernel_package_test(self, is_lpae, mock_dnf):


### PR DESCRIPTION
Use `-kernel-lpae` in the `%packages` section of the kickstart file
to exclude the package from the installation.

Resolves: rhbz#1947157