### PR TITLE
Disable the concurrency check in the error dialog in TUI

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -39,7 +39,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.4.0-1
 %define rpmver 4.15.0
-%define simplelinever 1.1-1
+%define simplelinever 1.9.0-1
 %define subscriptionmanagerver 1.26
 %define utillinuxver 2.15.1
 

--- a/pyanaconda/ui/tui/tuiobject.py
+++ b/pyanaconda/ui/tui/tuiobject.py
@@ -82,6 +82,15 @@ def report_check_func():
 
 class IpmiErrorDialog(ErrorDialog):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # This dialog is run by the error handler. The handler
+        # might be triggered by an error from a different thread.
+        # It is possible that we are already asking for a user
+        # input when we decide to show the dialog. That would
+        # violate the concurrency check, so disable it.
+        self.input_manager.skip_concurrency_check = True
+
     def input(self, args, key):
         """Call IPMI ABORTED. Everything else will be done by original implementation."""
         util.ipmi_report(constants.IPMI_ABORTED)


### PR DESCRIPTION
The `IpmiErrorDialog` dialog is run by the error handler. The handler might
be triggered by an error from a different thread. It is possible that we
are already asking for a user input when we decide to show the dialog.
That would violate the concurrency check, so disable it.

Related: rhbz#1807491

**Depends on:** https://github.com/rhinstaller/python-simpleline/pull/111