### PR TITLE
Pin version of pylint and astroid (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -37,6 +37,8 @@ RUN set -e; \
   dnf clean all
 
 RUN pip install \
+  "pylint==2.8.3" \
+  "astroid==2.5.6" \
   pocketlint \
   coverage \
   pycodestyle \


### PR DESCRIPTION
SSIA. Together with #3489 should enable rhel 9 CI container builds again.

(Tested locally in that combination.)