### PR TITLE
Change the root password spoke GUI design

### DIFF
--- a/docs/release-notes/root-spoke.rst
+++ b/docs/release-notes/root-spoke.rst
@@ -1,0 +1,13 @@
+:Type: GUI
+:Summary: Root spoke has been redesigned
+
+:Description:
+    Root spoke has been redesigned and is no longer ambiguous.
+    All root account options are visible only if root account is enabled.
+
+    The new layout also contains text to let users understand their choices.
+
+    Kickstart is not restricted by this.
+
+:Links:
+    - https://github.com/rhinstaller/anaconda/pull/3511

--- a/pyanaconda/ui/gui/spokes/root_password.glade
+++ b/pyanaconda/ui/gui/spokes/root_password.glade
@@ -5,7 +5,7 @@
   <requires lib="AnacondaWidgets" version="1.0"/>
   <object class="AnacondaSpokeWindow" id="passwordWindow">
     <property name="can_focus">False</property>
-    <property name="window_name" translatable="yes">ROOT PASSWORD</property>
+    <property name="window_name" translatable="yes">ROOT ACCOUNT</property>
     <signal name="button-clicked" handler="on_back_clicked" swapped="no"/>
     <child internal-child="main_box">
       <object class="GtkBox" id="AnacondaSpokeWindow-main_box1">

--- a/pyanaconda/ui/gui/spokes/root_password.glade
+++ b/pyanaconda/ui/gui/spokes/root_password.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface>
-  <requires lib="gtk+" version="3.6"/>
+  <requires lib="gtk+" version="3.12"/>
   <requires lib="AnacondaWidgets" version="1.0"/>
   <object class="AnacondaSpokeWindow" id="passwordWindow">
     <property name="can_focus">False</property>
@@ -33,135 +33,46 @@
         <child internal-child="alignment">
           <object class="GtkAlignment" id="AnacondaSpokeWindow-alignment1">
             <property name="can_focus">False</property>
+            <property name="margin_top">12</property>
             <property name="yalign">0</property>
             <property name="xscale">0</property>
             <property name="yscale">0.5</property>
+            <property name="bottom_padding">48</property>
+            <property name="left_padding">24</property>
+            <property name="right_padding">24</property>
             <child internal-child="action_area">
               <object class="GtkBox" id="AnacondaSpokeWindow-action_area1">
                 <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">start</property>
+                <property name="vexpand">True</property>
                 <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <property name="baseline_position">top</property>
                 <child>
-                  <object class="GtkGrid" id="pwgrid">
+                  <object class="GtkGrid" id="main_grid">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="valign">start</property>
+                    <property name="margin_start">12</property>
+                    <property name="margin_end">12</property>
+                    <property name="margin_top">12</property>
+                    <property name="margin_bottom">12</property>
+                    <property name="vexpand">True</property>
                     <property name="row_spacing">6</property>
                     <property name="column_spacing">6</property>
                     <child>
-                      <object class="GtkLabel" id="pwlabel">
+                      <object class="GtkLabel" id="lbTopLongText">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes" context="GUI|Password">_Root Password:</property>
-                        <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">password_entry</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="confirmlabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes" context="GUI|Password">_Confirm:</property>
-                        <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">password_confirmation_entry</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="password_entry">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="visibility">False</property>
-                        <property name="invisible_char">●</property>
-                        <signal name="changed" handler="on_password_changed" swapped="no"/>
-                        <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
-                        <child internal-child="accessible">
-                          <object class="AtkObject" id="password_entry-atkobject">
-                            <property name="AtkObject::accessible-name" translatable="yes">Password</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="password_confirmation_entry">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="visibility">False</property>
-                        <property name="invisible_char">●</property>
-                        <property name="activates_default">True</property>
-                        <signal name="changed" handler="on_password_confirmation_changed" swapped="no"/>
-                        <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
-                        <child internal-child="accessible">
-                          <object class="AtkObject" id="password_confirmation_entry-atkobject">
-                            <property name="AtkObject::accessible-name" translatable="yes">Confirm Password</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="box2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkLevelBar" id="password_bar">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="valign">center</property>
-                            <property name="max_value">4</property>
-                            <property name="mode">discrete</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="password_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="valign">center</property>
-                            <property name="xpad">6</property>
-                            <property name="label" translatable="yes">empty password</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="details">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">The root account is used for administering the system.  Enter a password for the root user.</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="label" translatable="yes">The root account is used for administering the system.
+
+The root user (also known as super user) has complete access to the entire system. For this reason, logging into this system as the root user is best done only to perform system maintenance or administration.</property>
                         <property name="wrap">True</property>
