### PR TITLE
Use a custom stylesheet to define CentOS-specific stylesheet data

### DIFF
--- a/data/product.d/centos-stream.conf
+++ b/data/product.d/centos-stream.conf
@@ -29,6 +29,8 @@ default_help_pages =
     centos_help_placeholder.xml
     centos_help_placeholder.xml
 
+custom_stylesheet = /usr/share/anaconda/pixmaps/redhat.css
+
 [Payload]
 enable_closest_mirror = True
 default_source = CLOSEST_MIRROR


### PR DESCRIPTION
This is a backport of #3179 to the rhel-8 branch.  CentOS is trying to take advantage of a custom stylesheet in centos-logos (see [rhbz#1974149](https://bugzilla.redhat.com/show_bug.cgi?id=1974149) and https://github.com/CentOS/centos-logos/issues/2).  It's not working and if I understand things correctly this is the change we need to enable it.