### PR TITLE
Change the description of "Encrypt my data" in the custom partitioning spoke

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/accordion.py
+++ b/pyanaconda/ui/gui/spokes/lib/accordion.py
@@ -535,7 +535,7 @@ class CreateNewPage(BasePage):
         label = Gtk.Label(
             label=C_(
                 "GUI|Custom Partitioning|Autopart Page",
-                "_Automatically created mount points can be encrypted by default:"
+                "_Encrypt automatically created mount points by default:"
             ),
             xalign=0,
             yalign=0.5,


### PR DESCRIPTION
Modify a label that describes the "Encrypt my data" checkbox.

(cherry picked from commit b26f7d12c7)

**Ported from:** https://github.com/rhinstaller/anaconda/pull/3379