### PR TITLE
Rename GitHub test to require test for the given branch (#infra)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,16 +20,16 @@ jobs:
         #     on -release, only -release
         #     on master, only master and ELN
         #release: [master, eln, '', f34-release]
-        release: ['', 'f35-devel', 'f35-release']
+        release: ['', 'master', 'f35-release']
         include:
-          - release: ''
+          - release: 'master'
             target_branch: 'master'
             ci_tag: 'master'
           #- release: eln
           #  target_branch: 'master'
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
-          - release: f35-devel
+          - release: ''
             target_branch: 'f35-devel'
             ci_tag: 'f35-devel'
           - release: f35-release
@@ -94,16 +94,16 @@ jobs:
       matrix:
         # For matrix details, see comments for the unit tests above.
         #release: [master, eln, '', f34-release]
-        release: ['', 'f35-devel', 'f35-release']
+        release: ['', 'master', 'f35-release']
         include:
-          - release: ''
+          - release: 'master'
             target_branch: 'master'
             ci_tag: 'master'
           #- release: eln
           #  target_branch: 'master'
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
-          - release: f35-devel
+          - release: ''
             target_branch: 'f35-devel'
             ci_tag: 'f35-devel'
           - release: f35-release


### PR DESCRIPTION
Renaming f35-devel to '' will correctly solve naming to the required tests on GitHub.