### PR TITLE
Disable anaconda-core's requirement on subscription-manager on CentOS

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -100,7 +100,7 @@ Requires: python3-systemd
 Requires: python3-productmd
 Requires: python3-dasbus >= %{dasbusver}
 Requires: flatpak-libs
-%if 0%{?rhel}
+%if %{defined rhel} && %{undefined centos}
 Requires: subscription-manager >= %{subscriptionmanagerver}
 %endif
 


### PR DESCRIPTION
Backport of https://github.com/rhinstaller/anaconda/pull/3535 .