+                        <property name="max_width_chars">60</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -170,48 +81,282 @@
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkRadioButton" id="disable_root_radio">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="group">enable_root_radio</property>
+                        <signal name="toggled" handler="on_root_enabled_changed" swapped="no"/>
+                        <child>
+                          <object class="GtkAccelLabel" id="lbDisableBold">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes" context="GUI|Password">_Disable root account</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0</property>
+                            <property name="accel_widget">disable_root_radio</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="enable_root_radio">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="on_root_enabled_changed" swapped="no"/>
+                        <child>
+                          <object class="GtkAccelLabel" id="lbEnableBold">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes" context="GUI|Password">_Enable root account</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0</property>
+                            <property name="accel_widget">enable_root_radio</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="lbDisableLongText">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_start">24</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="label" translatable="yes">Disabling the root account will lock the account and disable remote access with root account. This will prevent unintended administrative access to the system.</property>
+                        <property name="wrap">True</property>
+                        <property name="max_width_chars">60</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="lbEnableLongText">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_start">24</property>
+                        <property name="margin_bottom">12</property>
+                        <property name="label" translatable="yes" context="GUI|Password">Enabling the root account will allow you to set a root password and optionally enable remote access to root account on this system.</property>
+                        <property name="wrap">True</property>
+                        <property name="max_width_chars">60</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRevealer" id="password_revealer">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_start">24</property>
+                        <property name="transition_type">crossfade</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkGrid" id="pwgrid">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="hexpand">True</property>
+                                <property name="row_spacing">6</property>
+                                <property name="column_spacing">6</property>
+                                <child>
+                                  <object class="GtkLabel" id="pwlabel">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes" context="GUI|Password">_Root Password:</property>
+                                    <property name="use_underline">True</property>
+                                    <property name="mnemonic_widget">password_entry</property>
+                                    <property name="xalign">0</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="confirmlabel">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes" context="GUI|Password">_Confirm:</property>
+                                    <property name="use_underline">True</property>
+                                    <property name="mnemonic_widget">password_confirmation_entry</property>
+                                    <property name="xalign">0</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">0</property>
+                                    <property name="top_attach">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEntry" id="password_entry">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="visibility">False</property>
+                                    <property name="invisible_char">●</property>
+                                    <property name="width_chars">40</property>
+                                    <signal name="changed" handler="on_password_changed" swapped="no"/>
+                                    <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                                    <child internal-child="accessible">
+                                      <object class="AtkObject" id="password_entry-atkobject">
+                                        <property name="AtkObject::accessible-name" translatable="yes">Password</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEntry" id="password_confirmation_entry">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="visibility">False</property>
+                                    <property name="invisible_char">●</property>
+                                    <property name="activates_default">True</property>
+                                    <property name="width_chars">40</property>
+                                    <signal name="changed" handler="on_password_confirmation_changed" swapped="no"/>
+                                    <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                                    <child internal-child="accessible">
+                                      <object class="AtkObject" id="password_confirmation_entry-atkobject">
+                                        <property name="AtkObject::accessible-name" translatable="yes">Confirm Password</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="box2">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="spacing">6</property>
+                                    <child>
+                                      <object class="GtkLevelBar" id="password_bar">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="valign">center</property>
+                                        <property name="max_value">4</property>
+                                        <property name="mode">discrete</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="password_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="valign">center</property>
+                                        <property name="xpad">6</property>
+                                        <property name="label" translatable="yes">empty password</property>
+                                        <attributes>
+                                          <attribute name="weight" value="bold"/>
+                                        </attributes>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="top_attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="root_password_ssh_login_override">
+                                <property name="label" translatable="yes">Allow root SSH login with password</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin_top">6</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
                       <placeholder/>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">True</property>
