### PR TITLE
Fix boolean comparisons in asserts

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/__init__.py
+++ b/tests/unit_tests/pyanaconda_tests/__init__.py
@@ -117,7 +117,7 @@ def check_kickstart_interface(interface, ks_in, ks_out=None, ks_valid=True, ks_t
     if ks_in is not None:
         callback.assert_any_call(KICKSTART_MODULE.interface_name, {'Kickstarted': True}, [])
     else:
-        assert interface.Kickstarted == False
+        assert interface.Kickstarted is False
         callback.assert_not_called()
 
     # Test the temporary kickstart.

--- a/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
@@ -216,7 +216,7 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
     def test_default_configuration(self):
         # Make sure that we are able to import conf.
         from pyanaconda.core.configuration.anaconda import conf
-        assert conf.anaconda.debug == False
+        assert conf.anaconda.debug is False
 
     def test_source(self):
         conf = AnacondaConfiguration()

--- a/tests/unit_tests/pyanaconda_tests/core/test_profile.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_profile.py
@@ -434,7 +434,7 @@ class ProfileConfigurationTestCase(unittest.TestCase):
             self._load_profile(content)
 
     def test_find_nonexistent_profile(self):
-        assert self._loader.check_profile("custom-profile") == False
+        assert self._loader.check_profile("custom-profile") is False
         assert self._loader.detect_profile("custom-os", "custom-variant") == None
 
     def test_ignore_invalid_profile(self):

--- a/tests/unit_tests/pyanaconda_tests/core/test_util.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_util.py
@@ -64,7 +64,7 @@ class RunSystemctlTests(unittest.TestCase):
         """Test the is_service_installed function."""
         with patch('pyanaconda.core.util.execWithCapture') as execute:
             execute.return_value = "fake.service enabled enabled"
-            assert util.is_service_installed("fake") == True
+            assert util.is_service_installed("fake") is True
             execute.assert_called_once_with("systemctl", [
                 "list-unit-files", "fake.service", "--no-legend", "--root", "/mnt/sysroot"
             ])
@@ -567,7 +567,7 @@ class MiscTests(unittest.TestCase):
             # and the function needs to correctly survie that
             util.vtActivate.__globals__['execWithRedirect'] = raise_os_error
 
-            assert util.vtActivate(2) == False
+            assert util.vtActivate(2) is False
         finally:
             util.vtActivate.__globals__['execWithRedirect'] = _execWithRedirect
 
@@ -931,7 +931,7 @@ class MiscTests(unittest.TestCase):
     def test_is_lpae_available(self, is_arm, mock_open):
         """Test the is_lpae_available function."""
         is_arm.return_value = False
-        assert util.is_lpae_available() == False
+        assert util.is_lpae_available() is False
 
         is_arm.return_value = True
         cpu_info = """
@@ -947,7 +947,7 @@ class MiscTests(unittest.TestCase):
         """
 
         mock_open.return_value = StringIO(dedent(cpu_info))
-        assert util.is_lpae_available() == False
+        assert util.is_lpae_available() is False
 
         cpu_info = """
         processor       : 0
@@ -962,7 +962,7 @@ class MiscTests(unittest.TestCase):
         """
 
         mock_open.return_value = StringIO(dedent(cpu_info))
-        assert util.is_lpae_available() == True
+        assert util.is_lpae_available() is True
 
 
 class LazyObjectTestCase(unittest.TestCase):

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_kickstart.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_kickstart.py
@@ -247,7 +247,7 @@ class KickstartManagerTestCase(unittest.TestCase):
         assert module3.kickstart == self._m3_kickstart
         assert module4.kickstart == ""
 
-        assert report.is_valid() == False
+        assert report.is_valid() is False
         assert len(report.get_messages()) == 2
 
         error = report.get_messages()[0]
@@ -270,7 +270,7 @@ class KickstartManagerTestCase(unittest.TestCase):
         with self._create_ks_files([("ks.mgr.test.empty.cfg", ks_content)]) as filename:
             report = manager.read_kickstart_file(filename)
 
-        assert report.is_valid() == True
+        assert report.is_valid() is True
         assert len(report.get_messages()) == 0
 
         assert manager.generate_kickstart() == ""
@@ -286,7 +286,7 @@ blah
         with self._create_ks_files([("ks.mgr.test.unknown_sect.cfg", ks_content)]) as filename:
             report = manager.read_kickstart_file(filename)
 
-        assert report.is_valid() == False
+        assert report.is_valid() is False
         assert len(report.get_messages()) == 1
 
         error = report.get_messages()[0]
@@ -305,7 +305,7 @@ blah
         with self._create_ks_files([("ks.mgr.test.missing_end.cfg", ks_content)]) as filename:
             report = manager.read_kickstart_file(filename)
 
-        assert report.is_valid() == False
+        assert report.is_valid() is False
         assert len(report.get_messages()) == 1
 
         error = report.get_messages()[0]
@@ -323,7 +323,7 @@ network --device=ens3
         with self._create_ks_files([("ks.mgr.test.missing_include.cfg", ks_content)]) as filename:
             report = manager.read_kickstart_file(filename)
 
-        assert report.is_valid() == False
+        assert report.is_valid() is False
         assert len(report.get_messages()) == 1
 
         error = report.get_messages()[0]

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_kickstart_dispatcher.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_kickstart_dispatcher.py
@@ -213,9 +213,9 @@ class KickstartElementTest(unittest.TestCase):
         assert element.lineno == 4
         assert element.name == "network"
         assert element.content == "network --device=ens3 --activate\n"
-        assert element.is_command() == True
-        assert element.is_section() == False
-        assert element.is_addon() == False
+        assert element.is_command() is True
+        assert element.is_section() is False
+        assert element.is_addon() is False
 
         # Ordinary section
         element = KickstartElement(["%post", "--nochroot", "--interpreter", "/usr/bin/bash"],
@@ -226,9 +226,9 @@ class KickstartElementTest(unittest.TestCase):
         assert element.name == "post"
         assert element.content == \
             "%post --nochroot --interpreter /usr/bin/bash\necho POST1\n%end\n"
-        assert element.is_command() == False
-        assert element.is_section() == True
-        assert element.is_addon() == False
+        assert element.is_command() is False
+        assert element.is_section() is True
+        assert element.is_addon() is False
 
         # Ordinary addon
         element = KickstartElement(["%addon", "scorched", "--planet=Earth"],
@@ -238,10 +238,10 @@ class KickstartElementTest(unittest.TestCase):
         assert element.lineno == 9
         assert element.name == "scorched"
         assert element.content == "%addon scorched --planet=Earth\nnuke\n%end\n"
-        assert element.is_command() == False
+        assert element.is_command() is False
         # NOTE We do not consider addon being a section
-        assert element.is_section() == False
-        assert element.is_addon() == True
+        assert element.is_section() is False
+        assert element.is_addon() is True
 
         # Some more special commands
 
@@ -251,9 +251,9 @@ class KickstartElementTest(unittest.TestCase):
                                    1, filename)
         assert element.name == "text"
         assert element.content == "text\n"
-        assert element.is_command() == True
-        assert element.is_section() == False
-        assert element.is_addon() == False
+        assert element.is_command() is True
+        assert element.is_section() is False
+        assert element.is_addon() is False
 
         # Some more special sections
 
@@ -263,18 +263,18 @@ class KickstartElementTest(unittest.TestCase):
                                    1, filename)
         assert element.name == "pre"
         assert element.content == "%pre\necho PRE\n%end\n"
-        assert element.is_command() == False
-        assert element.is_section() == True
-        assert element.is_addon() == False
+        assert element.is_command() is False
+        assert element.is_section() is True
+        assert element.is_addon() is False
         # no body
         element = KickstartElement(["%packages", "--no-core"],
                                    [],
                                    1, filename)
         assert element.name == "packages"
         assert element.content == "%packages --no-core\n%end\n"
-        assert element.is_command() == False
-        assert element.is_section() == True
-        assert element.is_addon() == False
+        assert element.is_command() is False
+        assert element.is_section() is True
+        assert element.is_addon() is False
 
         # Some more special addons
 
@@ -284,18 +284,18 @@ class KickstartElementTest(unittest.TestCase):
                                    1, filename)
         assert element.name == "pony"
         assert element.content == "%addon pony --fly=True\n%end\n"
-        assert element.is_command() == False
-        assert element.is_section() == False
-        assert element.is_addon() == True
+        assert element.is_command() is False
+        assert element.is_section() is False
+        assert element.is_addon() is True
         # no name! - we don't fail
         element = KickstartElement(["%addon"],
                                    ["blah\n"],
                                    1, filename)
         assert element.name == ""
         assert element.content == "%addon\nblah\n%end\n"
-        assert element.is_command() == False
-        assert element.is_section() == False
-        assert element.is_addon() == True
+        assert element.is_command() is False
+        assert element.is_section() is False
+        assert element.is_addon() is True
 
 
 class TrackedKickstartElementsTest(unittest.TestCase):

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_modules.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_modules.py
@@ -102,7 +102,7 @@ class ModuleManagerTestCase(unittest.TestCase):
         observers = self._check_started_modules(task, service_names)
 
         for observer in observers:
-            assert observer.is_addon == False
+            assert observer.is_addon is False
 
     @patch("dasbus.client.observer.Gio")
     def test_start_addons(self, gio):
@@ -120,7 +120,7 @@ class ModuleManagerTestCase(unittest.TestCase):
         observers = self._check_started_modules(task, service_names)
 
         for observer in observers:
-            assert observer.is_addon == True
+            assert observer.is_addon is True
 
     @patch("dasbus.client.observer.Gio")
     def test_start_modules_forbidden(self, gio):

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_policy.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_policy.py
@@ -30,16 +30,16 @@ class PasswordPolicyTestCase(unittest.TestCase):
         policy = PasswordPolicy.from_defaults("root")
         assert policy.min_quality == 1
         assert policy.min_length == 6
