### PR TITLE
Don't set default of gpt option at cmdline parsing

### DIFF
--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -26,7 +26,7 @@ import fcntl
 import termios
 import struct
 
-from argparse import ArgumentParser, ArgumentError, HelpFormatter, Namespace, Action
+from argparse import ArgumentParser, ArgumentError, HelpFormatter, Namespace, Action, SUPPRESS
 
 from pyanaconda.flags import flags as flags_instance
 from pyanaconda.core.kernel import KernelArguments
@@ -519,7 +519,7 @@ def getArgumentParser(version_string, boot_cmdline=None):
                     help=help_parser.help_text("nompath"))
     ap.add_argument("--mpath", action="store_true", help=help_parser.help_text("mpath"))
 
-    ap.add_argument("--gpt", action="store_true", default=False, help=help_parser.help_text("gpt"))
+    ap.add_argument("--gpt", action="store_true", default=SUPPRESS, help=help_parser.help_text("gpt"))
 
     ap.add_argument("--nodmraid", dest="dmraid", action="store_false", default=True,
                     help=help_parser.help_text("nodmraid"))

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -363,7 +363,8 @@ class AnacondaConfiguration(Configuration):
         # Set the storage flags.
         self.storage._set_option("dmraid", opts.dmraid)
         self.storage._set_option("ibft", opts.ibft)
-        self.storage._set_option("gpt", opts.gpt)
+        if hasattr(opts, "gpt"):
+            self.storage._set_option("gpt", opts.gpt)
         self.storage._set_option("multipath_friendly_names", opts.multipath_friendly_names)
 
         # Set up the rescue mode.


### PR DESCRIPTION
Value of config option is always overridden by cmdline parsing result. A
cmdling parsing option with a default value will implicitly override the
corresponding value in a config file.

This patch set set default value of gpt option at cmdline parsing to
'argparse.SUPPRESS', so it is possible to distinguish the case when gpt option
is not passed in cmdline.

Without this fix, it is not possible to override storage.gpt option with a
config file, for example, '/etc/anaconda/profile.d/some.conf', even when gpt
option is not passed at the cmdline.

It is safe to remove default of gpt option at cmdline parsing, since storage.gpt
option defaults to False in the default config.