### PR TITLE
Revert "Install kbd-legacy if keyboard layout is "fi" (#1955793)"

### DIFF
--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -196,10 +196,8 @@ class LocalizationService(KickstartService):
         """
         requirements = []
 
-        # Install support for non-ascii keyboard layouts (#1919483)
-        # and special case "fi" layout (#1955793)
-        if self.vc_keymap and (self.vc_keymap == "fi" or
-                               not langtable.supports_ascii(self.vc_keymap)):
+        # Install support for non-ascii keyboard layouts (#1919483).
+        if self.vc_keymap and not langtable.supports_ascii(self.vc_keymap):
             requirements.append(Requirement.for_package(
                 package_name="kbd-legacy",
                 reason="Required to support the '{}' keymap.".format(self.vc_keymap)

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
@@ -171,17 +171,6 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
         assert requirements[0].type == "package"
         assert requirements[0].name == "kbd-legacy"
 
-        # "fi" keyboard layout is in kbd-legacy too (#1955793)
-        self.localization_interface.SetVirtualConsoleKeymap("fi")
-
-        requirements = Requirement.from_structure_list(
-            self.localization_interface.CollectRequirements()
-        )
-
-        assert len(requirements) == 1
-        assert requirements[0].type == "package"
-        assert requirements[0].name == "kbd-legacy"
-
     @patch_dbus_publish_object
     def test_install_with_task(self, publisher):
         """Test InstallWithTask."""


### PR DESCRIPTION
This reverts commit b9c33400831024394e351753d7e413643f6a4757.

(cherry-picked from https://github.com/rhinstaller/anaconda/pull/3614)

Resolves: rhbz#2003937