### PR TITLE
Rhel9 covscan fixes (1)

### DIFF
--- a/dracut/kickstart-genrules.sh
+++ b/dracut/kickstart-genrules.sh
@@ -13,11 +13,11 @@ case "${kickstart%%:*}" in
         if [ "$kstype" = "cdrom" ] && [ -z "$kspath" ]; then
             kspath="$ksdev"
             when_any_cdrom_appears \
-                fetch-kickstart-disk \$env{DEVNAME} "$kspath"
+                fetch-kickstart-disk "\$env{DEVNAME}" "$kspath"
         else
             ksdev=$(disk_to_dev_path $ksdev)
             when_diskdev_appears "$ksdev" \
-                fetch-kickstart-disk \$env{DEVNAME} "$kspath"
+                fetch-kickstart-disk "\$env{DEVNAME}" "$kspath"
         fi
         # "cdrom:" also means "wait forever for kickstart" because rhbz#1168902
         if [ "$kstype" = "cdrom" ]; then
@@ -30,7 +30,7 @@ case "${kickstart%%:*}" in
     "")
         if [ -z "$kickstart" -a -z "$(getarg inst.ks=)" ]; then
             when_diskdev_appears $(disk_to_dev_path LABEL=OEMDRV) \
-                fetch-kickstart-disk \$env{DEVNAME} "/ks.cfg"
+                fetch-kickstart-disk "\$env{DEVNAME}" "/ks.cfg"
         fi
     ;;
 esac

--- a/dracut/repo-genrules.sh
+++ b/dracut/repo-genrules.sh
@@ -10,17 +10,17 @@ case "$root" in
     splitsep ":" "$root" f diskdev diskpath
     diskdev=$(disk_to_dev_path $diskdev)
     when_diskdev_appears $diskdev \
-        anaconda-diskroot \$env{DEVNAME} $diskpath
+        anaconda-diskroot "\$env{DEVNAME}" $diskpath
   ;;
   anaconda-auto-cd)
     # special catch-all rule for CDROMs
     when_any_cdrom_appears \
-        anaconda-diskroot \$env{DEVNAME}
+        anaconda-diskroot "\$env{DEVNAME}"
     # HACK: anaconda demands that CDROMs be mounted at /mnt/install/source
     ln -s repo /run/install/source
   ;;
   anaconda-hmc)
     when_any_hmcdrv_appears \
-        anaconda-hmcroot \$env{DEVNAME}
+        anaconda-hmcroot "\$env{DEVNAME}"
   ;;
 esac

--- a/dracut/updates-genrules.sh
+++ b/dracut/updates-genrules.sh
@@ -18,7 +18,7 @@ case $updates in
         updates=${updates#hd:}; updates=${updates#cdrom:}
         splitsep ":" "$updates" dev path
         dev=$(disk_to_dev_path $dev)
-        when_diskdev_appears $dev fetch-updates-disk \$env{DEVNAME} $path
+        when_diskdev_appears $dev fetch-updates-disk "\$env{DEVNAME}" $path
         wait_for_updates
     ;;
 esac

--- a/pyanaconda/installation_tasks.py
+++ b/pyanaconda/installation_tasks.py
@@ -480,7 +480,7 @@ class Task(BaseTask):
             if self.running or self.done:
                 if self.running:
                     # attempt to start a task that is already running
-                    log.error("Can't start task %s - already done.")
+                    log.error("Can't start task %s - already running.")
                 else:
                     # attempt to start a task that an already finished task
                     log.error("Can't start task %s - already done.")


### PR DESCRIPTION
These are fixes for the errors marked as `[important]`.

Related to #3277, fixes some of [rhbz#1938677](https://bugzilla.redhat.com/show_bug.cgi?id=1938677).