### PR TITLE
Don't allow reformat if the requested file system is unsupported

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -276,9 +276,6 @@ CMDLINE_FILES = [
 CMDLINE_APPEND = ["modprobe.blacklist", "ifname", "ip"]
 CMDLINE_LIST = ["addrepo"]
 
-# Filesystems which are not supported by Anaconda
-UNSUPPORTED_FILESYSTEMS = ("ntfs", "tmpfs")
-
 # Default to these units when reading user input when no units given
 SIZE_UNITS_DEFAULT = "MiB"
 

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -277,7 +277,7 @@ CMDLINE_APPEND = ["modprobe.blacklist", "ifname", "ip"]
 CMDLINE_LIST = ["addrepo"]
 
 # Filesystems which are not supported by Anaconda
-UNSUPPORTED_FILESYSTEMS = ("btrfs", "ntfs", "tmpfs")
+UNSUPPORTED_FILESYSTEMS = ("ntfs", "tmpfs")
 
 # Default to these units when reading user input when no units given
 SIZE_UNITS_DEFAULT = "MiB"

--- a/pyanaconda/modules/storage/devicetree/utils.py
+++ b/pyanaconda/modules/storage/devicetree/utils.py
@@ -49,7 +49,8 @@ def is_supported_filesystem(fmt_type):
     return fmt.type \
         and fmt.supported \
         and fmt.formattable \
-        and (isinstance(fmt, FS) or fmt.type in ["biosboot", "prepboot", "swap"])
+        and (isinstance(fmt, FS) or fmt.type in ["biosboot", "prepboot", "swap"]) \
+        and fmt.type not in ("ntfs", "tmpfs")
 
 
 def get_supported_filesystems():

--- a/pyanaconda/modules/storage/devicetree/utils.py
+++ b/pyanaconda/modules/storage/devicetree/utils.py
@@ -21,7 +21,7 @@ import requests
 from blivet import udev
 from blivet.size import Size
 from blivet.errors import StorageError
-from blivet.formats import device_formats
+from blivet.formats import device_formats, get_format
 from blivet.formats.fs import FS
 from bytesize.bytesize import ROUND_HALF_UP
 
@@ -35,23 +35,31 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
+def is_supported_filesystem(fmt_type):
+    """Is the filesystem supported?
+
+    Return True if the installer can create this filesystem.
+    Otherwise, return False.
+
+    :param fmt_type: a name of the formatting type
+    :return: True or False
+    """
+    fmt = get_format(fmt_type)
+
+    return fmt.type \
+        and fmt.supported \
+        and fmt.formattable \
+        and (isinstance(fmt, FS) or fmt.type in ["biosboot", "prepboot", "swap"])
+
+
 def get_supported_filesystems():
     """Get the supported filesystems.
 
-    :return: a list of formats
+    Get a list of filesystems that can be created by the installer.
+
+    :return: a list of format types
     """
-    fs_types = []
-    for cls in device_formats.values():
-        obj = cls()
-
-        # btrfs is always handled by on_device_type_changed
-        supported_fs = (obj.supported and obj.formattable and
-                        (isinstance(obj, FS) or
-                         obj.type in ["biosboot", "prepboot", "swap"]))
-        if supported_fs:
-            fs_types.append(obj)
-
-    return fs_types
+    return list(filter(is_supported_filesystem, device_formats.keys()))
 
 
 def download_escrow_certificate(url):

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -360,7 +360,7 @@ class DeviceTreeViewer(ABC):
 
         :return: a list of filesystem names
         """
-        return [fmt.type for fmt in get_supported_filesystems() if fmt.type]
+        return get_supported_filesystems()
 
     def get_required_device_size(self, required_space):
         """Get device size we need to get the required space on the device.

--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -37,7 +37,8 @@ from pyanaconda.modules.storage.disk_initialization import DiskInitializationCon
 from pyanaconda.modules.storage.platform import platform, PLATFORM_MOUNT_POINTS
 from pyanaconda.product import productName, productVersion
 from pyanaconda.modules.storage.devicetree.root import Root
-from pyanaconda.modules.storage.devicetree.utils import get_supported_filesystems
+from pyanaconda.modules.storage.devicetree.utils import get_supported_filesystems, \
+    is_supported_filesystem
 from pyanaconda.core.storage import DEVICE_TEXT_MAP, PARTITION_ONLY_FORMAT_TYPES, \
     NAMED_DEVICE_TYPES, CONTAINER_DEVICE_TYPES, SUPPORTED_DEVICE_TYPES
 
@@ -966,7 +967,8 @@ def generate_device_factory_permissions(storage, request: DeviceFactoryRequest):
 
     permissions.reformat = \
         device.raw_device.exists \
-        and not device.raw_device.format_immutable
+        and not device.raw_device.format_immutable \
+        and is_supported_filesystem(request.format_type)
 
     permissions.device_size = \
         device.resizable or (

--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -28,7 +28,6 @@ from blivet.formats import get_format
 from blivet.size import Size
 
 from pyanaconda.anaconda_loggers import get_module_logger
-from pyanaconda.core.constants import UNSUPPORTED_FILESYSTEMS
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.errors.configuration import StorageConfigurationError
 from pyanaconda.modules.common.errors.storage import UnsupportedDeviceError, UnknownDeviceError
@@ -739,10 +738,7 @@ def collect_file_system_types(device):
     :return: a list of file system types
     """
     # Collect the supported filesystem types.
-    supported_types = {
-        fs_type for fs_type in get_supported_filesystems()
-        if fs_type not in UNSUPPORTED_FILESYSTEMS
-    }
+    supported_types = set(get_supported_filesystems())
 
     # Add possibly unsupported but still required file system types:
     # Add the device format type.

--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -740,8 +740,8 @@ def collect_file_system_types(device):
     """
     # Collect the supported filesystem types.
     supported_types = {
-        fs.type for fs in get_supported_filesystems()
-        if fs.type not in UNSUPPORTED_FILESYSTEMS
+        fs_type for fs_type in get_supported_filesystems()
+        if fs_type not in UNSUPPORTED_FILESYSTEMS
     }
 
     # Add possibly unsupported but still required file system types:

--- a/tests/nosetests/pyanaconda_tests/modules/storage/partitioning/module_scheduler_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/storage/partitioning/module_scheduler_test.py
@@ -455,7 +455,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         permissions = self.interface.GenerateDeviceFactoryPermissions(request)
         self.assertEqual(get_native(permissions), {
             'mount-point': False,
-            'reformat': True,
+            'reformat': False,
             'format-type': True,
             'label': False,
             'device-type': False,


### PR DESCRIPTION
Disable reformatting on the Manual Partitioning screen if the requested
file system is not supported by Blivet or Anaconda.

In TUI, don't allow to enter the ntfs and tmpfs file systems on the Assign
Mount Points screen. We should support the same file systems as in GUI.