### PR TITLE
Sync changelog with the current downstream development branch (#infra)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -429,9 +429,9 @@ desktop-file-install --dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_d
 
 * Thu Sep 23 2021 Radek Vykydal <rvykydal@redhat.com> - 34.25.0.17-1
 - Verify the OPAL compatibility with XFS features (vponcova)
-  Resolves: rhbz#1997832
+  Resolves: rhbz#2000923
 - Generate LVM device file after installation (vslavik)
-  Resolves: rhbz#2002550
+  Resolves: rhbz#2005034
 
 * Wed Sep 15 2021 Martin Kolman <mkolman@redhat.com> - 34.25.0.16-1
 - Support multi-org accounts in the GUI (mkolman)


### PR DESCRIPTION
Update BZ references in upstram development branch to be consistent with
current downstream development branch. The common upstream references
referred to the BZs fixed for beta before branching for beta in upstream
and were then updated downstream for the downstream devel branch. Sync
it now, and next time either use packit features or maybe create
upstream beta branch earlier.