### PR TITLE
Port from RHEL9: Replace the deprecated syspurpose CLI tool with SetSysrpose DBus call

### DIFF
--- a/pyanaconda/modules/subscription/runtime.py
+++ b/pyanaconda/modules/subscription/runtime.py
@@ -86,13 +86,15 @@ SystemSubscriptionData = namedtuple("SystemSubscriptionData",
 class SystemPurposeConfigurationTask(Task):
     """Installation task for setting system purpose."""
 
-    def __init__(self, system_purpose_data):
+    def __init__(self, rhsm_syspurpose_proxy, system_purpose_data):
         """Create a new system purpose configuration task.
 
+        :param rhsm_syspurpose_proxy: DBus proxy for the RHSM Syspurpose object
         :param system_purpose_data: system purpose data DBus structure
         :type system_purpose_data: DBusData instance
         """
         super().__init__()
+        self._rhsm_syspurpose_proxy = rhsm_syspurpose_proxy
         self._system_purpose_data = system_purpose_data
 
     @property
@@ -105,6 +107,7 @@ class SystemPurposeConfigurationTask(Task):
         #   replaced by new data
         return system_purpose.give_the_system_purpose(
             sysroot="/",
+            rhsm_syspurpose_proxy=self._rhsm_syspurpose_proxy,
             role=self._system_purpose_data.role,
             sla=self._system_purpose_data.sla,
             usage=self._system_purpose_data.usage,

--- a/pyanaconda/modules/subscription/subscription.py
+++ b/pyanaconda/modules/subscription/subscription.py
@@ -316,14 +316,18 @@ class SubscriptionService(KickstartService):
     def _apply_syspurpose(self):
         """Apply system purpose information to the installation environment."""
         log.debug("subscription: Applying system purpose data")
-        task = SystemPurposeConfigurationTask(system_purpose_data=self.system_purpose_data)
+        task = self.set_system_purpose_with_task()
         task.run()
 
     def set_system_purpose_with_task(self):
         """Set system purpose for the installed system with an installation task.
         :return: a DBus path of an installation task
         """
-        task = SystemPurposeConfigurationTask(system_purpose_data=self.system_purpose_data)
+        rhsm_syspurpose_proxy = self.rhsm_observer.get_proxy(RHSM_SYSPURPOSE)
+        task = SystemPurposeConfigurationTask(
+            rhsm_syspurpose_proxy=rhsm_syspurpose_proxy,
+            system_purpose_data=self.system_purpose_data
+        )
         return task
 
     # subscription request

--- a/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription.py
@@ -19,12 +19,12 @@
 #
 import os
 import unittest
-from unittest.mock import patch, call, Mock
+from unittest.mock import patch, Mock
 import tempfile
 
 from dasbus.typing import *  # pylint: disable=wildcard-import
+from dasbus.error import DBusError
 
-from pyanaconda.core import util
 from pyanaconda.core.constants import SECRET_TYPE_NONE, SECRET_TYPE_HIDDEN, SECRET_TYPE_TEXT, \
     SUBSCRIPTION_REQUEST_TYPE_USERNAME_PASSWORD, SUBSCRIPTION_REQUEST_TYPE_ORG_KEY, \
     DEFAULT_SUBSCRIPTION_REQUEST_TYPE
@@ -37,7 +37,7 @@ from pyanaconda.modules.common.structures.subscription import SystemPurposeData,
 from pyanaconda.modules.subscription.subscription import SubscriptionService
 from pyanaconda.modules.subscription.subscription_interface import SubscriptionInterface
 from pyanaconda.modules.subscription.system_purpose import get_valid_fields, _normalize_field, \
-    _match_field, process_field, give_the_system_purpose, SYSPURPOSE_UTILITY_PATH
+    _match_field, process_field, give_the_system_purpose
 from pyanaconda.modules.subscription.installation import ConnectToInsightsTask, \
     RestoreRHSMDefaultsTask, TransferSubscriptionTokensTask
 from pyanaconda.modules.subscription.runtime import SetRHSMConfigurationTask, \
@@ -151,73 +151,66 @@ class SystemPurposeLibraryTestCase(unittest.TestCase):
         assert process_field("PRODUCTION", [], "usage") == "PRODUCTION"
         assert process_field("foo", [], "usage") == "foo"
 
-    @patch("pyanaconda.core.util.execWithRedirect")
-    def test_set_system_pourpose_no_purpose(self, exec_with_redirect):
+    def test_set_system_pourpose_no_purpose(self):
         """Test that nothing is done if system has no purpose."""
         with tempfile.TemporaryDirectory() as sysroot:
+            # create fake RHSM Syspurpose DBus proxy
+            syspurpose_proxy = Mock()
             assert give_the_system_purpose(sysroot=sysroot,
-                                                    role="",
-                                                    sla="",
-                                                    usage="",
-                                                    addons=[])
-            exec_with_redirect.assert_not_called()
+                                           rhsm_syspurpose_proxy=syspurpose_proxy,
+                                           role="",
+                                           sla="",
+                                           usage="",
+                                           addons=[])
+            syspurpose_proxy.SetSyspurpose.assert_not_called()
 
-    @patch("pyanaconda.core.util.execWithRedirect")
-    def test_set_system_pourpose_no_syspurpose(self, exec_with_redirect):
-        """Test that nothing is done & False is returned if the syspurpose tool is missing."""
-        with tempfile.TemporaryDirectory() as sysroot:
-            assert not give_the_system_purpose(sysroot=sysroot,
-                                                     role="foo",
-                                                     sla="bar",
-                                                     usage="baz",
-                                                     addons=["a", "b", "c"])
-            exec_with_redirect.assert_not_called()
-
-    @patch("pyanaconda.core.util.execWithRedirect")
-    def test_set_system_pourpose(self, exec_with_redirect):
+    def test_set_system_pourpose(self):
         """Test that system purpose is set if syspurpose & data are both available."""
         with tempfile.TemporaryDirectory() as sysroot:
-            # create fake syspurpose tool file
-            utility_path = SYSPURPOSE_UTILITY_PATH
-            directory = os.path.split(utility_path)[0]
-            os.makedirs(util.join_paths(sysroot, directory))
-            os.mknod(util.join_paths(sysroot, utility_path))
-            # set return value to 0
-            exec_with_redirect.return_value = 0
+            # create fake RHSM Syspurpose DBus proxy
+            syspurpose_proxy = Mock()
             # set system purpose
             assert give_the_system_purpose(sysroot=sysroot,
-                                                    role="foo",
-                                                    sla="bar",
-                                                    usage="baz",
-                                                    addons=["a", "b", "c"])
+                                           rhsm_syspurpose_proxy=syspurpose_proxy,
+                                           role="foo",
+                                           sla="bar",
+                                           usage="baz",
+                                           addons=["a", "b", "c"])
             # check syspurpose invocations look correct
