### PR TITLE
Do not use cache when building containers in tests (#infra)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,8 @@ jobs:
           #  ci_tag: 'f34-release'
     env:
       CI_TAG: '${{ matrix.ci_tag }}'
-      CONTAINER_BUILD_ARGS: '${{ matrix.build-args }}'
+      # Always avoid using cache because cache is not correctly invalidated.
+      CONTAINER_BUILD_ARGS: '--no-cache ${{ matrix.build-args }}'
       TARGET_BRANCH_NAME: 'origin/${{ matrix.target_branch }}'
 
     steps:
@@ -107,7 +108,8 @@ jobs:
           #  ci_tag: 'f34-release'
     env:
       CI_TAG: '${{ matrix.ci_tag }}'
-      CONTAINER_BUILD_ARGS: '${{ matrix.build-args }}'
+      # Always avoid using cache because cache is not correctly invalidated.
+      CONTAINER_BUILD_ARGS: '--no-cache ${{ matrix.build-args }}'
       TARGET_BRANCH_NAME: 'origin/${{ matrix.target_branch }}'
 
     steps:


### PR DESCRIPTION
The cache during the containers build is not reliable because it cannot detect changes in most use-cases. Let's avoid using it to be sure.

The `--no-cache` is default when executing Makefile build commands, however, thanks to the environment variable, we are creating here, we erase the original Makefile value. This was introduced to change build arguments for ELN builds but when no arguments are used it will set "" and just erase the `--no-cache` default argument. Let's add it back workflow all the time.

Test [run](https://github.com/jkonecny12/anaconda/runs/2630291939?check_suite_focus=true).