### PR TITLE
Fix time setting for daylight savings, let Python do the work

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -43,7 +43,8 @@ RUN pip install --no-cache-dir \
   coverage \
   pycodestyle \
   dogtail \
-  rpmfluff
+  rpmfluff \
+  freezegun
 
 RUN mkdir /anaconda
 

--- a/pyanaconda/isys/__init__.py
+++ b/pyanaconda/isys/__init__.py
@@ -105,14 +105,7 @@ def set_system_date_time(year=None, month=None, day=None, hour=None, minute=None
     second = second if second is not None else now.second
 
     set_date = datetime.datetime(year, month, day, hour, minute, second, tzinfo=tz)
-
-    # Calculate the number of seconds between this time and timestamp 0
-    # pylint bug here: https://github.com/PyCQA/pylint/issues/1104
-    # pylint: disable=no-value-for-parameter
-    epoch = datetime.datetime.fromtimestamp(0, tz=utc).astimezone(tz)
-    timestamp = (set_date - epoch).total_seconds()
-
-    set_system_time(int(timestamp))
+    set_system_time(int(set_date.timestamp()))
 
 
 def total_memory():


### PR DESCRIPTION
Since the port from pytz to zoneinfo in #3167, anaconda has set
the system clock one hour too fast when installing for a timezone
that does daylight savings time, during daylight savings time.

There turns out to be a lot of history behind this calculation,
see https://bugzilla.redhat.com/show_bug.cgi?id=1965718#c4 for
details.

It turns out that since Python 3.3, datetime objects have the
`timestamp()` method, which does exactly what we want here. In
my tests it gives the correct answer in every problematic case,
including the one I found was broken in current code, and the
Kolkata and Aden timezones mentioned in
https://bugzilla.redhat.com/show_bug.cgi?id=1293314 . So I think
we should just use that.

Resolves: rhbz#1965718