-            exec_with_redirect.assert_has_calls(
-                [call("syspurpose", ["set-role", "foo"], root=sysroot),
-                 call("syspurpose", ["set-sla", "bar"], root=sysroot),
-                 call("syspurpose", ["set-usage", "baz"], root=sysroot),
-                 call("syspurpose", ["add", "addons", "a", "b", "c"], root=sysroot)])
+            syspurpose_proxy.SetSyspurpose.assert_called_once_with(
+                {
+                    "role": get_variant(Str, "foo"),
+                    "service_level_agreement": get_variant(Str, "bar"),
+                    "usage": get_variant(Str, "baz"),
+                    "addons": get_variant(List[Str], ["a", "b", "c"])
+                },
+                'en_US.UTF-8'
+            )
 
-    @patch("pyanaconda.core.util.execWithRedirect")
-    def test_set_system_pourpose_failure(self, exec_with_redirect):
-        """Test that failure to invoke the syspurpose tool is handled correctly."""
+    def test_set_system_pourpose_failure(self):
+        """Test that exception raised by SetSyspurpose DBus call is handled correctly."""
         with tempfile.TemporaryDirectory() as sysroot:
-            # create fake syspurpose tool file
-            utility_path = SYSPURPOSE_UTILITY_PATH
-            directory = os.path.split(utility_path)[0]
-            os.makedirs(util.join_paths(sysroot, directory))
-            os.mknod(util.join_paths(sysroot, utility_path))
-            # set return value no non-zero
-            exec_with_redirect.return_value = 1
-            # set system purpose
+            # create fake RHSM Syspurpose DBus proxy
+            syspurpose_proxy = Mock()
+            # raise DBusError with error message in JSON
+            syspurpose_proxy.SetSyspurpose.side_effect = DBusError("syspurpose error")
+            # set system purpose & False is returned due to the exception
             assert not give_the_system_purpose(sysroot=sysroot,
-                                                     role="foo",
-                                                     sla="bar",
-                                                     usage="baz",
-                                                     addons=["a", "b", "c"])
-            # check syspurpose invocations look correct
-            exec_with_redirect.assert_called_once_with("syspurpose",
-                                                       ["set-role", "foo"],
-                                                       root=sysroot)
+                                               rhsm_syspurpose_proxy=syspurpose_proxy,
+                                               role="foo",
+                                               sla="bar",
+                                               usage="baz",
+                                               addons=["a", "b", "c"])
+            # check the fake DBus method still was called correctly
+            syspurpose_proxy.SetSyspurpose.assert_called_once_with(
+                {
+                    "role": get_variant(Str, "foo"),
+                    "service_level_agreement": get_variant(Str, "bar"),
+                    "usage": get_variant(Str, "baz"),
+                    "addons": get_variant(List[Str], ["a", "b", "c"])
+                },
+                'en_US.UTF-8'
+            )
 
 
 class SubscriptionInterfaceTestCase(unittest.TestCase):
