### PR TITLE
Sync changelog with the current downstream development branch (#infra)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -382,14 +382,8 @@ desktop-file-install --dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_d
 * Thu Sep 30 2021 Radek Vykydal <rvykydal@redhat.com> - 33.16.6.1-1
 - Payload should wait for all storage related threads to finish (mkolman)
   Resolves: rhbz#2007615
-
-* Fri Sep 24 2021 Radek Vykydal <rvykydal@redhat.com> - 33.16.5.6-1
-- Payload should wait for all storage related threads to finish (mkolman)
-  Resolves: rhbz#2002203
-
-* Mon Sep 13 2021 Radek Vykydal <rvykydal@redhat.com> - 33.16.5.5-1
 - Remove misleading warning about inst.ks.device replacing ksdevice (rvykydal)
-  Resolves: rhbz#2001913
+  Resolves: rhbz#2002722
 
 * Mon Aug 02 2021 Radek Vykydal <rvykydal@redhat.com> - 33.16.5.4-1
 - Disable anaconda-core's requirement on subscription-manager on CentOS (carl)


### PR DESCRIPTION
We had a common upstream spec file for branched 8.5 (stabilize) and 8.6
(devel) for a short period of time. I modified the spec file changelog
BZ references for the current development branch (8.6) downstream to
comply with check-in policy and this PR should backport the spec file
update upstream.