### PR TITLE
Make the coverage status about tests informational

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -27,7 +27,8 @@ coverage:
       # Show a status for the unit tests.
       tests:
         paths:
-          - "tests/nosetests"
+          - "tests/nosetests/"
+        informational: true
 
 # Disable the pull request comment.
 comment: false


### PR DESCRIPTION
The status shouldn't block the pull requests.