### PR TITLE
Add Anaconda RPMs to kickstart tests execution

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -85,7 +85,8 @@ jobs:
        STATUS_NAME: kickstart-test
        TARGET_BRANCH: ${{ needs.pr-info.outputs.base_ref }}
        CONTAINER_TAG: 'lorax'
-       CONTAINER_NAME: 'quay.io/rhinstaller/anaconda-iso-creator'
+       ISO_BUILD_CONTAINER_NAME: 'quay.io/rhinstaller/anaconda-iso-creator'
+       RPM_BUILD_CONTAINER_NAME: 'quay.io/rhinstaller/anaconda-rpm'
        SKIP_KS_TESTS: ${{ needs.pr-info.outputs.skip_tests }}
        OPTIONAL_KS_TEST_ARGS: ${{ needs.pr-info.outputs.optional_test_args }}
     steps:
@@ -148,6 +149,16 @@ jobs:
           # set static tag to avoid complications when looking what tag is used
           sudo make -f ./Makefile.am anaconda-iso-creator-build CI_TAG=$CONTAINER_TAG
 
+      - name: Build anaconda-rpm container (for RPM build)
+        run: |
+          # set static tag to avoid complications when looking what tag is used
+          make -f ./Makefile.am anaconda-rpm-build CI_TAG=$CONTAINER_TAG
+
+      - name: Build Anaconda RPM files
+        run: |
+          # output of the build will be stored in ./result/build/01-rpm-build/*.rpm
+          make -f ./Makefile.am container-rpms-scratch CI_TAG=$CONTAINER_TAG
+
       - name: Prepare environment for lorax run
         run: |
           mkdir -p kickstart-tests/data/images
@@ -162,9 +173,9 @@ jobs:
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
           sudo podman run -i --rm --privileged \
             --tmpfs /var/tmp:rw,mode=1777 \
-            -v `pwd`:/anaconda:ro \
+            -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro \
             -v `pwd`/kickstart-tests/data/images:/images:z \
-            $CONTAINER_NAME:$CONTAINER_TAG
+            $ISO_BUILD_CONTAINER_NAME:$CONTAINER_TAG
 
       - name: Clean up after lorax
         if: always()
@@ -172,8 +183,9 @@ jobs:
           sudo losetup -d /dev/loop0 2> /dev/null || true
           sudo losetup -d /dev/loop1 2> /dev/null || true
 
