### PR TITLE
Add root_password_must_be_set config option

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -267,6 +267,11 @@ hidden_spokes =
 # Run GUI installer in a decorated window.
 decorated_window = False
 
+# do not have hard requirement on root password being set by default
+# NOTE: this is a temporary option introduced to fix a RHV issue
+#       (see rhbz#1981807)
+root_password_must_be_set = False
+
 
 [License]
 # A path to EULA (if any)

--- a/data/product.d/ovirt.conf
+++ b/data/product.d/ovirt.conf
@@ -26,3 +26,6 @@ req_partition_sizes =
 
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhv
+
+# require user to set root password during oVirt installation
+root_password_must_be_set = True

--- a/data/product.d/rhev.conf
+++ b/data/product.d/rhev.conf
@@ -26,3 +26,6 @@ req_partition_sizes =
 
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhv
+
+# require user to set root password during RHV installation
+root_password_must_be_set = True

--- a/pyanaconda/core/configuration/ui.py
+++ b/pyanaconda/core/configuration/ui.py
@@ -69,3 +69,8 @@ class UserInterfaceSection(Section):
         :return: True or False
         """
         return self._get_option("decorated_window", bool)
+
+    @property
+    def root_password_must_be_set(self):
+        """Require root password to be set."""
+        return self._get_option("root_password_must_be_set", bool)


### PR DESCRIPTION
Add the root_password_must_be_set Anaconda config file option that
requires root password to be set during the given installation run.

This option works for both TUI and GUI and overrides the normal behavior
where setting an admin user is sufficient and where root password
configuration is not enforced for kickstart installation at all.

As this feature was requested by RHV, also enable it in the RHV and
oVirt configuration files when we are at it.

Resolves: rhbz#1981807