### PR TITLE
Add multi organization account support

### DIFF
--- a/pyanaconda/modules/common/errors/subscription.py
+++ b/pyanaconda/modules/common/errors/subscription.py
@@ -43,3 +43,9 @@ class SubscriptionError(AnacondaError):
 class SatelliteProvisioningError(AnacondaError):
     """Failed to provision the installation environment for Satellite."""
     pass
+
+
+@dbus_error("MultipleOrganizationsError", namespace=ANACONDA_NAMESPACE)
+class MultipleOrganizationsError(AnacondaError):
+    """Account is member of more than one organization."""
+    pass

--- a/pyanaconda/modules/common/structures/subscription.py
+++ b/pyanaconda/modules/common/structures/subscription.py
@@ -140,6 +140,7 @@ class SubscriptionRequest(DBusData):
         #   need to be set
         self._organization = ""
         self._redhat_account_username = ""
+        self._redhat_account_organization = ""
         # Candlepin instance
         self._server_hostname = ""
         # CDN base url
@@ -226,6 +227,27 @@ class SubscriptionRequest(DBusData):
     @account_username.setter
     def account_username(self, account_username: Str):
         self._redhat_account_username = account_username
+
+    @property
+    def account_organization(self) -> Str:
+        """Red Hat account organization for subscription purposes.
+
+        In case the account for the given username is member
+        of multiple organizations, organization id needs to
+        be specified as well or else the registration attempt
+        will not be successful. This account dependent organization
+        id is deliberately separate from the org + key org id
+        to avoid collisions and issues in the GUI when switching
+        between authentication types.
+
+        :return: Red Hat account organization id
+        :rtype: str
+        """
+        return self._redhat_account_organization
+
+    @account_organization.setter
+    def account_organization(self, account_organization: Str):
+        self._redhat_account_organization = account_organization
 
     @property
     def server_hostname(self) -> Str:
@@ -533,3 +555,45 @@ class AttachedSubscription(DBusData):
     @consumed_entitlement_count.setter
     def consumed_entitlement_count(self, consumed_entitlement_count: Int):
         self._consumed_entitlement_count = consumed_entitlement_count
+
+
+class OrganizationData(DBusData):
+    """Data about a single organization in the Red Hat account system.
+
+    A Red Hat account is expected to be member of an organization,
+    with some accounts being members of more than one organization.
+    """
+
+    def __init__(self):
+        self._id = ""
+        self._name = ""
+
+    @property
+    def id(self) -> Str:
+        """Id of the organization.
+
+        Example: "abc123efg456"
+
+        :return: organization id
+        :rtype: str
+        """
+        return self._id
+
+    @id.setter
+    def id(self, organization_id: Str):
+        self._id = organization_id
+
+    @property
+    def name(self) -> Str:
+        """Name of the organization.
+
+        Example: "Foo Organization"
+
+        :return: organization name
+        :rtype: str
+        """
+        return self._name
+
+    @name.setter
+    def name(self, organization_name: Str):
+        self._name = organization_name

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -20,11 +20,29 @@
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.modules.common.structures.subscription import SystemPurposeData, \
-    SubscriptionRequest, AttachedSubscription
+    SubscriptionRequest, AttachedSubscription, OrganizationData
 from pyanaconda.modules.common.containers import TaskContainer
-from dasbus.server.interface import dbus_interface
+from pyanaconda.modules.common.task import TaskInterface
+from dasbus.server.interface import dbus_interface, dbus_class
 from dasbus.server.property import emits_properties_changed
 from dasbus.typing import *  # pylint: disable=wildcard-import
+
+
+@dbus_class
+class RetrieveOrganizationsTaskInterface(TaskInterface):
+    """The interface for a organization data parsing task.
+
+    Such a task returns a list of organization data objects.
+    """
+    @staticmethod
+    def convert_result(value) -> Variant:
+        """Convert the list of org data DBus structs.
+
+        Convert list of org data DBus structs to variant.
+        :param value: a validation report
+        :return: a variant with the structure
+        """
+        return get_variant(List[Structure], OrganizationData.to_structure_list(value))
 
 
 @dbus_interface(SUBSCRIPTION.interface_name)
@@ -181,4 +199,13 @@ class SubscriptionInterface(KickstartModuleInterface):
         """
         return TaskContainer.to_object_path(
             self.implementation.register_and_subscribe_with_task()
+        )
+
+    def RetrieveOrganizationsWithTask(self) -> ObjPath:
+        """Get organization data using a runtime DBus task.
+
+        :return: a DBus path of a runtime task
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.retrieve_organizations_with_task()
         )

--- a/pyanaconda/ui/gui/spokes/subscription.glade
+++ b/pyanaconda/ui/gui/spokes/subscription.glade
@@ -1,26 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <requires lib="AnacondaWidgets" version="1.0"/>
   <object class="AnacondaSpokeWindow" id="subscription_window">
