### PR TITLE
Check software selection in tasks

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -536,6 +536,11 @@ class DNFManager(object):
         log.info("The software selection has been resolved (%d packages selected).",
                  len(self._base.transaction))
 
+    def clear_selection(self):
+        """Clear the software selection."""
+        self._base.reset(goal=True)
+        log.debug("The software selection has been cleared.")
+
     @property
     def download_location(self):
         """The location for the package download."""

--- a/pyanaconda/modules/payloads/payload/dnf/utils.py
+++ b/pyanaconda/modules/payloads/payload/dnf/utils.py
@@ -57,17 +57,15 @@ def get_kernel_package(dnf_manager, exclude_list):
     # Find an installable one.
     for kernel_package in kernels:
         if kernel_package in exclude_list:
-            log.info("kernel: excluded %s", kernel_package)
             continue
 
         if not dnf_manager.is_package_available(kernel_package):
-            log.info("kernel: no such package %s", kernel_package)
+            log.info("No such package: %s", kernel_package)
             continue
 
-        log.info("kernel: selected %s", kernel_package)
         return kernel_package
 
-    log.error("kernel: failed to select a kernel from %s", kernels)
+    log.error("Failed to select a kernel from: %s", kernels)
     return None
 
 
@@ -100,26 +98,20 @@ def get_installation_specs(data: PackagesSelectionData, default_environment=None
 
     # Handle the environment.
     if data.default_environment_enabled and default_environment:
-        env = default_environment
-        log.info("selecting default environment: %s", env)
-        include_list.append("@{}".format(env))
+        log.info("Selecting default environment '%s'.", default_environment)
+        include_list.append("@{}".format(default_environment))
     elif data.environment:
-        env = data.environment
-        log.info("selected environment: %s", env)
-        include_list.append("@{}".format(env))
+        include_list.append("@{}".format(data.environment))
 
     # Handle the core group.
     if not data.core_group_enabled:
-        log.info("skipping core group due to %%packages "
-                 "--nocore; system may not be complete")
+        log.info("Skipping @core group; system may not be complete.")
         exclude_list.append("@core")
     else:
-        log.info("selected group: core")
         include_list.append("@core")
 
     # Handle groups.
     for group_name in data.excluded_groups:
-        log.debug("excluding group %s", group_name)
         exclude_list.append("@{}".format(group_name))
 
     for group_name in data.groups:
@@ -138,16 +130,13 @@ def get_installation_specs(data: PackagesSelectionData, default_environment=None
             # content of the DNF GROUP_PACKAGE_TYPES constant).
             group_spec = "@{}".format(group_name)
 
-        log.info("selected group: %s", group_name)
         include_list.append(group_spec)
 
     # Handle packages.
     for pkg_name in data.excluded_packages:
-        log.info("excluded package: %s", pkg_name)
         exclude_list.append(pkg_name)
 
     for pkg_name in data.packages:
-        log.info("selected package: %s", pkg_name)
         include_list.append(pkg_name)
 
     return include_list, exclude_list

--- a/pyanaconda/modules/payloads/payload/dnf/validation.py
+++ b/pyanaconda/modules/payloads/payload/dnf/validation.py
@@ -1,0 +1,129 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from contextlib import contextmanager
+
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.modules.common.structures.packages import PackagesSelectionData
+from pyanaconda.modules.common.structures.validation import ValidationReport
+from pyanaconda.modules.common.task import Task
+from pyanaconda.modules.payloads.payload.dnf.dnf_manager import MissingSpecsError, \
+    BrokenSpecsError, InvalidSelectionError
+from pyanaconda.modules.payloads.payload.dnf.utils import get_installation_specs, \
+    get_kernel_package
+
+log = get_module_logger(__name__)
+
+
+class CheckPackagesSelectionTask(Task):
+    """Validation task to check the software selection."""
+
+    def __init__(self, dnf_manager, selection: PackagesSelectionData):
+        """Create a task.
+
+        :param dnf_manager: a DNF manager
+        :param selection: a packages selection data
+        """
+        super().__init__()
+        self._dnf_manager = dnf_manager
+        self._selection = selection
+        self._include_list = []
+        self._exclude_list = []
+
+    @property
+    def name(self):
+        """The name of the task."""
+        return "Check the software selection"
+
+    def run(self):
+        """Run the task.
+
+        :return: a validation report
+        """
+        # Clear the previous selection.
+        self._clear_selection()
+
+        # Prepare the new selection.
+        self._collect_selected_specs()
+        self._collect_required_specs()
+
+        # Resolve the new selection.
+        return self._resolve_selection()
+
+    def _clear_selection(self):
+        """Clear the previous selection."""
+        self._dnf_manager.clear_selection()
+
+    def _collect_selected_specs(self):
+        """Collect specs for the selected software."""
+        log.debug("Collecting selected specs.")
+
+        # Get the default environment.
+        default_environment = self._dnf_manager.default_environment
+
+        # Get the installation specs.
+        include_list, exclude_list = get_installation_specs(
+            self._selection, default_environment
+        )
+
+        self._include_list.extend(include_list)
+        self._exclude_list.extend(exclude_list)
+
+    def _collect_required_specs(self):
+        """Collect specs for the required software."""
+        log.debug("Collecting required specs.")
+
+        # Add the kernel package.
+        kernel_package = get_kernel_package(self._dnf_manager, self._exclude_list)
+
+        if kernel_package:
+            self._include_list.append(kernel_package)
+
+    def _resolve_selection(self):
+        """Resolve the new selection."""
+        log.debug("Resolving the software selection.")
+        report = ValidationReport()
+
+        with self._reported_errors(report):
+            self._dnf_manager.disable_modules(self._selection.disabled_modules)
+
+        with self._reported_errors(report):
+            self._dnf_manager.enable_modules(self._selection.modules)
+
+        with self._reported_errors(report):
+            self._dnf_manager.apply_specs(self._include_list, self._exclude_list)
+
+        with self._reported_errors(report):
+            self._dnf_manager.resolve_selection()
+
+        log.debug("Resolving has been completed: %s", report)
+        return report
+
+    @contextmanager
+    def _reported_errors(self, report):
+        """Add exceptions into the validation report.
+
+        :param report: a validation report
+        """
+        try:
+            yield
+        except MissingSpecsError as e:
+            report.warning_messages.append(str(e))
+        except BrokenSpecsError as e:
+            report.error_messages.append(str(e))
+        except InvalidSelectionError as e:
+            report.error_messages.append(str(e))

--- a/pyanaconda/payload/errors.py
+++ b/pyanaconda/payload/errors.py
@@ -30,10 +30,6 @@ class PayloadSetupError(PayloadError):
     pass
 
 
-class DependencyError(PayloadError):
-    pass
-
-
 # installation
 class PayloadInstallError(PayloadError):
     pass

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/dnf_validation_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/dnf_validation_test.py
@@ -1,0 +1,125 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+
+from unittest.mock import Mock, patch
+
+from pyanaconda.modules.common.structures.packages import PackagesSelectionData
+from pyanaconda.modules.payloads.payload.dnf.dnf_manager import InvalidSelectionError, \
+    MissingSpecsError, BrokenSpecsError
+from pyanaconda.modules.payloads.payload.dnf.validation import CheckPackagesSelectionTask
+
+
+class CheckPackagesSelectionTaskTestCase(unittest.TestCase):
+    """Test the validation task for checking the packages selection."""
+
+    @patch("pyanaconda.modules.payloads.payload.dnf.validation.get_kernel_package")
+    def check_no_selection_test(self, kernel_getter):
+        kernel_getter.return_value = None
+
+        dnf_manager = Mock()
+        dnf_manager.default_environment = None
+
+        selection = PackagesSelectionData()
+        selection.default_environment_enabled = False
+        selection.core_group_enabled = False
+
+        task = CheckPackagesSelectionTask(dnf_manager, selection)
+        report = task.run()
+
+        dnf_manager.clear_selection.assert_called_once_with()
+        dnf_manager.disable_modules.assert_called_once_with([])
+        dnf_manager.enable_modules.assert_called_once_with([])
+        dnf_manager.apply_specs.assert_called_once_with([], ["@core"])
+        dnf_manager.resolve_selection.assert_called_once_with()
+        self.assertEqual(report.get_messages(), [])
+
+    @patch("pyanaconda.modules.payloads.payload.dnf.validation.get_kernel_package")
+    def check_default_selection_test(self, kernel_getter):
+        kernel_getter.return_value = "kernel"
+
+        dnf_manager = Mock()
+        dnf_manager.default_environment = "environment"
+
+        selection = PackagesSelectionData()
+        selection.default_environment_enabled = True
+        selection.core_group_enabled = True
+
+        task = CheckPackagesSelectionTask(dnf_manager, selection)
+        report = task.run()
+
+        dnf_manager.clear_selection.assert_called_once_with()
+        dnf_manager.disable_modules.assert_called_once_with([])
+        dnf_manager.enable_modules.assert_called_once_with([])
+        dnf_manager.apply_specs.assert_called_once_with(
+            ["@environment", "@core", "kernel"], []
+        )
+        dnf_manager.resolve_selection.assert_called_once_with()
+        self.assertEqual(report.get_messages(), [])
+
+    @patch("pyanaconda.modules.payloads.payload.dnf.validation.get_kernel_package")
+    def check_selection_test(self, kernel_getter):
+        kernel_getter.return_value = None
+        dnf_manager = Mock()
+
+        selection = PackagesSelectionData()
+        selection.core_group_enabled = False
+        selection.environment = "e1"
+
+        selection.packages = ["p1", "p2"]
+        selection.excluded_packages = ["p3", "p4"]
+
+        selection.groups = ["g1", "g2"]
+        selection.excluded_groups = ["g3", "g4"]
+
+        selection.modules = ["m1", "m2"]
+        selection.disabled_modules = ["m3", "m4"]
+
+        task = CheckPackagesSelectionTask(dnf_manager, selection)
+        report = task.run()
+
+        dnf_manager.clear_selection.assert_called_once_with()
+        dnf_manager.disable_modules.assert_called_once_with(
+            ["m3", "m4"]
+        )
+        dnf_manager.enable_modules.assert_called_once_with(
+            ["m1", "m2"]
+        )
+        dnf_manager.apply_specs.assert_called_once_with(
+            ["@e1", "@g1", "@g2", "p1", "p2"],
+            ["@core", "@g3", "@g4", "p3", "p4"]
+        )
+        dnf_manager.resolve_selection.assert_called_once_with()
+        self.assertEqual(report.get_messages(), [])
+
+    @patch("pyanaconda.modules.payloads.payload.dnf.validation.get_kernel_package")
+    def check_invalid_selection_test(self, kernel_getter):
+        kernel_getter.return_value = None
+        selection = PackagesSelectionData()
+
+        dnf_manager = Mock()
+        dnf_manager.disable_modules.side_effect = MissingSpecsError("e1")
+        dnf_manager.enable_modules.side_effect = BrokenSpecsError("e2")
+        dnf_manager.apply_specs.side_effect = MissingSpecsError("e3")
+        dnf_manager.resolve_selection.side_effect = InvalidSelectionError("e4")
+
+        task = CheckPackagesSelectionTask(dnf_manager, selection)
+        report = task.run()
+
+        self.assertEqual(report.error_messages, ["e2", "e4"])
+        self.assertEqual(report.warning_messages, ["e1", "e3"])

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
@@ -630,6 +630,10 @@ class DNFManagerTestCase(unittest.TestCase):
 
         self.assertEqual(expected, str(cm.exception))
 
+    def clear_selection_test(self):
+        """Test the clear_selection method."""
+        self.dnf_manager.clear_selection()
+
 
 class DNFManagerCompsTestCase(unittest.TestCase):
     """Test the comps abstraction of the DNF base."""

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
@@ -34,7 +34,8 @@ from pyanaconda.modules.common.errors.payload import UnknownCompsEnvironmentErro
     UnknownCompsGroupError
 from pyanaconda.modules.common.structures.comps import CompsEnvironmentData, CompsGroupData
 from pyanaconda.modules.common.structures.packages import PackagesConfigurationData
-from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager, InvalidSelectionError
+from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager, \
+    InvalidSelectionError, BrokenSpecsError, MissingSpecsError
 
 
 class DNFManagerTestCase(unittest.TestCase):
@@ -233,7 +234,7 @@ class DNFManagerTestCase(unittest.TestCase):
             module_depsolv_errors=["e1", "e2"]
         )
 
-        with self.assertRaises(MarkingErrors):
+        with self.assertRaises(BrokenSpecsError):
             self.dnf_manager.enable_modules(
                 module_specs=["m1", "m2:latest"]
             )
@@ -255,7 +256,7 @@ class DNFManagerTestCase(unittest.TestCase):
             module_depsolv_errors=["e1", "e2"]
         )
 
