### PR TITLE
Disable ELN testing on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,15 +18,15 @@ jobs:
         #     on -release, only -release
         #     on master, only master and ELN
         #release: [master, eln, '', f34-release]
-        release: ['', eln]
+        release: ['']
         include:
           - release: ''
             target_branch: 'master'
             ci_tag: 'master'
-          - release: eln
-            target_branch: 'master'
-            ci_tag: 'eln'
-            build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
+          #- release: eln
+          #  target_branch: 'master'
+          #  ci_tag: 'eln'
+          #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
           #- release: f34-devel
           #  target_branch: 'f34-devel'
           #  ci_tag: 'f34-devel'
@@ -108,15 +108,15 @@ jobs:
       matrix:
         # For matrix details, see comments for the unit tests above.
         #release: [master, eln, '', f34-release]
-        release: ['', eln]
+        release: ['']
         include:
           - release: ''
             target_branch: 'master'
             ci_tag: 'master'
-          - release: eln
-            target_branch: 'master'
-            ci_tag: 'eln'
-            build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
+          #- release: eln
+          #  target_branch: 'master'
+          #  ci_tag: 'eln'
+          #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
           #- release: f34-devel
           #  target_branch: 'f34-devel'
           #  ci_tag: 'f34-devel'

--- a/.packit.yml
+++ b/.packit.yml
@@ -19,14 +19,14 @@ jobs:
     metadata:
       targets:
         - fedora-rawhide
-        - fedora-eln
+#        - fedora-eln
 
   - job: copr_build
     trigger: commit
     metadata:
       targets:
         - fedora-rawhide
-        - fedora-eln
+#        - fedora-eln
       branch: master
       owner: "@rhinstaller"
       project: Anaconda


### PR DESCRIPTION
We don't want to have red all the time. Let's disable all ELN testing except container build. We can enable that back when ELN is more stable.

[Test run](https://github.com/jkonecny12/anaconda/runs/2446174661?check_suite_focus=true).