### PR TITLE
Don't run shell on every found virtualization console

### DIFF
--- a/data/systemd/anaconda-generator
+++ b/data/systemd/anaconda-generator
@@ -37,6 +37,7 @@ for tty in hvc0 hvc1 xvc0 hvsi0 hvsi1 hvsi2; do
     [ "$tty" = "$consoletty" ] && continue
     if [ -d /sys/class/tty/$tty ]; then
         service_on_tty anaconda-shell@.service $tty
+        break
     fi
 done
 

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -235,9 +235,9 @@ def copy_updated_files(tag, updates, cwd, builddir):
             if gitfile.endswith('.service') or gitfile.endswith(".target"):
                 # same for systemd services
                 install_to_dir(gitfile, "usr/lib/systemd/system")
-        elif gitfile.endswith('/anaconda-generator'):
-            # yeah, this should probably be more clever..
-            install_to_dir(gitfile, "usr/lib/systemd/system-generators")
+            elif gitfile.endswith('/anaconda-generator'):
+                # yeah, this should probably be more clever..
+                install_to_dir(gitfile, "usr/lib/systemd/system-generators")
         elif gitfile == "data/tmux.conf":
             install_to_dir(gitfile, "usr/share/anaconda")
         elif gitfile == "data/anaconda-gtk.css":


### PR DESCRIPTION
Fix a bug that was introduced in the commit 3427a30. The fix should resolve the
issue with `anaconda-shell@.service` that is repeatedly failing with a message:
`/dev/hvc1: cannot open as standard input: No such device`

Fix the `makeupdates` script to include anaconda-generator again.