### PR TITLE
Revert "ovirt / rhv: drop swap partition"

### DIFF
--- a/data/product.d/ovirt.conf
+++ b/data/product.d/ovirt.conf
@@ -16,6 +16,7 @@ default_partitioning =
     /var/crash     (size 10 GiB)
     /var/log       (size 8 GiB)
     /var/log/audit (size 2 GiB)
+    swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP
@@ -23,7 +24,6 @@ must_not_be_on_root = /var
 req_partition_sizes =
     /var   10 GiB
     /boot  1  GiB
-swap_is_recommended = False
 
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhel

--- a/data/product.d/rhvh.conf
+++ b/data/product.d/rhvh.conf
@@ -27,6 +27,7 @@ default_partitioning =
     /var/crash     (size 10 GiB)
     /var/log       (size 8 GiB)
     /var/log/audit (size 2 GiB)
+    swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP
@@ -34,7 +35,6 @@ must_not_be_on_root = /var
 req_partition_sizes =
     /var   10 GiB
     /boot  1  GiB
-swap_is_recommended = False
 
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhel

--- a/tests/unit_tests/pyanaconda_tests/test_product.py
+++ b/tests/unit_tests/pyanaconda_tests/test_product.py
@@ -154,6 +154,11 @@ VIRTUALIZATION_PARTITIONING = [
         lv=True,
         thin=True,
         encrypted=True,
+    ),
+    PartSpec(
+        fstype="swap",
+        lv=True,
+        encrypted=True,
     )
 ]
 


### PR DESCRIPTION
This reverts commit b894cd114a54bc3acbbdf2d6eab619644e685888.

It was decided that it's better to have swap partition after all.

RHBZ#1976005

Signed-off-by: Lev Veyde <lveyde@redhat.com>