### PR TITLE
Add base repo name for CentOS Stream after repository renaming

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -57,7 +57,8 @@ BASE_REPO_NAME = "anaconda"
 DEFAULT_REPOS = [productName.split('-')[0].lower(),
                  "fedora-modular-server",
                  "rawhide",
-                 "BaseOS"]
+                 "BaseOS",  # Used by RHEL
+                 "baseos"]  # Used by CentOS Stream
 
 DBUS_ANACONDA_SESSION_ADDRESS = "DBUS_ANACONDA_SESSION_BUS_ADDRESS"
 


### PR DESCRIPTION
CentOS Stream renamed the repository to make everything consistent. For that we have to keep old repository name for RHEL but also we need the new one for CentOS Stream.

Resolves: rhbz#1946347

Backport of https://github.com/rhinstaller/anaconda/pull/3313.