### PR TITLE
Use curl-minimal instead of curl in dockerfiles (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -14,7 +14,7 @@ COPY *.repo /etc/yum.repos.d/
 RUN set -e; \
   dnf update -y; \
   dnf install -y \
-  curl \
+  curl-minimal \
   /usr/bin/xargs \
   rpm-build \
   e2fsprogs \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -14,7 +14,7 @@ COPY *.repo /etc/yum.repos.d/
 RUN set -e; \
   dnf update -y; \
   dnf install -y \
-  curl \
+  curl-minimal \
   python3-pip \
   /usr/bin/xargs \
   rpm-build; \


### PR DESCRIPTION
Looks like there are some issues with the curl package on RHEL 9
at the moment, so try using curl-minimal instead. Also as we
don't  use advanced curl functionality we might as well keep
using just curl-minimal even after the current breakage is fixed.