### PR TITLE
Replace the deprecated syspurpose CLI tool with SetSysrpose DBus call

### DIFF
--- a/pyanaconda/modules/subscription/runtime.py
+++ b/pyanaconda/modules/subscription/runtime.py
@@ -86,13 +86,15 @@ SystemSubscriptionData = namedtuple("SystemSubscriptionData",
 class SystemPurposeConfigurationTask(Task):
     """Installation task for setting system purpose."""
 
-    def __init__(self, system_purpose_data):
+    def __init__(self, rhsm_syspurpose_proxy, system_purpose_data):
         """Create a new system purpose configuration task.
 
+        :param rhsm_syspurpose_proxy: DBus proxy for the RHSM Syspurpose object
         :param system_purpose_data: system purpose data DBus structure
         :type system_purpose_data: DBusData instance
         """
         super().__init__()
+        self._rhsm_syspurpose_proxy = rhsm_syspurpose_proxy
         self._system_purpose_data = system_purpose_data
 
     @property
@@ -105,6 +107,7 @@ class SystemPurposeConfigurationTask(Task):
         #   replaced by new data
         return system_purpose.give_the_system_purpose(
             sysroot="/",
+            rhsm_syspurpose_proxy=self._rhsm_syspurpose_proxy,
             role=self._system_purpose_data.role,
             sla=self._system_purpose_data.sla,
             usage=self._system_purpose_data.usage,

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -316,14 +316,18 @@ class SubscriptionService(KickstartService):
     def _apply_syspurpose(self):
         """Apply system purpose information to the installation environment."""
         log.debug("subscription: Applying system purpose data")
-        task = SystemPurposeConfigurationTask(system_purpose_data=self.system_purpose_data)
+        task = self.set_system_purpose_with_task()
         task.run()
 
     def set_system_purpose_with_task(self):
         """Set system purpose for the installed system with an installation task.
         :return: a DBus path of an installation task
         """
-        task = SystemPurposeConfigurationTask(system_purpose_data=self.system_purpose_data)
+        rhsm_syspurpose_proxy = self.rhsm_observer.get_proxy(RHSM_SYSPURPOSE)
+        task = SystemPurposeConfigurationTask(
+            rhsm_syspurpose_proxy=rhsm_syspurpose_proxy,
+            system_purpose_data=self.system_purpose_data
+        )
         return task
 
     # subscription request

--- a/tests/nosetests/pyanaconda_tests/modules/subscription/subscription_tasks_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/subscription/subscription_tasks_test.py
@@ -154,9 +154,12 @@ class SystemPurposeConfigurationTaskTestCase(unittest.TestCase):
         system_purpose_data.sla = "bar"
         system_purpose_data.usage = "baz"
         system_purpose_data.addons = ["a", "b", "c"]
-        task = SystemPurposeConfigurationTask(system_purpose_data)
+        # create a mock syspurpose proxy
+        syspurpose_proxy = Mock()
+        task = SystemPurposeConfigurationTask(syspurpose_proxy, system_purpose_data)
         task.run()
         give_the_system_purpose.assert_called_once_with(sysroot="/",
+                                                        rhsm_syspurpose_proxy=syspurpose_proxy,
                                                         role="foo",
                                                         sla="bar",
                                                         usage="baz",
@@ -175,9 +178,12 @@ class SystemPurposeConfigurationTaskTestCase(unittest.TestCase):
         system_purpose_data.sla = "bar"
         system_purpose_data.usage = "baz"
         system_purpose_data.addons = ["a", "b", "c"]
-        task = SystemPurposeConfigurationTask(system_purpose_data)
+        # create a mock syspurpose proxy
+        syspurpose_proxy = Mock()
+        task = SystemPurposeConfigurationTask(syspurpose_proxy, system_purpose_data)
         task.run()
         give_the_system_purpose.assert_called_once_with(sysroot="/",
+                                                        rhsm_syspurpose_proxy=syspurpose_proxy,
                                                         role="foo",
                                                         sla="bar",
                                                         usage="baz",


### PR DESCRIPTION
Use the SetSysrpose() RHSM DBus API method instead of the deprecated
syspurpose CLI tool.

Resolves: rhbz#1939708