+                    <property name="fill">False</property>
                     <property name="position">0</property>
                   </packing>
-                </child>
-                <child>
-                  <object class="GtkCheckButton" id="lock">
-                    <property name="label" translatable="yes">Lock root account</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="halign">start</property>
-                    <property name="draw_indicator">True</property>
-                    <signal name="clicked" handler="on_lock_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkCheckButton" id="root_password_ssh_login_override">
-                    <property name="label" translatable="yes">Allow root SSH login with password</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="halign">start</property>
-                    <property name="draw_indicator">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <placeholder/>
                 </child>
               </object>
             </child>

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -54,7 +54,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     category = UserSettingsCategory
 
     icon = "dialog-password-symbolic"
-    title = CN_("GUI|Spoke", "_Root Password")
+    title = CN_("GUI|Spoke", "_Root Account")
 
     @classmethod
     def should_run(cls, environment, data):

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -68,8 +68,6 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         NormalSpoke.__init__(self, *args)
         GUISpokeInputCheckHandler.__init__(self)
         self._users_module = USERS.get_proxy()
-        self._refresh_running = False
-        self._manually_locked = False
 
     def initialize(self):
         NormalSpoke.initialize(self)
@@ -79,8 +77,10 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self._password_confirmation_entry = self.builder.get_object("password_confirmation_entry")
         self._password_bar = self.builder.get_object("password_bar")
         self._password_label = self.builder.get_object("password_label")
-        self._lock = self.builder.get_object("lock")
+        self._enable_root_radio = self.builder.get_object("enable_root_radio")
+        self._disable_root_radio = self.builder.get_object("disable_root_radio")
         self._root_password_ssh_login_override = self.builder.get_object("root_password_ssh_login_override")
+        self._revealer = self.builder.get_object("password_revealer")
 
         # Install the password checks:
         # - Has a password been specified?
@@ -124,10 +124,6 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self.checker.add_check(self._validity_check)
         self.checker.add_check(self._ascii_check)
 
-        # the password entries should be sensitive on first entry to the spoke
-        self.password_entry.set_sensitive(True)
-        self.password_confirmation_entry.set_sensitive(True)
-
         # Set placeholders if the password has been set outside of the Anaconda
         # GUI we either don't really know anything about it if it's crypted
         # and still would not really want to expose it if its set in plaintext,
@@ -155,31 +151,30 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self.initialize_done()
 
     def refresh(self):
-        # report refresh is running
-        self._refresh_running = True
-        # set the state of the lock checkbox based on DBus data
-        # - set_active() apparently also triggers on_clicked() so
-        #   we use the _refresh_running atribute to differentiate
-        #   it from "real" clicks
-        self._lock.set_active(self._users_module.IsRootAccountLocked)
+        # set the locked/unlocked state based on DBus data
+        if self._users_module.IsRootAccountLocked:
+            control = self._disable_root_radio
+        else:
+            control = self._enable_root_radio
+        control.set_active(True)
+        self.on_root_enabled_changed(control)
+
         self._root_password_ssh_login_override.set_active(
             self._users_module.RootPasswordSSHLoginAllowed
         )
-        if not self._lock.get_active():
+        if self.root_enabled:
             # rerun checks so that we have a correct status message, if any
             self.checker.run_checks()
         # focus on the password field if it is sensitive
         if self.password_entry.get_sensitive():
             self.password_entry.grab_focus()
-        # report refresh finished running
-        self._refresh_running = False
 
     @property
     def status(self):
         if self._users_module.IsRootAccountLocked:
             # reconfig mode currently allows re-enabling a locked root account if
             # user sets a new root password
-            if is_reconfiguration_mode() and not self._lock.get_active():
+            if is_reconfiguration_mode() and not self.root_enabled:
                 return _("Disabled, set password to enable.")
             else:
                 return _("Root account is disabled.")
@@ -197,19 +192,20 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     def apply(self):
         pw = self.password
 
-        self._users_module.SetRootAccountLocked(self._lock.get_active())
+        enabled = self.root_enabled
+        self._users_module.SetRootAccountLocked(not enabled)
 
