### PR TITLE
Apply the bootloader options before the installation

### DIFF
--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -25,6 +25,7 @@ from blivet.formats.disklabel import DiskLabel
 from blivet.iscsi import iscsi
 from blivet.size import Size
 
+from pyanaconda.core.constants import BOOTLOADER_TIMEOUT_UNSET
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.network import iface_for_host_ip
 from pyanaconda.modules.storage.platform import platform, PLATFORM_DEVICE_TYPES, \
@@ -205,6 +206,8 @@ class BootLoader(object):
         # timeout in seconds
         self._timeout = None
         self.password = None
+        self.encrypted_password = None
+        self.secure = None
 
         # console/serial stuff
         self.console = ""
@@ -718,17 +721,60 @@ class BootLoader(object):
     def timeout(self, seconds):
         self._timeout = seconds
 
-    def set_boot_args(self, storage):
-        """Set up the boot command line."""
-        self._set_extra_boot_args()
+    def prepare(self, storage):
+        """Prepare the bootloader for the installation.
+
+        FIXME: Move this function into a task.
+        """
+        bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
+        self._update_flags(bootloader_proxy)
+        self._apply_password(bootloader_proxy)
+        self._apply_timeout(bootloader_proxy)
+        self._apply_zipl_secure_boot(bootloader_proxy)
+        self._set_extra_boot_args(bootloader_proxy)
         self._set_storage_boot_args(storage)
         self._preserve_some_boot_args()
         self._set_graphical_boot_args()
         self._set_security_boot_args()
 
-    def _set_extra_boot_args(self):
+    def _update_flags(self, bootloader_proxy):
+        """Update flags."""
+        if bootloader_proxy.KeepMBR:
+            log.debug("Don't update the MBR.")
+            self.keep_mbr = True
+
+        if bootloader_proxy.KeepBootOrder:
+            log.debug("Don't change the existing boot order.")
+            self.keep_boot_order = True
+
+    def _apply_password(self, bootloader_proxy):
+        """Set the password."""
+        if bootloader_proxy.IsPasswordSet:
+            log.debug("Applying bootloader password.")
+
+            if bootloader_proxy.IsPasswordEncrypted:
+                self.encrypted_password = bootloader_proxy.Password
+            else:
+                self.password = bootloader_proxy.Password
+
+    def _apply_timeout(self, bootloader_proxy):
+        """Set the timeout."""
+        timeout = bootloader_proxy.Timeout
+        if timeout != BOOTLOADER_TIMEOUT_UNSET:
+            log.debug("Applying bootloader timeout: %s", timeout)
+            self.timeout = timeout
+
+    def _apply_zipl_secure_boot(self, bootloader_proxy):
+        """Set up the ZIPL Secure Boot."""
+        if not blivet.arch.is_s390():
+            return
+
+        secure_boot = bootloader_proxy.ZIPLSecureBoot
+        log.debug("Applying ZIPL Secure Boot: %s", secure_boot)
+        self.secure = secure_boot
+
+    def _set_extra_boot_args(self, bootloader_proxy):
         """Set the extra boot args."""
-        bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
         self.boot_args.update(bootloader_proxy.ExtraArguments)
 
     def _set_storage_boot_args(self, storage):

--- a/pyanaconda/modules/storage/bootloader/execution.py
+++ b/pyanaconda/modules/storage/bootloader/execution.py
@@ -22,7 +22,7 @@ from pykickstart.errors import KickstartParseError
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import BOOTLOADER_ENABLED, BOOTLOADER_SKIPPED, \
-    BOOTLOADER_LOCATION_PARTITION, BOOTLOADER_TIMEOUT_UNSET
+    BOOTLOADER_LOCATION_PARTITION
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.constants.objects import BOOTLOADER
 from pyanaconda.modules.common.constants.services import STORAGE
@@ -67,12 +67,8 @@ class BootloaderExecutor(object):
         # Update the disk list. Disks are already sorted by Blivet.
         storage.bootloader.set_disk_list([d for d in storage.disks if d.partitioned])
 
