### PR TITLE
Tweak dependabot configuration - or not?

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,8 @@
 # Dependabot will check our GitHub actions and if there will be a new version of any action
 # Dependabot will create a pull request to update these.
+#
+# FIXME: Unfortunately, the Dependabot is checking only the default branch right now.
+#        Could be solved by https://github.com/dependabot/dependabot-core/issues/2511.
 
 # Set update schedule for GitHub Actions
 version: 2
@@ -10,3 +13,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    labels:
+      - "infrastructure"
+    commit-message:
+      prefix: "(#infra)"


### PR DESCRIPTION
Add:
- automatically set 'infrastructure' label to PR
- add '(#infra):' prefix to the commit messages (don't have suffix support)

Can't be done:
We can't have support for multiple branches. Only the default branch is allowed which is a bit pain :(.

Because of the second, I'm thinking if we want to have the dependabot at all. The problem is that branches created from the main branch would be stuck on the old action version forever and if there will be a security vulnerability than someone could just create PR to the other branch with the outdated version...

So maybe we want to have dependabot support but not merging these PRs. Basically just stay with the moving tag what we have now and having dependabot just as a heads-up that there is a new version of the action available? What do you think?