### PR TITLE
Avoid a race condition during Connect to Red Hat spoke initialization

### DIFF
--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -122,19 +122,26 @@ class SubscriptionSpoke(NormalSpoke):
         # overriden source tracking
         self._overridden_source_type = None
 
+        self._spoke_initialized = False
+
     # common spoke properties
 
     @property
     def ready(self):
-        """The subscription spoke is ready once its initialization thread finishes.
+        """The subscription spoke is ready once the spoke initialization thread finishes.
 
-        We do this to avoid the Subscription spoke being set mandatory in cases
-        where the current installation source is the CDN, but payload refres is still
-        running and it might change to CDROM later one. We achieve this by waiting
-        for tha payload refresh thread to finish in the Subscription spoke initialization
-        thread.
+        The spoke initialization thread waits for the subscription and payload initialization
+        threads, to avoid the Subscription spoke being set mandatory in cases
+        where the current installation source is the CDN, but payload refresh is still
+        running and it might change the installation source to CDROM later on.
+
+        NOTE: We don't actually wait for the spoke initialization thread to finish, we check
+              a variable it sets instead. This is due to the thread also sending the hub refresh
+              signal, which would trigger a race condition if the hub refresh is processed before
+              the spoke initialization thread finishes. Setting the variable and *then* sending
+              the hub refresh signal avoids this issue.
         """
-        return not threadMgr.get(THREAD_SUBSCRIPTION_SPOKE_INIT)
+        return self._spoke_initialized
 
 
     @property
@@ -660,7 +667,12 @@ class SubscriptionSpoke(NormalSpoke):
         self._update_registration_state()
         self._update_subscription_state()
 
-        # Send ready signal to main event loop
+        # we are done, mark the spoke as initialized
+        self._spoke_initialized = True
+
+        # Send ready signal to main event loop,
+        # which among other things refreshes the hub to make
+        # sure the Connect to Red Hat spokes shows up as ready.
         hubQ.send_ready(self.__class__.__name__, False)
 
         # report that we are done


### PR DESCRIPTION
The Subscription spoke which provides the Connect to Red Hat screen
needs to wait for both the subscription any payload setup threads
to finish before loading valid initial values and making the spoke
available to users.
    
This is implemented by starting a subscription spoke initialization thread
that waits for the subscription and payload threads to finish. Once both
threads terminate, the subscription spoke initialization thread will update
Subscription spoke state, notify the hub initialization is done and then
terminate.
    
This unfortunately introduces a race condition as the Connect to Red Hat
spoke is only considered ready once the initialization thread terminates.
If the refresh wins the race and is processed before the thread terminates,
the spoke will be marked as not ready and will stay that way until the
next hub refresh. This is why this condition is fixed by visiting an
accessible spoke and then returning back to the hub.
    
To fix this issue we introduce a new variable that marks the spoke
as fully initialized and set it before we send the hub refresh signal,
avoiding the race condition and making sure the spoke is marked as ready
once the refresh signal is processed.

~The Subscription spoke which provides the Connect to Red Hat screen
needs to wait for bot the subscription any payload setup threads
to finish before loading valid initial values and making the spoke
accessible to users.~

~This is implemented by starting a subscription spoke an initialization thread
that waits for the subscription and payload threads to finish. Once both
threads terminate, the subscription spoke initialization thread will update
Subscription spoke state, notify the hub initialization is done and then
terminate.~

~Unfortunately this means the spoke state updates, which among other
things manipulate GTK widgets, will be run from a non-main thread
(the subscription spoke initialization thread). This is a problem
as GTK is explicitly not thread safe and accessing it's objects from
non-main threads can lead to undefined behavior. Like say spoke status
not being updated correctly.~

~Wrapping the gtk_call_once() functions around the Subscription spoke
status update calls should serialize these calls into the main thread,
fixing the issue. Notifying the hub via the hub queue should be thread
safe & is done in other spokes from non-main threads, so wrapping that
as well should not be needed.~

Resolves: rhbz#1950053