### PR TITLE
Simplify the code for kickstart repositories

### DIFF
--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -329,15 +329,10 @@ class DNFPayload(Payload):
     ###
 
     @property
-    def addons(self):
-        """A list of addon repo names."""
-        return [r.name for r in self.data.repo.dataList()]
-
-    @property
     def _enabled_repos(self):
         """A list of names of the enabled repos."""
         enabled = []
-        for repo in self.addons:
+        for repo in [r.name for r in self.data.repo.dataList()]:
             if self.is_repo_enabled(repo):
                 enabled.append(repo)
 
@@ -482,7 +477,7 @@ class DNFPayload(Payload):
                 util.execWithRedirect("createrepo_c", [repo])
 
             repo_name = "DD-%d" % dir_num
-            if repo_name not in self.addons:
+            if repo_name not in [r.name for r in self.data.repo.dataList()]:
                 ks_repo = self.data.RepoData(name=repo_name,
                                              baseurl="file://" + repo,
                                              enabled=True)
@@ -792,7 +787,7 @@ class DNFPayload(Payload):
                         log.debug("repo %s: fall back enabled from default repos", id_)
                         repo.enable()
 
-        for repo in self.addons:
+        for repo in [r.name for r in self.data.repo.dataList()]:
             ksrepo = self.get_addon_repo(repo)
 
             if ksrepo.is_harddrive_based():
@@ -822,7 +817,7 @@ class DNFPayload(Payload):
 
             # fetch md for enabled repos
             enabled_repos = self._enabled_repos
-            for repo_name in self.addons:
+            for repo_name in [r.name for r in self.data.repo.dataList()]:
                 if repo_name in enabled_repos:
                     self._dnf_manager.load_repository(repo_name)
 
@@ -1045,7 +1040,7 @@ class DNFPayload(Payload):
             if base_repo_url is not None:
                 existing_urls.append(base_repo_url)
 
-            for ksrepo in self.addons:
+            for ksrepo in [r.name for r in self.data.repo.dataList()]:
                 baseurl = self.get_addon_repo(ksrepo).baseurl
                 existing_urls.append(baseurl)
 
