### PR TITLE
Few tweaks to `inst.ks.all` doc

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -237,9 +237,9 @@ For example:
 inst.ks.all
 ^^^^^^^^^^^
 
-All locations of type http, https or ftp specified with inst.ks will be used
-sequentially one by one until the kickstart file is fetched. Other locations
-will be ignored.
+All locations of type ``http``, ``https`` or ``ftp`` specified with
+``inst.ks`` will be used sequentially one by one until the kickstart file
+is fetched. Other locations will be ignored.
 
 In the following example, Anaconda will try to fetch the kickstart file at
 first from ``http://a/a.ks``, then from ``http://b/b.ks`` and finally from

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -238,8 +238,8 @@ inst.ks.all
 ^^^^^^^^^^^
 
 Use all locations of type ``http``, ``https`` or ``ftp`` specified with
-multiple ``inst.ks`` sequentially one by one until kickstart file is fetched. Other
-locations will be ignored.
+multiple ``inst.ks`` sequentially one by one until kickstart file is fetched.
+Locations of other types (eg. ``nfs``) will be ignored.
 
 Without this option, only last location specified by ``inst.ks`` is used.
 

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -238,7 +238,7 @@ inst.ks.all
 ^^^^^^^^^^^
 
 Use all locations of type ``http``, ``https`` or ``ftp`` specified with
-``inst.ks`` sequentially one by one until kickstart file is fetched. Other
+multiple ``inst.ks`` sequentially one by one until kickstart file is fetched. Other
 locations will be ignored.
 
 Without this option, only last location specified by ``inst.ks`` is used.

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -237,9 +237,9 @@ For example:
 inst.ks.all
 ^^^^^^^^^^^
 
-All locations of type ``http``, ``https`` or ``ftp`` specified with
-``inst.ks`` will be used sequentially one by one until the kickstart file
-is fetched. Other locations will be ignored.
+Use all locations of type ``http``, ``https`` or ``ftp`` specified with
+``inst.ks`` sequentially one by one until kickstart file is fetched. Other
+locations will be ignored.
 
 In the following example, Anaconda will try to fetch the kickstart file at
 first from ``http://a/a.ks``, then from ``http://b/b.ks`` and finally from

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -241,6 +241,8 @@ Use all locations of type ``http``, ``https`` or ``ftp`` specified with
 ``inst.ks`` sequentially one by one until kickstart file is fetched. Other
 locations will be ignored.
 
+Without this option, only last location specified by ``inst.ks`` is used.
+
 In the following example, Anaconda will try to fetch the kickstart file at
 first from ``http://a/a.ks``, then from ``http://b/b.ks`` and finally from
 ``http://c/c.ks``.


### PR DESCRIPTION
I found the section a hard to read -- I think the first paragraph is a bit ambiguous and does not draw clear  & full picture before moving to examples.

Here's my attempt to fix it in 3 small commits.