### PR TITLE
Remove unused repositories from iso build (#infra)

### DIFF
--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -34,8 +34,6 @@ lorax -p RHEL -v $MAJOR_VERSION -r $MINOR_VERSION --volid RHEL-$MAJOR_VERSION-$M
       --nomacboot \
       -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/BaseOS/x86_64/os/ \
       -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/AppStream/x86_64/os/ \
-      -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/CRB/x86_64/os/ \
-      -s http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9-Beta/latest-BUILDROOT-9/compose/Buildroot/x86_64/os/ \
       -s file://$PWD/result/build/01-rpm-build/ \
       $@ \
       lorax


### PR DESCRIPTION
The BUILDROOT repository was required by metacity, however, Lorax does not require metacity anymore.

Anaconda does not require metacity but the BUILDROOT repository is still required for other dependencies.

CRB repository wasn't required by Lorax even before. It's only for Anaconda build.