@@ -981,6 +974,12 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         self.subscription_interface.SetSystemPurposeData(
             SystemPurposeData.to_structure(system_purpose_data)
         )
+        # mock the rhsm syspurpose proxy
+        observer = Mock()
+        observer.get_proxy = Mock()
+        self.subscription_module._rhsm_observer = observer
+        syspurpose_proxy = Mock()
+        observer.get_proxy.return_value = syspurpose_proxy
         # check the task is created correctly
         task_path = self.subscription_interface.SetSystemPurposeWithTask()
         obj = check_task_creation(task_path, publisher, SystemPurposeConfigurationTask)
@@ -1009,9 +1008,17 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         self.subscription_interface.SetSystemPurposeData(
             SystemPurposeData.to_structure(system_purpose_data)
         )
+        # mock the rhsm syspurpose proxy
+        observer = Mock()
+        observer.get_proxy = Mock()
+        self.subscription_module._rhsm_observer = observer
+        syspurpose_proxy = Mock()
+        observer.get_proxy.return_value = syspurpose_proxy
+        # call the method we are testing
         self.subscription_module._apply_syspurpose()
         mock_give_purpose.assert_called_once_with(
             sysroot="/",
+            rhsm_syspurpose_proxy=syspurpose_proxy,
             role="foo",
             sla="bar",
             usage="baz",
@@ -1436,6 +1443,13 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         assert obj.implementation._connect_to_insights is True
 
     def _test_kickstart(self, ks_in, ks_out):
+        # mock the rhsm syspurpose proxy that gets requested during
+        # the attempt to set system purpose data after a new kickstart has been set
+        observer = Mock()
+        observer.get_proxy = Mock()
+        self.subscription_module._rhsm_observer = observer
+        syspurpose_proxy = Mock()
+        observer.get_proxy.return_value = syspurpose_proxy
         check_kickstart_interface(self.subscription_interface, ks_in, ks_out)
 
     def test_ks_out_no_kickstart(self):
@@ -1613,13 +1627,16 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         syspurpose --role="FOO" --sla="BAR" --usage="BAZ" --addon="F Product" --addon="B Feature"
         '''
         self._test_kickstart(ks_in, ks_out)
+        # drill down to the mocked syspurpose proxy
+        syspurpose_proxy = self.subscription_module._rhsm_observer.get_proxy.return_value
         # the SystemPurposeConfigurationTask should have been called,
         # which calls give_the_system_purpose()
-        mock_give_purpose.assert_called_once_with(role="FOO",
+        mock_give_purpose.assert_called_once_with(sysroot="/",
+                                                  rhsm_syspurpose_proxy=syspurpose_proxy,
+                                                  role="FOO",
                                                   sla="BAR",
                                                   usage="BAZ",
-                                                  addons=['F Product', 'B Feature'],
-                                                  sysroot="/")
+                                                  addons=['F Product', 'B Feature'])
 
     @patch("pyanaconda.modules.subscription.system_purpose.give_the_system_purpose")
     def test_ks_no_apply_syspurpose(self, mock_give_purpose):

--- a/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription_tasks.py
@@ -156,9 +156,12 @@ class SystemPurposeConfigurationTaskTestCase(unittest.TestCase):
         system_purpose_data.sla = "bar"
         system_purpose_data.usage = "baz"
         system_purpose_data.addons = ["a", "b", "c"]
-        task = SystemPurposeConfigurationTask(system_purpose_data)
+        # create a mock syspurpose proxy
+        syspurpose_proxy = Mock()
+        task = SystemPurposeConfigurationTask(syspurpose_proxy, system_purpose_data)
         task.run()
         give_the_system_purpose.assert_called_once_with(sysroot="/",
+                                                        rhsm_syspurpose_proxy=syspurpose_proxy,
                                                         role="foo",
                                                         sla="bar",
                                                         usage="baz",
@@ -177,9 +180,12 @@ class SystemPurposeConfigurationTaskTestCase(unittest.TestCase):
         system_purpose_data.sla = "bar"
         system_purpose_data.usage = "baz"
         system_purpose_data.addons = ["a", "b", "c"]
-        task = SystemPurposeConfigurationTask(system_purpose_data)
+        # create a mock syspurpose proxy
+        syspurpose_proxy = Mock()
+        task = SystemPurposeConfigurationTask(syspurpose_proxy, system_purpose_data)
         task.run()
         give_the_system_purpose.assert_called_once_with(sysroot="/",
+                                                        rhsm_syspurpose_proxy=syspurpose_proxy,
                                                         role="foo",
                                                         sla="bar",
                                                         usage="baz",


### PR DESCRIPTION
Use the SetSysrpose() RHSM DBus API method instead of the deprecated
syspurpose CLI tool.

(cherry picked from commit 992997f75e21dba61efea2774b911e3fd80201e4)

Resolves: rhbz#1939708