### PR TITLE
Fix issues from new pylint 2.10.2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,8 +48,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Anaconda'
-copyright = u'2015, Red Hat, Inc.'      # pylint: disable=redefined-builtin
+project = 'Anaconda'
+copyright = '2015, Red Hat, Inc.'      # pylint: disable=redefined-builtin
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -207,8 +207,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'Anaconda.tex', u'Anaconda Documentation',
-   u'Anaconda Team', 'manual'),
+  ('index', 'Anaconda.tex', 'Anaconda Documentation',
+   'Anaconda Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -237,8 +237,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'Anaconda', u'Anaconda Documentation',
-     [u'Anaconda Team'], 1)
+    ('index', 'Anaconda', 'Anaconda Documentation',
+     ['Anaconda Team'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -251,8 +251,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'Anaconda', u'Anaconda Documentation',
-   u'Anaconda Team', 'Anaconda', 'One line description of project.',
+  ('index', 'Anaconda', 'Anaconda Documentation',
+   'Anaconda Team', 'Anaconda', 'One line description of project.',
    'Miscellaneous'),
 ]
 
@@ -269,10 +269,10 @@ texinfo_documents = [
 # -- Options for Epub output ---------------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = u'Anaconda'
-epub_author = u'Anaconda Team'
-epub_publisher = u'Anaconda Team'
-epub_copyright = u'2015, Anaconda Team'
+epub_title = 'Anaconda'
+epub_author = 'Anaconda Team'
+epub_publisher = 'Anaconda Team'
+epub_copyright = '2015, Anaconda Team'
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.

--- a/pyanaconda/core/users.py
+++ b/pyanaconda/core/users.py
@@ -178,7 +178,7 @@ def guess_username(fullname):
     if len(fullname) > 0:
         username = fullname[-1].lower()
     else:
-        username = u""
+        username = ""
 
     # and prefix it with the first name initial
     if len(fullname) > 1:

--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -395,7 +395,7 @@ f%s(msg, non_ascii)
         eval(compile(code, "str_eval", "exec"))  # pylint: disable=eval-used
 
     # test non-ascii characters dumping
-    non_ascii = u'\u0159'
+    non_ascii = '\u0159'
 
     msg = "NOTABUG: testing exception handling"
 

--- a/pyanaconda/ui/tui/__init__.py
+++ b/pyanaconda/ui/tui/__init__.py
@@ -85,7 +85,7 @@ class TextUserInterface(ui.UserInterface):
     ENVIRONMENT = "anaconda"
 
     def __init__(self, storage, payload,
-                 productTitle=u"Anaconda", isFinal=True,
+                 productTitle="Anaconda", isFinal=True,
                  quitMessage=QUIT_MESSAGE):
         """
         For detailed description of the arguments see

--- a/pyanaconda/ui/tui/tuiobject.py
+++ b/pyanaconda/ui/tui/tuiobject.py
@@ -97,7 +97,7 @@ class TUIObject(UIScreen, common.UIObject):
     def __init__(self, data):
         UIScreen.__init__(self)
         common.UIObject.__init__(self, data)
-        self.title = u"Default title"
+        self.title = "Default title"
 
     @property
     def showable(self):

--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -74,6 +74,7 @@ disable=protected-access,
         unnecessary-pass,
         locally-disabled,
         file-ignored,
+        unspecified-encoding,
         C,
         R
 

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -27,7 +27,6 @@ class AnacondaLintConfig(CensorshipConfig):
             FalsePositive(r"^E1101.*: FedoraGeoIPProvider._refresh: Instance of 'LookupDict' has no 'ok' member"),
             FalsePositive(r"^E1101.*: HostipGeoIPProvider._refresh: Instance of 'LookupDict' has no 'ok' member"),
             FalsePositive(r"^E1101.*: Method 'PropertiesChanged' has no 'connect' member"),
-            FalsePositive(r"^E1101.*: NetworkService.get_team_devices: Instance of 'AttachedSubscription' has no 'device_type' member"),
 
             # TODO: BlockDev introspection needs to be added to pylint to handle these
             FalsePositive(r"E1101.*: Instance of 'int' has no 'dasd_is_fba' member"),

--- a/tests/unit_tests/pyanaconda_tests/core/test_util.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_util.py
@@ -515,10 +515,8 @@ class MiscTests(unittest.TestCase):
         test_paths = [
             "foo",
             "foo/bar/baz",
-            u"foo/bar/baz",
             "",
             "čřščščřščř",
-            u"čřščščřščř",
             "asdasd asdasd",
             "! spam"
         ]
@@ -577,28 +575,27 @@ class MiscTests(unittest.TestCase):
         """Test strip_accents."""
 
         # empty string
-        assert util.strip_accents(u"") == u""
         assert util.strip_accents("") == ""
 
         # some Czech accents
-        assert util.strip_accents(u"ěščřžýáíéúů") == u"escrzyaieuu"
-        assert util.strip_accents(u"v češtině") == u"v cestine"
-        assert util.strip_accents(u"měšťánek rozšíří HÁČKY") == u"mestanek rozsiri HACKY"
-        assert util.strip_accents(u"nejneobhospodařovávatelnějšímu") == \
-            u"nejneobhospodarovavatelnejsimu"
+        assert util.strip_accents("ěščřžýáíéúů") == "escrzyaieuu"
+        assert util.strip_accents("v češtině") == "v cestine"
+        assert util.strip_accents("měšťánek rozšíří HÁČKY") == "mestanek rozsiri HACKY"
+        assert util.strip_accents("nejneobhospodařovávatelnějšímu") == \
+            "nejneobhospodarovavatelnejsimu"
 
         # some German umlauts
-        assert util.strip_accents(u"Lärmüberhörer") == u"Larmuberhorer"
-        assert util.strip_accents(u"Heizölrückstoßabdämpfung") == \
-            u"Heizolrucksto\xdfabdampfung"
+        assert util.strip_accents("Lärmüberhörer") == "Larmuberhorer"
+        assert util.strip_accents("Heizölrückstoßabdämpfung") == \
+            "Heizolrucksto\xdfabdampfung"
 
         # some Japanese
-        assert util.strip_accents(u"日本語") == u"\u65e5\u672c\u8a9e"
-        assert util.strip_accents(u"アナコンダ") == u"\u30a2\u30ca\u30b3\u30f3\u30bf" # Anaconda
+        assert util.strip_accents("日本語") == "\u65e5\u672c\u8a9e"
+        assert util.strip_accents("アナコンダ") == "\u30a2\u30ca\u30b3\u30f3\u30bf" # Anaconda
 
         # combined
-        input_string = u"ASCI měšťánek アナコンダ Heizölrückstoßabdämpfung"
-        output_string = u"ASCI mestanek \u30a2\u30ca\u30b3\u30f3\u30bf Heizolrucksto\xdfabdampfung"
+        input_string = "ASCI měšťánek アナコンダ Heizölrückstoßabdämpfung"
+        output_string = "ASCI mestanek \u30a2\u30ca\u30b3\u30f3\u30bf Heizolrucksto\xdfabdampfung"
         assert util.strip_accents(input_string) == output_string
 
     def test_cmp_obj_attrs(self):
@@ -703,8 +700,8 @@ class MiscTests(unittest.TestCase):
         assert not util.have_word_match(None, None)
 
         # Compare designated unicode and "standard" unicode string and make sure nothing crashes
-        assert util.have_word_match("fête", u"fête champêtre")
-        assert util.have_word_match(u"fête", "fête champêtre")
+        assert util.have_word_match("fête", "fête champêtre")
+        assert util.have_word_match("fête", "fête champêtre")
 
     def test_parent_dir(self):
         """Test the parent_dir function"""


### PR DESCRIPTION
This PR solve three pylint issues which breaking our container refresh now:
- Ignore new pylint warning which is not important for Anaconda project.
- Remove not needed 'u' prefix for strings (spoilert alert -- all the strings in Python3 are unicode :hand_over_mouth: )
- Revert our disable for a flake we had because of NetworkManager. I was looking for last 5 builds and it was always marked as false positive so let's try to get it back again and see.