### PR TITLE
Add rhel-8 kickstart-tests support on PR (#infra)

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -56,6 +56,9 @@ jobs:
             echo "::set-output name=skip_tests::rhel-only"
           elif [ $(echo "$TARGET_BRANCH" | grep -E "f[[:digit:]]*-(devel|release)") ]; then
             echo "::set-output name=skip_tests::rhel-only"
+          elif [ "$TARGET_BRANCH" == "rhel-8" ]; then
+            echo "::set-output name=skip_tests::fedora-only,rhel-9-only"
+            echo "::set-output name=optional_test_args::--platform rhel8 --defaults ./scripts/defaults-rhel8.sh"
           elif [ "$TARGET_BRANCH" == "rhel-9" ]; then
             echo "::set-output name=skip_tests::fedora-only"
             echo "::set-output name=optional_test_args::--platform rhel9 --defaults ./scripts/defaults-rhel9.sh"


### PR DESCRIPTION
Let's add the last branch for kickstart tests support.

Test runs:
[rhel-8](https://github.com/jkonecny12/anaconda/runs/2676105176?check_suite_focus=true)
[rhel-9](https://github.com/jkonecny12/anaconda/runs/2676762231?check_suite_focus=true) -- it's failing here on missing package which seems to be repository issue

Depends on https://github.com/rhinstaller/anaconda/pull/3407 .