### PR TITLE
Rhel 9 disable built in help system for now

### DIFF
--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -61,6 +61,11 @@ default_help_pages =
     rhel_help_placeholder.xml
     rhel_help_placeholder.xml
 
+# FIXME: The help system is currently disabled
+# as help content has not yet been updated
+# for RHEL 9.
+help_directory =
+
 custom_stylesheet = /usr/share/anaconda/pixmaps/redhat.css
 blivet_gui_supported = False
 

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -105,6 +105,8 @@ class GUIObject(common.UIObject):
                            given GUI object. The default value of "" indicates
                            that the object has not specific help file assigned
                            and the default help file should be used.
+
+       hide_help_button -- Hide the button for showing help.
     """
     builderObjects = []
     mainWidgetName = None
@@ -116,6 +118,7 @@ class GUIObject(common.UIObject):
 
     uiFile = ""
     helpFile = None
+    hide_help_button = False
     translationDomain = "anaconda"
 
     def __init__(self, data):
@@ -158,6 +161,25 @@ class GUIObject(common.UIObject):
             self.builder.add_from_file(self._findUIFile())
 
         self.builder.connect_signals(self)
+
+    def initialize(self):
+        """Initialize the GUI of this instance. Runs once.
+
+        Hide the help button, if applicable.
+
+        Descendants will override this method to do more.
+        """
+        super().initialize()
+
+        if self.hide_help_button:
+            help_button = None
+            # some GUI elements we might encounter do not even have the get_help_button method
+            if hasattr(self.window, "get_help_button"):
+                help_button = self.window.get_help_button()
+            if not help_button:
+                return  # GUIObject descendants might be also dialogs which don't have the button
+            help_button.set_visible(False)
+            help_button.set_no_show_all(True)
 
     def _findUIFile(self):
         path = os.environ.get("UIPATH", "./:/usr/share/anaconda/ui/")

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -171,7 +171,7 @@ class GUIObject(common.UIObject):
         """
         super().initialize()
 
-        if self.hide_help_button:
+        if self.hide_help_button or not conf.ui.help_directory:
             help_button = None
             # some GUI elements we might encounter do not even have the get_help_button method
             if hasattr(self.window, "get_help_button"):

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -83,6 +83,7 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
         self._l12_module = LOCALIZATION.get_proxy()
 
     def initialize(self):
+        super().initialize()
         self.initialize_start()
         self._languageStore = self.builder.get_object("languageStore")
         self._languageEntry = self.builder.get_object("languageEntry")

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -139,6 +139,7 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
         return model[itr][3]
 
     def initialize(self):
+        super().initialize()
         self.initialize_start()
         self._languageStore = self.builder.get_object("languageStore")
         self._languageStoreFilter = self.builder.get_object("languageStoreFilter")

--- a/pyanaconda/ui/tui/tuiobject.py
+++ b/pyanaconda/ui/tui/tuiobject.py
@@ -23,6 +23,7 @@ from pyanaconda.core import util, constants
 from pyanaconda import input_checking
 from pyanaconda.core.i18n import _
 from pyanaconda.core.users import crypt_password
+from pyanaconda.core.configuration.anaconda import conf
 
 from simpleline.render.adv_widgets import ErrorDialog, GetInputScreen, GetPasswordInputScreen, YesNoDialog
 from simpleline.render.screen import UIScreen, Prompt
@@ -105,7 +106,7 @@ class TUIObject(UIScreen, common.UIObject):
 
     @property
     def has_help(self):
-        return self.helpFile is not None
+        return conf.ui.help_directory and self.helpFile is not None
 
     def refresh(self, args=None):
         """Put everything to display into self.window list."""


### PR DESCRIPTION
This combines a patch from @VladimirSlavik for individual help button hiding with a new config file option that globally disables the built-in help system in Anaconda.

Lastly, use this config file option in the RHEL config file to disable the built-in help system on RHEL 9 for now, due to updated help content not yet being available.