### PR TITLE
Switch from pull_request_target trigger to pull_request (#infra)

### DIFF
--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Clone Anaconda repository
         uses: actions/checkout@v2
         with:
+          # TODO: Are we able to remove ref, fetch-depth and Rebase task? Seems that the checkout
+          # without ref is doing the rebase for us.
           # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -1,7 +1,7 @@
 # Check if only infrastructure files are changed when infrastructure label is set.
 name: infrastructure-check
 on:
-  pull_request_target:
+  pull_request:
     types: [ "opened", "synchronize", "reopened", "labeled" ]
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Run validation tests
-on: pull_request_target
+on: pull_request
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
         with:
+          # TODO: Are we able to remove ref, fetch-depth and Rebase task? Seems that the checkout
+          # without ref is doing the rebase for us.
           # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -117,6 +119,8 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
         with:
+          # TODO: Are we able to remove ref, fetch-depth and Rebase task? Seems that the checkout
+          # without ref is doing the rebase for us.
           # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0


### PR DESCRIPTION
We are using the pull_request_target trigger everywhere because otherwise external contributors are able to attack our self-hosted runners by changing the workflow to use them. The problem is that the change of the workflow is executed
on the Pull Request before merge. 
However, the pull_request_target trigger has a few drawbacks. It will give the Pull Request access to secrets and a write permission (already solved) and it's harder to test changes to the workflow because the changes are not executed on Pull Request so it has to be tested on fork.

We can switch now to the recommended pull_request trigger because all the external contributors Pull Requests will be gated thanks to this feature:

https://github.blog/changelog/2021-07-01-github-actions-new-settings-for-maintainers/

Also we need to do that because this feature works only for pull_request trigger but not for pull_request_target trigger.