### PR TITLE
Remove blivet COPR repository from ELN containers (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -37,7 +37,6 @@ RUN set -ex; \
     dnf -y install cppcheck; \
   else \
     dnf copr enable -y ${copr_repo} fedora-eln-x86_64; \
-    dnf copr enable -y @storage/blivet-daily fedora-eln-x86_64; \
   fi; \
   curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/${git_branch}/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -28,7 +28,6 @@ RUN set -ex; \
     dnf copr enable -y @storage/blivet-daily fedora-${BRANCH%%-*}-x86_64; \
   else \
     dnf copr enable -y ${copr_repo} fedora-eln-x86_64; \
-    dnf copr enable -y @storage/blivet-daily fedora-eln-x86_64; \
   fi; \
   curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/${git_branch}/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \


### PR DESCRIPTION
Blivet doesn't have ELN builds in their COPR repository now. So using this repository will fail container build because the chroot is not available.

This should solve our current `Refresh anaconda containers` workflow.