### PR TITLE
Show mount points for other types of actions (#1953134)

### DIFF
--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -19,7 +19,6 @@
 #
 from abc import abstractmethod, ABC
 
-from blivet.deviceaction import ACTION_OBJECT_FORMAT
 from blivet.formats import get_format
 from blivet.size import Size
 
@@ -295,8 +294,8 @@ class DeviceTreeViewer(ABC):
         device = action.device
         data.device_name = device.name
 
-        if action.obj == ACTION_OBJECT_FORMAT:
-            data.attrs["mount-point"] = self._get_attribute(device.format, "mountpoint")
+        if action.is_create or action.is_device or action.is_format:
+            data.attrs["mount-point"] = self._get_attribute(action.format, "mountpoint")
 
         if getattr(device, "description", ""):
             data.attrs["serial"] = self._get_attribute(device, "serial")

--- a/tests/nosetests/pyanaconda_tests/modules/storage/module_device_tree_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/storage/module_device_tree_test.py
@@ -355,6 +355,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
         dev2 = StorageDevice(
             "dev2",
+            fmt=get_format("ext4", mountpoint="/boot"),
             size=Size("500 MiB"),
             serial="SERIAL",
             exists=True
@@ -370,7 +371,10 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             'object-description': 'blivet',
             'device-name': 'dev2',
             'device-description': 'dev2',
-            'attrs': {"serial": "SERIAL"},
+            'attrs': {
+                'serial': 'SERIAL',
+                'mount-point': '/boot'
+            },
         }
 
         self.assertEqual(get_native(self.interface.GetActions()), [
@@ -395,7 +399,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             'object-description': 'partition',
             'device-name': 'dev3',
             'device-description': 'dev3 on VENDOR MODEL',
-            'attrs': {},
+            'attrs': {'mount-point': '/home'},
         }
 
         action_4 = {


### PR DESCRIPTION
The Summary of Changes dialog from the Manual Partitioning screen should
show mount points for all create-related, device-related and format-related
actions.

Resolves: rhbz#1953134