-          # remove boot.iso the build container image together with the container
-          sudo podman rmi -f $CONTAINER_NAME:$CONTAINER_TAG || true
+          # remove container images together with the container
+          sudo podman rmi -f $ISO_BUILD_CONTAINER_NAME:$CONTAINER_TAG || true
+          sudo podman rmi -f $RPM_BUILD_CONTAINER_NAME:$CONTAINER_TAG || true
 
       - name: Run kickstart tests with ${{ needs.pr-info.outputs.launch_args }} in container
         working-directory: kickstart-tests

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -203,6 +203,7 @@ jobs:
           path: |
             kickstart-tests/data/logs/kstest.log
             kickstart-tests/data/logs/kstest-*/*.log
+            kickstart-tests/data/additional_repo/*.rpm
 
       - name: Set result status
         if: always()

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -158,6 +158,8 @@ jobs:
         run: |
           # output of the build will be stored in ./result/build/01-rpm-build/*.rpm
           make -f ./Makefile.am container-rpms-scratch CI_TAG=$CONTAINER_TAG
+          mkdir -p ./kickstart-tests/data/additional_repo/
+          cp -av ./result/build/01-rpm-build/*.rpm ./kickstart-tests/data/additional_repo/
 
       - name: Prepare environment for lorax run
         run: |
@@ -173,7 +175,7 @@ jobs:
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
           sudo podman run -i --rm --privileged \
             --tmpfs /var/tmp:rw,mode=1777 \
-            -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro \
+            -v `pwd`/kickstart-tests/data/additional_repo:/anaconda-rpms:ro \
             -v `pwd`/kickstart-tests/data/images:/images:z \
             $ISO_BUILD_CONTAINER_NAME:$CONTAINER_TAG
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -77,6 +77,8 @@ CONTAINER_BUILD_ARGS ?= --no-cache
 # HACK: bash's builtin `test -r` fails when running on Ubuntu host (GitHub) due to incompatible seccomp profile
 CONTAINER_TEST_ARGS ?= $(shell grep -q ID=ubuntu /etc/os-release && echo --security-opt=seccomp=unconfined)
 CONTAINER_REGISTRY ?= quay.io
+# Add additional args to the existing ones to container engine
+CONTAINER_ADD_ARGS ?=
 
 # anaconda-ci container
 CI_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-ci
@@ -169,6 +171,7 @@ release-and-tag:
 anaconda-ci-build:
 	$(CONTAINER_ENGINE) build \
 	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
 	--build-arg=git_branch=$(GIT_BRANCH) \
 	--build-arg=image=$(BASE_CONTAINER) \
 	--build-arg=copr_repo=$(COPR_REPO) \
@@ -178,6 +181,7 @@ anaconda-ci-build:
 anaconda-rpm-build:
 	$(CONTAINER_ENGINE) build \
 	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
 	--build-arg=git_branch=$(GIT_BRANCH) \
 	--build-arg=image=$(BASE_CONTAINER) \
 	--build-arg=copr_repo=$(COPR_REPO) \
@@ -187,6 +191,7 @@ anaconda-rpm-build:
 anaconda-iso-creator-build:
 	$(CONTAINER_ENGINE) build \
 	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
 	--build-arg=git_branch=$(GIT_BRANCH) \
 	--build-arg=image=$(BASE_CONTAINER) \
 	-t $(ISO_CREATOR_NAME):$(CI_TAG) \
@@ -195,10 +200,14 @@ anaconda-iso-creator-build:
 # User has to be logged first to be able to push the image.
 # See `podman login` for more info.
 anaconda-ci-push:
-	$(CONTAINER_ENGINE) push $(CI_NAME):$(CI_TAG)
+	$(CONTAINER_ENGINE) push \
+	$(CONTAINER_ADD_ARGS) \
+	$(CI_NAME):$(CI_TAG)
 
 anaconda-rpm-push:
-	$(CONTAINER_ENGINE) push $(RPM_NAME):$(CI_TAG)
+	$(CONTAINER_ENGINE) push \
+	$(CONTAINER_ADD_ARGS) \
+	$(RPM_NAME):$(CI_TAG)
 
 bumpver: po-pull
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \
@@ -250,18 +259,40 @@ ci:
 	fi
 
 container-ci:
-	$(CONTAINER_ENGINE) run --entrypoint /anaconda/dockerfile/anaconda-ci/run-build-and-arg $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) $(CI_NAME):$(CI_TAG) $(CI_CMD)
+	$(CONTAINER_ENGINE) run \
+	--entrypoint /anaconda/dockerfile/anaconda-ci/run-build-and-arg \
+	$(CONTAINER_TEST_ARGS) \
+	$(CI_TEST_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
+	$(CI_NAME):$(CI_TAG) \
+	$(CI_CMD)
 
 container-shell:
-	$(CONTAINER_ENGINE) run -it $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) $(CI_NAME):$(CI_TAG)
+	$(CONTAINER_ENGINE) run -it \
+	$(CONTAINER_TEST_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
+	$(CI_TEST_ARGS) \
+	$(CI_NAME):$(CI_TAG)
 
 container-rpm-test:
-	$(CONTAINER_ENGINE) run $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) -v $(CI_DOCKERFILE)/run-build-and-arg:/run-build-and-arg $(RPM_NAME):$(CI_TAG) sh -exc ' \
+	$(CONTAINER_ENGINE) run \
+	$(CONTAINER_TEST_ARGS) \
+	$(CI_TEST_ARGS) \
+	-v $(CI_DOCKERFILE)/run-build-and-arg:/run-build-and-arg \
+	$(CONTAINER_ADD_ARGS) \
+	$(RPM_NAME):$(CI_TAG) \
+	sh -exc ' \
 	    /run-build-and-arg make run-rpm-tests-only; \
 	    dnf install -y /tmp/anaconda/result/build/01-rpm-build/*.rpm'
 
 container-rpms:
-	$(CONTAINER_ENGINE) run $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) -v $(CI_DOCKERFILE)/run-build-and-arg:/run-build-and-arg $(RPM_NAME):$(CI_TAG) sh -exc ' \
+	$(CONTAINER_ENGINE) run \
+	$(CONTAINER_TEST_ARGS) \
+	$(CI_TEST_ARGS) \
+	-v $(CI_DOCKERFILE)/run-build-and-arg:/run-build-and-arg \
+	$(CONTAINER_ADD_ARGS) \
+	$(RPM_NAME):$(CI_TAG) \
+	sh -exc ' \
 			/run-build-and-arg make rpms && \
 			rm -rf ./result && \
 			cp -rv /tmp/anaconda/result ./'

--- a/Makefile.am
+++ b/Makefile.am
@@ -260,6 +260,12 @@ container-rpm-test:
 	    /run-build-and-arg make run-rpm-tests-only; \
 	    dnf install -y /tmp/anaconda/result/build/01-rpm-build/*.rpm'
 
+container-rpms:
+	$(CONTAINER_ENGINE) run $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) -v $(CI_DOCKERFILE)/run-build-and-arg:/run-build-and-arg $(RPM_NAME):$(CI_TAG) sh -exc ' \
+			/run-build-and-arg make rpms && \
+			rm -rf ./result && \
+			cp -rv /tmp/anaconda/result ./'
+
 check-branching:
 # checking if branching can be finished and all the pieces are in place
 	@echo "===================================="

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,8 @@ uninstall-hook:
 srcdir ?= $(CURDIR)
 
 ARCHIVE_TAG   = $(PACKAGE_NAME)-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE)
+# Set this to "true" if you want to have SRPM archive with test version
+TEST_BUILD	?= "false"
 
 # LOCALIZATION SETTINGS
 L10N_REPOSITORY ?= https://github.com/rhinstaller/anaconda-l10n.git
@@ -144,6 +146,9 @@ po-fallback:
 	-$(MAKE) po-pull
 
 scratch:
+	if [ "$(TEST_BUILD)" == "true" ]; then \
+		sed -ri '/AC_INIT/ s/\[[0-9.]+\]/[999999999]/' $(srcdir)/configure.ac; \
+	fi
 	$(MAKE) ARCHIVE_TAG=HEAD dist
 
 scratch-bumpver:
@@ -296,6 +301,9 @@ container-rpms:
 			/run-build-and-arg make rpms && \
 			rm -rf ./result && \
 			cp -rv /tmp/anaconda/result ./'
+
+container-rpms-scratch:
+	$(MAKE) -f ./Makefile.am CONTAINER_ADD_ARGS="-e TEST_BUILD=true" container-rpms
 
 check-branching:
 # checking if branching can be finished and all the pieces are in place

--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -4,6 +4,7 @@
 #
 # Execution example:
 #
+# make -f ./Makefile.am container-rpms-scratch # Create Anaconda RPM in `pwd`/result/... directory.
 # sudo make -f ./Makefile.am anaconda-iso-creator-build
 #
 # # pre-create loop devices because the container namespacing of /dev devices
@@ -11,7 +12,7 @@
 # sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
 #
 # # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
-# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`:/anaconda:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:master
+# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:master
 #
 # note:
 # - add `--network=slirp4netns` if you need to share network with host computer to reach
@@ -40,8 +41,9 @@ RUN set -ex; \
 
 COPY ["lorax-build", "/"]
 
-RUN mkdir /anaconda
+RUN mkdir /lorax && \
+  mkdir /anaconda-rpms
 
-WORKDIR /anaconda
+WORKDIR /lorax
 
 ENTRYPOINT /lorax-build

--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -1,40 +1,37 @@
 #!/bin/bash
 #
-# Build Anaconda package from the current working directory repository and build a boot.
-# iso by lorax. The boot.iso will be stored in `/images/` directory.
+# Build a boot.iso by lorax. The boot.iso will be stored in the `/images/` directory.
+# We have to build the RPMs files of Anaconda first and then add them as volume
+# mount to /anaconda-rpms to the container (could be RO mount).
+#
+#   make -f ./Makefile.am container-rpms-scratch
 #
 # Input directory:
-# /anaconda (Anaconda repository with RO access)
+# /anaconda-rpms/ (Anaconda RPM files for the build)
 #
 # Output directory:
 # /images (Where the boot.iso will be stored)
 #
 
 set -eux
-# /anaconda from host should be read-only, build in a copy
-cp -a /anaconda/ /tmp/
-cd /tmp/anaconda
 
-# build RPMs and repo for it; bump version so that it's higher than rawhide's
-echo "::group::Build Anaconda RPMs and make a repository"
-sed -ri '/AC_INIT/ s/\[[0-9.]+\]/[999999999]/' configure.ac
-./autogen.sh
-./configure
-make rpms
-createrepo_c result/build/01-rpm-build/
-echo "::endgroup::"
+INPUT_RPMS=/anaconda-rpms/
+REPO_DIR=/tmp/anaconda-rpms/
+
+# create repo from provided Anaconda RPMs
+mkdir -p $REPO_DIR
+cp -a $INPUT_RPMS/* $REPO_DIR
+createrepo_c $REPO_DIR
 
 # build boot.iso with our rpms
-echo "::group::Build boot.iso with the RPMs"
 . /etc/os-release
 # The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; use a mirror
 # The --volid argument can cause different network interface naming: https://github.com/rhinstaller/kickstart-tests/issues/448
 lorax -p Fedora -v $VERSION_ID -r $VERSION_ID \
       --volid Fedora-S-dvd-x86_64-rawh \
       -s http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/ \
-      -s file://$PWD/result/build/01-rpm-build/ \
+      -s file://$REPO_DIR/ \
       $@ \
       lorax
 
 cp lorax/images/boot.iso /images/
-echo "::endgroup::"


### PR DESCRIPTION
We need to have RPMs of Anaconda during the kickstart tests execution to be able to run InitialSetup reboot tests. To achieve that I took the cleanest approach to separate RPM build out of the ISO build where this build will be done in a separate anaconda-rpm container and then the RPMs are used in the anaconda-iso-creator container.

During this I've also added two new Makefile targets and Makefile variable:
- `container-rpms` <- target to build current Anaconda RPM files in the `anaconda-rpm` container
- `container-rpms-scratch` <- target shortcut to `container-rpms` to build Anaconda RPM with increased version
- `CONTAINER_ADD_ARGS` <- Makefile variable to be able to add new parameters to the podman execution. This variable is on purpose empty and should be used mostly by a user if needed. It is also used by `container-rpms-scratch` because it is just a shortcut to another `make` call. 

TODO:
Merge of this change will break KS tests on `rhel-9` and `rhel-8` branch. I have to backport parts of this changes there and ideally merge everything together. When this will be ready for merge (have reviews).
- [x] prepare backport to `rhel-9`
- [x] prepare backport to `rhel-8`