### PR TITLE
Add Satellite registration support

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -100,6 +100,9 @@ GRAPHICAL_TARGET = 'graphical.target'
 NETWORK_CONNECTION_TIMEOUT = 46  # in seconds
 NETWORK_CONNECTED_CHECK_INTERVAL = 0.1  # in seconds
 
+# Anaconda user agent
+USER_AGENT = "%s (anaconda)/%s" % (productName, productVersion)
+
 # DBus
 DEFAULT_DBUS_TIMEOUT = -1       # use default
 

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -23,6 +23,7 @@ from pyanaconda.modules.common.errors.installation import BootloaderInstallation
     InsightsClientMissingError, InsightsConnectError
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.errors.storage import UnusableStorageError
+from pyanaconda.modules.common.errors.subscription import SatelliteProvisioningError
 from pyanaconda.payload.errors import PayloadInstallError, DependencyError, PayloadSetupError
 
 
@@ -114,6 +115,9 @@ class ErrorHandler(object):
             # Subscription related errors
             InsightsClientMissingError.__name__: self._insightsErrorHandler,
             InsightsConnectError.__name__: self._insightsErrorHandler,
+
+            # Satellite
+            SatelliteProvisioningError.__name__: self._target_satellite_provisioning_error_handler,
 
             # General installation errors.
             NonCriticalInstallationError.__name__: self._non_critical_error_handler,
@@ -212,6 +216,13 @@ class ErrorHandler(object):
             return ERROR_CONTINUE
         else:
             return ERROR_RAISE
