### PR TITLE
Backport functionality for defining update repositories (#1961457)

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -97,6 +97,10 @@ check_supported_locales = False
 # Enable ssl verification for all HTTP connection
 verify_ssl = True
 
+# GPG keys to import to RPM database by default.
+# Specify paths on the installed system, each on a line.
+# Substitutions for $releasever and $basearch happen automatically.
+default_rpm_gpg_keys =
 
 [Security]
 # Enable SELinux usage in the installed system.

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -68,8 +68,8 @@ default_environment =
 # List of ignored packages.
 ignored_packages =
 
-# Enable installation of latest updates.
-enable_updates = True
+# Names of repositories that provide latest updates.
+updates_repositories =
 
 # List of .treeinfo variant types to enable.
 # Valid items:

--- a/data/product.d/centos-stream.conf
+++ b/data/product.d/centos-stream.conf
@@ -32,3 +32,5 @@ default_help_pages =
 [Payload]
 enable_closest_mirror = True
 default_source = CLOSEST_MIRROR
+default_rpm_gpg_keys =
+    /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial

--- a/data/product.d/fedora.conf
+++ b/data/product.d/fedora.conf
@@ -19,3 +19,7 @@ default_help_pages =
 [Payload]
 default_rpm_gpg_keys =
     /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+
+updates_repositories =
+    updates
+    updates-modular

--- a/data/product.d/fedora.conf
+++ b/data/product.d/fedora.conf
@@ -15,3 +15,7 @@ default_help_pages =
     fedora_help_placeholder.txt
     fedora_help_placeholder.xml
     fedora_help_placeholder.xml
+
+[Payload]
+default_rpm_gpg_keys =
+    /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch

--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -33,7 +33,6 @@ ignored_packages =
     btrfs-progs
     dmraid
 
-enable_updates = False
 enable_closest_mirror = False
 default_source = CDN
 

--- a/data/product.d/scientific-linux.conf
+++ b/data/product.d/scientific-linux.conf
@@ -20,8 +20,11 @@ kickstart_modules =
      org.fedoraproject.Anaconda.Modules.Services
 
 [Payload]
-enable_updates = True
 default_source = CLOSEST_MIRROR
+
+updates_repositories =
+    updates
+    updates-modular
 
 [User Interface]
 help_directory = /usr/share/anaconda/help/sl

--- a/pyanaconda/core/configuration/payload.py
+++ b/pyanaconda/core/configuration/payload.py
@@ -107,3 +107,8 @@ class PayloadSection(Section):
         this option.
         """
         return self._get_option("verify_ssl", bool)
+
+    @property
+    def default_rpm_gpg_keys(self):
+        """List of GPG keys to import into RPM database at end of installation."""
+        return self._get_option("default_rpm_gpg_keys", str).split()

--- a/pyanaconda/core/configuration/payload.py
+++ b/pyanaconda/core/configuration/payload.py
@@ -41,16 +41,17 @@ class PayloadSection(Section):
         return self._get_option("ignored_packages", str).split()
 
     @property
-    def enable_updates(self):
-        """Enable installation of latest updates.
+    def updates_repositories(self):
+        """List of names of repositories that provide latest updates.
 
-        This flag controls whether or not Anaconda should provide an option to
-        install the latest updates during installation source selection.
+        This option also controls whether or not Anaconda should provide
+        an option to install the latest updates during installation source
+        selection.
 
-        The installation of latest updates is selected by default, if the closest
-        mirror is selected, and the "updates" repo is enabled.
+        The installation of latest updates is selected by default, if
+        the closest mirror is selected, and the "updates" repo is enabled.
         """
-        return self._get_option("enable_updates", bool)
+        return self._get_option("updates_repositories", str).split()
 
     @property
     def enabled_repositories_from_treeinfo(self):

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -63,10 +63,6 @@ DEFAULT_REPOS = [productName.split('-')[0].lower(),
                  "BaseOS",  # Used by RHEL
                  "baseos"]  # Used by CentOS Stream
 
-# Get list of repo names which should be used as updates repos
-DEFAULT_UPDATE_REPOS = ["updates",
-                        "updates-modular"]
-
 DBUS_ANACONDA_SESSION_ADDRESS = "DBUS_ANACONDA_SESSION_BUS_ADDRESS"
 
 ANACONDA_BUS_CONF_FILE = "/usr/share/anaconda/dbus/anaconda-bus.conf"

--- a/pyanaconda/core/regexes.py
+++ b/pyanaconda/core/regexes.py
@@ -197,3 +197,6 @@ MAC_OCTET = re.compile(r'[a-fA-F0-9][a-fA-F0-9]')
 
 # Name of initramfs connection created by NM based on MAC
 NM_MAC_INITRAMFS_CONNECTION = re.compile(r'^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$')
+
+# OS version in os-release file
+OS_RELEASE_OS_VERSION = re.compile(r"VERSION_ID=[\"']?([0-9a-z._-]+)[\"']?")

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -47,6 +47,7 @@ from pyanaconda.core.constants import DRACUT_SHUTDOWN_EJECT, TRANSLATIONS_UPDATE
     IPMI_ABORTED, X_TIMEOUT, TAINT_HARDWARE_UNSUPPORTED, TAINT_SUPPORT_REMOVED, \
     WARNING_HARDWARE_UNSUPPORTED, WARNING_SUPPORT_REMOVED
 from pyanaconda.core.constants import SCREENSHOTS_DIRECTORY, SCREENSHOTS_TARGET_DIRECTORY
+from pyanaconda.core.regexes import OS_RELEASE_OS_VERSION
 from pyanaconda.errors import RemovedModuleError
 
 from pyanaconda.anaconda_logging import program_log_lock
@@ -1489,3 +1490,22 @@ def is_smt_enabled():
     except (IOError, ValueError):
         log.warning("Failed to detect SMT.")
         return False
+
+
+def get_os_version(sysroot=""):
+    """Find version of the OS from the os-release file.
+
+    See os-release(5).
+
+    :param str sysroot: Where to look.
+    :return str: The version
+    """
+    for filename in ("/etc/os-release", "/usr/lib/os-release"):
+        try:
+            with open(sysroot + filename, "r") as f:
+                data = f.read(4096)  # 4 kB should be enough for everyone!
+            return OS_RELEASE_OS_VERSION.findall(data)[0]
+        except (FileNotFoundError, IndexError):
+            pass
+
+    return None

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -1135,10 +1135,10 @@ class DNFPayload(Payload):
 
         # Enable or disable updates.
         if self._updates_enabled:
-            for repo in constants.DEFAULT_UPDATE_REPOS:
+            for repo in conf.payload.updates_repositories:
                 self.enable_repo(repo)
         else:
-            for repo in constants.DEFAULT_UPDATE_REPOS:
+            for repo in conf.payload.updates_repositories:
                 self.disable_repo(repo)
 
         # Disable updates-testing.

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -2037,6 +2037,17 @@ class DNFPayload(Payload):
         """Should we write the storage before doing the installation?"""
         return True
 
+    def _import_rpm_keys(self):
+        """Import GPG keys to RPM database."""
+        if conf.payload.default_rpm_gpg_keys:
+            # TODO: replace the interpolation with DNF once possible
+            arch = util.execWithCapture("uname", ["-i"]).strip().replace("'", "")
+            vers = util.get_os_version(conf.target.system_root)
+            for key in conf.payload.default_rpm_gpg_keys:
+                interpolated_key = key.replace("$releasever", vers).replace("$basearch", arch)
+                log.info("Importing GPG key to RPM database: %s", interpolated_key)
+                util.execInSysroot("rpm", ["--import", interpolated_key])
+
     def post_setup(self):
         """Perform post-setup tasks.
 
@@ -2075,6 +2086,9 @@ class DNFPayload(Payload):
         # We don't need the mother base anymore. Close it.
         self._base.close()
         super().post_install()
+
+        # rpm needs importing installed certificates manually, see rhbz#748320 and rhbz#185800
+        self._import_rpm_keys()
 
     @property
     def kernel_version_list(self):

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -776,7 +776,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         self._network_button.connect("toggled", self._update_url_entry_check)
 
         # Show or hide the updates option based on the configuration
-        if conf.payload.enable_updates:
+        if conf.payload.updates_repositories:
             really_show(self._updates_box)
         else:
             really_hide(self._updates_box)


### PR DESCRIPTION
This PR contains backports from Anaconda 34 to support defining automatically activated repositories to RHEL 8 for CentOS Stream Hyperscale spin.

Resolves: [rbhz#1961457](https://bugzilla.redhat.com/1961457).