### PR TITLE
Remove .coveragerc file from tarball (#infra)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = data docs dracut po pyanaconda scripts tests widgets utils
 
-EXTRA_DIST = COPYING .coveragerc
+EXTRA_DIST = COPYING
 
 # Include the xgettext wrapper so pot-update can be run from the source distribution
 # This is needed for make distcheck.


### PR DESCRIPTION
We don't need to have coverage output in gating. Making the tarball smaller is always a win!

This should be backported to https://github.com/rhinstaller/anaconda/pull/3462 and https://github.com/rhinstaller/anaconda/pull/3461 .