### PR TITLE
The results returned by check_admin_user_exists() may cause problems

### DIFF
--- a/pyanaconda/modules/users/users.py
+++ b/pyanaconda/modules/users/users.py
@@ -389,7 +389,10 @@ class UsersService(KickstartService):
         for user in self.users:
             if not user.lock:
                 if "wheel" in user.groups:
-                    return True
+                    if user.password != "":
+                        return True
+                    else:
+                        return False
 
         # no admin user found
         return False


### PR DESCRIPTION
with the user's password configuration when the following scenarios
are encountered on the text-based installation:
1. The root password is not set and is locked
2. Create user `user1` with administrator group and do not set password
3.completed() returned False, but mandatory() return false too,
This causes neither the root password nor the new user to have a password,
thus preventing users from accessing the system once the installation
 is complete.
Maybe we should check to see if the users of the wheel group have
a full password