### PR TITLE
  In text installation mode, the user selects the password but does not set the password forcibly

### DIFF
--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -224,7 +224,9 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     @property
     def mandatory(self):
         """Only mandatory if no admin user has been requested."""
-        return not self._users_module.CheckAdminUserExists()
+        return (not self._users_module.CheckAdminUserExists() or
+                (self._use_password and not bool(self.user.password or
+                                                 self.user.is_crypted)))
 
     @property
     def status(self):


### PR DESCRIPTION
In text mode, if you select `Use password` when you create a user and set it as an administrator group, you can start the installation without entering user password. But this goes against the logic of select the `Use password`:

create user1 eg:
```
1) [x] Create user
2) Full name
    user1
3) User name
    user1
4) [x] Use password
5) Password
6) [x] Administrator
7) Groups
    wheel
```
in the summary:
```
9) [ ] User creation
         (You must set a password)
```
The installation process is now ready to begin...