### PR TITLE
Switch from pull_request_target trigger to pull_request (#infra)

### DIFF
--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -1,7 +1,7 @@
 # Check if only infrastructure files are changed when infrastructure label is set.
 name: infrastructure-check
 on:
-  pull_request_target:
+  pull_request:
     types: [ "opened", "synchronize", "reopened", "labeled" ]
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,11 @@
 name: Run validation tests
-on: pull_request_target
+on: pull_request
 
 permissions:
   contents: read
 
 jobs:
   unit-tests:
-    environment: staging
     runs-on: [self-hosted, kstest]
     timeout-minutes: 30
     strategy:
@@ -61,7 +60,6 @@ jobs:
           path: test-logs/*
 
   rpm-tests:
-    environment: staging
     runs-on: [self-hosted, kstest]
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
We are using the pull_request_target trigger everywhere because otherwise external contributors are able to attack our self-hosted runners by changing the workflow to use them. The problem is that the change of the workflow is executed on the Pull Request before merge.
However, the pull_request_target trigger has a few drawbacks. It will give the Pull Request access to secrets and a write permission (already solved) and it's harder to test changes to the workflow because the changes are not executed on Pull Request so it has to be tested on fork.

We can switch now to the recommended pull_request trigger because all the external contributors Pull Requests will be gated thanks to this feature:

https://github.blog/changelog/2021-07-01-github-actions-new-settings-for-maintainers/

Also we need to do that because this feature works only for pull_request trigger but not for pull_request_target trigger.