### PR TITLE
In installer environment set static, not transient hostname

### DIFF
--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -238,8 +238,8 @@ class NetworkService(KickstartService):
             log.debug("Current hostname cannot be set.")
             return
 
-        self._hostname_service_proxy.SetHostname(hostname, False)
-        log.debug("Current hostname is set to %s", hostname)
+        self._hostname_service_proxy.SetStaticHostname(hostname, False)
+        log.debug("Current static hostname is set to %s", hostname)
 
     @property
     def nm_available(self):

--- a/tests/nosetests/pyanaconda_tests/modules/network/module_network_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/network/module_network_test.py
@@ -140,12 +140,12 @@ class NetworkInterfaceTestCase(unittest.TestCase):
         conf_mock.system.provides_system_bus = False
         self.network_module._connect_to_hostname_service()
         self.network_interface.SetCurrentHostname("dot.dot")
-        hostname_mock.SetHostname.assert_not_called()
+        hostname_mock.SetStaticHostname.assert_not_called()
 
         conf_mock.system.provides_system_bus = True
         self.network_module._connect_to_hostname_service()
         self.network_interface.SetCurrentHostname("dot.dot")
-        hostname_mock.SetHostname.assert_called_once_with("dot.dot", False)
+        hostname_mock.SetStaticHostname.assert_called_once_with("dot.dot", False)
 
     @patch("pyanaconda.modules.network.network.conf")
     @patch('pyanaconda.core.dbus.SystemBus.get_proxy')


### PR DESCRIPTION
It provides more stable / predictable environment for installer %post
scripts. For example prevents hostname changes by NetworkManager upon
device (re-)activation.

Resolves: rhbz#2009403