### PR TITLE
Don't automatically execute the default partitioning (#1954408)

### DIFF
--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -214,8 +214,6 @@ class Spoke(object, metaclass=ABCMeta):
         self._payload = payload
         self.applyOnSkip = False
 
-        self.visitedSinceApplied = True
-
         # entry and exit signals
         # - get the hub instance as a single argument
         self.entered = Signal()

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -188,13 +188,6 @@ class Hub(GUIObject, common.Hub):
                 self._updateCompleteness(spoke, update_continue=False)
                 spoke.selector.connect("button-press-event", self._on_spoke_clicked, spoke)
                 spoke.selector.connect("key-release-event", self._on_spoke_clicked, spoke)
-
-                # If this is a kickstart install, attempt to execute any provided ksdata now.
-                if flags.automatedInstall and spoke.ready and spoke.changed and \
-                   spoke.visitedSinceApplied:
-                    spoke.execute()
-                    spoke.visitedSinceApplied = False
-
                 selectors.append(spoke.selector)
 
             if not selectors:
@@ -345,15 +338,6 @@ class Hub(GUIObject, common.Hub):
                     else:
                         log.debug("kickstart installation, spoke %s is ready", spoke_title)
 
-                    # Spokes that were not initially ready got the execute call in
-                    # _createBox skipped.  Now that it's become ready, do it.  Note
-                    # that we also provide a way to skip this processing (see comments
-                    # communication.py) to prevent getting caught in a loop.
-                    if not args[1] and spoke.changed and spoke.visitedSinceApplied:
-                        log.debug("execute spoke from event loop %s", spoke.title.replace("_", ""))
-                        spoke.execute()
-                        spoke.visitedSinceApplied = False
-
                     if self.continuePossible:
                         if self._inSpoke:
                             self._autoContinue = False
@@ -430,19 +414,14 @@ class Hub(GUIObject, common.Hub):
         if not self._inSpoke:
             return
 
-        spoke.visitedSinceApplied = True
-
         # don't apply any actions if the spoke was visited automatically
         if spoke.automaticEntry:
             spoke.automaticEntry = False
             return
 
-        # Don't take visitedSinceApplied into account here.  It will always be
-        # True from the line above.
         if spoke.changed and (not spoke.skipTo or (spoke.skipTo and spoke.applyOnSkip)):
             spoke.apply()
             spoke.execute()
-            spoke.visitedSinceApplied = False
 
         spoke.exited.emit(spoke)
 

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -260,6 +260,9 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         self._selected_disks = []
         self._last_selected_disks = []
 
+        # Is the partitioning already configured?
+        self._is_preconfigured = bool(self._storage_module.CreatedPartitioning)
+
         # Find a partitioning to use.
         self._partitioning = find_partitioning()
         self._last_partitioning_method = self._partitioning.PartitioningMethod
@@ -634,9 +637,10 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         # Update the selected disks.
         select_default_disks()
 
-        # Apply the partitioning. Do not set ready in the automated
-        # installation before the execute method is run.
-        if flags.automatedInstall:
+        # Automatically apply the preconfigured partitioning.
+        # Do not set ready in the automated installation before
+        # the execute method is run.
+        if flags.automatedInstall and self._is_preconfigured:
             self.execute()
         else:
             self._ready = True

--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -61,6 +61,7 @@ class SummaryHub(TUIHub):
             sys.stdout.write(_("Starting automated install"))
             sys.stdout.flush()
             spokes = self._spokes.values()
+
             while not all(spoke.ready for spoke in spokes):
                 # Catch any asynchronous events (like storage crashing)
                 loop = App.get_event_loop()
@@ -70,9 +71,6 @@ class SummaryHub(TUIHub):
                 time.sleep(1)
 
             print('')
-            for spoke in spokes:
-                if spoke.changed:
-                    spoke.execute()
 
         return True
 

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -91,6 +91,11 @@ class StorageSpoke(NormalTUISpoke):
 
         self._available_disks = []
         self._selected_disks = []
+
+        # Is the partitioning already configured?
+        self._is_preconfigured = bool(self._storage_module.CreatedPartitioning)
+
+        # Find a partitioning to use.
         self._partitioning = find_partitioning()
 
         self.errors = []
@@ -408,8 +413,8 @@ class StorageSpoke(NormalTUISpoke):
         # Update the selected disks.
         select_default_disks()
 
-        # Apply the partitioning in the automated installation.
-        if flags.automatedInstall:
+        # Automatically apply the preconfigured partitioning.
+        if flags.automatedInstall and self._is_preconfigured:
             self.execute()
 
         # Storage is ready.

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -408,6 +408,10 @@ class StorageSpoke(NormalTUISpoke):
         # Update the selected disks.
         select_default_disks()
 
+        # Apply the partitioning in the automated installation.
+        if flags.automatedInstall:
+            self.execute()
+
         # Storage is ready.
         self._ready = True
 


### PR DESCRIPTION
We should automatically execute only a partitioning that was already configured by
the user, for example with a kickstart file.

Don't run the `execute` method in the kickstart installation in GUI and TUI by default.

(cherry picked from commits f5bcaf6, 31d35e9 and 9c0c7a7)

Resolves: rhbz#1954408