### PR TITLE
Fix Removed options inst.[product|variant] were subsections

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -999,13 +999,13 @@ automatically detected, so this is the same as ``inst.repo=nfs:``...
 .. inst.product:
 
 inst.product
-++++++++++++
+^^^^^^^^^^^^
 
 Use the ``inst.profile`` option instead.
 
 .. inst.variant:
 
 inst.variant
-++++++++++++
+^^^^^^^^^^^^
 
 Use the ``inst.profile`` option instead.


### PR DESCRIPTION
The inst.product and `inst.variant` are accidentally one level lower than the rest of the `Removed Options` in the documentation. That will cause having them as the subsection of the `repo=nfsiso` kernel boot option.

_Suggested-by: Alois Mahdal <amahdal>_