### PR TITLE
Make cppcheck optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,7 +97,7 @@ ANACONDA_PKG_CHECK_MODULES([LIBARCHIVE], [libarchive >= 3.0.4])
 SHUT_UP_GCC="-Wno-unused-result"
 
 # Add remaining compiler flags we want to use
-CFLAGS="$CFLAGS -Wall -Werror $SHUT_UP_GCC"
+CFLAGS="$CFLAGS -Wall -Werror $SHUT_UP_GCC -fanalyzer"
 
 
 # Perform arch related tests

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -264,6 +264,11 @@ represents a different class of tests. They are
     Some tests require root privileges and will be skipped if running as regular
     user!
 
+The `cppcheck` test is optional and is automatically skipped if the package is not available.
+
+The tests use the `automake "simple tests" framework <https://www.gnu.org/software/automake/manual/automake.html#Simple-Tests>`.
+The launcher scripts are listed under `TESTS` in `tests/Makefile.am`.
+
 .. _kickstart-tests: https://github.com/rhinstaller/kickstart-tests
 .. _quay.io: https://quay.io/repository/rhinstaller/anaconda-ci
 .. _unittest discover -k: https://docs.python.org/3/library/unittest.html#cmdoption-unittest-k

--- a/tests/cppcheck/runcppcheck.sh
+++ b/tests/cppcheck/runcppcheck.sh
@@ -9,8 +9,8 @@ fi
 . ${top_srcdir}/tests/lib/testlib.sh
 
 if ! type cppcheck > /dev/null 2>&1 ; then
-    echo "cppcheck must be installed"
-    exit 99
+    echo "SKIP - cppcheck must be installed to run it."
+    exit 77
 fi
 
 # If files were specified on the command line, use those. Otherwise, look


### PR DESCRIPTION
`cppcheck` is unwanted on the enterprise distros, so let's make it easy to skip it. All that is needed to turn it off is not including the package in the container.

Note: Port to RHEL 9 must also remove the package elsewhere, unless already done.