### PR TITLE
Define a unique id in the main spokes and hubs

### DIFF
--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -16,7 +16,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod, ABC
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import ANACONDA_ENVIRON, FIRSTBOOT_ENVIRON
@@ -157,7 +157,24 @@ class FirstbootOnlySpokeMixIn(object):
             return False
 
 
-class Spoke(object, metaclass=ABCMeta):
+class Screen(ABC):
+    """A representation of one UI screen."""
+
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen.
+
+        The screen id should match a regex: [a-z][a-z-]*
+        For example: installation-summary, storage-configuration
+
+        FIXME: Make this function abstract.
+
+        :return: a lowercase string or None
+        """
+        return None
+
+
+class Spoke(Screen):
     """A Spoke is a single configuration screen.  There are several different
        places where a Spoke can be displayed, each of which will have its own
        unique class.  A Spoke is typically used when an element in the Hub is
@@ -498,7 +515,7 @@ class StandaloneSpoke(Spoke):
         return None
 
 
-class Hub(object, metaclass=ABCMeta):
+class Hub(Screen):
     """A Hub is an overview UI screen.  A Hub consists of one or more grids of
        configuration options that the user may choose from.  Each grid is
        provided by a SpokeCategory, and each option is provided by a Spoke.

--- a/pyanaconda/ui/gui/hubs/summary.py
+++ b/pyanaconda/ui/gui/hubs/summary.py
@@ -37,6 +37,11 @@ class SummaryHub(Hub):
     uiFile = "hubs/summary.glade"
     helpFile = "SummaryHub.xml"
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "installation-summary"
+
     def __init__(self, data, storage, payload):
         """Create a new Hub instance.
 

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -509,6 +509,11 @@ class FilterSpoke(NormalSpoke):
 
     title = CN_("GUI|Spoke", "_Installation Destination")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "storage-advanced-configuration"
+
     def __init__(self, *args):
         super().__init__(*args)
         self.applyOnSkip = True

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -98,6 +98,11 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
 
     helpFile = "blivet-gui/index.page"
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "blivet-gui-partitioning"
+
     ### methods defined by API ###
     def __init__(self, data, storage, payload):
         """

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -103,6 +103,11 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     # If the user enters a smaller size, the GUI changes it to this value
     MIN_SIZE_ENTRY = Size("1 MiB")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "interactive-partitioning"
+
     def __init__(self, data, storage, payload):
         StorageCheckHandler.__init__(self)
         NormalSpoke.__init__(self, data, storage, payload)

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -175,6 +175,11 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
     _hack = TimezoneMap.TimezoneMap()
     del(_hack)
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "date-time-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/gui/spokes/installation_progress.py
+++ b/pyanaconda/ui/gui/spokes/installation_progress.py
@@ -48,6 +48,11 @@ class ProgressSpoke(StandaloneSpoke):
 
     postForHub = SummaryHub
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "installation-progress"
+
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
         self._totalSteps = 0

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -407,6 +407,11 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
     icon = "media-optical-symbolic"
     title = CN_("GUI|Spoke", "_Installation Source")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "software-source-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Don't run for any non-package payload."""

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -291,6 +291,11 @@ class KeyboardSpoke(NormalSpoke):
     icon = "input-keyboard-symbolic"
     title = CN_("GUI|Spoke", "_Keyboard")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "keyboard-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -63,6 +63,11 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
     icon = "accessories-character-map-symbolic"
     title = CN_("GUI|Spoke", "_Language Support")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "language-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1466,6 +1466,11 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
     category = SystemCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "network-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""
@@ -1621,6 +1626,11 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
 
     preForHub = SummaryHub
     priority = 10
+
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "network-pre-configuration"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -56,6 +56,11 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     icon = "dialog-password-symbolic"
     title = CN_("GUI|Spoke", "_Root Account")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "root-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -60,6 +60,11 @@ class SoftwareSelectionSpoke(NormalSpoke):
     icon = "package-x-generic-symbolic"
     title = CN_("GUI|Spoke", "_Software Selection")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "software-selection"
+
     @classmethod
     def should_run(cls, environment, data):
         """Don't run for any non-package payload."""

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -82,6 +82,11 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
     icon = "drive-harddisk-symbolic"
     title = CN_("GUI|Spoke", "Installation _Destination")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "storage-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Don't run the storage spoke on dir installations."""

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -75,6 +75,11 @@ class SubscriptionSpoke(NormalSpoke):
     REGISTRATION_PAGE = 0
     SUBSCRIPTION_STATUS_PAGE = 1
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "subscription-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """The Subscription spoke should run only if the Subscription module is available."""

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -231,6 +231,11 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
     icon = "avatar-default-symbolic"
     title = CN_("GUI|Spoke", "_User Creation")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "user-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -64,6 +64,11 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
     preForHub = SummaryHub
     priority = 0
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "language-pre-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -46,6 +46,11 @@ class SummaryHub(TUIHub):
     """
     helpFile = "SummaryHub.txt"
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "installation-summary"
+
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
         self.title = N_("Installation")

