### PR TITLE
Rhel 8 backport ks test split from the rpm build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -261,6 +261,12 @@ container-rpm-test:
 		/run-build-and-arg make run-rpm-tests-only; \
 		dnf install -y /tmp/anaconda/result/build/01-rpm-build/*.rpm'
 
+container-rpms:
+	$(CONTAINER_ENGINE) run $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) -v $(CI_DOCKERFILE)/run-build-and-arg:/run-build-and-arg $(RPM_NAME):$(CI_TAG) sh -exc ' \
+			/run-build-and-arg make rpms && \
+			rm -rf ./result && \
+			cp -rv /tmp/anaconda/result ./'
+
 check-branching:
 # checking if branching can be finished and all the pieces are in place
 	@echo "===================================="

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,6 +84,8 @@ CONTAINER_ENGINE ?= podman
 CONTAINER_BUILD_ARGS ?= --no-cache
 CONTAINER_TEST_ARGS ?=
 CONTAINER_REGISTRY ?= quay.io
+# Add additional args to the existing ones to container engine
+CONTAINER_ADD_ARGS ?=
 
 # anaconda-ci container
 CI_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-ci
@@ -181,14 +183,23 @@ release-and-tag:
 	$(MAKE) tag
 
 anaconda-ci-build:
-	$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_ARGS) -t $(CI_NAME):$(CI_TAG) $(CI_DOCKERFILE)
+	$(CONTAINER_ENGINE) build \
+	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
+	-t $(CI_NAME):$(CI_TAG) \
+	$(CI_DOCKERFILE)
 
 anaconda-rpm-build:
-	$(CONTAINER_ENGINE) build $(CONTAINER_BUILD_ARGS) -t $(RPM_NAME):$(CI_TAG) $(RPM_DOCKERFILE)
+	$(CONTAINER_ENGINE) build \
+	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
+	-t $(RPM_NAME):$(CI_TAG) \
+	$(RPM_DOCKERFILE)
 
 anaconda-iso-creator-build:
 	$(CONTAINER_ENGINE) build \
 	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
 	--build-arg=git_branch=$(GIT_BRANCH) \
 	--build-arg=image=registry.access.redhat.com/ubi8:latest \
 	-t $(ISO_CREATOR_NAME):$(CI_TAG) \
@@ -251,18 +262,40 @@ ci:
 	fi
 
 container-ci:
-	$(CONTAINER_ENGINE) run --entrypoint /anaconda/dockerfile/anaconda-ci/run-build-and-arg $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) $(CI_NAME):$(CI_TAG) $(CI_CMD)
+	$(CONTAINER_ENGINE) run \
+	--entrypoint /anaconda/dockerfile/anaconda-ci/run-build-and-arg \
+	$(CONTAINER_TEST_ARGS) \
+	$(CI_TEST_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
+	$(CI_NAME):$(CI_TAG) \
+	$(CI_CMD)
 
 container-shell:
-	$(CONTAINER_ENGINE) run -it $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) $(CI_NAME):$(CI_TAG)
+	$(CONTAINER_ENGINE) run -it \
+	$(CONTAINER_TEST_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
+	$(CI_TEST_ARGS) \
+	$(CI_NAME):$(CI_TAG)
 
 container-rpm-test:
-	$(CONTAINER_ENGINE) run -it $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) -v $(CI_DOCKERFILE)/run-build-and-arg:/run-build-and-arg $(RPM_NAME):$(CI_TAG) sh -exc ' \
-		/run-build-and-arg make run-rpm-tests-only; \
-		dnf install -y /tmp/anaconda/result/build/01-rpm-build/*.rpm'
+	$(CONTAINER_ENGINE) run -it \
+	$(CONTAINER_TEST_ARGS) \
+	$(CI_TEST_ARGS) \
+	-v $(CI_DOCKERFILE)/run-build-and-arg:/run-build-and-arg \
+	$(CONTAINER_ADD_ARGS) \
+	$(RPM_NAME):$(CI_TAG) \
+	sh -exc ' \
+	    /run-build-and-arg make run-rpm-tests-only; \
+	    dnf install -y /tmp/anaconda/result/build/01-rpm-build/*.rpm'
 
 container-rpms:
-	$(CONTAINER_ENGINE) run $(CONTAINER_TEST_ARGS) $(CI_TEST_ARGS) -v $(CI_DOCKERFILE)/run-build-and-arg:/run-build-and-arg $(RPM_NAME):$(CI_TAG) sh -exc ' \
+	$(CONTAINER_ENGINE) run \
+	$(CONTAINER_TEST_ARGS) \
+	$(CI_TEST_ARGS) \
+	-v $(CI_DOCKERFILE)/run-build-and-arg:/run-build-and-arg \
+	$(CONTAINER_ADD_ARGS) \
+	$(RPM_NAME):$(CI_TAG) \
+	sh -exc ' \
 			/run-build-and-arg make rpms && \
 			rm -rf ./result && \
 			cp -rv /tmp/anaconda/result ./'

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,8 @@ uninstall-hook:
 srcdir ?= $(CURDIR)
 
 ARCHIVE_TAG   = $(PACKAGE_NAME)-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE)
+# Set this to "true" if you want to have SRPM archive with test version
+TEST_BUILD	?= "false"
 
 # LOCALIZATION SETTINGS
 L10N_REPOSITORY ?= https://github.com/rhinstaller/anaconda-l10n.git
@@ -158,6 +160,9 @@ po-fallback:
 	-$(MAKE) po-pull
 
 scratch:
+	if [ "$(TEST_BUILD)" == "true" ]; then \
+		sed -ri '/AC_INIT/ s/\[[0-9.]+\]/[999999999]/' $(srcdir)/configure.ac; \
+	fi
 	$(MAKE) ARCHIVE_TAG=HEAD dist
 
 scratch-bumpver:
@@ -299,6 +304,9 @@ container-rpms:
 			/run-build-and-arg make rpms && \
 			rm -rf ./result && \
 			cp -rv /tmp/anaconda/result ./'
+
+container-rpms-scratch:
+	$(MAKE) -f ./Makefile.am CONTAINER_ADD_ARGS="-e TEST_BUILD=true" container-rpms
 
 check-branching:
 # checking if branching can be finished and all the pieces are in place

--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -4,6 +4,7 @@
 #
 # Execution example:
 #
+# make -f ./Makefile.am container-rpms-scratch # Create Anaconda RPM in `pwd`/result/... directory.
 # sudo make -f ./Makefile.am anaconda-iso-creator-build
 #
 # # pre-create loop devices because the container namespacing of /dev devices
@@ -11,7 +12,7 @@
 # sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
 #
 # # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
-# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`:/anaconda:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:rhel-8
+# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:rhel-8
 #
 # note:
 # - add `--network=slirp4netns` if you need to share network with host computer to reach
@@ -44,8 +45,9 @@ RUN set -ex; \
 
 COPY ["lorax-build", "/"]
 
-RUN mkdir /anaconda
+RUN mkdir /lorax && \
+  mkdir /anaconda-rpms
 
-WORKDIR /anaconda
+WORKDIR /lorax
 
 ENTRYPOINT /lorax-build

--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -1,31 +1,29 @@
 #!/bin/bash
 #
-# Build Anaconda package from the current working directory repository and build a boot.
-# iso by lorax. The boot.iso will be stored in `/images/` directory.
+# Build a boot.iso by lorax. The boot.iso will be stored in the `/images/` directory.
+# We have to build the RPMs files of Anaconda first and then add them as volume
+# mount to /anaconda-rpms to the container (could be RO mount).
+#
+#   make -f ./Makefile.am container-rpms-scratch
 #
 # Input directory:
-# /anaconda (Anaconda repository with RO access)
+# /anaconda-rpms/ (Anaconda RPM files for the build)
 #
 # Output directory:
 # /images (Where the boot.iso will be stored)
 #
 
 set -eux
-# /anaconda from host should be read-only, build in a copy
-cp -a /anaconda/ /tmp/
-cd /tmp/anaconda
 
-# build RPMs and repo for it; bump version so that it's higher than rawhide's
-echo "::group::Build Anaconda RPMs and make a repository"
-sed -ri '/AC_INIT/ s/\[[0-9.]+\]/[999999999]/' configure.ac
-./autogen.sh
-./configure
-make rpms
-createrepo_c result/build/01-rpm-build/
-echo "::endgroup::"
+INPUT_RPMS=/anaconda-rpms/
+REPO_DIR=/tmp/anaconda-rpms/
+
+# create repo from provided Anaconda RPMs
+mkdir -p $REPO_DIR
+cp -a $INPUT_RPMS/* $REPO_DIR
+createrepo_c $REPO_DIR
 
 # build boot.iso with our rpms
-echo "::group::Build boot.iso with the RPMs"
 . /etc/os-release
 MAJOR_VERSION=${VERSION_ID%%.*}
 MINOR_VERSION=${VERSION_ID#*.}
@@ -33,11 +31,10 @@ MINOR_VERSION=${VERSION_ID#*.}
 lorax -p RHEL -v $MAJOR_VERSION -r $MINOR_VERSION --volid RHEL-$MAJOR_VERSION-$MINOR_VERSION-0-BaseOS-x86_64 \
       --nomacboot \
       -s http://download.devel.redhat.com/nightly/rhel-8/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/ \
-          -s http://download.devel.redhat.com/nightly/rhel-8/RHEL-8/latest-RHEL-8/compose/AppStream/x86_64/os/ \
-          -s http://download.devel.redhat.com/nightly/rhel-8/RHEL-8/latest-RHEL-8/compose/CRB/x86_64/os/ \
-      -s file://$PWD/result/build/01-rpm-build/ \
+      -s http://download.devel.redhat.com/nightly/rhel-8/RHEL-8/latest-RHEL-8/compose/AppStream/x86_64/os/ \
+      -s http://download.devel.redhat.com/nightly/rhel-8/RHEL-8/latest-RHEL-8/compose/CRB/x86_64/os/ \
+      -s file://$REPO_DIR/ \
       $@ \
       lorax
 
 cp lorax/images/boot.iso /images/
-echo "::endgroup::"


### PR DESCRIPTION
Backport parts of #3460 to enable support for running kickstart tests installation with new RPM files.