-        # the checkbox makes it possible to override the default Open SSH
-        # policy of not allowing root to login with password
-        ssh_login_override = self._root_password_ssh_login_override.get_active()
-        self._users_module.SetRootPasswordSSHLoginAllowed(ssh_login_override)
+        if enabled:
+            # the checkbox makes it possible to override the default Open SSH
+            # policy of not allowing root to login with password
+            ssh_login_override = self._root_password_ssh_login_override.get_active()
+            self._users_module.SetRootPasswordSSHLoginAllowed(ssh_login_override)
 
         if not pw:
             self._users_module.ClearRootPassword()
             return
 
         # we have a password - set it to kickstart data
-
         self._users_module.SetCryptedRootPassword(crypt_password(pw))
 
         # clear any placeholders
@@ -232,6 +228,10 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         return not (self.completed and flags.automatedInstall
                     and not kickstarted_password_can_be_changed)
 
+    @property
+    def root_enabled(self):
+        return self._enable_root_radio.get_active()
+
     def _checks_done(self, error_message):
         """Update the warning with the input validation error from the first
            error message or clear warnings if all the checks were successful.
@@ -243,7 +243,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         unwaivable_check_failed = not self._confirm_check.result.success
 
         # set appropriate status bar message
-        if not error_message or self._lock.get_active():
+        if not error_message or not self.root_enabled:
             # all is fine, just clear the message
             self.clear_info()
         elif not self.password and not self.password_confirmation:
@@ -316,36 +316,32 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     def on_password_changed(self, editable, data=None):
         """Tell checker that the content of the password field changed."""
         self.checker.password.content = self.password
-        # unlock the password if user starts typing
-        self._lock.set_active(False)
 
     def on_password_confirmation_changed(self, editable, data=None):
         """Tell checker that the content of the password confirmation field changed."""
         self.checker.password_confirmation.content = self.password_confirmation
-        # unlock the password if user starts typing
-        self._lock.set_active(False)
 
     def on_password_icon_clicked(self, entry, icon_pos, event):
         """Called by Gtk callback when the icon of a password entry is clicked."""
         set_password_visibility(entry, not entry.get_visibility())
 
     def on_back_clicked(self, button):
-        # the GUI spoke input check handler handles the spoke exit logic for us
-        if self.try_to_go_back() or self._lock.get_active():
+        # disable root if no password is entered
+        if not self.password and not self.password_confirmation and \
+                not self._users_module.IsRootPasswordSet:
+            control = self._disable_root_radio
+            control.set_active(True)
+            self.on_root_enabled_changed(control)
+
+        # the GUI spoke input check handler handles the rest of the spoke exit logic for us
+        if self.try_to_go_back() or not self.root_enabled:
             NormalSpoke.on_back_clicked(self, button)
         else:
             log.info("Return to hub prevented by password checking rules.")
 
-    def on_lock_clicked(self, lock):
-        if self._refresh_running:
-            # this is not a "real" click, just refresh() setting the lock check
-            # box state based on data from the DBus module
-            if not self._manually_locked:
-                # if the checkbox has not yet been manipulated by the user
-                # we can ignore this run and not adjust the fields
-                return True
-        self.password_entry.set_sensitive(not lock.get_active())
-        self.password_confirmation_entry.set_sensitive(not lock.get_active())
-        if not lock.get_active():
+    def on_root_enabled_changed(self, control):
+        """Click event handler for root account enable and disable radio buttons."""
+        unlocked = (control == self._enable_root_radio)
+        self._revealer.set_reveal_child(unlocked)
+        if unlocked:
             self.password_entry.grab_focus()
-            self._manually_locked = True


### PR DESCRIPTION
This resolves ambiguity of what options are available when root is locked.

~~This is a draft because there are at least these TODOs:~~
- [x] make bold labels "clickable" 
- [x] verify the logic
- [x] find bugs etc. to link
- [x] consider renaming spoke to "Root account security"
- [x] ~~add an "empty password" banner~~ automatically switches to no password + locked instead.

See also: https://github.com/rhinstaller/anaconda/pull/3262#issuecomment-839202230
Suggested-by: Mairin Duffy <mairin@redhat.com> @mairin 