### PR TITLE
Remove misleading warning about inst.ks.device replacing ksdevice

### DIFF
--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -105,7 +105,6 @@ warn_renamed_arg "stage2" "inst.stage2"
 
 # kickstart
 warn_renamed_arg "ks" "inst.ks"
-warn_renamed_arg "ksdevice" "inst.ks.device"
 warn_renamed_arg "kssendmac" "inst.ks.sendmac"
 warn_renamed_arg "kssendsn" "inst.ks.sendsn"
 


### PR DESCRIPTION
Resolves: rhbz#2001913

Support for inst.ks.device has never been implemented while the vice
option is still working as a value used to supply device in case of
missing kickstart network --device option.

We will try to remove also support for this ksdevice functionality, it
would make no sense to make inst.ks.device working at this point.