### PR TITLE
Revert "The kernel boot argument sshd is removed and should warn user"

### DIFF
--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -62,7 +62,7 @@ check_depr_args "blacklist=" "inst.blacklist=%s"
 check_depr_arg "nofirewire" "inst.blacklist=firewire_ohci"
 
 # ssh
-check_removed_no_inst_arg "sshd" "inst.sshd"
+check_depr_arg "sshd" "inst.sshd"
 
 # serial was never supposed to be used for anything!
 check_removed_arg serial "To change the console use 'console=' instead."


### PR DESCRIPTION
This reverts commit 4de187300a24e021efb35caee21d0ee0ecb2673d.

Compose tools are not ready for the change in RHEL-9 yet.

Related: rhbz#1954672