### PR TITLE
ovirt: update help directory

### DIFF
--- a/data/profile.d/ovirt.conf
+++ b/data/profile.d/ovirt.conf
@@ -30,7 +30,7 @@ req_partition_sizes =
     /boot  1  GiB
 
 [User Interface]
-help_directory = /usr/share/anaconda/help/rhel
+help_directory = /usr/share/anaconda/help/en-US
 hidden_spokes = UserSpoke
 
 [Payload]


### PR DESCRIPTION
on CentOS Stream 9 the help directory is located at
/usr/share/anaconda/help/en-US

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>