### PR TITLE
Use the software selection cache in TUI

### DIFF
--- a/pyanaconda/ui/lib/software.py
+++ b/pyanaconda/ui/lib/software.py
@@ -17,6 +17,7 @@
 #
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
+from pyanaconda.modules.common.structures.packages import PackagesSelectionData
 
 log = get_module_logger(__name__)
 
@@ -65,3 +66,183 @@ def get_software_selection_status(dnf_manager, selection, kickstarted=False):
     # The valid environment is set.
     environment_data = dnf_manager.get_environment_data(selection.environment)
     return environment_data.name
+
+
+class SoftwareSelectionCache(object):
+    """The cache of the user software selection.
+
+    Use the software selection cache to select environments
+    and groups in the user interface.
+
+    The cache remembers groups that were selected by default
+    based on the current environment, explicitly selected by
+    the user and explicitly deselected.
+
+    Selected groups that are not available in the current
+    environment are ignored.
+    """
+
+    def __init__(self, dnf_manager):
+        """Create a new cache.
+
+        :param dnf_manager: a DNF manager
+        """
+        self._dnf_manager = dnf_manager
+        self._environment = ""
+        self._available_groups = set()
+        self._default_groups = set()
+        self._selected_groups = set()
+        self._deselected_groups = set()
+
+    @property
+    def environment(self):
+        """The selected environment.
+
+        :return: an environment id
+        """
+        return self._environment
+
+    @property
+    def available_environments(self):
+        """The available environments.
+
+        :return: a list of environment ids
+        """
+        return self._dnf_manager.environments
+
+    @property
+    def groups(self):
+        """The selected groups.
+
+        :return: a list of group ids
+        """
+        return sorted(filter(self.is_group_selected, self._available_groups))
+
+    @property
+    def available_groups(self):
+        """The available groups.
+
+        :return: a list of group ids
+        """
+        return sorted(self._available_groups)
+
+    def select_environment(self, environment):
+        """Select the specified environment.
+
+        :param str environment: an identifier of an environment
+        """
+        log.debug("Selecting the '%s' environment.", environment)
+
+        # Reset the environment configuration.
+        self._environment = ""
+        self._default_groups = set()
+        self._available_groups = set()
+
+        # No environment is specified.
+        if not environment:
+            return
+
+        # Get the environment data.
+        environment_data = self._dnf_manager.get_environment_data(environment)
+
+        # Select the environment.
+        self._environment = environment_data.id
+
+        # Select the default groups.
+        self._default_groups = set(environment_data.default_groups)
+
+        # Select the available groups.
+        self._available_groups = set(environment_data.get_available_groups())
+
+    def is_environment_selected(self, environment):
+        """Is the specified environment marked as selected?
+
+        :param str environment: an identifier of an environment
+        :return: True if the environment is marked as selected, otherwise False
+        """
+        return environment == self._environment
+
+    def select_group(self, group):
+        """Select the specified group.
+
+        :param str group: an identifier of a group
+        """
+        log.debug("Selecting the '%s' group.", group)
+
+        # Get the group data.
+        group_data = self._dnf_manager.get_group_data(group)
+
+        # Remove the group from the deselected groups.
+        self._deselected_groups.discard(group_data.id)
+
+        # Add the group to the selected groups if it is not a default.
+        if group_data.id not in self._default_groups:
+            self._selected_groups.add(group_data.id)
+
+    def deselect_group(self, group):
+        """Select or deselect the specified group.
+
+        :param str group: an identifier of a group
+        """
+        log.debug("Deselecting the '%s' group.", group)
+
+        # Get the group data.
+        group_data = self._dnf_manager.get_group_data(group)
+
+        # Add the group to the deselected groups. We don't need
+        # to remove the group from selected or default groups,
+        # because deselected groups have a higher priority.
+        self._deselected_groups.add(group_data.id)
+
+    def is_group_selected(self, group):
+        """Is the specified group marked as selected?
+
+        :param str group: an identifier of a group
+        :return: True if the group is marked as selected, otherwise False
+        """
+        # The group is not available in the current environment.
+        if group not in self._available_groups:
+            return False
+
+        # The group is explicitly deselected by the user.
+        if group in self._deselected_groups:
+            return False
+
+        # The group is selected by default or by the user.
+        return group in self._default_groups or group in self._selected_groups
+
+    def apply_selection_data(self, selection: PackagesSelectionData):
+        """Apply the selection data.
+
+        Invalid environments and groups will be ignored. If the environment
+        cannot be selected, we will choose a default one.
+
+        :param selection: a packages selection data
+        """
+        # Select the environment.
+        if self._dnf_manager.resolve_environment(selection.environment):
+            self.select_environment(selection.environment)
+        else:
+            log.warning("The '%s' environment couldn't be selected.", selection.environment)
+            self.select_environment(self._dnf_manager.default_environment)
+
+        # Select groups.
+        self._selected_groups = set()
+        self._deselected_groups = set()
+
+        for group in selection.groups:
+            if self._dnf_manager.resolve_group(group):
+                self.select_group(group)
+                continue
+
+            log.warning("The '%s' group couldn't be selected.", group)
+
+    def get_selection_data(self) -> PackagesSelectionData:
+        """Generate the selection data.
+
+        :return: a packages selection data
+        """
+        selection = PackagesSelectionData()
+        selection.environment = self.environment
+        selection.groups = self.groups
+        return selection

