### PR TITLE
Reduce permissions for our tests workflow (#infra)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,11 @@
 name: Run validation tests
 on: pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
-    environment: staging
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
@@ -83,7 +85,6 @@ jobs:
         uses: codecov/codecov-action@v1
 
   rpm-tests:
-    environment: staging
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
This workflow can only download content of the repository nothing else is permitted.

Thanks to this change we could avoid environment verification because even the external contributors can't really modify anything. `GITHUB_TOKEN` for this workflow can only read the content of the repository nothing else is allowed.

Test PRs:
[Success run.](https://github.com/jkonecny12/anaconda/pull/11/checks?check_run_id=2765057988)
[Test to push to repository.](https://github.com/jkonecny12/anaconda/pull/11/checks?check_run_id=2765041562#step:4:22) - This shouldn't be allowed!

*WIP*:
- [x] Secrets could still be read, however, we can solve that by moving our secrets to the environment level and use these environments for specific workflows.