### PR TITLE
Stop asking to load deprecated floppy driver

### DIFF
--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -24,7 +24,7 @@ done
 shopt -u nullglob
 
 if [ "$ARCH" != "s390" -a "$ARCH" != "s390x" ]; then
-    MODULE_LIST+=" floppy edd iscsi_ibft "
+    MODULE_LIST+=" edd iscsi_ibft "
 else
     MODULE_LIST+=" hmcdrv "
 fi


### PR DESCRIPTION
floppy driver seems to be no longer supplied with most recent
RHEL kernels, and attempt to load it shows a FATAL error
message during the boot, e.g. :

dracut-pre-udev[579]: modprobe: FATAL: Module floppy not found in
directory /lib/modules/4.18.0-304.x86_64

Signed-off-by: Lev Veyde <lveyde@redhat.com>