### PR TITLE
Fix COPR chroots in our Dockerfiles 

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -31,8 +31,12 @@ RUN set -ex; \
   python3-gobject-base \
   python3-pip; \
   if ! grep -q VARIANT.*eln /etc/os-release; then \
-    dnf copr enable -y ${copr_repo}; \
-    dnf copr enable -y @storage/blivet-daily; \
+    BRANCH="${git_branch}"; \
+    if [ $BRANCH == "master" ]; then \
+      BRANCH="rawhide"; \
+    fi; \
+    dnf copr enable -y ${copr_repo} fedora-${BRANCH%%-*}-x86_64; \
+    dnf copr enable -y @storage/blivet-daily fedora-${BRANCH%%-*}-x86_64; \
     dnf -y install cppcheck; \
   else \
     dnf copr enable -y ${copr_repo} fedora-eln-x86_64; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -20,8 +20,12 @@ RUN set -ex; \
   /usr/bin/xargs \
   rpm-build; \
   if ! grep -q VARIANT.*eln /etc/os-release; then \
-    dnf copr enable -y ${copr_repo}; \
-    dnf copr enable -y @storage/blivet-daily; \
+    BRANCH="${git_branch}"; \
+    if [ $BRANCH == "master" ]; then \
+      BRANCH="rawhide"; \
+    fi; \
+    dnf copr enable -y ${copr_repo} fedora-${BRANCH%%-*}-x86_64; \
+    dnf copr enable -y @storage/blivet-daily fedora-${BRANCH%%-*}-x86_64; \
   else \
     dnf copr enable -y ${copr_repo} fedora-eln-x86_64; \
     dnf copr enable -y @storage/blivet-daily fedora-eln-x86_64; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -19,8 +19,13 @@ RUN set -ex; \
   python3-pip \
   /usr/bin/xargs \
   rpm-build; \
-  if ! grep -q VARIANT.*eln /etc/os-release; then dnf copr enable -y ${copr_repo}; dnf copr enable -y @storage/blivet-daily; else \
-  dnf copr enable -y ${copr_repo} fedora-eln-x86_64; dnf copr enable -y @storage/blivet-daily fedora-eln-x86_64; fi; \
+  if ! grep -q VARIANT.*eln /etc/os-release; then \
+    dnf copr enable -y ${copr_repo}; \
+    dnf copr enable -y @storage/blivet-daily; \
+  else \
+    dnf copr enable -y ${copr_repo} fedora-eln-x86_64; \
+    dnf copr enable -y @storage/blivet-daily fedora-eln-x86_64; \
+  fi; \
   curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/${git_branch}/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   dnf clean all; \


### PR DESCRIPTION
Fedora Rawhide newest container has an issue that it is not successful to detect OS variant when enabling COPR repositories. Without this knowledge the build will fail. Let's make this obvious in our Dockerfiles.