### PR TITLE
Remove the configuration file for CentOS Linux

### DIFF
--- a/data/product.d/centos.conf
+++ b/data/product.d/centos.conf
@@ -1,7 +1,0 @@
-# Anaconda configuration file for CentOS Linux.
-
-[Product]
-product_name = CentOS Linux
-
-[Base Product]
-product_name = CentOS Stream

--- a/data/product.d/centos.conf
+++ b/data/product.d/centos.conf
@@ -1,4 +1,4 @@
-# Anaconda configuration file for CentOS Stream.
+# Anaconda configuration file for CentOS.
 
 [Product]
 product_name = CentOS Stream

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -269,11 +269,6 @@ class ProductConfigurationTestCase(unittest.TestCase):
             ENTERPRISE_PARTITIONING
         )
         self._check_default_product(
-            "CentOS Linux", "",
-            ["rhel.conf", "centos-stream.conf", "centos.conf"],
-            ENTERPRISE_PARTITIONING
-        )
-        self._check_default_product(
             "RHVH", "",
             ["rhel.conf", "rhvh.conf"],
             VIRTUALIZATION_PARTITIONING
@@ -304,7 +299,7 @@ class ProductConfigurationTestCase(unittest.TestCase):
 
     def product_module_difference_centos_rhel_test(self):
         """Test for expected CentOS & RHEL module list differences."""
-        centos_config = self._get_config("CentOS Linux")
+        centos_config = self._get_config("CentOS Stream")
         centos_modules = centos_config.anaconda.kickstart_modules
 
         rhel_config = self._get_config("Red Hat Enterprise Linux")

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -265,7 +265,7 @@ class ProductConfigurationTestCase(unittest.TestCase):
         )
         self._check_default_product(
             "CentOS Stream", "",
-            ["rhel.conf", "centos-stream.conf"],
+            ["rhel.conf", "centos.conf"],
             ENTERPRISE_PARTITIONING
         )
         self._check_default_product(
@@ -275,7 +275,7 @@ class ProductConfigurationTestCase(unittest.TestCase):
         )
         self._check_default_product(
             "oVirt Node Next", "",
-            ["rhel.conf", "centos-stream.conf", "ovirt.conf"],
+            ["rhel.conf", "centos.conf", "ovirt.conf"],
             VIRTUALIZATION_PARTITIONING
         )
         self._check_default_product(


### PR DESCRIPTION
Remove the configuration file for CentOS Linux.
This configuration file can be removed from upstream.

Rename the configuration file for CentOS Stream.
It is a base configuration for all CentOS based products.

**Related to:** https://github.com/rhinstaller/anaconda/pull/3388