### PR TITLE
Payload should wait for all storage related threads to finish

### DIFF
--- a/pyanaconda/payload/manager.py
+++ b/pyanaconda/payload/manager.py
@@ -22,7 +22,8 @@ from enum import IntEnum
 
 from dasbus.error import DBusError
 from pyanaconda.core.constants import THREAD_STORAGE, THREAD_PAYLOAD, THREAD_PAYLOAD_RESTART, \
-    THREAD_WAIT_FOR_CONNECTING_NM, THREAD_SUBSCRIPTION, PAYLOAD_TYPE_DNF
+    THREAD_WAIT_FOR_CONNECTING_NM, THREAD_SUBSCRIPTION, PAYLOAD_TYPE_DNF, \
+    THREAD_STORAGE_WATCHER, THREAD_EXECUTE_STORAGE
 from pyanaconda.core.i18n import _, N_
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload.errors import PayloadError
@@ -176,6 +177,8 @@ class PayloadManager(object):
         # Wait for storage
         self._set_state(PayloadState.WAITING_STORAGE)
         threadMgr.wait(THREAD_STORAGE)
+        threadMgr.wait(THREAD_STORAGE_WATCHER)
+        threadMgr.wait(THREAD_EXECUTE_STORAGE)
 
         # Wait for network
         self._set_state(PayloadState.WAITING_NETWORK)


### PR DESCRIPTION
Otherwise a race condition can happen when some of the storage related
threads run at the same time as the payload thread and both interact
with the Blivet storage instance.

This storage instance is not thread safe and two threads interacting
with it at the same time can result in a deadlock.

By waiting for all storage related threads to finish before running
the payload thread we can avoid this race condition and the resulting
deadlock.

Thanks a lot to Honza Stodola and Vendula Poncova for helping me track
down this kinda tricky race condition! :)

Resolves: rhbz#2002203