### PR TITLE
Add the load_repository method to the DNF manager

### DIFF
--- a/pyanaconda/modules/common/errors/payload.py
+++ b/pyanaconda/modules/common/errors/payload.py
@@ -54,3 +54,9 @@ class UnknownCompsEnvironmentError(AnacondaError):
 class UnknownCompsGroupError(AnacondaError):
     """The comps group is not recognized."""
     pass
+
+
+@dbus_error("UnknownRepositoryError", namespace=PAYLOADS_NAMESPACE)
+class UnknownRepositoryError(AnacondaError):
+    """The repository is not recognized."""
+    pass

--- a/pyanaconda/payload/errors.py
+++ b/pyanaconda/payload/errors.py
@@ -21,10 +21,6 @@ class PayloadError(Exception):
     pass
 
 
-class MetadataError(PayloadError):
-    pass
-
-
 # setup
 class PayloadSetupError(PayloadError):
     pass

--- a/pyanaconda/payload/manager.py
+++ b/pyanaconda/payload/manager.py
@@ -213,10 +213,14 @@ class PayloadManager(object):
         # Keep setting up package-based repositories
         # Download package metadata
         self._set_state(PayloadState.DOWNLOADING_PKG_METADATA)
+
+        # FIXME: This import is a temporary workaround. Use a DBus error instead.
+        from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManagerError
+
         try:
             payload.update_base_repo(fallback=fallback, checkmount=checkmount)
             payload.add_driver_repos()
-        except (OSError, DBusError, PayloadError) as e:
+        except (OSError, DBusError, PayloadError, DNFManagerError) as e:
             log.error("PayloadError: %s", e)
             self._error = self.ERROR_SETUP
             self._set_state(PayloadState.ERROR)


### PR DESCRIPTION
Call the `load_repository` method to download the repo metadata.