### PR TITLE
Don't assume Python modules are in sysconfig.get_path('purelib')

### DIFF
--- a/dracut/python-deps
+++ b/dracut/python-deps
@@ -23,24 +23,23 @@ import copy
 import os
 import sys
 import sysconfig
+from importlib.util import find_spec
 from modulefinder import ModuleFinder
-
-sitedir = sysconfig.get_path('purelib')
-libdir = sysconfig.get_config_var('LIBDEST')
 
 # stringprep is needed by the idna encoding, and idna is needed by requests.
 # The encoding import is implicit so ModuleFinder doesn't find it right.
-alsoNeeded = {sitedir+"/requests/__init__.py": libdir+"/stringprep.py"}
+alsoNeeded = {find_spec('requests').origin: find_spec('stringprep').origin}
 
 # A couple helper functions...
 def moduledir(pyfile):
     '''Given a python file, return the module dir it belongs to, or None.'''
-    for topdir in sitedir, libdir:
-        relpath = os.path.relpath(pyfile, topdir)
-        if '/' not in relpath: continue
-        modname = relpath.split('/')[0]
-        if modname not in ('..', 'site-packages'):
-            return os.path.join(topdir, modname)
+    for topdir in sys.path:
+        if topdir.startswith(sys.prefix + '/') and os.path.isdir(topdir):
+            relpath = os.path.relpath(pyfile, topdir)
+            if '/' not in relpath: continue
+            modname = relpath.split('/')[0]
+            if modname not in ('..', 'site-packages'):
+                return os.path.join(topdir, modname)
 
 # pylint: disable=redefined-outer-name
 def pyfiles(moddir):
@@ -55,13 +54,13 @@ mods = []
 deps = []
 
 scripts = copy.copy(sys.argv[1:])
-scripts.append(os.path.join(libdir,'site.py'))
-scripts.append(os.path.join(libdir,'sysconfig.py'))
+scripts.append(find_spec('site').origin)
+scripts.append(find_spec('sysconfig').origin)
 # platform-specific sysconfigdata module, needed by sysconfig, not
 # detected by ModuleFinder - RHBZ #1409177, Python #29113
 # this will only work and is only needed on Python 3.6+, so hedge it
 try:
-    sysconfmod = os.path.join(libdir, sysconfig._get_sysconfigdata_name() + '.py')
+    sysconfmod = os.path.join(find_spec(sysconfig._get_sysconfigdata_name()).origin)
     if os.path.exists(sysconfmod):
         scripts.append(sysconfmod)
 except AttributeError:


### PR DESCRIPTION
sysconfig.get_path('purelib') returns a location where pure Python modules
should be installed, which is not necessarily where they are loaded from.

Since Fedora 36, sysconfig uses a different install scheme for RPM packages
and for other packages (e.g. installed by pip, setuptools, distutils...).
Without additional context, the scheme for "other" is the default.
Hence, sysconfig.get_path('purelib') returns /usr/local/lib/python3.10/site-packages.
But dracut needs the files installed from RPM packages.

See the announcement about the change in Fedora's Python:
https://lists.fedoraproject.org/archives/list/python-devel@lists.fedoraproject.org/thread/AAGUFQZ4RZDU7KUN4HA43KQJCMSFR3GW/

Instead of directly asking for RPM locations,
we won't assume "where to install stuff" and "where is stuff imported from"
is the same question and we inspect sys.path instead.
To be able to reference specific Python modules,
we use importlib.util.find_spec() (available since Python 3.4).

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2012513

This change also has 2 added benefits:

 - It loads information from all Python import paths,
   not just 2, so when we add modules from /usr/lib64/python3.10/site-packages,
   this script won't need changes.

 - It does not assume where hardcoded modules are installed,
   so when requests turn into a single-file library requests.py or to an
   extension module (both unlikely, but technically possible),
   or sysconfig becomes a package with __init__.py,
   this script won't need changes.