### PR TITLE
Fix task to copy logs

### DIFF
--- a/pyanaconda/modules/boss/installation.py
+++ b/pyanaconda/modules/boss/installation.py
@@ -135,7 +135,7 @@ class CopyLogsTask(Task):
         """Set access bits"""
         items = glob.glob(join_paths(self._sysroot, ANACONDA_LOG_DIR, '*'))
         for item in items:
-            os.chmod(item, 0x0600)
+            os.chmod(item, 0o0600)
 
     def _copy_kickstart(self):
         """Copy input kickstart file"""
@@ -145,7 +145,7 @@ class CopyLogsTask(Task):
                 "/run/install/ks.cfg",
                 "/root/original-ks.cfg"
             )
-            os.chmod(join_paths(self._sysroot, "/root/original-ks.cfg"), 0x0600)
+            os.chmod(join_paths(self._sysroot, "/root/original-ks.cfg"), 0o0600)
         else:
             log.warning("Input kickstart will not be saved to the installed system due to the "
                         "nosave option.")

--- a/pyanaconda/modules/boss/installation.py
+++ b/pyanaconda/modules/boss/installation.py
@@ -70,7 +70,6 @@ class CopyLogsTask(Task):
         self._copy_dnf_debugdata()
         self._copy_post_script_logs()
         self._dump_journal()
-        self._chmod_logs()
 
     def _create_logs_directory(self):
         """Create directory for Anaconda logs on the install target"""
@@ -128,14 +127,10 @@ class CopyLogsTask(Task):
 
     def _dump_journal(self):
         """Dump journal from the installation environment"""
-        with open(join_paths(self._sysroot, ANACONDA_LOG_DIR, "journal.log"), "w") as logfile:
+        tempfile = "/tmp/journal.log"
+        with open(tempfile, "w") as logfile:
             execWithRedirect("journalctl", ["-b"], stdout=logfile)
-
-    def _chmod_logs(self):
-        """Set access bits"""
-        items = glob.glob(join_paths(self._sysroot, ANACONDA_LOG_DIR, '*'))
-        for item in items:
-            os.chmod(item, 0o0600)
+        self._copy_file_to_sysroot(tempfile, join_paths(ANACONDA_LOG_DIR, "journal.log"))
 
     def _copy_kickstart(self):
         """Copy input kickstart file"""
@@ -145,7 +140,6 @@ class CopyLogsTask(Task):
                 "/run/install/ks.cfg",
                 "/root/original-ks.cfg"
             )
-            os.chmod(join_paths(self._sysroot, "/root/original-ks.cfg"), 0o0600)
         else:
             log.warning("Input kickstart will not be saved to the installed system due to the "
                         "nosave option.")
@@ -159,28 +153,32 @@ class CopyLogsTask(Task):
         execWithRedirect("restorecon", ["-ir", ANACONDA_LOG_DIR], root=self._sysroot)
 
     def _copy_file_to_sysroot(self, src, dest):
-        """Copy a file, if it exists.
+        """Copy a file, if it exists, and set its access bits.
 
         :param str src: path to source file
         :param str dest: path to destination file within sysroot
         """
         if os.path.exists(src):
             log.info("Copying file: %s -> %s", src, dest)
+            full_dest_path = join_paths(self._sysroot, dest)
             shutil.copyfile(
                 src,
-                join_paths(self._sysroot, dest)
+                full_dest_path
             )
+            os.chmod(full_dest_path, 0o0600)
 
     def _copy_tree_to_sysroot(self, src, dest):
-        """Copy a directory tree, if it exists.
+        """Copy a directory tree, if it exists, and set its access bits.
 
         :param str src: path to source directory
         :param str dest: path to destination directory within sysroot
         """
         if os.path.exists(src):
             log.info("Copying directory tree: %s -> %s", src, dest)
+            full_dest_path = join_paths(self._sysroot, dest)
             shutil.copytree(
                 src,
-                join_paths(self._sysroot, dest),
+                full_dest_path,
                 dirs_exist_ok=True
             )
+            os.chmod(full_dest_path, 0o0600)

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_copy_logs_task.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_copy_logs_task.py
@@ -26,11 +26,10 @@ class CopyLogsTaskTest(unittest.TestCase):
     @patch("pyanaconda.modules.boss.installation.mkdirChain")
     @patch("pyanaconda.modules.boss.installation.conf")
     @patch("pyanaconda.modules.boss.installation.open")
-    @patch("pyanaconda.modules.boss.installation.os.chmod")
-    def test_run_all(self, chmod_mock, open_mock, conf_mock, mkdir_mock, exec_wr_mock, glob_mock):
+    def test_run_all(self, open_mock, conf_mock, mkdir_mock, exec_wr_mock, glob_mock):
         """Test the log copying task."""
         glob_mock.side_effect = [
-            ["/tmp/ks-script-blabbityblah.log"],
+            ["/tmp/ks-script-blabblah.log"],
             ["/somewhere/var/log/anaconda/anaconda.log"]
         ]
         conf_mock.target.can_save_installation_logs = True
