### PR TITLE
Generate LVM devices file

### DIFF
--- a/data/post-scripts/70-generate-lvm-device-file.ks
+++ b/data/post-scripts/70-generate-lvm-device-file.ks
@@ -1,0 +1,11 @@
+# Generate LVM devices file
+# /etc/lvm/devices/system.devices
+# This is a temporary workaround and should be reverted once blivet supports
+# manipulation of the file.
+# See: https://bugzilla.redhat.com/show_bug.cgi?id=2002550
+
+%post
+
+[ -e /usr/sbin/vgimportdevices ] && vgimportdevices -a
+
+%end

--- a/data/post-scripts/Makefile.am
+++ b/data/post-scripts/Makefile.am
@@ -16,5 +16,5 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 postscriptsdir = $(datadir)/$(PACKAGE_NAME)/post-scripts
-dist_postscripts_DATA = 80-setfilecons.ks 90-copy-screenshots.ks 99-copy-logs.ks
+dist_postscripts_DATA = 70-generate-lvm-device-file.ks 80-setfilecons.ks 90-copy-screenshots.ks 99-copy-logs.ks
 MAINTAINERCLEANFILES = Makefile.in


### PR DESCRIPTION
Resolves: [rhbz#2002550](https://bugzilla.redhat.com/show_bug.cgi?id=2002550) - or not. This is the first attempt, let's see if the file is needed in initramfs too, then we'd need a task.

Do not port to Fedora.