-        assert policy.allow_empty == False
-        assert policy.is_strict == False
+        assert policy.allow_empty is False
+        assert policy.is_strict is False
 
     def test_default_unknown_policy(self):
         """Test the default policy data for unknown policy."""
         policy = PasswordPolicy.from_defaults("test")
         assert policy.min_quality == 0
         assert policy.min_length == 0
-        assert policy.allow_empty == True
-        assert policy.is_strict == False
+        assert policy.allow_empty is True
+        assert policy.is_strict is False
 
     def test_to_structure_dict(self):
         """Test the to_structure_dict method."""

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_services.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_services.py
@@ -116,16 +116,16 @@ class ServicesInterfaceTestCase(unittest.TestCase):
     def test_post_install_tools_disabled(self):
         """Test the post-install-tools-enabled property."""
         # should not be marked as disabled by default
-        assert self.services_interface.PostInstallToolsEnabled == True
+        assert self.services_interface.PostInstallToolsEnabled is True
         # mark as disabled
         self.services_interface.SetPostInstallToolsEnabled(False)
-        assert self.services_interface.PostInstallToolsEnabled == False
+        assert self.services_interface.PostInstallToolsEnabled is False
         self.callback.assert_called_once_with(
             SERVICES.interface_name, {'PostInstallToolsEnabled': False}, []
         )
         # mark as not disabled again
         self.services_interface.SetPostInstallToolsEnabled(True)
-        assert self.services_interface.PostInstallToolsEnabled == True
+        assert self.services_interface.PostInstallToolsEnabled is True
         self.callback.assert_called_with(
             SERVICES.interface_name, {'PostInstallToolsEnabled': True}, []
         )
@@ -139,7 +139,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         ks_out = ""
         self._test_kickstart(ks_in, ks_out)
         assert self.services_interface.SetupOnBoot == SETUP_ON_BOOT_DEFAULT
-        assert self.services_interface.PostInstallToolsEnabled == True
+        assert self.services_interface.PostInstallToolsEnabled is True
 
     def test_kickstart_empty(self):
         """Test with empty string."""
@@ -147,7 +147,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         ks_out = ""
         self._test_kickstart(ks_in, ks_out)
         assert self.services_interface.SetupOnBoot == SETUP_ON_BOOT_DEFAULT
-        assert self.services_interface.PostInstallToolsEnabled == True
+        assert self.services_interface.PostInstallToolsEnabled is True
 
     def test_services_kickstart(self):
         """Test the services command."""
@@ -192,7 +192,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         """
         self._test_kickstart(ks_in, ks_out)
         assert self.services_interface.SetupOnBoot == SETUP_ON_BOOT_DISABLED
-        assert self.services_interface.PostInstallToolsEnabled == False
+        assert self.services_interface.PostInstallToolsEnabled is False
 
     def test_firstboot_enabled_kickstart(self):
         """Test the firstboot command - enabled."""
@@ -205,7 +205,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         """
         self._test_kickstart(ks_in, ks_out)
         assert self.services_interface.SetupOnBoot == SETUP_ON_BOOT_ENABLED
-        assert self.services_interface.PostInstallToolsEnabled == True
+        assert self.services_interface.PostInstallToolsEnabled is True
 
     def test_firstboot_reconfig_kickstart(self):
         """Test the firstboot command - reconfig."""
