### PR TITLE
Run RHEL COPR builds on kstest

### DIFF
--- a/.github/workflows/daily-rhel-copr.yml
+++ b/.github/workflows/daily-rhel-copr.yml
@@ -24,33 +24,9 @@ jobs:
         run: |
           sudo podman build --no-cache -t ${{ env.CI_CONTAINER }} anaconda/dockerfile/anaconda-rhel-copr
 
-      - name: Clone copr-builder repository
-        uses: actions/checkout@v2
-        with:
-          repository: vojtechtrefny/copr-builder
-          fetch-depth: 0
-          path: copr-builder
-
-      - name: Create copr-builder configuration
-        run: |
-          cat <<EOF > copr-builder/copr-builder-rhel.conf
-          [anaconda]
-          copr_user = rhinstaller-group
-          copr_repo = Anaconda
-          package = anaconda
-          git_url = https://github.com/rhinstaller/anaconda
-          git_branch = rhel-8
-          pre_archive_cmd = ./autogen.sh && ./configure
-          archive_cmd = make po-pull && make dist
-          EOF
-
-      - name: Copy token
-        run: |
-          cp /home/github/copr-rhel-token copr-builder/copr-rhel-token
-
       - name: Run copr-builder
         run: |
-          sudo podman run -i --rm --privileged -v `pwd`/copr-builder:/copr-builder:ro ${{ env.CI_CONTAINER }} <<EOF
+          sudo podman run -i --rm --privileged -v /home/github/copr-rhel-token:/copr-builder/copr-rhel-token:ro,z ${{ env.CI_CONTAINER }} <<EOF
           set -eux
           /copr-builder/copr-builder -v -c /copr-builder/copr-builder-rhel.conf -C /copr-builder/copr-rhel-token
           EOF

--- a/.github/workflows/daily-rhel-copr.yml
+++ b/.github/workflows/daily-rhel-copr.yml
@@ -9,16 +9,31 @@ on:
 jobs:
   build:
     name: copr-builder
-    runs-on: [self-hosted, ci-tasks, rhel-8]
+    runs-on: [self-hosted, kstest]
+    env:
+      CI_CONTAINER: rhinstaller/anaconda-rhel-copr:rhel-8
     steps:
-      - name: Checkout copr-builder repository
+      - name: Clone anaconda repository
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          fetch-depth: 0
+          path: anaconda
+
+      - name: Build the build container
+        run: |
+          sudo podman build --no-cache -t ${{ env.CI_CONTAINER }} anaconda/dockerfile/anaconda-rhel-copr
+
+      - name: Clone copr-builder repository
         uses: actions/checkout@v2
         with:
           repository: vojtechtrefny/copr-builder
+          fetch-depth: 0
+          path: copr-builder
 
       - name: Create copr-builder configuration
         run: |
-          cat <<EOF > copr-builder-rhel.conf
+          cat <<EOF > copr-builder/copr-builder-rhel.conf
           [anaconda]
           copr_user = rhinstaller-group
           copr_repo = Anaconda
@@ -29,5 +44,13 @@ jobs:
           archive_cmd = make po-pull && make dist
           EOF
 
+      - name: Copy token
+        run: |
+          cp /home/github/copr-rhel-token copr-builder/copr-rhel-token
+
       - name: Run copr-builder
-        run: ./copr-builder -v -c copr-builder-rhel.conf -C /copr-rhel
+        run: |
+          sudo podman run -i --rm --privileged -v `pwd`/copr-builder:/copr-builder:ro ${{ env.CI_CONTAINER }} <<EOF
+          set -eux
+          /copr-builder/copr-builder -v -c /copr-builder/copr-builder-rhel.conf -C /copr-builder/copr-rhel-token
+          EOF

--- a/dockerfile/anaconda-rhel-copr/Dockerfile
+++ b/dockerfile/anaconda-rhel-copr/Dockerfile
@@ -5,9 +5,15 @@ FROM ${image}
 ARG git_branch=master
 LABEL maintainer=anaconda-list@redhat.com
 
-# Prepare environment and install build dependencies
+# Install build dependencies
 RUN set -e; \
-  dnf install -y python3-copr; \
+  dnf install -y python3-copr git; \
+  git clone --depth 1 https://github.com/vojtechtrefny/copr-builder.git /copr-builder
+
+COPY ["copr-builder-rhel.conf", "/copr-builder"]
+
+# Add certificates needed to connect to the COPR
+RUN set -e; \
   curl -k https://password.corp.redhat.com/cacert.crt -o /etc/pki/ca-trust/source/anchors/Red_Hat_IS_CA.crt; \
   curl -k https://password.corp.redhat.com/RH-IT-Root-CA.crt -o /etc/pki/ca-trust/source/anchors/Red_Hat_IT_Root_CA.crt; \
   curl -k https://engineering.redhat.com/Eng-CA.crt -o /etc/pki/ca-trust/source/anchors/Eng_Ops_CA.crt; \
@@ -15,6 +21,4 @@ RUN set -e; \
   ln -sf /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/tls/certs/ca-bundle.crt; \
   update-ca-trust
 
-RUN mkdir -p /anaconda
-
-WORKDIR /anaconda
+WORKDIR /

--- a/dockerfile/anaconda-rhel-copr/Dockerfile
+++ b/dockerfile/anaconda-rhel-copr/Dockerfile
@@ -1,0 +1,20 @@
+ARG image=quay.io/rhinstaller/anaconda-ci:master
+FROM ${image}
+# FROM starts a new build stage with new ARGs. Put any ARGs after FROM unless required by the FROM itself.
+# see https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG git_branch=master
+LABEL maintainer=anaconda-list@redhat.com
+
+# Prepare environment and install build dependencies
+RUN set -e; \
+  dnf install -y python3-copr; \
+  curl -k https://password.corp.redhat.com/cacert.crt -o /etc/pki/ca-trust/source/anchors/Red_Hat_IS_CA.crt; \
+  curl -k https://password.corp.redhat.com/RH-IT-Root-CA.crt -o /etc/pki/ca-trust/source/anchors/Red_Hat_IT_Root_CA.crt; \
+  curl -k https://engineering.redhat.com/Eng-CA.crt -o /etc/pki/ca-trust/source/anchors/Eng_Ops_CA.crt; \
+  curl -k https://password.corp.redhat.com/pki-ca-chain.crt -o /etc/pki/ca-trust/source/anchors/PKI_CA_Chain.crt; \
+  ln -sf /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/tls/certs/ca-bundle.crt; \
+  update-ca-trust
+
+RUN mkdir -p /anaconda
+
+WORKDIR /anaconda

--- a/dockerfile/anaconda-rhel-copr/copr-builder-rhel.conf
+++ b/dockerfile/anaconda-rhel-copr/copr-builder-rhel.conf
@@ -1,0 +1,8 @@
+[anaconda]
+copr_user = rhinstaller-group
+copr_repo = Anaconda
+package = anaconda
+git_url = https://github.com/rhinstaller/anaconda
+git_branch = rhel-8
+pre_archive_cmd = ./autogen.sh && ./configure
+archive_cmd = make po-pull && make dist


### PR DESCRIPTION
Requires a new container with the certificates, and some changes to workers. See also the [internal gitlab PR in builders](https://gitlab.cee.redhat.com/rhinstaller/builders/-/merge_requests/67) for the changes there.

Successful run at https://github.com/vslavik-test-org/anaconda/runs/2326194094?check_suite_focus=true