### PR TITLE
Clean DNF to make the anaconda-rpm container smaller (#infra)

### DIFF
--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -22,6 +22,7 @@ RUN set -e; \
   if ! grep -q VARIANT.*eln /etc/os-release; then dnf copr enable -y ${copr_repo}; dnf copr enable -y @storage/blivet-daily; fi; \
   curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/${git_branch}/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
+  dnf clean all; \
   mkdir /anaconda
 
 RUN pip install nose


### PR DESCRIPTION
This is in general good practice.

(cherry picked from commit 9172d83dae4576b2baea6d8027bd533aef628c01)