### PR TITLE
Allow encryption of thin logical volumes (#1877777)

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -969,8 +969,7 @@ def generate_device_factory_permissions(storage, request: DeviceFactoryRequest):
         request.reformat \
         and not request.container_encrypted \
         and request.device_type not in {
-            devicefactory.DEVICE_TYPE_BTRFS,
-            devicefactory.DEVICE_TYPE_LVM_THINP
+            devicefactory.DEVICE_TYPE_BTRFS
         } \
         and not any(
             a.format.type == "luks" and a.format.exists


### PR DESCRIPTION
Encryption of thin logical volumes is supported now.

(cherry picked from commit 3db9b32)

Resolves: rhbz#1877777