--- a/pyanaconda/ui/tui/spokes/installation_progress.py
+++ b/pyanaconda/ui/tui/spokes/installation_progress.py
@@ -44,6 +44,11 @@ class ProgressSpoke(StandaloneTUISpoke):
     """
     postForHub = SummaryHub
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "installation-progress"
+
     def __init__(self, ksdata, storage, payload):
         self.initialize_start()
         super().__init__(ksdata, storage, payload)

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -68,6 +68,11 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
 
     SET_NETWORK_INSTALL_MODE = "network_install"
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "software-source-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Don't run for any non-package payload."""

--- a/pyanaconda/ui/tui/spokes/kernel_warning.py
+++ b/pyanaconda/ui/tui/spokes/kernel_warning.py
@@ -30,6 +30,11 @@ class KernelWarningSpoke(StandaloneTUISpoke):
     """Spoke for kernel-related warnings."""
     preForHub = SummaryHub
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "kernel-warning"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.title = N_("Warning: Processor has Simultaneous Multithreading (SMT) enabled")

--- a/pyanaconda/ui/tui/spokes/language_support.py
+++ b/pyanaconda/ui/tui/spokes/language_support.py
@@ -50,6 +50,11 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     helpFile = "LangSupportSpoke.txt"
     category = LocalizationCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "language-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -205,6 +205,11 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         NM.DeviceType.INFINIBAND,
     ]
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "network-configuration"
+
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)
         self.title = N_("Network configuration")

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -39,6 +39,11 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     helpFile = "PasswordSpoke.txt"
     category = UserSettingsCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "root-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/tui/spokes/shell_spoke.py
+++ b/pyanaconda/ui/tui/spokes/shell_spoke.py
@@ -27,6 +27,8 @@ from blivet import arch
 
 from simpleline.render.widgets import TextWidget
 
+__all__ = ["ShellSpoke"]
+
 
 class ShellSpoke(NormalTUISpoke):
     """
@@ -34,6 +36,11 @@ class ShellSpoke(NormalTUISpoke):
           :parts: 3
     """
     category = SystemCategory
+
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "shell"
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -48,6 +48,11 @@ class SoftwareSpoke(NormalTUISpoke):
     helpFile = "SoftwareSpoke.txt"
     category = SoftwareCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "software-selection"
+
     @classmethod
     def should_run(cls, environment, data):
         """Don't run for any non-package payload."""

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -80,6 +80,11 @@ class StorageSpoke(NormalTUISpoke):
     helpFile = "StorageSpoke.txt"
     category = SystemCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "storage-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Don't run the storage spoke on dir installations."""

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -54,6 +54,11 @@ class TimeSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     helpFile = "DateTimeSpoke.txt"
     category = LocalizationCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "date-time-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/tui/spokes/unsupported_hardware.py
+++ b/pyanaconda/ui/tui/spokes/unsupported_hardware.py
@@ -33,6 +33,11 @@ class UnsupportedHardwareSpoke(StandaloneTUISpoke):
     preForHub = SummaryHub
     priority = -10
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "unsupported-hardware-warning"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.title = N_("Unsupported Hardware Detected")

--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -48,6 +48,11 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     helpFile = "UserSpoke.txt"
     category = UserSettingsCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "user-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/tests/unit_tests/pyanaconda_tests/ui/test_simple_ui.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_simple_ui.py
@@ -18,12 +18,13 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import os
+import re
 import sys
 import unittest
 
 from unittest.mock import Mock, patch, create_autospec
 from pyanaconda.ui import UserInterface
-from pyanaconda.ui.common import StandaloneSpoke, Hub
+from pyanaconda.ui.common import StandaloneSpoke, Hub, Screen
 from tests.unit_tests.pyanaconda_tests import patch_dbus_get_proxy
 
 
@@ -60,15 +61,47 @@ class SimpleUITestCase(unittest.TestCase):
 
     @property
     def action_classes(self):
-        return self.interface._collectActionClasses(self.paths["spokes"], StandaloneSpoke)
+        actions = self.interface._collectActionClasses(self.paths["spokes"], StandaloneSpoke)
+        return self.interface._orderActionClasses(actions, self.hubs)
 
     @property
-    def ordered_action_classes(self):
-        return self.interface._orderActionClasses(self.action_classes, self.hubs)
+    def screens(self):
+        screens = self._get_subclasses(Screen)
+        prefixes = set(mask % "" for mask, _ in self.paths["hubs"])
+        prefixes.update(mask % "" for mask, _ in self.paths["spokes"])
+        return self._filter_prefixes(prefixes, screens)
 
