### PR TITLE
Install shim also for ARMv7 EFI

### DIFF
--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -204,11 +204,11 @@ class Aarch64EFIGRUB(EFIGRUB):
 
 class ArmEFIGRUB(EFIGRUB):
     _serial_consoles = ["ttyAMA", "ttyS"]
-    _efi_binary = "\\grubarm.efi"
+    _efi_binary = "\\shimarm.efi"
 
     def __init__(self):
         super().__init__()
-        self._packages32 = ["grub2-efi-arm"]
+        self._packages32 = ["grub2-efi-arm", "shim-arm"]
         self._is_32bit_firmware = True
 
 


### PR DESCRIPTION
Now that we have an ARMv7 shim build, we can install the shim package for
this architecture as well instead of booting GRUB directly. This makes it
consistent with other EFI arches that also contain shim in the boot path.

Suggested-by: Peter Robinson <pbrobinson@gmail.com>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>