-    <property name="can_focus">False</property>
-    <property name="window_name" translatable="yes">CONNECT TO RED HAT</property>
+    <property name="can-focus">False</property>
+    <property name="window-name" translatable="yes">CONNECT TO RED HAT</property>
     <signal name="button-clicked" handler="on_back_clicked" swapped="no"/>
     <child internal-child="main_box">
       <object class="GtkBox" id="AnacondaSpokeWindow-main_box1">
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
         <child internal-child="nav_box">
           <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child internal-child="nav_area">
+              <!-- n-columns=3 n-rows=3 -->
               <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">
-                <property name="can_focus">False</property>
-                <property name="margin_left">6</property>
-                <property name="margin_right">6</property>
-                <property name="margin_top">6</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">6</property>
+                <property name="margin-right">6</property>
+                <property name="margin-top">6</property>
               </object>
             </child>
           </object>
@@ -32,53 +33,54 @@
         </child>
         <child internal-child="alignment">
           <object class="GtkAlignment" id="AnacondaSpokeWindow-alignment1">
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="yalign">0</property>
-            <property name="top_padding">12</property>
-            <property name="bottom_padding">48</property>
-            <property name="left_padding">48</property>
-            <property name="right_padding">48</property>
+            <property name="top-padding">12</property>
+            <property name="bottom-padding">48</property>
+            <property name="left-padding">48</property>
+            <property name="right-padding">48</property>
             <child internal-child="action_area">
               <object class="GtkBox" id="AnacondaSpokeWindow-action_area1">
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">8</property>
                 <child>
                   <object class="GtkNotebook" id="main_notebook">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="vexpand">True</property>
-                    <property name="show_tabs">False</property>
-                    <property name="show_border">False</property>
+                    <property name="show-tabs">False</property>
+                    <property name="show-border">False</property>
                     <child>
                       <object class="GtkScrolledWindow" id="registration_scrolled_window">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <child>
                           <object class="GtkViewport" id="registration_viewport">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">center</property>
-                            <property name="shadow_type">none</property>
+                            <property name="shadow-type">none</property>
                             <child>
                               <object class="GtkBox" id="registration_box">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="halign">center</property>
                                 <property name="orientation">vertical</property>
                                 <property name="spacing">4</property>
                                 <child>
+                                  <!-- n-columns=3 n-rows=6 -->
                                   <object class="GtkGrid" id="registration_grid">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">center</property>
                                     <property name="valign">center</property>
-                                    <property name="row_spacing">4</property>
-                                    <property name="column_spacing">4</property>
+                                    <property name="row-spacing">4</property>
+                                    <property name="column-spacing">4</property>
                                     <child>
                                       <object class="GtkLabel" id="authentication_label">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="halign">end</property>
                                         <property name="label" translatable="yes">Authentication</property>
                                         <property name="justify">right</property>
@@ -87,23 +89,23 @@
                                         </attributes>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">0</property>
-                                        <property name="top_attach">0</property>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkBox" id="authetication_method_hbox">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <child>
                                           <object class="GtkRadioButton" id="account_radio_button">
                                             <property name="label" translatable="yes" context="GUI|Subscription|Authentication|Account">_Account</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="on_account_radio_button_toggled" swapped="no"/>
                                           </object>
                                           <packing>
@@ -116,10 +118,10 @@
                                           <object class="GtkRadioButton" id="activation_key_radio_button">
                                             <property name="label" translatable="yes" context="GUI|Subscription|Authetication|Activation Key">Activation _Key</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <property name="group">account_radio_button</property>
                                             <signal name="toggled" handler="on_activation_key_radio_button_toggled" swapped="no"/>
                                           </object>
@@ -131,155 +133,215 @@
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="top_attach">0</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">0</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkRevealer" id="account_revealer">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="transition_type">none</property>
-                                        <property name="reveal_child">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="transition-type">none</property>
+                                        <property name="reveal-child">True</property>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="account_grid">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="hexpand">True</property>
-                                            <property name="row_spacing">4</property>
-                                            <property name="column_spacing">4</property>
+                                            <property name="row-spacing">4</property>
+                                            <property name="column-spacing">4</property>
                                             <child>
                                               <object class="GtkLabel" id="username_label">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">User name</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkEntry" id="username_entry">
-                                                <property name="width_request">250</property>
+                                                <property name="width-request">250</property>
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="hexpand">True</property>
                                                 <signal name="changed" handler="on_username_entry_changed" swapped="no"/>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="password_label">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Password</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkEntry" id="password_entry">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="hexpand">True</property>
                                                 <property name="visibility">False</property>