@@ -218,7 +218,7 @@ class ServicesInterfaceTestCase(unittest.TestCase):
         """
         self._test_kickstart(ks_in, ks_out)
         assert self.services_interface.SetupOnBoot == SETUP_ON_BOOT_RECONFIG
-        assert self.services_interface.PostInstallToolsEnabled == True
+        assert self.services_interface.PostInstallToolsEnabled is True
 
 
 class ServicesTasksTestCase(unittest.TestCase):
@@ -331,7 +331,7 @@ class ServicesTasksTestCase(unittest.TestCase):
         assert post_install_tools_task == object_path
         assert isinstance(obj, TaskInterface)
         assert isinstance(obj.implementation, ConfigurePostInstallationToolsTask)
-        assert obj.implementation._tools_enabled == True
+        assert obj.implementation._tools_enabled is True
 
         # Services configuration
         object_path = publisher.call_args_list[2][0][0]

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_tasks.py
@@ -113,7 +113,7 @@ class TaskInterfaceTestCase(unittest.TestCase):
         self._set_up_task(self.SimpleTask())
 
         assert self.task_interface.Name == "Simple Task"
-        assert self.task_interface.IsRunning == False
+        assert self.task_interface.IsRunning is False
         assert self.task_interface.Steps == 1
         assert self.task_interface.Progress == (0, "")
 

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
@@ -98,48 +98,48 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
 
     def test_keyboard_seen(self):
         """Test the KeyboardKickstarted property."""
-        assert self.localization_interface.KeyboardKickstarted == False
+        assert self.localization_interface.KeyboardKickstarted is False
         ks_in = """
         lang cs_CZ.UTF-8
         """
         ks_in = dedent(ks_in).strip()
         self.localization_interface.ReadKickstart(ks_in)
-        assert self.localization_interface.KeyboardKickstarted == False
+        assert self.localization_interface.KeyboardKickstarted is False
         ks_in = """
         lang cs_CZ.UTF-8
         keyboard cz
         """
         ks_in = dedent(ks_in).strip()
         self.localization_interface.ReadKickstart(ks_in)
-        assert self.localization_interface.KeyboardKickstarted == True
+        assert self.localization_interface.KeyboardKickstarted is True
 
     def test_language_seen(self):
         """Test the LanguageKickstarted property."""
-        assert self.localization_interface.LanguageKickstarted == False
+        assert self.localization_interface.LanguageKickstarted is False
         ks_in = """
         keyboard cz
         """
         ks_in = dedent(ks_in).strip()
         self.localization_interface.ReadKickstart(ks_in)
-        assert self.localization_interface.LanguageKickstarted == False
+        assert self.localization_interface.LanguageKickstarted is False
         ks_in = """
         keyboard cz
         lang cs_CZ.UTF-8
         """
         ks_in = dedent(ks_in).strip()
         self.localization_interface.ReadKickstart(ks_in)
-        assert self.localization_interface.LanguageKickstarted == True
+        assert self.localization_interface.LanguageKickstarted is True
 
     def test_set_language_kickstarted(self):
         """Test SetLanguageKickstarted."""
         self.localization_interface.SetLanguageKickstarted(True)
-        assert self.localization_interface.LanguageKickstarted == True
+        assert self.localization_interface.LanguageKickstarted is True
         self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'LanguageKickstarted': True}, [])
 
     def test_set_keyboard_kickstarted(self):
         """Test SetLanguageKickstarted."""
         self.localization_interface.SetKeyboardKickstarted(True)
-        assert self.localization_interface.KeyboardKickstarted == True
+        assert self.localization_interface.KeyboardKickstarted is True
         self.callback.assert_called_once_with(LOCALIZATION.interface_name, {'KeyboardKickstarted': True}, [])
 
     @patch("pyanaconda.modules.localization.runtime.try_to_load_keymap")

--- a/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network.py
@@ -257,10 +257,10 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(task_path, publisher, NetworkInstallationTask)
 
-        assert obj.implementation._disable_ipv6 == True
-        assert obj.implementation._overwrite == False
+        assert obj.implementation._disable_ipv6 is True
+        assert obj.implementation._overwrite is False
         assert obj.implementation._network_ifaces == ["ens3", "ens4", "ens5"]
-        assert obj.implementation._configure_persistent_device_names == True
+        assert obj.implementation._configure_persistent_device_names is True
 
         self.network_module.log_task_result = Mock()
 
@@ -276,7 +276,7 @@ class NetworkInterfaceTestCase(unittest.TestCase):
 
         obj = check_task_creation(task_path, publisher, HostnameConfigurationTask)
 
-        assert obj.implementation._overwrite == False
+        assert obj.implementation._overwrite is False
         assert obj.implementation._hostname == "my_hostname"
 
     @patch_dbus_publish_object
@@ -1055,16 +1055,16 @@ class NetworkModuleTestCase(unittest.TestCase):
 
     def test_apply_boot_options_noipv6(self):
         """Test _apply_boot_options function for 'noipv6'."""
-        assert self.network_module.disable_ipv6 == False
+        assert self.network_module.disable_ipv6 is False
         mocked_kernel_args = {"something": "else"}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        assert self.network_module.disable_ipv6 == False
+        assert self.network_module.disable_ipv6 is False
         mocked_kernel_args = {'noipv6': None}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        assert self.network_module.disable_ipv6 == True
+        assert self.network_module.disable_ipv6 is True
         mocked_kernel_args = {}
         self.network_module._apply_boot_options(mocked_kernel_args)
-        assert self.network_module.disable_ipv6 == True
+        assert self.network_module.disable_ipv6 is True
 
     def test_apply_boot_options_bootif(self):
         """Test _apply_boot_options function for 'BOOTIF'."""

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_tree_info.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_tree_info.py
@@ -233,15 +233,15 @@ class TreeInfoMetadataTestCase(unittest.TestCase):
 
         repo_md = self.metadata.repositories[0]
         assert repo_md.type == "addon"
-        assert repo_md.enabled == False
+        assert repo_md.enabled is False
 
         repo_md = self.metadata.repositories[1]
         assert repo_md.type == "optional"
-        assert repo_md.enabled == False
+        assert repo_md.enabled is False
 
         repo_md = self.metadata.repositories[2]
         assert repo_md.type == "variant"
-        assert repo_md.enabled == True
+        assert repo_md.enabled is True
 
     def test_valid_repo(self):
         """Test the valid property of the repo metadata."""
@@ -250,10 +250,10 @@ class TreeInfoMetadataTestCase(unittest.TestCase):
             self.metadata.load_file(path)
 
             repo_md = self.metadata.repositories[0]
-            assert repo_md.valid == False
+            assert repo_md.valid is False
 
             self._create_directory(path, "repodata")
-            assert repo_md.valid == True
+            assert repo_md.valid is True
 
     def test_verify_image_base_repo(self):
         """Test the verify_image_base_repo method."""

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
@@ -405,18 +405,18 @@ class DNFInterfaceTestCase(unittest.TestCase):
 
     def test_packages_kickstarted_property(self):
         """Test the PackagesKickstarted property."""
-        assert self.interface.PackagesKickstarted == False
+        assert self.interface.PackagesKickstarted is False
 
         data = KickstartSpecificationHandler(
             PayloadKickstartSpecification
         )
 
         self.module.process_kickstart(data)
-        assert self.interface.PackagesKickstarted == False
+        assert self.interface.PackagesKickstarted is False
 
         data.packages.seen = True
         self.module.process_kickstart(data)
-        assert self.interface.PackagesKickstarted == True
+        assert self.interface.PackagesKickstarted is True
 
     def test_packages_selection_property(self):
         """Test the PackagesSelection property."""
@@ -612,14 +612,14 @@ class DNFModuleTestCase(unittest.TestCase):
 
     def test_is_network_required(self):
         """Test the is_network_required method."""
-        assert self.module.is_network_required() == False
+        assert self.module.is_network_required() is False
 
         source1 = self._create_source(SourceType.CDROM)
         self.module.set_sources([source1])
 
-        assert self.module.is_network_required() == False
+        assert self.module.is_network_required() is False
 
         source2 = self._create_source(SourceType.NFS)
         self.module.set_sources([source1, source2])
 
-        assert self.module.is_network_required() == True
+        assert self.module.is_network_required() is True

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
@@ -150,8 +150,8 @@ class DNFManagerTestCase(unittest.TestCase):
             "install_weak_deps = 1",
         )
 
-        assert self.dnf_manager._ignore_broken_packages == False
-        assert self.dnf_manager._ignore_missing_packages == False
+        assert self.dnf_manager._ignore_broken_packages is False
+        assert self.dnf_manager._ignore_missing_packages is False
 
         data.multilib_policy = MULTILIB_POLICY_ALL
         data.timeout = 100
@@ -168,8 +168,8 @@ class DNFManagerTestCase(unittest.TestCase):
             "install_weak_deps = 0",
         )
 
-        assert self.dnf_manager._ignore_broken_packages == True
-        assert self.dnf_manager._ignore_missing_packages == True
+        assert self.dnf_manager._ignore_broken_packages is True
+        assert self.dnf_manager._ignore_missing_packages is True
 
     def test_dump_configuration(self):
         """Test the dump of the DNF configuration."""
@@ -603,17 +603,17 @@ class DNFManagerTestCase(unittest.TestCase):
     def test_is_package_available(self, get_best_query):
         """Test the is_package_available method."""
         self.dnf_manager._base._sack = Mock()
-        assert self.dnf_manager.is_package_available("kernel") == True
+        assert self.dnf_manager.is_package_available("kernel") is True
 
         # No package.
         get_best_query.return_value = None
-        assert self.dnf_manager.is_package_available("kernel") == False
+        assert self.dnf_manager.is_package_available("kernel") is False
 
         # No metadata.
         self.dnf_manager._base._sack = None
 
         with self.assertLogs(level="WARNING") as cm:
-            assert self.dnf_manager.is_package_available("kernel") == False
+            assert self.dnf_manager.is_package_available("kernel") is False
 
         msg = "There is no metadata about packages!"
         assert any(map(lambda x: msg in x, cm.output))
@@ -827,13 +827,13 @@ class DNFManagerCompsTestCase(unittest.TestCase):
 
     def test_is_environment_valid(self):
         """Test the is_environment_valid method."""
-        assert self.dnf_manager.is_environment_valid("") == False
-        assert self.dnf_manager.is_environment_valid("e1") == False
+        assert self.dnf_manager.is_environment_valid("") is False
+        assert self.dnf_manager.is_environment_valid("e1") is False
 
         self._add_environment("e1")
 
-        assert self.dnf_manager.is_environment_valid("e1") == True
-        assert self.dnf_manager.is_environment_valid("e2") == False
+        assert self.dnf_manager.is_environment_valid("e1") is True
+        assert self.dnf_manager.is_environment_valid("e2") is False
 
     def test_get_environment_data_error(self):
         """Test the failed get_environment_data method."""
@@ -940,7 +940,7 @@ class DNFManagerReposTestCase(unittest.TestCase):
             self.dnf_manager.load_repository("r1")
 
         repo.load.assert_called_once()
-        assert repo.enabled == False
+        assert repo.enabled is False
         assert str(cm.value) == "Fake error!"
 
     def test_load_repository(self):
@@ -951,7 +951,7 @@ class DNFManagerReposTestCase(unittest.TestCase):
         self.dnf_manager.load_repository("r1")
 
         repo.load.assert_called_once()
-        assert repo.enabled == True
+        assert repo.enabled is True
 
     def _create_repo(self, repo, repo_dir):
         """Generate fake metadata for the repo."""
@@ -1025,29 +1025,29 @@ class DNFManagerReposTestCase(unittest.TestCase):
         """Test the verify_repomd_hashes method."""
         with TemporaryDirectory() as d:
             # Test no repository.
-            assert self.dnf_manager.verify_repomd_hashes() == False
+            assert self.dnf_manager.verify_repomd_hashes() is False
 
             # Create a repository.
             r = self._add_repo("r1")
             self._create_repo(r, d)
 
             # Test no loaded repository.
-            assert self.dnf_manager.verify_repomd_hashes() == False
+            assert self.dnf_manager.verify_repomd_hashes() is False
 
             # Test a loaded repository.
             self.dnf_manager.load_repomd_hashes()
-            assert self.dnf_manager.verify_repomd_hashes() == True
+            assert self.dnf_manager.verify_repomd_hashes() is True
 
             # Test a different content of metadata.
             with open(os.path.join(d, "repodata", "repomd.xml"), 'w') as f:
                 f.write("Different metadata for r1.")
 
-            assert self.dnf_manager.verify_repomd_hashes() == False
+            assert self.dnf_manager.verify_repomd_hashes() is False
 
             # Test a reloaded repository.
             self.dnf_manager.load_repomd_hashes()
-            assert self.dnf_manager.verify_repomd_hashes() == True
+            assert self.dnf_manager.verify_repomd_hashes() is True
 
             # Test the base reset.
             self.dnf_manager.reset_base()
-            assert self.dnf_manager.verify_repomd_hashes() == False
+            assert self.dnf_manager.verify_repomd_hashes() is False

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_cdrom.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_cdrom.py
@@ -86,7 +86,7 @@ class CdromSourceTestCase(unittest.TestCase):
 
     def test_network_required(self):
         """Test the property network_required."""
-        assert self.module.network_required == False
+        assert self.module.network_required is False
 
     def test_required_space(self):
         """Test the required_space property."""

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_flatpak.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_flatpak.py
@@ -52,7 +52,7 @@ class FlatpakSourceInterfaceTestCase(unittest.TestCase):
 
     def test_is_available(self):
         """Test the IsAvailable method."""
-        assert self.interface.IsAvailable() == False
+        assert self.interface.IsAvailable() is False
 
 
 class FlatpakSourceTestCase(unittest.TestCase):
@@ -67,7 +67,7 @@ class FlatpakSourceTestCase(unittest.TestCase):
 
     def test_network_required(self):
         """Test the network_required property."""
-        assert self.module.network_required == False
+        assert self.module.network_required is False
 
     def test_required_space(self):
         """Test the required_space property."""

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_harddrive.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_harddrive.py
@@ -109,7 +109,7 @@ class HardDriveSourceTestCase(unittest.TestCase):
 
     def test_network_required(self):
         """Test the property network_required."""
-        assert self.module.network_required == False
+        assert self.module.network_required is False
 
     def test_set_up_with_tasks(self):
         """Hard drive source set up task type and amount."""

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_hmc.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_hmc.py
@@ -55,7 +55,7 @@ class HMCSourceModuleTestCase(unittest.TestCase):
 
     def test_network_required(self):
         """Test the property network_required."""
-        assert self.module.network_required == False
+        assert self.module.network_required is False
 
     def test_required_space(self):
         """Test the required_space property."""

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_image.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_image.py
@@ -88,24 +88,24 @@ class LiveImageSourceTestCase(unittest.TestCase):
 
     def test_network_required(self):
         """Test the network_required property."""
-        assert self.module.network_required == False
+        assert self.module.network_required is False
 
         self.module.configuration.url = "file://my/path"
-        assert self.module.network_required == False
+        assert self.module.network_required is False
 
         self.module.configuration.url = "http://my/path"
-        assert self.module.network_required == True
+        assert self.module.network_required is True
 
         self.module.configuration.url = "https://my/path"
-        assert self.module.network_required == True
+        assert self.module.network_required is True
 
     def test_is_local(self):
         """Test the is_local property."""
         self.module.configuration.url = "file://my/path"
-        assert self.module.is_local == True
+        assert self.module.is_local is True
 
         self.module.configuration.url = "http://my/path"
-        assert self.module.is_local == False
+        assert self.module.is_local is False
 
     def test_get_state(self):
         """Test the source state."""

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_os.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_os.py
@@ -107,7 +107,7 @@ class LiveOSSourceTestCase(unittest.TestCase):
 
     def test_network_required(self):
         """Test the property network_required."""
-        assert self.module.network_required == False
+        assert self.module.network_required is False
 
     def test_required_space(self):
         """Test the required_space property."""

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_nfs.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_nfs.py
@@ -90,7 +90,7 @@ class NFSSourceTestCase(unittest.TestCase):
 
     def test_network_required(self):
         """Test the property network_required."""
-        assert self.module.network_required == True
+        assert self.module.network_required is True
 
     def test_required_space(self):
         """Test the required_space property."""

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_repo_files.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_repo_files.py
@@ -58,7 +58,7 @@ class RepoFilesSourceTestCase(unittest.TestCase):
 
     def test_network_required(self):
         """Test the property network_required."""
-        assert self.module.network_required == True
+        assert self.module.network_required is True
 
     def test_required_space(self):
         """Test the required_space property."""

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_rpm_ostree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_rpm_ostree.py
@@ -79,16 +79,16 @@ class OSTreeSourceTestCase(unittest.TestCase):
 
     def test_network_required(self):
         """Test the network_required property."""
-        assert self.module.network_required == False
+        assert self.module.network_required is False
 
         self.module.configuration.url = "file://my/path"
-        assert self.module.network_required == False
+        assert self.module.network_required is False
 
         self.module.configuration.url = "http://my/path"
-        assert self.module.network_required == True
+        assert self.module.network_required is True
 
         self.module.configuration.url = "https://my/path"
-        assert self.module.network_required == True
+        assert self.module.network_required is True
 
     def test_required_space(self):
         """Test the required_space property."""

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_url.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_url.py
@@ -300,7 +300,7 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
         )
 
     def test_default_install_properties(self):
-        assert self.url_source_interface.InstallRepoEnabled == False
+        assert self.url_source_interface.InstallRepoEnabled is False
 
 
 class URLSourceTestCase(unittest.TestCase):
@@ -311,19 +311,19 @@ class URLSourceTestCase(unittest.TestCase):
 
     def test_network_required(self):
         """Test the property network_required."""
-        assert self.module.network_required == False
+        assert self.module.network_required is False
 
         self.module.repo_configuration.url = "http://my/path"
-        assert self.module.network_required == True
+        assert self.module.network_required is True
 
         self.module.repo_configuration.url = "https://my/path"
-        assert self.module.network_required == True
+        assert self.module.network_required is True
 
         self.module.repo_configuration.url = "file://my/path"
-        assert self.module.network_required == False
+        assert self.module.network_required is False
 
         self.module.repo_configuration.url = "ftp://my/path"
-        assert self.module.network_required == True
+        assert self.module.network_required is True
 
     def test_required_space(self):
         """Test the required_space property."""

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/test_module_payloads.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/test_module_payloads.py
@@ -176,17 +176,17 @@ class PayloadsInterfaceTestCase(TestCase):
 
     def test_is_network_required(self):
         """Test the IsNetworkRequired method."""
-        assert self.payload_interface.IsNetworkRequired() == False
+        assert self.payload_interface.IsNetworkRequired() is False
 
         payload = self.payload_module.create_payload(PayloadType.DNF)
         self.payload_module.activate_payload(payload)
 
-        assert self.payload_interface.IsNetworkRequired() == False
+        assert self.payload_interface.IsNetworkRequired() is False
 
         source = self.payload_module.create_source(SourceType.NFS)
         payload.set_sources([source])
 
-        assert self.payload_interface.IsNetworkRequired() == True
+        assert self.payload_interface.IsNetworkRequired() is True
 
     def test_calculate_required_space(self):
         """Test the CalculateRequiredTest method."""

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
@@ -193,7 +193,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         assert obj.implementation._selinux_mode == SELinuxMode.DEFAULT
         # ConfigureFingerprintAuthTask
         obj = task_objs[1]
-        assert obj.implementation._fingerprint_auth_enabled == False
+        assert obj.implementation._fingerprint_auth_enabled is False
         # ConfigureAuthselectTask
         obj = task_objs[2]
         assert obj.implementation._authselect_options == []
@@ -203,7 +203,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         """Test module in default state with realm join task."""
         realm_join_task_path = self.security_interface.JoinRealmWithTask()
         obj = check_task_creation(realm_join_task_path, publisher, RealmJoinTask)
-        assert obj.implementation._realm_data.discovered == False
+        assert obj.implementation._realm_data.discovered is False
         assert obj.implementation._realm_data.name == ""
         assert obj.implementation._realm_data.join_options == []
 
@@ -255,7 +255,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         realm_join_task_path = self.security_interface.JoinRealmWithTask()
 
         obj = check_task_creation(realm_join_task_path, publisher, RealmJoinTask)
-        assert obj.implementation._realm_data.discovered == True
+        assert obj.implementation._realm_data.discovered is True
         assert obj.implementation._realm_data.name == "domain.example.com"
         assert obj.implementation._realm_data.join_options == ["--one-time-password=password"]
 
@@ -274,7 +274,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
 
         # realm join - after task creation
         obj = check_task_creation(realm_join_task_path, publisher, RealmJoinTask)
-        assert obj.implementation._realm_data.discovered == False
+        assert obj.implementation._realm_data.discovered is False
         assert obj.implementation._realm_data.name == "domain.example.com"
         assert obj.implementation._realm_data.join_options == []
 
@@ -288,7 +288,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         self.security_interface.SetRealm(RealmData.to_structure(realm2))
 
         # realm join - after realm data update
-        assert obj.implementation._realm_data.discovered == True
+        assert obj.implementation._realm_data.discovered is True
         assert obj.implementation._realm_data.name == "domain.example.com"
         assert obj.implementation._realm_data.join_options == ["--one-time-password=password"]
 
@@ -299,7 +299,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         obj = check_task_creation(task_path, publisher, PreconfigureFIPSTask)
         assert obj.implementation._sysroot == "/mnt/sysroot"
         assert obj.implementation._payload_type == PAYLOAD_TYPE_DNF
-        assert obj.implementation._fips_enabled == False
+        assert obj.implementation._fips_enabled is False
 
     @patch_dbus_publish_object
     def test_configure_fips_with_task(self, publisher):
@@ -307,7 +307,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         task_path = self.security_interface.ConfigureFIPSWithTask()
         obj = check_task_creation(task_path, publisher, ConfigureFIPSTask)
         assert obj.implementation._sysroot == "/mnt/sysroot"
-        assert obj.implementation._fips_enabled == False
+        assert obj.implementation._fips_enabled is False
 
     def test_collect_requirements_default(self):
         """Test requrements are empty by default."""

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_automatic.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_automatic.py
@@ -108,13 +108,13 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
 
     def test_requires_passphrase(self):
         """Test RequiresPassphrase."""
-        assert self.interface.RequiresPassphrase() == False
+        assert self.interface.RequiresPassphrase() is False
 
         self.module.request.encrypted = True
-        assert self.interface.RequiresPassphrase() == True
+        assert self.interface.RequiresPassphrase() is True
 
         self.module.request.passphrase = "123456"
-        assert self.interface.RequiresPassphrase() == False
+        assert self.interface.RequiresPassphrase() is False
 
     def test_reset(self):
         """Test the reset of the storage."""

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_custom.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_custom.py
@@ -101,11 +101,11 @@ class CustomPartitioningKickstartTestCase(unittest.TestCase):
     def test_requires_passphrase(self, publisher):
         """Test RequiresPassphrase."""
         self._process_kickstart("part /")
-        assert self.interface.RequiresPassphrase() == False
+        assert self.interface.RequiresPassphrase() is False
         self._process_kickstart("part / --encrypted")
-        assert self.interface.RequiresPassphrase() == True
+        assert self.interface.RequiresPassphrase() is True
         self.interface.SetPassphrase("123456")
-        assert self.interface.RequiresPassphrase() == False
+        assert self.interface.RequiresPassphrase() is False
 
     @patch_dbus_get_proxy
     @patch.object(InstallerStorage, 'mountpoints', new_callable=PropertyMock)

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_specification.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_specification.py
@@ -29,41 +29,41 @@ class PartitioningSpecificationTestCase(unittest.TestCase):
     def test_is_partition(self):
         """Test the is_partition method."""
         spec = PartSpec("/")
-        assert spec.is_partition(AUTOPART_TYPE_PLAIN) == True
-        assert spec.is_partition(AUTOPART_TYPE_LVM) == True
-        assert spec.is_partition(AUTOPART_TYPE_LVM_THINP) == True
-        assert spec.is_partition(AUTOPART_TYPE_BTRFS) == True
+        assert spec.is_partition(AUTOPART_TYPE_PLAIN) is True
+        assert spec.is_partition(AUTOPART_TYPE_LVM) is True
+        assert spec.is_partition(AUTOPART_TYPE_LVM_THINP) is True
+        assert spec.is_partition(AUTOPART_TYPE_BTRFS) is True
 
     def test_is_volume(self):
         """Test the is_volume method."""
         spec = PartSpec("/", lv=True)
-        assert spec.is_volume(AUTOPART_TYPE_PLAIN) == False
-        assert spec.is_volume(AUTOPART_TYPE_LVM) == True
-        assert spec.is_volume(AUTOPART_TYPE_LVM_THINP) == True
-        assert spec.is_volume(AUTOPART_TYPE_BTRFS) == False
+        assert spec.is_volume(AUTOPART_TYPE_PLAIN) is False
+        assert spec.is_volume(AUTOPART_TYPE_LVM) is True
+        assert spec.is_volume(AUTOPART_TYPE_LVM_THINP) is True
+        assert spec.is_volume(AUTOPART_TYPE_BTRFS) is False
 
         spec = PartSpec("/", lv=True, thin=True)
-        assert spec.is_volume(AUTOPART_TYPE_PLAIN) == False
-        assert spec.is_volume(AUTOPART_TYPE_LVM) == True
-        assert spec.is_volume(AUTOPART_TYPE_LVM_THINP) == True
-        assert spec.is_volume(AUTOPART_TYPE_BTRFS) == False
+        assert spec.is_volume(AUTOPART_TYPE_PLAIN) is False
+        assert spec.is_volume(AUTOPART_TYPE_LVM) is True
+        assert spec.is_volume(AUTOPART_TYPE_LVM_THINP) is True
+        assert spec.is_volume(AUTOPART_TYPE_BTRFS) is False
 
         spec = PartSpec("/", btr=True)
-        assert spec.is_volume(AUTOPART_TYPE_PLAIN) == False
-        assert spec.is_volume(AUTOPART_TYPE_LVM) == False
-        assert spec.is_volume(AUTOPART_TYPE_LVM_THINP) == False
-        assert spec.is_volume(AUTOPART_TYPE_BTRFS) == True
+        assert spec.is_volume(AUTOPART_TYPE_PLAIN) is False
+        assert spec.is_volume(AUTOPART_TYPE_LVM) is False
+        assert spec.is_volume(AUTOPART_TYPE_LVM_THINP) is False
+        assert spec.is_volume(AUTOPART_TYPE_BTRFS) is True
 
     def test_is_lvm_thin_volume(self):
         """Test the is_lvm_thin_volume method."""
         spec = PartSpec("/", lv=True)
-        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_PLAIN) == False
-        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM) == False
-        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM_THINP) == False
-        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_BTRFS) == False
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_PLAIN) is False
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM) is False
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM_THINP) is False
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_BTRFS) is False
 
         spec = PartSpec("/", lv=True, thin=True)
-        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_PLAIN) == False
-        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM) == False
-        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM_THINP) == True
-        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_BTRFS) == False
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_PLAIN) is False
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM) is False
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_LVM_THINP) is True
+        assert spec.is_lvm_thin_volume(AUTOPART_TYPE_BTRFS) is False

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_resizable.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_resizable.py
@@ -67,8 +67,8 @@ class ResizableDeviceTreeTestCase(unittest.TestCase):
             fmt=get_format("disklabel")
         ))
 
-        assert self.interface.IsDevicePartitioned("dev1") == False
-        assert self.interface.IsDevicePartitioned("dev2") == True
+        assert self.interface.IsDevicePartitioned("dev1") is False
+        assert self.interface.IsDevicePartitioned("dev2") is True
 
     @patch.object(FS, "update_size_info")
     def test_is_device_shrinkable(self, update_size_info):
@@ -83,15 +83,15 @@ class ResizableDeviceTreeTestCase(unittest.TestCase):
         )
 
         self._add_device(dev1)
-        assert self.interface.IsDeviceShrinkable("dev1") == False
+        assert self.interface.IsDeviceShrinkable("dev1") is False
 
         dev1._resizable = True
         dev1.format._resizable = True
         dev1.format._min_size = Size("1 GiB")
-        assert self.interface.IsDeviceShrinkable("dev1") == True
+        assert self.interface.IsDeviceShrinkable("dev1") is True
 
         dev1.format._min_size = Size("10 GiB")
-        assert self.interface.IsDeviceShrinkable("dev1") == False
+        assert self.interface.IsDeviceShrinkable("dev1") is False
 
     def test_get_device_partitions(self):
         """Test GetDevicePartitions."""

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
@@ -491,7 +491,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         dev2.protected = True
         permissions = self.interface.GenerateDeviceFactoryPermissions(request)
         for value in get_native(permissions).values():
-            assert value == False
+            assert value is False
 
     def test_generate_device_factory_permissions_btrfs(self):
         """Test GenerateDeviceFactoryPermissions with btrfs."""
@@ -673,9 +673,9 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(dev2)
         self._add_device(dev3)
 
-        assert self.interface.IsDeviceLocked("dev1") == False
-        assert self.interface.IsDeviceLocked("dev2") == False
-        assert self.interface.IsDeviceLocked("dev3") == True
+        assert self.interface.IsDeviceLocked("dev1") is False
+        assert self.interface.IsDeviceLocked("dev2") is False
+        assert self.interface.IsDeviceLocked("dev3") is True
 
     def test_check_completeness(self):
         """Test CheckCompleteness."""
@@ -739,8 +739,8 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(dev1)
         self._add_device(dev2)
 
-        assert self.interface.IsDeviceEditable("dev1") == False
-        assert self.interface.IsDeviceEditable("dev2") == True
+        assert self.interface.IsDeviceEditable("dev1") is False
+        assert self.interface.IsDeviceEditable("dev2") is True
 
     def test_collect_containers(self):
         """Test CollectContainers."""
@@ -847,7 +847,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
 
         assert request.container_spec == "testvg"
         assert request.container_name == "testvg"
-        assert request.container_encrypted == False
+        assert request.container_encrypted is False
         assert request.container_raid_level == ""
         assert request.container_size_policy == Size("1.5 GiB").get_bytes()
 
@@ -860,7 +860,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
 
         assert request.container_spec == ""
         assert request.container_name == "anaconda"
-        assert request.container_encrypted == False
+        assert request.container_encrypted is False
         assert request.container_raid_level == "single"
         assert request.container_size_policy == 0
 
@@ -873,7 +873,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
 
         assert request.container_spec == ""
         assert request.container_name == ""
-        assert request.container_encrypted == False
+        assert request.container_encrypted is False
         assert request.container_raid_level == ""
         assert request.container_size_policy == 0
 
@@ -917,7 +917,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
 
         assert request.container_spec == ""
         assert request.container_name == "anaconda"
-        assert request.container_encrypted == False
+        assert request.container_encrypted is False
         assert request.container_raid_level == "single"
         assert request.container_size_policy == 0
         assert request.disks == []
@@ -932,7 +932,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
 
         assert request.container_spec == "testvg"
         assert request.container_name == "testvg"
-        assert request.container_encrypted == False
+        assert request.container_encrypted is False
         assert request.container_raid_level == ""
         assert request.container_size_policy == Size("1.5 GiB").get_bytes()
         assert request.disks == []
@@ -946,13 +946,13 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             exists=True
         )
 
-        assert self.interface.IsDevice("dev1") == False
+        assert self.interface.IsDevice("dev1") is False
 
         self._add_device(dev1)
-        assert self.interface.IsDevice("dev1") == True
+        assert self.interface.IsDevice("dev1") is True
 
         dev1.complete = False
-        assert self.interface.IsDevice("dev1") == True
+        assert self.interface.IsDevice("dev1") is True
 
         self.storage.devicetree.hide(dev1)
-        assert self.interface.IsDevice("dev1") == True
+        assert self.interface.IsDevice("dev1") is True

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
@@ -154,10 +154,10 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
         self.bootloader_module.on_storage_changed(storage)
 
         storage.bootloader = GRUB2()
-        assert self.bootloader_interface.IsEFI() == False
+        assert self.bootloader_interface.IsEFI() is False
 
         storage.bootloader = EFIGRUB()
-        assert self.bootloader_interface.IsEFI() == True
+        assert self.bootloader_interface.IsEFI() is True
 
     def test_get_arguments(self):
         """Test GetArguments."""
@@ -185,10 +185,10 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
         self.bootloader_module.on_storage_changed(storage)
 
         storage.bootloader.has_windows.return_value = False
-        assert self.bootloader_interface.DetectWindows() == False
+        assert self.bootloader_interface.DetectWindows() is False
 
         storage.bootloader.has_windows.return_value = True
-        assert self.bootloader_interface.DetectWindows() == True
+        assert self.bootloader_interface.DetectWindows() is True
 
     @patch_dbus_publish_object
     def test_install_bootloader_with_tasks(self, publisher):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_dasd.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_dasd.py
@@ -46,7 +46,7 @@ class DASDInterfaceTestCase(unittest.TestCase):
 
     @patch("pyanaconda.modules.storage.dasd.dasd.arch.is_s390", return_value=True)
     def test_is_supported(self, is_supported):
-        assert self.dasd_interface.IsSupported() == True
+        assert self.dasd_interface.IsSupported() is True
 
     @patch_dbus_publish_object
     def test_discover_with_task(self, publisher):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -777,7 +777,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
         assert obj.implementation._storage == self.module.storage
         assert obj.implementation._device.name == "dev1"
-        assert obj.implementation._read_only == True
+        assert obj.implementation._read_only is True
 
     @patch_dbus_publish_object
     def test_find_devices_with_task(self, publisher):
@@ -863,21 +863,21 @@ class DeviceTreeUtilsTestCase(unittest.TestCase):
         supported.return_value = True
         formattable.return_value = False
 
-        assert utils.is_supported_filesystem("xfs") == False
+        assert utils.is_supported_filesystem("xfs") is False
 
         supported.return_value = False
         formattable.return_value = True
 
-        assert utils.is_supported_filesystem("xfs") == False
+        assert utils.is_supported_filesystem("xfs") is False
 
         supported.return_value = True
         formattable.return_value = True
 
-        assert utils.is_supported_filesystem("xfs") == True
-        assert utils.is_supported_filesystem("swap") == True
-        assert utils.is_supported_filesystem("biosboot") == True
+        assert utils.is_supported_filesystem("xfs") is True
+        assert utils.is_supported_filesystem("swap") is True
+        assert utils.is_supported_filesystem("biosboot") is True
 
-        assert utils.is_supported_filesystem("unknown") == False
-        assert utils.is_supported_filesystem("disklabel") == False
-        assert utils.is_supported_filesystem("ntfs") == False
-        assert utils.is_supported_filesystem("tmpfs") == False
+        assert utils.is_supported_filesystem("unknown") is False
+        assert utils.is_supported_filesystem("disklabel") is False
+        assert utils.is_supported_filesystem("ntfs") is False
+        assert utils.is_supported_filesystem("tmpfs") is False

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_disk_select.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_disk_select.py
@@ -88,13 +88,13 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
             self.disk_selection_interface.ValidateSelectedDisks([])
         )
 
-        assert report.is_valid() == True
+        assert report.is_valid() is True
 
         report = ValidationReport.from_structure(
             self.disk_selection_interface.ValidateSelectedDisks(["devX"])
         )
 
-        assert report.is_valid() == False
+        assert report.is_valid() is False
         assert report.error_messages == [
             "The selected disk devX is not recognized."
         ]
@@ -104,7 +104,7 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
             self.disk_selection_interface.ValidateSelectedDisks(["dev1"])
         )
 
-        assert report.is_valid() == False
+        assert report.is_valid() is False
         assert report.error_messages == [
             "You selected disk dev1, which contains devices that also use "
             "unselected disks dev2, dev3. You must select or de-select "
@@ -116,7 +116,7 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
             self.disk_selection_interface.ValidateSelectedDisks(["dev1", "dev2"])
         )
 
-        assert report.is_valid() == False
+        assert report.is_valid() is False
         assert report.error_messages == [
             "You selected disk dev1, which contains devices that also "
             "use unselected disk dev3. You must select or de-select "
@@ -131,7 +131,7 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
             self.disk_selection_interface.ValidateSelectedDisks(["dev1", "dev2", "dev3"])
         )
 
-        assert report.is_valid() == True
+        assert report.is_valid() is True
 
     def test_exclusive_disks_property(self):
         """Test the exclusive disks property."""

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_fcoe.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_fcoe.py
@@ -40,7 +40,7 @@ class FCOEInterfaceTestCase(unittest.TestCase):
 
     @patch("pyanaconda.modules.storage.fcoe.fcoe.has_fcoe", return_value=True)
     def test_is_supported(self, is_supported):
-        assert self.fcoe_interface.IsSupported() == True
+        assert self.fcoe_interface.IsSupported() is True
 
     def test_get_nics(self):
         """Test the get nics method."""
@@ -87,8 +87,8 @@ class FCOEInterfaceTestCase(unittest.TestCase):
         obj = check_task_creation(task_path, publisher, FCOEDiscoverTask)
 
         assert obj.implementation._nic == "eth0"
-        assert obj.implementation._dcb == False
-        assert obj.implementation._auto_vlan == True
+        assert obj.implementation._dcb is False
+        assert obj.implementation._auto_vlan is True
 
     @patch('pyanaconda.modules.storage.fcoe.fcoe.fcoe')
     def test_write_configuration(self, fcoe):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_iscsi.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_iscsi.py
@@ -63,7 +63,7 @@ class ISCSIInterfaceTestCase(unittest.TestCase):
 
     @patch("pyanaconda.modules.storage.iscsi.iscsi.iscsi", available=True)
     def test_is_supported(self, iscsi):
-        assert self.iscsi_interface.IsSupported() == True
+        assert self.iscsi_interface.IsSupported() is True
 
     @patch('pyanaconda.modules.storage.iscsi.iscsi.iscsi')
     def test_initator_property(self, iscsi):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_nvdimm.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_nvdimm.py
@@ -52,7 +52,7 @@ class NVDIMMInterfaceTestCase(unittest.TestCase):
         self.nvdimm_interface = NVDIMMInterface(self.nvdimm_module)
 
     def test_is_supported(self):
-        assert self.nvdimm_interface.IsSupported() == True
+        assert self.nvdimm_interface.IsSupported() is True
 
     def test_get_devices_to_ignore(self):
         """Test GetDevicesToIgnore."""

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_snapshot.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_snapshot.py
@@ -45,21 +45,21 @@ class SnapshotInterfaceTestCase(unittest.TestCase):
 
     def test_is_requested(self):
         """Test IsRequested."""
-        assert self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL) == False
-        assert self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL) == False
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL) is False
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL) is False
 
         self.module._requests = [Mock(when=SNAPSHOT_WHEN_PRE_INSTALL)]
-        assert self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL) == True
-        assert self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL) == False
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL) is True
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL) is False
 
         self.module._requests = [Mock(when=SNAPSHOT_WHEN_POST_INSTALL)]
-        assert self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL) == False
-        assert self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL) == True
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL) is False
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL) is True
 
         self.module._requests = [Mock(when=SNAPSHOT_WHEN_PRE_INSTALL),
                                  Mock(when=SNAPSHOT_WHEN_POST_INSTALL)]
-        assert self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL) == True
-        assert self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL) == True
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_PRE_INSTALL) is True
+        assert self.interface.IsRequested(SNAPSHOT_WHEN_POST_INSTALL) is True
 
     @patch_dbus_publish_object
     def test_create_with_task(self, publisher):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
@@ -1546,7 +1546,7 @@ class StorageValidationTasksTestCase(unittest.TestCase):
         storage_checker.check.return_value = report
 
         report = StorageValidateTask(storage).run()
-        assert report.is_valid() == True
+        assert report.is_valid() is True
         assert report.error_messages == []
         assert report.warning_messages == []
 
@@ -1562,6 +1562,6 @@ class StorageValidationTasksTestCase(unittest.TestCase):
         storage_checker.check.return_value = report
 
         report = StorageValidateTask(storage).run()
-        assert report.is_valid() == False
+        assert report.is_valid() is False
         assert report.error_messages == ["Fake error."]
         assert report.warning_messages == ["Fake warning.", "Fake another warning."]

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_zfcp.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_zfcp.py
@@ -40,7 +40,7 @@ class ZFCPInterfaceTestCase(unittest.TestCase):
 
     @patch("pyanaconda.modules.storage.dasd.dasd.arch.is_s390", return_value=True)
     def test_is_supported(self, is_supported):
-        assert self.zfcp_interface.IsSupported() == True
+        assert self.zfcp_interface.IsSupported() is True
 
     @patch_dbus_publish_object
     def test_discover_with_task(self, publisher):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_storage_checker.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_storage_checker.py
@@ -36,8 +36,8 @@ class StorageCheckerTests(unittest.TestCase):
         checker = StorageChecker()
         report = checker.check(None)
 
-        assert report.success == True
-        assert report.failure == False
+        assert report.success is True
+        assert report.failure is False
         assert report.errors == []
         assert report.warnings == []
 
@@ -51,7 +51,7 @@ class StorageCheckerTests(unittest.TestCase):
         checker.add_check(check)
         report = checker.check(None)
 
-        assert report.success == False
+        assert report.success is False
         assert report.errors == ["error"]
         assert report.warnings == []
 
@@ -64,7 +64,7 @@ class StorageCheckerTests(unittest.TestCase):
 
         checker.add_check(check)
         report = checker.check(None)
-        assert report.success == False
+        assert report.success is False
         assert report.errors == []
         assert report.warnings == ["warning"]
 
@@ -178,7 +178,7 @@ class StorageCheckerTests(unittest.TestCase):
 
         # Run the checker. OK
         report = checker.check(None)
-        assert report.success == True
+        assert report.success is True
         assert report.errors == []
         assert report.warnings == []
 
@@ -189,7 +189,7 @@ class StorageCheckerTests(unittest.TestCase):
 
         # Run the checker. FAIL
         report = checker.check(None)
-        assert report.success == False
+        assert report.success is False
         assert report.errors == [
             "x is not equal to 1",
             "y is not equal to 2",
@@ -199,7 +199,7 @@ class StorageCheckerTests(unittest.TestCase):
 
         # Run the checker. Test SKIP.
         report = checker.check(None, skip=(check_y,))
-        assert report.success == False
+        assert report.success is False
         assert report.errors == [
             "x is not equal to 1",
             "z is not equal to 3"
@@ -209,7 +209,7 @@ class StorageCheckerTests(unittest.TestCase):
         # Run the checker. Test CONSTRAINTS.
         constraints = {"x": 1, "y": 2, "z": 3}
         report = checker.check(None, constraints=constraints)
-        assert report.success == True
+        assert report.success is True
         assert report.errors == []
         assert report.warnings == []
 
@@ -219,7 +219,7 @@ class StorageCheckerTests(unittest.TestCase):
         checker.remove_check(check_z)
 
         report = checker.check(None)
-        assert report.success == True
+        assert report.success is True
         assert report.errors == []
         assert report.warnings == []
 

--- a/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription.py
@@ -1393,12 +1393,12 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         # TransferSubscriptionTokensTask
         obj = task_objs[1]
-        assert obj.implementation._transfer_subscription_tokens == False
+        assert obj.implementation._transfer_subscription_tokens is False
 
         # ConnectToInsightsTask
         obj = task_objs[2]
-        assert obj.implementation._subscription_attached == False
-        assert obj.implementation._connect_to_insights == False
+        assert obj.implementation._subscription_attached is False
+        assert obj.implementation._connect_to_insights is False
 
     @patch_dbus_publish_object
     def test_install_with_tasks_configured(self, publisher):
@@ -1428,12 +1428,12 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
 
         # TransferSubscriptionTokensTask
         obj = task_objs[1]
-        assert obj.implementation._transfer_subscription_tokens == True
+        assert obj.implementation._transfer_subscription_tokens is True
 
         # ConnectToInsightsTask
         obj = task_objs[2]
-        assert obj.implementation._subscription_attached == True
-        assert obj.implementation._connect_to_insights == True
+        assert obj.implementation._subscription_attached is True
+        assert obj.implementation._connect_to_insights is True
 
     def _test_kickstart(self, ks_in, ks_out):
         check_kickstart_interface(self.subscription_interface, ks_in, ks_out)

--- a/tests/unit_tests/pyanaconda_tests/modules/timezone/test_module_timezone.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/timezone/test_module_timezone.py
@@ -80,13 +80,13 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
     def test_utc_property(self):
         """Test the IsUtc property."""
         self.timezone_interface.SetIsUTC(True)
-        assert self.timezone_interface.IsUTC == True
+        assert self.timezone_interface.IsUTC is True
         self.callback.assert_called_once_with(TIMEZONE.interface_name, {'IsUTC': True}, [])
 
     def test_ntp_property(self):
         """Test the NTPEnabled property."""
         self.timezone_interface.SetNTPEnabled(False)
-        assert self.timezone_interface.NTPEnabled == False
+        assert self.timezone_interface.NTPEnabled is False
         self.callback.assert_called_once_with(TIMEZONE.interface_name, {'NTPEnabled': False}, [])
 
     def test_time_sources_property(self):
@@ -260,10 +260,10 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         # ConfigureTimezoneTask
         obj = task_objs[0]
         assert obj.implementation._timezone == "America/New_York"
-        assert obj.implementation._is_utc == False
+        assert obj.implementation._is_utc is False
         # ConfigureNTPTask
         obj = task_objs[1]
-        assert obj.implementation._ntp_enabled == True
+        assert obj.implementation._ntp_enabled is True
         assert obj.implementation._ntp_servers == []
 
     @patch_dbus_publish_object
@@ -299,11 +299,11 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         # ConfigureTimezoneTask
         obj = task_objs[0]
         assert obj.implementation._timezone == "Asia/Tokyo"
-        assert obj.implementation._is_utc == True
+        assert obj.implementation._is_utc is True
 
         # ConfigureNTPTask
         obj = task_objs[1]
-        assert obj.implementation._ntp_enabled == False
+        assert obj.implementation._ntp_enabled is False
         assert len(obj.implementation._ntp_servers) == 2
         assert compare_data(obj.implementation._ntp_servers[0], server)
         assert compare_data(obj.implementation._ntp_servers[1], pool)

--- a/tests/unit_tests/pyanaconda_tests/modules/users/test_module_users.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/users/test_module_users.py
@@ -72,11 +72,11 @@ class UsersInterfaceTestCase(unittest.TestCase):
         assert self.users_interface.Groups == []
         assert self.users_interface.SshKeys == []
         assert self.users_interface.RootPassword == ""
-        assert self.users_interface.IsRootPasswordSet == False
-        assert self.users_interface.IsRootAccountLocked == True
-        assert self.users_interface.IsRootPasswordCrypted == False
-        assert self.users_interface.RootPasswordSSHLoginAllowed == False
-        assert self.users_interface.CanChangeRootPassword == True
+        assert self.users_interface.IsRootPasswordSet is False
+        assert self.users_interface.IsRootAccountLocked is True
+        assert self.users_interface.IsRootPasswordCrypted is False
+        assert self.users_interface.RootPasswordSSHLoginAllowed is False
+        assert self.users_interface.CanChangeRootPassword is True
 
     def test_users_property(self):
         """Test the Users property."""
@@ -150,18 +150,18 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self.users_interface.SetCryptedRootPassword("abcef")
 
         assert self.users_interface.RootPassword == "abcef"
-        assert self.users_interface.IsRootPasswordCrypted == True
-        assert self.users_interface.IsRootPasswordSet == True
-        assert self.users_interface.IsRootAccountLocked == True
+        assert self.users_interface.IsRootPasswordCrypted is True
+        assert self.users_interface.IsRootPasswordSet is True
+        assert self.users_interface.IsRootAccountLocked is True
         self.callback.assert_called_once_with(USERS.interface_name, {'IsRootPasswordSet': True}, [])
 
     def test_set_crypted_roopw_and_unlock(self):
         """Test if setting crypted root password & unlocking it from kickstart works correctly."""
         self.users_interface.SetCryptedRootPassword("abcef")
 
-        assert self.users_interface.IsRootPasswordSet == True
-        assert self.users_interface.IsRootAccountLocked == True
-        assert self.users_interface.CanChangeRootPassword == True
+        assert self.users_interface.IsRootPasswordSet is True
+        assert self.users_interface.IsRootAccountLocked is True
+        assert self.users_interface.CanChangeRootPassword is True
         self.callback.assert_called_once_with(USERS.interface_name, {'IsRootPasswordSet': True}, [])
 
         # this should not be a valid admin user for interactive install
@@ -171,16 +171,16 @@ class UsersInterfaceTestCase(unittest.TestCase):
         # and needs to be unlocked via another DBus API call
         self.users_interface.SetRootAccountLocked(False)
 
-        assert self.users_interface.IsRootPasswordSet == True
-        assert self.users_interface.IsRootAccountLocked == False
+        assert self.users_interface.IsRootPasswordSet is True
+        assert self.users_interface.IsRootAccountLocked is False
         self.callback.assert_called_with(USERS.interface_name, {'IsRootAccountLocked': False}, [])
 
     def test_lock_root_account(self):
         """Test if root account can be locked via DBus correctly."""
         self.users_interface.SetRootAccountLocked(True)
 
-        assert self.users_interface.IsRootPasswordSet == False
-        assert self.users_interface.IsRootAccountLocked == True
+        assert self.users_interface.IsRootPasswordSet is False
+        assert self.users_interface.IsRootAccountLocked is True
         self.callback.assert_called_once_with(USERS.interface_name, {'IsRootAccountLocked': True}, [])
 
     def test_clear_rootpw(self):
@@ -188,16 +188,16 @@ class UsersInterfaceTestCase(unittest.TestCase):
         # set the password to something
         self.users_interface.SetCryptedRootPassword("abcef")
 
-        assert self.users_interface.IsRootPasswordSet == True
-        assert self.users_interface.IsRootAccountLocked == True
+        assert self.users_interface.IsRootPasswordSet is True
+        assert self.users_interface.IsRootAccountLocked is True
         self.callback.assert_called_once_with(USERS.interface_name, {'IsRootPasswordSet': True}, [])
 
         # clear it
         self.users_interface.ClearRootPassword()
 
         # check if it looks cleared
-        assert self.users_interface.IsRootPasswordSet == False
-        assert self.users_interface.IsRootAccountLocked == True
+        assert self.users_interface.IsRootPasswordSet is False
+        assert self.users_interface.IsRootAccountLocked is True
         self.callback.assert_called_with(USERS.interface_name, {'IsRootPasswordSet': False,
                                                                 'IsRootAccountLocked': True}, [])
 
@@ -210,27 +210,27 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self.users_interface.SetRootAccountLocked(False)
         self.callback.assert_called_with(USERS.interface_name, {'IsRootAccountLocked': False}, [])
 
-        assert self.users_interface.IsRootPasswordSet == True
-        assert self.users_interface.IsRootAccountLocked == False
+        assert self.users_interface.IsRootPasswordSet is True
+        assert self.users_interface.IsRootAccountLocked is False
 
         # clear it
         self.users_interface.ClearRootPassword()
 
         # check if it looks cleared
-        assert self.users_interface.IsRootPasswordSet == False
-        assert self.users_interface.IsRootAccountLocked == True
+        assert self.users_interface.IsRootPasswordSet is False
+        assert self.users_interface.IsRootAccountLocked is True
         self.callback.assert_called_with(USERS.interface_name, {'IsRootPasswordSet': False,
                                                                 'IsRootAccountLocked': True}, [])
 
     def test_allow_root_password_ssh_login(self):
         """Test if root password SSH login can be allowed."""
         self.users_interface.SetRootPasswordSSHLoginAllowed(True)
-        assert self.users_interface.RootPasswordSSHLoginAllowed == True
+        assert self.users_interface.RootPasswordSSHLoginAllowed is True
         self.callback.assert_called_once_with(USERS.interface_name, {'RootPasswordSSHLoginAllowed': True}, [])
 
         self.callback.reset_mock()
         self.users_interface.SetRootPasswordSSHLoginAllowed(False)
-        assert self.users_interface.RootPasswordSSHLoginAllowed == False
+        assert self.users_interface.RootPasswordSSHLoginAllowed is False
         self.callback.assert_called_once_with(USERS.interface_name, {'RootPasswordSSHLoginAllowed': False}, [])
 
     def test_admin_user_detection_1(self):
@@ -354,9 +354,9 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # root password should be empty and locked by default, but mutable
-        assert self.users_interface.IsRootPasswordSet == False
-        assert self.users_interface.IsRootAccountLocked == True
-        assert self.users_interface.CanChangeRootPassword == True
+        assert self.users_interface.IsRootPasswordSet is False
+        assert self.users_interface.IsRootAccountLocked is True
+        assert self.users_interface.CanChangeRootPassword is True
 
         # this should not be considered a valid admin user for interactive install
         assert not self.users_interface.CheckAdminUserExists()
@@ -371,9 +371,9 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # password should be marked as not set, locked and mutable
-        assert self.users_interface.IsRootPasswordSet == False
-        assert self.users_interface.IsRootAccountLocked == True
-        assert self.users_interface.CanChangeRootPassword == True
+        assert self.users_interface.IsRootPasswordSet is False
+        assert self.users_interface.IsRootAccountLocked is True
+        assert self.users_interface.CanChangeRootPassword is True
 
         # not a valid admin user from kickstart PoV
         assert not self.users_interface.CheckAdminUserExists()
@@ -390,9 +390,9 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # if rootpw shows up in the kickstart is should be reported as immutable
-        assert self.users_interface.IsRootPasswordSet == True
-        assert self.users_interface.IsRootAccountLocked == False
-        assert self.users_interface.CanChangeRootPassword == False
+        assert self.users_interface.IsRootPasswordSet is True
+        assert self.users_interface.IsRootAccountLocked is False
+        assert self.users_interface.CanChangeRootPassword is False
 
         # but this should still be a valid admin user from kickstart PoV
         assert self.users_interface.CheckAdminUserExists()
@@ -419,8 +419,8 @@ class UsersInterfaceTestCase(unittest.TestCase):
         """
         self._test_kickstart(ks_in, ks_out)
 
