### PR TITLE
Use C.UTF-8 if the requested locale is unsupported (#1958876)

### DIFF
--- a/tests/nosetests/pyanaconda_tests/localization_test.py
+++ b/tests/nosetests/pyanaconda_tests/localization_test.py
@@ -259,6 +259,20 @@ class LangcodeLocaleMatchingTests(unittest.TestCase):
         self.assertIsNone(localization.find_best_locale_match("ja", ["blah"]))
         self.assertIsNone(localization.find_best_locale_match("blah", ["en_US.UTF-8"]))
 
+    def find_best_locale_match_posix_test(self):
+        """Finding best POSIX matches should work as expected."""
+        match = localization.find_best_locale_match("C", ["C.UTF-8"])
+        self.assertEqual(match, "C.UTF-8")
+
+        match = localization.find_best_locale_match("C.UTF-8", ["en_US"])
+        self.assertEqual(match, "en_US")
+
+        match = localization.find_best_locale_match("en_US", ["C.UTF-8"])
+        self.assertEqual(match, None)
+
+        match = localization.find_best_locale_match("cs_CZ", ["C.UTF-8"])
+        self.assertEqual(match, None)
+
     def resolve_date_format_test(self):
         """All locales' date formats should be properly resolved."""
         locales = (line.strip() for line in execWithCapture("locale", ["-a"]).splitlines())

--- a/tests/nosetests/pyanaconda_tests/modules/localization/module_localization_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/localization/module_localization_test.py
@@ -380,24 +380,73 @@ class LocalizationModuleTestCase(unittest.TestCase):
         self.assertEqual(self.localization_module.x_layouts, [])
 
 
-class LocalizationTasksTestCase(unittest.TestCase):
-    """Test tasks of the localization module."""
+class LanguageInstallationTaskTestCase(unittest.TestCase):
+    """Test the language installation task."""
 
-    def language_installation_test(self):
-        """Test the language installation task."""
-        # Prepare sysroot.
+    def _run_task(self, lang, expected):
+        """Run the installation task.
+
+        :param lang: a value for LANG locale variable
+        :param expected: a content of /etc/locale.conf
+        """
         with tempfile.TemporaryDirectory() as root:
-
             # Prepare for the installation task.
-            conf = root + "/etc/locale.conf"
-            os.makedirs(os.path.dirname(conf), exist_ok=True)
+            locale_conf = root + "/etc/locale.conf"
+            os.makedirs(os.path.dirname(locale_conf), exist_ok=True)
 
             # Run the installation task.
-            LanguageInstallationTask(root, "cs_CZ.UTF-8").run()
+            task = LanguageInstallationTask(root, lang)
+            task.run()
 
-            # Check the result.
-            with open(root + "/etc/locale.conf") as f:
-                self.assertEqual(f.read(), "LANG=\"cs_CZ.UTF-8\"\n")
+            # Check the configuration file.
+            with open(locale_conf) as f:
+                content = f.read()
+
+            self.assertEqual(content, expected)
+
+    @patch("pyanaconda.modules.localization.installation.execWithCapture")
+    def invalid_locale_test(self, exec_mock):
+        """Test an installation with an invalid locale."""
+        exec_mock.return_value = "C.utf8"
+
+        self._run_task("C.UTF-8", "LANG=\"C.UTF-8\"\n")
+        self._run_task("en_US", "LANG=\"C.UTF-8\"\n")
+        self._run_task("cs_CZ.UTF-8", "LANG=\"C.UTF-8\"\n")
+        self._run_task("en_GB.ISO8859-15@euro", "LANG=\"C.UTF-8\"\n")
+
+    @patch("pyanaconda.modules.localization.installation.execWithCapture")
+    def unknown_locale_test(self, exec_mock):
+        """Test an installation of a unknown locale."""
+        exec_mock.side_effect = OSError("Fake!")
+
+        self._run_task("C.UTF-8", "LANG=\"C.UTF-8\"\n")
+        self._run_task("en_US", "LANG=\"en_US\"\n")
+        self._run_task("cs_CZ.UTF-8", "LANG=\"cs_CZ.UTF-8\"\n")
+        self._run_task("en_GB.ISO8859-15@euro", "LANG=\"en_GB.ISO8859-15@euro\"\n")
+
+    @patch("pyanaconda.modules.localization.installation.execWithCapture")
+    def valid_locale_test(self, exec_mock):
+        """Test an installation of a valid locale."""
+        locales = """
+        C.utf8
+        cs_CZ
+        cs_CZ.iso88592
+        cs_CZ.utf8
+        en_US
+        en_US.iso88591
+        en_US.iso885915
+        en_US.utf8
+        """
+        exec_mock.return_value = dedent(locales).strip()
+
+        self._run_task("C.UTF-8", "LANG=\"C.UTF-8\"\n")
+        self._run_task("en_US", "LANG=\"en_US\"\n")
+        self._run_task("cs_CZ.UTF-8", "LANG=\"cs_CZ.UTF-8\"\n")
+        self._run_task("en_GB.ISO8859-15@euro", "LANG=\"en_GB.ISO8859-15@euro\"\n")
+
+
+class LocalizationTasksTestCase(unittest.TestCase):
+    """Test tasks of the localization module."""
 
     @patch("pyanaconda.modules.localization.runtime.conf")
     def apply_keyboard_task_test_cant_acitvate(self, mocked_conf):


### PR DESCRIPTION
If there is no support for the requested locale, use `C.UTF-8` as a fallback.
The requested locale is considered to be supported if we are not able to
determine the supported locales due to missing tools.

In the `find_best_locale_match function`, skip langcodes with the POSIX variant
unless the provided locale is also a POSIX variant. Otherwise, the `en_US`
locale would match the `C` langcode and that is not desirable.

Resolves: rhbz#1958876