### PR TITLE
Unmount the source if the mount point is already in use when checking it

### DIFF
--- a/pyanaconda/modules/payloads/source/mount_tasks.py
+++ b/pyanaconda/modules/payloads/source/mount_tasks.py
@@ -71,15 +71,20 @@ class SetUpMountTask(Task, ABC):
     def run(self):
         """Run source setup."""
         log.debug("Mounting installation source")
-        self._check_mount()
+        if not self._check_mount():
+            task = TearDownMountTask(self._target_mount)
+            task.run()
         return self._do_mount()
 
     def _check_mount(self):
         """Check if the source is unmounted."""
         if os.path.ismount(self._target_mount):
-            raise SourceSetupError("The mount point {} is already in use.".format(
+            log.warning("The mount point {} is already in use. And it will be unmounted.".format(
                 self._target_mount
             ))
+            return False
+        else:
+            return True
 
     @abstractmethod
     def _do_mount(self):


### PR DESCRIPTION
When the service is restarted by "systemctl restart anaconda" command in tty2, anaconda will failed to mount a DBus source at a mount point generated from /run/install/source, for example /run/install/source/mount-0000-cdrom, because the mount point has been used by the anaconda process before restart and has not been unmounted before the process was terminated. We can fix it by unmounting the source when checking the mount point.