### PR TITLE
Create releases when tags are pushed (#infra)

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,79 @@
+name: Release from tags
+# Create a GitHub release when a tag is pushed.
+
+on:
+  push:
+    tags:
+      # this is a glob, not a regexp
+      - 'anaconda-*'
+
+permissions:
+  contents: write
+
+jobs:
+  release-from-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract version from the tag
+        id: get_version
+        # If the version does not fit the regexp, we'll just fail. TODO maybe abort instead?
+        run: |
+          echo "Checking pushed tag ref ${{ github.ref }}"
+          VER=$(echo ${{ github.ref }} | perl -ne '/^refs\/tags\/anaconda-([0-9]+(?:\.[0-9]+){1,3})-1$/ && print "$1\n";')
+          if [ -z "$VER" ] ; then
+            echo "Tag ref ${{ github.ref }} is not a valid release tag."
+            exit 1
+          else
+            echo "Tag ref ${{ github.ref }} detected as release version $VER."
+            echo "::set-output name=version::$VER"
+          fi
+
+      - name: Check out repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Build anaconda-rpm container (for RPM build)
+        run: |
+          make -f Makefile.am anaconda-rpm-build
+
+      - name: Run the build in the container
+        run: |
+          mkdir /tmp/results
+          podman run \
+            -i \
+            -v /tmp/results:/results \
+            -v `pwd`:/anaconda \
+            quay.io/rhinstaller/anaconda-rpm:master <<EOF
+
+          # prepare environment
+          set -eux
+
+          # install dependencies for translation canary
+          dnf install -y git python3-polib python3-pip
+          pip install --upgrade pip pocketlint
+
+          # build tarball
+          cd /anaconda
+          ./autogen.sh
+          ./configure
+          make release
+
+          # copy out stuff
+          cp anaconda-*.tar.bz2 /results
+
+          EOF
+
+      - name: Create the release
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NAME: ${{ steps.get_version.outputs.version }}
+        run: |
+          gh release create \
+            ${{ github.ref }} \
+            --draft \
+            --title "anaconda-$RELEASE_NAME" \
+            --notes "Anaconda release $RELEASE_NAME created automatically from git tag." \
+            /tmp/results/*


### PR DESCRIPTION
This runs the existing "make release" autotools target in our existing "standard" RPM test container. Only minimal changes are needed due to translation canary dependencies.

The output is a release visible on GitHub that contains the tarball with anaconda and translations.

Since this is an early version of the workflow, releases are created as drafts. They have to be manually un-drafted in the GitHub interface afterwards.

Thanks to @jkonecny12 for all help!