### PR TITLE
Set an upper bound to entered sizes (#1992585)

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -276,9 +276,6 @@ CMDLINE_FILES = [
 CMDLINE_APPEND = ["modprobe.blacklist", "ifname", "ip"]
 CMDLINE_LIST = ["addrepo"]
 
-# Default to these units when reading user input when no units given
-SIZE_UNITS_DEFAULT = "MiB"
-
 # An estimated ratio for metadata size to total disk space.
 STORAGE_METADATA_RATIO = 0.1
 

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -32,7 +32,7 @@ from dasbus.structure import compare_data
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import THREAD_EXECUTE_STORAGE, THREAD_STORAGE, \
-    SIZE_UNITS_DEFAULT, PARTITIONING_METHOD_INTERACTIVE
+    PARTITIONING_METHOD_INTERACTIVE
 from pyanaconda.core.i18n import _, N_, CP_, C_
 from pyanaconda.modules.common.constants.objects import BOOTLOADER, DISK_SELECTION
 from pyanaconda.modules.common.constants.services import STORAGE
@@ -1547,11 +1547,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         if not self._sizeEntry.get_sensitive():
             return
 
-        size = get_size_from_entry(
-            self._sizeEntry,
-            lower_bound=self.MIN_SIZE_ENTRY,
-            units=SIZE_UNITS_DEFAULT
-        )
+        size = get_size_from_entry(self._sizeEntry)
 
         # Show warning if the size string is invalid. Field self._error is used as a "flag" that
         # the last error was the same. This is done because this warning can fire on every change,


### PR DESCRIPTION
A device size in bytes has to be in a range of the UInt64 type. Values outside
of this range will trigger the overflow error when they will be propagated on
DBus. Set an upper bound to entered sizes to prevent this error.

Resolves: rhbz#1992585