### PR TITLE
Configure the multilib policy of the target system (#1571727)

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/installation.py
+++ b/pyanaconda/modules/payloads/payload/dnf/installation.py
@@ -1,0 +1,70 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core import util
+from pyanaconda.modules.common.task import Task
+
+log = get_module_logger(__name__)
+
+
+class UpdateDNFConfigurationTask(Task):
+    """The installation task to update the dnf.conf file."""
+
+    def __init__(self, sysroot, data):
+        """Create a new task.
+
+        :param sysroot: a path to the system root
+        :param data: a kickstart data
+        """
+        super().__init__()
+        self._sysroot = sysroot
+        self._data = data
+
+    @property
+    def name(self):
+        return "Update DNF configuration"
+
+    def run(self):
+        """Run the task."""
+        if self._data.packages.multiLib:
+            self._set_option("multilib_policy", "all")
+
+    def _set_option(self, option, value):
+        """Set a configuration option.
+
+        :param option: a name of the option
+        :param value: a value of the option
+        """
+        log.debug("Setting '%s' to '%s'.", option, value)
+
+        cmd = "dnf"
+        args = [
+            "config-manager",
+            "--save",
+            "--setopt={}={}".format(option, value),
+        ]
+
+        try:
+            rc = util.execWithRedirect(cmd, args, root=self._sysroot)
+        except OSError as e:
+            log.warning("Couldn't update the DNF configuration: %s", e)
+            return
+
+        if rc != 0:
+            log.warning("Failed to update the DNF configuration (%s).", rc)
+            return

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -42,6 +42,7 @@ from fnmatch import fnmatch
 from glob import glob
 
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
+from pyanaconda.modules.payloads.payload.dnf.installation import UpdateDNFConfigurationTask
 from pyanaconda.payload.source import SourceFactory, PayloadSourceTypeUnrecognized
 from pykickstart.constants import GROUP_ALL, GROUP_DEFAULT, KS_MISSING_IGNORE, GROUP_REQUIRED
 from pykickstart.parser import Group
@@ -2075,6 +2076,13 @@ class DNFPayload(Payload):
         # We don't need the mother base anymore. Close it.
         self._base.close()
         super().post_install()
+
+        # Update the DNF configuration.
+        task = UpdateDNFConfigurationTask(
+            sysroot=conf.target.system_root,
+            data=self.data
+        )
+        task.run()
 
     @property
     def kernel_version_list(self):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
@@ -1,0 +1,95 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import tempfile
+import unittest
+
+from unittest.mock import patch
+
+from pyanaconda.kickstart import AnacondaKSHandler
+from pyanaconda.modules.payloads.payload.dnf.installation import UpdateDNFConfigurationTask
+
+
+class UpdateDNFConfigurationTaskTestCase(unittest.TestCase):
+    """Test the UpdateDNFConfigurationTask class."""
+
+    @patch("pyanaconda.core.util.execWithRedirect")
+    def test_no_update(self, execute):
+        """Don't update the DNF configuration."""
+        with tempfile.TemporaryDirectory() as sysroot:
+            data = AnacondaKSHandler()
+
+            task = UpdateDNFConfigurationTask(sysroot, data)
+            task.run()
+
+            execute.assert_not_called()
+
+    @patch("pyanaconda.core.util.execWithRedirect")
+    def test_failed_update(self, execute):
+        """The update of the DNF configuration has failed."""
+        execute.return_value = 1
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            data = AnacondaKSHandler()
+            data.packages.multiLib = True
+
+            task = UpdateDNFConfigurationTask(sysroot, data)
+
+            with self.assertLogs(level="WARNING") as cm:
+                task.run()
+
+            msg = "Failed to update the DNF configuration (1)."
+            self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+
+    @patch("pyanaconda.core.util.execWithRedirect")
+    def test_error_update(self, execute):
+        """The update of the DNF configuration has failed."""
+        execute.side_effect = OSError("Fake!")
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            data = AnacondaKSHandler()
+            data.packages.multiLib = True
+
+            task = UpdateDNFConfigurationTask(sysroot, data)
+
+            with self.assertLogs(level="WARNING") as cm:
+                task.run()
+
+            msg = "Couldn't update the DNF configuration: Fake!"
+            self.assertTrue(any(map(lambda x: msg in x, cm.output)))
+
+    @patch("pyanaconda.core.util.execWithRedirect")
+    def test_multilib_policy(self, execute):
+        """Update the multilib policy."""
+        execute.return_value = 0
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            data = AnacondaKSHandler()
+            data.packages.multiLib = True
+
+            task = UpdateDNFConfigurationTask(sysroot, data)
+            task.run()
+
+            execute.assert_called_once_with(
+                "dnf",
+                [
+                    "config-manager",
+                    "--save",
+                    "--setopt=multilib_policy=all",
+                ],
+                root=sysroot
+            )


### PR DESCRIPTION
Write the multilib policy into the DNF configuration of the target system.

(cherry-picked from a commit d2566aa)

Resolves: rhbz#1571727