### PR TITLE
Add the ConfigureBootloaderWithTasks method

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -339,6 +339,16 @@ def _prepare_installation(payload, ksdata):
     bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
     bootloader_install = TaskQueue("Bootloader installation", N_("Installing boot loader"))
 
+    def run_configure_bootloader():
+        tasks = boss_proxy.CollectConfigureBootloaderTasks(
+            payload.kernel_version_list
+        )
+
+        for service, task in tasks:
+            sync_run_task(DBus.get_proxy(service, task))
+
+    bootloader_install.append(Task("Configure bootloader", run_configure_bootloader))
+
     def run_install_bootloader():
         tasks = bootloader_proxy.InstallBootloaderWithTasks(
             payload.type,

--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -113,6 +113,17 @@ class Boss(Service):
         """
         return self._install_manager.collect_configure_runtime_tasks()
 
+    def collect_configure_bootloader_tasks(self, kernel_versions):
+        """Collect tasks for configuration of the bootloader.
+
+        FIXME: This method temporarily uses only addons.
+        FIXME: This is a temporary workaround. The method might change.
+
+        :param kernel_versions: a list of kernel versions
+        :return: a list of task proxies
+        """
+        return self._install_manager.collect_configure_bootloader_tasks(kernel_versions)
+
     def collect_install_system_tasks(self):
         """Collect tasks for installation of the system.
 

--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -107,6 +107,19 @@ class BossInterface(InterfaceTemplate):
         proxies = self.implementation.collect_configure_runtime_tasks()
         return list(map(get_proxy_identification, proxies))
 
+    def CollectConfigureBootloaderTasks(self, kernel_versions: List[Str]) \
+            -> List[Tuple[BusName, ObjPath]]:
+        """Collect tasks for configuration of the bootloader.
+
+        FIXME: This method temporarily uses only addons.
+        FIXME: This is a temporary workaround. The method might change.
+
+        :param kernel_versions: a list of kernel versions
+        :return: a list of service names and object paths of tasks
+        """
+        proxies = self.implementation.collect_configure_bootloader_tasks(kernel_versions)
+        return list(map(get_proxy_identification, proxies))
+
     def CollectInstallSystemTasks(self) -> List[Tuple[BusName, ObjPath]]:
         """Collect tasks for installation of the system.
 

--- a/pyanaconda/modules/boss/install_manager/install_manager.py
+++ b/pyanaconda/modules/boss/install_manager/install_manager.py
@@ -70,6 +70,19 @@ class InstallManager(object):
         """
         return self._collect_tasks(lambda proxy: proxy.ConfigureWithTasks())
 
+    def collect_configure_bootloader_tasks(self, kernel_versions):
+        """Collect tasks for configuration of the bootloader.
+
+        FIXME: This method temporarily uses only addons.
+        FIXME: This is a temporary workaround. The method might change.
+
+        :param kernel_versions: a list of kernel versions
+        :return: a list of task proxies
+        """
+        return self._collect_tasks(
+            lambda proxy: proxy.ConfigureBootloaderWithTasks(kernel_versions)
+        )
+
     def collect_install_system_tasks(self):
         """Collect tasks for installation of the system.
 

--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -277,6 +277,16 @@ class KickstartService(Service, KickstartBaseModule):
         """
         return []
 
+    def configure_bootloader_with_tasks(self, kernel_versions):
+        """Configure the bootloader after the payload installation with a list of tasks.
+
+        FIXME: This is a temporary workaround. The method might change.
+
+        :param kernel_versions: a list of kernel versions
+        :return: a list of tasks
+        """
+        return []
+
     def install_with_tasks(self):
         """Return installation tasks of this module.
 

--- a/pyanaconda/modules/common/base/base_interface.py
+++ b/pyanaconda/modules/common/base/base_interface.py
@@ -143,6 +143,18 @@ class KickstartModuleInterface(KickstartModuleInterfaceTemplate):
             self.implementation.configure_with_tasks()
         )
 
+    def ConfigureBootloaderWithTasks(self, kernel_versions: List[Str]) -> List[ObjPath]:
+        """Configure the bootloader after the payload installation.
+
+        FIXME: This is a temporary workaround. The method might change.
+
+        :param kernel_versions: a list of kernel versions
+        :return: list of object paths of installation tasks
+        """
+        return TaskContainer.to_object_path_list(
+            self.implementation.configure_bootloader_with_tasks(kernel_versions)
+        )
+
     def InstallWithTasks(self) -> List[ObjPath]:
         """Returns installation tasks of this module.
 

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
@@ -75,6 +75,7 @@ class BossInterfaceTestCase(unittest.TestCase):
         module_proxy = Mock()
         module_proxy.ConfigureWithTasks.return_value = ["/task/1", "/task/2"]
         module_proxy.InstallWithTasks.return_value = ["/task/3", "/task/4"]
+        module_proxy.ConfigureBootloaderWithTasks.return_value = ["/task/5", "/task/6"]
         self._add_module(service_name, available=available, proxy=module_proxy)
 
     def _get_mocked_proxy(self, service_name, object_path):
@@ -179,6 +180,27 @@ class BossInterfaceTestCase(unittest.TestCase):
             ("A", "/task/2"),
             ("B", "/task/1"),
             ("B", "/task/2"),
+        ])
+
+    @patch("pyanaconda.modules.boss.boss_interface.get_object_handler")
+    @patch_dbus_get_proxy
+    def test_collect_configure_bootloader_tasks(self, proxy_getter, handler_getter):
+        """Test CollectConfigureBootloaderTasks."""
+        version = "4.17.7-200.fc28.x86_64"
+        self.assertEqual(self.interface.CollectConfigureBootloaderTasks([version]), [])
+
+        self._add_module_with_tasks("A")
+        self._add_module_with_tasks("B")
+        self._add_module_with_tasks("C", available=False)
+
+        proxy_getter.side_effect = self._get_mocked_proxy
+        handler_getter.side_effect = self._get_mocked_handler
+
+        self.assertEqual(self.interface.CollectConfigureBootloaderTasks([version]), [
+            ("A", "/task/5"),
+            ("A", "/task/6"),
+            ("B", "/task/5"),
+            ("B", "/task/6"),
         ])
 
     @patch("pyanaconda.modules.boss.boss_interface.get_object_handler")

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_base.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_base.py
@@ -19,9 +19,14 @@ import unittest
 import warnings
 
 from dasbus.typing import *  # pylint: disable=wildcard-import
