### PR TITLE
Add missing permissions reduction to rest of our workflows

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -5,6 +5,9 @@ on:
   # be able to start this action manually from a actions tab when needed
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   refresh-containers:
     name: Refresh anaconda containers

--- a/.github/workflows/daily-rhel-copr.yml
+++ b/.github/workflows/daily-rhel-copr.yml
@@ -6,6 +6,9 @@ on:
   # be able to start this action manually from a actions tab when needed
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: copr-builder

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -4,6 +4,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   pr-info:
     if: startsWith(github.event.comment.body, '/kickstart-test')

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   pr-info:

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -6,6 +6,9 @@ on:
       - f[0-9]+-devel
       - f[0-9]+-release
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tests-contributors.yml
+++ b/.github/workflows/tests-contributors.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
   pr-info:

--- a/.github/workflows/tests-contributors.yml
+++ b/.github/workflows/tests-contributors.yml
@@ -6,6 +6,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   pr-info:
     if: startsWith(github.event.comment.body, '/test')


### PR DESCRIPTION
This will add only required permissions to all our existing workflows on `master` branch.

Tested on:
* [Build current anaconda rhel-8 branch in RHEL COPR](https://github.com/jkonecny12/anaconda/runs/3078744223?check_suite_focus=true)
* [Refresh container images](https://github.com/jkonecny12/anaconda/runs/3078737495?check_suite_focus=true)
* [Run tests on push](https://github.com/jkonecny12/anaconda/runs/3078856237?check_suite_focus=true)
* [Run validation tests for external contributors](https://github.com/jkonecny12/anaconda/runs/3078864350?check_suite_focus=true)
* [kickstart-tests](https://github.com/jkonecny12/anaconda/runs/3078859929?check_suite_focus=true)