### PR TITLE
Use secrets from the environment not organization (#infra)

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -9,6 +9,7 @@ jobs:
   refresh-containers:
     name: Refresh anaconda containers
     runs-on: ubuntu-20.04
+    environment: quay.io
     # we need to have matrix to cover all branches because schedule is run only on default branch
     # we can add here fedora branches (e.g. f33-devel) to cover their support when needed
     strategy:


### PR DESCRIPTION
We are possible to remove gating on Rawhide by using GH permissions. That will allow us to reduce what user can do with the repository. However, we can't solve access to secrets this way. To avoid users reading our secrets we will move the secrets from organization level to environment which will be used only on place where it should be used.