### PR TITLE
Fix pylint flake: Comps.environments is expected to be string (#infra)

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
@@ -700,6 +700,7 @@ class DNFManagerCompsTestCase(unittest.TestCase):
 
         def environment_by_pattern(name):
             for e in comps.environments:
+                # pylint: disable=no-member
                 if name in (e.id, e.ui_name):
                     return e
 


### PR DESCRIPTION
We don't know what is causing this but it is not reproducible everywhere. Seems really like a flake

Fixing this problem:
```
 ************* Module unit_tests.pyanaconda_tests.modules.payloads.payload.test_module_payload_dnf_manager
E1101(no-member):unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py:703,28: DNFManagerCompsTestCase._create_comps.environment_by_pattern: Instance of 'str' has no 'id' member
E1101(no-member):unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py:703,34: DNFManagerCompsTestCase._create_comps.environment_by_pattern: Instance of 'str' has no 'ui_name' member
```