### PR TITLE
Resolve filename into associated loop device

### DIFF
--- a/pyanaconda/payload/utils.py
+++ b/pyanaconda/payload/utils.py
@@ -49,6 +49,9 @@ def get_device_path(device_name):
 
     device_tree = STORAGE.get_proxy(DEVICE_TREE)
     device_data = DeviceData.from_structure(device_tree.GetDeviceData(device_name))
+    if device_data.type == 'file' and device_data.children:
+        # resolve file path to associated loop device, if any
+        device_data = DeviceData.from_structure(device_tree.GetDeviceData(device_data.children[0]))
     return device_data.path
 
 


### PR DESCRIPTION
This fixes checking if given (disk image) file is mounted somewhere,
especially as /run/initramfs/repo.
PackagePayload._device_is_mounted_as_source() depends on it.

Some more details at https://github.com/QubesOS/qubes-issues/issues/6792

This is related to https://bugzilla.redhat.com/show_bug.cgi?id=1830553, although is not enough to fix it completely on Fedora 34 Server install.

cc @jkonecny12 