### PR TITLE
Disable container build for Fedora 35 (#infra)

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container-tag: ['master', 'eln', 'f35-devel', 'f35-release']
+        container-tag: ['master', 'eln'] #, 'f35-devel', 'f35-release']
         container-type: ['ci', 'rpm']
         include:
           - container-tag: master
@@ -26,10 +26,10 @@ jobs:
           - container-tag: eln
             branch: master
             base-container: 'quay.io/fedoraci/fedora:eln-x86_64'
-          - container-tag: f35-devel
-            branch: f35-devel
-          - container-tag: f35-release
-            branch: f35-release
+          # - container-tag: f35-devel
+          #   branch: f35-devel
+          # - container-tag: f35-release
+          #   branch: f35-release
     env:
       CI_TAG: '${{ matrix.container-tag }}'
     timeout-minutes: 60


### PR DESCRIPTION
Fedora 35 was already released so there is no reason to have a container for that build. Also we are seeing a pylint flake there.

I'm talking about this https://github.com/rhinstaller/anaconda/runs/4117118082?check_suite_focus=true .