### PR TITLE
Stop using distutils to compare kernel versions

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -99,6 +99,7 @@ Requires: python3-pwquality
 Requires: python3-systemd
 Requires: python3-productmd
 Requires: python3-dasbus >= %{dasbusver}
+Requires: python3-packaging
 Requires: flatpak-libs
 %if %{defined rhel} && %{undefined centos}
 Requires: subscription-manager >= %{subscriptionmanagerver}

--- a/pyanaconda/modules/payloads/base/utils.py
+++ b/pyanaconda/modules/payloads/base/utils.py
@@ -21,7 +21,7 @@ import functools
 import os
 import stat
 
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -75,6 +75,6 @@ def sort_kernel_version_list(kernel_version_list):
 
 def _compare_versions(v1, v2):
     """Compare two version number strings."""
-    first_version = LooseVersion(v1)
-    second_version = LooseVersion(v2)
+    first_version = parse_version(v1)
+    second_version = parse_version(v2)
     return (first_version > second_version) - (first_version < second_version)


### PR DESCRIPTION
Use packaging instead.

Resolves: [rhbz#2003407](https://bugzilla.redhat.com/show_bug.cgi?id=2003407)

 ~~I'm all ears for better alternatives, this adds another dependency.~~ Already a blivet dependency so this is zero change.

Also, maybe we could eradicate the usage in our dracut code too and be rid of `distutils` completely...