### PR TITLE
Remove RPM_TESTS_ARGS support

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,7 +40,6 @@ EXTRA_DIST += $(top_srcdir)/translation-canary/translation_canary/*.py \
 	      $(top_srcdir)/translation-canary/translation_canary/*/*.py
 
 UNIT_TESTS_PATTERN ?= ""
-RPM_TESTS_ARGS ?= ""
 PEP8_TARGETS ?= ""
 
 # Test scripts need to be listed both here and in TESTS

--- a/tests/rpm_tests.sh
+++ b/tests/rpm_tests.sh
@@ -11,6 +11,4 @@ if [ $# -eq 0 ]; then
     set -- "${top_srcdir}"/tests/rpm_tests
 fi
 
-# TODO: RPM_TESTS_ARGS are not usable in the container environment. Do we want to keep it?
-# That variable is not propagated from Makefile which is because the way the test is executed.
-exec python3 -m unittest discover -t $top_srcdir -v -b ${RPM_TESTS_ARGS:+-k} $RPM_TESTS_ARGS -s $@
+exec python3 -m unittest discover -t $top_srcdir -v -b -s $@


### PR DESCRIPTION
Reasons for removal:
- I don't think anyone ever used this variable.
- Doesn't work reliably after container workflow switch.
- Tests are fast enough here so there is no need to execute just some.