-        with self.assertRaises(MarkingErrors):
+        with self.assertRaises(BrokenSpecsError):
             self.dnf_manager.disable_modules(
                 module_specs=["m1", "m2:latest"]
             )
@@ -281,7 +282,17 @@ class DNFManagerTestCase(unittest.TestCase):
             error_group_specs=["@g1"]
         )
 
-        with self.assertRaises(MarkingErrors):
+        with self.assertRaises(BrokenSpecsError):
+            self.dnf_manager.apply_specs(
+                include_list=["@g1", "p1"],
+                exclude_list=["@g2", "p2"]
+            )
+
+        install_specs.side_effect = MarkingErrors(
+            no_match_group_specs=["@g1"]
+        )
+
+        with self.assertRaises(MissingSpecsError):
             self.dnf_manager.apply_specs(
                 include_list=["@g1", "p1"],
                 exclude_list=["@g2", "p2"]
@@ -328,7 +339,7 @@ class DNFManagerTestCase(unittest.TestCase):
             error_pkg_specs=["p1"]
         )
 
-        with self.assertRaises(MarkingErrors):
+        with self.assertRaises(BrokenSpecsError):
             self.dnf_manager.apply_specs(
                 include_list=["@g1", "p1"],
                 exclude_list=["@g2", "p2"]

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_utils_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_utils_test.py
@@ -48,8 +48,8 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
         with self.assertLogs(level="ERROR") as cm:
             kernel = get_kernel_package(dnf_manager, exclude_list=[])
 
-        msg = "kernel: failed to select a kernel"
-        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+        msg = "Failed to select a kernel"
+        self.assertIn(msg, "\n".join(cm.output))
         self.assertEqual(kernel, None)
 
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.is_lpae_available")


### PR DESCRIPTION
The DNF manager should raise the `MissingSpecsError` and `BrokenSpecsError`
exceptions instead of `dnf.exceptions.MarkingErrors`.

Run the `CheckPackagesSelectionTask` task to check the packages selection.
The task returns a validation report.

Run the `ResolvePackagesTask` to resolve the packages selection during the installation.

Call the `check_software_selection` function to check the software selection from
GUI or TUI. Allow the user to handle any software selection errors.
