### PR TITLE
Update the pixel depth of xvnc server from 16 to 24

### DIFF
--- a/pyanaconda/vnc.py
+++ b/pyanaconda/vnc.py
@@ -241,7 +241,7 @@ class VncServer(object):
 
         # Lets start the xvnc.
         xvnccommand = [XVNC_BINARY_NAME, ":%s" % constants.X_DISPLAY_NUMBER,
-                       "-depth", "16", "-br",
+                       "-depth", "24", "-br",
                        "IdleTimeout=0", "-auth", "/dev/null", "-once",
                        "DisconnectClients=false", "desktop=%s" % (self.desktop,),
                        "SecurityTypes=%s" % SecurityTypes, "rfbauth=%s" % rfbauth]


### PR DESCRIPTION
Resolves rhbz#1973607

24 bits is the value recommended for RHEL 7+ whith GNOME.

Value of 16 bits is causing artifacts with gnome-kiosk in installer on
z15.