### PR TITLE
Fix boot options generated by the dracut module

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -157,7 +157,7 @@ class DracutURL(Url, DracutArgsMixin):
         if self.noverifyssl:
             args.append("rd.noverifyssl")
         if self.proxy:
-            args.append("proxy=%s" % self.proxy)
+            args.append("inst.proxy=%s" % self.proxy)
 
         return "\n".join(args)
 
@@ -249,7 +249,7 @@ class DracutDisplayMode(DisplayMode, DracutArgsMixin):
 class DracutBootloader(Bootloader, DracutArgsMixin):
     def dracut_args(self, args, lineno, obj):
         if self.extlinux:
-            return "extlinux"
+            return "inst.extlinux"
 
 # FUTURE: keymap, lang... device? selinux?
 

--- a/tests/nosetests/dracut_tests/parse-kickstart_test.py
+++ b/tests/nosetests/dracut_tests/parse-kickstart_test.py
@@ -93,7 +93,7 @@ class ParseKickstartTestCase(BaseTestCase):
         self.assertEqual(len(lines), 3, lines)
         self.assertEqual(lines[0], "inst.repo=https://host.at.foo.com/path/to/tree", lines)
         self.assertEqual(lines[1], "rd.noverifyssl", lines)
-        self.assertEqual(lines[2], "proxy=http://localhost:8123", lines)
+        self.assertEqual(lines[2], "inst.proxy=http://localhost:8123", lines)
 
     def updates_test(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -257,4 +257,4 @@ network --device=lo --vlanid=171 --interfacename=vlan171
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertEqual(lines[0], "extlinux", lines)
+            self.assertEqual(lines[0], "inst.extlinux", lines)


### PR DESCRIPTION
Add the `inst.` prefix to the anaconda boot options.