### PR TITLE
Master drop workflow podman fail hotfix

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -30,26 +30,6 @@ jobs:
       CI_TAG: '${{ matrix.container-tag }}'
     timeout-minutes: 60
     steps:
-      # FIXME: This is a temporary workaround for Ubuntu 20.04 20210419.1.
-      # See: https://github.com/actions/virtual-environments/issues/3229
-      - name: Fix the broken rootless podman on Ubuntu 20.04 20210419.1
-        run: |
-          # Create directories for a custom storage configuration file.
-          mkdir -p ~/.config/containers/
-
-          # Create a custom storage configuration file for the rootless mode.
-          cat > ~/.config/containers/storage.conf << EOF
-
-          [storage]
-          driver = "overlay"
-          graphroot = "/home/runner/.local/share/containers/storage"
-
-          [storage.options]
-          mount_program = "/usr/bin/fuse-overlayfs"
-          additionalimagestores = []
-
-          EOF
-
       - name: Checkout anaconda repository
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,26 +39,6 @@ jobs:
       TARGET_BRANCH_NAME: 'origin/${{ matrix.target_branch }}'
 
     steps:
-      # FIXME: This is a temporary workaround for Ubuntu 20.04 20210419.1.
-      # See: https://github.com/actions/virtual-environments/issues/3229
-      - name: Fix the broken rootless podman on Ubuntu 20.04 20210419.1
-        run: |
-          # Create directories for a custom storage configuration file.
-          mkdir -p ~/.config/containers/
-
-          # Create a custom storage configuration file for the rootless mode.
-          cat > ~/.config/containers/storage.conf << EOF
-
-          [storage]
-          driver = "overlay"
-          graphroot = "/home/runner/.local/share/containers/storage"
-
-          [storage.options]
-          mount_program = "/usr/bin/fuse-overlayfs"
-          additionalimagestores = []
-
-          EOF
-
       - name: Clone repository
         uses: actions/checkout@v2
         with:
@@ -129,26 +109,6 @@ jobs:
       TARGET_BRANCH_NAME: 'origin/${{ matrix.target_branch }}'
 
     steps:
-      # FIXME: This is a temporary workaround for Ubuntu 20.04 20210419.1.
-      # See: https://github.com/actions/virtual-environments/issues/3229
-      - name: Fix the broken rootless podman on Ubuntu 20.04 20210419.1
-        run: |
-          # Create directories for a custom storage configuration file.
-          mkdir -p ~/.config/containers/
-
-          # Create a custom storage configuration file for the rootless mode.
-          cat > ~/.config/containers/storage.conf << EOF
-
-          [storage]
-          driver = "overlay"
-          graphroot = "/home/runner/.local/share/containers/storage"
-
-          [storage.options]
-          mount_program = "/usr/bin/fuse-overlayfs"
-          additionalimagestores = []
-
-          EOF
-
       - name: Clone repository
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,8 +63,7 @@ jobs:
 
       # build container if files for dockerfile changed in the PR
       - name: Build anaconda-ci container
-        # FIXME: always build ELN container, until we publish it to quay.io
-        if: steps.check-dockerfile-changed.outputs.changed || matrix.release == 'eln'
+        if: steps.check-dockerfile-changed.outputs.changed
         run: make -f Makefile.am anaconda-ci-build
 
       - name: Run tests in anaconda-ci container


### PR DESCRIPTION
Remove workaround added because of failing podman.

Also remove forgotten check to build ELN containers all the time.

[Test run for ci tests](https://github.com/jkonecny12/anaconda/runs/2508911220?check_suite_focus=true).
[Test run for container update](https://github.com/jkonecny12/anaconda/actions/runs/813288812). Expected failure when login quay (missing credentials) and missing F34 branches on my fork.