-                                                <property name="invisible_char">●</property>
+                                                <property name="invisible-char">●</property>
                                                 <signal name="changed" handler="on_password_entry_changed" swapped="no"/>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkRevealer" id="select_organization_label_revealer">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="transition-type">none</property>
+                                                <child>
+                                                  <object class="GtkLabel" id="select_organization_label">
+                                                    <property name="can-focus">False</property>
+                                                    <property name="label" translatable="yes">Organization</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkRevealer" id="select_organization_combobox_revealer">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="transition-type">none</property>
+                                                <child>
+                                                  <object class="GtkComboBoxText" id="select_organization_combobox">
+                                                    <property name="can-focus">False</property>
+                                                    <signal name="changed" handler="on_select_organization_combobox_changed" swapped="no"/>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="top_attach">1</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">1</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkRevealer" id="activation_key_revealer">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="transition_type">none</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="transition-type">none</property>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="activation_key_grid">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="hexpand">True</property>
-                                            <property name="row_spacing">4</property>
-                                            <property name="column_spacing">4</property>
+                                            <property name="row-spacing">4</property>
+                                            <property name="column-spacing">4</property>
                                             <child>
                                               <object class="GtkLabel" id="organization_label">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Organization</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="activation_key_label">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Activation Key</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkEntry" id="organization_entry">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="hexpand">True</property>
                                                 <signal name="changed" handler="on_organization_entry_changed" swapped="no"/>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkEntry" id="activation_key_entry">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="hexpand">True</property>
-                                                <property name="placeholder_text" translatable="yes">key1,key2,...</property>
+                                                <property name="placeholder-text" translatable="yes">key1,key2,...</property>
                                                 <signal name="changed" handler="on_activation_key_entry_changed" swapped="no"/>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="top_attach">2</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">2</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="purpose_label">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="halign">end</property>
                                         <property name="label" translatable="yes">Purpose</property>
                                         <property name="justify">right</property>
@@ -288,115 +350,125 @@
                                         </attributes>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">0</property>
-                                        <property name="top_attach">3</property>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">3</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkRevealer" id="system_purpose_revealer">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <child>
+                                          <!-- n-columns=3 n-rows=3 -->
                                           <object class="GtkGrid" id="system_purpose_grid">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="row_spacing">4</property>
-                                            <property name="column_spacing">4</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="row-spacing">4</property>
+                                            <property name="column-spacing">4</property>
                                             <child>
                                               <object class="GtkLabel" id="usage_label">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Usage</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">2</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">2</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="role_label">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">Role</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkLabel" id="sla_label">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <property name="halign">start</property>
                                                 <property name="label" translatable="yes">SLA</property>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">0</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">0</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="system_purpose_role_combobox">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <signal name="changed" handler="on_system_purpose_role_combobox_changed" swapped="no"/>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">0</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">0</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="system_purpose_sla_combobox">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <signal name="changed" handler="on_system_purpose_sla_combobox_changed" swapped="no"/>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">1</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">1</property>
                                               </packing>
                                             </child>
                                             <child>
                                               <object class="GtkComboBoxText" id="system_purpose_usage_combobox">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
+                                                <property name="can-focus">False</property>
                                                 <signal name="changed" handler="on_system_purpose_usage_combobox_changed" swapped="no"/>
                                               </object>
                                               <packing>
-                                                <property name="left_attach">1</property>
-                                                <property name="top_attach">2</property>
+                                                <property name="left-attach">1</property>
+                                                <property name="top-attach">2</property>
                                               </packing>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
+                                            </child>
+                                            <child>
+                                              <placeholder/>
                                             </child>
                                           </object>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="top_attach">4</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">4</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkCheckButton" id="system_purpose_checkbox">
                                         <property name="label" translatable="yes" context="GUI|Subscription|Set System Purpose">Set System Purpose</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
                                         <signal name="toggled" handler="on_system_purpose_checkbox_toggled" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="top_attach">3</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">3</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel" id="insights_label">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="halign">end</property>
                                         <property name="label" translatable="yes">Insights</property>
                                         <property name="justify">right</property>
@@ -405,24 +477,42 @@
                                         </attributes>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">0</property>
-                                        <property name="top_attach">5</property>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">5</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkCheckButton" id="insights_checkbox">
                                         <property name="label" translatable="yes" context="GUI|Subscription|Red Hat Insights">Connect to Red Hat _Insights</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
                                         <property name="active">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="draw-indicator">True</property>
                                       </object>
                                       <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="top_attach">5</property>
+                                        <property name="left-attach">1</property>
+                                        <property name="top-attach">5</property>
                                       </packing>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
                                     </child>
                                     <child>
                                       <placeholder/>
@@ -443,180 +533,209 @@
                                 <child>
                                   <object class="GtkExpander" id="options_expander">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <child>
