### PR TITLE
Remove blivet daily builds from Anaconda dailies (#infra)

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -32,8 +32,6 @@ jobs:
       owner: "@rhinstaller"
       project: Anaconda
       preserve_project: True
-      additional_repos:
-        - "copr://@storage/blivet-daily"
 
 #  - job: copr_build
 #    trigger: commit


### PR DESCRIPTION
We need to remove it here because ELN is not build by blivet now. So to avoid this problem, I'm removing the COPR repository from global settings and set it only to `fedora-rawhide-x86_64` chroot only on COPR manually.

Am I able to convinced you @vojtechtrefny to enable ELN back for daily builds? :) 