### PR TITLE
subscription: allow dates in ISO 8601 format (port to RHEL 9)

### DIFF
--- a/pyanaconda/modules/subscription/runtime.py
+++ b/pyanaconda/modules/subscription/runtime.py
@@ -397,6 +397,13 @@ class ParseAttachedSubscriptionsTask(Task):
         """Return pretty human readable date based on date from the input JSON."""
         # fallback in case of the parsing fails
         date_string = date_from_json
+        # try to parse the date as ISO 8601 first
+        try:
+            date = datetime.datetime.strptime(date_from_json, "%Y-%m-%d")
+            # get a nice human readable date
+            return date.strftime("%b %d, %Y")
+        except ValueError:
+            pass
         try:
             # The start/end date in GetPools() output seems to be formatted as
             # "Locale’s appropriate date representation.".

--- a/tests/nosetests/pyanaconda_tests/modules/subscription/subscription_tasks_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/subscription/subscription_tasks_test.py
@@ -748,6 +748,8 @@ class ParseAttachedSubscriptionsTaskTestCase(unittest.TestCase):
     def pretty_date_test(self):
         """Test the pretty date method of ParseAttachedSubscriptionsTask."""
         pretty_date_method = ParseAttachedSubscriptionsTask._pretty_date
+        # try to parse ISO 8601 first
+        self.assertEqual(pretty_date_method("2015-12-22"), "Dec 22, 2015")
         # the method expects short mm/dd/yy dates
         self.assertEqual(pretty_date_method("12/22/15"), "Dec 22, 2015")
         # returns the input if parsing fails
@@ -781,6 +783,15 @@ class ParseAttachedSubscriptionsTaskTestCase(unittest.TestCase):
                     "starts": "now",
                     "ends": "never",
                     "quantity_used": "1000"
+                },
+                {
+                    "subscription_name": "Foo Bar Beta NG",
+                    "service_level": "much wow",
+                    "sku": "ABC5678",
+                    "contract": "12344321",
+                    "starts": "2020-05-12",
+                    "ends": "never",
+                    "quantity_used": "1000"
                 }
             ]
 
@@ -802,6 +813,15 @@ class ParseAttachedSubscriptionsTaskTestCase(unittest.TestCase):
                 "sku": "ABC4321",
                 "contract": "87654321",
                 "start-date": "now",
+                "end-date": "never",
+                "consumed-entitlement-count": 1000
+            },
+            {
+                "name": "Foo Bar Beta NG",
+                "service-level": "much wow",
+                "sku": "ABC5678",
+                "contract": "12344321",
+                "start-date": "May 12, 2020",
                 "end-date": "never",
                 "consumed-entitlement-count": 1000
             }


### PR DESCRIPTION
Right now, the date returned by D-Bus method calls of
subscription-manager have a locale-specific format, which can be hard to
parse. A planned change is to return all the dates in ISO 8601 format:
https://github.com/candlepin/subscription-manager/pull/2551

Hence, make the subscription module able to cope with the future value:
first try to parse the date as ISO 8601, and if it does not work try to
parse as it is done today. Add small unit testing data to check that
both ISO 8601 and the locale-specific formats work.

(cherry picked from commit f65f7fd4da0cdff2e358e37561925319e364f521)

Resolves: rhbz#1947447