### PR TITLE
Fix creation of user account with empty password

### DIFF
--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -548,8 +548,8 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         # Skip the empty password checks if no username is set,
         # otherwise the user will not be able to leave the
         # spoke if password is not set but policy requires that.
-        self._empty_check.skip = not new_username
-        self._validity_check.skip = not new_username
+        self._empty_check.skip = not new_username or not self.password_required
+        self._validity_check.skip = not new_username or not self.password_required
         # Re-run the password checks against the new username
         self.checker.run_checks()
 


### PR DESCRIPTION
Make it possible to always create a user account without a password
after the "Require a password to use this account" checkbox
in the Anaconda GUI is unchecked.

Previously it was possible to get into a situation when password
validation checks would be active even if the checkbox was unchecked,
preventing user account with empty password from being created in the
Anaconda GUI.

The activation conditions of these checks has been fixed, so it should now
be possible to create a user account with empty password at all times.

Resolves: rhbz#1687315