### PR TITLE
remove authconfig support

### DIFF
--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -22,7 +22,6 @@
 # pylint:disable=unused-import
 
 # Supported kickstart commands.
-from pykickstart.commands.authconfig import F28_Authconfig as Authconfig
 from pykickstart.commands.authselect import F28_Authselect as Authselect
 from pykickstart.commands.autopart import F29_AutoPart as AutoPart
 from pykickstart.commands.autostep import F34_AutoStep as AutoStep

--- a/pyanaconda/modules/security/installation.py
+++ b/pyanaconda/modules/security/installation.py
@@ -33,7 +33,6 @@ log = get_module_logger(__name__)
 
 REALM_TOOL_NAME = "realm"
 AUTHSELECT_TOOL_PATH = "/usr/bin/authselect"
-AUTHCONFIG_TOOL_PATH = "/usr/sbin/authconfig"
 PAM_SO_PATH = "/lib/security/pam_fprintd.so"
 PAM_SO_64_PATH = "/lib64/security/pam_fprintd.so"
 
@@ -356,7 +355,7 @@ class RealmJoinTask(Task):
 def run_auth_tool(cmd, args, root, required=True):
     """Run an authentication related tool.
 
-    This generally means either authselect or the legacy authconfig tool.
+    This generally means authselect.
     :param str cmd: path to the tool to be run
     :param list(str) args: list of arguments passed to the tool
     :param str root: a path to the root in which the tool should be run
@@ -441,37 +440,5 @@ class ConfigureAuthselectTask(Task):
             run_auth_tool(
                 AUTHSELECT_TOOL_PATH,
                 self._authselect_options + ["--force"],
-                self._sysroot
-            )
-
-
-class ConfigureAuthconfigTask(Task):
-    """Installation task for Authconfig configuration.
-
-    NOTE: Authconfig is deprecated, this is present temporarily
-          as long as we want to provide backward compatibility
-          for the authconfig command in kickstart.
-    """
-
-    def __init__(self, sysroot, authconfig_options):
-        """Create a new Authconfig configuration task.
-
-        :param str sysroot: a path to the root of the target system
-        :param list authconfig_options: options for authconfig
-        """
-        super().__init__()
-        self._sysroot = sysroot
-        self._authconfig_options = authconfig_options
-
-    @property
-    def name(self):
-        return "Authconfig configuration"
-
-    def run(self):
-        # Apply the authconfig options from the kickstart file (deprecated).
-        if self._authconfig_options:
-            run_auth_tool(
-                AUTHCONFIG_TOOL_PATH,
-                ["--update", "--nostart"] + self._authconfig_options,
                 self._sysroot
             )

--- a/pyanaconda/modules/security/kickstart.py
+++ b/pyanaconda/modules/security/kickstart.py
@@ -23,8 +23,6 @@ from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMAN
 class SecurityKickstartSpecification(KickstartSpecification):
 
     commands = {
-        "auth": COMMANDS.Authconfig,
-        "authconfig": COMMANDS.Authconfig,
         "authselect": COMMANDS.Authselect,
         "selinux": COMMANDS.SELinux,
         "realm": COMMANDS.Realm

--- a/pyanaconda/modules/security/security_interface.py
+++ b/pyanaconda/modules/security/security_interface.py
@@ -35,7 +35,6 @@ class SecurityInterface(KickstartModuleInterface):
         super().connect_signals()
         self.watch_property("SELinux", self.implementation.selinux_changed)
         self.watch_property("Authselect", self.implementation.authselect_changed)
-        self.watch_property("Authconfig", self.implementation.authconfig_changed)
         self.watch_property(
             "FingerprintAuthEnabled", self.implementation.fingerprint_auth_enabled_changed
         )
@@ -82,28 +81,6 @@ class SecurityInterface(KickstartModuleInterface):
         :param args: a list of arguments
         """
         self.implementation.set_authselect(args)
-
-    @property
-    def Authconfig(self) -> List[Str]:
-        """Arguments for the authconfig tool.
-
-        Authconfig is deprecated, use authselect.
-
-        :return: a list of arguments
-        """
-        return self.implementation.authconfig
-
-    @emits_properties_changed
-    def SetAuthconfig(self, args: List[Str]):
-        """Set the arguments for the authconfig tool.
-
-        Authconfig is deprecated, use authselect.
-
-        Example: ['--passalgo=yescrypt', '--useshadow']
-
-        :param args: a list of arguments
-        """
-        self.implementation.set_authconfig(args)
 
     @property
     def Realm(self) -> Structure:


### PR DESCRIPTION
Authconfig compatibility tool (from authselect-compat) will be removed from Fedora 35:
https://fedoraproject.org/wiki/Changes/RemoveAuthselectCompatPackage