### PR TITLE
Add a log message for successful installation

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -380,3 +380,5 @@ def run_installation(payload, ksdata):
 
     # done
     progress_complete()
+    # this message is automatically detected by QE tools, do not change it lightly
+    log.info("All tasks in the installation queue are done. Installation successfully finished.")


### PR DESCRIPTION
The message is visible only in logs of the installation environment, because logs have been already copied to the new system.

Resolves: [rhbz#1949487](https://bugzilla.redhat.com/show_bug.cgi?id=1949487)
Resolves: [rhbz#1955312](https://bugzilla.redhat.com/show_bug.cgi?id=1955312)

CC @velezd @jstodola 