### PR TITLE
Raise kickstart errors only during kickstart parsing

### DIFF
--- a/pyanaconda/modules/storage/bootloader/execution.py
+++ b/pyanaconda/modules/storage/bootloader/execution.py
@@ -17,9 +17,8 @@
 #
 import blivet.arch
 from blivet.devices import iScsiDiskDevice
-from pyanaconda.modules.storage.bootloader.base import BootLoaderError
-from pykickstart.errors import KickstartParseError
 
+from pyanaconda.modules.storage.bootloader.base import BootLoaderError
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import BOOTLOADER_ENABLED, BOOTLOADER_SKIPPED, \
     BOOTLOADER_LOCATION_PARTITION
@@ -142,16 +141,16 @@ class BootloaderExecutor(object):
         matched_disks = device_matches(boot_drive, devicetree=storage.devicetree, disks_only=True)
 
         if not matched_disks:
-            raise KickstartParseError(_("No match found for given boot drive "
-                                        "\"{}\".").format(boot_drive))
+            raise BootLoaderError(_("No match found for given boot drive "
+                                    "\"{}\".").format(boot_drive))
 
         if len(matched_disks) > 1:
-            raise KickstartParseError(_("More than one match found for given boot drive "
-                                        "\"{}\".").format(boot_drive))
+            raise BootLoaderError(_("More than one match found for given boot drive "
+                                    "\"{}\".").format(boot_drive))
 
         if matched_disks[0] not in usable_disks:
-            raise KickstartParseError(_("Requested boot drive \"{}\" doesn't exist or cannot "
-                                        "be used.").format(boot_drive))
+            raise BootLoaderError(_("Requested boot drive \"{}\" doesn't exist or cannot "
+                                    "be used.").format(boot_drive))
 
     def _find_drive_with_stage1(self, storage, usable_disks):
         """Find a drive with a valid stage1 device."""

--- a/pyanaconda/modules/storage/devicetree/utils.py
+++ b/pyanaconda/modules/storage/devicetree/utils.py
@@ -25,8 +25,6 @@ from blivet.formats import device_formats, get_format
 from blivet.formats.fs import FS
 from bytesize.bytesize import ROUND_HALF_UP
 
-from pykickstart.errors import KickstartError
-
 from pyanaconda.core import util
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.constants.services import NETWORK
@@ -76,7 +74,9 @@ def download_escrow_certificate(url):
         network_proxy = NETWORK.get_proxy()
 
         if not network_proxy.Connected:
-            raise KickstartError(_("Escrow certificate %s requires the network.") % url)
+            raise StorageError(
+                _("Escrow certificate {} requires the network.").format(url)
+            )
 
     # Download the certificate.
     log.info("Downloading an escrow certificate from: %s", url)
@@ -84,11 +84,14 @@ def download_escrow_certificate(url):
     try:
         request = util.requests_session().get(url, verify=True)
     except requests.exceptions.SSLError as e:
-        raise KickstartError(_("SSL error while downloading the escrow certificate:\n\n%s") % e) \
-            from e
+        raise StorageError(
+            _("SSL error while downloading the escrow certificate:\n\n{}").format(str(e))
+        ) from e
     except requests.exceptions.RequestException as e:
-        raise KickstartError(_("The following error was encountered while downloading the "
-                               "escrow certificate:\n\n%s") % e) from e
+        raise StorageError(
+            _("The following error was encountered while downloading "
+              "the escrow certificate:\n\n{}").format(str(e))
+        ) from e
 
     try:
         certificate = request.content

--- a/pyanaconda/modules/storage/partitioning/base_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/base_partitioning.py
@@ -17,7 +17,6 @@
 #
 from abc import abstractmethod, ABCMeta
 from blivet.errors import StorageError, InconsistentPVSectorSize
-from pykickstart.errors import KickstartParseError
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
@@ -58,7 +57,7 @@ class PartitioningTask(Task, metaclass=ABCMeta):
                 str(e).strip(),
                 _(INCONSISTENT_SECTOR_SIZES_SUGGESTIONS)
             ]))
