### PR TITLE
Add check for infrastructure PRs (#infra)

### DIFF
--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -50,3 +50,16 @@ jobs:
           if [ "$failed_check" == "yes" ]; then
             exit 1
           fi
+
+      - name: Check if all commits have (#infra)
+        run: |
+          set -eux
+
+          # match (#infra) at the end of the commit message
+          for i in "$(git log --oneline origin/${{ github.event.pull_request.base.ref }}..HEAD)"; do
+
+            if ! [[ $i =~ \(#infra\)$ ]]; then
+              echo "$i --> Is missing (#infra!)"
+              exit 1
+            fi
+          done

--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -4,10 +4,12 @@ on:
   pull_request_target:
     types: [ "opened", "synchronize", "reopened", "labeled" ]
 
+permissions:
+  contents: read
+
 jobs:
   infra-check:
     if: contains(github.event.pull_request.labels.*.name, 'infrastructure')
-    environment: staging
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -1,0 +1,52 @@
+# Check if only infrastructure files are changed when infrastructure label is set.
+name: infrastructure-check
+on:
+  pull_request_target:
+    types: [ "opened", "synchronize", "reopened", "labeled" ]
+
+jobs:
+  infra-check:
+    if: contains(github.event.pull_request.labels.*.name, 'infrastructure')
+    environment: staging
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Clone Anaconda repository
+        uses: actions/checkout@v2
+        with:
+          # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Get list of changed files
+        run: |
+          set -eux
+          changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}..HEAD)
+          # print for debugging
+          echo "$changed_files"
+
+          # load infrastructure file list
+          . .structure-config
+
+          failed_check="no"
+
+          for f in $changed_files; do
+            matched="no"
+
+            for infra_f in $INFRASTRUCTURE_FILES; do
+              if [[ "$f" =~ "$infra_f" ]]; then
+                matched="yes"
+                break
+              fi
+            done
+
+            if [ $matched == "no" ]; then
+              echo "$f is not part of the infrastructure"
+              failed_check="yes"
+            fi
+
+          done
+
+          if [ "$failed_check" == "yes" ]; then
+            exit 1
+          fi

--- a/.structure-config
+++ b/.structure-config
@@ -1,0 +1,1 @@
+INFRASTRUCTURE_FILES='.github/ dockerfile/ scripts/testing/ scripts/githooks/'


### PR DESCRIPTION
This check will verify that PR is changing only files for the infrastructure and won't touch files important by the project.

This check will be started for all PRs marked by the 'infrastructure' label.

Add configuration file to the project which could be used for future project structure. Could be used for new updates_image generation.

Tested:
[failure](https://github.com/jkonecny12/anaconda/runs/2747322866?check_suite_focus=true)
[success](https://github.com/jkonecny12/anaconda/runs/2747412290?check_suite_focus=true)
[failure commit message check](https://github.com/jkonecny12/anaconda/runs/2774092337?check_suite_focus=true)
[success commit message check](https://github.com/jkonecny12/anaconda/runs/2774096384?check_suite_focus=true)
[successful run with permissions modification](https://github.com/jkonecny12/anaconda/runs/2782523817?check_suite_focus=true)
[failure when Makefile has changed](https://github.com/jkonecny12/anaconda/runs/2783695454?check_suite_focus=true)