### PR TITLE
Do not use pip cache when building containers (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -38,7 +38,7 @@ RUN set -e; \
   rpmspec -q --requires /tmp/anaconda.spec | grep -v anaconda | xargs -d '\n' dnf install -y; \
   dnf clean all
 
-RUN pip install \
+RUN pip install --no-cache-dir \
   pocketlint \
   coverage \
   pycodestyle \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -24,6 +24,6 @@ RUN set -e; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   mkdir /anaconda
 
-RUN pip install nose
+RUN pip install --no-cache-dir nose
 
 WORKDIR /anaconda


### PR DESCRIPTION
Saves a bit more space.

Successful run: https://github.com/vslavik-test-org/anaconda/actions/runs/832532251
(All jobs die on login, container build and test run is successful.)