### PR TITLE
Change the makeupdates path on master to python3.10

### DIFF
--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -33,7 +33,7 @@ RPM_FOLDER_NAME = os.path.expanduser("~/.anaconda_updates_rpm_cache")
 RPM_RELEASE_DIR_TEMPLATE = "for_%s"
 
 # The Python site-packages path for pyanaconda.
-SITE_PACKAGES_PATH = "./usr/lib64/python3.9/site-packages/"
+SITE_PACKAGES_PATH = "./usr/lib64/python3.10/site-packages/"
 
 # Anaconda scripts that should be installed into the libexec folder
 LIBEXEC_SCRIPTS = ["log-capture", "start-module", "apply-updates"]


### PR DESCRIPTION
Rawhide is on Python 3.10 now, so this is needed to make updates
images actually do anything on Rawhide ISOs.

Signed-off-by: Adam Williamson <awilliam@redhat.com>