### PR TITLE
Remove misleading warning about inst.ks.device replacing ksdevice

### DIFF
--- a/dracut/parse-anaconda-net.sh
+++ b/dracut/parse-anaconda-net.sh
@@ -16,9 +16,7 @@ mac_to_bootif() {
 
 # handle ksdevice (tell us which device to use for ip= stuff later)
 export ksdevice=""
-# TODO: Remove support for ksdevice. It's deprecated a long time already
-# this should be inst.ksdevice however, this is deprecated a long time so we don't have
-# any inst.ksdevice. Let's just ignore this for now.
+# TODO: Remove support for ksdevice.
 ksdev_val=$(getarg ksdevice=)
 if [ -n "$ksdev_val" ]; then
     case "$ksdev_val" in

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -95,7 +95,6 @@ check_removed_no_inst_arg "stage2" "inst.stage2"
 
 # kickstart
 check_removed_no_inst_arg "ks" "inst.ks"
-check_removed_no_inst_arg "ksdevice" "inst.ks.device"
 check_removed_no_inst_arg "kssendmac" "inst.ks.sendmac"
 check_removed_no_inst_arg "kssendsn" "inst.ks.sendsn"
 


### PR DESCRIPTION
Resolves: rhbz#2000140

Support for inst.ks.device has never been implemented while the ksdevice
option is still working as a value used to supply device in case of
missing kickstart network --device option.

We will try to remove also support for this ksdevice functionality, so
it would make no sense to make inst.ks.device working at this point.