--- a/pyanaconda/ui/lib/software.py
+++ b/pyanaconda/ui/lib/software.py
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.anaconda_loggers import get_module_logger
+
+log = get_module_logger(__name__)
+
+
+def is_software_selection_complete(dnf_manager, selection, kickstarted=False):
+    """Check the completeness of the software selection.
+
+    :param dnf_manager: a DNF manager
+    :param selection: a packages selection data
+    :param kickstarted: is the selection configured by a kickstart file?
+    :return: True if the selection is complete, otherwise False
+    """
+    # The environment doesn't have to be set for the automated installation.
+    if kickstarted and not selection.environment:
+        return True
+
+    # The selected environment has to be valid.
+    return dnf_manager.is_environment_valid(selection.environment)

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -19,12 +19,11 @@
 from pyanaconda.flags import flags
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.context import context
-from pyanaconda.ui.lib.software import is_software_selection_complete, \
-    get_software_selection_status
+from pyanaconda.ui.lib.software import get_software_selection_status, \
+    is_software_selection_complete, SoftwareSelectionCache
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.threading import threadMgr, AnacondaThread
-from pyanaconda.payload.manager import payloadMgr, PayloadState
-from pyanaconda.payload.errors import DependencyError, NoSuchGroup
+from pyanaconda.payload.errors import DependencyError
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.core.constants import THREAD_PAYLOAD, THREAD_CHECK_SOFTWARE, \
     THREAD_SOFTWARE_WATCHER, PAYLOAD_TYPE_DNF
@@ -42,7 +41,7 @@ __all__ = ["SoftwareSpoke"]
 
 
 class SoftwareSpoke(NormalTUISpoke):
-    """ Spoke used to read new value of text to represent source repo.
+    """The spoke for choosing the software.
 
        .. inheritance-diagram:: SoftwareSpoke
           :parts: 3
@@ -66,19 +65,20 @@ class SoftwareSpoke(NormalTUISpoke):
         self._tx_id = None
 
         # Get the packages configuration.
-        self._selection = self.payload.get_packages_selection()
+        self._selection_cache = SoftwareSelectionCache(self._dnf_manager)
 
-        # are we taking values (package list) from a kickstart file?
+        # Are we taking values (package list) from a kickstart file?
         self._kickstarted = flags.automatedInstall and self.payload.proxy.PackagesKickstarted
-
-        # Register event listeners to update our status on payload events
-        payloadMgr.add_listener(PayloadState.STARTED, self._payload_start)
-        payloadMgr.add_listener(PayloadState.ERROR, self._payload_error)
 
     @property
     def _dnf_manager(self):
         """The DNF manager."""
         return self.payload.dnf_manager
+
+    @property
+    def _selection(self):
+        """The packages selection."""
+        return self.payload.get_packages_selection()
 
     def initialize(self):
         """Initialize the spoke."""
@@ -102,15 +102,17 @@ class SoftwareSpoke(NormalTUISpoke):
 
     def _initialize_selection(self):
         """Initialize and check the software selection."""
