### PR TITLE
Unify GUI & TUI root spoke completeness conditions

### DIFF
--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -60,7 +60,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     @property
     def completed(self):
-        return bool(self._users_module.IsRootPasswordSet or self._users_module.IsRootAccountLocked)
+        return self._users_module.IsRootPasswordSet
 
     @property
     def showable(self):


### PR DESCRIPTION
Port of #3655 to downstream.

---

TUI showed Root spoke as completed, even if it was not. This happened because the default state is "no root password = locked", and the spoke took locked root as completed too.

That behavior was not consistent with GUI, and has been fixed in RHEL 8. However, for some reason the fix did not get upstreamed.

With this change:
- GUI and TUI root spokes use identical logic to determine if they are
  mandatory and completed.
- TUI shows both root and user spoke as uncompleted and mandatory on startup.
- TUI shows root spoke as uncompleted but not mandatory if admin user exists.
- The RHEL 8 change is finally ported upstream.

Resolves: [rhbz#1999646](https://bugzilla.redhat.com/show_bug.cgi?id=1999646)

(cherry picked from commit 856b002fe59cda4db939ec6f55b9919b9d54a4f5)