### PR TITLE
The kernel boot argument sshd is removed and should warn user

### DIFF
--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -65,7 +65,7 @@ was removed. Please use $new_arg instead."
 }
 
 # ssh
-check_depr_arg "sshd" "inst.sshd"
+check_removed_no_inst_arg "sshd" "inst.sshd"
 
 # serial was never supposed to be used for anything!
 check_removed_arg serial "To change the console use 'console=' instead."


### PR DESCRIPTION
Booting with sshd is not supported anymore. User have to use inst.sshd. Warn user in Dracut about that.

The `sshd` will not allow users to use sshd service but it won't print warning for user. This is better clean solution.