-        assert self.users_interface.IsRootPasswordSet == True
-        assert self.users_interface.IsRootAccountLocked == False
+        assert self.users_interface.IsRootPasswordSet is True
+        assert self.users_interface.IsRootAccountLocked is False
 
     def test_kickstart_lock_root_account(self):
         """Test locking the root account via kickstart."""
@@ -434,9 +434,9 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # password should be marked as not set, locked and immutable
-        assert self.users_interface.IsRootPasswordSet == False
-        assert self.users_interface.IsRootAccountLocked == True
-        assert self.users_interface.CanChangeRootPassword == False
+        assert self.users_interface.IsRootPasswordSet is False
+        assert self.users_interface.IsRootAccountLocked is True
+        assert self.users_interface.CanChangeRootPassword is False
 
         # but this should still be a valid admin user from kickstart PoV
         assert self.users_interface.CheckAdminUserExists()
@@ -453,9 +453,9 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # password should be marked as set, locked and immutable
-        assert self.users_interface.IsRootPasswordSet == True
-        assert self.users_interface.IsRootAccountLocked == True
-        assert self.users_interface.CanChangeRootPassword == False
+        assert self.users_interface.IsRootPasswordSet is True
+        assert self.users_interface.IsRootAccountLocked is True
+        assert self.users_interface.CanChangeRootPassword is False
 
         # but this should still be a valid admin user from kickstart PoV
         assert self.users_interface.CheckAdminUserExists()
