### PR TITLE
Add new configuration options for the DBus module activation

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -7,18 +7,29 @@
 debug = False
 
 # Enable Anaconda addons.
-addons_enabled = True
+# This option is deprecated and will be removed in in the future.
+# addons_enabled = True
 
 # List of enabled Anaconda DBus modules.
-kickstart_modules =
-    org.fedoraproject.Anaconda.Modules.Timezone
-    org.fedoraproject.Anaconda.Modules.Network
-    org.fedoraproject.Anaconda.Modules.Localization
-    org.fedoraproject.Anaconda.Modules.Security
-    org.fedoraproject.Anaconda.Modules.Users
-    org.fedoraproject.Anaconda.Modules.Payloads
-    org.fedoraproject.Anaconda.Modules.Storage
-    org.fedoraproject.Anaconda.Modules.Services
+# This option is deprecated and will be removed in in the future.
+# kickstart_modules =
+
+# List of Anaconda DBus modules that can be activated.
+# Supported patterns: MODULE.PREFIX.*, MODULE.NAME
+activatable_modules =
+    org.fedoraproject.Anaconda.Modules.*
+    org.fedoraproject.Anaconda.Addons.*
+
+# List of Anaconda DBus modules that are not allowed to run.
+# Supported patterns: MODULE.PREFIX.*, MODULE.NAME
+forbidden_modules =
+
+# List of Anaconda DBus modules that can fail to run.
+# The installation won't be aborted because of them.
+# Supported patterns: MODULE.PREFIX.*, MODULE.NAME
+optional_modules =
+    org.fedoraproject.Anaconda.Modules.Subscription
+    org.fedoraproject.Anaconda.Addons.*
 
 
 [Installation System]

--- a/data/profile.d/centos.conf
+++ b/data/profile.d/centos.conf
@@ -10,17 +10,8 @@ base_profile = rhel
 os_id = centos
 
 [Anaconda]
-# List of enabled Anaconda DBus modules for RHEL.
-#  but without org.fedoraproject.Anaconda.Modules.Subscription
-kickstart_modules =
-    org.fedoraproject.Anaconda.Modules.Timezone
-    org.fedoraproject.Anaconda.Modules.Network
-    org.fedoraproject.Anaconda.Modules.Localization
-    org.fedoraproject.Anaconda.Modules.Security
-    org.fedoraproject.Anaconda.Modules.Users
-    org.fedoraproject.Anaconda.Modules.Payloads
-    org.fedoraproject.Anaconda.Modules.Storage
-    org.fedoraproject.Anaconda.Modules.Services
+forbidden_modules =
+    org.fedoraproject.Anaconda.Modules.Subscription
 
 [Bootloader]
 efi_dir = centos

--- a/data/profile.d/fedora-eln.conf
+++ b/data/profile.d/fedora-eln.conf
@@ -10,6 +10,10 @@ base_profile = rhel
 os_id = fedora
 variant_id = eln
 
+[Anaconda]
+forbidden_modules =
+    org.fedoraproject.Anaconda.Modules.Subscription
+
 [Bootloader]
 efi_dir = fedora
 
@@ -24,16 +28,3 @@ default_environment = custom-environment
 default_source = CLOSEST_MIRROR
 default_rpm_gpg_keys =
     /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
-
-[Anaconda]
-# List of enabled Anaconda DBus modules.
-kickstart_modules =
-    org.fedoraproject.Anaconda.Modules.Timezone
-    org.fedoraproject.Anaconda.Modules.Network
-    org.fedoraproject.Anaconda.Modules.Localization
-    org.fedoraproject.Anaconda.Modules.Security
-    org.fedoraproject.Anaconda.Modules.Users
-    org.fedoraproject.Anaconda.Modules.Payloads
-    org.fedoraproject.Anaconda.Modules.Storage
-    org.fedoraproject.Anaconda.Modules.Services
-

--- a/data/profile.d/rhel.conf
+++ b/data/profile.d/rhel.conf
@@ -8,19 +8,6 @@ profile_id = rhel
 # Match os-release values.
 os_id = rhel
 
