### PR TITLE
Add brltty to boot.iso

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -223,6 +223,7 @@ Requires: gsettings-desktop-schemas
 Requires: nm-connection-editor
 Requires: librsvg2
 Requires: gnome-kiosk
+Requires: brltty
 
 %description install-img-deps
 The anaconda-install-img-deps metapackage lists all boot.iso installation image dependencies.

--- a/data/systemd/anaconda.target
+++ b/data/systemd/anaconda.target
@@ -13,5 +13,6 @@ Wants=anaconda-sshd.service
 Wants=anaconda-pre.service
 Wants=anaconda-fips.service
 Wants=systemd-logind.service
+Wants=brltty.service
 Wants=rhsm.service
 After=rhsm.service

--- a/docs/release-notes/brltty.rst
+++ b/docs/release-notes/brltty.rst
@@ -1,0 +1,12 @@
+:Type: Accessibility
+:Summary: Server images offer limited support for braille devices
+
+:Description:
+    The Server image (boot.iso) now contains the `brltty` accessibility software.
+    This means that some braille output devices can be automatically detected and used.
+
+    This feature works only in text mode, started with the `inst.text` boot option.
+
+:Links:
+    - https://bugzilla.redhat.com/show_bug.cgi?id=1584679
+    - https://github.com/rhinstaller/anaconda/pull/3434


### PR DESCRIPTION
This adds brltty to boot.iso and starts it with default configuration. That means:
- Some usb braille devices might be automatically detected and used.
- This works only in TUI, no GUI.
- No method of configuration is added.

https://bugzilla.redhat.com/show_bug.cgi?id=1584679