### PR TITLE
Install kbd-legacy if keyboard layout is "fi" (#1955793)

### DIFF
--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -196,8 +196,10 @@ class LocalizationService(KickstartService):
         """
         requirements = []
 
-        # Install support for non-ascii keyboard layouts (#1919483).
-        if self.vc_keymap and not langtable.supports_ascii(self.vc_keymap):
+        # Install support for non-ascii keyboard layouts (#1919483)
+        # and special case "fi" layout (#1955793)
+        if self.vc_keymap and (self.vc_keymap == "fi" or
+                               not langtable.supports_ascii(self.vc_keymap)):
             requirements.append(Requirement.for_package(
                 package_name="kbd-legacy",
                 reason="Required to support the '{}' keymap.".format(self.vc_keymap)

--- a/tests/nosetests/pyanaconda_tests/modules/localization/module_localization_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/localization/module_localization_test.py
@@ -169,6 +169,17 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
         self.assertEqual(requirements[0].type, "package")
         self.assertEqual(requirements[0].name, "kbd-legacy")
 
+        # "fi" keyboard layout is in kbd-legacy too (#1955793)
+        self.localization_interface.SetVirtualConsoleKeymap("fi")
+
+        requirements = Requirement.from_structure_list(
+            self.localization_interface.CollectRequirements()
+        )
+
+        self.assertEqual(len(requirements), 1)
+        self.assertEqual(requirements[0].type, "package")
+        self.assertEqual(requirements[0].name, "kbd-legacy")
+
     @patch_dbus_publish_object
     def install_with_task_test(self, publisher):
         """Test InstallWithTask."""


### PR DESCRIPTION
fi is a special case, as described in
https://bugzilla.redhat.com/show_bug.cgi?id=1955793#c6 , where
the layout is taken from kbd-legacy even though the xkb layout
does support ASCII input. So we have to special-case it here.

Signed-off-by: Adam Williamson <awilliam@redhat.com>