### PR TITLE
Use the similar solution on RHEL-8 branch to gate contributors as on master

### DIFF
--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -1,7 +1,7 @@
 # Check if only infrastructure files are changed when infrastructure label is set.
 name: infrastructure-check
 on:
-  pull_request_target:
+  pull_request:
     types: [ "opened", "synchronize", "reopened", "labeled" ]
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,47 +1,21 @@
-# Run rhel-8 unit tests for organization members only.
-# This avoids running untrusted and unreviewed code on self-hosted runners.
-name: owner-unit-tests-rhel-8
-on: [pull_request_target]
+name: Run validation tests
+on: pull_request
 
 permissions:
   contents: read
 
 jobs:
-  pr-info:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Query comment author repository permissions
-        uses: octokit/request-action@v2.x
-        id: user_permission
-        with:
-          route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # restrict running of tests to users with admin or write permission for the repository
-      # see https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-repository-permissions-for-a-user
-      # store output if user is allowed in allowed_user job output so it has to be checked in downstream job
-      - name: Check if user does have correct permissions
-        if: contains('admin write', fromJson(steps.user_permission.outputs.data).permission)
-        id: check_user_perm
-        run: |
-          echo "User '${{ github.event.sender.login }}' has permission '${{ fromJson(steps.user_permission.outputs.data).permission }}' allowed values: 'admin', 'write'"
-          echo "::set-output name=allowed_user::true"
-
-    outputs:
-      allowed_user: ${{ steps.check_user_perm.outputs.allowed_user }}
-
-  # Run unit tests only if user have write or admin rights
   unit-tests:
-    needs: pr-info
-    if: needs.pr-info.outputs.allowed_user == 'true'
     runs-on: [self-hosted, kstest]
+    timeout-minutes: 30
     env:
       TARGET_BRANCH_NAME: origin/rhel-8
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
         with:
+          # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
@@ -52,11 +26,11 @@ jobs:
           git log --oneline -1 ${{ env.TARGET_BRANCH_NAME }}
           git rebase ${{ env.TARGET_BRANCH_NAME }}
 
-      - name: Build CI test container
-        run: |
-          make -f Makefile.am anaconda-ci-build
+      # build container if files for dockerfile changed in the PR
+      - name: Build anaconda-ci container
+        run: make -f Makefile.am anaconda-ci-build
 
-      - name: Run tests in container
+      - name: Run tests in anaconda-ci container
         run: |
           # put the log in the output, where it's easy to read and link to
           make -f Makefile.am container-ci || { cat test-logs/test-suite.log; exit 1; }
@@ -68,18 +42,17 @@ jobs:
           name: logs
           path: test-logs/*
 
-  # Run rpm tests only if user have write or admin rights
   rpm-tests:
-    needs: pr-info
-    if: needs.pr-info.outputs.allowed_user == 'true'
     runs-on: [self-hosted, kstest]
     timeout-minutes: 30
     env:
       TARGET_BRANCH_NAME: origin/rhel-8
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
         with:
+          # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
@@ -100,5 +73,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: 'logs-rpm-test'
+          name: 'logs-rpm-test (${{ matrix.ci_tag }})'
           path: test-logs/*


### PR DESCRIPTION
This will simplify our work with the workflows. It will make this workflow closer to the master version and also we could remove the external contributors specific workflow from master branch.

We don't need to have pr-info anymore because all external contributors are gated by

https://github.blog/changelog/2021-07-01-github-actions-new-settings-for-maintainers/