### PR TITLE
Rhel 9 improve dracut errors visibility

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -245,6 +245,9 @@ if __name__ == "__main__":
         stdout_log.warning("All Anaconda kernel boot arguments are now required to use "
                            "'inst.' prefix!")
 
+    # print errors encountered during boot
+    startup_utils.print_dracut_errors(stdout_log)
+
     from pyanaconda import isys
 
     util.ipmi_report(constants.IPMI_STARTED)

--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -37,6 +37,7 @@ dist_dracut_SCRIPTS = module-setup.sh \
                       anaconda-copy-s390ccwconf.sh \
                       anaconda-ifcfg.sh \
                       anaconda-set-kernel-hung-timeout.sh \
+                      anaconda-error-reporting.sh \
                       fetch-kickstart-net.sh \
                       fetch-kickstart-disk \
                       fetch-updates-disk \

--- a/dracut/anaconda-error-reporting.sh
+++ b/dracut/anaconda-error-reporting.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Print what went wrong during the boot from installation perspective because Dracut seems
+# to timeout soon!
+#
+
+warn "############# Anaconda installer errors begin #############"
+warn "#                                                         #"
+warn "It seems that the boot has failed. Possible causes include "
+warn "missing inst.stage2 or inst.repo boot parameters on the "
+warn "kernel cmdline. Please verify that you have specified "
+warn "inst.stage2 or inst.repo."
+warn "Please also note that the 'inst.' prefix is now mandatory."
+warn "#                                                         #"
+warn "############# Anaconda installer errors end ###############"
+
+sleep 1

--- a/dracut/anaconda-error-reporting.sh
+++ b/dracut/anaconda-error-reporting.sh
@@ -12,6 +12,12 @@ warn "kernel cmdline. Please verify that you have specified "
 warn "inst.stage2 or inst.repo."
 warn "Please also note that the 'inst.' prefix is now mandatory."
 warn "#                                                         #"
+warn "####     Installer errors encountered during boot:     ####"
+warn "#                                                         #"
+while read -r line; do
+    warn "$line"
+done < /run/anaconda/initrd_errors.txt
+warn "#                                                         #"
 warn "############# Anaconda installer errors end ###############"
 
 sleep 1

--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -4,6 +4,16 @@ command -v unpack_img >/dev/null || . /lib/img-lib.sh
 command -v getarg >/dev/null || . /lib/dracut-lib.sh
 command -v fetch_url >/dev/null || . /lib/url-lib.sh
 
+# show critical error messages more visible to user
+warn_critical() {
+    local msg="$1"
+    if ! [ -d /run/anaconda ]; then
+        mkdir -p /run/anaconda
+    fi
+    echo "$msg" >> /run/anaconda/initrd_errors.txt
+    warn "$msg"
+}
+
 # config_get SECTION KEY < FILE
 # read an .ini-style config file, find the KEY in the given SECTION, and return
 # the value provided for that key.

--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -139,7 +139,7 @@ anaconda_net_root() {
         return 0
     fi
 
-    warn "anaconda: failed to fetch stage2 from $repo"
+    warn_critical "anaconda: failed to fetch stage2 from $repo"
     return 1
 }
 

--- a/dracut/anaconda-netroot.sh
+++ b/dracut/anaconda-netroot.sh
@@ -83,7 +83,7 @@ case $repo in
         done
     ;;
     *)
-        warn "unknown network repo URL: $repo"
+        warn_critical "unknown network repository URL: $repo"
         return 1
     ;;
 esac

--- a/dracut/fetch-driver-net.sh
+++ b/dracut/fetch-driver-net.sh
@@ -2,6 +2,8 @@
 # fetch-driver-net - fetch driver from the network.
 # runs from the "initqueue/online" hook whenever a net interface comes online
 
+command -v warn_critical >/dev/null || . /lib/anaconda-lib.sh
+
 # initqueue/online hook passes interface name as $1
 netif="$1"
 
@@ -24,7 +26,7 @@ for dd in $DD_NET; do
             echo "$dd" >> /tmp/dd_net.done # mark it done so we don't fetch it again
             driver-updates --net "$dd" "$driver"
         else