@@ -473,9 +473,9 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # password should be marked as not set, locked and mutable
-        assert self.users_interface.IsRootPasswordSet == False
-        assert self.users_interface.IsRootAccountLocked == True
-        assert self.users_interface.CanChangeRootPassword == True
+        assert self.users_interface.IsRootPasswordSet is False
+        assert self.users_interface.IsRootAccountLocked is True
+        assert self.users_interface.CanChangeRootPassword is True
 
         # no a valid admin user exists from kickstart PoV
         assert not self.users_interface.CheckAdminUserExists()
@@ -493,9 +493,9 @@ class UsersInterfaceTestCase(unittest.TestCase):
         self._test_kickstart(ks_in, ks_out)
 
         # password should be marked as not set, locked and mutable
-        assert self.users_interface.IsRootPasswordSet == False
-        assert self.users_interface.IsRootAccountLocked == True
-        assert self.users_interface.CanChangeRootPassword == True
+        assert self.users_interface.IsRootPasswordSet is False
+        assert self.users_interface.IsRootAccountLocked is True
+        assert self.users_interface.CanChangeRootPassword is True
 
         # provides a valid admin user exists from kickstart PoV
         assert self.users_interface.CheckAdminUserExists()

--- a/tests/unit_tests/pyanaconda_tests/test_argparse.py
+++ b/tests/unit_tests/pyanaconda_tests/test_argparse.py
@@ -129,14 +129,14 @@ class ArgparseTest(unittest.TestCase):
         opts, _removed = self._parseCmdline([])
         conf.set_from_opts(opts)
 
