### PR TITLE
Remove unnecessary package from anaconda-ci container (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -25,7 +25,6 @@ RUN set -ex; \
   libicu \
   lttng-ust \
   rpm-ostree \
-  patch \
   pykickstart \
   python3-pip \
   python3-lxml \


### PR DESCRIPTION
It was introduced by 473daecb1e6db643c8da22d34f281a19fff91fe1 to apply custom patch from upstream but that part is already removed from the anaconda-ci so let's remove also this package.