### PR TITLE
Add hotfix for Ubuntu hosts for container refresh

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -30,6 +30,26 @@ jobs:
       CI_TAG: '${{ matrix.container-tag }}'
     timeout-minutes: 60
     steps:
+      # FIXME: This is a temporary workaround for Ubuntu 20.04 20210419.1.
+      # See: https://github.com/actions/virtual-environments/issues/3229
+      - name: Fix the broken rootless podman on Ubuntu 20.04 20210419.1
+        run: |
+          # Create directories for a custom storage configuration file.
+          mkdir -p ~/.config/containers/
+
+          # Create a custom storage configuration file for the rootless mode.
+          cat > ~/.config/containers/storage.conf << EOF
+
+          [storage]
+          driver = "overlay"
+          graphroot = "/home/runner/.local/share/containers/storage"
+
+          [storage.options]
+          mount_program = "/usr/bin/fuse-overlayfs"
+          additionalimagestores = []
+
+          EOF
+
       - name: Checkout anaconda repository
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Podman doesn't work correctly on Ubuntu hosts now. Let's apply a workaround also for container refresh workflow.

[Test run](https://github.com/jkonecny12/anaconda/runs/2438129783?check_suite_focus=true) is expected to have everything failed. My fork can't push to our repository and doesn't have f34-release. However, the build of the image is successful which was a [failure](https://github.com/rhinstaller/anaconda/actions/runs/783822545) before.