### PR TITLE
Remove autostep functionality

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -264,7 +264,6 @@ TAR_SUFFIX = (".tar", ".tbz", ".tgz", ".txz", ".tar.bz2", "tar.gz", "tar.xz")
 
 # screenshots
 SCREENSHOTS_DIRECTORY = "/tmp/anaconda-screenshots"
-SCREENSHOTS_TARGET_DIRECTORY = "/root/anaconda-screenshots"
 
 CMDLINE_FILES = [
     "/proc/cmdline",

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -25,7 +25,6 @@ import subprocess
 import unicodedata
 # Used for ascii_lowercase, ascii_uppercase constants
 import string  # pylint: disable=deprecated-module
-import shutil
 import tempfile
 import re
 import gettext
@@ -46,7 +45,6 @@ from pyanaconda.core.process_watchers import WatchProcesses
 from pyanaconda.core.constants import DRACUT_SHUTDOWN_EJECT, TRANSLATIONS_UPDATE_DIR, \
     IPMI_ABORTED, X_TIMEOUT, TAINT_HARDWARE_UNSUPPORTED, TAINT_SUPPORT_REMOVED, \
     WARNING_HARDWARE_UNSUPPORTED, WARNING_SUPPORT_REMOVED
-from pyanaconda.core.constants import SCREENSHOTS_DIRECTORY, SCREENSHOTS_TARGET_DIRECTORY
 from pyanaconda.errors import RemovedModuleError
 
 from pyanaconda.anaconda_logging import program_log_lock
@@ -1217,24 +1215,6 @@ def join_paths(path, *paths):
         new_paths.append(p.lstrip(os.path.sep))
 
     return os.path.join(path, *new_paths)
-
-
-def save_screenshots():
-    """Save screenshots to the installed system"""
-    if not os.path.exists(SCREENSHOTS_DIRECTORY):
-        # there are no screenshots to copy
-        return
-    target_path = sysroot_path(SCREENSHOTS_TARGET_DIRECTORY)
-    log.info("saving screenshots taken during the installation to: %s", target_path)
-    try:
-        # create the screenshots directory
-        mkdirChain(target_path)
-        # copy all screenshots
-        for filename in os.listdir(SCREENSHOTS_DIRECTORY):
-            shutil.copy(os.path.join(SCREENSHOTS_DIRECTORY, filename), target_path)
-
-    except OSError:
-        log.exception("saving screenshots to installed system failed")
 
 
 def touch(file_path):

--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -57,7 +57,6 @@ class Hub(GUIObject, common.Hub):
           :parts: 3
     """
 
-    handles_autostep = True
     _hubs_collection = []
 
     # Should we automatically go to next hub if processing is done and there are no
@@ -107,9 +106,6 @@ class Hub(GUIObject, common.Hub):
         # The checker itself is left alone so the error message doesn't accidentally get
         # cleaered.
         self._checker_ignore = False
-
-        self._spokesToStepIn = []
-        self._spokeAutostepIndex = 0
 
         self._gridColumns = 3
 
@@ -414,11 +410,10 @@ class Hub(GUIObject, common.Hub):
         if not self._inSpoke:
             return
 
-        # don't apply any actions if the spoke was visited automatically
-        if spoke.automaticEntry:
-            spoke.automaticEntry = False
-            return
+        spoke.visitedSinceApplied = True
 
+        # Don't take visitedSinceApplied into account here.  It will always be
+        # True from the line above.
         if spoke.changed and (not spoke.skipTo or (spoke.skipTo and spoke.applyOnSkip)):
             spoke.apply()
             spoke.execute()
@@ -446,49 +441,3 @@ class Hub(GUIObject, common.Hub):
         # Otherwise, switch back to the hub (that's us!)
         else:
             self.main_window.returnToHub()
-
-    def _doAutostep(self):
-        """Autostep through all spokes managed by this hub"""
-        log.info("autostepping through all spokes on hub %s", self.__class__.__name__)
-
-        # create a list of all spokes in reverse alphabetic order, we will pop() from it when
-        # processing all the spokes so the screenshots will actually be in alphabetic order
-        self._spokesToStepIn = list(reversed(sorted(self._spokes.values(), key=lambda x: x.__class__.__name__)))
-
-        # we can't just loop over all the spokes due to the asynchronous nature of GtkStack, so we start by
-        # autostepping to the first spoke, this will trigger a callback that steps to the next spoke,
-        # until we run out of unvisited spokes
-        self._autostepSpoke()
-
-    def _autostepSpoke(self):
-        """Process a single spoke, if no more spokes are available report autostep as finished for the hub."""
-        # do we have some spokes to work on ?
-        if self._spokesToStepIn:
-            # take one of them
-            spoke = self._spokesToStepIn.pop()
-
-            # increment the number of processed spokes
-            self._spokeAutostepIndex += 1
-
-            log.debug("stepping to spoke %s (%d/%d)", spoke.__class__.__name__, self._spokeAutostepIndex, len(self._spokes))
-
-            # notify the spoke about the upcoming automatic entry and set a callback that will be called
-            # once the spoke has been successfully processed
-            spoke.automaticEntry = True
-            spoke.autostepDoneCallback = lambda x: self._autostepSpoke()
-
-            # if this is the last spoke, tell it to return to hub once processed
-            if self._spokesToStepIn == []:
-                spoke.lastAutostepSpoke = True
-            gtk_call_once(self._on_spoke_clicked, None, None, spoke)
-        else:
-            log.info("autostep for hub %s finished", self.__class__.__name__)
-            gtk_call_once(self._doPostAutostep)
-
-    def _doPostAutostep(self):
-        if self._spokesToStepIn:
-            # there are still spokes that need to be stepped in
-            return
-        # we are done, re-emit the continue clicked signal we "consumed" previously
-        # so that the Anaconda GUI can switch to the next screen (or quit)
-        self.window.emit("continue-clicked")

--- a/pyanaconda/ui/gui/spokes/__init__.py
+++ b/pyanaconda/ui/gui/spokes/__init__.py
@@ -18,7 +18,6 @@
 
 from pyanaconda.ui import common
 from pyanaconda.ui.gui import GUIObject
-from pyanaconda.ui.gui.utils import gtk_call_once
 from pyanaconda.ui.lib.help import start_yelp
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -35,8 +34,6 @@ class StandaloneSpoke(GUIObject, common.StandaloneSpoke):
           :parts: 3
     """
 
-    handles_autostep = True
-
     def __init__(self, data, storage, payload):
         GUIObject.__init__(self, data)
         common.StandaloneSpoke.__init__(self, storage, payload)
@@ -46,11 +43,6 @@ class StandaloneSpoke(GUIObject, common.StandaloneSpoke):
 
     def _on_continue_clicked(self, window, user_data=None):
         self.apply()
-
-    def _doPostAutostep(self):
-        # we are done, re-emit the continue clicked signal we "consumed" previously
-        # so that the Anaconda GUI can switch to the next screen
-        gtk_call_once(self.window.emit, "continue-clicked")
 
 
 # Inherit abstract methods from common.NormalSpoke

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -324,9 +324,8 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
     # Override the default in StandaloneSpoke so we can display the beta
     # warning dialog first.
     def _on_continue_clicked(self, window, user_data=None):
-        # Don't display the betanag dialog if this is the final release or
-        # when autostep has been requested as betanag breaks the autostep logic.
-        if not isFinal and not self.data.autostep.seen:
+        # Don't display the betanag dialog if this is the final release.
+        if not isFinal:
             dlg = self.builder.get_object("betaWarnDialog")
             with self.main_window.enlightbox(dlg):
                 rc = dlg.run()


### PR DESCRIPTION
Port of #2978

---

Autostep did not work for some time already, this merely removes the no longer
used code. Automatic screenshots are gone with this, too. Manual screenshots
remain available.

Resolves: [rhbz#1976913](https://bugzilla.redhat.com/show_bug.cgi?id=1976913)

(cherry picked from commit 8a2645135cbb21151372369c8fb95e1d45f0b538)