-        assert conf.storage.dmraid == True
-        assert conf.storage.ibft == True
+        assert conf.storage.dmraid is True
+        assert conf.storage.ibft is True
 
         opts, _removed = self._parseCmdline(['--nodmraid', '--ibft'])
         conf.set_from_opts(opts)
 
-        assert conf.storage.dmraid == False
-        assert conf.storage.ibft == True
+        assert conf.storage.dmraid is False
+        assert conf.storage.ibft is True
 
     def test_target(self):
         conf = AnacondaConfiguration.from_defaults()
@@ -144,25 +144,25 @@ class ArgparseTest(unittest.TestCase):
         opts, _removed = self._parseCmdline([])
         conf.set_from_opts(opts)
 
-        assert conf.target.is_hardware == True
-        assert conf.target.is_image == False
-        assert conf.target.is_directory == False
+        assert conf.target.is_hardware is True
+        assert conf.target.is_image is False
+        assert conf.target.is_directory is False
         assert conf.target.physical_root == "/mnt/sysimage"
 
         opts, _removed = self._parseCmdline(['--image=/what/ever.img'])
         conf.set_from_opts(opts)
 
-        assert conf.target.is_hardware == False
-        assert conf.target.is_image == True
-        assert conf.target.is_directory == False
+        assert conf.target.is_hardware is False
+        assert conf.target.is_image is True
+        assert conf.target.is_directory is False
         assert conf.target.physical_root == "/mnt/sysimage"
 
         opts, _removed = self._parseCmdline(['--dirinstall=/what/ever'])
         conf.set_from_opts(opts)
 
