### PR TITLE
Remove default values for Dockerfile arguments (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -1,9 +1,27 @@
-ARG image=registry.fedoraproject.org/fedora:rawhide
+# The `image` arg will set base image for the build.
+# possible values:
+#   registry.fedoraproject.org/fedora:35
+#   registry.fedoraproject.org/fedora:rawhide
+#   registry-proxy.engineering.redhat.com/rh-osbs/ubi9:latest # private source
+#   registry.access.redhat.com/ubi8/ubi # public source
+ARG image
 FROM ${image}
 # FROM starts a new build stage with new ARGs. Put any ARGs after FROM unless required by the FROM itself.
 # see https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
-ARG git_branch=master
-ARG copr_repo=@rhinstaller/Anaconda
+
+# The `git_branch` arg will set git branch of Anaconda from which we are downloding spec file to get
+# dependencies.
+# possible values:
+#   master
+#   f35-devel
+#   f35-release
+ARG git_branch
+
+# The `copr_repo` arg will set Anaconda daily builds copr repository.
+# possible values:
+#   @rhinstaller/Anaconda
+#   @rhinstaller/Anaconda-devel
+ARG copr_repo
 LABEL maintainer=anaconda-list@redhat.com
 
 # On ELN, BaseOS+AppStream don't have all our build dependencies; this provides the "Everything" compose

--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -19,7 +19,13 @@
 #   repositories (VPN for example)
 #
 
-ARG image=registry.fedoraproject.org/fedora:rawhide
+# The `image` arg will set base image for the build.
+# possible values:
+#   registry.fedoraproject.org/fedora:35
+#   registry.fedoraproject.org/fedora:rawhide
+#   registry-proxy.engineering.redhat.com/rh-osbs/ubi9:latest # private source
+#   registry.access.redhat.com/ubi8/ubi # public source
+ARG image
 FROM ${image}
 # FROM starts a new build stage with new ARGs. Put any ARGs after FROM unless required by the FROM itself.
 # see https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact

--- a/dockerfile/anaconda-rhel-copr/Dockerfile
+++ b/dockerfile/anaconda-rhel-copr/Dockerfile
@@ -2,7 +2,7 @@ ARG image=quay.io/rhinstaller/anaconda-ci:master
 FROM ${image}
 # FROM starts a new build stage with new ARGs. Put any ARGs after FROM unless required by the FROM itself.
 # see https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
-ARG git_branch=master
+
 LABEL maintainer=anaconda-list@redhat.com
 
 # Install build dependencies

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -1,8 +1,21 @@
-ARG image=registry.fedoraproject.org/fedora:rawhide
+# The `image` arg will set base image for the build.
+# possible values:
+#   registry.fedoraproject.org/fedora:35
+#   registry.fedoraproject.org/fedora:rawhide
+#   registry-proxy.engineering.redhat.com/rh-osbs/ubi9:latest # private source
+#   registry.access.redhat.com/ubi8/ubi # public source
+ARG image
 FROM ${image}
 # FROM starts a new build stage with new ARGs. Put any ARGs after FROM unless required by the FROM itself.
 # see https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
-ARG git_branch=master
+
+# The `git_branch` arg will set git branch of Anaconda from which we are downloding spec file to get
+# dependencies.
+# possible values:
+#   master
+#   f35-devel
+#   f35-release
+ARG git_branch
 ARG copr_repo=@rhinstaller/Anaconda
 LABEL maintainer=anaconda-list@redhat.com
 


### PR DESCRIPTION
All the values are set by Makefile anyway and it will make the branching a lot easier.

Avoid changing the `anaconda-rhel-copr` Dockerfile because it's invoked only on `master` from GitHub workflow with the same argument all the time.