### PR TITLE
Show correctly that no admin user is set up

### DIFF
--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -186,7 +186,10 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     @property
     def mandatory(self):
-        """Only mandatory if no admin user has been requested."""
+        """Only mandatory if no admin user has been requested.
+
+        See also doc for the property completed().
+        """
         return not self._users_module.CheckAdminUserExists()
 
     def apply(self):
@@ -216,7 +219,14 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     @property
     def completed(self):
-        return self._users_module.IsRootPasswordSet
+        """Is the spoke completed?
+
+        For root and user, the mandatory+completed pair is a complicated hack. Having an usable
+        admin user is mandatory, but it is not clear if it should be an unlocked root, or a sudoer.
+        Thus, mandatory on both spokes checks admin user, and complete then checks again: Both the
+        spoke-specific completion condition, as well as existence of an admin.
+        """
+        return self._users_module.IsRootPasswordSet and self._users_module.CheckAdminUserExists()
 
     @property
     def sensitive(self):

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -459,7 +459,10 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
 
     @property
     def mandatory(self):
-        """Only mandatory if no admin user has been requested."""
+        """Only mandatory if no admin user has been requested.
+
+        See also doc for the property completed().
+        """
         return not self._users_module.CheckAdminUserExists()
 
     def apply(self):
@@ -503,7 +506,15 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
 
     @property
     def completed(self):
-        return bool(get_user_list(self._users_module))
+        """Is the spoke completed?
+
+        For root and user, the mandatory+completed pair is a complicated hack. Having an usable
+        admin user is mandatory, but it is not clear if it should be an unlocked root, or a sudoer.
+        Thus, mandatory on both spokes checks admin user, and complete then checks again: Both the
+        spoke-specific completion condition, as well as existence of an admin.
+        """
+        return bool(get_user_list(self._users_module)) \
+               and self._users_module.CheckAdminUserExists()
 
     def on_password_required_toggled(self, togglebutton=None, data=None):
         """Called by Gtk callback when the "Use password" check


### PR DESCRIPTION
A quick fix for admin user detection in GUI. Previously, it was possible to satisfy the conditions just by setting root password, even if root was locked.

Code-wise, adding `and self._users_module.CheckAdminUserExists()` to `completed` of root and user spokes will make the respective spoke signal incomplete at the right time = displaying the exclamation mark and red text.

The one question is how to signal that the user has a choice of resolving this in *both* spokes. Easiest fix would be doing both, which is the initial submission here.

Resolves: [rhbz#2015508](https://bugzilla.redhat.com/show_bug.cgi?id=2015508)