### PR TITLE
RHEL 8 Xorg timeout fix

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -251,7 +251,6 @@ def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
         if x11_status.timed_out:
             log.debug("SIGUSR1 received after X server timeout. Switching back to tty1. "
                       "SIGUSR1 now again initiates test of exception reporting.")
-            vtActivate(1)
             signal.signal(signal.SIGUSR1, old_sigusr1_handler)
 
     # preexec_fn to add the SIGUSR1 handler in the child we are starting

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -47,7 +47,7 @@ from pyanaconda.core.constants import DRACUT_SHUTDOWN_EJECT, TRANSLATIONS_UPDATE
     IPMI_ABORTED, X_TIMEOUT, TAINT_HARDWARE_UNSUPPORTED, TAINT_SUPPORT_REMOVED, \
     WARNING_HARDWARE_UNSUPPORTED, WARNING_SUPPORT_REMOVED
 from pyanaconda.core.constants import SCREENSHOTS_DIRECTORY, SCREENSHOTS_TARGET_DIRECTORY
-from pyanaconda.errors import RemovedModuleError, ExitError
+from pyanaconda.errors import RemovedModuleError
 
 from pyanaconda.anaconda_logging import program_log_lock
 from pyanaconda.anaconda_loggers import get_module_logger, get_program_logger
@@ -204,6 +204,15 @@ def startProgram(argv, root='/', stdin=None, stdout=subprocess.PIPE, stderr=subp
                             preexec_fn=preexec, cwd=root, env=env, **kwargs)
 
 
+class X11Status:
+    """Status of Xorg launch.
+
+    Values of an instance can be modified from the handler functions.
+    """
+    def __init__(self):
+        self.started = False
+
+
 def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
     """ Start X and return once X is ready to accept connections.
 
@@ -217,23 +226,23 @@ def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
         :param output_redirect: file or file descriptor to redirect stdout and stderr to
         :param timeout: Number of seconds to timing out.
     """
-    # Use a list so the value can be modified from the handler function
-    x11_started = [False]
+    x11_status = X11Status()
 
     def sigusr1_handler(num, frame):
         log.debug("X server has signalled a successful start.")
-        x11_started[0] = True
+        x11_status.started = True
 
     # Fail after, let's say a minute, in case something weird happens
     # and we don't receive SIGUSR1
     def sigalrm_handler(num, frame):
         # Check that it didn't make it under the wire
-        if x11_started[0]:
+        if x11_status.started:
             return
         log.error("Timeout trying to start %s", argv[0])
-        raise ExitError("Timeout trying to start %s" % argv[0])
+        raise TimeoutError("Timeout trying to start %s" % argv[0])
 
-    # preexec_fn to add the SIGUSR1 handler in the child
+    # preexec_fn to add the SIGUSR1 handler in the child we are starting
+    # see man page XServer(1), section "signals"
     def sigusr1_preexec():
         signal.signal(signal.SIGUSR1, signal.SIG_IGN)
 
@@ -249,8 +258,8 @@ def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
                                  preexec_fn=sigusr1_preexec)
         WatchProcesses.watch_process(childproc, argv[0])
 
-        # Wait for SIGUSR1
-        while not x11_started[0]:
+        # Wait for SIGUSR1 or SIGALRM
+        while not x11_status.started:
             signal.pause()
 
     finally:

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -249,8 +249,10 @@ def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
     # Handle delayed start after timeout
     def sigusr1_too_late_handler(num, frame):
         if x11_status.timed_out:
-            log.debug("SIGUSR1 received after X server timeout. Switching back to tty1.")
+            log.debug("SIGUSR1 received after X server timeout. Switching back to tty1. "
+                      "SIGUSR1 now again initiates test of exception reporting.")
             vtActivate(1)
+            signal.signal(signal.SIGUSR1, old_sigusr1_handler)
 
     # preexec_fn to add the SIGUSR1 handler in the child we are starting
     # see man page XServer(1), section "signals"
@@ -283,8 +285,12 @@ def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
             signal.signal(signal.SIGUSR1, old_sigusr1_handler)
         elif x11_status.timed_out:
             signal.signal(signal.SIGUSR1, sigusr1_too_late_handler)
