### PR TITLE
Fix name of the infra check workflow task (#infra)

### DIFF
--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -27,7 +27,7 @@ jobs:
           git log --oneline -1 origin/${{ github.event.pull_request.base.ref }}
           git rebase origin/${{ github.event.pull_request.base.ref }}
 
-      - name: Get list of changed files
+      - name: Check if all changed files are infra related
         run: |
           changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}..HEAD)
           # print for debugging


### PR DESCRIPTION
The original name doesn't tell what is the check doing.