-            warn "Failed to fetch driver from $dd"
+            warn_critical "Failed to fetch driver from $dd"
         fi
 
     else

--- a/dracut/fetch-kickstart-disk
+++ b/dracut/fetch-kickstart-disk
@@ -40,5 +40,5 @@ if [ -f /tmp/ks.cfg ]; then
     parse_kickstart /tmp/ks.cfg
     run_kickstart
 else
-    warn "Can't get kickstart from $dev:$path"
+    warn_critical "Can't get kickstart from $dev:$path"
 fi

--- a/dracut/fetch-kickstart-net.sh
+++ b/dracut/fetch-kickstart-net.sh
@@ -60,7 +60,7 @@ case $kickstart in
         locations="$(</tmp/ks_urls)"
     ;;
     *)
-        warn "unknown network kickstart URL: $kickstart"
+        warn_critical "unknown network kickstart URL: $kickstart"
         return 1
     ;;
 esac
@@ -89,7 +89,7 @@ for kickstart in \$locations; do
         run_kickstart
         break
     else
-        warn "anaconda: failed to fetch kickstart from \$kickstart"
+        warn_critical "anaconda: failed to fetch kickstart from \$kickstart"
     fi
 done
 rm \$job # remove self from initqueue

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -68,6 +68,8 @@ install() {
     inst_simple "$moddir/driver-updates@.service" "/etc/systemd/system/driver-updates@.service"
     # rpm configuration file (needed by dd_extract)
     inst "/usr/lib/rpm/rpmrc"
+    # timeout script for errors reporting
+    inst_hook initqueue/timeout 50 "$moddir/anaconda-error-reporting.sh"
     # python deps for parse-kickstart. DOUBLE WOOOO
     PYTHONHASHSEED=42 $moddir/python-deps $moddir/parse-kickstart $moddir/driver_updates.py | while read dep; do
         case "$dep" in

--- a/dracut/parse-anaconda-kickstart.sh
+++ b/dracut/parse-anaconda-kickstart.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # parse-anaconda-kickstart.sh: handle kickstart settings
 
+command -v warn_critical >/dev/null || . /lib/anaconda-lib.sh
+
 # no need to do this twice
 [ -f /tmp/ks.cfg.done ] && return
 
@@ -36,8 +38,8 @@ case "${kickstart%%:*}" in
             [ "$root" = "anaconda-kickstart" ] && root=""
             > /tmp/ks.cfg.done
         else
-            warn "inst.ks='$kickstart'"
-            warn "can't find $kspath!"
+            warn_critical "inst.ks='$kickstart'"
+            warn_critical "can't find $kspath!"
         fi
     ;;
 esac

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -32,8 +32,8 @@ set_http_header "X-Anaconda-System-Release" "$product"
 # convenience function to warn the user about old argument names.
 warn_renamed_arg() {
     local arg=""
-    arg="$(getarg $1)" && warn "'$1=$arg'" && \
-        warn "$1 has been deprecated and will be removed. Please use $2 instead."
+    arg="$(getarg $1)" && warn_critical "'$1=$arg'" && \
+        warn_critical "$1 has been deprecated and will be removed. Please use $2 instead."
 }
 
 # check for deprecated arg, warn user, and write new arg to /etc/cmdline
@@ -43,7 +43,7 @@ check_depr_arg() {
     arg="$(getarg $1)"
     [ "$arg" ] || return 1
     newval=$(printf "$2" "$arg")
-    [ "$quiet" ] || warn "'$1' is deprecated. Using '$newval' instead."
+    [ "$quiet" ] || warn_critical "'$1' is deprecated. Using '$newval' instead."
     echo "$newval" >> /etc/cmdline.d/75-anaconda-options.conf
 }
 check_depr_args() {
@@ -53,8 +53,8 @@ check_depr_args() {
 check_removed_arg() {
     local arg="$1"; shift
     if getarg "$arg" > /dev/null; then
-        warn "'$arg' is deprecated and has been removed."
-        [ -n "$*" ] && warn "$*"
+        warn_critical "'$arg' is deprecated and has been removed."
+        [ -n "$*" ] && warn_critical "$*"
     fi
 }
 

--- a/dracut/parse-anaconda-repo.sh
+++ b/dracut/parse-anaconda-repo.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # parse-repo-options.sh: parse the inst.repo= arg and set root/netroot
 
+command -v warn_critical >/dev/null || . /lib/anaconda-lib.sh
+
 # If there's a root= arg, we'll just use that
 getarg root= >/dev/null && return
 
@@ -41,7 +43,7 @@ if [ -n "$repo" ]; then
             root="anaconda-hmc"
         ;;
         *)
-            warn "Invalid value for 'inst.$arg': $repo"
+            warn_critical "Invalid value for 'inst.$arg': $repo"
         ;;
     esac
 fi

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -524,3 +524,6 @@ RHSM_SYSPURPOSE_FILE_PATH = "/etc/rhsm/syspurpose/syspurpose.json"
 # GID and UID modes
 ID_MODE_USE_VALUE = "ID_MODE_USE_VALUE"
 ID_MODE_USE_DEFAULT = "ID_MODE_USE_DEFAULT"
+
+# Path to the initrd critical warnings log file created by us in Dracut.
+DRACUT_ERRORS_PATH = "/run/anaconda/initrd_errors.txt"

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -31,7 +31,7 @@ from pyanaconda.anaconda_loggers import get_stdout_logger, get_module_logger
 from pyanaconda.core import util, constants
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import TEXT_ONLY_TARGET, SETUP_ON_BOOT_DEFAULT, \
-    SETUP_ON_BOOT_ENABLED
+    SETUP_ON_BOOT_ENABLED, DRACUT_ERRORS_PATH
 from pyanaconda.core.i18n import _
 from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.flags import flags
@@ -579,3 +579,20 @@ def initialize_security():
     # Enable fingerprint option by default (#481273).
     if not flags.automatedInstall:
         security_proxy.SetFingerprintAuthEnabled(True)
+
+
+def print_dracut_errors(stdout_logger):
+    """Print Anaconda critical warnings from Dracut to user before starting Anaconda.
+
+    :param stdout_logger: python logger to stdout
+    """
+    try:
+        with open(DRACUT_ERRORS_PATH, "rt") as fd:
+            section_name = "Installer errors encountered during boot"
+            msg = "\n{:#^70}\n{}\n{:#^70}".format(  # add starting \n because timestamp
+                " " + section_name + " ",           # start of the section
+                "".join(fd.readlines()),            # errors from Dracut
+                " " + section_name + " end ")       # end of the section
+            stdout_logger.warning(msg)
+    except OSError:
+        pass

--- a/tests/nosetests/pyanaconda_tests/core/test_startup_utils.py
+++ b/tests/nosetests/pyanaconda_tests/core/test_startup_utils.py
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Test code from the startup_utils.py. Most of the parts are not
+# easy to test but we can try to improve that.
+#
+
+import unittest
+
+from unittest.mock import patch, mock_open, Mock
+from textwrap import dedent
+
+from pyanaconda.startup_utils import print_dracut_errors
+
+
+class StartupUtilsTestCase(unittest.TestCase):
+
+    def test_print_dracut_errors(self):
+        logger_mock = Mock()
+
+        with patch("pyanaconda.startup_utils.open", mock_open(read_data="test text")) as m:
+            print_dracut_errors(logger_mock)
+
+            m.assert_called_once_with("/run/anaconda/initrd_errors.txt", "rt")
+
+            logger_mock.warning.assert_called_once_with(
+                dedent("""
+                ############## Installer errors encountered during boot ##############
+                test text
+                ############ Installer errors encountered during boot end ############"""))
+
+    @patch("pyanaconda.core.constants.DRACUT_ERRORS_PATH", "None")
+    def test_print_dracut_errors_missing_file(self):
+        logger_mock = Mock()
+        print_dracut_errors(logger_mock)
+        logger_mock.assert_not_called()


### PR DESCRIPTION
Backport of https://github.com/rhinstaller/anaconda/pull/3533 .

When there is an error printed in Dracut it is scrolled out pretty fast (most of the time). Users could find them in journal but that is not always an easy thing to do and you have to be an advanced user to know where to look.

By this change set, I'm trying to improve the situation. Now you are able to see the errors when Dracut starts to timeout and also after a boot before Anaconda is started.

_Resolves: rhbz#1983098_