### PR TITLE
Require biosdevname package if biosdevname=1 boot option is set

### DIFF
--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -315,6 +315,12 @@ class NetworkService(KickstartService):
                 "prefixdevname",
                 reason="Necessary for persistent network device naming feature."
             ))
+        # biosdevname
+        if self._is_using_biosdevname(kernel_arguments):
+            requirements.append(Requirement.for_package(
+                "biosdevname",
+                reason="Necessary for biosdevname network device naming feature."
+            ))
 
         return requirements
 
@@ -694,3 +700,6 @@ class NetworkService(KickstartService):
 
     def _is_using_persistent_device_names(self, kernel_args):
         return 'net.ifnames.prefix' in kernel_args
+
+    def _is_using_biosdevname(self, kernel_args):
+        return kernel_args.get('biosdevname') == "1"


### PR DESCRIPTION
Resolves: rhbz#1964455

Note: the patch is using the same mechanism as with prefixdevname.
In RHEL8 biosdevname was part of @core group.