### PR TITLE
Prepare for removal of product vars from constants

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -34,11 +34,7 @@ from pyanaconda import product
 productName = product.productName
 productVersion = product.productVersion
 isFinal = product.isFinal
-
-# for use in device names, eg: "fedora", "rhel"
-shortProductName = productName.lower()          # pylint: disable=no-member
-if productName.count(" "):                      # pylint: disable=no-member
-    shortProductName = ''.join(s[0] for s in shortProductName.split())
+shortProductName = product.shortProductName
 
 # The default virtio port.
 VIRTIO_PORT = "/dev/virtio-ports/org.fedoraproject.anaconda.log.0"

--- a/pyanaconda/modules/payloads/payload/dnf/tree_info.py
+++ b/pyanaconda/modules/payloads/payload/dnf/tree_info.py
@@ -25,8 +25,8 @@ from requests import RequestException
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.constants import URL_TYPE_BASEURL, NETWORK_CONNECTION_TIMEOUT, \
-    DEFAULT_REPOS, productName, productVersion
+from pyanaconda.core.constants import URL_TYPE_BASEURL, NETWORK_CONNECTION_TIMEOUT, DEFAULT_REPOS
+from pyanaconda.product import productName, productVersion
 from pyanaconda.core.payload import split_protocol, ProxyString, ProxyStringError
 from pyanaconda.core.util import requests_session, xprogressive_delay
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData

--- a/pyanaconda/modules/storage/checker/utils.py
+++ b/pyanaconda/modules/storage/checker/utils.py
@@ -26,8 +26,9 @@ from blivet.devicefactory import get_device_type
 from blivet.size import Size
 
 from pyanaconda import isys
+from pyanaconda.product import productName
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.constants import productName, STORAGE_REFORMAT_BLOCKLIST, \
+from pyanaconda.core.constants import STORAGE_REFORMAT_BLOCKLIST, \
     STORAGE_REFORMAT_ALLOWLIST, STORAGE_MIN_PARTITION_SIZES, STORAGE_MIN_RAM, \
     STORAGE_SWAP_IS_RECOMMENDED, STORAGE_MUST_BE_ON_ROOT, STORAGE_MUST_BE_ON_LINUXFS, \
     STORAGE_LUKS2_MIN_RAM, STORAGE_ROOT_DEVICE_TYPES, STORAGE_REQ_PARTITION_SIZES, \

--- a/pyanaconda/modules/storage/devicetree/model.py
+++ b/pyanaconda/modules/storage/devicetree/model.py
@@ -29,7 +29,7 @@ from blivet.devicelibs.crypto import DEFAULT_LUKS_VERSION
 from pyanaconda.core import util
 from pyanaconda.modules.storage.bootloader import BootLoaderFactory
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.constants import shortProductName
+from pyanaconda.product import shortProductName
 from pyanaconda.modules.storage.devicetree.fsset import FSSet
 from pyanaconda.modules.storage.devicetree.utils import download_escrow_certificate, \
     find_live_backing_device

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -55,6 +55,7 @@ from pyanaconda.payload import utils as payload_utils
 from pyanaconda.payload.base import Payload
 from pyanaconda.payload.errors import PayloadError, PayloadSetupError
 from pyanaconda.payload.image import find_first_iso_image, find_optical_install_media
+from pyanaconda.product import isFinal
 from pyanaconda.modules.payloads.payload.dnf.tree_info import TreeInfoMetadata, NoTreeInfoError, \
     TreeInfoMetadataError
 from pyanaconda.progress import progress_message
@@ -794,7 +795,7 @@ class DNFPayload(Payload):
                 id_ = repo.id
                 if 'source' in id_ or 'debuginfo' in id_:
                     self._disable_repo(id_)
-                elif constants.isFinal and 'rawhide' in id_:
+                elif isFinal and 'rawhide' in id_:
                     self._disable_repo(id_)
 
             # fetch md for enabled repos

--- a/pyanaconda/product.py
+++ b/pyanaconda/product.py
@@ -41,6 +41,11 @@ productVersion = config.get("Main", "Version")
 if productVersion == "development":
     productVersion = "rawhide"
 
+# for use in device names, eg: "fedora", "rhel"
+shortProductName = productName.lower()          # pylint: disable=no-member
+if productName.count(" "):                      # pylint: disable=no-member
+    shortProductName = ''.join(s[0] for s in shortProductName.split())
+
 
 def trim_product_version_for_ui(version):
     """Trim off parts of version that should not be displayed in UI.


### PR DESCRIPTION
Some steps towards removing product-related variables from `pyanaconda.core.constants`. These are mostly re-imported from `pyanaconda.product` anyway.

It is not possible to fully remove them yet, because initial setup and addons depend on these too. So these are only changes inside anaconda codebase, actual removal must come later. After this is merged & released, https://github.com/OpenSCAP/oscap-anaconda-addon/pull/171 can go, and after that is handled, we can delete the product stuff in `constants` with another PR.