### PR TITLE
Remove not required dependencies from anaconda-ci container

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -18,7 +18,6 @@ RUN set -ex; \
   curl \
   /usr/bin/xargs \
   rpm-build \
-  e2fsprogs \
   git \
   bzip2 \
   rpm-ostree \

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -21,8 +21,6 @@ RUN set -ex; \
   e2fsprogs \
   git \
   bzip2 \
-  libicu \
-  lttng-ust \
   rpm-ostree \
   pykickstart \
   python3-pip \


### PR DESCRIPTION
Remove dependencies used to connect to GitHub as self-hosted runner (we don't support this use-case anymore).
Remove `e2fsprogs` dependency. It seemed to be installed as test dependency but I was able to run the tests locally without it.