### PR TITLE
Add a shim script to translate signals from Xorg

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -258,6 +258,8 @@ def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
         signal.alarm(0)
         signal.signal(SIG42, signal.SIG_IGN)  # ignore it or die by unhandled signal later
         signal.signal(signal.SIGALRM, old_sigalrm_handler)
+        if x11_started[0] and conf.system.can_switch_tty:
+            vtActivate(6)
 
 
 def _run_program(argv, root='/', stdin=None, stdout=None, env_prune=None, log_output=True,

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -156,7 +156,8 @@ def start_x11(xtimeout):
     """Start the X server for the Anaconda GUI."""
 
     # Start Xorg and wait for it become ready
-    util.startX(["Xorg", "-br", "-logfile", "/tmp/X.log",
+    util.startX(["/usr/libexec/anaconda/anaconda-xorg-shim",
+                 "-br", "-logfile", "/tmp/X.log",
                  ":%s" % constants.X_DISPLAY_NUMBER, "vt6", "-s", "1440", "-ac",
                  "-nolisten", "tcp", "-dpi", "96",
                  "-noreset"],
@@ -339,6 +340,8 @@ def setup_display(anaconda, options):
             stdout_log.warning("X startup failed, falling back to text mode")
             anaconda.display_mode = constants.DisplayModes.TUI
             anaconda.gui_startup_failed = True
+            if conf.system.can_switch_tty:
+                util.vtActivate(1)
             time.sleep(2)
 
         if not anaconda.gui_startup_failed:

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -160,7 +160,7 @@ def start_x11(xtimeout):
                  "-br", "-logfile", "/tmp/X.log",
                  ":%s" % constants.X_DISPLAY_NUMBER, "vt6", "-s", "1440", "-ac",
                  "-nolisten", "tcp", "-dpi", "96",
-                 "-noreset"],
+                 "-noreset", "-novtswitch", "-keeptty"],
                 output_redirect=subprocess.DEVNULL, timeout=xtimeout)
 
 

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -17,7 +17,8 @@
 
 scriptsdir = $(libexecdir)/$(PACKAGE_NAME)
 dist_scripts_SCRIPTS = upd-updates run-anaconda \
-                       anaconda-pre-log-gen log-capture start-module apply-updates
+                       anaconda-pre-log-gen log-capture start-module apply-updates \
+                       anaconda-xorg-shim
 
 dist_noinst_SCRIPTS  = upd-kernel makeupdates makebumpver
 

--- a/scripts/anaconda-xorg-shim
+++ b/scripts/anaconda-xorg-shim
@@ -25,6 +25,7 @@ start_message = "Xorg signal shim started by {} as {}.".format(os.getppid(), os.
 subprocess.run(["systemd-cat"], input=start_message.encode("ascii"), check=True)
 params = ["/bin/Xorg"] + sys.argv[1:]
 old_handler = signal.signal(signal.SIGUSR1, handler)
+import time; time.sleep(10)
 process = subprocess.Popen(params, preexec_fn=preexec)  # pylint:disable=subprocess-popen-preexec-fn
 process.wait()
 signal.signal(signal.SIGUSR1, old_handler)

--- a/scripts/anaconda-xorg-shim
+++ b/scripts/anaconda-xorg-shim
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+
+# Xorg sends SIGUSR1, but we use that to force-run exception handler that terminates anaconda.
+# If we give up waiting on Xorg, and it still manages to start eventually, it kills us this way.
+# Hence this shim to translate the signal to something else.
+
+import signal
+import subprocess
+import sys
+import os
+
+
+def handler(num, frame):
+    handler_message = "Xorg signal shim received SIGUSR1 from Xorg, passing on as SIGRTMIN+8."
+    subprocess.run(["systemd-cat"], input=handler_message.encode("ascii"), check=True)
+    os.kill(os.getppid(), signal.SIGRTMIN + 8)
+
+
+def preexec():
+    # change signal mask for Xorg process, so that it knows to send it - see man Xserver
+    signal.signal(signal.SIGUSR1, signal.SIG_IGN)
+
+
+start_message = "Xorg signal shim started by {} as {}.".format(os.getppid(), os.getpid())
+subprocess.run(["systemd-cat"], input=start_message.encode("ascii"), check=True)
+params = ["/bin/Xorg"] + sys.argv[1:]
+old_handler = signal.signal(signal.SIGUSR1, handler)
+process = subprocess.Popen(params, preexec_fn=preexec)  # pylint:disable=subprocess-popen-preexec-fn
+process.wait()
+signal.signal(signal.SIGUSR1, old_handler)

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -36,7 +36,7 @@ RPM_RELEASE_DIR_TEMPLATE = "for_%s"
 SITE_PACKAGES_PATH = "./usr/lib64/python3.9/site-packages/"
 
 # Anaconda scripts that should be installed into the libexec folder
-LIBEXEC_SCRIPTS = ["log-capture", "start-module", "apply-updates"]
+LIBEXEC_SCRIPTS = ["log-capture", "start-module", "apply-updates", "anaconda-xorg-shim"]
 
 
 def get_archive_tag(configure, spec):


### PR DESCRIPTION
Yet another PR for the X thing, after #3107, #3132, and #3141. Thanks to @bitcoffeeiux and @poncovka.

This adds a shim script to translate the signals to make sure they are no longer the same: `SIGUSR1` - > `SIGRTMIN+8` (most probably 42). The non-responsive Xorg is left to be.

Resolves: [rhbz#1918702](https://bugzilla.redhat.com/show_bug.cgi?id=1918702)