### PR TITLE
Use U disk to install the system cannot automatically locate the available repo problem

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -259,6 +259,9 @@ if __name__ == "__main__":
     from pyanaconda.core.kernel import kernel_arguments
     (opts, depr) = parse_arguments(boot_cmdline=kernel_arguments)
 
+    if not opts.method:
+        opts.method = opts.stage2
+
     from pyanaconda.core.configuration.anaconda import conf
     conf.set_from_opts(opts)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19882390/126456361-c9be9c32-3d49-46ca-9be6-2e583e53749b.png)

Using tools such as rufus 、ventoy 、UltraISO to make boot disk will stuck in the Installation Source stage, the verification fails, unable to proceed to the next step

This pr sets the default repo path. The ISO already has a mount point for the yum repository when starting the installation, so this path can be reused during the repository search phase.

Please take a look, thank you~