### PR TITLE
Disable NM autoconnections in Anaconda

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -338,6 +338,7 @@ desktop-file-install --dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_d
 %{_prefix}/lib/systemd/system-generators/*
 %{_bindir}/instperf
 %{_bindir}/anaconda-disable-nm-ibft-plugin
+%{_bindir}/anaconda-nm-disable-autocons
 %{_sbindir}/anaconda
 %{_sbindir}/handle-sshpw
 %{_datadir}/anaconda

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -27,6 +27,7 @@ dist_systemd_DATA = anaconda.service \
                     instperf.service \
                     anaconda-sshd.service \
                     anaconda-nm-config.service \
+                    anaconda-nm-disable-autocons.service \
                     anaconda-pre.service \
                     anaconda-fips.service
 

--- a/data/systemd/anaconda-generator
+++ b/data/systemd/anaconda-generator
@@ -41,4 +41,5 @@ for tty in hvc0 hvc1 xvc0 hvsi0 hvsi1 hvsi2; do
 done
 
 ln -sf $systemd_dir/anaconda-nm-config.service $target_dir/anaconda-nm-config.service
+ln -sf $systemd_dir/anaconda-nm-disable-autocons.service $target_dir/anaconda-nm-disable-autocons.service
 ln -sf $systemd_dir/anaconda-pre.service $target_dir/anaconda-pre.service

--- a/data/systemd/anaconda-nm-disable-autocons.service
+++ b/data/systemd/anaconda-nm-disable-autocons.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=NetworkManager autoconnections configuration for Anaconda installation environment
+Before=NetworkManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/anaconda-nm-disable-autocons
+

--- a/data/systemd/anaconda-nm-disable-autocons.service
+++ b/data/systemd/anaconda-nm-disable-autocons.service
@@ -1,4 +1,6 @@
 [Unit]
+ConditionKernelCommandLine=|ip
+ConditionKernelCommandLine=|inst.ks
 Description=NetworkManager autoconnections configuration for Anaconda installation environment
 Before=NetworkManager.service
 

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -21,7 +21,8 @@ dist_scripts_SCRIPTS = upd-updates run-anaconda \
 
 dist_noinst_SCRIPTS  = upd-kernel makeupdates makebumpver
 
-dist_bin_SCRIPTS = analog anaconda-cleanup instperf anaconda-disable-nm-ibft-plugin
+dist_bin_SCRIPTS = analog anaconda-cleanup instperf anaconda-disable-nm-ibft-plugin \
+                   anaconda-nm-disable-autocons
 
 stage2scriptsdir = $(datadir)/$(PACKAGE_NAME)
 dist_stage2scripts_SCRIPTS = restart-anaconda

--- a/scripts/anaconda-nm-disable-autocons
+++ b/scripts/anaconda-nm-disable-autocons
@@ -1,0 +1,5 @@
+#!/bin/sh
+cat > /etc/NetworkManager/conf.d/90-anaconda-no-auto-default.conf << EOF
+[main]
+no-auto-default=*
+EOF


### PR DESCRIPTION
The NM autoconnections (automatic network connection via dhcp) used to
be disabled via lorax. Let's move it into anaconda so we have
better control over it depending on the use case, eg by adding:

ConditionKernelCommandLine=|ip
ConditionKernelCommandLine=|inst.ks

Resolves: rhbz#TODO