-[Anaconda]
-# List of enabled Anaconda DBus modules for RHEL.
-kickstart_modules =
-    org.fedoraproject.Anaconda.Modules.Timezone
-    org.fedoraproject.Anaconda.Modules.Network
-    org.fedoraproject.Anaconda.Modules.Localization
-    org.fedoraproject.Anaconda.Modules.Security
-    org.fedoraproject.Anaconda.Modules.Users
-    org.fedoraproject.Anaconda.Modules.Payloads
-    org.fedoraproject.Anaconda.Modules.Storage
-    org.fedoraproject.Anaconda.Modules.Services
-    org.fedoraproject.Anaconda.Modules.Subscription
-
 [Installation System]
 # The detection is disabled since #1645686.
 # can_detect_unsupported_hardware = True

--- a/data/profile.d/scientific-linux.conf
+++ b/data/profile.d/scientific-linux.conf
@@ -8,17 +8,8 @@ base_profile = rhel
 os_id = scientific
 
 [Anaconda]
-# List of enabled Anaconda DBus modules for RHEL.
-#  but without org.fedoraproject.Anaconda.Modules.Subscription
-kickstart_modules =
-    org.fedoraproject.Anaconda.Modules.Timezone
-    org.fedoraproject.Anaconda.Modules.Network
-    org.fedoraproject.Anaconda.Modules.Localization
-    org.fedoraproject.Anaconda.Modules.Security
-    org.fedoraproject.Anaconda.Modules.Users
-    org.fedoraproject.Anaconda.Modules.Payloads
-    org.fedoraproject.Anaconda.Modules.Storage
-    org.fedoraproject.Anaconda.Modules.Services
+forbidden_modules =
+    org.fedoraproject.Anaconda.Modules.Subscription
 
 [Payload]
 default_source = CLOSEST_MIRROR

--- a/docs/release-notes/module_activation.rst
+++ b/docs/release-notes/module_activation.rst
@@ -1,0 +1,21 @@
+:Type: Anaconda configuration options
+:Summary: Add new configuration options for the Anaconda DBus module activation
+
+:Description:
+    We have introduced new configuration options that affect the detection and activation of
+    the Anaconda DBus modules. Use the ``activatable_modules`` option to specify Anaconda DBus
+    modules that can be activated. Use the ``forbidden_modules`` option to specify modules that
+    are not allowed to run. Use the ``optional_modules`` to specify modules that can fail to run
+    without aborting the installation.
+
+    The DBus modules can be specified by a DBus name or by a prefix of the name that ends with
+    an asterisk. For example::
+
+        org.fedoraproject.Anaconda.Modules.Timezone
+        org.fedoraproject.Anaconda.Addons.*
+
+    The ``addons_enabled`` and ``kickstart_modules`` options are deprecated and will be removed
+    in the future.
+
+:Links:
+    - https://github.com/rhinstaller/anaconda/pull/3464

--- a/pyanaconda/core/configuration/base.py
+++ b/pyanaconda/core/configuration/base.py
@@ -145,6 +145,14 @@ class Section(ABC):
         self._section_name = section_name
         self._parser = parser
 
+    def _has_option(self, option_name):
+        """Is the specified option defined?.
+
+        :param option_name: an option name
+        :return: True or False
+        """
+        return self._parser.has_option(self._section_name, option_name)
+
     def _get_option(self, option_name, converter=None):
         """Get a converted value of the option.
 

--- a/pyanaconda/modules/boss/module_manager/module_manager.py
+++ b/pyanaconda/modules/boss/module_manager/module_manager.py
@@ -45,9 +45,10 @@ class ModuleManager(object):
     def start_modules_with_task(self):
         """Start modules with the task."""
         task = StartModulesTask(
-            DBus,
-            conf.anaconda.kickstart_modules,
-            conf.anaconda.addons_enabled
+            message_bus=DBus,
+            activatable=conf.anaconda.activatable_modules,
+            forbidden=conf.anaconda.forbidden_modules,
+            optional=conf.anaconda.optional_modules,
         )
         task.succeeded_signal.connect(
             lambda: self.set_module_observers(task.get_result())

--- a/pyanaconda/modules/boss/module_manager/module_observer.py
+++ b/pyanaconda/modules/boss/module_manager/module_observer.py
@@ -14,9 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from pyanaconda.anaconda_loggers import get_module_logger
-from dasbus.namespace import get_namespace_from_name, get_dbus_path
+from dasbus.namespace import get_namespace_from_name, get_dbus_path, get_dbus_name
 from dasbus.client.observer import DBusObserver, DBusObserverError
+
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.modules.common.constants.namespaces import ADDONS_NAMESPACE
 
 log = get_module_logger(__name__)
 
@@ -24,16 +26,15 @@ log = get_module_logger(__name__)
 class ModuleObserver(DBusObserver):
     """Observer of an Anaconda module."""
 
-    def __init__(self, message_bus, service_name, is_addon=False):
+    def __init__(self, message_bus, service_name):
         """Creates a module observer.
 
         :param message_bus: a message bus
         :param service_name: a DBus name of a service