-        except (StorageError, KickstartParseError, ValueError) as e:
+        except (StorageError, ValueError) as e:
             self._handle_storage_error(e, str(e))
         except BootLoaderError as e:
             self._handle_bootloader_error(e, str(e))

--- a/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
@@ -15,8 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from blivet.errors import StorageError
 from blivet.formats import get_format
-from pykickstart.errors import KickstartParseError
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
@@ -61,22 +61,24 @@ class ManualPartitioningTask(NonInteractivePartitioningTask):
 
         device = storage.devicetree.resolve_device(device_spec)
         if device is None:
-            raise KickstartParseError(_("Unknown or invalid device '%s' specified") % device_spec)
+            raise StorageError(
+                _("Unknown or invalid device '{}' specified").format(device_spec)
+            )
 
         if reformat:
             if format_type:
                 fmt = get_format(format_type)
 
                 if not fmt:
-                    raise KickstartParseError(
-                        _("Unknown or invalid format '%(format)s' specified for device "
-                          "'%(device)s'") % {"format": format_type, "device": device_spec}
+                    raise StorageError(
+                        _("Unknown or invalid format '{}' specified for "
+                          "device '{}'").format(format_type, device_spec)
                     )
             else:
                 old_fmt = device.format
 
                 if not old_fmt or old_fmt.type is None:
-                    raise KickstartParseError(_("No format on device '%s'") % device_spec)
+                    raise StorageError(_("No format on device '{}'").format(device_spec))
 
                 fmt = get_format(old_fmt.type)
             storage.format_device(device, fmt)

--- a/pyanaconda/modules/storage/snapshot/snapshot.py
+++ b/pyanaconda/modules/storage/snapshot/snapshot.py
@@ -17,9 +17,9 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from blivet.errors import StorageError
 from pykickstart.constants import SNAPSHOT_WHEN_PRE_INSTALL, CLEARPART_TYPE_ALL, \
     SNAPSHOT_WHEN_POST_INSTALL
-from pykickstart.errors import KickstartParseError
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.dbus import DBus
@@ -121,7 +121,7 @@ class SnapshotModule(KickstartBaseModule):
             log.debug("Validating the snapshot request for: %s", request.name)
             try:
                 get_snapshot_device(request, storage.devicetree)
-            except KickstartParseError as e:
+            except (StorageError, ValueError) as e:
                 report_error(str(e))
 
     def create_with_task(self, when):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_snapshot.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_snapshot.py
@@ -20,10 +20,11 @@
 import unittest
 from unittest.mock import patch, Mock
 
+from blivet.errors import StorageError
+
 from tests.unit_tests.pyanaconda_tests import patch_dbus_publish_object, check_task_creation
 
 from pykickstart.constants import SNAPSHOT_WHEN_POST_INSTALL, SNAPSHOT_WHEN_PRE_INSTALL
-from pykickstart.errors import KickstartParseError
 
 from pyanaconda.modules.common.errors.storage import UnavailableStorageError
 from pyanaconda.modules.storage.snapshot import SnapshotModule
@@ -86,7 +87,7 @@ class SnapshotInterfaceTestCase(unittest.TestCase):
         report_warning.assert_not_called()
 
         # Test failing check.
-        device_getter.side_effect = KickstartParseError("Fake error")
+        device_getter.side_effect = StorageError("Fake error")
         self.module.verify_requests(Mock(), Mock(), report_error, report_warning)
         report_error.assert_called_once_with("Fake error")
         report_warning.assert_not_called()
@@ -97,7 +98,7 @@ class SnapshotTasksTestCase(unittest.TestCase):
 
     def test_get_snapshot_device_fail(self):
         """Test the snapshot device."""
-        with self.assertRaises(KickstartParseError):
+        with self.assertRaises(StorageError):
             get_snapshot_device(Mock(name="post-snapshot", origin="fedora/root"), Mock())
 
     @patch('pyanaconda.modules.storage.snapshot.device.LVMLogicalVolumeDevice')


### PR DESCRIPTION
We are not able to correctly handle kickstart errors when we don't parse
a kickstart file. For example, we would show a wrong line number.

Resolves: rhbz#1851234