### PR TITLE
Allow to use no default product configuration (#1947939)

### DIFF
--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -19,6 +19,7 @@
 #
 import os
 
+from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.bootloader import BootloaderSection, BootloaderType
 from pyanaconda.core.configuration.license import LicenseSection
 from pyanaconda.core.configuration.network import NetworkSection
@@ -33,6 +34,7 @@ from pyanaconda.core.configuration.product import ProductLoader
 from pyanaconda.core.configuration.ui import UserInterfaceSection
 from pyanaconda.core.constants import ANACONDA_CONFIG_TMP, ANACONDA_CONFIG_DIR
 
+log = get_module_logger(__name__)
 
 __all__ = ["conf", "AnacondaConfiguration"]
 
@@ -226,11 +228,13 @@ class AnacondaConfiguration(Configuration):
             product_name = default_product
             variant_name = ""
 
-        # Or fail.
+        # Or use no product configuration.
         else:
-            raise ConfigurationError(
-                "Unable to find any suitable configuration files for this product."
+            log.warning(
+                "Unable to find any suitable configuration files for the detected "
+                "product and variant names. No product configuration will be used."
             )
+            return
 
         # Read the configuration files of the product.
         config_paths = loader.collect_configurations(product_name, variant_name)

--- a/tests/nosetests/pyanaconda_tests/core/configuration_test.py
+++ b/tests/nosetests/pyanaconda_tests/core/configuration_test.py
@@ -312,13 +312,14 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
     def set_from_no_product_test(self):
         conf = AnacondaConfiguration.from_defaults()
 
-        with self.assertRaises(ConfigurationError) as cm:
+        with self.assertLogs(level="WARNING") as cm:
             conf.set_from_product()
 
-        expected = "Unable to find any suitable configuration files " \
-                   "for this product."
+        expected = \
+            "Unable to find any suitable configuration files for the detected " \
+            "product and variant names. No product configuration will be used."
 
-        self.assertEqual(str(cm.exception), expected)
+        self.assertIn(expected, "\n".join(cm.output))
 
     @patch("pyanaconda.core.configuration.anaconda.ANACONDA_CONFIG_DIR", CONFIG_DIR)
     def set_from_requested_product_test(self):
@@ -354,16 +355,17 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
         conf = AnacondaConfiguration.from_defaults()
 
         # Test an unknown .buildstamp product.
-        with self.assertRaises(ConfigurationError) as cm:
+        with self.assertLogs(level="WARNING") as cm:
             conf.set_from_product(
                 buildstamp_product="Unknown product",
                 buildstamp_variant="Unknown variant",
             )
 
-        expected = "Unable to find any suitable configuration files " \
-                   "for this product."
+        expected = \
+            "Unable to find any suitable configuration files for the detected " \
+            "product and variant names. No product configuration will be used."
 
-        self.assertEqual(str(cm.exception), expected)
+        self.assertIn(expected, "\n".join(cm.output))
 
         # Test a known .buildstamp product.
         conf.set_from_product(
@@ -382,15 +384,16 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
         conf = AnacondaConfiguration.from_defaults()
 
         # Test an unknown default product.
-        with self.assertRaises(ConfigurationError) as cm:
+        with self.assertLogs(level="WARNING") as cm:
             conf.set_from_product(
                 default_product="Unknown product",
             )
 
-        expected = "Unable to find any suitable configuration files " \
-                   "for this product."
+        expected = \
+            "Unable to find any suitable configuration files for the detected " \
+            "product and variant names. No product configuration will be used."
 
-        self.assertEqual(str(cm.exception), expected)
+        self.assertIn(expected, "\n".join(cm.output))
 
         # Test a known default product.
         conf.set_from_product(


### PR DESCRIPTION
Don't raise an exception if we are not able to find a suitable product
configuration for the detected product name. The installer is able to
continue without it. Issue a warning instead.

Resolves: rhbz#1947939