### PR TITLE
Migrate tests to pytest framework

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -50,7 +50,8 @@ RUN pip install --no-cache-dir \
   pycodestyle \
   dogtail \
   rpmfluff \
-  freezegun
+  freezegun \
+  pytest
 
 RUN mkdir /anaconda
 

--- a/tests/unit_tests.sh
+++ b/tests/unit_tests.sh
@@ -11,4 +11,4 @@ if [ $# -eq 0 ]; then
     set -- $top_srcdir/tests/unit_tests
 fi
 
-exec python3 -m unittest discover -t $top_srcdir -v -b ${UNIT_TESTS_PATTERN:+-k $UNIT_TESTS_PATTERN} -s $@
+exec pytest ${UNIT_TESTS_PATTERN:+-k $UNIT_TESTS_PATTERN} $@

--- a/tests/unit_tests/dd_tests/test_dd.py
+++ b/tests/unit_tests/dd_tests/test_dd.py
@@ -143,18 +143,18 @@ class ASelfTestCase(unittest.TestCase):
         """check if rpmfluff is working"""
         p = make_rpm(outdir=self.tmpdir)
         rpmfile = os.path.basename(p.get_built_rpm(expectedArch))
-        self.assertTrue(rpmfile in os.listdir(self.tmpdir))
+        assert rpmfile in os.listdir(self.tmpdir)
 
     def test_rpmfluff_payload(self):
         """check if rpmfluff can add files to built RPMs"""
         p = make_rpm(outdir=self.tmpdir, payload=(binfile, kofile))
         rpmfile = os.path.basename(p.get_built_rpm(expectedArch))
-        self.assertTrue(rpmfile in os.listdir(self.tmpdir))
+        assert rpmfile in os.listdir(self.tmpdir)
 
     def test_utils_exist(self):
         """check that the dd utilities exist"""
-        self.assertTrue("dd_list" in os.listdir(UTILDIR))
-        self.assertTrue("dd_extract" in os.listdir(UTILDIR))
+        assert "dd_list" in os.listdir(UTILDIR)
+        assert "dd_extract" in os.listdir(UTILDIR)
 
 
 class DD_List_TestCase(unittest.TestCase):
@@ -175,16 +175,16 @@ class DD_List_TestCase(unittest.TestCase):
         """dd_list: check output format"""
         rpm = make_rpm(self.tmpdir, for_kernel_ver=self.k_ver)
         drivers = self.dd_list()
-        self.assertEqual(len(drivers), 1)
+        assert len(drivers) == 1
         d = drivers[0]
-        self.assertEqual(d.name, rpm.name)
-        self.assertEqual(d.description, rpm.basePackage.description)
-        self.assertTrue(d.description)
-        self.assertTrue(os.path.exists(d.source))
-        self.assertIn("modules", d.flags)
-        self.assertIn("firmwares", d.flags)
-        self.assertNotIn("binaries", d.flags)
-        self.assertNotIn("libraries", d.flags)
+        assert d.name == rpm.name
+        assert d.description == rpm.basePackage.description
+        assert d.description
+        assert os.path.exists(d.source)
+        assert "modules" in d.flags
+        assert "firmwares" in d.flags
+        assert "binaries" not in d.flags
+        assert "libraries" not in d.flags
 
     def test_dd_list_multiple(self):
         """dd_list: multiple outputs for multiple packages"""
@@ -192,45 +192,45 @@ class DD_List_TestCase(unittest.TestCase):
         for name in names:
             make_rpm(self.tmpdir, name=name, for_kernel_ver=self.k_ver)
         drivers = self.dd_list()
-        self.assertEqual(len(drivers), len(names))
-        self.assertEqual(set(d.name for d in drivers), set(names))
+        assert len(drivers) == len(names)
+        assert set(d.name for d in drivers) == set(names)
 
     def test_dd_list_binaries(self):
         """dd_list: 'Provides:installer-enhancement' implies bins/libs"""
         make_rpm(self.tmpdir, for_anaconda_ver=self.a_ver)
         drivers = self.dd_list()
-        self.assertFalse(drivers == [])
+        assert not (drivers == [])
         d = drivers[0]
-        self.assertIn("binaries", d.flags)
-        self.assertIn("libraries", d.flags)
-        self.assertNotIn("modules", d.flags)
-        self.assertNotIn("firmwares", d.flags)
+        assert "binaries" in d.flags
+        assert "libraries" in d.flags
+        assert "modules" not in d.flags
+        assert "firmwares" not in d.flags
 
     def test_dd_list_old_kmods(self):
         """dd_list: ignore kmods if our kernel is too old"""
         make_rpm(self.tmpdir, for_kernel_ver="5.0.1-555")
-        self.assertEqual(self.dd_list(), [])
+        assert self.dd_list() == []
 
     def test_dd_list_z_stream_kmods(self):
         """dd_list: accept kmods for z-stream kernels (#1207831)"""
         make_rpm(self.tmpdir, for_kernel_ver=self.k_ver)
         drivers = self.dd_list(kernel_ver=self.k_ver+".3")
-        self.assertNotEqual(drivers, [])
+        assert drivers != []
         d = drivers[0]
-        self.assertIn("modules", d.flags)
+        assert "modules" in d.flags
 
     def test_dd_list_anaconda_old(self):
         """dd_list: ignore installer-enhancements if version doesn't match"""
         make_rpm(self.tmpdir, for_anaconda_ver="23.0")
-        self.assertEqual(self.dd_list(), [])
+        assert self.dd_list() == []
 
     def test_dd_list_no_rpms(self):
         """dd_list: empty directory returns no results"""
-        self.assertEqual(self.dd_list(), [])
+        assert self.dd_list() == []
 
     def test_dd_list_missing_dir(self):
         """dd_list: missing directory returns no results"""
-        self.assertEqual(self.dd_list(dd_dir="/non/existent/path"), [])
+        assert self.dd_list(dd_dir="/non/existent/path") == []
 
 
 class DD_Extract_TestCase(unittest.TestCase):
@@ -266,11 +266,11 @@ class DD_Extract_TestCase(unittest.TestCase):
             out_path = self.outdir+item.path
             if isinstance(item, TextRPMFile):
                 with open(out_path) as f:
-                    self.assertEqual(item.contents, f.read())
+                    assert item.contents == f.read()
             elif isinstance(item, BinRPMFile):
-                self.assertTrue(os.path.exists(out_path))
+                assert os.path.exists(out_path)
                 # check that file have some generated content
-                self.assertGreater(os.stat(out_path).st_size, 1)
+                assert os.stat(out_path).st_size > 1
 
     def test_dd_extract_chmod(self):
         """dd_extract: files get correct mode (#1222056)"""
@@ -281,24 +281,24 @@ class DD_Extract_TestCase(unittest.TestCase):
                 binmode = os.stat(self.outdir+f.path).st_mode
                 expectmode = int(f.kwargs['mode'], 8)
                 print("testing", f.path)
-                self.assertEqual(binmode & expectmode, expectmode)
+                assert binmode & expectmode == expectmode
 
     def test_dd_extract_modules(self):
         """dd_extract: using --modules extracts only .ko files"""
         outfiles = self.dd_extract(flags='--modules')
-        self.assertEqual(outfiles, set([self.outdir+kofile.path]))
+        assert outfiles == set([self.outdir+kofile.path])
 
     def test_dd_extract_binaries(self):
         """dd_extract: using --binaries extracts only /bin, /sbin, etc."""
         outfiles = self.dd_extract(flags='--binaries')
-        self.assertEqual(outfiles, set([self.outdir+binfile.path]))
+        assert outfiles == set([self.outdir+binfile.path])
 
     def test_dd_extract_libs(self):
         """dd_extract: using --libraries extracts only /lib etc."""
         outfiles = self.dd_extract(flags='--libraries')
-        self.assertEqual(outfiles, set([self.outdir+libfile.path]))
+        assert outfiles == set([self.outdir+libfile.path])
 
     def test_dd_extract_firmware(self):
         """dd_extract: using --firmwares extracts only /lib/firmware"""
         outfiles = self.dd_extract(flags='--firmwares')
-        self.assertEqual(outfiles, set([self.outdir+fwfile.path]))
+        assert outfiles == set([self.outdir+fwfile.path])

--- a/tests/unit_tests/dracut_tests/test_dracut_source.py
+++ b/tests/unit_tests/dracut_tests/test_dracut_source.py
@@ -89,6 +89,6 @@ class SourcesTestCase(unittest.TestCase):
                         continue
 
                     # fail on every line which does not have 'mount -o ro'
-                    self.assertRegex(line, r'\bmount +-o *[a-z,]*ro',
-                                     "Dracut mount in '{}' on line '{}' is not read-only!"
-                                     .format(path, num))
+                    assert re.search(r'\bmount +-o *[a-z,]*ro', line), \
+                        "Dracut mount in '{}' on line '{}' is not read-only!" \
+                        .format(path, num)

--- a/tests/unit_tests/dracut_tests/test_driver_updates.py
+++ b/tests/unit_tests/dracut_tests/test_driver_updates.py
@@ -87,7 +87,7 @@ class SelfTestCase(FileTestCaseBase):
         filepaths = ["sub/dir/test.file", "testfile"]
         self.makefiles(*filepaths)
         for f in filepaths:
-            self.assertTrue(os.path.exists(self.tmpdir+'/'+f))
+            assert os.path.exists(self.tmpdir+'/'+f)
 
 
 class TestCopyFiles(FileTestCaseBase):
@@ -97,7 +97,7 @@ class TestCopyFiles(FileTestCaseBase):
         self.makefiles("dest/file3")
         copy_files(files, self.destdir, self.srcdir)
         result = set(listfiles(self.destdir))
-        self.assertEqual(result, set(["file1", "subdir/file2", "file3"]))
+        assert result == set(["file1", "subdir/file2", "file3"])
 
     def test_overwrite(self):
         """copy_file: overwrite files in destdir if they have the same name"""
@@ -107,8 +107,8 @@ class TestCopyFiles(FileTestCaseBase):
         with open(dest, 'w') as outf:
             outf.write("destfile")
         copy_files([src], self.destdir, self.srcdir)
-        self.assertEqual(list(listfiles(self.destdir)), ["file1"])
-        self.assertEqual(open(dest).read(), "srcfile")
+        assert list(listfiles(self.destdir)) == ["file1"]
+        assert open(dest).read() == "srcfile"
 
     def test_samefile(self):
         """copy_file: skip files already in destdir"""
@@ -116,14 +116,14 @@ class TestCopyFiles(FileTestCaseBase):
         with open(dest, 'w') as outf:
             outf.write("destfile")
         copy_files([dest], self.destdir, "src")
-        self.assertEqual(list(listfiles(self.destdir)), ["file1"])
-        self.assertEqual(open(dest).read(), "destfile")
+        assert list(listfiles(self.destdir)) == ["file1"]
+        assert open(dest).read() == "destfile"
 
     def test_copy_to_parent(self):
         """copy_file: skip files in subdirs of destdir"""
         files = self.makefiles("dest/subdir/file1")
         copy_files(files, self.destdir, "src")
-        self.assertEqual(list(iter_files(self.destdir)), files)
+        assert list(iter_files(self.destdir)) == files
 
     def test_copy_kernel(self):
         """copy_file: strip leading module directories"""
@@ -131,7 +131,7 @@ class TestCopyFiles(FileTestCaseBase):
                                "src/lib/modules/3.2.1-900.fc47.x86_64/kernel/other.ko.xz")
         copy_files(files, self.destdir, self.srcdir+"/lib/modules")
         result = set(listfiles(self.destdir))
-        self.assertEqual(result, set(["subdir/module.ko", "other.ko.xz"]))
+        assert result == set(["subdir/module.ko", "other.ko.xz"])
 
 
 class TestIterFiles(FileTestCaseBase):
@@ -140,14 +140,14 @@ class TestIterFiles(FileTestCaseBase):
         files = set(self.makefiles("src/file1", "dest/file2", "src/sub/file3"))
         makedir(self.tmpdir+'/empty/dir')
         result = set(iter_files(self.tmpdir))
-        self.assertEqual(files, result)
+        assert files == result
 
     def test_pattern(self):
         """iter_files: match filename against glob pattern"""
         self.makefiles("src/file1.so", "src/sub.ko/file2")
         goodfiles = set(self.makefiles("src/sub/file1.ko", "src/file2.ko.xz"))
         result = set(iter_files(self.tmpdir, pattern="*.ko*"))
-        self.assertEqual(result, goodfiles)
+        assert result == goodfiles
 
 
 class TestMoveFiles(FileTestCaseBase):
@@ -155,8 +155,8 @@ class TestMoveFiles(FileTestCaseBase):
         """move_files: move files to destdir"""
         files = self.makefiles("src/file1", "src/subdir/file2")
         move_files(files, self.destdir, self.srcdir)
-        self.assertEqual(set(listfiles(self.destdir)), set(["file1", "subdir/file2"]))
-        self.assertEqual(list(iter_files(self.srcdir)), [])
+        assert set(listfiles(self.destdir)) == set(["file1", "subdir/file2"])
+        assert list(iter_files(self.srcdir)) == []
 
     def test_overwrite(self):
         """move_files: overwrite files with the same name"""
@@ -166,9 +166,9 @@ class TestMoveFiles(FileTestCaseBase):
         with open(dest, 'w') as outf:
             outf.write("destfile")
         move_files([src], self.destdir, self.srcdir)
-        self.assertEqual(list(listfiles(self.destdir)), ["file1"])
-        self.assertEqual(open(dest).read(), "srcfile")
-        self.assertEqual(list(iter_files(self.srcdir)), [])
+        assert list(listfiles(self.destdir)) == ["file1"]
+        assert open(dest).read() == "srcfile"
+        assert list(iter_files(self.srcdir)) == []
 
     def test_samefile(self):
         """move_files: leave files alone if they're already in destdir"""
@@ -176,14 +176,14 @@ class TestMoveFiles(FileTestCaseBase):
         with open(dest, 'w') as outf:
             outf.write("destfile")
         move_files([dest], self.destdir, self.srcdir)
-        self.assertEqual(list(listfiles(self.destdir)), ["file1"])
-        self.assertEqual(open(dest).read(), "destfile")
+        assert list(listfiles(self.destdir)) == ["file1"]
+        assert open(dest).read() == "destfile"
 
     def test_move_to_parent(self):
         """move_files: leave files alone if they're in a subdir of destdir"""
         files = set(self.makefiles("dest/subdir/file1", "dest/file2"))
         move_files(files, self.destdir, self.srcdir)
-        self.assertEqual(set(iter_files(self.destdir)), files)
+        assert set(iter_files(self.destdir)) == files
 
 
 class TestAppendLine(FileTestCaseBase):
@@ -192,7 +192,7 @@ class TestAppendLine(FileTestCaseBase):
         line = "this is a line of text with no newline"
         outfile = self.tmpdir+'/outfile'
         append_line(outfile, line)
-        self.assertEqual(open(outfile).read(), line+'\n')
+        assert open(outfile).read() == line+'\n'
 
     def test_append(self):
         """append_line: adds a line to the end of an existing file"""
@@ -203,7 +203,7 @@ class TestAppendLine(FileTestCaseBase):
                 outf.write(line+'\n')
         line = "this line contains a newline already\n"
         append_line(outfile, line)
-        self.assertEqual(open(outfile).read(), '\n'.join(oldlines+[line]))
+        assert open(outfile).read() == '\n'.join(oldlines+[line])
 
 
 from driver_updates import read_lines
@@ -211,11 +211,11 @@ class TestReadLine(FileTestCaseBase):
     def test_empty(self):
         """read_lines: return [] for empty file"""
         [empty] = self.makefiles("emptyfile")
-        self.assertEqual(read_lines(empty), [])
+        assert read_lines(empty) == []
 
     def test_missing(self):
         """read_lines: return [] for missing file"""
-        self.assertEqual(read_lines(self.tmpdir+'/no-such-file'),[])
+        assert read_lines(self.tmpdir+'/no-such-file') == []
 
     def test_readlines(self):
         """read_lines: returns a list of lines without trailing newlines"""
@@ -224,7 +224,7 @@ class TestReadLine(FileTestCaseBase):
         with open(outfile, 'w') as outf:
             outf.write(filedata)
         lines = read_lines(outfile)
-        self.assertEqual(lines, ['line one', 'line two','','line four'])
+        assert lines == ['line one', 'line two','','line four']
 
     def test_readline_and_append_line(self):
         """read_lines: returns items as passed to append_line"""
@@ -232,23 +232,23 @@ class TestReadLine(FileTestCaseBase):
         items = ["one", "two", "five"]
         for i in items:
             append_line(filename, i)
-        self.assertEqual(items, read_lines(filename))
+        assert items == read_lines(filename)
 
 
 class TestMkdirSeq(FileTestCaseBase):
     def test_basic(self):
         """mkdir_seq: first dir ends with 1"""
         newdir = mkdir_seq(self.srcdir+'/DD-')
-        self.assertEqual(newdir, self.srcdir+'/DD-1')
-        self.assertTrue(os.path.isdir(newdir))
+        assert newdir == self.srcdir+'/DD-1'
+        assert os.path.isdir(newdir)
 
     def test_one_exists(self):
         """mkdir_seq: increment number if file exists"""
         firstdir = mkdir_seq(self.srcdir+'/DD-')
         newdir = mkdir_seq(self.srcdir+'/DD-')
-        self.assertEqual(newdir, self.srcdir+'/DD-2')
-        self.assertTrue(os.path.isdir(newdir))
-        self.assertTrue(os.path.isdir(firstdir))
+        assert newdir == self.srcdir+'/DD-2'
+        assert os.path.isdir(newdir)
+        assert os.path.isdir(firstdir)
 
 
 from driver_updates import find_repos, save_repo, ARCH
@@ -276,8 +276,8 @@ class TestFindRepos(FileTestCaseBase):
         """find_repos: return RPM dir if a valid repo is found"""
         makerepo(self.tmpdir)
         repos = find_repos(self.tmpdir)
-        self.assertEqual(repos, [self.tmpdir+'/rpms/'+ARCH])
-        self.assertTrue(os.path.isdir(repos[0]))
+        assert repos == [self.tmpdir+'/rpms/'+ARCH]
+        assert os.path.isdir(repos[0])
 
     def test_multiple_subdirs(self):
         """find_repos: descend multiple subdirs if needed"""
@@ -285,7 +285,7 @@ class TestFindRepos(FileTestCaseBase):
         makerepo(self.tmpdir+'/sub/driver1')
         makerepo(self.tmpdir+'/sub/driver2')
         repos = find_repos(self.tmpdir)
-        self.assertEqual(len(repos),3)
+        assert len(repos) == 3
 
 
 class TestSaveRepo(FileTestCaseBase):
@@ -303,8 +303,8 @@ class TestSaveRepo(FileTestCaseBase):
                               "repodata/filelists.xml.gz",
                               "repodata/primary.xml.gz",
                               "repodata/other.xml.gz"])
-        self.assertEqual(set(listfiles(saved)), expected_files)
-        self.assertEqual(saved, os.path.join(self.destdir, "DD-1"))
+        assert set(listfiles(saved)) == expected_files
+        assert saved == os.path.join(self.destdir, "DD-1")
 
     def test_single_file(self):
         """save_repo: copies a single file to /run/install/DD-X"""
@@ -315,8 +315,8 @@ class TestSaveRepo(FileTestCaseBase):
         makefile(repo + '/fake-something3.rpm')
         saved = save_repo(file_path, target=self.destdir)
         # check that only the single file was copied
-        self.assertEqual(set(listfiles(saved)), set(["fake-something1.rpm"]))
-        self.assertEqual(saved, os.path.join(self.destdir, "DD-1"))
+        assert set(listfiles(saved)) == set(["fake-something1.rpm"])
+        assert saved == os.path.join(self.destdir, "DD-1")
 
     def test_multiple_repo_folders(self):
         """save_repo: copies directory contents to multiple /run/install/DD-X folders"""
@@ -349,12 +349,12 @@ class TestSaveRepo(FileTestCaseBase):
 
         # check that everything was copied correctly
         full_copy_expected_files = set(["fake-something1.rpm", "fake-something2.rpm", "fake-something3.rpm", "repodata"])
-        self.assertEqual(set(listfiles(saved1)), full_copy_expected_files)
-        self.assertEqual(saved1, os.path.join(self.destdir, "DD-1"))
-        self.assertEqual(set(listfiles(saved2)), full_copy_expected_files)
-        self.assertEqual(saved2, os.path.join(self.destdir, "DD-2"))
-        self.assertEqual(set(listfiles(saved3)), set(["fake-something2.rpm"]))
-        self.assertEqual(saved3, os.path.join(self.destdir, "DD-3"))
+        assert set(listfiles(saved1)) == full_copy_expected_files
+        assert saved1 == os.path.join(self.destdir, "DD-1")
+        assert set(listfiles(saved2)) == full_copy_expected_files
+        assert saved2 == os.path.join(self.destdir, "DD-2")
+        assert set(listfiles(saved3)) == set(["fake-something2.rpm"])
+        assert saved3 == os.path.join(self.destdir, "DD-3")
 
 from driver_updates import mount, umount, mounted
 class MountTestCase(unittest.TestCase):
@@ -367,7 +367,7 @@ class MountTestCase(unittest.TestCase):
         mountpoint = mount(dev)
         mkdir.assert_called_once_with('/media/DD-')
         check_call.assert_called_once_with(["mount", dev, mnt])
-        self.assertEqual(mnt, mountpoint)
+        assert mnt == mountpoint
 
     @mock.patch('driver_updates.mkdir_seq')
     @mock.patch('driver_updates.subprocess.check_call')
@@ -376,7 +376,7 @@ class MountTestCase(unittest.TestCase):
         dev, mnt = '/dev/fake', '/media/fake'
         mount(dev, mnt)
         check_call.assert_called_once_with(["mount", dev, mnt])
-        self.assertFalse(mkdir.called)
+        assert not mkdir.called
 
     @mock.patch('driver_updates.subprocess.call')
     def test_umount(self, call):
@@ -393,8 +393,8 @@ class MountTestCase(unittest.TestCase):
         mock_mount.return_value = mnt
         with mounted(dev, mnt) as mountpoint:
             mock_mount.assert_called_once_with(dev, mnt)
-            self.assertFalse(mock_umount.called)
-            self.assertEqual(mountpoint, mnt)
+            assert not mock_umount.called
+            assert mountpoint == mnt
         mock_umount.assert_called_once_with(mnt)
 
 
@@ -431,14 +431,14 @@ class DDUtilsTestCase(unittest.TestCase):
         anaconda, kernel = '19.0', os.uname()[2]
         result = dd_list(fake_module.repo)
         cmd = check_output.call_args[0][0]
-        self.assertIn(kernel, cmd)
-        self.assertIn(anaconda, cmd)
-        self.assertIn(fake_module.repo, cmd)
-        self.assertTrue(cmd[0].endswith("dd_list"))
-        self.assertEqual(len(result), 2)
+        assert kernel in cmd
+        assert anaconda in cmd
+        assert fake_module.repo in cmd
+        assert cmd[0].endswith("dd_list")
+        assert len(result) == 2
         mod, enh = sorted(result, key=lambda d: d.name)
-        self.assertEqual(mod.__dict__, fake_module.__dict__)
-        self.assertEqual(enh.__dict__, fake_enhancement.__dict__)
+        assert mod.__dict__ == fake_module.__dict__
+        assert enh.__dict__ == fake_enhancement.__dict__
 
     @mock.patch("driver_updates.subprocess.check_output")
     def test_dd_extract(self, check_output):
@@ -447,11 +447,11 @@ class DDUtilsTestCase(unittest.TestCase):
         outdir = "/output/dir"
         dd_extract(rpm, outdir)
         cmd = check_output.call_args[0][0]
-        self.assertIn(os.uname()[2], cmd)
-        self.assertIn(rpm, cmd)
-        self.assertIn(outdir, cmd)
-        self.assertIn("-blmf", cmd)
-        self.assertTrue(cmd[0].endswith("dd_extract"))
+        assert os.uname()[2] in cmd
+        assert rpm in cmd
+        assert outdir in cmd
+        assert "-blmf" in cmd
+        assert cmd[0].endswith("dd_extract")
 
 
 from driver_updates import extract_drivers, grab_driver_files, load_drivers
@@ -479,8 +479,8 @@ class ExtractDriversTestCase(unittest.TestCase):
         mock_extract.assert_called_once_with(
             fake_enhancement.source, "/updates"
         )
-        self.assertFalse(mock_append.called)
-        self.assertFalse(mock_save.called)
+        assert not mock_append.called
+        assert not mock_save.called
 
     def test_repo(self, mock_extract, mock_append, mock_save, *args):
         """extract_drivers(repos=[...]) extracts all drivers from named repos"""
@@ -517,18 +517,18 @@ class GrabDriverFilesTestCase(FileTestCaseBase):
                                  list_aliases=lambda _x: []):
             moddict = grab_driver_files(outdir)
 
-        self.assertEqual(moddict, {"funk": [], "lolfs": []})
+        assert moddict == {"funk": [], "lolfs": []}
         modfiles = set(['net/funk.ko', 'fs/lolfs.ko.xz'])
         fwfiles = set(['funk.fw', 'fs/lolfs.fw'])
         # modules/firmware are *not* in their old locations
-        self.assertEqual([f for f in modules+firmware if os.path.exists(f)], [])
+        assert [f for f in modules+firmware if os.path.exists(f)] == []
         # modules are in the system's updates dir
-        self.assertEqual(set(listfiles(mod_upd_dir)), modfiles)
+        assert set(listfiles(mod_upd_dir)) == modfiles
         # modules are also in outdir's updates dir
-        self.assertEqual(set(listfiles(outdir+'/'+mod_upd_dir)), modfiles)
+        assert set(listfiles(outdir+'/'+mod_upd_dir)) == modfiles
         # repeat for firmware
-        self.assertEqual(set(listfiles(fw_upd_dir)), fwfiles)
-        self.assertEqual(set(listfiles(outdir+'/'+fw_upd_dir)), fwfiles)
+        assert set(listfiles(fw_upd_dir)) == fwfiles
+        assert set(listfiles(outdir+'/'+fw_upd_dir)) == fwfiles
 
 
 class LoadDriversTestCase(unittest.TestCase):
@@ -671,7 +671,7 @@ class ProcessDriverDiskTestCase(unittest.TestCase):
         dev = '/dev/fake'
         self.mocks['extract_drivers'].return_value = False
         process_driver_disk(dev)
-        self.assertFalse(self.mocks['grab_driver_files'].called)
+        assert not self.mocks['grab_driver_files'].called
 
 
 from driver_updates import process_driver_rpm
@@ -707,8 +707,8 @@ class FinishedTestCase(FileTestCaseBase):
         requeststr = "WOW SOMETHING OR OTHER"
         mark_finished(requeststr, topdir=self.tmpdir)
         finished = self.tmpdir+'/dd_finished'
-        self.assertTrue(os.path.exists(finished))
-        self.assertEqual(read_lines(finished), [requeststr])
+        assert os.path.exists(finished)
+        assert read_lines(finished) == [requeststr]
 
     def test_all_finished(self):
         """all_finished: True if all lines from dd_todo are in dd_finished"""
@@ -716,17 +716,17 @@ class FinishedTestCase(FileTestCaseBase):
         requests = ['one', 'two', 'final thingy']
         with open(todo, 'w') as outf:
             outf.write(''.join(r+'\n' for r in requests))
-        self.assertEqual(set(read_lines(todo)), set(requests))
+        assert set(read_lines(todo)) == set(requests)
         for r in reversed(requests):
-            self.assertFalse(all_finished(topdir=self.tmpdir))
+            assert not all_finished(topdir=self.tmpdir)
             mark_finished(r, topdir=self.tmpdir)
-        self.assertTrue(all_finished(topdir=self.tmpdir))
+        assert all_finished(topdir=self.tmpdir)
 
     def test_extra_finished(self):
         """all_finished: True if dd_finished has more items than dd_todo"""
         self.test_all_finished()
         mark_finished("BONUS", topdir=self.tmpdir)
-        self.assertTrue(all_finished(topdir=self.tmpdir))
+        assert all_finished(topdir=self.tmpdir)
 
     def test_finish(self):
         """finish: mark request finished, and write dd.done if all complete"""
@@ -737,9 +737,9 @@ class FinishedTestCase(FileTestCaseBase):
             outf.write(''.join(r+'\n' for r in requests))
         for r in reversed(requests):
             print("marking %s" % r)
-            self.assertFalse(os.path.exists(done))
+            assert not os.path.exists(done)
             finish(r, topdir=self.tmpdir)
-        self.assertTrue(os.path.exists(done))
+        assert os.path.exists(done)
 
 
 from driver_updates import get_deviceinfo, DeviceInfo
@@ -785,18 +785,18 @@ class DeviceInfoTestCase(unittest.TestCase):
     def test_basic(self, get_disk_labels, check_output):
         """get_deviceinfo: parses DeviceInfo from blkid etc."""
         disks = get_deviceinfo()
-        self.assertEqual(len(disks), 4)
+        assert len(disks) == 4
         disks.sort(key=lambda d: d.device)
         loop, efi, boot, root = disks
-        self.assertEqual(vars(boot), vars(devicelist[0]))
-        self.assertEqual(vars(efi), vars(devicelist[1]))
-        self.assertEqual(vars(root), vars(devicelist[2]))
-        self.assertEqual(vars(loop), vars(devicelist[3]))
+        assert vars(boot) == vars(devicelist[0])
+        assert vars(efi) == vars(devicelist[1])
+        assert vars(root) == vars(devicelist[2])
+        assert vars(loop) == vars(devicelist[3])
 
     def test_shortdev(self):
         d = DeviceInfo(DEVNAME="/dev/disk/by-label/OEMDRV")
         with mock.patch("os.path.realpath", return_value="/dev/i2o/hdb"):
-            self.assertEqual(d.shortdev, "i2o/hdb")
+            assert d.shortdev == "i2o/hdb"
 
 # TODO: test TextMenu itself
 
@@ -814,14 +814,14 @@ class DeviceMenuTestCase(unittest.TestCase):
         """device_menu: 'c' exits the menu"""
         with mock.patch('driver_updates._input', side_effect=['c']):
             dev = device_menu()
-        self.assertEqual(dev, [])
-        self.assertEqual(self.mocks['get_deviceinfo'].call_count, 1)
+        assert dev == []
+        assert self.mocks['get_deviceinfo'].call_count == 1
 
     def test_device_menu_refresh(self):
         """device_menu: 'r' makes the menu refresh"""
         with mock.patch('driver_updates._input', side_effect=['r','c']):
             device_menu()
-        self.assertEqual(self.mocks['get_deviceinfo'].call_count, 2)
+        assert self.mocks['get_deviceinfo'].call_count == 2
 
     @mock.patch("sys.stdout", new_callable=StringIO)
     def test_device_menu(self, stdout):
@@ -830,16 +830,16 @@ class DeviceMenuTestCase(unittest.TestCase):
         with mock.patch('driver_updates._input', return_value=choose_num):
             result = device_menu()
         # if you hit '2' you should get the corresponding device from the list
-        self.assertEqual(len(result), 1)
+        assert len(result) == 1
         dev = result[0]
-        self.assertEqual(vars(dev), vars(devicelist[int(choose_num)-1]))
+        assert vars(dev) == vars(devicelist[int(choose_num)-1])
         # find the corresponding line on-screen
         screen = [l.strip() for l in stdout.getvalue().splitlines()]
         match = [l for l in screen if l.startswith(choose_num+')')]
-        self.assertEqual(len(match), 1)
+        assert len(match) == 1
         line = match.pop(0)
         # the device name (at least) should be on this line
-        self.assertIn(os.path.basename(dev.device), line)
+        assert os.path.basename(dev.device) in line
 
 
 from driver_updates import list_aliases
@@ -850,4 +850,4 @@ class ListAliasesTestCase(unittest.TestCase):
         alias_list = list_aliases(modname)
 
         check_output.assert_called_once_with(["modinfo", "-F", "alias", modname], universal_newlines=True)
-        self.assertEqual(alias_list, ["alias1", "alias2", modname])
+        assert alias_list == ["alias1", "alias2", modname]

--- a/tests/unit_tests/dracut_tests/test_parse_kickstart.py
+++ b/tests/unit_tests/dracut_tests/test_parse_kickstart.py
@@ -20,6 +20,7 @@ import unittest
 import tempfile
 import shutil
 import subprocess
+import re
 
 class BaseTestCase(unittest.TestCase):
     def setUp(self):
@@ -58,7 +59,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-        self.assertEqual(lines[0], "inst.repo=cdrom", lines)
+        assert lines[0] == "inst.repo=cdrom", lines
 
     def test_harddrive(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -66,7 +67,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-        self.assertEqual(lines[0], "inst.repo=hd:sda4:/path/to/tree", lines)
+        assert lines[0] == "inst.repo=hd:sda4:/path/to/tree", lines
 
     def test_nfs(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -74,7 +75,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-        self.assertEqual(lines[0], "inst.repo=nfs:nolock,timeo=50:host.at.foo.com:/path/to/tree", lines)
+        assert lines[0] == "inst.repo=nfs:nolock,timeo=50:host.at.foo.com:/path/to/tree", lines
 
     def test_nfs_2(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -82,7 +83,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-        self.assertEqual(lines[0], "inst.repo=nfs:host.at.foo.com:/path/to/tree", lines)
+        assert lines[0] == "inst.repo=nfs:host.at.foo.com:/path/to/tree", lines
 
     def test_url(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -90,10 +91,10 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-        self.assertEqual(len(lines), 3, lines)
-        self.assertEqual(lines[0], "inst.repo=https://host.at.foo.com/path/to/tree", lines)
-        self.assertEqual(lines[1], "rd.noverifyssl", lines)
-        self.assertEqual(lines[2], "inst.proxy=http://localhost:8123", lines)
+        assert len(lines) == 3, lines
+        assert lines[0] == "inst.repo=https://host.at.foo.com/path/to/tree", lines
+        assert lines[1] == "rd.noverifyssl", lines
+        assert lines[2] == "inst.proxy=http://localhost:8123", lines
 
     def test_updates(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -101,7 +102,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-        self.assertEqual(lines[0], "live.updates=http://host.at.foo.com/path/to/updates.img", lines)
+        assert lines[0] == "live.updates=http://host.at.foo.com/path/to/updates.img", lines
 
     def test_mediacheck(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -109,7 +110,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-        self.assertEqual(lines[0], "rd.live.check", lines)
+        assert lines[0] == "rd.live.check", lines
 
     def test_driverdisk(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -117,7 +118,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-        self.assertEqual(lines[0], "inst.dd=hd:sda5")
+        assert lines[0] == "inst.dd=hd:sda5"
 
     def test_driverdisk_2(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -125,7 +126,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-        self.assertEqual(lines[0], "inst.dd=http://host.att.foo.com/path/to/dd", lines)
+        assert lines[0] == "inst.dd=http://host.att.foo.com/path/to/dd", lines
 
     def test_network(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -134,7 +135,7 @@ class ParseKickstartTestCase(BaseTestCase):
             lines = self.execParseKickstart(ks_file.name)
 
             print(lines)
-            self.assertEqual(lines[0], "ip=ens3:dhcp: bootdev=ens3")
+            assert lines[0] == "ip=ens3:dhcp: bootdev=ens3"
 
     def test_network_2(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -142,7 +143,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertEqual(lines[0], "ifname=ksdev0:aa:bb:cc:dd:ee:ff ip=ksdev0:dhcp: bootdev=ksdev0", lines)
+            assert lines[0] == "ifname=ksdev0:aa:bb:cc:dd:ee:ff ip=ksdev0:dhcp: bootdev=ksdev0", lines
 
     def test_network_static(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -150,7 +151,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertEqual(lines[0], "ip=10.0.2.15::10.0.2.254:255.255.255.0::ens3:none: nameserver=10.0.2.10 bootdev=ens3")
+            assert lines[0] == "ip=10.0.2.15::10.0.2.254:255.255.255.0::ens3:none: nameserver=10.0.2.10 bootdev=ens3"
 
     def test_network_bond(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -158,7 +159,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertEqual(lines[0], "ip=bond0:dhcp:1500 bootdev=bond0 bond=bond0:enp4s0,enp7s0:mode=active-backup,primary=enp4s0:1500")
+            assert lines[0] == "ip=bond0:dhcp:1500 bootdev=bond0 bond=bond0:enp4s0,enp7s0:mode=active-backup,primary=enp4s0:1500"
 
     def test_network_bond_2(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -167,7 +168,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertEqual(lines[0], "ip=bond0:dhcp: bootdev=bond0 bond=bond0:enp4s0,enp7s0::")
+            assert lines[0] == "ip=bond0:dhcp: bootdev=bond0 bond=bond0:enp4s0,enp7s0::"
 
     def test_network_bond_3(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -176,7 +177,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertEqual(lines[0], "ip=bond0:dhcp:1500 bootdev=bond0 bond=bond0:enp4s0,enp7s0::1500")
+            assert lines[0] == "ip=bond0:dhcp:1500 bootdev=bond0 bond=bond0:enp4s0,enp7s0::1500"
 
     def test_network_bridge(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -184,7 +185,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertEqual(lines[0], "ip=br0:dhcp: bootdev=br0 bridge=br0:eth0")
+            assert lines[0] == "ip=br0:dhcp: bootdev=br0 bridge=br0:eth0"
 
     def test_network_team(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -192,7 +193,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertEqual(lines, [])
+            assert lines == []
 
     def test_network_vlan(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -200,7 +201,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertEqual(lines, [])
+            assert lines == []
 
     def test_network_ipv6_only(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -208,7 +209,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertRegex(lines[0], r"ip=\[1:2:3:4:5:6:7:8\]:.*")
+            assert re.search(r"ip=\[1:2:3:4:5:6:7:8\]:.*", lines[0])
 
     def test_displaymode(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -216,7 +217,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertEqual(lines[0], "inst.cmdline", lines)
+            assert lines[0] == "inst.cmdline", lines
 
     def test_displaymode_2(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -224,7 +225,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertEqual(lines[0], "inst.graphical", lines)
+            assert lines[0] == "inst.graphical", lines
 
     def test_displaymode_3(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -232,7 +233,7 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertEqual(lines[0], "inst.text", lines)
+            assert lines[0] == "inst.text", lines
 
     def test_bootloader(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -240,4 +241,4 @@ class ParseKickstartTestCase(BaseTestCase):
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            self.assertEqual(lines[0], "inst.extlinux", lines)
+            assert lines[0] == "inst.extlinux", lines

--- a/tests/unit_tests/pyanaconda_tests/__init__.py
+++ b/tests/unit_tests/pyanaconda_tests/__init__.py
@@ -80,10 +80,9 @@ def clear_version_from_kickstart_string(ks_in):
     )
 
 
-def check_kickstart_interface(test, interface, ks_in, ks_out=None, ks_valid=True, ks_tmp=None):
+def check_kickstart_interface(interface, ks_in, ks_out=None, ks_valid=True, ks_tmp=None):
     """Test the parsing and generating of a kickstart module.
 
-    :param test: instance of TestCase
     :param interface: instance of KickstartModuleInterface
     :param ks_in: string with the input kickstart
     :param ks_out: string with the output kickstart
@@ -142,11 +141,10 @@ class PropertiesChangedCallback(Mock):
         )
 
 
-def check_dbus_property(test, interface_id, interface, property_name,
+def check_dbus_property(interface_id, interface, property_name,
                         in_value, out_value=None, getter=None, setter=None, changed=None):
     """Check DBus property.
 
-    :param test: instance of TestCase
     :param interface_id: instance of DBusInterfaceIdentifier
     :param interface: instance of a DBus interface
     :param property_name: a DBus property name
@@ -180,25 +178,23 @@ def check_dbus_property(test, interface_id, interface, property_name,
     assert getter() == out_value
 
 
-def check_task_creation(test, task_path, publisher, task_class, index=0):
+def check_task_creation(task_path, publisher, task_class, index=0):
     """Check that the DBus task is correctly created.
 
-    :param test: instance of TestCase
     :param task_path: DBus path of the task
     :param publisher: Mock instance of the publish_object method
     :param task_class: class of the tested task
     :param index: an index of the published object
     :return: instance of the task
     """
-    obj = check_dbus_object_creation(test, task_path, publisher, task_class, index)
+    obj = check_dbus_object_creation(task_path, publisher, task_class, index)
     assert isinstance(obj, TaskInterface)
     return obj
 
 
-def check_task_creation_list(test, task_paths, publisher, task_classes):
+def check_task_creation_list(task_paths, publisher, task_classes):
     """Check that the list of DBus task is correctly created.
 
-    :param test: instance of TestCase
     :param task_paths: DBus paths of the tasks
     :type task_paths: [str]
     :param publisher: Mock instance of the publish_object method
@@ -215,16 +211,15 @@ def check_task_creation_list(test, task_paths, publisher, task_classes):
 
     # Check each published task.
     for i in range(task_count):
-        task_proxy = check_task_creation(test, task_paths[i], publisher, task_classes[i], i)
+        task_proxy = check_task_creation(task_paths[i], publisher, task_classes[i], i)
         task_proxies.append(task_proxy)
 
     return task_proxies
 
 
-def check_dbus_object_creation(test, path, publisher, klass, index=0):
+def check_dbus_object_creation(path, publisher, klass, index=0):
     """Check that the custom DBus object is correctly created.
 
-    :param test: instance of TestCase
     :param path: DBus path of the published object
     :param publisher: Mock instance of the publish_object method
     :param klass: class of the tested DBus object

--- a/tests/unit_tests/pyanaconda_tests/__init__.py
+++ b/tests/unit_tests/pyanaconda_tests/__init__.py
@@ -101,7 +101,7 @@ def check_kickstart_interface(test, interface, ks_in, ks_out=None, ks_valid=True
         result = KickstartReport.from_structure(
             interface.ReadKickstart(ks_in)
         )
-        test.assertEqual(ks_valid, result.is_valid())
+        assert ks_valid == result.is_valid()
 
     if not ks_valid:
         return result
@@ -112,13 +112,13 @@ def check_kickstart_interface(test, interface, ks_in, ks_out=None, ks_valid=True
     # Generate a kickstart
     ks_out = dedent(ks_out).strip()
     ks_generated = clear_version_from_kickstart_string(interface.GenerateKickstart()).strip()
-    test.assertEqual(ks_out, ks_generated)
+    assert ks_out == ks_generated
 
     # Test the properties changed callback.
     if ks_in is not None:
         callback.assert_any_call(KICKSTART_MODULE.interface_name, {'Kickstarted': True}, [])
     else:
-        test.assertEqual(interface.Kickstarted, False)
+        assert interface.Kickstarted == False
         callback.assert_not_called()
 
     # Test the temporary kickstart.
@@ -126,7 +126,7 @@ def check_kickstart_interface(test, interface, ks_in, ks_out=None, ks_valid=True
         return
 
     ks_tmp = dedent(ks_tmp).strip()
-    test.assertEqual(ks_tmp, interface.GenerateTemporaryKickstart().strip())
+    assert ks_tmp == interface.GenerateTemporaryKickstart().strip()
 
     return result
 
@@ -177,7 +177,7 @@ def check_dbus_property(test, interface_id, interface, property_name,
     if not getter:
         getter = lambda: getattr(interface, property_name)
 
-    test.assertEqual(getter(), out_value)
+    assert getter() == out_value
 
 
 def check_task_creation(test, task_path, publisher, task_class, index=0):
@@ -191,7 +191,7 @@ def check_task_creation(test, task_path, publisher, task_class, index=0):
     :return: instance of the task
     """
     obj = check_dbus_object_creation(test, task_path, publisher, task_class, index)
-    test.assertIsInstance(obj, TaskInterface)
+    assert isinstance(obj, TaskInterface)
     return obj
 
 
@@ -210,8 +210,8 @@ def check_task_creation_list(test, task_paths, publisher, task_classes):
     task_count = len(task_paths)
 
     # Check the number of published tasks.
-    test.assertEqual(task_count, publisher.call_count)
-    test.assertEqual(task_count, len(task_classes))
+    assert task_count == publisher.call_count
+    assert task_count == len(task_classes)
 
     # Check each published task.
     for i in range(task_count):
@@ -231,12 +231,12 @@ def check_dbus_object_creation(test, path, publisher, klass, index=0):
     :param index: an index of the published object
     """
     # A valid index of a call should be less than the number of calls.
-    test.assertLess(index, publisher.call_count)
+    assert index < publisher.call_count
     object_path, obj = publisher.call_args_list[index][0]
 
-    test.assertEqual(path, object_path)
-    test.assertIsInstance(obj.implementation, klass)
-    test.assertIsInstance(obj, BasicInterfaceTemplate)
+    assert path == object_path
+    assert isinstance(obj.implementation, klass)
+    assert isinstance(obj, BasicInterfaceTemplate)
     return obj
 
 

--- a/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
@@ -20,6 +20,7 @@
 import os
 import tempfile
 import unittest
+import pytest
 from textwrap import dedent
 from unittest.mock import patch
 
@@ -72,10 +73,10 @@ class ConfigurationTestCase(unittest.TestCase):
     def test_invalid_read(self):
         parser = create_parser()
 
-        with self.assertRaises(ConfigurationFileError) as cm:
+        with pytest.raises(ConfigurationFileError) as cm:
             read_config(parser, "nonexistent/path/to/file")
 
-        self.assertEqual(cm.exception._filename, "nonexistent/path/to/file")
+        assert cm.value._filename == "nonexistent/path/to/file"
 
     def test_write(self):
         parser = create_parser()
@@ -87,55 +88,55 @@ class ConfigurationTestCase(unittest.TestCase):
             f.flush()
 
             # Check the config file.
-            self.assertEqual(f.read().strip(), self._content.strip())
+            assert f.read().strip() == self._content.strip()
 
     def test_invalid_write(self):
         parser = create_parser()
 
-        with self.assertRaises(ConfigurationFileError) as cm:
+        with pytest.raises(ConfigurationFileError) as cm:
             write_config(parser, "nonexistent/path/to/file")
 
-        self.assertEqual(cm.exception._filename, "nonexistent/path/to/file")
-        self.assertTrue(str(cm.exception).startswith(
+        assert cm.value._filename == "nonexistent/path/to/file"
+        assert str(cm.value).startswith(
             "The following error has occurred while handling the configuration file"
-        ))
+        )
 
     def test_get(self):
         parser = create_parser()
         self._read_content(parser)
 
-        self.assertEqual(get_option(parser, "Main", "string"), "Hello")
-        self.assertEqual(get_option(parser, "Main", "integer"), "1")
-        self.assertEqual(get_option(parser, "Main", "boolean"), "False")
+        assert get_option(parser, "Main", "string") == "Hello"
+        assert get_option(parser, "Main", "integer") == "1"
+        assert get_option(parser, "Main", "boolean") == "False"
 
-        self.assertEqual(get_option(parser, "Main", "string", str), "Hello")
-        self.assertEqual(get_option(parser, "Main", "integer", int), 1)
-        self.assertEqual(get_option(parser, "Main", "boolean", bool), False)
+        assert get_option(parser, "Main", "string", str) == "Hello"
+        assert get_option(parser, "Main", "integer", int) == 1
+        assert get_option(parser, "Main", "boolean", bool) == False
 
     def test_invalid_get(self):
         parser = create_parser()
         self._read_content(parser)
 
         # Invalid value.
-        with self.assertRaises(ConfigurationDataError) as cm:
+        with pytest.raises(ConfigurationDataError) as cm:
             get_option(parser, "Main", "string", bool)
 
-        self.assertEqual(cm.exception._section, "Main")
-        self.assertEqual(cm.exception._option, "string")
+        assert cm.value._section == "Main"
+        assert cm.value._option == "string"
 
         # Invalid option.
-        with self.assertRaises(ConfigurationDataError) as cm:
+        with pytest.raises(ConfigurationDataError) as cm:
             get_option(parser, "Main", "unknown")
 
-        self.assertEqual(cm.exception._section, "Main")
-        self.assertEqual(cm.exception._option, "unknown")
+        assert cm.value._section == "Main"
+        assert cm.value._option == "unknown"
 
         # Invalid section.
-        with self.assertRaises(ConfigurationDataError) as cm:
+        with pytest.raises(ConfigurationDataError) as cm:
             get_option(parser, "Unknown", "unknown")
 
-        self.assertEqual(cm.exception._section, "Unknown")
-        self.assertEqual(cm.exception._option, "unknown")
+        assert cm.value._section == "Unknown"
+        assert cm.value._option == "unknown"
 
     def test_set(self):
         parser = create_parser()
@@ -145,35 +146,35 @@ class ConfigurationTestCase(unittest.TestCase):
         set_option(parser, "Main", "integer", 2)
         set_option(parser, "Main", "boolean", True)
 
-        self.assertEqual(get_option(parser, "Main", "string"), "Hi")
-        self.assertEqual(get_option(parser, "Main", "integer"), "2")
-        self.assertEqual(get_option(parser, "Main", "boolean"), "True")
+        assert get_option(parser, "Main", "string") == "Hi"
+        assert get_option(parser, "Main", "integer") == "2"
+        assert get_option(parser, "Main", "boolean") == "True"
 
-        self.assertEqual(get_option(parser, "Main", "string", str), "Hi")
-        self.assertEqual(get_option(parser, "Main", "integer", int), 2)
-        self.assertEqual(get_option(parser, "Main", "boolean", bool), True)
+        assert get_option(parser, "Main", "string", str) == "Hi"
+        assert get_option(parser, "Main", "integer", int) == 2
+        assert get_option(parser, "Main", "boolean", bool) == True
 
     def test_invalid_set(self):
         parser = create_parser()
         self._read_content(parser)
 
         # Invalid option.
-        with self.assertRaises(ConfigurationDataError) as cm:
+        with pytest.raises(ConfigurationDataError) as cm:
             set_option(parser, "Main", "unknown", "value")
 
-        self.assertEqual(cm.exception._section, "Main")
-        self.assertEqual(cm.exception._option, "unknown")
+        assert cm.value._section == "Main"
+        assert cm.value._option == "unknown"
 
         # Invalid section.
-        with self.assertRaises(ConfigurationDataError) as cm:
+        with pytest.raises(ConfigurationDataError) as cm:
             set_option(parser, "Unknown", "unknown", "value")
 
-        self.assertEqual(cm.exception._section, "Unknown")
-        self.assertEqual(cm.exception._option, "unknown")
+        assert cm.value._section == "Unknown"
+        assert cm.value._option == "unknown"
 
-        self.assertTrue(str(cm.exception).startswith(
+        assert str(cm.value).startswith(
             "The following error has occurred while handling the option"
-        ))
+        )
 
     def test_configuration(self):
         config = Configuration()
@@ -186,10 +187,8 @@ class ConfigurationTestCase(unittest.TestCase):
 
             config.read_from_directory(directory)
 
-            self.assertEqual(
-                [os.path.relpath(path, directory) for path in config.get_sources()],
+            assert [os.path.relpath(path, directory) for path in config.get_sources()] == \
                 ["a.conf", "b.conf", "d.conf"]
-            )
 
 
 class AnacondaConfigurationTestCase(unittest.TestCase):
@@ -217,18 +216,18 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
     def test_default_configuration(self):
         # Make sure that we are able to import conf.
         from pyanaconda.core.configuration.anaconda import conf
-        self.assertEqual(conf.anaconda.debug, False)
+        assert conf.anaconda.debug == False
 
     def test_source(self):
         conf = AnacondaConfiguration()
         sources = conf.get_sources()
-        self.assertEqual(sources, [])
+        assert sources == []
 
     def test_default_source(self):
         conf = AnacondaConfiguration.from_defaults()
         sources = conf.get_sources()
-        self.assertEqual(len(sources), 1)
-        self.assertEqual(sources[0], os.environ.get("ANACONDA_CONFIG_TMP"))
+        assert len(sources) == 1
+        assert sources[0] == os.environ.get("ANACONDA_CONFIG_TMP")
 
     def test_default_validation(self):
         conf = AnacondaConfiguration.from_defaults()
@@ -237,17 +236,17 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
         # Set invalid value.
         parser = conf.get_parser()
         parser["Anaconda"]["debug"] = "string"
-        with self.assertRaises(ConfigurationError):
+        with pytest.raises(ConfigurationError):
             conf.validate()
 
         # Remove a required option.
         parser.remove_option("Anaconda", "debug")
-        with self.assertRaises(ConfigurationError):
+        with pytest.raises(ConfigurationError):
             conf.validate()
 
         # Remove a required section.
         parser.remove_section("Anaconda")
-        with self.assertRaises(ConfigurationError):
+        with pytest.raises(ConfigurationError):
             conf.validate()
 
     def test_read(self):
@@ -255,8 +254,8 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
 
         with tempfile.NamedTemporaryFile("w") as f:
             conf.read(f.name)
-            self.assertEqual(len(conf.get_sources()), 1)
-            self.assertEqual(conf.get_sources()[0], f.name)
+            assert len(conf.get_sources()) == 1
+            assert conf.get_sources()[0] == f.name
 
     def test_default_read(self):
         AnacondaConfiguration.from_defaults()
@@ -267,7 +266,7 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
         with tempfile.NamedTemporaryFile("r+") as f:
             conf.write(f.name)
             f.flush()
-            self.assertFalse(f.read(), "The file should be empty.")
+            assert not f.read(), "The file should be empty."
 
     def test_default_write(self):
         conf = AnacondaConfiguration.from_defaults()
@@ -275,7 +274,7 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
         with tempfile.NamedTemporaryFile("r+") as f:
             conf.write(f.name)
             f.flush()
-            self.assertTrue(f.read(), "The file shouldn't be empty.")
+            assert f.read(), "The file shouldn't be empty."
 
     def test_set_from_files(self):
         conf = AnacondaConfiguration.from_defaults()
@@ -308,37 +307,33 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
                     f.write("")
 
             # Check the paths.
-            self.assertEqual(
-                [os.path.relpath(path, d) for path in paths],
+            assert [os.path.relpath(path, d) for path in paths] == \
                 ["nonexistent", "empty", "a.conf", "conf.d"]
-            )
 
             conf._sources = []
             conf.set_from_files(paths)
 
             # Check the loaded files.
-            self.assertEqual(
-                [os.path.relpath(path, d) for path in conf.get_sources()],
+            assert [os.path.relpath(path, d) for path in conf.get_sources()] == \
                 ["a.conf", "conf.d/b.conf", "conf.d/c.conf"]
-            )
 
     def _check_configuration_sources(self, conf, file_names):
         """Check the loaded configuration sources."""
         file_paths = [os.path.join(CONFIG_DIR, path) for path in file_names]
-        self.assertEqual(file_paths, conf.get_sources())
+        assert file_paths == conf.get_sources()
 
     @patch("pyanaconda.core.configuration.anaconda.ANACONDA_CONFIG_DIR", CONFIG_DIR)
     def test_set_from_requested_profile(self):
         conf = AnacondaConfiguration.from_defaults()
 
         # Test an unknown requested profile.
-        with self.assertRaises(ConfigurationError) as cm:
+        with pytest.raises(ConfigurationError) as cm:
             conf.set_from_profile("unknown-profile")
 
         expected = "Unable to find any suitable configuration files " \
                    "for the 'unknown-profile' profile."
 
-        self.assertEqual(str(cm.exception), expected)
+        assert str(cm.value) == expected
 
         # Test a known requested profile.
         conf.set_from_profile("fedora-workstation")
@@ -361,7 +356,7 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
             "Unable to find any suitable configuration files for the detected " \
             "os-release values. No profile configuration will be used."
 
-        self.assertIn(expected, "\n".join(cm.output))
+        assert expected in "\n".join(cm.output)
 
         # Test known os-release values.
         conf.set_from_detected_profile("fedora", "workstation")
@@ -375,9 +370,9 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
     def _check_pattern(self, pattern):
         """Check the specified module pattern."""
         if pattern.endswith(".*"):
-            self.assertIn(pattern[:-2], self.MODULE_NAMESPACES)
+            assert pattern[:-2] in self.MODULE_NAMESPACES
         else:
-            self.assertIn(pattern, self.MODULE_NAMES)
+            assert pattern in self.MODULE_NAMES
 
     def test_activatable_modules(self):
         """Test the activatable_modules option."""
@@ -389,11 +384,11 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
     def test_kickstart_modules(self):
         """Test the kickstart_modules option."""
         conf = AnacondaConfiguration.from_defaults()
-        self.assertEqual(conf.anaconda.activatable_modules, [
+        assert conf.anaconda.activatable_modules == [
             "org.fedoraproject.Anaconda.Modules.*",
             "org.fedoraproject.Anaconda.Addons.*"
 
-        ])
+        ]
 
         parser = conf.get_parser()
         parser.read_string(dedent("""
@@ -406,12 +401,12 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
 
         """))
 
-        self.assertEqual(conf.anaconda.activatable_modules, [
+        assert conf.anaconda.activatable_modules == [
             "org.fedoraproject.Anaconda.Modules.Timezone",
             "org.fedoraproject.Anaconda.Modules.Localization",
             "org.fedoraproject.Anaconda.Modules.Security",
             "org.fedoraproject.Anaconda.Addons.*"
-        ])
+        ]
 
         for pattern in conf.anaconda.activatable_modules:
             self._check_pattern(pattern)
@@ -426,7 +421,7 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
     def test_addons_enabled_modules(self):
         """Test the addons_enabled option."""
         conf = AnacondaConfiguration.from_defaults()
-        self.assertEqual(conf.anaconda.forbidden_modules, [])
+        assert conf.anaconda.forbidden_modules == []
 
         parser = conf.get_parser()
         parser.read_string(dedent("""
@@ -439,11 +434,11 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
 
         """))
 
-        self.assertEqual(conf.anaconda.forbidden_modules, [
+        assert conf.anaconda.forbidden_modules == [
             "org.fedoraproject.Anaconda.Modules.Timezone",
             "org.fedoraproject.Anaconda.Modules.Localization",
             "org.fedoraproject.Anaconda.Modules.Security",
-        ])
+        ]
 
         parser.read_string(dedent("""
 
@@ -452,11 +447,11 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
 
         """))
 
-        self.assertEqual(conf.anaconda.forbidden_modules, [
+        assert conf.anaconda.forbidden_modules == [
             "org.fedoraproject.Anaconda.Modules.Timezone",
             "org.fedoraproject.Anaconda.Modules.Localization",
             "org.fedoraproject.Anaconda.Modules.Security",
-        ])
+        ]
 
         parser.read_string(dedent("""
 
@@ -465,12 +460,12 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
 
         """))
 
-        self.assertEqual(conf.anaconda.forbidden_modules, [
+        assert conf.anaconda.forbidden_modules == [
             "org.fedoraproject.Anaconda.Addons.*",
             "org.fedoraproject.Anaconda.Modules.Timezone",
             "org.fedoraproject.Anaconda.Modules.Localization",
             "org.fedoraproject.Anaconda.Modules.Security",
-        ])
+        ]
 
         for pattern in conf.anaconda.forbidden_modules:
             self._check_pattern(pattern)
@@ -484,11 +479,11 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
 
     def test_bootloader(self):
         conf = AnacondaConfiguration.from_defaults()
-        self.assertIn("selinux", conf.bootloader.preserved_arguments)
+        assert "selinux" in conf.bootloader.preserved_arguments
 
     def test_default_partitioning(self):
         conf = AnacondaConfiguration.from_defaults()
-        self.assertEqual(conf.storage.default_partitioning, [
+        assert conf.storage.default_partitioning == [
             {
                 'name': '/',
                 'min': Size("1024 MiB"),
@@ -498,52 +493,52 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
                 'min': Size("500 MiB"),
                 'free': Size("50 GiB"),
             }
-        ])
+        ]
 
     def test_convert_partitioning(self):
         convert_line = StorageSection._convert_partitioning_line
 
-        self.assertEqual(convert_line("/ (min 1 GiB, max 2 GiB, free 20 GiB)"), {
+        assert convert_line("/ (min 1 GiB, max 2 GiB, free 20 GiB)") == {
             "name": "/",
             "min": Size("1 GiB"),
             "max": Size("2 GiB"),
             "free": Size("20 GiB")
-        })
+        }
 
-        self.assertEqual(convert_line("/home (size 1 GiB)"), {
+        assert convert_line("/home (size 1 GiB)") == {
             "name": "/home",
             "size": Size("1 GiB")
-        })
+        }
 
-        self.assertEqual(convert_line("swap"), {
+        assert convert_line("swap") == {
             "name": "swap"
-        })
+        }
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             convert_line("")
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             convert_line("(size 1 GiB)")
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             convert_line("/home (size)")
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             convert_line("/home (invalid 1 GiB)")
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             convert_line("/home  (size 1 GiB, min 2 GiB)")
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             convert_line("/home  (max 2 GiB)")
 
     def test_default_installation_source(self):
         conf = AnacondaConfiguration.from_defaults()
-        self.assertEqual(conf.payload.default_source, SOURCE_TYPE_CLOSEST_MIRROR)
+        assert conf.payload.default_source == SOURCE_TYPE_CLOSEST_MIRROR
 
     def test_default_password_policies(self):
         conf = AnacondaConfiguration.from_defaults()
-        self.assertEqual(conf.ui.password_policies, [
+        assert conf.ui.password_policies == [
             {
                 'name': 'root',
                 "quality": 1,
@@ -558,41 +553,41 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
                 "quality": 1,
                 "length": 6,
             },
-        ])
+        ]
 
     def test_convert_password_policy(self):
         convert_line = UserInterfaceSection._convert_policy_line
 
-        self.assertEqual(convert_line("root (quality 100, length 10, empty, strict)"), {
+        assert convert_line("root (quality 100, length 10, empty, strict)") == {
             "name": "root",
             "quality": 100,
             "length": 10,
             "empty": True,
             "strict": True,
-        })
+        }
 
-        self.assertEqual(convert_line("luks (quality 100, length 10)"), {
+        assert convert_line("luks (quality 100, length 10)") == {
             "name": "luks",
             "quality": 100,
             "length": 10,
-        })
+        }
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             convert_line("")
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             convert_line("(empty)")
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             convert_line("user (quality)")
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             convert_line("user (invalid 100)")
 
         # Missing length.
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             convert_line("user (quality 100)")
 
         # Missing quality.
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             convert_line("user (length 10)")

--- a/tests/unit_tests/pyanaconda_tests/core/test_dbus.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_dbus.py
@@ -19,6 +19,7 @@
 #
 import tempfile
 import unittest
+import pytest
 from unittest.mock import patch
 
 from pyanaconda.core.dbus import AnacondaMessageBus, DefaultMessageBus
@@ -34,8 +35,8 @@ class AnacondaDBusConnectionTestCase(unittest.TestCase):
     """Test Anaconda DBus connection."""
 
     def _check_addressed_connection(self, message_bus, getter, address):
-        self.assertIsNotNone(message_bus.connection)
-        self.assertEqual(message_bus.address, address)
+        assert message_bus.connection is not None
+        assert message_bus.address == address
         getter.assert_called_once_with(
             address,
             (
@@ -47,7 +48,7 @@ class AnacondaDBusConnectionTestCase(unittest.TestCase):
         )
 
     def _check_anaconda_connection(self, message_bus, getter):
-        with self.assertRaises(ConnectionError):
+        with pytest.raises(ConnectionError):
             self._check_addressed_connection(message_bus, getter, "ADDRESS")
 
         with tempfile.NamedTemporaryFile("w") as f:

--- a/tests/unit_tests/pyanaconda_tests/core/test_kernel.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_kernel.py
@@ -31,58 +31,58 @@ class KernelArgumentsTests(unittest.TestCase):
             "derp=no nobody=0")
 
         # test using "in" operator on the class
-        self.assertTrue("blah" in ka)
-        self.assertTrue("foo" in ka)
-        self.assertFalse("thisisnotthere" in ka)
-        self.assertFalse("body" in ka)
-        self.assertTrue("nobody" in ka)
+        assert "blah" in ka
+        assert "foo" in ka
+        assert not ("thisisnotthere" in ka)
+        assert not ("body" in ka)
+        assert "nobody" in ka
 
         # test the get() method
-        self.assertEqual(ka.get("foo"), "anything")
-        self.assertIsNone(ka.get("thisisnotthere"))
-        self.assertEqual(ka.get("thisisnotthere", "fallback"), "fallback")
+        assert ka.get("foo") == "anything"
+        assert ka.get("thisisnotthere") is None
+        assert ka.get("thisisnotthere", "fallback") == "fallback"
 
         # test the is_enabled() method
-        self.assertTrue(ka.is_enabled("blah"))  # present
-        self.assertTrue(ka.is_enabled("foo"))  # any value
-        self.assertTrue(ka.is_enabled("bar"))  # 1 = any value
-        self.assertFalse(ka.is_enabled("baz"))  # 0
-        self.assertTrue(ka.is_enabled("nowhere"))  # present
-        self.assertTrue(ka.is_enabled("nothing"))  # present
-        self.assertFalse(ka.is_enabled("beep"))  # off
-        self.assertTrue(ka.is_enabled("derp"))  # no = any value
-        self.assertFalse(ka.is_enabled("nobody"))  # 0
-        self.assertFalse(ka.is_enabled("thing"))  # not present
-        self.assertFalse(ka.is_enabled("where"))  # not present
+        assert ka.is_enabled("blah")  # present
+        assert ka.is_enabled("foo")  # any value
+        assert ka.is_enabled("bar")  # 1 = any value
+        assert not ka.is_enabled("baz")  # 0
+        assert ka.is_enabled("nowhere")  # present
+        assert ka.is_enabled("nothing")  # present
+        assert not ka.is_enabled("beep")  # off
+        assert ka.is_enabled("derp")  # no = any value
+        assert not ka.is_enabled("nobody")  # 0
+        assert not ka.is_enabled("thing")  # not present
+        assert not ka.is_enabled("where")  # not present
 
     def test_real_parsing_and_adding(self):
         """Test file spec handling in KernelArguments."""
 
         ka = KernelArguments()
-        self.assertEqual(ka.read(["/proc/cmdlin*", "/nonexistent/file"]), ["/proc/cmdline"])
-        self.assertEqual(ka.read("/another/futile/attempt"), [])
+        assert ka.read(["/proc/cmdlin*", "/nonexistent/file"]) == ["/proc/cmdline"]
+        assert ka.read("/another/futile/attempt") == []
 
     def test_special_argument_handling(self):
         """Test handling of special arguments in KernelArguments."""
 
         ka = KernelArguments.from_string("modprobe.blacklist=floppy modprobe.blacklist=reiserfs")
-        self.assertEqual(ka.get("modprobe.blacklist"), "floppy reiserfs")
+        assert ka.get("modprobe.blacklist") == "floppy reiserfs"
         ka.read_string("inst.addrepo=yum inst.addrepo=dnf")
-        self.assertEqual(ka.get("addrepo"), ["yum", "dnf"])
+        assert ka.get("addrepo") == ["yum", "dnf"]
         ka.read_string("inst.ks=kickstart")
-        self.assertEqual(ka.get("ks"), "kickstart")
+        assert ka.get("ks") == "kickstart"
 
     def test_items(self):
         """Test KernelArguments access to contents with iterator."""
 
         ka = KernelArguments.from_defaults()
         it = ka.items()
-        self.assertIsInstance(it, Iterable)
+        assert isinstance(it, Iterable)
         root_seen = False
         for k, v in it:  # pylint: disable=unused-variable
             if k == "root":
                 root_seen = True
-        self.assertTrue(root_seen)
+        assert root_seen
 
     def test_items_raw(self):
         """Test KernelArguments access to raw contents with iterator."""
@@ -91,18 +91,18 @@ class KernelArgumentsTests(unittest.TestCase):
             "blah inst.foo=anything inst.nothing=indeed")
         it = ka.items_raw()
 
-        self.assertIsInstance(it, Iterable)
+        assert isinstance(it, Iterable)
 
         res = dict()
         for k, v in it:
             res[k] = v
 
-        self.assertIn("inst.foo", res)
-        self.assertIn("blah", res)
-        self.assertIn("inst.nothing", res)
+        assert "inst.foo" in res
+        assert "blah" in res
+        assert "inst.nothing" in res
 
-        self.assertEqual(res["inst.nothing"], "indeed")
+        assert res["inst.nothing"] == "indeed"
 
     def test_shared_instance(self):
         """Test the kernel.kernel_arguments instance."""
-        self.assertTrue("root" in kernel_arguments)
+        assert "root" in kernel_arguments

--- a/tests/unit_tests/pyanaconda_tests/core/test_signal.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_signal.py
@@ -44,22 +44,22 @@ class SignalTestCase(unittest.TestCase):
         """Test if a method can be correctly connected to a signal."""
         signal = Signal()
         foo = FooClass()
-        self.assertIsNone(foo.var)
+        assert foo.var is None
         # connect the signal
         signal.connect(foo.set_var)
         # trigger the signal
         signal.emit("bar")
         # check if the callback triggered correctly
-        self.assertEqual(foo.var, "bar")
+        assert foo.var == "bar"
         # try to trigger the signal again
         signal.emit("baz")
-        self.assertEqual(foo.var, "baz")
+        assert foo.var == "baz"
         # now try to disconnect the signal
         signal.disconnect(foo.set_var)
         # check that calling the signal again
         # no longer triggers the callback
         signal.emit("anaconda")
-        self.assertEqual(foo.var, "baz")
+        assert foo.var == "baz"
 
     def test_function(self):
         """Test if a local function can be correctly connected to a signal."""
@@ -69,28 +69,28 @@ class SignalTestCase(unittest.TestCase):
             self.var = value
 
         signal = Signal()
-        self.assertIsNone(self.var)
+        assert self.var is None
         # connect the signal
         signal.connect(set_var)
         # trigger the signal
         signal.emit("bar")
         # check if the callback triggered correctly
-        self.assertEqual(self.var, "bar")
+        assert self.var == "bar"
         # try to trigger the signal again
         signal.emit("baz")
-        self.assertEqual(self.var, "baz")
+        assert self.var == "baz"
         # now try to disconnect the signal
         signal.disconnect(set_var)
         # check that calling the signal again
         # no longer triggers the callback
         signal.emit("anaconda")
-        self.assertEqual(self.var, "baz")
+        assert self.var == "baz"
 
     def test_lambda(self):
         """Test if a lambda can be correctly connected to a signal."""
         foo = FooClass()
         signal = Signal()
-        self.assertIsNone(foo.var)
+        assert foo.var is None
         # connect the signal
         # pylint: disable=unnecessary-lambda
         lambda_instance = lambda x: foo.set_var(x)
@@ -98,16 +98,16 @@ class SignalTestCase(unittest.TestCase):
         # trigger the signal
         signal.emit("bar")
         # check if the callback triggered correctly
-        self.assertEqual(foo.var, "bar")
+        assert foo.var == "bar"
         # try to trigger the signal again
         signal.emit("baz")
-        self.assertEqual(foo.var, "baz")
+        assert foo.var == "baz"
         # now try to disconnect the signal
         signal.disconnect(lambda_instance)
         # check that calling the signal again
         # no longer triggers the callback
         signal.emit("anaconda")
-        self.assertEqual(foo.var, "baz")
+        assert foo.var == "baz"
 
     def test_clear(self):
         """Test if the clear() method correctly clears any connected callbacks."""
@@ -117,9 +117,9 @@ class SignalTestCase(unittest.TestCase):
         signal = Signal()
         foo = FooClass()
         lambda_foo = FooClass()
-        self.assertIsNone(foo.var)
-        self.assertIsNone(lambda_foo.var)
-        self.assertIsNone(self.var)
+        assert foo.var is None
+        assert lambda_foo.var is None
+        assert self.var is None
         # connect the callbacks
         signal.connect(set_var)
         signal.connect(foo.set_var)
@@ -128,22 +128,22 @@ class SignalTestCase(unittest.TestCase):
         # trigger the signal
         signal.emit("bar")
         # check that the callbacks were triggered
-        self.assertEqual(self.var, "bar")
-        self.assertEqual(foo.var, "bar")
-        self.assertEqual(lambda_foo.var, "bar")
+        assert self.var == "bar"
+        assert foo.var == "bar"
+        assert lambda_foo.var == "bar"
         # clear the callbacks
         signal.clear()
         # trigger the signal again
         signal.emit("anaconda")
         # check that the callbacks were not triggered
-        self.assertEqual(self.var, "bar")
-        self.assertEqual(foo.var, "bar")
-        self.assertEqual(lambda_foo.var, "bar")
+        assert self.var == "bar"
+        assert foo.var == "bar"
+        assert lambda_foo.var == "bar"
 
     def test_signal_chain(self):
         """Check if signals can be chained together."""
         foo = FooClass()
-        self.assertIsNone(foo.var)
+        assert foo.var is None
         signal1 = Signal()
         signal1.connect(foo.set_var)
         signal2 = Signal()
@@ -153,4 +153,4 @@ class SignalTestCase(unittest.TestCase):
         # trigger the chain
         signal3.emit("bar")
         # check if the initial callback was triggered
-        self.assertEqual(foo.var, "bar")
+        assert foo.var == "bar"

--- a/tests/unit_tests/pyanaconda_tests/core/test_user.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_user.py
@@ -30,8 +30,8 @@ class UserNameTests(unittest.TestCase):
 
     def _assert_name(self, name, expected_validity):
         valid, message = self._check_name(name)
-        self.assertEqual(valid, expected_validity, message)
-        self.assertEqual(not valid, message is not None)
+        assert valid == expected_validity, message
+        assert (not valid) == (message is not None)
 
     def _assert_username(self, name, expected_validity):
         self._assert_name(name, expected_validity)

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
@@ -112,7 +112,7 @@ class BossInterfaceTestCase(unittest.TestCase):
     def test_start_modules_with_task(self, publisher):
         """Test StartModulesWithTask."""
         task_path = self.interface.StartModulesWithTask()
-        task_proxy = check_task_creation(self, task_path, publisher, StartModulesTask)
+        task_proxy = check_task_creation(task_path, publisher, StartModulesTask)
         task = task_proxy.implementation
 
         callback = Mock()

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
@@ -95,18 +95,18 @@ class BossInterfaceTestCase(unittest.TestCase):
 
     def test_get_modules(self):
         """Test GetModules."""
-        self.assertEqual(self.interface.GetModules(), [])
+        assert self.interface.GetModules() == []
 
         self._add_module("org.fedoraproject.Anaconda.Modules.A")
         self._add_module("org.fedoraproject.Anaconda.Modules.B")
         self._add_module("org.fedoraproject.Anaconda.Addons.C", available=False)
         self._add_module("org.fedoraproject.Anaconda.Addons.D")
 
-        self.assertEqual(self.interface.GetModules(), [
+        assert self.interface.GetModules() == [
             "org.fedoraproject.Anaconda.Modules.A",
             "org.fedoraproject.Anaconda.Modules.B",
             "org.fedoraproject.Anaconda.Addons.D"
-        ])
+        ]
 
     @patch_dbus_publish_object
     def test_start_modules_with_task(self, publisher):
@@ -128,28 +128,28 @@ class BossInterfaceTestCase(unittest.TestCase):
         with tempfile.NamedTemporaryFile("r+") as f:
             report = self.interface.ReadKickstartFile(f.name)
 
-        self.assertEqual(report, {
+        assert report == {
             "error-messages": get_variant(List[Structure], []),
             "warning-messages": get_variant(List[Structure], [])
-        })
+        }
 
     def test_generate_kickstart(self):
         """Test GenerateKickstart."""
-        self.assertEqual(self.interface.GenerateKickstart(), "")
+        assert self.interface.GenerateKickstart() == ""
 
     def test_set_locale(self):
         """Test SetLocale."""
-        self.assertEqual(self.interface.SetLocale(DEFAULT_LANG), None)
+        assert self.interface.SetLocale(DEFAULT_LANG) is None
 
     def test_collect_requirements(self):
         """Test CollectRequirements."""
-        self.assertEqual(self.interface.CollectRequirements(), [])
+        assert self.interface.CollectRequirements() == []
 
         self._add_module_with_requirement("A", package_name="a")
         self._add_module_with_requirement("B", package_name="b")
         self._add_module_with_requirement("C", package_name="c", available=False)
 
-        self.assertEqual(self.interface.CollectRequirements(), [
+        assert self.interface.CollectRequirements() == [
             {
                 "type": get_variant(Str, "package"),
                 "name": get_variant(Str, "a"),
@@ -160,13 +160,13 @@ class BossInterfaceTestCase(unittest.TestCase):
                 "name": get_variant(Str, "b"),
                 "reason": get_variant(Str, "Required by B.")
             }
-        ])
+        ]
 
     @patch("pyanaconda.modules.boss.boss_interface.get_object_handler")
     @patch_dbus_get_proxy
     def test_collect_configure_runtime_tasks(self, proxy_getter, handler_getter):
         """Test CollectConfigureRuntimeTasks."""
-        self.assertEqual(self.interface.CollectConfigureRuntimeTasks(), [])
+        assert self.interface.CollectConfigureRuntimeTasks() == []
 
         self._add_module_with_tasks("A")
         self._add_module_with_tasks("B")
@@ -175,19 +175,19 @@ class BossInterfaceTestCase(unittest.TestCase):
         proxy_getter.side_effect = self._get_mocked_proxy
         handler_getter.side_effect = self._get_mocked_handler
 
-        self.assertEqual(self.interface.CollectConfigureRuntimeTasks(), [
+        assert self.interface.CollectConfigureRuntimeTasks() == [
             ("A", "/task/1"),
             ("A", "/task/2"),
             ("B", "/task/1"),
             ("B", "/task/2"),
-        ])
+        ]
 
     @patch("pyanaconda.modules.boss.boss_interface.get_object_handler")
     @patch_dbus_get_proxy
     def test_collect_configure_bootloader_tasks(self, proxy_getter, handler_getter):
         """Test CollectConfigureBootloaderTasks."""
         version = "4.17.7-200.fc28.x86_64"
-        self.assertEqual(self.interface.CollectConfigureBootloaderTasks([version]), [])
+        assert self.interface.CollectConfigureBootloaderTasks([version]) == []
 
         self._add_module_with_tasks("A")
         self._add_module_with_tasks("B")
@@ -196,18 +196,18 @@ class BossInterfaceTestCase(unittest.TestCase):
         proxy_getter.side_effect = self._get_mocked_proxy
         handler_getter.side_effect = self._get_mocked_handler
 
-        self.assertEqual(self.interface.CollectConfigureBootloaderTasks([version]), [
+        assert self.interface.CollectConfigureBootloaderTasks([version]) == [
             ("A", "/task/5"),
             ("A", "/task/6"),
             ("B", "/task/5"),
             ("B", "/task/6"),
-        ])
+        ]
 
     @patch("pyanaconda.modules.boss.boss_interface.get_object_handler")
     @patch_dbus_get_proxy
     def test_collect_install_system_tasks(self, proxy_getter, handler_getter):
         """Test CollectInstallSystemTasks."""
-        self.assertEqual(self.interface.CollectInstallSystemTasks(), [])
+        assert self.interface.CollectInstallSystemTasks() == []
 
         self._add_module_with_tasks("A")
         self._add_module_with_tasks("B")
@@ -216,13 +216,13 @@ class BossInterfaceTestCase(unittest.TestCase):
         proxy_getter.side_effect = self._get_mocked_proxy
         handler_getter.side_effect = self._get_mocked_handler
 
-        self.assertEqual(self.interface.CollectInstallSystemTasks(), [
+        assert self.interface.CollectInstallSystemTasks() == [
             ("A", "/task/3"),
             ("A", "/task/4"),
             ("B", "/task/3"),
             ("B", "/task/4"),
-        ])
+        ]
 
     def test_quit(self):
         """Test Quit."""
-        self.assertEqual(self.interface.Quit(), None)
+        assert self.interface.Quit() is None

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_install.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_install.py
@@ -30,7 +30,7 @@ class InstallManagerTestCase(unittest.TestCase):
         install_manager = InstallManager()
         install_manager.on_module_observers_changed([])
         proxies = install_manager.collect_install_system_tasks()
-        self.assertEqual(proxies, [])
+        assert proxies == []
 
     def test_install_with_no_tasks(self):
         """Install with no tasks."""
@@ -42,7 +42,7 @@ class InstallManagerTestCase(unittest.TestCase):
         install_manager = InstallManager()
         install_manager.on_module_observers_changed([observer])
         proxies = install_manager.collect_install_system_tasks()
-        self.assertEqual(proxies, [])
+        assert proxies == []
 
     @patch_dbus_get_proxy
     def test_install_one_task(self, proxy_getter):
@@ -59,7 +59,7 @@ class InstallManagerTestCase(unittest.TestCase):
         install_manager = InstallManager()
         install_manager.on_module_observers_changed([observer])
         proxies = install_manager.collect_install_system_tasks()
-        self.assertEqual(proxies, [task_proxy])
+        assert proxies == [task_proxy]
 
         proxy_getter.assert_called_once_with("A", "/A/1")
 
@@ -89,7 +89,7 @@ class InstallManagerTestCase(unittest.TestCase):
         install_manager = InstallManager()
         install_manager.on_module_observers_changed(observers)
         proxies = install_manager.collect_install_system_tasks()
-        self.assertEqual(proxies, [task_proxy, task_proxy, task_proxy])
+        assert proxies == [task_proxy, task_proxy, task_proxy]
 
         proxy_getter.assert_has_calls([
             call("A", "/A/1"),
@@ -123,7 +123,7 @@ class InstallManagerTestCase(unittest.TestCase):
         install_manager = InstallManager()
         install_manager.on_module_observers_changed(observers)
         proxies = install_manager.collect_configure_runtime_tasks()
-        self.assertEqual(proxies, [task_proxy, task_proxy, task_proxy])
+        assert proxies == [task_proxy, task_proxy, task_proxy]
 
         proxy_getter.assert_has_calls([
             call("A", "/A/1"),

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_kickstart.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_kickstart.py
@@ -242,27 +242,27 @@ class KickstartManagerTestCase(unittest.TestCase):
         with self._create_ks_files(self._kickstart_include) as filename:
             report = manager.read_kickstart_file(filename)
 
-        self.assertEqual(module1.kickstart, self._m1_kickstart)
-        self.assertEqual(module2.kickstart, self._m2_kickstart)
-        self.assertEqual(module3.kickstart, self._m3_kickstart)
-        self.assertEqual(module4.kickstart, "")
+        assert module1.kickstart == self._m1_kickstart
+        assert module2.kickstart == self._m2_kickstart
+        assert module3.kickstart == self._m3_kickstart
+        assert module4.kickstart == ""
 
-        self.assertEqual(report.is_valid(), False)
-        self.assertEqual(len(report.get_messages()), 2)
+        assert report.is_valid() == False
+        assert len(report.get_messages()) == 2
 
         error = report.get_messages()[0]
-        self.assertEqual(error.module_name, "1")
-        self.assertEqual(error.file_name, "ks.manager.test.include1.cfg")
-        self.assertEqual(error.line_number, 5)
-        self.assertEqual(error.message, "Mocked parse error: \"PARSE_ERROR\" found")
+        assert error.module_name == "1"
+        assert error.file_name == "ks.manager.test.include1.cfg"
+        assert error.line_number == 5
+        assert error.message == "Mocked parse error: \"PARSE_ERROR\" found"
 
         error = report.get_messages()[1]
-        self.assertEqual(error.module_name, "3")
-        self.assertEqual(error.file_name, "ks.manager.test.include.cfg")
-        self.assertEqual(error.line_number, 41)
-        self.assertEqual(error.message, "Mocked parse error: \"PARSE_ERROR\" found")
+        assert error.module_name == "3"
+        assert error.file_name == "ks.manager.test.include.cfg"
+        assert error.line_number == 41
+        assert error.message == "Mocked parse error: \"PARSE_ERROR\" found"
 
-        self.assertEqual(manager.generate_kickstart(), self._m123_kickstart)
+        assert manager.generate_kickstart() == self._m123_kickstart
 
     def test_nothing_to_parse(self):
         ks_content = ""
@@ -270,10 +270,10 @@ class KickstartManagerTestCase(unittest.TestCase):
         with self._create_ks_files([("ks.mgr.test.empty.cfg", ks_content)]) as filename:
             report = manager.read_kickstart_file(filename)
 
-        self.assertEqual(report.is_valid(), True)
-        self.assertEqual(len(report.get_messages()), 0)
+        assert report.is_valid() == True
+        assert len(report.get_messages()) == 0
 
-        self.assertEqual(manager.generate_kickstart(), "")
+        assert manager.generate_kickstart() == ""
 
     def test_unknown_section_split(self):
         ks_content = """
@@ -286,14 +286,14 @@ blah
         with self._create_ks_files([("ks.mgr.test.unknown_sect.cfg", ks_content)]) as filename:
             report = manager.read_kickstart_file(filename)
 
-        self.assertEqual(report.is_valid(), False)
-        self.assertEqual(len(report.get_messages()), 1)
+        assert report.is_valid() == False
+        assert len(report.get_messages()) == 1
 
         error = report.get_messages()[0]
-        self.assertEqual(error.module_name, "org.fedoraproject.Anaconda.Boss")
-        self.assertEqual(error.file_name, "ks.mgr.test.unknown_sect.cfg")
-        self.assertEqual(error.line_number, 2)
-        self.assertEqual(error.message, 'Unknown kickstart section: %unknown_section')
+        assert error.module_name == "org.fedoraproject.Anaconda.Boss"
+        assert error.file_name == "ks.mgr.test.unknown_sect.cfg"
+        assert error.line_number == 2
+        assert error.message == 'Unknown kickstart section: %unknown_section'
 
     def test_missing_section_end_split(self):
         ks_content = """
@@ -305,14 +305,14 @@ blah
         with self._create_ks_files([("ks.mgr.test.missing_end.cfg", ks_content)]) as filename:
             report = manager.read_kickstart_file(filename)
 
-        self.assertEqual(report.is_valid(), False)
-        self.assertEqual(len(report.get_messages()), 1)
+        assert report.is_valid() == False
+        assert len(report.get_messages()) == 1
 
         error = report.get_messages()[0]
-        self.assertEqual(error.module_name, "org.fedoraproject.Anaconda.Boss")
-        self.assertEqual(error.file_name, "ks.mgr.test.missing_end.cfg")
-        self.assertEqual(error.line_number, 3)
-        self.assertEqual(error.message, 'Section %packages does not end with %end.')
+        assert error.module_name == "org.fedoraproject.Anaconda.Boss"
+        assert error.file_name == "ks.mgr.test.missing_end.cfg"
+        assert error.line_number == 3
+        assert error.message == 'Section %packages does not end with %end.'
 
     def test_missing_include_split(self):
         ks_content = """
@@ -323,24 +323,16 @@ network --device=ens3
         with self._create_ks_files([("ks.mgr.test.missing_include.cfg", ks_content)]) as filename:
             report = manager.read_kickstart_file(filename)
 
-        self.assertEqual(report.is_valid(), False)
-        self.assertEqual(len(report.get_messages()), 1)
+        assert report.is_valid() == False
+        assert len(report.get_messages()) == 1
 
         error = report.get_messages()[0]
-        self.assertEqual(
-            error.module_name, "org.fedoraproject.Anaconda.Boss"
-        )
-        self.assertEqual(
-            error.file_name, "ks.mgr.test.missing_include.cfg"
-        )
-        self.assertEqual(
-            error.line_number, 0
-        )
-        self.assertEqual(
-            error.message,
-            "Unable to open input kickstart file: Error opening file: "
+        assert error.module_name == "org.fedoraproject.Anaconda.Boss"
+        assert error.file_name == "ks.mgr.test.missing_include.cfg"
+        assert error.line_number == 0
+        assert error.message == \
+            "Unable to open input kickstart file: Error opening file: " \
             "[Errno 2] No such file or directory: 'missing_include.cfg'"
-        )
 
 
 class TestModule(object):

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_kickstart_dispatcher.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_kickstart_dispatcher.py
@@ -21,6 +21,7 @@
 import unittest
 import os
 import shlex
+import pytest
 from contextlib import contextmanager
 
 from pyanaconda.modules.boss.kickstart_manager.element import KickstartElement,\
@@ -208,39 +209,39 @@ class KickstartElementTest(unittest.TestCase):
         element = KickstartElement(["network", "--device=ens3", "--activate"],
                                    ["network --device=ens3 --activate\n"],
                                    4, filename)
-        self.assertEqual(element.filename, filename)
-        self.assertEqual(element.lineno, 4)
-        self.assertEqual(element.name, "network")
-        self.assertEqual(element.content, "network --device=ens3 --activate\n")
-        self.assertEqual(element.is_command(), True)
-        self.assertEqual(element.is_section(), False)
-        self.assertEqual(element.is_addon(), False)
+        assert element.filename == filename
+        assert element.lineno == 4
+        assert element.name == "network"
+        assert element.content == "network --device=ens3 --activate\n"
+        assert element.is_command() == True
+        assert element.is_section() == False
+        assert element.is_addon() == False
 
         # Ordinary section
         element = KickstartElement(["%post", "--nochroot", "--interpreter", "/usr/bin/bash"],
                                    ["echo POST1\n"],
                                    12, filename)
-        self.assertEqual(element.filename, filename)
-        self.assertEqual(element.lineno, 12)
-        self.assertEqual(element.name, "post")
-        self.assertEqual(element.content,
-                         "%post --nochroot --interpreter /usr/bin/bash\necho POST1\n%end\n")
-        self.assertEqual(element.is_command(), False)
-        self.assertEqual(element.is_section(), True)
-        self.assertEqual(element.is_addon(), False)
+        assert element.filename == filename
+        assert element.lineno == 12
+        assert element.name == "post"
+        assert element.content == \
+            "%post --nochroot --interpreter /usr/bin/bash\necho POST1\n%end\n"
+        assert element.is_command() == False
+        assert element.is_section() == True
+        assert element.is_addon() == False
 
         # Ordinary addon
         element = KickstartElement(["%addon", "scorched", "--planet=Earth"],
                                    ["nuke\n"],
                                    9, filename)
-        self.assertEqual(element.filename, filename)
-        self.assertEqual(element.lineno, 9)
-        self.assertEqual(element.name, "scorched")
-        self.assertEqual(element.content, "%addon scorched --planet=Earth\nnuke\n%end\n")
-        self.assertEqual(element.is_command(), False)
+        assert element.filename == filename
+        assert element.lineno == 9
+        assert element.name == "scorched"
+        assert element.content == "%addon scorched --planet=Earth\nnuke\n%end\n"
+        assert element.is_command() == False
         # NOTE We do not consider addon being a section
-        self.assertEqual(element.is_section(), False)
-        self.assertEqual(element.is_addon(), True)
+        assert element.is_section() == False
+        assert element.is_addon() == True
 
         # Some more special commands
 
@@ -248,11 +249,11 @@ class KickstartElementTest(unittest.TestCase):
         element = KickstartElement(["text"],
                                    ["text\n"],
                                    1, filename)
-        self.assertEqual(element.name, "text")
-        self.assertEqual(element.content, "text\n")
-        self.assertEqual(element.is_command(), True)
-        self.assertEqual(element.is_section(), False)
-        self.assertEqual(element.is_addon(), False)
+        assert element.name == "text"
+        assert element.content == "text\n"
+        assert element.is_command() == True
+        assert element.is_section() == False
+        assert element.is_addon() == False
 
         # Some more special sections
 
@@ -260,20 +261,20 @@ class KickstartElementTest(unittest.TestCase):
         element = KickstartElement(["%pre"],
                                    ["echo PRE\n"],
                                    1, filename)
-        self.assertEqual(element.name, "pre")
-        self.assertEqual(element.content, "%pre\necho PRE\n%end\n")
-        self.assertEqual(element.is_command(), False)
-        self.assertEqual(element.is_section(), True)
-        self.assertEqual(element.is_addon(), False)
+        assert element.name == "pre"
+        assert element.content == "%pre\necho PRE\n%end\n"
+        assert element.is_command() == False
+        assert element.is_section() == True
+        assert element.is_addon() == False
         # no body
         element = KickstartElement(["%packages", "--no-core"],
                                    [],
                                    1, filename)
-        self.assertEqual(element.name, "packages")
-        self.assertEqual(element.content, "%packages --no-core\n%end\n")
-        self.assertEqual(element.is_command(), False)
-        self.assertEqual(element.is_section(), True)
-        self.assertEqual(element.is_addon(), False)
+        assert element.name == "packages"
+        assert element.content == "%packages --no-core\n%end\n"
+        assert element.is_command() == False
+        assert element.is_section() == True
+        assert element.is_addon() == False
 
         # Some more special addons
 
@@ -281,20 +282,20 @@ class KickstartElementTest(unittest.TestCase):
         element = KickstartElement(["%addon", "pony", "--fly=True"],
                                    [],
                                    1, filename)
-        self.assertEqual(element.name, "pony")
-        self.assertEqual(element.content, "%addon pony --fly=True\n%end\n")
-        self.assertEqual(element.is_command(), False)
-        self.assertEqual(element.is_section(), False)
-        self.assertEqual(element.is_addon(), True)
+        assert element.name == "pony"
+        assert element.content == "%addon pony --fly=True\n%end\n"
+        assert element.is_command() == False
+        assert element.is_section() == False
+        assert element.is_addon() == True
         # no name! - we don't fail
         element = KickstartElement(["%addon"],
                                    ["blah\n"],
                                    1, filename)
-        self.assertEqual(element.name, "")
-        self.assertEqual(element.content, "%addon\nblah\n%end\n")
-        self.assertEqual(element.is_command(), False)
-        self.assertEqual(element.is_section(), False)
-        self.assertEqual(element.is_addon(), True)
+        assert element.name == ""
+        assert element.content == "%addon\nblah\n%end\n"
+        assert element.is_command() == False
+        assert element.is_section() == False
+        assert element.is_addon() == True
 
 
 class TrackedKickstartElementsTest(unittest.TestCase):
@@ -369,30 +370,29 @@ echo POST1
         for element in expected_elements:
             elements.append(element)
 
-        self.assertEqual(elements.all_elements, expected_elements)
+        assert elements.all_elements == expected_elements
 
         # filtering
         network_commands = elements.get_elements(commands=["network"])
-        self.assertEqual(network_commands, [self._element2, self._element3])
+        assert network_commands == [self._element2, self._element3]
 
         pony_addon = elements.get_elements(addons=["pony"])
-        self.assertEqual(pony_addon, [self._element4])
+        assert pony_addon == [self._element4]
 
         pre_sections = elements.get_elements(sections=["pre"])
-        self.assertEqual(pre_sections, [self._element1])
+        assert pre_sections == [self._element1]
         # addon is not considered a section
         addon_sections = elements.get_elements(sections=["addon"])
-        self.assertEqual(addon_sections, [])
+        assert addon_sections == []
 
         mixed_elements = elements.get_elements(commands=["network"],
                                                sections=["pre", "post"],
                                                addons=["pony"])
-        self.assertEqual(mixed_elements,
-                         [self._element1, self._element2, self._element3, self._element4,
-                          self._element7])
+        assert mixed_elements == \
+            [self._element1, self._element2, self._element3, self._element4, self._element7]
 
         # nothing required - nothing got
-        self.assertEqual(elements.get_elements(), [])
+        assert elements.get_elements() == []
 
     def test_tracked_kickstart_elements_tracking(self):
         """Test tracking of elements."""
@@ -409,19 +409,18 @@ echo POST1
                                                                addons=["pony"])
         unprocessed_elements = elements.unprocessed_elements
         # still keeping order of elements
-        self.assertEqual(unprocessed_elements,
-                         [self._element5, self._element6, self._element7])
+        assert unprocessed_elements == [self._element5, self._element6, self._element7]
         # nothing is missing
-        self.assertEqual(set(elements.all_elements),
-                         set.union(set(processed_elements), set(unprocessed_elements)))
+        assert set(elements.all_elements) == \
+            set.union(set(processed_elements), set(unprocessed_elements))
         # elements once processed remain processed if you just get them
         elements.get_elements(commands=["network"], sections=["pre"], addons=["pony"])
-        self.assertEqual(elements.unprocessed_elements, unprocessed_elements)
+        assert elements.unprocessed_elements == unprocessed_elements
         # processing some more elements - firewall command
         firewall_elements = elements.get_and_process_elements(commands=["firewall"])
-        self.assertEqual(set(elements.unprocessed_elements),
-                         set.difference(set(unprocessed_elements), set(firewall_elements)))
-        self.assertEqual(elements.unprocessed_elements, [self._element6, self._element7])
+        assert set(elements.unprocessed_elements) == \
+                         set.difference(set(unprocessed_elements), set(firewall_elements))
+        assert elements.unprocessed_elements == [self._element6, self._element7]
 
     def test_tracked_kickstart_elements_dump_kickstart(self):
         """Test dumping of elements into kickstart."""
@@ -434,7 +433,7 @@ echo POST1
             elements.append(element)
 
         dumped_ks = elements.get_kickstart_from_elements(elements.all_elements)
-        self.assertEqual(dumped_ks, self._expected_ks_content)
+        assert dumped_ks == self._expected_ks_content
 
     def test_tracked_kickstart_elements_get_refs_kickstart(self):
         """Test getting of element references."""
@@ -447,7 +446,7 @@ echo POST1
             elements.append(element)
 
         element_refs = elements.get_references_from_elements(elements.all_elements)
-        self.assertEqual(element_refs, self._expected_element_refs)
+        assert element_refs == self._expected_element_refs
 
 
 class SplitKickstartParserTest(unittest.TestCase):
@@ -509,10 +508,10 @@ echo POST1
         os.remove(filename)
 
         for element, expected in zip(result.all_elements, expected_result):
-            self.assertEqual(element.filename, filename)
-            self.assertEqual((element.name, element.content, element.lineno), expected)
+            assert element.filename == filename
+            assert (element.name, element.content, element.lineno) == expected
 
-        self.assertEqual(result.get_kickstart_from_elements(result.all_elements), ks_content)
+        assert result.get_kickstart_from_elements(result.all_elements) == ks_content
 
         # Reading kickstart from string
 
@@ -520,10 +519,10 @@ echo POST1
         result = ksparser.split_from_string(ks_content)
 
         for element, expected in zip(result.all_elements, expected_result):
-            self.assertEqual(element.filename, filename)
-            self.assertEqual((element.name, element.content, element.lineno), expected)
+            assert element.filename == filename
+            assert (element.name, element.content, element.lineno) == expected
 
-        self.assertEqual(result.get_kickstart_from_elements(result.all_elements), ks_content)
+        assert result.get_kickstart_from_elements(result.all_elements) == ks_content
 
         # Reading kickstart from string supplying filename
 
@@ -531,12 +530,12 @@ echo POST1
         result = ksparser.split_from_string(ks_content, filename=filename)
 
         for element, expected in zip(result.all_elements, expected_result):
-            self.assertEqual(element.filename, filename)
-            self.assertEqual((element.name, element.content, element.lineno), expected)
+            assert element.filename == filename
+            assert (element.name, element.content, element.lineno) == expected
 
         # Dumping kickstart
 
-        self.assertEqual(result.get_kickstart_from_elements(result.all_elements), ks_content)
+        assert result.get_kickstart_from_elements(result.all_elements) == ks_content
 
     @contextmanager
     def _create_ks_files(self, kickstart):
@@ -567,9 +566,9 @@ echo POST1
                 header = element.content.strip().split("\n")[0]
                 # Headers are not stored as source lines but go through shlex
                 # parsing before we can store them in result.
-                self.assertEqual(shlex.split(header), shlex.split(kickstart_line))
+                assert shlex.split(header) == shlex.split(kickstart_line)
             elif element.is_command():
-                self.assertEqual(element.content, kickstart_line)
+                assert element.content == kickstart_line
 
     def _split_kickstart_parser_test(self, ksparser, kickstart_files, expected_output=None):
         with self._create_ks_files(kickstart_files) as filename:
@@ -581,14 +580,14 @@ echo POST1
         result1_kickstart = result1.get_kickstart_from_elements(result1.all_elements)
         if expected_output is not None:
             # Compare with expected output kickstart
-            self.assertEqual(result1_kickstart, expected_output)
+            assert result1_kickstart == expected_output
 
         # Now do one more pass on resulting (flat) kickstart
         result2 = ksparser.split_from_string(result1_kickstart)
         # the result will be different in most cases because of different references
         # but the kickstart should be the same now
         result2_kickstart = result2.get_kickstart_from_elements(result2.all_elements)
-        self.assertEqual(result1_kickstart, result2_kickstart)
+        assert result1_kickstart == result2_kickstart
 
     def test_split_kickstart_parser(self):
         """Test splitting and dumping of various kickstart samples."""
@@ -605,7 +604,8 @@ echo POST1
         ksparser = SplitKickstartParser(handler, valid_sections)
         for kickstart_files in self._flat_kickstarts_raising:
             _filename, content = kickstart_files[0]
-            self.assertRaises(KickstartParseError, ksparser.split_from_string, content)
+            with pytest.raises(KickstartParseError):
+                ksparser.split_from_string(content)
 
     def test_split_from_string_filename(self):
         """Test splitting kickstart supplied by string."""
@@ -619,11 +619,11 @@ echo POST1
         # Kickstart from string has "<MAIN>" as filename
         result = ksparser.split_from_string(content)
         for element in result.all_elements:
-            self.assertEqual(element.filename, SplitKickstartParser.unknown_filename)
+            assert element.filename == SplitKickstartParser.unknown_filename
         # Or the value supplied by filename optional argument
         result = ksparser.split_from_string(content, filename=filename)
         for element in result.all_elements:
-            self.assertEqual(element.filename, filename)
+            assert element.filename == filename
 
     def test_valid_sections(self):
         """Test setting of valid sections for the parser."""
@@ -636,11 +636,12 @@ echo POST1
         returned_valid_sections = ksparser.valid_sections
         # valid_sections returns new list, not a reference to the internal object
         returned_valid_sections.append("%test")
-        self.assertNotEqual(returned_valid_sections, ksparser.valid_sections)
+        assert returned_valid_sections != ksparser.valid_sections
 
         ksparser.valid_sections = ["%packages"]
         # Invalid section raises exception
-        self.assertRaises(KickstartParseError, ksparser.split_from_string, content)
+        with pytest.raises(KickstartParseError):
+            ksparser.split_from_string(content)
         # setting valid sections back to the original, the exception is gone
         ksparser.valid_sections = valid_sections
         ksparser.split_from_string(content)
@@ -661,7 +662,7 @@ network --devce=ens9 --activate
         handler = makeVersion()
         ksparser = SplitKickstartParser(handler)
         result = ksparser.split_from_string(ks_content)
-        self.assertEqual(len(result.all_elements), 4)
+        assert len(result.all_elements) == 4
 
     def test_conflicting_commands(self):
         """Test conflicting commands in kickstart.
@@ -684,7 +685,7 @@ autopart --encrypted --passphrase=starost --type=lvm
         handler = makeVersion()
         ksparser = SplitKickstartParser(handler)
         result = ksparser.split_from_string(ks_content)
-        self.assertEqual(len(result.all_elements), 7)
+        assert len(result.all_elements) == 7
 
     def test_missing_include(self):
         """Test behaviour for missing kickstart include files."""
@@ -696,7 +697,8 @@ network --device=ens3
         handler = makeVersion()
         ksparser = SplitKickstartParser(handler)
         # By default raises error
-        self.assertRaises(KickstartError, ksparser.split_from_string, ks_content)
+        with pytest.raises(KickstartError):
+            ksparser.split_from_string(ks_content)
         # But can be configured not to
         ksparser = SplitKickstartParser(handler, missing_include_is_fatal=False)
         ksparser.split_from_string(ks_content)

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_module_ui.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_module_ui.py
@@ -37,7 +37,6 @@ class UIInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             USER_INTERFACE,
             self.interface,
             *args, **kwargs

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_module_ui.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_module_ui.py
@@ -49,12 +49,12 @@ class UIInterfaceTestCase(unittest.TestCase):
             self.interface.PasswordPolicies)
 
         expected_names = {"root", "user", "luks"}
-        self.assertEqual(policies.keys(), expected_names)
+        assert policies.keys() == expected_names
 
         for name in expected_names:
             policy = policies[name]
             expected_policy = PasswordPolicy.from_defaults(name)
-            self.assertTrue(compare_data(policy, expected_policy))
+            assert compare_data(policy, expected_policy)
 
     def test_password_policies_property(self):
         """Test the password policies property."""

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_modules.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_modules.py
@@ -16,6 +16,7 @@
 # Red Hat, Inc.
 #
 import unittest
+import pytest
 from unittest.mock import Mock, patch
 
 from dasbus.constants import DBUS_START_REPLY_SUCCESS, DBUS_FLAG_NONE
@@ -60,7 +61,7 @@ class ModuleManagerTestCase(unittest.TestCase):
         task._callbacks.put((None, fake_callbacks))
         observers = task.run()
 
-        self.assertEqual([o.service_name for o in observers], service_names)
+        assert [o.service_name for o in observers] == service_names
         return observers
 
     def test_start_no_modules(self):
@@ -101,7 +102,7 @@ class ModuleManagerTestCase(unittest.TestCase):
         observers = self._check_started_modules(task, service_names)
 
         for observer in observers:
-            self.assertEqual(observer.is_addon, False)
+            assert observer.is_addon == False
 
     @patch("dasbus.client.observer.Gio")
     def test_start_addons(self, gio):
@@ -119,7 +120,7 @@ class ModuleManagerTestCase(unittest.TestCase):
         observers = self._check_started_modules(task, service_names)
 
         for observer in observers:
-            self.assertEqual(observer.is_addon, True)
+            assert observer.is_addon == True
 
     @patch("dasbus.client.observer.Gio")
     def test_start_modules_forbidden(self, gio):
@@ -169,11 +170,11 @@ class ModuleManagerTestCase(unittest.TestCase):
 
         task._callbacks.put((None, fake_callbacks))
 
-        with self.assertRaises(UnavailableModuleError) as cm:
+        with pytest.raises(UnavailableModuleError) as cm:
             task.run()
 
         expected = "Service org.fedoraproject.Anaconda.Modules.A has failed to start: Fake error!"
-        self.assertEqual(str(cm.exception), expected)
+        assert str(cm.value) == expected
 
     @patch("dasbus.client.observer.Gio")
     def test_start_addon_failed(self, gio):
@@ -203,12 +204,12 @@ class ModuleManagerTestCase(unittest.TestCase):
                 task._start_service_by_name_callback(call, observer)
 
         task._callbacks.put((None, fake_callbacks))
-        self.assertEqual(task.run(), [])
+        assert task.run() == []
 
     @patch("dasbus.client.observer.Gio")
     def test_get_service_names(self, gio):
         """Get service names of running modules."""
-        self.assertEqual(self._manager.get_service_names(), [])
+        assert self._manager.get_service_names() == []
 
         service_names = [
             "org.fedoraproject.Anaconda.Modules.A",
@@ -220,4 +221,4 @@ class ModuleManagerTestCase(unittest.TestCase):
         observers = self._check_started_modules(task, service_names)
 
         self._manager.set_module_observers(observers)
-        self.assertEqual(self._manager.get_service_names(), service_names)
+        assert self._manager.get_service_names() == service_names

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_observer.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_observer.py
@@ -18,6 +18,7 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import pytest
 from unittest.mock import Mock
 
 from dasbus.client.observer import DBusObserverError
@@ -31,7 +32,7 @@ class ModuleObserverTestCase(unittest.TestCase):
         """Set up the observer."""
         observer._service_available = Mock()
         observer._service_unavailable = Mock()
-        self.assertFalse(observer.is_service_available)
+        assert not observer.is_service_available
 
     def _make_service_available(self, observer):
         """Make the service available."""
@@ -40,7 +41,7 @@ class ModuleObserverTestCase(unittest.TestCase):
 
     def _test_if_service_available(self, observer):
         """Test if service is available."""
-        self.assertTrue(observer.is_service_available)
+        assert observer.is_service_available
 
         observer._service_available.emit.assert_called_once_with(observer)
         observer._service_available.reset_mock()
@@ -55,7 +56,7 @@ class ModuleObserverTestCase(unittest.TestCase):
 
     def _test_if_service_unavailable(self, observer):
         """Test if service is unavailable."""
-        self.assertFalse(observer.is_service_available)
+        assert not observer.is_service_available
 
         observer._service_unavailable.emit.assert_called_once_with(observer)
         observer._service_unavailable.reset_mock()
@@ -70,24 +71,24 @@ class ModuleObserverTestCase(unittest.TestCase):
 
         # Setup the observer.
         self._setup_observer(observer)
-        self.assertIsNone(observer._proxy)
+        assert observer._proxy is None
 
-        with self.assertRaises(DBusObserverError):
+        with pytest.raises(DBusObserverError):
             observer.proxy.DoSomething()
 
         # Service available.
         self._make_service_available(observer)
-        self.assertIsNone(observer._proxy)
+        assert observer._proxy is None
 
         # Access the proxy.
         observer.proxy.DoSomething()
         dbus.get_proxy.assert_called_once_with("my.test.module", "/my/test/module")
-        self.assertIsNotNone(observer._proxy)
+        assert observer._proxy is not None
 
         # Service unavailable.
 
         self._make_service_unavailable(observer)
-        self.assertIsNone(observer._proxy)
+        assert observer._proxy is None
 
-        with self.assertRaises(DBusObserverError):
+        with pytest.raises(DBusObserverError):
             observer.proxy.DoSomething()

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_base.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_base.py
@@ -57,7 +57,7 @@ class BaseModuleTestCase(unittest.TestCase):
             'warning-messages': get_variant(List[Structure], [])
         }
 
-        self.assertEqual(interface.ReadKickstart(""), report)
+        assert interface.ReadKickstart("") == report
 
     def test_read_kickstart_error_line_number(self):
         """Test ReadKickstart with a custom error on a specified line."""
@@ -81,7 +81,7 @@ class BaseModuleTestCase(unittest.TestCase):
             'warning-messages': get_variant(List[Structure], [])
         }
 
-        self.assertEqual(interface.ReadKickstart(""), report)
+        assert interface.ReadKickstart("") == report
 
     def test_read_kickstart_warning(self):
         """Test ReadKickstart with a custom warning."""
@@ -114,7 +114,7 @@ class BaseModuleTestCase(unittest.TestCase):
             'warning-messages': get_variant(List[Structure], [first_warning, second_warning])
         }
 
-        self.assertEqual(interface.ReadKickstart(""), report)
+        assert interface.ReadKickstart("") == report
 
     def test_default_configure_bootloader_with_tasks(self):
         """Test the ConfigureBootloaderWithTasks method with defaults."""
@@ -122,7 +122,7 @@ class BaseModuleTestCase(unittest.TestCase):
         interface = KickstartModuleInterface(service)
 
         tasks = interface.ConfigureBootloaderWithTasks(["1", "2", "3"])
-        self.assertEqual(tasks, [])
+        assert tasks == []
 
     @patch_dbus_publish_object
     def test_configure_bootloader_with_tasks(self, publisher):

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_base.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_base.py
@@ -146,4 +146,4 @@ class BaseModuleTestCase(unittest.TestCase):
         interface = KickstartModuleInterface(service)
 
         tasks = interface.ConfigureBootloaderWithTasks(["1", "2", "3"])
-        check_task_creation_list(self, tasks, publisher, [Task1])
+        check_task_creation_list(tasks, publisher, [Task1])

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_policy.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_policy.py
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 import unittest
+import pytest
+
 from dasbus.typing import get_variant, Int
 from pyanaconda.modules.common.structures.policy import PasswordPolicy
 
@@ -26,18 +28,18 @@ class PasswordPolicyTestCase(unittest.TestCase):
     def test_default_known_policy(self):
         """Test the default policy data."""
         policy = PasswordPolicy.from_defaults("root")
-        self.assertEqual(policy.min_quality, 1)
-        self.assertEqual(policy.min_length, 6)
-        self.assertEqual(policy.allow_empty, False)
-        self.assertEqual(policy.is_strict, False)
+        assert policy.min_quality == 1
+        assert policy.min_length == 6
+        assert policy.allow_empty == False
+        assert policy.is_strict == False
 
     def test_default_unknown_policy(self):
         """Test the default policy data for unknown policy."""
         policy = PasswordPolicy.from_defaults("test")
-        self.assertEqual(policy.min_quality, 0)
-        self.assertEqual(policy.min_length, 0)
-        self.assertEqual(policy.allow_empty, True)
-        self.assertEqual(policy.is_strict, False)
+        assert policy.min_quality == 0
+        assert policy.min_length == 0
+        assert policy.allow_empty == True
+        assert policy.is_strict == False
 
     def test_to_structure_dict(self):
         """Test the to_structure_dict method."""
@@ -51,7 +53,7 @@ class PasswordPolicyTestCase(unittest.TestCase):
         p3.quality = 3
 
         # Test an invalid argument.
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             PasswordPolicy.to_structure_dict([])
 
         # Test a valid argument.
@@ -59,11 +61,11 @@ class PasswordPolicyTestCase(unittest.TestCase):
             "p1": p1, "p2": p2, "p3": p3
         })
 
-        self.assertEqual(structures, {
+        assert structures == {
             "p1": PasswordPolicy.to_structure(p1),
             "p2": PasswordPolicy.to_structure(p2),
             "p3": PasswordPolicy.to_structure(p3),
-        })
+        }
 
     def test_from_structure_dict(self):
         """Test the from_structure_dict method."""
@@ -72,7 +74,7 @@ class PasswordPolicyTestCase(unittest.TestCase):
         s3 = {"min-quality": get_variant(Int, 3)}
 
         # Test an invalid argument.
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             PasswordPolicy.from_structure_dict([])
 
         # Test a valid argument.
@@ -80,7 +82,7 @@ class PasswordPolicyTestCase(unittest.TestCase):
             "s1": s1, "s2": s2, "s3": s3
         })
 
-        self.assertEqual(objects.keys(), {"s1", "s2", "s3"})
-        self.assertEqual(objects["s1"].min_quality, 1)
-        self.assertEqual(objects["s2"].min_quality, 2)
-        self.assertEqual(objects["s3"].min_quality, 3)
+        assert objects.keys() == {"s1", "s2", "s3"}
+        assert objects["s1"].min_quality == 1
+        assert objects["s2"].min_quality == 2
+        assert objects["s3"].min_quality == 3

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_requirements.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_requirements.py
@@ -25,12 +25,12 @@ class ModuleRequirementsTestCase(unittest.TestCase):
 
     def test_package_requirement(self):
         requirement = Requirement.for_package("package-name", "reason")
-        self.assertEqual(requirement.type, "package")
-        self.assertEqual(requirement.name, "package-name")
-        self.assertEqual(requirement.reason, "reason")
+        assert requirement.type == "package"
+        assert requirement.name == "package-name"
+        assert requirement.reason == "reason"
 
     def test_group_requirement(self):
         requirement = Requirement.for_group("group-name", "reason")
-        self.assertEqual(requirement.type, "group")
-        self.assertEqual(requirement.name, "group-name")
-        self.assertEqual(requirement.reason, "reason")
+        assert requirement.type == "group"
+        assert requirement.name == "group-name"
+        assert requirement.reason == "reason"

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_secret_data.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_secret_data.py
@@ -32,30 +32,28 @@ class SecretDataTestCase(unittest.TestCase):
         """Test the string representation of SecretData."""
         data = SecretData()
         expected = "SecretData(type='NONE', value_set=False)"
-        self.assertEqual(str(data), expected)
-        self.assertEqual(repr(data), expected)
+        assert str(data) == expected
+        assert repr(data) == expected
 
         data.set_secret("secret")
         expected = "SecretData(type='TEXT', value_set=True)"
-        self.assertEqual(str(data), expected)
-        self.assertEqual(repr(data), expected)
+        assert str(data) == expected
+        assert repr(data) == expected
 
         data.hide_secret()
         expected = "SecretData(type='HIDDEN', value_set=False)"
-        self.assertEqual(str(data), expected)
-        self.assertEqual(repr(data), expected)
+        assert str(data) == expected
+        assert repr(data) == expected
 
     def test_get_structure(self):
         """Test the DBus structure with SecretData."""
         data = SecretData()
 
-        self.assertEqual(
-            SecretData.to_structure(data),
+        assert SecretData.to_structure(data) == \
             {
                 'type': get_variant(Str, SECRET_TYPE_NONE),
                 'value': get_variant(Str, "")
             }
-        )
 
         data = SecretData.from_structure(
             {
@@ -64,38 +62,38 @@ class SecretDataTestCase(unittest.TestCase):
             }
         )
 
-        self.assertEqual(data.type, SECRET_TYPE_TEXT)
-        self.assertEqual(data.value, "secret")
+        assert data.type == SECRET_TYPE_TEXT
+        assert data.value == "secret"
 
     def test_set_secret(self):
         """Test the set_secret method of SecretData."""
         data = SecretData()
         data.set_secret("secret")
-        self.assertEqual(data.type, SECRET_TYPE_TEXT)
-        self.assertEqual(data.value, "secret")
+        assert data.type == SECRET_TYPE_TEXT
+        assert data.value == "secret"
 
         data.set_secret(None)
-        self.assertEqual(data.type, SECRET_TYPE_NONE)
-        self.assertEqual(data.value, "")
+        assert data.type == SECRET_TYPE_NONE
+        assert data.value == ""
 
     def test_hide_secret(self):
         """Test the hide_secret method of SecretData."""
         data = SecretData()
         data.hide_secret()
-        self.assertEqual(data.type, SECRET_TYPE_NONE)
-        self.assertEqual(data.value, "")
+        assert data.type == SECRET_TYPE_NONE
+        assert data.value == ""
 
         data.type = SECRET_TYPE_TEXT
         data.value = "secret"
         data.hide_secret()
-        self.assertEqual(data.type, SECRET_TYPE_HIDDEN)
-        self.assertEqual(data.value, "")
+        assert data.type == SECRET_TYPE_HIDDEN
+        assert data.value == ""
 
         data.type = SECRET_TYPE_HIDDEN
         data.value = "secret"
         data.hide_secret()
-        self.assertEqual(data.type, SECRET_TYPE_HIDDEN)
-        self.assertEqual(data.value, "")
+        assert data.type == SECRET_TYPE_HIDDEN
+        assert data.value == ""
 
 
 class SecretDataListTestCase(unittest.TestCase):
@@ -105,30 +103,28 @@ class SecretDataListTestCase(unittest.TestCase):
         """Test the string representation of SecretDataList."""
         data = SecretDataList()
         expected = "SecretDataList(type='NONE', value_set=False)"
-        self.assertEqual(str(data), expected)
-        self.assertEqual(repr(data), expected)
+        assert str(data) == expected
+        assert repr(data) == expected
 
         data.set_secret("secret")
         expected = "SecretDataList(type='TEXT', value_set=True)"
-        self.assertEqual(str(data), expected)
-        self.assertEqual(repr(data), expected)
+        assert str(data) == expected
+        assert repr(data) == expected
 
         data.hide_secret()
         expected = "SecretDataList(type='HIDDEN', value_set=False)"
-        self.assertEqual(str(data), expected)
-        self.assertEqual(repr(data), expected)
+        assert str(data) == expected
+        assert repr(data) == expected
 
     def test_get_structure(self):
         """Test the DBus structure with SecretDataList."""
         data = SecretDataList()
 
-        self.assertEqual(
-            SecretDataList.to_structure(data),
+        assert SecretDataList.to_structure(data) == \
             {
                 'type': get_variant(Str, SECRET_TYPE_NONE),
                 'value': get_variant(List[Str], [])
             }
-        )
 
         data = SecretDataList.from_structure(
             {
@@ -137,38 +133,38 @@ class SecretDataListTestCase(unittest.TestCase):
             }
         )
 
-        self.assertEqual(data.type, SECRET_TYPE_TEXT)
-        self.assertEqual(data.value, ["s1", "s2", "s3"])
+        assert data.type == SECRET_TYPE_TEXT
+        assert data.value == ["s1", "s2", "s3"]
 
     def test_set_secret(self):
         """Test the set_secret method of SecretDataList."""
         data = SecretDataList()
         data.set_secret(["s1", "s2", "s3"])
-        self.assertEqual(data.type, SECRET_TYPE_TEXT)
-        self.assertEqual(data.value, ["s1", "s2", "s3"])
+        assert data.type == SECRET_TYPE_TEXT
+        assert data.value == ["s1", "s2", "s3"]
 
         data.set_secret(None)
-        self.assertEqual(data.type, SECRET_TYPE_NONE)
-        self.assertEqual(data.value, [])
+        assert data.type == SECRET_TYPE_NONE
+        assert data.value == []
 
     def test_hide_secret(self):
         """Test the hide_secret method of SecretDataList."""
         data = SecretDataList()
         data.hide_secret()
-        self.assertEqual(data.type, SECRET_TYPE_NONE)
-        self.assertEqual(data.value, [])
+        assert data.type == SECRET_TYPE_NONE
+        assert data.value == []
 
         data.type = SECRET_TYPE_TEXT
         data.value = ["s1", "s2", "s3"]
         data.hide_secret()
-        self.assertEqual(data.type, SECRET_TYPE_HIDDEN)
-        self.assertEqual(data.value, [])
+        assert data.type == SECRET_TYPE_HIDDEN
+        assert data.value == []
 
         data.type = SECRET_TYPE_HIDDEN
         data.value = ["s1", "s2", "s3"]
         data.hide_secret()
-        self.assertEqual(data.type, SECRET_TYPE_HIDDEN)
-        self.assertEqual(data.value, [])
+        assert data.type == SECRET_TYPE_HIDDEN
+        assert data.value == []
 
 
 class DataWithSecretsTestCase(unittest.TestCase):
@@ -217,8 +213,8 @@ class DataWithSecretsTestCase(unittest.TestCase):
             "b=SecretData(type='TEXT', value_set=True), " \
             "c=SecretDataList(type='TEXT', value_set=True))"
 
-        self.assertEqual(str(data), expected)
-        self.assertEqual(repr(data), expected)
+        assert str(data) == expected
+        assert repr(data) == expected
 
         hide_secrets(data)
 
@@ -228,8 +224,8 @@ class DataWithSecretsTestCase(unittest.TestCase):
             "b=SecretData(type='HIDDEN', value_set=False), " \
             "c=SecretDataList(type='HIDDEN', value_set=False))"
 
-        self.assertEqual(str(data), expected)
-        self.assertEqual(repr(data), expected)
+        assert str(data) == expected
+        assert repr(data) == expected
 
     def test_hide_secrets(self):
         """Test the function hide_secrets."""
@@ -238,19 +234,19 @@ class DataWithSecretsTestCase(unittest.TestCase):
         data.b.set_secret("b")
         data.c.set_secret(["c1", "c2", "c3"])
 
-        self.assertEqual(get_native(self.Data.to_structure(data)), {
+        assert get_native(self.Data.to_structure(data)) == {
             "a": "a",
             "b": {"type": SECRET_TYPE_TEXT, "value": "b"},
             "c": {"type": SECRET_TYPE_TEXT, "value": ["c1", "c2", "c3"]},
-        })
+        }
 
         hide_secrets(data)
 
-        self.assertEqual(get_native(self.Data.to_structure(data)), {
+        assert get_native(self.Data.to_structure(data)) == {
             "a": "a",
             "b": {"type": SECRET_TYPE_HIDDEN, "value": ""},
             "c": {"type": SECRET_TYPE_HIDDEN, "value": []},
-        })
+        }
 
     def test_get_public_copy(self):
         """Test the function hide_secrets."""
@@ -260,16 +256,16 @@ class DataWithSecretsTestCase(unittest.TestCase):
         data_1.c.set_secret(["c1", "c2", "c3"])
         data_2 = get_public_copy(data_1)
 
-        self.assertIsNot(data_1, data_2)
+        assert data_1 is not data_2
 
-        self.assertEqual(get_native(self.Data.to_structure(data_1)), {
+        assert get_native(self.Data.to_structure(data_1)) == {
             "a": "a",
             "b": {"type": SECRET_TYPE_TEXT, "value": "b"},
             "c": {"type": SECRET_TYPE_TEXT, "value": ["c1", "c2", "c3"]},
-        })
+        }
 
-        self.assertEqual(get_native(self.Data.to_structure(data_2)), {
+        assert get_native(self.Data.to_structure(data_2)) == {
             "a": "a",
             "b": {"type": SECRET_TYPE_HIDDEN, "value": ""},
             "c": {"type": SECRET_TYPE_HIDDEN, "value": []},
-        })
+        }

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_services.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_services.py
@@ -55,15 +55,15 @@ class ServicesInterfaceTestCase(unittest.TestCase):
 
     def test_kickstart_properties(self):
         """Test kickstart properties."""
-        self.assertEqual(self.services_interface.KickstartCommands, ["firstboot", "services", "skipx", "xconfig"])
-        self.assertEqual(self.services_interface.KickstartSections, [])
-        self.assertEqual(self.services_interface.KickstartAddons, [])
+        assert self.services_interface.KickstartCommands == ["firstboot", "services", "skipx", "xconfig"]
+        assert self.services_interface.KickstartSections == []
+        assert self.services_interface.KickstartAddons == []
         self.callback.assert_not_called()
 
     def test_enabled_services_property(self):
         """Test the enabled services property."""
         self.services_interface.SetEnabledServices(["a", "b", "c"])
-        self.assertEqual(self.services_interface.EnabledServices, ["a", "b", "c"])
+        assert self.services_interface.EnabledServices == ["a", "b", "c"]
         self.callback.assert_called_once_with(
             SERVICES.interface_name, {'EnabledServices': ["a", "b", "c"]}, []
         )
@@ -71,7 +71,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
     def test_disabled_services_property(self):
         """Test the disabled services property."""
         self.services_interface.SetDisabledServices(["a", "b", "c"])
-        self.assertEqual(self.services_interface.DisabledServices, ["a", "b", "c"])
+        assert self.services_interface.DisabledServices == ["a", "b", "c"]
         self.callback.assert_called_once_with(
             SERVICES.interface_name, {'DisabledServices': ["a", "b", "c"]}, []
         )
@@ -79,12 +79,12 @@ class ServicesInterfaceTestCase(unittest.TestCase):
     def test_default_target_property_default_graphical(self):
         """Test the default target property - default value."""
         self.callback.assert_not_called()
-        self.assertEqual(self.services_interface.DefaultTarget, "")
+        assert self.services_interface.DefaultTarget == ""
 
     def test_default_target_property_graphical(self):
         """Test the default target property - set graphical target."""
         self.services_interface.SetDefaultTarget(GRAPHICAL_TARGET)
-        self.assertEqual(self.services_interface.DefaultTarget, GRAPHICAL_TARGET)
+        assert self.services_interface.DefaultTarget == GRAPHICAL_TARGET
         self.callback.assert_called_once_with(
             SERVICES.interface_name, {'DefaultTarget': GRAPHICAL_TARGET}, []
         )
@@ -92,7 +92,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
     def test_default_target_property_text(self):
         """Test the default target property - set text target."""
         self.services_interface.SetDefaultTarget(TEXT_ONLY_TARGET)
-        self.assertEqual(self.services_interface.DefaultTarget, TEXT_ONLY_TARGET)
+        assert self.services_interface.DefaultTarget == TEXT_ONLY_TARGET
         self.callback.assert_called_once_with(
             SERVICES.interface_name, {'DefaultTarget': TEXT_ONLY_TARGET}, []
         )
@@ -100,7 +100,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
     def test_default_desktop_property(self):
         """Test the default desktop property."""
         self.services_interface.SetDefaultDesktop("KDE")
-        self.assertEqual(self.services_interface.DefaultDesktop, "KDE")
+        assert self.services_interface.DefaultDesktop == "KDE"
         self.callback.assert_called_once_with(
             SERVICES.interface_name, {'DefaultDesktop': "KDE"}, []
         )
@@ -108,7 +108,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
     def test_setup_on_boot_property(self):
         """Test the setup on boot property."""
         self.services_interface.SetSetupOnBoot(SETUP_ON_BOOT_DISABLED)
-        self.assertEqual(self.services_interface.SetupOnBoot, SETUP_ON_BOOT_DISABLED)
+        assert self.services_interface.SetupOnBoot == SETUP_ON_BOOT_DISABLED
         self.callback.assert_called_once_with(
             SERVICES.interface_name, {'SetupOnBoot': SETUP_ON_BOOT_DISABLED}, []
         )
@@ -116,16 +116,16 @@ class ServicesInterfaceTestCase(unittest.TestCase):
     def test_post_install_tools_disabled(self):
         """Test the post-install-tools-enabled property."""
         # should not be marked as disabled by default
-        self.assertEqual(self.services_interface.PostInstallToolsEnabled, True)
+        assert self.services_interface.PostInstallToolsEnabled == True
         # mark as disabled
         self.services_interface.SetPostInstallToolsEnabled(False)
-        self.assertEqual(self.services_interface.PostInstallToolsEnabled, False)
+        assert self.services_interface.PostInstallToolsEnabled == False
         self.callback.assert_called_once_with(
             SERVICES.interface_name, {'PostInstallToolsEnabled': False}, []
         )
         # mark as not disabled again
         self.services_interface.SetPostInstallToolsEnabled(True)
-        self.assertEqual(self.services_interface.PostInstallToolsEnabled, True)
+        assert self.services_interface.PostInstallToolsEnabled == True
         self.callback.assert_called_with(
             SERVICES.interface_name, {'PostInstallToolsEnabled': True}, []
         )
@@ -138,16 +138,16 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         ks_in = None
         ks_out = ""
         self._test_kickstart(ks_in, ks_out)
-        self.assertEqual(self.services_interface.SetupOnBoot, SETUP_ON_BOOT_DEFAULT)
-        self.assertEqual(self.services_interface.PostInstallToolsEnabled, True)
+        assert self.services_interface.SetupOnBoot == SETUP_ON_BOOT_DEFAULT
+        assert self.services_interface.PostInstallToolsEnabled == True
 
     def test_kickstart_empty(self):
         """Test with empty string."""
         ks_in = ""
         ks_out = ""
         self._test_kickstart(ks_in, ks_out)
-        self.assertEqual(self.services_interface.SetupOnBoot, SETUP_ON_BOOT_DEFAULT)
-        self.assertEqual(self.services_interface.PostInstallToolsEnabled, True)
+        assert self.services_interface.SetupOnBoot == SETUP_ON_BOOT_DEFAULT
+        assert self.services_interface.PostInstallToolsEnabled == True
 
     def test_services_kickstart(self):
         """Test the services command."""
@@ -191,8 +191,8 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         firstboot --disable
         """
         self._test_kickstart(ks_in, ks_out)
-        self.assertEqual(self.services_interface.SetupOnBoot, SETUP_ON_BOOT_DISABLED)
-        self.assertEqual(self.services_interface.PostInstallToolsEnabled, False)
+        assert self.services_interface.SetupOnBoot == SETUP_ON_BOOT_DISABLED
+        assert self.services_interface.PostInstallToolsEnabled == False
 
     def test_firstboot_enabled_kickstart(self):
         """Test the firstboot command - enabled."""
@@ -204,8 +204,8 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         firstboot --enable
         """
         self._test_kickstart(ks_in, ks_out)
-        self.assertEqual(self.services_interface.SetupOnBoot, SETUP_ON_BOOT_ENABLED)
-        self.assertEqual(self.services_interface.PostInstallToolsEnabled, True)
+        assert self.services_interface.SetupOnBoot == SETUP_ON_BOOT_ENABLED
+        assert self.services_interface.PostInstallToolsEnabled == True
 
     def test_firstboot_reconfig_kickstart(self):
         """Test the firstboot command - reconfig."""
@@ -217,8 +217,8 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         firstboot --reconfig
         """
         self._test_kickstart(ks_in, ks_out)
-        self.assertEqual(self.services_interface.SetupOnBoot, SETUP_ON_BOOT_RECONFIG)
-        self.assertEqual(self.services_interface.PostInstallToolsEnabled, True)
+        assert self.services_interface.SetupOnBoot == SETUP_ON_BOOT_RECONFIG
+        assert self.services_interface.PostInstallToolsEnabled == True
 
 
 class ServicesTasksTestCase(unittest.TestCase):
@@ -254,7 +254,7 @@ class ServicesTasksTestCase(unittest.TestCase):
             ).run()
 
             with open(os.path.join(sysroot, "etc/sysconfig/anaconda")) as f:
-                self.assertEqual(f.read().strip(), content.strip())
+                assert f.read().strip() == content.strip()
 
     @patch('pyanaconda.modules.services.installation.get_anaconda_version_string')
     def test_disable_post_install_tools(self, version_getter):
@@ -278,7 +278,7 @@ class ServicesTasksTestCase(unittest.TestCase):
             ).run()
 
             with open(os.path.join(sysroot, "etc/sysconfig/anaconda")) as f:
-                self.assertEqual(f.read().strip(), content.strip())
+                assert f.read().strip() == content.strip()
 
     @patch('pyanaconda.modules.services.installation.conf')
     def test_skip_post_install_tools(self, conf):
@@ -294,13 +294,13 @@ class ServicesTasksTestCase(unittest.TestCase):
             conf.target.is_image = True
             task.run()
 
-            self.assertFalse(os.path.isfile(os.path.join(sysroot, "etc/sysconfig/anaconda")))
+            assert not os.path.isfile(os.path.join(sysroot, "etc/sysconfig/anaconda"))
 
             conf.target.is_directory = True
             conf.target.is_image = False
             task.run()
 
-            self.assertFalse(os.path.isfile(os.path.join(sysroot, "etc/sysconfig/anaconda")))
+            assert not os.path.isfile(os.path.join(sysroot, "etc/sysconfig/anaconda"))
 
 
     @patch_dbus_publish_object
@@ -319,47 +319,47 @@ class ServicesTasksTestCase(unittest.TestCase):
         object_path = publisher.call_args_list[0][0][0]
         obj = publisher.call_args_list[0][0][1]
 
-        self.assertEqual(is_task_path, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, ConfigureInitialSetupTask)
-        self.assertEqual(obj.implementation._setup_on_boot, SetupOnBootAction.DEFAULT)
+        assert is_task_path == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, ConfigureInitialSetupTask)
+        assert obj.implementation._setup_on_boot == SetupOnBootAction.DEFAULT
 
         # post install tools configuration
         object_path = publisher.call_args_list[1][0][0]
         obj = publisher.call_args_list[1][0][1]
 
-        self.assertEqual(post_install_tools_task, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, ConfigurePostInstallationToolsTask)
-        self.assertEqual(obj.implementation._tools_enabled, True)
+        assert post_install_tools_task == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, ConfigurePostInstallationToolsTask)
+        assert obj.implementation._tools_enabled == True
 
         # Services configuration
         object_path = publisher.call_args_list[2][0][0]
         obj = publisher.call_args_list[2][0][1]
 
-        self.assertEqual(services_task_path, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, ConfigureServicesTask)
-        self.assertEqual(obj.implementation._enabled_services, [])
-        self.assertEqual(obj.implementation._disabled_services, [])
+        assert services_task_path == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, ConfigureServicesTask)
+        assert obj.implementation._enabled_services == []
+        assert obj.implementation._disabled_services == []
 
         # Default systemd target configuration
         object_path = publisher.call_args_list[3][0][0]
         obj = publisher.call_args_list[3][0][1]
 
-        self.assertEqual(target_task_path, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, ConfigureSystemdDefaultTargetTask)
-        self.assertEqual(obj.implementation._default_target, "")
+        assert target_task_path == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, ConfigureSystemdDefaultTargetTask)
+        assert obj.implementation._default_target == ""
 
         # Default desktop configuration
         object_path = publisher.call_args_list[4][0][0]
         obj = publisher.call_args_list[4][0][1]
 
-        self.assertEqual(desktop_task_path, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, ConfigureDefaultDesktopTask)
-        self.assertEqual(obj.implementation._default_desktop, "")
+        assert desktop_task_path == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, ConfigureDefaultDesktopTask)
+        assert obj.implementation._default_desktop == ""
 
     @patch_dbus_publish_object
     def test_initial_setup_config_task_enable(self, publisher):
@@ -374,10 +374,10 @@ class ServicesTasksTestCase(unittest.TestCase):
         object_path = publisher.call_args_list[0][0][0]
         obj = publisher.call_args_list[0][0][1]
 
-        self.assertEqual(is_task_path, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, ConfigureInitialSetupTask)
-        self.assertEqual(obj.implementation._setup_on_boot, SetupOnBootAction.ENABLED)
+        assert is_task_path == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, ConfigureInitialSetupTask)
+        assert obj.implementation._setup_on_boot == SetupOnBootAction.ENABLED
 
     @patch_dbus_publish_object
     def test_initial_setup_config_task_disable(self, publisher):
@@ -392,10 +392,10 @@ class ServicesTasksTestCase(unittest.TestCase):
         object_path = publisher.call_args_list[0][0][0]
         obj = publisher.call_args_list[0][0][1]
 
-        self.assertEqual(is_task_path, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, ConfigureInitialSetupTask)
-        self.assertEqual(obj.implementation._setup_on_boot, SetupOnBootAction.DISABLED)
+        assert is_task_path == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, ConfigureInitialSetupTask)
+        assert obj.implementation._setup_on_boot == SetupOnBootAction.DISABLED
 
     @patch_dbus_publish_object
     def test_initial_setup_config_task_reconfig(self, publisher):
@@ -410,10 +410,10 @@ class ServicesTasksTestCase(unittest.TestCase):
         object_path = publisher.call_args_list[0][0][0]
         obj = publisher.call_args_list[0][0][1]
 
-        self.assertEqual(is_task_path, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, ConfigureInitialSetupTask)
-        self.assertEqual(obj.implementation._setup_on_boot, SetupOnBootAction.RECONFIG)
+        assert is_task_path == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, ConfigureInitialSetupTask)
+        assert obj.implementation._setup_on_boot == SetupOnBootAction.RECONFIG
 
     @patch_dbus_publish_object
     def test_configure_services_task(self, publisher):
@@ -429,11 +429,11 @@ class ServicesTasksTestCase(unittest.TestCase):
         object_path = publisher.call_args_list[2][0][0]
         obj = publisher.call_args_list[2][0][1]
 
-        self.assertEqual(services_task_path, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, ConfigureServicesTask)
-        self.assertEqual(obj.implementation._enabled_services, ["a", "b", "c"])
-        self.assertEqual(obj.implementation._disabled_services, ["c", "e", "f"])
+        assert services_task_path == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, ConfigureServicesTask)
+        assert obj.implementation._enabled_services == ["a", "b", "c"]
+        assert obj.implementation._disabled_services == ["c", "e", "f"]
 
     @patch_dbus_publish_object
     def test_configure_systemd_target_task_text(self, publisher):
@@ -448,10 +448,10 @@ class ServicesTasksTestCase(unittest.TestCase):
         object_path = publisher.call_args_list[3][0][0]
         obj = publisher.call_args_list[3][0][1]
 
-        self.assertEqual(target_task_path, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, ConfigureSystemdDefaultTargetTask)
-        self.assertEqual(obj.implementation._default_target, TEXT_ONLY_TARGET)
+        assert target_task_path == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, ConfigureSystemdDefaultTargetTask)
+        assert obj.implementation._default_target == TEXT_ONLY_TARGET
 
     @patch_dbus_publish_object
     def test_configure_systemd_target_task_graphical(self, publisher):
@@ -466,10 +466,10 @@ class ServicesTasksTestCase(unittest.TestCase):
         object_path = publisher.call_args_list[3][0][0]
         obj = publisher.call_args_list[3][0][1]
 
-        self.assertEqual(target_task_path, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, ConfigureSystemdDefaultTargetTask)
-        self.assertEqual(obj.implementation._default_target, GRAPHICAL_TARGET)
+        assert target_task_path == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, ConfigureSystemdDefaultTargetTask)
+        assert obj.implementation._default_target == GRAPHICAL_TARGET
 
     @patch_dbus_publish_object
     def test_configure_default_desktop_task(self, publisher):
@@ -484,7 +484,7 @@ class ServicesTasksTestCase(unittest.TestCase):
         object_path = publisher.call_args_list[4][0][0]
         obj = publisher.call_args_list[4][0][1]
 
-        self.assertEqual(desktop_task_path, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, ConfigureDefaultDesktopTask)
-        self.assertEqual(obj.implementation._default_desktop, "GNOME")
+        assert desktop_task_path == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, ConfigureDefaultDesktopTask)
+        assert obj.implementation._default_desktop == "GNOME"

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_services.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_services.py
@@ -131,7 +131,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         )
 
     def _test_kickstart(self, ks_in, ks_out):
-        check_kickstart_interface(self, self.services_interface, ks_in, ks_out)
+        check_kickstart_interface(self.services_interface, ks_in, ks_out)
 
     def test_no_kickstart(self):
         """Test with no kickstart."""

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_util.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_util.py
@@ -47,7 +47,7 @@ class IsModuleAvailableTestCase(unittest.TestCase):
          ]
         boss_proxy.GetModules.return_value = running_modules
         # call the function
-        self.assertTrue(is_module_available(SUBSCRIPTION))
+        assert is_module_available(SUBSCRIPTION)
 
     @patch("pyanaconda.modules.common.constants.services.BOSS.get_proxy")
     def test_is_module_not_available(self, get_proxy):
@@ -67,4 +67,4 @@ class IsModuleAvailableTestCase(unittest.TestCase):
          ]
         boss_proxy.GetModules.return_value = running_modules
         # call the function
-        self.assertFalse(is_module_available(SUBSCRIPTION))
+        assert not is_module_available(SUBSCRIPTION)

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
@@ -20,6 +20,8 @@
 import os
 import tempfile
 import unittest
+import pytest
+
 from unittest.mock import patch, Mock, call
 
 from textwrap import dedent
@@ -59,85 +61,85 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
 
     def test_kickstart_properties(self):
         """Test kickstart properties."""
-        self.assertEqual(self.localization_interface.KickstartCommands, ["keyboard", "lang"])
-        self.assertEqual(self.localization_interface.KickstartSections, [])
-        self.assertEqual(self.localization_interface.KickstartAddons, [])
+        assert self.localization_interface.KickstartCommands == ["keyboard", "lang"]
+        assert self.localization_interface.KickstartSections == []
+        assert self.localization_interface.KickstartAddons == []
         self.callback.assert_not_called()
 
     def test_language_property(self):
         """Test the Language property."""
         self.localization_interface.SetLanguage("cs_CZ.UTF-8")
-        self.assertEqual(self.localization_interface.Language, "cs_CZ.UTF-8")
+        assert self.localization_interface.Language == "cs_CZ.UTF-8"
         self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'Language': 'cs_CZ.UTF-8'}, [])
 
     def test_language_support_property(self):
         """Test the LanguageSupport property."""
         self.localization_interface.SetLanguageSupport(["fr_FR"])
-        self.assertEqual(self.localization_interface.LanguageSupport, ["fr_FR"])
+        assert self.localization_interface.LanguageSupport == ["fr_FR"]
         self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'LanguageSupport': ["fr_FR"]}, [])
 
     def test_vc_keymap_property(self):
         """Test the VirtualConsoleKeymap property."""
         self.localization_interface.SetVirtualConsoleKeymap("cz")
-        self.assertEqual(self.localization_interface.VirtualConsoleKeymap, "cz")
+        assert self.localization_interface.VirtualConsoleKeymap == "cz"
         self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'VirtualConsoleKeymap': 'cz'}, [])
 
     def test_x_layouts_property(self):
         """Test the XLayouts property."""
         self.localization_interface.SetXLayouts(["en", "cz(querty)"])
-        self.assertEqual(self.localization_interface.XLayouts, ["en", "cz(querty)"])
+        assert self.localization_interface.XLayouts == ["en", "cz(querty)"]
         self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'XLayouts': ["en", "cz(querty)"]}, [])
 
     def test_switch_options_property(self):
         """Test the LayoutSwitchOptions property."""
         self.localization_interface.SetLayoutSwitchOptions(["grp:alt_shift_toggle"])
-        self.assertEqual(self.localization_interface.LayoutSwitchOptions, ["grp:alt_shift_toggle"])
+        assert self.localization_interface.LayoutSwitchOptions == ["grp:alt_shift_toggle"]
         self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'LayoutSwitchOptions': ["grp:alt_shift_toggle"]}, [])
 
     def test_keyboard_seen(self):
         """Test the KeyboardKickstarted property."""
-        self.assertEqual(self.localization_interface.KeyboardKickstarted, False)
+        assert self.localization_interface.KeyboardKickstarted == False
         ks_in = """
         lang cs_CZ.UTF-8
         """
         ks_in = dedent(ks_in).strip()
         self.localization_interface.ReadKickstart(ks_in)
-        self.assertEqual(self.localization_interface.KeyboardKickstarted, False)
+        assert self.localization_interface.KeyboardKickstarted == False
         ks_in = """
         lang cs_CZ.UTF-8
         keyboard cz
         """
         ks_in = dedent(ks_in).strip()
         self.localization_interface.ReadKickstart(ks_in)
-        self.assertEqual(self.localization_interface.KeyboardKickstarted, True)
+        assert self.localization_interface.KeyboardKickstarted == True
 
     def test_language_seen(self):
         """Test the LanguageKickstarted property."""
-        self.assertEqual(self.localization_interface.LanguageKickstarted, False)
+        assert self.localization_interface.LanguageKickstarted == False
         ks_in = """
         keyboard cz
         """
         ks_in = dedent(ks_in).strip()
         self.localization_interface.ReadKickstart(ks_in)
-        self.assertEqual(self.localization_interface.LanguageKickstarted, False)
+        assert self.localization_interface.LanguageKickstarted == False
         ks_in = """
         keyboard cz
         lang cs_CZ.UTF-8
         """
         ks_in = dedent(ks_in).strip()
         self.localization_interface.ReadKickstart(ks_in)
-        self.assertEqual(self.localization_interface.LanguageKickstarted, True)
+        assert self.localization_interface.LanguageKickstarted == True
 
     def test_set_language_kickstarted(self):
         """Test SetLanguageKickstarted."""
         self.localization_interface.SetLanguageKickstarted(True)
-        self.assertEqual(self.localization_interface.LanguageKickstarted, True)
+        assert self.localization_interface.LanguageKickstarted == True
         self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'LanguageKickstarted': True}, [])
 
     def test_set_keyboard_kickstarted(self):
         """Test SetLanguageKickstarted."""
         self.localization_interface.SetKeyboardKickstarted(True)
-        self.assertEqual(self.localization_interface.KeyboardKickstarted, True)
+        assert self.localization_interface.KeyboardKickstarted == True
         self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'KeyboardKickstarted': True}, [])
 
     @patch("pyanaconda.modules.localization.runtime.try_to_load_keymap")
@@ -147,16 +149,16 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
         # conf.system.can_activate_keyboard value is.
         mocked_load_keymap.return_value = True
         self.localization_interface.SetKeyboard("us")
-        self.assertEqual(self.localization_interface.VirtualConsoleKeymap, "us")
+        assert self.localization_interface.VirtualConsoleKeymap == "us"
 
     def test_collect_requirements(self):
         """Test the CollectRequirements method."""
         # No default requirements.
-        self.assertEqual(self.localization_interface.CollectRequirements(), [])
+        assert self.localization_interface.CollectRequirements() == []
 
         # No additional support for ascii keyboard layouts.
         self.localization_interface.SetVirtualConsoleKeymap("en")
-        self.assertEqual(self.localization_interface.CollectRequirements(), [])
+        assert self.localization_interface.CollectRequirements() == []
 
         # Additional support for non-ascii keyboard layouts.
         self.localization_interface.SetVirtualConsoleKeymap("ru")
@@ -165,9 +167,9 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
             self.localization_interface.CollectRequirements()
         )
 
-        self.assertEqual(len(requirements), 1)
-        self.assertEqual(requirements[0].type, "package")
-        self.assertEqual(requirements[0].name, "kbd-legacy")
+        assert len(requirements) == 1
+        assert requirements[0].type == "package"
+        assert requirements[0].name == "kbd-legacy"
 
         # "fi" keyboard layout is in kbd-legacy too (#1955793)
         self.localization_interface.SetVirtualConsoleKeymap("fi")
@@ -176,9 +178,9 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
             self.localization_interface.CollectRequirements()
         )
 
-        self.assertEqual(len(requirements), 1)
-        self.assertEqual(requirements[0].type, "package")
-        self.assertEqual(requirements[0].name, "kbd-legacy")
+        assert len(requirements) == 1
+        assert requirements[0].type == "package"
+        assert requirements[0].name == "kbd-legacy"
 
     @patch_dbus_publish_object
     def test_install_with_task(self, publisher):
@@ -197,20 +199,20 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
         object_path = publisher.call_args_list[0][0][0]
         obj = publisher.call_args_list[0][0][1]
 
-        self.assertEqual(language_installation_task_path, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, LanguageInstallationTask)
-        self.assertEqual(obj.implementation._lang, "cs_CZ.UTF-8")
+        assert language_installation_task_path == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, LanguageInstallationTask)
+        assert obj.implementation._lang == "cs_CZ.UTF-8"
 
         object_path = publisher.call_args_list[1][0][0]
         obj = publisher.call_args_list[1][0][1]
 
-        self.assertEqual(keyboard_installation_task_path, object_path)
-        self.assertIsInstance(obj, TaskInterface)
-        self.assertIsInstance(obj.implementation, KeyboardInstallationTask)
-        self.assertEqual(obj.implementation._x_layouts, ['cz', 'cz (qwerty)'])
-        self.assertEqual(obj.implementation._vc_keymap, 'us')
-        self.assertEqual(obj.implementation._switch_options, ["grp:alt_shift_toggle"])
+        assert keyboard_installation_task_path == object_path
+        assert isinstance(obj, TaskInterface)
+        assert isinstance(obj.implementation, KeyboardInstallationTask)
+        assert obj.implementation._x_layouts == ['cz', 'cz (qwerty)']
+        assert obj.implementation._vc_keymap == 'us'
+        assert obj.implementation._switch_options == ["grp:alt_shift_toggle"]
 
     @patch_dbus_publish_object
     def test_populate_missing_keyboard_configuration_with_task(self, publisher):
@@ -221,8 +223,8 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
         task_path = self.localization_interface.PopulateMissingKeyboardConfigurationWithTask()
 
         obj = check_task_creation(self, task_path, publisher, GetMissingKeyboardConfigurationTask)
-        self.assertEqual(obj.implementation._vc_keymap, 'us')
-        self.assertEqual(obj.implementation._x_layouts, ['cz', 'cz (qwerty)'])
+        assert obj.implementation._vc_keymap == 'us'
+        assert obj.implementation._x_layouts == ['cz', 'cz (qwerty)']
 
     @patch_dbus_publish_object
     def test_apply_keyboard_with_task(self, publisher):
@@ -234,9 +236,9 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
         task_path = self.localization_interface.ApplyKeyboardWithTask()
 
         obj = check_task_creation(self, task_path, publisher, ApplyKeyboardTask)
-        self.assertEqual(obj.implementation._vc_keymap, 'us')
-        self.assertEqual(obj.implementation._x_layouts, ['cz', 'cz (qwerty)'])
-        self.assertEqual(obj.implementation._switch_options, ["grp:alt_shift_toggle"])
+        assert obj.implementation._vc_keymap == 'us'
+        assert obj.implementation._x_layouts == ['cz', 'cz (qwerty)']
+        assert obj.implementation._switch_options == ["grp:alt_shift_toggle"]
 
     def _test_kickstart(self, ks_in, ks_out):
         check_kickstart_interface(self, self.localization_interface, ks_in, ks_out)
@@ -370,25 +372,25 @@ class LocalizationModuleTestCase(unittest.TestCase):
         self.localization_module.set_vc_keymap("cz")
         self.localization_module.set_x_layouts([])
         self.localization_module.set_from_generic_keyboard_setting("us")
-        self.assertEqual(self.localization_module.vc_keymap, "cz")
-        self.assertEqual(self.localization_module.x_layouts, [])
+        assert self.localization_module.vc_keymap == "cz"
+        assert self.localization_module.x_layouts == []
 
         self.localization_module.set_vc_keymap("")
         self.localization_module.set_x_layouts(["cz"])
         self.localization_module.set_from_generic_keyboard_setting("us")
-        self.assertEqual(self.localization_module.vc_keymap, "")
-        self.assertEqual(self.localization_module.x_layouts, ["cz"])
+        assert self.localization_module.vc_keymap == ""
+        assert self.localization_module.x_layouts == ["cz"]
 
     def test_update_settings_from_task(self):
         """Test _update_settings_from_task."""
         result = (["cz (qwerty)"], "us")
         self.localization_module._update_settings_from_task(result)
-        self.assertEqual(self.localization_module.vc_keymap, "us")
-        self.assertEqual(self.localization_module.x_layouts, ["cz (qwerty)"])
+        assert self.localization_module.vc_keymap == "us"
+        assert self.localization_module.x_layouts == ["cz (qwerty)"]
         result = ([], "")
         self.localization_module._update_settings_from_task(result)
-        self.assertEqual(self.localization_module.vc_keymap, "")
-        self.assertEqual(self.localization_module.x_layouts, [])
+        assert self.localization_module.vc_keymap == ""
+        assert self.localization_module.x_layouts == []
 
 
 class LanguageInstallationTaskTestCase(unittest.TestCase):
@@ -413,7 +415,7 @@ class LanguageInstallationTaskTestCase(unittest.TestCase):
             with open(locale_conf) as f:
                 content = f.read()
 
-            self.assertEqual(content, expected)
+            assert content == expected
 
     @patch("pyanaconda.modules.localization.installation.execWithCapture")
     def test_invalid_locale(self, exec_mock):
@@ -472,7 +474,7 @@ class LocalizationTasksTestCase(unittest.TestCase):
             switch_options="grp:alt_shift_toggle"
         )
         result = task.run()
-        self.assertEqual(result, (x_layouts, vc_keymap))
+        assert result == (x_layouts, vc_keymap)
 
     @patch("pyanaconda.modules.localization.runtime.conf")
     def test_apply_keyboard_task_no_values(self, mocked_conf):
@@ -487,7 +489,7 @@ class LocalizationTasksTestCase(unittest.TestCase):
             switch_options="grp:alt_shift_toggle"
         )
         result = task.run()
-        self.assertEqual(result, (x_layouts, vc_keymap))
+        assert result == (x_layouts, vc_keymap)
 
     @patch("pyanaconda.modules.localization.runtime.write_vc_configuration")
     @patch("pyanaconda.modules.localization.runtime.conf")
@@ -518,7 +520,7 @@ class LocalizationTasksTestCase(unittest.TestCase):
             switch_options=switch_options
         )
         result = task.run()
-        self.assertEqual(result, (result_x_layouts, result_vc_keymap))
+        assert result == (result_x_layouts, result_vc_keymap)
 
     def test_apply_keyboard_task(self):
         """Test the ApplyKeyboardTask."""
@@ -591,7 +593,7 @@ class LocalizationTasksTestCase(unittest.TestCase):
             vc_keymap="",
         )
         result = task.run()
-        self.assertEqual(result, (x_layouts_result, vc_keymap_result))
+        assert result == (x_layouts_result, vc_keymap_result)
 
     def _get_missing_keyboard_configuration_test(self,
                                                  x_layouts,
@@ -609,7 +611,7 @@ class LocalizationTasksTestCase(unittest.TestCase):
             x_layouts,
             vc_keymap
         )
-        self.assertEqual(result, (result_x_layouts, result_vc_keymap))
+        assert result == (result_x_layouts, result_vc_keymap)
 
     def test_get_missing_keyboard_configuration(self):
         """Test the get_missing_keyboard_configuration."""
@@ -667,7 +669,7 @@ class LocalizationTasksTestCase(unittest.TestCase):
             keyboard=keyboard
         )
         result = task.run()
-        self.assertEqual(result, (result_x_layouts, result_vc_keymap))
+        assert result == (result_x_layouts, result_vc_keymap)
 
     def test_assign_generic_keyboard_setting_task(self):
 
@@ -717,17 +719,17 @@ class LocalizationTasksTestCase(unittest.TestCase):
         exec_with_redirect.return_value = 0
         rc = try_to_load_keymap(keymap)
         exec_with_redirect.assert_called_once_with("loadkeys", [keymap])
-        self.assertTrue(rc)
+        assert rc
 
         exec_with_redirect.reset_mock()
         exec_with_redirect.return_value = 1
         rc = try_to_load_keymap(keymap)
         exec_with_redirect.assert_called_once_with("loadkeys", [keymap])
-        self.assertFalse(rc)
+        assert not rc
 
         exec_with_redirect.reset_mock()
         exec_with_redirect.side_effect = OSError("mock exception")
-        with self.assertRaises(KeyboardConfigurationError):
+        with pytest.raises(KeyboardConfigurationError):
             rc = try_to_load_keymap(keymap)
         exec_with_redirect.assert_called_once_with("loadkeys", [keymap])
 
@@ -736,7 +738,7 @@ class LocalizationTasksTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as root:
             vc_keymap = "us"
             # /etc dir does not exist in root therefore the exception
-            with self.assertRaises(KeyboardInstallationError):
+            with pytest.raises(KeyboardInstallationError):
                 write_vc_configuration(vc_keymap, root)
 
         with tempfile.TemporaryDirectory() as root:
@@ -746,10 +748,8 @@ class LocalizationTasksTestCase(unittest.TestCase):
             fpath = os.path.normpath(root + VC_CONF_FILE_PATH)
             # Check the result.
             with open(fpath) as f:
-                self.assertEqual(
-                    f.read(),
+                assert f.read() == \
                     'KEYMAP="{}"\nFONT="{}"\n'.format(vc_keymap, DEFAULT_VC_FONT)
-                )
 
     @patch.dict(os.environ, {"LANG": "ru_RU.UTF-8"})
     def test_write_vc_configuration_env(self):
@@ -762,10 +762,8 @@ class LocalizationTasksTestCase(unittest.TestCase):
             fpath = os.path.normpath(root + VC_CONF_FILE_PATH)
             # Check the result.
             with open(fpath) as f:
-                self.assertEqual(
-                    f.read(),
+                assert f.read() == \
                     'KEYMAP="{}"\nFONT="{}"\n'.format(vc_keymap, vc_font)
-                )
 
     def test_write_x_configuration(self):
         """Test write_x_configuration_test."""
@@ -940,9 +938,9 @@ class LocaledWrapperTestCase(unittest.TestCase):
 
     def _guarded_localed_wrapper_calls_check(self, localed_wrapper):
         """Test that calls to LocaledWrapper are guarded not to fail."""
-        self.assertEqual(localed_wrapper.keymap, "")
-        self.assertEqual(localed_wrapper.options, [])
-        self.assertEqual(localed_wrapper.layouts_variants, [])
+        assert localed_wrapper.keymap == ""
+        assert localed_wrapper.options == []
+        assert localed_wrapper.layouts_variants == []
         localed_wrapper.set_keymap("cz")
         localed_wrapper.set_keymap("cz", convert=True)
         localed_wrapper.convert_keymap("cz")
@@ -969,26 +967,20 @@ class LocaledWrapperTestCase(unittest.TestCase):
         mocked_localed_proxy.X11Layout = "cz,fi,us,fr"
         mocked_localed_proxy.X11Variant = "qwerty,,euro"
         mocked_localed_proxy.X11Options = "grp:alt_shift_toggle,grp:ctrl_alt_toggle"
-        self.assertEqual(
-            localed_wrapper.keymap,
+        assert localed_wrapper.keymap == \
             "cz"
-        )
-        self.assertEqual(
-            localed_wrapper.layouts_variants,
+        assert localed_wrapper.layouts_variants == \
             ["cz (qwerty)", "fi", "us (euro)", "fr"]
-        )
-        self.assertEqual(
-            localed_wrapper.options,
+        assert localed_wrapper.options == \
             ["grp:alt_shift_toggle", "grp:ctrl_alt_toggle"]
-        )
 
         mocked_localed_proxy.VConsoleKeymap = ""
         mocked_localed_proxy.X11Layout = ""
         mocked_localed_proxy.X11Variant = ""
         mocked_localed_proxy.X11Options = ""
-        self.assertEqual(localed_wrapper.keymap, "")
-        self.assertEqual(localed_wrapper.options, [])
-        self.assertEqual(localed_wrapper.layouts_variants, [])
+        assert localed_wrapper.keymap == ""
+        assert localed_wrapper.options == []
+        assert localed_wrapper.layouts_variants == []
 
     @patch("pyanaconda.modules.localization.localed.SystemBus")
     @patch("pyanaconda.modules.localization.localed.LOCALED")

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
@@ -222,7 +222,7 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
 
         task_path = self.localization_interface.PopulateMissingKeyboardConfigurationWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, GetMissingKeyboardConfigurationTask)
+        obj = check_task_creation(task_path, publisher, GetMissingKeyboardConfigurationTask)
         assert obj.implementation._vc_keymap == 'us'
         assert obj.implementation._x_layouts == ['cz', 'cz (qwerty)']
 
@@ -235,13 +235,13 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
 
         task_path = self.localization_interface.ApplyKeyboardWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, ApplyKeyboardTask)
+        obj = check_task_creation(task_path, publisher, ApplyKeyboardTask)
         assert obj.implementation._vc_keymap == 'us'
         assert obj.implementation._x_layouts == ['cz', 'cz (qwerty)']
         assert obj.implementation._switch_options == ["grp:alt_shift_toggle"]
 
     def _test_kickstart(self, ks_in, ks_out):
-        check_kickstart_interface(self, self.localization_interface, ks_in, ks_out)
+        check_kickstart_interface(self.localization_interface, ks_in, ks_out)
 
     def test_no_kickstart(self):
         """Test with no kickstart."""

--- a/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network.py
@@ -21,6 +21,8 @@ import unittest
 import tempfile
 import os
 import shutil
+import pytest
+
 from textwrap import dedent
 from unittest.mock import patch, Mock
 
@@ -82,9 +84,9 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
     def test_kickstart_properties(self):
         """Test kickstart properties."""
-        self.assertEqual(self.network_interface.KickstartCommands, ["network", "firewall"])
-        self.assertEqual(self.network_interface.KickstartSections, [])
-        self.assertEqual(self.network_interface.KickstartAddons, [])
+        assert self.network_interface.KickstartCommands == ["network", "firewall"]
+        assert self.network_interface.KickstartSections == []
+        assert self.network_interface.KickstartAddons == []
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
@@ -103,9 +105,9 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         locale = "en_US.UTF-8"
         mocked_os.environ = {}
         self.network_interface.SetLocale(locale)
-        self.assertEqual(mocked_os.environ["LANG"], locale)
+        assert mocked_os.environ["LANG"] == locale
         setlocale.assert_called_once_with(LC_ALL, locale)
-        self.assertEqual(pyanaconda.core.util._child_env['LANG'], locale)
+        assert pyanaconda.core.util._child_env['LANG'] == locale
 
     def test_hostname_property(self):
         """Test the hostname property."""
@@ -124,11 +126,11 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
         conf_mock.system.provides_system_bus = False
         self.network_module._connect_to_hostname_service()
-        self.assertEqual(self.network_interface.GetCurrentHostname(), "")
+        assert self.network_interface.GetCurrentHostname() == ""
 
         conf_mock.system.provides_system_bus = True
         self.network_module._connect_to_hostname_service()
-        self.assertEqual(self.network_interface.GetCurrentHostname(), "dot.dot")
+        assert self.network_interface.GetCurrentHostname() == "dot.dot"
 
     @patch("pyanaconda.modules.network.network.conf")
     @patch('pyanaconda.core.dbus.SystemBus.get_proxy')
@@ -172,7 +174,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
     def test_connected(self):
         """Test getting connectivity status does not fail."""
         connected = self.network_interface.Connected
-        self.assertIn(connected, (True, False))
+        assert connected in (True, False)
 
     def test_connecting(self):
         """Test checking connecting status does not fail."""
@@ -185,37 +187,37 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         self.network_module.nm_client = nm_client
 
         nm_client._set_state(NM.State.CONNECTED_LOCAL)
-        self.assertTrue(self.network_interface.Connected)
+        assert self.network_interface.Connected
 
         nm_client._set_state(NM.State.DISCONNECTED)
-        self.assertFalse(self.network_interface.Connected)
+        assert not self.network_interface.Connected
         self.callback.assert_called_with(NETWORK.interface_name, {'Connected': False}, [])
-        self.assertFalse(self.network_interface.IsConnecting())
+        assert not self.network_interface.IsConnecting()
 
         nm_client._set_state(NM.State.CONNECTED_SITE)
-        self.assertTrue(self.network_interface.Connected)
+        assert self.network_interface.Connected
         self.callback.assert_called_with(NETWORK.interface_name, {'Connected': True}, [])
-        self.assertFalse(self.network_interface.IsConnecting())
+        assert not self.network_interface.IsConnecting()
 
         nm_client._set_state(NM.State.CONNECTED_GLOBAL)
-        self.assertTrue(self.network_interface.Connected)
+        assert self.network_interface.Connected
         self.callback.assert_called_with(NETWORK.interface_name, {'Connected': True}, [])
-        self.assertFalse(self.network_interface.IsConnecting())
+        assert not self.network_interface.IsConnecting()
 
         nm_client._set_state(NM.State.CONNECTING)
-        self.assertFalse(self.network_interface.Connected)
+        assert not self.network_interface.Connected
         self.callback.assert_called_with(NETWORK.interface_name, {'Connected': False}, [])
-        self.assertTrue(self.network_interface.IsConnecting())
+        assert self.network_interface.IsConnecting()
 
         nm_client._set_state(NM.State.CONNECTED_LOCAL)
-        self.assertTrue(self.network_interface.Connected)
+        assert self.network_interface.Connected
         self.callback.assert_called_with(NETWORK.interface_name, {'Connected': True}, [])
-        self.assertFalse(self.network_interface.IsConnecting())
+        assert not self.network_interface.IsConnecting()
 
     def test_nm_availability(self):
         self.network_module.nm_client = None
-        self.assertTrue(self.network_interface.Connected)
-        self.assertFalse(self.network_interface.IsConnecting())
+        assert self.network_interface.Connected
+        assert not self.network_interface.IsConnecting()
 
     def test_create_device_configurations(self):
         """Test creating device configurations does not fail."""
@@ -223,7 +225,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
     def test_get_device_configurations(self):
         """Test GetDeviceConfigurations."""
-        self.assertListEqual(self.network_interface.GetDeviceConfigurations(), [])
+        assert self.network_interface.GetDeviceConfigurations() == []
 
     def test_network_device_configuration_changed(self):
         """Test NetworkDeviceConfigurationChanged."""
@@ -231,9 +233,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
     def test_get_dracut_arguments(self):
         """Test GetDracutArguments."""
-        self.assertListEqual(
-            self.network_interface.GetDracutArguments("ens3", "10.10.10.10", "", False), []
-        )
+        assert self.network_interface.GetDracutArguments("ens3", "10.10.10.10", "", False) == []
 
     def test_log_configuration_state(self):
         """Test LogConfigurationState."""
@@ -258,10 +258,10 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, NetworkInstallationTask)
 
-        self.assertEqual(obj.implementation._disable_ipv6, True)
-        self.assertEqual(obj.implementation._overwrite, False)
-        self.assertEqual(obj.implementation._network_ifaces, ["ens3", "ens4", "ens5"])
-        self.assertEqual(obj.implementation._configure_persistent_device_names, True)
+        assert obj.implementation._disable_ipv6 == True
+        assert obj.implementation._overwrite == False
+        assert obj.implementation._network_ifaces == ["ens3", "ens4", "ens5"]
+        assert obj.implementation._configure_persistent_device_names == True
 
         self.network_module.log_task_result = Mock()
 
@@ -277,8 +277,8 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, HostnameConfigurationTask)
 
-        self.assertEqual(obj.implementation._overwrite, False)
-        self.assertEqual(obj.implementation._hostname, "my_hostname")
+        assert obj.implementation._overwrite == False
+        assert obj.implementation._hostname == "my_hostname"
 
     @patch_dbus_publish_object
     @patch('pyanaconda.modules.network.installation.update_connection_values')
@@ -297,10 +297,8 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, ConfigureActivationOnBootTask)
 
-        self.assertEqual(
-            set(obj.implementation._onboot_ifaces),
+        assert set(obj.implementation._onboot_ifaces) == \
             set(["ens3", "ens4"])
-        )
 
         self.network_module.log_task_result = Mock()
 
@@ -366,10 +364,8 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         """Test GetSupportedDevices."""
         # No NM available
         self.network_module.nm_client = None
-        self.assertEqual(
-            self.network_interface.GetSupportedDevices(),
+        assert self.network_interface.GetSupportedDevices() == \
             []
-        )
 
         # Mocked NM
         self.network_module.nm_client = Mock()
@@ -385,38 +381,30 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         )
 
         devs_infos = self.network_interface.GetSupportedDevices()
-        self.assertDictEqual(
-            devs_infos[0],
+        assert devs_infos[0] == \
             {
                 'device-name': get_variant(Str, "ens3"),
                 'hw-address': get_variant(Str, "33:33:33:33:33:33"),
                 'device-type': get_variant(Int, NM.DeviceType.ETHERNET)
             }
-        )
-        self.assertDictEqual(
-            devs_infos[1],
+        assert devs_infos[1] == \
             {
                 'device-name': get_variant(Str, "ens4"),
                 'hw-address': get_variant(Str, "44:44:44:44:44:44"),
                 'device-type': get_variant(Int, NM.DeviceType.ETHERNET)
             }
-        )
-        self.assertDictEqual(
-            devs_infos[2],
+        assert devs_infos[2] == \
             {
                 'device-name': get_variant(Str, "ens5"),
                 'hw-address': get_variant(Str, "55:55:55:55:55:55"),
                 'device-type': get_variant(Int, NM.DeviceType.ETHERNET)
             }
-        )
-        self.assertDictEqual(
-            devs_infos[3],
+        assert devs_infos[3] == \
             {
                 'device-name': get_variant(Str, "team0"),
                 'hw-address': get_variant(Str, "33:33:33:33:33:33"),
                 'device-type': get_variant(Int, NM.DeviceType.TEAM)
             }
-        )
 
     def _mock_nm_active_connections(self, connection_specs):
         active_connections = []
@@ -438,10 +426,8 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         """Test GetActivatedInterfaces."""
         # No NM available
         self.network_module.nm_client = None
-        self.assertEqual(
-            self.network_interface.GetActivatedInterfaces(),
+        assert self.network_interface.GetActivatedInterfaces() == \
             []
-        )
 
         # Mocked NM
         self.network_module.nm_client = Mock()
@@ -459,10 +445,8 @@ class NetworkInterfaceTestCase(unittest.TestCase):
                 (True, [])
             ]
         )
-        self.assertListEqual(
-            self.network_interface.GetActivatedInterfaces(),
+        assert self.network_interface.GetActivatedInterfaces() == \
             ["ens3", "ens5", "ens7", "bond0", "devA", "devB"]
-        )
 
     def _test_kickstart(self, ks_in, ks_out, **kwargs):
         check_kickstart_interface(self, self.network_interface, ks_in, ks_out, **kwargs)
@@ -559,7 +543,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
     def test_default_requirements(self):
         """Test that by default no packages are required by the network module."""
-        self.assertEqual(self.network_interface.CollectRequirements(), [])
+        assert self.network_interface.CollectRequirements() == []
 
     def test_kickstart_firewall_package_requirements(self):
         """Test that firewall command in kickstart results in request for firewalld package."""
@@ -570,13 +554,13 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         firewall --enabled --service=ftp,http,smtp,ssh
         """
         self._test_kickstart(ks_in, ks_out)
-        self.assertEqual(self.network_interface.CollectRequirements(), [
+        assert self.network_interface.CollectRequirements() == [
             {
                 "type": get_variant(Str, "package"),
                 "name": get_variant(Str, "firewalld"),
                 "reason": get_variant(Str, "Requested by the firewall kickstart command.")
             }
-        ])
+        ]
 
     def test_teamd_requirements(self):
         """Test that mocked team devices result in request for teamd package."""
@@ -590,13 +574,13 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         )
 
         # check that the teamd package is requested
-        self.assertEqual(self.network_interface.CollectRequirements(), [
+        assert self.network_interface.CollectRequirements() == [
             {
                 "type": get_variant(Str, "package"),
                 "name": get_variant(Str, "teamd"),
                 "reason": get_variant(Str, "Necessary for network team device configuration.")
             }
-        ])
+        ]
 
     @patch("pyanaconda.modules.network.network.kernel_arguments")
     def test_biosdevname_requirements(self, mocked_kernel_arguments):
@@ -605,7 +589,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         kernel_args = KernelArguments.from_string("biosdevname=1")
         with patch("pyanaconda.modules.network.network.kernel_arguments", kernel_args):
             # check that the biosdevname package is requested
-            self.assertEqual(self.network_interface.CollectRequirements(), [
+            assert self.network_interface.CollectRequirements() == [
                 {
                     "type": get_variant(Str, "package"),
                     "name": get_variant(Str, "biosdevname"),
@@ -614,15 +598,15 @@ class NetworkInterfaceTestCase(unittest.TestCase):
                         "Necessary for biosdevname network device naming feature."
                     )
                 }
-            ])
+            ]
 
         kernel_args = KernelArguments.from_string("biosdevname=0")
         with patch("pyanaconda.modules.network.network.kernel_arguments", kernel_args):
-            self.assertEqual(self.network_interface.CollectRequirements(), [])
+            assert self.network_interface.CollectRequirements() == []
 
         kernel_args = KernelArguments.from_string("biosdevname")
         with patch("pyanaconda.modules.network.network.kernel_arguments", kernel_args):
-            self.assertEqual(self.network_interface.CollectRequirements(), [])
+            assert self.network_interface.CollectRequirements() == []
 
     def test_kickstart_invalid_hostname(self):
         """Test that invalid hostname in kickstart is not accepted"""
@@ -653,11 +637,11 @@ class FirewallInterfaceTestCase(unittest.TestCase):
 
     def test_default_property_values(self):
         """Test the default firewall module values are as expected."""
-        self.assertEqual(self.firewall_interface.FirewallMode, FIREWALL_DEFAULT)
-        self.assertListEqual(self.firewall_interface.EnabledPorts, [])
-        self.assertListEqual(self.firewall_interface.Trusts, [])
-        self.assertListEqual(self.firewall_interface.EnabledServices, [])
-        self.assertListEqual(self.firewall_interface.DisabledServices, [])
+        assert self.firewall_interface.FirewallMode == FIREWALL_DEFAULT
+        assert self.firewall_interface.EnabledPorts == []
+        assert self.firewall_interface.Trusts == []
+        assert self.firewall_interface.EnabledServices == []
+        assert self.firewall_interface.DisabledServices == []
 
     def test_set_use_system_defaults(self):
         """Test if the use-system-firewall-defaults option can be set."""
@@ -767,7 +751,7 @@ class HostnameConfigurationTaskTestCase(unittest.TestCase):
 
             with open(hostname_file_path, "r") as f:
                 content = f.read()
-            self.assertEqual(content, "{}\n".format(hostname))
+            assert content == "{}\n".format(hostname)
 
             shutil.rmtree(hostname_dir)
 
@@ -783,7 +767,7 @@ class HostnameConfigurationTaskTestCase(unittest.TestCase):
                 overwrite=True
             )
 
-            with self.assertRaises(NetworkInstallationError):
+            with pytest.raises(NetworkInstallationError):
                 task.run()
 
 
@@ -806,11 +790,11 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, ConfigureFirewallTask)
 
-        self.assertEqual(obj.implementation._firewall_mode, FirewallMode.DEFAULT)
-        self.assertEqual(obj.implementation._enabled_services, [])
-        self.assertEqual(obj.implementation._disabled_services, [])
-        self.assertEqual(obj.implementation._enabled_ports, [])
-        self.assertEqual(obj.implementation._trusts, [])
+        assert obj.implementation._firewall_mode == FirewallMode.DEFAULT
+        assert obj.implementation._enabled_services == []
+        assert obj.implementation._disabled_services == []
+        assert obj.implementation._enabled_ports == []
+        assert obj.implementation._trusts == []
 
     @patch('pyanaconda.core.util.execInSysroot')
     def test_firewall_config_task_enable_missing_tool(self, execInSysroot):
@@ -826,7 +810,7 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
                                          enabled_ports = [],
                                          trusts = [])
             # should raise an exception
-            with self.assertRaises(FirewallConfigurationError):
+            with pytest.raises(FirewallConfigurationError):
                 task.run()
             # should not call execInSysroot
             execInSysroot.assert_not_called()
@@ -892,7 +876,7 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
             task = ConfigureFirewallTask(sysroot=sysroot,
                                          firewall_mode = FirewallMode.DEFAULT,
                                          enabled_services = [],
@@ -911,7 +895,7 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
 
             task = ConfigureFirewallTask(sysroot=sysroot,
                                          firewall_mode = FirewallMode.ENABLED,
@@ -930,7 +914,7 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
 
             task = ConfigureFirewallTask(sysroot=sysroot,
                                          firewall_mode = FirewallMode.ENABLED,
@@ -952,7 +936,7 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
 
             task = ConfigureFirewallTask(sysroot=sysroot,
                                          firewall_mode = FirewallMode.ENABLED,
@@ -973,7 +957,7 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
 
             task = ConfigureFirewallTask(sysroot=sysroot,
                                          firewall_mode = FirewallMode.ENABLED,
@@ -994,7 +978,7 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
 
             task = ConfigureFirewallTask(sysroot=sysroot,
                                          firewall_mode = FirewallMode.DISABLED,
@@ -1013,7 +997,7 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
 
             task = ConfigureFirewallTask(sysroot=sysroot,
                                          firewall_mode = FirewallMode.DISABLED,
@@ -1036,7 +1020,7 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/firewall-offline-cmd"))
 
             task = ConfigureFirewallTask(sysroot=sysroot,
                                          firewall_mode = FirewallMode.USE_SYSTEM_DEFAULTS,
@@ -1060,139 +1044,82 @@ class NetworkModuleTestCase(unittest.TestCase):
 
     def test_apply_boot_options_ksdevice(self):
         """Test _apply_boot_options function for 'ksdevice'."""
-        self.assertEqual(
-            self.network_module.default_device_specification,
-            DEFAULT_DEVICE_SPECIFICATION
-        )
+        assert self.network_module.default_device_specification == DEFAULT_DEVICE_SPECIFICATION
         mocked_kernel_args = {"something": "else"}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.default_device_specification,
-            DEFAULT_DEVICE_SPECIFICATION
-        )
+        assert self.network_module.default_device_specification == DEFAULT_DEVICE_SPECIFICATION
         mocked_kernel_args = {'ksdevice': "ens3"}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.default_device_specification,
-            "ens3"
-        )
+        assert self.network_module.default_device_specification == "ens3"
         mocked_kernel_args = {}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.default_device_specification,
-            "ens3"
-        )
+        assert self.network_module.default_device_specification == "ens3"
 
     def test_apply_boot_options_noipv6(self):
         """Test _apply_boot_options function for 'noipv6'."""
-        self.assertEqual(
-            self.network_module.disable_ipv6,
-            False
-        )
+        assert self.network_module.disable_ipv6 == False
         mocked_kernel_args = {"something": "else"}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.disable_ipv6,
-            False
-        )
+        assert self.network_module.disable_ipv6 == False
         mocked_kernel_args = {'noipv6': None}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.disable_ipv6,
-            True
-        )
+        assert self.network_module.disable_ipv6 == True
         mocked_kernel_args = {}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.disable_ipv6,
-            True
-        )
+        assert self.network_module.disable_ipv6 == True
 
     def test_apply_boot_options_bootif(self):
         """Test _apply_boot_options function for 'BOOTIF'."""
-        self.assertEqual(
-            self.network_module.bootif,
-            None
-        )
+        assert self.network_module.bootif is None
         mocked_kernel_args = {"something": "else"}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.bootif,
-            None
-        )
+        assert self.network_module.bootif is None
         mocked_kernel_args = {'BOOTIF': "01-f4-ce-46-2c-44-7a"}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.bootif,
-            "F4:CE:46:2C:44:7A"
-        )
+        assert self.network_module.bootif == "F4:CE:46:2C:44:7A"
         mocked_kernel_args = {}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.bootif,
-            "F4:CE:46:2C:44:7A"
-        )
+        assert self.network_module.bootif == "F4:CE:46:2C:44:7A"
         # Do not crash on trash
         mocked_kernel_args = {'BOOTIF': ""}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.bootif,
-            ""
-        )
+        assert self.network_module.bootif == ""
 
     def test_apply_boot_options_ifname(self):
         """Test _apply_boot_options function for 'ifname'."""
-        self.assertEqual(
-            self.network_module.ifname_option_values,
-            []
-        )
+        assert self.network_module.ifname_option_values == []
         mocked_kernel_args = {"something": "else"}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.ifname_option_values,
-            []
-        )
+        assert self.network_module.ifname_option_values == []
         mocked_kernel_args = {'ifname': "ens3f0:00:15:17:96:75:0a"}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.ifname_option_values,
-            ["ens3f0:00:15:17:96:75:0a"]
-        )
+        assert self.network_module.ifname_option_values == ["ens3f0:00:15:17:96:75:0a"]
         mocked_kernel_args = {'ifname': "ens3f0:00:15:17:96:75:0a ens3f1:00:15:17:96:75:0b"}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.ifname_option_values,
+        assert self.network_module.ifname_option_values == \
             ["ens3f0:00:15:17:96:75:0a", "ens3f1:00:15:17:96:75:0b"]
-        )
         mocked_kernel_args = {}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.ifname_option_values,
+        assert self.network_module.ifname_option_values == \
             ["ens3f0:00:15:17:96:75:0a", "ens3f1:00:15:17:96:75:0b"]
-        )
         mocked_kernel_args = {'ifname': "bla bla"}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertEqual(
-            self.network_module.ifname_option_values,
-            ["bla", "bla"]
-        )
+        assert self.network_module.ifname_option_values == ["bla", "bla"]
 
     def test_apply_boot_options(self):
         """Test _apply_boot_options for multiple options."""
-        self.assertListEqual(
-            [
+        assert [
                 self.network_module.bootif,
                 self.network_module.ifname_option_values,
                 self.network_module.disable_ipv6,
                 self.network_module.default_device_specification,
-            ],
+            ] == \
             [
                 None,
                 [],
                 False,
                 DEFAULT_DEVICE_SPECIFICATION,
             ]
-        )
         mocked_kernel_args = {
             'something_else': None,
             'ifname': 'ens3f0:00:15:17:96:75:0a ens3f1:00:15:17:96:75:0b',
@@ -1202,20 +1129,18 @@ class NetworkModuleTestCase(unittest.TestCase):
             'ksdevice': 'ens11',
         }
         self.network_module._apply_boot_options(mocked_kernel_args)
-        self.assertListEqual(
-            [
+        assert [
                 self.network_module.bootif,
                 self.network_module.ifname_option_values,
                 self.network_module.disable_ipv6,
                 self.network_module.default_device_specification,
-            ],
+            ] == \
             [
                 "F4:CE:46:2C:44:7A",
                 ["ens3f0:00:15:17:96:75:0a", "ens3f1:00:15:17:96:75:0b"],
                 True,
                 "ens11",
             ]
-        )
 
 
 class InstallationTaskTestCase(unittest.TestCase):
@@ -1268,11 +1193,11 @@ class InstallationTaskTestCase(unittest.TestCase):
         mocked_conf_dir = os.path.join(self._target_mocked_root, conf_dir.lstrip("/"))
         with open(os.path.join(mocked_conf_dir, file_name), "r") as f:
             content = f.read().strip()
-        self.assertEqual(content, expected_content)
+        assert content == expected_content
 
     def _check_config_file_does_not_exist(self, conf_dir, file_name):
         mocked_conf_dir = os.path.join(self._target_mocked_root, conf_dir.lstrip("/"))
-        self.assertFalse(os.path.exists(os.path.join(mocked_conf_dir, file_name)))
+        assert not os.path.exists(os.path.join(mocked_conf_dir, file_name))
 
     def _mock_task_paths(self, task):
         # Mock the paths in the task
@@ -1743,7 +1668,7 @@ class InstallationTaskTestCase(unittest.TestCase):
         )
         self._mock_task_paths(task)
 
-        with self.assertRaises(NetworkInstallationError):
+        with pytest.raises(NetworkInstallationError):
             task._disable_ipv6_on_system(self._target_root)
 
     def test_network_instalation_task_missing_target_dir(self):

--- a/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network.py
@@ -90,7 +90,6 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             NETWORK,
             self.network_interface,
             *args, **kwargs
@@ -256,7 +255,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
         task_path = self.network_interface.InstallNetworkWithTask(False)
 
-        obj = check_task_creation(self, task_path, publisher, NetworkInstallationTask)
+        obj = check_task_creation(task_path, publisher, NetworkInstallationTask)
 
         assert obj.implementation._disable_ipv6 == True
         assert obj.implementation._overwrite == False
@@ -275,7 +274,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
         task_path = self.network_interface.ConfigureHostnameWithTask(False)
 
-        obj = check_task_creation(self, task_path, publisher, HostnameConfigurationTask)
+        obj = check_task_creation(task_path, publisher, HostnameConfigurationTask)
 
         assert obj.implementation._overwrite == False
         assert obj.implementation._hostname == "my_hostname"
@@ -295,7 +294,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
             ["ens3"],
         )
 
-        obj = check_task_creation(self, task_path, publisher, ConfigureActivationOnBootTask)
+        obj = check_task_creation(task_path, publisher, ConfigureActivationOnBootTask)
 
         assert set(obj.implementation._onboot_ifaces) == \
             set(["ens3", "ens4"])
@@ -321,7 +320,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         self._mock_supported_devices([("ens3", "", 0)])
         task_path = self.network_interface.ApplyKickstartWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, ApplyKickstartTask)
+        obj = check_task_creation(task_path, publisher, ApplyKickstartTask)
 
         self.network_module.log_task_result = Mock()
 
@@ -333,7 +332,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         """Test DumpMissingConfigFilesWithTask."""
         task_path = self.network_interface.DumpMissingConfigFilesWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, DumpMissingConfigFilesTask)
+        obj = check_task_creation(task_path, publisher, DumpMissingConfigFilesTask)
 
         self.network_module.log_task_result = Mock()
 
@@ -449,7 +448,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
             ["ens3", "ens5", "ens7", "bond0", "devA", "devB"]
 
     def _test_kickstart(self, ks_in, ks_out, **kwargs):
-        check_kickstart_interface(self, self.network_interface, ks_in, ks_out, **kwargs)
+        check_kickstart_interface(self.network_interface, ks_in, ks_out, **kwargs)
 
     def test_no_kickstart(self):
         """Test with no kickstart."""
@@ -629,7 +628,6 @@ class FirewallInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             FIREWALL,
             self.firewall_interface,
             *args, **kwargs
@@ -788,7 +786,7 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
         """Test the Firewall configuration task - basic."""
         task_path = self.firewall_interface.InstallWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, ConfigureFirewallTask)
+        obj = check_task_creation(task_path, publisher, ConfigureFirewallTask)
 
         assert obj.implementation._firewall_mode == FirewallMode.DEFAULT
         assert obj.implementation._enabled_services == []

--- a/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_config_file.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_config_file.py
@@ -88,16 +88,13 @@ class ConfigFileTestCase(unittest.TestCase):
              """),
         ]
         self._dump_files(all_files, root_path=self._root_dir)
-        self.assertSetEqual(
-            set(get_config_files_paths(root_path=self._root_dir)),
+        assert set(get_config_files_paths(root_path=self._root_dir)) == \
             set([
                 os.path.normpath(self._root_dir + IFCFG_FILE_1),
                 os.path.normpath(self._root_dir + IFCFG_FILE_2),
                 os.path.normpath(self._root_dir + KEYFILE_1),
                 os.path.normpath(self._root_dir + KEYFILE_2),
             ])
-
-        )
 
     @patch("pyanaconda.modules.network.config_file.get_config_files_paths")
     def test_get_config_files_content(self, get_config_files_paths_mock):
@@ -125,25 +122,13 @@ class ConfigFileTestCase(unittest.TestCase):
             "{}/dir/file2".format(self._root_dir),
         ]
         content = get_config_files_content(self._root_dir)
-        self.assertEqual(dedent(content).strip(), dedent(expected_content).strip())
+        assert dedent(content).strip() == dedent(expected_content).strip()
 
     def test_is_config_file_for_system(self):
         """Test is_config_file_for_system function."""
-        self.assertTrue(
-            is_config_file_for_system(os.path.join(KEYFILE_DIR, "ens3.nmconnection"))
-        )
-        self.assertTrue(
-            is_config_file_for_system(os.path.join(IFCFG_DIR, "ifcfg-ens5"))
-        )
-        self.assertFalse(
-            is_config_file_for_system("foo/bar")
-        )
-        self.assertFalse(
-            is_config_file_for_system("/run/NetworkManager/system-connections/ens3.nmconnection")
-        )
-        self.assertFalse(
-            is_config_file_for_system(os.path.join(IFCFG_DIR, "ifcfg-lo"))
-        )
-        self.assertFalse(
-            is_config_file_for_system(os.path.join(KEYFILE_DIR, "ens3"))
-        )
+        assert is_config_file_for_system(os.path.join(KEYFILE_DIR, "ens3.nmconnection"))
+        assert is_config_file_for_system(os.path.join(IFCFG_DIR, "ifcfg-ens5"))
+        assert not is_config_file_for_system("foo/bar")
+        assert not is_config_file_for_system("/run/NetworkManager/system-connections/ens3.nmconnection")
+        assert not is_config_file_for_system(os.path.join(IFCFG_DIR, "ifcfg-lo"))
+        assert not is_config_file_for_system(os.path.join(KEYFILE_DIR, "ens3"))

--- a/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_nm_client.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_nm_client.py
@@ -98,31 +98,16 @@ class NMClientTestCase(unittest.TestCase):
         }
         get_iface_from_connection.side_effect = lambda nm_client, uuid: uuid_to_iface[uuid]
 
-        self.assertSetEqual(
-            get_ports_from_connections(nm_client, "team", []),
-            set()
-        )
-        self.assertSetEqual(
-            get_ports_from_connections(nm_client, "bridge", ["bridge0"]),
-            set()
-        )
-        self.assertSetEqual(
-            get_ports_from_connections(nm_client, "team", ["team2"]),
-            set()
-        )
+        assert get_ports_from_connections(nm_client, "team", []) == set()
+        assert get_ports_from_connections(nm_client, "bridge", ["bridge0"]) == set()
+        assert get_ports_from_connections(nm_client, "team", ["team2"]) == set()
         # Matching of any specification is enough
-        self.assertSetEqual(
-            get_ports_from_connections(nm_client, "team", ["team_nonexisting", TEAM1_UUID]),
+        assert get_ports_from_connections(nm_client, "team", ["team_nonexisting", TEAM1_UUID]) == \
             set([("ens11", "ens11", ENS11_UUID)])
-        )
-        self.assertSetEqual(
-            get_ports_from_connections(nm_client, "team", ["team0"]),
+        assert get_ports_from_connections(nm_client, "team", ["team0"]) == \
             set([("team_0_slave_1", "ens7", ENS7_UUID), ("team_0_slave_2", "ens8", ENS8_UUID)])
-        )
-        self.assertSetEqual(
-            get_ports_from_connections(nm_client, "team", [TEAM1_UUID]),
+        assert get_ports_from_connections(nm_client, "team", [TEAM1_UUID]) == \
             set([("ens11", "ens11", ENS11_UUID)])
-        )
 
     @patch("pyanaconda.modules.network.nm_client.get_connections_available_for_iface")
     @patch("pyanaconda.modules.network.nm_client.get_ports_from_connections")
@@ -141,11 +126,9 @@ class NMClientTestCase(unittest.TestCase):
             },
         ]
         con = self._get_mock_objects_from_attrs(cons_attrs)[0]
-        self.assertSetEqual(
-            get_dracut_arguments_from_connection(nm_client, con, "", "10.34.39.2",
-                                                 "my.host.name", ibft=True),
+        assert get_dracut_arguments_from_connection(nm_client, con, "", "10.34.39.2",
+                                                    "my.host.name", ibft=True) == \
             set(["rd.iscsi.ibft"])
-        )
 
         # ibft connection on s390 with missing s390 options
         is_s390.return_value = True
@@ -163,11 +146,9 @@ class NMClientTestCase(unittest.TestCase):
             },
         ]
         con = self._get_mock_objects_from_attrs(cons_attrs)[0]
-        self.assertSetEqual(
-            get_dracut_arguments_from_connection(nm_client, con, "", "10.34.39.2",
-                                                 "my.host.name", ibft=True),
+        assert get_dracut_arguments_from_connection(nm_client, con, "", "10.34.39.2",
+                                                    "my.host.name", ibft=True) == \
             set(["rd.iscsi.ibft"])
-        )
 
         # ibft connection on s390 with s390 options
         is_s390.return_value = True
@@ -187,12 +168,10 @@ class NMClientTestCase(unittest.TestCase):
             },
         ]
         con = self._get_mock_objects_from_attrs(cons_attrs)[0]
-        self.assertSetEqual(
-            get_dracut_arguments_from_connection(nm_client, con, "", "10.34.39.2",
-                                                 "my.host.name", ibft=True),
+        assert get_dracut_arguments_from_connection(nm_client, con, "", "10.34.39.2",
+                                                    "my.host.name", ibft=True) == \
             set(["rd.iscsi.ibft",
                  "rd.znet=qeth,0.0.0900,0.0.0901,0.0.0902,layer2=1,portname=FOOBAR,portno=0"])
-        )
 
         # IPv4 config auto, IPv6 config auto, mac address specified
         is_s390.return_value = False
@@ -219,19 +198,15 @@ class NMClientTestCase(unittest.TestCase):
         ]
         con = self._get_mock_objects_from_attrs(cons_attrs)[0]
         # IPv4 target
-        self.assertSetEqual(
-            get_dracut_arguments_from_connection(nm_client, con, "ens3", "10.34.39.2",
-                                                 "my.host.name", ibft=False),
+        assert get_dracut_arguments_from_connection(nm_client, con, "ens3", "10.34.39.2",
+                                                    "my.host.name", ibft=False) == \
             set(["ip=ens3:dhcp",
                  "ifname=ens3:11:11:11:11:11:aa"])
-        )
         # IPv6 target
-        self.assertSetEqual(
-            get_dracut_arguments_from_connection(nm_client, con, "ens3", "2001::cafe:beef",
-                                                 "my.host.name", ibft=False),
+        assert get_dracut_arguments_from_connection(nm_client, con, "ens3", "2001::cafe:beef",
+                                                    "my.host.name", ibft=False) == \
             set(["ip=ens3:auto6",
                  "ifname=ens3:11:11:11:11:11:aa"])
-        )
 
         # IPv4 config static, mac address not specified, s390
         is_s390.return_value = True
@@ -265,12 +240,10 @@ class NMClientTestCase(unittest.TestCase):
             },
         ]
         con = self._get_mock_objects_from_attrs(cons_attrs)[0]
-        self.assertSetEqual(
-            get_dracut_arguments_from_connection(nm_client, con, "ens4", "10.40.49.4",
-                                                 "my.host.name", ibft=False),
+        assert get_dracut_arguments_from_connection(nm_client, con, "ens4", "10.40.49.4",
+                                                    "my.host.name", ibft=False) == \
             set(["ip=10.34.39.44::10.34.39.2:255.255.255.0:my.host.name:ens4:none",
                  "rd.znet=qeth,0.0.0900,0.0.0901,0.0.0902,layer2=1,portname=FOOBAR,portno=0"])
-        )
 
         # IPv6 config dhcp
         is_s390.return_value = False
@@ -291,11 +264,9 @@ class NMClientTestCase(unittest.TestCase):
             },
         ]
         con = self._get_mock_objects_from_attrs(cons_attrs)[0]
-        self.assertSetEqual(
-            get_dracut_arguments_from_connection(nm_client, con, "ens3", "2001::cafe:beef",
-                                                 "my.host.name", ibft=False),
+        assert get_dracut_arguments_from_connection(nm_client, con, "ens3", "2001::cafe:beef",
+                                                    "my.host.name", ibft=False) == \
             set(["ip=ens3:dhcp6"])
-        )
 
         # IPv6 config manual
         is_s390.return_value = False
@@ -324,11 +295,9 @@ class NMClientTestCase(unittest.TestCase):
             },
         ]
         con = self._get_mock_objects_from_attrs(cons_attrs)[0]
-        self.assertSetEqual(
-            get_dracut_arguments_from_connection(nm_client, con, "ens3", "2001::cafe:beef",
-                                                 "my.host.name", ibft=False),
+        assert get_dracut_arguments_from_connection(nm_client, con, "ens3", "2001::cafe:beef",
+                                                    "my.host.name", ibft=False) == \
             set(["ip=[2001::5/64]::[2001::1]::my.host.name:ens3:none"])
-        )
 
         # IPv4 config auto, team
         is_s390.return_value = False
@@ -351,12 +320,10 @@ class NMClientTestCase(unittest.TestCase):
             ("ens8", "ens8", "ac4a0747-d1ea-4119-903b-18f3adad9116"),
         ])
         # IPv4 target
-        self.assertSetEqual(
-            get_dracut_arguments_from_connection(nm_client, con, "team0", "10.34.39.2",
-                                                 "my.host.name", ibft=False),
+        assert get_dracut_arguments_from_connection(nm_client, con, "team0", "10.34.39.2",
+                                                    "my.host.name", ibft=False) == \
             set(["ip=team0:dhcp",
                  "team=team0:ens7,ens8"])
-        )
 
         # IPv4 config auto, vlan, s390, parent specified by interface name
         is_s390.return_value = True
@@ -398,13 +365,11 @@ class NMClientTestCase(unittest.TestCase):
         parent_cons = self._get_mock_objects_from_attrs(parent_cons_attrs)
         get_connections_available_for_iface.return_value = parent_cons
         # IPv4 target
-        self.assertSetEqual(
-            get_dracut_arguments_from_connection(nm_client, con, "ens11.111", "10.34.39.2",
-                                                 "my.host.name", ibft=False),
+        assert get_dracut_arguments_from_connection(nm_client, con, "ens11.111", "10.34.39.2",
+                                                    "my.host.name", ibft=False) == \
             set(["ip=ens11.111:dhcp",
                  "vlan=ens11.111:ens11",
                  "rd.znet=qeth,0.0.0900,0.0.0901,0.0.0902,layer2=1,portname=FOOBAR,portno=0"])
-        )
 
         # IPv4 config auto, vlan, parent specified by connection uuid
         VLAN_PARENT_UUID = "5e6ead30-d133-4c8c-ba59-818c5ced6a7c"
@@ -436,12 +401,10 @@ class NMClientTestCase(unittest.TestCase):
         parent_con = self._get_mock_objects_from_attrs(parent_cons_attrs)[0]
         nm_client.get_connection_by_uuid.return_value = parent_con
         # IPv4 target
-        self.assertSetEqual(
-            get_dracut_arguments_from_connection(nm_client, con, "ens12.111", "10.34.39.2",
-                                                 "my.host.name", ibft=False),
+        assert get_dracut_arguments_from_connection(nm_client, con, "ens12.111", "10.34.39.2",
+                                                    "my.host.name", ibft=False) == \
             set(["ip=ens12.111:dhcp",
                  "vlan=ens12.111:ens12"])
-        )
 
         # IPv4 config auto, vlan, parent specified by connection uuid, s390 (we
         # need the parent connection in s390 case, not only parent iface)
@@ -486,13 +449,11 @@ class NMClientTestCase(unittest.TestCase):
         parent_cons = self._get_mock_objects_from_attrs(parent_cons_attrs)
         nm_client.get_connection_by_uuid.return_value = parent_con
         # IPv4 target
-        self.assertSetEqual(
-            get_dracut_arguments_from_connection(nm_client, con, "ens13.111", "10.34.39.2",
-                                                 "my.host.name", ibft=False),
+        assert get_dracut_arguments_from_connection(nm_client, con, "ens13.111", "10.34.39.2",
+                                                    "my.host.name", ibft=False) == \
             set(["ip=ens13.111:dhcp",
                  "vlan=ens13.111:ens13",
                  "rd.znet=qeth,0.0.0900,0.0.0901,0.0.0902,layer2=1,portname=FOOBAR,portno=0"])
-        )
 
     @patch("pyanaconda.modules.network.nm_client.get_vlan_interface_name_from_connection")
     @patch("pyanaconda.modules.network.nm_client.is_config_file_for_system")
@@ -640,35 +601,21 @@ class NMClientTestCase(unittest.TestCase):
 
         # No config files
         is_config_file_for_system.return_value = False
-        self.assertEqual(
-            get_config_file_connection_of_device(nm_client, "ens3"),
-            ""
-        )
+        assert get_config_file_connection_of_device(nm_client, "ens3") == ""
 
         is_config_file_for_system.return_value = True
         is_s390.return_value = False
 
         # ethernet
         # interface name has precedence
-        self.assertEqual(
-            get_config_file_connection_of_device(nm_client, "ens3"),
-            ENS3_UUID
-        )
+        assert get_config_file_connection_of_device(nm_client, "ens3") == ENS3_UUID
         # port conections are ignored
-        self.assertEqual(
-            get_config_file_connection_of_device(nm_client, "ens7"),
-            ENS7_UUID
-        )
+        assert get_config_file_connection_of_device(nm_client, "ens7") == ENS7_UUID
         # port conections are ignored
-        self.assertEqual(
-            get_config_file_connection_of_device(nm_client, "ens9"),
-            ""
-        )
+        assert get_config_file_connection_of_device(nm_client, "ens9") == ""
         # config bound to hwaddr
-        self.assertEqual(
-            get_config_file_connection_of_device(nm_client, "ens8", device_hwaddr=HWADDR_ENS8),
+        assert get_config_file_connection_of_device(nm_client, "ens8", device_hwaddr=HWADDR_ENS8) == \
             ENS8_UUID
-        )
         # config bound to hwaddr, no hint
         hwaddr_to_iface = {
             HWADDR_ENS3: "ens3",
@@ -676,49 +623,25 @@ class NMClientTestCase(unittest.TestCase):
             HWADDR_ENS11: "ens11",
         }
         get_iface_from_hwaddr.side_effect = lambda nm_client, hwaddr: hwaddr_to_iface[hwaddr]
-        self.assertEqual(
-            get_config_file_connection_of_device(nm_client, "ens11"),
-            ENS11_UUID
-        )
+        assert get_config_file_connection_of_device(nm_client, "ens11") == ENS11_UUID
         # config not bound
-        self.assertEqual(
-            get_config_file_connection_of_device(nm_client, "ens12"),
-            ""
-        )
+        assert get_config_file_connection_of_device(nm_client, "ens12") == ""
         # config not bound, use id (s390)
         is_s390.return_value = True
-        self.assertEqual(
-            get_config_file_connection_of_device(nm_client, "ens12"),
-            ENS12_UUID
-        )
+        assert get_config_file_connection_of_device(nm_client, "ens12") == ENS12_UUID
         is_s390.return_value = False
 
         # vlan
         get_vlan_interface_name_from_connection.return_value = "vlan222"
-        self.assertEqual(
-            get_config_file_connection_of_device(nm_client, "vlan222"),
-            VLAN222_UUID
-        )
+        assert get_config_file_connection_of_device(nm_client, "vlan222") == VLAN222_UUID
         # team
-        self.assertEqual(
-            get_config_file_connection_of_device(nm_client, "team0"),
-            TEAM0_UUID
-        )
+        assert get_config_file_connection_of_device(nm_client, "team0") == TEAM0_UUID
         # bond
-        self.assertEqual(
-            get_config_file_connection_of_device(nm_client, "bond0"),
-            BOND0_UUID
-        )
+        assert get_config_file_connection_of_device(nm_client, "bond0") == BOND0_UUID
         # bridge
-        self.assertEqual(
-            get_config_file_connection_of_device(nm_client, "bridge0"),
-            BRIDGE0_UUID
-        )
+        assert get_config_file_connection_of_device(nm_client, "bridge0") == BRIDGE0_UUID
         # infiniband, first wins
-        self.assertEqual(
-            get_config_file_connection_of_device(nm_client, "ens33"),
-            ENS33_UUID
-        )
+        assert get_config_file_connection_of_device(nm_client, "ens33") == ENS33_UUID
 
     @patch("pyanaconda.modules.network.nm_client.get_team_port_config_from_connection")
     @patch("pyanaconda.modules.network.nm_client.get_ports_from_connections")
@@ -982,4 +905,4 @@ class NMClientTestCase(unittest.TestCase):
                 expected_ks = dedent(expected_ks).strip()
             if generated_ks:
                 generated_ks = dedent(str(generated_ks)).strip()
-            self.assertEqual(generated_ks, expected_ks)
+            assert generated_ks == expected_ks

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/module_payload_shared.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/module_payload_shared.py
@@ -30,14 +30,12 @@ from pyanaconda.modules.payloads.constants import SourceState
 
 class PayloadKickstartSharedTest(object):
 
-    def __init__(self, test, payload_service, payload_service_intf):
+    def __init__(self, payload_service, payload_service_intf):
         """Setup shared payload testing object for testing kickstart.
 
-        :param test: instance of TestCase
         :param payload_service: main payload service module
         :param payload_service_intf: main payload service interface
         """
-        self._test = test
         self.payload_service = payload_service
         self.payload_service_interface = payload_service_intf
 
@@ -53,8 +51,7 @@ class PayloadKickstartSharedTest(object):
         :type expected_publish_calls: int
         """
         with patch('pyanaconda.core.dbus.DBus.publish_object') as publisher:
-            result = check_kickstart_interface(self._test,
-                                               self.payload_service_interface,
+            result = check_kickstart_interface(self.payload_service_interface,
                                                ks_in, ks_out, ks_valid, ks_tmp)
 
             if ks_valid and expected_publish_calls != 0:
@@ -72,16 +69,14 @@ class PayloadKickstartSharedTest(object):
 
 class PayloadSharedTest(object):
 
-    def __init__(self, test, payload, payload_intf):
+    def __init__(self, payload, payload_intf):
         """Setup shared payload test object for common payload testing.
 
-        :param test: instance of TestCase
         :param payload: payload module
         :type payload: instance of PayloadBase class
         :param payload_intf: payload module interface
         :type payload_intf: instance of PayloadBaseInterface class
         """
-        self._test = test
         self.payload = payload
         self.payload_interface = payload_intf
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/module_payload_shared.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/module_payload_shared.py
@@ -17,6 +17,8 @@
 #
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 #
+import pytest
+
 from unittest.mock import patch, Mock
 
 from tests.unit_tests.pyanaconda_tests import check_kickstart_interface
@@ -57,7 +59,7 @@ class PayloadKickstartSharedTest(object):
 
             if ks_valid and expected_publish_calls != 0:
                 publisher.assert_called()
-                self._test.assertEqual(publisher.call_count, expected_publish_calls)
+                assert publisher.call_count == expected_publish_calls
             else:
                 publisher.assert_not_called()
 
@@ -90,7 +92,7 @@ class PayloadSharedTest(object):
         :type payload_type: value of the payload.base.constants.PayloadType enum
         """
         t = self.payload_interface.Type
-        self._test.assertEqual(t, payload_type.value)
+        assert t == payload_type.value
 
     @staticmethod
     def prepare_source(source_type, state=SourceState.READY):
@@ -106,7 +108,7 @@ class PayloadSharedTest(object):
 
     def check_empty_sources(self):
         """Default check for payload with no sources set."""
-        self._test.assertEqual([], self.payload_interface.Sources)
+        assert self.payload_interface.Sources == []
 
     def set_and_check_sources(self, test_sources, exception=None):
         """Default check to set sources.
@@ -136,7 +138,7 @@ class PayloadSharedTest(object):
         paths = PayloadSourceContainer.to_object_path_list(test_sources)
 
         if exception:
-            with self._test.assertRaises(exception) as cm:
+            with pytest.raises(exception) as cm:
                 self.payload_interface.SetSources(paths)
             return cm
 
@@ -152,4 +154,4 @@ class PayloadSharedTest(object):
         """
         expected_paths = PayloadSourceContainer.to_object_path_list(expected_sources)
 
-        self._test.assertEqual(self.payload_interface.Sources, expected_paths)
+        assert self.payload_interface.Sources == expected_paths

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_validation.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_validation.py
@@ -47,7 +47,7 @@ class CheckPackagesSelectionTaskTestCase(unittest.TestCase):
         dnf_manager.enable_modules.assert_called_once_with([])
         dnf_manager.apply_specs.assert_called_once_with([], ["@core"])
         dnf_manager.resolve_selection.assert_called_once_with()
-        self.assertEqual(report.get_messages(), [])
+        assert report.get_messages() == []
 
     @patch("pyanaconda.modules.payloads.payload.dnf.validation.get_kernel_package")
     def test_check_default_selection(self, kernel_getter):
@@ -70,7 +70,7 @@ class CheckPackagesSelectionTaskTestCase(unittest.TestCase):
             ["@environment", "@core", "kernel"], []
         )
         dnf_manager.resolve_selection.assert_called_once_with()
-        self.assertEqual(report.get_messages(), [])
+        assert report.get_messages() == []
 
     @patch("pyanaconda.modules.payloads.payload.dnf.validation.get_kernel_package")
     def test_check_selection(self, kernel_getter):
@@ -105,7 +105,7 @@ class CheckPackagesSelectionTaskTestCase(unittest.TestCase):
             ["@core", "@g3", "@g4", "p3", "p4"]
         )
         dnf_manager.resolve_selection.assert_called_once_with()
-        self.assertEqual(report.get_messages(), [])
+        assert report.get_messages() == []
 
     @patch("pyanaconda.modules.payloads.payload.dnf.validation.get_kernel_package")
     def test_check_invalid_selection(self, kernel_getter):
@@ -121,5 +121,5 @@ class CheckPackagesSelectionTaskTestCase(unittest.TestCase):
         task = CheckPackagesSelectionTask(dnf_manager, selection)
         report = task.run()
 
-        self.assertEqual(report.error_messages, ["e2", "e4"])
-        self.assertEqual(report.warning_messages, ["e1", "e3"])
+        assert report.error_messages == ["e2", "e4"]
+        assert report.warning_messages == ["e1", "e3"]

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_flatpak_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_flatpak_manager.py
@@ -45,12 +45,12 @@ class FlatpakTest(unittest.TestCase):
 
     def test_is_available(self):
         """Test check for flatpak availability of the system sources."""
-        self.assertFalse(FlatpakManager.is_source_available())
+        assert not FlatpakManager.is_source_available()
 
         with TemporaryDirectory() as temp:
             FlatpakManager.LOCAL_REMOTE_PATH = "file://" + temp
 
-            self.assertTrue(FlatpakManager.is_source_available())
+            assert FlatpakManager.is_source_available()
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_manager.Transaction")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_manager.Installation")
@@ -68,10 +68,10 @@ class FlatpakTest(unittest.TestCase):
 
         expected_remote_calls = [call.set_gpg_verify(False),
                                  call.set_url(flatpak.LOCAL_REMOTE_PATH)]
-        self.assertEqual(self._remote.method_calls, expected_remote_calls)
+        assert self._remote.method_calls == expected_remote_calls
 
         expected_remote_calls = [call.add_remote(self._remote, False, None)]
-        self.assertEqual(self._installation.method_calls, expected_remote_calls)
+        assert self._installation.method_calls == expected_remote_calls
 
     def test_cleanup_call_without_initialize(self):
         """Test the cleanup call without initialize."""
@@ -140,7 +140,7 @@ class FlatpakTest(unittest.TestCase):
 
         installation_size = flatpak.get_required_size()
 
-        self.assertEqual(installation_size, 5100)
+        assert installation_size == 5100
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_manager.Transaction")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_manager.Installation")
@@ -157,7 +157,7 @@ class FlatpakTest(unittest.TestCase):
 
         installation_size = flatpak.get_required_size()
 
-        self.assertEqual(installation_size, 0)
+        assert installation_size == 0
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_manager.Transaction")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_manager.Installation")
@@ -200,7 +200,7 @@ class FlatpakTest(unittest.TestCase):
                                            None),
                           call.run()]
 
-        self.assertEqual(self._transaction.mock_calls, expected_calls)
+        assert self._transaction.mock_calls == expected_calls
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_manager.Transaction")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_manager.Installation")
@@ -217,8 +217,8 @@ class FlatpakTest(unittest.TestCase):
         remote_cls.new.assert_called_with("hive")
         self._remote.set_gpg_verify.assert_called_with(True)
         self._remote.set_url("url://zerglings/home")
-        self.assertEqual(remote_cls.new.call_count, 2)
-        self.assertEqual(self._installation.add_remote.call_count, 2)
+        assert remote_cls.new.call_count == 2
+        assert self._installation.add_remote.call_count == 2
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_manager.Transaction")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_manager.Installation")
@@ -281,7 +281,7 @@ class FlatpakTest(unittest.TestCase):
             open_calls.append(call(ref_file_path, "wb"))
 
         # test that every file is read and written
-        self.assertEqual(open_mock.call_count, 2 * len(expected_refs))
+        assert open_mock.call_count == 2 * len(expected_refs)
 
         open_mock.has_calls(open_calls)
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_image_installation.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_image_installation.py
@@ -66,7 +66,7 @@ class InstallationProgressTestCase(unittest.TestCase):
             call("Synchronizing writes to disk"),
             call("Installing software 0%")
         ]
-        self.assertEqual(callback.call_args_list, expected)
+        assert callback.call_args_list == expected
 
     @patch("time.sleep")
     @patch("os.statvfs")
@@ -107,4 +107,4 @@ class InstallationProgressTestCase(unittest.TestCase):
             call("Installing software 80%"),
             call("Installing software 100%"),
         ]
-        self.assertEqual(callback.call_args_list, expected)
+        assert callback.call_args_list == expected

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_base.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_base.py
@@ -42,8 +42,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         self.module = DNFModule()
         self.interface = DNFInterface(self.module)
 
-        self.shared_tests = PayloadSharedTest(self,
-                                              payload=self.module,
+        self.shared_tests = PayloadSharedTest(payload=self.module,
                                               payload_intf=self.interface)
 
     def test_type(self):
@@ -163,7 +162,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         self.module.add_source(source)
 
         task_path = self.interface.SetUpSourcesWithTask()
-        obj = check_task_creation(self, task_path, publisher, SetUpSourcesTask)
+        obj = check_task_creation(task_path, publisher, SetUpSourcesTask)
         assert obj.implementation._sources == [source]
 
     @patch_dbus_publish_object
@@ -173,5 +172,5 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         self.module.add_source(source)
 
         task_path = self.interface.TearDownSourcesWithTask()
-        obj = check_task_creation(self, task_path, publisher, TearDownSourcesTask)
+        obj = check_task_creation(task_path, publisher, TearDownSourcesTask)
         assert obj.implementation._sources == [source]

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_base.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_base.py
@@ -21,6 +21,7 @@
 # this with an existing payload so use DNF just as dummy test payload.
 #
 import unittest
+import pytest
 from unittest.mock import patch
 
 from pyanaconda.modules.payloads.base.initialization import SetUpSourcesTask, TearDownSourcesTask
@@ -51,9 +52,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
     @patch.object(DNFModule, "supported_source_types", [SourceType.URL])
     def test_supported_sources(self):
         """Test supported sources API."""
-        self.assertEqual(
-            [SourceType.URL.value],
-            self.interface.SupportedSourceTypes)
+        assert [SourceType.URL.value] == self.interface.SupportedSourceTypes
 
     def test_sources_empty(self):
         """Test sources API for emptiness."""
@@ -92,7 +91,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         self.shared_tests.set_and_check_sources(sources)
 
         source2 = self.shared_tests.prepare_source(SourceType.NFS)
-        with self.assertRaises(IncompatibleSourceError):
+        with pytest.raises(IncompatibleSourceError):
             self.module.add_source(source2)
 
         self.shared_tests.check_sources(sources)
@@ -107,7 +106,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
         self.shared_tests.set_and_check_sources(sources)
 
         source2 = self.shared_tests.prepare_source(SourceType.URL)
-        with self.assertRaises(SourceSetupError):
+        with pytest.raises(SourceSetupError):
             self.module.add_source(source2)
 
         self.shared_tests.check_sources(sources)
@@ -134,7 +133,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
 
         msg = "Source type {} is not supported by this payload.".format(
             SourceType.LIVE_OS_IMAGE.value)
-        self.assertEqual(str(cm.exception), msg)
+        assert str(cm.value) == msg
 
     @patch.object(DNFModule, "supported_source_types", [SourceType.NFS, SourceType.URL])
     @patch_dbus_publish_object
@@ -165,7 +164,7 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
 
         task_path = self.interface.SetUpSourcesWithTask()
         obj = check_task_creation(self, task_path, publisher, SetUpSourcesTask)
-        self.assertEqual(obj.implementation._sources, [source])
+        assert obj.implementation._sources == [source]
 
     @patch_dbus_publish_object
     def test_tear_down_sources_with_task(self, publisher):
@@ -175,4 +174,4 @@ class PayloadBaseInterfaceTestCase(unittest.TestCase):
 
         task_path = self.interface.TearDownSourcesWithTask()
         obj = check_task_creation(self, task_path, publisher, TearDownSourcesTask)
-        self.assertEqual(obj.implementation._sources, [source])
+        assert obj.implementation._sources == [source]

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
@@ -56,15 +56,15 @@ class DNFKSTestCase(unittest.TestCase):
 
     def _check_properties(self, expected_source_type):
         payload = self.shared_ks_tests.get_payload()
-        self.assertIsInstance(payload, DNFModule)
+        assert isinstance(payload, DNFModule)
 
         # verify sources set
         if expected_source_type is None:
-            self.assertFalse(payload.sources)
+            assert not payload.sources
         else:
             sources = payload.sources
-            self.assertEqual(1, len(sources))
-            self.assertEqual(sources[0].type.value, expected_source_type)
+            assert 1 == len(sources)
+            assert sources[0].type.value == expected_source_type
 
     def test_cdrom_kickstart(self):
         ks_in = """
@@ -116,7 +116,7 @@ class DNFKSTestCase(unittest.TestCase):
         harddrive --partition=nsa-device
         """
         self.shared_ks_tests.check_kickstart(ks_in, ks_valid=False, expected_publish_calls=0)
-        self.assertEqual(self.interface.ActivePayload, "")
+        assert self.interface.ActivePayload == ""
 
     def test_nfs_kickstart(self):
         ks_in = """
@@ -388,16 +388,15 @@ class DNFInterfaceTestCase(unittest.TestCase):
 
     def test_supported_sources(self):
         """Test DNF supported sources API."""
-        self.assertEqual(
-            [SOURCE_TYPE_CDROM,
+        assert [SOURCE_TYPE_CDROM,
              SOURCE_TYPE_HDD,
              SOURCE_TYPE_HMC,
              SOURCE_TYPE_NFS,
              SOURCE_TYPE_REPO_FILES,
              SOURCE_TYPE_CLOSEST_MIRROR,
              SOURCE_TYPE_CDN,
-             SOURCE_TYPE_URL],
-            self.interface.SupportedSourceTypes)
+             SOURCE_TYPE_URL] == \
+            self.interface.SupportedSourceTypes
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
@@ -409,18 +408,18 @@ class DNFInterfaceTestCase(unittest.TestCase):
 
     def test_packages_kickstarted_property(self):
         """Test the PackagesKickstarted property."""
-        self.assertEqual(self.interface.PackagesKickstarted, False)
+        assert self.interface.PackagesKickstarted == False
 
         data = KickstartSpecificationHandler(
             PayloadKickstartSpecification
         )
 
         self.module.process_kickstart(data)
-        self.assertEqual(self.interface.PackagesKickstarted, False)
+        assert self.interface.PackagesKickstarted == False
 
         data.packages.seen = True
         self.module.process_kickstart(data)
-        self.assertEqual(self.interface.PackagesKickstarted, True)
+        assert self.interface.PackagesKickstarted == True
 
     def test_packages_selection_property(self):
         """Test the PackagesSelection property."""
@@ -527,7 +526,7 @@ class DNFInterfaceTestCase(unittest.TestCase):
 
         expected = [self._generate_expected_repo_configuration_dict("file:///install_source/cdrom")]
 
-        self.assertEqual(self.interface.GetRepoConfigurations(), expected)
+        assert self.interface.GetRepoConfigurations() == expected
 
     @patch("pyanaconda.modules.payloads.source.hmc.hmc.HMCSourceModule.mount_point",
            new_callable=PropertyMock)
@@ -541,7 +540,7 @@ class DNFInterfaceTestCase(unittest.TestCase):
 
         expected = [self._generate_expected_repo_configuration_dict("file:///install_source/hmc")]
 
-        self.assertEqual(self.interface.GetRepoConfigurations(), expected)
+        assert self.interface.GetRepoConfigurations() == expected
 
     @patch("pyanaconda.modules.payloads.source.nfs.nfs.NFSSourceModule.install_tree_path",
            new_callable=PropertyMock)
@@ -555,7 +554,7 @@ class DNFInterfaceTestCase(unittest.TestCase):
 
         expected = [self._generate_expected_repo_configuration_dict("file:///install_source/nfs")]
 
-        self.assertEqual(self.interface.GetRepoConfigurations(), expected)
+        assert self.interface.GetRepoConfigurations() == expected
 
     @patch("pyanaconda.modules.payloads.source.harddrive.harddrive.HardDriveSourceModule.install_tree_path",
            new_callable=PropertyMock)
@@ -569,7 +568,7 @@ class DNFInterfaceTestCase(unittest.TestCase):
 
         expected = [self._generate_expected_repo_configuration_dict("file:///install_source/harddrive")]
 
-        self.assertEqual(self.interface.GetRepoConfigurations(), expected)
+        assert self.interface.GetRepoConfigurations() == expected
 
     @patch_dbus_publish_object
     def test_url_get_repo_configurations(self, publisher):
@@ -602,7 +601,7 @@ class DNFInterfaceTestCase(unittest.TestCase):
             "included-packages": get_variant(List[Str], [])
         }]
 
-        self.assertEqual(self.interface.GetRepoConfigurations(), expected)
+        assert self.interface.GetRepoConfigurations() == expected
 
 
 class DNFModuleTestCase(unittest.TestCase):
@@ -616,14 +615,14 @@ class DNFModuleTestCase(unittest.TestCase):
 
     def test_is_network_required(self):
         """Test the is_network_required method."""
-        self.assertEqual(self.module.is_network_required(), False)
+        assert self.module.is_network_required() == False
 
         source1 = self._create_source(SourceType.CDROM)
         self.module.set_sources([source1])
 
-        self.assertEqual(self.module.is_network_required(), False)
+        assert self.module.is_network_required() == False
 
         source2 = self._create_source(SourceType.NFS)
         self.module.set_sources([source1, source2])
 
-        self.assertEqual(self.module.is_network_required(), True)
+        assert self.module.is_network_required() == True

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
@@ -50,8 +50,7 @@ class DNFKSTestCase(unittest.TestCase):
         self.module = PayloadsService()
         self.interface = PayloadsInterface(self.module)
 
-        self.shared_ks_tests = PayloadKickstartSharedTest(self,
-                                                          self.module,
+        self.shared_ks_tests = PayloadKickstartSharedTest(self.module,
                                                           self.interface)
 
     def _check_properties(self, expected_source_type):
@@ -379,8 +378,7 @@ class DNFInterfaceTestCase(unittest.TestCase):
         self.module = DNFModule()
         self.interface = DNFInterface(self.module)
 
-        self.shared_tests = PayloadSharedTest(self,
-                                              payload=self.module,
+        self.shared_tests = PayloadSharedTest(payload=self.module,
                                               payload_intf=self.interface)
 
     def test_type(self):
@@ -400,7 +398,6 @@ class DNFInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             PAYLOAD_DNF,
             self.interface,
             *args, **kwargs

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
@@ -18,6 +18,7 @@
 import os
 import tempfile
 import unittest
+import pytest
 
 from unittest.mock import patch, call, Mock
 
@@ -46,7 +47,7 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
 
     def _check_macros(self, task, mock_rpm, expected_macros):
         """Check that the expected macros are set up."""
-        self.assertEqual(task._macros, expected_macros)
+        assert task._macros == expected_macros
 
         calls = [call(*macro) for macro in expected_macros]
         mock_rpm.addMacro.assert_has_calls(calls)
@@ -146,7 +147,7 @@ class ImportRPMKeysTaskTestCase(unittest.TestCase):
                 task.run()
 
             msg = "No GPG keys to import."
-            self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+            assert any(map(lambda x: msg in x, cm.output))
 
     def test_import_no_rpm(self):
         """Import GPG keys without installed rpm."""
@@ -157,7 +158,7 @@ class ImportRPMKeysTaskTestCase(unittest.TestCase):
                 task.run()
 
             msg = "Can not import GPG keys to RPM database"
-            self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+            assert any(map(lambda x: msg in x, cm.output))
 
     @patch("pyanaconda.modules.payloads.payload.dnf.installation.util.execWithRedirect")
     def test_import_error(self, mock_exec):
@@ -172,7 +173,7 @@ class ImportRPMKeysTaskTestCase(unittest.TestCase):
                 task.run()
 
             msg = "Failed to import the GPG key."
-            self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+            assert any(map(lambda x: msg in x, cm.output))
 
     @patch("pyanaconda.modules.payloads.payload.dnf.installation.util.execWithRedirect")
     def test_import_keys(self, mock_exec):
@@ -228,7 +229,7 @@ class DownloadPackagesTaskTestCase(unittest.TestCase):
         task.progress_changed_signal.connect(callback)
         task.run()
 
-        self.assertEqual(task.name, "Download packages")
+        assert task.name == "Download packages"
         dnf_manager.download_packages.assert_called_once_with(task.report_progress)
 
         callback.assert_has_calls([
@@ -258,7 +259,7 @@ class InstallPackagesTaskTestCase(unittest.TestCase):
         task.progress_changed_signal.connect(callback)
         task.run()
 
-        self.assertEqual(task.name, "Install packages")
+        assert task.name == "Install packages"
         dnf_manager.install_packages.assert_called_once_with(task.report_progress)
 
         callback.assert_has_calls([
@@ -292,15 +293,15 @@ class PrepareDownloadLocationTaskTestCase(unittest.TestCase):
             os.mknod(os.path.join(path, "f3"))
 
             task = PrepareDownloadLocationTask(dnf_manager)
-            self.assertEqual(task.run(), path)
+            assert task.run() == path
 
             # The manager should apply the location.
             dnf_manager.set_download_location.assert_called_once_with(path)
 
             # The files should be deleted.
-            self.assertFalse(os.path.exists(os.path.join(path, "f1")))
-            self.assertFalse(os.path.exists(os.path.join(path, "f2")))
-            self.assertFalse(os.path.exists(os.path.join(path, "f3")))
+            assert not os.path.exists(os.path.join(path, "f1"))
+            assert not os.path.exists(os.path.join(path, "f2"))
+            assert not os.path.exists(os.path.join(path, "f3"))
 
 
 class CleanUpDownloadLocationTaskTestCase(unittest.TestCase):
@@ -333,9 +334,9 @@ class CleanUpDownloadLocationTaskTestCase(unittest.TestCase):
             task.run()
 
             # The files should be deleted.
-            self.assertFalse(os.path.exists(os.path.join(path, "f1")))
-            self.assertFalse(os.path.exists(os.path.join(path, "f2")))
-            self.assertFalse(os.path.exists(os.path.join(path, "f3")))
+            assert not os.path.exists(os.path.join(path, "f1"))
+            assert not os.path.exists(os.path.join(path, "f2"))
+            assert not os.path.exists(os.path.join(path, "f3"))
 
 
 class ResolvePackagesTaskTestCase(unittest.TestCase):
@@ -403,22 +404,22 @@ class ResolvePackagesTaskTestCase(unittest.TestCase):
         dnf_manager.disable_modules.side_effect = MissingSpecsError("e1")
         dnf_manager.apply_specs.side_effect = MissingSpecsError("e2")
 
-        with self.assertRaises(NonCriticalInstallationError) as cm:
+        with pytest.raises(NonCriticalInstallationError) as cm:
             task = ResolvePackagesTask(dnf_manager, selection)
             task.run()
 
         expected = "e1\n\ne2"
-        self.assertEqual(str(cm.exception), expected)
+        assert str(cm.value) == expected
 
         dnf_manager.enable_modules.side_effect = BrokenSpecsError("e3")
         dnf_manager.resolve_selection.side_effect = InvalidSelectionError("e4")
 
-        with self.assertRaises(PayloadInstallationError) as cm:
+        with pytest.raises(PayloadInstallationError) as cm:
             task = ResolvePackagesTask(dnf_manager, selection)
             task.run()
 
         expected = "e3\n\ne4"
-        self.assertEqual(str(cm.exception), expected)
+        assert str(cm.value) == expected
 
 
 class UpdateDNFConfigurationTaskTestCase(unittest.TestCase):
@@ -450,7 +451,7 @@ class UpdateDNFConfigurationTaskTestCase(unittest.TestCase):
                 task.run()
 
             msg = "Failed to update the DNF configuration (1)."
-            self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+            assert any(map(lambda x: msg in x, cm.output))
 
     @patch("pyanaconda.core.util.execWithRedirect")
     def test_error_update(self, execute):
@@ -467,7 +468,7 @@ class UpdateDNFConfigurationTaskTestCase(unittest.TestCase):
                 task.run()
 
             msg = "Couldn't update the DNF configuration: Fake!"
-            self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+            assert any(map(lambda x: msg in x, cm.output))
 
     @patch("pyanaconda.core.util.execWithRedirect")
     def test_multilib_policy(self, execute):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_requirements.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_requirements.py
@@ -47,7 +47,7 @@ class DNFRequirementsTestCase(unittest.TestCase):
 
     def _compare_requirements(self, requirements, expected):
         """Compare the given lists of requirements."""
-        self.assertEqual(str(requirements), str(expected))
+        assert str(requirements) == str(expected)
 
     @patch_dbus_get_proxy_with_cache
     def test_collect_language_requirements(self, proxy_getter):
@@ -83,7 +83,7 @@ class DNFRequirementsTestCase(unittest.TestCase):
         self._compare_requirements(requirements, [r1, r2])
 
         msg = "Selected locale 'sr_RS@cyrilic' does not match any available langpacks."
-        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+        assert any(map(lambda x: msg in x, cm.output))
 
     @patch('pyanaconda.core.util.execWithCapture')
     def test_collect_platform_requirements(self, execute):
@@ -99,12 +99,12 @@ class DNFRequirementsTestCase(unittest.TestCase):
         # No platform is detected.
         execute.return_value = None
         requirements = collect_platform_requirements(dnf_manager)
-        self.assertEqual(requirements, [])
+        assert requirements == []
 
         # Unsupported platform is detected.
         execute.return_value = "qemu"
         requirements = collect_platform_requirements(dnf_manager)
-        self.assertEqual(requirements, [])
+        assert requirements == []
 
         # Supported platform is detected.
         execute.return_value = "vmware"
@@ -121,7 +121,7 @@ class DNFRequirementsTestCase(unittest.TestCase):
     def test_collect_driver_disk_requirements(self):
         """Test the function collect_driver_disk_requirements."""
         requirements = collect_driver_disk_requirements("/non/existent/file")
-        self.assertEqual(requirements, [])
+        assert requirements == []
 
         r1 = self._create_requirement(
             name="p1",
@@ -169,10 +169,10 @@ class DNFRequirementsTestCase(unittest.TestCase):
             apply_requirements(requirements, include_list, exclude_list)
 
         msg = "Unsupported type 'INVALID' of the requirement."
-        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+        assert any(map(lambda x: msg in x, cm.output))
 
-        self.assertEqual(include_list, [])
-        self.assertEqual(exclude_list, [])
+        assert include_list == []
+        assert exclude_list == []
 
     @patch('pyanaconda.modules.payloads.payload.dnf.requirements.conf')
     def test_apply_requirements_ignored_packages(self, conf_mock):
@@ -188,10 +188,10 @@ class DNFRequirementsTestCase(unittest.TestCase):
             apply_requirements(requirements, include_list, exclude_list)
 
         msg = "Requirement 'a' is ignored by the configuration."
-        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+        assert any(map(lambda x: msg in x, cm.output))
 
-        self.assertEqual(include_list, [])
-        self.assertEqual(exclude_list, [])
+        assert include_list == []
+        assert exclude_list == []
 
     @patch('pyanaconda.modules.payloads.payload.dnf.requirements.conf')
     def test_apply_requirements_excluded_packages(self, conf_mock):
@@ -207,10 +207,10 @@ class DNFRequirementsTestCase(unittest.TestCase):
             apply_requirements(requirements, include_list, exclude_list)
 
         msg = "Requirement 'a' is ignored because it's excluded."
-        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+        assert any(map(lambda x: msg in x, cm.output))
 
-        self.assertEqual(include_list, [])
-        self.assertEqual(exclude_list, ["a"])
+        assert include_list == []
+        assert exclude_list == ["a"]
 
     @patch('pyanaconda.modules.payloads.payload.dnf.requirements.conf')
     def test_apply_requirements(self, conf_mock):
@@ -230,10 +230,10 @@ class DNFRequirementsTestCase(unittest.TestCase):
             apply_requirements(requirements, include_list, exclude_list)
 
         msg = "Requirement 'a' is applied. Reason: Required by A."
-        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+        assert any(map(lambda x: msg in x, cm.output))
 
         msg = "Requirement '@c' is applied. Reason: Required by C."
-        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+        assert any(map(lambda x: msg in x, cm.output))
 
-        self.assertEqual(include_list, ["p1", "p2", "@g1", "@g2", "a", "@c"])
-        self.assertEqual(exclude_list, ["b", "@d"])
+        assert include_list == ["p1", "p2", "@g1", "@g2", "a", "@c"]
+        assert exclude_list == ["b", "@d"]

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_utils.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_utils.py
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 import unittest
+import pytest
+
 from textwrap import dedent
 from unittest.mock import patch, Mock
 
@@ -38,7 +40,7 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
     def test_get_kernel_package_excluded(self):
         """Test the get_kernel_package function with kernel excluded."""
         kernel = get_kernel_package(Mock(), exclude_list=["kernel"])
-        self.assertEqual(kernel, None)
+        assert kernel is None
 
     def test_get_kernel_package_unavailable(self):
         """Test the get_kernel_package function with unavailable packages."""
@@ -49,8 +51,8 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
             kernel = get_kernel_package(dnf_manager, exclude_list=[])
 
         msg = "Failed to select a kernel"
-        self.assertIn(msg, "\n".join(cm.output))
-        self.assertEqual(kernel, None)
+        assert msg in "\n".join(cm.output)
+        assert kernel is None
 
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.is_lpae_available")
     def test_get_kernel_package_lpae(self, is_lpae):
@@ -61,10 +63,10 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
         dnf_manager.is_package_available.return_value = True
 
         kernel = get_kernel_package(dnf_manager, exclude_list=[])
-        self.assertEqual(kernel, "kernel-lpae")
+        assert kernel == "kernel-lpae"
 
         kernel = get_kernel_package(dnf_manager, exclude_list=["kernel-lpae"])
-        self.assertEqual(kernel, "kernel")
+        assert kernel == "kernel"
 
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.is_lpae_available")
     def test_get_kernel_package(self, is_lpae):
@@ -75,52 +77,52 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
         dnf_manager.is_package_available.return_value = True
 
         kernel = get_kernel_package(dnf_manager, exclude_list=[])
-        self.assertEqual(kernel, "kernel")
+        assert kernel == "kernel"
 
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.productVersion", "invalid")
     def test_get_product_release_version_invalid(self):
         """Test the get_product_release_version function with an invalid value."""
-        self.assertEqual(get_product_release_version(), "rawhide")
+        assert get_product_release_version() == "rawhide"
 
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.productVersion", "28")
     def test_get_product_release_version_number(self):
         """Test the get_product_release_version function with a valid number."""
-        self.assertEqual(get_product_release_version(), "28")
+        assert get_product_release_version() == "28"
 
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.productVersion", "7.4")
     def test_get_product_release_version_dot(self):
         """Test the get_product_release_version function with a dot."""
-        self.assertEqual(get_product_release_version(), "7.4")
+        assert get_product_release_version() == "7.4"
 
     def test_get_installation_specs_default(self):
         """Test the get_installation_specs function with defaults."""
         data = PackagesSelectionData()
-        self.assertEqual(get_installation_specs(data), (["@core"], []))
+        assert get_installation_specs(data) == (["@core"], [])
 
     def test_get_installation_specs_nocore(self):
         """Test the get_installation_specs function without core."""
         data = PackagesSelectionData()
         data.core_group_enabled = False
-        self.assertEqual(get_installation_specs(data), ([], ["@core"]))
+        assert get_installation_specs(data) == ([], ["@core"])
 
     def test_get_installation_specs_environment(self):
         """Test the get_installation_specs function with environment."""
         data = PackagesSelectionData()
         data.environment = "environment-1"
 
-        self.assertEqual(get_installation_specs(data), (
+        assert get_installation_specs(data) == (
             ["@environment-1", "@core"], []
-        ))
+        )
 
         env = "environment-2"
-        self.assertEqual(get_installation_specs(data, default_environment=env), (
+        assert get_installation_specs(data, default_environment=env) == (
             ["@environment-1", "@core"], []
-        ))
+        )
 
         data.default_environment_enabled = True
-        self.assertEqual(get_installation_specs(data, default_environment=env), (
+        assert get_installation_specs(data, default_environment=env) == (
             ["@environment-2", "@core"], []
-        ))
+        )
 
     def test_get_installation_specs_packages(self):
         """Test the get_installation_specs function with packages."""
@@ -128,9 +130,9 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
         data.packages = ["p1", "p2", "p3"]
         data.excluded_packages = ["p4", "p5", "p6"]
 
-        self.assertEqual(get_installation_specs(data), (
+        assert get_installation_specs(data) == (
             ["@core", "p1", "p2", "p3"], ["p4", "p5", "p6"]
-        ))
+        )
 
     def test_get_installation_specs_groups(self):
         """Test the get_installation_specs function with groups."""
@@ -145,7 +147,7 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
             "g6": GROUP_PACKAGE_TYPES_ALL,
         }
 
-        self.assertEqual(get_installation_specs(data), (
+        assert get_installation_specs(data) == (
             [
                 "@core",
                 "@g1/mandatory,conditional",
@@ -156,7 +158,7 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
                 "@g5",
                 "@g6"
             ]
-        ))
+        )
 
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.rpm")
     def test_get_kernel_version_list(self, mock_rpm):
@@ -178,13 +180,13 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
         ts.dbMatch.return_value = [hdr_1, hdr_2]
 
         mock_rpm.TransactionSet.return_value = ts
-        self.assertEqual(get_kernel_version_list(), [
+        assert get_kernel_version_list() == [
             '5.8.15-201.fc32.x86_64',
             '5.8.16-200.fc32.x86_64',
             '6.8.15-201.fc32.x86_64',
             '7.8.16-200.fc32.x86_64',
             '8.8.18-200.fc32.x86_64'
-        ])
+        ]
 
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.execWithCapture")
     def test_get_free_space(self, exec_mock):
@@ -202,7 +204,7 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
         """
         exec_mock.return_value = dedent(output).strip()
 
-        self.assertEqual(get_free_space_map(), {
+        assert get_free_space_map() == {
             '/dev': Size("100 KiB"),
             '/dev/shm': Size("200 KiB"),
             '/run': Size("300 KiB"),
@@ -211,7 +213,7 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
             '/boot': Size("600 KiB"),
             '/home': Size("700 KiB"),
             '/boot/efi': Size("800 KiB"),
-        })
+        }
 
     @patch("os.statvfs")
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.conf")
@@ -227,11 +229,11 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
         conf_mock.target.is_hardware = False
         statvfs_mock.return_value = Mock(f_frsize=1024, f_bfree=300)
 
-        self.assertEqual(get_free_space_map(), {
+        assert get_free_space_map() == {
             '/': Size("100 KiB"),
             '/boot': Size("200 KiB"),
             '/var/tmp': Size("300 KiB"),
-        })
+        }
 
     def test_pick_mount_points(self):
         """Test the _pick_mount_points function."""
@@ -254,13 +256,13 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
             download_size=Size("0.5 G"),
             install_size=Size("0.5 G")
         )
-        self.assertEqual(sufficient, {
+        assert sufficient == {
             "/var/tmp",
             "/mnt/sysroot",
             "/mnt/sysroot/home",
             "/mnt/sysroot/tmp",
             "/mnt/sysroot/var"
-        })
+        }
 
         # No mount point is big enough for installation.
         # Choose non-sysroot mount points for download.
@@ -269,9 +271,9 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
             download_size=Size("0.5 G"),
             install_size=Size("1.5 G")
         )
-        self.assertEqual(sufficient, {
+        assert sufficient == {
             "/var/tmp",
-        })
+        }
 
         # No mount point is big enough for installation or download.
         sufficient = _pick_mount_points(
@@ -279,7 +281,7 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
             download_size=Size("1.5 G"),
             install_size=Size("1.5 G")
         )
-        self.assertEqual(sufficient, set())
+        assert sufficient == set()
 
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.get_free_space_map")
     def test_pick_download_location(self, free_space_getter):
@@ -300,7 +302,7 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
         }
 
         path = pick_download_location(dnf_manager)
-        self.assertEqual(path, "/var/tmp/dnf.package.cache")
+        assert path == "/var/tmp/dnf.package.cache"
 
         # Found mount points only for download.
         # Use the biggest mount point.
@@ -310,17 +312,17 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
         }
 
         path = pick_download_location(dnf_manager)
-        self.assertEqual(path, "/mnt/sysroot/tmp/dnf.package.cache")
+        assert path == "/mnt/sysroot/tmp/dnf.package.cache"
 
         # No mount point to use.
         # Fail with an exception.
         free_space_getter.return_value = {}
 
-        with self.assertRaises(RuntimeError) as cm:
+        with pytest.raises(RuntimeError) as cm:
             pick_download_location(dnf_manager)
 
         msg = "Not enough disk space to download the packages; size 100 B."
-        self.assertEqual(str(cm.exception), msg)
+        assert str(cm.value) == msg
 
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.execWithCapture")
     @patch_dbus_get_proxy_with_cache
@@ -348,24 +350,24 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
         device_tree.GetMountPoints.side_effect = get_mount_points
         device_tree.GetFileSystemFreeSpace.side_effect = get_free_space
 
-        self.assertEqual(get_free_space_map(current=True, scheduled=False), {
+        assert get_free_space_map(current=True, scheduled=False) == {
             '/': Size("100 KiB"),
             '/tmp': Size("200 KiB"),
-        })
+        }
 
-        self.assertEqual(get_free_space_map(current=False, scheduled=True), {
+        assert get_free_space_map(current=False, scheduled=True) == {
             '/mnt/sysroot': Size("300 KiB"),
             '/mnt/sysroot/boot': Size("400 KiB"),
-        })
+        }
 
-        self.assertEqual(get_free_space_map(current=True, scheduled=True), {
+        assert get_free_space_map(current=True, scheduled=True) == {
             '/': Size("100 KiB"),
             '/tmp': Size("200 KiB"),
             '/mnt/sysroot': Size("300 KiB"),
             '/mnt/sysroot/boot': Size("400 KiB"),
-        })
+        }
 
-        self.assertEqual(get_free_space_map(current=False, scheduled=False), {})
+        assert get_free_space_map(current=False, scheduled=False) == {}
 
     @patch("pyanaconda.modules.payloads.payload.dnf.utils.get_free_space_map")
     def test_calculate_required_space(self, free_space_getter):
@@ -381,21 +383,21 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
         # No mount point to use.
         # The total size is required.
         free_space_getter.return_value = {}
-        self.assertEqual(calculate_required_space(dnf_manager), total_size)
+        assert calculate_required_space(dnf_manager) == total_size
 
         # Found a mount point for download and install.
         # The total size is required.
         free_space_getter.return_value = {
             "/mnt/sysroot/home": total_size
         }
-        self.assertEqual(calculate_required_space(dnf_manager), total_size)
+        assert calculate_required_space(dnf_manager) == total_size
 
         # Found a mount point for download.
         # The installation size is required.
         free_space_getter.return_value = {
             "/var/tmp": download_size
         }
-        self.assertEqual(calculate_required_space(dnf_manager), installation_size)
+        assert calculate_required_space(dnf_manager) == installation_size
 
         # The biggest mount point can be used for download and install.
         # The total size is required.
@@ -403,4 +405,4 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
             "/var/tmp": download_size,
             "/mnt/sysroot": total_size
         }
-        self.assertEqual(calculate_required_space(dnf_manager), total_size)
+        assert calculate_required_space(dnf_manager) == total_size

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_factory.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_factory.py
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import pytest
+
 from unittest.case import TestCase
 
 from pyanaconda.core.kickstart.specification import KickstartSpecificationHandler, \
@@ -33,13 +35,13 @@ class PayloadFactoryTestCase(TestCase):
         """Test PayloadFactory create method."""
         for payload_type in PayloadType:
             module = PayloadFactory.create_payload(payload_type)
-            self.assertIsInstance(module, PayloadBase)
-            self.assertIsInstance(module.for_publication(), PayloadBaseInterface)
-            self.assertEqual(module.type, payload_type)
+            assert isinstance(module, PayloadBase)
+            assert isinstance(module.for_publication(), PayloadBaseInterface)
+            assert module.type == payload_type
 
     def test_failed_create_payload(self):
         """Test failed create method of the payload factory."""
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             PayloadFactory.create_payload("INVALID")
 
     def test_create_payload_from_ks(self):
@@ -95,4 +97,4 @@ class PayloadFactoryTestCase(TestCase):
         handler = KickstartSpecificationHandler(specification)
         parser = KickstartSpecificationParser(handler, specification)
         parser.readKickstartFromString(kickstart)
-        self.assertEqual(payload_type, PayloadFactory.get_type_for_kickstart(handler))
+        assert payload_type == PayloadFactory.get_type_for_kickstart(handler)

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
@@ -20,6 +20,7 @@
 import os
 import tempfile
 import unittest
+import pytest
 
 from unittest.mock import patch
 from tempfile import TemporaryDirectory
@@ -54,7 +55,7 @@ class LiveUtilsTestCase(unittest.TestCase):
         with TemporaryDirectory() as temp:
             result = get_kernel_version_list(temp)
 
-        self.assertEqual(result, [])
+        assert result == []
 
     def test_kernel_list(self):
         """Test get kernel list function."""
@@ -73,7 +74,7 @@ class LiveUtilsTestCase(unittest.TestCase):
 
             kernel_list = get_kernel_version_list(temp)
 
-            self.assertListEqual(kernel_list, self._kernel_test_valid_list)
+            assert kernel_list == self._kernel_test_valid_list
 
 
 class InstallFromImageTaskTestCase(unittest.TestCase):
@@ -113,11 +114,11 @@ class InstallFromImageTaskTestCase(unittest.TestCase):
             mount_point="/mnt/source"
         )
 
-        with self.assertRaises(PayloadInstallationError) as cm:
+        with pytest.raises(PayloadInstallationError) as cm:
             task.run()
 
         msg = "Failed to install image: Fake!"
-        self.assertTrue(str(cm.exception), msg)
+        assert str(cm.value), msg
 
     @patch("pyanaconda.modules.payloads.payload.live_image.installation.execWithRedirect")
     def test_install_image_task_failed_return_code(self, exec_with_redirect):
@@ -128,11 +129,11 @@ class InstallFromImageTaskTestCase(unittest.TestCase):
             mount_point="/mnt/source"
         )
 
-        with self.assertRaises(PayloadInstallationError) as cm:
+        with pytest.raises(PayloadInstallationError) as cm:
             task.run()
 
         msg = "Failed to install image: rsync excited with code 11"
-        self.assertTrue(str(cm.exception), msg)
+        assert str(cm.value), msg
 
 
 class InstallFromTarTaskTestCase(unittest.TestCase):
@@ -176,11 +177,11 @@ class InstallFromTarTaskTestCase(unittest.TestCase):
             tarfile="/source.tar"
         )
 
-        with self.assertRaises(PayloadInstallationError) as cm:
+        with pytest.raises(PayloadInstallationError) as cm:
             task.run()
 
         msg = "Failed to install tar: Fake!"
-        self.assertTrue(str(cm.exception), msg)
+        assert str(cm.value), msg
 
 
 class VerifyImageChecksumTestCase(unittest.TestCase):
@@ -205,7 +206,7 @@ class VerifyImageChecksumTestCase(unittest.TestCase):
                 task.run()
 
         msg = "No checksum to verify."
-        self.assertIn(msg, "\n".join(cm.output))
+        assert msg in "\n".join(cm.output)
 
     def test_verify_checksum(self):
         """Test the verification of a checksum."""
@@ -225,7 +226,7 @@ class VerifyImageChecksumTestCase(unittest.TestCase):
                 task.run()
 
         msg = "Checksum of the image does match."
-        self.assertIn(msg, "\n".join(cm.output))
+        assert msg in "\n".join(cm.output)
 
     def test_verify_wrong_checksum(self):
         """Test the verification of a wrong checksum."""
@@ -237,8 +238,8 @@ class VerifyImageChecksumTestCase(unittest.TestCase):
                 checksum="incorrect"
             )
 
-            with self.assertRaises(PayloadInstallationError) as cm:
+            with pytest.raises(PayloadInstallationError) as cm:
                 task.run()
 
         msg = "Checksum of the image does not match."
-        self.assertEqual(str(cm.exception), msg)
+        assert str(cm.value) == msg

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
@@ -118,7 +118,7 @@ class InstallFromImageTaskTestCase(unittest.TestCase):
             task.run()
 
         msg = "Failed to install image: Fake!"
-        assert str(cm.value), msg
+        assert str(cm.value) == msg
 
     @patch("pyanaconda.modules.payloads.payload.live_image.installation.execWithRedirect")
     def test_install_image_task_failed_return_code(self, exec_with_redirect):
@@ -132,8 +132,8 @@ class InstallFromImageTaskTestCase(unittest.TestCase):
         with pytest.raises(PayloadInstallationError) as cm:
             task.run()
 
-        msg = "Failed to install image: rsync excited with code 11"
-        assert str(cm.value), msg
+        msg = "Failed to install image: rsync exited with code 11"
+        assert str(cm.value) == msg
 
 
 class InstallFromTarTaskTestCase(unittest.TestCase):
@@ -181,7 +181,7 @@ class InstallFromTarTaskTestCase(unittest.TestCase):
             task.run()
 
         msg = "Failed to install tar: Fake!"
-        assert str(cm.value), msg
+        assert str(cm.value) == msg
 
 
 class VerifyImageChecksumTestCase(unittest.TestCase):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live_image.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live_image.py
@@ -38,8 +38,7 @@ class LiveImageKSTestCase(unittest.TestCase):
         self.payload_module = PayloadsService()
         self.payload_module_interface = PayloadsInterface(self.payload_module)
 
-        self.shared_tests = PayloadKickstartSharedTest(self,
-                                                       self.payload_module,
+        self.shared_tests = PayloadKickstartSharedTest(self.payload_module,
                                                        self.payload_module_interface)
 
     def test_liveimg_simple_kickstart(self):
@@ -104,8 +103,7 @@ class LiveImageInterfaceTestCase(unittest.TestCase):
         self.live_image_module = LiveImageModule()
         self.live_image_interface = LiveImageInterface(self.live_image_module)
 
-        self.shared_tests = PayloadSharedTest(self,
-                                              payload=self.live_image_module,
+        self.shared_tests = PayloadSharedTest(payload=self.live_image_module,
                                               payload_intf=self.live_image_interface)
 
     def test_type(self):
@@ -129,20 +127,20 @@ class LiveImageModuleTestCase(unittest.TestCase):
     def test_install_with_task_from_tar(self):
         """Test Live Image install with tasks from tarfile."""
         # task_path = self.live_image_interface.PreInstallWithTasks()
-        # check_task_creation_list(self, task_path, publisher, [SetupInstallationSourceImageTask])
+        # check_task_creation_list(task_path, publisher, [SetupInstallationSourceImageTask])
 
         # task_path = self.live_image_interface.InstallWithTasks()
-        # check_task_creation_list(self, task_path, publisher, [InstallFromTarTask])
+        # check_task_creation_list(task_path, publisher, [InstallFromTarTask])
         assert self.module.install_with_tasks() == []
 
     @patch_dbus_publish_object
     def test_install_with_task_from_image(self, publisher):
         """Test Live Image install with tasks from image."""
         # task_path = self.live_image_interface.PreInstallWithTasks()
-        # check_task_creation_list(self, task_path, publisher, [SetupInstallationSourceImageTask])
+        # check_task_creation_list(task_path, publisher, [SetupInstallationSourceImageTask])
 
         # task_path = self.live_image_interface.InstallWithTasks()
-        # check_task_creation_list(self, task_path, publisher, [InstallFromImageTask])
+        # check_task_creation_list(task_path, publisher, [InstallFromImageTask])
         assert self.module.install_with_tasks() == []
 
     @patch_dbus_publish_object

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live_image.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live_image.py
@@ -119,12 +119,12 @@ class LiveImageModuleTestCase(unittest.TestCase):
 
     def test_calculate_required_space(self):
         """Test the calculate_required_space method."""
-        self.assertEqual(self.module.calculate_required_space(), 0)
+        assert self.module.calculate_required_space() == 0
 
         source = SourceFactory.create_source(SourceType.LIVE_IMAGE)
         self.module.add_source(source)
 
-        self.assertEqual(self.module.calculate_required_space(), 1024 * 1024 * 1024)
+        assert self.module.calculate_required_space() == 1024 * 1024 * 1024
 
     def test_install_with_task_from_tar(self):
         """Test Live Image install with tasks from tarfile."""
@@ -133,7 +133,7 @@ class LiveImageModuleTestCase(unittest.TestCase):
 
         # task_path = self.live_image_interface.InstallWithTasks()
         # check_task_creation_list(self, task_path, publisher, [InstallFromTarTask])
-        self.assertEqual(self.module.install_with_tasks(), [])
+        assert self.module.install_with_tasks() == []
 
     @patch_dbus_publish_object
     def test_install_with_task_from_image(self, publisher):
@@ -143,7 +143,7 @@ class LiveImageModuleTestCase(unittest.TestCase):
 
         # task_path = self.live_image_interface.InstallWithTasks()
         # check_task_creation_list(self, task_path, publisher, [InstallFromImageTask])
-        self.assertEqual(self.module.install_with_tasks(), [])
+        assert self.module.install_with_tasks() == []
 
     @patch_dbus_publish_object
     def test_post_install_with_tasks(self, publisher):
@@ -165,4 +165,4 @@ class LiveImageModuleTestCase(unittest.TestCase):
         #     self.assertEqual(object_path, task_paths[i])
         #     self.assertIsInstance(obj, TaskInterface)
         #     self.assertIsInstance(obj.implementation, task_classes[i])
-        self.assertEqual(self.module.post_install_with_tasks(), [])
+        assert self.module.post_install_with_tasks() == []

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live_os.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live_os.py
@@ -38,8 +38,7 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
         self.live_os_module = LiveOSModule()
         self.live_os_interface = LiveOSInterface(self.live_os_module)
 
-        self.shared_tests = PayloadSharedTest(self,
-                                              payload=self.live_os_module,
+        self.shared_tests = PayloadSharedTest(payload=self.live_os_module,
                                               payload_intf=self.live_os_interface)
 
         self.callback = PropertiesChangedCallback()
@@ -102,7 +101,7 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
 
         task_path = self.live_os_interface.SetUpSourcesWithTask()
 
-        check_task_creation(self, task_path, publisher, SetUpSourcesTask)
+        check_task_creation(task_path, publisher, SetUpSourcesTask)
 
     @patch_dbus_publish_object
     def test_tear_down_installation_source_task(self, publisher):
@@ -111,7 +110,7 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
 
         task_path = self.live_os_interface.TearDownSourcesWithTask()
 
-        check_task_creation(self, task_path, publisher, TearDownSourcesTask)
+        check_task_creation(task_path, publisher, TearDownSourcesTask)
 
 
 class LiveOSModuleTestCase(unittest.TestCase):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live_os.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live_os.py
@@ -59,9 +59,8 @@ class LiveOSInterfaceTestCase(unittest.TestCase):
 
     def test_supported_sources(self):
         """Test LiveOS supported sources API."""
-        self.assertEqual(
-            [SOURCE_TYPE_LIVE_OS_IMAGE],
-            self.live_os_interface.SupportedSourceTypes)
+        assert [SOURCE_TYPE_LIVE_OS_IMAGE] == \
+            self.live_os_interface.SupportedSourceTypes
 
     @patch_dbus_publish_object
     def test_set_source(self, publisher):
@@ -126,7 +125,7 @@ class LiveOSModuleTestCase(unittest.TestCase):
 
     def test_get_kernel_version_list(self):
         """Test the get_kernel_version_list method."""
-        self.assertEqual(self.module.get_kernel_version_list(), [])
+        assert self.module.get_kernel_version_list() == []
 
     def test_install_with_task(self):
         """Test the install_with_tasks method."""
@@ -136,7 +135,7 @@ class LiveOSModuleTestCase(unittest.TestCase):
         # tasks = self.module.install_with_tasks()
         # self.assertEqual(len(tasks), 1)
         # self.assertIsInstance(tasks[0], InstallFromImageTask)
-        self.assertEqual(self.module.install_with_tasks(), [])
+        assert self.module.install_with_tasks() == []
 
     def test_install_with_task_no_source(self):
         """Test Live OS install with tasks with no source fail."""
@@ -147,4 +146,4 @@ class LiveOSModuleTestCase(unittest.TestCase):
     def test_post_install_with_tasks(self):
         """Test Live OS post installation configuration task."""
         tasks = self.module.post_install_with_tasks()
-        self.assertEqual(len(tasks), 0)
+        assert len(tasks) == 0

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree.py
@@ -43,7 +43,6 @@ class RPMOSTreeInterfaceTestCase(unittest.TestCase):
         self.interface = RPMOSTreeInterface(self.module)
 
         self.shared_tests = PayloadSharedTest(
-            test=self,
             payload=self.module,
             payload_intf=self.interface
         )
@@ -68,7 +67,6 @@ class RPMOSTreeKickstartTestCase(unittest.TestCase):
         self.module = PayloadsService()
         self.interface = PayloadsInterface(self.module)
         self.shared_ks_tests = PayloadKickstartSharedTest(
-            test=self,
             payload_service=self.module,
             payload_service_intf=self.interface
         )

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree.py
@@ -54,10 +54,10 @@ class RPMOSTreeInterfaceTestCase(unittest.TestCase):
 
     def test_supported_sources(self):
         """Test the SupportedSourceTypes property."""
-        self.assertEqual(self.interface.SupportedSourceTypes, [
+        assert self.interface.SupportedSourceTypes == [
             SOURCE_TYPE_RPM_OSTREE,
             SOURCE_TYPE_FLATPAK,
-        ])
+        ]
 
 
 class RPMOSTreeKickstartTestCase(unittest.TestCase):
@@ -75,14 +75,14 @@ class RPMOSTreeKickstartTestCase(unittest.TestCase):
 
     def _check_properties(self, expected_source_type):
         payload = self.shared_ks_tests.get_payload()
-        self.assertIsInstance(payload, RPMOSTreeModule)
+        assert isinstance(payload, RPMOSTreeModule)
 
         if expected_source_type is None:
-            self.assertFalse(payload.sources)
+            assert not payload.sources
         else:
             sources = payload.sources
-            self.assertEqual(1, len(sources))
-            self.assertEqual(sources[0].type.value, expected_source_type)
+            assert 1 == len(sources)
+            assert sources[0].type.value == expected_source_type
 
     def test_ostree_kickstart(self):
         ks_in = """
@@ -117,18 +117,18 @@ class RPMOSTreeModuleTestCase(unittest.TestCase):
 
     def _assert_is_instance_list(self, objects, classes):
         """Check if objects are instances of classes."""
-        self.assertEqual(len(objects), len(classes))
+        assert len(objects) == len(classes)
 
         for obj, cls in zip(objects, classes):
-            self.assertIsInstance(obj, cls)
+            assert isinstance(obj, cls)
 
     def test_get_kernel_version_list(self):
         """Test the get_kernel_version_list method."""
-        self.assertEqual(self.module.get_kernel_version_list(), [])
+        assert self.module.get_kernel_version_list() == []
 
     def test_install_with_tasks(self):
         """Test the install_with_tasks method."""
-        self.assertEqual(self.module.install_with_tasks(), [])
+        assert self.module.install_with_tasks() == []
 
         rpm_source = SourceFactory.create_source(SourceType.RPM_OSTREE)
         self.module.set_sources([rpm_source])
@@ -176,14 +176,14 @@ class RPMOSTreeModuleTestCase(unittest.TestCase):
             # Fake the task run.
             task.succeeded_signal.emit()
 
-        self.assertEqual(self.module._internal_mounts, [
+        assert self.module._internal_mounts == [
             "/path/PrepareOSTreeMountTargetsTask/1",
             "/path/PrepareOSTreeMountTargetsTask/2"
-        ])
+        ]
 
     def test_post_install_with_tasks(self):
         """Test the post_install_with_tasks method."""
-        self.assertEqual(self.module.post_install_with_tasks(), [])
+        assert self.module.post_install_with_tasks() == []
 
         rpm_source = SourceFactory.create_source(SourceType.RPM_OSTREE)
         self.module.set_sources([rpm_source])
@@ -208,5 +208,5 @@ class RPMOSTreeModuleTestCase(unittest.TestCase):
             TearDownOSTreeMountTargetsTask
         ])
 
-        self.assertEqual(tasks[0]._sources, [rpm_source])
-        self.assertEqual(tasks[1]._internal_mounts, ["/path/1", "/path/2"])
+        assert tasks[0]._sources == [rpm_source]
+        assert tasks[1]._internal_mounts == ["/path/1", "/path/2"]

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_flatpak.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_flatpak.py
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 import unittest
+import pytest
+
 from unittest.mock import patch
 from tempfile import TemporaryDirectory
 
@@ -45,6 +47,6 @@ class InstallFlatpakTaskTest(unittest.TestCase):
         fm_instance.install_all.side_effect = PayloadInstallationError
 
         with TemporaryDirectory() as temp:
-            with self.assertRaises(PayloadInstallationError):
+            with pytest.raises(PayloadInstallationError):
                 task = InstallFlatpaksTask(temp)
                 task.run()

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -17,6 +17,7 @@
 #
 import tempfile
 import os
+import pytest
 
 import unittest
 from unittest.mock import patch, call, MagicMock
@@ -56,12 +57,12 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
 
         data = _make_config_data()
         task = PrepareOSTreeMountTargetsTask("/sysroot", "/physroot", data)
-        self.assertEqual(len(task._internal_mounts), 0)
+        assert len(task._internal_mounts) == 0
 
         # everything left out
         task._setup_internal_bindmount("/src")
         exec_mock.assert_called_once_with("mount", ["--rbind", "/physroot/src", "/sysroot/src"])
-        self.assertListEqual(task._internal_mounts, ["/sysroot/src"])
+        assert task._internal_mounts == ["/sysroot/src"]
         mkdir_mock.assert_not_called()
         task._internal_mounts.clear()
         exec_mock.reset_mock()
@@ -69,7 +70,7 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
         # all equal to defaults but present - same as above but dest is used
         task._setup_internal_bindmount("/src", "/dest", True, False, True)
         exec_mock.assert_called_once_with("mount", ["--rbind", "/physroot/src", "/sysroot/dest"])
-        self.assertListEqual(task._internal_mounts, ["/sysroot/dest"])
+        assert task._internal_mounts == ["/sysroot/dest"]
         mkdir_mock.assert_not_called()
         task._internal_mounts.clear()
         exec_mock.reset_mock()
@@ -77,7 +78,7 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
         # src_physical off - makes it sysroot->sysroot
         task._setup_internal_bindmount("/src", "/dest", False, False, True)
         exec_mock.assert_called_once_with("mount", ["--rbind", "/sysroot/src", "/sysroot/dest"])
-        self.assertListEqual(task._internal_mounts, ["/sysroot/dest"])
+        assert task._internal_mounts == ["/sysroot/dest"]
         mkdir_mock.assert_not_called()
         task._internal_mounts.clear()
         exec_mock.reset_mock()
@@ -88,8 +89,8 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
             call("mount", ["--bind", "/physroot/src", "/physroot/src"]),
             call("mount", ["--bind", "-o", "remount,ro", "/physroot/src", "/physroot/src"])
         ])
-        self.assertEqual(len(exec_mock.mock_calls), 2)
-        self.assertListEqual(task._internal_mounts, ["/physroot/src"])
+        assert len(exec_mock.mock_calls) == 2
+        assert task._internal_mounts == ["/physroot/src"]
         mkdir_mock.assert_not_called()
         task._internal_mounts.clear()
         exec_mock.reset_mock()
@@ -97,7 +98,7 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
         # recurse off - bind instead of rbind
         task._setup_internal_bindmount("/src", "/dest", True, False, False)
         exec_mock.assert_called_once_with("mount", ["--bind", "/physroot/src", "/sysroot/dest"])
-        self.assertListEqual(task._internal_mounts, ["/sysroot/dest"])
+        assert task._internal_mounts == ["/sysroot/dest"]
         mkdir_mock.assert_not_called()
         task._internal_mounts.clear()
         exec_mock.reset_mock()
@@ -107,7 +108,7 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
         exists_mock.return_value = False
         task._setup_internal_bindmount("/src", "/dest", True, False, False)
         exec_mock.assert_called_once_with("mount", ["--bind", "/physroot/src", "/sysroot/dest"])
-        self.assertListEqual(task._internal_mounts, ["/sysroot/dest"])
+        assert task._internal_mounts == ["/sysroot/dest"]
         mkdir_mock.assert_called_with("/sysroot/dest")
         task._internal_mounts.clear()
         exec_mock.reset_mock()
@@ -131,11 +132,9 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
         task = PrepareOSTreeMountTargetsTask("/sysroot", "/physroot", data)
         created_mount_points = task.run()
 
-        self.assertListEqual(
-            created_mount_points,
+        assert created_mount_points == \
             ["/sysroot/usr", "/sysroot/dev", "/sysroot/proc", "/sysroot/run", "/sysroot/sys",
              "/sysroot/var", "/sysroot/etc", "/sysroot/home", "/sysroot/sysroot"]
-        )
         exec_mock.assert_has_calls([
             call("mount", ["--bind", "/sysroot/usr", "/sysroot/usr"]),
             call("mount", ["--bind", "-o", "remount,ro", "/sysroot/usr", "/sysroot/usr"]),
@@ -168,7 +167,7 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
             call("mount", ["--bind", "/physroot/home", "/sysroot/home"]),
             call("mount", ["--bind", "/physroot/", "/sysroot/sysroot"])
         ])
-        self.assertEqual(len(exec_mock.mock_calls), 20)
+        assert len(exec_mock.mock_calls) == 20
         mkdir_mock.assert_called_once_with("/sysroot/var/lib")
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
@@ -188,11 +187,9 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
         task = PrepareOSTreeMountTargetsTask("/sysroot", "/physroot", data)
         created_mount_points = task.run()
 
-        self.assertListEqual(
-            created_mount_points,
+        assert created_mount_points == \
             ["/sysroot/usr", "/sysroot/dev", "/sysroot/proc", "/sysroot/run", "/sysroot/sys",
              "/sysroot/var", "/sysroot/etc", "/sysroot/home", "/sysroot/sysroot"]
-        )
         exec_mock.assert_has_calls([
             call("mount", ["--bind", "/sysroot/usr", "/sysroot/usr"]),
             call("mount", ["--bind", "-o", "remount,ro", "/sysroot/usr", "/sysroot/usr"]),
@@ -225,7 +222,7 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
             call("mount", ["--bind", "/physroot/home", "/sysroot/home"]),
             call("mount", ["--bind", "/physroot/", "/sysroot/sysroot"])
         ])
-        self.assertEqual(len(exec_mock.mock_calls), 20)
+        assert len(exec_mock.mock_calls) == 20
         mkdir_mock.assert_called_once_with("/sysroot/var/lib")
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
@@ -243,11 +240,11 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
         }
         task = PrepareOSTreeMountTargetsTask("/sysroot", "/physroot", data)
 
-        with self.assertRaises(PayloadInstallationError) as cm:
+        with pytest.raises(PayloadInstallationError) as cm:
             task.run()
 
         msg = "The command 'mount --bind /sysroot/usr /sysroot/usr' exited with the code 1."
-        self.assertEqual(str(cm.exception), msg)
+        assert str(cm.value) == msg
 
 
 class TearDownOSTreeMountTargetsTaskTestCase(unittest.TestCase):
@@ -291,7 +288,7 @@ class TearDownOSTreeMountTargetsTaskTestCase(unittest.TestCase):
             task.run()
 
         msg = "Unmounting /sysroot/usr has failed: Fake!"
-        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+        assert any(map(lambda x: msg in x, cm.output))
 
 
 class CopyBootloaderDataTaskTestCase(unittest.TestCase):
@@ -310,10 +307,10 @@ class CopyBootloaderDataTaskTestCase(unittest.TestCase):
 
         task = CopyBootloaderDataTask("/sysroot", "/physroot")
 
-        with self.assertRaises(PayloadInstallationError) as cm:
+        with pytest.raises(PayloadInstallationError) as cm:
             task.run()
 
-        self.assertEqual(str(cm.exception), "Failed to copy bootloader data: Fake!")
+        assert str(cm.value) == "Failed to copy bootloader data: Fake!"
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.path.isdir")
@@ -458,14 +455,14 @@ class ChangeOSTreeRemoteTaskTestCase(unittest.TestCase):
         repo.remote_change.assert_called_once()
         args, kwargs = repo.remote_change.call_args
 
-        self.assertEqual(len(args), 5)
-        self.assertEqual(len(kwargs), 1)
+        assert len(args) == 5
+        assert len(kwargs) == 1
 
-        self.assertEqual(args[0], sysroot_file)
-        self.assertEqual(args[2], "remote")
-        self.assertEqual(args[3], "url")
-        self.assertEqual(args[4].unpack(), options or {})
-        self.assertEqual(kwargs["cancellable"], None)
+        assert args[0] == sysroot_file
+        assert args[2] == "remote"
+        assert args[3] == "url"
+        assert args[4].unpack() == (options or {})
+        assert kwargs["cancellable"] is None
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.Gio.File")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.OSTree.Sysroot")
@@ -650,17 +647,14 @@ class PullRemoteAndDeleteTaskTestCase(unittest.TestCase):
 
         context_mock.assert_called_once()
         async_new_mock.assert_called_once()
-        self.assertEqual(len(sysroot_new_mock.mock_calls), 4)
+        assert len(sysroot_new_mock.mock_calls) == 4
         # 1 above, 1 direct in run(), 2 on the result: load(), get_repo()
 
         repo_mock.pull_with_options.assert_called_once()
         name, args, kwargs = repo_mock.pull_with_options.mock_calls[0]
         opts = args[1]
-        self.assertEqual(type(opts), Variant)
-        self.assertDictEqual(
-            opts.unpack(),
-            {"refs": ["ref"]}
-        )
+        assert type(opts) == Variant
+        assert opts.unpack() == {"refs": ["ref"]}
         repo_mock.remote_delete.assert_called_once_with("remote", None)
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.create_new_context")
@@ -676,23 +670,20 @@ class PullRemoteAndDeleteTaskTestCase(unittest.TestCase):
         repo_mock.pull_with_options.side_effect = [GError("blah")]
 
         with patch.object(PullRemoteAndDeleteTask, "report_progress") as progress_mock:
-            with self.assertRaises(PayloadInstallationError) as ex:
+            with pytest.raises(PayloadInstallationError) as ex:
                 task = PullRemoteAndDeleteTask(data)
                 task.run()
 
         context_mock.assert_called_once()
         async_new_mock.assert_called_once()
-        self.assertEqual(len(sysroot_new_mock.mock_calls), 4)
+        assert len(sysroot_new_mock.mock_calls) == 4
         # 1 above, 1 direct in run(), 2 on the result: load(), get_repo()
 
         repo_mock.pull_with_options.assert_called_once()
         name, args, kwargs = repo_mock.pull_with_options.mock_calls[0]
         opts = args[1]
-        self.assertEqual(type(opts), Variant)
-        self.assertDictEqual(
-            opts.unpack(),
-            {"refs": ["ref"]}
-        )
+        assert type(opts) == Variant
+        assert opts.unpack() == {"refs": ["ref"]}
         repo_mock.remote_delete.assert_not_called()
 
     def test_pull_progress_report(self):
@@ -754,7 +745,7 @@ class SetSystemRootTaskTestCase(unittest.TestCase):
         task = SetSystemRootTask("/physroot")
         task.run()
 
-        self.assertEqual(len(new_sysroot_mock.mock_calls), 2+4)
+        assert len(new_sysroot_mock.mock_calls) == 2+4
         # 2 above: new, get_deployments;
         # 4 in run(): new(), load(), get_deployments(), get_deployment_directory()
         set_mock.assert_called_once()

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -670,7 +670,7 @@ class PullRemoteAndDeleteTaskTestCase(unittest.TestCase):
         repo_mock.pull_with_options.side_effect = [GError("blah")]
 
         with patch.object(PullRemoteAndDeleteTask, "report_progress") as progress_mock:
-            with pytest.raises(PayloadInstallationError) as ex:
+            with pytest.raises(PayloadInstallationError):
                 task = PullRemoteAndDeleteTask(data)
                 task.run()
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_cdn.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_cdn.py
@@ -32,15 +32,15 @@ class CDNSourceInterfaceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test the type of CDN."""
-        self.assertEqual(SOURCE_TYPE_CDN, self.interface.Type)
+        assert SOURCE_TYPE_CDN == self.interface.Type
 
     def test_description(self):
         """Test the description of CDN."""
-        self.assertEqual("Red Hat CDN", self.interface.Description)
+        assert "Red Hat CDN" == self.interface.Description
 
     def test_required_space(self):
         """Test the required_space property."""
-        self.assertEqual(self.module.required_space, 0)
+        assert self.module.required_space == 0
 
     def test_repr(self):
-        self.assertEqual(repr(self.module), "Source(type='CDN')")
+        assert repr(self.module) == "Source(type='CDN')"

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_cdrom.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_cdrom.py
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 import unittest
+import pytest
+
 from unittest.mock import call, DEFAULT, Mock, patch
 
 from pyanaconda.core.constants import SOURCE_TYPE_CDROM
@@ -42,17 +44,17 @@ class CdromSourceInterfaceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test CD-ROM source has a correct type specified."""
-        self.assertEqual(SOURCE_TYPE_CDROM, self.interface.Type)
+        assert SOURCE_TYPE_CDROM == self.interface.Type
 
     def test_device(self):
         """Test CD-ROM source Device API."""
-        self.assertEqual(self.interface.DeviceName, "")
+        assert self.interface.DeviceName == ""
 
         task = self.module.set_up_with_tasks()[0]
         task.get_result = Mock(return_value="top_secret")
         task.succeeded_signal.emit()
 
-        self.assertEqual(self.interface.DeviceName, "top_secret")
+        assert self.interface.DeviceName == "top_secret"
 
 
 class CdromSourceTestCase(unittest.TestCase):
@@ -63,35 +65,35 @@ class CdromSourceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test CD-ROM source module has a correct type."""
-        self.assertEqual(SourceType.CDROM, self.module.type)
+        assert SourceType.CDROM == self.module.type
 
     @patch("os.path.ismount")
     def test_get_state(self, ismount_mock):
         """Test CD-ROM source state."""
         ismount_mock.return_value = False
-        self.assertEqual(SourceState.UNREADY, self.module.get_state())
+        assert SourceState.UNREADY == self.module.get_state()
 
         ismount_mock.reset_mock()
         ismount_mock.return_value = True
 
-        self.assertEqual(SourceState.READY, self.module.get_state())
+        assert SourceState.READY == self.module.get_state()
 
         ismount_mock.assert_called_once_with(self.module.mount_point)
 
     def test_description(self):
         """Hard drive source description."""
-        self.assertEqual("Local media", self.interface.Description)
+        assert "Local media" == self.interface.Description
 
     def test_network_required(self):
         """Test the property network_required."""
-        self.assertEqual(self.module.network_required, False)
+        assert self.module.network_required == False
 
     def test_required_space(self):
         """Test the required_space property."""
-        self.assertEqual(self.module.required_space, 0)
+        assert self.module.required_space == 0
 
     def test_repr(self):
-        self.assertEqual(repr(self.module), "Source(type='CDROM')")
+        assert repr(self.module) == "Source(type='CDROM')"
 
     def test_set_up_with_tasks(self):
         """Test CD-ROM Source set up call."""
@@ -104,10 +106,10 @@ class CdromSourceTestCase(unittest.TestCase):
 
         # Check the number of the tasks
         task_number = len(task_classes)
-        self.assertEqual(task_number, len(tasks))
+        assert task_number == len(tasks)
 
         for i in range(task_number):
-            self.assertIsInstance(tasks[i], task_classes[i])
+            assert isinstance(tasks[i], task_classes[i])
 
     def test_tear_down_with_tasks(self):
         """Test CD-ROM Source ready state for tear down."""
@@ -120,10 +122,10 @@ class CdromSourceTestCase(unittest.TestCase):
 
         # check the number of tasks
         task_number = len(task_classes)
-        self.assertEqual(task_number, len(tasks))
+        assert task_number == len(tasks)
 
         for i in range(task_number):
-            self.assertIsInstance(tasks[i], task_classes[i])
+            assert isinstance(tasks[i], task_classes[i])
 
 
 class CdromSourceSetupTaskTestCase(unittest.TestCase):
@@ -136,7 +138,7 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
         """Test CD-ROM Source setup installation source task name."""
         task = SetUpCdromSourceTask(self.mount_location)
 
-        self.assertEqual(task.name, "Set up CD-ROM Installation Source")
+        assert task.name == "Set up CD-ROM Installation Source"
 
     @staticmethod
     def set_up_device_tree(num_cdroms):
@@ -194,36 +196,26 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
                                                 mount_mock,
                                                 "test{}".format(n))
 
-        self.assertEqual(device_tree_mock.GetDeviceData.call_count, num_called)
-        self.assertEqual(mount_mock.call_count, num_called)
+        assert device_tree_mock.GetDeviceData.call_count == num_called
+        assert mount_mock.call_count == num_called
 
     def _check_if_device_was_tried(self,
                                    device_tree_mock,
                                    mount_mock,
                                    device_name):
-        self.assertIn(
-            call(device_name),
-            device_tree_mock.GetDeviceData.mock_calls
-        )
+        assert call(device_name) in device_tree_mock.GetDeviceData.mock_calls
 
-        self.assertIn(
-            call("/dev/cdrom-{}".format(device_name), self.mount_location, "iso9660", "ro"),
+        assert call("/dev/cdrom-{}".format(device_name), self.mount_location, "iso9660", "ro") in \
             mount_mock.mock_calls
-        )
 
     def _check_if_device_was_not_tried(self,
                                        device_tree_mock,
                                        mount_mock,
                                        device_name):
-        self.assertNotIn(
-            call(device_name),
-            device_tree_mock.GetDeviceData.mock_calls
-        )
+        assert call(device_name) not in device_tree_mock.GetDeviceData.mock_calls
 
-        self.assertNotIn(
-            call("/dev/cdrom-{}".format(device_name), self.mount_location, "iso9660", "ro"),
+        assert call("/dev/cdrom-{}".format(device_name), self.mount_location, "iso9660", "ro") not in \
             mount_mock.mock_calls
-        )
 
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.kernel_arguments")
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.is_valid_install_disk")
@@ -262,7 +254,7 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
         unmount_mock.assert_not_called()
 
         # Test device name returned
-        self.assertEqual(result, "test1")
+        assert result == "test1"
 
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.kernel_arguments")
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.is_valid_install_disk")
@@ -293,13 +285,13 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
         self.assert_resolve_and_mount_calls(device_tree, mount_mock, 1, 1)
 
         # Only first was mounted
-        self.assertEqual(valid_mock.call_count, 1)
+        assert valid_mock.call_count == 1
 
         #  First device was used no unmount should be called
         unmount_mock.assert_not_called()
 
         # Test device name returned
-        self.assertEqual(result, "test0")
+        assert result == "test0"
 
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.kernel_arguments")
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.is_valid_install_disk")
@@ -333,13 +325,13 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
         self.assert_resolve_and_mount_calls(device_tree, mount_mock, 1, 1)
 
         # Only first was mounted
-        self.assertEqual(valid_mock.call_count, 1)
+        assert valid_mock.call_count == 1
 
         #  First device was used no unmount should be called
         unmount_mock.assert_not_called()
 
         # Test device name returned
-        self.assertEqual(result, "test0")
+        assert result == "test0"
 
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.kernel_arguments")
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.is_valid_install_disk")
@@ -372,13 +364,13 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
         self.assert_resolve_and_mount_calls(device_tree, mount_mock, 1, 1)
 
         # Only first was mounted
-        self.assertEqual(valid_mock.call_count, 1)
+        assert valid_mock.call_count == 1
 
         #  First device was used no unmount should be called
         unmount_mock.assert_not_called()
 
         # Test device name returned
-        self.assertEqual(result, "test0")
+        assert result == "test0"
 
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.kernel_arguments")
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.is_valid_install_disk")
@@ -412,13 +404,13 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
         self.assert_resolve_and_mount_calls(device_tree, mount_mock, 1, 1)
 
         # Only first was mounted
-        self.assertEqual(valid_mock.call_count, 1)
+        assert valid_mock.call_count == 1
 
         #  First device was used no unmount should be called
         unmount_mock.assert_not_called()
 
         # Test device name returned
-        self.assertEqual(result, "test0")
+        assert result == "test0"
 
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.kernel_arguments")
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.is_valid_install_disk")
@@ -453,7 +445,7 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
         self.assert_resolve_and_mount_calls(device_tree, mount_mock, 3, 1)
 
         # Only 2 & 3 were mounted
-        self.assertEqual(valid_mock.call_count, 2)
+        assert valid_mock.call_count == 2
         # It makes no sense to check how validation was called because all mounting is to the same
         # path.
 
@@ -461,7 +453,7 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
         unmount_mock.assert_called_once_with(self.mount_location)
 
         # Test device name returned
-        self.assertEqual(result, "test2")
+        assert result == "test2"
 
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.kernel_arguments")
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.is_valid_install_disk")
@@ -484,7 +476,7 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
         mount_mock.side_effect = PayloadSetupError("Mocked failure")
         valid_mock.return_value = True
 
-        with self.assertRaises(SourceSetupError) as cm:
+        with pytest.raises(SourceSetupError) as cm:
             task = SetUpCdromSourceTask(self.mount_location)
             task.run()
 
@@ -494,7 +486,7 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
         valid_mock.assert_not_called()
         unmount_mock.assert_not_called()
         # exception happened due to no disk
-        self.assertEqual(str(cm.exception), "Found no CD-ROM")
+        assert str(cm.value) == "Found no CD-ROM"
 
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.kernel_arguments")
     @patch("pyanaconda.modules.payloads.source.cdrom.initialization.is_valid_install_disk")
@@ -516,7 +508,7 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
         proxy_getter.return_value = device_tree
         valid_mock.return_value = False
 
-        with self.assertRaises(SourceSetupError) as cm:
+        with pytest.raises(SourceSetupError) as cm:
             task = SetUpCdromSourceTask(self.mount_location)
             task.run()
 
@@ -526,4 +518,4 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
         valid_mock.assert_called_once()
         unmount_mock.assert_called_once()
         # exception happened due to no disk
-        self.assertEqual(str(cm.exception), "Found no CD-ROM")
+        assert str(cm.value) == "Found no CD-ROM"

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_closest_mirror.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_closest_mirror.py
@@ -34,15 +34,15 @@ class ClosestMirrorSourceInterfaceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test the type of CDN."""
-        self.assertEqual(SOURCE_TYPE_CLOSEST_MIRROR, self.interface.Type)
+        assert SOURCE_TYPE_CLOSEST_MIRROR == self.interface.Type
 
     def test_description(self):
         """Test the description of CDN."""
-        self.assertEqual("Closest mirror", self.interface.Description)
+        assert "Closest mirror" == self.interface.Description
 
     def test_required_space(self):
         """Test the required_space property."""
-        self.assertEqual(self.module.required_space, 0)
+        assert self.module.required_space == 0
 
     def test_repr(self):
-        self.assertEqual(repr(self.module), "Source(type='CLOSEST_MIRROR')")
+        assert repr(self.module) == "Source(type='CLOSEST_MIRROR')"

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_factory.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_factory.py
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import pytest
+
 from unittest.case import TestCase
 
 from pyanaconda.modules.payloads.constants import SourceType
@@ -30,11 +32,11 @@ class SourceFactoryTestCase(TestCase):
         """Test SourceFactory create method."""
         for source_type in SourceType:
             module = SourceFactory.create_source(source_type)
-            self.assertIsInstance(module, PayloadSourceBase)
-            self.assertIsInstance(module.for_publication(), PayloadSourceBaseInterface)
-            self.assertEqual(module.type, source_type)
+            assert isinstance(module, PayloadSourceBase)
+            assert isinstance(module.for_publication(), PayloadSourceBaseInterface)
+            assert module.type == source_type
 
     def test_failed_create_source(self):
         """Test failed create method of the source factory."""
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             SourceFactory.create_source("INVALID")

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_flatpak.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_flatpak.py
@@ -37,7 +37,6 @@ class FlatpakSourceInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             PAYLOAD_SOURCE_RPM_OSTREE,
             self.interface,
             *args, **kwargs

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_flatpak.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_flatpak.py
@@ -45,15 +45,15 @@ class FlatpakSourceInterfaceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test the Type property."""
-        self.assertEqual(self.interface.Type, SOURCE_TYPE_FLATPAK)
+        assert self.interface.Type == SOURCE_TYPE_FLATPAK
 
     def test_description(self):
         """Test the Description property."""
-        self.assertEqual(self.interface.Description, "Flatpak")
+        assert self.interface.Description == "Flatpak"
 
     def test_is_available(self):
         """Test the IsAvailable method."""
-        self.assertEqual(self.interface.IsAvailable(), False)
+        assert self.interface.IsAvailable() == False
 
 
 class FlatpakSourceTestCase(unittest.TestCase):
@@ -64,18 +64,18 @@ class FlatpakSourceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test the type property."""
-        self.assertEqual(self.module.type, SourceType.FLATPAK)
+        assert self.module.type == SourceType.FLATPAK
 
     def test_network_required(self):
         """Test the network_required property."""
-        self.assertEqual(self.module.network_required, False)
+        assert self.module.network_required == False
 
     def test_required_space(self):
         """Test the required_space property."""
-        self.assertEqual(self.module.required_space, 0)
+        assert self.module.required_space == 0
 
         self.module._set_required_space(1024)
-        self.assertEqual(self.module.required_space, 1024)
+        assert self.module.required_space == 1024
 
     @patch("pyanaconda.modules.payloads.source.flatpak.flatpak.GetFlatpaksSizeTask.run")
     def test_set_required_space_with_task(self, run_mock):
@@ -85,26 +85,26 @@ class FlatpakSourceTestCase(unittest.TestCase):
         for task in self.module.set_up_with_tasks():
             task.run_with_signals()
 
-        self.assertEqual(self.module.required_space, 1024)
+        assert self.module.required_space == 1024
 
     def test_get_state(self):
         """Test the source state."""
-        self.assertEqual(self.module.get_state(), SourceState.NOT_APPLICABLE)
+        assert self.module.get_state() == SourceState.NOT_APPLICABLE
 
     def test_set_up_with_tasks(self):
         """Test the set-up tasks."""
         tasks = self.module.set_up_with_tasks()
 
-        self.assertEqual(len(tasks), 1)
-        self.assertIsInstance(tasks[0], GetFlatpaksSizeTask)
+        assert len(tasks) == 1
+        assert isinstance(tasks[0], GetFlatpaksSizeTask)
 
     def test_tear_down_with_tasks(self):
         """Test the tear-down tasks."""
-        self.assertEqual(self.module.tear_down_with_tasks(), [])
+        assert self.module.tear_down_with_tasks() == []
 
     def test_repr(self):
         """Test the string representation."""
-        self.assertEqual(repr(self.module), "Source(type='FLATPAK')")
+        assert repr(self.module) == "Source(type='FLATPAK')"
 
 
 class GetFlatpaksSizeTaskTest(unittest.TestCase):
@@ -118,8 +118,8 @@ class GetFlatpaksSizeTaskTest(unittest.TestCase):
         with TemporaryDirectory() as temp:
             task = GetFlatpaksSizeTask(temp)
             result = task.run()
-            self.assertIsInstance(result, int)
-            self.assertEqual(result, 123456789)
+            assert isinstance(result, int)
+            assert result == 123456789
 
         fm_instance.initialize_with_path.assert_called_once_with("/var/tmp/anaconda-flatpak-temp")
         fm_instance.get_required_size.assert_called_once()

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_harddrive.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_harddrive.py
@@ -16,6 +16,7 @@
 # Red Hat, Inc.
 #
 import unittest
+import pytest
 
 from pyanaconda.core.constants import SOURCE_TYPE_HDD
 from unittest.mock import patch, Mock
@@ -67,18 +68,18 @@ class HardDriveSourceInterfaceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Hard drive source has a correct type specified."""
-        self.assertEqual(SOURCE_TYPE_HDD, self.interface.Type)
+        assert SOURCE_TYPE_HDD == self.interface.Type
 
     def test_description(self):
         """Hard drive source description."""
         self.interface.SetPartition("device")
         self.interface.SetDirectory("/directory")
-        self.assertEqual("device:/directory", self.interface.Description)
+        assert "device:/directory" == self.interface.Description
 
     def test_empty_properties(self):
         """Hard drive source properties are empty when not set."""
-        self.assertEqual(self.interface.Partition, "")
-        self.assertEqual(self.interface.Directory, "")
+        assert self.interface.Partition == ""
+        assert self.interface.Directory == ""
 
     def test_setting_properties(self):
         """Hard drive source properties are correctly set."""
@@ -87,15 +88,15 @@ class HardDriveSourceInterfaceTestCase(unittest.TestCase):
 
     def test_iso_path(self):
         """Hard drive source has a correct iso path."""
-        self.assertEqual(self.interface.GetIsoPath(), "")
+        assert self.interface.GetIsoPath() == ""
 
         self.module._iso_name = "GLaDOS.iso"
         self.interface.SetDirectory("/super/secret/base")
-        self.assertEqual(self.interface.GetIsoPath(), "/super/secret/base/GLaDOS.iso")
+        assert self.interface.GetIsoPath() == "/super/secret/base/GLaDOS.iso"
 
         self.module._iso_name = ""
         self.interface.SetDirectory("/path/to/install/tree")
-        self.assertEqual(self.interface.GetIsoPath(), "")
+        assert self.interface.GetIsoPath() == ""
 
 
 class HardDriveSourceTestCase(unittest.TestCase):
@@ -105,11 +106,11 @@ class HardDriveSourceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Hard drive source module has a correct type."""
-        self.assertEqual(SourceType.HDD, self.module.type)
+        assert SourceType.HDD == self.module.type
 
     def test_network_required(self):
         """Test the property network_required."""
-        self.assertEqual(self.module.network_required, False)
+        assert self.module.network_required == False
 
     def test_set_up_with_tasks(self):
         """Hard drive source set up task type and amount."""
@@ -122,17 +123,17 @@ class HardDriveSourceTestCase(unittest.TestCase):
 
         # Check the number of the tasks
         task_number = len(task_classes)
-        self.assertEqual(task_number, len(tasks))
+        assert task_number == len(tasks)
 
         for i in range(task_number):
-            self.assertIsInstance(tasks[i], task_classes[i])
+            assert isinstance(tasks[i], task_classes[i])
 
     @patch("os.path.ismount")
     def test_ready_state(self, ismount):
         """Hard drive source ready state for set up."""
         ismount.return_value = False
 
-        self.assertEqual(self.module.get_state(), SourceState.UNREADY)
+        assert self.module.get_state() == SourceState.UNREADY
         ismount.assert_called_once_with(self.module._device_mount)
 
         ismount.reset_mock()
@@ -142,7 +143,7 @@ class HardDriveSourceTestCase(unittest.TestCase):
         task.get_result = Mock(return_value=SetupHardDriveResult("/my/path", ""))
         task.succeeded_signal.emit()
 
-        self.assertEqual(self.module.get_state(), SourceState.READY)
+        assert self.module.get_state() == SourceState.READY
         ismount.assert_called_once_with(self.module._device_mount)
 
     def test_return_handler(self):
@@ -153,8 +154,8 @@ class HardDriveSourceTestCase(unittest.TestCase):
         )
         task.succeeded_signal.emit()
 
-        self.assertEqual(self.module.install_tree_path, iso_mount_location)
-        self.assertEqual(self.module._iso_name, "iso_name.iso")
+        assert self.module.install_tree_path == iso_mount_location
+        assert self.module._iso_name == "iso_name.iso"
 
     def test_return_handler_without_iso(self):
         """Hard drive source setup result propagates back when no ISO is involved.
@@ -167,17 +168,15 @@ class HardDriveSourceTestCase(unittest.TestCase):
         )
         task.succeeded_signal.emit()
 
-        self.assertEqual(self.module.install_tree_path, iso_mount_location)
-        self.assertEqual(self.module._iso_name, "")
+        assert self.module.install_tree_path == iso_mount_location
+        assert self.module._iso_name == ""
 
     def test_repr(self):
         self.module.set_device("device")
         self.module.set_directory("directory")
         self.module._install_tree_path = "install-tree-path"
-        self.assertEqual(
-            repr(self.module),
+        assert repr(self.module) == \
             "Source(type='HDD', partition='device', directory='directory')"
-        )
 
 
 class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
@@ -185,7 +184,7 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
     def test_setup_install_source_task_name(self):
         """Hard drive source setup task name."""
         task = _create_setup_task()
-        self.assertEqual(task.name, "Set up Hard drive installation source")
+        assert task.name == "Set up Hard drive installation source"
 
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
            return_value=True)
@@ -205,7 +204,7 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
         find_and_mount_iso_image_mock.assert_called_once_with(
             device_mount_location + path_on_device, iso_mount_location
         )
-        self.assertEqual(result, SetupHardDriveResult(iso_mount_location, "skynet.iso"))
+        assert result == SetupHardDriveResult(iso_mount_location, "skynet.iso")
 
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
            return_value=True)
@@ -231,7 +230,7 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
         verify_valid_repository_mock.assert_called_once_with(
             device_mount_location + path_on_device
         )
-        self.assertEqual(result, SetupHardDriveResult(device_mount_location + path_on_device, ""))
+        assert result == SetupHardDriveResult(device_mount_location + path_on_device, "")
 
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
            return_value=True)
@@ -247,7 +246,7 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
                                       find_and_mount_device_mock):
         """Hard drive source setup failure to find anything."""
         task = _create_setup_task()
-        with self.assertRaises(SourceSetupError) as cm:
+        with pytest.raises(SourceSetupError) as cm:
             task.run()
 
         find_and_mount_device_mock.assert_called_once_with(
@@ -263,38 +262,38 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
         unmount_mock.assert_called_once_with(
             device_mount_location
         )
-        self.assertTrue(str(cm.exception).startswith(
+        assert str(cm.value).startswith(
             "Nothing useful found for Hard drive ISO source"
-        ))
+        )
 
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
            return_value=False)
     def test_failure_to_find_mount_device(self, find_and_mount_device_mock):
         """Hard drive source setup failure to find partition device."""
         task = _create_setup_task()
-        with self.assertRaises(SourceSetupError) as cm:
+        with pytest.raises(SourceSetupError) as cm:
             task.run()
 
         find_and_mount_device_mock.assert_called_once_with(
             device_spec,
             device_mount_location
         )
-        self.assertTrue(str(cm.exception).startswith(
+        assert str(cm.value).startswith(
             "Could not mount device specified as"
-        ))
+        )
 
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.os.path.ismount",
            return_value=True)
     def test_failure_mount_already_used(self, ismount_mock):
         """Hard drive source setup failure to mount partition device."""
         task = _create_setup_task()
-        with self.assertRaises(SourceSetupError) as cm:
+        with pytest.raises(SourceSetupError) as cm:
             task.run()
 
         ismount_mock.assert_called_once()  # must die on first check
-        self.assertTrue(str(cm.exception).startswith(
+        assert str(cm.value).startswith(
             "The mount point"
-        ))
+        )
 
 
 class HardDriveSourceTearDownTestCase(unittest.TestCase):
@@ -304,14 +303,14 @@ class HardDriveSourceTearDownTestCase(unittest.TestCase):
 
     def test_required_space(self):
         """Test the required_space property."""
-        self.assertEqual(self.source_module.required_space, 0)
+        assert self.source_module.required_space == 0
 
     def test_tear_down_task_order(self):
         """Hard drive source tear down task order."""
         tasks = self.source_module.tear_down_with_tasks()
-        self.assertEqual(len(tasks), 2)
-        self.assertIsInstance(tasks[0], TearDownMountTask)
-        self.assertIsInstance(tasks[1], TearDownMountTask)
+        assert len(tasks) == 2
+        assert isinstance(tasks[0], TearDownMountTask)
+        assert isinstance(tasks[1], TearDownMountTask)
         name_suffixes = ["-iso", "-device"]
         for task, fragment in zip(tasks, name_suffixes):
-            self.assertTrue(task._target_mount.endswith(fragment))
+            assert task._target_mount.endswith(fragment)

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_harddrive.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_harddrive.py
@@ -60,7 +60,6 @@ class HardDriveSourceInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             PAYLOAD_SOURCE_HARDDRIVE,
             self.interface,
             *args, **kwargs

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_hmc.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_hmc.py
@@ -18,6 +18,7 @@
 #
 import tempfile
 import unittest
+import pytest
 
 from unittest.mock import patch, call
 
@@ -39,11 +40,11 @@ class HMCSourceInterfaceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test the type of SE/HMC."""
-        self.assertEqual(SOURCE_TYPE_HMC, self.interface.Type)
+        assert SOURCE_TYPE_HMC == self.interface.Type
 
     def test_description(self):
         """Test the description of SE/HMC."""
-        self.assertEqual("Local media via SE/HMC", self.interface.Description)
+        assert "Local media via SE/HMC" == self.interface.Description
 
 
 class HMCSourceModuleTestCase(unittest.TestCase):
@@ -54,44 +55,44 @@ class HMCSourceModuleTestCase(unittest.TestCase):
 
     def test_network_required(self):
         """Test the property network_required."""
-        self.assertEqual(self.module.network_required, False)
+        assert self.module.network_required == False
 
     def test_required_space(self):
         """Test the required_space property."""
-        self.assertEqual(self.module.required_space, 0)
+        assert self.module.required_space == 0
 
     @patch("os.path.ismount")
     def test_get_state(self, ismount_mock):
         """Test SE/HMC source state."""
         ismount_mock.return_value = False
-        self.assertEqual(SourceState.UNREADY, self.module.get_state())
+        assert SourceState.UNREADY == self.module.get_state()
 
         ismount_mock.reset_mock()
         ismount_mock.return_value = True
 
-        self.assertEqual(SourceState.READY, self.module.get_state())
+        assert SourceState.READY == self.module.get_state()
 
         ismount_mock.assert_called_once_with(self.module.mount_point)
 
     def test_set_up_with_tasks(self):
         """Get tasks to set up SE/HMC."""
         tasks = self.module.set_up_with_tasks()
-        self.assertEqual(len(tasks), 1)
+        assert len(tasks) == 1
 
         task = tasks[0]
-        self.assertIsInstance(task, SetUpHMCSourceTask)
-        self.assertEqual(task._target_mount, self.module.mount_point)
+        assert isinstance(task, SetUpHMCSourceTask)
+        assert task._target_mount == self.module.mount_point
 
     def test_tear_down_with_tasks(self):
         """Get tasks to tear down SE/HMC."""
         tasks = self.module.tear_down_with_tasks()
-        self.assertEqual(len(tasks), 1)
+        assert len(tasks) == 1
 
         task = tasks[0]
-        self.assertIsInstance(task, TearDownMountTask)
+        assert isinstance(task, TearDownMountTask)
 
     def test_repr(self):
-        self.assertEqual(repr(self.module), "Source(type='HMC')")
+        assert repr(self.module) == "Source(type='HMC')"
 
 
 class HMCSourceTasksTestCase(unittest.TestCase):
@@ -104,11 +105,11 @@ class HMCSourceTasksTestCase(unittest.TestCase):
             task = SetUpHMCSourceTask(d)
 
             execute.side_effect = [1, 1]
-            with self.assertRaises(SourceSetupError):
+            with pytest.raises(SourceSetupError):
                 task.run()
 
             execute.side_effect = [0, 1]
-            with self.assertRaises(SourceSetupError):
+            with pytest.raises(SourceSetupError):
                 task.run()
 
             execute.reset_mock()

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_image.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_image.py
@@ -17,6 +17,8 @@
 #
 import tempfile
 import unittest
+import pytest
+
 from unittest.mock import patch, Mock
 
 from dasbus.typing import get_variant, Str, Bool
@@ -54,11 +56,11 @@ class LiveImageSourceInterfaceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test the Type property."""
-        self.assertEqual(SOURCE_TYPE_LIVE_IMAGE, self.interface.Type)
+        assert SOURCE_TYPE_LIVE_IMAGE == self.interface.Type
 
     def test_description(self):
         """Test the Description property."""
-        self.assertEqual("Live image", self.interface.Description)
+        assert "Live image" == self.interface.Description
 
     def test_configuration(self):
         """Test the configuration property."""
@@ -83,51 +85,51 @@ class LiveImageSourceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test the type property."""
-        self.assertEqual(SourceType.LIVE_IMAGE, self.module.type)
+        assert SourceType.LIVE_IMAGE == self.module.type
 
     def test_network_required(self):
         """Test the network_required property."""
-        self.assertEqual(self.module.network_required, False)
+        assert self.module.network_required == False
 
         self.module.configuration.url = "file://my/path"
-        self.assertEqual(self.module.network_required, False)
+        assert self.module.network_required == False
 
         self.module.configuration.url = "http://my/path"
-        self.assertEqual(self.module.network_required, True)
+        assert self.module.network_required == True
 
         self.module.configuration.url = "https://my/path"
-        self.assertEqual(self.module.network_required, True)
+        assert self.module.network_required == True
 
     def test_is_local(self):
         """Test the is_local property."""
         self.module.configuration.url = "file://my/path"
-        self.assertEqual(self.module.is_local, True)
+        assert self.module.is_local == True
 
         self.module.configuration.url = "http://my/path"
-        self.assertEqual(self.module.is_local, False)
+        assert self.module.is_local == False
 
     def test_get_state(self):
         """Test the source state."""
-        self.assertEqual(SourceState.NOT_APPLICABLE, self.module.get_state())
+        assert SourceState.NOT_APPLICABLE == self.module.get_state()
 
     def test_required_space(self):
         """Test the required_space property."""
-        self.assertEqual(self.module.required_space, 1024 * 1024 * 1024)
+        assert self.module.required_space == 1024 * 1024 * 1024
 
         self.module._required_space = 12345
-        self.assertEqual(self.module.required_space, 12345)
+        assert self.module.required_space == 12345
 
     def test_set_up_with_tasks(self):
         """Test the set-up tasks."""
         self.module.configuration.url = "file://my/path"
         tasks = self.module.set_up_with_tasks()
-        self.assertEqual(len(tasks), 1)
-        self.assertIsInstance(tasks[0], SetUpLocalImageSourceTask)
+        assert len(tasks) == 1
+        assert isinstance(tasks[0], SetUpLocalImageSourceTask)
 
         self.module.configuration.url = "http://my/path"
         tasks = self.module.set_up_with_tasks()
-        self.assertEqual(len(tasks), 1)
-        self.assertIsInstance(tasks[0], SetUpRemoteImageSourceTask)
+        assert len(tasks) == 1
+        assert isinstance(tasks[0], SetUpRemoteImageSourceTask)
 
     @patch.object(SetUpLocalImageSourceTask, "run")
     def test_handle_setup_task_result(self, runner):
@@ -140,21 +142,21 @@ class LiveImageSourceTestCase(unittest.TestCase):
             task.run_with_signals()
 
         runner.assert_called_once_with()
-        self.assertEqual(self.module.required_space, 12345)
+        assert self.module.required_space == 12345
 
     def test_tear_down_with_tasks(self):
         """Test the tear-down tasks."""
-        self.assertEqual(self.module.tear_down_with_tasks(), [])
+        assert self.module.tear_down_with_tasks() == []
 
     def test_repr(self):
         """Test the string representation."""
         self.module.configuration.url = "file://my/path"
-        self.assertEqual(repr(self.module), str(
+        assert repr(self.module) == str(
             "Source("
             "type='LIVE_IMAGE', "
             "url='file://my/path'"
             ")"
-        ))
+        )
 
 
 class SetUpLocalImageSourceTaskTestCase(unittest.TestCase):
@@ -166,10 +168,10 @@ class SetUpLocalImageSourceTaskTestCase(unittest.TestCase):
         configuration.url = "file:///my/invalid/path"
 
         task = SetUpLocalImageSourceTask(configuration)
-        with self.assertRaises(SourceSetupError) as cm:
+        with pytest.raises(SourceSetupError) as cm:
             task.run()
 
-        self.assertEqual(str(cm.exception), "File /my/invalid/path does not exist.")
+        assert str(cm.value) == "File /my/invalid/path does not exist."
 
     @patch("os.stat")
     def test_empty_image(self, os_stat):
@@ -185,8 +187,8 @@ class SetUpLocalImageSourceTaskTestCase(unittest.TestCase):
             result = task.run()
 
             # Check the result.
-            self.assertIsInstance(result, SetupImageResult)
-            self.assertEqual(result, SetupImageResult(None))
+            assert isinstance(result, SetupImageResult)
+            assert result == SetupImageResult(None)
 
     @patch("os.stat")
     def test_fake_image(self, os_stat):
@@ -206,8 +208,8 @@ class SetUpLocalImageSourceTaskTestCase(unittest.TestCase):
             result = task.run()
 
             # Check the result.
-            self.assertIsInstance(result, SetupImageResult)
-            self.assertEqual(result, SetupImageResult(3072))
+            assert isinstance(result, SetupImageResult)
+            assert result == SetupImageResult(3072)
 
 
 class SetUpRemoteImageSourceTaskTestCase(unittest.TestCase):
@@ -225,11 +227,11 @@ class SetUpRemoteImageSourceTaskTestCase(unittest.TestCase):
         configuration.url = "http://my/fake/path"
 
         task = SetUpRemoteImageSourceTask(configuration)
-        with self.assertRaises(SourceSetupError) as cm:
+        with pytest.raises(SourceSetupError) as cm:
             task.run()
 
         # Check the exception.
-        self.assertEqual(str(cm.exception), "Error while handling a request: Fake!")
+        assert str(cm.value) == "Error while handling a request: Fake!"
 
     @patch("pyanaconda.modules.payloads.source.live_image.initialization.requests_session")
     def test_invalid_response(self, session_getter):
@@ -244,11 +246,11 @@ class SetUpRemoteImageSourceTaskTestCase(unittest.TestCase):
         configuration.url = "http://my/fake/path"
 
         task = SetUpRemoteImageSourceTask(configuration)
-        with self.assertRaises(SourceSetupError) as cm:
+        with pytest.raises(SourceSetupError) as cm:
             task.run()
 
         # Check the exception.
-        self.assertEqual(str(cm.exception), "The request has failed: 303")
+        assert str(cm.value) == "The request has failed: 303"
 
     @patch("pyanaconda.modules.payloads.source.live_image.initialization.requests_session")
     def test_missing_size(self, session_getter):
@@ -268,8 +270,8 @@ class SetUpRemoteImageSourceTaskTestCase(unittest.TestCase):
         result = task.run()
 
         # Check the result.
-        self.assertIsInstance(result, SetupImageResult)
-        self.assertEqual(result, SetupImageResult(None))
+        assert isinstance(result, SetupImageResult)
+        assert result == SetupImageResult(None)
 
     @patch("pyanaconda.modules.payloads.source.live_image.initialization.requests_session")
     def test_fake_request(self, session_getter):
@@ -289,5 +291,5 @@ class SetUpRemoteImageSourceTaskTestCase(unittest.TestCase):
         result = task.run()
 
         # Check the result.
-        self.assertIsInstance(result, SetupImageResult)
-        self.assertEqual(result, SetupImageResult(4000))
+        assert isinstance(result, SetupImageResult)
+        assert result == SetupImageResult(4000)

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_image.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_image.py
@@ -48,7 +48,6 @@ class LiveImageSourceInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             PAYLOAD_SOURCE_LIVE_IMAGE,
             self.interface,
             *args, **kwargs

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_os.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_os.py
@@ -18,6 +18,7 @@
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 #
 import unittest
+import pytest
 
 from unittest.mock import Mock, patch
 
@@ -45,20 +46,20 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test Live OS source has a correct type specified."""
-        self.assertEqual(SOURCE_TYPE_LIVE_OS_IMAGE, self.interface.Type)
+        assert SOURCE_TYPE_LIVE_OS_IMAGE == self.interface.Type
 
     def test_description(self):
         """Test NFS source description."""
-        self.assertEqual("Live OS", self.interface.Description)
+        assert "Live OS" == self.interface.Description
 
     def test_image_path_empty_properties(self):
         """Test Live OS payload image path property when not set."""
-        self.assertEqual(self.interface.ImagePath, "")
+        assert self.interface.ImagePath == ""
 
     def test_image_path_properties(self):
         """Test Live OS payload image path property is correctly set."""
         self.interface.SetImagePath("/my/supper/image/path")
-        self.assertEqual(self.interface.ImagePath, "/my/supper/image/path")
+        assert self.interface.ImagePath == "/my/supper/image/path"
         self.callback.assert_called_once_with(
             PAYLOAD_SOURCE_LIVE_OS.interface_name, {"ImagePath": "/my/supper/image/path"}, [])
 
@@ -74,7 +75,7 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
         stat_mock.S_ISBLK = Mock()
         stat_mock.S_ISBLK.return_value = False
 
-        self.assertEqual(self.interface.DetectLiveOSImage(), "")
+        assert self.interface.DetectLiveOSImage() == ""
 
     @patch("pyanaconda.modules.payloads.source.live_os.live_os.os.stat")
     def test_detect_live_os_image_failed_nothing_found(self, os_stat_mock):
@@ -83,7 +84,7 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
         # otherwise we will skip the whole sequence
         os_stat_mock.side_effect = FileNotFoundError()
 
-        self.assertEqual(self.interface.DetectLiveOSImage(), "")
+        assert self.interface.DetectLiveOSImage() == ""
 
     @patch("pyanaconda.modules.payloads.source.live_os.live_os.stat")
     @patch("pyanaconda.modules.payloads.source.live_os.live_os.os.stat")
@@ -96,7 +97,7 @@ class LiveOSSourceInterfaceTestCase(unittest.TestCase):
         detected_image = self.interface.DetectLiveOSImage()
         stat_mock.S_ISBLK.assert_called_once()
 
-        self.assertEqual(detected_image, "/dev/mapper/live-base")
+        assert detected_image == "/dev/mapper/live-base"
 
 
 class LiveOSSourceTestCase(unittest.TestCase):
@@ -106,22 +107,22 @@ class LiveOSSourceTestCase(unittest.TestCase):
 
     def test_network_required(self):
         """Test the property network_required."""
-        self.assertEqual(self.module.network_required, False)
+        assert self.module.network_required == False
 
     def test_required_space(self):
         """Test the required_space property."""
-        self.assertEqual(self.module.required_space, 0)
+        assert self.module.required_space == 0
 
     @patch("os.path.ismount")
     def test_get_state(self, ismount_mock):
         """Test LiveOS source state."""
         ismount_mock.return_value = False
-        self.assertEqual(SourceState.UNREADY, self.module.get_state())
+        assert SourceState.UNREADY == self.module.get_state()
 
         ismount_mock.reset_mock()
         ismount_mock.return_value = True
 
-        self.assertEqual(SourceState.READY, self.module.get_state())
+        assert SourceState.READY == self.module.get_state()
 
         ismount_mock.assert_called_once_with(self.module.mount_point)
 
@@ -136,10 +137,10 @@ class LiveOSSourceTestCase(unittest.TestCase):
 
         # Check the number of the tasks
         task_number = len(task_classes)
-        self.assertEqual(task_number, len(tasks))
+        assert task_number == len(tasks)
 
         for i in range(task_number):
-            self.assertIsInstance(tasks[i], task_classes[i])
+            assert isinstance(tasks[i], task_classes[i])
 
     def test_tear_down_with_tasks(self):
         """Test Live OS Source ready state for tear down."""
@@ -152,14 +153,14 @@ class LiveOSSourceTestCase(unittest.TestCase):
 
         # check the number of tasks
         task_number = len(task_classes)
-        self.assertEqual(task_number, len(tasks))
+        assert task_number == len(tasks)
 
         for i in range(task_number):
-            self.assertIsInstance(tasks[i], task_classes[i])
+            assert isinstance(tasks[i], task_classes[i])
 
     def test_repr(self):
         self.module.set_image_path("/some/path")
-        self.assertEqual(repr(self.module), "Source(type='LIVE_OS_IMAGE', image='/some/path')")
+        assert repr(self.module) == "Source(type='LIVE_OS_IMAGE', image='/some/path')"
 
 
 class LiveOSSourceTasksTestCase(unittest.TestCase):
@@ -171,7 +172,7 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
                 "/path/to/mount/source/image"
             )
 
-        self.assertEqual(task.name, "Set up Live OS Installation Source")
+        assert task.name == "Set up Live OS Installation Source"
 
     @patch("pyanaconda.modules.payloads.source.live_os.initialization.mount")
     @patch("pyanaconda.modules.payloads.source.live_os.initialization.stat")
@@ -208,7 +209,7 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
         device_tree.ResolveDevice = Mock()
         device_tree.ResolveDevice.return_value = ""
 
-        with self.assertRaises(SourceSetupError, msg="Failed to find liveOS image!"):
+        with pytest.raises(SourceSetupError):
             SetUpLiveOSSourceTask(
                 "/path/to/base/image",
                 "/path/to/mount/source/image"
@@ -233,8 +234,7 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
         stat_mock.S_ISBLK = Mock()
         stat_mock.S_ISBLK.return_value = False
 
-        with self.assertRaises(SourceSetupError,
-                               msg="/path/to/base/image is not a valid block device"):
+        with pytest.raises(SourceSetupError):
             SetUpLiveOSSourceTask(
                 "/path/to/base/image",
                 "/path/to/mount/source/image"
@@ -259,7 +259,7 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
 
         mount.return_value = -20
 
-        with self.assertRaises(SourceSetupError, msg="Failed to mount the install tree"):
+        with pytest.raises(SourceSetupError):
             SetUpLiveOSSourceTask(
                 "/path/to/base/image",
                 "/path/to/mount/source/image"

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_os.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_os.py
@@ -209,11 +209,13 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
         device_tree.ResolveDevice = Mock()
         device_tree.ResolveDevice.return_value = ""
 
-        with pytest.raises(SourceSetupError):
+        with pytest.raises(SourceSetupError) as cm:
             SetUpLiveOSSourceTask(
                 "/path/to/base/image",
                 "/path/to/mount/source/image"
             ).run()
+
+        assert str(cm.value) == "Failed to find liveOS image!"
 
     @patch("pyanaconda.modules.payloads.source.live_os.initialization.stat")
     @patch("os.stat")
@@ -259,8 +261,10 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
 
         mount.return_value = -20
 
-        with pytest.raises(SourceSetupError):
+        with pytest.raises(SourceSetupError) as cm:
             SetUpLiveOSSourceTask(
                 "/path/to/base/image",
                 "/path/to/mount/source/image"
             ).run()
+
+        assert str(cm.value) == "Failed to mount the install tree"

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_nfs.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_nfs.py
@@ -72,7 +72,6 @@ class NFSSourceInterfaceTestCase(unittest.TestCase):
     def test_url_properties(self):
         """Test NFS source URL property is correctly set."""
         check_dbus_property(
-            self,
             PAYLOAD_SOURCE_NFS,
             self.interface,
             "URL",

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_nfs.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_nfs.py
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 import unittest
+import pytest
+
 from unittest.mock import patch, Mock
 
 from pyanaconda.core.constants import SOURCE_TYPE_NFS
@@ -56,16 +58,16 @@ class NFSSourceInterfaceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test NFS source has a correct type specified."""
-        self.assertEqual(SOURCE_TYPE_NFS, self.interface.Type)
+        assert SOURCE_TYPE_NFS == self.interface.Type
 
     def test_description(self):
         """Test NFS source description."""
         self.interface.SetURL("nfs:server:/path")
-        self.assertEqual("NFS server nfs:server:/path", self.interface.Description)
+        assert "NFS server nfs:server:/path" == self.interface.Description
 
     def test_url_empty_properties(self):
         """Test NFS source URL property when not set."""
-        self.assertEqual(self.interface.URL, "")
+        assert self.interface.URL == ""
 
     def test_url_properties(self):
         """Test NFS source URL property is correctly set."""
@@ -85,21 +87,21 @@ class NFSSourceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test NFS source module has a correct type."""
-        self.assertEqual(SourceType.NFS, self.module.type)
+        assert SourceType.NFS == self.module.type
 
     def test_network_required(self):
         """Test the property network_required."""
-        self.assertEqual(self.module.network_required, True)
+        assert self.module.network_required == True
 
     def test_required_space(self):
         """Test the required_space property."""
-        self.assertEqual(self.module.required_space, 0)
+        assert self.module.required_space == 0
 
     @patch("os.path.ismount")
     def test_get_state(self, ismount_mock):
         """Test NFS source state."""
         ismount_mock.return_value = False
-        self.assertEqual(SourceState.UNREADY, self.module.get_state())
+        assert SourceState.UNREADY == self.module.get_state()
 
         ismount_mock.reset_mock()
         ismount_mock.return_value = True
@@ -107,7 +109,7 @@ class NFSSourceTestCase(unittest.TestCase):
         task = self.module.set_up_with_tasks()[0]
         task.get_result = Mock(return_value="/my/path")
         task.succeeded_signal.emit()
-        self.assertEqual(SourceState.READY, self.module.get_state())
+        assert SourceState.READY == self.module.get_state()
 
         ismount_mock.assert_called_once_with(self.module._device_mount)
 
@@ -122,10 +124,10 @@ class NFSSourceTestCase(unittest.TestCase):
 
         # Check the number of the tasks
         task_number = len(task_classes)
-        self.assertEqual(task_number, len(tasks))
+        assert task_number == len(tasks)
 
         for i in range(task_number):
-            self.assertIsInstance(tasks[i], task_classes[i])
+            assert isinstance(tasks[i], task_classes[i])
 
     def test_tear_down_with_tasks(self):
         """Test NFS Source ready state for tear down."""
@@ -139,22 +141,19 @@ class NFSSourceTestCase(unittest.TestCase):
 
         # check the number of tasks
         task_number = len(task_classes)
-        self.assertEqual(task_number, len(tasks))
+        assert task_number == len(tasks)
 
         for i in range(task_number):
-            self.assertIsInstance(tasks[i], task_classes[i])
+            assert isinstance(tasks[i], task_classes[i])
 
     def test_url_property(self):
         """Test NFS source URL property is correctly set."""
         self.module.set_url(NFS_URL)
-        self.assertEqual(NFS_URL, self.module.url)
+        assert NFS_URL == self.module.url
 
     def test_repr(self):
         self.module.set_url(NFS_URL)
-        self.assertEqual(
-            repr(self.module),
-            "Source(type='NFS', url='nfs:example.com:/some/path')"
-        )
+        assert repr(self.module) == "Source(type='NFS', url='nfs:example.com:/some/path')"
 
 
 class NFSSourceSetupTaskTestCase(unittest.TestCase):
@@ -162,7 +161,7 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
     def test_setup_install_source_task_name(self):
         """Test NFS Source setup installation source task name."""
         task = SetUpNFSSourceTask(DEVICE_MOUNT_LOCATION, ISO_MOUNT_LOCATION, NFS_URL)
-        self.assertEqual(task.name, "Set up NFS installation source")
+        assert task.name == "Set up NFS installation source"
 
     @patch("pyanaconda.modules.payloads.source.nfs.initialization.find_and_mount_iso_image",
            return_value="trojan.iso")
@@ -182,7 +181,7 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
         find_and_mount_iso_image_mock.assert_called_once_with(DEVICE_MOUNT_LOCATION,
                                                               ISO_MOUNT_LOCATION)
 
-        self.assertEqual(result, ISO_MOUNT_LOCATION)
+        assert result == ISO_MOUNT_LOCATION
 
     @patch("pyanaconda.modules.payloads.source.nfs.initialization.find_and_mount_iso_image",
            return_value="trojan.iso")
@@ -202,7 +201,7 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
         find_and_mount_iso_image_mock.assert_called_once_with(DEVICE_MOUNT_LOCATION + "/super.iso",
                                                               ISO_MOUNT_LOCATION)
 
-        self.assertEqual(result, ISO_MOUNT_LOCATION)
+        assert result == ISO_MOUNT_LOCATION
 
     @patch("pyanaconda.modules.payloads.source.nfs.initialization.verify_valid_repository",
            return_value=True)
@@ -227,7 +226,7 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
 
         verify_valid_repository_mock.assert_called_once_with(DEVICE_MOUNT_LOCATION)
 
-        self.assertEqual(result, DEVICE_MOUNT_LOCATION)
+        assert result == DEVICE_MOUNT_LOCATION
 
     @patch("pyanaconda.modules.payloads.source.nfs.initialization.find_and_mount_iso_image",
            return_value="trojan.iso")
@@ -269,7 +268,7 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
         """Test NFS source setup failure"""
         task = SetUpNFSSourceTask(DEVICE_MOUNT_LOCATION, ISO_MOUNT_LOCATION, NFS_URL)
 
-        with self.assertRaises(SourceSetupError):
+        with pytest.raises(SourceSetupError):
             task.run()
 
         mount_mock.assert_called_once_with(NFS_ADDRESS, DEVICE_MOUNT_LOCATION, fstype="nfs",
@@ -289,7 +288,7 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
         """Test NFS can't find anything to install from"""
         task = SetUpNFSSourceTask(DEVICE_MOUNT_LOCATION, ISO_MOUNT_LOCATION, NFS_URL)
 
-        with self.assertRaises(SourceSetupError):
+        with pytest.raises(SourceSetupError):
             task.run()
 
         mount_mock.assert_called_once_with(NFS_ADDRESS, DEVICE_MOUNT_LOCATION, fstype="nfs",
@@ -309,13 +308,13 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
     def test_failure_mount_already_used(self, ismount_mock):
         """NFS source setup failure to mount partition device."""
         task = _create_setup_task()
-        with self.assertRaises(SourceSetupError) as cm:
+        with pytest.raises(SourceSetupError) as cm:
             task.run()
 
         ismount_mock.assert_called_once()  # must die on first check
-        self.assertTrue(str(cm.exception).startswith(
+        assert str(cm.value).startswith(
             "The mount point"
-        ))
+        )
 
 
 class NFSSourceTearDownTestCase(unittest.TestCase):
@@ -326,9 +325,9 @@ class NFSSourceTearDownTestCase(unittest.TestCase):
     def test_tear_down_task_order(self):
         """NFS source tear down task order."""
         tasks = self.source_module.tear_down_with_tasks()
-        self.assertEqual(len(tasks), 2)
-        self.assertIsInstance(tasks[0], TearDownMountTask)
-        self.assertIsInstance(tasks[1], TearDownMountTask)
+        assert len(tasks) == 2
+        assert isinstance(tasks[0], TearDownMountTask)
+        assert isinstance(tasks[1], TearDownMountTask)
         name_suffixes = ["-iso", "-device"]
         for task, fragment in zip(tasks, name_suffixes):
-            self.assertTrue(task._target_mount.endswith(fragment))
+            assert task._target_mount.endswith(fragment)

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_repo_files.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_repo_files.py
@@ -16,9 +16,10 @@
 # Red Hat, Inc.
 #
 import os
-from tempfile import TemporaryDirectory
-
 import unittest
+import pytest
+
+from tempfile import TemporaryDirectory
 
 from pyanaconda.core.constants import SOURCE_TYPE_REPO_FILES
 from pyanaconda.modules.common.errors.payload import SourceSetupError
@@ -38,11 +39,11 @@ class RepoFilesSourceInterfaceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test Repo files source has a correct type specified."""
-        self.assertEqual(SOURCE_TYPE_REPO_FILES, self.interface.Type)
+        assert SOURCE_TYPE_REPO_FILES == self.interface.Type
 
     def test_description(self):
         """Test NFS source description."""
-        self.assertEqual("Local repositories", self.interface.Description)
+        assert "Local repositories" == self.interface.Description
 
 
 class RepoFilesSourceTestCase(unittest.TestCase):
@@ -53,33 +54,33 @@ class RepoFilesSourceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test Repo files source module has a correct type."""
-        self.assertEqual(SourceType.REPO_FILES, self.module.type)
+        assert SourceType.REPO_FILES == self.module.type
 
     def test_network_required(self):
         """Test the property network_required."""
-        self.assertEqual(self.module.network_required, True)
+        assert self.module.network_required == True
 
     def test_required_space(self):
         """Test the required_space property."""
-        self.assertEqual(self.module.required_space, 0)
+        assert self.module.required_space == 0
 
     def test_repr(self):
-        self.assertEqual(repr(self.module), "Source(type='REPO_FILES')")
+        assert repr(self.module) == "Source(type='REPO_FILES')"
 
     def test_set_up_with_tasks(self):
         """Test Repo files Source set up call."""
         tasks = self.module.set_up_with_tasks()
-        self.assertEqual(len(tasks), 1)
-        self.assertIsInstance(tasks[0], SetUpRepoFilesSourceTask)
+        assert len(tasks) == 1
+        assert isinstance(tasks[0], SetUpRepoFilesSourceTask)
 
     def test_tear_down_with_tasks(self):
         """Test Repo files Source ready state for tear down."""
         tasks = self.module.tear_down_with_tasks()
-        self.assertEqual([], tasks)
+        assert [] == tasks
 
     def test_ready_state(self):
         """Test Repo files Source ready state for set up."""
-        self.assertTrue(self.module.get_state())
+        assert self.module.get_state()
 
 
 class RepoFilesSourceSetupTaskTestCase(unittest.TestCase):
@@ -87,7 +88,7 @@ class RepoFilesSourceSetupTaskTestCase(unittest.TestCase):
     def test_setup_install_source_task_name(self):
         """Test Repo files Source setup installation source task name."""
         task = SetUpRepoFilesSourceTask([""])
-        self.assertEqual(task.name, "Set up Repo files Installation Source")
+        assert task.name == "Set up Repo files Installation Source"
 
     def test_setup_install_source_task_success(self):
         with TemporaryDirectory() as temp_dir_name:
@@ -96,5 +97,5 @@ class RepoFilesSourceSetupTaskTestCase(unittest.TestCase):
 
     def test_setup_install_source_task_failure(self):
         with TemporaryDirectory() as temp_dir_name:
-            with self.assertRaises(SourceSetupError, msg="repo files not found"):
+            with pytest.raises(SourceSetupError):
                 SetUpRepoFilesSourceTask([temp_dir_name]).run()

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_repo_files.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_repo_files.py
@@ -97,5 +97,7 @@ class RepoFilesSourceSetupTaskTestCase(unittest.TestCase):
 
     def test_setup_install_source_task_failure(self):
         with TemporaryDirectory() as temp_dir_name:
-            with pytest.raises(SourceSetupError):
+            with pytest.raises(SourceSetupError) as cm:
                 SetUpRepoFilesSourceTask([temp_dir_name]).run()
+
+            assert str(cm.value) == "repo files not found"

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_rpm_ostree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_rpm_ostree.py
@@ -38,7 +38,6 @@ class OSTreeSourceInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             PAYLOAD_SOURCE_RPM_OSTREE,
             self.interface,
             *args, **kwargs

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_rpm_ostree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_rpm_ostree.py
@@ -46,11 +46,11 @@ class OSTreeSourceInterfaceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test the Type property."""
-        self.assertEqual(SOURCE_TYPE_RPM_OSTREE, self.interface.Type)
+        assert SOURCE_TYPE_RPM_OSTREE == self.interface.Type
 
     def test_description(self):
         """Test the Description property."""
-        self.assertEqual("RPM OSTree", self.interface.Description)
+        assert "RPM OSTree" == self.interface.Description
 
     def test_configuration(self):
         """Test the configuration property."""
@@ -76,54 +76,54 @@ class OSTreeSourceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test the type property."""
-        self.assertEqual(SourceType.RPM_OSTREE, self.module.type)
+        assert SourceType.RPM_OSTREE == self.module.type
 
     def test_network_required(self):
         """Test the network_required property."""
-        self.assertEqual(self.module.network_required, False)
+        assert self.module.network_required == False
 
         self.module.configuration.url = "file://my/path"
-        self.assertEqual(self.module.network_required, False)
+        assert self.module.network_required == False
 
         self.module.configuration.url = "http://my/path"
-        self.assertEqual(self.module.network_required, True)
+        assert self.module.network_required == True
 
         self.module.configuration.url = "https://my/path"
-        self.assertEqual(self.module.network_required, True)
+        assert self.module.network_required == True
 
     def test_required_space(self):
         """Test the required_space property."""
-        self.assertEqual(self.module.required_space, 500000000)
+        assert self.module.required_space == 500000000
 
     def test_get_state(self):
         """Test the source state."""
-        self.assertEqual(SourceState.NOT_APPLICABLE, self.module.get_state())
+        assert SourceState.NOT_APPLICABLE == self.module.get_state()
 
     def test_set_up_with_tasks(self):
         """Test the set-up tasks."""
-        self.assertEqual(self.module.set_up_with_tasks(), [])
+        assert self.module.set_up_with_tasks() == []
 
     def test_tear_down_with_tasks(self):
         """Test the tear-down tasks."""
-        self.assertEqual(self.module.tear_down_with_tasks(), [])
+        assert self.module.tear_down_with_tasks() == []
 
     def test_repr(self):
         """Test the string representation."""
-        self.assertEqual(repr(self.module), str(
+        assert repr(self.module) == str(
             "Source("
             "type='RPM_OSTREE', "
             "osname='', "
             "url=''"
             ")"
-        ))
+        )
 
         self.module.configuration.osname = "fedora-atomic"
         self.module.configuration.url = "https://kojipkgs.fedoraproject.org/atomic/repo"
 
-        self.assertEqual(repr(self.module), str(
+        assert repr(self.module) == str(
             "Source("
             "type='RPM_OSTREE', "
             "osname='fedora-atomic', "
             "url='https://kojipkgs.fedoraproject.org/atomic/repo'"
             ")"
-        ))
+        )

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_url.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_url.py
@@ -18,6 +18,7 @@
 # Red Hat Author(s): Jiri Konecny <jkonecny@redhat.com>
 #
 import unittest
+import pytest
 
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
@@ -59,14 +60,14 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
 
     def test_type(self):
         """Test URL source has a correct type specified."""
-        self.assertEqual(SOURCE_TYPE_URL, self.url_source_interface.Type)
+        assert SOURCE_TYPE_URL == self.url_source_interface.Type
 
     def test_description(self):
         """Test URL source description."""
         rc = RepoConfigurationData()
         rc.url = "http://example.com/"
         self.url_source_interface.SetRepoConfiguration(rc.to_structure(rc))
-        self.assertEqual("http://example.com/", self.url_source_module.description)
+        assert "http://example.com/" == self.url_source_module.description
 
     def test_set_name_properties(self):
         data = RepoConfigurationData()
@@ -87,7 +88,7 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
         conf1 = RepoConfigurationData.from_structure(interface1.RepoConfiguration)
         conf2 = RepoConfigurationData.from_structure(interface2.RepoConfiguration)
 
-        self.assertNotEqual(conf1.name, conf2.name)
+        assert conf1.name != conf2.name
 
     def test_set_url_base_source_properties(self):
         data = RepoConfigurationData()
@@ -124,7 +125,7 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
         data.url = "http://test"
         data.type = "DOES-NOT-EXISTS"
 
-        with self.assertRaises(InvalidValueError):
+        with pytest.raises(InvalidValueError):
             self._check_dbus_property(
                 "RepoConfiguration",
                 RepoConfigurationData.to_structure(data)
@@ -133,8 +134,8 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
         # new value shouldn't be set
         old_data = self.url_source_interface.RepoConfiguration
         old_data = RepoConfigurationData.from_structure(old_data)
-        self.assertEqual(old_data.url, "")
-        self.assertEqual(old_data.type, URL_TYPE_BASEURL)
+        assert old_data.url == ""
+        assert old_data.type == URL_TYPE_BASEURL
 
     def test_enable_ssl_verification_properties(self):
         data = RepoConfigurationData()
@@ -171,7 +172,7 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
         repo_conf = RepoConfigurationData.from_structure(repo_data)
         ssl_conf = repo_conf.ssl_configuration
 
-        self.assertTrue(ssl_conf.is_empty())
+        assert ssl_conf.is_empty()
 
     def test_ssl_configuration_is_not_empty_properties(self):
         ssl_conf = SSLConfigurationData()
@@ -189,7 +190,7 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
             self.url_source_interface.RepoConfiguration
         )
 
-        self.assertFalse(repo_data_2.ssl_configuration.is_empty())
+        assert not repo_data_2.ssl_configuration.is_empty()
 
     def test_set_proxy_properties(self):
         data = RepoConfigurationData()
@@ -204,7 +205,7 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
         data = RepoConfigurationData()
         data.proxy = "https:///no/server/hostname"
 
-        with self.assertRaises(InvalidValueError):
+        with pytest.raises(InvalidValueError):
             self._check_dbus_property(
                 "RepoConfiguration",
                 RepoConfigurationData.to_structure(data)
@@ -213,7 +214,7 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
         # new value shouldn't be set
         old_data = self.url_source_interface.RepoConfiguration
         old_data = RepoConfigurationData.from_structure(old_data)
-        self.assertEqual(old_data.proxy, "")
+        assert old_data.proxy == ""
 
     def test_set_cost_properties(self):
         data = RepoConfigurationData()
@@ -228,7 +229,7 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
         repo_conf = self.url_source_interface.RepoConfiguration
         repo_conf = RepoConfigurationData.from_structure(repo_conf)
 
-        self.assertEqual(repo_conf.cost, DNF_DEFAULT_REPO_COST)
+        assert repo_conf.cost == DNF_DEFAULT_REPO_COST
 
     def test_set_excluded_packages_properties(self):
         data = RepoConfigurationData()
@@ -284,8 +285,8 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
         data = RepoConfigurationData()
         data.name = self._generate_repo_name()
 
-        self.assertEqual(self.url_source_interface.RepoConfiguration,
-                         RepoConfigurationData.to_structure(data))
+        assert self.url_source_interface.RepoConfiguration == \
+            RepoConfigurationData.to_structure(data)
 
     def test_set_true_install_properties(self):
         self._check_dbus_property(
@@ -300,7 +301,7 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
         )
 
     def test_default_install_properties(self):
-        self.assertEqual(self.url_source_interface.InstallRepoEnabled, False)
+        assert self.url_source_interface.InstallRepoEnabled == False
 
 
 class URLSourceTestCase(unittest.TestCase):
@@ -311,50 +312,48 @@ class URLSourceTestCase(unittest.TestCase):
 
     def test_network_required(self):
         """Test the property network_required."""
-        self.assertEqual(self.module.network_required, False)
+        assert self.module.network_required == False
 
         self.module.repo_configuration.url = "http://my/path"
-        self.assertEqual(self.module.network_required, True)
+        assert self.module.network_required == True
 
         self.module.repo_configuration.url = "https://my/path"
-        self.assertEqual(self.module.network_required, True)
+        assert self.module.network_required == True
 
         self.module.repo_configuration.url = "file://my/path"
-        self.assertEqual(self.module.network_required, False)
+        assert self.module.network_required == False
 
         self.module.repo_configuration.url = "ftp://my/path"
-        self.assertEqual(self.module.network_required, True)
+        assert self.module.network_required == True
 
     def test_required_space(self):
         """Test the required_space property."""
-        self.assertEqual(self.module.required_space, 0)
+        assert self.module.required_space == 0
 
     def test_ready_state(self):
         """Check ready state of URL source.
 
         It will be always True there is no state.
         """
-        self.assertTrue(self.module.get_state())
+        assert self.module.get_state()
 
     def test_set_up_with_tasks(self):
         """Get set up tasks for url source.
 
         No task is required. Will be an empty list.
         """
-        self.assertEqual(self.module.set_up_with_tasks(), [])
+        assert self.module.set_up_with_tasks() == []
 
     def test_tear_down_with_tasks(self):
         """Get tear down tasks for url source.
 
         No task is required. Will be an empty list.
         """
-        self.assertEqual(self.module.tear_down_with_tasks(), [])
+        assert self.module.tear_down_with_tasks() == []
 
     def test_repr(self):
         config = RepoConfigurationData()
         config.url = "http://some.example.com/repository"
         self.module.set_repo_configuration(config)
-        self.assertEqual(
-            repr(self.module),
+        assert repr(self.module) == \
             "Source(type='URL', url='http://some.example.com/repository')"
-        )

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_url.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_url.py
@@ -47,7 +47,6 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
             in_value["name"] = get_variant(Str, name)
 
         check_dbus_property(
-            self,
             PAYLOAD_SOURCE_URL,
             self.url_source_interface,
             property_name,

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_utils.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_utils.py
@@ -30,7 +30,7 @@ class IsValidMethodTestCase(unittest.TestCase):
            return_value=StringIO("timestamp\ndescription\ntest-arch\n"))
     def test_success(self, open_mock, get_arch_mock):
         """Test installation disk validation - arch match."""
-        self.assertTrue(is_valid_install_disk("/some/dir"))
+        assert is_valid_install_disk("/some/dir")
 
     @patch("pyanaconda.modules.payloads.source.utils.get_arch",
            return_value="does-not-match")
@@ -38,7 +38,7 @@ class IsValidMethodTestCase(unittest.TestCase):
            return_value=StringIO("timestamp\ndescription\ntest-arch\n"))
     def test_fail_arch(self, open_mock, get_arch_mock):
         """Test installation disk validation - arch mismatch."""
-        self.assertFalse(is_valid_install_disk("/some/dir"))
+        assert not is_valid_install_disk("/some/dir")
 
     @patch("pyanaconda.modules.payloads.source.utils.get_arch")
     @patch("pyanaconda.modules.payloads.source.utils.open",
@@ -46,5 +46,5 @@ class IsValidMethodTestCase(unittest.TestCase):
     def test_fail_no_file(self, open_mock, get_arch_mock):
         """Test installation disk validation - no file."""
         # the exception is caught inside - check that get_arch() is not called instead
-        self.assertFalse(is_valid_install_disk("/some/dir"))
+        assert not is_valid_install_disk("/some/dir")
         get_arch_mock.assert_not_called()

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/test_module_payload_base_utils.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/test_module_payload_base_utils.py
@@ -26,14 +26,14 @@ class PayloadBaseUtilsTest(TestCase):
         """Test the get_dir_size function."""
 
         # dev null should have a size == 0
-        self.assertEqual(get_dir_size('/dev/null'), 0)
+        assert get_dir_size('/dev/null') == 0
 
         # incorrect path should also return 0
-        self.assertEqual(get_dir_size('/dev/null/foo'), 0)
+        assert get_dir_size('/dev/null/foo') == 0
 
         # check if an int is always returned
-        self.assertIsInstance(get_dir_size('/dev/null'), int)
-        self.assertIsInstance(get_dir_size('/dev/null/foo'), int)
+        assert isinstance(get_dir_size('/dev/null'), int)
+        assert isinstance(get_dir_size('/dev/null/foo'), int)
 
         # TODO: mock some dirs and check if their size is
         # computed correctly
@@ -55,7 +55,7 @@ class PayloadBaseUtilsTest(TestCase):
         ]
 
         sort_kernel_version_list(kernel_version_list)
-        self.assertEqual(kernel_version_list, [
+        assert kernel_version_list == [
             '1.1.1-100.f1',
             '1.1.1-100.f2',
             '1.1.1-999.f1',
@@ -66,7 +66,7 @@ class PayloadBaseUtilsTest(TestCase):
             '1.10.1-100.f1',
             '9.1.1-100.f1',
             '10.1.1-100.f1'
-        ])
+        ]
 
         # Test real versions.
         kernel_version_list = [
@@ -80,7 +80,7 @@ class PayloadBaseUtilsTest(TestCase):
         ]
 
         sort_kernel_version_list(kernel_version_list)
-        self.assertEqual(kernel_version_list, [
+        assert kernel_version_list == [
             '5.8.15-201.fc32.x86_64',
             '5.8.16-200.fc32.x86_64',
             '5.8.18-200.fc32.x86_64',
@@ -88,4 +88,4 @@ class PayloadBaseUtilsTest(TestCase):
             '5.9.8-100.fc33.x86_64',
             '5.9.8-200.fc33.x86_64',
             '5.10.0-0.rc4.78.fc34.x86_64'
-        ])
+        ]

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/test_module_payloads.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/test_module_payloads.py
@@ -55,8 +55,7 @@ class PayloadsInterfaceTestCase(TestCase):
         self.payload_module = PayloadsService()
         self.payload_interface = PayloadsInterface(self.payload_module)
 
-        self.shared_ks_tests = PayloadKickstartSharedTest(self,
-                                                          self.payload_module,
+        self.shared_ks_tests = PayloadKickstartSharedTest(self.payload_module,
                                                           self.payload_interface)
 
     def test_kickstart_properties(self):
@@ -167,7 +166,7 @@ class PayloadsInterfaceTestCase(TestCase):
         """Test creation of the Live OS source module."""
         source_path = self.payload_interface.CreateSource(SOURCE_TYPE_LIVE_OS_IMAGE)
 
-        check_dbus_object_creation(self, source_path, publisher, LiveOSSourceModule)
+        check_dbus_object_creation(source_path, publisher, LiveOSSourceModule)
 
     @patch_dbus_publish_object
     def test_create_invalid_source(self, publisher):
@@ -225,7 +224,7 @@ class PayloadsInterfaceTestCase(TestCase):
         self.payload_module.activate_payload(payload)
 
         tasks_paths = self.payload_interface.InstallWithTasks()
-        check_task_creation_list(self, tasks_paths, publisher, [
+        check_task_creation_list(tasks_paths, publisher, [
             PrepareSystemForInstallationTask
         ])
 
@@ -238,7 +237,7 @@ class PayloadsInterfaceTestCase(TestCase):
         self.payload_module.activate_payload(payload)
 
         tasks_paths = self.payload_interface.PostInstallWithTasks()
-        check_task_creation_list(self, tasks_paths, publisher, [
+        check_task_creation_list(tasks_paths, publisher, [
             CopyDriverDisksFilesTask
         ])
 
@@ -255,7 +254,7 @@ class PayloadsInterfaceTestCase(TestCase):
 
         publisher.reset_mock()
         task_paths = self.payload_interface.TeardownWithTasks()
-        check_task_creation_list(self, task_paths, publisher, [TearDownSourcesTask])
+        check_task_creation_list(task_paths, publisher, [TearDownSourcesTask])
 
 
 class PrepareSystemForInstallationTaskTestCase(TestCase):

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
@@ -59,7 +59,6 @@ class SecurityInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             SECURITY,
             self.security_interface,
             *args, **kwargs
@@ -109,7 +108,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         )
 
     def _test_kickstart(self, ks_in, ks_out):
-        check_kickstart_interface(self, self.security_interface, ks_in, ks_out)
+        check_kickstart_interface(self.security_interface, ks_in, ks_out)
 
     def test_no_kickstart(self):
         """Test with no kickstart."""
@@ -160,7 +159,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
     def test_realm_discover_default(self, publisher):
         """Test module in default state with realm discover task."""
         realm_discover_task_path = self.security_interface.DiscoverRealmWithTask()
-        obj = check_task_creation(self, realm_discover_task_path, publisher, RealmDiscoverTask)
+        obj = check_task_creation(realm_discover_task_path, publisher, RealmDiscoverTask)
         assert obj.implementation._realm_data.name == ""
         assert obj.implementation._realm_data.discover_options == []
 
@@ -174,7 +173,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         self.security_interface.SetRealm(RealmData.to_structure(realm))
         realm_discover_task_path = self.security_interface.DiscoverRealmWithTask()
 
-        obj = check_task_creation(self, realm_discover_task_path, publisher, RealmDiscoverTask)
+        obj = check_task_creation(realm_discover_task_path, publisher, RealmDiscoverTask)
         assert obj.implementation._realm_data.name == "domain.example.com"
         assert obj.implementation._realm_data.discover_options == ["--client-software=sssd"]
 
@@ -187,7 +186,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
             ConfigureAuthselectTask,
         ]
         task_paths = self.security_interface.InstallWithTasks()
-        task_objs = check_task_creation_list(self, task_paths, publisher, task_classes)
+        task_objs = check_task_creation_list(task_paths, publisher, task_classes)
 
         # ConfigureSELinuxTask
         obj = task_objs[0]
@@ -203,7 +202,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
     def test_realm_join_default(self, publisher):
         """Test module in default state with realm join task."""
         realm_join_task_path = self.security_interface.JoinRealmWithTask()
-        obj = check_task_creation(self, realm_join_task_path, publisher, RealmJoinTask)
+        obj = check_task_creation(realm_join_task_path, publisher, RealmJoinTask)
         assert obj.implementation._realm_data.discovered == False
         assert obj.implementation._realm_data.name == ""
         assert obj.implementation._realm_data.join_options == []
@@ -231,7 +230,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
             ConfigureAuthselectTask,
         ]
         task_paths = self.security_interface.InstallWithTasks()
-        task_objs = check_task_creation_list(self, task_paths, publisher, task_classes)
+        task_objs = check_task_creation_list(task_paths, publisher, task_classes)
 
         # ConfigureSELinuxTask
         obj = task_objs[0]
@@ -255,7 +254,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         self.security_interface.SetRealm(RealmData.to_structure(realm))
         realm_join_task_path = self.security_interface.JoinRealmWithTask()
 
-        obj = check_task_creation(self, realm_join_task_path, publisher, RealmJoinTask)
+        obj = check_task_creation(realm_join_task_path, publisher, RealmJoinTask)
         assert obj.implementation._realm_data.discovered == True
         assert obj.implementation._realm_data.name == "domain.example.com"
         assert obj.implementation._realm_data.join_options == ["--one-time-password=password"]
@@ -274,7 +273,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         realm_join_task_path = self.security_interface.JoinRealmWithTask()
 
         # realm join - after task creation
-        obj = check_task_creation(self, realm_join_task_path, publisher, RealmJoinTask)
+        obj = check_task_creation(realm_join_task_path, publisher, RealmJoinTask)
         assert obj.implementation._realm_data.discovered == False
         assert obj.implementation._realm_data.name == "domain.example.com"
         assert obj.implementation._realm_data.join_options == []
@@ -297,7 +296,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
     def test_preconfigure_fips_with_task(self, publisher):
         """Test the PreconfigureFIPSWithTask method."""
         task_path = self.security_interface.PreconfigureFIPSWithTask(PAYLOAD_TYPE_DNF)
-        obj = check_task_creation(self, task_path, publisher, PreconfigureFIPSTask)
+        obj = check_task_creation(task_path, publisher, PreconfigureFIPSTask)
         assert obj.implementation._sysroot == "/mnt/sysroot"
         assert obj.implementation._payload_type == PAYLOAD_TYPE_DNF
         assert obj.implementation._fips_enabled == False
@@ -306,7 +305,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
     def test_configure_fips_with_task(self, publisher):
         """Test the ConfigureFIPSWithTask method."""
         task_path = self.security_interface.ConfigureFIPSWithTask()
-        obj = check_task_creation(self, task_path, publisher, ConfigureFIPSTask)
+        obj = check_task_creation(task_path, publisher, ConfigureFIPSTask)
         assert obj.implementation._sysroot == "/mnt/sysroot"
         assert obj.implementation._fips_enabled == False
 

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
@@ -20,6 +20,8 @@
 import unittest
 import tempfile
 import os
+import pytest
+
 from unittest.mock import patch
 
 from pyanaconda.core.configuration.target import TargetType
@@ -65,10 +67,10 @@ class SecurityInterfaceTestCase(unittest.TestCase):
 
     def test_kickstart_properties(self):
         """Test kickstart properties."""
-        self.assertEqual(self.security_interface.KickstartCommands,
-                         ["authselect", "selinux", "realm"])
-        self.assertEqual(self.security_interface.KickstartSections, [])
-        self.assertEqual(self.security_interface.KickstartAddons, [])
+        assert self.security_interface.KickstartCommands == \
+                         ["authselect", "selinux", "realm"]
+        assert self.security_interface.KickstartSections == []
+        assert self.security_interface.KickstartAddons == []
         self.callback.assert_not_called()
 
     def test_selinux_property(self):
@@ -159,8 +161,8 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         """Test module in default state with realm discover task."""
         realm_discover_task_path = self.security_interface.DiscoverRealmWithTask()
         obj = check_task_creation(self, realm_discover_task_path, publisher, RealmDiscoverTask)
-        self.assertEqual(obj.implementation._realm_data.name, "")
-        self.assertEqual(obj.implementation._realm_data.discover_options, [])
+        assert obj.implementation._realm_data.name == ""
+        assert obj.implementation._realm_data.discover_options == []
 
     @patch_dbus_publish_object
     def test_realm_discover_configured(self, publisher):
@@ -173,8 +175,8 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         realm_discover_task_path = self.security_interface.DiscoverRealmWithTask()
 
         obj = check_task_creation(self, realm_discover_task_path, publisher, RealmDiscoverTask)
-        self.assertEqual(obj.implementation._realm_data.name, "domain.example.com")
-        self.assertEqual(obj.implementation._realm_data.discover_options, ["--client-software=sssd"])
+        assert obj.implementation._realm_data.name == "domain.example.com"
+        assert obj.implementation._realm_data.discover_options == ["--client-software=sssd"]
 
     @patch_dbus_publish_object
     def test_install_with_tasks_default(self, publisher):
@@ -189,22 +191,22 @@ class SecurityInterfaceTestCase(unittest.TestCase):
 
         # ConfigureSELinuxTask
         obj = task_objs[0]
-        self.assertEqual(obj.implementation._selinux_mode, SELinuxMode.DEFAULT)
+        assert obj.implementation._selinux_mode == SELinuxMode.DEFAULT
         # ConfigureFingerprintAuthTask
         obj = task_objs[1]
-        self.assertEqual(obj.implementation._fingerprint_auth_enabled, False)
+        assert obj.implementation._fingerprint_auth_enabled == False
         # ConfigureAuthselectTask
         obj = task_objs[2]
-        self.assertEqual(obj.implementation._authselect_options, [])
+        assert obj.implementation._authselect_options == []
 
     @patch_dbus_publish_object
     def test_realm_join_default(self, publisher):
         """Test module in default state with realm join task."""
         realm_join_task_path = self.security_interface.JoinRealmWithTask()
         obj = check_task_creation(self, realm_join_task_path, publisher, RealmJoinTask)
-        self.assertEqual(obj.implementation._realm_data.discovered, False)
-        self.assertEqual(obj.implementation._realm_data.name, "")
-        self.assertEqual(obj.implementation._realm_data.join_options, [])
+        assert obj.implementation._realm_data.discovered == False
+        assert obj.implementation._realm_data.name == ""
+        assert obj.implementation._realm_data.join_options == []
 
     @patch_dbus_publish_object
     def test_install_with_tasks_configured(self, publisher):
@@ -233,13 +235,13 @@ class SecurityInterfaceTestCase(unittest.TestCase):
 
         # ConfigureSELinuxTask
         obj = task_objs[0]
-        self.assertEqual(obj.implementation._selinux_mode, SELinuxMode.PERMISSIVE)
+        assert obj.implementation._selinux_mode == SELinuxMode.PERMISSIVE
         # ConfigureFingerprintAuthTask
         obj = task_objs[1]
-        self.assertEqual(obj.implementation._fingerprint_auth_enabled, fingerprint)
+        assert obj.implementation._fingerprint_auth_enabled == fingerprint
         # ConfigureAuthselectTask
         obj = task_objs[2]
-        self.assertEqual(obj.implementation._authselect_options, authselect)
+        assert obj.implementation._authselect_options == authselect
 
     @patch_dbus_publish_object
     def test_realm_join_configured(self, publisher):
@@ -254,9 +256,9 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         realm_join_task_path = self.security_interface.JoinRealmWithTask()
 
         obj = check_task_creation(self, realm_join_task_path, publisher, RealmJoinTask)
-        self.assertEqual(obj.implementation._realm_data.discovered, True)
-        self.assertEqual(obj.implementation._realm_data.name, "domain.example.com")
-        self.assertEqual(obj.implementation._realm_data.join_options, ["--one-time-password=password"])
+        assert obj.implementation._realm_data.discovered == True
+        assert obj.implementation._realm_data.name == "domain.example.com"
+        assert obj.implementation._realm_data.join_options == ["--one-time-password=password"]
 
     @patch_dbus_publish_object
     def test_realm_data_propagation(self, publisher):
@@ -273,9 +275,9 @@ class SecurityInterfaceTestCase(unittest.TestCase):
 
         # realm join - after task creation
         obj = check_task_creation(self, realm_join_task_path, publisher, RealmJoinTask)
-        self.assertEqual(obj.implementation._realm_data.discovered, False)
-        self.assertEqual(obj.implementation._realm_data.name, "domain.example.com")
-        self.assertEqual(obj.implementation._realm_data.join_options, [])
+        assert obj.implementation._realm_data.discovered == False
+        assert obj.implementation._realm_data.name == "domain.example.com"
+        assert obj.implementation._realm_data.join_options == []
 
         # change realm data and check the changes propagate to the realm join task
         realm2 = RealmData()
@@ -287,43 +289,43 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         self.security_interface.SetRealm(RealmData.to_structure(realm2))
 
         # realm join - after realm data update
-        self.assertEqual(obj.implementation._realm_data.discovered, True)
-        self.assertEqual(obj.implementation._realm_data.name, "domain.example.com")
-        self.assertEqual(obj.implementation._realm_data.join_options, ["--one-time-password=password"])
+        assert obj.implementation._realm_data.discovered == True
+        assert obj.implementation._realm_data.name == "domain.example.com"
+        assert obj.implementation._realm_data.join_options == ["--one-time-password=password"]
 
     @patch_dbus_publish_object
     def test_preconfigure_fips_with_task(self, publisher):
         """Test the PreconfigureFIPSWithTask method."""
         task_path = self.security_interface.PreconfigureFIPSWithTask(PAYLOAD_TYPE_DNF)
         obj = check_task_creation(self, task_path, publisher, PreconfigureFIPSTask)
-        self.assertEqual(obj.implementation._sysroot, "/mnt/sysroot")
-        self.assertEqual(obj.implementation._payload_type, PAYLOAD_TYPE_DNF)
-        self.assertEqual(obj.implementation._fips_enabled, False)
+        assert obj.implementation._sysroot == "/mnt/sysroot"
+        assert obj.implementation._payload_type == PAYLOAD_TYPE_DNF
+        assert obj.implementation._fips_enabled == False
 
     @patch_dbus_publish_object
     def test_configure_fips_with_task(self, publisher):
         """Test the ConfigureFIPSWithTask method."""
         task_path = self.security_interface.ConfigureFIPSWithTask()
         obj = check_task_creation(self, task_path, publisher, ConfigureFIPSTask)
-        self.assertEqual(obj.implementation._sysroot, "/mnt/sysroot")
-        self.assertEqual(obj.implementation._fips_enabled, False)
+        assert obj.implementation._sysroot == "/mnt/sysroot"
+        assert obj.implementation._fips_enabled == False
 
     def test_collect_requirements_default(self):
         """Test requrements are empty by default."""
         reqs = self.security_interface.CollectRequirements()
-        self.assertListEqual(reqs, [])
+        assert reqs == []
 
     @patch("pyanaconda.modules.security.security.kernel_arguments")
     def test_fips_requirements(self, kernel_arguments_mock):
         """Test the package requirements for fips."""
         kernel_arguments_mock.is_enabled.return_value = True
-        self.assertEqual(self.security_interface.CollectRequirements(), [
+        assert self.security_interface.CollectRequirements() == [
             {
                 "type": get_variant(Str, "package"),
                 "name": get_variant(Str, "/usr/bin/fips-mode-setup"),
                 "reason": get_variant(Str, "Required for FIPS compliance.")
             }
-        ])
+        ]
         kernel_arguments_mock.is_enabled.assert_called_once_with("fips")
 
     def test_realmd_requirements(self):
@@ -338,7 +340,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         self.security_interface.SetRealm(RealmData.to_structure(realm))
 
         # check that the teamd package is requested
-        self.assertEqual(self.security_interface.CollectRequirements(), [
+        assert self.security_interface.CollectRequirements() == [
             {
                 "type": get_variant(Str, "package"),
                 "name": get_variant(Str, "realmd"),
@@ -354,7 +356,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
                 "name": get_variant(Str, "bar"),
                 "reason": get_variant(Str, "Needed to join a realm.")
             }
-        ])
+        ]
 
     def test_authselect_requirements(self):
         """Test that package requirements for authselect propagate correctly."""
@@ -363,18 +365,18 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         requirements = Requirement.from_structure_list(
             self.security_interface.CollectRequirements()
         )
-        self.assertEqual(len(requirements), 1)
-        self.assertEqual(requirements[0].type, "package")
-        self.assertEqual(requirements[0].name, "authselect")
+        assert len(requirements) == 1
+        assert requirements[0].type == "package"
+        assert requirements[0].name == "authselect"
 
         self.security_interface.SetAuthselect([])
         self.security_interface.SetFingerprintAuthEnabled(True)
         requirements = Requirement.from_structure_list(
             self.security_interface.CollectRequirements()
         )
-        self.assertEqual(len(requirements), 1)
-        self.assertEqual(requirements[0].type, "package")
-        self.assertEqual(requirements[0].name, "authselect")
+        assert len(requirements) == 1
+        assert requirements[0].type == "package"
+        assert requirements[0].name == "authselect"
 
 
 class SecurityTasksTestCase(unittest.TestCase):
@@ -405,7 +407,7 @@ class SecurityTasksTestCase(unittest.TestCase):
             ).run()
 
             with open(os.path.join(sysroot, "etc/selinux/config")) as f:
-                self.assertEqual(f.read().strip(), content.strip())
+                assert f.read().strip() == content.strip()
 
     def test_configure_selinux_task_enforcing(self):
         """Test SELinux configuration task - SELinux enforcing."""
@@ -423,7 +425,7 @@ class SecurityTasksTestCase(unittest.TestCase):
             ).run()
 
             with open(os.path.join(sysroot, "etc/selinux/config")) as f:
-                self.assertEqual(f.read().strip(), content.strip())
+                assert f.read().strip() == content.strip()
 
     def test_configure_selinux_task_permissive(self):
         """Test SELinux configuration task - SELinux permissive."""
@@ -441,7 +443,7 @@ class SecurityTasksTestCase(unittest.TestCase):
             ).run()
 
             with open(os.path.join(sysroot, "etc/selinux/config")) as f:
-                self.assertEqual(f.read().strip(), content.strip())
+                assert f.read().strip() == content.strip()
 
     def test_configure_selinux_task_default(self):
         """Test SELinux configuration task - SELinux default."""
@@ -462,7 +464,7 @@ class SecurityTasksTestCase(unittest.TestCase):
             ).run()
 
             with open(os.path.join(sysroot, "etc/selinux/config")) as f:
-                self.assertEqual(f.read().strip(), content.strip())
+                assert f.read().strip() == content.strip()
 
     @patch('pyanaconda.core.util.execWithCapture')
     def test_realm_discover_success_task(self, execWithCapture):
@@ -475,7 +477,7 @@ class SecurityTasksTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/realm"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/realm")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/realm"))
 
             realm_data = RealmData()
             realm_data.name = "foo-domain"
@@ -490,8 +492,8 @@ class SecurityTasksTestCase(unittest.TestCase):
                                                   filter_stderr=True)
 
             # check if the results returned by the task look correct
-            self.assertTrue(new_realm_data.discovered)
-            self.assertListEqual(new_realm_data.required_packages, ["realmd", "package-foo", "package-bar", "package-baz"])
+            assert new_realm_data.discovered
+            assert new_realm_data.required_packages == ["realmd", "package-foo", "package-bar", "package-baz"]
 
     @patch('pyanaconda.core.util.execWithCapture')
     def test_realm_discover_success_with_garbage_task(self, execWithCapture):
@@ -509,7 +511,7 @@ class SecurityTasksTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/realm"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/realm")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/realm"))
 
             realm_data = RealmData()
             realm_data.name = "foo-domain"
@@ -524,8 +526,8 @@ class SecurityTasksTestCase(unittest.TestCase):
                                                   filter_stderr=True)
 
             # check if the results returned by the task look correct
-            self.assertTrue(new_realm_data.discovered)
-            self.assertListEqual(new_realm_data.required_packages, ["realmd", "package-foo", "package-bar", "package-baz"])
+            assert new_realm_data.discovered
+            assert new_realm_data.required_packages == ["realmd", "package-foo", "package-bar", "package-baz"]
 
     @patch('pyanaconda.core.util.execWithCapture')
     def test_realm_discover_success_no_extra_packages_with_garbage_task(self, execWithCapture):
@@ -539,7 +541,7 @@ class SecurityTasksTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/realm"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/realm")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/realm"))
 
             realm_data = RealmData()
             realm_data.name = "foo-domain"
@@ -554,8 +556,8 @@ class SecurityTasksTestCase(unittest.TestCase):
                                                   filter_stderr=True)
 
             # check if the results returned by the task look correct
-            self.assertTrue(new_realm_data.discovered)
-            self.assertListEqual(new_realm_data.required_packages, ["realmd"])
+            assert new_realm_data.discovered
+            assert new_realm_data.required_packages == ["realmd"]
 
     @patch('pyanaconda.core.util.execWithCapture')
     def test_realm_discover_failure(self, execWithCapture):
@@ -565,7 +567,7 @@ class SecurityTasksTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/realm"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/realm")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/realm"))
 
             realm_data = RealmData()
             realm_data.name = "foo-domain"
@@ -580,9 +582,9 @@ class SecurityTasksTestCase(unittest.TestCase):
                                                   filter_stderr=True)
 
             # check if the results returned by the task look correct
-            self.assertFalse(new_realm_data.discovered)
+            assert not new_realm_data.discovered
             # if realm discover invocation fails to discover a realm, we still add realmd as a required package
-            self.assertListEqual(new_realm_data.required_packages, ["realmd"])
+            assert new_realm_data.required_packages == ["realmd"]
 
     @patch('pyanaconda.core.util.execWithCapture')
     def test_realm_discover_failure_with_exception(self, execWithCapture):
@@ -593,7 +595,7 @@ class SecurityTasksTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/realm"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/realm")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/realm"))
 
             realm_data = RealmData()
             realm_data.name = "foo-domain"
@@ -608,9 +610,9 @@ class SecurityTasksTestCase(unittest.TestCase):
                                                   filter_stderr=True)
 
             # check if the results returned by the task look correct
-            self.assertFalse(new_realm_data.discovered)
+            assert not new_realm_data.discovered
             # if realm discover invocation fails hard, we don't add realmd as a required package
-            self.assertListEqual(new_realm_data.required_packages, [])
+            assert new_realm_data.required_packages == []
 
     @patch('pyanaconda.core.util.execWithCapture')
     def test_realm_discover_no_realm_name(self, execWithCapture):
@@ -618,7 +620,7 @@ class SecurityTasksTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/realm"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/realm")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/realm"))
 
             realm_data = RealmData()
             realm_data.name = ""
@@ -631,9 +633,9 @@ class SecurityTasksTestCase(unittest.TestCase):
             execWithCapture.assert_not_called()
 
             # no realm name so it can not be discovered
-            self.assertFalse(new_realm_data.discovered)
+            assert not new_realm_data.discovered
             # if realm can't be discovered, we can't join it so no extra packages are needed
-            self.assertListEqual(new_realm_data.required_packages, [])
+            assert new_realm_data.required_packages == []
 
     @patch('pyanaconda.core.util.execWithRedirect')
     def test_realm_join(self, execWithRedirect):
@@ -641,7 +643,7 @@ class SecurityTasksTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/realm"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/realm")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/realm"))
 
             realm_data = RealmData()
             realm_data.name = "foo-realm"
@@ -661,7 +663,7 @@ class SecurityTasksTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/realm"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/realm")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/realm"))
 
             realm_data = RealmData()
             realm_data.name = "foo-realm"
@@ -684,7 +686,7 @@ class SecurityTasksTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/realm"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/realm")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/realm"))
 
             realm_data = RealmData()
             realm_data.name = "foo-realm"
@@ -707,7 +709,7 @@ class SecurityTasksTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/realm"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/realm")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/realm"))
 
             realm_data = RealmData()
             realm_data.name = "foo-realm"
@@ -728,7 +730,7 @@ class SecurityTasksTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(os.path.join(sysroot, "usr/bin"))
             os.mknod(os.path.join(sysroot, "usr/bin/realm"))
-            self.assertTrue(os.path.exists(os.path.join(sysroot, "usr/bin/realm")))
+            assert os.path.exists(os.path.join(sysroot, "usr/bin/realm"))
 
             realm_data = RealmData()
             realm_data.name = "foo-realm"
@@ -825,7 +827,7 @@ class SecurityTasksTestCase(unittest.TestCase):
                 sysroot=sysroot,
                 authselect_options=["select", "sssd", "with-mkhomedir"]
             )
-            with self.assertRaises(SecurityInstallationError):
+            with pytest.raises(SecurityInstallationError):
                 task.run()
             execWithRedirect.assert_not_called()
 
@@ -856,7 +858,7 @@ class SecurityTasksTestCase(unittest.TestCase):
             task.run()
 
         msg = "FIPS is not enabled. Skipping."
-        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+        assert any(map(lambda x: msg in x, cm.output))
 
     def test_preconfigure_fips_task_payload(self):
         """Test the PreconfigureFIPSTask task with a wrong payload."""
@@ -870,7 +872,7 @@ class SecurityTasksTestCase(unittest.TestCase):
             task.run()
 
         msg = "Don't set up FIPS for the RPM_OSTREE payload."
-        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+        assert any(map(lambda x: msg in x, cm.output))
 
     def test_preconfigure_fips_task_error(self):
         """Test the PreconfigureFIPSTask task with a wrong policy."""
@@ -880,11 +882,11 @@ class SecurityTasksTestCase(unittest.TestCase):
             fips_enabled=True,
         )
 
-        with self.assertRaises(SecurityInstallationError) as cm:
+        with pytest.raises(SecurityInstallationError) as cm:
             task.run()
 
         msg = "FIPS is not correctly set up in the installation environment."
-        self.assertEqual(str(cm.exception), msg)
+        assert str(cm.value) == msg
 
     @patch("pyanaconda.modules.security.installation.shutil")
     @patch("pyanaconda.modules.security.installation.util")
@@ -924,7 +926,7 @@ class SecurityTasksTestCase(unittest.TestCase):
             task.run()
 
         msg = "FIPS is not enabled. Skipping."
-        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+        assert any(map(lambda x: msg in x, cm.output))
 
     @patch("pyanaconda.modules.security.installation.conf")
     def test_configure_fips_task_image(self, mock_conf):
@@ -941,7 +943,7 @@ class SecurityTasksTestCase(unittest.TestCase):
             task.run()
 
         msg = "Don't set up FIPS on IMAGE."
-        self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+        assert any(map(lambda x: msg in x, cm.output))
 
     @patch("pyanaconda.modules.security.installation.util")
     def test_configure_fips_task(self, mock_util):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_automatic.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_automatic.py
@@ -61,7 +61,6 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             AUTO_PARTITIONING,
             self.interface,
             *args, **kwargs
@@ -76,7 +75,7 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
         """Test the device tree."""
         self.module.on_storage_changed(Mock())
         path = self.interface.GetDeviceTree()
-        obj = check_dbus_object_creation(self, path, publisher, ResizableDeviceTreeModule)
+        obj = check_dbus_object_creation(path, publisher, ResizableDeviceTreeModule)
         assert obj.implementation.storage == self.module.storage
 
         self.module.on_partitioning_reset()
@@ -138,7 +137,7 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
         self.module.on_storage_changed(Mock())
         task_path = self.interface.ConfigureWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, AutomaticPartitioningTask)
+        obj = check_task_creation(task_path, publisher, AutomaticPartitioningTask)
 
         assert obj.implementation._storage == self.module.storage
         assert obj.implementation._request == self.module.request
@@ -149,7 +148,7 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
         self.module.on_storage_changed(Mock())
         task_path = self.interface.ValidateWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, StorageValidateTask)
+        obj = check_task_creation(task_path, publisher, StorageValidateTask)
         assert obj.implementation._storage == self.module.storage
 
         report = ValidationReport()

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_blivet.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_blivet.py
@@ -21,6 +21,8 @@ import os
 import sys
 import pickle
 import unittest
+import pytest
+
 from unittest.mock import patch
 
 from pyanaconda.modules.storage.devicetree import create_storage
@@ -61,24 +63,24 @@ class BlivetPartitioningInterfaceTestCase(unittest.TestCase):
 
         # We should be able to create the Storage module
         storage_module = StorageService()
-        self.assertIsNotNone(storage_module.storage)
+        assert storage_module.storage is not None
 
         # We should be able to create the Blivet module.
         from pyanaconda.modules.storage.partitioning.constants import PartitioningMethod
         blivet_module = storage_module.create_partitioning(PartitioningMethod.BLIVET)
-        self.assertIsNotNone(blivet_module.storage)
+        assert blivet_module.storage is not None
 
         # Import the exception again.
         from pyanaconda.modules.common.errors.storage import UnsupportedPartitioningError
 
         # Handle the missing support.
-        with self.assertRaises(UnsupportedPartitioningError):
-            self.assertFalse(blivet_module.storage_handler)  # pylint: disable=no-member
+        with pytest.raises(UnsupportedPartitioningError):
+            assert not blivet_module.storage_handler  # pylint: disable=no-member
 
-        with self.assertRaises(UnsupportedPartitioningError):
-            self.assertFalse(blivet_module.request_handler)  # pylint: disable=no-member
+        with pytest.raises(UnsupportedPartitioningError):
+            assert not blivet_module.request_handler  # pylint: disable=no-member
 
-        with self.assertRaises(UnsupportedPartitioningError):
+        with pytest.raises(UnsupportedPartitioningError):
             request = pickle.dumps(("call", "get_disks", []))
             blivet_module.send_request(request)  # pylint: disable=no-member
 
@@ -86,15 +88,15 @@ class BlivetPartitioningInterfaceTestCase(unittest.TestCase):
     def test_storage_handler(self):
         """Test the storage_handler property."""
         self.module.on_storage_changed(create_storage())
-        self.assertIsNotNone(self.module.storage_handler)
-        self.assertEqual(self.module.storage, self.module.storage_handler.storage)
+        assert self.module.storage_handler is not None
+        assert self.module.storage == self.module.storage_handler.storage
 
     @unittest.skipUnless(HAVE_BLIVET_GUI, "blivet-gui not installed")
     def test_request_handler(self):
         """Test the request_handler property."""
         self.module.on_storage_changed(create_storage())
-        self.assertIsNotNone(self.module.request_handler)
-        self.assertEqual(self.module.storage_handler, self.module.request_handler.blivet_utils)
+        assert self.module.request_handler is not None
+        assert self.module.storage_handler == self.module.request_handler.blivet_utils
 
     @unittest.skipUnless(HAVE_BLIVET_GUI, "blivet-gui not installed")
     def test_send_request(self):
@@ -106,8 +108,8 @@ class BlivetPartitioningInterfaceTestCase(unittest.TestCase):
         answer = pickle.loads(answer)
 
         from blivetgui.communication.proxy_utils import ProxyID  # pylint: disable=import-error
-        self.assertIsInstance(answer, ProxyID)
-        self.assertEqual(answer.id, 0)
+        assert isinstance(answer, ProxyID)
+        assert answer.id == 0
 
     @patch_dbus_publish_object
     def test_configure_with_task(self, publisher):
@@ -117,4 +119,4 @@ class BlivetPartitioningInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, InteractivePartitioningTask)
 
-        self.assertEqual(obj.implementation._storage, self.module.storage)
+        assert obj.implementation._storage == self.module.storage

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_blivet.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_blivet.py
@@ -117,6 +117,6 @@ class BlivetPartitioningInterfaceTestCase(unittest.TestCase):
         self.module.on_storage_changed(create_storage())
         task_path = self.interface.ConfigureWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, InteractivePartitioningTask)
+        obj = check_task_creation(task_path, publisher, InteractivePartitioningTask)
 
         assert obj.implementation._storage == self.module.storage

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_custom.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_custom.py
@@ -69,7 +69,7 @@ class CustomPartitioningInterfaceTestCase(unittest.TestCase):
         self.module.process_kickstart(Mock())
         task_path = self.interface.ConfigureWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, CustomPartitioningTask)
+        obj = check_task_creation(task_path, publisher, CustomPartitioningTask)
 
         assert obj.implementation._storage == self.module.storage
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_custom.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_custom.py
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import pytest
+
 from unittest.mock import Mock, PropertyMock, patch
 
 from blivet.devices import PartitionDevice
@@ -48,17 +50,17 @@ class CustomPartitioningInterfaceTestCase(unittest.TestCase):
 
     def test_publication(self):
         """Test the DBus representation."""
-        self.assertIsInstance(self.module.for_publication(), CustomPartitioningInterface)
+        assert isinstance(self.module.for_publication(), CustomPartitioningInterface)
 
     def test_data(self, ):
         """Test the data property."""
-        with self.assertRaises(UnavailableDataError):
+        with pytest.raises(UnavailableDataError):
             if self.module.data:
                 self.fail("The data should not be available.")
 
         data = Mock()
         self.module.process_kickstart(data)
-        self.assertEqual(self.module.data, data)
+        assert self.module.data == data
 
     @patch_dbus_publish_object
     def test_configure_with_task(self, publisher):
@@ -69,7 +71,7 @@ class CustomPartitioningInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, CustomPartitioningTask)
 
-        self.assertEqual(obj.implementation._storage, self.module.storage)
+        assert obj.implementation._storage == self.module.storage
 
 
 class CustomPartitioningKickstartTestCase(unittest.TestCase):
@@ -99,11 +101,11 @@ class CustomPartitioningKickstartTestCase(unittest.TestCase):
     def test_requires_passphrase(self, publisher):
         """Test RequiresPassphrase."""
         self._process_kickstart("part /")
-        self.assertEqual(self.interface.RequiresPassphrase(), False)
+        assert self.interface.RequiresPassphrase() == False
         self._process_kickstart("part / --encrypted")
-        self.assertEqual(self.interface.RequiresPassphrase(), True)
+        assert self.interface.RequiresPassphrase() == True
         self.interface.SetPassphrase("123456")
-        self.assertEqual(self.interface.RequiresPassphrase(), False)
+        assert self.interface.RequiresPassphrase() == False
 
     @patch_dbus_get_proxy
     @patch.object(InstallerStorage, 'mountpoints', new_callable=PropertyMock)
@@ -119,13 +121,13 @@ class CustomPartitioningKickstartTestCase(unittest.TestCase):
 
         # set up the storage
         self.module.on_storage_changed(create_storage())
-        self.assertTrue(self.module.storage)
+        assert self.module.storage
 
         self.module.storage.bootloader.stage1_device = bootloader_device_obj
 
         # initialize ksdata
         ksdata = self._setup_kickstart()
-        self.assertIn("part prepboot", str(ksdata))
+        assert "part prepboot" in str(ksdata)
 
     @patch_dbus_get_proxy
     @patch.object(InstallerStorage, 'devices', new_callable=PropertyMock)
@@ -143,8 +145,8 @@ class CustomPartitioningKickstartTestCase(unittest.TestCase):
 
         # set up the storage
         self.module.on_storage_changed(create_storage())
-        self.assertTrue(self.module.storage)
+        assert self.module.storage
 
         # initialize ksdata
         ksdata = self._setup_kickstart()
-        self.assertIn("part biosboot", str(ksdata))
+        assert "part biosboot" in str(ksdata)

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_factory.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_factory.py
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import pytest
+
 from unittest.mock import patch, PropertyMock
 
 from blivet.formats.fs import BTRFS
@@ -37,13 +39,13 @@ class PartitioningFactoryTestCase(unittest.TestCase):
         """Test create_partitioning."""
         for method in PartitioningMethod:
             module = PartitioningFactory.create_partitioning(method)
-            self.assertIsInstance(module, PartitioningModule)
-            self.assertIsInstance(module.for_publication(), PartitioningInterface)
-            self.assertEqual(module.partitioning_method, method)
+            assert isinstance(module, PartitioningModule)
+            assert isinstance(module.for_publication(), PartitioningInterface)
+            assert module.partitioning_method == method
 
     def test_failed_partitioning(self):
         """Test failed create_partitioning."""
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             PartitioningFactory.create_partitioning("INVALID")
 
     @patch.object(BTRFS, "formattable", new_callable=PropertyMock)
@@ -96,4 +98,4 @@ class PartitioningFactoryTestCase(unittest.TestCase):
         handler = KickstartSpecificationHandler(specification)
         parser = KickstartSpecificationParser(handler, specification)
         parser.readKickstartFromString(kickstart)
-        self.assertEqual(method, PartitioningFactory.get_method_for_kickstart(handler))
+        assert method == PartitioningFactory.get_method_for_kickstart(handler)

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_interactive.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_interactive.py
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import pytest
+
 from unittest.mock import patch
 
 from blivet import devicefactory
@@ -58,7 +60,7 @@ class InteractivePartitioningInterfaceTestCase(unittest.TestCase):
 
     def test_publication(self):
         """Test the DBus representation."""
-        self.assertIsInstance(self.module.for_publication(), InteractivePartitioningInterface)
+        assert isinstance(self.module.for_publication(), InteractivePartitioningInterface)
 
     @patch_dbus_publish_object
     def test_device_tree(self, publisher):
@@ -69,7 +71,7 @@ class InteractivePartitioningInterfaceTestCase(unittest.TestCase):
 
     def test_method_property(self):
         """Test Method property."""
-        self.assertEqual(self.interface.PartitioningMethod, PARTITIONING_METHOD_INTERACTIVE)
+        assert self.interface.PartitioningMethod == PARTITIONING_METHOD_INTERACTIVE
 
     @patch_dbus_publish_object
     def test_lazy_storage(self, publisher):
@@ -77,17 +79,17 @@ class InteractivePartitioningInterfaceTestCase(unittest.TestCase):
         self.module.on_storage_changed(create_storage())
 
         device_tree_module = self.module.get_device_tree()
-        self.assertIsNone(self.module._storage_playground)
+        assert self.module._storage_playground is None
 
         device_tree_module.get_disks()
-        self.assertIsNotNone(self.module._storage_playground)
+        assert self.module._storage_playground is not None
 
         self.module.on_partitioning_reset()
         self.module.on_storage_changed(create_storage())
-        self.assertIsNone(self.module._storage_playground)
+        assert self.module._storage_playground is None
 
         device_tree_module.get_actions()
-        self.assertIsNotNone(self.module._storage_playground)
+        assert self.module._storage_playground is not None
 
     @patch_dbus_publish_object
     def test_get_device_tree(self, publisher):
@@ -100,18 +102,18 @@ class InteractivePartitioningInterfaceTestCase(unittest.TestCase):
         publisher.assert_called_once()
         object_path, obj = publisher.call_args[0]
 
-        self.assertEqual(tree_path, object_path)
-        self.assertIsInstance(obj, DeviceTreeInterface)
+        assert tree_path == object_path
+        assert isinstance(obj, DeviceTreeInterface)
 
-        self.assertEqual(obj.implementation, self.module._device_tree_module)
-        self.assertEqual(obj.implementation.storage, self.module.storage)
-        self.assertTrue(tree_path.endswith("/DeviceTree/1"))
+        assert obj.implementation == self.module._device_tree_module
+        assert obj.implementation.storage == self.module.storage
+        assert tree_path.endswith("/DeviceTree/1")
 
         publisher.reset_mock()
 
-        self.assertEqual(tree_path, self.interface.GetDeviceTree())
-        self.assertEqual(tree_path, self.interface.GetDeviceTree())
-        self.assertEqual(tree_path, self.interface.GetDeviceTree())
+        assert tree_path == self.interface.GetDeviceTree()
+        assert tree_path == self.interface.GetDeviceTree()
+        assert tree_path == self.interface.GetDeviceTree()
 
         publisher.assert_not_called()
 
@@ -123,7 +125,7 @@ class InteractivePartitioningInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, InteractivePartitioningTask)
 
-        self.assertEqual(obj.implementation._storage, self.module.storage)
+        assert obj.implementation._storage == self.module.storage
 
 
 class InteractiveUtilsTestCase(unittest.TestCase):
@@ -140,7 +142,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
     def test_generate_device_factory_request_unsupported(self):
         device = StorageDevice("dev1")
 
-        with self.assertRaises(UnsupportedDeviceError):
+        with pytest.raises(UnsupportedDeviceError):
             utils.generate_device_factory_request(self.storage, device)
 
     @patch("blivet.devices.dm.blockdev")
@@ -148,7 +150,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
         disk = DiskDevice("dev2")
 
         request = utils.generate_device_factory_request(self.storage, disk)
-        self.assertEqual(DeviceFactoryRequest.to_structure(request), {
+        assert DeviceFactoryRequest.to_structure(request) == {
             "device-spec": get_variant(Str, "dev2"),
             "disks": get_variant(List[Str], ["dev2"]),
             "mount-point": get_variant(Str, ""),
@@ -166,7 +168,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "container-size-policy": get_variant(Int64, devicefactory.SIZE_POLICY_AUTO),
             "container-encrypted": get_variant(Bool, False),
             "container-raid-level": get_variant(Str, ""),
-        })
+        }
 
         partition = PartitionDevice(
             "dev3",
@@ -176,7 +178,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
         )
 
         request = utils.generate_device_factory_request(self.storage, partition)
-        self.assertEqual(DeviceFactoryRequest.to_structure(request), {
+        assert DeviceFactoryRequest.to_structure(request) == {
             "device-spec": get_variant(Str, "dev3"),
             "disks": get_variant(List[Str], ["dev2"]),
             "mount-point": get_variant(Str, "/"),
@@ -194,7 +196,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "container-size-policy": get_variant(Int64, devicefactory.SIZE_POLICY_AUTO),
             "container-encrypted": get_variant(Bool, False),
             "container-raid-level": get_variant(Str, ""),
-        })
+        }
 
     @patch("blivet.devices.dm.blockdev")
     def test_generate_device_factory_request_lvm(self, blockdev):
@@ -223,7 +225,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
         )
 
         request = utils.generate_device_factory_request(self.storage, lv)
-        self.assertEqual(DeviceFactoryRequest.to_structure(request), {
+        assert DeviceFactoryRequest.to_structure(request) == {
             "device-spec": get_variant(Str, "testvg-testlv"),
             "disks": get_variant(List[Str], []),
             "mount-point": get_variant(Str, ""),
@@ -241,7 +243,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "container-size-policy": get_variant(Int64, Size("1.5 GiB")),
             "container-encrypted": get_variant(Bool, False),
             "container-raid-level": get_variant(Str, ""),
-        })
+        }
 
     @patch("blivet.devices.dm.blockdev")
     def test_generate_device_factory_request_raid(self, blockdev):
@@ -260,7 +262,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
         )
 
         request = utils.generate_device_factory_request(self.storage, device)
-        self.assertEqual(DeviceFactoryRequest.to_structure(request), {
+        assert DeviceFactoryRequest.to_structure(request) == {
             "device-spec": get_variant(Str, "dev3"),
             "disks": get_variant(List[Str], ["dev1", "dev2"]),
             "mount-point": get_variant(Str, ""),
@@ -278,7 +280,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "container-size-policy": get_variant(Int64, 0),
             "container-encrypted": get_variant(Bool, False),
             "container-raid-level": get_variant(Str, ""),
-        })
+        }
 
     @patch("blivet.devices.dm.blockdev")
     def test_generate_device_factory_request_btrfs(self, blockdev):
@@ -300,7 +302,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
         )
 
         request = utils.generate_device_factory_request(self.storage, dev3)
-        self.assertEqual(DeviceFactoryRequest.to_structure(request), {
+        assert DeviceFactoryRequest.to_structure(request) == {
             "device-spec": get_variant(Str, dev3.name),
             "disks": get_variant(List[Str], []),
             "mount-point": get_variant(Str, "/boot"),
@@ -318,7 +320,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "container-size-policy": get_variant(Int64, Size("10 GiB").get_bytes()),
             "container-encrypted": get_variant(Bool, False),
             "container-raid-level": get_variant(Str, "single"),
-        })
+        }
 
     def test_get_device_factory_arguments(self):
         """Test get_device_factory_arguments."""
@@ -344,7 +346,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
         request.luks_version = "luks1"
         request.device_raid_level = "raid1"
 
-        self.assertEqual(utils.get_device_factory_arguments(self.storage, request), {
+        assert utils.get_device_factory_arguments(self.storage, request) == {
             "device": dev3,
             "disks": [dev1, dev2],
             "device_type": devicefactory.DEVICE_TYPE_LVM_THINP,
@@ -360,7 +362,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "container_size": devicefactory.SIZE_POLICY_AUTO,
             "container_raid_level": None,
             "container_encrypted": False
-        })
+        }
 
         request = DeviceFactoryRequest()
         request.device_spec = "dev3"
@@ -371,7 +373,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
         request.container_encrypted = True
         request.container_raid_level = "raid1"
 
-        self.assertEqual(utils.get_device_factory_arguments(self.storage, request), {
+        assert utils.get_device_factory_arguments(self.storage, request) == {
             "device": dev3,
             "disks": [dev1, dev2],
             "device_type": devicefactory.DEVICE_TYPE_LVM,
@@ -387,4 +389,4 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "container_size": Size("10 GiB"),
             "container_raid_level": raid.RAID1,
             "container_encrypted": True
-        })
+        }

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_interactive.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_interactive.py
@@ -67,7 +67,7 @@ class InteractivePartitioningInterfaceTestCase(unittest.TestCase):
         """Test the device tree."""
         self.module.on_storage_changed(create_storage())
         path = self.interface.GetDeviceTree()
-        check_dbus_object_creation(self, path, publisher, DeviceTreeSchedulerModule)
+        check_dbus_object_creation(path, publisher, DeviceTreeSchedulerModule)
 
     def test_method_property(self):
         """Test Method property."""
@@ -123,7 +123,7 @@ class InteractivePartitioningInterfaceTestCase(unittest.TestCase):
         self.module.on_storage_changed(create_storage())
         task_path = self.interface.ConfigureWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, InteractivePartitioningTask)
+        obj = check_task_creation(task_path, publisher, InteractivePartitioningTask)
 
         assert obj.implementation._storage == self.module.storage
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_manual.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_manual.py
@@ -53,7 +53,6 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             MANUAL_PARTITIONING,
             self.interface,
             *args, **kwargs
@@ -246,7 +245,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
         self.module.on_storage_changed(Mock())
         task_path = self.interface.ConfigureWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, ManualPartitioningTask)
+        obj = check_task_creation(task_path, publisher, ManualPartitioningTask)
 
         assert obj.implementation._storage == self.module.storage
         assert obj.implementation._requests == self.module.requests

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_manual.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_manual.py
@@ -49,7 +49,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
 
     def test_publication(self):
         """Test the DBus representation."""
-        self.assertIsInstance(self.module.for_publication(), ManualPartitioningInterface)
+        assert isinstance(self.module.for_publication(), ManualPartitioningInterface)
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
@@ -120,7 +120,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
     def test_gather_no_requests(self):
         """Test GatherRequests with no devices."""
         self.module.on_storage_changed(create_storage())
-        self.assertEqual(self.interface.GatherRequests(), [])
+        assert self.interface.GatherRequests() == []
 
     def test_gather_unusable_requests(self):
         """Test GatherRequests with unusable devices."""
@@ -132,7 +132,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
             size=Size(0)
         ))
 
-        self.assertEqual(self.interface.GatherRequests(), [])
+        assert self.interface.GatherRequests() == []
 
         # Add protected device.
         device = StorageDevice(
@@ -142,7 +142,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
 
         device.protected = True
         self._add_device(device)
-        self.assertEqual(self.interface.GatherRequests(), [])
+        assert self.interface.GatherRequests() == []
 
         # Add unselected disk.
         self._add_device(DiskDevice(
@@ -151,7 +151,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
         ))
 
         self.module.on_selected_disks_changed(["dev1", "dev2"])
-        self.assertEqual(self.interface.GatherRequests(), [])
+        assert self.interface.GatherRequests() == []
 
     def test_gather_requests(self):
         """Test GatherRequests."""
@@ -169,7 +169,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
             fmt=get_format("swap"))
         )
 
-        self.assertEqual(self.interface.GatherRequests(), [
+        assert self.interface.GatherRequests() == [
             {
                 'device-spec': get_variant(Str, '/dev/dev1'),
                 'format-options': get_variant(Str, ''),
@@ -186,7 +186,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
                 'mount-point': get_variant(Str, ''),
                 'reformat': get_variant(Bool, False)
             }
-        ])
+        ]
 
     def test_gather_requests_combination(self):
         """Test GatherRequests with user requests."""
@@ -221,7 +221,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
         self.module.set_requests([req1, req3])
 
         # Get requests for dev1 and dev2.
-        self.assertEqual(self.interface.GatherRequests(), [
+        assert self.interface.GatherRequests() == [
             {
                 'device-spec': get_variant(Str, '/dev/dev1'),
                 'format-options': get_variant(Str, '-L BOOT'),
@@ -238,7 +238,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
                 'mount-point': get_variant(Str, ''),
                 'reformat': get_variant(Bool, False)
             }
-        ])
+        ]
 
     @patch_dbus_publish_object
     def test_configure_with_task(self, publisher):
@@ -248,5 +248,5 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, ManualPartitioningTask)
 
-        self.assertEqual(obj.implementation._storage, self.module.storage)
-        self.assertEqual(obj.implementation._requests, self.module.requests)
+        assert obj.implementation._storage == self.module.storage
+        assert obj.implementation._requests == self.module.requests

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_specification.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_specification.py
@@ -29,41 +29,41 @@ class PartitioningSpecificationTestCase(unittest.TestCase):
     def test_is_partition(self):
         """Test the is_partition method."""
         spec = PartSpec("/")
-        self.assertEqual(spec.is_partition(AUTOPART_TYPE_PLAIN), True)
-        self.assertEqual(spec.is_partition(AUTOPART_TYPE_LVM), True)
-        self.assertEqual(spec.is_partition(AUTOPART_TYPE_LVM_THINP), True)
-        self.assertEqual(spec.is_partition(AUTOPART_TYPE_BTRFS), True)
+        assert spec.is_partition(AUTOPART_TYPE_PLAIN) == True
+        assert spec.is_partition(AUTOPART_TYPE_LVM) == True
+        assert spec.is_partition(AUTOPART_TYPE_LVM_THINP) == True
+        assert spec.is_partition(AUTOPART_TYPE_BTRFS) == True
 
     def test_is_volume(self):
         """Test the is_volume method."""
         spec = PartSpec("/", lv=True)
-        self.assertEqual(spec.is_volume(AUTOPART_TYPE_PLAIN), False)
-        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM), True)
-        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM_THINP), True)
-        self.assertEqual(spec.is_volume(AUTOPART_TYPE_BTRFS), False)
+        assert spec.is_volume(AUTOPART_TYPE_PLAIN) == False
+        assert spec.is_volume(AUTOPART_TYPE_LVM) == True
+        assert spec.is_volume(AUTOPART_TYPE_LVM_THINP) == True
+        assert spec.is_volume(AUTOPART_TYPE_BTRFS) == False
 
         spec = PartSpec("/", lv=True, thin=True)
-        self.assertEqual(spec.is_volume(AUTOPART_TYPE_PLAIN), False)
-        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM), True)
-        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM_THINP), True)
-        self.assertEqual(spec.is_volume(AUTOPART_TYPE_BTRFS), False)
+        assert spec.is_volume(AUTOPART_TYPE_PLAIN) == False
+        assert spec.is_volume(AUTOPART_TYPE_LVM) == True
+        assert spec.is_volume(AUTOPART_TYPE_LVM_THINP) == True
+        assert spec.is_volume(AUTOPART_TYPE_BTRFS) == False
 
         spec = PartSpec("/", btr=True)
-        self.assertEqual(spec.is_volume(AUTOPART_TYPE_PLAIN), False)
-        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM), False)
-        self.assertEqual(spec.is_volume(AUTOPART_TYPE_LVM_THINP), False)
-        self.assertEqual(spec.is_volume(AUTOPART_TYPE_BTRFS), True)
+        assert spec.is_volume(AUTOPART_TYPE_PLAIN) == False
+        assert spec.is_volume(AUTOPART_TYPE_LVM) == False
+        assert spec.is_volume(AUTOPART_TYPE_LVM_THINP) == False
+        assert spec.is_volume(AUTOPART_TYPE_BTRFS) == True
 
     def test_is_lvm_thin_volume(self):
         """Test the is_lvm_thin_volume method."""
         spec = PartSpec("/", lv=True)
-        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_PLAIN), False)
-        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM), False)
-        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM_THINP), False)
-        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_BTRFS), False)
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_PLAIN) == False
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM) == False
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM_THINP) == False
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_BTRFS) == False
 
         spec = PartSpec("/", lv=True, thin=True)
-        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_PLAIN), False)
-        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM), False)
-        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM_THINP), True)
-        self.assertEqual(spec.is_lvm_thin_volume(AUTOPART_TYPE_BTRFS), False)
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_PLAIN) == False
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM) == False
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM_THINP) == True
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_BTRFS) == False

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
@@ -544,7 +544,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             PartitioningRequest.to_structure(request)
         )
 
-        obj = check_task_creation(self, task_path, publisher, InteractiveAutoPartitioningTask)
+        obj = check_task_creation(task_path, publisher, InteractiveAutoPartitioningTask)
         assert obj.implementation._storage == self.module.storage
         assert compare_data(obj.implementation._request, request)
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
@@ -18,6 +18,7 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import pytest
 import copy
 from unittest.mock import patch, Mock
 
@@ -70,14 +71,12 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
 
     def test_publication(self):
         """Test the DBus representation."""
-        self.assertIsInstance(self.module.for_publication(), DeviceTreeSchedulerInterface)
+        assert isinstance(self.module.for_publication(), DeviceTreeSchedulerInterface)
 
     def test_generate_system_name(self):
         """Test GenerateSystemName."""
-        self.assertEqual(
-            self.interface.GenerateSystemName(),
+        assert self.interface.GenerateSystemName() == \
             "New anaconda bluesky Installation"
-        )
 
     def test_generate_system_data(self):
         """Test GenerateSystemData."""
@@ -86,18 +85,18 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(StorageDevice("dev3", fmt=get_format("swap")))
 
         os_data = self.interface.GenerateSystemData("dev1")
-        self.assertEqual(get_native(os_data), {
+        assert get_native(os_data) == {
             'mount-points': {'/boot': 'dev1', '/': 'dev2'},
             'os-name': 'New anaconda bluesky Installation',
             'swap-devices': ['dev3']
-        })
+        }
 
     def test_collect_new_devices(self):
         """Test CollectNewDevices."""
         self._add_device(StorageDevice("dev1", fmt=get_format("ext4", mountpoint="/boot")))
         self._add_device(StorageDevice("dev2", fmt=get_format("ext4", mountpoint="/")))
         self._add_device(StorageDevice("dev3", fmt=get_format("swap")))
-        self.assertEqual(self.interface.CollectNewDevices("dev1"), ["dev1", "dev2", "dev3"])
+        assert self.interface.CollectNewDevices("dev1") == ["dev1", "dev2", "dev3"]
 
     def test_collect_unused_devices(self):
         """Test CollectUnusedDevices."""
@@ -126,7 +125,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(dev3)
         self._add_device(dev4)
 
-        self.assertEqual(self.interface.CollectUnusedDevices(), ["dev2", "dev3"])
+        assert self.interface.CollectUnusedDevices() == ["dev2", "dev3"]
 
     @patch.object(FS, "update_size_info")
     def test_collect_supported_systems(self, update_size_info):
@@ -157,22 +156,20 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         )]
 
         os_data_list = self.interface.CollectSupportedSystems()
-        self.assertEqual(get_native(os_data_list), [{
+        assert get_native(os_data_list) == [{
             'os-name': 'My Linux',
             'mount-points': {'/': 'dev2'},
             'swap-devices': ['dev3']
-        }])
+        }]
 
     def test_get_default_file_system(self):
         """Test GetDefaultFileSystem."""
-        self.assertEqual(self.interface.GetDefaultFileSystem(), "ext4")
+        assert self.interface.GetDefaultFileSystem() == "ext4"
 
     def test_get_supported_raid_levels(self):
         """Test GetSupportedRaidLevels."""
-        self.assertEqual(
-            self.interface.GetSupportedRaidLevels(DEVICE_TYPE_LVM),
+        assert self.interface.GetSupportedRaidLevels(DEVICE_TYPE_LVM) == \
             ['linear', 'raid1', 'raid10', 'raid4', 'raid5', 'raid6', 'striped']
-        )
 
     @patch('pyanaconda.modules.storage.partitioning.interactive.utils.get_format')
     @patch('pyanaconda.modules.storage.partitioning.interactive.utils.platform', new_callable=EFI)
@@ -188,19 +185,19 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             "dev2",
             fmt=get_format("ext4", mountpoint="/")
         ))
-        self.assertEqual(self.interface.CollectUnusedMountPoints(), [
+        assert self.interface.CollectUnusedMountPoints() == [
             '/boot/efi', '/home', '/var', 'swap', 'biosboot'
-        ])
+        ]
 
     def _check_report(self, report, error_message=None):
         """Check the given validation report."""
         errors = [error_message] if error_message else []
         warnings = []
 
-        self.assertEqual(get_native(report), {
+        assert get_native(report) == {
             "error-messages": errors,
             "warning-messages": warnings
-        })
+        }
 
     def test_validate_mount_point(self):
         """Test ValidateMountPoint."""
@@ -326,7 +323,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(dev2)
 
         request = self.interface.GenerateDeviceFactoryRequest("dev2")
-        self.assertEqual(get_native(request), {
+        assert get_native(request) == {
             'device-spec': 'dev2',
             'disks': ['dev1'],
             'mount-point': '/',
@@ -344,7 +341,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             'container-size-policy': SIZE_POLICY_AUTO,
             'container-encrypted': False,
             'container-raid-level': '',
-        })
+        }
 
     def test_reset_device_factory_request(self):
         """Test reset_container_data."""
@@ -358,39 +355,39 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         request.container_raid_level = "raid1"
         request.reset_container_data()
 
-        self.assertEqual(compare_data(request, default), True)
+        assert compare_data(request, default) == True
 
     def test_get_default_luks_version(self):
         """Test GetDefaultLUKSVersion."""
-        self.assertEqual(self.interface.GetDefaultLUKSVersion(), "luks2")
+        assert self.interface.GetDefaultLUKSVersion() == "luks2"
 
     def test_generate_device_name(self):
         """Test GenerateDeviceName."""
-        self.assertEqual(self.interface.GenerateDeviceName("/home", "ext4"), "home")
+        assert self.interface.GenerateDeviceName("/home", "ext4") == "home"
 
     def test_get_file_systems_for_device(self):
         """Test GetFileSystemsForDevice."""
         self._add_device(StorageDevice("dev1", fmt=get_format("ext4")))
         result = self.interface.GetFileSystemsForDevice("dev1")
 
-        self.assertIsInstance(result, list)
-        self.assertNotEqual(len(result), 0)
-        self.assertIn("ext4", result)
+        assert isinstance(result, list)
+        assert len(result) != 0
+        assert "ext4" in result
 
         for fs in result:
-            self.assertIsInstance(fs, str)
-            self.assertEqual(fs, get_format(fs).type)
+            assert isinstance(fs, str)
+            assert fs == get_format(fs).type
 
     def test_get_device_types_for_device(self):
         """Test GetDeviceTypesForDevice."""
         self._add_device(DiskDevice("dev1"))
-        self.assertEqual(self.interface.GetDeviceTypesForDevice("dev1"), [
+        assert self.interface.GetDeviceTypesForDevice("dev1") == [
             DEVICE_TYPE_LVM,
             DEVICE_TYPE_MD,
             DEVICE_TYPE_PARTITION,
             DEVICE_TYPE_DISK,
             DEVICE_TYPE_LVM_THINP,
-        ])
+        ]
 
     def test_validate_device_factory_request(self):
         """Test ValidateDeviceFactoryRequest."""
@@ -453,7 +450,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
 
         request = self.interface.GenerateDeviceFactoryRequest("dev1")
         permissions = self.interface.GenerateDeviceFactoryPermissions(request)
-        self.assertEqual(get_native(permissions), {
+        assert get_native(permissions) == {
             'mount-point': False,
             'reformat': False,
             'format-type': True,
@@ -469,11 +466,11 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             'container-size-policy': False,
             'container-encrypted': False,
             'container-raid-level': False,
-        })
+        }
 
         request = self.interface.GenerateDeviceFactoryRequest("dev2")
         permissions = self.interface.GenerateDeviceFactoryPermissions(request)
-        self.assertEqual(get_native(permissions), {
+        assert get_native(permissions) == {
             'mount-point': True,
             'reformat': False,
             'format-type': True,
@@ -489,12 +486,12 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             'container-size-policy': False,
             'container-encrypted': False,
             'container-raid-level': False,
-        })
+        }
 
         dev2.protected = True
         permissions = self.interface.GenerateDeviceFactoryPermissions(request)
         for value in get_native(permissions).values():
-            self.assertEqual(value, False)
+            assert value == False
 
     def test_generate_device_factory_permissions_btrfs(self):
         """Test GenerateDeviceFactoryPermissions with btrfs."""
@@ -517,7 +514,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             request = self.interface.GenerateDeviceFactoryRequest(dev2.name)
             permissions = self.interface.GenerateDeviceFactoryPermissions(request)
 
-        self.assertEqual(get_native(permissions), {
+        assert get_native(permissions) == {
             'mount-point': False,
             'reformat': False,
             'format-type': False,
@@ -533,7 +530,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             'container-size-policy': True,
             'container-encrypted': True,
             'container-raid-level': True,
-        })
+        }
 
     @patch_dbus_publish_object
     def test_schedule_partitions_with_task(self, publisher):
@@ -548,8 +545,8 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         )
 
         obj = check_task_creation(self, task_path, publisher, InteractiveAutoPartitioningTask)
-        self.assertEqual(obj.implementation._storage, self.module.storage)
-        self.assertTrue(compare_data(obj.implementation._request, request))
+        assert obj.implementation._storage == self.module.storage
+        assert compare_data(obj.implementation._request, request)
 
     def test_destroy_device(self):
         """Test DestroyDevice."""
@@ -580,24 +577,24 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self.module.storage.devicetree._add_device(dev2)
         self.module.storage.devicetree._add_device(dev3)
 
-        with self.assertRaises(StorageConfigurationError):
+        with pytest.raises(StorageConfigurationError):
             self.interface.DestroyDevice("dev1")
 
-        self.assertIn(dev1, self.module.storage.devices)
-        self.assertIn(dev2, self.module.storage.devices)
-        self.assertIn(dev3, self.module.storage.devices)
+        assert dev1 in self.module.storage.devices
+        assert dev2 in self.module.storage.devices
+        assert dev3 in self.module.storage.devices
 
         self.interface.DestroyDevice("dev2")
 
-        self.assertNotIn(dev1, self.module.storage.devices)
-        self.assertNotIn(dev2, self.module.storage.devices)
-        self.assertIn(dev3, self.module.storage.devices)
+        assert dev1 not in self.module.storage.devices
+        assert dev2 not in self.module.storage.devices
+        assert dev3 in self.module.storage.devices
 
         self.interface.DestroyDevice("dev3")
 
-        self.assertNotIn(dev1, self.module.storage.devices)
-        self.assertNotIn(dev2, self.module.storage.devices)
-        self.assertNotIn(dev3, self.module.storage.devices)
+        assert dev1 not in self.module.storage.devices
+        assert dev2 not in self.module.storage.devices
+        assert dev3 not in self.module.storage.devices
 
     def test_reset_device(self):
         """Test ResetDevice."""
@@ -630,27 +627,27 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self.module.storage.devicetree._add_device(dev2)
         self.module.storage.devicetree._add_device(dev3)
 
-        with self.assertRaises(StorageConfigurationError):
+        with pytest.raises(StorageConfigurationError):
             self.interface.ResetDevice("dev1")
 
-        self.assertIn(dev1, self.module.storage.devices)
-        self.assertIn(dev2, self.module.storage.devices)
-        self.assertIn(dev3, self.module.storage.devices)
-        self.assertEqual(dev3.format.type, "xfs")
+        assert dev1 in self.module.storage.devices
+        assert dev2 in self.module.storage.devices
+        assert dev3 in self.module.storage.devices
+        assert dev3.format.type == "xfs"
 
         self.interface.ResetDevice("dev2")
 
-        self.assertNotIn(dev1, self.module.storage.devices)
-        self.assertNotIn(dev2, self.module.storage.devices)
-        self.assertIn(dev3, self.module.storage.devices)
-        self.assertEqual(dev3.format.type, "xfs")
+        assert dev1 not in self.module.storage.devices
+        assert dev2 not in self.module.storage.devices
+        assert dev3 in self.module.storage.devices
+        assert dev3.format.type == "xfs"
 
         self.interface.ResetDevice("dev3")
 
-        self.assertNotIn(dev1, self.module.storage.devices)
-        self.assertNotIn(dev2, self.module.storage.devices)
-        self.assertIn(dev3, self.module.storage.devices)
-        self.assertEqual(dev3.format.type, "ext4")
+        assert dev1 not in self.module.storage.devices
+        assert dev2 not in self.module.storage.devices
+        assert dev3 in self.module.storage.devices
+        assert dev3.format.type == "ext4"
 
     def test_is_device_locked(self):
         """Test IsDeviceLocked."""
@@ -676,9 +673,9 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(dev2)
         self._add_device(dev3)
 
-        self.assertEqual(self.interface.IsDeviceLocked("dev1"), False)
-        self.assertEqual(self.interface.IsDeviceLocked("dev2"), False)
-        self.assertEqual(self.interface.IsDeviceLocked("dev3"), True)
+        assert self.interface.IsDeviceLocked("dev1") == False
+        assert self.interface.IsDeviceLocked("dev2") == False
+        assert self.interface.IsDeviceLocked("dev3") == True
 
     def test_check_completeness(self):
         """Test CheckCompleteness."""
@@ -742,8 +739,8 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(dev1)
         self._add_device(dev2)
 
-        self.assertEqual(self.interface.IsDeviceEditable("dev1"), False)
-        self.assertEqual(self.interface.IsDeviceEditable("dev2"), True)
+        assert self.interface.IsDeviceEditable("dev1") == False
+        assert self.interface.IsDeviceEditable("dev2") == True
 
     def test_collect_containers(self):
         """Test CollectContainers."""
@@ -760,8 +757,8 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(dev1)
         self._add_device(dev2)
 
-        self.assertEqual(self.interface.CollectContainers(DEVICE_TYPE_BTRFS), [dev2.name])
-        self.assertEqual(self.interface.CollectContainers(DEVICE_TYPE_LVM), [])
+        assert self.interface.CollectContainers(DEVICE_TYPE_BTRFS) == [dev2.name]
+        assert self.interface.CollectContainers(DEVICE_TYPE_LVM) == []
 
     def test_get_container_free_space(self):
         """Test GetContainerFreeSpace."""
@@ -779,11 +776,11 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(dev2)
 
         free_space = self.interface.GetContainerFreeSpace("dev1")
-        self.assertEqual(free_space, 0)
+        assert free_space == 0
 
         free_space = self.interface.GetContainerFreeSpace("dev2")
-        self.assertGreater(free_space, Size("9 GiB").get_bytes())
-        self.assertLess(free_space, Size("10 GiB").get_bytes())
+        assert free_space > Size("9 GiB").get_bytes()
+        assert free_space < Size("10 GiB").get_bytes()
 
     @patch_dbus_get_proxy
     def test_generate_container_name(self, proxy_getter):
@@ -793,13 +790,13 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
 
         network_proxy.Hostname = "localhost"
         network_proxy.GetCurrentHostname.return_value = "localhost"
-        self.assertEqual(self.interface.GenerateContainerName(), "anaconda")
+        assert self.interface.GenerateContainerName() == "anaconda"
 
         network_proxy.GetCurrentHostname.return_value = "hostname"
-        self.assertEqual(self.interface.GenerateContainerName(), "anaconda_hostname")
+        assert self.interface.GenerateContainerName() == "anaconda_hostname"
 
         network_proxy.Hostname = "best.hostname"
-        self.assertEqual(self.interface.GenerateContainerName(), "anaconda_best")
+        assert self.interface.GenerateContainerName() == "anaconda_best"
 
     @patch_dbus_get_proxy
     def test_generate_container_data(self, proxy_getter):
@@ -848,11 +845,11 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             )
         )
 
-        self.assertEqual(request.container_spec, "testvg")
-        self.assertEqual(request.container_name, "testvg")
-        self.assertEqual(request.container_encrypted, False)
-        self.assertEqual(request.container_raid_level, "")
-        self.assertEqual(request.container_size_policy, Size("1.5 GiB").get_bytes())
+        assert request.container_spec == "testvg"
+        assert request.container_name == "testvg"
+        assert request.container_encrypted == False
+        assert request.container_raid_level == ""
+        assert request.container_size_policy == Size("1.5 GiB").get_bytes()
 
         request.device_type = DEVICE_TYPE_BTRFS
         request = DeviceFactoryRequest.from_structure(
@@ -861,11 +858,11 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             )
         )
 
-        self.assertEqual(request.container_spec, "")
-        self.assertEqual(request.container_name, "anaconda")
-        self.assertEqual(request.container_encrypted, False)
-        self.assertEqual(request.container_raid_level, "single")
-        self.assertEqual(request.container_size_policy, 0)
+        assert request.container_spec == ""
+        assert request.container_name == "anaconda"
+        assert request.container_encrypted == False
+        assert request.container_raid_level == "single"
+        assert request.container_size_policy == 0
 
         request.device_type = DEVICE_TYPE_PARTITION
         request = DeviceFactoryRequest.from_structure(
@@ -874,11 +871,11 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             )
         )
 
-        self.assertEqual(request.container_spec, "")
-        self.assertEqual(request.container_name, "")
-        self.assertEqual(request.container_encrypted, False)
-        self.assertEqual(request.container_raid_level, "")
-        self.assertEqual(request.container_size_policy, 0)
+        assert request.container_spec == ""
+        assert request.container_name == ""
+        assert request.container_encrypted == False
+        assert request.container_raid_level == ""
+        assert request.container_size_policy == 0
 
     def test_update_container_data(self):
         """Test UpdateContainerData."""
@@ -904,7 +901,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         request = DeviceFactoryRequest()
         request.device_type = DEVICE_TYPE_PARTITION
 
-        with self.assertRaises(StorageError):
+        with pytest.raises(StorageError):
             self.interface.UpdateContainerData(
                     DeviceFactoryRequest.to_structure(request),
                     "anaconda"
@@ -918,12 +915,12 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             )
         )
 
-        self.assertEqual(request.container_spec, "")
-        self.assertEqual(request.container_name, "anaconda")
-        self.assertEqual(request.container_encrypted, False)
-        self.assertEqual(request.container_raid_level, "single")
-        self.assertEqual(request.container_size_policy, 0)
-        self.assertEqual(request.disks, [])
+        assert request.container_spec == ""
+        assert request.container_name == "anaconda"
+        assert request.container_encrypted == False
+        assert request.container_raid_level == "single"
+        assert request.container_size_policy == 0
+        assert request.disks == []
 
         request.device_type = DEVICE_TYPE_LVM
         request = DeviceFactoryRequest.from_structure(
@@ -933,12 +930,12 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             )
         )
 
-        self.assertEqual(request.container_spec, "testvg")
-        self.assertEqual(request.container_name, "testvg")
-        self.assertEqual(request.container_encrypted, False)
-        self.assertEqual(request.container_raid_level, "")
-        self.assertEqual(request.container_size_policy, Size("1.5 GiB").get_bytes())
-        self.assertEqual(request.disks, [])
+        assert request.container_spec == "testvg"
+        assert request.container_name == "testvg"
+        assert request.container_encrypted == False
+        assert request.container_raid_level == ""
+        assert request.container_size_policy == Size("1.5 GiB").get_bytes()
+        assert request.disks == []
 
     def test_is_device(self):
         """Test IsDevice."""
@@ -949,13 +946,13 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             exists=True
         )
 
-        self.assertEqual(self.interface.IsDevice("dev1"), False)
+        assert self.interface.IsDevice("dev1") == False
 
         self._add_device(dev1)
-        self.assertEqual(self.interface.IsDevice("dev1"), True)
+        assert self.interface.IsDevice("dev1") == True
 
         dev1.complete = False
-        self.assertEqual(self.interface.IsDevice("dev1"), True)
+        assert self.interface.IsDevice("dev1") == True
 
         self.storage.devicetree.hide(dev1)
-        self.assertEqual(self.interface.IsDevice("dev1"), True)
+        assert self.interface.IsDevice("dev1") == True

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_clearpart.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_clearpart.py
@@ -84,119 +84,106 @@ class ClearPartTestCase(unittest.TestCase):
         # clearpart type none
         #
         self._config.initialization_mode = CLEAR_PARTITIONS_NONE
-        self.assertFalse(self._can_remove(sda1),
-                         msg="type none should not clear any partitions")
-        self.assertFalse(self._can_remove(sda2),
-                         msg="type none should not clear any partitions")
+        assert not self._can_remove(sda1), \
+            "type none should not clear any partitions"
+        assert not self._can_remove(sda2), \
+            "type none should not clear any partitions"
 
         self._config.initialize_labels = False
-        self.assertFalse(self._can_remove(sda),
-                         msg="type none should not clear non-empty disks")
-        self.assertFalse(self._can_remove(sdb),
-                         msg="type none should not clear formatting from "
-                             "unpartitioned disks")
+        assert not self._can_remove(sda), \
+            "type none should not clear non-empty disks"
+        assert not self._can_remove(sdb), \
+            "type none should not clear formatting from unpartitioned disks"
 
-        self.assertFalse(self._can_remove(sdc),
-                         msg="type none should not clear empty disk without "
-                             "initlabel")
-        self.assertFalse(self._can_remove(sdd),
-                         msg="type none should not clear empty partition table "
-                             "without initlabel")
+        assert not self._can_remove(sdc), \
+            "type none should not clear empty disk without initlabel"
+        assert not self._can_remove(sdd), \
+            "type none should not clear empty partition table without initlabel"
 
         self._config.initialize_labels = True
-        self.assertFalse(self._can_remove(sda),
-                         msg="type none should not clear non-empty disks even "
-                             "with initlabel")
-        self.assertFalse(self._can_remove(sdb),
-                         msg="type non should not clear formatting from "
-                             "unpartitioned disks even with initlabel")
-        self.assertTrue(self._can_remove(sdc),
-                        msg="type none should clear empty disks when initlabel "
-                            "is set")
-        self.assertTrue(self._can_remove(sdd),
-                        msg="type none should clear empty partition table when "
-                            "initlabel is set")
+        assert not self._can_remove(sda), \
+            "type none should not clear non-empty disks even with initlabel"
+        assert not self._can_remove(sdb), \
+            "type non should not clear formatting from unpartitioned disks even with initlabel"
+        assert self._can_remove(sdc), \
+            "type none should clear empty disks when initlabel is set"
+        assert self._can_remove(sdd), \
+            "type none should clear empty partition table when initlabel is set"
 
         #
         # clearpart type linux
         #
         self._config.initialization_mode = CLEAR_PARTITIONS_LINUX
-        self.assertTrue(self._can_remove(sda1),
-                        msg="type linux should clear partitions containing "
-                            "ext4 filesystems")
-        self.assertFalse(self._can_remove(sda2),
-                         msg="type linux should not clear partitions "
-                             "containing vfat filesystems")
+        assert self._can_remove(sda1), \
+            "type linux should clear partitions containing ext4 filesystems"
+        assert not self._can_remove(sda2), \
+            "type linux should not clear partitions containing vfat filesystems"
 
         self._config.initialize_labels = False
-        self.assertFalse(self._can_remove(sda),
-                         msg="type linux should not clear non-empty disklabels")
-        self.assertTrue(self._can_remove(sdb),
-                        msg="type linux should clear linux-native whole-disk "
-                            "formatting regardless of initlabel setting")
-        self.assertFalse(self._can_remove(sdc),
-                         msg="type linux should not clear unformatted disks "
-                             "unless initlabel is set")
-        self.assertFalse(self._can_remove(sdd),
-                         msg="type linux should not clear disks with empty "
-                             "partition tables unless initlabel is set")
+        assert not self._can_remove(sda), \
+            "type linux should not clear non-empty disklabels"
+        assert self._can_remove(sdb), \
+            "type linux should clear linux-native whole-disk " \
+            "formatting regardless of initlabel setting"
+        assert not self._can_remove(sdc), \
+            "type linux should not clear unformatted disks unless initlabel is set"
+        assert not self._can_remove(sdd), \
+            "type linux should not clear disks with empty " \
+            "partition tables unless initlabel is set"
 
         self._config.initialize_labels = True
-        self.assertFalse(self._can_remove(sda),
-                         msg="type linux should not clear non-empty disklabels")
-        self.assertTrue(self._can_remove(sdb),
-                        msg="type linux should clear linux-native whole-disk "
-                            "formatting regardless of initlabel setting")
-        self.assertTrue(self._can_remove(sdc),
-                        msg="type linux should clear unformatted disks when "
-                        "initlabel is set")
-        self.assertTrue(self._can_remove(sdd),
-                        msg="type linux should clear disks with empty "
-                        "partition tables when initlabel is set")
+        assert not self._can_remove(sda), \
+            "type linux should not clear non-empty disklabels"
+        assert self._can_remove(sdb), \
+            "type linux should clear linux-native whole-disk " \
+            "formatting regardless of initlabel setting"
+        assert self._can_remove(sdc), \
+            "type linux should clear unformatted disks when initlabel is set"
+        assert self._can_remove(sdd), \
+            "type linux should clear disks with empty " \
+            "partition tables when initlabel is set"
 
         sda1.protected = True
-        self.assertFalse(self._can_remove(sda1),
-                         msg="protected devices should never be cleared")
-        self.assertFalse(self._can_remove(sda),
-                         msg="disks containing protected devices should never "
-                             "be cleared")
+        assert not self._can_remove(sda1), \
+            "protected devices should never be cleared"
+        assert not self._can_remove(sda), \
+            "disks containing protected devices should never be cleared"
         sda1.protected = False
 
         #
         # clearpart type all
         #
         self._config.initialization_mode = CLEAR_PARTITIONS_ALL
-        self.assertTrue(self._can_remove(sda1),
-                        msg="type all should clear all partitions")
-        self.assertTrue(self._can_remove(sda2),
-                        msg="type all should clear all partitions")
+        assert self._can_remove(sda1), \
+            "type all should clear all partitions"
+        assert self._can_remove(sda2), \
+            "type all should clear all partitions"
 
         self._config.initialize_labels = False
-        self.assertTrue(self._can_remove(sda),
-                        msg="type all should initialize all disks")
-        self.assertTrue(self._can_remove(sdb),
-                        msg="type all should initialize all disks")
-        self.assertTrue(self._can_remove(sdc),
-                        msg="type all should initialize all disks")
-        self.assertTrue(self._can_remove(sdd),
-                        msg="type all should initialize all disks")
+        assert self._can_remove(sda), \
+            "type all should initialize all disks"
+        assert self._can_remove(sdb), \
+            "type all should initialize all disks"
+        assert self._can_remove(sdc), \
+            "type all should initialize all disks"
+        assert self._can_remove(sdd), \
+            "type all should initialize all disks"
 
         self._config.initialize_labels = True
-        self.assertTrue(self._can_remove(sda),
-                        msg="type all should initialize all disks")
-        self.assertTrue(self._can_remove(sdb),
-                        msg="type all should initialize all disks")
-        self.assertTrue(self._can_remove(sdc),
-                        msg="type all should initialize all disks")
-        self.assertTrue(self._can_remove(sdd),
-                        msg="type all should initialize all disks")
+        assert self._can_remove(sda), \
+            "type all should initialize all disks"
+        assert self._can_remove(sdb), \
+            "type all should initialize all disks"
+        assert self._can_remove(sdc), \
+            "type all should initialize all disks"
+        assert self._can_remove(sdd), \
+            "type all should initialize all disks"
 
         sda1.protected = True
-        self.assertFalse(self._can_remove(sda1),
-                         msg="protected devices should never be cleared")
-        self.assertFalse(self._can_remove(sda),
-                         msg="disks containing protected devices should never "
-                             "be cleared")
+        assert not self._can_remove(sda1), \
+            "protected devices should never be cleared"
+        assert not self._can_remove(sda), \
+            "disks containing protected devices should never be cleared"
         sda1.protected = False
 
         #

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_fsset.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_fsset.py
@@ -52,10 +52,10 @@ class FSSetTestCase(unittest.TestCase):
         devices = self.fsset.system_filesystems
 
         # There are some devices in the list.
-        self.assertTrue(devices)
+        assert devices
 
         # The devices are always the same.
-        self.assertEqual(devices, self.fsset.system_filesystems)
+        assert devices == self.fsset.system_filesystems
 
     @patch("pyanaconda.modules.storage.devicetree.fsset.platform", X86())
     def test_collect_filesystems(self):
@@ -64,7 +64,7 @@ class FSSetTestCase(unittest.TestCase):
         mount_points = self._get_mount_points(devices)
         format_types = self._get_format_types(devices)
 
-        self.assertEqual(mount_points, [
+        assert mount_points == [
             '/dev',
             '/dev/pts',
             '/dev/shm',
@@ -74,9 +74,9 @@ class FSSetTestCase(unittest.TestCase):
             '/sys',
             '/sys/fs/selinux',
             '/tmp',
-        ])
+        ]
 
-        self.assertEqual(format_types, [
+        assert format_types == [
             'bind',
             'devpts',
             'tmpfs',
@@ -86,7 +86,7 @@ class FSSetTestCase(unittest.TestCase):
             'sysfs',
             'selinuxfs',
             'tmpfs',
-        ])
+        ]
 
     @patch("pyanaconda.modules.storage.devicetree.fsset.platform", EFI())
     def test_collect_filesystems_efi(self):
@@ -95,7 +95,7 @@ class FSSetTestCase(unittest.TestCase):
         mount_points = self._get_mount_points(devices)
         format_types = self._get_format_types(devices)
 
-        self.assertEqual(mount_points, [
+        assert mount_points == [
             '/dev',
             '/dev/pts',
             '/dev/shm',
@@ -106,9 +106,9 @@ class FSSetTestCase(unittest.TestCase):
             '/sys/firmware/efi/efivars',
             '/sys/fs/selinux',
             '/tmp',
-        ])
+        ]
 
-        self.assertEqual(format_types, [
+        assert format_types == [
             'bind',
             'devpts',
             'tmpfs',
@@ -119,7 +119,7 @@ class FSSetTestCase(unittest.TestCase):
             'efivarfs',
             'selinuxfs',
             'tmpfs',
-        ])
+        ]
 
     @patch("pyanaconda.modules.storage.devicetree.fsset.platform", X86())
     def test_collect_filesystems_tmp(self):
@@ -130,7 +130,7 @@ class FSSetTestCase(unittest.TestCase):
         mount_points = self._get_mount_points(devices)
         format_types = self._get_format_types(devices)
 
-        self.assertEqual(mount_points, [
+        assert mount_points == [
             '/dev',
             '/dev/pts',
             '/dev/shm',
@@ -140,9 +140,9 @@ class FSSetTestCase(unittest.TestCase):
             '/sys',
             '/sys/fs/selinux',
             '/tmp',
-        ])
+        ]
 
-        self.assertEqual(format_types, [
+        assert format_types == [
             'bind',
             'devpts',
             'tmpfs',
@@ -152,7 +152,7 @@ class FSSetTestCase(unittest.TestCase):
             'sysfs',
             'selinuxfs',
             'ext4',
-        ])
+        ]
 
     @patch("pyanaconda.modules.storage.devicetree.fsset.platform", X86())
     def test_collect_filesystems_extra(self):
@@ -167,7 +167,7 @@ class FSSetTestCase(unittest.TestCase):
         mount_points = self._get_mount_points(devices)
         format_types = self._get_format_types(devices)
 
-        self.assertEqual(mount_points, [
+        assert mount_points == [
             None,
             None,
             '/',
@@ -182,9 +182,9 @@ class FSSetTestCase(unittest.TestCase):
             '/sys',
             '/sys/fs/selinux',
             '/tmp',
-        ])
+        ]
 
-        self.assertEqual(format_types, [
+        assert format_types == [
             'swap',
             'swap',
             'ext4',
@@ -199,4 +199,4 @@ class FSSetTestCase(unittest.TestCase):
             'sysfs',
             'selinuxfs',
             'tmpfs',
-        ])
+        ]

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_grub_raid.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_grub_raid.py
@@ -101,7 +101,7 @@ class GRUBRaidSimpleTest(unittest.TestCase):
         install_targets = set(self.grub.install_targets)
         expected_targets = set([(self.sda, self.sda3)])
 
-        self.assertEqual(install_targets, expected_targets)
+        assert install_targets == expected_targets
 
     def test_grub_partition_partition(self):
         """Test installing GRUB to a partition stage1 and partition stage2"""
@@ -114,7 +114,7 @@ class GRUBRaidSimpleTest(unittest.TestCase):
         install_targets = set(self.grub.install_targets)
         expected_targets = set([(self.sda1, self.sda3)])
 
-        self.assertEqual(install_targets, expected_targets)
+        assert install_targets == expected_targets
 
     def test_grub_mbr_raid1(self):
         """Test installing GRUB to a MBR stage1 and RAID1 stage2"""
@@ -128,7 +128,7 @@ class GRUBRaidSimpleTest(unittest.TestCase):
         install_targets = set(self.grub.install_targets)
         expected_targets = set([(self.sda, self.boot_md), (self.sdb, self.boot_md)])
 
-        self.assertEqual(install_targets, expected_targets)
+        assert install_targets == expected_targets
 
     def test_grub_partition_raid1(self):
         """Test installing GRUB to a partition stage1 and MBR stage2"""
@@ -142,7 +142,7 @@ class GRUBRaidSimpleTest(unittest.TestCase):
         install_targets = set(self.grub.install_targets)
         expected_targets = set([(self.sda1, self.boot_md)])
 
-        self.assertEqual(install_targets, expected_targets)
+        assert install_targets == expected_targets
 
     def test_grub_btrfs(self):
         """Test installing GRUB to a MBR stage1 and btrfs RAID stage2"""
@@ -157,7 +157,7 @@ class GRUBRaidSimpleTest(unittest.TestCase):
         install_targets = set(self.grub.install_targets)
         expected_targets = set([(self.sda, self.boot_btrfs), (self.sdb, self.boot_btrfs)])
 
-        self.assertEqual(install_targets, expected_targets)
+        assert install_targets == expected_targets
 
     def test_grub_partition_btrfs(self):
         """Test installing GRUB to a partition stage1 and MBR stage2"""
@@ -171,4 +171,4 @@ class GRUBRaidSimpleTest(unittest.TestCase):
         install_targets = set(self.grub.install_targets)
         expected_targets = set([(self.sda1, self.boot_btrfs)])
 
-        self.assertEqual(install_targets, expected_targets)
+        assert install_targets == expected_targets

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
@@ -20,6 +20,7 @@
 import os
 import tempfile
 import unittest
+import pytest
 
 from unittest import mock
 from unittest.mock import Mock, patch
@@ -71,7 +72,7 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
 
     def test_get_default_type(self):
         """Test GetDefaultType."""
-        self.assertEqual(self.bootloader_interface.GetDefaultType(), "DEFAULT")
+        assert self.bootloader_interface.GetDefaultType() == "DEFAULT"
 
     def test_bootloader_mode_property(self):
         """Test the bootloader mode property."""
@@ -147,21 +148,21 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
 
     def test_is_efi(self):
         """Test IsEFI."""
-        with self.assertRaises(UnavailableStorageError):
+        with pytest.raises(UnavailableStorageError):
             self.bootloader_interface.IsEFI()
 
         storage = Mock()
         self.bootloader_module.on_storage_changed(storage)
 
         storage.bootloader = GRUB2()
-        self.assertEqual(self.bootloader_interface.IsEFI(), False)
+        assert self.bootloader_interface.IsEFI() == False
 
         storage.bootloader = EFIGRUB()
-        self.assertEqual(self.bootloader_interface.IsEFI(), True)
+        assert self.bootloader_interface.IsEFI() == True
 
     def test_get_arguments(self):
         """Test GetArguments."""
-        with self.assertRaises(UnavailableStorageError):
+        with pytest.raises(UnavailableStorageError):
             self.bootloader_interface.GetArguments()
 
         storage = Mock()
@@ -169,11 +170,11 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
 
         storage.bootloader = GRUB2()
         storage.bootloader.boot_args.update(["x=1", "y=2"])
-        self.assertEqual(self.bootloader_interface.GetArguments(), ["x=1", "y=2"])
+        assert self.bootloader_interface.GetArguments() == ["x=1", "y=2"]
 
     def test_detect_windows(self):
         """Test DetectWindows."""
-        with self.assertRaises(UnavailableStorageError):
+        with pytest.raises(UnavailableStorageError):
             self.bootloader_interface.DetectWindows()
 
         device = Mock()
@@ -185,10 +186,10 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
         self.bootloader_module.on_storage_changed(storage)
 
         storage.bootloader.has_windows.return_value = False
-        self.assertEqual(self.bootloader_interface.DetectWindows(), False)
+        assert self.bootloader_interface.DetectWindows() == False
 
         storage.bootloader.has_windows.return_value = True
-        self.assertEqual(self.bootloader_interface.DetectWindows(), True)
+        assert self.bootloader_interface.DetectWindows() == True
 
     @patch_dbus_publish_object
     def test_install_bootloader_with_tasks(self, publisher):
@@ -362,11 +363,11 @@ class BootloaderTasksTestCase(unittest.TestCase):
         bootloader.add_image.assert_called_once()
         image = bootloader.add_image.call_args[0][0]
 
-        self.assertIsInstance(image, LinuxBootLoaderImage)
-        self.assertEqual(image, bootloader.default)
-        self.assertEqual(image.version, version)
-        self.assertEqual(image.label, "anaconda")
-        self.assertEqual(image.device, storage.root_device)
+        assert isinstance(image, LinuxBootLoaderImage)
+        assert image == bootloader.default
+        assert image.version == version
+        assert image.label == "anaconda"
+        assert image.device == storage.root_device
 
     def test_install(self):
         """Test the installation task for the boot loader."""
@@ -442,9 +443,9 @@ class BootloaderTasksTestCase(unittest.TestCase):
                     ], root=root
                 )
             ])
-            self.assertFalse(os.path.exists(
+            assert not os.path.exists(
                 root + "/boot/loader/entries/fake.conf"
-            ))
+            )
 
         exec_mock.reset_mock()
         exec_mock.return_value = 0
@@ -677,37 +678,37 @@ class BootLoaderFactoryTestCase(unittest.TestCase):
     def test_create_boot_loader(self):
         """Test create_boot_loader."""
         boot_loader = BootLoaderFactory.create_boot_loader()
-        self.assertIsNotNone(boot_loader)
-        self.assertIsInstance(boot_loader, BootLoader)
+        assert boot_loader is not None
+        assert isinstance(boot_loader, BootLoader)
 
     def test_get_generic_class(self):
         """Test get_generic_class."""
         cls = BootLoaderFactory.get_generic_class()
-        self.assertEqual(cls, BootLoader)
+        assert cls == BootLoader
 
     @reset_boot_loader_factory()
     def test_get_default_class(self):
         """Test get_default_class."""
         cls = BootLoaderFactory.get_default_class()
-        self.assertEqual(cls, None)
+        assert cls is None
 
         BootLoaderFactory.set_default_class(EXTLINUX)
         cls = BootLoaderFactory.get_default_class()
-        self.assertEqual(cls, EXTLINUX)
+        assert cls == EXTLINUX
 
     def test_get_class_by_name(self):
         """Test get_class_by_name."""
         cls = BootLoaderFactory.get_class_by_name("EXTLINUX")
-        self.assertEqual(cls, EXTLINUX)
+        assert cls == EXTLINUX
 
         cls = BootLoaderFactory.get_class_by_name("DEFAULT")
-        self.assertEqual(cls, None)
+        assert cls is None
 
     def test_get_class_by_platform(self):
         """Test get_class_by_platform."""
         # Test unknown platform.
         cls = BootLoaderFactory.get_class_by_platform(Mock())
-        self.assertEqual(cls, None)
+        assert cls is None
 
         # Test known platforms.
         boot_loader_by_platform = {
@@ -726,8 +727,8 @@ class BootLoaderFactoryTestCase(unittest.TestCase):
         for platform_type, boot_loader_class in boot_loader_by_platform.items():
             # Get the boot loader class.
             cls = BootLoaderFactory.get_class_by_platform(platform_type)
-            self.assertEqual(cls, boot_loader_class)
+            assert cls == boot_loader_class
 
             # Get the boot loader instance.
             obj = cls()
-            self.assertIsInstance(obj, BootLoader)
+            assert isinstance(obj, BootLoader)

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
@@ -64,7 +64,6 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             BOOTLOADER,
             self.bootloader_interface,
             *args, **kwargs
@@ -210,7 +209,7 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
             PAYLOAD_TYPE_LIVE_IMAGE, [version]
         )
 
-        check_task_creation_list(self, task_paths, publisher, task_classes)
+        check_task_creation_list(task_paths, publisher, task_classes)
 
     @patch_dbus_publish_object
     def test_generate_initramfs_with_tasks(self, publisher):
@@ -230,7 +229,7 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
             PAYLOAD_TYPE_LIVE_IMAGE, [version]
         )
 
-        check_task_creation_list(self, task_paths, publisher, task_classes)
+        check_task_creation_list(task_paths, publisher, task_classes)
 
 
 class BootloaderTasksTestCase(unittest.TestCase):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_dasd.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_dasd.py
@@ -53,7 +53,7 @@ class DASDInterfaceTestCase(unittest.TestCase):
         """Test DiscoverWithTask."""
         task_path = self.dasd_interface.DiscoverWithTask("0.0.A100")
 
-        obj = check_task_creation(self, task_path, publisher, DASDDiscoverTask)
+        obj = check_task_creation(task_path, publisher, DASDDiscoverTask)
 
         assert obj.implementation._device_number == "0.0.A100"
 
@@ -62,7 +62,7 @@ class DASDInterfaceTestCase(unittest.TestCase):
         """Test the discover task."""
         task_path = self.dasd_interface.FormatWithTask(["/dev/sda", "/dev/sdb"])
 
-        obj = check_task_creation(self, task_path, publisher, DASDFormatTask)
+        obj = check_task_creation(task_path, publisher, DASDFormatTask)
 
         assert obj.implementation._dasds == ["/dev/sda", "/dev/sdb"]
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_dasd.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_dasd.py
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import pytest
+
 from unittest.mock import patch, call
 
 from blivet.devices import DASDDevice
@@ -44,7 +46,7 @@ class DASDInterfaceTestCase(unittest.TestCase):
 
     @patch("pyanaconda.modules.storage.dasd.dasd.arch.is_s390", return_value=True)
     def test_is_supported(self, is_supported):
-        self.assertEqual(self.dasd_interface.IsSupported(), True)
+        assert self.dasd_interface.IsSupported() == True
 
     @patch_dbus_publish_object
     def test_discover_with_task(self, publisher):
@@ -53,7 +55,7 @@ class DASDInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, DASDDiscoverTask)
 
-        self.assertEqual(obj.implementation._device_number, "0.0.A100")
+        assert obj.implementation._device_number == "0.0.A100"
 
     @patch_dbus_publish_object
     def test_format_with_task(self, publisher):
@@ -62,18 +64,18 @@ class DASDInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, DASDFormatTask)
 
-        self.assertEqual(obj.implementation._dasds, ["/dev/sda", "/dev/sdb"])
+        assert obj.implementation._dasds == ["/dev/sda", "/dev/sdb"]
 
     @patch('pyanaconda.modules.storage.dasd.format.blockdev')
     def test_find_formattable(self, blockdev):
         """Test FindFormattable."""
-        with self.assertRaises(UnavailableStorageError):
+        with pytest.raises(UnavailableStorageError):
             self.dasd_interface.FindFormattable(["dev1"])
 
         storage = create_storage()
         self.dasd_module.on_storage_changed(storage)
 
-        with self.assertRaises(UnknownDeviceError):
+        with pytest.raises(UnknownDeviceError):
             self.dasd_interface.FindFormattable(["dev1"])
 
         storage.devicetree._add_device(
@@ -87,30 +89,30 @@ class DASDInterfaceTestCase(unittest.TestCase):
         )
 
         # The policy doesn't allow tp format anything.
-        self.assertEqual(self.dasd_interface.FindFormattable(["dev1"]), [])
+        assert self.dasd_interface.FindFormattable(["dev1"]) == []
 
         # The policy allows to format unformatted, but there are only FBA DASDs.
         self.dasd_module.on_format_unrecognized_enabled_changed(True)
         blockdev.s390.dasd_is_fba.return_value = True
-        self.assertEqual(self.dasd_interface.FindFormattable(["dev1"]), [])
+        assert self.dasd_interface.FindFormattable(["dev1"]) == []
 
         # The policy allows to format unformatted, but there are none.
         self.dasd_module.on_format_unrecognized_enabled_changed(True)
         blockdev.s390.dasd_is_fba.return_value = False
         blockdev.s390.dasd_needs_format.return_value = False
-        self.assertEqual(self.dasd_interface.FindFormattable(["dev1"]), [])
+        assert self.dasd_interface.FindFormattable(["dev1"]) == []
 
         # The policy allows to format LDL, but there are none.
         self.dasd_module.on_format_unrecognized_enabled_changed(False)
         self.dasd_module.on_format_ldl_enabled_changed(True)
         blockdev.s390.dasd_is_ldl.return_value = False
-        self.assertEqual(self.dasd_interface.FindFormattable(["dev1"]), [])
+        assert self.dasd_interface.FindFormattable(["dev1"]) == []
 
         # The policy allows to format all and there are all.
         self.dasd_module.on_format_unrecognized_enabled_changed(True)
         blockdev.s390.dasd_needs_format.return_value = True
         blockdev.s390.dasd_is_ldl.return_value = True
-        self.assertEqual(self.dasd_interface.FindFormattable(["dev1"]), ["dev1"])
+        assert self.dasd_interface.FindFormattable(["dev1"]) == ["dev1"]
 
 
 class DASDTasksTestCase(unittest.TestCase):
@@ -118,7 +120,7 @@ class DASDTasksTestCase(unittest.TestCase):
 
     def test_discovery_fails(self):
         """Test the failing discovery task."""
-        with self.assertRaises(StorageDiscoveryError):
+        with pytest.raises(StorageDiscoveryError):
             DASDDiscoverTask("x.y.z").run()
 
     @patch('pyanaconda.modules.storage.dasd.discover.blockdev')

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -757,7 +757,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         """Test FindExistingSystemsWithTask."""
         task_path = self.interface.FindExistingSystemsWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, FindExistingSystemsTask)
+        obj = check_task_creation(task_path, publisher, FindExistingSystemsTask)
 
         assert obj.implementation._devicetree == self.module.storage.devicetree
 
@@ -773,7 +773,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
         task_path = self.interface.MountExistingSystemWithTask("dev1", True)
 
-        obj = check_task_creation(self, task_path, publisher, MountExistingSystemTask)
+        obj = check_task_creation(task_path, publisher, MountExistingSystemTask)
 
         assert obj.implementation._storage == self.module.storage
         assert obj.implementation._device.name == "dev1"
@@ -784,7 +784,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         """Test FindDevicesWithTask."""
         task_path = self.interface.FindDevicesWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, FindDevicesTask)
+        obj = check_task_creation(task_path, publisher, FindDevicesTask)
 
         assert obj.implementation._devicetree == self.module.storage.devicetree
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -19,6 +19,8 @@
 #
 import tempfile
 import unittest
+import pytest
+
 from unittest.mock import patch, Mock, PropertyMock
 
 from tests.unit_tests.pyanaconda_tests import patch_dbus_publish_object, check_task_creation
@@ -55,7 +57,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
     def test_publication(self):
         """Check the DBus representation."""
-        self.assertIsInstance(self.module.for_publication(), DeviceTreeInterface)
+        assert isinstance(self.module.for_publication(), DeviceTreeInterface)
 
     @property
     def storage(self):
@@ -68,16 +70,16 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
     def test_get_root_device(self):
         """Test GetRootDevice."""
-        self.assertEqual(self.interface.GetRootDevice(), "")
+        assert self.interface.GetRootDevice() == ""
 
         self._add_device(StorageDevice("dev1", fmt=get_format("ext4", mountpoint="/")))
         self._add_device(StorageDevice("dev2", fmt=get_format("ext4", mountpoint="/home")))
 
-        self.assertEqual(self.interface.GetRootDevice(), "dev1")
+        assert self.interface.GetRootDevice() == "dev1"
 
     def test_get_devices(self):
         """Test GetDevices."""
-        self.assertEqual(self.interface.GetDevices(), [])
+        assert self.interface.GetDevices() == []
 
         self._add_device(DiskDevice(
             "dev1",
@@ -91,11 +93,11 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             size=Size("10 GiB")
         ))
 
-        self.assertEqual(self.interface.GetDevices(), ["dev1", "dev2"])
+        assert self.interface.GetDevices() == ["dev1", "dev2"]
 
     def test_get_disks(self):
         """Test GetDisks."""
-        self.assertEqual(self.interface.GetDisks(), [])
+        assert self.interface.GetDisks() == []
 
         self._add_device(DiskDevice(
             "dev1",
@@ -104,19 +106,19 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             size=Size("10 GiB"))
         )
 
-        self.assertEqual(self.interface.GetDisks(), ["dev1"])
+        assert self.interface.GetDisks() == ["dev1"]
 
     def test_get_mount_points(self):
         """Test GetMountPoints."""
-        self.assertEqual(self.interface.GetMountPoints(), {})
+        assert self.interface.GetMountPoints() == {}
 
         self._add_device(StorageDevice("dev1", fmt=get_format("ext4", mountpoint="/")))
         self._add_device(StorageDevice("dev2", fmt=get_format("ext4", mountpoint="/home")))
 
-        self.assertEqual(self.interface.GetMountPoints(), {
+        assert self.interface.GetMountPoints() == {
             "/": "dev1",
             "/home": "dev2"
-        })
+        }
 
     def test_get_device_data(self):
         """Test GetDeviceData."""
@@ -132,7 +134,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             uuid="1234-56-7890"
         ))
 
-        self.assertEqual(self.interface.GetDeviceData("dev1"), {
+        assert self.interface.GetDeviceData("dev1") == {
             'type': get_variant(Str, 'disk'),
             'name': get_variant(Str, 'dev1'),
             'path': get_variant(Str, '/dev/dev1'),
@@ -153,11 +155,11 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             'description': get_variant(
                 Str, "VENDOR_ID MODEL_ID 0x0000000000000000"
             )
-        })
+        }
 
     def test_get_unknown_device_data(self):
         """Test GetDeviceData for unknown."""
-        with self.assertRaises(UnknownDeviceError):
+        with pytest.raises(UnknownDeviceError):
             self.interface.GetDeviceData("dev1")
 
     def test_get_dasd_device_data(self):
@@ -171,10 +173,10 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         ))
 
         data = self.interface.GetDeviceData("dev1")
-        self.assertEqual(data['type'], get_variant(Str, 'dasd'))
-        self.assertEqual(data['attrs'], get_variant(Dict[Str, Str], {
+        assert data['type'] == get_variant(Str, 'dasd')
+        assert data['attrs'] == get_variant(Dict[Str, Str], {
             "bus-id": "0.0.0201"
-        }))
+        })
 
     def test_get_fcoe_device_data(self):
         """Test GetDeviceData for FCoE."""
@@ -188,10 +190,10 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         ))
 
         data = self.interface.GetDeviceData("dev1")
-        self.assertEqual(data['type'], get_variant(Str, 'fcoe'))
-        self.assertEqual(data['attrs'], get_variant(Dict[Str, Str], {
+        assert data['type'] == get_variant(Str, 'fcoe')
+        assert data['attrs'] == get_variant(Dict[Str, Str], {
             "path-id": "pci-0000:00:00.0-bla-1"
-        }))
+        })
 
     def test_get_iscsi_device_data(self):
         """Test GetDeviceData for iSCSI."""
@@ -214,14 +216,14 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         ))
 
         data = self.interface.GetDeviceData("dev1")
-        self.assertEqual(data['type'], get_variant(Str, 'iscsi'))
-        self.assertEqual(data['attrs'], get_variant(Dict[Str, Str], {
+        assert data['type'] == get_variant(Str, 'iscsi')
+        assert data['attrs'] == get_variant(Dict[Str, Str], {
             "port": "3260",
             "initiator": "iqn.1994-05.com.redhat:blabla",
             "lun": "0",
             "target": "iqn.2014-08.com.example:t1",
             "path-id": "pci-0000:00:00.0-bla-1"
-        }))
+        })
 
     def test_get_nvdimm_device_data(self):
         """Test GetDeviceData for NVDIMM."""
@@ -236,12 +238,12 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         ))
 
         data = self.interface.GetDeviceData("dev1")
-        self.assertEqual(data['type'], get_variant(Str, 'nvdimm'))
-        self.assertEqual(data['attrs'], get_variant(Dict[Str, Str], {
+        assert data['type'] == get_variant(Str, 'nvdimm')
+        assert data['attrs'] == get_variant(Dict[Str, Str], {
             "mode": "sector",
             "namespace": "namespace0.0",
             "path-id": "pci-0000:00:00.0-bla-1"
-        }))
+        })
 
     def test_get_zfcp_device_data(self):
         """Test GetDeviceData for zFCP."""
@@ -255,12 +257,12 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         ))
 
         data = self.interface.GetDeviceData("dev1")
-        self.assertEqual(data['type'], get_variant(Str, 'zfcp'))
-        self.assertEqual(data['attrs'], get_variant(Dict[Str, Str], {
+        assert data['type'] == get_variant(Str, 'zfcp')
+        assert data['attrs'] == get_variant(Dict[Str, Str], {
             "fcp-lun": "0x5719000000000000",
             "wwpn": "0x5005076300c18154",
             "hba-id": "0.0.010a"
-        }))
+        })
 
     def test_get_format_data(self):
         """Test GetFormatData."""
@@ -277,7 +279,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         )
         self._add_device(dev1)
 
-        self.assertEqual(self.interface.GetFormatData("dev1"), {
+        assert self.interface.GetFormatData("dev1") == {
             'type': get_variant(Str, 'ext4'),
             'mountable': get_variant(Bool, True),
             'attrs': get_variant(Dict[Str, Str], {
@@ -286,7 +288,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
                 "mount-point": "/home"
             }),
             'description': get_variant(Str, 'ext4'),
-        })
+        }
 
         fmt2 = get_format(
             "luks"
@@ -299,21 +301,21 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         )
         self._add_device(dev2)
 
-        self.assertEqual(self.interface.GetFormatData("dev2"), {
+        assert self.interface.GetFormatData("dev2") == {
             'type': get_variant(Str, 'luks'),
             'mountable': get_variant(Bool, False),
             'attrs': get_variant(Dict[Str, Str], {}),
             'description': get_variant(Str, 'LUKS'),
-        })
+        }
 
     def test_get_format_type_data(self):
         """Test GetFormatTypeData."""
-        self.assertEqual(self.interface.GetFormatTypeData("swap"), {
+        assert self.interface.GetFormatTypeData("swap") == {
             'type': get_variant(Str, 'swap'),
             'mountable': get_variant(Bool, False),
             'attrs': get_variant(Dict[Str, Str], {}),
             'description': get_variant(Str, 'swap'),
-        })
+        }
 
     def test_get_all_format_type_data(self):
         """Test GetFormatTypeData for all format types."""
@@ -321,11 +323,11 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             data = DeviceFormatData.from_structure(
                 self.interface.GetFormatTypeData(format_type)
             )
-            self.assertEqual(format_type or "", data.type)
+            assert (format_type or "") == data.type
 
     def test_get_actions(self):
         """Test GetActions."""
-        self.assertEqual(self.interface.GetActions(), [])
+        assert self.interface.GetActions() == []
 
         dev1 = DiskDevice(
             "dev1",
@@ -349,9 +351,9 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             'attrs': {},
         }
 
-        self.assertEqual(get_native(self.interface.GetActions()), [
+        assert get_native(self.interface.GetActions()) == [
             action_1
-        ])
+        ]
 
         dev2 = StorageDevice(
             "dev2",
@@ -377,10 +379,10 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             },
         }
 
-        self.assertEqual(get_native(self.interface.GetActions()), [
+        assert get_native(self.interface.GetActions()) == [
             action_2,
             action_1
-          ])
+          ]
 
         dev3 = PartitionDevice(
             "dev3",
@@ -412,27 +414,27 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             'attrs': {'mount-point': '/home'},
         }
 
-        self.assertEqual(get_native(self.interface.GetActions()), [
+        assert get_native(self.interface.GetActions()) == [
             action_2,
             action_1,
             action_3,
             action_4,
-          ])
+          ]
 
     def test_get_supported_file_systems(self):
         """Test GetSupportedFileSystems."""
         result = self.interface.GetSupportedFileSystems()
-        self.assertIsInstance(result, list)
-        self.assertNotEqual(len(result), 0)
+        assert isinstance(result, list)
+        assert len(result) != 0
 
         for fs in result:
-            self.assertIsInstance(fs, str)
-            self.assertEqual(fs, get_format(fs).type)
+            assert isinstance(fs, str)
+            assert fs == get_format(fs).type
 
     def test_get_required_device_size(self):
         """Test GetRequiredDeviceSize."""
         required_size = self.interface.GetRequiredDeviceSize(Size("1 GiB").get_bytes())
-        self.assertEqual(Size("1280 MiB").get_bytes(), required_size, Size(required_size))
+        assert Size("1280 MiB").get_bytes() == required_size, Size(required_size)
 
     def test_get_file_system_free_space(self):
         """Test GetFileSystemFreeSpace."""
@@ -449,11 +451,11 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         )
 
         total_size = self.interface.GetFileSystemFreeSpace([])
-        self.assertEqual(total_size, 0)
+        assert total_size == 0
 
         total_size = self.interface.GetFileSystemFreeSpace(["/", "/usr"])
-        self.assertLess(total_size, Size("10 GiB").get_bytes())
-        self.assertGreater(total_size, Size("8 GiB").get_bytes())
+        assert total_size < Size("10 GiB").get_bytes()
+        assert total_size > Size("8 GiB").get_bytes()
 
     @patch("blivet.formats.disklabel.DiskLabel.free", new_callable=PropertyMock)
     @patch("blivet.formats.disklabel.DiskLabel.get_platform_label_types")
@@ -481,12 +483,12 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         ))
 
         total_size = self.interface.GetDiskFreeSpace([])
-        self.assertEqual(total_size, 0)
+        assert total_size == 0
 
         total_size = self.interface.GetDiskFreeSpace(["dev1", "dev2", "dev3"])
-        self.assertEqual(total_size, Size("8 GiB").get_bytes())
+        assert total_size == Size("8 GiB").get_bytes()
 
-        with self.assertRaises(UnknownDeviceError):
+        with pytest.raises(UnknownDeviceError):
             self.interface.GetDiskFreeSpace(["dev1", "dev2", "devX"])
 
     @patch("blivet.formats.disklabel.DiskLabel.get_platform_label_types")
@@ -513,13 +515,13 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         ))
 
         total_size = self.interface.GetDiskReclaimableSpace([])
-        self.assertEqual(total_size, 0)
+        assert total_size == 0
 
         # FIXME: Test on devices with a reclaimable space.
         total_size = self.interface.GetDiskReclaimableSpace(["dev1", "dev2", "dev3"])
-        self.assertEqual(total_size, 0)
+        assert total_size == 0
 
-        with self.assertRaises(UnknownDeviceError):
+        with pytest.raises(UnknownDeviceError):
             self.interface.GetDiskReclaimableSpace(["dev1", "dev2", "devX"])
 
     def test_get_disk_total_space(self):
@@ -540,15 +542,15 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         ))
 
         total_size = self.interface.GetDiskTotalSpace(["dev1", "dev2"])
-        self.assertEqual(total_size, Size("10 GiB").get_bytes())
+        assert total_size == Size("10 GiB").get_bytes()
 
     def test_resolve_device(self):
         """Test ResolveDevice."""
         self._add_device(DiskDevice("dev1"))
 
-        self.assertEqual(self.interface.ResolveDevice("dev0"), "")
-        self.assertEqual(self.interface.ResolveDevice("dev1"), "dev1")
-        self.assertEqual(self.interface.ResolveDevice("/dev/dev1"), "dev1")
+        assert self.interface.ResolveDevice("dev0") == ""
+        assert self.interface.ResolveDevice("dev1") == "dev1"
+        assert self.interface.ResolveDevice("/dev/dev1") == "dev1"
 
     def test_get_ancestors(self):
         """Test GetAncestors."""
@@ -567,11 +569,11 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         dev5 = StorageDevice("dev5", parents=[dev4])
         self._add_device(dev5)
 
-        self.assertEqual(self.interface.GetAncestors(["dev1"]), [])
-        self.assertEqual(self.interface.GetAncestors(["dev2"]), ["dev1"])
-        self.assertEqual(self.interface.GetAncestors(["dev3"]), ["dev1", "dev2"])
-        self.assertEqual(self.interface.GetAncestors(["dev2", "dev3"]), ["dev1", "dev2"])
-        self.assertEqual(self.interface.GetAncestors(["dev2", "dev5"]), ["dev1", "dev4"])
+        assert self.interface.GetAncestors(["dev1"]) == []
+        assert self.interface.GetAncestors(["dev2"]) == ["dev1"]
+        assert self.interface.GetAncestors(["dev3"]) == ["dev1", "dev2"]
+        assert self.interface.GetAncestors(["dev2", "dev3"]) == ["dev1", "dev2"]
+        assert self.interface.GetAncestors(["dev2", "dev5"]) == ["dev1", "dev4"]
 
     @patch.object(StorageDevice, "setup")
     def test_setup_device(self, setup):
@@ -599,12 +601,10 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             mount.assert_called_once_with(mountpoint=d, options=None)
 
         mount.side_effect = FSError("Fake error.")
-        with self.assertRaises(MountFilesystemError) as cm:
+        with pytest.raises(MountFilesystemError) as cm:
             self.interface.MountDevice("dev1", "/path", "")
 
-        self.assertEqual(
-            str(cm.exception), "Failed to mount dev1 at /path: Fake error."
-        )
+        assert str(cm.value) == "Failed to mount dev1 at /path: Fake error."
 
     @patch.object(FS, "mount")
     def test_mount_device_with_options(self, mount):
@@ -616,12 +616,10 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             mount.assert_called_once_with(mountpoint=d, options="ro,auto")
 
         mount.side_effect = FSError("Fake error.")
-        with self.assertRaises(MountFilesystemError) as cm:
+        with pytest.raises(MountFilesystemError) as cm:
             self.interface.MountDevice("dev1", "/path", "ro,auto")
 
-        self.assertEqual(
-            str(cm.exception), "Failed to mount dev1 at /path: Fake error."
-        )
+        assert str(cm.value) == "Failed to mount dev1 at /path: Fake error."
 
     @patch.object(FS, "unmount")
     def test_unmount_device(self, unmount):
@@ -633,12 +631,10 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             unmount.assert_called_once_with(mountpoint=d)
 
         unmount.side_effect = FSError("Fake error.")
-        with self.assertRaises(MountFilesystemError) as cm:
+        with pytest.raises(MountFilesystemError) as cm:
             self.interface.UnmountDevice("dev1", "/path")
 
-        self.assertEqual(
-            str(cm.exception), "Failed to unmount dev1 from /path: Fake error."
-        )
+        assert str(cm.value) == "Failed to unmount dev1 from /path: Fake error."
 
     @patch.object(Iso9660FS, "check_module")
     def test_find_install_media(self, check_module):
@@ -661,7 +657,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         dev3.controllable = True
         self._add_device(dev3)
 
-        self.assertEqual(self.interface.FindOpticalMedia(), ["dev1", "dev2"])
+        assert self.interface.FindOpticalMedia() == ["dev1", "dev2"]
 
     @patch.object(FS, "update_size_info")
     def test_find_mountable_partitions(self, update_size_info):
@@ -675,7 +671,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             fmt=get_format("ext4", exists=True)
         ))
 
-        self.assertEqual(self.interface.FindMountablePartitions(), ["dev2"])
+        assert self.interface.FindMountablePartitions() == ["dev2"]
 
     @patch.object(LUKS, "setup")
     @patch.object(LUKSDevice, "teardown")
@@ -691,34 +687,34 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         dev2 = LUKSDevice("dev2", parents=[dev1], fmt=get_format("luks"), size=Size("10 GiB"))
         self._add_device(dev2)
 
-        self.assertEqual(self.interface.UnlockDevice("dev2", "passphrase"), True)
+        assert self.interface.UnlockDevice("dev2", "passphrase") == True
 
         device_setup.assert_called_once()
         format_setup.assert_called_once()
         device_teardown.assert_not_called()
         self.storage.devicetree.populate.assert_called_once()
         self.storage.devicetree.teardown_all.assert_called_once()
-        self.assertTrue(dev2.format.has_key)
+        assert dev2.format.has_key
 
         device_setup.side_effect = StorageError("Fake error")
-        self.assertEqual(self.interface.UnlockDevice("dev2", "passphrase"), False)
+        assert self.interface.UnlockDevice("dev2", "passphrase") == False
 
         device_teardown.assert_called_once()
-        self.assertFalse(dev2.format.has_key)
+        assert not dev2.format.has_key
 
     def test_find_unconfigured_luks(self):
         """Test FindUnconfiguredLUKS."""
-        self.assertEqual(self.interface.FindUnconfiguredLUKS(), [])
+        assert self.interface.FindUnconfiguredLUKS() == []
 
         dev1 = StorageDevice("dev1", fmt=get_format("ext4"), size=Size("10 GiB"))
         self._add_device(dev1)
 
-        self.assertEqual(self.interface.FindUnconfiguredLUKS(), [])
+        assert self.interface.FindUnconfiguredLUKS() == []
 
         dev2 = LUKSDevice("dev2", parents=[dev1], fmt=get_format("luks"), size=Size("10 GiB"))
         self._add_device(dev2)
 
-        self.assertEqual(self.interface.FindUnconfiguredLUKS(), ["dev2"])
+        assert self.interface.FindUnconfiguredLUKS() == ["dev2"]
 
     def test_set_device_passphrase(self):
         """Test SetDevicePassphrase."""
@@ -728,18 +724,18 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         dev2 = LUKSDevice("dev2", parents=[dev1], fmt=get_format("luks"), size=Size("10 GiB"))
         self._add_device(dev2)
 
-        self.assertEqual(self.interface.FindUnconfiguredLUKS(), ["dev2"])
+        assert self.interface.FindUnconfiguredLUKS() == ["dev2"]
         self.interface.SetDevicePassphrase("dev2", "123456")
-        self.assertEqual(self.interface.FindUnconfiguredLUKS(), [])
+        assert self.interface.FindUnconfiguredLUKS() == []
 
     def test_get_fstab_spec(self):
         """Test GetFstabSpec."""
         self._add_device(StorageDevice("dev1", fmt=get_format("ext4", uuid="123")))
-        self.assertEqual(self.interface.GetFstabSpec("dev1"), "UUID=123")
+        assert self.interface.GetFstabSpec("dev1") == "UUID=123"
 
     def test_get_existing_systems(self):
         """Test GetExistingSystems."""
-        self.assertEqual(self.interface.GetExistingSystems(), [])
+        assert self.interface.GetExistingSystems() == []
 
         root_device = StorageDevice("dev1", fmt=get_format("ext4"))
         swap_device = StorageDevice("dev2", fmt=get_format("swap"))
@@ -750,11 +746,11 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             swaps=[swap_device]
         )]
 
-        self.assertEqual(self.interface.GetExistingSystems(), [{
+        assert self.interface.GetExistingSystems() == [{
             'os-name': get_variant(Str, 'My Linux'),
             'mount-points': get_variant(Dict[Str, Str], {'/': 'dev1'}),
             'swap-devices': get_variant(List[Str], ['dev2'])
-        }])
+        }]
 
     @patch_dbus_publish_object
     def test_find_existing_systems_with_task(self, publisher):
@@ -763,12 +759,12 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, FindExistingSystemsTask)
 
-        self.assertEqual(obj.implementation._devicetree, self.module.storage.devicetree)
+        assert obj.implementation._devicetree == self.module.storage.devicetree
 
         roots = [Root(name="My Linux")]
         obj.implementation._set_result(roots)
         obj.implementation.succeeded_signal.emit()
-        self.assertEqual(self.storage.roots, roots)
+        assert self.storage.roots == roots
 
     @patch_dbus_publish_object
     def test_mount_existing_system_with_task(self, publisher):
@@ -779,9 +775,9 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, MountExistingSystemTask)
 
-        self.assertEqual(obj.implementation._storage, self.module.storage)
-        self.assertEqual(obj.implementation._device.name, "dev1")
-        self.assertEqual(obj.implementation._read_only, True)
+        assert obj.implementation._storage == self.module.storage
+        assert obj.implementation._device.name == "dev1"
+        assert obj.implementation._read_only == True
 
     @patch_dbus_publish_object
     def test_find_devices_with_task(self, publisher):
@@ -790,7 +786,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, FindDevicesTask)
 
-        self.assertEqual(obj.implementation._devicetree, self.module.storage.devicetree)
+        assert obj.implementation._devicetree == self.module.storage.devicetree
 
     def test_get_device_mount_options(self):
         """Test GetDeviceMountOptions."""
@@ -799,11 +795,11 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             size=Size("10 GiB")
         )
         self._add_device(dev1)
-        self.assertEqual(self.interface.GetDeviceMountOptions("dev1"), "")
+        assert self.interface.GetDeviceMountOptions("dev1") == ""
 
         dev1.format = get_format("ext4")
         dev1.format.options = "defaults,ro"
-        self.assertEqual(self.interface.GetDeviceMountOptions("dev1"), "defaults,ro")
+        assert self.interface.GetDeviceMountOptions("dev1") == "defaults,ro"
 
     def test_set_device_mount_options(self):
         """Test SetDeviceMountOptions."""
@@ -814,15 +810,15 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         self._add_device(dev1)
 
         self.interface.SetDeviceMountOptions("dev1", "auto")
-        self.assertEqual(dev1.format.options, "auto")
+        assert dev1.format.options == "auto"
 
         self.interface.SetDeviceMountOptions("dev1", "")
-        self.assertEqual(dev1.format.options, None)
+        assert dev1.format.options is None
 
         dev1.format = get_format("ext4")
         dev1.format.options = "defaults,ro"
         self.interface.SetDeviceMountOptions("dev1", "")
-        self.assertEqual(dev1.format.options, "defaults")
+        assert dev1.format.options == "defaults"
 
 
 class DeviceTreeTasksTestCase(unittest.TestCase):
@@ -831,7 +827,7 @@ class DeviceTreeTasksTestCase(unittest.TestCase):
     def test_find_existing_systems(self):
         storage = create_storage()
         task = FindExistingSystemsTask(storage.devicetree)
-        self.assertEqual(task.run(), [])
+        assert task.run() == []
 
     @patch('pyanaconda.modules.storage.devicetree.rescue.mount_existing_system')
     def test_mount_existing_system(self, mount):
@@ -867,21 +863,21 @@ class DeviceTreeUtilsTestCase(unittest.TestCase):
         supported.return_value = True
         formattable.return_value = False
 
-        self.assertEqual(utils.is_supported_filesystem("xfs"), False)
+        assert utils.is_supported_filesystem("xfs") == False
 
         supported.return_value = False
         formattable.return_value = True
 
-        self.assertEqual(utils.is_supported_filesystem("xfs"), False)
+        assert utils.is_supported_filesystem("xfs") == False
 
         supported.return_value = True
         formattable.return_value = True
 
-        self.assertEqual(utils.is_supported_filesystem("xfs"), True)
-        self.assertEqual(utils.is_supported_filesystem("swap"), True)
-        self.assertEqual(utils.is_supported_filesystem("biosboot"), True)
+        assert utils.is_supported_filesystem("xfs") == True
+        assert utils.is_supported_filesystem("swap") == True
+        assert utils.is_supported_filesystem("biosboot") == True
 
-        self.assertEqual(utils.is_supported_filesystem("unknown"), False)
-        self.assertEqual(utils.is_supported_filesystem("disklabel"), False)
-        self.assertEqual(utils.is_supported_filesystem("ntfs"), False)
-        self.assertEqual(utils.is_supported_filesystem("tmpfs"), False)
+        assert utils.is_supported_filesystem("unknown") == False
+        assert utils.is_supported_filesystem("disklabel") == False
+        assert utils.is_supported_filesystem("ntfs") == False
+        assert utils.is_supported_filesystem("tmpfs") == False

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_disk_init.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_disk_init.py
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import pytest
+
 from unittest.mock import Mock
 
 from pykickstart.constants import CLEARPART_TYPE_NONE
@@ -108,12 +110,12 @@ class DiskInitializationModuleTestCase(unittest.TestCase):
 
     def test_storage_property(self):
         """Test the storage property."""
-        with self.assertRaises(UnavailableStorageError):
-            self.assertIsNotNone(self.disk_init_module.storage)
+        with pytest.raises(UnavailableStorageError):
+            assert self.disk_init_module.storage is not None
 
         storage = Mock()
         self.disk_init_module.on_storage_changed(storage)
-        self.assertEqual(self.disk_init_module.storage, storage)
+        assert self.disk_init_module.storage == storage
 
     def test_setup_kickstart(self):
         """Test setup_kickstart with storage."""
@@ -124,6 +126,6 @@ class DiskInitializationModuleTestCase(unittest.TestCase):
         self.disk_init_module.set_initialization_mode(InitializationMode.CLEAR_NONE)
         self.disk_init_module.setup_kickstart(data)
 
-        self.assertEqual(data.clearpart.type, CLEARPART_TYPE_NONE)
-        self.assertEqual(data.clearpart.devices, [])
-        self.assertEqual(data.clearpart.drives, [])
+        assert data.clearpart.type == CLEARPART_TYPE_NONE
+        assert data.clearpart.devices == []
+        assert data.clearpart.drives == []

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_disk_init.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_disk_init.py
@@ -45,7 +45,6 @@ class DiskInitializationInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             DISK_INITIALIZATION,
             self.disk_init_interface,
             *args, **kwargs

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_disk_select.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_disk_select.py
@@ -18,6 +18,7 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import pytest
 
 from blivet.devices import DiskDevice
 from blivet.formats import get_format
@@ -88,50 +89,50 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
             self.disk_selection_interface.ValidateSelectedDisks([])
         )
 
-        self.assertEqual(report.is_valid(), True)
+        assert report.is_valid() == True
 
         report = ValidationReport.from_structure(
             self.disk_selection_interface.ValidateSelectedDisks(["devX"])
         )
 
-        self.assertEqual(report.is_valid(), False)
-        self.assertEqual(report.error_messages, [
+        assert report.is_valid() == False
+        assert report.error_messages == [
             "The selected disk devX is not recognized."
-        ])
-        self.assertEqual(report.warning_messages, [])
+        ]
+        assert report.warning_messages == []
 
         report = ValidationReport.from_structure(
             self.disk_selection_interface.ValidateSelectedDisks(["dev1"])
         )
 
-        self.assertEqual(report.is_valid(), False)
-        self.assertEqual(report.error_messages, [
+        assert report.is_valid() == False
+        assert report.error_messages == [
             "You selected disk dev1, which contains devices that also use "
             "unselected disks dev2, dev3. You must select or de-select "
             "these disks as a set."
-        ])
-        self.assertEqual(report.warning_messages, [])
+        ]
+        assert report.warning_messages == []
 
         report = ValidationReport.from_structure(
             self.disk_selection_interface.ValidateSelectedDisks(["dev1", "dev2"])
         )
 
-        self.assertEqual(report.is_valid(), False)
-        self.assertEqual(report.error_messages, [
+        assert report.is_valid() == False
+        assert report.error_messages == [
             "You selected disk dev1, which contains devices that also "
             "use unselected disk dev3. You must select or de-select "
             "these disks as a set.",
             "You selected disk dev2, which contains devices that also "
             "use unselected disk dev3. You must select or de-select "
             "these disks as a set."
-        ])
-        self.assertEqual(report.warning_messages, [])
+        ]
+        assert report.warning_messages == []
 
         report = ValidationReport.from_structure(
             self.disk_selection_interface.ValidateSelectedDisks(["dev1", "dev2", "dev3"])
         )
 
-        self.assertEqual(report.is_valid(), True)
+        assert report.is_valid() == True
 
     def test_exclusive_disks_property(self):
         """Test the exclusive disks property."""
@@ -166,8 +167,8 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
 
     def test_get_usable_disks(self):
         """Test the GetUsableDisks method."""
-        with self.assertRaises(UnavailableStorageError):
+        with pytest.raises(UnavailableStorageError):
             self.disk_selection_interface.GetUsableDisks()
 
         self.disk_selection_module.on_storage_changed(create_storage())
-        self.assertEqual(self.disk_selection_interface.GetUsableDisks(), [])
+        assert self.disk_selection_interface.GetUsableDisks() == []

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_disk_select.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_disk_select.py
@@ -43,7 +43,6 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             DISK_SELECTION,
             self.disk_selection_interface,
             *args, **kwargs

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_fcoe.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_fcoe.py
@@ -84,7 +84,7 @@ class FCOEInterfaceTestCase(unittest.TestCase):
             True  # auto_vlan
         )
 
-        obj = check_task_creation(self, task_path, publisher, FCOEDiscoverTask)
+        obj = check_task_creation(task_path, publisher, FCOEDiscoverTask)
 
         assert obj.implementation._nic == "eth0"
         assert obj.implementation._dcb == False

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_iscsi.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_iscsi.py
@@ -63,7 +63,7 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
 
     @patch("pyanaconda.modules.storage.iscsi.iscsi.iscsi", available=True)
     def test_is_supported(self, iscsi):
-        self.assertEqual(self.iscsi_interface.IsSupported(), True)
+        assert self.iscsi_interface.IsSupported() == True
 
     @patch('pyanaconda.modules.storage.iscsi.iscsi.iscsi')
     def test_initator_property(self, iscsi):
@@ -72,7 +72,7 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
         iscsi.initiator_set = False
         self.iscsi_interface.SetInitiator(initiator_name)
         iscsi.initiator = initiator_name
-        self.assertEqual(self.iscsi_interface.Initiator, initiator_name)
+        assert self.iscsi_interface.Initiator == initiator_name
         iscsi.initiator_set = True
         initiator_name2 = "iqn.1994-05.com.redhat:blablabla"
         self.iscsi_interface.SetInitiator(initiator_name2)
@@ -83,7 +83,7 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
     @patch('pyanaconda.modules.storage.iscsi.iscsi.iscsi')
     def test_can_set_initiator(self, iscsi):
         """Test CanSetInitiator method."""
-        self.assertIsInstance(self.iscsi_interface.CanSetInitiator(), bool)
+        assert isinstance(self.iscsi_interface.CanSetInitiator(), bool)
 
     @patch('pyanaconda.modules.storage.iscsi.iscsi.iscsi')
     def test_get_interface_mode(self, iscsi):
@@ -100,7 +100,7 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
         result = self.iscsi_interface.IsNodeFromIbft(
             Node.to_structure(self._node)
         )
-        self.assertFalse(result)
+        assert not result
 
         blivet_node = Mock()
         blivet_node.name = self._node.name
@@ -111,7 +111,7 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
         result = self.iscsi_interface.IsNodeFromIbft(
             Node.to_structure(self._node)
         )
-        self.assertTrue(result)
+        assert result
 
     @patch('pyanaconda.modules.storage.iscsi.iscsi.iscsi')
     def test_get_interface(self, iscsi):
@@ -120,8 +120,8 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
             "iface0" : "ens3",
             "iface1" : "ens7",
         }
-        self.assertEqual(self.iscsi_interface.GetInterface("iface0"), "ens3")
-        self.assertEqual(self.iscsi_interface.GetInterface("nonexisting"), "")
+        assert self.iscsi_interface.GetInterface("iface0") == "ens3"
+        assert self.iscsi_interface.GetInterface("nonexisting") == ""
 
     @patch_dbus_publish_object
     def test_discover_with_task(self, publisher):
@@ -135,11 +135,11 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, ISCSIDiscoverTask)
 
-        self.assertIsInstance(obj, ISCSIDiscoverTaskInterface)
+        assert isinstance(obj, ISCSIDiscoverTaskInterface)
 
-        self.assertEqual(obj.implementation._portal, self._portal)
-        self.assertEqual(obj.implementation._credentials, self._credentials)
-        self.assertEqual(obj.implementation._interfaces_mode, IscsiInterfacesMode.DEFAULT)
+        assert obj.implementation._portal == self._portal
+        assert obj.implementation._credentials == self._credentials
+        assert obj.implementation._interfaces_mode == IscsiInterfacesMode.DEFAULT
 
     @patch_dbus_publish_object
     def test_login_with_task(self, publisher):
@@ -152,9 +152,9 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, ISCSILoginTask)
 
-        self.assertEqual(obj.implementation._portal, self._portal)
-        self.assertEqual(obj.implementation._credentials, self._credentials)
-        self.assertEqual(obj.implementation._node, self._node)
+        assert obj.implementation._portal == self._portal
+        assert obj.implementation._credentials == self._credentials
+        assert obj.implementation._node == self._node
 
     @patch('pyanaconda.modules.storage.iscsi.iscsi.iscsi')
     def test_write_configuration(self, iscsi):
@@ -173,18 +173,14 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
 
         # The node is iBFT node
         iscsi.ibft_nodes = [blivet_node]
-        self.assertEqual(
-            self.iscsi_interface.GetDracutArguments(Node.to_structure(self._node)),
+        assert self.iscsi_interface.GetDracutArguments(Node.to_structure(self._node)) == \
             ["rd.iscsi.firmware"]
-        )
 
         # The node is not found
         iscsi.ibft_nodes = []
         iscsi.get_node.return_value = None
-        self.assertEqual(
-            self.iscsi_interface.GetDracutArguments(Node.to_structure(self._node)),
+        assert self.iscsi_interface.GetDracutArguments(Node.to_structure(self._node)) == \
             []
-        )
 
         iscsi.ifaces = {
             "iface0": "ens3",
@@ -198,21 +194,17 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
         blivet_node.password = ""
         blivet_node.r_password = ""
         iscsi.initiator = "iqn.1994-05.com.redhat:blablabla"
-        self.assertEqual(
-            self.iscsi_interface.GetDracutArguments(Node.to_structure(self._node)),
+        assert self.iscsi_interface.GetDracutArguments(Node.to_structure(self._node)) == \
             ["netroot=iscsi:@10.43.136.67::3260:iface0:ens3::iqn.2014-08.com.example:t1",
              "rd.iscsi.initiator=iqn.1994-05.com.redhat:blablabla"]
-        )
 
         # The node is active, with default interface
         iscsi.get_node.return_value = blivet_node
         blivet_node.iface = "default"
         iscsi.initiator = "iqn.1994-05.com.redhat:blablabla"
-        self.assertEqual(
-            self.iscsi_interface.GetDracutArguments(Node.to_structure(self._node)),
+        assert self.iscsi_interface.GetDracutArguments(Node.to_structure(self._node)) == \
             ["netroot=iscsi:@10.43.136.67::3260::iqn.2014-08.com.example:t1",
              "rd.iscsi.initiator=iqn.1994-05.com.redhat:blablabla"]
-        )
 
         # The node is active, with offload interface, and reverse chap
         iscsi.get_node.return_value = blivet_node
@@ -222,8 +214,6 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
         blivet_node.r_password = "r_passwd"
         blivet_node.iface = "qedi.a6:26:77:80:00:63"
         iscsi.initiator = "iqn.1994-05.com.redhat:blablabla"
-        self.assertEqual(
-            self.iscsi_interface.GetDracutArguments(Node.to_structure(self._node)),
+        assert self.iscsi_interface.GetDracutArguments(Node.to_structure(self._node)) == \
             ["netroot=iscsi:uname:passwd:r_uname:r_passwd@10.43.136.67::3260:qedi.a6:26:77:80:00:63:qedi.a6:26:77:80:00:63::iqn.2014-08.com.example:t1",
              "rd.iscsi.initiator=iqn.1994-05.com.redhat:blablabla"]
-        )

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_iscsi.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_iscsi.py
@@ -133,7 +133,7 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
             interfaces_mode
         )
 
-        obj = check_task_creation(self, task_path, publisher, ISCSIDiscoverTask)
+        obj = check_task_creation(task_path, publisher, ISCSIDiscoverTask)
 
         assert isinstance(obj, ISCSIDiscoverTaskInterface)
 
@@ -150,7 +150,7 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
             Node.to_structure(self._node),
         )
 
-        obj = check_task_creation(self, task_path, publisher, ISCSILoginTask)
+        obj = check_task_creation(task_path, publisher, ISCSILoginTask)
 
         assert obj.implementation._portal == self._portal
         assert obj.implementation._credentials == self._credentials

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_nvdimm.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_nvdimm.py
@@ -67,7 +67,7 @@ class NVDIMMInterfaceTestCase(unittest.TestCase):
         """Test ReconfigureWithTask."""
         task_path = self.nvdimm_interface.ReconfigureWithTask("namespace0.0", "sector", 512)
 
-        obj = check_task_creation(self, task_path, publisher, NVDIMMReconfigureTask)
+        obj = check_task_creation(task_path, publisher, NVDIMMReconfigureTask)
 
         assert obj.implementation._namespace == "namespace0.0"
         assert obj.implementation._mode == "sector"

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_nvdimm.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_nvdimm.py
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
 #
 import unittest
+import pytest
+
 from textwrap import dedent
 from unittest.mock import patch, Mock
 
@@ -50,11 +52,11 @@ class NVDIMMInterfaceTestCase(unittest.TestCase):
         self.nvdimm_interface = NVDIMMInterface(self.nvdimm_module)
 
     def test_is_supported(self):
-        self.assertEqual(self.nvdimm_interface.IsSupported(), True)
+        assert self.nvdimm_interface.IsSupported() == True
 
     def test_get_devices_to_ignore(self):
         """Test GetDevicesToIgnore."""
-        self.assertEqual(self.nvdimm_interface.GetDevicesToIgnore(), [])
+        assert self.nvdimm_interface.GetDevicesToIgnore() == []
 
     def test_set_namespaces_to_use(self):
         """Test SetNamespacesToUse."""
@@ -67,18 +69,18 @@ class NVDIMMInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, NVDIMMReconfigureTask)
 
-        self.assertEqual(obj.implementation._namespace, "namespace0.0")
-        self.assertEqual(obj.implementation._mode, "sector")
-        self.assertEqual(obj.implementation._sector_size, 512)
+        assert obj.implementation._namespace == "namespace0.0"
+        assert obj.implementation._mode == "sector"
+        assert obj.implementation._sector_size == 512
 
-        self.assertIsNone(self.nvdimm_module.find_action("namespace0.0"))
+        assert self.nvdimm_module.find_action("namespace0.0") is None
         obj.implementation.succeeded_signal.emit()
 
         action = self.nvdimm_module.find_action("namespace0.0")
-        self.assertEqual(action.action, NVDIMM_ACTION_RECONFIGURE)
-        self.assertEqual(action.namespace, "namespace0.0")
-        self.assertEqual(action.mode, "sector")
-        self.assertEqual(action.sectorsize, 512)
+        assert action.action == NVDIMM_ACTION_RECONFIGURE
+        assert action.namespace == "namespace0.0"
+        assert action.mode == "sector"
+        assert action.sectorsize == 512
 
 
 class NVDIMMTasksTestCase(unittest.TestCase):
@@ -86,7 +88,7 @@ class NVDIMMTasksTestCase(unittest.TestCase):
 
     def test_failed_reconfiguration(self):
         """Test the reconfiguration test."""
-        with self.assertRaises(StorageConfigurationError):
+        with pytest.raises(StorageConfigurationError):
             NVDIMMReconfigureTask("namespace0.0", "sector", 512).run()
 
     @patch("pyanaconda.modules.storage.nvdimm.reconfigure.nvdimm")
@@ -152,10 +154,8 @@ class NVDIMMKickstartTestCase(unittest.TestCase):
 
     def _check(self, expected_ks):
         """Check the generated kickstart."""
-        self.assertEqual(
-            clear_version_from_kickstart_string(self.storage_module.generate_kickstart()).strip(),
+        assert clear_version_from_kickstart_string(self.storage_module.generate_kickstart()).strip() == \
             dedent(expected_ks).strip()
-        )
 
     def _check_ignored(self, expected_devices):
         """Check the ignored devices."""
@@ -168,7 +168,7 @@ class NVDIMMKickstartTestCase(unittest.TestCase):
             }
 
             ignored_devices = self.nvdimm_module.get_devices_to_ignore()
-            self.assertEqual(sorted(ignored_devices), expected_devices)
+            assert sorted(ignored_devices) == expected_devices
 
     # Test setting use from UI
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_snapshot.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_snapshot.py
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import pytest
+
 from unittest.mock import patch, Mock
 
 from blivet.errors import StorageError
@@ -43,26 +45,26 @@ class SnapshotInterfaceTestCase(unittest.TestCase):
 
     def test_is_requested(self):
         """Test IsRequested."""
-        self.assertEqual(self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL), False)
-        self.assertEqual(self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL), False)
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL) == False
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL) == False
 
         self.module._requests = [Mock(when=SNAPSHOT_WHEN_PRE_INSTALL)]
-        self.assertEqual(self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL), True)
-        self.assertEqual(self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL), False)
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL) == True
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL) == False
 
         self.module._requests = [Mock(when=SNAPSHOT_WHEN_POST_INSTALL)]
-        self.assertEqual(self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL), False)
-        self.assertEqual(self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL), True)
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL) == False
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL) == True
 
         self.module._requests = [Mock(when=SNAPSHOT_WHEN_PRE_INSTALL),
                                  Mock(when=SNAPSHOT_WHEN_POST_INSTALL)]
-        self.assertEqual(self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL), True)
-        self.assertEqual(self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL), True)
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL) == True
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL) == True
 
     @patch_dbus_publish_object
     def test_create_with_task(self, publisher):
         """Test CreateWithTask."""
-        with self.assertRaises(UnavailableStorageError):
+        with pytest.raises(UnavailableStorageError):
             self.interface.CreateWithTask(SNAPSHOT_WHEN_PRE_INSTALL)
 
         self.module.on_storage_changed(Mock())
@@ -70,9 +72,9 @@ class SnapshotInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, SnapshotCreateTask)
 
-        self.assertEqual(obj.implementation._storage, self.module.storage)
-        self.assertEqual(obj.implementation._requests, [])
-        self.assertEqual(obj.implementation._when, SNAPSHOT_WHEN_PRE_INSTALL)
+        assert obj.implementation._storage == self.module.storage
+        assert obj.implementation._requests == []
+        assert obj.implementation._when == SNAPSHOT_WHEN_PRE_INSTALL
 
     @patch('pyanaconda.modules.storage.snapshot.snapshot.get_snapshot_device')
     def test_verify_requests(self, device_getter):
@@ -98,7 +100,7 @@ class SnapshotTasksTestCase(unittest.TestCase):
 
     def test_get_snapshot_device_fail(self):
         """Test the snapshot device."""
-        with self.assertRaises(StorageError):
+        with pytest.raises(StorageError):
             get_snapshot_device(Mock(name="post-snapshot", origin="fedora/root"), Mock())
 
     @patch('pyanaconda.modules.storage.snapshot.device.LVMLogicalVolumeDevice')
@@ -111,7 +113,7 @@ class SnapshotTasksTestCase(unittest.TestCase):
         devicetree.get_device_by_name.side_effect = [Mock(), None]
 
         request = Mock(name="post-snapshot", origin="fedora/root")
-        self.assertEqual(get_snapshot_device(request, devicetree), device)
+        assert get_snapshot_device(request, devicetree) == device
 
     @patch('pyanaconda.modules.storage.snapshot.create.get_snapshot_device')
     def test_creation(self, device_getter):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_snapshot.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_snapshot.py
@@ -70,7 +70,7 @@ class SnapshotInterfaceTestCase(unittest.TestCase):
         self.module.on_storage_changed(Mock())
         task_path = self.interface.CreateWithTask(SNAPSHOT_WHEN_PRE_INSTALL)
 
-        obj = check_task_creation(self, task_path, publisher, SnapshotCreateTask)
+        obj = check_task_creation(task_path, publisher, SnapshotCreateTask)
 
         assert obj.implementation._storage == self.module.storage
         assert obj.implementation._requests == []

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
@@ -76,7 +76,6 @@ class StorageInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             STORAGE,
             self.storage_interface,
             *args, **kwargs
@@ -134,7 +133,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
         """Test ScanDevicesWithTask."""
         task_path = self.storage_interface.ScanDevicesWithTask()
 
-        obj = check_task_creation(self, task_path, publisher, ScanDevicesTask)
+        obj = check_task_creation(task_path, publisher, ScanDevicesTask)
 
         assert obj.implementation._storage is not None
 
@@ -333,7 +332,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
     def test_write_configuration_with_task(self, publisher):
         """Test WriteConfigurationWithTask."""
         task_path = self.storage_interface.WriteConfigurationWithTask()
-        check_task_creation(self, task_path, publisher, WriteConfigurationTask)
+        check_task_creation(task_path, publisher, WriteConfigurationTask)
 
     @patch_dbus_publish_object
     def test_teardown_with_tasks(self, publisher):
@@ -387,7 +386,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
         assert self.storage_interface.KickstartAddons == []
 
     def _test_kickstart(self, ks_in, ks_out, **kwargs):
-        check_kickstart_interface(self, self.storage_interface, ks_in, ks_out, **kwargs)
+        check_kickstart_interface(self.storage_interface, ks_in, ks_out, **kwargs)
 
     def test_no_kickstart(self):
         """Test with no kickstart."""

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage_bootloader_args.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage_bootloader_args.py
@@ -29,12 +29,12 @@ class BootLoaderArgsTestCase(unittest.TestCase):
 
         args.add("first")
         args.add("second")
-        self.assertEqual(str(args), "first second")
-        self.assertEqual(list(args), ["first", "second"])
+        assert str(args) == "first second"
+        assert list(args) == ["first", "second"]
 
         args.add("first")
-        self.assertEqual(str(args), "second first")
-        self.assertEqual(list(args), ["second", "first"])
+        assert str(args) == "second first"
+        assert list(args) == ["second", "first"]
 
     def test_update(self):
         """BootLoaderArguments.update reorders things as expected."""
@@ -42,9 +42,9 @@ class BootLoaderArgsTestCase(unittest.TestCase):
 
         args.update(["one", "two", "three"])
         args.update("abc")
-        self.assertEqual(str(args), "one two three a b c")
+        assert str(args) == "one two three a b c"
         args.update(["three", "two"])
-        self.assertEqual(str(args), "one a b c three two")
+        assert str(args) == "one a b c three two"
 
     def test_ip_merge(self):
         """BootLoaderArguments.__str__ reorders ip= as expected."""
@@ -52,15 +52,9 @@ class BootLoaderArgsTestCase(unittest.TestCase):
         args.update(["start", "blah"])
         args.update(["ip=ens0p3:dhcp6", "ip=::::tester::dhcp", "ip=ens0p3:dhcp"])
         args.add("end")
-        self.assertEqual(
-            list(args),
+        assert list(args) == \
             ["start", "blah", "ip=ens0p3:dhcp6", "ip=::::tester::dhcp", "ip=ens0p3:dhcp", "end"]
-        )
-        self.assertEqual(
-            str(args),
+        assert str(args) == \
             "start blah ip=::::tester::dhcp end ip=ens0p3:dhcp,dhcp6"
-        )
-        self.assertEqual(
-            list(args),
+        assert list(args) == \
             ["start", "blah", "ip=::::tester::dhcp", "end", "ip=ens0p3:dhcp,dhcp6"]
-        )

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage_checker.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage_checker.py
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import pytest
+
 from unittest.mock import patch, Mock
 
 from blivet.size import Size
@@ -44,16 +46,16 @@ class StorageCheckerInterfaceTestCase(unittest.TestCase):
             get_variant(Int, 987 * 1024 * 1024)
         )
 
-        self.assertEqual(storage_checker.constraints[STORAGE_MIN_RAM], Size("987 MiB"))
+        assert storage_checker.constraints[STORAGE_MIN_RAM] == Size("987 MiB")
 
-        with self.assertRaises(UnsupportedValueError) as cm:
+        with pytest.raises(UnsupportedValueError) as cm:
             self.interface.SetConstraint(
                 STORAGE_LUKS2_MIN_RAM,
                 get_variant(Int, 987 * 1024 * 1024)
             )
 
-        self.assertEqual(str(cm.exception), "Constraint 'luks2_min_ram' is not supported.")
-        self.assertEqual(storage_checker.constraints[STORAGE_LUKS2_MIN_RAM], Size("128 MiB"))
+        assert str(cm.value) == "Constraint 'luks2_min_ram' is not supported."
+        assert storage_checker.constraints[STORAGE_LUKS2_MIN_RAM] == Size("128 MiB")
 
 
 class StorageCheckerVerificationTestCase(unittest.TestCase):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_zfcp.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_zfcp.py
@@ -18,6 +18,8 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import pytest
+
 from unittest.mock import patch
 
 from pyanaconda.core.configuration.anaconda import conf
@@ -38,7 +40,7 @@ class ZFCPInterfaceTestCase(unittest.TestCase):
 
     @patch("pyanaconda.modules.storage.dasd.dasd.arch.is_s390", return_value=True)
     def test_is_supported(self, is_supported):
-        self.assertEqual(self.zfcp_interface.IsSupported(), True)
+        assert self.zfcp_interface.IsSupported() == True
 
     @patch_dbus_publish_object
     def test_discover_with_task(self, publisher):
@@ -51,9 +53,9 @@ class ZFCPInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(self, task_path, publisher, ZFCPDiscoverTask)
 
-        self.assertEqual(obj.implementation._device_number, "0.0.fc00")
-        self.assertEqual(obj.implementation._wwpn, "0x5105074308c212e9")
-        self.assertEqual(obj.implementation._lun, "0x401040a000000000")
+        assert obj.implementation._device_number == "0.0.fc00"
+        assert obj.implementation._wwpn == "0x5105074308c212e9"
+        assert obj.implementation._lun == "0x401040a000000000"
 
     @patch('pyanaconda.modules.storage.zfcp.zfcp.zfcp')
     @patch("pyanaconda.modules.storage.zfcp.zfcp.arch.is_s390", return_value=True)
@@ -69,13 +71,13 @@ class ZFCPTasksTestCase(unittest.TestCase):
     def test_discovery_fails(self):
         """Test the failing discovery task."""
 
-        with self.assertRaises(StorageDiscoveryError):
+        with pytest.raises(StorageDiscoveryError):
             ZFCPDiscoverTask("", "", "").run()
 
-        with self.assertRaises(StorageDiscoveryError):
+        with pytest.raises(StorageDiscoveryError):
             ZFCPDiscoverTask("0.0.fc00", "", "").run()
 
-        with self.assertRaises(StorageDiscoveryError):
+        with pytest.raises(StorageDiscoveryError):
             ZFCPDiscoverTask("0.0.fc00", "0x5105074308c212e9", "").run()
 
     @patch('pyanaconda.modules.storage.zfcp.discover.zfcp')

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_zfcp.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_zfcp.py
@@ -51,7 +51,7 @@ class ZFCPInterfaceTestCase(unittest.TestCase):
             "0x401040a000000000"
         )
 
-        obj = check_task_creation(self, task_path, publisher, ZFCPDiscoverTask)
+        obj = check_task_creation(task_path, publisher, ZFCPDiscoverTask)
 
         assert obj.implementation._device_number == "0.0.fc00"
         assert obj.implementation._wwpn == "0x5105074308c212e9"

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
@@ -16,6 +16,7 @@
 # Red Hat, Inc.
 #
 import unittest
+import pytest
 from unittest.mock import patch
 
 from blivet.devicelibs import raid
@@ -52,14 +53,14 @@ class PlatformTestCase(unittest.TestCase):
             non_linux_format_types = []
 
         platform = get_platform()
-        self.assertEqual(platform.__class__, platform_cls)
-        self.assertEqual(platform.packages, packages)
-        self.assertEqual(platform.non_linux_format_types, non_linux_format_types)
+        assert platform.__class__ == platform_cls
+        assert platform.packages == packages
+        assert platform.non_linux_format_types == non_linux_format_types
 
     def _check_partitions(self, *partitions):
         """Check the platform-specific partitions."""
         platform = get_platform()
-        self.assertEqual(platform.partitions, list(partitions))
+        assert platform.partitions == list(partitions)
 
     def _check_constraints(self, descriptions, constraints, error_message):
         """Check the platform-specific constraints."""
@@ -74,9 +75,9 @@ class PlatformTestCase(unittest.TestCase):
         all_constraints.update(constraints)
 
         platform = get_platform()
-        self.assertEqual(platform.stage1_descriptions, descriptions)
-        self.assertEqual(platform.stage1_constraints, all_constraints)
-        self.assertEqual(platform.stage1_suggestion, error_message)
+        assert platform.stage1_descriptions == descriptions
+        assert platform.stage1_constraints == all_constraints
+        assert platform.stage1_suggestion == error_message
 
     @patch("pyanaconda.modules.storage.platform.arch")
     def test_x86(self, arch):
@@ -472,17 +473,17 @@ class PlatformTestCase(unittest.TestCase):
         arch.is_ppc.return_value = True
         arch.get_ppc_machine.return_value = "INVALID"
 
-        with self.assertRaises(SystemError) as cm:
+        with pytest.raises(SystemError) as cm:
             get_platform()
 
-        self.assertEqual(str(cm.exception), "Unsupported PPC machine type: INVALID")
+        assert str(cm.value) == "Unsupported PPC machine type: INVALID"
 
     @patch("pyanaconda.modules.storage.platform.arch")
     def test_unsupported_platform(self, arch):
         """Test an unsupported platform."""
         self._reset_arch(arch)
 
-        with self.assertRaises(SystemError) as cm:
+        with pytest.raises(SystemError) as cm:
             get_platform()
 
-        self.assertEqual(str(cm.exception), "Could not determine system architecture.")
+        assert str(cm.value) == "Could not determine system architecture."

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_storage_checker.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_storage_checker.py
@@ -19,6 +19,7 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import pytest
 import pyanaconda.modules.storage.checker.utils as checks
 
 from blivet.size import Size
@@ -35,10 +36,10 @@ class StorageCheckerTests(unittest.TestCase):
         checker = StorageChecker()
         report = checker.check(None)
 
-        self.assertEqual(report.success, True)
-        self.assertEqual(report.failure, False)
-        self.assertListEqual(report.errors, [])
-        self.assertListEqual(report.warnings, [])
+        assert report.success == True
+        assert report.failure == False
+        assert report.errors == []
+        assert report.warnings == []
 
     def test_simple_error(self):
         """Test an simple error report."""
@@ -50,9 +51,9 @@ class StorageCheckerTests(unittest.TestCase):
         checker.add_check(check)
         report = checker.check(None)
 
-        self.assertEqual(report.success, False)
-        self.assertListEqual(report.errors, ["error"])
-        self.assertListEqual(report.warnings, [])
+        assert report.success == False
+        assert report.errors == ["error"]
+        assert report.warnings == []
 
     def test_simple_warning(self):
         """Test an simple warning report."""
@@ -63,18 +64,18 @@ class StorageCheckerTests(unittest.TestCase):
 
         checker.add_check(check)
         report = checker.check(None)
-        self.assertEqual(report.success, False)
-        self.assertListEqual(report.errors, [])
-        self.assertListEqual(report.warnings, ["warning"])
+        assert report.success == False
+        assert report.errors == []
+        assert report.warnings == ["warning"]
 
     def test_simple_info(self):
         """Test simple info messages. """
         checker = StorageChecker()
         report = checker.check(None)
-        self.assertListEqual(report.info, [
+        assert report.info == [
             "Storage check started with constraints {}.",
             "Storage check finished with success."
-        ])
+        ]
 
     def test_info(self):
         """Test info messages. """
@@ -95,7 +96,7 @@ class StorageCheckerTests(unittest.TestCase):
         checker.add_check(skipped_check)
 
         report = checker.check(None, skip=(skipped_check,))
-        self.assertListEqual(report.info, [
+        assert report.info == [
             "Storage check started with constraints {'x': None}.",
             "Run sanity check error_check.",
             "Found sanity error: error",
@@ -103,18 +104,20 @@ class StorageCheckerTests(unittest.TestCase):
             "Found sanity warning: warning",
             "Skipped sanity check skipped_check.",
             "Storage check finished with failure(s)."
-        ])
+        ]
 
     def test_simple_constraints(self):
         """Test simple constraint adding."""
         checker = StorageChecker()
 
         # Try to add a new constraint with a wrong method.
-        self.assertRaises(KeyError, checker.set_constraint, "x", None)
+        with pytest.raises(KeyError):
+            checker.set_constraint("x", None)
 
         # Try to add a new constraint two times.
         checker.add_constraint("x", None)
-        self.assertRaises(KeyError, checker.add_constraint, "x", None)
+        with pytest.raises(KeyError):
+            checker.add_constraint("x", None)
 
     def test_check_constraints(self):
         """Test constraints checking."""
@@ -125,27 +128,27 @@ class StorageCheckerTests(unittest.TestCase):
 
         checker.add_check(check)
         report = checker.check(None)
-        self.assertListEqual(report.warnings, ["{}"])
+        assert report.warnings == ["{}"]
 
         checker.add_constraint("x", 1)
         report = checker.check(None)
-        self.assertListEqual(report.warnings, ["{'x': 1}"])
+        assert report.warnings == ["{'x': 1}"]
 
         checker.set_constraint("x", 0)
         report = checker.check(None)
-        self.assertListEqual(report.warnings, ["{'x': 0}"])
+        assert report.warnings == ["{'x': 0}"]
 
     def test_dictionary_constraints(self):
         """Test the dictionary constraints."""
         checker = StorageChecker()
 
         checker.add_constraint("x", {"a": 1, "b": 2, "c": 3})
-        self.assertIn("x", checker.constraints)
-        self.assertEqual(checker.constraints["x"], {"a": 1, "b": 2, "c": 3})
+        assert "x" in checker.constraints
+        assert checker.constraints["x"] == {"a": 1, "b": 2, "c": 3}
 
         checker.set_constraint("x", {"e": 4, "f": 5})
-        self.assertIn("x", checker.constraints)
-        self.assertEqual(checker.constraints["x"], {"e": 4, "f": 5})
+        assert "x" in checker.constraints
+        assert checker.constraints["x"] == {"e": 4, "f": 5}
 
     def test_complicated(self):
         """Run a complicated check."""
@@ -175,9 +178,9 @@ class StorageCheckerTests(unittest.TestCase):
 
         # Run the checker. OK
         report = checker.check(None)
-        self.assertEqual(report.success, True)
-        self.assertListEqual(report.errors, [])
-        self.assertListEqual(report.warnings, [])
+        assert report.success == True
+        assert report.errors == []
+        assert report.warnings == []
 
         # Set constraints to different values.
         checker.set_constraint("x", 0)
@@ -186,29 +189,29 @@ class StorageCheckerTests(unittest.TestCase):
 
         # Run the checker. FAIL
         report = checker.check(None)
-        self.assertEqual(report.success, False)
-        self.assertListEqual(report.errors, [
+        assert report.success == False
+        assert report.errors == [
             "x is not equal to 1",
             "y is not equal to 2",
             "z is not equal to 3"
-        ])
-        self.assertListEqual(report.warnings, [])
+        ]
+        assert report.warnings == []
 
         # Run the checker. Test SKIP.
         report = checker.check(None, skip=(check_y,))
-        self.assertEqual(report.success, False)
-        self.assertListEqual(report.errors, [
+        assert report.success == False
+        assert report.errors == [
             "x is not equal to 1",
             "z is not equal to 3"
-        ])
-        self.assertListEqual(report.warnings, [])
+        ]
+        assert report.warnings == []
 
         # Run the checker. Test CONSTRAINTS.
         constraints = {"x": 1, "y": 2, "z": 3}
         report = checker.check(None, constraints=constraints)
-        self.assertEqual(report.success, True)
-        self.assertListEqual(report.errors, [])
-        self.assertListEqual(report.warnings, [])
+        assert report.success == True
+        assert report.errors == []
+        assert report.warnings == []
 
         # Remove checks.
         checker.remove_check(check_x)
@@ -216,9 +219,9 @@ class StorageCheckerTests(unittest.TestCase):
         checker.remove_check(check_z)
 
         report = checker.check(None)
-        self.assertEqual(report.success, True)
-        self.assertListEqual(report.errors, [])
-        self.assertListEqual(report.warnings, [])
+        assert report.success == True
+        assert report.errors == []
+        assert report.warnings == []
 
     def test_default_settings(self):
         """Check the default storage checker."""
@@ -226,7 +229,7 @@ class StorageCheckerTests(unittest.TestCase):
         checker.set_default_constraints()
         checker.set_default_checks()
 
-        self.assertEqual(checker.constraints, {
+        assert checker.constraints == {
             checks.STORAGE_MIN_RAM:  Size("320 MiB"),
             checks.STORAGE_ROOT_DEVICE_TYPES: set(),
             checks.STORAGE_MIN_PARTITION_SIZES: {
@@ -253,9 +256,9 @@ class StorageCheckerTests(unittest.TestCase):
             },
             checks.STORAGE_SWAP_IS_RECOMMENDED: False,
             checks.STORAGE_LUKS2_MIN_RAM: Size("128 MiB"),
-        })
+        }
 
-        self.assertEqual(checker.checks, [
+        assert checker.checks == [
             checks.verify_root,
             checks.verify_s390_constraints,
             checks.verify_partition_formatting,
@@ -273,4 +276,4 @@ class StorageCheckerTests(unittest.TestCase):
             checks.verify_luks2_memory_requirements,
             checks.verify_mounted_partitions,
             checks.verify_lvm_destruction,
-        ])
+        ]

--- a/tests/unit_tests/pyanaconda_tests/modules/subscription/test_rhsm_observer.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/subscription/test_rhsm_observer.py
@@ -19,6 +19,8 @@
 #
 
 import unittest
+import pytest
+
 from unittest.mock import patch, Mock, PropertyMock
 
 from dasbus.typing import get_variant, Str
@@ -50,7 +52,7 @@ class StartRHSMTaskTestCase(unittest.TestCase):
         config_proxy = Mock()
         get_proxy.return_value = config_proxy
         # run the task and expect it to succeed
-        self.assertTrue(task.run())
+        assert task.run()
         # check service was started correctly
         start_service.assert_called_once_with("rhsm.service")
         # check proxy was requested
@@ -82,7 +84,7 @@ class StartRHSMTaskTestCase(unittest.TestCase):
         config_proxy = Mock()
         get_proxy.return_value = config_proxy
         # run the task and expect it to succeed
-        self.assertTrue(task.run())
+        assert task.run()
         # check service was started correctly
         start_service.assert_called_once_with("rhsm.service")
         # check proxy was requested
@@ -109,7 +111,7 @@ class StartRHSMTaskTestCase(unittest.TestCase):
         # simulate successful systemd service start
         start_service.return_value = 1
         # run the task and expect it to fail
-        self.assertFalse(task.run())
+        assert not task.run()
         # check service was started correctly
         start_service.assert_called_once_with("rhsm.service")
         # check proxy was not requested
@@ -124,7 +126,7 @@ class StartRHSMTaskTestCase(unittest.TestCase):
         task.get_result = Mock()
         task.get_result.return_value = True
         # test the method
-        self.assertTrue(task.is_service_available(1))
+        assert task.is_service_available(1)
 
     def test_is_service_available_failure(self):
         """Test StartRHSMTask - test is_service_available() - failure."""
@@ -135,7 +137,7 @@ class StartRHSMTaskTestCase(unittest.TestCase):
         task.get_result = Mock()
         task.get_result.return_value = False
         # test the method
-        self.assertFalse(task.is_service_available(1))
+        assert not task.is_service_available(1)
 
     @patch("pyanaconda.threading.threadMgr.get")
     def test_is_service_available_timeout(self, thread_mgr_get):
@@ -153,13 +155,13 @@ class StartRHSMTaskTestCase(unittest.TestCase):
             task.get_result = Mock()
             task.get_result.return_value = False
             # make sure is_running is True
-            self.assertTrue(task.is_running)
+            assert task.is_running
             # us a mock thread, so that it's
             # join method exists immediately
             mock_thread = Mock()
             thread_mgr_get.return_value = mock_thread
             # test the method times out
-            self.assertFalse(task.is_service_available(timeout=1.0))
+            assert not task.is_service_available(timeout=1.0)
             # check that the mock thread join() was called with expected
             # timeout
             mock_thread.join.assert_called_once_with(1.0)
@@ -179,7 +181,7 @@ class StartRHSMTaskTestCase(unittest.TestCase):
             task.get_result = Mock()
             task.get_result.return_value = True
             # make sure is_running is True
-            self.assertTrue(task.is_running)
+            assert task.is_running
             # assure is_running switches to False before
             # the method starts waiting on the mock thread
             mock_thread = Mock()
@@ -192,7 +194,7 @@ class StartRHSMTaskTestCase(unittest.TestCase):
             # by replacing the thread by Mock instance,
             # we can avoid running the method in a thread
             # as it will join() Mock instance not a real thread
-            self.assertTrue(task.is_service_available(timeout=1.0))
+            assert task.is_service_available(timeout=1.0)
             # check that the mock thread was joined with the
             # expected timeout value
             mock_thread.join.assert_called_once_with(1.0)
@@ -205,7 +207,7 @@ class RHSMObserverTestCase(unittest.TestCase):
         """Set up the observer."""
         observer._service_available = Mock()
         observer._service_unavailable = Mock()
-        self.assertFalse(observer.is_service_available)
+        assert not observer.is_service_available
 
     def _make_service_available(self, observer):
         """Make the service available."""
@@ -214,7 +216,7 @@ class RHSMObserverTestCase(unittest.TestCase):
 
     def _test_if_service_available(self, observer):
         """Test if service is available."""
-        self.assertTrue(observer.is_service_available)
+        assert observer.is_service_available
 
         observer._service_available.emit.assert_called_once_with(observer)
         observer._service_available.reset_mock()
@@ -229,7 +231,7 @@ class RHSMObserverTestCase(unittest.TestCase):
 
     def _test_if_service_unavailable(self, observer):
         """Test if service is unavailable."""
-        self.assertFalse(observer.is_service_available)
+        assert not observer.is_service_available
 
         observer._service_available.emit.assert_not_called()
         observer._service_available.reset_mock()
@@ -279,7 +281,7 @@ class RHSMObserverTestCase(unittest.TestCase):
         self._setup_observer(observer)
         self._make_service_unavailable(observer)
         # DBusObserverError should be raise
-        with self.assertRaises(DBusObserverError):
+        with pytest.raises(DBusObserverError):
             observer.get_proxy("BAZ")
         # the observer should raise the exception before trying to get a proxy
         get_proxy.assert_not_called()

--- a/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription.py
@@ -78,34 +78,34 @@ class SystemPurposeLibraryTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             no_file = os.path.join(tempdir, "foo.json")
             roles, slas, usage_types = get_valid_fields(valid_fields_file_path=no_file)
-            self.assertListEqual(roles, [])
-            self.assertListEqual(slas, [])
-            self.assertListEqual(usage_types, [])
+            assert roles == []
+            assert slas == []
+            assert usage_types == []
 
         # check empty value list is handled correctly
         with tempfile.NamedTemporaryFile(mode="w+t") as testfile:
             testfile.write(SYSPURPOSE_VALID_VALUES_JSON_EMPTY)
             testfile.flush()
             roles, slas, usage_types = get_valid_fields(valid_fields_file_path=testfile.name)
-            self.assertListEqual(roles, [])
-            self.assertListEqual(slas, [])
-            self.assertListEqual(usage_types, [])
+            assert roles == []
+            assert slas == []
+            assert usage_types == []
 
         # check correctly populated json file is parsed correctly
         with tempfile.NamedTemporaryFile(mode="w+t") as testfile:
             testfile.write(SYSPURPOSE_VALID_VALUES_JSON)
             testfile.flush()
             roles, slas, usage_types = get_valid_fields(valid_fields_file_path=testfile.name)
-            self.assertListEqual(roles, ["role_a", "role_b", "role_c"])
-            self.assertListEqual(slas, ["sla_a", "sla_b", "sla_c"])
-            self.assertListEqual(usage_types, ["usage_a", "usage_b", "usage_c"])
+            assert roles == ["role_a", "role_b", "role_c"]
+            assert slas == ["sla_a", "sla_b", "sla_c"]
+            assert usage_types == ["usage_a", "usage_b", "usage_c"]
 
     def test_normalize_field(self):
         """Test that the system purpose valid field normalization works."""
         # this should basically just lower case the input
-        self.assertEqual(_normalize_field("AAA"), "aaa")
-        self.assertEqual(_normalize_field("Ab"), "ab")
-        self.assertEqual(_normalize_field("A b C"), "a b c")
+        assert _normalize_field("AAA") == "aaa"
+        assert _normalize_field("Ab") == "ab"
+        assert _normalize_field("A b C") == "a b c"
 
     def test_match_field(self):
         """Test that the system purpose valid field matching works."""
@@ -115,32 +115,18 @@ class SystemPurposeLibraryTestCase(unittest.TestCase):
         # in the GUI even if the user typosed the case or similar.
 
         # these should match
-        self.assertEqual(
-            _match_field("production", ["Production", "Development", "Testing"]),
+        assert _match_field("production", ["Production", "Development", "Testing"]) == \
             "Production"
-        )
-        self.assertEqual(
-            _match_field("Production", ["Production", "Development", "Testing"]),
+        assert _match_field("Production", ["Production", "Development", "Testing"]) == \
             "Production"
-        )
-        self.assertEqual(
-            _match_field("DEVELOPMENT", ["Production", "Development", "Testing"]),
+        assert _match_field("DEVELOPMENT", ["Production", "Development", "Testing"]) == \
             "Development"
-        )
 
         # these should not match but return the original value
-        self.assertIsNone(
-            _match_field("custom", ["Production", "Development", "Testing"]),
-        )
-        self.assertIsNone(
-            _match_field("Prod", ["Production", "Development", "Testing"]),
-        )
-        self.assertIsNone(
-            _match_field("Production 1", ["Production", "Development", "Testing"]),
-        )
-        self.assertIsNone(
-            _match_field("Production Development", ["Production", "Development", "Testing"]),
-        )
+        assert _match_field("custom", ["Production", "Development", "Testing"]) is None
+        assert _match_field("Prod", ["Production", "Development", "Testing"]) is None
+        assert _match_field("Production 1", ["Production", "Development", "Testing"]) is None
+        assert _match_field("Production Development", ["Production", "Development", "Testing"]) is None
 
     def test_process_field(self):
         """Test that the system purpose field processing works."""
@@ -148,43 +134,43 @@ class SystemPurposeLibraryTestCase(unittest.TestCase):
         valid_values = ["Production", "Development", "Testing"]
 
         # empty string
-        self.assertEqual(process_field("", valid_values, "usage"), "")
+        assert process_field("", valid_values, "usage") == ""
 
         # well known value with different case
-        self.assertEqual(process_field("production", valid_values, "usage"), "Production")
-        self.assertEqual(process_field("PRODUCTION", valid_values, "usage"), "Production")
+        assert process_field("production", valid_values, "usage") == "Production"
+        assert process_field("PRODUCTION", valid_values, "usage") == "Production"
 
         # well known value with matching case
-        self.assertEqual(process_field("Production", valid_values, "usage"), "Production")
+        assert process_field("Production", valid_values, "usage") == "Production"
 
         # fully custom value
-        self.assertEqual(process_field("foo", valid_values, "usage"), "foo")
-        self.assertEqual(process_field("foo BAR", valid_values, "usage"), "foo BAR")
+        assert process_field("foo", valid_values, "usage") == "foo"
+        assert process_field("foo BAR", valid_values, "usage") == "foo BAR"
 
         # empty list of well known values
-        self.assertEqual(process_field("PRODUCTION", [], "usage"), "PRODUCTION")
-        self.assertEqual(process_field("foo", [], "usage"), "foo")
+        assert process_field("PRODUCTION", [], "usage") == "PRODUCTION"
+        assert process_field("foo", [], "usage") == "foo"
 
     @patch("pyanaconda.core.util.execWithRedirect")
     def test_set_system_pourpose_no_purpose(self, exec_with_redirect):
         """Test that nothing is done if system has no purpose."""
         with tempfile.TemporaryDirectory() as sysroot:
-            self.assertTrue(give_the_system_purpose(sysroot=sysroot,
+            assert give_the_system_purpose(sysroot=sysroot,
                                                     role="",
                                                     sla="",
                                                     usage="",
-                                                    addons=[]))
+                                                    addons=[])
             exec_with_redirect.assert_not_called()
 
     @patch("pyanaconda.core.util.execWithRedirect")
     def test_set_system_pourpose_no_syspurpose(self, exec_with_redirect):
         """Test that nothing is done & False is returned if the syspurpose tool is missing."""
         with tempfile.TemporaryDirectory() as sysroot:
-            self.assertFalse(give_the_system_purpose(sysroot=sysroot,
+            assert not give_the_system_purpose(sysroot=sysroot,
                                                      role="foo",
                                                      sla="bar",
                                                      usage="baz",
-                                                     addons=["a", "b", "c"]))
+                                                     addons=["a", "b", "c"])
             exec_with_redirect.assert_not_called()
 
     @patch("pyanaconda.core.util.execWithRedirect")
@@ -199,11 +185,11 @@ class SystemPurposeLibraryTestCase(unittest.TestCase):
             # set return value to 0
             exec_with_redirect.return_value = 0
             # set system purpose
-            self.assertTrue(give_the_system_purpose(sysroot=sysroot,
+            assert give_the_system_purpose(sysroot=sysroot,
                                                     role="foo",
                                                     sla="bar",
                                                     usage="baz",
-                                                    addons=["a", "b", "c"]))
+                                                    addons=["a", "b", "c"])
             # check syspurpose invocations look correct
             exec_with_redirect.assert_has_calls(
                 [call("syspurpose", ["set-role", "foo"], root=sysroot),
@@ -223,11 +209,11 @@ class SystemPurposeLibraryTestCase(unittest.TestCase):
             # set return value no non-zero
             exec_with_redirect.return_value = 1
             # set system purpose
-            self.assertFalse(give_the_system_purpose(sysroot=sysroot,
+            assert not give_the_system_purpose(sysroot=sysroot,
                                                      role="foo",
                                                      sla="bar",
                                                      usage="baz",
-                                                     addons=["a", "b", "c"]))
+                                                     addons=["a", "b", "c"])
             # check syspurpose invocations look correct
             exec_with_redirect.assert_called_once_with("syspurpose",
                                                        ["set-role", "foo"],
@@ -260,9 +246,9 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
     def test_kickstart_properties(self):
         """Test kickstart properties."""
-        self.assertEqual(self.subscription_interface.KickstartCommands, ["syspurpose", "rhsm"])
-        self.assertEqual(self.subscription_interface.KickstartSections, [])
-        self.assertEqual(self.subscription_interface.KickstartAddons, [])
+        assert self.subscription_interface.KickstartCommands == ["syspurpose", "rhsm"]
+        assert self.subscription_interface.KickstartSections == []
+        assert self.subscription_interface.KickstartAddons == []
         self.callback.assert_not_called()
 
     def test_system_purpose_data(self):
@@ -284,7 +270,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         }
 
         # compare the two
-        self.assertEqual(SystemPurposeData.to_structure(system_purpose_data), expected_dict)
+        assert SystemPurposeData.to_structure(system_purpose_data) == expected_dict
 
         # feed it to the DBus interface
         self.subscription_interface.SetSystemPurposeData(
@@ -293,7 +279,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         # compare the result with expected data
         output = self.subscription_interface.SystemPurposeData
-        self.assertEqual(output, expected_dict)
+        assert output == expected_dict
 
     def test_system_purpose_data_comparison(self):
         """Test SystemPurposeData instance equality comparison."""
@@ -322,24 +308,24 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         different_system_purpose_data.addons = ["different_a", "different_b", "different_c"]
 
         # same content should be considered the same
-        self.assertTrue(system_purpose_data == system_purpose_data_clone)
+        assert system_purpose_data == system_purpose_data_clone
 
         # different content should not be considered the same
-        self.assertFalse(system_purpose_data == different_system_purpose_data)
-        self.assertFalse(system_purpose_data_clone == different_system_purpose_data)
+        assert not (system_purpose_data == different_system_purpose_data)
+        assert not (system_purpose_data_clone == different_system_purpose_data)
 
         # comparing with something else than a SystemPurposeData instance should
         # not crash & always return False
-        self.assertNotEqual(system_purpose_data, "foo")
-        self.assertNotEqual(system_purpose_data, None)
-        self.assertNotEqual(system_purpose_data, object())
+        assert system_purpose_data != "foo"
+        assert system_purpose_data is not None
+        assert system_purpose_data != object()
 
     def test_system_purpose_data_helper(self):
         """Test the SystemPurposeData DBus structure data availability helper method."""
 
         # empty
         data = SystemPurposeData()
-        self.assertFalse(data.check_data_available())
+        assert not data.check_data_available()
 
         # full
         data = SystemPurposeData()
@@ -347,14 +333,14 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         data.sla = "bar"
         data.usage = "baz"
         data.addons = ["a", "b", "c"]
-        self.assertTrue(data.check_data_available())
+        assert data.check_data_available()
 
         # partially populated
         data = SystemPurposeData()
         data.role = "foo"
         data.usage = "baz"
         data.addons = ["a"]
-        self.assertTrue(data.check_data_available())
+        assert data.check_data_available()
 
     def test_set_system_purpose(self):
         """Test if setting system purpose data from DBUS works correctly."""
@@ -373,10 +359,10 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         output_structure = self.subscription_interface.SystemPurposeData
         output_system_purpose_data = SystemPurposeData.from_structure(output_structure)
 
-        self.assertEqual(output_system_purpose_data.role, "foo")
-        self.assertEqual(output_system_purpose_data.sla, "bar")
-        self.assertEqual(output_system_purpose_data.usage, "baz")
-        self.assertEqual(output_system_purpose_data.addons, ["a", "b", "c"])
+        assert output_system_purpose_data.role == "foo"
+        assert output_system_purpose_data.sla == "bar"
+        assert output_system_purpose_data.usage == "baz"
+        assert output_system_purpose_data.addons == ["a", "b", "c"]
 
     def test_subscription_request_data_defaults(self):
         """Test the SubscriptionRequest DBus structure defaults."""
@@ -400,10 +386,8 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         }
 
         # compare the empty structure with expected default values
-        self.assertEqual(
-            get_native(SubscriptionRequest.to_structure(empty_request)),
+        assert get_native(SubscriptionRequest.to_structure(empty_request)) == \
             expected_default_dict
-        )
 
     def test_subscription_request_data_full(self):
         """Test completely populated SubscriptionRequest DBus structure."""
@@ -437,10 +421,8 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         }
 
         # compare the fully populated structure with expected values
-        self.assertEqual(
-            get_native(SubscriptionRequest.to_structure(full_request)),
+        assert get_native(SubscriptionRequest.to_structure(full_request)) == \
             expected_full_dict
-        )
 
         # set it to the module interface
         self.subscription_interface.SetSubscriptionRequest(
@@ -465,10 +447,8 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
             "server-proxy-password": {"type": SECRET_TYPE_HIDDEN, "value": ""},
         }
 
-        self.assertEqual(
-            output_dict,
+        assert output_dict == \
             expected_full_output_dict
-        )
 
     def test_set_subscription_request_password(self):
         """Test if setting username+password subscription request from DBUS works correctly."""
@@ -774,12 +754,12 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         # check all three values are actually set to what we expect
         internal_request = self.subscription_module._subscription_request
-        self.assertEqual(internal_request.account_password.value,
-                         "bar_password")
-        self.assertEqual(internal_request.activation_keys.value,
-                         ["key_foo", "key_bar", "key_baz"])
-        self.assertEqual(internal_request.server_proxy_password.value,
-                         "foo_proxy_password")
+        assert internal_request.account_password.value == \
+            "bar_password"
+        assert internal_request.activation_keys.value == \
+            ["key_foo", "key_bar", "key_baz"]
+        assert internal_request.server_proxy_password.value == \
+            "foo_proxy_password"
 
         # set SubscriptionRequest on input with empty value
         # and type set to HIDDEN
@@ -831,12 +811,12 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         # check all three values are actually still set to what we expect
         internal_request = self.subscription_module._subscription_request
-        self.assertEqual(internal_request.account_password.value,
-                         "bar_password")
-        self.assertEqual(internal_request.activation_keys.value,
-                         ["key_foo", "key_bar", "key_baz"])
-        self.assertEqual(internal_request.server_proxy_password.value,
-                         "foo_proxy_password")
+        assert internal_request.account_password.value == \
+            "bar_password"
+        assert internal_request.activation_keys.value == \
+            ["key_foo", "key_bar", "key_baz"]
+        assert internal_request.server_proxy_password.value == \
+            "foo_proxy_password"
 
     def test_attached_subscription_defaults(self):
         """Test the AttachedSubscription DBus structure defaults."""
@@ -855,10 +835,8 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
             "consumed-entitlement-count": get_variant(Int, 1)
         }
         # compare the empty structure with expected default values
-        self.assertEqual(
-            AttachedSubscription.to_structure(empty_request),
+        assert AttachedSubscription.to_structure(empty_request) == \
             expected_default_dict
-        )
 
     def test_attached_subscription_full(self):
         """Test the AttachedSubscription DBus structure that is fully populated."""
@@ -884,15 +862,13 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
             "consumed-entitlement-count": get_variant(Int, 9001)
         }
         # compare the full structure with expected values
-        self.assertEqual(
-            AttachedSubscription.to_structure(full_request),
+        assert AttachedSubscription.to_structure(full_request) == \
             expected_default_dict
-        )
 
     def test_insights_property(self):
         """Test the InsightsEnabled property."""
         # should be False by default
-        self.assertFalse(self.subscription_interface.InsightsEnabled)
+        assert not self.subscription_interface.InsightsEnabled
 
         # try setting the property
         self._check_dbus_property(
@@ -907,7 +883,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
     def test_registered_property(self):
         """Test the IsRegistered property."""
         # should be false by default
-        self.assertFalse(self.subscription_interface.IsRegistered)
+        assert not self.subscription_interface.IsRegistered
 
         # this property can't be set by client as it is set as the result of
         # subscription attempts, so we need to call the internal module interface
@@ -925,12 +901,12 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         )
 
         # at the end the property should be True
-        self.assertTrue(self.subscription_interface.IsRegistered)
+        assert self.subscription_interface.IsRegistered
 
     def test_subscription_attached_property(self):
         """Test the IsSubscriptionAttached property."""
         # should be false by default
-        self.assertFalse(self.subscription_interface.IsSubscriptionAttached)
+        assert not self.subscription_interface.IsSubscriptionAttached
 
         # this property can't be set by client as it is set as the result of
         # subscription attempts, so we need to call the internal module interface
@@ -948,12 +924,12 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         )
 
         # at the end the property should be True
-        self.assertTrue(self.subscription_interface.IsSubscriptionAttached)
+        assert self.subscription_interface.IsSubscriptionAttached
 
     def test_attached_subscriptions_property(self):
         """Test the AttachedSubscriptions property."""
         # should return an empty list by default
-        self.assertEqual(self.subscription_interface.AttachedSubscriptions, [])
+        assert self.subscription_interface.AttachedSubscriptions == []
         # this property can't be set by client as it is set as the result of
         # subscription attempts, so we need to call the internal module interface
         # via a custom setter
@@ -992,7 +968,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         )
         # at the end the property should return the expected list
         # of AttachedSubscription structures
-        self.assertEqual(self.subscription_interface.AttachedSubscriptions, subscription_structs)
+        assert self.subscription_interface.AttachedSubscriptions == subscription_structs
 
     @patch_dbus_publish_object
     def test_set_system_purpose_with_task(self, publisher):
@@ -1017,7 +993,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
             "usage": get_variant(Str, "baz"),
             "addons": get_variant(List[Str], ["a", "b", "c"])
         }
-        self.assertEqual(SystemPurposeData.to_structure(data_from_module), expected_dict)
+        assert SystemPurposeData.to_structure(data_from_module) == expected_dict
 
     @patch("pyanaconda.modules.subscription.system_purpose.give_the_system_purpose")
     def test_apply_syspurpose(self, mock_give_purpose):
@@ -1046,7 +1022,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
     def test_get_rhsm_config_defaults(self):
         """Test the get_rhsm_config_defaults() method."""
         # cache should be None by default
-        self.assertIsNone(self.subscription_module._rhsm_config_defaults)
+        assert self.subscription_module._rhsm_config_defaults is None
 
         # create a default config
         default_config = {
@@ -1095,14 +1071,14 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         result2 = self.subscription_module.get_rhsm_config_defaults()
 
         # make sure the results are identical
-        self.assertEqual(result1, result2)
+        assert result1 == result2
 
         # make sure the results contain the expected dict
         # - even though GetAll() returns a variant, the
         #   get_rhsm_config_default() should convert it
         #   to a native Python dict
-        self.assertEqual(result1, flat_default_config)
-        self.assertEqual(result2, flat_default_config)
+        assert result1 == flat_default_config
+        assert result2 == flat_default_config
 
         # check the property requested the correct DBus object
         observer.get_proxy.assert_called_once_with(RHSM_CONFIG)
@@ -1114,7 +1090,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         """Test package requirements - module in default state."""
         # by default no packages should be required
         requirements = self.subscription_interface.CollectRequirements()
-        self.assertEqual(requirements, [])
+        assert requirements == []
 
     def test_package_requirements_insights(self):
         """Test package requirements - connect to Insights enabled."""
@@ -1128,7 +1104,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
              "reason": "Needed to connect the target system to Red Hat Insights.",
              "type": "package"}
         ]
-        self.assertEqual(get_native(requirements), expected_requirements)
+        assert get_native(requirements) == expected_requirements
 
     @patch_dbus_publish_object
     def test_set_rhsm_config_with_task(self, publisher):
@@ -1192,7 +1168,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         task_path = self.subscription_interface.SetRHSMConfigWithTask()
         obj = check_task_creation(self, task_path, publisher, SetRHSMConfigurationTask)
         # check all the data got propagated to the module correctly
-        self.assertEqual(obj.implementation._rhsm_config_proxy, config_proxy)
+        assert obj.implementation._rhsm_config_proxy == config_proxy
         task_request = obj.implementation._request
         expected_full_dict = {
             "type": SUBSCRIPTION_REQUEST_TYPE_ORG_KEY,
@@ -1207,10 +1183,8 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
             "activation-keys": {"type": SECRET_TYPE_TEXT, "value": ["key1", "key2", "key3"]},
             "server-proxy-password": {"type": SECRET_TYPE_TEXT, "value": "foo_proxy_password"},
         }
-        self.assertEqual(
-                get_native(SubscriptionRequest.to_structure(task_request)),
-                expected_full_dict)
-        self.assertEqual(obj.implementation._rhsm_config_defaults, flat_default_config)
+        assert get_native(SubscriptionRequest.to_structure(task_request)) == expected_full_dict
+        assert obj.implementation._rhsm_config_defaults == flat_default_config
 
     @patch_dbus_publish_object
     def test_register_with_username_password(self, publisher):
@@ -1243,13 +1217,13 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         task_path = self.subscription_interface.RegisterUsernamePasswordWithTask()
         obj = check_task_creation(self, task_path, publisher, RegisterWithUsernamePasswordTask)
         # check all the data got propagated to the module correctly
-        self.assertEqual(obj.implementation._rhsm_register_server_proxy, register_server_proxy)
-        self.assertEqual(obj.implementation._username, "foo_user")
-        self.assertEqual(obj.implementation._password, "foo_password")
+        assert obj.implementation._rhsm_register_server_proxy == register_server_proxy
+        assert obj.implementation._username == "foo_user"
+        assert obj.implementation._password == "foo_password"
         # trigger the succeeded signal
         obj.implementation.succeeded_signal.emit()
         # check this set the registered property to True
-        self.assertTrue(self.subscription_interface.IsRegistered)
+        assert self.subscription_interface.IsRegistered
 
     @patch_dbus_publish_object
     def test_register_with_organization_key(self, publisher):
@@ -1282,13 +1256,13 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         task_path = self.subscription_interface.RegisterOrganizationKeyWithTask()
         obj = check_task_creation(self, task_path, publisher, RegisterWithOrganizationKeyTask)
         # check all the data got propagated to the module correctly
-        self.assertEqual(obj.implementation._rhsm_register_server_proxy, register_server_proxy)
-        self.assertEqual(obj.implementation._organization, "123456789")
-        self.assertEqual(obj.implementation._activation_keys, ["key1", "key2", "key3"])
+        assert obj.implementation._rhsm_register_server_proxy == register_server_proxy
+        assert obj.implementation._organization == "123456789"
+        assert obj.implementation._activation_keys == ["key1", "key2", "key3"]
         # trigger the succeeded signal
         obj.implementation.succeeded_signal.emit()
         # check this set the registered property to True
-        self.assertTrue(self.subscription_interface.IsRegistered)
+        assert self.subscription_interface.IsRegistered
 
     @patch_dbus_publish_object
     def test_unregister(self, publisher):
@@ -1303,12 +1277,12 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         task_path = self.subscription_interface.UnregisterWithTask()
         obj = check_task_creation(self, task_path, publisher, UnregisterTask)
         # check all the data got propagated to the module correctly
-        self.assertEqual(obj.implementation._rhsm_unregister_proxy, rhsm_unregister_proxy)
+        assert obj.implementation._rhsm_unregister_proxy == rhsm_unregister_proxy
         # trigger the succeeded signal
         obj.implementation.succeeded_signal.emit()
         # check this set the subscription-attached & registered properties to False
-        self.assertFalse(self.subscription_interface.IsRegistered)
-        self.assertFalse(self.subscription_interface.IsSubscriptionAttached)
+        assert not self.subscription_interface.IsRegistered
+        assert not self.subscription_interface.IsSubscriptionAttached
 
     @patch_dbus_publish_object
     def test_attach_subscription(self, publisher):
@@ -1324,7 +1298,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
             SystemPurposeData.to_structure(system_purpose_data)
         )
         # make sure system is not subscribed
-        self.assertFalse(self.subscription_interface.IsSubscriptionAttached)
+        assert not self.subscription_interface.IsSubscriptionAttached
         # make sure the task gets dummy rhsm attach proxy
         observer = Mock()
         self.subscription_module._rhsm_observer = observer
@@ -1333,12 +1307,12 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         task_path = self.subscription_interface.AttachSubscriptionWithTask()
         obj = check_task_creation(self, task_path, publisher, AttachSubscriptionTask)
         # check all the data got propagated to the module correctly
-        self.assertEqual(obj.implementation._rhsm_attach_proxy, rhsm_attach_proxy)
-        self.assertEqual(obj.implementation._sla, "bar")
+        assert obj.implementation._rhsm_attach_proxy == rhsm_attach_proxy
+        assert obj.implementation._sla == "bar"
         # trigger the succeeded signal
         obj.implementation.succeeded_signal.emit()
         # check this set subscription_attached to True
-        self.assertTrue(self.subscription_interface.IsSubscriptionAttached)
+        assert self.subscription_interface.IsSubscriptionAttached
 
     @patch_dbus_publish_object
     def test_parse_attached_subscriptions(self, publisher):
@@ -1354,8 +1328,8 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         task_path = self.subscription_interface.ParseAttachedSubscriptionsWithTask()
         obj = check_task_creation(self, task_path, publisher, ParseAttachedSubscriptionsTask)
         # check all the data got propagated to the module correctly
-        self.assertEqual(obj.implementation._rhsm_entitlement_proxy, rhsm_entitlement_proxy)
-        self.assertEqual(obj.implementation._rhsm_syspurpose_proxy, rhsm_syspurpose_proxy)
+        assert obj.implementation._rhsm_entitlement_proxy == rhsm_entitlement_proxy
+        assert obj.implementation._rhsm_syspurpose_proxy == rhsm_syspurpose_proxy
         # prepare some testing data
         subscription_structs = [
             {
@@ -1393,8 +1367,8 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         # trigger the succeeded signal
         obj.implementation.succeeded_signal.emit()
         # check this set attached subscription and system purpose as expected
-        self.assertEqual(self.subscription_interface.AttachedSubscriptions, subscription_structs)
-        self.assertEqual(self.subscription_interface.SystemPurposeData, system_purpose_struct)
+        assert self.subscription_interface.AttachedSubscriptions == subscription_structs
+        assert self.subscription_interface.SystemPurposeData == system_purpose_struct
 
     @patch_dbus_publish_object
     def test_install_with_tasks_default(self, publisher):
@@ -1416,16 +1390,16 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         # RestoreRHSMDefaultsTask
         obj = task_objs[0]
-        self.assertEqual(obj.implementation._rhsm_config_proxy, config_proxy)
+        assert obj.implementation._rhsm_config_proxy == config_proxy
 
         # TransferSubscriptionTokensTask
         obj = task_objs[1]
-        self.assertEqual(obj.implementation._transfer_subscription_tokens, False)
+        assert obj.implementation._transfer_subscription_tokens == False
 
         # ConnectToInsightsTask
         obj = task_objs[2]
-        self.assertEqual(obj.implementation._subscription_attached, False)
-        self.assertEqual(obj.implementation._connect_to_insights, False)
+        assert obj.implementation._subscription_attached == False
+        assert obj.implementation._connect_to_insights == False
 
     @patch_dbus_publish_object
     def test_install_with_tasks_configured(self, publisher):
@@ -1451,16 +1425,16 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         # RestoreRHSMDefaultsTask
         obj = task_objs[0]
-        self.assertEqual(obj.implementation._rhsm_config_proxy, config_proxy)
+        assert obj.implementation._rhsm_config_proxy == config_proxy
 
         # TransferSubscriptionTokensTask
         obj = task_objs[1]
-        self.assertEqual(obj.implementation._transfer_subscription_tokens, True)
+        assert obj.implementation._transfer_subscription_tokens == True
 
         # ConnectToInsightsTask
         obj = task_objs[2]
-        self.assertEqual(obj.implementation._subscription_attached, True)
-        self.assertEqual(obj.implementation._connect_to_insights, True)
+        assert obj.implementation._subscription_attached == True
+        assert obj.implementation._connect_to_insights == True
 
     def _test_kickstart(self, ks_in, ks_out):
         check_kickstart_interface(self, self.subscription_interface, ks_in, ks_out)
@@ -1480,10 +1454,10 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         # also test resulting module state
         structure = self.subscription_interface.SystemPurposeData
         system_purpose_data = SystemPurposeData.from_structure(structure)
-        self.assertEqual(system_purpose_data.role, "")
-        self.assertEqual(system_purpose_data.sla, "")
-        self.assertEqual(system_purpose_data.usage, "")
-        self.assertEqual(system_purpose_data.addons, [])
+        assert system_purpose_data.role == ""
+        assert system_purpose_data.sla == ""
+        assert system_purpose_data.usage == ""
+        assert system_purpose_data.addons == []
 
     def test_ks_out_set_role(self):
         """Check kickstart with role being used."""
@@ -1540,10 +1514,10 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         structure = self.subscription_interface.SystemPurposeData
         system_purpose_data = SystemPurposeData.from_structure(structure)
-        self.assertEqual(system_purpose_data.role, 'FOO')
-        self.assertEqual(system_purpose_data.sla, 'BAR')
-        self.assertEqual(system_purpose_data.usage, 'BAZ')
-        self.assertEqual(system_purpose_data.addons, ["F Product", "B Feature"])
+        assert system_purpose_data.role == 'FOO'
+        assert system_purpose_data.sla == 'BAR'
+        assert system_purpose_data.usage == 'BAZ'
+        assert system_purpose_data.addons == ["F Product", "B Feature"]
 
     def test_ks_out_rhsm_parse(self):
         """Check the rhsm kickstart command is parsed correctly."""
@@ -1561,28 +1535,25 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         structure = self.subscription_interface.SubscriptionRequest
         subscription_request = SubscriptionRequest.from_structure(structure)
         # both org id and one key have been used, request should be org & key type
-        self.assertEqual(subscription_request.type, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY)
-        self.assertEqual(subscription_request.organization, "123")
-        self.assertEqual(subscription_request.activation_keys.value, [])
+        assert subscription_request.type == SUBSCRIPTION_REQUEST_TYPE_ORG_KEY
+        assert subscription_request.organization == "123"
+        assert subscription_request.activation_keys.value == []
         # keys should be hidden
-        self.assertEqual(subscription_request.activation_keys.type,
-                         SECRET_TYPE_HIDDEN)
+        assert subscription_request.activation_keys.type == SECRET_TYPE_HIDDEN
         # account username & password should be empty
-        self.assertEqual(subscription_request.account_username, "")
-        self.assertEqual(subscription_request.account_password.value, "")
-        self.assertEqual(subscription_request.account_password.type,
-                         SECRET_TYPE_NONE)
-        self.assertEqual(subscription_request.server_hostname, "candlepin.foo.com")
-        self.assertEqual(subscription_request.rhsm_baseurl, "cdn.foo.com")
-        self.assertEqual(subscription_request.server_proxy_hostname, "proxy.com")
-        self.assertEqual(subscription_request.server_proxy_port, 9001)
-        self.assertEqual(subscription_request._server_proxy_user, "user")
-        self.assertEqual(subscription_request._server_proxy_password.value, "")
-        self.assertEqual(subscription_request._server_proxy_password.type,
-                         SECRET_TYPE_HIDDEN)
+        assert subscription_request.account_username == ""
+        assert subscription_request.account_password.value == ""
+        assert subscription_request.account_password.type == SECRET_TYPE_NONE
+        assert subscription_request.server_hostname == "candlepin.foo.com"
+        assert subscription_request.rhsm_baseurl == "cdn.foo.com"
+        assert subscription_request.server_proxy_hostname == "proxy.com"
+        assert subscription_request.server_proxy_port == 9001
+        assert subscription_request._server_proxy_user == "user"
+        assert subscription_request._server_proxy_password.value == ""
+        assert subscription_request._server_proxy_password.type == SECRET_TYPE_HIDDEN
 
         # insights should be enabled
-        self.assertTrue(self.subscription_interface.InsightsEnabled)
+        assert self.subscription_interface.InsightsEnabled
 
     def test_ks_out_rhsm_no_insights(self):
         """Check Insights is not enabled from kickstart without --connect-to-insights."""
@@ -1595,7 +1566,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # insights should not be
-        self.assertFalse(self.subscription_interface.InsightsEnabled)
+        assert not self.subscription_interface.InsightsEnabled
 
     def test_ks_out_rhsm_and_syspurpose(self):
         """Check that if both rhsm and syspurpose are used all works correctly."""
@@ -1615,22 +1586,22 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         structure = self.subscription_interface.SystemPurposeData
         system_purpose_data = SystemPurposeData.from_structure(structure)
-        self.assertEqual(system_purpose_data.role, 'FOO')
-        self.assertEqual(system_purpose_data.sla, 'BAR')
-        self.assertEqual(system_purpose_data.usage, 'BAZ')
-        self.assertEqual(system_purpose_data.addons, ["F Product", "B Feature"])
+        assert system_purpose_data.role == 'FOO'
+        assert system_purpose_data.sla == 'BAR'
+        assert system_purpose_data.usage == 'BAZ'
+        assert system_purpose_data.addons == ["F Product", "B Feature"]
 
         # check subscription request and insights
 
         structure = self.subscription_interface.SubscriptionRequest
         subscription_request = SubscriptionRequest.from_structure(structure)
         # both org id and one key have been used, request should be org & key type
-        self.assertEqual(subscription_request.type, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY)
-        self.assertEqual(subscription_request.organization, "123")
-        self.assertEqual(subscription_request.activation_keys.value, [])
-        self.assertEqual(subscription_request.activation_keys.type, SECRET_TYPE_HIDDEN)
+        assert subscription_request.type == SUBSCRIPTION_REQUEST_TYPE_ORG_KEY
+        assert subscription_request.organization == "123"
+        assert subscription_request.activation_keys.value == []
+        assert subscription_request.activation_keys.type == SECRET_TYPE_HIDDEN
         # insights should be enabled
-        self.assertTrue(self.subscription_interface.InsightsEnabled)
+        assert self.subscription_interface.InsightsEnabled
 
     @patch("pyanaconda.modules.subscription.system_purpose.give_the_system_purpose")
     def test_ks_apply_syspurpose(self, mock_give_purpose):

--- a/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription.py
@@ -238,7 +238,6 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             SUBSCRIPTION,
             self.subscription_interface,
             *args, **kwargs
@@ -984,7 +983,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         )
         # check the task is created correctly
         task_path = self.subscription_interface.SetSystemPurposeWithTask()
-        obj = check_task_creation(self, task_path, publisher, SystemPurposeConfigurationTask)
+        obj = check_task_creation(task_path, publisher, SystemPurposeConfigurationTask)
         # check the system purpose data got propagated to the module correctly
         data_from_module = obj.implementation._system_purpose_data
         expected_dict = {
@@ -1166,7 +1165,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         # check the task is created correctly
         task_path = self.subscription_interface.SetRHSMConfigWithTask()
-        obj = check_task_creation(self, task_path, publisher, SetRHSMConfigurationTask)
+        obj = check_task_creation(task_path, publisher, SetRHSMConfigurationTask)
         # check all the data got propagated to the module correctly
         assert obj.implementation._rhsm_config_proxy == config_proxy
         task_request = obj.implementation._request
@@ -1215,7 +1214,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         # check the task is created correctly
         task_path = self.subscription_interface.RegisterUsernamePasswordWithTask()
-        obj = check_task_creation(self, task_path, publisher, RegisterWithUsernamePasswordTask)
+        obj = check_task_creation(task_path, publisher, RegisterWithUsernamePasswordTask)
         # check all the data got propagated to the module correctly
         assert obj.implementation._rhsm_register_server_proxy == register_server_proxy
         assert obj.implementation._username == "foo_user"
@@ -1254,7 +1253,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         # check the task is created correctly
         task_path = self.subscription_interface.RegisterOrganizationKeyWithTask()
-        obj = check_task_creation(self, task_path, publisher, RegisterWithOrganizationKeyTask)
+        obj = check_task_creation(task_path, publisher, RegisterWithOrganizationKeyTask)
         # check all the data got propagated to the module correctly
         assert obj.implementation._rhsm_register_server_proxy == register_server_proxy
         assert obj.implementation._organization == "123456789"
@@ -1275,7 +1274,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         rhsm_unregister_proxy = observer.get_proxy.return_value
         # check the task is created correctly
         task_path = self.subscription_interface.UnregisterWithTask()
-        obj = check_task_creation(self, task_path, publisher, UnregisterTask)
+        obj = check_task_creation(task_path, publisher, UnregisterTask)
         # check all the data got propagated to the module correctly
         assert obj.implementation._rhsm_unregister_proxy == rhsm_unregister_proxy
         # trigger the succeeded signal
@@ -1305,7 +1304,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         rhsm_attach_proxy = observer.get_proxy.return_value
         # check the task is created correctly
         task_path = self.subscription_interface.AttachSubscriptionWithTask()
-        obj = check_task_creation(self, task_path, publisher, AttachSubscriptionTask)
+        obj = check_task_creation(task_path, publisher, AttachSubscriptionTask)
         # check all the data got propagated to the module correctly
         assert obj.implementation._rhsm_attach_proxy == rhsm_attach_proxy
         assert obj.implementation._sla == "bar"
@@ -1326,7 +1325,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         observer.get_proxy.side_effect = [rhsm_entitlement_proxy, rhsm_syspurpose_proxy]
         # check the task is created correctly
         task_path = self.subscription_interface.ParseAttachedSubscriptionsWithTask()
-        obj = check_task_creation(self, task_path, publisher, ParseAttachedSubscriptionsTask)
+        obj = check_task_creation(task_path, publisher, ParseAttachedSubscriptionsTask)
         # check all the data got propagated to the module correctly
         assert obj.implementation._rhsm_entitlement_proxy == rhsm_entitlement_proxy
         assert obj.implementation._rhsm_syspurpose_proxy == rhsm_syspurpose_proxy
@@ -1386,7 +1385,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
             ConnectToInsightsTask
         ]
         task_paths = self.subscription_interface.InstallWithTasks()
-        task_objs = check_task_creation_list(self, task_paths, publisher, task_classes)
+        task_objs = check_task_creation_list(task_paths, publisher, task_classes)
 
         # RestoreRHSMDefaultsTask
         obj = task_objs[0]
@@ -1421,7 +1420,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
             ConnectToInsightsTask
         ]
         task_paths = self.subscription_interface.InstallWithTasks()
-        task_objs = check_task_creation_list(self, task_paths, publisher, task_classes)
+        task_objs = check_task_creation_list(task_paths, publisher, task_classes)
 
         # RestoreRHSMDefaultsTask
         obj = task_objs[0]
@@ -1437,7 +1436,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         assert obj.implementation._connect_to_insights == True
 
     def _test_kickstart(self, ks_in, ks_out):
-        check_kickstart_interface(self, self.subscription_interface, ks_in, ks_out)
+        check_kickstart_interface(self.subscription_interface, ks_in, ks_out)
 
     def test_ks_out_no_kickstart(self):
         """Test with no kickstart."""

--- a/tests/unit_tests/pyanaconda_tests/modules/timezone/test_module_timezone.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/timezone/test_module_timezone.py
@@ -58,7 +58,6 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             TIMEZONE,
             self.timezone_interface,
             *args, **kwargs
@@ -110,7 +109,7 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         )
 
     def _test_kickstart(self, ks_in, ks_out):
-        check_kickstart_interface(self, self.timezone_interface, ks_in, ks_out)
+        check_kickstart_interface(self.timezone_interface, ks_in, ks_out)
 
     def test_no_kickstart(self):
         """Test with no kickstart."""
@@ -256,7 +255,7 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
             ConfigureNTPTask,
         ]
         task_paths = self.timezone_interface.InstallWithTasks()
-        task_objs = check_task_creation_list(self, task_paths, publisher, task_classes)
+        task_objs = check_task_creation_list(task_paths, publisher, task_classes)
 
         # ConfigureTimezoneTask
         obj = task_objs[0]
@@ -295,7 +294,7 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
             ConfigureNTPTask,
         ]
         task_paths = self.timezone_interface.InstallWithTasks()
-        task_objs = check_task_creation_list(self, task_paths, publisher, task_classes)
+        task_objs = check_task_creation_list(task_paths, publisher, task_classes)
 
         # ConfigureTimezoneTask
         obj = task_objs[0]

--- a/tests/unit_tests/pyanaconda_tests/modules/users/test_module_users.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/users/test_module_users.py
@@ -54,10 +54,9 @@ class UsersInterfaceTestCase(unittest.TestCase):
 
     def test_kickstart_properties(self):
         """Test kickstart properties."""
-        self.assertEqual(self.users_interface.KickstartCommands,
-                         ["rootpw", "user", "group", "sshkey"])
-        self.assertEqual(self.users_interface.KickstartSections, [])
-        self.assertEqual(self.users_interface.KickstartAddons, [])
+        assert self.users_interface.KickstartCommands == ["rootpw", "user", "group", "sshkey"]
+        assert self.users_interface.KickstartSections == []
+        assert self.users_interface.KickstartAddons == []
         self.callback.assert_not_called()
 
     def _check_dbus_property(self, *args, **kwargs):
@@ -70,15 +69,15 @@ class UsersInterfaceTestCase(unittest.TestCase):
 
     def test_default_property_values(self):
         """Test the default user module values are as expected."""
-        self.assertEqual(self.users_interface.Users, [])
-        self.assertEqual(self.users_interface.Groups, [])
-        self.assertEqual(self.users_interface.SshKeys, [])
-        self.assertEqual(self.users_interface.RootPassword, "")
-        self.assertEqual(self.users_interface.IsRootPasswordSet, False)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, True)
-        self.assertEqual(self.users_interface.IsRootPasswordCrypted, False)
-        self.assertEqual(self.users_interface.RootPasswordSSHLoginAllowed, False)
-        self.assertEqual(self.users_interface.CanChangeRootPassword, True)
+        assert self.users_interface.Users == []
+        assert self.users_interface.Groups == []
+        assert self.users_interface.SshKeys == []
+        assert self.users_interface.RootPassword == ""
+        assert self.users_interface.IsRootPasswordSet == False
+        assert self.users_interface.IsRootAccountLocked == True
+        assert self.users_interface.IsRootPasswordCrypted == False
+        assert self.users_interface.RootPasswordSSHLoginAllowed == False
+        assert self.users_interface.CanChangeRootPassword == True
 
     def test_users_property(self):
         """Test the Users property."""
@@ -151,38 +150,38 @@ class UsersInterfaceTestCase(unittest.TestCase):
         """Test if setting crypted root password works correctly."""
         self.users_interface.SetCryptedRootPassword("abcef")
 
-        self.assertEqual(self.users_interface.RootPassword, "abcef")
-        self.assertEqual(self.users_interface.IsRootPasswordCrypted, True)
-        self.assertEqual(self.users_interface.IsRootPasswordSet, True)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, True)
+        assert self.users_interface.RootPassword == "abcef"
+        assert self.users_interface.IsRootPasswordCrypted == True
+        assert self.users_interface.IsRootPasswordSet == True
+        assert self.users_interface.IsRootAccountLocked == True
         self.callback.assert_called_once_with(USERS.interface_name, {'IsRootPasswordSet': True}, [])
 
     def test_set_crypted_roopw_and_unlock(self):
         """Test if setting crypted root password & unlocking it from kickstart works correctly."""
         self.users_interface.SetCryptedRootPassword("abcef")
 
-        self.assertEqual(self.users_interface.IsRootPasswordSet, True)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, True)
-        self.assertEqual(self.users_interface.CanChangeRootPassword, True)
+        assert self.users_interface.IsRootPasswordSet == True
+        assert self.users_interface.IsRootAccountLocked == True
+        assert self.users_interface.CanChangeRootPassword == True
         self.callback.assert_called_once_with(USERS.interface_name, {'IsRootPasswordSet': True}, [])
 
         # this should not be a valid admin user for interactive install
-        self.assertFalse(self.users_interface.CheckAdminUserExists())
+        assert not self.users_interface.CheckAdminUserExists()
 
         # root password is locked by default and remains locked even after a password is set
         # and needs to be unlocked via another DBus API call
         self.users_interface.SetRootAccountLocked(False)
 
-        self.assertEqual(self.users_interface.IsRootPasswordSet, True)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, False)
+        assert self.users_interface.IsRootPasswordSet == True
+        assert self.users_interface.IsRootAccountLocked == False
         self.callback.assert_called_with(USERS.interface_name, {'IsRootAccountLocked': False}, [])
 
     def test_lock_root_account(self):
         """Test if root account can be locked via DBus correctly."""
         self.users_interface.SetRootAccountLocked(True)
 
-        self.assertEqual(self.users_interface.IsRootPasswordSet, False)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, True)
+        assert self.users_interface.IsRootPasswordSet == False
+        assert self.users_interface.IsRootAccountLocked == True
         self.callback.assert_called_once_with(USERS.interface_name, {'IsRootAccountLocked': True}, [])
 
     def test_clear_rootpw(self):
@@ -190,16 +189,16 @@ class UsersInterfaceTestCase(unittest.TestCase):
         # set the password to something
         self.users_interface.SetCryptedRootPassword("abcef")
 
-        self.assertEqual(self.users_interface.IsRootPasswordSet, True)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, True)
+        assert self.users_interface.IsRootPasswordSet == True
+        assert self.users_interface.IsRootAccountLocked == True
         self.callback.assert_called_once_with(USERS.interface_name, {'IsRootPasswordSet': True}, [])
 
         # clear it
         self.users_interface.ClearRootPassword()
 
         # check if it looks cleared
-        self.assertEqual(self.users_interface.IsRootPasswordSet, False)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, True)
+        assert self.users_interface.IsRootPasswordSet == False
+        assert self.users_interface.IsRootAccountLocked == True
         self.callback.assert_called_with(USERS.interface_name, {'IsRootPasswordSet': False,
                                                                 'IsRootAccountLocked': True}, [])
 
@@ -212,27 +211,27 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self.users_interface.SetRootAccountLocked(False)
         self.callback.assert_called_with(USERS.interface_name, {'IsRootAccountLocked': False}, [])
 
-        self.assertEqual(self.users_interface.IsRootPasswordSet, True)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, False)
+        assert self.users_interface.IsRootPasswordSet == True
+        assert self.users_interface.IsRootAccountLocked == False
 
         # clear it
         self.users_interface.ClearRootPassword()
 
         # check if it looks cleared
-        self.assertEqual(self.users_interface.IsRootPasswordSet, False)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, True)
+        assert self.users_interface.IsRootPasswordSet == False
+        assert self.users_interface.IsRootAccountLocked == True
         self.callback.assert_called_with(USERS.interface_name, {'IsRootPasswordSet': False,
                                                                 'IsRootAccountLocked': True}, [])
 
     def test_allow_root_password_ssh_login(self):
         """Test if root password SSH login can be allowed."""
         self.users_interface.SetRootPasswordSSHLoginAllowed(True)
-        self.assertEqual(self.users_interface.RootPasswordSSHLoginAllowed, True)
+        assert self.users_interface.RootPasswordSSHLoginAllowed == True
         self.callback.assert_called_once_with(USERS.interface_name, {'RootPasswordSSHLoginAllowed': True}, [])
 
         self.callback.reset_mock()
         self.users_interface.SetRootPasswordSSHLoginAllowed(False)
-        self.assertEqual(self.users_interface.RootPasswordSSHLoginAllowed, False)
+        assert self.users_interface.RootPasswordSSHLoginAllowed == False
         self.callback.assert_called_once_with(USERS.interface_name, {'RootPasswordSSHLoginAllowed': False}, [])
 
     def test_admin_user_detection_1(self):
@@ -251,7 +250,7 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self.users_interface.SetUsers(UserData.to_structure_list([user1, user2]))
         self.users_interface.SetCryptedRootPassword("abc")
         self.users_interface.SetRootAccountLocked(False)
-        self.assertTrue(self.users_interface.CheckAdminUserExists())
+        assert self.users_interface.CheckAdminUserExists()
 
     def test_admin_user_detection_2(self):
         """Test that admin user detection works correctly - 0 admins (case 1)."""
@@ -269,7 +268,7 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self.users_interface.SetUsers(UserData.to_structure_list([user1, user2]))
         self.users_interface.SetCryptedRootPassword("abc")
         self.users_interface.SetRootAccountLocked(True)
-        self.assertFalse(self.users_interface.CheckAdminUserExists())
+        assert not self.users_interface.CheckAdminUserExists()
 
     def test_admin_user_detection_3(self):
         """Test that admin user detection works correctly - 1 admin (case 2)."""
@@ -287,7 +286,7 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self.users_interface.SetUsers(UserData.to_structure_list([user1, user2]))
         self.users_interface.SetCryptedRootPassword("abc")
         self.users_interface.SetRootAccountLocked(False)
-        self.assertTrue(self.users_interface.CheckAdminUserExists())
+        assert self.users_interface.CheckAdminUserExists()
 
     def test_admin_user_detection_4(self):
         """Test that admin user detection works correctly - 1 admin (case 3)."""
@@ -305,7 +304,7 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self.users_interface.SetUsers(UserData.to_structure_list([user1, user2]))
         self.users_interface.SetCryptedRootPassword("abc")
         self.users_interface.SetRootAccountLocked(True)
-        self.assertTrue(self.users_interface.CheckAdminUserExists())
+        assert self.users_interface.CheckAdminUserExists()
 
     def test_admin_user_detection_5(self):
         """Test that admin user detection works correctly - 1 admin (case 4)."""
@@ -323,7 +322,7 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self.users_interface.SetUsers(UserData.to_structure_list([user1, user2]))
         self.users_interface.SetCryptedRootPassword("abc")
         self.users_interface.SetRootAccountLocked(True)
-        self.assertTrue(self.users_interface.CheckAdminUserExists())
+        assert self.users_interface.CheckAdminUserExists()
 
     def test_admin_user_detection_6(self):
         """Test that admin user detection works correctly - 1 admin (case 5)."""
@@ -341,7 +340,7 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self.users_interface.SetUsers(UserData.to_structure_list([user1, user2]))
         self.users_interface.SetCryptedRootPassword("abc")
         self.users_interface.SetRootAccountLocked(False)
-        self.assertTrue(self.users_interface.CheckAdminUserExists())
+        assert self.users_interface.CheckAdminUserExists()
 
     def _test_kickstart(self, ks_in, ks_out, ks_tmp=None):
         check_kickstart_interface(self, self.users_interface, ks_in, ks_out, ks_tmp=ks_tmp)
@@ -356,12 +355,12 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # root password should be empty and locked by default, but mutable
-        self.assertEqual(self.users_interface.IsRootPasswordSet, False)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, True)
-        self.assertEqual(self.users_interface.CanChangeRootPassword, True)
+        assert self.users_interface.IsRootPasswordSet == False
+        assert self.users_interface.IsRootAccountLocked == True
+        assert self.users_interface.CanChangeRootPassword == True
 
         # this should not be considered a valid admin user for interactive install
-        self.assertFalse(self.users_interface.CheckAdminUserExists())
+        assert not self.users_interface.CheckAdminUserExists()
 
     def test_kickstart_empty(self):
         """Test with empty string."""
@@ -373,12 +372,12 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # password should be marked as not set, locked and mutable
-        self.assertEqual(self.users_interface.IsRootPasswordSet, False)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, True)
-        self.assertEqual(self.users_interface.CanChangeRootPassword, True)
+        assert self.users_interface.IsRootPasswordSet == False
+        assert self.users_interface.IsRootAccountLocked == True
+        assert self.users_interface.CanChangeRootPassword == True
 
         # not a valid admin user from kickstart PoV
-        self.assertFalse(self.users_interface.CheckAdminUserExists())
+        assert not self.users_interface.CheckAdminUserExists()
 
     def test_kickstart_set_rootpw(self):
         """Test the setting root password via kickstart."""
@@ -392,12 +391,12 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # if rootpw shows up in the kickstart is should be reported as immutable
-        self.assertEqual(self.users_interface.IsRootPasswordSet, True)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, False)
-        self.assertEqual(self.users_interface.CanChangeRootPassword, False)
+        assert self.users_interface.IsRootPasswordSet == True
+        assert self.users_interface.IsRootAccountLocked == False
+        assert self.users_interface.CanChangeRootPassword == False
 
         # but this should still be a valid admin user from kickstart PoV
-        self.assertTrue(self.users_interface.CheckAdminUserExists())
+        assert self.users_interface.CheckAdminUserExists()
 
     def test_kickstart_set_plain_rootpw(self):
         """Test the setting plaintext root password via kickstart."""
@@ -421,8 +420,8 @@ class UsersInterfaceTestCase(unittest.TestCase):
         """
         self._test_kickstart(ks_in, ks_out)
 
-        self.assertEqual(self.users_interface.IsRootPasswordSet, True)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, False)
+        assert self.users_interface.IsRootPasswordSet == True
+        assert self.users_interface.IsRootAccountLocked == False
 
     def test_kickstart_lock_root_account(self):
         """Test locking the root account via kickstart."""
@@ -436,12 +435,12 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # password should be marked as not set, locked and immutable
-        self.assertEqual(self.users_interface.IsRootPasswordSet, False)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, True)
-        self.assertEqual(self.users_interface.CanChangeRootPassword, False)
+        assert self.users_interface.IsRootPasswordSet == False
+        assert self.users_interface.IsRootAccountLocked == True
+        assert self.users_interface.CanChangeRootPassword == False
 
         # but this should still be a valid admin user from kickstart PoV
-        self.assertTrue(self.users_interface.CheckAdminUserExists())
+        assert self.users_interface.CheckAdminUserExists()
 
     def test_kickstart_lock_root_account_with_password(self):
         """Test locking the root account with a password via kickstart."""
@@ -455,12 +454,12 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # password should be marked as set, locked and immutable
-        self.assertEqual(self.users_interface.IsRootPasswordSet, True)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, True)
-        self.assertEqual(self.users_interface.CanChangeRootPassword, False)
+        assert self.users_interface.IsRootPasswordSet == True
+        assert self.users_interface.IsRootAccountLocked == True
+        assert self.users_interface.CanChangeRootPassword == False
 
         # but this should still be a valid admin user from kickstart PoV
-        self.assertTrue(self.users_interface.CheckAdminUserExists())
+        assert self.users_interface.CheckAdminUserExists()
 
     def test_kickstart_user(self):
         """Test kickstart user input and output."""
@@ -475,12 +474,12 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # password should be marked as not set, locked and mutable
-        self.assertEqual(self.users_interface.IsRootPasswordSet, False)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, True)
-        self.assertEqual(self.users_interface.CanChangeRootPassword, True)
+        assert self.users_interface.IsRootPasswordSet == False
+        assert self.users_interface.IsRootAccountLocked == True
+        assert self.users_interface.CanChangeRootPassword == True
 
         # no a valid admin user exists from kickstart PoV
-        self.assertFalse(self.users_interface.CheckAdminUserExists())
+        assert not self.users_interface.CheckAdminUserExists()
 
     def test_kickstart_user_admin(self):
         """Test kickstart admin user input and output."""
@@ -495,12 +494,12 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # password should be marked as not set, locked and mutable
-        self.assertEqual(self.users_interface.IsRootPasswordSet, False)
-        self.assertEqual(self.users_interface.IsRootAccountLocked, True)
-        self.assertEqual(self.users_interface.CanChangeRootPassword, True)
+        assert self.users_interface.IsRootPasswordSet == False
+        assert self.users_interface.IsRootAccountLocked == True
+        assert self.users_interface.CanChangeRootPassword == True
 
         # provides a valid admin user exists from kickstart PoV
-        self.assertTrue(self.users_interface.CheckAdminUserExists())
+        assert self.users_interface.CheckAdminUserExists()
 
     def test_kickstart_users(self):
         """Test kickstart users input and output."""
@@ -597,20 +596,20 @@ class UsersDataTestCase(unittest.TestCase):
         user_data_3 = UserData()
         user_data_3.name = "foo"
 
-        self.assertTrue(user_data_1 == user_data_3)
-        self.assertFalse(user_data_1 == user_data_2)
-        self.assertFalse(user_data_2 == user_data_1)
-        self.assertFalse(user_data_2 == user_data_3)
+        assert user_data_1 == user_data_3
+        assert not (user_data_1 == user_data_2)
+        assert not (user_data_2 == user_data_1)
+        assert not (user_data_2 == user_data_3)
 
         # now try changing the name on existing instance
         user_data_1.name = "bar"
         user_data_2.name = "foo"
         user_data_3.name = "foo"
 
-        self.assertFalse(user_data_1 == user_data_2)
-        self.assertFalse(user_data_1 == user_data_3)
-        self.assertTrue(user_data_2 == user_data_3)
-        self.assertTrue(user_data_3 == user_data_2)
+        assert not (user_data_1 == user_data_2)
+        assert not (user_data_1 == user_data_3)
+        assert user_data_2 == user_data_3
+        assert user_data_3 == user_data_2
 
         # only name is used, other attributes should not influence the comparison
         user_data_a = UserData()
@@ -625,79 +624,79 @@ class UsersDataTestCase(unittest.TestCase):
         user_data_b.gid = 2
         user_data_b.homedir = "/bar"
 
-        self.assertTrue(user_data_a == user_data_b)
+        assert user_data_a == user_data_b
 
     def test_has_admin_priviledges(self):
         """Test the has_admin_priviledges() method works correctly."""
 
         user_data = UserData()
         user_data.groups = ["wheel"]
-        self.assertTrue(user_data.has_admin_priviledges())
+        assert user_data.has_admin_priviledges()
 
         user_data = UserData()
         user_data.groups = ["foo"]
-        self.assertFalse(user_data.has_admin_priviledges())
+        assert not user_data.has_admin_priviledges()
 
         user_data = UserData()
         user_data.groups = ["foo", "wheel", "bar"]
-        self.assertTrue(user_data.has_admin_priviledges())
+        assert user_data.has_admin_priviledges()
 
         # multiple wheels
         user_data = UserData()
         user_data.groups = ["foo", "wheel", "bar", "wheel", "baz"]
-        self.assertTrue(user_data.has_admin_priviledges())
+        assert user_data.has_admin_priviledges()
 
         # group name is case sensitive
         user_data = UserData()
         user_data.groups = ["WHEEL", "Wheel"]
-        self.assertFalse(user_data.has_admin_priviledges())
+        assert not user_data.has_admin_priviledges()
 
     def test_set_admin_priviledges(self):
         """Test setting user admin privileges works correctly."""
         user_data = UserData()
-        self.assertFalse(user_data.has_admin_priviledges())
-        self.assertNotIn("wheel", user_data.groups)
+        assert not user_data.has_admin_priviledges()
+        assert "wheel" not in user_data.groups
 
         # turn it on
         user_data.set_admin_priviledges(True)
-        self.assertTrue(user_data.has_admin_priviledges())
-        self.assertIn("wheel", user_data.groups)
+        assert user_data.has_admin_priviledges()
+        assert "wheel" in user_data.groups
 
         # turn it off
         user_data.set_admin_priviledges(False)
-        self.assertFalse(user_data.has_admin_priviledges())
-        self.assertNotIn("wheel", user_data.groups)
+        assert not user_data.has_admin_priviledges()
+        assert "wheel" not in user_data.groups
 
         # existing groups - turn in on
         user_data = UserData()
         user_data.groups = ["foo", "bar"]
         user_data.set_admin_priviledges(True)
-        self.assertTrue(user_data.has_admin_priviledges())
-        self.assertIn("wheel", user_data.groups)
-        self.assertIn("foo", user_data.groups)
-        self.assertIn("bar", user_data.groups)
+        assert user_data.has_admin_priviledges()
+        assert "wheel" in user_data.groups
+        assert "foo" in user_data.groups
+        assert "bar" in user_data.groups
 
         # existing groups - turn in off
         user_data.set_admin_priviledges(False)
-        self.assertFalse(user_data.has_admin_priviledges())
-        self.assertNotIn("wheel", user_data.groups)
-        self.assertIn("foo", user_data.groups)
-        self.assertIn("bar", user_data.groups)
+        assert not user_data.has_admin_priviledges()
+        assert "wheel" not in user_data.groups
+        assert "foo" in user_data.groups
+        assert "bar" in user_data.groups
 
         # group wheel added externally
         user_data = UserData()
         user_data.groups = ["foo", "bar", "wheel"]
-        self.assertTrue(user_data.has_admin_priviledges())
-        self.assertIn("wheel", user_data.groups)
-        self.assertIn("foo", user_data.groups)
-        self.assertIn("bar", user_data.groups)
+        assert user_data.has_admin_priviledges()
+        assert "wheel" in user_data.groups
+        assert "foo" in user_data.groups
+        assert "bar" in user_data.groups
 
         # now remove the wheel group via API
         user_data.set_admin_priviledges(False)
-        self.assertFalse(user_data.has_admin_priviledges())
-        self.assertNotIn("wheel", user_data.groups)
-        self.assertIn("foo", user_data.groups)
-        self.assertIn("bar", user_data.groups)
+        assert not user_data.has_admin_priviledges()
+        assert "wheel" not in user_data.groups
+        assert "foo" in user_data.groups
+        assert "bar" in user_data.groups
 
     def test_getter_setter(self):
         """Test getters and setters for the User UID and GID values."""
@@ -705,45 +704,45 @@ class UsersDataTestCase(unittest.TestCase):
         user_data.name = "user"
 
         # everything should be unset by default
-        self.assertEqual(user_data.uid, 0)
-        self.assertEqual(user_data.uid_mode, ID_MODE_USE_DEFAULT)
-        self.assertEqual(user_data.get_uid(), None)
-        self.assertEqual(user_data.gid, 0)
-        self.assertEqual(user_data.gid_mode, ID_MODE_USE_DEFAULT)
-        self.assertEqual(user_data.get_gid(), None)
+        assert user_data.uid == 0
+        assert user_data.uid_mode == ID_MODE_USE_DEFAULT
+        assert user_data.get_uid() is None
+        assert user_data.gid == 0
+        assert user_data.gid_mode == ID_MODE_USE_DEFAULT
+        assert user_data.get_gid() is None
 
         user_data.set_uid(123)
         user_data.set_gid(456)
 
         # now everything is set
-        self.assertEqual(user_data.uid, 123)
-        self.assertEqual(user_data.uid_mode, ID_MODE_USE_VALUE)
-        self.assertEqual(user_data.get_uid(), 123)
-        self.assertEqual(user_data.gid, 456)
-        self.assertEqual(user_data.gid_mode, ID_MODE_USE_VALUE)
-        self.assertEqual(user_data.get_gid(), 456)
+        assert user_data.uid == 123
+        assert user_data.uid_mode == ID_MODE_USE_VALUE
+        assert user_data.get_uid() == 123
+        assert user_data.gid == 456
+        assert user_data.gid_mode == ID_MODE_USE_VALUE
+        assert user_data.get_gid() == 456
 
         user_data.uid_mode = ID_MODE_USE_DEFAULT
         user_data.gid_mode = ID_MODE_USE_DEFAULT
 
         # mode should decide whether numbers are used, regardless of being stored
-        self.assertEqual(user_data.uid_mode, ID_MODE_USE_DEFAULT)
-        self.assertEqual(user_data.uid, 123)
-        self.assertEqual(user_data.get_uid(), None)
-        self.assertEqual(user_data.gid_mode, ID_MODE_USE_DEFAULT)
-        self.assertEqual(user_data.gid, 456)
-        self.assertEqual(user_data.get_gid(), None)
+        assert user_data.uid_mode == ID_MODE_USE_DEFAULT
+        assert user_data.uid == 123
+        assert user_data.get_uid() is None
+        assert user_data.gid_mode == ID_MODE_USE_DEFAULT
+        assert user_data.gid == 456
+        assert user_data.get_gid() is None
 
         user_data.set_uid(None)
         user_data.set_gid(None)
 
         # setting None resets everything
-        self.assertEqual(user_data.uid, 0)
-        self.assertEqual(user_data.uid_mode, ID_MODE_USE_DEFAULT)
-        self.assertEqual(user_data.get_uid(), None)
-        self.assertEqual(user_data.gid, 0)
-        self.assertEqual(user_data.gid_mode, ID_MODE_USE_DEFAULT)
-        self.assertEqual(user_data.get_gid(), None)
+        assert user_data.uid == 0
+        assert user_data.uid_mode == ID_MODE_USE_DEFAULT
+        assert user_data.get_uid() is None
+        assert user_data.gid == 0
+        assert user_data.gid_mode == ID_MODE_USE_DEFAULT
+        assert user_data.get_gid() is None
 
 
 class GroupsDataTestCase(unittest.TestCase):
@@ -755,30 +754,30 @@ class GroupsDataTestCase(unittest.TestCase):
         group_data.name = "group"
 
         # everything should be unset by default
-        self.assertEqual(group_data.gid, 0)
-        self.assertEqual(group_data.gid_mode, ID_MODE_USE_DEFAULT)
-        self.assertEqual(group_data.get_gid(), None)
+        assert group_data.gid == 0
+        assert group_data.gid_mode == ID_MODE_USE_DEFAULT
+        assert group_data.get_gid() is None
 
         group_data.set_gid(789)
 
         # now everything is set
-        self.assertEqual(group_data.gid, 789)
-        self.assertEqual(group_data.gid_mode, ID_MODE_USE_VALUE)
-        self.assertEqual(group_data.get_gid(), 789)
+        assert group_data.gid == 789
+        assert group_data.gid_mode == ID_MODE_USE_VALUE
+        assert group_data.get_gid() == 789
 
         group_data.gid_mode = ID_MODE_USE_DEFAULT
 
         # mode should decide whether numbers are used, regardless of being stored
-        self.assertEqual(group_data.gid_mode, ID_MODE_USE_DEFAULT)
-        self.assertEqual(group_data.gid, 789)
-        self.assertEqual(group_data.get_gid(), None)
+        assert group_data.gid_mode == ID_MODE_USE_DEFAULT
+        assert group_data.gid == 789
+        assert group_data.get_gid() is None
 
         group_data.set_gid(None)
 
         # setting None resets everything
-        self.assertEqual(group_data.gid, 0)
-        self.assertEqual(group_data.gid_mode, ID_MODE_USE_DEFAULT)
-        self.assertEqual(group_data.get_gid(), None)
+        assert group_data.gid == 0
+        assert group_data.gid_mode == ID_MODE_USE_DEFAULT
+        assert group_data.get_gid() is None
 
 
 class SharedUICodeTestCase(unittest.TestCase):
@@ -792,7 +791,7 @@ class SharedUICodeTestCase(unittest.TestCase):
         users_module_mock = Mock()
         users_module_mock.Users = []
         user_data_list = get_user_list(users_module_mock)
-        self.assertEqual(user_data_list, [])
+        assert user_data_list == []
 
     def test_get_default_user(self):
         """Test that default user is correctly added by get_user_list()."""
@@ -800,9 +799,9 @@ class SharedUICodeTestCase(unittest.TestCase):
         users_module_mock.Users = []
         user_data_list = get_user_list(users_module_mock, add_default=True)
 
-        self.assertEqual(len(user_data_list), 1)
-        self.assertIsInstance(user_data_list[0], UserData)
-        self.assertTrue(compare_data(user_data_list[0], UserData()))
+        assert len(user_data_list) == 1
+        assert isinstance(user_data_list[0], UserData)
+        assert compare_data(user_data_list[0], UserData())
 
     def test_get_user_list(self):
         """Test the shared get_user_list() method."""
@@ -834,29 +833,29 @@ class SharedUICodeTestCase(unittest.TestCase):
         users_module_mock.Users = UserData.to_structure_list([user1, user2])
         user_data_list = get_user_list(users_module_mock)
 
-        self.assertEqual(len(user_data_list), 2)
-        self.assertIsInstance(user_data_list[0], UserData)
-        self.assertIsInstance(user_data_list[1], UserData)
-        self.assertTrue(compare_data(user_data_list[0], user1))
-        self.assertTrue(compare_data(user_data_list[1], user2))
+        assert len(user_data_list) == 2
+        assert isinstance(user_data_list[0], UserData)
+        assert isinstance(user_data_list[1], UserData)
+        assert compare_data(user_data_list[0], user1)
+        assert compare_data(user_data_list[1], user2)
 
         user_data_list = get_user_list(users_module_mock, add_default=True)
 
-        self.assertEqual(len(user_data_list), 2)
-        self.assertIsInstance(user_data_list[0], UserData)
-        self.assertIsInstance(user_data_list[1], UserData)
-        self.assertTrue(compare_data(user_data_list[0], user1))
-        self.assertTrue(compare_data(user_data_list[1], user2))
+        assert len(user_data_list) == 2
+        assert isinstance(user_data_list[0], UserData)
+        assert isinstance(user_data_list[1], UserData)
+        assert compare_data(user_data_list[0], user1)
+        assert compare_data(user_data_list[1], user2)
 
         user_data_list = get_user_list(users_module_mock, add_default=True, add_if_not_empty=True)
 
-        self.assertEqual(len(user_data_list), 3)
-        self.assertIsInstance(user_data_list[0], UserData)
-        self.assertIsInstance(user_data_list[1], UserData)
-        self.assertIsInstance(user_data_list[2], UserData)
-        self.assertTrue(compare_data(user_data_list[0], UserData()))
-        self.assertTrue(compare_data(user_data_list[1], user1))
-        self.assertTrue(compare_data(user_data_list[2], user2))
+        assert len(user_data_list) == 3
+        assert isinstance(user_data_list[0], UserData)
+        assert isinstance(user_data_list[1], UserData)
+        assert isinstance(user_data_list[2], UserData)
+        assert compare_data(user_data_list[0], UserData())
+        assert compare_data(user_data_list[1], user1)
+        assert compare_data(user_data_list[2], user2)
 
     def test_set_user_list(self):
         """Test the shared set_user_list() method."""
@@ -888,16 +887,16 @@ class SharedUICodeTestCase(unittest.TestCase):
         set_user_list(users_module_mock, [user1, user2])
         user_data_list = users_module_mock.SetUsers.call_args[0][0]
 
-        self.assertEqual(len(user_data_list), 2)
-        self.assertEqual(user_data_list[0], UserData.to_structure(user1))
-        self.assertEqual(user_data_list[1], UserData.to_structure(user2))
+        assert len(user_data_list) == 2
+        assert user_data_list[0] == UserData.to_structure(user1)
+        assert user_data_list[1] == UserData.to_structure(user2)
 
         user1.name = ""
         set_user_list(users_module_mock, [user1, user2], remove_unset=True)
         user_data_list = users_module_mock.SetUsers.call_args[0][0]
 
-        self.assertEqual(len(user_data_list), 1)
-        self.assertEqual(user_data_list[0], UserData.to_structure(user2))
+        assert len(user_data_list) == 1
+        assert user_data_list[0] == UserData.to_structure(user2)
 
 
 class UsersModuleTasksTestCase(unittest.TestCase):
@@ -922,13 +921,13 @@ class UsersModuleTasksTestCase(unittest.TestCase):
             os.makedirs(os.path.dirname(config_path))
 
             # no config should exist before we run the task
-            self.assertFalse(os.path.exists(config_path))
+            assert not os.path.exists(config_path)
 
             task = ConfigureRootPasswordSSHLoginTask(sysroot=sysroot, password_allowed=True)
             task.run()
 
             # correct override config should exist after we run the task
-            self.assertTrue(os.path.exists(config_path))
+            assert os.path.exists(config_path)
 
             expected_content = dedent("""
             # This file has been generated by the Anaconda Installer.
@@ -939,10 +938,7 @@ class UsersModuleTasksTestCase(unittest.TestCase):
             with open(config_path, "rt") as f:
                 config_content = f.read()
 
-            self.assertEqual(
-                config_content.strip(),
-                expected_content.strip()
-            )
+            assert config_content.strip() == expected_content.strip()
 
     def test_root_ssh_password_config_task_disabled(self):
         """Test the root password SSH login configuration task - disabled (no config file)."""
@@ -952,10 +948,10 @@ class UsersModuleTasksTestCase(unittest.TestCase):
             os.makedirs(os.path.dirname(config_path))
 
             # no config should exist before we run the task
-            self.assertFalse(os.path.exists(config_path))
+            assert not os.path.exists(config_path)
 
             task = ConfigureRootPasswordSSHLoginTask(sysroot=sysroot, password_allowed=False)
             task.run()
 
             # correct override config should exist after we run the task
-            self.assertFalse(os.path.exists(config_path))
+            assert not os.path.exists(config_path)

--- a/tests/unit_tests/pyanaconda_tests/modules/users/test_module_users.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/users/test_module_users.py
@@ -61,7 +61,6 @@ class UsersInterfaceTestCase(unittest.TestCase):
 
     def _check_dbus_property(self, *args, **kwargs):
         check_dbus_property(
-            self,
             USERS,
             self.users_interface,
             *args, **kwargs
@@ -343,7 +342,7 @@ class UsersInterfaceTestCase(unittest.TestCase):
         assert self.users_interface.CheckAdminUserExists()
 
     def _test_kickstart(self, ks_in, ks_out, ks_tmp=None):
-        check_kickstart_interface(self, self.users_interface, ks_in, ks_out, ks_tmp=ks_tmp)
+        check_kickstart_interface(self.users_interface, ks_in, ks_out, ks_tmp=ks_tmp)
 
     def test_no_kickstart(self):
         """Test with no kickstart."""
@@ -560,25 +559,25 @@ class UsersInterfaceTestCase(unittest.TestCase):
             ConfigureRootPasswordSSHLoginTask
         ]
         task_paths = self.users_interface.InstallWithTasks()
-        check_task_creation_list(self, task_paths, publisher, task_classes)
+        check_task_creation_list(task_paths, publisher, task_classes)
 
     @patch_dbus_publish_object
     def test_configure_groups_with_task(self, publisher):
         """Test ConfigureGroupsWithTask."""
         task_path = self.users_interface.ConfigureGroupsWithTask()
-        check_task_creation(self, task_path, publisher, CreateGroupsTask)
+        check_task_creation(task_path, publisher, CreateGroupsTask)
 
     @patch_dbus_publish_object
     def test_configure_users_with_task(self, publisher):
         """Test ConfigureUsersWithTask."""
         task_path = self.users_interface.ConfigureUsersWithTask()
-        check_task_creation(self, task_path, publisher, CreateUsersTask)
+        check_task_creation(task_path, publisher, CreateUsersTask)
 
     @patch_dbus_publish_object
     def test_set_root_password_with_task(self, publisher):
         """Test SetRootPasswordWithTask."""
         task_path = self.users_interface.SetRootPasswordWithTask()
-        check_task_creation(self, task_path, publisher, SetRootPasswordTask)
+        check_task_creation(task_path, publisher, SetRootPasswordTask)
 
 
 class UsersDataTestCase(unittest.TestCase):

--- a/tests/unit_tests/pyanaconda_tests/test_argparse.py
+++ b/tests/unit_tests/pyanaconda_tests/test_argparse.py
@@ -33,62 +33,62 @@ class ArgparseTest(unittest.TestCase):
     def test_without_inst_prefix(self):
         boot_cmdline = KernelArguments.from_string("stage2=http://cool.server.com/test")
         opts, removed = self._parseCmdline([], boot_cmdline=boot_cmdline)
-        self.assertEqual(opts.stage2, None)
-        self.assertEqual(removed, ["stage2"])
+        assert opts.stage2 is None
+        assert removed == ["stage2"]
 
         boot_cmdline = KernelArguments.from_string("stage2=http://cool.server.com/test "
                                                    "vnc")
         opts, removed = self._parseCmdline([], boot_cmdline=boot_cmdline)
-        self.assertEqual(opts.stage2, None)
-        self.assertFalse(opts.vnc)
-        self.assertListEqual(removed, ["stage2", "vnc"])
+        assert opts.stage2 is None
+        assert not opts.vnc
+        assert removed == ["stage2", "vnc"]
 
     def test_with_inst_prefix(self):
         boot_cmdline = KernelArguments.from_string("inst.stage2=http://cool.server.com/test")
         opts, removed = self._parseCmdline([], boot_cmdline=boot_cmdline)
-        self.assertEqual(opts.stage2, "http://cool.server.com/test")
-        self.assertEqual(removed, [])
+        assert opts.stage2 == "http://cool.server.com/test"
+        assert removed == []
 
         boot_cmdline = KernelArguments.from_string("inst.stage2=http://cool.server.com/test "
                                                    "inst.vnc")
         opts, removed = self._parseCmdline([], boot_cmdline=boot_cmdline)
-        self.assertEqual(opts.stage2, "http://cool.server.com/test")
-        self.assertTrue(opts.vnc)
-        self.assertEqual(removed, [])
+        assert opts.stage2 == "http://cool.server.com/test"
+        assert opts.vnc
+        assert removed == []
 
     def test_inst_prefix_mixed(self):
         boot_cmdline = KernelArguments.from_string("inst.stage2=http://cool.server.com/test "
                                                    "vnc")
         opts, removed = self._parseCmdline([], boot_cmdline=boot_cmdline)
-        self.assertEqual(opts.stage2, "http://cool.server.com/test")
-        self.assertFalse(opts.vnc)
-        self.assertListEqual(removed, ["vnc"])
+        assert opts.stage2 == "http://cool.server.com/test"
+        assert not opts.vnc
+        assert removed == ["vnc"]
 
     def test_display_mode(self):
         opts, _removed = self._parseCmdline(['--cmdline'])
-        self.assertEqual(opts.display_mode, DisplayModes.TUI)
-        self.assertTrue(opts.noninteractive)
+        assert opts.display_mode == DisplayModes.TUI
+        assert opts.noninteractive
 
         opts, _removed = self._parseCmdline(['--graphical'])
-        self.assertEqual(opts.display_mode, DisplayModes.GUI)
-        self.assertFalse(opts.noninteractive)
+        assert opts.display_mode == DisplayModes.GUI
+        assert not opts.noninteractive
 
         opts, _removed = self._parseCmdline(['--text'])
-        self.assertEqual(opts.display_mode, DisplayModes.TUI)
-        self.assertFalse(opts.noninteractive)
+        assert opts.display_mode == DisplayModes.TUI
+        assert not opts.noninteractive
 
         opts, _removed = self._parseCmdline(['--noninteractive'])
-        self.assertTrue(opts.noninteractive)
+        assert opts.noninteractive
 
         # Test the default
         opts, _removed = self._parseCmdline([])
-        self.assertEqual(opts.display_mode, DisplayModes.GUI)
-        self.assertFalse(opts.noninteractive)
+        assert opts.display_mode == DisplayModes.GUI
+        assert not opts.noninteractive
 
         # console=whatever in the boot args defaults to --text
         boot_cmdline = KernelArguments.from_string("console=/dev/ttyS0")
         opts, _removed = self._parseCmdline([], boot_cmdline=boot_cmdline)
-        self.assertEqual(opts.display_mode, DisplayModes.TUI)
+        assert opts.display_mode == DisplayModes.TUI
 
     def test_selinux(self):
         from pykickstart.constants import SELINUX_DISABLED, SELINUX_ENFORCING
@@ -96,32 +96,32 @@ class ArgparseTest(unittest.TestCase):
 
         # with no arguments, use SELINUX_DEFAULT
         opts, _removed = self._parseCmdline([])
-        self.assertEqual(opts.selinux, SELINUX_DEFAULT)
+        assert opts.selinux == SELINUX_DEFAULT
 
         # --selinux or --selinux=1 means SELINUX_ENFORCING
         opts, _removed = self._parseCmdline(['--selinux'])
-        self.assertEqual(opts.selinux, SELINUX_ENFORCING)
+        assert opts.selinux == SELINUX_ENFORCING
 
         # --selinux=0 means SELINUX_DISABLED
         opts, _removed = self._parseCmdline(['--selinux=0'])
-        self.assertEqual(opts.selinux, SELINUX_DISABLED)
+        assert opts.selinux == SELINUX_DISABLED
 
         # --noselinux means SELINUX_DISABLED
         opts, _removed = self._parseCmdline(['--noselinux'])
-        self.assertEqual(opts.selinux, SELINUX_DISABLED)
+        assert opts.selinux == SELINUX_DISABLED
 
     def test_dirinstall(self):
         # when not specified, dirinstall should evaluate to False
         opts, _removed = self._parseCmdline([])
-        self.assertFalse(opts.dirinstall)
+        assert not opts.dirinstall
 
         # with no argument, dirinstall should default to /mnt/sysimage
         opts, _removed = self._parseCmdline(['--dirinstall'])
-        self.assertEqual(opts.dirinstall, "/mnt/sysimage")
+        assert opts.dirinstall == "/mnt/sysimage"
 
         # with an argument, dirinstall should use that
         opts, _removed = self._parseCmdline(['--dirinstall=/what/ever'])
-        self.assertEqual(opts.dirinstall, "/what/ever")
+        assert opts.dirinstall == "/what/ever"
 
     def test_storage(self):
         conf = AnacondaConfiguration.from_defaults()
@@ -129,14 +129,14 @@ class ArgparseTest(unittest.TestCase):
         opts, _removed = self._parseCmdline([])
         conf.set_from_opts(opts)
 
-        self.assertEqual(conf.storage.dmraid, True)
-        self.assertEqual(conf.storage.ibft, True)
+        assert conf.storage.dmraid == True
+        assert conf.storage.ibft == True
 
         opts, _removed = self._parseCmdline(['--nodmraid', '--ibft'])
         conf.set_from_opts(opts)
 
-        self.assertEqual(conf.storage.dmraid, False)
-        self.assertEqual(conf.storage.ibft, True)
+        assert conf.storage.dmraid == False
+        assert conf.storage.ibft == True
 
     def test_target(self):
         conf = AnacondaConfiguration.from_defaults()
@@ -144,26 +144,26 @@ class ArgparseTest(unittest.TestCase):
         opts, _removed = self._parseCmdline([])
         conf.set_from_opts(opts)
 
-        self.assertEqual(conf.target.is_hardware, True)
-        self.assertEqual(conf.target.is_image, False)
-        self.assertEqual(conf.target.is_directory, False)
-        self.assertEqual(conf.target.physical_root, "/mnt/sysimage")
+        assert conf.target.is_hardware == True
+        assert conf.target.is_image == False
+        assert conf.target.is_directory == False
+        assert conf.target.physical_root == "/mnt/sysimage"
 
         opts, _removed = self._parseCmdline(['--image=/what/ever.img'])
         conf.set_from_opts(opts)
 
-        self.assertEqual(conf.target.is_hardware, False)
-        self.assertEqual(conf.target.is_image, True)
-        self.assertEqual(conf.target.is_directory, False)
-        self.assertEqual(conf.target.physical_root, "/mnt/sysimage")
+        assert conf.target.is_hardware == False
+        assert conf.target.is_image == True
+        assert conf.target.is_directory == False
+        assert conf.target.physical_root == "/mnt/sysimage"
 
         opts, _removed = self._parseCmdline(['--dirinstall=/what/ever'])
         conf.set_from_opts(opts)
 
-        self.assertEqual(conf.target.is_hardware, False)
-        self.assertEqual(conf.target.is_image, False)
-        self.assertEqual(conf.target.is_directory, True)
-        self.assertEqual(conf.target.physical_root, "/what/ever")
+        assert conf.target.is_hardware == False
+        assert conf.target.is_image == False
+        assert conf.target.is_directory == True
+        assert conf.target.physical_root == "/what/ever"
 
     def test_system(self):
         conf = AnacondaConfiguration.from_defaults()
@@ -171,27 +171,27 @@ class ArgparseTest(unittest.TestCase):
         opts, _removed = self._parseCmdline([])
         conf.set_from_opts(opts)
 
-        self.assertEqual(conf.system._is_boot_iso, True)
-        self.assertEqual(conf.system._is_live_os, False)
-        self.assertEqual(conf.system._is_unknown, False)
+        assert conf.system._is_boot_iso == True
+        assert conf.system._is_live_os == False
+        assert conf.system._is_unknown == False
 
         opts, _removed = self._parseCmdline(['--liveinst'])
         conf.set_from_opts(opts)
 
-        self.assertEqual(conf.system._is_boot_iso, False)
-        self.assertEqual(conf.system._is_live_os, True)
-        self.assertEqual(conf.system._is_unknown, False)
+        assert conf.system._is_boot_iso == False
+        assert conf.system._is_live_os == True
+        assert conf.system._is_unknown == False
 
         opts, _removed = self._parseCmdline(['--dirinstall=/what/ever'])
         conf.set_from_opts(opts)
 
-        self.assertEqual(conf.system._is_boot_iso, False)
-        self.assertEqual(conf.system._is_live_os, False)
-        self.assertEqual(conf.system._is_unknown, True)
+        assert conf.system._is_boot_iso == False
+        assert conf.system._is_live_os == False
+        assert conf.system._is_unknown == True
 
         opts, _removed = self._parseCmdline(['--image=/what/ever.img'])
         conf.set_from_opts(opts)
 
-        self.assertEqual(conf.system._is_boot_iso, False)
-        self.assertEqual(conf.system._is_live_os, False)
-        self.assertEqual(conf.system._is_unknown, True)
+        assert conf.system._is_boot_iso == False
+        assert conf.system._is_live_os == False
+        assert conf.system._is_unknown == True

--- a/tests/unit_tests/pyanaconda_tests/test_controller.py
+++ b/tests/unit_tests/pyanaconda_tests/test_controller.py
@@ -62,7 +62,7 @@ class InstallTasksTestCase(unittest.TestCase):
         # initialization as done the init_done signal of the
         # controller should be triggered. So check that
         # it really happened.
-        self.assertEqual(self._test_variable1, 1)
+        assert self._test_variable1 == 1
 
     def test_controller_robustness(self):
         """Check of controller handles various edge cases."""
@@ -89,7 +89,7 @@ class InstallTasksTestCase(unittest.TestCase):
         ctrl.module_init_done(module5)
         ctrl.module_init_done(module4)
         # check that the init_done has not yet been triggered
-        self.assertEqual(self._test_variable1, 0)
+        assert self._test_variable1 == 0
 
         # mark the modules as being initialized
         ctrl.module_init_start(module1)
@@ -106,7 +106,7 @@ class InstallTasksTestCase(unittest.TestCase):
         ctrl.module_init_done(module6)
 
         # check that the init_done has not yet been triggered
-        self.assertEqual(self._test_variable1, 0)
+        assert self._test_variable1 == 0
 
         # report modules initialization as being finished
         # - order should not matter
@@ -123,4 +123,4 @@ class InstallTasksTestCase(unittest.TestCase):
         ctrl.module_init_done(module8)
 
         # check that the init_done signal has been triggered only once
-        self.assertEqual(self._test_variable1, 1)
+        assert self._test_variable1 == 1

--- a/tests/unit_tests/pyanaconda_tests/test_installation_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/test_installation_tasks.py
@@ -58,35 +58,35 @@ class InstallTasksTestCase(unittest.TestCase):
     def test_task(self):
         """Check that task works correctly."""
         task = Task("foo", self._set_var_5, ("anaconda",))
-        self.assertEqual(task.name, "foo")
-        self.assertEqual(task.summary, "Task: foo")
-        self.assertIsNone(task.parent)
-        self.assertIsNone(task.elapsed_time)
+        assert task.name == "foo"
+        assert task.summary == "Task: foo"
+        assert task.parent is None
+        assert task.elapsed_time is None
         # check initial state of the testing variables
-        self.assertIsNone(self._test_variable4)
-        self.assertIsNone(self._test_variable5)
-        self.assertIsNone(self._test_variable6)
+        assert self._test_variable4 is None
+        assert self._test_variable5 is None
+        assert self._test_variable6 is None
         # check task state
-        self.assertFalse(task.done)
-        self.assertFalse(task.running)
+        assert not task.done
+        assert not task.running
         # connect callbacks
         task.started.connect(self._set_var_4)
         task.completed.connect(self._set_var_6)
         # check if the task is executed correctly
         task.start()
-        self.assertTrue(task.done)
-        self.assertFalse(task.running)
-        self.assertEqual(self._test_variable5, "anaconda")
-        self.assertIs(self._test_variable4, task)
-        self.assertIs(self._test_variable6, task)
+        assert task.done
+        assert not task.running
+        assert self._test_variable5 == "anaconda"
+        assert self._test_variable4 is task
+        assert self._test_variable6 is task
         # it should be possible to execute the task only once
         task.start()
-        self.assertTrue(task.done)
-        self.assertFalse(task.running)
-        self.assertIsNotNone(task.elapsed_time)
-        self.assertEqual(self._test_variable5, "anaconda")
-        self.assertIs(self._test_variable4, task)
-        self.assertIs(self._test_variable6, task)
+        assert task.done
+        assert not task.running
+        assert task.elapsed_time is not None
+        assert self._test_variable5 == "anaconda"
+        assert self._test_variable4 is task
+        assert self._test_variable6 is task
 
     def test_task_kwargs(self):
         """Check that works correctly with kwargs."""
@@ -94,69 +94,69 @@ class InstallTasksTestCase(unittest.TestCase):
             self._set_var_5((arg1, foo))
 
         task = Task("foo", custom_function, task_args=("anaconda",), task_kwargs={"foo": "bar"})
-        self.assertEqual(task.name, "foo")
-        self.assertEqual(task.summary, "Task: foo")
-        self.assertIsNone(task.parent)
-        self.assertIsNone(task.elapsed_time)
+        assert task.name == "foo"
+        assert task.summary == "Task: foo"
+        assert task.parent is None
+        assert task.elapsed_time is None
         # check initial state of the testing variables
-        self.assertIsNone(self._test_variable4)
-        self.assertIsNone(self._test_variable5)
-        self.assertIsNone(self._test_variable6)
+        assert self._test_variable4 is None
+        assert self._test_variable5 is None
+        assert self._test_variable6 is None
         # check task state
-        self.assertFalse(task.done)
-        self.assertFalse(task.running)
+        assert not task.done
+        assert not task.running
         # connect callbacks
         task.started.connect(self._set_var_4)
         task.completed.connect(self._set_var_6)
         # check if the task is executed correctly
         task.start()
-        self.assertTrue(task.done)
-        self.assertFalse(task.running)
-        self.assertEqual(self._test_variable5, ("anaconda", "bar"))
-        self.assertIs(self._test_variable4, task)
-        self.assertIs(self._test_variable6, task)
+        assert task.done
+        assert not task.running
+        assert self._test_variable5 == ("anaconda", "bar")
+        assert self._test_variable4 is task
+        assert self._test_variable6 is task
         # it should be possible to execute the task only once
         task.start()
-        self.assertTrue(task.done)
-        self.assertFalse(task.running)
-        self.assertIsNotNone(task.elapsed_time)
-        self.assertEqual(self._test_variable5, ("anaconda", "bar"))
-        self.assertIs(self._test_variable4, task)
-        self.assertIs(self._test_variable6, task)
+        assert task.done
+        assert not task.running
+        assert task.elapsed_time is not None
+        assert self._test_variable5 == ("anaconda", "bar")
+        assert self._test_variable4 is task
+        assert self._test_variable6 is task
 
     def test_task_no_args(self):
         """Check if task with no arguments works correctly."""
         task = Task("foo", self._increment_var1)
-        self.assertEqual(task.name, "foo")
-        self.assertEqual(task.summary, "Task: foo")
-        self.assertIsNone(task.parent)
-        self.assertIsNone(task.elapsed_time)
+        assert task.name == "foo"
+        assert task.summary == "Task: foo"
+        assert task.parent is None
+        assert task.elapsed_time is None
         # check initial state of the testing variables
-        self.assertEqual(self._test_variable1, 0)
-        self.assertIsNone(self._test_variable4)
-        self.assertIsNone(self._test_variable5)
-        self.assertIsNone(self._test_variable6)
+        assert self._test_variable1 == 0
+        assert self._test_variable4 is None
+        assert self._test_variable5 is None
+        assert self._test_variable6 is None
         # check task state
-        self.assertFalse(task.done)
-        self.assertFalse(task.running)
+        assert not task.done
+        assert not task.running
         # connect callbacks
         task.started.connect(self._set_var_4)
         task.completed.connect(self._set_var_6)
         # check if the task is executed correctly
         task.start()
-        self.assertTrue(task.done)
-        self.assertFalse(task.running)
-        self.assertEqual(self._test_variable1, 1)
-        self.assertIs(self._test_variable4, task)
-        self.assertIs(self._test_variable6, task)
+        assert task.done
+        assert not task.running
+        assert self._test_variable1 == 1
+        assert self._test_variable4 is task
+        assert self._test_variable6 is task
         # it should be possible to execute the task only once
         task.start()
-        self.assertTrue(task.done)
-        self.assertFalse(task.running)
-        self.assertIsNotNone(task.elapsed_time)
-        self.assertEqual(self._test_variable1, 1)
-        self.assertIs(self._test_variable4, task)
-        self.assertIs(self._test_variable6, task)
+        assert task.done
+        assert not task.running
+        assert task.elapsed_time is not None
+        assert self._test_variable1 == 1
+        assert self._test_variable4 is task
+        assert self._test_variable6 is task
 
     def test_task_subclass_light(self):
         """Check if a Task subclass with custom run_task() method works."""
@@ -179,16 +179,16 @@ class InstallTasksTestCase(unittest.TestCase):
         task.started.connect(self._set_var_4)
         task.completed.connect(self._set_var_6)
         # verify initial state
-        self.assertEqual(task.var1, 0)
-        self.assertIsNone(task.var2)
+        assert task.var1 == 0
+        assert task.var2 is None
         # run the custom task
         task.start()
         # verify that the custom payload was run
-        self.assertEqual(task.var1, 2)
-        self.assertEqual(task.var2, "anaconda")
+        assert task.var1 == 2
+        assert task.var2 == "anaconda"
         # verify that the started/completed signals were triggered
-        self.assertIs(self._test_variable4, task)
-        self.assertIs(self._test_variable6, task)
+        assert self._test_variable4 is task
+        assert self._test_variable6 is task
 
     def test_task_subclass_heavy(self):
         """Check if a Task subclass with custom start() method works."""
@@ -213,17 +213,17 @@ class InstallTasksTestCase(unittest.TestCase):
         task.started.connect(self._set_var_4)
         task.completed.connect(self._set_var_6)
         # verify initial state
-        self.assertEqual(task.var1, 0)
-        self.assertIsNone(task.var2)
+        assert task.var1 == 0
+        assert task.var2 is None
         # run the custom task
         task.start()
         # verify that the custom payload was run
-        self.assertEqual(task.var1, 2)
-        self.assertEqual(task.var2, "anaconda")
+        assert task.var1 == 2
+        assert task.var2 == "anaconda"
         # verify that the started/completed signals were *not* triggered
         # (as they are not called by the reimplemented start() method)
-        self.assertIsNone(self._test_variable4)
-        self.assertIsNone(self._test_variable6)
+        assert self._test_variable4 is None
+        assert self._test_variable6 is None
 
     def test_task_subclass_kwargs(self):
         """Check if kwarg passing works for Task subclasses."""
@@ -239,25 +239,25 @@ class InstallTasksTestCase(unittest.TestCase):
 
         # check that the kwarg has been propagated correctly
         task = TestTask("foo", self._set_var_5, ("anaconda",))
-        self.assertEqual(task.custom_option, "foo")
+        assert task.custom_option == "foo"
         # also check that the task still works as expected
         task.start()
-        self.assertEqual(self._test_variable5, "anaconda")
+        assert self._test_variable5 == "anaconda"
 
     def test_empty_task_queue(self):
         """Check that an empty task queue works correctly."""
         # first check if empty task queue works correctly
         task_queue = TaskQueue("foo", status_message="foo status message")
-        self.assertEqual(task_queue.name, "foo")
-        self.assertEqual(task_queue.status_message, "foo status message")
-        self.assertEqual(task_queue.task_count, 0)
-        self.assertEqual(task_queue.queue_count, 0)
-        self.assertIsNone(task_queue.current_task_number)
-        self.assertIsNone(task_queue.current_queue_number)
-        self.assertEqual(task_queue.progress, 0.0)
-        self.assertFalse(task_queue.running)
-        self.assertFalse(task_queue.done)
-        self.assertGreater(len(task_queue.summary), 0)
+        assert task_queue.name == "foo"
+        assert task_queue.status_message == "foo status message"
+        assert task_queue.task_count == 0
+        assert task_queue.queue_count == 0
+        assert task_queue.current_task_number is None
+        assert task_queue.current_queue_number is None
+        assert task_queue.progress == 0.0
+        assert not task_queue.running
+        assert not task_queue.done
+        assert len(task_queue.summary) > 0
         # connect started/completed callbacks
 
         # these should be triggered
@@ -273,19 +273,19 @@ class InstallTasksTestCase(unittest.TestCase):
         # it should be possible to start an empty task queue
         task_queue.start()
         # check state after the run
-        self.assertFalse(task_queue.running)
-        self.assertTrue(task_queue.done)
-        self.assertIsNone(task_queue.current_queue_number)
-        self.assertIsNone(task_queue.current_task_number)
-        self.assertEqual(task_queue.task_count, 0)
-        self.assertEqual(task_queue.queue_count, 0)
+        assert not task_queue.running
+        assert task_queue.done
+        assert task_queue.current_queue_number is None
+        assert task_queue.current_task_number is None
+        assert task_queue.task_count == 0
+        assert task_queue.queue_count == 0
         # started/completed signals should still be triggered, even
         # if the queue is empty
-        self.assertIs(self._test_variable4, task_queue)
-        self.assertIs(self._test_variable5, task_queue)
+        assert self._test_variable4 is task_queue
+        assert self._test_variable5 is task_queue
         # the nested queue/task signals should not be triggered if
         # the queue is empty
-        self.assertIsNone(self._test_variable6)
+        assert self._test_variable6 is None
 
     def test_task_queue_processing(self):
         """Check that task queue processing works correctly."""
@@ -303,10 +303,10 @@ class InstallTasksTestCase(unittest.TestCase):
             self._queue_completed_count += 1
 
         # verify initial content of callback counters
-        self.assertEqual(self._task_started_count, 0)
-        self.assertEqual(self._task_completed_count, 0)
-        self.assertEqual(self._queue_started_count, 0)
-        self.assertEqual(self._queue_completed_count, 0)
+        assert self._task_started_count == 0
+        assert self._task_completed_count == 0
+        assert self._queue_started_count == 0
+        assert self._queue_completed_count == 0
         # create some groups
         group1 = TaskQueue(name="group1", status_message="processing group1")
         group1.append(Task("increment var 1", self._increment_var1))
@@ -328,33 +328,33 @@ class InstallTasksTestCase(unittest.TestCase):
         # and one top-level task
         queue1.append(Task("increment var 1", self._increment_var1))
         # check that the groups have been added correctly
-        self.assertEqual(len(queue1), 4)
-        self.assertEqual(queue1[0].name, "group1")
-        self.assertEqual(len(queue1[0]), 1)
-        self.assertEqual(queue1[1].name, "group2")
-        self.assertEqual(len(queue1[1]), 2)
-        self.assertEqual(queue1[2].name, "group3")
-        self.assertEqual(len(queue1[2]), 0)
-        self.assertEqual(queue1.queue_count, 3)
-        self.assertEqual(queue1.task_count, 4)
+        assert len(queue1) == 4
+        assert queue1[0].name == "group1"
+        assert len(queue1[0]) == 1
+        assert queue1[1].name == "group2"
+        assert len(queue1[1]) == 2
+        assert queue1[2].name == "group3"
+        assert len(queue1[2]) == 0
+        assert queue1.queue_count == 3
+        assert queue1.task_count == 4
         # summary is generated recursively
-        self.assertTrue(bool(queue1.summary))
+        assert bool(queue1.summary)
         # start the queue
         queue1.start()
         # check if the tasks were correctly executed
-        self.assertEqual(self._test_variable1, 2)
-        self.assertEqual(self._test_variable2, 2)
-        self.assertEqual(self._test_variable3, 0)
+        assert self._test_variable1 == 2
+        assert self._test_variable2 == 2
+        assert self._test_variable3 == 0
         # check that the task & queue signals were triggered correctly
-        self.assertEqual(self._task_started_count, 4)
-        self.assertEqual(self._task_completed_count, 4)
-        self.assertEqual(self._queue_started_count, 3)
-        self.assertEqual(self._queue_completed_count, 3)
+        assert self._task_started_count == 4
+        assert self._task_completed_count == 4
+        assert self._queue_started_count == 3
+        assert self._queue_completed_count == 3
         # check queue state after execution
-        self.assertFalse(queue1.running)
-        self.assertTrue(queue1.done)
-        self.assertIsNone(queue1.current_task_number)
-        self.assertIsNone(queue1.current_queue_number)
+        assert not queue1.running
+        assert queue1.done
+        assert queue1.current_task_number is None
+        assert queue1.current_queue_number is None
         # create another queue and add some task groups and tasks to it
         group4 = TaskQueue(name="group 4", status_message="processing group4")
         group4.append(Task("increment var 1", self._increment_var1))
@@ -366,6 +366,6 @@ class InstallTasksTestCase(unittest.TestCase):
         # start the second queue
         queue2.start()
         # check the tasks also properly executed
-        self.assertEqual(self._test_variable1, 3)
-        self.assertEqual(self._test_variable2, 2)
-        self.assertEqual(self._test_variable3, 1)
+        assert self._test_variable1 == 3
+        assert self._test_variable2 == 2
+        assert self._test_variable3 == 1

--- a/tests/unit_tests/pyanaconda_tests/test_keyboard.py
+++ b/tests/unit_tests/pyanaconda_tests/test_keyboard.py
@@ -18,6 +18,7 @@
 
 from pyanaconda import keyboard
 import unittest
+import pytest
 
 class ParsingAndJoiningTests(unittest.TestCase):
     def test_layout_variant_parsing(self):
@@ -25,48 +26,47 @@ class ParsingAndJoiningTests(unittest.TestCase):
 
         # valid layout variant specs
         layout, variant = keyboard.parse_layout_variant("cz (qwerty)")
-        self.assertEqual(layout, "cz")
-        self.assertEqual(variant, "qwerty")
+        assert layout == "cz"
+        assert variant == "qwerty"
 
         layout, variant = keyboard.parse_layout_variant("cz (dvorak-ucw)")
-        self.assertEqual(layout, "cz")
-        self.assertEqual(variant, "dvorak-ucw")
+        assert layout == "cz"
+        assert variant == "dvorak-ucw"
 
         # a valid layout variant spec with no variant specified
         layout, variant = keyboard.parse_layout_variant("cz")
-        self.assertEqual(layout, "cz")
-        self.assertEqual(variant, "")
+        assert layout == "cz"
+        assert variant == ""
 
         # a valid layout variant spec containing a slash
         layout, variant = keyboard.parse_layout_variant("nec_vndr/jp")
-        self.assertEqual(layout, "nec_vndr/jp")
-        self.assertEqual(variant, "")
+        assert layout == "nec_vndr/jp"
+        assert variant == ""
 
         # an invalid layout variant spec (missing layout)
-        with self.assertRaises(keyboard.InvalidLayoutVariantSpec):
+        with pytest.raises(keyboard.InvalidLayoutVariantSpec):
             layout, variant = keyboard.parse_layout_variant("")
 
         # another invalid layout variant spec (invalid layout)
-        with self.assertRaises(keyboard.InvalidLayoutVariantSpec):
+        with pytest.raises(keyboard.InvalidLayoutVariantSpec):
             layout, variant = keyboard.parse_layout_variant("&*&%$")
 
         # another invalid layout variant spec (square brackets)
-        with self.assertRaises(keyboard.InvalidLayoutVariantSpec):
+        with pytest.raises(keyboard.InvalidLayoutVariantSpec):
             layout, variant = keyboard.parse_layout_variant("cz [qwerty]")
 
         # another invalid layout variant spec (invalid variant)
-        with self.assertRaises(keyboard.InvalidLayoutVariantSpec):
+        with pytest.raises(keyboard.InvalidLayoutVariantSpec):
             layout, variant = keyboard.parse_layout_variant("cz (&*&*)")
 
     def test_layout_variant_joining(self):
         """Should correctly join keyboard layout and variant to a string spec."""
 
         # both layout and variant specified
-        self.assertEqual(keyboard.join_layout_variant("cz", "qwerty"),
-                         "cz (qwerty)")
+        assert keyboard.join_layout_variant("cz", "qwerty") == "cz (qwerty)"
 
         # no variant specified
-        self.assertEqual(keyboard.join_layout_variant("cz"), "cz")
+        assert keyboard.join_layout_variant("cz") == "cz"
 
     def test_layout_variant_parse_join(self):
         """Parsing and joining valid layout and variant spec should have no effect."""
@@ -74,16 +74,16 @@ class ParsingAndJoiningTests(unittest.TestCase):
         specs = ("cz", "cz (qwerty)")
         for spec in specs:
             (layout, variant) = keyboard.parse_layout_variant(spec)
-            self.assertEqual(spec, keyboard.join_layout_variant(layout, variant))
+            assert spec == keyboard.join_layout_variant(layout, variant)
 
     def test_layout_variant_normalize(self):
         """Normalizing layout and variant strings should work as expected."""
 
         # no effect on normalized layout and variant string
-        self.assertEqual(keyboard.normalize_layout_variant("cz (qwerty)"), "cz (qwerty)")
-        self.assertEqual(keyboard.normalize_layout_variant("cz"), "cz")
+        assert keyboard.normalize_layout_variant("cz (qwerty)") == "cz (qwerty)"
+        assert keyboard.normalize_layout_variant("cz") == "cz"
 
         # normalize spaces
-        self.assertEqual(keyboard.normalize_layout_variant("cz(qwerty)"), "cz (qwerty)")
-        self.assertEqual(keyboard.normalize_layout_variant("cz ( qwerty )"), "cz (qwerty)")
-        self.assertEqual(keyboard.normalize_layout_variant("cz "), "cz")
+        assert keyboard.normalize_layout_variant("cz(qwerty)") == "cz (qwerty)"
+        assert keyboard.normalize_layout_variant("cz ( qwerty )") == "cz (qwerty)"
+        assert keyboard.normalize_layout_variant("cz ") == "cz"

--- a/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
+++ b/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
@@ -18,7 +18,9 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import pytest
 import warnings
+
 from textwrap import dedent
 
 from pykickstart.base import RemovedCommand
@@ -216,7 +218,7 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         parser.readKickstartFromString(dedent(kickstart_input))
 
         if kickstart_output is not None:
-            self.assertEqual(str(handler).strip(), dedent(kickstart_output).strip())
+            assert str(handler).strip() == dedent(kickstart_output).strip()
 
         return handler
 
@@ -225,7 +227,7 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         specification = self.SpecificationA
         self.parse_kickstart(specification, "")
 
-        with self.assertRaises(KickstartParseError):
+        with pytest.raises(KickstartParseError):
             self.parse_kickstart(specification, "skipx")
 
     def test_command_specification(self):
@@ -234,7 +236,7 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         self.parse_kickstart(specification, "")
         self.parse_kickstart(specification, "skipx")
 
-        with self.assertRaises(KickstartParseError):
+        with pytest.raises(KickstartParseError):
             self.parse_kickstart(specification, "xconfig")
 
     def test_command_with_data_specification(self):
@@ -243,7 +245,7 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         self.parse_kickstart(specification, "")
         self.parse_kickstart(specification, "user --name John")
 
-        with self.assertRaises(KickstartParseError):
+        with pytest.raises(KickstartParseError):
             self.parse_kickstart(specification, "xconfig")
 
     def test_section_specification(self):
@@ -254,7 +256,7 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         self.parse_kickstart(specification, "%packages\n%end")
         self.parse_kickstart(specification, "%packages\na\nb\nc\n%end")
 
-        with self.assertRaises(KickstartParseError):
+        with pytest.raises(KickstartParseError):
             self.parse_kickstart(specification, "xconfig")
 
     def test_full_specification(self):
@@ -276,7 +278,7 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         %end
         """))
 
-        with self.assertRaises(KickstartParseError):
+        with pytest.raises(KickstartParseError):
             self.parse_kickstart(specification, "xconfig")
 
     def test_first_addon_specification(self):
@@ -291,9 +293,9 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         %end
         """
         handler = self.parse_kickstart(specification, ks_in, ks_out)
-        self.assertEqual(handler.addons.my_test_1.foo, None)
-        self.assertEqual(handler.addons.my_test_1.bar, False)
-        self.assertEqual(handler.addons.my_test_1.lines, [])
+        assert handler.addons.my_test_1.foo is None
+        assert handler.addons.my_test_1.bar == False
+        assert handler.addons.my_test_1.lines == []
 
         ks_in = """
         %addon my_test_1 --foo=10 --bar
@@ -310,11 +312,11 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         %end
         """
         handler = self.parse_kickstart(specification, ks_in, ks_out)
-        self.assertEqual(handler.addons.my_test_1.foo, 10)
-        self.assertEqual(handler.addons.my_test_1.bar, True)
-        self.assertEqual(handler.addons.my_test_1.lines, ["1", "2", "3"])
+        assert handler.addons.my_test_1.foo == 10
+        assert handler.addons.my_test_1.bar == True
+        assert handler.addons.my_test_1.lines == ["1", "2", "3"]
 
-        with self.assertRaises(KickstartParseError):
+        with pytest.raises(KickstartParseError):
             self.parse_kickstart(specification, """
             %addon my_test_1 --invalid-arg
             %end
@@ -332,7 +334,7 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         %end
         """
         handler = self.parse_kickstart(specification, ks_in, ks_out)
-        self.assertEqual(handler.addons.my_test_2.args, [])
+        assert handler.addons.my_test_2.args == []
 
         ks_in = """
         %addon my_test_2 --arg1 --arg2 --arg3
@@ -343,9 +345,9 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         %end
         """
         handler = self.parse_kickstart(specification, ks_in, ks_out)
-        self.assertEqual(handler.addons.my_test_2.args, ["--arg1", "--arg2", "--arg3"])
+        assert handler.addons.my_test_2.args == ["--arg1", "--arg2", "--arg3"]
 
-        with self.assertRaises(KickstartParseError):
+        with pytest.raises(KickstartParseError):
             self.parse_kickstart(specification, """
             %addon my_test_2
             Invalid line!
@@ -356,9 +358,9 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         specification = self.SpecificationF
 
         handler = self.parse_kickstart(specification, "", "")
-        self.assertIsInstance(handler.addons, AddonRegistry)
-        self.assertIsInstance(handler.addons.my_test_1, TestData1)
-        self.assertIsInstance(handler.addons.my_test_2, TestData2)
+        assert isinstance(handler.addons, AddonRegistry)
+        assert isinstance(handler.addons.my_test_1, TestData1)
+        assert isinstance(handler.addons.my_test_2, TestData2)
 
         ks_in = """
         %addon my_test_1 --foo=10 --bar
@@ -378,7 +380,7 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         """
         self.parse_kickstart(specification, ks_in, ks_out)
 
-        with self.assertRaises(KickstartParseError):
+        with pytest.raises(KickstartParseError):
             self.parse_kickstart(specification, """
            %addon my_test_unknown
            %end
@@ -433,7 +435,7 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
                 continue
 
             print("Checking command {}...".format(name))
-            self.assertIsInstance(children[name](), parents[name])
+            assert isinstance(children[name](), parents[name])
 
     def test_version(self):
         """Check versions of kickstart commands and data objects."""
@@ -471,7 +473,7 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
                 specified.discard(name)
 
         # Check the differences.
-        self.assertEqual(specified, expected)
+        assert specified == expected
 
     def test_disjoint_commands(self):
         """Check if the commands are specified at most once."""
@@ -556,6 +558,6 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
         # Otherwise, they has to be handled by the main process.
         for name, command in kickstart.commandMap.items():
             if issubclass(command, kickstart.UselessCommand):
-                self.assertIn(name, module_names)
+                assert name in module_names
             else:
-                self.assertIn(name, anaconda_names)
+                assert name in anaconda_names

--- a/tests/unit_tests/pyanaconda_tests/test_ks_version.py
+++ b/tests/unit_tests/pyanaconda_tests/test_ks_version.py
@@ -47,7 +47,7 @@ class CommandVersionTestCase(unittest.TestCase):
             if isinstance(children[name](), kickstart.UselessCommand):
                 continue
 
-            self.assertIsInstance(children[name](), parents[name])
+            assert isinstance(children[name](), parents[name])
 
     def test_commands(self):
         """Test that anaconda uses the right versions of kickstart commands"""

--- a/tests/unit_tests/pyanaconda_tests/test_network.py
+++ b/tests/unit_tests/pyanaconda_tests/test_network.py
@@ -25,37 +25,37 @@ class NetworkTests(unittest.TestCase):
     def test_is_valid_hostname(self):
         """Test hostname validation."""
 
-        self.assertFalse(network.is_valid_hostname("")[0])
-        self.assertFalse(network.is_valid_hostname(None)[0])
+        assert not network.is_valid_hostname("")[0]
+        assert not network.is_valid_hostname(None)[0]
 
         # section length < 64
-        self.assertTrue(network.is_valid_hostname("h"*63)[0])
-        self.assertFalse(network.is_valid_hostname("h"*64)[0])
+        assert network.is_valid_hostname("h"*63)[0]
+        assert not network.is_valid_hostname("h"*64)[0]
 
         # length < 65
-        self.assertTrue(network.is_valid_hostname("section." * 7+"sectionx")[0])
-        self.assertFalse(network.is_valid_hostname("section." * 7+"sectionxx")[0])
+        assert network.is_valid_hostname("section." * 7+"sectionx")[0]
+        assert not network.is_valid_hostname("section." * 7+"sectionxx")[0]
 
-        self.assertFalse(network.is_valid_hostname(
-            "section.must.be..nonempty.")[0])
-        self.assertFalse(network.is_valid_hostname(
-            ".section.must.be.nonempty.")[0])
-        self.assertTrue(network.is_valid_hostname(
-            "section.can.contain.only.alphanums.012.or.hyp-hens")[0])
-        self.assertFalse(network.is_valid_hostname(
-            "section.can.contain.only.alphanums.012.or.hyp-hens!!!")[0])
-        self.assertFalse(network.is_valid_hostname(
-            "section.may.not.start.with.-hyphen")[0])
-        self.assertFalse(network.is_valid_hostname(
-            "section.may.not.end.with.hyphen-")[0])
+        assert not network.is_valid_hostname(
+            "section.must.be..nonempty.")[0]
+        assert not network.is_valid_hostname(
+            ".section.must.be.nonempty.")[0]
+        assert network.is_valid_hostname(
+            "section.can.contain.only.alphanums.012.or.hyp-hens")[0]
+        assert not network.is_valid_hostname(
+            "section.can.contain.only.alphanums.012.or.hyp-hens!!!")[0]
+        assert not network.is_valid_hostname(
+            "section.may.not.start.with.-hyphen")[0]
+        assert not network.is_valid_hostname(
+            "section.may.not.end.with.hyphen-")[0]
 
-        self.assertTrue(network.is_valid_hostname("0-0.")[0])
-        self.assertTrue(network.is_valid_hostname("0.")[0])
+        assert network.is_valid_hostname("0-0.")[0]
+        assert network.is_valid_hostname("0.")[0]
 
-        self.assertFalse(network.is_valid_hostname("Lennart's Laptop")[0])
+        assert not network.is_valid_hostname("Lennart's Laptop")[0]
 
-        self.assertFalse(network.is_valid_hostname("own.hostname.cannot.end.in.dot.",
-                                                   local=True)[0])
+        assert not network.is_valid_hostname("own.hostname.cannot.end.in.dot.",
+                                             local=True)[0]
 
     def test_prefix2netmask2prefix(self):
         """Test netmask and prefix conversion."""
@@ -95,10 +95,10 @@ class NetworkTests(unittest.TestCase):
                 (32, "255.255.255.255"),
                ]
         for prefix, netmask in lore:
-            self.assertEqual(network.prefix_to_netmask(prefix), netmask)
-            self.assertEqual(network.netmask_to_prefix(netmask), prefix)
+            assert network.prefix_to_netmask(prefix) == netmask
+            assert network.netmask_to_prefix(netmask) == prefix
 
-        self.assertEqual(network.prefix_to_netmask(33), "255.255.255.255")
+        assert network.prefix_to_netmask(33) == "255.255.255.255"
 
     def test_nm_check_ip_address(self,):
         """Test IPv4 and IPv6 address checks."""
@@ -203,56 +203,56 @@ class NetworkTests(unittest.TestCase):
 
         # test good IPv4
         for i in good_IPv4_tests:
-            self.assertTrue(network.check_ip_address(i, version=4))
-            self.assertTrue(network.check_ip_address(i))
-            self.assertFalse(network.check_ip_address(i, version=6))
+            assert network.check_ip_address(i, version=4)
+            assert network.check_ip_address(i)
+            assert not network.check_ip_address(i, version=6)
 
         # test bad Ipv4
         for i in bad_IPv4_tests:
-            self.assertFalse(network.check_ip_address(i))
-            self.assertFalse(network.check_ip_address(i, version=4))
-            self.assertFalse(network.check_ip_address(i, version=6))
+            assert not network.check_ip_address(i)
+            assert not network.check_ip_address(i, version=4)
+            assert not network.check_ip_address(i, version=6)
 
         # test good IPv6
         for i in good_IPv6_tests:
-            self.assertTrue(network.check_ip_address(i, version=6))
-            self.assertTrue(network.check_ip_address(i))
-            self.assertFalse(network.check_ip_address(i, version=4))
+            assert network.check_ip_address(i, version=6)
+            assert network.check_ip_address(i)
+            assert not network.check_ip_address(i, version=4)
 
         # test bad IPv6
         for i in bad_IPv6_tests:
-            self.assertFalse(network.check_ip_address(i))
-            self.assertFalse(network.check_ip_address(i, version=6))
-            self.assertFalse(network.check_ip_address(i, version=4))
+            assert not network.check_ip_address(i)
+            assert not network.check_ip_address(i, version=6)
+            assert not network.check_ip_address(i, version=4)
 
     def test_hostname_from_cmdline(self):
         """Test extraction of hostname from cmdline."""
         cmdline = {"ip": "10.34.102.244::10.34.102.54:255.255.255.0:myhostname:ens9:none"}
-        self.assertEqual(network.hostname_from_cmdline(cmdline), "myhostname")
+        assert network.hostname_from_cmdline(cmdline) == "myhostname"
         # ip takes precedence
         cmdline = {"ip": "10.34.102.244::10.34.102.54:255.255.255.0:myhostname:ens9:none",
                    "hostname": "hostname_bootopt"}
-        self.assertEqual(network.hostname_from_cmdline(cmdline), "myhostname")
+        assert network.hostname_from_cmdline(cmdline) == "myhostname"
         cmdline = {"ip": "ens3:dhcp"}
-        self.assertEqual(network.hostname_from_cmdline(cmdline), "")
+        assert network.hostname_from_cmdline(cmdline) == ""
         cmdline = {"ip": "ens3:dhcp:1500"}
-        self.assertEqual(network.hostname_from_cmdline(cmdline), "")
+        assert network.hostname_from_cmdline(cmdline) == ""
         cmdline = {"ip": "ens3:dhcp",
                    "hostname": "hostname_bootopt"}
-        self.assertEqual(network.hostname_from_cmdline(cmdline), "hostname_bootopt")
+        assert network.hostname_from_cmdline(cmdline) == "hostname_bootopt"
         # two ip configurations
         cmdline = {"ip": "ens3:dhcp 10.34.102.244::10.34.102.54:255.255.255.0:myhostname:ens9:none"}
-        self.assertEqual(network.hostname_from_cmdline(cmdline), "myhostname")
+        assert network.hostname_from_cmdline(cmdline) == "myhostname"
         # ipv6 configuration
         cmdline = {"ip": "[fd00:10:100::84:5]::[fd00:10:100::86:49]:80:myhostname:ens50:none"}
-        self.assertEqual(network.hostname_from_cmdline(cmdline), "myhostname")
+        assert network.hostname_from_cmdline(cmdline) == "myhostname"
         cmdline = {"ip": "[fd00:10:100::84:5]:::80:myhostname:ens50:none"}
-        self.assertEqual(network.hostname_from_cmdline(cmdline), "myhostname")
+        assert network.hostname_from_cmdline(cmdline) == "myhostname"
         cmdline = {"ip": "[fd00:10:100::84:5]::[fd00:10:100::86:49]:80::ens50:none"}
-        self.assertEqual(network.hostname_from_cmdline(cmdline), "")
+        assert network.hostname_from_cmdline(cmdline) == ""
         cmdline = {"ip": "[fd00:10:100::84:5]::[fd00:10:100::86:49]:80::ens50:none "
                          "ens3:dhcp 10.34.102.244::10.34.102.54:255.255.255.0:myhostname:ens9:none"}
-        self.assertEqual(network.hostname_from_cmdline(cmdline), "myhostname")
+        assert network.hostname_from_cmdline(cmdline) == "myhostname"
         # automatic ip= whith MAC address set
         cmdline = {"ip": "ens3:dhcp::52:54:00:12:34:56"}
-        self.assertEqual(network.hostname_from_cmdline(cmdline), "")
+        assert network.hostname_from_cmdline(cmdline) == ""

--- a/tests/unit_tests/pyanaconda_tests/test_password_quality.py
+++ b/tests/unit_tests/pyanaconda_tests/test_password_quality.py
@@ -38,10 +38,10 @@ class PasswordQuality(unittest.TestCase):
         request.password = ""
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertEqual(check.result.password_score, 1)  # empty password is fine with emptyok policy
-        self.assertEqual(check.result.status_text, _(constants.SecretStatus.EMPTY.value))
-        self.assertEqual(check.result.password_quality, 0)
-        self.assertIsNotNone(check.result.error_message)
+        assert check.result.password_score == 1  # empty password is fine with emptyok policy
+        assert check.result.status_text == _(constants.SecretStatus.EMPTY.value)
+        assert check.result.password_quality == 0
+        assert check.result.error_message is not None
         # empty password should override password-too-short messages
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
@@ -49,10 +49,10 @@ class PasswordQuality(unittest.TestCase):
         request.password = ""
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertEqual(check.result.password_score, 1)
-        self.assertEqual(check.result.status_text, _(constants.SecretStatus.EMPTY.value))
-        self.assertEqual(check.result.password_quality, 0)
-        self.assertIsNotNone(check.result.error_message)
+        assert check.result.password_score == 1
+        assert check.result.status_text == _(constants.SecretStatus.EMPTY.value)
+        assert check.result.password_quality == 0
+        assert check.result.error_message is not None
 
     def test_password_empty_ok(self):
         """Check if the empty_ok flag works correctly."""
@@ -62,10 +62,10 @@ class PasswordQuality(unittest.TestCase):
         request.password = ""
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertEqual(check.result.password_score, 1)
-        self.assertEqual(check.result.status_text, _(constants.SecretStatus.EMPTY.value))
-        self.assertEqual(check.result.password_quality, 0)
-        self.assertIsNotNone(check.result.error_message)
+        assert check.result.password_score == 1
+        assert check.result.status_text == _(constants.SecretStatus.EMPTY.value)
+        assert check.result.password_quality == 0
+        assert check.result.error_message is not None
         # empty_ok with password length
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
@@ -74,10 +74,10 @@ class PasswordQuality(unittest.TestCase):
         request.password = ""
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertEqual(check.result.password_score, 1)
-        self.assertEqual(check.result.status_text, _(constants.SecretStatus.EMPTY.value))
-        self.assertEqual(check.result.password_quality, 0)
-        self.assertIsNotNone(check.result.error_message)
+        assert check.result.password_score == 1
+        assert check.result.status_text == _(constants.SecretStatus.EMPTY.value)
+        assert check.result.password_quality == 0
+        assert check.result.error_message is not None
         # non-empty passwords that are too short should still get a score of 0 & the "too short" message
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
@@ -86,10 +86,10 @@ class PasswordQuality(unittest.TestCase):
         request.password = "123"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertEqual(check.result.password_score, 0)
-        self.assertEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
-        self.assertEqual(check.result.password_quality, 0)
-        self.assertIsNotNone(check.result.error_message)
+        assert check.result.password_score == 0
+        assert check.result.status_text == _(constants.SecretStatus.TOO_SHORT.value)
+        assert check.result.password_quality == 0
+        assert check.result.error_message is not None
         # also check a long-enough password, just in case
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
@@ -98,10 +98,10 @@ class PasswordQuality(unittest.TestCase):
         request.password = "1234567891"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertEqual(check.result.password_score, 1)
-        self.assertEqual(check.result.status_text, _(constants.SecretStatus.WEAK.value))
-        self.assertEqual(check.result.password_quality, 0)
-        self.assertIsNotNone(check.result.error_message)
+        assert check.result.password_score == 1
+        assert check.result.status_text == _(constants.SecretStatus.WEAK.value)
+        assert check.result.password_quality == 0
+        assert check.result.error_message is not None
 
     def test_password_length(self):
         """Check if minimal password length is checked properly."""
@@ -112,8 +112,8 @@ class PasswordQuality(unittest.TestCase):
         request.password = "123"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertEqual(check.result.password_score, 0)
-        self.assertEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
+        assert check.result.password_score == 0
+        assert check.result.status_text == _(constants.SecretStatus.TOO_SHORT.value)
 
         # weak but long enough
         request = input_checking.PasswordCheckRequest()
@@ -121,8 +121,8 @@ class PasswordQuality(unittest.TestCase):
         request.password = "123456"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertEqual(check.result.password_score, 1)
-        self.assertEqual(check.result.status_text, _(constants.SecretStatus.WEAK.value))
+        assert check.result.password_score == 1
+        assert check.result.status_text == _(constants.SecretStatus.WEAK.value)
 
         # check if setting password length works correctly
         request = input_checking.PasswordCheckRequest()
@@ -131,16 +131,16 @@ class PasswordQuality(unittest.TestCase):
         request.password = "12345"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertEqual(check.result.password_score, 0)
-        self.assertEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
+        assert check.result.password_score == 0
+        assert check.result.status_text == _(constants.SecretStatus.TOO_SHORT.value)
         request = input_checking.PasswordCheckRequest()
         request.policy = get_policy()
         request.policy.min_length = 10
         request.password = "1234567891"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertGreater(check.result.password_score, 0)
-        self.assertNotEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
+        assert check.result.password_score > 0
+        assert check.result.status_text != _(constants.SecretStatus.TOO_SHORT.value)
 
     def test_password_quality(self):
         """Check if libpwquality gives reasonable numbers & score is assigned correctly."""
@@ -150,10 +150,10 @@ class PasswordQuality(unittest.TestCase):
         request.password = " "
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertEqual(check.result.password_score, 0)
-        self.assertEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
-        self.assertEqual(check.result.password_quality, 0)
-        self.assertIsNotNone(check.result.error_message)
+        assert check.result.password_score == 0
+        assert check.result.status_text == _(constants.SecretStatus.TOO_SHORT.value)
+        assert check.result.password_quality == 0
+        assert check.result.error_message is not None
 
         # "anaconda" is a dictionary word
         request = input_checking.PasswordCheckRequest()
@@ -161,11 +161,11 @@ class PasswordQuality(unittest.TestCase):
         request.password = "anaconda"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertGreater(check.result.password_score, 0)
-        self.assertNotEqual(check.result.status_text, _(constants.SecretStatus.EMPTY.value))
-        self.assertNotEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
-        self.assertEqual(check.result.password_quality, 0)
-        self.assertIsNotNone(check.result.error_message)
+        assert check.result.password_score > 0
+        assert check.result.status_text != _(constants.SecretStatus.EMPTY.value)
+        assert check.result.status_text != _(constants.SecretStatus.TOO_SHORT.value)
+        assert check.result.password_quality == 0
+        assert check.result.error_message is not None
 
         # "jelenovipivonelej" is a palindrome
         request = input_checking.PasswordCheckRequest()
@@ -173,11 +173,11 @@ class PasswordQuality(unittest.TestCase):
         request.password = "jelenovipivonelej"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertGreater(check.result.password_score, 0)
-        self.assertNotEqual(check.result.status_text, _(constants.SecretStatus.EMPTY.value))
-        self.assertNotEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
-        self.assertEqual(check.result.password_quality, 0)
-        self.assertIsNotNone(check.result.error_message)
+        assert check.result.password_score > 0
+        assert check.result.status_text != _(constants.SecretStatus.EMPTY.value)
+        assert check.result.status_text != _(constants.SecretStatus.TOO_SHORT.value)
+        assert check.result.password_quality == 0
+        assert check.result.error_message is not None
 
         # "4naconda-" gives a quality of 27 on RHEL7
         request = input_checking.PasswordCheckRequest()
@@ -185,7 +185,7 @@ class PasswordQuality(unittest.TestCase):
         request.password = "4naconda-"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertIs(check.result.error_message, "")
+        assert check.result.error_message is ""
 
         # "4naconda----" gives a quality of 52 on RHEL7
         request = input_checking.PasswordCheckRequest()
@@ -193,7 +193,7 @@ class PasswordQuality(unittest.TestCase):
         request.password = "4naconda----"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertIs(check.result.error_message, "")
+        assert check.result.error_message is ""
 
         # "----4naconda----" gives a quality of 80 on RHEL7
         request = input_checking.PasswordCheckRequest()
@@ -201,7 +201,7 @@ class PasswordQuality(unittest.TestCase):
         request.password = "----4naconda----"
         check = input_checking.PasswordValidityCheck()
         check.run(request)
-        self.assertIs(check.result.error_message, "")
+        assert check.result.error_message is ""
 
         # "?----4naconda----?" gives a quality of 100 on RHEL7
         request = input_checking.PasswordCheckRequest()
@@ -211,10 +211,10 @@ class PasswordQuality(unittest.TestCase):
         check.run(request)
 
         # this should (hopefully) give quality 100 everywhere
-        self.assertEqual(check.result.password_score, 4)  # quality > 90
-        self.assertEqual(check.result.status_text, _(constants.SecretStatus.STRONG.value))
-        self.assertEqual(check.result.password_quality, 100)
-        self.assertIs(check.result.error_message, "")
+        assert check.result.password_score == 4  # quality > 90
+        assert check.result.status_text == _(constants.SecretStatus.STRONG.value)
+        assert check.result.password_quality == 100
+        assert check.result.error_message is ""
 
         # a long enough strong password with minlen set
         request = input_checking.PasswordCheckRequest()
@@ -224,10 +224,10 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         # this should (hopefully) give quality 100 everywhere
-        self.assertEqual(check.result.password_score, 4)  # quality > 90
-        self.assertEqual(check.result.status_text, _(constants.SecretStatus.STRONG.value))
-        self.assertEqual(check.result.password_quality, 100)
-        self.assertIs(check.result.error_message, "")
+        assert check.result.password_score == 4  # quality > 90
+        assert check.result.status_text == _(constants.SecretStatus.STRONG.value)
+        assert check.result.password_quality == 100
+        assert check.result.error_message is ""
 
         # minimum password length overrides strong passwords for score and status
         request = input_checking.PasswordCheckRequest()
@@ -237,8 +237,8 @@ class PasswordQuality(unittest.TestCase):
         check = input_checking.PasswordValidityCheck()
         check.run(request)
         # this should (hopefully) give quality 100 everywhere
-        self.assertEqual(check.result.password_score, 0)  # too short
-        self.assertEqual(check.result.status_text, _(constants.SecretStatus.TOO_SHORT.value))
-        self.assertEqual(check.result.password_quality, 0)  # dependent on password length
-        self.assertIs(check.result.error_message,
-                      _(constants.SECRET_TOO_SHORT[constants.SecretType.PASSWORD]))
+        assert check.result.password_score == 0  # too short
+        assert check.result.status_text == _(constants.SecretStatus.TOO_SHORT.value)
+        assert check.result.password_quality == 0  # dependent on password length
+        assert check.result.error_message is \
+            _(constants.SECRET_TOO_SHORT[constants.SecretType.PASSWORD])

--- a/tests/unit_tests/pyanaconda_tests/test_payload.py
+++ b/tests/unit_tests/pyanaconda_tests/test_payload.py
@@ -18,6 +18,7 @@
 # Authors: Jiri Konecny <jkonecny@redhat.com>
 #
 import unittest
+import pytest
 
 import pyanaconda.core.payload as util
 
@@ -28,56 +29,56 @@ class PayloadUtilsTests(unittest.TestCase):
         """Test parseNfsUrl."""
 
         # empty NFS url should return 3 blanks
-        self.assertEqual(util.parse_nfs_url(""), ("", "", ""))
+        assert util.parse_nfs_url("") == ("", "", "")
 
         # the string is delimited by :, there is one prefix and 3 parts,
         # the prefix is discarded and all parts after the 3th part
         # are also discarded
-        self.assertEqual(util.parse_nfs_url("discard:options:host:path"),
-                         ("options", "host", "path"))
-        self.assertEqual(util.parse_nfs_url("discard:options:host:path:foo:bar"),
-                         ("options", "host", "path"))
-        self.assertEqual(util.parse_nfs_url(":options:host:path::"),
-                         ("options", "host", "path"))
-        self.assertEqual(util.parse_nfs_url(":::::"),
-                         ("", "", ""))
+        assert util.parse_nfs_url("discard:options:host:path") == \
+            ("options", "host", "path")
+        assert util.parse_nfs_url("discard:options:host:path:foo:bar") == \
+            ("options", "host", "path")
+        assert util.parse_nfs_url(":options:host:path::") == \
+            ("options", "host", "path")
+        assert util.parse_nfs_url(":::::") == \
+            ("", "", "")
 
         # if there is only prefix & 2 parts,
         # the two parts are host and path
-        self.assertEqual(util.parse_nfs_url("prefix:host:path"),
-                         ("", "host", "path"))
-        self.assertEqual(util.parse_nfs_url(":host:path"),
-                         ("", "host", "path"))
-        self.assertEqual(util.parse_nfs_url("::"),
-                         ("", "", ""))
+        assert util.parse_nfs_url("prefix:host:path") == \
+            ("", "host", "path")
+        assert util.parse_nfs_url(":host:path") == \
+            ("", "host", "path")
+        assert util.parse_nfs_url("::") == \
+            ("", "", "")
 
         # if there is only a prefix and single part,
         # the part is the host
 
-        self.assertEqual(util.parse_nfs_url("prefix:host"),
-                         ("", "host", ""))
-        self.assertEqual(util.parse_nfs_url(":host"),
-                         ("", "host", ""))
-        self.assertEqual(util.parse_nfs_url(":"),
-                         ("", "", ""))
+        assert util.parse_nfs_url("prefix:host") == \
+            ("", "host", "")
+        assert util.parse_nfs_url(":host") == \
+            ("", "host", "")
+        assert util.parse_nfs_url(":") == \
+            ("", "", "")
 
     def test_create_nfs_url(self):
         """Test create_nfs_url."""
 
-        self.assertEqual(util.create_nfs_url("", ""), "")
-        self.assertEqual(util.create_nfs_url("", "", None), "")
-        self.assertEqual(util.create_nfs_url("", "", ""), "")
+        assert util.create_nfs_url("", "") == ""
+        assert util.create_nfs_url("", "", None) == ""
+        assert util.create_nfs_url("", "", "") == ""
 
-        self.assertEqual(util.create_nfs_url("host", ""), "nfs:host:")
-        self.assertEqual(util.create_nfs_url("host", "", "options"), "nfs:options:host:")
+        assert util.create_nfs_url("host", "") == "nfs:host:"
+        assert util.create_nfs_url("host", "", "options") == "nfs:options:host:"
 
-        self.assertEqual(util.create_nfs_url("host", "path"), "nfs:host:path")
-        self.assertEqual(util.create_nfs_url("host", "/path", "options"), "nfs:options:host:/path")
+        assert util.create_nfs_url("host", "path") == "nfs:host:path"
+        assert util.create_nfs_url("host", "/path", "options") == "nfs:options:host:/path"
 
-        self.assertEqual(util.create_nfs_url("host", "/path/to/something"),
-                         "nfs:host:/path/to/something")
-        self.assertEqual(util.create_nfs_url("host", "/path/to/something", "options"),
-                         "nfs:options:host:/path/to/something")
+        assert util.create_nfs_url("host", "/path/to/something") == \
+            "nfs:host:/path/to/something"
+        assert util.create_nfs_url("host", "/path/to/something", "options") == \
+            "nfs:options:host:/path/to/something"
 
     def test_nfs_combine(self):
         """Test combination of parse and create nfs functions."""
@@ -87,28 +88,22 @@ class PayloadUtilsTests(unittest.TestCase):
         options = "options"
 
         url = util.create_nfs_url(host, path, options)
-        self.assertEqual(util.parse_nfs_url(url), (options, host, path))
+        assert util.parse_nfs_url(url) == (options, host, path)
 
         url = "nfs:options:host:/my/path"
         (options, host, path) = util.parse_nfs_url(url)
-        self.assertEqual(util.create_nfs_url(host, path, options), url)
+        assert util.create_nfs_url(host, path, options) == url
 
     def test_split_protocol(self):
         """Test split protocol test."""
 
-        self.assertEqual(util.split_protocol("http://abc/cde"),
-                         ("http://", "abc/cde"))
-        self.assertEqual(util.split_protocol("https://yay/yay"),
-                         ("https://", "yay/yay"))
-        self.assertEqual(util.split_protocol("ftp://ups/spu"),
-                         ("ftp://", "ups/spu"))
-        self.assertEqual(util.split_protocol("file:///test/file"),
-                         ("file://", "/test/file"))
-        self.assertEqual(util.split_protocol("nfs:ups/spu:/abc:opts"),
-                         ("", "nfs:ups/spu:/abc:opts"))
-        self.assertEqual(util.split_protocol("http:/typo/test"),
-                         ("", "http:/typo/test"))
-        self.assertEqual(util.split_protocol(""), ("", ""))
+        assert util.split_protocol("http://abc/cde") == ("http://", "abc/cde")
+        assert util.split_protocol("https://yay/yay") == ("https://", "yay/yay")
+        assert util.split_protocol("ftp://ups/spu") == ("ftp://", "ups/spu")
+        assert util.split_protocol("file:///test/file") == ("file://", "/test/file")
+        assert util.split_protocol("nfs:ups/spu:/abc:opts") == ("", "nfs:ups/spu:/abc:opts")
+        assert util.split_protocol("http:/typo/test") == ("", "http:/typo/test")
+        assert util.split_protocol("") == ("", "")
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             util.split_protocol("http://ftp://ups/this/is/not/correct")

--- a/tests/unit_tests/pyanaconda_tests/test_payload_source.py
+++ b/tests/unit_tests/pyanaconda_tests/test_payload_source.py
@@ -20,6 +20,7 @@
 
 
 import unittest
+import pytest
 import enum
 
 from pyanaconda.modules.common.constants.services import PAYLOADS
@@ -76,23 +77,22 @@ class TestSourceFactoryTests(unittest.TestCase):
             klass = val.map_to_classes()
 
             if klass is None:
-                with self.assertRaises(PayloadSourceTypeUnrecognized):
+                with pytest.raises(PayloadSourceTypeUnrecognized):
                     SourceFactory.parse_repo_cmdline_string(val.value)
                 continue
 
             source = SourceFactory.parse_repo_cmdline_string(val.value)
-            self.assertIsInstance(source, klass,
-                                  "Instance of source {} expected - get {}".format(klass, source))
+            assert isinstance(source, klass), \
+                "Instance of source {} expected - get {}".format(klass, source)
 
     def _check_is_methods(self, check_method, valid_array, type_str):
         for val in TestValues:
 
             ret = check_method(val.value)
             if val in valid_array:
-                self.assertTrue(ret, "Value {} is not marked as {}".format(val.value, type_str))
+                assert ret, "Value {} is not marked as {}".format(val.value, type_str)
             else:
-                self.assertFalse(ret, "Value {} should non be marked as {}".format(val.value,
-                                                                                   type_str))
+                assert not ret, "Value {} should non be marked as {}".format(val.value, type_str)
 
     def test_is_cdrom(self):
         self._check_is_methods(SourceFactory.is_cdrom,
@@ -144,7 +144,7 @@ class TestSourceFactoryTests(unittest.TestCase):
         source_proxy = source.create_proxy()
 
         payloads_proxy.CreateSource.assert_called_once_with(source_type)
-        self.assertEqual(source_proxy, PAYLOADS.get_proxy("my/source/1"))
+        assert source_proxy == PAYLOADS.get_proxy("my/source/1")
 
         return source_proxy
 

--- a/tests/unit_tests/pyanaconda_tests/test_product.py
+++ b/tests/unit_tests/pyanaconda_tests/test_product.py
@@ -33,4 +33,4 @@ class ProductFromBuildstampTests(unittest.TestCase):
         ]
 
         for original, trimmed in trimmed_versions:
-            self.assertEqual(trimmed, trim_product_version_for_ui(original))
+            assert trimmed == trim_product_version_for_ui(original)

--- a/tests/unit_tests/pyanaconda_tests/test_secret_agent.py
+++ b/tests/unit_tests/pyanaconda_tests/test_secret_agent.py
@@ -63,10 +63,10 @@ class SecretAgentTestCase(unittest.TestCase):
         ]
         for key in valid_keys:
             secret['value'] = key
-            self.assertTrue(self.agent._validate_staticwep(secret))
+            assert self.agent._validate_staticwep(secret)
         for key in invalid_keys:
             secret['value'] = key
-            self.assertFalse(self.agent._validate_staticwep(secret))
+            assert not self.agent._validate_staticwep(secret)
 
         secret['wep_key_type'] = NM.WepKeyType.PASSPHRASE
         valid_keys = [
@@ -79,10 +79,10 @@ class SecretAgentTestCase(unittest.TestCase):
         ]
         for key in valid_keys:
             secret['value'] = key
-            self.assertTrue(self.agent._validate_staticwep(secret))
+            assert self.agent._validate_staticwep(secret)
         for key in invalid_keys:
             secret['value'] = key
-            self.assertFalse(self.agent._validate_staticwep(secret))
+            assert not self.agent._validate_staticwep(secret)
 
     def test_validate_wpapsk(self):
         """Test validate_wpapsk method."""
@@ -105,10 +105,10 @@ class SecretAgentTestCase(unittest.TestCase):
         ]
         for key in valid_keys:
             secret['value'] = key
-            self.assertTrue(self.agent._validate_wpapsk(secret))
+            assert self.agent._validate_wpapsk(secret)
         for key in invalid_keys:
             secret['value'] = key
-            self.assertFalse(self.agent._validate_wpapsk(secret))
+            assert not self.agent._validate_wpapsk(secret)
 
     def _mock_secret_agent_dialog_ui_callback(self, entered_value):
         def ui_callback(content):
@@ -175,7 +175,7 @@ class SecretAgentTestCase(unittest.TestCase):
             hints,
             no_interaction_flags
         )
-        self.assertIsNone(result)
+        assert result is None
 
         # UI cancelled
         self.agent.set_ui_callback(lambda x: False)
@@ -186,7 +186,7 @@ class SecretAgentTestCase(unittest.TestCase):
             hints,
             allowed_interaction_flags
         )
-        self.assertEqual(result, {setting_name: {}})
+        assert result == {setting_name: {}}
 
         # Mock what SecretAgentDialog does in the iu callback
         secret_value = GLib.Variant('s', "mypassword")
@@ -204,7 +204,7 @@ class SecretAgentTestCase(unittest.TestCase):
             hints,
             allowed_interaction_flags
         )
-        self.assertEqual(result, {setting_name: {}})
+        assert result == {setting_name: {}}
         connection_hash['connection']['type'] = orig_type
 
         # WPA key management
@@ -217,7 +217,7 @@ class SecretAgentTestCase(unittest.TestCase):
             hints,
             allowed_interaction_flags
         )
-        self.assertEqual(result, {setting_name: {'psk': secret_value}})
+        assert result == {setting_name: {'psk': secret_value}}
         connection_hash['802-11-wireless-security']['key-mgmt'] = 'wpa-psk'
         result = self.agent.GetSecrets(
             connection_hash,
@@ -226,7 +226,7 @@ class SecretAgentTestCase(unittest.TestCase):
             hints,
             allowed_interaction_flags
         )
-        self.assertEqual(result, {setting_name: {'psk': secret_value}})
+        assert result == {setting_name: {'psk': secret_value}}
         connection_hash['802-11-wireless-security']['key-mgmt'] = orig_key_mgmt
 
         # WEP key management
@@ -239,7 +239,7 @@ class SecretAgentTestCase(unittest.TestCase):
             hints,
             allowed_interaction_flags
         )
-        self.assertEqual(result, {setting_name: {'wep-key0': secret_value}})
+        assert result == {setting_name: {'wep-key0': secret_value}}
         connection_hash['802-11-wireless-security']['key-mgmt'] = orig_key_mgmt
 
         # WPA-Enterprise
@@ -254,7 +254,7 @@ class SecretAgentTestCase(unittest.TestCase):
             hints,
             allowed_interaction_flags
         )
-        self.assertEqual(result, {setting_name: {'password': secret_value}})
+        assert result == {setting_name: {'password': secret_value}}
         connection_hash['802-11-wireless-security']['eap'] = ['tls']
         result = self.agent.GetSecrets(
             connection_hash,
@@ -263,6 +263,6 @@ class SecretAgentTestCase(unittest.TestCase):
             hints,
             allowed_interaction_flags
         )
-        self.assertEqual(result, {setting_name: {'private-key-password': secret_value}})
+        assert result == {setting_name: {'private-key-password': secret_value}}
         connection_hash['802-11-wireless-security'].pop('eap')
         connection_hash['802-11-wireless-security']['key-mgmt'] = orig_key_mgmt

--- a/tests/unit_tests/pyanaconda_tests/test_simpleconfig.py
+++ b/tests/unit_tests/pyanaconda_tests/test_simpleconfig.py
@@ -39,38 +39,38 @@ KEY2="A single ' inside" # And comment "with quotes"
 
             config = SimpleConfigFile(testconfig.name)
             config.read()
-            self.assertEqual(config.get("ESSID"), "Example Network #1")
-            self.assertEqual(config.get("ESSID2"), "Network #2")
-            self.assertEqual(config.get("COMMENT"), "Save this string")
-            self.assertEqual(str(config), self.TEST_CONFIG)
+            assert config.get("ESSID") == "Example Network #1"
+            assert config.get("ESSID2") == "Network #2"
+            assert config.get("COMMENT") == "Save this string"
+            assert str(config) == self.TEST_CONFIG
 
     def test_unquote(self):
-        self.assertEqual(simpleconfig.unquote("plain string"), "plain string")
-        self.assertEqual(simpleconfig.unquote('"double quote"'), "double quote")
-        self.assertEqual(simpleconfig.unquote("'single quote'"), "single quote")
+        assert simpleconfig.unquote("plain string") == "plain string"
+        assert simpleconfig.unquote('"double quote"') == "double quote"
+        assert simpleconfig.unquote("'single quote'") == "single quote"
 
     def test_quote(self):
-        self.assertEqual(simpleconfig.quote("nospaces"), "nospaces")
-        self.assertEqual(simpleconfig.quote("plain string"), '"plain string"')
-        self.assertEqual(simpleconfig.quote("alwaysquote", always=True), '"alwaysquote"')
+        assert simpleconfig.quote("nospaces") == "nospaces"
+        assert simpleconfig.quote("plain string") == '"plain string"'
+        assert simpleconfig.quote("alwaysquote", always=True) == '"alwaysquote"'
 
     def test_set_and_get(self):
         """Setting and getting values"""
         scf = SimpleConfigFile()
         scf.set(('key1', 'value1'))
-        self.assertEqual(scf.get('key1'), 'value1')
+        assert scf.get('key1') == 'value1'
         scf.set(('KEY2', 'value2'))
-        self.assertEqual(scf.get('key2'), 'value2')
+        assert scf.get('key2') == 'value2'
         scf.set(('KEY3', 'value3'))
-        self.assertEqual(scf.get('KEY3'), 'value3')
+        assert scf.get('KEY3') == 'value3'
         scf.set(('key4', 'value4'))
-        self.assertEqual(scf.get('KEY4'), 'value4')
+        assert scf.get('KEY4') == 'value4'
 
     def test_unset(self):
         scf = SimpleConfigFile()
         scf.set(('key1', 'value1'))
         scf.unset(('key1'))
-        self.assertEqual(scf.get('key1'), '')
+        assert scf.get('key1') == ''
 
     def test_write(self):
         with tempfile.NamedTemporaryFile(mode="wt") as testconfig:
@@ -78,7 +78,7 @@ KEY2="A single ' inside" # And comment "with quotes"
             scf.set(('key1', 'value1'))
             scf.write(testconfig.name)
             testconfig.flush()
-            self.assertEqual(open(testconfig.name).read(), 'KEY1=value1\n')
+            assert open(testconfig.name).read() == 'KEY1=value1\n'
 
     def test_read(self):
         with tempfile.NamedTemporaryFile(mode="wt") as testconfig:
@@ -86,7 +86,7 @@ KEY2="A single ' inside" # And comment "with quotes"
             open(testconfig.name, 'w').write('KEY1="value1"\n')
             testconfig.flush()
             scf.read(testconfig.name)
-            self.assertEqual(scf.get('key1'), 'value1')
+            assert scf.get('key1') == 'value1'
 
     def test_read_write(self):
         with tempfile.NamedTemporaryFile(mode="wt") as testconfig:
@@ -97,7 +97,7 @@ KEY2="A single ' inside" # And comment "with quotes"
             scf.read(testconfig.name)
             scf.write(testconfig.name)
             testconfig.flush()
-            self.assertEqual(open(testconfig.name).read(), self.TEST_CONFIG)
+            assert open(testconfig.name).read() == self.TEST_CONFIG
 
     def test_read_write__perms(self):
         with tempfile.NamedTemporaryFile(mode="wt") as testconfig:
@@ -114,7 +114,7 @@ KEY2="A single ' inside" # And comment "with quotes"
 
             # Write uses a tmpfile and renames it in place
             # Make sure the permissions are still 0764
-            self.assertEqual(os.stat(testconfig.name).st_mode, 0o100764)
+            assert os.stat(testconfig.name).st_mode == 0o100764
 
     def test_write_new_keys(self):
         with tempfile.NamedTemporaryFile(mode="wt") as testconfig:
@@ -127,8 +127,7 @@ KEY2="A single ' inside" # And comment "with quotes"
             scf.write(testconfig.name)
             testconfig.flush()
 
-            self.assertEqual(open(testconfig.name).read(),
-                             self.TEST_CONFIG+"KEY1=value1\n")
+            assert open(testconfig.name).read() == self.TEST_CONFIG+"KEY1=value1\n"
 
     def test_remove_key(self):
         with tempfile.NamedTemporaryFile(mode="wt") as testconfig:
@@ -137,13 +136,13 @@ KEY2="A single ' inside" # And comment "with quotes"
 
             scf = SimpleConfigFile()
             scf.read(testconfig.name)
-            self.assertEqual(scf.get("BOOT"), "always")
+            assert scf.get("BOOT") == "always"
             scf.unset("BOOT")
             scf.write(testconfig.name)
             testconfig.flush()
             scf.reset()
             scf.read(testconfig.name)
-            self.assertEqual(scf.get("BOOT"), "")
+            assert scf.get("BOOT") == ""
 
     def test_use_tmp(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as testconfig:
@@ -159,10 +158,10 @@ KEY2="A single ' inside" # And comment "with quotes"
             scf.write(testconfig.name, use_tmp=True)
 
             # Check the new contents
-            self.assertEqual(open(testconfig.name).read(), 'KEY1=value2\n')
+            assert open(testconfig.name).read() == 'KEY1=value2\n'
 
             # Check that the original file handle still points to the old contents
-            self.assertEqual(testconfig.read(), 'KEY1=value1\n')
+            assert testconfig.read() == 'KEY1=value1\n'
 
     def test_use_tmp_multifs(self):
         # Open a file on a non-default filesystem
@@ -179,10 +178,10 @@ KEY2="A single ' inside" # And comment "with quotes"
             scf.write(testconfig.name, use_tmp=True)
 
             # Check the new contents
-            self.assertEqual(open(testconfig.name).read(), 'KEY1=value2\n')
+            assert open(testconfig.name).read() == 'KEY1=value2\n'
 
             # Check that the original file handle still points to the old contents
-            self.assertEqual(testconfig.read(), 'KEY1=value1\n')
+            assert testconfig.read() == 'KEY1=value1\n'
 
     def test_no_use_tmp(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as testconfig:
@@ -198,7 +197,7 @@ KEY2="A single ' inside" # And comment "with quotes"
             scf.write(testconfig.name, use_tmp=False)
 
             # Check the new contents
-            self.assertEqual(open(testconfig.name).read(), 'KEY1=value2\n')
+            assert open(testconfig.name).read() == 'KEY1=value2\n'
 
             # Check that the original file handle points to the replaced contents
-            self.assertEqual(testconfig.read(), 'KEY1=value2\n')
+            assert testconfig.read() == 'KEY1=value2\n'

--- a/tests/unit_tests/pyanaconda_tests/test_subscription_helpers.py
+++ b/tests/unit_tests/pyanaconda_tests/test_subscription_helpers.py
@@ -55,11 +55,11 @@ class CheckSystemPurposeSetTestCase(unittest.TestCase):
             directory = os.path.split(syspurpose_path)[0]
             os.makedirs(util.join_paths(sysroot, directory))
             os.mknod(util.join_paths(sysroot, syspurpose_path))
-            self.assertTrue(check_system_purpose_set(sysroot))
+            assert check_system_purpose_set(sysroot)
 
         # system purpose not set
         with tempfile.TemporaryDirectory() as sysroot:
-            self.assertFalse(check_system_purpose_set(sysroot))
+            assert not check_system_purpose_set(sysroot)
 
 
 class AsynchronousRegistrationTestCase(unittest.TestCase):
@@ -164,7 +164,7 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         # simulate subscription request
         subscription_proxy.SubscriptionRequest = self.KEY_REQUEST
         # run the function
-        self.assertTrue(org_keys_sufficient())
+        assert org_keys_sufficient()
 
     @patch("pyanaconda.modules.common.constants.services.SUBSCRIPTION.get_proxy")
     def test_org_keys_sufficient_not_sufficient(self, get_proxy):
@@ -173,16 +173,16 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         # simulate subscription request
         subscription_proxy.SubscriptionRequest = self.KEY_MISSING_REQUEST
         # run the function
-        self.assertFalse(org_keys_sufficient())
+        assert not org_keys_sufficient()
 
     def test_org_keys_sufficient_direct_request(self):
         """Test the org_keys_sufficient() helper method - direct request."""
         # run the function with sufficient authentication data
         request = SubscriptionRequest.from_structure(self.KEY_REQUEST)
-        self.assertTrue(org_keys_sufficient(subscription_request=request))
+        assert org_keys_sufficient(subscription_request=request)
         # run the function with insufficient authentication data
         request = SubscriptionRequest.from_structure(self.KEY_MISSING_REQUEST)
-        self.assertFalse(org_keys_sufficient(subscription_request=request))
+        assert not org_keys_sufficient(subscription_request=request)
 
     @patch("pyanaconda.modules.common.constants.services.SUBSCRIPTION.get_proxy")
     def test_username_password_sufficient(self, get_proxy):
@@ -191,7 +191,7 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         # simulate subscription request
         subscription_proxy.SubscriptionRequest = self.PASSWORD_REQUEST
         # run the function
-        self.assertTrue(username_password_sufficient())
+        assert username_password_sufficient()
 
     @patch("pyanaconda.modules.common.constants.services.SUBSCRIPTION.get_proxy")
     def test_username_password_sufficient_not_sufficient(self, get_proxy):
@@ -200,16 +200,16 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         # simulate subscription request
         subscription_proxy.SubscriptionRequest = self.PASSWORD_MISSING_REQUEST
         # run the function
-        self.assertFalse(username_password_sufficient())
+        assert not username_password_sufficient()
 
     def test_username_password_sufficient_direct_request(self):
         """Test the username_password_sufficient() helper method - direct request."""
         # run the function with sufficient authentication data
         request = SubscriptionRequest.from_structure(self.PASSWORD_REQUEST)
-        self.assertTrue(username_password_sufficient(subscription_request=request))
+        assert username_password_sufficient(subscription_request=request)
         # run the function with insufficient authentication data
         request = SubscriptionRequest.from_structure(self.PASSWORD_MISSING_REQUEST)
-        self.assertFalse(username_password_sufficient(subscription_request=request))
+        assert not username_password_sufficient(subscription_request=request)
 
     @patch("pyanaconda.ui.lib.subscription.switch_source")
     @patch("pyanaconda.modules.common.task.sync_run_task")
@@ -793,17 +793,17 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         dnf_payload.type = PAYLOAD_TYPE_DNF
         source_proxy = dnf_payload.get_source_proxy.return_value
         source_proxy.Type = SOURCE_TYPE_CDN
-        self.assertTrue(check_cdn_is_installation_source(dnf_payload))
+        assert check_cdn_is_installation_source(dnf_payload)
         # check CDN is not reported as used
         dnf_payload = Mock()
         dnf_payload.type = PAYLOAD_TYPE_DNF
         source_proxy = dnf_payload.get_source_proxy.return_value
         source_proxy.Type = SOURCE_TYPE_CDROM
-        self.assertFalse(check_cdn_is_installation_source(dnf_payload))
+        assert not check_cdn_is_installation_source(dnf_payload)
         # check an unsupported (non DNF) source is handled correctly
         ostree_payload = Mock()
         ostree_payload.type = PAYLOAD_TYPE_RPM_OSTREE
-        self.assertFalse(check_cdn_is_installation_source(ostree_payload))
+        assert not check_cdn_is_installation_source(ostree_payload)
 
     @patch_dbus_get_proxy_with_cache
     def test_is_cdn_registration_required(self, proxy_getter):
@@ -820,16 +820,16 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         subscription_proxy = SUBSCRIPTION.get_proxy()
         subscription_proxy.IsSubscriptionAttached = False
 
-        self.assertEqual(is_cdn_registration_required(dnf_payload), True)
+        assert is_cdn_registration_required(dnf_payload) == True
 
         subscription_proxy.IsSubscriptionAttached = True
-        self.assertEqual(is_cdn_registration_required(dnf_payload), False)
+        assert is_cdn_registration_required(dnf_payload) == False
 
         boss_proxy.GetModules.return_value = []
-        self.assertEqual(is_cdn_registration_required(dnf_payload), False)
+        assert is_cdn_registration_required(dnf_payload) == False
 
         source_proxy.Type = SOURCE_TYPE_CDROM
-        self.assertEqual(is_cdn_registration_required(dnf_payload), False)
+        assert is_cdn_registration_required(dnf_payload) == False
 
     @patch("pyanaconda.ui.lib.subscription.switch_source")
     @patch("pyanaconda.modules.common.task.sync_run_task")

--- a/tests/unit_tests/pyanaconda_tests/test_timezone.py
+++ b/tests/unit_tests/pyanaconda_tests/test_timezone.py
@@ -28,17 +28,17 @@ class TimezonesListings(unittest.TestCase):
     def test_string_timezones(self):
         """Check if returned timezones are plain strings, not unicode objects."""
         for (region, zones) in timezone.get_all_regions_and_timezones().items():
-            self.assertIsInstance(region, str)
+            assert isinstance(region, str)
 
             for zone in zones:
-                self.assertIsInstance(zone, str)
+                assert isinstance(zone, str)
 
     def test_all_timezones_valid(self):
         """Check if all returned timezones are considered valid timezones."""
 
         for (region, zones) in timezone.get_all_regions_and_timezones().items():
             for zone in zones:
-                self.assertTrue(timezone.is_valid_timezone(region + "/" + zone))
+                assert timezone.is_valid_timezone(region + "/" + zone)
 
 
 class TerritoryTimezones(unittest.TestCase):
@@ -46,12 +46,12 @@ class TerritoryTimezones(unittest.TestCase):
         """Check if the returned value is string for a valid territory."""
 
         zone = timezone.get_preferred_timezone("CZ")
-        self.assertIsInstance(zone, str)
+        assert isinstance(zone, str)
 
     def test_invalid_territory_zones(self):
         """Check if None is return for an invalid territory."""
 
-        self.assertIsNone(timezone.get_preferred_timezone("nonexistent"))
+        assert timezone.get_preferred_timezone("nonexistent") is None
 
 
 class s390HWclock(unittest.TestCase):
@@ -61,14 +61,14 @@ class s390HWclock(unittest.TestCase):
     def test_s390_save_hw_clock(self, exec_mock, s390_mock):
         """Check that save_hw_clock does nothing on s390."""
         timezone.save_hw_clock(Mock())
-        self.assertFalse(exec_mock.called)
+        assert not exec_mock.called
 
     @patch('pyanaconda.timezone.arch.is_s390', return_value=True)
     @patch('pyanaconda.timezone.util.execWithRedirect')
     def test_s390_time_initialize(self, exec_mock, s390_mock):
         """Check that time_initialize doesn't call hwclock on s390."""
         timezone.time_initialize(Mock())
-        self.assertFalse(exec_mock.called)
+        assert not exec_mock.called
 
 
 class SystemTime(unittest.TestCase):

--- a/tests/unit_tests/pyanaconda_tests/ui/test_common_code.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_common_code.py
@@ -68,4 +68,4 @@ class CommonCodeTestCase(unittest.TestCase):
         # then A & B as they have the same sort order but A comes before B
         # on the alphabet.
         expected_category_list = [CccCategory, AaaCategory, BbbCategory]
-        self.assertEqual(sort_categories(category_list), expected_category_list)
+        assert sort_categories(category_list) == expected_category_list

--- a/tests/unit_tests/pyanaconda_tests/ui/test_simple_ui.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_simple_ui.py
@@ -100,7 +100,7 @@ class SimpleUITestCase(unittest.TestCase):
 
             if priority in res:
                 msg = "Spokes {} and {} have the same priority!".format(res[priority], name)
-                self.assertNotIn(priority, res, msg)
+                assert priority not in res, msg
             res[priority] = name
 
     @patch_dbus_get_proxy
@@ -111,18 +111,18 @@ class SimpleUITestCase(unittest.TestCase):
 
         # Check the hubs
         from pyanaconda.ui.tui.hubs.summary import SummaryHub
-        self.assertEqual(self.hubs, [SummaryHub])
+        assert self.hubs == [SummaryHub]
 
         # Check the actions classes.
-        self.assertEqual(self._get_action_class_names(), [
+        assert self._get_action_class_names() == [
             "UnsupportedHardwareSpoke",
             "KernelWarningSpoke",
             "SummaryHub",
             "ProgressSpoke"
-        ])
+        ]
 
         # Check the Summary hub.
-        self.assertEqual(self._get_category_names(SummaryHub), {
+        assert self._get_category_names(SummaryHub) == {
             'CustomizationCategory': [],
             'LocalizationCategory': [
                 'LangSpoke',
@@ -141,7 +141,7 @@ class SimpleUITestCase(unittest.TestCase):
                 'PasswordSpoke',
                 'UserSpoke'
             ]
-        })
+        }
 
         # Force us to always decide order of standalone spokes based on priority not by name.
         # This will ordering errors easier to spot.
@@ -159,15 +159,15 @@ class SimpleUITestCase(unittest.TestCase):
 
         # Check the hubs.
         from pyanaconda.ui.gui.hubs.summary import SummaryHub
-        self.assertEqual(self.hubs, [SummaryHub])
+        assert self.hubs == [SummaryHub]
 
         # Check the actions classes.
-        self.assertEqual(self._get_action_class_names(), [
+        assert self._get_action_class_names() == [
             'WelcomeLanguageSpoke',
             'NetworkStandaloneSpoke',
             'SummaryHub',
             'ProgressSpoke'
-        ])
+        ]
 
         # Check the Summary hub.
         cat_system = [
@@ -180,7 +180,7 @@ class SimpleUITestCase(unittest.TestCase):
         if not HAVE_BLIVET_GUI:
             cat_system.remove('BlivetGuiSpoke')
 
-        self.assertEqual(self._get_category_names(SummaryHub), {
+        assert self._get_category_names(SummaryHub) == {
             'CustomizationCategory': [],
             'LocalizationCategory': [
                 'DatetimeSpoke',
@@ -197,7 +197,6 @@ class SimpleUITestCase(unittest.TestCase):
                 'PasswordSpoke',
                 'UserSpoke'
             ]}
-        )
 
         # Force us to always decide order of standalone spokes based on priority not by name.
         # This will ordering errors easier to spot.
@@ -225,5 +224,5 @@ class SimpleUITestCase(unittest.TestCase):
         list1 = [SpokeC, SpokeB, SpokeE, SpokeD, SpokeA]
 
         # the input list ordering shouldn't matter sorting should be based on class names
-        self.assertEqual([SpokeA, SpokeB, SpokeC, hub, SpokeD, SpokeE],
-                         UserInterface._orderActionClasses(list1, [hub]))
+        assert [SpokeA, SpokeB, SpokeC, hub, SpokeD, SpokeE] == \
+            UserInterface._orderActionClasses(list1, [hub])

--- a/tests/unit_tests/pyanaconda_tests/ui/test_software.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_software.py
@@ -38,18 +38,18 @@ class SoftwareSelectionUITestCase(unittest.TestCase):
         dnf_manager = Mock(spec=DNFManager)
         dnf_manager.is_environment_valid.return_value = True
 
-        self.assertTrue(is_software_selection_complete(dnf_manager, selection))
-        self.assertTrue(is_software_selection_complete(dnf_manager, selection, kickstarted=True))
+        assert is_software_selection_complete(dnf_manager, selection)
+        assert is_software_selection_complete(dnf_manager, selection, kickstarted=True)
 
         dnf_manager.is_environment_valid.return_value = False
 
-        self.assertFalse(is_software_selection_complete(dnf_manager, selection))
-        self.assertFalse(is_software_selection_complete(dnf_manager, selection, kickstarted=True))
+        assert not is_software_selection_complete(dnf_manager, selection)
+        assert not is_software_selection_complete(dnf_manager, selection, kickstarted=True)
 
         selection.environment = ""
 
-        self.assertFalse(is_software_selection_complete(dnf_manager, selection))
-        self.assertTrue(is_software_selection_complete(dnf_manager, selection, kickstarted=True))
+        assert not is_software_selection_complete(dnf_manager, selection)
+        assert is_software_selection_complete(dnf_manager, selection, kickstarted=True)
 
     def test_get_software_selection_status(self):
         """Test the get_software_selection_status function."""
@@ -64,26 +64,26 @@ class SoftwareSelectionUITestCase(unittest.TestCase):
         dnf_manager.get_environment_data.return_value = environment_data
 
         status = get_software_selection_status(dnf_manager, selection)
-        self.assertEqual(status, "The e1 environment")
+        assert status == "The e1 environment"
 
         status = get_software_selection_status(dnf_manager, selection, kickstarted=True)
-        self.assertEqual(status, "The e1 environment")
+        assert status == "The e1 environment"
 
         dnf_manager.is_environment_valid.return_value = False
 
         status = get_software_selection_status(dnf_manager, selection)
-        self.assertEqual(status, "Selected environment is not valid")
+        assert status == "Selected environment is not valid"
 
         status = get_software_selection_status(dnf_manager, selection, kickstarted=True)
-        self.assertEqual(status, "Invalid environment specified in kickstart")
+        assert status == "Invalid environment specified in kickstart"
 
         selection.environment = ""
 
         status = get_software_selection_status(dnf_manager, selection)
-        self.assertEqual(status, "Please confirm software selection")
+        assert status == "Please confirm software selection"
 
         status = get_software_selection_status(dnf_manager, selection, kickstarted=True)
-        self.assertEqual(status, "Custom software selected")
+        assert status == "Custom software selected"
 
 
 class SoftwareSelectionCacheTestCase(unittest.TestCase):
@@ -114,67 +114,67 @@ class SoftwareSelectionCacheTestCase(unittest.TestCase):
     def test_available_environments(self):
         """Test the available_environments property."""
         self.dnf_manager.environments = []
-        self.assertEqual(self.cache.available_environments, [])
+        assert self.cache.available_environments == []
 
         self.dnf_manager.environments = ["e1", "e2"]
-        self.assertEqual(self.cache.available_environments, ["e1", "e2"])
+        assert self.cache.available_environments == ["e1", "e2"]
 
     def test_is_environment_selected(self):
         """Test the is_environment_selected method."""
-        self.assertEqual(self.cache.is_environment_selected("e1"), False)
+        assert self.cache.is_environment_selected("e1") == False
 
         self.cache.select_environment("e1")
-        self.assertEqual(self.cache.is_environment_selected("e1"), True)
+        assert self.cache.is_environment_selected("e1") == True
 
         self.cache.select_environment("")
-        self.assertEqual(self.cache.is_environment_selected("e1"), False)
+        assert self.cache.is_environment_selected("e1") == False
 
     def test_environment(self):
         """Test the environment property."""
-        self.assertEqual(self.cache.environment, "")
+        assert self.cache.environment == ""
 
         self.cache.select_environment("e1")
-        self.assertEqual(self.cache.environment, "e1")
+        assert self.cache.environment == "e1"
 
     def test_available_groups(self):
         """Test the available_groups property."""
         self.cache.select_environment("e1")
-        self.assertEqual(self.cache.available_groups, ["g1", "g2", "g3", "g4", "g5"])
+        assert self.cache.available_groups == ["g1", "g2", "g3", "g4", "g5"]
 
         self.cache.select_environment("")
-        self.assertEqual(self.cache.available_groups, [])
+        assert self.cache.available_groups == []
 
     def test_groups(self):
         """Test the groups property."""
         self.environment_data.default_groups = ["g2", "g4"]
 
         self.cache.select_environment("e1")
-        self.assertEqual(self.cache.groups, ["g2", "g4"])
+        assert self.cache.groups == ["g2", "g4"]
 
         self.cache.select_group("g1")
-        self.assertEqual(self.cache.groups, ["g1", "g2", "g4"])
+        assert self.cache.groups == ["g1", "g2", "g4"]
 
         self.cache.deselect_group("g4")
-        self.assertEqual(self.cache.groups, ["g1", "g2"])
+        assert self.cache.groups == ["g1", "g2"]
 
     def test_is_group_selected(self):
         """Test the is_group_selected method."""
         self.environment_data.default_groups = ["g2", "g4"]
 
         self.cache.select_environment("e1")
-        self.assertEqual(self.cache.is_group_selected("g1"), False)
-        self.assertEqual(self.cache.is_group_selected("g4"), True)
-        self.assertEqual(self.cache.is_group_selected("g7"), False)
+        assert self.cache.is_group_selected("g1") == False
+        assert self.cache.is_group_selected("g4") == True
+        assert self.cache.is_group_selected("g7") == False
 
         self.cache.select_group("g1")
-        self.assertEqual(self.cache.is_group_selected("g1"), True)
-        self.assertEqual(self.cache.is_group_selected("g4"), True)
-        self.assertEqual(self.cache.is_group_selected("g7"), False)
+        assert self.cache.is_group_selected("g1") == True
+        assert self.cache.is_group_selected("g4") == True
+        assert self.cache.is_group_selected("g7") == False
 
         self.cache.deselect_group("g4")
-        self.assertEqual(self.cache.is_group_selected("g1"), True)
-        self.assertEqual(self.cache.is_group_selected("g4"), False)
-        self.assertEqual(self.cache.is_group_selected("g7"), False)
+        assert self.cache.is_group_selected("g1") == True
+        assert self.cache.is_group_selected("g4") == False
+        assert self.cache.is_group_selected("g7") == False
 
     def test_apply_selection_data(self):
         """Test the apply_selection_data method."""
@@ -183,8 +183,8 @@ class SoftwareSelectionCacheTestCase(unittest.TestCase):
         selection.groups = ["g1", "g2", "g3"]
 
         self.cache.apply_selection_data(selection)
-        self.assertEqual(self.cache.environment, "e1")
-        self.assertEqual(self.cache.groups, ["g1", "g2", "g3"])
+        assert self.cache.environment == "e1"
+        assert self.cache.groups == ["g1", "g2", "g3"]
 
     def test_apply_selection_data_default_environment(self):
         """Test the apply_selection_data method with a default environment."""
@@ -195,8 +195,8 @@ class SoftwareSelectionCacheTestCase(unittest.TestCase):
         selection.environment = "e2"
 
         self.cache.apply_selection_data(selection)
-        self.assertEqual(self.cache.environment, "e1")
-        self.assertEqual(self.cache.groups, [])
+        assert self.cache.environment == "e1"
+        assert self.cache.groups == []
 
     def test_apply_selection_data_invalid_environment(self):
         """Test the apply_selection_data method with an invalid environment."""
@@ -207,8 +207,8 @@ class SoftwareSelectionCacheTestCase(unittest.TestCase):
         selection.environment = "e2"
 
         self.cache.apply_selection_data(selection)
-        self.assertEqual(self.cache.environment, "")
-        self.assertEqual(self.cache.groups, [])
+        assert self.cache.environment == ""
+        assert self.cache.groups == []
 
     def test_apply_selection_data_invalid_groups(self):
         """Test the apply_selection_data method with invalid groups."""
@@ -219,8 +219,8 @@ class SoftwareSelectionCacheTestCase(unittest.TestCase):
         selection.groups = ["g1", "g2", "g3"]
 
         self.cache.apply_selection_data(selection)
-        self.assertEqual(self.cache.environment, "e1")
-        self.assertEqual(self.cache.groups, [])
+        assert self.cache.environment == "e1"
+        assert self.cache.groups == []
 
     def test_get_selection_data(self):
         """Test the get_selection_data method."""
@@ -234,7 +234,7 @@ class SoftwareSelectionCacheTestCase(unittest.TestCase):
         expected.groups = ["g1", "g2", "g3"]
 
         data = self.cache.get_selection_data()
-        self.assertTrue(compare_data(data, expected))
+        assert compare_data(data, expected)
 
     def test_default_selection(self):
         """Test the default environment and group selection."""
@@ -242,38 +242,38 @@ class SoftwareSelectionCacheTestCase(unittest.TestCase):
         self.environment_data.default_groups = ["g2", "g4"]
 
         self.cache.select_environment("e1")
-        self.assertEqual(self.cache.groups, ["g2", "g4"])
+        assert self.cache.groups == ["g2", "g4"]
 
         self.cache.select_group("g2")
-        self.assertEqual(self.cache.groups, ["g2", "g4"])
+        assert self.cache.groups == ["g2", "g4"]
 
         self.cache.select_group("g4")
-        self.assertEqual(self.cache.groups, ["g2", "g4"])
+        assert self.cache.groups == ["g2", "g4"]
 
         self.environment_data.id = "e2"
         self.environment_data.default_groups = ["g1", "g3", "g5"]
 
         self.cache.select_environment("e2")
-        self.assertEqual(self.cache.groups, ["g1", "g3", "g5"])
+        assert self.cache.groups == ["g1", "g3", "g5"]
 
     def test_selection(self):
         """Test the environment and group selection."""
         self.environment_data.id = "e1"
 
         self.cache.select_environment("e1")
-        self.assertEqual(self.cache.groups, [])
+        assert self.cache.groups == []
 
         self.cache.select_group("g2")
-        self.assertEqual(self.cache.groups, ["g2"])
+        assert self.cache.groups == ["g2"]
 
         self.cache.select_group("g4")
-        self.assertEqual(self.cache.groups, ["g2", "g4"])
+        assert self.cache.groups == ["g2", "g4"]
 
         self.environment_data.id = "e2"
         self.environment_data.default_groups = ["g1", "g3", "g5"]
 
         self.cache.select_environment("e2")
-        self.assertEqual(self.cache.groups, ["g1", "g2", "g3", "g4", "g5"])
+        assert self.cache.groups == ["g1", "g2", "g3", "g4", "g5"]
 
     def test_deselection(self):
         """Test the environment and group deselection."""
@@ -281,22 +281,22 @@ class SoftwareSelectionCacheTestCase(unittest.TestCase):
         self.environment_data.default_groups = ["g2", "g4"]
 
         self.cache.select_environment("e1")
-        self.assertEqual(self.cache.groups, ["g2", "g4"])
+        assert self.cache.groups == ["g2", "g4"]
 
         self.cache.select_group("g1")
-        self.assertEqual(self.cache.groups, ["g1", "g2", "g4"])
+        assert self.cache.groups == ["g1", "g2", "g4"]
 
         self.cache.deselect_group("g4")
-        self.assertEqual(self.cache.groups, ["g1", "g2"])
+        assert self.cache.groups == ["g1", "g2"]
 
         self.cache.select_group("g5")
-        self.assertEqual(self.cache.groups, ["g1", "g2", "g5"])
+        assert self.cache.groups == ["g1", "g2", "g5"]
 
         self.cache.deselect_group("g5")
-        self.assertEqual(self.cache.groups, ["g1", "g2"])
+        assert self.cache.groups == ["g1", "g2"]
 
         self.environment_data.id = "e2"
         self.environment_data.default_groups = ["g2", "g3", "g4", "g5"]
 
         self.cache.select_environment("e2")
-        self.assertEqual(self.cache.groups, ["g1", "g2", "g3"])
+        assert self.cache.groups == ["g1", "g2", "g3"]

--- a/tests/unit_tests/pyanaconda_tests/ui/test_subscription_spoke.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_subscription_spoke.py
@@ -34,17 +34,17 @@ class SubscriptionSpokeHelpersTestCase(unittest.TestCase):
                            ("Standard", "Standard", True),
                            ("Premium", "Premium", False)]
         output = handle_user_provided_value("Standard", valid_values)
-        self.assertEqual(output, expected_output)
+        assert output == expected_output
         # user provided value does not match one of the valid values
         expected_output = [("Self Support", "Self Support", False),
                            ("Standard", "Standard", False),
                            ("Premium", "Premium", False),
                            ("Custom", "Other (Custom)", True)]
         output = handle_user_provided_value("Custom", valid_values)
-        self.assertEqual(output, expected_output)
+        assert output == expected_output
         # user provided empty string
         expected_output = [("Self Support", "Self Support", False),
                            ("Standard", "Standard", False),
                            ("Premium", "Premium", False)]
         output = handle_user_provided_value("", valid_values)
-        self.assertEqual(output, expected_output)
+        assert output == expected_output

--- a/tests/unit_tests/pyanaconda_tests/ui/test_ui_custom_spoke.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_ui_custom_spoke.py
@@ -66,10 +66,10 @@ class CustomStorageHelpersTestCase(unittest.TestCase):
         }
         """).strip()
 
-        self.assertEqual(generate_request_description(request), expected)
+        assert generate_request_description(request) == expected
 
         original = copy.deepcopy(request)
-        self.assertEqual(generate_request_description(request, original), expected)
+        assert generate_request_description(request, original) == expected
 
         request.device_name = "dev4"
         request.disks = ["dev1"]
@@ -97,4 +97,4 @@ class CustomStorageHelpersTestCase(unittest.TestCase):
         }
         """).strip()
 
-        self.assertEqual(generate_request_description(request, original), expected)
+        assert generate_request_description(request, original) == expected

--- a/tests/unit_tests/pyanaconda_tests/ui/test_ui_payload.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_ui_payload.py
@@ -16,6 +16,8 @@
 # Red Hat, Inc.
 #
 import unittest
+import pytest
+
 from unittest.mock import patch
 
 from pyanaconda.core.constants import PAYLOAD_TYPE_LIVE_OS, PAYLOAD_TYPE_DNF, SOURCE_TYPE_CDROM
@@ -37,7 +39,7 @@ class PayloadUITestCase(unittest.TestCase):
         payload_proxy = PAYLOADS.get_proxy("/my/path")
         payload_proxy.Type = PAYLOAD_TYPE_LIVE_OS
 
-        self.assertEqual(create_payload(PAYLOAD_TYPE_LIVE_OS), payload_proxy)
+        assert create_payload(PAYLOAD_TYPE_LIVE_OS) == payload_proxy
         payloads_proxy.CreatePayload.assert_called_once_with(PAYLOAD_TYPE_LIVE_OS)
         payloads_proxy.ActivatePayload.assert_called_once_with("/my/path")
 
@@ -55,12 +57,12 @@ class PayloadUITestCase(unittest.TestCase):
         payload_proxy_2.Type = PAYLOAD_TYPE_DNF
 
         # Get the active payload.
-        self.assertEqual(get_payload(PAYLOAD_TYPE_LIVE_OS), payload_proxy_1)
-        self.assertEqual(get_payload(PAYLOAD_TYPE_LIVE_OS), payload_proxy_1)
+        assert get_payload(PAYLOAD_TYPE_LIVE_OS) == payload_proxy_1
+        assert get_payload(PAYLOAD_TYPE_LIVE_OS) == payload_proxy_1
         payloads_proxy.ActivatePayload.assert_not_called()
 
         # Or create a new one.
-        self.assertEqual(get_payload(PAYLOAD_TYPE_DNF), payload_proxy_2)
+        assert get_payload(PAYLOAD_TYPE_DNF) == payload_proxy_2
         payloads_proxy.ActivatePayload.assert_called_once_with("/my/path2")
 
     @patch_dbus_get_proxy_with_cache
@@ -72,7 +74,7 @@ class PayloadUITestCase(unittest.TestCase):
         source_proxy = PAYLOADS.get_proxy("/my/source")
         source_proxy.Type = SOURCE_TYPE_CDROM
 
-        self.assertEqual(create_source(SOURCE_TYPE_CDROM), source_proxy)
+        assert create_source(SOURCE_TYPE_CDROM) == source_proxy
         payloads_proxy.CreateSource.assert_called_once_with(SOURCE_TYPE_CDROM)
 
     @patch("pyanaconda.ui.lib.payload.get_object_path")
@@ -95,13 +97,14 @@ class PayloadUITestCase(unittest.TestCase):
         source_proxy_1 = PAYLOADS.get_proxy("/my/source/1")
 
         payload_proxy.Sources = ["/my/source/1", "/my/source/2", "/my/source/3"]
-        self.assertEqual(get_source(payload_proxy), source_proxy_1)
+        assert get_source(payload_proxy) == source_proxy_1
 
         payload_proxy.Sources = ["/my/source/1"]
-        self.assertEqual(get_source(payload_proxy), source_proxy_1)
+        assert get_source(payload_proxy) == source_proxy_1
 
         payload_proxy.Sources = []
-        self.assertRaises(ValueError, get_source, payload_proxy)
+        with pytest.raises(ValueError):
+            get_source(payload_proxy)
 
         payloads_proxy = PAYLOADS.get_proxy()
         payloads_proxy.CreateSource.return_value = "/my/source/4"
@@ -110,7 +113,7 @@ class PayloadUITestCase(unittest.TestCase):
         get_object_path.return_value = "/my/source/4"
 
         payload_proxy.Sources = []
-        self.assertEqual(get_source(payload_proxy, SOURCE_TYPE_CDROM), source_proxy_4)
+        assert get_source(payload_proxy, SOURCE_TYPE_CDROM) == source_proxy_4
         payloads_proxy.CreateSource.assert_called_once_with(SOURCE_TYPE_CDROM)
         payload_proxy.SetSources.assert_called_once_with(["/my/source/4"])
 

--- a/tests/unit_tests/regex_tests/test_dasd_name.py
+++ b/tests/unit_tests/regex_tests/test_dasd_name.py
@@ -57,4 +57,4 @@ class DASDNameRegexTestCase(unittest.TestCase):
                 '',
                 ]
 
-        self.assertTrue(regex_match(DASD_DEVICE_NUMBER, good_tests, bad_tests))
+        assert regex_match(DASD_DEVICE_NUMBER, good_tests, bad_tests)

--- a/tests/unit_tests/regex_tests/test_groupparse.py
+++ b/tests/unit_tests/regex_tests/test_groupparse.py
@@ -48,4 +48,4 @@ class GroupParseTestCase(unittest.TestCase):
                  ("", ("", None)),
                  ]
 
-        self.assertTrue(regex_group(GROUPLIST_FANCY_PARSE, tests))
+        assert regex_group(GROUPLIST_FANCY_PARSE, tests)

--- a/tests/unit_tests/regex_tests/test_hostname.py
+++ b/tests/unit_tests/regex_tests/test_hostname.py
@@ -80,7 +80,7 @@ class IPv4RegexTestCase(unittest.TestCase):
                 ]
 
         ipv4_re = re.compile('^(' + IPV4_PATTERN_WITHOUT_ANCHORS + ')$')
-        self.assertTrue(regex_match(ipv4_re, good_tests, bad_tests))
+        assert regex_match(ipv4_re, good_tests, bad_tests)
 
 
 class IPv6RegexTestCase(unittest.TestCase):
@@ -169,4 +169,4 @@ class IPv6RegexTestCase(unittest.TestCase):
                 ]
 
         ipv6_re = re.compile('^(' + IPV6_PATTERN_WITHOUT_ANCHORS + ')$')
-        self.assertTrue(regex_match(ipv6_re, good_tests, bad_tests))
+        assert regex_match(ipv6_re, good_tests, bad_tests)

--- a/tests/unit_tests/regex_tests/test_initamfs_con_name.py
+++ b/tests/unit_tests/regex_tests/test_initamfs_con_name.py
@@ -42,4 +42,4 @@ class NMMacInitramfsConnectionTestCase(unittest.TestCase):
             '80:00:02:00:fe:80:00:00:00:00:00:00:f4:52:14:03:00:7b:cb:a3',
         ]
 
-        self.assertTrue(regex_match(NM_MAC_INITRAMFS_CONNECTION, good_tests, bad_tests))
+        assert regex_match(NM_MAC_INITRAMFS_CONNECTION, good_tests, bad_tests)

--- a/tests/unit_tests/regex_tests/test_iscsi_name.py
+++ b/tests/unit_tests/regex_tests/test_iscsi_name.py
@@ -51,7 +51,7 @@ class iSCSIiqnnameRegexTestCase(unittest.TestCase):
                 'iqn.2014-15.com.example:iscsi no space allowed',
                 ]
 
-        self.assertTrue(regex_match(ISCSI_IQN_NAME_REGEX, good_tests, bad_tests))
+        assert regex_match(ISCSI_IQN_NAME_REGEX, good_tests, bad_tests)
 
 
 class iSCSIeuinameRegexTestCase(unittest.TestCase):
@@ -71,4 +71,4 @@ class iSCSIeuinameRegexTestCase(unittest.TestCase):
                 'eui.AAAABBBBCCCCD4567'
                 ]
 
-        self.assertTrue(regex_match(ISCSI_EUI_NAME_REGEX, good_tests, bad_tests))
+        assert regex_match(ISCSI_EUI_NAME_REGEX, good_tests, bad_tests)

--- a/tests/unit_tests/regex_tests/test_repo_name.py
+++ b/tests/unit_tests/regex_tests/test_repo_name.py
@@ -43,4 +43,4 @@ class RepoNameTestCase(unittest.TestCase):
                 '[reponame]'
                 ]
 
-        self.assertTrue(regex_match(REPO_NAME_VALID, good_tests, bad_tests))
+        assert regex_match(REPO_NAME_VALID, good_tests, bad_tests)

--- a/tests/unit_tests/regex_tests/test_url.py
+++ b/tests/unit_tests/regex_tests/test_url.py
@@ -389,4 +389,4 @@ class URLRegexTestCase(unittest.TestCase):
                   ( "http://fe80::1234:56:78/blah/blah", None)
                 ]
 
-        self.assertTrue(regex_group(URL_PARSE, tests))
+        assert regex_group(URL_PARSE, tests)

--- a/tests/unit_tests/regex_tests/test_username.py
+++ b/tests/unit_tests/regex_tests/test_username.py
@@ -39,7 +39,7 @@ class UsernameRegexTestCase(unittest.TestCase):
         # These are invalid full names
         bad_tests = ['George:Burdell']
 
-        self.assertTrue(regex_match(GECOS_VALID, good_tests, bad_tests))
+        assert regex_match(GECOS_VALID, good_tests, bad_tests)
 
     def test_username(self):
         """Test a list of possible username values."""
@@ -74,7 +74,7 @@ class UsernameRegexTestCase(unittest.TestCase):
                 ]
 
         # The group name checks for the same thing as the user name
-        self.assertTrue(regex_match(NAME_VALID, good_tests, bad_tests))
+        assert regex_match(NAME_VALID, good_tests, bad_tests)
 
     def test_grouplist_simple(self):
         good_tests = [
@@ -106,4 +106,4 @@ class UsernameRegexTestCase(unittest.TestCase):
                 'gburdell, wheel,'
                 ]
 
-        self.assertTrue(regex_match(GROUPLIST_SIMPLE_VALID, good_tests, bad_tests))
+        assert regex_match(GROUPLIST_SIMPLE_VALID, good_tests, bad_tests)

--- a/tests/unit_tests/regex_tests/test_zfcp_name.py
+++ b/tests/unit_tests/regex_tests/test_zfcp_name.py
@@ -51,7 +51,7 @@ class ZFCPNameRegexTestCase(unittest.TestCase):
                 '',
                 ]
 
-        self.assertTrue(regex_match(ZFCP_LUN_NUMBER, good_tests, bad_tests))
+        assert regex_match(ZFCP_LUN_NUMBER, good_tests, bad_tests)
 
     def test_wwpn_name(self):
         good_tests = [
@@ -80,4 +80,4 @@ class ZFCPNameRegexTestCase(unittest.TestCase):
             '',
         ]
 
-        self.assertTrue(regex_match(ZFCP_WWPN_NUMBER, good_tests, bad_tests))
+        assert regex_match(ZFCP_WWPN_NUMBER, good_tests, bad_tests)


### PR DESCRIPTION
Running our tests with pytest was pretty easy at the end. And when I was doing that I also executed script to migrate assert statements which discovered a few issues in how we used asserts and even tests which did not worked as expected.

The `assert` statement is really much more readable and easier to spot errors compared to functions.

During the transition I did:
- Switch to `pytest`.
- Change assertSomething methods to the `assert` call.
- Fix broken tests spot thanks to the migration.
- Remove test classes in our helper functions which are not required anymore.

Example output from our tests:

```
$ cat test-logs/unit_tests.log
============================= test session starts ==============================
platform linux -- Python 3.10.0b4, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /tmp/anaconda/tests
collected 1738 items

unit_tests/dd_tests/test_dd.py .................                         [  0%]
unit_tests/dracut_tests/test_dracut_source.py .                          [  1%]
unit_tests/dracut_tests/test_driver_updates.py ......................... [  2%]
............................                                             [  4%]
unit_tests/dracut_tests/test_parse_kickstart.py .......................  [  5%]
unit_tests/pyanaconda_tests/test_argparse.py .........                   [  5%]
unit_tests/pyanaconda_tests/test_controller.py ..                        [  6%]
unit_tests/pyanaconda_tests/test_installation_tasks.py ........          [  6%]
unit_tests/pyanaconda_tests/test_keyboard.py ....                        [  6%]
unit_tests/pyanaconda_tests/test_kickstart_specification.py ............ [  7%]
....                                                                     [  7%]
unit_tests/pyanaconda_tests/test_ks_version.py ...                       [  7%]
unit_tests/pyanaconda_tests/test_localization.py ......................  [  9%]
unit_tests/pyanaconda_tests/test_network.py ....                         [  9%]
unit_tests/pyanaconda_tests/test_password_quality.py ....                [  9%]
unit_tests/pyanaconda_tests/test_payload.py ....                         [  9%]
unit_tests/pyanaconda_tests/test_payload_source.py ...............       [ 10%]
unit_tests/pyanaconda_tests/test_product.py .                            [ 10%]
unit_tests/pyanaconda_tests/test_secret_agent.py ....                    [ 10%]
unit_tests/pyanaconda_tests/test_simple_import.py .                      [ 10%]
unit_tests/pyanaconda_tests/test_simpleconfig.py ..............          [ 11%]
unit_tests/pyanaconda_tests/test_subscription_helpers.py ............... [ 12%]
.................                                                        [ 13%]
unit_tests/pyanaconda_tests/test_timezone.py .........                   [ 14%]
unit_tests/pyanaconda_tests/core/test_configuration.py ................. [ 15%]
..............                                                           [ 15%]
unit_tests/pyanaconda_tests/core/test_dbus.py ..                         [ 16%]
unit_tests/pyanaconda_tests/core/test_kernel.py ......                   [ 16%]
unit_tests/pyanaconda_tests/core/test_profile.py ...........             [ 17%]
unit_tests/pyanaconda_tests/core/test_signal.py .....                    [ 17%]
unit_tests/pyanaconda_tests/core/test_startup_utils.py ..                [ 17%]
unit_tests/pyanaconda_tests/core/test_user.py ......................     [ 18%]
unit_tests/pyanaconda_tests/core/test_user_create.py ................... [ 19%]
                                                                         [ 19%]
unit_tests/pyanaconda_tests/core/test_util.py .......................... [ 21%]
..................                                                       [ 22%]
unit_tests/pyanaconda_tests/modules/boss/test_boss.py ..........         [ 22%]
unit_tests/pyanaconda_tests/modules/boss/test_install.py .....           [ 23%]
unit_tests/pyanaconda_tests/modules/boss/test_kickstart.py .....         [ 23%]
unit_tests/pyanaconda_tests/modules/boss/test_kickstart_dispatcher.py .. [ 23%]
...........                                                              [ 24%]
unit_tests/pyanaconda_tests/modules/boss/test_module_ui.py ..            [ 24%]
unit_tests/pyanaconda_tests/modules/boss/test_modules.py ........        [ 24%]
unit_tests/pyanaconda_tests/modules/boss/test_observer.py .              [ 24%]
unit_tests/pyanaconda_tests/modules/common/test_base.py .....            [ 25%]
unit_tests/pyanaconda_tests/modules/common/test_policy.py ....           [ 25%]
unit_tests/pyanaconda_tests/modules/common/test_requirements.py ..       [ 25%]
unit_tests/pyanaconda_tests/modules/common/test_secret_data.py ......... [ 26%]
..                                                                       [ 26%]
unit_tests/pyanaconda_tests/modules/common/test_services.py ............ [ 26%]
................                                                         [ 27%]
unit_tests/pyanaconda_tests/modules/common/test_tasks.py ............... [ 28%]
.........                                                                [ 29%]
unit_tests/pyanaconda_tests/modules/common/test_util.py ..               [ 29%]
unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py . [ 29%]
............................................                             [ 31%]
unit_tests/pyanaconda_tests/modules/network/test_module_network.py ..... [ 32%]
.................................................................        [ 35%]
unit_tests/pyanaconda_tests/modules/network/test_module_network_config_file.py . [ 35%]
..                                                                       [ 36%]
unit_tests/pyanaconda_tests/modules/network/test_module_network_nm_client.py . [ 36%]
...                                                                      [ 36%]
unit_tests/pyanaconda_tests/modules/payloads/test_module_payload_base_utils.py . [ 36%]
.                                                                        [ 36%]
unit_tests/pyanaconda_tests/modules/payloads/test_module_payloads.py ... [ 36%]
.........................                                                [ 37%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_tree_info.py . [ 38%]
................                                                         [ 38%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_validation.py . [ 39%]
...                                                                      [ 39%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_flatpak_manager.py . [ 39%]
..........                                                               [ 39%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_image_installation.py . [ 39%]
.                                                                        [ 39%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_base.py . [ 39%]
...........                                                              [ 40%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py . [ 40%]
.............................                                            [ 42%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py . [ 42%]
.....................                                                    [ 43%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py . [ 43%]
.......................................................                  [ 46%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_requirements.py . [ 46%]
.......                                                                  [ 47%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_utils.py . [ 47%]
..................                                                       [ 48%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_factory.py . [ 48%]
..                                                                       [ 48%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py . [ 48%]
.........                                                                [ 49%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live_image.py . [ 49%]
.........                                                                [ 49%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live_os.py . [ 49%]
..........                                                               [ 50%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree.py . [ 50%]
........                                                                 [ 50%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_flatpak.py . [ 50%]
.                                                                        [ 50%]
unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py . [ 51%]
.......................                                                  [ 52%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_base.py . [ 52%]
............                                                             [ 53%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_cdn.py . [ 53%]
...                                                                      [ 53%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_cdrom.py . [ 53%]
..................                                                       [ 54%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_closest_mirror.py . [ 54%]
...                                                                      [ 54%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_factory.py . [ 54%]
.                                                                        [ 54%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_flatpak.py . [ 54%]
...........                                                              [ 55%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_harddrive.py . [ 55%]
...................                                                      [ 56%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_hmc.py . [ 56%]
........                                                                 [ 57%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_image.py . [ 57%]
..................                                                       [ 58%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_os.py . [ 58%]
.................                                                        [ 59%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_nfs.py . [ 59%]
.....................                                                    [ 60%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_repo_files.py . [ 60%]
...........                                                              [ 61%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_rpm_ostree.py . [ 61%]
.........                                                                [ 61%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_url.py . [ 61%]
..............................                                           [ 63%]
unit_tests/pyanaconda_tests/modules/payloads/source/test_source_utils.py . [ 63%]
..                                                                       [ 63%]
unit_tests/pyanaconda_tests/modules/security/test_module_security.py ... [ 63%]
............................................                             [ 66%]
unit_tests/pyanaconda_tests/modules/storage/test_clearpart.py ..F        [ 66%]
unit_tests/pyanaconda_tests/modules/storage/test_fsset.py .....          [ 66%]
unit_tests/pyanaconda_tests/modules/storage/test_grub_raid.py ......     [ 67%]
unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py .. [ 67%]
..........................                                               [ 68%]
unit_tests/pyanaconda_tests/modules/storage/test_module_dasd.py .......  [ 69%]
unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py . [ 69%]
............................................                             [ 71%]
unit_tests/pyanaconda_tests/modules/storage/test_module_disk_init.py ... [ 72%]
......                                                                   [ 72%]
unit_tests/pyanaconda_tests/modules/storage/test_module_disk_select.py . [ 72%]
......                                                                   [ 72%]
unit_tests/pyanaconda_tests/modules/storage/test_module_fcoe.py .......  [ 73%]
unit_tests/pyanaconda_tests/modules/storage/test_module_iscsi.py ....... [ 73%]
...                                                                      [ 73%]
unit_tests/pyanaconda_tests/modules/storage/test_module_nvdimm.py ...... [ 74%]
.....................                                                    [ 75%]
unit_tests/pyanaconda_tests/modules/storage/test_module_snapshot.py .... [ 75%]
..                                                                       [ 75%]
unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py ..... [ 75%]
........................................................................ [ 80%]
.........                                                                [ 80%]
unit_tests/pyanaconda_tests/modules/storage/test_module_storage_bootloader_args.py . [ 80%]
..                                                                       [ 80%]
unit_tests/pyanaconda_tests/modules/storage/test_module_storage_checker.py . [ 80%]
.                                                                        [ 80%]
unit_tests/pyanaconda_tests/modules/storage/test_module_zfcp.py .....    [ 81%]
unit_tests/pyanaconda_tests/modules/storage/test_platform.py ........... [ 81%]
...                                                                      [ 81%]
unit_tests/pyanaconda_tests/modules/storage/test_storage_checker.py .... [ 82%]
......                                                                   [ 82%]
unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_automatic.py . [ 82%]
............                                                             [ 83%]
unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_blivet.py . [ 83%]
....                                                                     [ 83%]
unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_custom.py . [ 83%]
.....                                                                    [ 83%]
unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_factory.py . [ 84%]
..                                                                       [ 84%]
unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_interactive.py . [ 84%]
...........                                                              [ 84%]
unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_manual.py . [ 84%]
......                                                                   [ 85%]
unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_specification.py . [ 85%]
..                                                                       [ 85%]
unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_resizable.py . [ 85%]
......                                                                   [ 85%]
unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py . [ 85%]
..................................                                       [ 87%]
unit_tests/pyanaconda_tests/modules/subscription/test_rhsm_observer.py . [ 87%]
.........                                                                [ 88%]
unit_tests/pyanaconda_tests/modules/subscription/test_subscription.py .. [ 88%]
..................................................                       [ 91%]
unit_tests/pyanaconda_tests/modules/subscription/test_subscription_tasks.py . [ 91%]
.............................                                            [ 93%]
unit_tests/pyanaconda_tests/modules/timezone/test_module_timezone.py ... [ 93%]
...........................                                              [ 94%]
unit_tests/pyanaconda_tests/modules/users/test_module_users.py ......... [ 95%]
...................................                                      [ 97%]
unit_tests/pyanaconda_tests/ui/test_common_code.py .                     [ 97%]
unit_tests/pyanaconda_tests/ui/test_simple_ui.py ...                     [ 97%]
unit_tests/pyanaconda_tests/ui/test_software.py ................         [ 98%]
unit_tests/pyanaconda_tests/ui/test_subscription_spoke.py .              [ 98%]
unit_tests/pyanaconda_tests/ui/test_ui_custom_spoke.py .                 [ 98%]
unit_tests/pyanaconda_tests/ui/test_ui_payload.py .......                [ 99%]
unit_tests/regex_tests/test_dasd_name.py .                               [ 99%]
unit_tests/regex_tests/test_groupparse.py .                              [ 99%]
unit_tests/regex_tests/test_hostname.py ...                              [ 99%]
unit_tests/regex_tests/test_ibft_device_name.py .                        [ 99%]
unit_tests/regex_tests/test_initamfs_con_name.py .                       [ 99%]
unit_tests/regex_tests/test_iscsi_name.py ..                             [ 99%]
unit_tests/regex_tests/test_netmask.py .                                 [ 99%]
unit_tests/regex_tests/test_repo_name.py .                               [ 99%]
unit_tests/regex_tests/test_url.py .                                     [ 99%]
unit_tests/regex_tests/test_username.py ...                              [ 99%]
unit_tests/regex_tests/test_zfcp_name.py ..                              [100%]

=================================== FAILURES ===================================
_____________________ ClearPartTestCase.test_should_clear ______________________

self = <tests.unit_tests.pyanaconda_tests.modules.storage.test_clearpart.ClearPartTestCase testMethod=test_should_clear>

    def test_should_clear(self):
        """ Test the can_remove method. """
        DiskDevice = blivet.devices.DiskDevice
        PartitionDevice = blivet.devices.PartitionDevice
    
        # sda is a disk with an existing disklabel containing two partitions
        sda = DiskDevice("sda", size=100000, exists=True)
        sda.format = blivet.formats.get_format("disklabel", device=sda.path,
                                               exists=True)
        sda.format._parted_disk = mock.Mock()
        sda.format._parted_device = mock.Mock()
        sda.format._parted_disk.configure_mock(partitions=[])
        self._storage.devicetree._add_device(sda)
    
        # sda1 is a partition containing an existing ext4 filesystem
        sda1 = PartitionDevice("sda1", size=500, exists=True,
                               parents=[sda])
        sda1._parted_partition = mock.Mock(**{'type': PARTITION_NORMAL,
                                              'getLength.return_value': int(sda1.size),
                                              'getFlag.return_value': 0})
        sda1.format = blivet.formats.get_format("ext4", mountpoint="/boot",
                                                device=sda1.path,
                                                exists=True)
        self._storage.devicetree._add_device(sda1)
    
        # sda2 is a partition containing an existing vfat filesystem
        sda2 = PartitionDevice("sda2", size=10000, exists=True,
                               parents=[sda])
        sda2._parted_partition = mock.Mock(**{'type': PARTITION_NORMAL,
                                              'getLength.return_value': int(sda2.size),
                                              'getFlag.return_value': 0})
        sda2.format = blivet.formats.get_format("vfat", mountpoint="/foo",
                                                device=sda2.path,
                                                exists=True)
        self._storage.devicetree._add_device(sda2)
    
        # sdb is an unpartitioned disk containing an xfs filesystem
        sdb = DiskDevice("sdb", size=100000, exists=True)
        sdb.format = blivet.formats.get_format("xfs", device=sdb.path,
                                               exists=True)
        self._storage.devicetree._add_device(sdb)
    
        # sdc is an unformatted/uninitialized/empty disk
        sdc = DiskDevice("sdc", size=100000, exists=True)
        self._storage.devicetree._add_device(sdc)
    
        # sdd is a disk containing an existing disklabel with no partitions
        sdd = DiskDevice("sdd", size=100000, exists=True)
        sdd.format = blivet.formats.get_format("disklabel", device=sdd.path,
                                               exists=True)
        self._storage.devicetree._add_device(sdd)
    
        #
        # clearpart type none
        #
        self._config.initialization_mode = CLEAR_PARTITIONS_NONE
        assert not self._can_remove(sda1), \
                        "type none should not clear any partitions"
        assert not self._can_remove(sda2), \
                        "type none should not clear any partitions"
    
        self._config.initialize_labels = False
        assert not self._can_remove(sda), \
                        "type none should not clear non-empty disks"
        assert not self._can_remove(sdb), \
                        "type none should not clear formatting from unpartitioned disks"
    
        assert not self._can_remove(sdc), \
                        "type none should not clear empty disk without initlabel"
        assert not self._can_remove(sdd), \
                        "type none should not clear empty partition table without initlabel"
    
        self._config.initialize_labels = True
>       assert not self._can_remove(sda), \
                        "type none should not clear non-empty disks even with initlabel"

unit_tests/pyanaconda_tests/modules/storage/test_clearpart.py:102: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
unit_tests/pyanaconda_tests/modules/storage/test_clearpart.py:27: in _can_remove
    return self._config.can_remove(self._storage, device)
../pyanaconda/modules/storage/disk_initialization/configuration.py:66: in can_remove
    if not device.is_empty:
/usr/lib/python3.10/site-packages/blivet/threads.py:53: in run_with_lock
    return m(*args, **kwargs)
/usr/lib/python3.10/site-packages/blivet/devices/storage.py:816: in is_empty
    return all(p.type == "partition" and p.is_magic for p in self.children)
/usr/lib/python3.10/site-packages/blivet/threads.py:53: in run_with_lock
    return m(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[TypeError("'<' not supported between instances of 'Mock' and 'Mock'") raised in repr()] DiskDevice object at 0x7f23506d4cd0>

    @property
    def children(self):
        """List of this device's immediate descendants."""
>       return sorted(self._children[:], key=util.natural_sort_key)
E       TypeError: '<' not supported between instances of 'Mock' and 'Mock'

/usr/lib/python3.10/site-packages/blivet/devices/device.py:167: TypeError
------------------------------ Captured log call -------------------------------
WARNING  blivet:util.py:385 queue/rotational is not a valid attribute
WARNING  blivet:util.py:385 queue/rotational is not a valid attribute
WARNING  blivet:util.py:385 queue/rotational is not a valid attribute
WARNING  blivet:util.py:385 queue/rotational is not a valid attribute
=============================== warnings summary ===============================
unit_tests/pyanaconda_tests/test_kickstart_specification.py::ModuleSpecificationsTestCase::test_all_commands
  /tmp/anaconda/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py:471: UserWarning: Skipping the missing name: rhsm
    warnings.warn("Skipping the missing name: {}".format(name))

unit_tests/pyanaconda_tests/test_kickstart_specification.py::ModuleSpecificationsTestCase::test_all_commands
  /tmp/anaconda/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py:471: UserWarning: Skipping the missing name: syspurpose
    warnings.warn("Skipping the missing name: {}".format(name))

unit_tests/pyanaconda_tests/test_kickstart_specification.py::ModuleSpecificationsTestCase::test_disjoint_commands
  /tmp/anaconda/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py:487: UserWarning: Skipping the shared name liveimg.
    warnings.warn("Skipping the shared name {}.".format(name))

unit_tests/pyanaconda_tests/test_kickstart_specification.py::ModuleSpecificationsTestCase::test_version
  /tmp/anaconda/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py:434: UserWarning: Skipping the missing name: syspurpose
    warnings.warn("Skipping the missing name: {}".format(name))

unit_tests/pyanaconda_tests/test_kickstart_specification.py::ModuleSpecificationsTestCase::test_version
  /tmp/anaconda/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py:434: UserWarning: Skipping the missing name: rhsm
    warnings.warn("Skipping the missing name: {}".format(name))

unit_tests/pyanaconda_tests/core/test_configuration.py::AnacondaConfigurationTestCase::test_addons_enabled_modules
unit_tests/pyanaconda_tests/core/test_configuration.py::AnacondaConfigurationTestCase::test_addons_enabled_modules
unit_tests/pyanaconda_tests/core/test_configuration.py::AnacondaConfigurationTestCase::test_addons_enabled_modules
  /tmp/anaconda/pyanaconda/core/configuration/anaconda.py:109: DeprecationWarning: The addons_enabled configuration option is deprecated and will be removed in in the future.
    warnings.warn(

unit_tests/pyanaconda_tests/core/test_configuration.py::AnacondaConfigurationTestCase::test_kickstart_modules
unit_tests/pyanaconda_tests/core/test_configuration.py::AnacondaConfigurationTestCase::test_kickstart_modules
  /tmp/anaconda/pyanaconda/core/configuration/anaconda.py:76: DeprecationWarning: The kickstart_modules configuration option is deprecated and will be removed in in the future.
    warnings.warn(

unit_tests/pyanaconda_tests/core/test_util.py::RunProgramTests::test_exec_readlines
unit_tests/pyanaconda_tests/core/test_util.py::RunProgramTests::test_exec_readlines
unit_tests/pyanaconda_tests/core/test_util.py::RunProgramTests::test_exec_readlines
unit_tests/pyanaconda_tests/core/test_util.py::RunProgramTests::test_exec_readlines
unit_tests/pyanaconda_tests/core/test_util.py::RunProgramTests::test_exec_readlines_auto_kill
unit_tests/pyanaconda_tests/core/test_util.py::RunProgramTests::test_exec_readlines_exits
unit_tests/pyanaconda_tests/core/test_util.py::RunProgramTests::test_exec_readlines_filter_stderr
unit_tests/pyanaconda_tests/core/test_util.py::RunProgramTests::test_exec_readlines_normal_output
unit_tests/pyanaconda_tests/core/test_util.py::RunProgramTests::test_exec_readlines_signals
  /usr/lib64/python3.10/subprocess.py:955: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
    self.stdout = io.open(c2pread, 'rb', bufsize)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=========================== short test summary info ============================
FAILED unit_tests/pyanaconda_tests/modules/storage/test_clearpart.py::ClearPartTestCase::test_should_clear
============ 1 failed, 1737 passed, 19 warnings in 91.71s (0:01:31) ============
FAIL unit_tests.sh (exit status: 1)
```

That broken test above is something in Rawhide tests (not pytest). It has to be solved before this can be merged.