+
+    def _target_satellite_provisioning_error_handler(self, exn):
+        message = _("Failed to provision the target system for Satellite.")
+        details = str(exn)
+
+        self.ui.showDetailedError(message, details)
+        return ERROR_RAISE
 
     def _non_critical_error_handler(self, exn):
         message = _("The following error occurred during the installation:"

--- a/pyanaconda/modules/common/errors/installation.py
+++ b/pyanaconda/modules/common/errors/installation.py
@@ -97,3 +97,9 @@ class InsightsConnectError(InstallationError):
 class SubscriptionTokenTransferError(InstallationError):
     """Exception for errors during subscription token transfer."""
     pass
+
+
+@dbus_error("TargetSatelliteProvisioningError", namespace=ANACONDA_NAMESPACE)
+class TargetSatelliteProvisioningError(InstallationError):
+    """Exception for errors when provisioning target system for Satellite."""
+    pass

--- a/pyanaconda/modules/common/errors/subscription.py
+++ b/pyanaconda/modules/common/errors/subscription.py
@@ -37,3 +37,9 @@ class UnregistrationError(AnacondaError):
 class SubscriptionError(AnacondaError):
     """Subscription attempt failed."""
     pass
+
+
+@dbus_error("SatelliteProvisioningError", namespace=ANACONDA_NAMESPACE)
+class SatelliteProvisioningError(AnacondaError):
+    """Failed to provision the installation environment for Satellite."""
+    pass

--- a/pyanaconda/modules/subscription/constants.py
+++ b/pyanaconda/modules/subscription/constants.py
@@ -20,3 +20,5 @@
 
 # name of the RHSM systemd unit
 RHSM_SERVICE_NAME = "rhsm.service"
+# server hostname prefix marking the URL as not Satellite
+SERVER_HOSTNAME_NOT_SATELLITE_PREFIX = "not-satellite:"

--- a/pyanaconda/modules/subscription/constants.py
+++ b/pyanaconda/modules/subscription/constants.py
@@ -1,0 +1,22 @@
+#
+# Private constants for the subscription module.
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+# name of the RHSM systemd unit
+RHSM_SERVICE_NAME = "rhsm.service"

--- a/pyanaconda/modules/subscription/initialization.py
+++ b/pyanaconda/modules/subscription/initialization.py
@@ -30,14 +30,14 @@ from pyanaconda.threading import threadMgr
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.common.errors.task import NoResultError
 
+from pyanaconda.modules.subscription.constants import RHSM_SERVICE_NAME
+
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
 class StartRHSMTask(Task):
     """Task for starting the RHSM DBus service."""
-
-    RHSM_SYSTEMD_UNIT_NAME = "rhsm.service"
 
     def __init__(self, verify_ssl=True):
         """Create a new task for starting the RHSM DBus service.
@@ -72,7 +72,7 @@ class StartRHSMTask(Task):
         # - this is blocking, but as we are effectively running in a thread
         # it should not be an issue
         # - if the return code is non-zero, return False immediately
-        rc = util.start_service(self.RHSM_SYSTEMD_UNIT_NAME)
+        rc = util.start_service(RHSM_SERVICE_NAME)
         if rc:
             log.warning(
                 "subscription: RHSM systemd service failed to start with error code: %s",

--- a/pyanaconda/modules/subscription/installation.py
+++ b/pyanaconda/modules/subscription/installation.py
@@ -28,6 +28,8 @@ from pyanaconda.core.subscription import check_system_purpose_set
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.common.errors.installation import InsightsConnectError, \
     InsightsClientMissingError, SubscriptionTokenTransferError
+from pyanaconda.modules.common.errors.subscription import SatelliteProvisioningError
+from pyanaconda.modules.subscription import satellite
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -244,3 +246,58 @@ class TransferSubscriptionTokensTask(Task):
 
         # transfer the RHSM config file
         self._transfer_file(self.RHSM_CONFIG_FILE_PATH, "RHSM config file")
+
+
+class ProvisionTargetSystemForSatelliteTask(Task):
+    """Provision target system for communication with Satellite.
+
+    If the System gets registered to Satellite at installation time,
+    the provisioning is applied only to the installation environment.
+    This task makes sure it is applied also on the target system.
+
+    Run the appropriate Satellite provisioning script on the target system.
+
+    This should assure the target system has all the needed self certificates
+    installed and rhsm.conf tweaks applied.
+    """
+
+    def __init__(self, provisioning_script):
+        """Create a new task.
+
+        :param str provisioning_script: Satellite provisioning script in string form
+        """
+        super().__init__()
+        self._provisioning_script = provisioning_script
+
+    @property
+    def name(self):
+        return "Provisioning target system for Satellite"
+
+    def run(self):
+        """Provision target system for Satellite.
+
+        First check if we are actually registered to a Satellite instance
+        by checking if we got a provisioning script.
+
+        If not, do nothing.
+
+        If we are registered to a Satellite instance, run the Satellite
+        provisioning script that has been downloaded from the instance previously.
+
+        """
+        if self._provisioning_script:
+            log.debug("subscription: provisioning target system for Satellite")
+            provisioning_success = satellite.run_satellite_provisioning_script(
+                provisioning_script=self._provisioning_script,
+                run_on_target_system=True
+
+            )
+            if provisioning_success:
+                log.debug("subscription: target system successfully provisioned for Satellite")
+            else:
+                raise SatelliteProvisioningError("Satellite provisioning script failed.")
+        else:
+            # lets assume here that no provisioning script == not registered to Satellite
+            log.debug(
+                "subscription: not registered to Satellite, skipping Satellite provisioning."
+            )

--- a/pyanaconda/modules/subscription/satellite.py
+++ b/pyanaconda/modules/subscription/satellite.py
@@ -1,0 +1,179 @@
+#
+# Satellite support purpose library.
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import os
+import tempfile
+
+from requests import RequestException
+
+from pyanaconda.core import constants, util
+
+from pyanaconda.core.payload import ProxyString, ProxyStringError
+from pyanaconda.core.configuration.anaconda import conf
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+# the well-known path of the Satellite instance URL where
+# the provisioning script should be located
+PROVISIONING_SCRIPT_SUB_PATH = "/pub/katello-rhsm-consumer"
+
+
+def download_satellite_provisioning_script(satellite_url, proxy_url=None):
+    """Download provisioning script from a Red Hat Satellite instance.
+
+    Download the provisioning script from a Satellite instance and return
+    it as a string.
+
+    Satellite instances usually have self signed certificates and also some tweaks
+    are usually required in rhsm.conf to connect to a customer run Satellite instance
+    instead of to Hosted Candlepin for subscription purposes.
+
+    Each Satellite instance thus hosts a provisioning script available over plain
+    HTTP that client machines can download and execute. This script has minimal dependencies
+    and provisions the machine to be able to talk to the one given Satellite instance
+    by installing it's self signed certificates and adjusting rhsm.conf.
+
+    NOTE: As the script is downloaded over plain HTTP it is advised to ever only
+          provision machines from a Satellite instance on a trusted network, to
+          avoid the possibility of the provisioning script being tempered with
+          during transit.
+
+    :param str satellite_url: Satellite instance URL
+    :param proxy_url: proxy URL to use when fetching the script
+    :type proxy_url: str or None if not set
+    :returns: True on success, False otherwise
+    """
+    # make sure the URL starts with protocol
+    if not satellite_url.startswith("http"):
+        satellite_url = "http://" + satellite_url
+
+    # construct the URL pointing to the provisioning script
+    script_url = satellite_url + PROVISIONING_SCRIPT_SUB_PATH
+
+    log.debug("subscription: fetching Satellite provisioning script from: %s", script_url)
+
+    headers = {"user-agent": constants.USER_AGENT}
+    proxies = {}
+    provisioning_script = ""
+
+    # process proxy URL (if any)
+    if proxy_url is not None:
+        try:
+            proxy = ProxyString(proxy_url)
+            proxies = {"http": proxy.url,
+                       "https": proxy.url}
+        except ProxyStringError as e:
+            log.info("subscription: failed to parse proxy when fetching Satellite"
+                     " provisioning script %s: %s",
+                     proxy_url, e)
+
+    with util.requests_session() as session:
+        try:
+            # NOTE: we explicitly don't verify SSL certificates while
+            #       downloading the provisioning script as the Satellite
+            #       instance will most likely have it's own self signed certs that
+            #       will only be trusted once the provisioning script runs
+            result = session.get(script_url, headers=headers,
+                                 proxies=proxies, verify=False,
+                                 timeout=constants.NETWORK_CONNECTION_TIMEOUT)
+            if result.ok:
+                provisioning_script = result.text
+                result.close()
+                log.debug("subscription: Satellite provisioning script downloaded (%d characters)",
+                          len(provisioning_script))
+                return provisioning_script
+            else:
+                log.debug("subscription: server returned %i code when downloading"
+                          " Satellite provisioning script", result.status_code)
+                result.close()
+                return None
+        except RequestException as e:
+            log.debug("subscription: can't download Satellite provisioning script"
+                      " from %s with proxy: %s. Error: %s", script_url, proxies, e)
+            return None
+
+
+def run_satellite_provisioning_script(provisioning_script=None, run_on_target_system=False):
+    """Run the Satellite provisioning script.
+
+    Each Satellite instance provides a provisioning script that will
+    enable the currently running environment to talk to the given
+    Satellite instance.
+
+    This means that the self-signed certificates of the given
+    Satellite instance will be installed to the system but also some
+    necessary changes will be done to rhsm.conf.
+
+    As we need to provision both the installation *and* target system
+    to talk to Satellite we need to run the provisioning script twice,
+    once in the installation environment and once on the target system.
+
+    This is achieved by running this function first in the installation environment
+    with run_on_target_system == False before a registration attempt.
+    And then in the installation phase with run_on_target_system == True.
+
+    Implementation wise we just always run the script from a tempfile.
+
+    That way we can easily run it in the installation environment as well
+    as in the target system chroot with minimum code needed to make sure
+    it exists where we need it
+
+    :param str provisioning_script: content of the Satellite provisioning script
+                                    or None if no script is available
+    :param str run_on_target_system: run in the target system chroot instead,
+                                     otherwise run in the installation environment
+    :return: True on success, False otherwise
+    :rtype: bool
+    """
+    # first check we actually have the script
+    if provisioning_script is None:
+        log.warning("subscription: satellite provisioning script not available")
+        return False
+
+    # now that we have something to run, check where to run it
+    if run_on_target_system:
+        # run in the target system chroot
+        sysroot = conf.target.system_root
+    else:
+        # run in installation environment
+        sysroot = "/"
+
+    # create the tempfile containing the script in the sysroot in /tmp, just in case
+    sysroot_tmp = util.join_paths(sysroot, "/tmp")
+    # make sure the path exists
+    util.mkdirChain(sysroot_tmp)
+    with tempfile.NamedTemporaryFile(mode="w+t", dir=sysroot_tmp, prefix="satellite-") as tf:
+        # write the provisioning script to the tempfile & flush any caches, just in case
+        tf.write(provisioning_script)
+        tf.flush()
+        # We always set root to the correct sysroot, so the script will always
+        # look like it is in /tmp. So just split the randomly generated file name
+        # and combine it with /tmp to get sysroot specific script path.
+        filename = os.path.basename(tf.name)
+        chroot_script_path = os.path.join("/tmp", filename)
+        # and execute it in the sysroot
+        rc = util.execWithRedirect("bash", argv=[chroot_script_path], root=sysroot)
+        if rc == 0:
+            log.debug("subscription: satellite provisioning script executed successfully")
+            return True
+        else:
+            log.debug("subscription: satellite provisioning script executed with error")
+            return False

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -539,6 +539,8 @@ class SubscriptionService(KickstartService):
           the INFO log level in rhsm.conf or else target system will
           end up with RHSM logging in DEBUG mode
         - transfer subscription tokens
+        - apply Satellite provisioning on the target system,
+          in case we are registered to Satellite
         - connect to insights, this can run only once subscription
           tokens are in place on the target system or else it would
           fail as Insights client needs the subscription tokens to
@@ -553,6 +555,9 @@ class SubscriptionService(KickstartService):
             TransferSubscriptionTokensTask(
                 sysroot=conf.target.system_root,
                 transfer_subscription_tokens=self.subscription_attached
+            ),
+            ProvisionTargetSystemForSatelliteTask(
+                provisioning_script=self._satellite_provisioning_script,
             ),
             ConnectToInsightsTask(
                 sysroot=conf.target.system_root,

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -43,6 +43,8 @@ class SubscriptionInterface(KickstartModuleInterface):
                             self.implementation.connect_to_insights_changed)
         self.watch_property("IsRegistered",
                             self.implementation.registered_changed)
+        self.watch_property("IsRegisteredToSatellite",
+                            self.implementation.registered_to_satellite_changed)
         self.watch_property("IsSubscriptionAttached",
                             self.implementation.subscription_attached_changed)
 
@@ -145,6 +147,11 @@ class SubscriptionInterface(KickstartModuleInterface):
         return self.implementation.registered
 
     @property
+    def IsRegisteredToSatellite(self) -> Bool:
+        """Report if the system is registered to a Satellite instance."""
+        return self.implementation.registered_to_satellite
+
+    @property
     def IsSubscriptionAttached(self) -> Bool:
         """Report if an entitlement has been successfully attached."""
         return self.implementation.subscription_attached
@@ -158,24 +165,6 @@ class SubscriptionInterface(KickstartModuleInterface):
             self.implementation.set_rhsm_config_with_task()
         )
 
-    def RegisterUsernamePasswordWithTask(self) -> ObjPath:
-        """Register with username & password using a runtime DBus task.
-
-        :return: a DBus path of an installation task
-        """
-        return TaskContainer.to_object_path(
-            self.implementation.register_username_password_with_task()
-        )
-
-    def RegisterOrganizationKeyWithTask(self) -> ObjPath:
-        """Register with organization & keys(s) using a runtime DBus task.
-
-        :return: a DBus path of an installation task
-        """
-        return TaskContainer.to_object_path(
-            self.implementation.register_organization_key_with_task()
-        )
-
     def UnregisterWithTask(self) -> ObjPath:
         """Unregister using a runtime DBus task.
 
@@ -185,20 +174,11 @@ class SubscriptionInterface(KickstartModuleInterface):
             self.implementation.unregister_with_task()
         )
 