-        # Apply the settings.
-        self._update_flags(storage, bootloader_proxy)
+        # Apply settings related to boot devices.
         self._apply_location(storage, bootloader_proxy)
-        self._apply_password(storage, bootloader_proxy)
-        self._apply_timeout(storage, bootloader_proxy)
-        self._apply_zipl_secure_boot(storage, bootloader_proxy)
         self._apply_drive_order(storage, bootloader_proxy, dry_run=dry_run)
         self._apply_boot_drive(storage, bootloader_proxy, dry_run=dry_run)
 
@@ -80,16 +76,6 @@ class BootloaderExecutor(object):
         if not dry_run:
             storage.bootloader.stage2_device = storage.boot_device
             storage.bootloader.set_stage1_device(storage.devices)
-
-    def _update_flags(self, storage, bootloader_proxy):
-        """Update flags."""
-        if bootloader_proxy.KeepMBR:
-            log.debug("Don't update the MBR.")
-            storage.bootloader.keep_mbr = True
-
-        if bootloader_proxy.KeepBootOrder:
-            log.debug("Don't change the existing boot order.")
-            storage.bootloader.keep_boot_order = True
 
     def _apply_location(self, storage, bootloader_proxy):
         """Set the location."""
@@ -99,32 +85,6 @@ class BootloaderExecutor(object):
         storage.bootloader.set_preferred_stage1_type(
             "boot" if location == BOOTLOADER_LOCATION_PARTITION else "mbr"
         )
-
-    def _apply_password(self, storage, bootloader_proxy):
-        """Set the password."""
-        if bootloader_proxy.IsPasswordSet:
-            log.debug("Applying bootloader password.")
-
-            if bootloader_proxy.IsPasswordEncrypted:
-                storage.bootloader.encrypted_password = bootloader_proxy.Password
-            else:
-                storage.bootloader.password = bootloader_proxy.Password
-
-    def _apply_timeout(self, storage, bootloader_proxy):
-        """Set the timeout."""
-        timeout = bootloader_proxy.Timeout
-        if timeout != BOOTLOADER_TIMEOUT_UNSET:
-            log.debug("Applying bootloader timeout: %s", timeout)
-            storage.bootloader.timeout = timeout
-
-    def _apply_zipl_secure_boot(self, storage, bootloader_proxy):
-        """Set up the ZIPL Secure Boot."""
-        if not blivet.arch.is_s390():
-            return
-
-        secure_boot = bootloader_proxy.ZIPLSecureBoot
-        log.debug("Applying ZIPL Secure Boot: %s", secure_boot)
-        storage.bootloader.secure = secure_boot
 
     def _is_usable_disk(self, d):
         """Is the disk usable for the bootloader?

--- a/pyanaconda/modules/storage/bootloader/utils.py
+++ b/pyanaconda/modules/storage/bootloader/utils.py
@@ -208,9 +208,8 @@ def install_boot_loader(storage):
     stage2_device = storage.bootloader.stage2_device
     log.info("boot loader stage2 target device is %s", stage2_device.name)
 
-    # Set up the arguments.
-    # FIXME: do this from elsewhere?
-    storage.bootloader.set_boot_args(storage)
+    # Prepare the bootloader for the installation.
+    storage.bootloader.prepare(storage)
 
     # Install the bootloader.
     storage.bootloader.write()

--- a/tests/nosetests/pyanaconda_tests/modules/storage/module_bootloader_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/storage/module_bootloader_test.py
@@ -380,7 +380,7 @@ class BootloaderTasksTestCase(unittest.TestCase):
         bootloader.write.assert_not_called()
 
         InstallBootloaderTask(storage, BootloaderMode.ENABLED).run()
-        bootloader.set_boot_args.assert_called_once()
+        bootloader.prepare.assert_called_once()
         bootloader.write.assert_called_once()
 
     @patch('pyanaconda.modules.storage.bootloader.utils.execWithRedirect')


### PR DESCRIPTION
Some of the bootloader options are not needed until the installation.
If we apply them during the scheduling of the partitions, it won't be
possible to change them after that, for example, from an add-on. Let's
apply these options later, right before the bootloader installation.

Suggested-by: bitcoffee <854182924@qq.com>