-    def _get_action_class_names(self):
-        classes = self.interface._orderActionClasses(self.action_classes, self.hubs)
-        return [cls.__name__ for cls in classes]
+    def _get_subclasses(self, cls):
+        subclasses = set()
+
+        for subcls in cls.__subclasses__():
+            subclasses.add(subcls)
+            subclasses.update(self._get_subclasses(subcls))
+
+        return subclasses
+
+    def _filter_prefixes(self, prefixes, classes):
+        return list(filter(lambda s: any(map(s.__module__.startswith, prefixes)), classes))
+
+    def _get_screen_ids(self, screens):
+        return [cls.get_screen_id() for cls in screens]
+
+    def _check_hubs(self, expected_hubs):
+        """Check hub classes."""
+        assert self.hubs == expected_hubs
+
+    def _check_actions(self, expected_ids):
+        """Check the action classes."""
+        screen_ids = self._get_screen_ids(self.action_classes)
+        assert screen_ids == expected_ids
+
+    def _check_categories(self, hub_class, expected_ids):
+        """Check categories and spoke classes."""
+        categories = self._get_categories(hub_class)
+        actual_ids = {c.__name__:  self._get_screen_ids(s) for c, s in categories.items()}
+
+        assert {c: sorted(s) for c, s in actual_ids.items()} \
+            == {c: sorted(s) for c, s in expected_ids.items()}
 
     def _get_categories(self, hub_class):
         hub = hub_class(self.data, self.storage, self.payload)
@@ -76,18 +109,44 @@ class SimpleUITestCase(unittest.TestCase):
         hub.set_path("categories", self.paths["categories"])
         return hub._collectCategoriesAndSpokes()
 
-    def _get_category_names(self, hub_class):
-        categories = self._get_categories(hub_class)
-        return {c.__name__:  list(sorted(s.__name__ for s in categories[c])) for c in categories}
+    def _check_screens(self, expected_ids):
+        """Check the screens."""
+        screen_ids = set()
+
+        for screen in self.screens:
+            screen_id = screen.get_screen_id()
+
+            # FIXME: Require the screen id.
+            if screen_id is None:
+                continue
+
+            # Check the format of the screen id.
+            assert re.fullmatch(r'[a-z][a-z-]*', screen_id)
+
+            # Don't mention 'hub' or 'spoke' in the screen id.
+            assert "hub" not in screen_id.split("-")
+            assert "spoke" not in screen_id.split("-")
+
+            # Check uniqueness of screen ids.
+            assert screen_id not in screen_ids
+            screen_ids.add(screen_id)
+
+        # Check the expected ids.
+        assert sorted(screen_ids) == sorted(expected_ids)
+
+    def _check_interface(self):
+        """Check the user interface."""
+        self._check_spokes_priority_uniqueness()
 
     def _check_spokes_priority_uniqueness(self):
         # Force us to always decide order of standalone spokes based on priority not by name.
         # This will ordering errors easier to spot.
-        spokes = self.ordered_action_classes
+        spokes = self.action_classes
 
         for hub in self.hubs:
             pre_spokes = UserInterface._filter_spokes_by_pre_for_hub_reference(spokes, hub)
             self._check_spokes_with_same_priority(pre_spokes)
+
             post_spokes = UserInterface._filter_spokes_by_post_for_hub_reference(spokes, hub)
             self._check_spokes_with_same_priority(post_spokes)
 
@@ -111,41 +170,68 @@ class SimpleUITestCase(unittest.TestCase):
 
         # Check the hubs
         from pyanaconda.ui.tui.hubs.summary import SummaryHub
-        assert self.hubs == [SummaryHub]
+        self._check_hubs([SummaryHub])
 
         # Check the actions classes.
-        assert self._get_action_class_names() == [
-            "UnsupportedHardwareSpoke",
-            "KernelWarningSpoke",
-            "SummaryHub",
-            "ProgressSpoke"
-        ]
+        self._check_actions([
+            "unsupported-hardware-warning",
+            "kernel-warning",
+            "installation-summary",
+            "installation-progress",
+        ])
 
         # Check the Summary hub.
-        assert self._get_category_names(SummaryHub) == {
+        self._check_categories(SummaryHub, {
             'CustomizationCategory': [],
             'LocalizationCategory': [
-                'LangSpoke',
-                'TimeSpoke'
+                'language-configuration',
+                'date-time-configuration',
             ],
             'SoftwareCategory': [
-                'SoftwareSpoke',
-                'SourceSpoke'
+                'software-selection',
+                'software-source-configuration',
             ],
             'SystemCategory': [
-                'NetworkSpoke',
-                'ShellSpoke',
-                'StorageSpoke'
+                'network-configuration',
+                'storage-configuration',
+                'shell',
             ],
             'UserSettingsCategory': [
-                'PasswordSpoke',
-                'UserSpoke'
+                'root-configuration',
+                'user-configuration',
             ]
-        }
+        })
 
