### PR TITLE
the func completed() logic not same in tui/spokes/root_password.py and gui/spokes/root_password.py

### DIFF
--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -60,7 +60,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     @property
     def completed(self):
-        return bool(self._users_module.IsRootPasswordSet or self._users_module.IsRootAccountLocked)
+        return self._users_module.IsRootPasswordSet
 
     @property
     def showable(self):


### PR DESCRIPTION
Why can't we unify their logic?
gui/spokes/root_password:
def completed(self):
        return self._users_module.IsRootPasswordSet