### PR TITLE
Use the set-up and tear-down tasks of the Live OS image source

### DIFF
--- a/pyanaconda/modules/payloads/source/live_os/live_os.py
+++ b/pyanaconda/modules/payloads/source/live_os/live_os.py
@@ -114,10 +114,13 @@ class LiveOSSourceModule(PayloadSourceBase, MountingSourceMixin):
         """Tear down the installation source.
 
         :return: list of tasks required for the source clean-up
-        :rtype: [TearDownMountTask]
+        :rtype: [Task]
         """
-        task = TearDownMountTask(self._mount_point)
-        return [task]
+        return [
+            TearDownMountTask(
+                target_mount=self.mount_point
+            )
+        ]
 
     def set_up_with_tasks(self):
         """Set up the installation source for installation.
@@ -125,5 +128,9 @@ class LiveOSSourceModule(PayloadSourceBase, MountingSourceMixin):
         :return: list of tasks required for the source setup
         :rtype: [Task]
         """
-        task = SetUpLiveOSSourceTask(self._image_path, self.mount_point)
-        return [task]
+        return [
+            SetUpLiveOSSourceTask(
+                image_path=self.image_path,
+                target_mount=self.mount_point
+            )
+        ]

--- a/pyanaconda/payload/live/payload_liveos.py
+++ b/pyanaconda/payload/live/payload_liveos.py
@@ -15,17 +15,13 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-import os
-import stat
-
 from blivet.size import Size
 from pyanaconda.anaconda_loggers import get_packaging_logger
-from pyanaconda.core.constants import PAYLOAD_TYPE_LIVE_OS, INSTALL_TREE, SOURCE_TYPE_LIVE_OS_IMAGE
+from pyanaconda.core.constants import PAYLOAD_TYPE_LIVE_OS, INSTALL_TREE
 from pyanaconda.core.i18n import _
-from pyanaconda.modules.common.constants.services import PAYLOADS
-from pyanaconda.modules.common.task import sync_run_task
-from pyanaconda.payload import utils as payload_utils
-from pyanaconda.payload.errors import PayloadSetupError
+from pyanaconda.modules.payloads.source.live_os.initialization import DetectLiveOSImageTask, \
+    SetUpLiveOSSourceTask
+from pyanaconda.modules.payloads.source.mount_tasks import TearDownMountTask
 from pyanaconda.payload.live.payload_base import BaseLivePayload
 from pyanaconda.progress import progressQ
 
@@ -42,52 +38,24 @@ class LiveOSPayload(BaseLivePayload):
         """The DBus type of the payload."""
         return PAYLOAD_TYPE_LIVE_OS
 
-    @staticmethod
-    def _get_live_os_image():
-        """Detect live os image on the system.
-
-        FIXME: This is a temporary workaround.
-
-        :return: a path to the image
-        """
-        payloads_proxy = PAYLOADS.get_proxy()
-        source_path = payloads_proxy.CreateSource(SOURCE_TYPE_LIVE_OS_IMAGE)
-        source_proxy = PAYLOADS.get_proxy(source_path)
-
-        task_path = source_proxy.DetectImageWithTask()
-        task = PAYLOADS.get_proxy(task_path)
-        sync_run_task(task)
-
-        return source_proxy.ImagePath
-
     def setup(self):
-        super().setup()
         # Mount the live device and copy from it instead of the overlay at /
-        osimg_spec = self._get_live_os_image()
+        task = DetectLiveOSImageTask()
+        image_path = task.run()
 
-        if not osimg_spec:
-            raise PayloadSetupError("No live image found!")
-
-        osimg = payload_utils.resolve_device(osimg_spec)
-        if not osimg:
-            raise PayloadSetupError("Unable to find osimg for {}".format(osimg_spec))
-
-        osimg_path = payload_utils.get_device_path(osimg)
-        if not stat.S_ISBLK(os.stat(osimg_path)[stat.ST_MODE]):
-            raise PayloadSetupError("{} is not a valid block device".format(osimg_spec))
-
-        rc = payload_utils.mount(osimg_path, INSTALL_TREE, fstype="auto", options="ro")
-        if rc != 0:
-            raise PayloadSetupError("Failed to mount the install tree")
+        task = SetUpLiveOSSourceTask(
+            image_path=image_path,
+            target_mount=INSTALL_TREE
+        )
+        task.run()
 
         # Grab the kernel version list now so it's available after umount
         self._update_kernel_version_list()
 
     def unsetup(self):
