### PR TITLE
[WIP] modprobe compressed kernel modules

### DIFF
--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -14,7 +14,7 @@ MODULE_LIST="cramfs squashfs iscsi_tcp "
 shopt -s nullglob
 
 SCSI_MODULES=/lib/modules/$KERNEL/kernel/drivers/scsi/device_handler/
-for m in $SCSI_MODULES/*.ko; do
+for m in $SCSI_MODULES/*.ko*; do
     # Shell spew to work around not having basename
     # Trim the paths off the prefix, then the . suffix
     a="${m##*/}"


### PR DESCRIPTION
```
$ ls /lib/modules/$(uname -r)/kernel/drivers/scsi/device_handler/* -1v
/lib/modules/5.10.47-generic-2rosa2019.1-x86_64/kernel/drivers/scsi/device_handler/scsi_dh_alua.ko.zst
/lib/modules/5.10.47-generic-2rosa2019.1-x86_64/kernel/drivers/scsi/device_handler/scsi_dh_emc.ko.zst
/lib/modules/5.10.47-generic-2rosa2019.1-x86_64/kernel/drivers/scsi/device_handler/scsi_dh_hp_sw.ko.zst
/lib/modules/5.10.47-generic-2rosa2019.1-x86_64/kernel/drivers/scsi/device_handler/scsi_dh_rdac.ko.zst
```

Testing changes:

```
[user@rosa2019 dracut]$ cat /tmp/9
KERNEL=$(uname -r)
SCSI_MODULES=/lib/modules/$KERNEL/kernel/drivers/scsi/device_handler/
for m in $SCSI_MODULES/*.ko*; do
    # Shell spew to work around not having basename
    # Trim the paths off the prefix, then the . suffix
    a="${m##*/}"
    MODULE_LIST+=" ${a%.*}"
done

echo $MODULE_LIST
[user@rosa2019 dracut]$ bash /tmp/9
scsi_dh_alua.ko scsi_dh_emc.ko scsi_dh_hp_sw.ko scsi_dh_rdac.ko
[user@rosa2019 dracut]$
```

Noted by slava86@