### PR TITLE
Use curl-minimal instead of curl in dockerfiles (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -31,9 +31,11 @@ COPY ["eln.repo", "/etc/yum.repos.d"]
 RUN set -ex; \
   if grep -q VARIANT.*eln /etc/os-release; then sed -i 's/enabled=0/enabled=1/' /etc/yum.repos.d/eln.repo; fi; \
   dnf update -y; \
+  dnf install -y --allowerasing \
+  curl-minimal \
+  libcurl-minimal; \
   dnf install -y \
   'dnf-command(copr)' \
-  curl \
   /usr/bin/xargs \
   rpm-build \
   git \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -26,9 +26,11 @@ COPY ["eln.repo", "/etc/yum.repos.d"]
 RUN set -ex; \
   if grep -q VARIANT.*eln /etc/os-release; then sed -i 's/enabled=0/enabled=1/' /etc/yum.repos.d/eln.repo; fi; \
   dnf update -y; \
+  dnf install -y --allowerasing \
+  curl-minimal \
+  libcurl-minimal;\
   dnf install -y \
   'dnf-command(copr)' \
-  curl \
   python3-pip \
   /usr/bin/xargs \
   rpm-build; \


### PR DESCRIPTION
Looks like using the fill curl package makes it more likely
to hit package dependency issues so use curl-minimal - we don't
use advanced curl functionality anyway & it might even make the
container smaller.

(cherry picked from commit 47f41ba9a2993ceef42af64e27a37299bb8f1291)