### PR TITLE
Bump required rpm version

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -38,7 +38,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define pykickstartver 3.32-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.4.0-1
-%define rpmver 4.10.0
+%define rpmver 4.15.0
 %define simplelinever 1.1-1
 %define subscriptionmanagerver 1.26
 %define utillinuxver 2.15.1


### PR DESCRIPTION
The no-bytes API that was taken for granted in the `pyanaconda.core.string` module refactoring requires at least rpm 4.15.0.