+                                      <!-- n-columns=3 n-rows=6 -->
                                       <object class="GtkGrid" id="options_grid">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="row_spacing">4</property>
-                                        <property name="column_spacing">4</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="row-spacing">4</property>
+                                        <property name="column-spacing">4</property>
                                         <child>
                                           <object class="GtkCheckButton" id="custom_rhsm_baseurl_checkbox">
                                             <property name="label" translatable="yes">Custom base URL</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="on_custom_rhsm_baseurl_checkbox_toggled" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">4</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">4</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkRevealer" id="custom_rhsm_baseurl_revealer">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
                                               <object class="GtkEntry" id="custom_rhsm_baseurl_entry">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <signal name="changed" handler="on_custom_rhsm_baseurl_entry_changed" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">5</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">5</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkRevealer" id="custom_server_hostname_revealer">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
                                               <object class="GtkEntry" id="custom_server_hostname_entry">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <signal name="changed" handler="on_custom_server_hostname_entry_changed" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">3</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">3</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="custom_server_hostname_checkbox">
                                             <property name="label" translatable="yes">Satellite URL</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="on_custom_server_hostname_checkbox_toggled" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">2</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkCheckButton" id="http_proxy_checkbox">
                                             <property name="label" translatable="yes">Use HTTP proxy</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="on_http_proxy_checkbox_toggled" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkRevealer" id="http_proxy_revealer">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <child>
+                                              <!-- n-columns=3 n-rows=3 -->
                                               <object class="GtkGrid" id="http_proxy_grid">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="row_spacing">4</property>
-                                                <property name="column_spacing">4</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="row-spacing">4</property>
+                                                <property name="column-spacing">4</property>
                                                 <child>
                                                   <object class="GtkLabel" id="http_proxy_location_label">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="halign">start</property>
                                                     <property name="label" translatable="yes">Location</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">0</property>
-                                                    <property name="top_attach">0</property>
+                                                    <property name="left-attach">0</property>
+                                                    <property name="top-attach">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel" id="http_proxy_username_label">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="halign">start</property>
                                                     <property name="label" translatable="yes">User name</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">0</property>
-                                                    <property name="top_attach">1</property>
+                                                    <property name="left-attach">0</property>
+                                                    <property name="top-attach">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkLabel" id="http_proxy_password_label">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
+                                                    <property name="can-focus">False</property>
                                                     <property name="halign">start</property>
                                                     <property name="label" translatable="yes">Password</property>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">0</property>
-                                                    <property name="top_attach">2</property>
+                                                    <property name="left-attach">0</property>
+                                                    <property name="top-attach">2</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkEntry" id="http_proxy_location_entry">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
+                                                    <property name="can-focus">True</property>
                                                     <property name="hexpand">True</property>
-                                                    <property name="placeholder_text" translatable="yes">hostname:port</property>
+                                                    <property name="placeholder-text" translatable="yes">hostname:port</property>
                                                     <signal name="changed" handler="on_http_proxy_location_entry_changed" swapped="no"/>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">1</property>
-                                                    <property name="top_attach">0</property>
+                                                    <property name="left-attach">1</property>
+                                                    <property name="top-attach">0</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkEntry" id="http_proxy_username_entry">
-                                                    <property name="width_request">250</property>
+                                                    <property name="width-request">250</property>
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
+                                                    <property name="can-focus">True</property>
                                                     <signal name="changed" handler="on_http_proxy_username_entry_changed" swapped="no"/>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">1</property>
-                                                    <property name="top_attach">1</property>
+                                                    <property name="left-attach">1</property>
+                                                    <property name="top-attach">1</property>
                                                   </packing>
                                                 </child>
                                                 <child>
                                                   <object class="GtkEntry" id="http_proxy_password_entry">
                                                     <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
+                                                    <property name="can-focus">True</property>
                                                     <property name="visibility">False</property>
-                                                    <property name="invisible_char">●</property>
+                                                    <property name="invisible-char">●</property>
                                                     <signal name="changed" handler="on_http_proxy_password_entry_changed" swapped="no"/>
                                                   </object>
                                                   <packing>
-                                                    <property name="left_attach">1</property>
-                                                    <property name="top_attach">2</property>
+                                                    <property name="left-attach">1</property>
+                                                    <property name="top-attach">2</property>
                                                   </packing>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
+                                                </child>
+                                                <child>
+                                                  <placeholder/>
                                                 </child>
                                               </object>
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
+                                        </child>
+                                        <child>
+                                          <placeholder/>
                                         </child>
                                         <child>
                                           <placeholder/>
@@ -641,11 +760,11 @@
                                     <child type="label">
                                       <object class="GtkBox">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <child>
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Options</property>
                                           </object>
                                           <packing>
