### PR TITLE
Enable the zram-generator service again (#1975881)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -222,10 +222,7 @@ Requires: gdb
 Requires: rsync
 # only WeakRequires elsewhere and not guaranteed to be present
 Requires: device-mapper-multipath
-# FIXME: do not require on RHEL until the package is ready
-%if 0%{?rhel} != 9
-Requires: zram-generator-defaults
-%endif
+Requires: rust-zram-generator
 
 %description install-img-deps
 The anaconda-install-img-deps metapackage lists all boot.iso installation image dependencies.


### PR DESCRIPTION
Install the `rust-zram-generator` package on the boot.iso image
to install and enable the `zram-generator` service.

Resolves: rhbz#1975881