### PR TITLE
Use yescrypt hashing method for shadow passwords

### DIFF
--- a/pyanaconda/core/users.py
+++ b/pyanaconda/core/users.py
@@ -29,6 +29,7 @@ from pyanaconda.core.regexes import GROUPLIST_FANCY_PARSE, NAME_VALID, PORTABLE_
 import crypt
 from pyanaconda.core.i18n import _
 import re
+from random import SystemRandom as sr
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -43,13 +44,25 @@ def crypt_password(password):
     :returns: crypted representation of the original password
     :rtype: str
     """
+    # yescrypt is not supported by Python's crypt module,
+    # so we need to generate the setting ourselves
+    b64 = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    setting = "$y$j9T$" + "".join(sr().choice(b64) for sc in range(24))
+
+    # and try to compute the password hash using our yescrypt setting
     try:
-        cryptpw = crypt.crypt(password, crypt.METHOD_SHA512)
-    except OSError as exc:
-        raise RuntimeError(_(
-            "Unable to encrypt password: unsupported "
-            "algorithm {}").format(crypt.METHOD_SHA512)
-        ) from exc
+        cryptpw = crypt.crypt(password, setting)
+
+    # Fallback to sha512crypt, if yescrypt is not supported
+    except OSError:
+        log.info("yescrypt is not supported, falling back to sha512crypt")
+        try:
+            cryptpw = crypt.crypt(password, crypt.METHOD_SHA512)
+        except OSError as exc:
+            raise RuntimeError(_(
+                "Unable to encrypt password: unsupported "
+                "algorithm {}").format(crypt.METHOD_SHA512)
+            ) from exc
 
     return cryptpw
 

--- a/pyanaconda/core/users.py
+++ b/pyanaconda/core/users.py
@@ -43,13 +43,13 @@ def crypt_password(password):
     :returns: crypted representation of the original password
     :rtype: str
     """
-    cryptpw = crypt.crypt(password, crypt.METHOD_SHA512)
-
-    if cryptpw is None:
+    try:
+        cryptpw = crypt.crypt(password, crypt.METHOD_SHA512)
+    except OSError as exc:
         raise RuntimeError(_(
             "Unable to encrypt password: unsupported "
             "algorithm {}").format(crypt.METHOD_SHA512)
-        )
+        ) from exc
 
     return cryptpw
 

--- a/pyanaconda/modules/common/structures/user.py
+++ b/pyanaconda/modules/common/structures/user.py
@@ -234,9 +234,18 @@ class UserData(DBusData):
 
         To create an encrypted password you can use python:
 
+        python3 -c 'import crypt; print(crypt.crypt("My Password", "$y$j9T$My Sault"))'
+
+        This will compute a hash of your password using the yescrypt hasing method and
+        your provided salt.
+
+        If the yescrypt method is not supported by your system, you can use the
+        sha512crypt hashing method:
+
         python3 -c 'import crypt; print(crypt.crypt("My Password", "$6$My Sault"))'
 
-        This will generate sha512 crypt of your password using your provided salt.
+        This will compute a hash of your password using the sha512crypt hasing method
+        and your provided salt.
 
         For example: "CorrectHorseBatteryStaple"
 

--- a/pyanaconda/modules/security/security_interface.py
+++ b/pyanaconda/modules/security/security_interface.py
@@ -99,7 +99,7 @@ class SecurityInterface(KickstartModuleInterface):
 
         Authconfig is deprecated, use authselect.
 
-        Example: ['--passalgo=sha512', '--useshadow']
+        Example: ['--passalgo=yescrypt', '--useshadow']
 
         :param args: a list of arguments
         """

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
@@ -89,7 +89,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         """Test the authconfig property."""
         self._check_dbus_property(
             "Authconfig",
-            ["--passalgo=sha512", "--useshadow"]
+            ["--passalgo=yescrypt", "--useshadow"]
         )
 
     def test_fingerprint_auth_enabled(self):
@@ -142,22 +142,22 @@ class SecurityInterfaceTestCase(unittest.TestCase):
     def test_auth_kickstart(self):
         """Test the auth command."""
         ks_in = """
-        auth --passalgo=sha512 --useshadow
+        auth --passalgo=yescrypt --useshadow
         """
         ks_out = """
         # System authorization information
-        auth --passalgo=sha512 --useshadow
+        auth --passalgo=yescrypt --useshadow
         """
         self._test_kickstart(ks_in, ks_out)
 
     def test_authconfig_kickstart(self):
         """Test the authconfig command."""
         ks_in = """
-        authconfig --passalgo=sha512 --useshadow
+        authconfig --passalgo=yescrypt --useshadow
         """
         ks_out = """
         # System authorization information
-        auth --passalgo=sha512 --useshadow
+        auth --passalgo=yescrypt --useshadow
         """
         self._test_kickstart(ks_in, ks_out)
 
@@ -249,7 +249,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         realm.discovered = True
 
         authselect = ['select', 'sssd']
-        authconfig = ['--passalgo=sha512', '--useshadow']
+        authconfig = ['--passalgo=yescrypt', '--useshadow']
         fingerprint = True
 
         self.security_interface.SetRealm(RealmData.to_structure(realm))
@@ -398,7 +398,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
     def test_authselect_requirements(self):
         """Test that package requirements for authselect propagate correctly."""
 
-        self.security_interface.SetAuthconfig(['--passalgo=sha512', '--useshadow'])
+        self.security_interface.SetAuthconfig(['--passalgo=yescrypt', '--useshadow'])
         requirements = Requirement.from_structure_list(
             self.security_interface.CollectRequirements()
         )
@@ -906,7 +906,7 @@ class SecurityTasksTestCase(unittest.TestCase):
             execWithRedirect.reset_mock()
             task = ConfigureAuthconfigTask(
                 sysroot=sysroot,
-                authconfig_options=["--passalgo=sha512", "--useshadow"]
+                authconfig_options=["--passalgo=yescrypt", "--useshadow"]
             )
             with self.assertRaises(SecurityInstallationError):
                 task.run()
@@ -917,12 +917,12 @@ class SecurityTasksTestCase(unittest.TestCase):
             os.mknod(authconfig_path)
             task = ConfigureAuthconfigTask(
                 sysroot=sysroot,
-                authconfig_options=["--passalgo=sha512", "--useshadow"]
+                authconfig_options=["--passalgo=yescrypt", "--useshadow"]
             )
             task.run()
             execWithRedirect.assert_called_once_with(
                 AUTHCONFIG_TOOL_PATH,
-                ["--update", "--nostart", "--passalgo=sha512", "--useshadow"],
+                ["--update", "--nostart", "--passalgo=yescrypt", "--useshadow"],
                 root=sysroot
             )
             os.remove(authconfig_path)


### PR DESCRIPTION
The yescrypt hashing method is considered to be much stronger than sha512crypt and fully supported by libxcrypt.  It is based on NIST-approved primitives and on par with argon2 in strength.

Fresh installed systems, as well as newly computed hashes for the UNIX shadow file should prefer this method.