### PR TITLE
Infrastructure fixes on rhel-9 branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,6 @@ jobs:
             ci_tag: 'rhel-9'
     env:
       CI_TAG: '${{ matrix.ci_tag }}'
-      CONTAINER_BUILD_ARGS: '${{ matrix.build-args }}'
       TARGET_BRANCH_NAME: 'origin/${{ matrix.target_branch }}'
 
     steps:
@@ -73,7 +72,6 @@ jobs:
             ci_tag: 'rhel-9'
     env:
       CI_TAG: '${{ matrix.ci_tag }}'
-      CONTAINER_BUILD_ARGS: '${{ matrix.build-args }}'
       TARGET_BRANCH_NAME: 'origin/${{ matrix.target_branch }}'
 
     steps:

--- a/dockerfile/anaconda-ci/rhel-9.repo
+++ b/dockerfile/anaconda-ci/rhel-9.repo
@@ -1,4 +1,4 @@
-[RHEL-8-CRB]
+[RHEL-9-CRB]
 name=crb
 baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/CRB/$basearch/os/
 enabled=1


### PR DESCRIPTION
Fix two issues I was able to spot on rhel-9 branch:
* typo in the repository name
* containers wasn't build but used from a cache which is a bit dangerous because podman is not able to discover that the cache has changed for most situations.

Tested [here](https://github.com/jkonecny12/anaconda/pull/13/checks?check_run_id=2629517883).