-    def AttachSubscriptionWithTask(self) -> ObjPath:
-        """Attach subscription using a runtime DBus task.
+    def RegisterAndSubscribeWithTask(self) -> ObjPath:
+        """Register and subscribe with a runtime DBus task.
 
-        :return: a DBus path of an installation task
+        :return: a DBus path of a runtime task
         """
         return TaskContainer.to_object_path(
-            self.implementation.attach_subscription_with_task()
-        )
-
-    def ParseAttachedSubscriptionsWithTask(self) -> ObjPath:
-        """Parse attached subscriptions using a runtime DBus task.
-
-        :return: a DBus path of an installation task
-        """
-        return TaskContainer.to_object_path(
-            self.implementation.parse_attached_subscriptions_with_task()
+            self.implementation.register_and_subscribe_with_task()
         )

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -73,14 +73,11 @@ from pyanaconda.payload.errors import MetadataError, PayloadError, NoSuchGroup, 
     PayloadInstallError, PayloadSetupError
 from pyanaconda.payload.image import find_first_iso_image, find_optical_install_media
 from pyanaconda.payload.install_tree_metadata import InstallTreeMetadata
-from pyanaconda.product import productName, productVersion
 from pyanaconda.progress import progressQ, progress_message
 from pyanaconda.ui.lib.payload import get_payload, get_source, create_source, set_source, \
     set_up_sources, tear_down_sources
 
 log = get_packaging_logger()
-
-USER_AGENT = "%s (anaconda)/%s" % (productName, productVersion)
 
 __all__ = ["DNFPayload"]
 
@@ -1311,7 +1308,7 @@ class DNFPayload(Payload):
                 log.info("Failed to parse proxy for _getTreeInfo %s: %s",
                          proxy_url, e)
 
-        headers = {"user-agent": USER_AGENT}
+        headers = {"user-agent": constants.USER_AGENT}
         self._install_tree_metadata = InstallTreeMetadata()
         try:
             ret = self._install_tree_metadata.load_url(url, proxies, ssl_verify, ssl_cert, headers)

--- a/pyanaconda/payload/dnf/repomd.py
+++ b/pyanaconda/payload/dnf/repomd.py
@@ -22,7 +22,7 @@ from requests import RequestException
 from pyanaconda.anaconda_loggers import get_packaging_logger
 from pyanaconda.core import util, constants
 from pyanaconda.core.payload import ProxyString, ProxyStringError
-from pyanaconda.payload.dnf.utils import USER_AGENT
+from pyanaconda.core.constants import USER_AGENT
 
 log = get_packaging_logger()
 

--- a/pyanaconda/payload/dnf/utils.py
+++ b/pyanaconda/payload/dnf/utils.py
@@ -24,13 +24,11 @@ from pyanaconda.anaconda_loggers import get_packaging_logger
 from pyanaconda.payload.dnf.transaction_progress import TransactionProgress
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.product import productName, productVersion
 
 log = get_packaging_logger()
 
 DNF_PACKAGE_CACHE_DIR_SUFFIX = 'dnf.package.cache'
 YUM_REPOS_DIR = "/etc/yum.repos.d/"
-USER_AGENT = "%s (anaconda)/%s" % (productName, productVersion)
 
 
 def get_df_map():

--- a/pyanaconda/ui/gui/spokes/subscription.glade
+++ b/pyanaconda/ui/gui/spokes/subscription.glade
@@ -725,10 +725,10 @@
                                 <property name="can_focus">False</property>
                                 <property name="spacing">4</property>
                                 <child>
-                                  <object class="GtkLabel" id="properly_subscribed_label">
+                                  <object class="GtkLabel" id="subscription_status_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">The system has been properly subscribed</property>
+                                    <property name="label">""</property>
                                     <attributes>
                                       <attribute name="weight" value="bold"/>
                                       <attribute name="scale" value="1.2"/>

--- a/pyanaconda/ui/gui/spokes/subscription.glade
+++ b/pyanaconda/ui/gui/spokes/subscription.glade
@@ -500,7 +500,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="custom_server_hostname_checkbox">
-                                            <property name="label" translatable="yes">Custom server URL</property>
+                                            <property name="label" translatable="yes">Satellite URL</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -609,6 +609,7 @@ class SubscriptionSpoke(NormalSpoke):
         # * the subscription status tab * #
 
         # general status
+        self._subscription_status_label = self.builder.get_object("subscription_status_label")
         self._method_status_label = self.builder.get_object("method_status_label")
         self._role_status_label = self.builder.get_object("role_status_label")
         self._sla_status_label = self.builder.get_object("sla_status_label")
@@ -983,7 +984,10 @@ class SubscriptionSpoke(NormalSpoke):
         elif self.registration_error:
             return _("Registration failed.")
         elif self.subscription_attached:
-            return _("Registered.")
+            if self._subscription_module.IsRegisteredToSatellite:
+                return _("Registered to Satellite.")
+            else:
+                return _("Registered.")
         else:
             return _("Not registered.")
 
@@ -1013,6 +1017,16 @@ class SubscriptionSpoke(NormalSpoke):
         Update state of the part of the spoke, that shows data about the
         currently attached subscriptions.
         """
