### PR TITLE
Use RHEL help content for RHV/Ovirt (#1915910)

### DIFF
--- a/data/product.d/ovirt.conf
+++ b/data/product.d/ovirt.conf
@@ -25,4 +25,4 @@ req_partition_sizes =
     /boot  1  GiB
 
 [User Interface]
-help_directory = /usr/share/anaconda/help/rhv
+help_directory = /usr/share/anaconda/help/rhel

--- a/data/product.d/rhev.conf
+++ b/data/product.d/rhev.conf
@@ -25,4 +25,4 @@ req_partition_sizes =
     /boot  1  GiB
 
 [User Interface]
-help_directory = /usr/share/anaconda/help/rhv
+help_directory = /usr/share/anaconda/help/rhel


### PR DESCRIPTION
As we don't have any RHV/Ovirt specific help content,
the RHEL help content should be the most suitable.

(cherry-picked from a commit eb11ca7)

Resolves: rhbz#1915910