### PR TITLE
The kernel boot argument sshd is removed and should warn user

### DIFF
--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -68,7 +68,7 @@ check_depr_args "blacklist=" "inst.blacklist=%s"
 check_depr_arg "nofirewire" "inst.blacklist=firewire_ohci"
 
 # ssh
-check_depr_arg "sshd" "inst.sshd"
+check_removed_no_inst_arg "sshd" "inst.sshd"
 
 # serial was never supposed to be used for anything!
 check_removed_arg serial "To change the console use 'console=' instead."


### PR DESCRIPTION
Booting with sshd is not supported anymore. User have to use inst.sshd. Warn user in Dracut about that.

Backport of https://github.com/rhinstaller/anaconda/pull/3319 .

Resolves: rhbz#1954672