### PR TITLE
Remove support for some of the buildstamp options

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -61,8 +61,6 @@ if [ $IMAGE_INSTALL = 1 ]; then
     export ANACONDA_PRODUCTVERSION=$(rpmquery -q --qf '%{VERSION}' anaconda | cut -d. -f1)
 fi
 
-export ANACONDA_BUGURL=${ANACONDA_BUGURL:="https://bugzilla.redhat.com/bugzilla/"}
-
 RELEASE=$(rpm -q --qf '%{Release}' --whatprovides system-release)
 if [ "${RELEASE:0:2}" = "0." ]; then
     export ANACONDA_ISFINAL="false"

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -33,7 +33,6 @@ ADDON_PATHS = ["/usr/share/anaconda/addons"]
 from pyanaconda import product
 productName = product.productName
 productVersion = product.productVersion
-productArch = product.productArch
 isFinal = product.isFinal
 
 # for use in device names, eg: "fedora", "rhel"

--- a/pyanaconda/product.py
+++ b/pyanaconda/product.py
@@ -26,7 +26,6 @@ from pyanaconda.core.i18n import _
 # .buildstamp, environment, stupid last ditch hardcoded defaults.
 config = configparser.ConfigParser()
 config.add_section("Main")
-config.set("Main", "Arch", os.environ.get("ANACONDA_PRODUCTARCH", os.uname()[4]))
 config.set("Main", "BugURL", os.environ.get("ANACONDA_BUGURL", "your distribution provided bug reporting tool"))
 config.set("Main", "IsFinal", os.environ.get("ANACONDA_ISFINAL", "false"))
 config.set("Main", "Product", os.environ.get("ANACONDA_PRODUCTNAME", "anaconda"))
@@ -40,14 +39,11 @@ config.read(["/.buildstamp", os.environ.get("PRODBUILDPATH", "")])
 # Set up some variables we import throughout, applying a couple transforms as necessary.
 bugUrl = config.get("Main", "BugURL")
 isFinal = config.getboolean("Main", "IsFinal")
-productArch = config.get("Main", "Arch")
 productName = config.get("Main", "Product")
 productVariant = config.get("Main", "Variant")
 productStamp = config.get("Main", "UUID")
 productVersion = config.get("Main", "Version")
 
-if not productArch and productStamp.index(".") != -1:           # pylint: disable=no-member
-    productArch = productStamp[productStamp.index(".") + 1:]      # pylint: disable=no-member
 if productVersion == "development":
     productVersion = "rawhide"
 

--- a/pyanaconda/product.py
+++ b/pyanaconda/product.py
@@ -26,7 +26,6 @@ from pyanaconda.core.i18n import _
 # .buildstamp, environment, stupid last ditch hardcoded defaults.
 config = configparser.ConfigParser()
 config.add_section("Main")
-config.set("Main", "BugURL", os.environ.get("ANACONDA_BUGURL", "your distribution provided bug reporting tool"))
 config.set("Main", "IsFinal", os.environ.get("ANACONDA_ISFINAL", "false"))
 config.set("Main", "Product", os.environ.get("ANACONDA_PRODUCTNAME", "anaconda"))
 config.set("Main", "Variant", os.environ.get("ANACONDA_PRODUCTVARIANT", ""))
@@ -36,7 +35,6 @@ config.set("Main", "Version", os.environ.get("ANACONDA_PRODUCTVERSION", "bluesky
 config.read(["/.buildstamp", os.environ.get("PRODBUILDPATH", "")])
 
 # Set up some variables we import throughout, applying a couple transforms as necessary.
-bugUrl = config.get("Main", "BugURL")
 isFinal = config.getboolean("Main", "IsFinal")
 productName = config.get("Main", "Product")
 productVariant = config.get("Main", "Variant")

--- a/pyanaconda/product.py
+++ b/pyanaconda/product.py
@@ -30,7 +30,6 @@ config.set("Main", "BugURL", os.environ.get("ANACONDA_BUGURL", "your distributio
 config.set("Main", "IsFinal", os.environ.get("ANACONDA_ISFINAL", "false"))
 config.set("Main", "Product", os.environ.get("ANACONDA_PRODUCTNAME", "anaconda"))
 config.set("Main", "Variant", os.environ.get("ANACONDA_PRODUCTVARIANT", ""))
-config.set("Main", "UUID", "")
 config.set("Main", "Version", os.environ.get("ANACONDA_PRODUCTVERSION", "bluesky"))
 
 # Now read in the .buildstamp file, wherever it may be.
@@ -41,7 +40,6 @@ bugUrl = config.get("Main", "BugURL")
 isFinal = config.getboolean("Main", "IsFinal")
 productName = config.get("Main", "Product")
 productVariant = config.get("Main", "Variant")
-productStamp = config.get("Main", "UUID")
 productVersion = config.get("Main", "Version")
 
 if productVersion == "development":


### PR DESCRIPTION
We don't use the `Arch`, `UUID` and `BugURL` options from the `.buildstamp` file.

