### PR TITLE
Fix admin user password condition handling in TUI

### DIFF
--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -223,8 +223,15 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     @property
     def mandatory(self):
-        """Only mandatory if no admin user has been requested."""
-        return not self._users_module.CheckAdminUserExists()
+        """The spoke is mandatory only if some input is missing.
+
+        Possible reasons to be mandatory:
+        - No admin user has been created
+        - Password has been requested but not entered
+        """
+        return (not self._users_module.CheckAdminUserExists() or
+                (self._use_password and not bool(self.user.password or
+                                                 self.user.is_crypted)))
 
     @property
     def status(self):


### PR DESCRIPTION
Suggested edits for #3408. Do not merge yet, please.

Code @bitcoffeeiux, docstring & commit message @VladimirSlavik.

Previously, in text mode, if an user was created as admin, installation could start even if password was requested for the user but not entered. With this patch, password presence is checked for the user, too.