### PR TITLE
Add logic to the bootloader task during installation to set the password for the bootloader

### DIFF
--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -972,6 +972,9 @@ class BootLoader(object):
     def install(self, args=None):
         raise NotImplementedError()
 
+    def set_boot_password(self, bootloader_proxy):
+        pass
+
 
 def get_interface_hw_address(iface):
     """Get hardware address of network interface."""

--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -538,6 +538,13 @@ class GRUB2(BootLoader):
 
         return valid
 
+    def set_boot_password(self, bootloader_proxy):
+        if bootloader_proxy.IsPasswordSet:
+            if bootloader_proxy.IsPasswordEncrypted:
+                self.encrypted_password = bootloader_proxy.Password
+            else:
+                self.password = bootloader_proxy.Password
+
 
 class IPSeriesGRUB2(GRUB2):
     """IPSeries GRUBv2"""

--- a/pyanaconda/modules/storage/bootloader/utils.py
+++ b/pyanaconda/modules/storage/bootloader/utils.py
@@ -23,6 +23,8 @@ from pyanaconda.modules.storage.bootloader.image import LinuxBootLoaderImage
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.util import decode_bytes, execWithRedirect
 from pyanaconda.product import productName
+from pyanaconda.modules.common.constants.objects import BOOTLOADER
+from pyanaconda.modules.common.constants.services import STORAGE
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -207,6 +209,10 @@ def install_boot_loader(storage):
 
     stage2_device = storage.bootloader.stage2_device
     log.info("boot loader stage2 target device is %s", stage2_device.name)
+
+    # Set up the bootloader password
+    bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
+    storage.bootloader.set_boot_password(bootloader_proxy)
 
     # Set up the arguments.
     # FIXME: do this from elsewhere?


### PR DESCRIPTION
i wrote my own addon for the grub2 password set, the spoke in the SystemCategory along with the Storage spoke, but the bootloader password is now written to disk only when partitioning in storage spoke, not at the beginning of the installation. 
So if the storage spoke is complete, the password for the bootloader is stored in the bootloader_proxy instead of written to the storage
I think this is not reasonable