### PR TITLE
make US keyboard layout easier to find in Anaconda

### DIFF
--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -134,8 +134,9 @@ class AddLayoutDialog(GUIObject):
     def _initialize(self):
         common_layouts = self._xkl_wrapper.get_common_layouts()
         available_layouts = self._xkl_wrapper.get_available_layouts()
+        common_layouts.remove(DEFAULT_KEYBOARD)
 
-        arranged_layouts = sorted(common_layouts, key=self._sort_layout) + \
+        arranged_layouts = [DEFAULT_KEYBOARD] + sorted(common_layouts, key=self._sort_layout) + \
             sorted(list(set(available_layouts) - set(common_layouts)), key=self._sort_layout)
 
         # we add arranged layouts in the treeview store


### PR DESCRIPTION
**Use Case**: 
As a US keyboard layout user, I would like to be able to find the US keyboard layout in my own language quickly and easily in the Anaconda installer.

a discussion around the use case is [here](https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/WFVVUOKIGHARF5Z2FQXRORM4RXFIMBOJ/).