### PR TITLE
Upgrade pip in the anaconda-ci container (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -63,7 +63,8 @@ RUN set -ex; \
   rpmspec -q --requires /tmp/anaconda.spec | grep -v anaconda | xargs -d '\n' dnf install -y; \
   dnf clean all
 
-RUN pip install --no-cache-dir \
+RUN pip install --no-cache-dir --upgrade pip; \
+  pip install --no-cache-dir \
   pocketlint \
   coverage \
   pycodestyle \


### PR DESCRIPTION
Use the latest `pip` to install the test dependencies.