@@ -51,30 +50,19 @@ class CopyLogsTaskTest(unittest.TestCase):
                 "/var/log/anaconda/" + logfile
             )
 
-        copy_file_mock.assert_any_call(
-            "/root/lorax-packages.log",
-            "/var/log/anaconda/lorax-packages.log"
-        )
-
-        copy_file_mock.assert_any_call(
-            "/tmp/ks-script-blabbityblah.log",
-            "/var/log/anaconda/ks-script-blabbityblah.log"
-        )
+        copy_file_mock.assert_has_calls([
+            call("/root/lorax-packages.log", "/var/log/anaconda/lorax-packages.log"),
+            call("/tmp/ks-script-blabblah.log", "/var/log/anaconda/ks-script-blabblah.log"),
+            call("/tmp/journal.log", "/var/log/anaconda/journal.log")
+        ], any_order=True)
 
         copy_tree_mock.assert_has_calls([
             call("/tmp/pre-anaconda-logs", "/var/log/anaconda/"),
             call("/root/debugdata", "/var/log/anaconda/dnf_debugdata/")
         ])
 
-        glob_mock.assert_has_calls([
-            call("/tmp/ks-script*.log"),
-            call("/somewhere/var/log/anaconda/*")
-        ])
-        chmod_mock.assert_has_calls([
-            call("/somewhere/var/log/anaconda/anaconda.log", 0o0600),
-            call("/somewhere/root/original-ks.cfg", 0o0600)
-        ])
-        open_mock.assert_called_once_with("/somewhere/var/log/anaconda/journal.log", "w")
+        glob_mock.assert_called_with("/tmp/ks-script*.log")
+        open_mock.assert_called_once_with("/tmp/journal.log", "w")
 
         exec_wr_mock.assert_has_calls([
             # Warning: Constructing the argument to the first call requires a call to one of the
@@ -89,9 +77,7 @@ class CopyLogsTaskTest(unittest.TestCase):
     @patch("pyanaconda.modules.boss.installation.mkdirChain")
     @patch("pyanaconda.modules.boss.installation.conf")
     @patch("pyanaconda.modules.boss.installation.open")
-    @patch("pyanaconda.modules.boss.installation.os.chmod")
-    def test_nosave_logs(self, chmod_mock, open_mock, conf_mock, mkdir_mock, exec_wr_mock,
-                         glob_mock):
+    def test_nosave_logs(self, open_mock, conf_mock, mkdir_mock, exec_wr_mock, glob_mock):
         """Test nosave for logs"""
         glob_mock.return_value = []
         conf_mock.target.can_save_installation_logs = False
@@ -102,8 +88,10 @@ class CopyLogsTaskTest(unittest.TestCase):
             with patch.object(CopyLogsTask, "_copy_tree_to_sysroot") as copy_tree_mock:
                 task.run()
 
-        copy_file_mock.assert_called_once_with("/run/install/ks.cfg", "/root/original-ks.cfg")
-        chmod_mock.assert_called_once_with("/somewhere/root/original-ks.cfg", 0o0600)
+        copy_file_mock.assert_called_once_with(
+            "/run/install/ks.cfg",
+            "/root/original-ks.cfg"
+        )
 
         exec_wr_mock.assert_called_once_with(
             "restorecon",
@@ -121,9 +109,7 @@ class CopyLogsTaskTest(unittest.TestCase):
     @patch("pyanaconda.modules.boss.installation.mkdirChain")
     @patch("pyanaconda.modules.boss.installation.conf")
     @patch("pyanaconda.modules.boss.installation.open")
-    @patch("pyanaconda.modules.boss.installation.os.chmod")
-    def test_nosave_input_ks(self, chmod_mock, open_mock, conf_mock, mkdir_mock, exec_wr_mock,
-                             glob_mock):
+    def test_nosave_input_ks(self, open_mock, conf_mock, mkdir_mock, exec_wr_mock, glob_mock):
         """Test nosave for kickstart"""
         glob_mock.return_value = ["/somewhere/var/log/anaconda/anaconda.log"]
         conf_mock.target.can_save_installation_logs = True
@@ -143,16 +129,14 @@ class CopyLogsTaskTest(unittest.TestCase):
         assert exec_wr_mock.called
         assert glob_mock.called
         assert open_mock.called
-        assert chmod_mock.called
 
     @patch("pyanaconda.modules.boss.installation.glob.glob")
     @patch("pyanaconda.modules.boss.installation.execWithRedirect")
     @patch("pyanaconda.modules.boss.installation.mkdirChain")
     @patch("pyanaconda.modules.boss.installation.conf")
     @patch("pyanaconda.modules.boss.installation.open")
-    @patch("pyanaconda.modules.boss.installation.os.chmod")
-    def test_nosave_logs_and_input_ks(self, chmod_mock, open_mock, conf_mock, mkdir_mock,
-                                      exec_wr_mock, glob_mock):
+    def test_nosave_logs_and_input_ks(self, open_mock, conf_mock, mkdir_mock, exec_wr_mock,
+                                      glob_mock):
         """Test nosave for both logs and kickstart"""
         glob_mock.return_value = []
         conf_mock.target.can_save_installation_logs = False
@@ -175,11 +159,11 @@ class CopyLogsTaskTest(unittest.TestCase):
         copy_file_mock.assert_not_called()
         copy_tree_mock.assert_not_called()
         open_mock.assert_not_called()
-        chmod_mock.assert_not_called()
 
     @patch("pyanaconda.modules.boss.installation.shutil.copyfile")
     @patch("pyanaconda.modules.boss.installation.os.path.exists")
-    def test_copy_file_to_sysroot(self, exists_mock, copyfile_mock):
+    @patch("pyanaconda.modules.boss.installation.os.chmod")
+    def test_copy_file_to_sysroot(self, chmod_mock, exists_mock, copyfile_mock):
         """Test _copy_file_to_sysroot"""
         task = CopyLogsTask("/somewhere")
 
@@ -187,7 +171,9 @@ class CopyLogsTaskTest(unittest.TestCase):
         task._copy_file_to_sysroot("/some/source", "/another/destination")
         exists_mock.assert_called_with("/some/source")
         copyfile_mock.assert_called_with("/some/source", "/somewhere/another/destination")
+        chmod_mock.assert_called_with("/somewhere/another/destination", 0o0600)
 
+        chmod_mock.reset_mock()
         exists_mock.reset_mock()
         copyfile_mock.reset_mock()
 
@@ -195,10 +181,12 @@ class CopyLogsTaskTest(unittest.TestCase):
         task._copy_file_to_sysroot("/more/data", "/there")
         exists_mock.assert_called_with("/more/data")
         copyfile_mock.assert_not_called()
+        chmod_mock.assert_not_called()
 
     @patch("pyanaconda.modules.boss.installation.shutil.copytree")
     @patch("pyanaconda.modules.boss.installation.os.path.exists")
-    def test_copy_tree_to_sysroot(self, exists_mock, copytree_mock):
+    @patch("pyanaconda.modules.boss.installation.os.chmod")
+    def test_copy_tree_to_sysroot(self, chmod_mock, exists_mock, copytree_mock):
         """Test _copy_tree_to_sysroot"""
         task = CopyLogsTask("/somewhere")
 
@@ -210,7 +198,9 @@ class CopyLogsTaskTest(unittest.TestCase):
             "/somewhere/another/destination/",
             dirs_exist_ok=True
         )
+        chmod_mock.assert_called_with("/somewhere/another/destination/", 0o0600)
 
+        chmod_mock.reset_mock()
         exists_mock.reset_mock()
         copytree_mock.reset_mock()
 
@@ -218,3 +208,4 @@ class CopyLogsTaskTest(unittest.TestCase):
         task._copy_tree_to_sysroot("/more/data", "/there")
         exists_mock.assert_called_with("/more/data")
         copytree_mock.assert_not_called()
+        chmod_mock.assert_not_called()

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_copy_logs_task.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_copy_logs_task.py
@@ -71,8 +71,8 @@ class CopyLogsTaskTest(unittest.TestCase):
             call("/somewhere/var/log/anaconda/*")
         ])
         chmod_mock.assert_has_calls([
-            call("/somewhere/var/log/anaconda/anaconda.log", 0x0600),
-            call("/somewhere/root/original-ks.cfg", 0x0600)
+            call("/somewhere/var/log/anaconda/anaconda.log", 0o0600),
+            call("/somewhere/root/original-ks.cfg", 0o0600)
         ])
         open_mock.assert_called_once_with("/somewhere/var/log/anaconda/journal.log", "w")
 
@@ -103,7 +103,7 @@ class CopyLogsTaskTest(unittest.TestCase):
                 task.run()
 
         copy_file_mock.assert_called_once_with("/run/install/ks.cfg", "/root/original-ks.cfg")
-        chmod_mock.assert_called_once_with("/somewhere/root/original-ks.cfg", 0x0600)
+        chmod_mock.assert_called_once_with("/somewhere/root/original-ks.cfg", 0o0600)
 
         exec_wr_mock.assert_called_once_with(
             "restorecon",


### PR DESCRIPTION
See https://github.com/rhinstaller/anaconda/pull/3571#issuecomment-922119290

CC @AdamWill 

Note that kickstart tests are blind to this: The crash happens only if input kickstart can be copied but none was actually used.