### PR TITLE
Enable COPR build for Fedora 35

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -33,14 +33,14 @@ jobs:
       project: Anaconda
       preserve_project: True
 
-#  - job: copr_build
-#    trigger: commit
-#    metadata:
-#      targets:
-#        - fedora-latest
-#      branch: f34-devel
-#      owner: "@rhinstaller"
-#      project: Anaconda-devel
-#      preserve_project: True
-#      additional_repos:
-#        - "copr://@storage/blivet-daily"
+  - job: copr_build
+    trigger: commit
+    metadata:
+      targets:
+        - fedora-latest
+      branch: f35-devel
+      owner: "@rhinstaller"
+      project: Anaconda-devel
+      preserve_project: True
+      additional_repos:
+        - "copr://@storage/blivet-daily"


### PR DESCRIPTION
We would like to have daily builds of the Anaconda for f35-devel branch. Packit will handle that.