### PR TITLE
Bump codecov/codecov-action from 1 to 2 (#infra)

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
           path: test-logs/*
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
 
   rpm-tests:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Bumps the version of `codecov/codecov-action` to the latest one.