### PR TITLE
Increase the minimal suggested size for /boot

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -214,7 +214,7 @@ min_partition_sizes =
     /tmp   50  MiB
     /var   384 MiB
     /home  100 MiB
-    /boot  200 MiB
+    /boot  512 MiB
 
 # Required minimal sizes of partitions.
 # Specify a mount point and a size on each line.

--- a/tests/nosetests/pyanaconda_tests/modules/storage/storage_checker_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/storage/storage_checker_test.py
@@ -235,7 +235,7 @@ class StorageCheckerTests(unittest.TestCase):
                 '/tmp': Size("50 MiB"),
                 '/var': Size("384 MiB"),
                 '/home': Size("100 MiB"),
-                '/boot': Size("200 MiB")
+                '/boot': Size("512 MiB")
             },
             checks.STORAGE_REQ_PARTITION_SIZES: dict(),
             checks.STORAGE_MUST_BE_ON_LINUXFS: {


### PR DESCRIPTION
Formerly 200, now 512 MiB.

Resolves: [rhbz#1907245](https://bugzilla.redhat.com/show_bug.cgi?id=1907245)