+            # Kill Xorg because from now on we will not use it. It will exit only after sending
+            # the signal, but at least we don't have to track that.
+            WatchProcesses.unwatch_process(childproc)
+            childproc.terminate()
             log.debug("Exception handler test suspended to prevent accidental activation by "
-                      "delayed Xorg start. All further SIGUSR1 will be handled with suspicion.")
+                      "delayed Xorg start. Next SIGUSR1 will be handled as delayed Xorg start.")
             # Raise an exception to notify the caller that things went wrong. This affects
             # particularly pyanaconda.display.do_startup_x11_actions(), where the window manager
             # is started immediately after this. The WM would just wait forever.

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -211,6 +211,10 @@ class X11Status:
     """
     def __init__(self):
         self.started = False
+        self.timed_out = False
+
+    def needs_waiting(self):
+        return not (self.started or self.timed_out)
 
 
 def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
@@ -228,7 +232,8 @@ def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
     """
     x11_status = X11Status()
 
-    def sigusr1_handler(num, frame):
+    # Handle successful start before timeout
+    def sigusr1_success_handler(num, frame):
         log.debug("X server has signalled a successful start.")
         x11_status.started = True
 
@@ -238,8 +243,18 @@ def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
         # Check that it didn't make it under the wire
         if x11_status.started:
             return
+        x11_status.timed_out = True
+        signal.signal(signal.SIGUSR1, sigusr1_too_late_handler)
         log.error("Timeout trying to start %s", argv[0])
+        log.debug("Exception handler test suspended to prevent accidental activation by delayed "
+                  "Xorg start. All further SIGUSR1 will be handled with suspicion.")
         raise TimeoutError("Timeout trying to start %s" % argv[0])
+
+    # Handle delayed start after timeout
+    def sigusr1_too_late_handler(num, frame):
+        if x11_status.timed_out:
+            log.debug("SIGUSR1 received after X server timeout. Switching back to tty1.")
+            vtActivate(1)
 
     # preexec_fn to add the SIGUSR1 handler in the child we are starting
     # see man page XServer(1), section "signals"
@@ -247,7 +262,7 @@ def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
         signal.signal(signal.SIGUSR1, signal.SIG_IGN)
 
     try:
-        old_sigusr1_handler = signal.signal(signal.SIGUSR1, sigusr1_handler)
+        old_sigusr1_handler = signal.signal(signal.SIGUSR1, sigusr1_success_handler)
         old_sigalrm_handler = signal.signal(signal.SIGALRM, sigalrm_handler)
 
         # Start the timer
@@ -259,13 +274,14 @@ def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
         WatchProcesses.watch_process(childproc, argv[0])
 
         # Wait for SIGUSR1 or SIGALRM
-        while not x11_status.started:
+        while x11_status.needs_waiting():
             signal.pause()
 
     finally:
-        # Put everything back where it was
+        # Put everything back where it was, if possible
         signal.alarm(0)
-        signal.signal(signal.SIGUSR1, old_sigusr1_handler)
+        if x11_status.started:
+            signal.signal(signal.SIGUSR1, old_sigusr1_handler)
         signal.signal(signal.SIGALRM, old_sigalrm_handler)
 
 

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -244,11 +244,7 @@ def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
         if x11_status.started:
             return
         x11_status.timed_out = True
-        signal.signal(signal.SIGUSR1, sigusr1_too_late_handler)
         log.error("Timeout trying to start %s", argv[0])
-        log.debug("Exception handler test suspended to prevent accidental activation by delayed "
-                  "Xorg start. All further SIGUSR1 will be handled with suspicion.")
-        raise TimeoutError("Timeout trying to start %s" % argv[0])
 
     # Handle delayed start after timeout
     def sigusr1_too_late_handler(num, frame):
@@ -278,11 +274,21 @@ def startX(argv, output_redirect=None, timeout=X_TIMEOUT):
             signal.pause()
 
     finally:
-        # Put everything back where it was, if possible
+        # Stop the timer
         signal.alarm(0)
+        signal.signal(signal.SIGALRM, old_sigalrm_handler)
+
+        # Handle outcome of X start attempt
         if x11_status.started:
             signal.signal(signal.SIGUSR1, old_sigusr1_handler)
