### PR TITLE
Log statistics about the image installation

### DIFF
--- a/pyanaconda/modules/payloads/payload/live_image/installation.py
+++ b/pyanaconda/modules/payloads/payload/live_image/installation.py
@@ -159,6 +159,7 @@ class InstallFromImageTask(Task):
         cmd = "rsync"
         args = [
             "-pogAXtlHrDx",
+            "--stats",
             "--exclude", "/dev/",
             "--exclude", "/proc/",
             "--exclude", "/tmp/*",

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
@@ -92,6 +92,7 @@ class InstallFromImageTaskTestCase(unittest.TestCase):
 
         exec_with_redirect.assert_called_once_with("rsync", [
             "-pogAXtlHrDx",
+            "--stats",
             "--exclude", "/dev/",
             "--exclude", "/proc/",
             "--exclude", "/tmp/*",


### PR DESCRIPTION
Run `rsync` with the `--stats` option to get some info about the installation.