@@ -666,9 +785,9 @@
                                 <child>
                                   <object class="GtkLabel" id="registration_status_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_top">8</property>
-                                    <property name="margin_bottom">8</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">8</property>
+                                    <property name="margin-bottom">8</property>
                                     <property name="label" translatable="yes">The system is currently not registered.</property>
                                     <attributes>
                                       <attribute name="weight" value="bold"/>
@@ -685,10 +804,10 @@
                                     <property name="label" translatable="yes" context="GUI|Subscription|Register">_Register</property>
                                     <property name="visible">True</property>
                                     <property name="sensitive">False</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
                                     <property name="halign">center</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="clicked" handler="on_register_button_clicked" swapped="no"/>
                                   </object>
                                   <packing>
@@ -709,25 +828,25 @@
                     <child>
                       <object class="GtkBox" id="subscription_status_box">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_top">8</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-top">8</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">4</property>
                         <child>
                           <object class="GtkBox" id="status_box">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <property name="spacing">4</property>
                             <child>
                               <object class="GtkBox" id="top_level_status_box">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">4</property>
                                 <child>
                                   <object class="GtkLabel" id="subscription_status_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label">""</property>
                                     <attributes>
                                       <attribute name="weight" value="bold"/>
@@ -744,10 +863,10 @@
                                   <object class="GtkButton" id="unregister_button">
                                     <property name="label" translatable="yes" context="GUI|Subscription|Unregister">_Unregister</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
                                     <property name="halign">center</property>
-                                    <property name="use_underline">True</property>
+                                    <property name="use-underline">True</property>
                                     <signal name="clicked" handler="on_unregister_button_clicked" swapped="no"/>
                                   </object>
                                   <packing>
@@ -765,18 +884,19 @@
                               </packing>
                             </child>
                             <child>
+                              <!-- n-columns=3 n-rows=5 -->
                               <object class="GtkGrid" id="status_grid">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin_top">8</property>
-                                <property name="row_spacing">4</property>
-                                <property name="column_spacing">8</property>
+                                <property name="margin-top">8</property>
+                                <property name="row-spacing">4</property>
+                                <property name="column-spacing">8</property>
                                 <child>
                                   <object class="GtkLabel" id="method_label">
                                     <property name="name">method_label</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">end</property>
                                     <property name="label" translatable="yes">Method</property>
                                     <property name="justify">right</property>
@@ -785,15 +905,15 @@
                                     </attributes>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">0</property>
-                                    <property name="top_attach">0</property>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">0</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="system_purpose_label">
                                     <property name="name">system_purpose_label</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">end</property>
                                     <property name="label" translatable="yes">System Purpose</property>
                                     <property name="justify">right</property>
@@ -802,51 +922,51 @@
                                     </attributes>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">0</property>
-                                    <property name="top_attach">1</property>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">1</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="method_status_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="label">lorem ipsum</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="top_attach">0</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">0</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="role_status_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="label">lorem ipsum</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="top_attach">1</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">1</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="sla_status_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="label">lorem ipsum</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="top_attach">2</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="another_insights_label">
                                     <property name="name">insights_label</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">end</property>
                                     <property name="label" translatable="yes">Insights</property>
                                     <property name="justify">right</property>
@@ -855,33 +975,48 @@
                                     </attributes>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">0</property>
-                                    <property name="top_attach">4</property>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">4</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="insights_status_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="label">lorem ipsum</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="top_attach">4</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">4</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="usage_status_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="label">lorem ipsum</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="top_attach">3</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">3</property>
                                   </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <placeholder/>
                                 </child>
                                 <child>
                                   <placeholder/>
@@ -906,10 +1041,10 @@
                         <child>
                           <object class="GtkLabel" id="attached_subscriptions_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin_top">16</property>
-                            <property name="margin_bottom">4</property>
+                            <property name="margin-top">16</property>
+                            <property name="margin-bottom">4</property>
                             <property name="label" translatable="yes">No subscriptions have been attached to the system</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
@@ -925,18 +1060,18 @@
                         <child>
                           <object class="GtkScrolledWindow" id="subscriptions_scrolled_window">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="can-focus">True</property>
                             <property name="vexpand">True</property>
                             <child>
                               <object class="GtkViewport" id="subscriptions_viewport">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="shadow_type">none</property>
+                                <property name="can-focus">False</property>
+                                <property name="shadow-type">none</property>
                                 <child>
                                   <object class="GtkListBox" id="subscriptions_listbox">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="selection_mode">none</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="selection-mode">none</property>
                                     <style>
                                       <class name="subscriptions_listbox"/>
                                     </style>

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -19,6 +19,8 @@
 
 from enum import IntEnum
 
+from dasbus.typing import unwrap_variant
+
 from pyanaconda.flags import flags
 from pyanaconda.threading import threadMgr, AnacondaThread
 
