### PR TITLE
Add the repositories property to the DNF manager

### DIFF
--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -18,7 +18,6 @@
 #
 import configparser
 import os
-import threading
 import dnf.exceptions
 import dnf.repo
 
@@ -95,12 +94,6 @@ class DNFPayload(Payload):
         # This will create a default source if there is none.
         self._configure()
 
-        # Protect access to _base.repos to ensure that the dictionary is not
-        # modified while another thread is attempting to iterate over it. The
-        # lock only needs to be held during operations that change the number
-        # of repos or that iterate over the repos.
-        self._repos_lock = threading.RLock()
-
         # save repomd metadata
         self._repoMD_list = []
 
@@ -116,6 +109,14 @@ class DNFPayload(Payload):
         FIXME: This is a temporary property.
         """
         return self._dnf_manager._base
+
+    @property
+    def _repos_lock(self):
+        """A lock for a dictionary of DNF repositories.
+
+        FIXME: This is a temporary property.
+        """
+        return self._dnf_manager._lock
 
     def set_from_opts(self, opts):
         """Set the payload from the Anaconda cmdline options.
@@ -326,12 +327,6 @@ class DNFPayload(Payload):
     ###
     # METHODS FOR WORKING WITH REPOSITORIES
     ###
-
-    @property
-    def repos(self):
-        """A list of repo identifiers, not objects themselves."""
-        with self._repos_lock:
-            return [r.id for r in self._base.repos.values()]
 
     @property
     def addons(self):

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1229,7 +1229,8 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
             return _("Invalid repository name")
 
         cnames = [constants.BASE_REPO_NAME] + constants.DEFAULT_REPOS + \
-                 [r for r in self.payload.repos if r not in self.payload.addons]
+                 [r for r in self.payload.dnf_manager.repositories
+                  if r not in self.payload.addons]
         if repo_name in cnames:
             return _("Repository name conflicts with internal repository name.")
 

--- a/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/payloads/payload/module_payload_dnf_manager_test.py
@@ -885,12 +885,23 @@ class DNFManagerReposTestCase(unittest.TestCase):
     def _add_repo(self, repo_id):
         """Add a mocked repo with the specified id."""
         repo = Mock(spec=Repo)
+        repo.id = repo_id
         repo.baseurl = ["http://url/{}".format(repo_id)]
         repo.mirrorlist = None
         repo.metalink = None
 
         self.repos[repo_id] = repo
         return repo
+
+    def repositories_test(self):
+        """Test the repositories property."""
+        self.assertEqual(self.dnf_manager.repositories, [])
+
+        self._add_repo("r1")
+        self._add_repo("r2")
+        self._add_repo("r3")
+
+        self.assertEqual(self.dnf_manager.repositories, ["r1", "r2", "r3"])
 
     def load_repository_unknown_test(self):
         """Test the load_repository method with an unknown repo."""


### PR DESCRIPTION
Use the `repositories` property to get a list of repository identifiers.