### PR TITLE
Use daily builds for ELN containers

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -26,7 +26,7 @@ jobs:
     metadata:
       targets:
         - fedora-rawhide
-#        - fedora-eln
+        - fedora-eln
       branch: master
       owner: "@rhinstaller"
       project: Anaconda

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -32,7 +32,8 @@ RUN set -ex; \
   policycoreutils \
   python3-gobject-base \
   python3-pip; \
-  if ! grep -q VARIANT.*eln /etc/os-release; then dnf copr enable -y ${copr_repo}; dnf copr enable -y @storage/blivet-daily; fi; \
+  if ! grep -q VARIANT.*eln /etc/os-release; then dnf copr enable -y ${copr_repo}; dnf copr enable -y @storage/blivet-daily; else \
+  dnf copr enable -y ${copr_repo} fedora-eln-x86_64; dnf copr enable -y @storage/blivet-daily fedora-eln-x86_64; fi; \
   curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/${git_branch}/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   rpmspec -q --requires /tmp/anaconda.spec | grep -v anaconda | xargs -d '\n' dnf install -y; \

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer=anaconda-list@redhat.com
 COPY ["eln.repo", "/etc/yum.repos.d"]
 
 # Prepare environment and install build dependencies
-RUN set -e; \
+RUN set -ex; \
   if grep -q VARIANT.*eln /etc/os-release; then sed -i 's/enabled=0/enabled=1/' /etc/yum.repos.d/eln.repo; fi; \
   dnf update -y; \
   dnf install -y \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -19,7 +19,8 @@ RUN set -ex; \
   python3-pip \
   /usr/bin/xargs \
   rpm-build; \
-  if ! grep -q VARIANT.*eln /etc/os-release; then dnf copr enable -y ${copr_repo}; dnf copr enable -y @storage/blivet-daily; fi; \
+  if ! grep -q VARIANT.*eln /etc/os-release; then dnf copr enable -y ${copr_repo}; dnf copr enable -y @storage/blivet-daily; else \
+  dnf copr enable -y ${copr_repo} fedora-eln-x86_64; dnf copr enable -y @storage/blivet-daily fedora-eln-x86_64; fi; \
   curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/${git_branch}/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   dnf clean all; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer=anaconda-list@redhat.com
 COPY ["eln.repo", "/etc/yum.repos.d"]
 
 # Prepare environment and install build dependencies
-RUN set -e; \
+RUN set -ex; \
   if grep -q VARIANT.*eln /etc/os-release; then sed -i 's/enabled=0/enabled=1/' /etc/yum.repos.d/eln.repo; fi; \
   dnf update -y; \
   dnf install -y \


### PR DESCRIPTION
ELN containers had disabled daily builds repositories. I don't know exact reason, it might be because it's harder to enable them (see commit message) or because there were not available during creation of the containers.

Add these back to avoid failures with dependencies because we are waiting for a build.

Also enable ELN nightly builds for Anaconda project. Our other projects have it enabled so why not Anaconda.