### PR TITLE
Use C.UTF-8 if the requested locale is unsupported

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/test_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/test_localization.py
@@ -259,6 +259,20 @@ class LangcodeLocaleMatchingTests(unittest.TestCase):
         self.assertIsNone(localization.find_best_locale_match("ja", ["blah"]))
         self.assertIsNone(localization.find_best_locale_match("blah", ["en_US.UTF-8"]))
 
+    def test_find_best_locale_match_posix(self):
+        """Finding best POSIX matches should work as expected."""
+        match = localization.find_best_locale_match("C", ["C.UTF-8"])
+        self.assertEqual(match, "C.UTF-8")
+
+        match = localization.find_best_locale_match("C.UTF-8", ["en_US"])
+        self.assertEqual(match, "en_US")
+
+        match = localization.find_best_locale_match("en_US", ["C.UTF-8"])
+        self.assertEqual(match, None)
+
+        match = localization.find_best_locale_match("cs_CZ", ["C.UTF-8"])
+        self.assertEqual(match, None)
+
     # TODO: Remove this skip when environment is stable again.
     @unittest.skip("Getting: 'UnicodeDecodeError' on some environments.")
     def test_resolve_date_format(self):


### PR DESCRIPTION
If there is no support for the requested locale, use C.UTF-8 as a fallback.
The requested locale is considered to be supported if we are not able to
determine the supported locales due to missing tools.

In the `find_best_locale_match function`, skip langcodes with the POSIX variant
unless the provided locale is also a POSIX variant. Otherwise, the `en_US`
locale would match the `C` langcode and that is not desirable.

**Ported from:** https://github.com/rhinstaller/anaconda/pull/3450