### PR TITLE
Check source type directly, not via DBus

### DIFF
--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -858,9 +858,8 @@ class SubscriptionSpoke(NormalSpoke):
 
         # check if the current installation source will be overriden
         # and remember it if it is the case
-        source_proxy = self.payload.get_source_proxy()
-        source_type = source_proxy.Type
-        if source_type in SOURCE_TYPES_OVERRIDEN_BY_CDN:
+        source_type = self.payload.source_type
+        if source_type is not None and source_type in SOURCE_TYPES_OVERRIDEN_BY_CDN:
             self._overridden_source_type = source_type
         else:
             # no override will happen, so clear the variable


### PR DESCRIPTION
Not all payloads are available via DBus in RHEL 9 Anaconda,
so use the payload instance directly when checking payload type
in the Connect to Red Hat spokes. Also in some cases the payload
type could be None instead of a string, so handle that as well.

This should fix the issue with RHV, which uses the liveimg payload,
which is not available via DBus on RHEL 9, leading to a crash.

(cherry picked from commit d6ea3b39b839e4822ea7d1e9afea5fb81352b732)

Related: rhbz#1941578
Resolves: rhbz#1955311