-        super().unsetup()
-
         # Unmount a previously mounted live tree
-        payload_utils.unmount(INSTALL_TREE)
+        task = TearDownMountTask(INSTALL_TREE)
+        task.run()
 
     def pre_install(self):
         """ Perform pre-installation tasks. """

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_os.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_os.py
@@ -184,9 +184,9 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
                 "/path/to/mount/source/image"
             )
 
-        assert task.name == "Set up Live OS Installation Source"
+        assert task.name == "Set up a Live OS image"
 
-    @patch("pyanaconda.modules.payloads.source.live_os.initialization.mount")
+    @patch("pyanaconda.modules.payloads.source.live_os.initialization.blivet.util.mount")
     @patch("pyanaconda.modules.payloads.source.live_os.initialization.stat")
     @patch("os.stat")
     @patch_dbus_get_proxy
@@ -227,7 +227,7 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
                 "/path/to/mount/source/image"
             ).run()
 
-        assert str(cm.value) == "Failed to find liveOS image!"
+        assert str(cm.value) == "Failed to resolve the Live OS image."
 
     @patch("pyanaconda.modules.payloads.source.live_os.initialization.stat")
     @patch("os.stat")
@@ -237,10 +237,10 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
         device_tree = Mock()
         proxy_getter.return_value = device_tree
         device_tree.ResolveDevice = Mock()
-        device_tree.ResolveDevice.return_value = "resolvedDeviceName"
+        device_tree.ResolveDevice.return_value = "dev1"
 
         device = DeviceData()
-        device.path = "/resolved/path/to/base/image"
+        device.path = "/dev/dev1"
 
         device_tree.GetDeviceData = Mock()
         device_tree.GetDeviceData.return_value = DeviceData.to_structure(device)
@@ -248,13 +248,15 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
         stat_mock.S_ISBLK = Mock()
         stat_mock.S_ISBLK.return_value = False
 
-        with pytest.raises(SourceSetupError):
+        with pytest.raises(SourceSetupError) as cm:
             SetUpLiveOSSourceTask(
                 "/path/to/base/image",
                 "/path/to/mount/source/image"
             ).run()
 
-    @patch("pyanaconda.modules.payloads.source.live_os.initialization.mount")
+        assert str(cm.value) == "/dev/dev1 is not a valid block device."
+
+    @patch("pyanaconda.modules.payloads.source.live_os.initialization.blivet.util.mount")
     @patch("pyanaconda.modules.payloads.source.live_os.initialization.stat")
     @patch("os.stat")
     @patch_dbus_get_proxy
@@ -263,10 +265,10 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
         device_tree = Mock()
         proxy_getter.return_value = device_tree
         device_tree.ResolveDevice = Mock()
-        device_tree.ResolveDevice.return_value = "resolvedDeviceName"
+        device_tree.ResolveDevice.return_value = "dev1"
 
         device = DeviceData()
-        device.path = "/resolved/path/to/base/image"
+        device.path = "/dev/dev1"
 
         device_tree.GetDeviceData = Mock()
         device_tree.GetDeviceData.return_value = DeviceData.to_structure(device)
@@ -279,4 +281,4 @@ class LiveOSSourceTasksTestCase(unittest.TestCase):
                 "/path/to/mount/source/image"
             ).run()
 
-        assert str(cm.value) == "Failed to mount the install tree"
+        assert str(cm.value) == "Failed to mount the Live OS image."


### PR DESCRIPTION
* Clean up the tasks and use them in the Live OS payload class.
* Run the task for the Live OS image detection directly.