### PR TITLE
Add support for gnome-kiosk

### DIFF
--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -182,9 +182,16 @@ def do_startup_x11_actions():
     else:
         xdg_data_dirs = datadir + '/window-manager:/usr/share'
 
-    childproc = util.startProgram(["metacity", "--display", ":1", "--sm-disable"],
-                                  env_add={'XDG_DATA_DIRS': xdg_data_dirs})
-    WatchProcesses.watch_process(childproc, "metacity")
+    vm = "gnome-kiosk"
+    try:
+        childproc = util.startProgram(["gnome-kiosk", "--display", ":1", "--sm-disable", "--x11"],
+                                      env_add={'XDG_DATA_DIRS': xdg_data_dirs})
+    except FileNotFoundError as e:
+        log.warning("gnome-kiosk not found: %s, trying metacity", e)
+        vm = "metacity"
+        childproc = util.startProgram(["metacity", "--display", ":1", "--sm-disable"],
+                                      env_add={'XDG_DATA_DIRS': xdg_data_dirs})
+    WatchProcesses.watch_process(childproc, vm)
 
 
 def set_x_resolution(runres):


### PR DESCRIPTION
This is initial patch for transition from metacity to gnome-kiosk.

For a short period of time (sync between anaconda and lorax) anaconda will support both.
It is possible that this lorax patch will be required:
https://github.com/weldr/lorax/pull/1138
If so, I will do the switch by updating the dependency in anaconda.spec (metacity -> gnome-kiosk) after the lorax part is merged and built.
