### PR TITLE
Disable anaconda-core's requirement on subscription-manager on CentOS

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -101,7 +101,7 @@ Requires: python3-systemd
 Requires: python3-productmd
 Requires: python3-dasbus >= %{dasbusver}
 Requires: flatpak-libs
-%if 0%{?rhel}
+%if %{defined rhel} && %{undefined centos}
 Requires: python3-syspurpose
 Requires: subscription-manager >= 1.26
 %endif


### PR DESCRIPTION
Resolves: rhbz#1984958