### PR TITLE
Enable ELN ~smoke tests~ COPR builds again (#infra)

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -20,7 +20,7 @@ jobs:
     metadata:
       targets:
         - fedora-rawhide
-#        - fedora-eln
+        - fedora-eln
 
   - job: copr_build
     trigger: commit


### PR DESCRIPTION
This will enable ELN COPR build on PR ~and also try to installation of the package there~.

I would like to re-enable the ELN tests because they are working more than 2 weeks without a problem. Let's try it again with the ELN.

*UPDATE*:
Unfortunately AWS images are still not solved for ELN so we can't use testing functionality of Packit for ELN.