-from pyanaconda.modules.common.base import KickstartService, KickstartModuleInterface
+
 from pykickstart.errors import KickstartParseError, KickstartParseWarning, \
     KickstartDeprecationWarning
+
+from tests.unit_tests.pyanaconda_tests import patch_dbus_publish_object, check_task_creation_list
+
+from pyanaconda.modules.common.base import KickstartService, KickstartModuleInterface
+from pyanaconda.modules.common.task import Task
 
 
 class BaseModuleTestCase(unittest.TestCase):
@@ -110,3 +115,35 @@ class BaseModuleTestCase(unittest.TestCase):
         }
 
         self.assertEqual(interface.ReadKickstart(""), report)
+
+    def test_default_configure_bootloader_with_tasks(self):
+        """Test the ConfigureBootloaderWithTasks method with defaults."""
+        service = KickstartService()
+        interface = KickstartModuleInterface(service)
+
+        tasks = interface.ConfigureBootloaderWithTasks(["1", "2", "3"])
+        self.assertEqual(tasks, [])
+
+    @patch_dbus_publish_object
+    def test_configure_bootloader_with_tasks(self, publisher):
+        """Test the ConfigureBootloaderWithTasks method."""
+        class Task1(Task):
+
+            @property
+            def name(self):
+                """The name of the task."""
+                return "Task 1"
+
+            def run(self):
+                """Nothing to do."""
+
+        class Service(KickstartService):
+            def configure_bootloader_with_tasks(self, kernel_versions):
+                """Return a list of installation tasks."""
+                return [Task1()]
+
+        service = Service()
+        interface = KickstartModuleInterface(service)
+
+        tasks = interface.ConfigureBootloaderWithTasks(["1", "2", "3"])
+        check_task_creation_list(self, tasks, publisher, [Task1])


### PR DESCRIPTION
Add DBus support for installation tasks that can be run after the payload
installation and before the bootloader installations. The tasks can work
with the provided kernel version list generated from the installed payload.

This feature was requested by kdump-anaconda-addon.