### PR TITLE
Enable codecov.io

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,38 @@
+codecov:
+  # Don't wait for all other statuses to pass.
+  require_ci_to_pass: false
+
+coverage:
+  # Shift the color range.
+  range: 50..90
+  # Set up the pull request status.
+  status:
+    patch:
+      # Disable the default status for the patch.
+      default: false
+    project:
+      # Disable the default status for the project.
+      default: false
+      # Show a status for the DBus API.
+      api:
+        paths:
+          - "pyanaconda/modules/**/*_interface.py"
+      # Show a status for the core.
+      core:
+        paths:
+          - "pyanaconda/"
+          - "!pyanaconda/ui/tui/"
+          - "!pyanaconda/ui/gui/"
+        threshold: 5%
+      # Show a status for the unit tests.
+      tests:
+        paths:
+          - "tests/nosetests"
+
+# Disable the pull request comment.
+comment: false
+
+# Ignore some paths.
+ignore:
+  - "translation-canary/"
+  - "widgets/"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,6 +99,9 @@ jobs:
           name: 'logs (${{ matrix.ci_tag }})'
           path: test-logs/*
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+
   rpm-tests:
     environment: staging
     runs-on: ubuntu-20.04

--- a/Makefile.am
+++ b/Makefile.am
@@ -335,6 +335,7 @@ run-rpm-tests-only: rpms
 
 coverage-report:
 	$(COVERAGE) combine tests/.coverage.*
+	$(COVERAGE) xml -o tests/coverage-report.xml
 	$(COVERAGE) report -m --omit "tests/*" > tests/coverage-report.log
 	$(COVERAGE) report -m --include "tests/*" > tests/coverage-tests.log
 	$(COVERAGE) report -m --include "pyanaconda/dbus*,pyanaconda/modules/*,pyanaconda/core/*" \

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,10 @@ Anaconda is the OS installer used by Fedora, RHEL, CentOS and other Linux distri
     :alt: Documentation Status
     :target: https://anaconda-installer.readthedocs.io/en/latest/?badge=latest
 
+.. image:: https://codecov.io/gh/rhinstaller/anaconda/branch/master/graph/badge.svg
+    :alt: Coverage status
+    :target: https://codecov.io/gh/rhinstaller/anaconda
+
 .. image:: https://translate.fedoraproject.org/widgets/anaconda/-/master/svg-badge.svg
     :alt: Translation status
     :target: https://translate.fedoraproject.org/engage/anaconda/?utm_source=widget

--- a/dockerfile/anaconda-ci/run-build-and-arg
+++ b/dockerfile/anaconda-ci/run-build-and-arg
@@ -15,7 +15,8 @@ copy_logs() {
     mkdir -p /anaconda/test-logs/
     # clean up from previous run
     rm -rf /anaconda/test-logs/*
-    find -name '*.log' -exec cp '{}' /anaconda/test-logs/ \;
+    # copy logs and coverage reports
+    find \( -name '*.log' -o -name 'coverage*.xml' \) -exec cp '{}' /anaconda/test-logs/ \;
 }
 trap copy_logs EXIT INT QUIT PIPE
 


### PR DESCRIPTION
Generate an XML report of coverage results and upload it to codecov.io.

Add a configuration file for codecov.io.

Show the current coverage in the README file.