### PR TITLE
Fix customization after branching in container refresh GH workflow (#infra)

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container-tag: ['master', 'eln'] # 'f34-devel', 'f34-release'
+        container-tag: ['master', 'eln', 'f35-devel', 'f35-release']
         container-type: ['ci', 'rpm']
         include:
           - container-tag: master


### PR DESCRIPTION
~The BASE_CONTAINER is also inner variable in Makefile so the local variable is used even if the expansion doesn't take place. Renaming the local variable will solve this issue.~
The issue was a different one. I forget to specify tags before matrix.

Test [run](https://github.com/jkonecny12/anaconda/runs/3432553419?check_suite_focus=true).