+        # top level status label
+        if self._subscription_module.IsRegisteredToSatellite:
+            self._subscription_status_label.set_text(
+                _("The system is registered to a Satellite instance.")
+            )
+        else:
+            self._subscription_status_label.set_text(
+                _("The system is registered.")
+            )
+
         # authentication method
         if self.authentication_method == AuthenticationMethod.USERNAME_PASSWORD:
             method_string = _("Registered with account {}").format(

--- a/tests/nosetests/pyanaconda_tests/modules/subscription/satellite_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/subscription/satellite_test.py
@@ -1,0 +1,219 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+import unittest
+from unittest.mock import patch
+from requests import RequestException
+
+from pyanaconda.modules.subscription.satellite import download_satellite_provisioning_script, \
+    run_satellite_provisioning_script, PROVISIONING_SCRIPT_SUB_PATH
+from pyanaconda.core.constants import USER_AGENT, NETWORK_CONNECTION_TIMEOUT
+
+
+class SatelliteLibraryTestCase(unittest.TestCase):
+    """Test the Satellite provisioning code."""
+    # this code at the moment basically just downloads the Satellite provisioning
+    # script from the Satellite instance with one method, then runs it with the other
+
+    @patch("pyanaconda.core.util.requests_session")
+    def script_download_no_prefix_test(self, get_session):
+        """Test the download_satellite_provisioning_script function - no prefix."""
+        # mock the Python Request session
+        session = get_session.return_value.__enter__.return_value
+        result = session.get.return_value
+        result.ok = True
+        result.text = "foo script text"
+        # run the download method
+        script_text = download_satellite_provisioning_script("satellite.example.com")
+        # check script text was returned
+        self.assertEqual("foo script text", script_text)
+        # check the session was called correctly
+        session.get.assert_called_once_with(
+            'http://satellite.example.com' + PROVISIONING_SCRIPT_SUB_PATH,
+            headers={"user-agent": USER_AGENT},
+            proxies={},
+            verify=False,
+            timeout=NETWORK_CONNECTION_TIMEOUT
+        )
+        result.close.assert_called_once()
+
+    @patch("pyanaconda.core.util.requests_session")
+    def script_download_http_test(self, get_session):
+        """Test the download_satellite_provisioning_script function - http prefix."""
+        # mock the Python Request session
+        session = get_session.return_value.__enter__.return_value
+        result = session.get.return_value
+        result.ok = True
+        result.text = "foo script text"
+        # run the download method
+        script_text = download_satellite_provisioning_script("http://satellite.example.com")
+        # check script text was returned
+        self.assertEqual("foo script text", script_text)
+        # check the session was called correctly
+        session.get.assert_called_once_with(
+            'http://satellite.example.com' + PROVISIONING_SCRIPT_SUB_PATH,
+            headers={"user-agent": USER_AGENT},
+            proxies={},
+            verify=False,
+            timeout=NETWORK_CONNECTION_TIMEOUT
+        )
+        result.close.assert_called_once()
+
+    @patch("pyanaconda.core.util.requests_session")
+    def script_download_https_test(self, get_session):
+        """Test the download_satellite_provisioning_script function - https prefix."""
+        # mock the Python Request session
+        session = get_session.return_value.__enter__.return_value
+        result = session.get.return_value
+        result.ok = True
+        result.text = "foo script text"
+        # run the download method
+        script_text = download_satellite_provisioning_script("https://satellite.example.com")
+        # check script text was returned
+        self.assertEqual("foo script text", script_text)
+        # check the session was called correctly
+        session.get.assert_called_once_with(
+            'https://satellite.example.com' + PROVISIONING_SCRIPT_SUB_PATH,
+            headers={"user-agent": USER_AGENT},
+            proxies={},
+            verify=False,
+            timeout=NETWORK_CONNECTION_TIMEOUT
+        )
+        result.close.assert_called_once()
+
+    @patch("pyanaconda.core.util.requests_session")
+    def script_download_not_ok_test(self, get_session):
+        """Test the download_satellite_provisioning_script function - result not ok."""
+        # mock the Python Request session
+        session = get_session.return_value.__enter__.return_value
+        result = session.get.return_value
+        result.ok = False
+        result.text = "foo script text"
+        # run the download method
+        script_text = download_satellite_provisioning_script("satellite.example.com")
+        # if result has ok == False, None should be returned instead of script text
+        self.assertIsNone(script_text)
+        # check the session was called correctly
+        session.get.assert_called_once_with(
+            'http://satellite.example.com' + PROVISIONING_SCRIPT_SUB_PATH,
+            headers={"user-agent": USER_AGENT},
+            proxies={},
+            verify=False,
+            timeout=NETWORK_CONNECTION_TIMEOUT
+        )
+        result.close.assert_called_once()
+
+    @patch("pyanaconda.core.util.requests_session")
+    def script_download_exception_test(self, get_session):
+        """Test the download_satellite_provisioning_script function - exception."""
+        # mock the Python Request session
+        session = get_session.return_value.__enter__.return_value
+        session.get.side_effect = RequestException()
+        # run the download method
+        script_text = download_satellite_provisioning_script("satellite.example.com")
+        # if requests throw an exception, None should be returned instead of script text
+        self.assertIsNone(script_text)
+        # check the session was called correctly
+        session.get.assert_called_once_with(
+            'http://satellite.example.com' + PROVISIONING_SCRIPT_SUB_PATH,
+            headers={"user-agent": USER_AGENT},
+            proxies={},
+            verify=False,
+            timeout=NETWORK_CONNECTION_TIMEOUT
+        )
+
+    def run_satellite_provisioning_script_no_script_test(self):
+        """Test the run_satellite_provisioning_script function - no script."""
+        # if no script is provided, False should be returned
+        self.assertFalse(run_satellite_provisioning_script(provisioning_script=None))
+
+    @patch('tempfile.NamedTemporaryFile')
+    @patch('pyanaconda.core.util.execWithRedirect')
+    def run_satellite_provisioning_script_success_test(self, exec_with_redirect, named_tempfile):
+        """Test the run_satellite_provisioning_script function - success."""
+        # simulate successful script run
+        exec_with_redirect.return_value = 0
+        # get the actual file object
+        file_object = named_tempfile.return_value.__enter__.return_value
+        # fake a random name
+        file_object.name = "totally_random_name"
+        file_object = named_tempfile.return_value.__enter__.return_value
+        # successful run should return True
+        self.assertTrue(run_satellite_provisioning_script(provisioning_script="foo script"))
+        # check the tempfile was created correctly
+        named_tempfile.assert_called_once_with(mode='w+t', dir='/tmp', prefix='satellite-')
+        # check the temp file was written out
+        file_object.write.assert_called_once_with("foo script")
+        # test the script was executed properly
+        exec_with_redirect.assert_called_once_with('bash',
+                                                   argv=['/tmp/totally_random_name'],
+                                                   root='/')
+
+    @patch("pyanaconda.modules.subscription.satellite.conf")
+    @patch('tempfile.NamedTemporaryFile')
+    @patch('pyanaconda.core.util.execWithRedirect')
+    def run_satellite_provisioning_script_success_chroot_test(self, exec_with_redirect,
+                                                              named_tempfile, patched_conf):
+        """Test the run_satellite_provisioning_script function - success in chroot."""
+        # mock sysroot
+        patched_conf.target.system_root = "/foo/sysroot"
+        # simulate successful script run
+        exec_with_redirect.return_value = 0
+        # get the actual file object
+        file_object = named_tempfile.return_value.__enter__.return_value
+        # fake a random name
+        file_object.name = "totally_random_name"
+        file_object = named_tempfile.return_value.__enter__.return_value
+        # successful run should return True
+        self.assertTrue(
+            run_satellite_provisioning_script(provisioning_script="foo script",
+                                              run_on_target_system=True)
+        )
+        # check the tempfile was created correctly
+        named_tempfile.assert_called_once_with(mode='w+t',
+                                               dir='/foo/sysroot/tmp',
+                                               prefix='satellite-')
+        # check the temp file was written out
+        file_object.write.assert_called_once_with("foo script")
+        # test the script was executed properly
+        exec_with_redirect.assert_called_once_with('bash',
+                                                   argv=['/tmp/totally_random_name'],
+                                                   root='/foo/sysroot')
+
+    @patch('tempfile.NamedTemporaryFile')
+    @patch('pyanaconda.core.util.execWithRedirect')
+    def run_satellite_provisioning_script_failure_test(self, exec_with_redirect, named_tempfile):
+        """Test the run_satellite_provisioning_script function - failure."""
+        # simulate unsuccessful script run
+        exec_with_redirect.return_value = 1
+        # get the actual file object
+        file_object = named_tempfile.return_value.__enter__.return_value
+        # fake a random name
+        file_object.name = "totally_random_name"
+        file_object = named_tempfile.return_value.__enter__.return_value
+        # failed run should return False
+        self.assertFalse(run_satellite_provisioning_script(provisioning_script="foo script"))
+        # check the tempfile was created correctly
+        named_tempfile.assert_called_once_with(mode='w+t', dir='/tmp', prefix='satellite-')
+        # check the temp file was written out
+        file_object.write.assert_called_once_with("foo script")
+        # test the script was executed properly
+        exec_with_redirect.assert_called_once_with('bash',
+                                                   argv=['/tmp/totally_random_name'],
+                                                   root='/')

--- a/tests/nosetests/pyanaconda_tests/modules/subscription/subscription_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/subscription/subscription_test.py
@@ -23,7 +23,6 @@ from unittest.mock import patch, Mock
 import tempfile
 
 from dasbus.typing import *  # pylint: disable=wildcard-import
-from dasbus.error import DBusError
 
 from pyanaconda.core.constants import SECRET_TYPE_NONE, SECRET_TYPE_HIDDEN, SECRET_TYPE_TEXT, \
     SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY, \
@@ -36,8 +35,6 @@ from pyanaconda.modules.common.structures.subscription import SystemPurposeData,
 
 from pyanaconda.modules.subscription.subscription import SubscriptionService
 from pyanaconda.modules.subscription.subscription_interface import SubscriptionInterface
-from pyanaconda.modules.subscription.system_purpose import get_valid_fields, _normalize_field, \
-    _match_field, process_field, give_the_system_purpose
 from pyanaconda.modules.subscription.installation import ConnectToInsightsTask, \
     RestoreRHSMDefaultsTask, TransferSubscriptionTokensTask
 from pyanaconda.modules.subscription.runtime import SetRHSMConfigurationTask, \
@@ -48,183 +45,6 @@ from pyanaconda.modules.subscription.runtime import SetRHSMConfigurationTask, \
 from tests.nosetests.pyanaconda_tests import check_kickstart_interface, check_dbus_property, \
     PropertiesChangedCallback, patch_dbus_publish_object, check_task_creation_list, \
     check_task_creation
-
-# content of a valid populated valid values json file for system purpose testing
-SYSPURPOSE_VALID_VALUES_JSON = """
-{
-"role" : ["role_a", "role_b", "role_c"],
-"service_level_agreement" : ["sla_a", "sla_b", "sla_c"],
-"usage" : ["usage_a", "usage_b", "usage_c"]
-}
-"""
-
-# content of a valid but not populated valid values json file for system purpose testing
-SYSPURPOSE_VALID_VALUES_JSON_EMPTY = """
-{
-"role" : [],
-"service_level_agreement" : [],
-"usage" : []
-}
-"""
-
-
-class SystemPurposeLibraryTestCase(unittest.TestCase):
-    """Test the system purpose data handling code."""
-
-    def system_purpose_valid_json_parsing_test(self):
-        """Test that the JSON file holding valid system purpose values is parsed correctly."""
-        # check file missing completely
-        # - use path in tempdir to a file that has not been created and thus does not exist
-        with tempfile.TemporaryDirectory() as tempdir:
-            no_file = os.path.join(tempdir, "foo.json")
-            roles, slas, usage_types = get_valid_fields(valid_fields_file_path=no_file)
-            self.assertListEqual(roles, [])
-            self.assertListEqual(slas, [])
-            self.assertListEqual(usage_types, [])
-
-        # check empty value list is handled correctly
-        with tempfile.NamedTemporaryFile(mode="w+t") as testfile:
-            testfile.write(SYSPURPOSE_VALID_VALUES_JSON_EMPTY)
-            testfile.flush()
-            roles, slas, usage_types = get_valid_fields(valid_fields_file_path=testfile.name)
-            self.assertListEqual(roles, [])
-            self.assertListEqual(slas, [])
-            self.assertListEqual(usage_types, [])
-
-        # check correctly populated json file is parsed correctly
-        with tempfile.NamedTemporaryFile(mode="w+t") as testfile:
-            testfile.write(SYSPURPOSE_VALID_VALUES_JSON)
-            testfile.flush()
-            roles, slas, usage_types = get_valid_fields(valid_fields_file_path=testfile.name)
-            self.assertListEqual(roles, ["role_a", "role_b", "role_c"])
-            self.assertListEqual(slas, ["sla_a", "sla_b", "sla_c"])
-            self.assertListEqual(usage_types, ["usage_a", "usage_b", "usage_c"])
-
-    def normalize_field_test(self):
-        """Test that the system purpose valid field normalization works."""
-        # this should basically just lower case the input
-        self.assertEqual(_normalize_field("AAA"), "aaa")
-        self.assertEqual(_normalize_field("Ab"), "ab")
-        self.assertEqual(_normalize_field("A b C"), "a b c")
-
-    def match_field_test(self):
-        """Test that the system purpose valid field matching works."""
-        # The function is used on system purpose data from kickstart
-        # and it tries to match the given value to a well known value
-        # from the valid field.json. This way we can pre-select values
-        # in the GUI even if the user typosed the case or similar.
-
-        # these should match
-        self.assertEqual(
-            _match_field("production", ["Production", "Development", "Testing"]),
-            "Production"
-        )
-        self.assertEqual(
-            _match_field("Production", ["Production", "Development", "Testing"]),
-            "Production"
-        )
-        self.assertEqual(
-            _match_field("DEVELOPMENT", ["Production", "Development", "Testing"]),
-            "Development"
-        )
-
-        # these should not match but return the original value
-        self.assertIsNone(
-            _match_field("custom", ["Production", "Development", "Testing"]),
-        )
-        self.assertIsNone(
-            _match_field("Prod", ["Production", "Development", "Testing"]),
-        )
-        self.assertIsNone(
-            _match_field("Production 1", ["Production", "Development", "Testing"]),
-        )
-        self.assertIsNone(
-            _match_field("Production Development", ["Production", "Development", "Testing"]),
-        )
-
-    def process_field_test(self):
-        """Test that the system purpose field processing works."""
-
-        valid_values = ["Production", "Development", "Testing"]
-
-        # empty string
-        self.assertEqual(process_field("", valid_values, "usage"), "")
-
-        # well known value with different case
-        self.assertEqual(process_field("production", valid_values, "usage"), "Production")
-        self.assertEqual(process_field("PRODUCTION", valid_values, "usage"), "Production")
-
-        # well known value with matching case
-        self.assertEqual(process_field("Production", valid_values, "usage"), "Production")
-
-        # fully custom value
-        self.assertEqual(process_field("foo", valid_values, "usage"), "foo")
-        self.assertEqual(process_field("foo BAR", valid_values, "usage"), "foo BAR")
-
-        # empty list of well known values
-        self.assertEqual(process_field("PRODUCTION", [], "usage"), "PRODUCTION")
-        self.assertEqual(process_field("foo", [], "usage"), "foo")
-
-    def set_system_pourpose_no_purpose_test(self):
-        """Test that nothing is done if system has no purpose."""
-        with tempfile.TemporaryDirectory() as sysroot:
-            # create fake RHSM Syspurpose DBus proxy
-            syspurpose_proxy = Mock()
-            self.assertTrue(give_the_system_purpose(sysroot=sysroot,
-                                                    rhsm_syspurpose_proxy=syspurpose_proxy,
-                                                    role="",
-                                                    sla="",
-                                                    usage="",
-                                                    addons=[]))
-            syspurpose_proxy.SetSyspurpose.assert_not_called()
-
-    def set_system_pourpose_test(self):
-        """Test that system purpose is set if syspurpose & data are both available."""
-        with tempfile.TemporaryDirectory() as sysroot:
-            # create fake RHSM Syspurpose DBus proxy
-            syspurpose_proxy = Mock()
-            # set system purpose
-            self.assertTrue(give_the_system_purpose(sysroot=sysroot,
-                                                    rhsm_syspurpose_proxy=syspurpose_proxy,
-                                                    role="foo",
-                                                    sla="bar",
-                                                    usage="baz",
-                                                    addons=["a", "b", "c"]))
-            # check syspurpose invocations look correct
-            syspurpose_proxy.SetSyspurpose.assert_called_once_with(
-                {
-                    "role": get_variant(Str, "foo"),
-                    "service_level_agreement": get_variant(Str, "bar"),
-                    "usage": get_variant(Str, "baz"),
-                    "addons": get_variant(List[Str], ["a", "b", "c"])
-                },
-                'en_US.UTF-8'
-            )
-
-    def set_system_pourpose_failure_test(self):
-        """Test that exception raised by SetSyspurpose DBus call is handled correctly."""
-        with tempfile.TemporaryDirectory() as sysroot:
-            # create fake RHSM Syspurpose DBus proxy
-            syspurpose_proxy = Mock()
-            # raise DBusError with error message in JSON
-            syspurpose_proxy.SetSyspurpose.side_effect = DBusError("syspurpose error")
-            # set system purpose & False is returned due to the exception
-            self.assertFalse(give_the_system_purpose(sysroot=sysroot,
-                                                     rhsm_syspurpose_proxy=syspurpose_proxy,
-                                                     role="foo",
-                                                     sla="bar",
-                                                     usage="baz",
-                                                     addons=["a", "b", "c"]))
-            # check the fake DBus method still was called correctly
-            syspurpose_proxy.SetSyspurpose.assert_called_once_with(
-                {
-                    "role": get_variant(Str, "foo"),
-                    "service_level_agreement": get_variant(Str, "bar"),
-                    "usage": get_variant(Str, "baz"),
-                    "addons": get_variant(List[Str], ["a", "b", "c"])
-                },
-                'en_US.UTF-8'
-            )
 
 
 class SubscriptionInterfaceTestCase(unittest.TestCase):

--- a/tests/nosetests/pyanaconda_tests/modules/subscription/system_purpose_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/subscription/system_purpose_test.py
@@ -1,0 +1,206 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+import os
+import unittest
+from unittest.mock import Mock
+import tempfile
+
+from dasbus.typing import *  # pylint: disable=wildcard-import
+from dasbus.error import DBusError
+
+from pyanaconda.modules.subscription.system_purpose import get_valid_fields, _normalize_field, \
+    _match_field, process_field, give_the_system_purpose
+
+# content of a valid populated valid values json file for system purpose testing
+SYSPURPOSE_VALID_VALUES_JSON = """
+{
+"role" : ["role_a", "role_b", "role_c"],
+"service_level_agreement" : ["sla_a", "sla_b", "sla_c"],
+"usage" : ["usage_a", "usage_b", "usage_c"]
+}
+"""
+
+# content of a valid but not populated valid values json file for system purpose testing
+SYSPURPOSE_VALID_VALUES_JSON_EMPTY = """
+{
+"role" : [],
+"service_level_agreement" : [],
+"usage" : []
+}
+"""
+
+
+class SystemPurposeLibraryTestCase(unittest.TestCase):
+    """Test the system purpose data handling code."""
+
+    def system_purpose_valid_json_parsing_test(self):
+        """Test that the JSON file holding valid system purpose values is parsed correctly."""
+        # check file missing completely
+        # - use path in tempdir to a file that has not been created and thus does not exist
+        with tempfile.TemporaryDirectory() as tempdir:
+            no_file = os.path.join(tempdir, "foo.json")
+            roles, slas, usage_types = get_valid_fields(valid_fields_file_path=no_file)
+            self.assertListEqual(roles, [])
+            self.assertListEqual(slas, [])
+            self.assertListEqual(usage_types, [])
+
+        # check empty value list is handled correctly
+        with tempfile.NamedTemporaryFile(mode="w+t") as testfile:
+            testfile.write(SYSPURPOSE_VALID_VALUES_JSON_EMPTY)
+            testfile.flush()
+            roles, slas, usage_types = get_valid_fields(valid_fields_file_path=testfile.name)
+            self.assertListEqual(roles, [])
+            self.assertListEqual(slas, [])
+            self.assertListEqual(usage_types, [])
+
+        # check correctly populated json file is parsed correctly
+        with tempfile.NamedTemporaryFile(mode="w+t") as testfile:
+            testfile.write(SYSPURPOSE_VALID_VALUES_JSON)
+            testfile.flush()
+            roles, slas, usage_types = get_valid_fields(valid_fields_file_path=testfile.name)
+            self.assertListEqual(roles, ["role_a", "role_b", "role_c"])
+            self.assertListEqual(slas, ["sla_a", "sla_b", "sla_c"])
+            self.assertListEqual(usage_types, ["usage_a", "usage_b", "usage_c"])
+
+    def normalize_field_test(self):
+        """Test that the system purpose valid field normalization works."""
+        # this should basically just lower case the input
+        self.assertEqual(_normalize_field("AAA"), "aaa")
+        self.assertEqual(_normalize_field("Ab"), "ab")
+        self.assertEqual(_normalize_field("A b C"), "a b c")
+
+    def match_field_test(self):
+        """Test that the system purpose valid field matching works."""
+        # The function is used on system purpose data from kickstart
+        # and it tries to match the given value to a well known value
+        # from the valid field.json. This way we can pre-select values
+        # in the GUI even if the user typosed the case or similar.
+
+        # these should match
+        self.assertEqual(
+            _match_field("production", ["Production", "Development", "Testing"]),
+            "Production"
+        )
+        self.assertEqual(
+            _match_field("Production", ["Production", "Development", "Testing"]),
+            "Production"
+        )
+        self.assertEqual(
+            _match_field("DEVELOPMENT", ["Production", "Development", "Testing"]),
+            "Development"
+        )
+
+        # these should not match but return the original value
+        self.assertIsNone(
+            _match_field("custom", ["Production", "Development", "Testing"]),
+        )
+        self.assertIsNone(
+            _match_field("Prod", ["Production", "Development", "Testing"]),
+        )
+        self.assertIsNone(
+            _match_field("Production 1", ["Production", "Development", "Testing"]),
+        )
+        self.assertIsNone(
+            _match_field("Production Development", ["Production", "Development", "Testing"]),
+        )
+
+    def process_field_test(self):
+        """Test that the system purpose field processing works."""
+
+        valid_values = ["Production", "Development", "Testing"]
+
+        # empty string
+        self.assertEqual(process_field("", valid_values, "usage"), "")
+
+        # well known value with different case
+        self.assertEqual(process_field("production", valid_values, "usage"), "Production")
+        self.assertEqual(process_field("PRODUCTION", valid_values, "usage"), "Production")
+
+        # well known value with matching case
+        self.assertEqual(process_field("Production", valid_values, "usage"), "Production")
+
+        # fully custom value
+        self.assertEqual(process_field("foo", valid_values, "usage"), "foo")
+        self.assertEqual(process_field("foo BAR", valid_values, "usage"), "foo BAR")
+
+        # empty list of well known values
+        self.assertEqual(process_field("PRODUCTION", [], "usage"), "PRODUCTION")
+        self.assertEqual(process_field("foo", [], "usage"), "foo")
+
+    def set_system_pourpose_no_purpose_test(self):
+        """Test that nothing is done if system has no purpose."""
+        with tempfile.TemporaryDirectory() as sysroot:
+            # create fake RHSM Syspurpose DBus proxy
+            syspurpose_proxy = Mock()
+            self.assertTrue(give_the_system_purpose(sysroot=sysroot,
+                                                    rhsm_syspurpose_proxy=syspurpose_proxy,
+                                                    role="",
+                                                    sla="",
+                                                    usage="",
+                                                    addons=[]))
+            syspurpose_proxy.SetSyspurpose.assert_not_called()
+
+    def set_system_pourpose_test(self):
+        """Test that system purpose is set if syspurpose & data are both available."""
+        with tempfile.TemporaryDirectory() as sysroot:
+            # create fake RHSM Syspurpose DBus proxy
+            syspurpose_proxy = Mock()
+            # set system purpose
+            self.assertTrue(give_the_system_purpose(sysroot=sysroot,
+                                                    rhsm_syspurpose_proxy=syspurpose_proxy,
+                                                    role="foo",
+                                                    sla="bar",
+                                                    usage="baz",
+                                                    addons=["a", "b", "c"]))
+            # check syspurpose invocations look correct
+            syspurpose_proxy.SetSyspurpose.assert_called_once_with(
+                {
+                    "role": get_variant(Str, "foo"),
+                    "service_level_agreement": get_variant(Str, "bar"),
+                    "usage": get_variant(Str, "baz"),
+                    "addons": get_variant(List[Str], ["a", "b", "c"])
+                },
+                'en_US.UTF-8'
+            )
+
+    def set_system_pourpose_failure_test(self):
+        """Test that exception raised by SetSyspurpose DBus call is handled correctly."""
+        with tempfile.TemporaryDirectory() as sysroot:
+            # create fake RHSM Syspurpose DBus proxy
+            syspurpose_proxy = Mock()
+            # raise DBusError with error message in JSON
+            syspurpose_proxy.SetSyspurpose.side_effect = DBusError("syspurpose error")
+            # set system purpose & False is returned due to the exception
+            self.assertFalse(give_the_system_purpose(sysroot=sysroot,
+                                                     rhsm_syspurpose_proxy=syspurpose_proxy,
+                                                     role="foo",
+                                                     sla="bar",
+                                                     usage="baz",
+                                                     addons=["a", "b", "c"]))
+            # check the fake DBus method still was called correctly
+            syspurpose_proxy.SetSyspurpose.assert_called_once_with(
+                {
+                    "role": get_variant(Str, "foo"),
+                    "service_level_agreement": get_variant(Str, "bar"),
+                    "usage": get_variant(Str, "baz"),
+                    "addons": get_variant(List[Str], ["a", "b", "c"])
+                },
+                'en_US.UTF-8'
+            )


### PR DESCRIPTION
Add support to Anaconda to register no only to Red Hat run subscription infrastructure (usually called Hosted Candlepin) but also to custom Red Hat Satellite instances run by customers.

This is implemented by a couple new tasks and and a new library module called `satellite`.

To register to a Satellite instance instead of to Hosted Candlepin the use sets the Satellite URL in the GUI or the `--server-hostname` option of the `rhsm` kickstart command. Then at registration time Anaconda will try to fetch and execute a Satellite provisioning script from this URL.

If this is successful, the registration process will continue but the machine will end up talking to the Satellite instance instead of to Hosted Candlepin.

Also at installation time, execute the provisioning script on the target system after installation, so that the installed system is also properly provisioned for the given Satellite instance as well.

**NOTE:** Most Satellite instances use self signed certificates and only after the provisioning script has been run the chain of trust containing these self signed certificates is established. 

Due to this it is recommended only ever register to Satellite via a trusted network where an attacker can't replace the provisioning script in transit as it by necessity has to be transferred a secure SSL connection being established (as before the script is run no chain of trust to the Satellite instance exists).

**TODO**
- [x] check registration to Satellite from kickstart works as well
- [x] check the system can still work with Satellite and its repositories after installation
- [x] check Satellite provided repos can be used as installation source (needs content added to Satellite test instance)
- [x] check why install time token transfer fails (likely caused by missing entitlements on Satellite test instance)
- [x] rename "Red Hat CDN" to "Satellite" when system is registered to Satellite, roll back to "Red Hat CDN" if unregistered at installation time
- [x] ~find why source spoke status is not updated after un-registration from Satellite~ actually a race condition in payload thread, see details in a comment below
- [x] adjust and fixup unit tests to cover Satellite functionality
- [x] resolve and remove all `#FIXME` items in the code