### PR TITLE
Handle handle get_layout() method returning None (#1976526)

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -339,8 +339,11 @@ class ResizeDialog(GUIObject):
         :type default_size: Size
         """
         # Turn off wrapping of the displayed values.
+        # If the values are not being displayed (get_layout() return None)
+        # we don't need to turn off the wrapping as nothing will be displayed.
         layout = self._resize_slider.get_layout()
-        layout.set_width(-1)
+        if layout is not None:
+            layout.set_width(-1)
 
         # Convert the Sizes to ints
         min_size = int(min_size)


### PR DESCRIPTION
Looks like the GTK Scale object might return None from the
get_layout() method if no label is actually being displayed.

As we only interact with the layout to configure text wrapping,
we can just skip doing anything if None is returned as no text
will be displayed anyway.

Resolves: rhbz#1976526