### PR TITLE
fsset: Ignore all swap activation errors in turn_on_swap

### DIFF
--- a/pyanaconda/modules/storage/devicetree/fsset.py
+++ b/pyanaconda/modules/storage/devicetree/fsset.py
@@ -530,8 +530,7 @@ class FSSet(object):
                 try:
                     device.setup()
                     device.format.setup()
-                except (blockdev.SwapOldError, blockdev.SwapSuspendError,
-                        blockdev.SwapUnknownError, blockdev.SwapPagesizeError) as e:
+                except blockdev.SwapActivateError as e:
                     log.error("Failed to activate swap on '%s': %s", device.name, str(e))
                     break
                 else:


### PR DESCRIPTION
BlockDev.swap.swapon can also raise the generic SwapActivateError
when the swapon ioctl fails and all the other errors here are
inherited from it so using it safer. We might also add some more
special exception for other swapon errors in the future so using
SwapActivateError will cover these too.

Resolves: rhbz#1977413

Note: This is currently broken because libblockdev raises a wrong exception, see https://github.com/storaged-project/libblockdev/pull/654 We can either wait for the libblockdev fix or use the even more generic `SwapError`. (Also blivet should really use its custom exceptions everywhere instead of propagating libblockdev exceptions and forcing you to deal with these low level issues, but that's a completely different story.)