### PR TITLE
Mark a flaky pylint warning as a false positive (#infra)

### DIFF
--- a/pyanaconda/modules/common/structures/subscription.py
+++ b/pyanaconda/modules/common/structures/subscription.py
@@ -23,7 +23,8 @@ from pyanaconda.core.constants import DEFAULT_SUBSCRIPTION_REQUEST_TYPE
 
 from pyanaconda.modules.common.structures.secret import SecretData, SecretDataList
 
-__all__ = ["SystemPurposeData", "SubscriptionRequest"]
+__all__ = ["SystemPurposeData", "SubscriptionRequest", "AttachedSubscription"]
+
 
 class SystemPurposeData(DBusData):
     """System purpose data."""
@@ -112,11 +113,11 @@ class SystemPurposeData(DBusData):
         # addon ordering is not important
         if set(self.addons) != set(other_instance.addons):
             return False
-        elif(self.role != other_instance.role):
+        elif self.role != other_instance.role:
             return False
-        elif(self.sla != other_instance.sla):
+        elif self.sla != other_instance.sla:
             return False
-        elif(self.usage != other_instance.usage):
+        elif self.usage != other_instance.usage:
             return False
         else:
             return True

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -27,6 +27,7 @@ class AnacondaLintConfig(CensorshipConfig):
             FalsePositive(r"^E1101.*: FedoraGeoIPProvider._refresh: Instance of 'LookupDict' has no 'ok' member"),
             FalsePositive(r"^E1101.*: HostipGeoIPProvider._refresh: Instance of 'LookupDict' has no 'ok' member"),
             FalsePositive(r"^E1101.*: Method 'PropertiesChanged' has no 'connect' member"),
+            FalsePositive(r"^E1101.*: NetworkService.get_team_devices: Instance of 'AttachedSubscription' has no 'device_type' member"),
 
             # TODO: BlockDev introspection needs to be added to pylint to handle these
             FalsePositive(r"E1101.*: Instance of 'int' has no 'dasd_is_fba' member"),


### PR DESCRIPTION
The warning from `NetworkService.get_team_devices` about the `device_type` member of
`AttachedSubscription` class appears randomly, but it is always a false positive.
