### PR TITLE
Fix Satellite provisioning rollback after unregistration

### DIFF
--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -686,6 +686,10 @@ class SubscriptionService(KickstartService):
         self.set_attached_subscriptions([])
         # clear the Satellite registration status as well
         self.set_registered_to_satellite(False)
+        # don't forget to also clear the Satellite provisioning
+        # script, or else it will be run by the target system
+        # provisioning task
+        self._set_satellite_provisioning_script(None)
 
     def _set_system_subscription_data(self, system_subscription_data):
         """A helper method invoked in ParseAttachedSubscritionsTask completed signal.

--- a/tests/nosetests/pyanaconda_tests/modules/subscription/subscription_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/subscription/subscription_test.py
@@ -1110,6 +1110,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         """Test UnregisterTask creation - system registered to Satellite."""
         # simulate system being subscribed & registered to Satellite
         self.subscription_module.set_subscription_attached(True)
+        self.subscription_module._set_satellite_provisioning_script("foo script")
         self.subscription_module.set_registered_to_satellite(True)
         # simulate RHSM config backup
         self.subscription_module._rhsm_conf_before_satellite_provisioning = {
@@ -1132,6 +1133,8 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         self.assertFalse(self.subscription_interface.IsRegistered)
         self.assertFalse(self.subscription_interface.IsRegisteredToSatellite)
         self.assertFalse(self.subscription_interface.IsSubscriptionAttached)
+        # check the provisioning scrip has been cleared
+        self.assertIsNone(self.subscription_module._satellite_provisioning_script)
 
     @patch_dbus_publish_object
     def install_with_tasks_default_test(self, publisher):


### PR DESCRIPTION
After unregistering the machine from a Satellite instance, also
clear the cached provisioning script.

Otherwise the target system Satellite provisioning installation
task will run as it is triggered by the provisioning script
being available.

Resolves: rhbz#2006718