### PR TITLE
ovirt / rhv: drop swap partition

### DIFF
--- a/data/product.d/ovirt.conf
+++ b/data/product.d/ovirt.conf
@@ -16,7 +16,6 @@ default_partitioning =
     /var/crash     (size 10 GiB)
     /var/log       (size 8 GiB)
     /var/log/audit (size 2 GiB)
-    swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP
@@ -24,6 +23,7 @@ must_not_be_on_root = /var
 req_partition_sizes =
     /var   10 GiB
     /boot  1  GiB
+swap_is_recommended = False
 
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhel

--- a/data/product.d/rhvh.conf
+++ b/data/product.d/rhvh.conf
@@ -27,7 +27,6 @@ default_partitioning =
     /var/crash     (size 10 GiB)
     /var/log       (size 8 GiB)
     /var/log/audit (size 2 GiB)
-    swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP
@@ -35,6 +34,7 @@ must_not_be_on_root = /var
 req_partition_sizes =
     /var   10 GiB
     /boot  1  GiB
+swap_is_recommended = False
 
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhel

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -154,11 +154,6 @@ VIRTUALIZATION_PARTITIONING = [
         lv=True,
         thin=True,
         encrypted=True,
-    ),
-    PartSpec(
-        fstype="swap",
-        lv=True,
-        encrypted=True,
     )
 ]
 


### PR DESCRIPTION
swap partition is not needed on oVirt Node / RHV-H

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>