### PR TITLE
Use .codecov.yml from the main branch

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,6 @@
 codecov:
+  # Use the yaml from a specific branch.
+  strict_yaml_branch: master
   # Don't wait for all other statuses to pass.
   require_ci_to_pass: false
 


### PR DESCRIPTION
Always use the latest codecov configuration from a specific branch.