### PR TITLE
Call Lorax with the Resilient Storage repository (#infra)

### DIFF
--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -34,6 +34,7 @@ lorax -p RHEL -v $MAJOR_VERSION -r $MINOR_VERSION --volid RHEL-$MAJOR_VERSION-$M
       --nomacboot \
       -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/BaseOS/x86_64/os/ \
       -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/AppStream/x86_64/os/ \
+      -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/ResilientStorage/x86_64/os/ \
       -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/CRB/x86_64/os/ \
       -s http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9-Beta/latest-BUILDROOT-9/compose/Buildroot/x86_64/os/ \
       -s file://$PWD/result/build/01-rpm-build/ \


### PR DESCRIPTION
The Lorax templates require the `gfs2-utils` package that is provided by the the Resilient Storage repository.