@@ -34,9 +36,10 @@ from pyanaconda.core.async_utils import async_action_wait
 
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION, NETWORK
 from pyanaconda.modules.common.structures.subscription import SystemPurposeData, \
-    SubscriptionRequest, AttachedSubscription
+    SubscriptionRequest, AttachedSubscription, OrganizationData
+from pyanaconda.modules.common.errors.subscription import MultipleOrganizationsError
 from pyanaconda.modules.common.util import is_module_available
-from pyanaconda.modules.common.task import sync_run_task
+from pyanaconda.modules.common.task import sync_run_task, async_run_task
 
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.spokes.lib.subscription import fill_combobox, \
@@ -318,6 +321,9 @@ class SubscriptionSpoke(NormalSpoke):
     def on_username_entry_changed(self, editable):
         self.subscription_request.account_username = editable.get_text()
         self._update_registration_state()
+        # changes to username can invalidate the organization list,
+        # so hide it if the username changes
+        self._disable_org_selection_for_account()
 
     def on_password_entry_changed(self, editable):
         entered_text = editable.get_text()
@@ -325,6 +331,11 @@ class SubscriptionSpoke(NormalSpoke):
             self.enable_password_placeholder(False)
         self.subscription_request.account_password.set_secret(entered_text)
         self._update_registration_state()
+
+    def on_select_organization_combobox_changed(self, combobox):
+        log.debug("Subscription GUI: organization selected for account: %s",
+                  combobox.get_active_id())
+        self.subscription_request.account_organization = combobox.get_active_id()
 
     def on_organization_entry_changed(self, editable):
         self.subscription_request.organization = editable.get_text()
@@ -546,6 +557,17 @@ class SubscriptionSpoke(NormalSpoke):
         self._account_revealer = self.builder.get_object("account_revealer")
         self._username_entry = self.builder.get_object("username_entry")
         self._password_entry = self.builder.get_object("password_entry")
+
+        # authentication - account - org selection
+        self._select_organization_label_revealer = self.builder.get_object(
+            "select_organization_label_revealer"
+        )
+        self._select_organization_combobox_revealer = self.builder.get_object(
+            "select_organization_combobox_revealer"
+        )
+        self._select_organization_combobox = self.builder.get_object(
+            "select_organization_combobox"
+        )
 
         # authentication - activation key
         self._activation_key_revealer = self.builder.get_object("activation_key_revealer")
@@ -949,17 +971,61 @@ class SubscriptionSpoke(NormalSpoke):
     def _subscription_error_callback(self, error):
         log.debug("Subscription GUI: registration & attach failed")
         # store the error message
-        self.registration_error = str(error_message)
+        self.registration_error = str(error)
         # even if we fail, we are technically done,
         # so clear the phase
         self.registration_phase = None
         # update registration and subscription parts of the spoke
         self._update_registration_state()
         self._update_subscription_state()
+        # if the error is an instance of multi-org error,
+        # fetch organization list & enable org selection
+        # checkbox
+        if isinstance(error, MultipleOrganizationsError):
+            task_path = self._subscription_module.RetrieveOrganizationsWithTask()
+            task_proxy = SUBSCRIPTION.get_proxy(task_path)
+            async_run_task(task_proxy, self._process_org_list)
         # re-enable controls, so user can try again
         self.set_registration_controls_sensitive(True)
         # notify hub
         hubQ.send_ready(self.__class__.__name__)