-        # Force us to always decide order of standalone spokes based on priority not by name.
-        # This will ordering errors easier to spot.
-        self._check_spokes_priority_uniqueness()
+        # Check the screens.
+        self._check_screens([
+            # Warnings
+            "unsupported-hardware-warning",
+            "kernel-warning",
+
+            # Installation
+            'installation-summary',
+            'installation-progress',
+
+            # Localization
+            'date-time-configuration',
+            'language-configuration',
+
+            # Software
+            'software-selection',
+            'software-source-configuration',
+
+            # System
+            'network-configuration',
+            'storage-configuration',
+            'shell',
+
+            # User settings
+            'root-configuration',
+            'user-configuration',
+        ])
+
+        # Run general checks on the user interface.
+        self._check_interface()
 
     @patch_dbus_get_proxy
     @patch("pyanaconda.ui.gui.Gtk.Builder")
@@ -159,48 +245,86 @@ class SimpleUITestCase(unittest.TestCase):
 
         # Check the hubs.
         from pyanaconda.ui.gui.hubs.summary import SummaryHub
-        assert self.hubs == [SummaryHub]
+        self._check_hubs([SummaryHub])
 
         # Check the actions classes.
-        assert self._get_action_class_names() == [
-            'WelcomeLanguageSpoke',
-            'NetworkStandaloneSpoke',
-            'SummaryHub',
-            'ProgressSpoke'
-        ]
+        self._check_actions([
+            'language-pre-configuration',
+            'network-pre-configuration',
+            'installation-summary',
+            'installation-progress'
+        ])
 
         # Check the Summary hub.
-        cat_system = [
-                'BlivetGuiSpoke',
-                'CustomPartitioningSpoke',
-                'FilterSpoke',
-                'NetworkSpoke',
-                'StorageSpoke'
-                ]
-        if not HAVE_BLIVET_GUI:
-            cat_system.remove('BlivetGuiSpoke')
+        system_category = [
+            'blivet-gui-partitioning',
+            'interactive-partitioning',
+            'storage-advanced-configuration',
+            'network-configuration',
+            'storage-configuration'
+        ]
 
-        assert self._get_category_names(SummaryHub) == {
+        if not HAVE_BLIVET_GUI:
+            system_category.remove('blivet-gui-partitioning')
+
+        self._check_categories(SummaryHub, {
             'CustomizationCategory': [],
             'LocalizationCategory': [
-                'DatetimeSpoke',
-                'KeyboardSpoke',
-                'LangsupportSpoke'
+                'date-time-configuration',
+                'keyboard-configuration',
+                'language-configuration'
             ],
             'SoftwareCategory': [
-                'SoftwareSelectionSpoke',
-                'SourceSpoke',
-                'SubscriptionSpoke'
+                'software-selection',
+                'software-source-configuration',
+                'subscription-configuration'
             ],
-            'SystemCategory': cat_system,
+            'SystemCategory': system_category,
             'UserSettingsCategory': [
-                'PasswordSpoke',
-                'UserSpoke'
-            ]}
+                'root-configuration',
+                'user-configuration'
+            ]
+        })
 
-        # Force us to always decide order of standalone spokes based on priority not by name.
-        # This will ordering errors easier to spot.
-        self._check_spokes_priority_uniqueness()
+        # Check the screens.
+        screen_ids = [
+            # Installation
+            'installation-summary',
+            'installation-progress',
+
+            # Localization
+            'language-pre-configuration',
+            'language-configuration',
+            'date-time-configuration',
+            'keyboard-configuration',
+
+            # Software
+            'software-selection',
+            'software-source-configuration',
+            'subscription-configuration',
+
+            # System
+            'network-pre-configuration',
+            'network-configuration',
+
+            # Storage
+            'storage-configuration',
+            'storage-advanced-configuration',
+            'interactive-partitioning',
+            'blivet-gui-partitioning',
+
+            # User settings
+            'root-configuration',
+            'user-configuration',
+        ]
+
+        if not HAVE_BLIVET_GUI:
+            screen_ids.remove('blivet-gui-partitioning')
+
+        self._check_screens(screen_ids)
+
+        # Run general checks on the user interface.
+        self._check_interface()
 
     def test_correct_spokes_ordering(self):
         # create fake spokes with the same priority


### PR DESCRIPTION
Implement the `get_screen_id` method in spokes and hubs that provide
built-in help. Eventually, all spokes and hubs should have a unique
screen id.