### PR TITLE
Make it possible to skip install time Insights errors (#1931069)

### DIFF
--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -260,6 +260,17 @@ class ErrorHandler(object):
         self.ui.showError(message)
         return ERROR_RAISE
 
+    def _insightsErrorHandler(self, exn):
+        message = _("An error occurred during Red Hat Insights configuration. "
+                    "Would you like to ignore this and continue with "
+                    "installation?")
+        message += "\n\n" + str(exn)
+
+        if self.ui.showYesNoQuestion(message):
+            return ERROR_CONTINUE
+        else:
+            return ERROR_RAISE
+
     def cb(self, exn):
         """This method is the callback that all error handling should pass
            through.  The return value is one of the ERROR_* constants defined
@@ -292,6 +303,8 @@ class ErrorHandler(object):
             "DependencyError": self._dependencyErrorHandler,
             BootloaderInstallationError.__name__: self._bootLoaderErrorHandler,
             "PasswordCryptError": self._passwordCryptErrorHandler,
+            "InsightsClientMissingError": self._insightsErrorHandler,
+            "InsightsConnectError": self._insightsErrorHandler,
         }
 
         if exn.__class__.__name__ in _map:

--- a/pyanaconda/modules/subscription/installation.py
+++ b/pyanaconda/modules/subscription/installation.py
@@ -78,7 +78,7 @@ class ConnectToInsightsTask(Task):
         log.debug("insights-connect-task: connecting to insights")
         rc = util.execWithRedirect(self.INSIGHTS_TOOL_PATH, ["--register"], root=self._sysroot)
         if rc:
-            raise InsightsConnectError("Connecting to Red Hat Insights failed.")
+            raise InsightsConnectError("Failed to connect to Red Hat Insights.")
 
 
 class RestoreRHSMDefaultsTask(Task):


### PR DESCRIPTION
Instead of crashing with a traceback if the install time attempt to
connect to Red Hat Insights fails, show an error dialog with the options
to either continue or abort the installation.

Resolves: rhbz#1931069