-        if self.errors or not self.payload.base_repo:
+        if not self._source_is_set:
             log.debug("Skip the initialization of the software selection.")
             return
 
         if not self._kickstarted:
-            # Set the environment.
-            self._selection.environment = self._dnf_manager.default_environment or ""
+            # Use the default environment.
+            self._selection_cache.select_environment(
+                self._dnf_manager.default_environment
+            )
 
-            # Apply the initial selection.
+            # Apply the default selection.
             self.apply()
 
         # Check the initial software selection.
@@ -121,43 +123,45 @@ class SoftwareSpoke(NormalTUISpoke):
         # and only like this we can be sure we are really initialized.
         threadMgr.wait(THREAD_CHECK_SOFTWARE)
 
-    def _payload_start(self):
-        self.errors = []
+    @property
+    def ready(self):
+        """Is the spoke ready?
 
-    def _payload_error(self):
-        self.errors = [payloadMgr.error]
+        By default, the software selection spoke is not ready. We have to
+        wait until the installation source spoke is completed. This could be
+        because the user filled something out, or because we're done fetching
+        repo metadata from the mirror list, or we detected a DVD/CD.
+        """
+        return not self._processing_data and self._source_is_set
 
-    def _translate_env_name_to_id(self, environment):
-        """ Return the id of the selected environment or None. """
-        if not environment:
-            # None means environment is not set, no need to try translate that to an id
-            return None
-        try:
-            return self.payload.environment_id(environment)
-        except NoSuchGroup:
-            return None
+    @property
+    def _source_is_set(self):
+        """Is the installation source set?"""
+        return self.payload.base_repo is not None
 
-    def _get_available_addons(self, environment_id):
-        """ Return all add-ons of the specific environment. """
-        addons = []
+    @property
+    def _source_has_changed(self):
+        """Has the installation source changed?"""
+        return self._tx_id != self.payload.tx_id
 
-        if environment_id in self.payload.environment_addons:
-            for addons_list in self.payload.environment_addons[environment_id]:
-                addons.extend(addons_list)
-
-        return addons
+    @property
+    def _processing_data(self):
+        """Is the spoke processing data?"""
+        return threadMgr.get(THREAD_SOFTWARE_WATCHER) \
+            or threadMgr.get(THREAD_PAYLOAD) \
+            or threadMgr.get(THREAD_CHECK_SOFTWARE)
 
     @property
     def status(self):
         """The status of the spoke."""
+        if self._processing_data:
+            return _("Processing...")
+        if not self._source_is_set:
+            return _("Installation source not set up")
+        if self._source_has_changed:
+            return _("Source changed - please verify")
         if self.errors:
             return _("Error checking software selection")
