### PR TITLE
Don't return None from is_supported_filesystem (#1979854)

### DIFF
--- a/pyanaconda/modules/storage/devicetree/utils.py
+++ b/pyanaconda/modules/storage/devicetree/utils.py
@@ -46,11 +46,13 @@ def is_supported_filesystem(fmt_type):
     """
     fmt = get_format(fmt_type)
 
-    return fmt.type \
-        and fmt.supported \
-        and fmt.formattable \
-        and (isinstance(fmt, FS) or fmt.type in ["biosboot", "prepboot", "swap"]) \
+    return bool(
+        fmt.type
+        and fmt.supported
+        and fmt.formattable
+        and (isinstance(fmt, FS) or fmt.type in ["biosboot", "prepboot", "swap"])
         and fmt.type not in ("ntfs", "tmpfs")
+    )
 
 
 def get_supported_filesystems():


### PR DESCRIPTION
The `is_supported_filesystem` function should never return `None`. Otherwise,
the installation might fail with a traceback for an unknown format type.

Resolves: rhbz#1979854