### PR TITLE
Fix application of network --mtu kickstart option in Anaconda

### DIFF
--- a/pyanaconda/modules/network/nm_client.py
+++ b/pyanaconda/modules/network/nm_client.py
@@ -498,6 +498,8 @@ def create_connections_from_ksdata(nm_client, network_data, device_name, ifname_
             s390cfg = get_s390_settings(device_name)
             _update_wired_connection_with_s390_settings(con, s390cfg)
 
+    update_connection_wired_settings_from_ksdata(con, network_data)
+
     connections.append((con, device_to_activate))
     connections.extend(port_connections)
 
@@ -697,6 +699,8 @@ def update_connection_from_ksdata(nm_client, connection, network_data, device_na
     # IP configuration
     update_connection_ip_settings_from_ksdata(connection, network_data)
 
+    update_connection_wired_settings_from_ksdata(connection, network_data)
+
     s_con = connection.get_setting_connection()
     s_con.set_property(NM.SETTING_CONNECTION_AUTOCONNECT, network_data.onboot)
 
@@ -786,6 +790,27 @@ def update_connection_ip_settings_from_ksdata(connection, network_data):
                 s_ip4.add_dns(ns)
             else:
                 log.error("IP address %s is not valid", ns)
+
+
+def update_connection_wired_settings_from_ksdata(connection, network_data):
+    """Update NM connection wired settings from kickstart in place.
+
+    :param connection: existing NetworkManager connection to be updated
+    :type connection: NM.RemoteConnection
+    :param network_data: kickstart configuation to be applied to the connection
+    :type network_data: pykickstart NetworkData
+    """
+    if network_data.mtu:
+        try:
+            mtu = int(network_data.mtu)
+        except ValueError:
+            log.error("Value of network --mtu option is not valid: %s", network_data.mtu)
+        else:
+            s_wired = connection.get_setting_wired()
+            if not s_wired:
+                s_wired = NM.SettingWired.new()
+                connection.add_setting(s_wired)
+            s_wired.props.mtu = mtu
 
 
 def bind_settings_to_mac(nm_client, s_connection, s_wired, device_name=None, bind_exclusively=True):

--- a/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_nm_client.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_nm_client.py
@@ -23,7 +23,8 @@ from textwrap import dedent
 
 from pyanaconda.modules.network.nm_client import get_ports_from_connections, \
     get_dracut_arguments_from_connection, get_config_file_connection_of_device, \
-    get_kickstart_network_data, NM_BRIDGE_DUMPED_SETTINGS_DEFAULTS
+    get_kickstart_network_data, NM_BRIDGE_DUMPED_SETTINGS_DEFAULTS, \
+    update_connection_wired_settings_from_ksdata
 from pyanaconda.core.kickstart.commands import NetworkData
 from pyanaconda.modules.network.constants import NM_CONNECTION_TYPE_WIFI, \
     NM_CONNECTION_TYPE_ETHERNET, NM_CONNECTION_TYPE_VLAN, NM_CONNECTION_TYPE_BOND, \
@@ -906,3 +907,39 @@ class NMClientTestCase(unittest.TestCase):
             if generated_ks:
                 generated_ks = dedent(str(generated_ks)).strip()
             assert generated_ks == expected_ks
+
+    def test_update_connection_wired_settings_from_ksdata(self):
+        """Test update_connection_wired_settings_from_ksdata."""
+        network_data = Mock()
+        connection = Mock()
+        wired_setting = Mock()
+
+        connection.get_setting_wired.return_value = wired_setting
+
+        # --mtu default value
+        network_data.mtu = ""
+        update_connection_wired_settings_from_ksdata(connection, network_data)
+        connection.get_setting_wired.assert_not_called()
+
+        # Invalid value
+        # --mtu=non-int
+        network_data.mtu = "non-int"
+        connection.reset_mock()
+        update_connection_wired_settings_from_ksdata(connection, network_data)
+        connection.get_setting_wired.assert_not_called()
+
+        # Valid value
+        # --mtu=9000
+        # The connection already has wired setting
+        connection.reset_mock()
+        network_data.mtu = "9000"
+        update_connection_wired_settings_from_ksdata(connection, network_data)
+        connection.get_setting_wired.assert_called_once()
+
+        # Valid value
+        # --mtu=9000
+        # The connection does not have wired setting yet
+        connection.get_setting_wired.return_value = None
+        connection.reset_mock()
+        update_connection_wired_settings_from_ksdata(connection, network_data)
+        connection.add_setting.assert_called_once()


### PR DESCRIPTION
This was broken when application of kickstart network command was moved
to Anaconda.