@@ -1089,7 +1084,7 @@ class DNFPayload(Payload):
         """
         disabled_repo_names = []
 
-        for ks_repo_name in self.addons:
+        for ks_repo_name in [r.name for r in self.data.repo.dataList()]:
             repo = self.get_addon_repo(ks_repo_name)
             if repo.treeinfo_origin:
                 log.debug("Removing old treeinfo repository %s", ks_repo_name)
@@ -1169,7 +1164,7 @@ class DNFPayload(Payload):
     def post_install(self):
         """Perform post-installation tasks."""
         # Write selected kickstart repos to target system
-        for ks_repo in (ks for ks in (self.get_addon_repo(r) for r in self.addons) if ks.install):
+        for ks_repo in (ks for ks in (self.get_addon_repo(r) for r in [r.name for r in self.data.repo.dataList()]) if ks.install):
             if ks_repo.baseurl.startswith("nfs://"):
                 log.info("Skip writing nfs repo %s to target system.", ks_repo.name)
                 continue

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -328,16 +328,6 @@ class DNFPayload(Payload):
     # METHODS FOR WORKING WITH REPOSITORIES
     ###
 
-    @property
-    def _enabled_repos(self):
-        """A list of names of the enabled repos."""
-        enabled = []
-        for repo in [r.name for r in self.data.repo.dataList()]:
-            if self.is_repo_enabled(repo):
-                enabled.append(repo)
-
-        return enabled
-
     def get_addon_repo(self, repo_id):
         """Return a ksdata Repo instance matching the specified repo id."""
         repo = None
@@ -816,7 +806,11 @@ class DNFPayload(Payload):
                     self._disable_repo(id_)
 
             # fetch md for enabled repos
-            enabled_repos = self._enabled_repos
+            enabled_repos = []
+            for repo in [r.name for r in self.data.repo.dataList()]:
+                if self.is_repo_enabled(repo):
+                    enabled_repos.append(repo)
+
             for repo_name in [r.name for r in self.data.repo.dataList()]:
                 if repo_name in enabled_repos:
                     self._dnf_manager.load_repository(repo_name)

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -445,7 +445,10 @@ class DNFPayload(Payload):
             repos.pop(idx)
 
     def add_driver_repos(self):
-        """Add driver repositories and packages."""
+        """Add driver repositories and packages.
+
+        FIXME: Don't run this code on every payload restart.
+        """
         # Drivers are loaded by anaconda-dracut, their repos are copied
         # into /run/install/DD-X where X is a number starting at 1. The list of
         # packages that were selected is in /run/install/dd_packages
@@ -466,12 +469,22 @@ class DNFPayload(Payload):
                 log.info("Running createrepo on %s", repo)
                 util.execWithRedirect("createrepo_c", [repo])
 
+            # Generate the repo name.
             repo_name = "DD-%d" % dir_num
-            if repo_name not in [r.name for r in self.data.repo.dataList()]:
-                ks_repo = self.data.RepoData(name=repo_name,
-                                             baseurl="file://" + repo,
-                                             enabled=True)
-                self._add_repo_to_dnf_and_ks(ks_repo)
+
+            # The repo has been already created (#1268357).
+            for ks_repo in self.data.repo.dataList():
+                if repo_name == ks_repo.name:
+                    continue
+
+            # Or create a new one.
+            ks_repo = self.data.RepoData(
+                name=repo_name,
+                baseurl="file://" + repo,
+                enabled=True
+            )
+
+            self._add_repo_to_dnf_and_ks(ks_repo)
 
     @property
     def space_required(self):
@@ -777,9 +790,7 @@ class DNFPayload(Payload):
                         log.debug("repo %s: fall back enabled from default repos", id_)
                         repo.enable()
 
-        for repo in [r.name for r in self.data.repo.dataList()]:
-            ksrepo = self.get_addon_repo(repo)
-
+        for ksrepo in self.data.repo.dataList():
             if ksrepo.is_harddrive_based():
                 ksrepo.baseurl = self._setup_harddrive_addon_repo(ksrepo)
 
@@ -806,14 +817,9 @@ class DNFPayload(Payload):
                     self._disable_repo(id_)
 
             # fetch md for enabled repos
-            enabled_repos = []
-            for repo in [r.name for r in self.data.repo.dataList()]:
-                if self.is_repo_enabled(repo):
-                    enabled_repos.append(repo)
-
-            for repo_name in [r.name for r in self.data.repo.dataList()]:
-                if repo_name in enabled_repos:
-                    self._dnf_manager.load_repository(repo_name)
+            for ks_repo in self.data.repo.dataList():
+                if self.is_repo_enabled(ks_repo.name):
+                    self._dnf_manager.load_repository(ks_repo.name)
 
     def _find_and_mount_iso(self, device, device_mount_dir, iso_path, iso_mount_dir):
         """Find and mount installation source from ISO on device.
@@ -1034,8 +1040,8 @@ class DNFPayload(Payload):
             if base_repo_url is not None:
                 existing_urls.append(base_repo_url)
 
-            for ksrepo in [r.name for r in self.data.repo.dataList()]:
-                baseurl = self.get_addon_repo(ksrepo).baseurl
+            for ks_repo in self.data.repo.dataList():
+                baseurl = ks_repo.baseurl
                 existing_urls.append(baseurl)
 
             enabled_repositories_from_treeinfo = conf.payload.enabled_repositories_from_treeinfo
