### PR TITLE
Rhel 9 fix centos stream repo name

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -57,7 +57,8 @@ BASE_REPO_NAME = "anaconda"
 DEFAULT_REPOS = [productName.split('-')[0].lower(),
                  "fedora-modular-server",
                  "rawhide",
-                 "BaseOS"]
+                 "BaseOS",  # Used by RHEL
+                 "baseos"]  # Used by CentOS Stream
 
 DBUS_ANACONDA_SESSION_ADDRESS = "DBUS_ANACONDA_SESSION_BUS_ADDRESS"
 


### PR DESCRIPTION
CentOS Stream renamed the repository to make everything consistent. For that we have to keep old repository name for RHEL but also we need the new one for CentOS Stream.

Resolves: rhbz#1955331

Backport of https://github.com/rhinstaller/anaconda/pull/3314