### PR TITLE
data/profile.d: Add profiles for KDE & Kinoite Spins

### DIFF
--- a/data/profile.d/fedora-kde.conf
+++ b/data/profile.d/fedora-kde.conf
@@ -1,0 +1,17 @@
+# Anaconda configuration file for Fedora KDE Spin.
+
+[Profile]
+# Define the profile.
+profile_id = fedora-kde
+base_profile = fedora
+
+[Profile Detection]
+# Match os-release values.
+os_id = fedora
+variant_id = kde
+
+[Payload]
+default_environment = kde-desktop-environment
+
+[Bootloader]
+menu_auto_hide = True

--- a/data/profile.d/fedora-kinoite.conf
+++ b/data/profile.d/fedora-kinoite.conf
@@ -1,0 +1,11 @@
+# Anaconda configuration file for Fedora Kinoite.
+
+[Profile]
+# Define the profile.
+profile_id = fedora-kinoite
+base_profile = fedora-kde
+
+[Profile Detection]
+# Match os-release values.
+os_id = fedora
+variant_id = kinoite

--- a/tests/unit_tests/pyanaconda_tests/core/test_profile.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_profile.py
@@ -251,6 +251,18 @@ class ProfileConfigurationTestCase(unittest.TestCase):
             WORKSTATION_PARTITIONING
         )
         self._check_default_profile(
+            "fedora-kde",
+            ("fedora", "kde"),
+            ["fedora.conf", "fedora-kde.conf"],
+            WORKSTATION_PARTITIONING
+        )
+        self._check_default_profile(
+            "fedora-kinoite",
+            ("fedora", "kinoite"),
+            ["fedora.conf", "fedora-kde.conf", "fedora-kinoite.conf"],
+            WORKSTATION_PARTITIONING
+        )
+        self._check_default_profile(
             "fedora-iot",
             ("fedora", "iot"),
             ["fedora.conf", "fedora-iot.conf"],


### PR DESCRIPTION
Both profiles are based on Workstation but use the generic Fedora Linux
branding until we make specific ones for those two spins.

Fedora Kinoite is a new Fedora variant similar to Fedora Silverblue,
introduced in Fedora 35.

See https://fedoraproject.org/wiki/Changes/Fedora_Kinoite