-        assert conf.target.is_hardware == False
-        assert conf.target.is_image == False
-        assert conf.target.is_directory == True
+        assert conf.target.is_hardware is False
+        assert conf.target.is_image is False
+        assert conf.target.is_directory is True
         assert conf.target.physical_root == "/what/ever"
 
     def test_target_nosave(self):
@@ -220,27 +220,27 @@ class ArgparseTest(unittest.TestCase):
         opts, _removed = self._parseCmdline([])
         conf.set_from_opts(opts)
 
-        assert conf.system._is_boot_iso == True
-        assert conf.system._is_live_os == False
-        assert conf.system._is_unknown == False
+        assert conf.system._is_boot_iso is True
+        assert conf.system._is_live_os is False
+        assert conf.system._is_unknown is False
 
         opts, _removed = self._parseCmdline(['--liveinst'])
         conf.set_from_opts(opts)
 
-        assert conf.system._is_boot_iso == False
-        assert conf.system._is_live_os == True
-        assert conf.system._is_unknown == False
+        assert conf.system._is_boot_iso is False
+        assert conf.system._is_live_os is True
+        assert conf.system._is_unknown is False
 
         opts, _removed = self._parseCmdline(['--dirinstall=/what/ever'])
         conf.set_from_opts(opts)
 
