### PR TITLE
Do not install Anaconda dependencies to iso-creator container

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -205,7 +205,6 @@ anaconda-iso-creator-build:
 	$(CONTAINER_ENGINE) build \
 	$(CONTAINER_BUILD_ARGS) \
 	$(CONTAINER_ADD_ARGS) \
-	--build-arg=git_branch=$(GIT_BRANCH) \
 	--build-arg=image=registry.access.redhat.com/ubi8:latest \
 	-t $(ISO_CREATOR_NAME):$(CI_TAG) \
   $(ISO_CREATOR_DOCKERFILE)

--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -23,7 +23,6 @@ ARG image=registry.access.redhat.com/ubi8:latest
 FROM ${image}
 # FROM starts a new build stage with new ARGs. Put any ARGs after FROM unless required by the FROM itself.
 # see https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
-ARG git_branch=rhel-8
 LABEL maintainer=anaconda-list@redhat.com
 
 # Enable our repositories
@@ -34,13 +33,8 @@ COPY *.repo /etc/yum.repos.d/
 RUN set -ex; \
   dnf update -y; \
   dnf install -y \
-  curl \
-  /usr/bin/xargs \
-  rpm-build \
   createrepo_c \
   lorax; \
-  curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/${git_branch}/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
-  rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   dnf clean all
 
 COPY ["lorax-build", "/"]


### PR DESCRIPTION
We don't need Anaconda dependencies anymore because Anaconda is now build in a separate step. Now the iso-creator container is used only to build the boot.iso.

This will reduce size of the iso-creator container image from 1.1GB -> less than 400MB (based on my local testing).

(cherry picked from commit e9e747cb51844bcdc33471cfcfc34ca72799f617)