### PR TITLE
Don't add a prefix to the dependabot pull requests (#infra)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
     labels:
+      # Don't merge the pull request without #infra.
+      # TODO: Add the (#infra) suffix once supported.
       - "infrastructure"
-    commit-message:
-      prefix: "(#infra)"
+      - "blocked"


### PR DESCRIPTION
Add the `(#infra)` suffix once supported as it is required by the infrastructure
check. For now, add the `blocked` label to make sure that the pull request won't
be merged without it. We could create drafts instead of pull requests, but
that's not supported as well.