-        if not self.ready:
-            return _("Processing...")
-        if not self.payload.base_repo:
-            return _("Installation source not set up")
-        if not self.txid_valid:
-            return _("Source changed - please verify")
 
         return get_software_selection_status(
             dnf_manager=self._dnf_manager,
@@ -170,7 +174,7 @@ class SoftwareSpoke(NormalTUISpoke):
         """Is the spoke complete?"""
         return self.ready \
             and not self.errors \
-            and self.txid_valid \
+            and not self._source_has_changed \
             and is_software_selection_complete(
                 dnf_manager=self._dnf_manager,
                 selection=self._selection,
@@ -181,131 +185,87 @@ class SoftwareSpoke(NormalTUISpoke):
         """Set up the spoke right before it is used."""
         super().setup(args)
 
-        # Join the initialization thread to block on it
+        # Wait for the payload to be ready.
         threadMgr.wait(THREAD_SOFTWARE_WATCHER)
+        threadMgr.wait(THREAD_PAYLOAD)
 
-        # Get the packages configuration.
-        self._selection = self.payload.get_packages_selection()
+        # Create a new software selection cache.
+        self._selection_cache = SoftwareSelectionCache(self._dnf_manager)
+        self._selection_cache.apply_selection_data(self._selection)
 
         return True
 
     def refresh(self, args=None):
         """ Refresh screen. """
         NormalTUISpoke.refresh(self, args)
-
-        threadMgr.wait(THREAD_PAYLOAD)
         self._container = None
 
-        if not self.payload.base_repo:
+        if not self._source_is_set:
             message = TextWidget(_("Installation source needs to be set up first."))
             self.window.add_with_separator(message)
             return
 
         threadMgr.wait(THREAD_CHECK_SOFTWARE)
-        self._container = ListColumnContainer(2, columns_width=38, spacing=2)
+        self._container = ListColumnContainer(
+            columns=2,
+            columns_width=38,
+            spacing=2
+        )
 
-        if args is None:
-            msg = self._refresh_environments()
-        else:
-            msg = self._refresh_addons(args)
+        for environment in self._selection_cache.available_environments:
+            data = self._dnf_manager.get_environment_data(environment)
+            selected = self._selection_cache.is_environment_selected(environment)
 
-        self.window.add_with_separator(TextWidget(msg))
+            widget = CheckboxWidget(
+                title=data.name,
+                completed=selected
+            )
+
+            self._container.add(
+                widget,
+                callback=self._select_environment,
+                data=data.id
+            )
+
+        self.window.add_with_separator(TextWidget(_("Base environment")))
         self.window.add_with_separator(self._container)
 
-    def _refresh_environments(self):
-        environments = self.payload.environments
-
-        for env in environments:
-            name = self.payload.environment_description(env)[0]
-            selected = (env == self._selection.environment)
-            widget = CheckboxWidget(title="%s" % name, completed=selected)
-            self._container.add(widget, callback=self._set_environment_callback, data=env)
-
-        return _("Base environment")
-
-    def _refresh_addons(self, available_addons):
-        for addon_id in available_addons:
-            name = self.payload.group_description(addon_id)[0]
-            selected = addon_id in self._selection.groups
-            widget = CheckboxWidget(title="%s" % name, completed=selected)
-            self._container.add(widget, callback=self._set_addons_callback, data=addon_id)
-
-        if available_addons:
-            return _("Additional software for selected environment")
-        else:
-            return _("No additional software to select.")
-
-    def _set_environment_callback(self, data):
-        self._selection.environment = data
-
-    def _set_addons_callback(self, data):
-        if data not in self._selection.groups:
-            self._selection.groups.append(data)
-        else:
-            self._selection.groups.remove(data)
+    def _select_environment(self, data):
+        self._selection_cache.select_environment(data)
 
     def input(self, args, key):
-        """ Handle the input; this chooses the desktop environment. """
-        if self._container is not None and self._container.process_user_input(key):
-            self.redraw()
-        else:
-            if key.lower() == Prompt.CONTINUE:
+        """Handle the user input."""
+        if self._container is None:
+            return super().input(args, key)
 
-                # No environment was selected, close
-                if not self._selection.environment:
-                    self.close()
+        if self._container.process_user_input(key):
+            return InputState.PROCESSED_AND_REDRAW
 
-                # The environment was selected, switch screen
-                elif args is None:
-                    # Get addons for the selected environment
-                    environment = self._selection.environment
-                    environment_id = self._translate_env_name_to_id(environment)
-                    addons = self._get_available_addons(environment_id)
+        if key.lower() == Prompt.CONTINUE:
+            if self._selection_cache.environment:
+                # The environment was selected, switch the screen.
+                spoke = AdditionalSoftwareSpoke(
+                    self.data,
+                    self.storage,
+                    self.payload,
+                    self._selection_cache
+                )
+                ScreenHandler.push_screen_modal(spoke)
+                self.apply()
+                self.execute()
 
-                    # Switch the screen
-                    ScreenHandler.replace_screen(self, addons)
+            return InputState.PROCESSED_AND_CLOSE
 
-                # The addons were selected, apply and close
-                else:
-                    self.apply()
-                    self.execute()
-                    self.close()
-            else:
-                return super().input(args, key)
-
-        return InputState.PROCESSED
-
-    @property
-    def ready(self):
-        """Is the spoke ready?
-
-        By default, the software selection spoke is not ready. We have to
-        wait until the installation source spoke is completed. This could be
-        because the user filled something out, or because we're done fetching
-        repo metadata from the mirror list, or we detected a DVD/CD.
-        """
-        return not threadMgr.get(THREAD_SOFTWARE_WATCHER) \
-            and not threadMgr.get(THREAD_PAYLOAD) \
-            and not threadMgr.get(THREAD_CHECK_SOFTWARE) \
-            and self.payload.base_repo is not None
+        return super().input(args, key)
 
     def apply(self):
         """Apply the changes."""
         self._kickstarted = False
 
-        # Clear packages data.
-        self._selection.packages = []
-        self._selection.excluded_packages = []
+        selection = self._selection_cache.get_selection_data()
+        log.debug("Setting new software selection: %s", selection)
 
-        # Clear groups data.
-        self._selection.excluded_groups = []
-        self._selection.groups_package_types = {}
-
-        # Select valid groups.
-        # FIXME: Remove invalid groups from selected groups.
-
-        log.debug("Setting new software selection: %s", self._selection)
-        self.payload.set_packages_selection(self._selection)
+        self.payload.set_packages_selection(selection)
 
     def execute(self):
         """Execute the changes."""
@@ -320,12 +280,79 @@ class SoftwareSpoke(NormalTUISpoke):
             self.payload.check_software_selection()
         except DependencyError as e:
             self.errors = [str(e)]
-            self._tx_id = None
             log.warning("Transaction error %s", str(e))
         else:
+            self.errors = []
+        finally:
             self._tx_id = self.payload.tx_id
 
+    def closed(self):
+        """The spoke has been closed."""
+        super().closed()
+
+        # Run the setup method again on entry.
+        self.screen_ready = False
+
+
+class AdditionalSoftwareSpoke(NormalTUISpoke):
+    """The spoke for choosing the additional software."""
+    category = SoftwareCategory
+
+    def __init__(self, data, storage, payload, selection_cache):
+        super().__init__(data, storage, payload)
+        self.title = N_("Software selection")
+        self._container = None
+        self._selection_cache = selection_cache
+
     @property
-    def txid_valid(self):
-        """ Whether we have a valid dnf tx id. """
-        return self._tx_id == self.payload.tx_id
+    def _dnf_manager(self):
+        """The DNF manager."""
+        return self.payload.dnf_manager
+
+    def refresh(self, args=None):
+        """Refresh the screen."""
+        NormalTUISpoke.refresh(self, args)
+
+        self._container = ListColumnContainer(
+            columns=2,
+            columns_width=38,
+            spacing=2
+        )
+
+        for group in self._selection_cache.available_groups:
+            data = self._dnf_manager.get_group_data(group)
+            selected = self._selection_cache.is_group_selected(group)
+
+            widget = CheckboxWidget(
+                title=data.name,
+                completed=selected
+            )
+
+            self._container.add(
+                widget,
+                callback=self._select_group,
+                data=data.id
+            )
+
+        if self._selection_cache.available_groups:
+            msg = _("Additional software for selected environment")
+        else:
+            msg = _("No additional software to select.")
+
+        self.window.add_with_separator(TextWidget(msg))
+        self.window.add_with_separator(self._container)
+
+    def _select_group(self, group):
+        if not self._selection_cache.is_group_selected(group):
+            self._selection_cache.select_group(group)
+        else:
+            self._selection_cache.deselect_group(group)
+
+    def input(self, args, key):
+        if self._container.process_user_input(key):
+            return InputState.PROCESSED_AND_REDRAW
+        else:
+            return super().input(args, key)
+
+    def apply(self):
+        pass

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -19,7 +19,8 @@
 from pyanaconda.flags import flags
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.context import context
-from pyanaconda.ui.lib.software import is_software_selection_complete
+from pyanaconda.ui.lib.software import is_software_selection_complete, \
+    get_software_selection_status
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload.manager import payloadMgr, PayloadState
@@ -148,7 +149,7 @@ class SoftwareSpoke(NormalTUISpoke):
 
     @property
     def status(self):
-        """ Where we are in the process """
+        """The status of the spoke."""
         if self.errors:
             return _("Error checking software selection")
         if not self.ready:
@@ -157,15 +158,12 @@ class SoftwareSpoke(NormalTUISpoke):
             return _("Installation source not set up")
         if not self.txid_valid:
             return _("Source changed - please verify")
-        if not self._selection.environment:
-            # KS installs with %packages will have an env selected, unless
-            # they did an install without a desktop environment. This should
-            # catch that one case.
-            if self._kickstarted:
-                return _("Custom software selected")
-            return _("Nothing selected")
 
-        return self.payload.environment_description(self._selection.environment)[0]
+        return get_software_selection_status(
+            dnf_manager=self._dnf_manager,
+            selection=self._selection,
+            kickstarted=self._kickstarted
+        )
 
     @property
     def completed(self):

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -19,6 +19,7 @@
 from pyanaconda.flags import flags
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.context import context
+from pyanaconda.ui.lib.software import is_software_selection_complete
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload.manager import payloadMgr, PayloadState
@@ -168,18 +169,15 @@ class SoftwareSpoke(NormalTUISpoke):
 
     @property
     def completed(self):
-        """ Make sure our threads are done running and vars are set.
-
-           WARNING: This can be called before the spoke is finished initializing
-           if the spoke starts a thread. It should make sure it doesn't access
-           things until they are completely setup.
-        """
-        processing_done = self.ready and not self.errors and self.txid_valid
-
-        if flags.automatedInstall or self._kickstarted:
-            return processing_done and self.payload.base_repo and self.payload.proxy.PackagesKickstarted
-        else:
-            return processing_done and self.payload.base_repo and self._selection.environment
+        """Is the spoke complete?"""
+        return self.ready \
+            and not self.errors \
+            and self.txid_valid \
+            and is_software_selection_complete(
+                dnf_manager=self._dnf_manager,
+                selection=self._selection,
+                kickstarted=self._kickstarted
+            )
 
     def setup(self, args):
         """Set up the spoke right before it is used."""

--- a/tests/nosetests/pyanaconda_tests/ui/software_test.py
+++ b/tests/nosetests/pyanaconda_tests/ui/software_test.py
@@ -18,11 +18,13 @@
 import unittest
 from unittest.mock import Mock
 
-from pyanaconda.modules.common.structures.comps import CompsEnvironmentData
+from dasbus.structure import compare_data
+
+from pyanaconda.modules.common.structures.comps import CompsEnvironmentData, CompsGroupData
 from pyanaconda.modules.common.structures.packages import PackagesSelectionData
 from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager
 from pyanaconda.ui.lib.software import is_software_selection_complete, \
-    get_software_selection_status
+    get_software_selection_status, SoftwareSelectionCache
 
 
 class SoftwareSelectionUITestCase(unittest.TestCase):
@@ -82,3 +84,219 @@ class SoftwareSelectionUITestCase(unittest.TestCase):
 
         status = get_software_selection_status(dnf_manager, selection, kickstarted=True)
         self.assertEqual(status, "Custom software selected")
+
+
+class SoftwareSelectionCacheTestCase(unittest.TestCase):
+    """Test the cache for the Software Selection spoke."""
+
+    def setUp(self):
+        """Set up the test."""
+        self.environment_data = CompsEnvironmentData()
+        self.environment_data.id = "e1"
+        self.environment_data.optional_groups = ["g1", "g2", "g3", "g4", "g5"]
+
+        self.dnf_manager = Mock(spec=DNFManager)
+
+        self.dnf_manager.resolve_environment.return_value = True
+        self.dnf_manager.get_environment_data.return_value = self.environment_data
+
+        self.dnf_manager.get_group_data.side_effect = self._get_group_data
+        self.dnf_manager.resolve_group.return_value = True
+
+        self.cache = SoftwareSelectionCache(self.dnf_manager)
+
+    def _get_group_data(self, group):
+        """Mock the get_group_data method of the DNF manager."""
+        data = CompsGroupData()
+        data.id = group
+        return data
+
+    def available_environments_test(self):
+        """Test the available_environments property."""
+        self.dnf_manager.environments = []
+        self.assertEqual(self.cache.available_environments, [])
+
+        self.dnf_manager.environments = ["e1", "e2"]
+        self.assertEqual(self.cache.available_environments, ["e1", "e2"])
+
+    def is_environment_selected_test(self):
+        """Test the is_environment_selected method."""
+        self.assertEqual(self.cache.is_environment_selected("e1"), False)
+
+        self.cache.select_environment("e1")
+        self.assertEqual(self.cache.is_environment_selected("e1"), True)
+
+        self.cache.select_environment("")
+        self.assertEqual(self.cache.is_environment_selected("e1"), False)
+
+    def environment_test(self):
+        """Test the environment property."""
+        self.assertEqual(self.cache.environment, "")
+
+        self.cache.select_environment("e1")
+        self.assertEqual(self.cache.environment, "e1")
+
+    def available_groups_test(self):
+        """Test the available_groups property."""
+        self.cache.select_environment("e1")
+        self.assertEqual(self.cache.available_groups, ["g1", "g2", "g3", "g4", "g5"])
+
+        self.cache.select_environment("")
+        self.assertEqual(self.cache.available_groups, [])
+
+    def groups_test(self):
+        """Test the groups property."""
+        self.environment_data.default_groups = ["g2", "g4"]
+
+        self.cache.select_environment("e1")
+        self.assertEqual(self.cache.groups, ["g2", "g4"])
+
+        self.cache.select_group("g1")
+        self.assertEqual(self.cache.groups, ["g1", "g2", "g4"])
+
+        self.cache.deselect_group("g4")
+        self.assertEqual(self.cache.groups, ["g1", "g2"])
+
+    def is_group_selected_test(self):
+        """Test the is_group_selected method."""
+        self.environment_data.default_groups = ["g2", "g4"]
+
+        self.cache.select_environment("e1")
+        self.assertEqual(self.cache.is_group_selected("g1"), False)
+        self.assertEqual(self.cache.is_group_selected("g4"), True)
+        self.assertEqual(self.cache.is_group_selected("g7"), False)
+
+        self.cache.select_group("g1")
+        self.assertEqual(self.cache.is_group_selected("g1"), True)
+        self.assertEqual(self.cache.is_group_selected("g4"), True)
+        self.assertEqual(self.cache.is_group_selected("g7"), False)
+
+        self.cache.deselect_group("g4")
+        self.assertEqual(self.cache.is_group_selected("g1"), True)
+        self.assertEqual(self.cache.is_group_selected("g4"), False)
+        self.assertEqual(self.cache.is_group_selected("g7"), False)
+
+    def apply_selection_data_test(self):
+        """Test the apply_selection_data method."""
+        selection = PackagesSelectionData()
+        selection.environment = "e1"
+        selection.groups = ["g1", "g2", "g3"]
+
+        self.cache.apply_selection_data(selection)
+        self.assertEqual(self.cache.environment, "e1")
+        self.assertEqual(self.cache.groups, ["g1", "g2", "g3"])
+
+    def apply_selection_data_default_environment_test(self):
+        """Test the apply_selection_data method with a default environment."""
+        self.dnf_manager.default_environment = "e1"
+        self.dnf_manager.resolve_environment.return_value = False
+
+        selection = PackagesSelectionData()
+        selection.environment = "e2"
+
+        self.cache.apply_selection_data(selection)
+        self.assertEqual(self.cache.environment, "e1")
+        self.assertEqual(self.cache.groups, [])
+
+    def apply_selection_data_invalid_environment_test(self):
+        """Test the apply_selection_data method with an invalid environment."""
+        self.dnf_manager.default_environment = ""
+        self.dnf_manager.resolve_environment.return_value = False
+
+        selection = PackagesSelectionData()
+        selection.environment = "e2"
+
+        self.cache.apply_selection_data(selection)
+        self.assertEqual(self.cache.environment, "")
+        self.assertEqual(self.cache.groups, [])
+
+    def apply_selection_data_invalid_groups_test(self):
+        """Test the apply_selection_data method with invalid groups."""
+        self.dnf_manager.resolve_group.return_value = False
+
+        selection = PackagesSelectionData()
+        selection.environment = "e1"
+        selection.groups = ["g1", "g2", "g3"]
+
+        self.cache.apply_selection_data(selection)
+        self.assertEqual(self.cache.environment, "e1")
+        self.assertEqual(self.cache.groups, [])
+
+    def get_selection_data_test(self):
+        """Test the get_selection_data method."""
+        self.cache.select_environment("e1")
+        self.cache.select_group("g1")
+        self.cache.select_group("g2")
+        self.cache.select_group("g3")
+
+        expected = PackagesSelectionData()
+        expected.environment = "e1"
+        expected.groups = ["g1", "g2", "g3"]
+
+        data = self.cache.get_selection_data()
+        self.assertTrue(compare_data(data, expected))
+
+    def default_selection_test(self):
+        """Test the default environment and group selection."""
+        self.environment_data.id = "e1"
+        self.environment_data.default_groups = ["g2", "g4"]
+
+        self.cache.select_environment("e1")
+        self.assertEqual(self.cache.groups, ["g2", "g4"])
+
+        self.cache.select_group("g2")
+        self.assertEqual(self.cache.groups, ["g2", "g4"])
+
+        self.cache.select_group("g4")
+        self.assertEqual(self.cache.groups, ["g2", "g4"])
+
+        self.environment_data.id = "e2"
+        self.environment_data.default_groups = ["g1", "g3", "g5"]
+
+        self.cache.select_environment("e2")
+        self.assertEqual(self.cache.groups, ["g1", "g3", "g5"])
+
+    def selection_test(self):
+        """Test the environment and group selection."""
+        self.environment_data.id = "e1"
+
+        self.cache.select_environment("e1")
+        self.assertEqual(self.cache.groups, [])
+
+        self.cache.select_group("g2")
+        self.assertEqual(self.cache.groups, ["g2"])
+
+        self.cache.select_group("g4")
+        self.assertEqual(self.cache.groups, ["g2", "g4"])
+
+        self.environment_data.id = "e2"
+        self.environment_data.default_groups = ["g1", "g3", "g5"]
+
+        self.cache.select_environment("e2")
+        self.assertEqual(self.cache.groups, ["g1", "g2", "g3", "g4", "g5"])
+
+    def deselection_test(self):
+        """Test the environment and group deselection."""
+        self.environment_data.id = "e1"
+        self.environment_data.default_groups = ["g2", "g4"]
+
+        self.cache.select_environment("e1")
+        self.assertEqual(self.cache.groups, ["g2", "g4"])
+
+        self.cache.select_group("g1")
+        self.assertEqual(self.cache.groups, ["g1", "g2", "g4"])
+
+        self.cache.deselect_group("g4")
+        self.assertEqual(self.cache.groups, ["g1", "g2"])
+
+        self.cache.select_group("g5")
+        self.assertEqual(self.cache.groups, ["g1", "g2", "g5"])
+
+        self.cache.deselect_group("g5")
+        self.assertEqual(self.cache.groups, ["g1", "g2"])
+
+        self.environment_data.id = "e2"
+        self.environment_data.default_groups = ["g2", "g3", "g4", "g5"]
+
+        self.cache.select_environment("e2")
+        self.assertEqual(self.cache.groups, ["g1", "g2", "g3"])

--- a/tests/nosetests/pyanaconda_tests/ui/software_test.py
+++ b/tests/nosetests/pyanaconda_tests/ui/software_test.py
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+from unittest.mock import Mock
+
+from pyanaconda.modules.common.structures.packages import PackagesSelectionData
+from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager
+from pyanaconda.ui.lib.software import is_software_selection_complete
+
+
+class SoftwareSelectionUITestCase(unittest.TestCase):
+    """Test the helper functions of the Software Selection spoke."""
+
+    def is_software_selection_complete_test(self):
+        """Test the is_software_selection_complete function."""
+        selection = PackagesSelectionData()
+        selection.environment = "e1"
+
+        dnf_manager = Mock(spec=DNFManager)
+        dnf_manager.is_environment_valid.return_value = True
+
+        self.assertTrue(is_software_selection_complete(dnf_manager, selection))
+        self.assertTrue(is_software_selection_complete(dnf_manager, selection, kickstarted=True))
+
+        dnf_manager.is_environment_valid.return_value = False
+
+        self.assertFalse(is_software_selection_complete(dnf_manager, selection))
+        self.assertFalse(is_software_selection_complete(dnf_manager, selection, kickstarted=True))
+
+        selection.environment = ""
+
+        self.assertFalse(is_software_selection_complete(dnf_manager, selection))
+        self.assertTrue(is_software_selection_complete(dnf_manager, selection, kickstarted=True))


### PR DESCRIPTION
Use the DNF manager and the software selection cache to choose environments
and groups in the text user interface.

The cache remembers groups that were selected by default based on the current
environment, explicitly selected by the user or explicitly deselected. This is based
on the current implementation of the software selection in GUI.

The software selection in GUI will be refactorized in a follow-up pull request.