@@ -1078,15 +1084,14 @@ class DNFPayload(Payload):
         """
         disabled_repo_names = []
 
-        for ks_repo_name in [r.name for r in self.data.repo.dataList()]:
-            repo = self.get_addon_repo(ks_repo_name)
-            if repo.treeinfo_origin:
-                log.debug("Removing old treeinfo repository %s", ks_repo_name)
+        for ks_repo in list(self.data.repo.dataList()):
+            if ks_repo.treeinfo_origin:
+                log.debug("Removing old treeinfo repository %s", ks_repo.name)
 
-                if not repo.enabled:
-                    disabled_repo_names.append(ks_repo_name)
+                if not ks_repo.enabled:
+                    disabled_repo_names.append(ks_repo.name)
 
-                self._remove_repo(ks_repo_name)
+                self._remove_repo(ks_repo.name)
 
         return disabled_repo_names
 
@@ -1158,7 +1163,10 @@ class DNFPayload(Payload):
     def post_install(self):
         """Perform post-installation tasks."""
         # Write selected kickstart repos to target system
-        for ks_repo in (ks for ks in (self.get_addon_repo(r) for r in [r.name for r in self.data.repo.dataList()]) if ks.install):
+        for ks_repo in self.data.repo.dataList():
+            if not ks_repo.install:
+                continue
+
             if ks_repo.baseurl.startswith("nfs://"):
                 log.info("Skip writing nfs repo %s to target system.", ks_repo.name)
                 continue

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1230,7 +1230,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
 
         cnames = [constants.BASE_REPO_NAME] + constants.DEFAULT_REPOS + \
                  [r for r in self.payload.dnf_manager.repositories
-                  if r not in self.payload.addons]
+                  if r not in [r.name for r in self.data.repo.dataList()]]
         if repo_name in cnames:
             return _("Repository name conflicts with internal repository name.")
 
@@ -1425,7 +1425,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
             ui_orig_names = [r[REPO_OBJ].orig_name for r in self._repo_store]
 
             # Remove repos from payload that were removed in the UI
-            for repo_name in [r for r in self.payload.addons if r not in ui_orig_names]:
+            for repo_name in [r for r in [r.name for r in self.data.repo.dataList()] if r not in ui_orig_names]:
                 repo = self.payload.get_addon_repo(repo_name)
                 # TODO: Need an API to do this w/o touching dnf (not add_repo)
                 # FIXME: Is this still needed for dnf?
@@ -1466,7 +1466,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
 
         with self._repo_store_lock:
             self._repo_store.clear()
-            repos = self.payload.addons
+            repos = [r.name for r in self.data.repo.dataList()]
             log.debug("Setting up repos: %s", repos)
             for name in repos:
                 repo = self.payload.get_addon_repo(name)

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1218,6 +1218,23 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
             return _("Duplicate repository names.")
         return InputCheck.CHECK_OK
 
+    def _is_conflicting_repo_name(self, repo_name):
+        if repo_name == constants.BASE_REPO_NAME:
+            return True
+
+        if repo_name in constants.DEFAULT_REPOS:
+            return True
+
+        for ks_repo in self.data.repo.dataList():
+            if repo_name == ks_repo.name:
+                return False
+
+        for repo_id in self.payload.dnf_manager.repositories:
+            if repo_name == repo_id:
+                return True
+
+        return False
+
     def _check_repo_name(self, inputcheck):
         # Input object is name of the repository
         repo_name = self._get_repo_by_id(inputcheck.input_obj).name
@@ -1228,10 +1245,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         if not REPO_NAME_VALID.match(repo_name):
             return _("Invalid repository name")
 
-        cnames = [constants.BASE_REPO_NAME] + constants.DEFAULT_REPOS + \
-                 [r for r in self.payload.dnf_manager.repositories
-                  if r not in [r.name for r in self.data.repo.dataList()]]
-        if repo_name in cnames:
+        if self._is_conflicting_repo_name(repo_name):
             return _("Repository name conflicts with internal repository name.")
 
         return InputCheck.CHECK_OK
@@ -1425,8 +1439,10 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
             ui_orig_names = [r[REPO_OBJ].orig_name for r in self._repo_store]
 
             # Remove repos from payload that were removed in the UI
-            for repo_name in [r for r in [r.name for r in self.data.repo.dataList()] if r not in ui_orig_names]:
-                repo = self.payload.get_addon_repo(repo_name)
+            for repo in list(self.data.repo.dataList()):
+                if repo.name in ui_orig_names:
+                    continue
+
                 # TODO: Need an API to do this w/o touching dnf (not add_repo)
                 # FIXME: Is this still needed for dnf?
                 self.payload.data.repo.dataList().remove(repo)
@@ -1466,16 +1482,14 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
 
         with self._repo_store_lock:
             self._repo_store.clear()
-            repos = [r.name for r in self.data.repo.dataList()]
-            log.debug("Setting up repos: %s", repos)
-            for name in repos:
-                repo = self.payload.get_addon_repo(name)
+            for repo in self.data.repo.dataList():
+                log.debug("Setting up repo: %s", repo.name)
                 ks_repo = self.data.RepoData.create_copy(repo)
                 # Track the original name, user may change .name
-                ks_repo.orig_name = name
+                ks_repo.orig_name = repo.name
                 # Add addon repository id for identification
                 ks_repo.repo_id = next(self._repo_counter)
-                self._repo_store.append([self.payload.is_repo_enabled(name),
+                self._repo_store.append([self.payload.is_repo_enabled(repo.name),
                                         ks_repo.name,
                                         ks_repo])
 


### PR DESCRIPTION
Remove the `addons` and `_enabled_repos` properties of the DNF payload and simplify the related code.