### PR TITLE
Roll back Satellite provisioning if subscription attempt fails with e…

### DIFF
--- a/pyanaconda/modules/subscription/utils.py
+++ b/pyanaconda/modules/subscription/utils.py
@@ -1,0 +1,39 @@
+#
+# Utility functions for network module
+#
+# Copyright (C) 2021 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+def flatten_rhsm_nested_dict(nested_dict):
+    """Convert the GetAll() returned nested dict into a flat one.
+
+    RHSM returns a nested dict with categories on top
+    and category keys & values inside. This is not convenient
+    for setting keys based on original values, so
+    let's normalize the dict to the flat key based
+    structure similar to what's used by SetAll().
+
+    :param dict nested_dict: the nested dict returned by GetAll()
+    :return: flat key/value dictionary, similar to format used by SetAll()
+    :rtype: dict
+    """
+    flat_dict = {}
+    for category_key, category_dict in nested_dict.items():
+        for key, value in category_dict.items():
+            flat_key = "{}.{}".format(category_key, key)
+            flat_dict[flat_key] = value
+    return flat_dict

--- a/tests/nosetests/pyanaconda_tests/modules/subscription/subscription_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/subscription/subscription_test.py
@@ -1113,10 +1113,7 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         self.subscription_module._set_satellite_provisioning_script("foo script")
         self.subscription_module.set_registered_to_satellite(True)
         # simulate RHSM config backup
-        self.subscription_module._rhsm_conf_before_satellite_provisioning = {
-            "foo":
-                {"bar": "baz"}
-        }
+        self.subscription_module._rhsm_conf_before_satellite_provisioning = {"foo.bar": "baz"}
         # make sure the task gets dummy rhsm unregister proxy
         rhsm_observer = Mock()
         self.subscription_module._rhsm_observer = rhsm_observer

--- a/tests/nosetests/pyanaconda_tests/modules/subscription/utils_test.py
+++ b/tests/nosetests/pyanaconda_tests/modules/subscription/utils_test.py
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
+
+import unittest
+
+from pyanaconda.modules.subscription.utils import flatten_rhsm_nested_dict
+
+
+class FlattenRHSMNestedDictTestCase(unittest.TestCase):
+    """Test the RHSM nested dict flattening function."""
+
+    def empty_dict_test(self):
+        """Test the flattening function can handle an empty dict being passed."""
+        self.assertEqual(flatten_rhsm_nested_dict({}), {})
+
+    def nested_dict_test(self):
+        """Test the flattening function can handle a nested dict being passed."""
+        self.assertEqual(flatten_rhsm_nested_dict({"foo": {"bar": "baz"}}), {"foo.bar": "baz"})


### PR DESCRIPTION
…rror

Previously Satellite provisioning was only rolled back when the
"Unregister" button has been pressed.

Turns out this is not sufficient, as provisioning happens quite early,
yet the registration and subscription attempt can still end with an
error. The system will then be provisioned for Satellite, but not
registered to it, so no "Unregister" button would be available to
roll back the provisioning.

So instead, make sure Satellite provisioning is always rolled back
if registration to satellite fails in one of tis phases.

And while we are at it refactor the RHSM config dict flattening method
to a function in an utility module and cover all the new and changed
code with unit tests.

Resolves: rhbz#2010865