### PR TITLE
Clean up repositories for CI (#infra)

### DIFF
--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -32,6 +32,7 @@ lorax -p RHEL -v $MAJOR_VERSION -r $MINOR_VERSION --volid RHEL-$MAJOR_VERSION-$M
       --nomacboot \
       -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/BaseOS/x86_64/os/ \
       -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/AppStream/x86_64/os/ \
+      -s http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9-Beta/latest-BUILDROOT-9/compose/Buildroot/x86_64/os/ \
       -s file://$REPO_DIR/ \
       $@ \
       lorax

--- a/dockerfile/anaconda-iso-creator/rhel-9.repo
+++ b/dockerfile/anaconda-iso-creator/rhel-9.repo
@@ -1,11 +1,3 @@
-[RHEL-9-CRB]
-name=crb
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/CRB/$basearch/os/
-enabled=1
-gpgcheck=0
-install_weak_deps=0
-module_hotfixes=1
-
 [RHEL-9-BaseOS]
 name=baseos
 baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/BaseOS/$basearch/os/
@@ -17,14 +9,6 @@ module_hotfixes=1
 [RHEL-9-AppStream]
 name=appstream
 baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/AppStream/$basearch/os/
-enabled=1
-gpgcheck=0
-install_weak_deps=0
-module_hotfixes=1
-
-[RHEL-9-Buildroot]
-name=buildroot
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9-Beta/latest-BUILDROOT-9/compose/Buildroot/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0

--- a/dockerfile/anaconda-rpm/rhel-9.repo
+++ b/dockerfile/anaconda-rpm/rhel-9.repo
@@ -1,4 +1,4 @@
-[RHEL-8-CRB]
+[RHEL-9-CRB]
 name=crb
 baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9/compose/CRB/$basearch/os/
 enabled=1


### PR DESCRIPTION
* Fix an id of the CRB repository.
* Don't use CRB and Buildroot to install lorax.
* Temporarily use the Buildroot repository for the ISO build.