-        signal.signal(signal.SIGALRM, old_sigalrm_handler)
+        elif x11_status.timed_out:
+            signal.signal(signal.SIGUSR1, sigusr1_too_late_handler)
+            log.debug("Exception handler test suspended to prevent accidental activation by "
+                      "delayed Xorg start. All further SIGUSR1 will be handled with suspicion.")
+            # Raise an exception to notify the caller that things went wrong. This affects
+            # particularly pyanaconda.display.do_startup_x11_actions(), where the window manager
+            # is started immediately after this. The WM would just wait forever.
+            raise TimeoutError("Timeout trying to start %s" % argv[0])
 
 
 def _run_program(argv, root='/', stdin=None, stdout=None, env_prune=None, log_output=True,

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -88,7 +88,7 @@ def ask_vnc_question(anaconda, vnc_server, message):
     App.initialize()
     loop = App.get_event_loop()
     loop.set_quit_callback(tui_quit_callback)
-    spoke = AskVNCSpoke(anaconda.ksdata, message)
+    spoke = AskVNCSpoke(anaconda.ksdata, message=message)
     ScreenHandler.schedule_screen(spoke)
     App.run()
 

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -56,8 +56,8 @@ X_TIMEOUT_ADVICE = \
     "The default is 60 seconds.\n" \
     "Load the stage2 image into memory with the rd.live.ram boot option to decrease access " \
     "time.\n" \
-    "Enforce text mode when installing from remote media with the inst.text boot option."
-#  on RHEL also: "Use the customer portal download URL in ilo/drac devices for greater speed."
+    "Enforce text mode when installing from remote media with the inst.text boot option.\n" \
+    "Use the customer portal download URL in ilo/drac devices for greater speed."
 
 
 # Spice

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -22,6 +22,7 @@
 import os
 import subprocess
 import time
+import textwrap
 import pkgutil
 
 from pyanaconda.core.configuration.anaconda import conf
@@ -48,6 +49,15 @@ from simpleline.render.screen_handler import ScreenHandler
 from pyanaconda.anaconda_loggers import get_module_logger, get_stdout_logger
 log = get_module_logger(__name__)
 stdout_log = get_stdout_logger()
+
+X_TIMEOUT_ADVICE = \
+    "Do not load the stage2 image over a slow network link.\n" \
+    "Wait longer for the X server startup with the inst.xtimeout=<SECONDS> boot option." \
+    "The default is 60 seconds.\n" \
+    "Load the stage2 image into memory with the rd.live.ram boot option to decrease access " \
+    "time.\n" \
+    "Enforce text mode when installing from remote media with the inst.text boot option."
+#  on RHEL also: "Use the customer portal download URL in ilo/drac devices for greater speed."
 
 
 # Spice
@@ -314,9 +324,23 @@ def setup_display(anaconda, options):
         try:
             start_x11(xtimeout)
             do_startup_x11_actions()
-        except (OSError, RuntimeError) as e:
+        except TimeoutError as e:
             log.warning("X startup failed: %s", e)
-            stdout_log.warning("X startup failed, falling back to text mode")
+            print("\nX did not start in the expected time, falling back to text mode. There are "
+                  "multiple ways to avoid this issue:")
+            wrapper = textwrap.TextWrapper(initial_indent=" * ", subsequent_indent="   ",
+                                           width=os.get_terminal_size().columns - 3)
+            for line in X_TIMEOUT_ADVICE.split("\n"):
+                print(wrapper.fill(line))
+            util.vtActivate(1)
+            anaconda.display_mode = constants.DisplayModes.TUI
+            anaconda.gui_startup_failed = True
+            time.sleep(2)
+
+        except (OSError, RuntimeError) as e:
+            log.warning("X or window manager startup failed: %s", e)
+            print("\nX or window manager startup failed, falling back to text mode.")
+            util.vtActivate(1)
             anaconda.display_mode = constants.DisplayModes.TUI
             anaconda.gui_startup_failed = True
             time.sleep(2)


### PR DESCRIPTION
Port of #3304. Almost 1:1 with the RHEL 9 port in #3348.

Resolves [rhbz#1918702](https://bugzilla.redhat.com/show_bug.cgi?id=1918702).