-        :param is_addon: is the observed module an addon?
         """
         super().__init__(message_bus, service_name)
         self._proxy = None
-        self._is_addon = is_addon
+        self._is_addon = service_name.startswith(get_dbus_name(*ADDONS_NAMESPACE))
         self._namespace = get_namespace_from_name(service_name)
         self._object_path = get_dbus_path(*self._namespace)
 

--- a/pyanaconda/modules/subscription/__main__.py
+++ b/pyanaconda/modules/subscription/__main__.py
@@ -17,9 +17,15 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Initialize the service.
 from pyanaconda.modules.common import init
 init()
 
+# Check the initial conditions.
+from pyanaconda.modules.subscription.initialization import check_initial_conditions
+check_initial_conditions()
+
+# Start the service.
 from pyanaconda.modules.subscription.subscription import SubscriptionService
 service = SubscriptionService()
 service.run()

--- a/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
@@ -24,6 +24,7 @@ from textwrap import dedent
 from unittest.mock import patch
 
 from blivet.size import Size
+from dasbus.namespace import get_dbus_name
 
 from pyanaconda.core.configuration.anaconda import AnacondaConfiguration
 from pyanaconda.core.configuration.base import create_parser, read_config, write_config, \
@@ -31,7 +32,7 @@ from pyanaconda.core.configuration.base import create_parser, read_config, write
     Configuration
 from pyanaconda.core.configuration.storage import StorageSection
 from pyanaconda.core.configuration.ui import UserInterfaceSection
-from pyanaconda.modules.common.constants import services
+from pyanaconda.modules.common.constants import services, namespaces
 from pyanaconda.core.constants import SOURCE_TYPE_CLOSEST_MIRROR
 
 # Path to the configuration directory of the repo.
@@ -194,6 +195,25 @@ class ConfigurationTestCase(unittest.TestCase):
 class AnacondaConfigurationTestCase(unittest.TestCase):
     """Test the Anaconda configuration."""
 
+    # Full names of the Anaconda modules.
+    MODULE_NAMES = set(map(lambda s: s.service_name, (
+        services.TIMEZONE,
+        services.NETWORK,
+        services.LOCALIZATION,
+        services.SECURITY,
+        services.USERS,
+        services.PAYLOADS,
+        services.STORAGE,
+        services.SERVICES,
+        services.SUBSCRIPTION,
+    )))
+
+    # Known namespaces of the Anaconda modules.
+    MODULE_NAMESPACES = set(map(lambda n: get_dbus_name(*n), (
+        namespaces.MODULES_NAMESPACE,
+        namespaces.ADDONS_NAMESPACE,
+    )))
+
     def test_default_configuration(self):
         # Make sure that we are able to import conf.
         from pyanaconda.core.configuration.anaconda import conf
@@ -352,22 +372,115 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
             "profile.d/fedora-workstation.conf"
         ])
 
-    def test_kickstart_modules(self):
+    def _check_pattern(self, pattern):
+        """Check the specified module pattern."""
+        if pattern.endswith(".*"):
+            self.assertIn(pattern[:-2], self.MODULE_NAMESPACES)
+        else:
+            self.assertIn(pattern, self.MODULE_NAMES)
+
+    def test_activatable_modules(self):
+        """Test the activatable_modules option."""
         conf = AnacondaConfiguration.from_defaults()
 
-        self.assertEqual(
-            set(conf.anaconda.kickstart_modules),
-            set(service.service_name for service in (
-                services.TIMEZONE,
-                services.NETWORK,
-                services.LOCALIZATION,
-                services.SECURITY,
-                services.USERS,
-                services.PAYLOADS,
-                services.STORAGE,
-                services.SERVICES
-            ))
-        )
+        for pattern in conf.anaconda.activatable_modules:
+            self._check_pattern(pattern)
+
+    def test_kickstart_modules(self):
+        """Test the kickstart_modules option."""
+        conf = AnacondaConfiguration.from_defaults()
+        self.assertEqual(conf.anaconda.activatable_modules, [
+            "org.fedoraproject.Anaconda.Modules.*",
+            "org.fedoraproject.Anaconda.Addons.*"
+
+        ])
+
+        parser = conf.get_parser()
+        parser.read_string(dedent("""
+
+        [Anaconda]
+        kickstart_modules =
+            org.fedoraproject.Anaconda.Modules.Timezone
+            org.fedoraproject.Anaconda.Modules.Localization
+            org.fedoraproject.Anaconda.Modules.Security
+
+        """))
+
+        self.assertEqual(conf.anaconda.activatable_modules, [
+            "org.fedoraproject.Anaconda.Modules.Timezone",
+            "org.fedoraproject.Anaconda.Modules.Localization",
+            "org.fedoraproject.Anaconda.Modules.Security",
+            "org.fedoraproject.Anaconda.Addons.*"
+        ])
+
+        for pattern in conf.anaconda.activatable_modules:
+            self._check_pattern(pattern)
+
+    def test_forbidden_modules(self):
+        """Test the forbidden_modules option."""
+        conf = AnacondaConfiguration.from_defaults()
+
+        for pattern in conf.anaconda.forbidden_modules:
+            self._check_pattern(pattern)
+
+    def test_addons_enabled_modules(self):
+        """Test the addons_enabled option."""
+        conf = AnacondaConfiguration.from_defaults()
+        self.assertEqual(conf.anaconda.forbidden_modules, [])
+
+        parser = conf.get_parser()
+        parser.read_string(dedent("""
+
+        [Anaconda]
+        forbidden_modules =
+            org.fedoraproject.Anaconda.Modules.Timezone
+            org.fedoraproject.Anaconda.Modules.Localization
+            org.fedoraproject.Anaconda.Modules.Security
+
+        """))
+
+        self.assertEqual(conf.anaconda.forbidden_modules, [
+            "org.fedoraproject.Anaconda.Modules.Timezone",
+            "org.fedoraproject.Anaconda.Modules.Localization",
+            "org.fedoraproject.Anaconda.Modules.Security",
+        ])
+
+        parser.read_string(dedent("""
+
+        [Anaconda]
+        addons_enabled = True
+
+        """))
+
+        self.assertEqual(conf.anaconda.forbidden_modules, [
+            "org.fedoraproject.Anaconda.Modules.Timezone",
+            "org.fedoraproject.Anaconda.Modules.Localization",
+            "org.fedoraproject.Anaconda.Modules.Security",
+        ])
+
+        parser.read_string(dedent("""
+
+        [Anaconda]
+        addons_enabled = False
+
+        """))
+
+        self.assertEqual(conf.anaconda.forbidden_modules, [
+            "org.fedoraproject.Anaconda.Addons.*",
+            "org.fedoraproject.Anaconda.Modules.Timezone",
+            "org.fedoraproject.Anaconda.Modules.Localization",
+            "org.fedoraproject.Anaconda.Modules.Security",
+        ])
+
+        for pattern in conf.anaconda.forbidden_modules:
+            self._check_pattern(pattern)
+
+    def test_optional_modules(self):
+        """Test the optional_modules option."""
+        conf = AnacondaConfiguration.from_defaults()
+
+        for pattern in conf.anaconda.optional_modules:
+            self._check_pattern(pattern)
 
     def test_bootloader(self):
         conf = AnacondaConfiguration.from_defaults()

--- a/tests/unit_tests/pyanaconda_tests/core/test_profile.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_profile.py
@@ -294,32 +294,6 @@ class ProfileConfigurationTestCase(unittest.TestCase):
             ENTERPRISE_PARTITIONING
         )
 
-    def test_profile_module_list_difference_fedora_rhel(self):
-        """Test for expected Fedora & RHEL module list differences."""
-        fedora_config = self._get_config("fedora")
-        fedora_modules = fedora_config.anaconda.kickstart_modules
-
-        rhel_config = self._get_config("rhel")
-        rhel_modules = rhel_config.anaconda.kickstart_modules
-
-        difference = list(set(rhel_modules) - set(fedora_modules))
-        expected_difference = ["org.fedoraproject.Anaconda.Modules.Subscription"]
-
-        self.assertListEqual(difference, expected_difference)
-
-    def test_profile_module_difference_centos_rhel(self):
-        """Test for expected CentOS & RHEL module list differences."""
-        centos_config = self._get_config("centos")
-        centos_modules = centos_config.anaconda.kickstart_modules
-
-        rhel_config = self._get_config("rhel")
-        rhel_modules = rhel_config.anaconda.kickstart_modules
-
-        difference = list(set(rhel_modules) - set(centos_modules))
-        expected_difference = ["org.fedoraproject.Anaconda.Modules.Subscription"]
-
-        self.assertListEqual(difference, expected_difference)
-
     def _compare_profile_files(self, file_name, other_file_name, ignored_sections=()):
         parser = create_parser()
         read_config(parser, os.path.join(PROFILE_DIR, file_name))

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_modules.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_modules.py
@@ -32,6 +32,18 @@ class ModuleManagerTestCase(unittest.TestCase):
     def setUp(self):
         self._manager = ModuleManager()
         self._message_bus = Mock()
+        self._message_bus.proxy.ListActivatableNames.return_value = [
+            "org.fedoraproject.Anaconda.Boss",
+            "org.fedoraproject.Anaconda.Addons.A",
+            "org.fedoraproject.Anaconda.Addons.B",
+            "org.fedoraproject.Anaconda.Addons.C",
+            "org.fedoraproject.Anaconda.Modules.A",
+            "org.fedoraproject.Anaconda.Modules.B",
+            "org.fedoraproject.Anaconda.Modules.C",
+            "org.fedoraproject.InitialSetup.Modules.A",
+            "org.fedoraproject.InitialSetup.Modules.B",
+            "org.fedoraproject.InitialSetup.Modules.C",
+        ]
 
     def _check_started_modules(self, task, service_names):
         """Check the started modules."""
@@ -53,7 +65,7 @@ class ModuleManagerTestCase(unittest.TestCase):
 
     def test_start_no_modules(self):
         """Start no modules."""
-        task = StartModulesTask(self._message_bus, [], addons_enabled=False)
+        task = StartModulesTask(self._message_bus, [], [], [])
         self._check_started_modules(task, [])
 
     @patch("dasbus.client.observer.Gio")
@@ -62,8 +74,7 @@ class ModuleManagerTestCase(unittest.TestCase):
         service_names = [
             "org.fedoraproject.Anaconda.Modules.A"
         ]
-
-        task = StartModulesTask(self._message_bus, service_names, addons_enabled=False)
+        task = StartModulesTask(self._message_bus, service_names, [], [])
         (observer, ) = self._check_started_modules(task, service_names)  # pylint: disable=unbalanced-tuple-unpacking
 
         bus_proxy = self._message_bus.proxy
@@ -86,26 +97,57 @@ class ModuleManagerTestCase(unittest.TestCase):
             "org.fedoraproject.Anaconda.Modules.C",
         ]
 
-        task = StartModulesTask(self._message_bus, service_names, addons_enabled=False)
-        self._check_started_modules(task, service_names)
+        task = StartModulesTask(self._message_bus, service_names, [], [])
+        observers = self._check_started_modules(task, service_names)
+
+        for observer in observers:
+            self.assertEqual(observer.is_addon, False)
 
     @patch("dasbus.client.observer.Gio")
     def test_start_addons(self, gio):
         """Start addons."""
+        service_namespaces = [
+            "org.fedoraproject.Anaconda.Addons.*"
+        ]
         service_names = [
             "org.fedoraproject.Anaconda.Addons.A",
             "org.fedoraproject.Anaconda.Addons.B",
             "org.fedoraproject.Anaconda.Addons.C"
         ]
 
-        bus_proxy = self._message_bus.proxy
-        bus_proxy.ListActivatableNames.return_value = [
-            *service_names,
-            "org.fedoraproject.Anaconda.D",
-            "org.fedoraproject.E",
+        task = StartModulesTask(self._message_bus, service_namespaces, [], [])
+        observers = self._check_started_modules(task, service_names)
+
+        for observer in observers:
+            self.assertEqual(observer.is_addon, True)
+
+    @patch("dasbus.client.observer.Gio")
+    def test_start_modules_forbidden(self, gio):
+        """Try to start forbidden modules."""
+        service_namespaces = [
+            "org.fedoraproject.Anaconda.Modules.*",
+            "org.fedoraproject.Anaconda.Addons.*",
+            "org.fedoraproject.InitialSetup.Modules.*",
+        ]
+        forbidden_names = [
+            "org.fedoraproject.Anaconda.Modules.B",
+            "org.fedoraproject.Anaconda.Addons.C",
+            "org.fedoraproject.InitialSetup.*",
+        ]
+        service_names = [
+            "org.fedoraproject.Anaconda.Addons.A",
+            "org.fedoraproject.Anaconda.Addons.B",
+            "org.fedoraproject.Anaconda.Modules.A",
+            "org.fedoraproject.Anaconda.Modules.C",
         ]
 
-        task = StartModulesTask(self._message_bus, [], addons_enabled=True)
+        task = StartModulesTask(
+            message_bus=self._message_bus,
+            activatable=service_namespaces,
+            forbidden=forbidden_names,
+            optional=[]
+        )
+
         self._check_started_modules(task, service_names)
 
     def test_start_module_failed(self):
@@ -116,7 +158,7 @@ class ModuleManagerTestCase(unittest.TestCase):
             "org.fedoraproject.Anaconda.Modules.C",
         ]
 
-        task = StartModulesTask(self._message_bus, service_names, addons_enabled=False)
+        task = StartModulesTask(self._message_bus, service_names, [], [])
 
         def call():
             raise DBusError("Fake error!")
@@ -136,20 +178,21 @@ class ModuleManagerTestCase(unittest.TestCase):
     @patch("dasbus.client.observer.Gio")
     def test_start_addon_failed(self, gio):
         """Fail to start an add-on."""
+        service_namespaces = [
+            "org.fedoraproject.Anaconda.Addons.*"
+        ]
         service_names = [
             "org.fedoraproject.Anaconda.Addons.A",
             "org.fedoraproject.Anaconda.Addons.B",
             "org.fedoraproject.Anaconda.Addons.C"
         ]
 
-        bus_proxy = self._message_bus.proxy
-        bus_proxy.ListActivatableNames.return_value = [
-            *service_names,
-            "org.fedoraproject.Anaconda.D",
-            "org.fedoraproject.E",
-        ]
-
-        task = StartModulesTask(self._message_bus, [], addons_enabled=True)
+        task = StartModulesTask(
+            message_bus=self._message_bus,
+            activatable=service_namespaces,
+            optional=service_namespaces,
+            forbidden=[]
+        )
         self._check_started_modules(task, service_names)
 
         def call():
@@ -173,7 +216,7 @@ class ModuleManagerTestCase(unittest.TestCase):
             "org.fedoraproject.Anaconda.Modules.C",
         ]
 
-        task = StartModulesTask(self._message_bus, service_names, addons_enabled=False)
+        task = StartModulesTask(self._message_bus, service_names, [], [])
         observers = self._check_started_modules(task, service_names)
 
         self._manager.set_module_observers(observers)


### PR DESCRIPTION
Use the `activatable_modules` option to specify Anaconda DBus modules that can be
activated. Use the `forbidden_modules` option to specify modules that are not
allowed to run. Use the `optional_modules` to specify modules that can fail to
run without aborting the installation.

The `addons_enabled` and `kickstart_modules` options are deprecated and will be
removed in the future.

Don't start the Subscription module if the initial conditions are not met.

**TODO:**
- [x] Add release notes.
- [x] Test with `livemedia-creator --no-virt`.
- [x] Test with addons.
- [x] Test with `initial-setup`.
- [x] Test with RHEL.

Related: rhbz#1957063