+
+    def _process_org_list(self, task_proxy):
+        """Process org listing for account.
+
+        Called as an async callback of the organization listing runtime task.
+
+        :param task_proxy: a task
+        """
+        # finish the task
+        task_proxy.Finish()
+        # process the organization list
+        org_struct_list = unwrap_variant(task_proxy.GetResult())
+        org_list = OrganizationData.from_structure_list(org_struct_list)
+        # fill the combobox
+        self._select_organization_combobox.remove_all()
+        # also add a placeholder and make it the active item so it is visible
+        self._select_organization_combobox.append("", _("Not Specified"))
+        self._select_organization_combobox.set_active_id("")
+        for org in org_list:
+            self._select_organization_combobox.append(org.id, org.name)
+        # show the combobox
+        self._enable_org_selection_for_account()
+
+    def _enable_org_selection_for_account(self):
+        self._select_organization_label_revealer.set_reveal_child(True)
+        self._select_organization_combobox_revealer.set_reveal_child(True)
+
+    def _disable_org_selection_for_account(self):
+        """Disable the org selection combobox.
+
+        And also wipe the last used organization id or else it might be used
+        for the next registration attempt with a different username,
+        triggering confusing authetication failures.
+        """
+        self._subscription_request.account_organization = ""
+        self._select_organization_label_revealer.set_reveal_child(False)
+        self._select_organization_combobox_revealer.set_reveal_child(False)
 
     def _get_status_message(self):
         """Get status message describing current spoke state.

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -946,10 +946,10 @@ class SubscriptionSpoke(NormalSpoke):
         self._update_registration_state()
 
     @async_action_wait
-    def _subscription_error_callback(self, error_message):
+    def _subscription_error_callback(self, error):
         log.debug("Subscription GUI: registration & attach failed")
         # store the error message
-        self.registration_error = error_message
+        self.registration_error = str(error_message)
         # even if we fail, we are technically done,
         # so clear the phase
         self.registration_phase = None

--- a/pyanaconda/ui/lib/subscription.py
+++ b/pyanaconda/ui/lib/subscription.py
@@ -129,7 +129,7 @@ def dummy_progress_callback(subscription_phase):
     pass
 
 
-def dummy_error_callback(error_message):
+def dummy_error_callback(error):
     """Dummy error reporting function used if no custom callback is set."""
     pass
 
@@ -183,7 +183,7 @@ def register_and_subscribe(payload, progress_callback=None, error_callback=None,
     :param payload: Anaconda payload instance
     :param progress_callback: progress callback function, takes one argument, subscription phase
     :type progress_callback: callable(subscription_phase)
-    :param error_callback: error callback function, takes one argument, the error message
+    :param error_callback: error callback function, takes one argument, the error instance
     :type error_callback: callable(error_message)
     :param bool restart_payload: should payload restart be attempted if it appears necessary ?
 
@@ -249,7 +249,7 @@ def register_and_subscribe(payload, progress_callback=None, error_callback=None,
             log.debug("registration attempt: unregistration failed: %s", e)
             # Failing to unregister the system is an unrecoverable error,
             # so we end there.
-            error_callback(str(e))
+            error_callback(e)
             return
         log.debug("Subscription GUI: unregistration succeeded")
 
@@ -269,15 +269,15 @@ def register_and_subscribe(payload, progress_callback=None, error_callback=None,
         task.sync_run_task(task_proxy)
     except SatelliteProvisioningError as e:
         log.debug("registration attempt: Satellite provisioning failed: %s", e)
-        error_callback(str(e))
+        error_callback(e)
         return
     except RegistrationError as e:
         log.debug("registration attempt: registration attempt failed: %s", e)
-        error_callback(str(e))
+        error_callback(e)
         return
     except SubscriptionError as e:
         log.debug("registration attempt: failed to attach subscription: %s", e)
-        error_callback(str(e))
+        error_callback(e)
         return
 
     # check if the current installation source should be overridden by
@@ -349,7 +349,7 @@ def unregister(payload, overridden_source_type, progress_callback=None, error_ca
             task.sync_run_task(task_proxy)
         except UnregistrationError as e:
             log.debug("registration attempt: unregistration failed: %s", e)
-            error_callback(str(e))
+            error_callback(e)
             return
 
         # If the CDN overrode an installation source we should revert that

--- a/pyanaconda/ui/lib/subscription.py
+++ b/pyanaconda/ui/lib/subscription.py
@@ -34,7 +34,7 @@ from pyanaconda.modules.common.structures.subscription import SubscriptionReques
 from pyanaconda.modules.common.structures.secret import SECRET_TYPE_HIDDEN, \
     SECRET_TYPE_TEXT
 from pyanaconda.modules.common.errors.subscription import RegistrationError, \
-    UnregistrationError, SubscriptionError, SatelliteProvisioningError
+    UnregistrationError, SubscriptionError, SatelliteProvisioningError, MultipleOrganizationsError
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -269,6 +269,13 @@ def register_and_subscribe(payload, progress_callback=None, error_callback=None,
         task.sync_run_task(task_proxy)
     except SatelliteProvisioningError as e:
         log.debug("registration attempt: Satellite provisioning failed: %s", e)
+        error_callback(e)
+        return
+    except MultipleOrganizationsError as e:
+        log.debug(
+            "registration attempt: please specify org id for current account and try again: %s",
+            e
+        )
         error_callback(e)
         return
     except RegistrationError as e:

--- a/tests/nosetests/pyanaconda_tests/subscription_helpers_test.py
+++ b/tests/nosetests/pyanaconda_tests/subscription_helpers_test.py
@@ -297,7 +297,8 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         # - this should add additional unregister phase and task
         subscription_proxy.IsRegistered = True
         # make the first (unregistration) task fail
-        run_task.side_effect = [True, UnregistrationError("unregistration failed")]
+        unregistration_error = UnregistrationError("unregistration failed")
+        run_task.side_effect = [True, unregistration_error]
         # run the function
         register_and_subscribe(payload=payload,
                                progress_callback=progress_callback,
@@ -309,7 +310,7 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
             [call(SubscriptionPhase.UNREGISTER)]
         )
         # and the error callback should have been triggered
-        error_callback.assert_called_once_with("unregistration failed")
+        error_callback.assert_called_once_with(unregistration_error)
         # we should have requested the appropriate tasks
         subscription_proxy.SetRHSMConfigWithTask.assert_called_once()
         subscription_proxy.UnregisterWithTask.assert_called_once()
@@ -332,7 +333,8 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         # simulate the system not being registered
         subscription_proxy.IsRegistered = False
         # make the first (registration) task fail
-        run_task.side_effect = [True, SatelliteProvisioningError("Satellite provisioning failed")]
+        sat_error = SatelliteProvisioningError("Satellite provisioning failed")
+        run_task.side_effect = [True, sat_error]
         # run the function
         register_and_subscribe(payload=payload,
                                progress_callback=progress_callback,
@@ -344,7 +346,7 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
             [call(SubscriptionPhase.REGISTER)]
         )
         # and the error callback should have been triggered
-        error_callback.assert_called_once_with("Satellite provisioning failed")
+        error_callback.assert_called_once_with(sat_error)
         # we should have requested the appropriate tasks
         subscription_proxy.SetRHSMConfigWithTask.assert_called_once()
         subscription_proxy.RegisterAndSubscribeWithTask.assert_called_once()
@@ -367,7 +369,8 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         # simulate the system not being registered
         subscription_proxy.IsRegistered = False
         # make the first (registration) task fail
-        run_task.side_effect = [True, RegistrationError("registration failed")]
+        registration_error = RegistrationError("registration failed")
+        run_task.side_effect = [True, registration_error]
         # run the function
         register_and_subscribe(payload=payload,
                                progress_callback=progress_callback,
@@ -379,7 +382,7 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
             [call(SubscriptionPhase.REGISTER)]
         )
         # and the error callback should have been triggered
-        error_callback.assert_called_once_with("registration failed")
+        error_callback.assert_called_once_with(registration_error)
         # we should have requested the appropriate tasks
         subscription_proxy.SetRHSMConfigWithTask.assert_called_once()
         subscription_proxy.RegisterAndSubscribeWithTask.assert_called_once()
@@ -501,7 +504,8 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         # simulate the system not being registered
         subscription_proxy.IsRegistered = False
         # make the second (RegisterAndSubscribe) task fail with SubscriptionError
-        run_task.side_effect = [True, SubscriptionError("failed to attach subscription")]
+        subscription_error = SubscriptionError("failed to attach subscription")
+        run_task.side_effect = [True, subscription_error]
         # run the function
         register_and_subscribe(payload=payload,
                                progress_callback=progress_callback,
@@ -513,7 +517,7 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
             [call(SubscriptionPhase.REGISTER)]
         )
         # and the error callback should have been triggered
-        error_callback.assert_called_once_with("failed to attach subscription")
+        error_callback.assert_called_once_with(subscription_error)
         # we should have requested the appropriate tasks
         subscription_proxy.SetRHSMConfigWithTask.assert_called_once()
         subscription_proxy.RegisterAndSubscribeWithTask.assert_called_once()
@@ -587,7 +591,8 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         # simulate the system being registered,
         subscription_proxy.IsRegistered = True
         # make the unregistration task fail
-        run_task.side_effect = [True, UnregistrationError("unregistration failed")]
+        unregistration_error = UnregistrationError("unregistration failed")
+        run_task.side_effect = [True, unregistration_error]
         # run the function
         unregister(payload=payload,
                    overridden_source_type=None,
@@ -598,7 +603,7 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
             [call(SubscriptionPhase.UNREGISTER)]
         )
         # and the error callback should have been triggered
-        error_callback.assert_called_once_with("unregistration failed")
+        error_callback.assert_called_once_with(unregistration_error)
         # we should have requested the appropriate tasks
         subscription_proxy.SetRHSMConfigWithTask.assert_called_once()
         subscription_proxy.UnregisterWithTask.assert_called_once()


### PR DESCRIPTION
This PR adds support for working with Red Hat accounts accounts that belong to more than one organization.

While such accounts don't seem to exist on Red Hat hosted subscription infrastructure, they are often used on customer Satellite instances. Due to this is multi-organization account support is an important part of the wider Satellite support work.

**NOTE:** At the moment this PR is based on top of the main Satellite support PR, as it would be effectively impossible to test (only Satellite instances realistically provide multi-organization accounts). Due to this **the last three commits** are the ones relevant to multi-org support, with the remaining ones coming from the [main Satellite support PR](https://github.com/rhinstaller/anaconda/pull/3485).

**TODO**
- [x] verify unregistration behavior
- [x] fixup unit tests