### PR TITLE
Add Silverblue specific logos to profile.

### DIFF
--- a/data/profile.d/fedora-silverblue.conf
+++ b/data/profile.d/fedora-silverblue.conf
@@ -9,3 +9,6 @@ base_profile = fedora-workstation
 # Match os-release values.
 os_id = fedora
 variant_id = silverblue
+
+[User Interface]
+custom_stylesheet = /usr/share/anaconda/pixmaps/silverblue/fedora-silverblue.css


### PR DESCRIPTION
We would like to use custom Silverblue logo during the installation (resolves fedora-silverblue/issue-tracker#184). This should do the job, I hope nothing more is needed. 
