### PR TITLE
Make clear that team and vlan from ks in initramfs is not supported

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -393,6 +393,14 @@ def ksnet_to_dracut(args, lineno, net, bootdev=False):
     if net.bondslaves:
         line.append("bond=%s:%s:%s:%s" % (net.device, net.bondslaves, net.bondopts, net.mtu))
 
+    if net.teamslaves:
+        line = []
+        log.error("Network team configuration from kickstart in initramfs is not supported.")
+
+    if net.vlanid:
+        line = []
+        log.error("Network vlan configuration from kickstart in initramfs is not supported.")
+
     return " ".join(line)
 
 def process_kickstart(ksfile):

--- a/tests/nosetests/dracut_tests/parse-kickstart_test.py
+++ b/tests/nosetests/dracut_tests/parse-kickstart_test.py
@@ -186,6 +186,22 @@ class ParseKickstartTestCase(BaseTestCase):
 
             self.assertEqual(lines[0], "ip=br0:dhcp: bootdev=br0 bridge=br0:eth0")
 
+    def network_team_test(self):
+        with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
+            ks_file.write("network --bootproto=dhcp --device=team0 --ipv6=auto --teamslaves=\"ens7'{\\\"prio\\\":100,\\\"sticky\\\":true}',ens8'{\\\"prio\\\":200}'\" --teamconfig=\"{\\\"runner\\\":{\\\"name\\\":\\\"activebackup\\\",\\\"hwaddr_policy\\\":\\\"same_all\\\"},\\\"link_watch\\\":{\\\"name\\\":\\\"ethtool\\\"}}\"")
+            ks_file.flush()
+            lines = self.execParseKickstart(ks_file.name)
+
+            self.assertEqual(lines, [])
+
+    def network_vlan_test(self):
+        with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
+            ks_file.write("network --bootproto=dhcp --device=ens7 --ipv6=auto --vlanid=233")
+            ks_file.flush()
+            lines = self.execParseKickstart(ks_file.name)
+
+            self.assertEqual(lines, [])
+
     def network_ipv6_only_test(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
             ks_file.write("""network --noipv4 --hostname=blah.test.com --ipv6=1:2:3:4:5:6:7:8 --ipv6gateway=2001:beaf:cafe::1 --device lo --nameserver=1:1:1:1::,2:2:2:2::""")


### PR DESCRIPTION
Anaconda would reparse the vlan or team configuration to invalid dracut
configuration.

For vlan the parent device configuration like:
ip=ens7:dhcp: bootdev=ens7

For team a non-existing device configuration like:
ip=team0:dhcp: bootdev=team0

Follow up of
commit 68c74fa5f8cca195dee1058dd9238704fd73e228