-        assert conf.system._is_boot_iso == False
-        assert conf.system._is_live_os == False
-        assert conf.system._is_unknown == True
+        assert conf.system._is_boot_iso is False
+        assert conf.system._is_live_os is False
+        assert conf.system._is_unknown is True
 
         opts, _removed = self._parseCmdline(['--image=/what/ever.img'])
         conf.set_from_opts(opts)
 
-        assert conf.system._is_boot_iso == False
-        assert conf.system._is_live_os == False
-        assert conf.system._is_unknown == True
+        assert conf.system._is_boot_iso is False
+        assert conf.system._is_live_os is False
+        assert conf.system._is_unknown is True

--- a/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
+++ b/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
@@ -294,7 +294,7 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         """
         handler = self.parse_kickstart(specification, ks_in, ks_out)
         assert handler.addons.my_test_1.foo is None
-        assert handler.addons.my_test_1.bar == False
+        assert handler.addons.my_test_1.bar is False
         assert handler.addons.my_test_1.lines == []
 
         ks_in = """
@@ -313,7 +313,7 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         """
         handler = self.parse_kickstart(specification, ks_in, ks_out)
         assert handler.addons.my_test_1.foo == 10
-        assert handler.addons.my_test_1.bar == True
+        assert handler.addons.my_test_1.bar is True
         assert handler.addons.my_test_1.lines == ["1", "2", "3"]
 
         with pytest.raises(KickstartParseError):

--- a/tests/unit_tests/pyanaconda_tests/test_subscription_helpers.py
+++ b/tests/unit_tests/pyanaconda_tests/test_subscription_helpers.py
@@ -820,16 +820,16 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         subscription_proxy = SUBSCRIPTION.get_proxy()
         subscription_proxy.IsSubscriptionAttached = False
 
-        assert is_cdn_registration_required(dnf_payload) == True
+        assert is_cdn_registration_required(dnf_payload) is True
 
         subscription_proxy.IsSubscriptionAttached = True
-        assert is_cdn_registration_required(dnf_payload) == False
+        assert is_cdn_registration_required(dnf_payload) is False
 
         boss_proxy.GetModules.return_value = []
-        assert is_cdn_registration_required(dnf_payload) == False
+        assert is_cdn_registration_required(dnf_payload) is False
 
         source_proxy.Type = SOURCE_TYPE_CDROM
-        assert is_cdn_registration_required(dnf_payload) == False
+        assert is_cdn_registration_required(dnf_payload) is False
 
     @patch("pyanaconda.ui.lib.subscription.switch_source")
     @patch("pyanaconda.modules.common.task.sync_run_task")

--- a/tests/unit_tests/pyanaconda_tests/ui/test_software.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_software.py
@@ -121,13 +121,13 @@ class SoftwareSelectionCacheTestCase(unittest.TestCase):
 
     def test_is_environment_selected(self):
         """Test the is_environment_selected method."""
-        assert self.cache.is_environment_selected("e1") == False
+        assert self.cache.is_environment_selected("e1") is False
 
         self.cache.select_environment("e1")
-        assert self.cache.is_environment_selected("e1") == True
+        assert self.cache.is_environment_selected("e1") is True
 
         self.cache.select_environment("")
-        assert self.cache.is_environment_selected("e1") == False
+        assert self.cache.is_environment_selected("e1") is False
 
     def test_environment(self):
         """Test the environment property."""
@@ -162,19 +162,19 @@ class SoftwareSelectionCacheTestCase(unittest.TestCase):
         self.environment_data.default_groups = ["g2", "g4"]
 
         self.cache.select_environment("e1")
-        assert self.cache.is_group_selected("g1") == False
-        assert self.cache.is_group_selected("g4") == True
-        assert self.cache.is_group_selected("g7") == False
+        assert self.cache.is_group_selected("g1") is False
+        assert self.cache.is_group_selected("g4") is True
+        assert self.cache.is_group_selected("g7") is False
 
         self.cache.select_group("g1")
-        assert self.cache.is_group_selected("g1") == True
-        assert self.cache.is_group_selected("g4") == True
-        assert self.cache.is_group_selected("g7") == False
+        assert self.cache.is_group_selected("g1") is True
+        assert self.cache.is_group_selected("g4") is True
+        assert self.cache.is_group_selected("g7") is False
 
         self.cache.deselect_group("g4")
-        assert self.cache.is_group_selected("g1") == True
-        assert self.cache.is_group_selected("g4") == False
-        assert self.cache.is_group_selected("g7") == False
+        assert self.cache.is_group_selected("g1") is True
+        assert self.cache.is_group_selected("g4") is False
+        assert self.cache.is_group_selected("g7") is False
 
     def test_apply_selection_data(self):
         """Test the apply_selection_data method."""


### PR DESCRIPTION
These were previously changed in bulk after switch to pytest.

In other words:
```s/assert ([^\s]+) == (True|False)/assert $1 is $2/```