### PR TITLE
Enable the built-in help content (#1995945)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -25,7 +25,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define fcoeutilsver 1.0.12-3.20100323git
 %define gettextver 0.19.8
 %define gtk3ver 3.22.17
-%define helpver 22.1-1
+%define helpver 9.0.0-1
 %define isomd5sumver 1.0.10
 %define langtablever 0.0.54
 %define libarchivever 3.0.4

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -271,9 +271,6 @@ custom_stylesheet =
 # The path to a directory with help files.
 help_directory = /usr/share/anaconda/help
 
-# Default help pages for TUI, GUI and Live OS.
-default_help_pages =
-
 # Is the partitioning with blivet-gui supported?
 blivet_gui_supported = True
 

--- a/data/product.d/centos-stream.conf
+++ b/data/product.d/centos-stream.conf
@@ -13,11 +13,5 @@ forbidden_modules =
 [Bootloader]
 efi_dir = centos
 
-[User Interface]
-default_help_pages =
-    CentOSPlaceholder.txt
-    CentOSPlaceholder.html
-    CentOSPlaceholder.html
-
 [Payload]
 default_source = CLOSEST_MIRROR

--- a/data/product.d/fedora-eln.conf
+++ b/data/product.d/fedora-eln.conf
@@ -13,12 +13,6 @@ forbidden_modules =
 [Bootloader]
 efi_dir = fedora
 
-[User Interface]
-default_help_pages =
-    FedoraPlaceholder.txt
-    FedoraPlaceholder.html
-    FedoraPlaceholderWithLinks.html
-
 [Payload]
 default_environment = custom-environment
 default_source = CLOSEST_MIRROR

--- a/data/product.d/fedora.conf
+++ b/data/product.d/fedora.conf
@@ -13,6 +13,9 @@ efi_dir = fedora
 default_scheme = BTRFS
 btrfs_compression = zstd:1
 
+[User Interface]
+help_directory = /usr/share/anaconda/help/fedora
+
 [Payload]
 default_source = CLOSEST_MIRROR
 

--- a/data/product.d/fedora.conf
+++ b/data/product.d/fedora.conf
@@ -13,12 +13,6 @@ efi_dir = fedora
 default_scheme = BTRFS
 btrfs_compression = zstd:1
 
-[User Interface]
-default_help_pages =
-    FedoraPlaceholder.txt
-    FedoraPlaceholder.html
-    FedoraPlaceholderWithLinks.html
-
 [Payload]
 default_source = CLOSEST_MIRROR
 

--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -43,11 +43,7 @@ default_partitioning =
 swap_is_recommended = True
 
 [User Interface]
-# FIXME: The help system is currently disabled
-# as help content has not yet been updated
-# for RHEL 9.
-help_directory =
-
+help_directory = /usr/share/anaconda/help/rhel
 custom_stylesheet = /usr/share/anaconda/pixmaps/redhat.css
 blivet_gui_supported = False
 

--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -43,11 +43,6 @@ default_partitioning =
 swap_is_recommended = True
 
 [User Interface]
-default_help_pages =
-    rhel_help_placeholder.txt
-    rhel_help_placeholder.xml
-    rhel_help_placeholder.xml
-
 # FIXME: The help system is currently disabled
 # as help content has not yet been updated
 # for RHEL 9.

--- a/data/product.d/scientific-linux.conf
+++ b/data/product.d/scientific-linux.conf
@@ -16,9 +16,3 @@ default_source = CLOSEST_MIRROR
 updates_repositories =
     updates
     updates-modular
-
-[User Interface]
-default_help_pages =
-    SLPlaceholder.txt
-    SLPlaceholder.html
-    SLPlaceholder.html

--- a/pyanaconda/core/configuration/system.py
+++ b/pyanaconda/core/configuration/system.py
@@ -176,8 +176,3 @@ class SystemSection(Section):
     def provides_resolver_config(self):
         """Can we copy /etc/resolv.conf to the target system?"""
         return self._is_boot_iso
-
-    @property
-    def provides_web_browser(self):
-        """Can we redirect users to web pages?"""
-        return self._is_live_os

--- a/pyanaconda/core/configuration/ui.py
+++ b/pyanaconda/core/configuration/ui.py
@@ -35,19 +35,6 @@ class UserInterfaceSection(Section):
         return self._get_option("help_directory", str)
 
     @property
-    def default_help_pages(self):
-        """Default help pages for TUI, GUI and Live OS."""
-        values = self._get_option("default_help_pages", str).split()
-
-        if not values:
-            return "", "", ""
-
-        if len(values) != 3:
-            raise ValueError("Invalid number of values: {}".format(values))
-
-        return tuple(values)
-
-    @property
     def blivet_gui_supported(self):
         """Is the partitioning with blivet-gui supported?"""
         return self._get_option("blivet_gui_supported", bool)

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -78,10 +78,6 @@ DEFAULT_KEYBOARD = "us"
 
 DRACUT_SHUTDOWN_EJECT = "/run/initramfs/usr/lib/dracut/hooks/shutdown/99anaconda-eject.sh"
 
-# Help.
-HELP_MAIN_PAGE_GUI = "Installation_Guide.xml"
-HELP_MAIN_PAGE_TUI = "Installation_Guide.txt"
-
 # VNC questions
 USEVNC = N_("Start VNC")
 USETEXT = N_("Use text mode")

--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -16,8 +16,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
-from abc import ABCMeta, abstractproperty
+from abc import abstractproperty, ABC
 
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import ANACONDA_ENVIRON, FIRSTBOOT_ENVIRON
@@ -158,7 +157,24 @@ class FirstbootOnlySpokeMixIn(object):
             return False
 
 
-class Spoke(object, metaclass=ABCMeta):
+class Screen(ABC):
+    """A representation of one UI screen."""
+
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen.
+
+        The screen id should match a regex: [a-z][a-z-]*
+        For example: installation-summary, storage-configuration
+
+        FIXME: Make this function abstract.
+
+        :return: a lowercase string or None
+        """
+        return None
+
+
+class Spoke(Screen):
     """A Spoke is a single configuration screen.  There are several different
        places where a Spoke can be displayed, each of which will have its own
        unique class.  A Spoke is typically used when an element in the Hub is
@@ -498,7 +514,7 @@ class StandaloneSpoke(Spoke):
         return None
 
 
-class Hub(object, metaclass=ABCMeta):
+class Hub(Screen):
     """A Hub is an overview UI screen.  A Hub consists of one or more grids of
        configuration options that the user may choose from.  Each grid is
        provided by a SpokeCategory, and each option is provided by a Spoke.

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -117,7 +117,6 @@ class GUIObject(common.UIObject):
     focusWidgetName = None
 
     uiFile = ""
-    helpFile = None
     hide_help_button = False
     translationDomain = "anaconda"
 

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -45,7 +45,7 @@ from pyanaconda.ui.gui.utils import unbusyCursor
 from pyanaconda.core.async_utils import async_action_wait
 from pyanaconda.ui.gui.utils import watch_children, unwatch_children
 from pyanaconda.ui.gui.helpers import autoinstall_stopped
-from pyanaconda.ui.lib.help import start_yelp, get_help_path
+from pyanaconda.ui.lib.help import show_graphical_help_for_screen
 import os.path
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -932,7 +932,7 @@ class GraphicalUserInterface(UserInterface):
     def _on_help_clicked(self, window, obj):
         # the help button has been clicked, start the yelp viewer with
         # content for the current screen
-        start_yelp(get_help_path(obj.helpFile))
+        show_graphical_help_for_screen(obj.get_screen_id())
 
     def _on_quit_clicked(self, win, userData=None):
         if not win.get_quit_button():

--- a/pyanaconda/ui/gui/hubs/summary.py
+++ b/pyanaconda/ui/gui/hubs/summary.py
@@ -35,7 +35,6 @@ class SummaryHub(Hub):
     builderObjects = ["summaryWindow"]
     mainWidgetName = "summaryWindow"
     uiFile = "hubs/summary.glade"
-    helpFile = "SummaryHub.xml"
 
     @staticmethod
     def get_screen_id():

--- a/pyanaconda/ui/gui/hubs/summary.py
+++ b/pyanaconda/ui/gui/hubs/summary.py
@@ -37,6 +37,11 @@ class SummaryHub(Hub):
     uiFile = "hubs/summary.glade"
     helpFile = "SummaryHub.xml"
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "installation-summary"
+
     def __init__(self, data, storage, payload):
         """Create a new Hub instance.
 

--- a/pyanaconda/ui/gui/spokes/__init__.py
+++ b/pyanaconda/ui/gui/spokes/__init__.py
@@ -18,7 +18,7 @@
 
 from pyanaconda.ui import common
 from pyanaconda.ui.gui import GUIObject
-from pyanaconda.ui.lib.help import start_yelp, get_help_path
+from pyanaconda.ui.lib.help import show_graphical_help_for_screen
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -65,7 +65,7 @@ class NormalSpoke(GUIObject, common.NormalSpoke):
     def _on_help_clicked(self, window):
         # the help button has been clicked, start the yelp viewer with
         # content for the current spoke
-        start_yelp(get_help_path(self.helpFile))
+        show_graphical_help_for_screen(self.get_screen_id())
 
     def on_back_clicked(self, button):
         # Notify the hub that we're finished.

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -503,10 +503,7 @@ class FilterSpoke(NormalSpoke):
                       "searchModel", "multipathModel", "otherModel", "zModel", "nvdimmModel"]
     mainWidgetName = "filterWindow"
     uiFile = "spokes/advanced_storage.glade"
-    helpFile = "FilterSpoke.xml"
-
     category = SystemCategory
-
     title = CN_("GUI|Spoke", "_Installation Destination")
 
     @staticmethod

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -509,6 +509,11 @@ class FilterSpoke(NormalSpoke):
 
     title = CN_("GUI|Spoke", "_Installation Destination")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "storage-advanced-configuration"
+
     def __init__(self, *args):
         super().__init__(*args)
         self.applyOnSkip = True

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -104,6 +104,11 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
 
     helpFile = "blivet-gui/index.page"
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "blivet-gui-partitioning"
+
     ### methods defined by API ###
     def __init__(self, data, storage, payload):
         """

--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -102,8 +102,6 @@ class BlivetGuiSpoke(NormalSpoke, StorageCheckHandler):
     # title of the spoke (will be displayed on the hub)
     title = CN_("GUI|Spoke", "_Blivet-GUI Partitioning")
 
-    helpFile = "blivet-gui/index.page"
-
     @staticmethod
     def get_screen_id():
         """Return a unique id of this UI screen."""

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -94,8 +94,6 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
                       "luksVersionStore"]
     mainWidgetName = "customStorageWindow"
     uiFile = "spokes/custom_storage.glade"
-    helpFile = "CustomSpoke.xml"
-
     category = SystemCategory
     title = N_("MANUAL PARTITIONING")
 

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -105,6 +105,11 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
     # If the user enters a smaller size, the GUI changes it to this value
     MIN_SIZE_ENTRY = Size("1 MiB")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "interactive-partitioning"
+
     def __init__(self, data, storage, payload):
         StorageCheckHandler.__init__(self)
         NormalSpoke.__init__(self, data, storage, payload)

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -403,6 +403,11 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
     _hack = TimezoneMap.TimezoneMap()
     del(_hack)
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "date-time-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -391,10 +391,7 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
     mainWidgetName = "datetimeWindow"
     uiFile = "spokes/datetime_spoke.glade"
-    helpFile = "DateTimeSpoke.xml"
-
     category = LocalizationCategory
-
     icon = "preferences-system-time-symbolic"
     title = CN_("GUI|Spoke", "_Time & Date")
 

--- a/pyanaconda/ui/gui/spokes/installation_progress.py
+++ b/pyanaconda/ui/gui/spokes/installation_progress.py
@@ -48,6 +48,11 @@ class ProgressSpoke(StandaloneSpoke):
 
     postForHub = SummaryHub
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "installation-progress"
+
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
         self._totalSteps = 0

--- a/pyanaconda/ui/gui/spokes/installation_progress.py
+++ b/pyanaconda/ui/gui/spokes/installation_progress.py
@@ -44,8 +44,6 @@ class ProgressSpoke(StandaloneSpoke):
     builderObjects = ["progressWindow"]
     mainWidgetName = "progressWindow"
     uiFile = "spokes/installation_progress.glade"
-    helpFile = "ProgressHub.xml"
-
     postForHub = SummaryHub
 
     @staticmethod

--- a/pyanaconda/ui/gui/spokes/installation_progress.py
+++ b/pyanaconda/ui/gui/spokes/installation_progress.py
@@ -45,6 +45,7 @@ class ProgressSpoke(StandaloneSpoke):
     mainWidgetName = "progressWindow"
     uiFile = "spokes/installation_progress.glade"
     postForHub = SummaryHub
+    hide_help_button = True
 
     @staticmethod
     def get_screen_id():

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -407,6 +407,11 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
     icon = "media-optical-symbolic"
     title = CN_("GUI|Spoke", "_Installation Source")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "software-source-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Don't run for any non-package payload."""

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -400,8 +400,6 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
                       "dirImage", "repoStore"]
     mainWidgetName = "sourceWindow"
     uiFile = "spokes/installation_source.glade"
-    helpFile = "SourceSpoke.xml"
-
     category = SoftwareCategory
 
     icon = "media-optical-symbolic"

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -284,10 +284,7 @@ class KeyboardSpoke(NormalSpoke):
                       "layoutTestBuffer"]
     mainWidgetName = "keyboardWindow"
     uiFile = "spokes/keyboard.glade"
-    helpFile = "KeyboardSpoke.xml"
-
     category = LocalizationCategory
-
     icon = "input-keyboard-symbolic"
     title = CN_("GUI|Spoke", "_Keyboard")
 

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -291,6 +291,11 @@ class KeyboardSpoke(NormalSpoke):
     icon = "input-keyboard-symbolic"
     title = CN_("GUI|Spoke", "_Keyboard")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "keyboard-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -63,6 +63,11 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
     icon = "accessories-character-map-symbolic"
     title = CN_("GUI|Spoke", "_Language Support")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "language-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/gui/spokes/language_support.py
+++ b/pyanaconda/ui/gui/spokes/language_support.py
@@ -56,10 +56,7 @@ class LangsupportSpoke(NormalSpoke, LangLocaleHandler):
     mainWidgetName = "langsupportWindow"
     focusWidgetName = "languageEntry"
     uiFile = "spokes/language_support.glade"
-    helpFile = "LangSupportSpoke.xml"
-
     category = LocalizationCategory
-
     icon = "accessories-character-map-symbolic"
     title = CN_("GUI|Spoke", "_Language Support")
 

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1465,11 +1465,8 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
                       "liststore_add_device"]
     mainWidgetName = "networkWindow"
     uiFile = "spokes/network.glade"
-    helpFile = "NetworkSpoke.xml"
-
     title = CN_("GUI|Spoke", "_Network & Host Name")
     icon = "network-transmit-receive-symbolic"
-
     category = SystemCategory
 
     @staticmethod

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1472,6 +1472,11 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
 
     category = SystemCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "network-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""
@@ -1627,6 +1632,11 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
 
     preForHub = SummaryHub
     priority = 10
+
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "network-pre-configuration"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -56,6 +56,11 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     icon = "dialog-password-symbolic"
     title = CN_("GUI|Spoke", "_Root Password")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "root-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -49,10 +49,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     mainWidgetName = "passwordWindow"
     focusWidgetName = "password_entry"
     uiFile = "spokes/root_password.glade"
-    helpFile = "PasswordSpoke.xml"
-
     category = UserSettingsCategory
-
     icon = "dialog-password-symbolic"
     title = CN_("GUI|Spoke", "_Root Password")
 

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -76,6 +76,11 @@ class SoftwareSelectionSpoke(NormalSpoke):
     # user de-selected
     _ADDON_DESELECTED = 2
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "software-selection"
+
     @classmethod
     def should_run(cls, environment, data):
         """Don't run for any non-package payload."""

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -61,10 +61,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
     builderObjects = ["addonStore", "environmentStore", "softwareWindow"]
     mainWidgetName = "softwareWindow"
     uiFile = "spokes/software_selection.glade"
-    helpFile = "SoftwareSpoke.xml"
-
     category = SoftwareCategory
-
     icon = "package-x-generic-symbolic"
     title = CN_("GUI|Spoke", "_Software Selection")
 

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -74,10 +74,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
     builderObjects = ["storageWindow", "addSpecializedImage"]
     mainWidgetName = "storageWindow"
     uiFile = "spokes/storage.glade"
-    helpFile = "StorageSpoke.xml"
-
     category = SystemCategory
-
     # other candidates: computer-symbolic, folder-symbolic
     icon = "drive-harddisk-symbolic"
     title = CN_("GUI|Spoke", "Installation _Destination")

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -82,6 +82,11 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
     icon = "drive-harddisk-symbolic"
     title = CN_("GUI|Spoke", "Installation _Destination")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "storage-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Don't run the storage spoke on dir installations."""

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -78,6 +78,11 @@ class SubscriptionSpoke(NormalSpoke):
     REGISTRATION_PAGE = 0
     SUBSCRIPTION_STATUS_PAGE = 1
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "subscription-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """The Subscription spoke should run only if the Subscription module is available."""

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -224,10 +224,7 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
     mainWidgetName = "userCreationWindow"
     focusWidgetName = "fullname_entry"
     uiFile = "spokes/user.glade"
-    helpFile = "UserSpoke.xml"
-
     category = UserSettingsCategory
-
     icon = "avatar-default-symbolic"
     title = CN_("GUI|Spoke", "_User Creation")
 

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -231,6 +231,11 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
     icon = "avatar-default-symbolic"
     title = CN_("GUI|Spoke", "_User Creation")
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "user-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -57,7 +57,6 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
     mainWidgetName = "welcomeWindow"
     focusWidgetName = "languageEntry"
     uiFile = "spokes/welcome.glade"
-    helpFile = "WelcomeSpoke.xml"
     builderObjects = ["languageStore", "languageStoreFilter", "localeStore",
                       "welcomeWindow", "betaWarnDialog"]
 

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -64,6 +64,11 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
     preForHub = SummaryHub
     priority = 0
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "language-pre-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/lib/help.py
+++ b/pyanaconda/ui/lib/help.py
@@ -18,6 +18,7 @@
 """
 Anaconda built-in help module
 """
+import functools
 import os
 import json
 from collections import namedtuple
@@ -107,6 +108,7 @@ def _get_help_args_for_screen(display_mode, screen_id):
     return None
 
 
+@functools.cache
 def _get_help_mapping(display_mode):
     """Parse the json file containing the help mapping.
 

--- a/pyanaconda/ui/tui/hubs/__init__.py
+++ b/pyanaconda/ui/tui/hubs/__init__.py
@@ -18,7 +18,7 @@
 #
 from pyanaconda import lifecycle
 from pyanaconda.ui.tui.tuiobject import TUIObject
-from pyanaconda.ui.lib.help import get_help_path
+from pyanaconda.ui.lib.help import get_help_path_for_screen
 from pyanaconda.ui import common
 
 from simpleline.render.adv_widgets import HelpScreen
@@ -123,6 +123,10 @@ class TUIHub(TUIObject, common.Hub):
         item = data
         ScreenHandler.push_screen(item)
 
+    def _get_help(self):
+        """Get the help path for this screen."""
+        return get_help_path_for_screen(self.get_screen_id())
+
     def input(self, args, key):
         """Handle user input. Numbers are used to show a spoke, the rest is passed
         to the higher level for processing."""
@@ -138,10 +142,12 @@ class TUIHub(TUIObject, common.Hub):
                         print(_("Please complete all spokes before continuing"))
                         return InputState.DISCARDED
             elif key == Prompt.HELP:
-                if self.has_help:
-                    help_path = get_help_path(self.helpFile, True)
+                help_path = self._get_help()
+
+                if help_path:
                     ScreenHandler.push_screen_modal(HelpScreen(help_path))
                     return InputState.PROCESSED_AND_REDRAW
+
             return key
 
     def prompt(self, args=None):
@@ -161,7 +167,7 @@ class TUIHub(TUIObject, common.Hub):
         if self._spoke_count == 1:
             prompt.add_option("1", _("to enter the %(spoke_title)s spoke") % {"spoke_title": list(self._spokes.values())[0].title})
 
-        if self.has_help:
+        if self._get_help():
             prompt.add_help_option()
 
         return prompt

--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -44,7 +44,6 @@ class SummaryHub(TUIHub):
        .. inheritance-diagram:: SummaryHub
           :parts: 3
     """
-    helpFile = "SummaryHub.txt"
 
     @staticmethod
     def get_screen_id():

--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -46,6 +46,11 @@ class SummaryHub(TUIHub):
     """
     helpFile = "SummaryHub.txt"
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "installation-summary"
+
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)
         self.title = N_("Installation")

--- a/pyanaconda/ui/tui/spokes/__init__.py
+++ b/pyanaconda/ui/tui/spokes/__init__.py
@@ -16,10 +16,9 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
 from pyanaconda.ui.common import Spoke, StandaloneSpoke, NormalSpoke
 from pyanaconda.ui.tui.tuiobject import TUIObject
-from pyanaconda.ui.lib.help import get_help_path
+from pyanaconda.ui.lib.help import get_help_path_for_screen
 from pyanaconda.core.i18n import N_, _
 
 from simpleline.render.adv_widgets import HelpScreen
@@ -96,11 +95,16 @@ class NormalTUISpoke(TUISpoke, NormalSpoke):
           :parts: 3
     """
 
+    def _get_help(self):
+        """Get the help path for this screen."""
+        return get_help_path_for_screen(self.get_screen_id())
+
     def input(self, args, key):
         """Handle the input."""
         if key.lower() == Prompt.HELP:
-            if self.has_help:
-                help_path = get_help_path(self.helpFile, True)
+            help_path = self._get_help()
+
+            if help_path:
                 ScreenHandler.push_screen_modal(HelpScreen(help_path))
                 return InputState.PROCESSED_AND_REDRAW
 
@@ -110,7 +114,7 @@ class NormalTUISpoke(TUISpoke, NormalSpoke):
         """Return the prompt."""
         prompt = TUISpoke.prompt(self, args)
 
-        if self.has_help:
+        if self._get_help():
             prompt.add_help_option()
 
         return prompt

--- a/pyanaconda/ui/tui/spokes/installation_progress.py
+++ b/pyanaconda/ui/tui/spokes/installation_progress.py
@@ -44,6 +44,11 @@ class ProgressSpoke(StandaloneTUISpoke):
     """
     postForHub = SummaryHub
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "installation-progress"
+
     def __init__(self, ksdata, storage, payload):
         self.initialize_start()
         super().__init__(ksdata, storage, payload)

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -63,7 +63,6 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
        .. inheritance-diagram:: SourceSpoke
           :parts: 3
     """
-    helpFile = "SourceSpoke.txt"
     category = SoftwareCategory
 
     SET_NETWORK_INSTALL_MODE = "network_install"

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -68,6 +68,11 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
 
     SET_NETWORK_INSTALL_MODE = "network_install"
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "software-source-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Don't run for any non-package payload."""

--- a/pyanaconda/ui/tui/spokes/kernel_warning.py
+++ b/pyanaconda/ui/tui/spokes/kernel_warning.py
@@ -30,6 +30,11 @@ class KernelWarningSpoke(StandaloneTUISpoke):
     """Spoke for kernel-related warnings."""
     preForHub = SummaryHub
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "kernel-warning"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.title = N_("Warning: Processor has Simultaneous Multithreading (SMT) enabled")

--- a/pyanaconda/ui/tui/spokes/language_support.py
+++ b/pyanaconda/ui/tui/spokes/language_support.py
@@ -50,6 +50,11 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     helpFile = "LangSupportSpoke.txt"
     category = LocalizationCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "language-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/tui/spokes/language_support.py
+++ b/pyanaconda/ui/tui/spokes/language_support.py
@@ -47,7 +47,6 @@ class LangSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
        .. inheritance-diagram:: LangSpoke
           :parts: 3
     """
-    helpFile = "LangSupportSpoke.txt"
     category = LocalizationCategory
 
     @staticmethod

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -205,6 +205,11 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         NM.DeviceType.INFINIBAND,
     ]
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "network-configuration"
+
     def __init__(self, data, storage, payload):
         NormalTUISpoke.__init__(self, data, storage, payload)
         self.title = N_("Network configuration")

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -198,7 +198,6 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
        .. inheritance-diagram:: NetworkSpoke
           :parts: 3
     """
-    helpFile = "NetworkSpoke.txt"
     category = SystemCategory
     configurable_device_types = [
         NM.DeviceType.ETHERNET,

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -39,6 +39,11 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     helpFile = "PasswordSpoke.txt"
     category = UserSettingsCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "root-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -36,7 +36,6 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
        .. inheritance-diagram:: PasswordSpoke
           :parts: 3
     """
-    helpFile = "PasswordSpoke.txt"
     category = UserSettingsCategory
 
     @staticmethod

--- a/pyanaconda/ui/tui/spokes/shell_spoke.py
+++ b/pyanaconda/ui/tui/spokes/shell_spoke.py
@@ -27,6 +27,8 @@ from blivet import arch
 
 from simpleline.render.widgets import TextWidget
 
+__all__ = ["ShellSpoke"]
+
 
 class ShellSpoke(NormalTUISpoke):
     """
@@ -34,6 +36,11 @@ class ShellSpoke(NormalTUISpoke):
           :parts: 3
     """
     category = SystemCategory
+
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "shell"
 
     def __init__(self, data, storage, payload):
         super().__init__(data, storage, payload)

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -47,7 +47,6 @@ class SoftwareSpoke(NormalTUISpoke):
        .. inheritance-diagram:: SoftwareSpoke
           :parts: 3
     """
-    helpFile = "SoftwareSpoke.txt"
     category = SoftwareCategory
 
     @staticmethod

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -50,6 +50,11 @@ class SoftwareSpoke(NormalTUISpoke):
     helpFile = "SoftwareSpoke.txt"
     category = SoftwareCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "software-selection"
+
     @classmethod
     def should_run(cls, environment, data):
         """Don't run for any non-package payload."""

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -77,7 +77,6 @@ class StorageSpoke(NormalTUISpoke):
        .. inheritance-diagram:: StorageSpoke
           :parts: 3
     """
-    helpFile = "StorageSpoke.txt"
     category = SystemCategory
 
     @staticmethod

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -80,6 +80,11 @@ class StorageSpoke(NormalTUISpoke):
     helpFile = "StorageSpoke.txt"
     category = SystemCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "storage-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Don't run the storage spoke on dir installations."""

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -51,7 +51,6 @@ CallbackTimezoneArgs = namedtuple("CallbackTimezoneArgs", ["region", "timezone"]
 
 
 class TimeSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
-    helpFile = "DateTimeSpoke.txt"
     category = LocalizationCategory
 
     @staticmethod

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -54,6 +54,11 @@ class TimeSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     helpFile = "DateTimeSpoke.txt"
     category = LocalizationCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "date-time-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/tui/spokes/unsupported_hardware.py
+++ b/pyanaconda/ui/tui/spokes/unsupported_hardware.py
@@ -33,6 +33,11 @@ class UnsupportedHardwareSpoke(StandaloneTUISpoke):
     preForHub = SummaryHub
     priority = -10
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "unsupported-hardware-warning"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.title = N_("Unsupported Hardware Detected")

--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -48,6 +48,11 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     helpFile = "UserSpoke.txt"
     category = UserSettingsCategory
 
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "user-configuration"
+
     @classmethod
     def should_run(cls, environment, data):
         """Should the spoke run?"""

--- a/pyanaconda/ui/tui/spokes/user.py
+++ b/pyanaconda/ui/tui/spokes/user.py
@@ -45,7 +45,6 @@ class UserSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
        .. inheritance-diagram:: UserSpoke
           :parts: 3
     """
-    helpFile = "UserSpoke.txt"
     category = UserSettingsCategory
 
     @staticmethod

--- a/pyanaconda/ui/tui/tuiobject.py
+++ b/pyanaconda/ui/tui/tuiobject.py
@@ -23,7 +23,6 @@ from pyanaconda.core import util, constants
 from pyanaconda import input_checking
 from pyanaconda.core.i18n import _
 from pyanaconda.core.users import crypt_password
-from pyanaconda.core.configuration.anaconda import conf
 
 from simpleline.render.adv_widgets import ErrorDialog, GetInputScreen, GetPasswordInputScreen, YesNoDialog
 from simpleline.render.screen import UIScreen, Prompt
@@ -103,10 +102,6 @@ class TUIObject(UIScreen, common.UIObject):
     @property
     def showable(self):
         return True
-
-    @property
-    def has_help(self):
-        return conf.ui.help_directory and self.helpFile is not None
 
     def refresh(self, args=None):
         """Put everything to display into self.window list."""

--- a/pyanaconda/ui/tui/tuiobject.py
+++ b/pyanaconda/ui/tui/tuiobject.py
@@ -92,8 +92,6 @@ class TUIObject(UIScreen, common.UIObject):
     """Base class for Anaconda specific TUI screens. Implements the
     common pyanaconda.ui.common.UIObject interface"""
 
-    helpFile = None
-
     def __init__(self, data):
         UIScreen.__init__(self)
         common.UIObject.__init__(self, data)

--- a/tests/unit_tests/pyanaconda_tests/ui/test_help.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_help.py
@@ -1,0 +1,262 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import os
+import tempfile
+
+import unittest
+from unittest.mock import patch
+
+from pyanaconda.core.constants import DisplayModes
+from pyanaconda.ui.lib.help import _get_help_mapping, show_graphical_help, _get_help_args, \
+    HelpArguments, get_help_path_for_screen, show_graphical_help_for_screen, localize_help_file, \
+    _get_help_args_for_screen
+
+INVALID_MAPPING = """
+This is an invalid mapping.
+"""
+
+GUI_MAPPING = """
+{
+  "_default_": {
+    "file": "Installation_Guide.xml",
+    "anchor": ""
+  },
+  "installation-summary": {
+    "file": "SummaryHub.xml",
+    "anchor": ""
+  },
+    "user-configuration": {
+    "file": "UserSpoke.xml",
+    "anchor": "create-user"
+  }
+}
+"""
+
+TUI_MAPPING = """
+{
+  "_default_": {
+    "file": "Installation_Guide.txt"
+  },
+  "installation-summary": {
+    "file": "SummaryHub.txt"
+  },
+  "user-configuration": {
+    "file": "UserSpoke.txt"
+  }
+}
+"""
+
+
+class HelpSupportTestCase(unittest.TestCase):
+    """Test the built-in help support."""
+
+    def _create_file(self, file_dir, file_name, file_content):
+        """Create a file with the help mapping."""
+        os.makedirs(file_dir, exist_ok=True)
+        file_path = os.path.join(file_dir, file_name)
+
+        with open(file_path, mode="w") as f:
+            f.write(file_content)
+
+    @patch('pyanaconda.ui.lib.help.conf')
+    def test_get_help_mapping(self, conf_mock):
+        """Test the _get_help_mapping function."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            conf_mock.ui.help_directory = tmp_dir
+
+            assert _get_help_mapping(DisplayModes.TUI) == {}
+
+            self._create_file(tmp_dir, "anaconda-tui.json", INVALID_MAPPING)
+            assert _get_help_mapping(DisplayModes.TUI) == {}
+
+            self._create_file(tmp_dir, "anaconda-gui.json", GUI_MAPPING)
+            assert _get_help_mapping(DisplayModes.GUI) == {
+                "_default_": {
+                    "file": "Installation_Guide.xml",
+                    "anchor": ""
+                },
+                "installation-summary": {
+                    "file": "SummaryHub.xml",
+                    "anchor": ""
+                },
+                "user-configuration": {
+                    "file": "UserSpoke.xml",
+                    "anchor": "create-user"
+                }
+            }
+
+    @patch('pyanaconda.ui.lib.help.conf')
+    def test_get_help_args(self, conf_mock):
+        """Test the _get_help_args function."""
+        conf_mock.ui.help_directory = "/fake/path"
+
+        mapping = {
+            "_default_": {
+                "file": "Installation_Guide.xml",
+                "anchor": ""
+            },
+            "installation-summary": {
+                "file": "SummaryHub.xml",
+                "anchor": ""
+            },
+            "user-configuration": {
+                "file": "UserSpoke.xml",
+                "anchor": "create-user"
+            }
+        }
+
+        assert _get_help_args({}, "") == \
+            HelpArguments("", "", "")
+
+        assert _get_help_args({}, "installation-summary") == \
+            HelpArguments("", "", "")
+
+        assert _get_help_args(mapping, "installation-summary") == \
+            HelpArguments("", "SummaryHub.xml", "")
+
+        assert _get_help_args(mapping, "user-configuration") == \
+            HelpArguments("", "UserSpoke.xml", "create-user")
+
+        assert _get_help_args(mapping, "unknown-spoke") == \
+            HelpArguments("", "", "")
+
+    def test_localize_help_file(self):
+        """Test the localize_help_file function."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+
+            # No available file.
+            assert localize_help_file("file.txt", tmp_dir, "cs_CZ.UTF-8") is None
+
+            # File in default locale.
+            self._create_file(
+                file_name="file.txt",
+                file_dir=os.path.join(tmp_dir, "en-US"),
+                file_content="<content for en_US.UTF-8>"
+            )
+
+            assert localize_help_file("file.txt", tmp_dir, "cs_CZ.UTF-8") == \
+                os.path.join(tmp_dir, "en-US", "file.txt")
+
+            # File in both locales.
+            self._create_file(
+                file_name="file.txt",
+                file_dir=os.path.join(tmp_dir, "cs-CZ"),
+                file_content="<content for cs_CZ.UTF-8>"
+            )
+
+            assert localize_help_file("file.txt", tmp_dir, "cs_CZ.UTF-8") == \
+                os.path.join(tmp_dir, "cs-CZ", "file.txt")
+
+    @patch('pyanaconda.ui.lib.help.conf')
+    def test_get_help_args_for_screen(self, conf_mock):
+        """Test the _get_help_args_for_screen function."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            conf_mock.ui.help_directory = tmp_dir
+            content_dir = os.path.join(tmp_dir, "en-US")
+
+            # No mapping.
+            assert _get_help_args_for_screen(DisplayModes.GUI, "installation-summary") is None
+
+            # No help and no default.
+            self._create_file(tmp_dir, "anaconda-gui.json", GUI_MAPPING)
+            assert _get_help_args_for_screen(DisplayModes.GUI, "installation-summary") is None
+
+            # No help, return default.
+            self._create_file(content_dir, "Installation_Guide.xml", "<guide>")
+            help_path = os.path.join(tmp_dir, "en-US", "Installation_Guide.xml")
+
+            assert _get_help_args_for_screen(DisplayModes.GUI, "installation-summary") == \
+                HelpArguments(help_path, "Installation_Guide.xml", "")
+
+            # Return help.
+            self._create_file(content_dir, "SummaryHub.xml", "<summary>")
+            help_path = os.path.join(tmp_dir, "en-US", "SummaryHub.xml")
+
+            assert _get_help_args_for_screen(DisplayModes.GUI, "installation-summary") == \
+                HelpArguments(help_path, "SummaryHub.xml", "")
+
+            # Return help with anchor.
+            self._create_file(content_dir, "UserSpoke.xml", "<user>")
+            help_path = os.path.join(tmp_dir, "en-US", "UserSpoke.xml")
+
+            assert _get_help_args_for_screen(DisplayModes.GUI, "user-configuration") == \
+                HelpArguments(help_path, "UserSpoke.xml", "create-user")
+
+    @patch('pyanaconda.ui.lib.help.startProgram')
+    def test_show_graphical_help(self, starter):
+        """Test the show_graphical_help function."""
+        show_graphical_help("/my/file")
+        starter.assert_called_once_with(["yelp", "/my/file"], reset_lang=False)
+        starter.reset_mock()
+
+        show_graphical_help("/my/file", "my-anchor")
+        starter.assert_called_once_with(["yelp", "ghelp:/my/file?my-anchor"], reset_lang=False)
+        starter.reset_mock()
+
+        show_graphical_help("")
+        starter.assert_not_called()
+
+    @patch('pyanaconda.ui.lib.help.conf')
+    def test_get_help_path_for_screen(self, conf_mock):
+        """Test the get_help_path_for_screen function."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            conf_mock.ui.help_directory = tmp_dir
+            content_dir = os.path.join(tmp_dir, "en-US")
+
+            # No help.
+            self._create_file(tmp_dir, "anaconda-tui.json", TUI_MAPPING)
+            assert get_help_path_for_screen("installation-summary") is None
+
+            # Help file.
+            self._create_file(content_dir, "SummaryHub.txt", "<summary>")
+            self._create_file(content_dir, "UserSpoke.txt", "<user>")
+
+            assert get_help_path_for_screen("installation-summary") == \
+                os.path.join(tmp_dir, "en-US", "SummaryHub.txt")
+
+            assert get_help_path_for_screen("user-configuration") == \
+                os.path.join(tmp_dir, "en-US", "UserSpoke.txt")
+
+    @patch('pyanaconda.ui.lib.help.startProgram')
+    @patch('pyanaconda.ui.lib.help.conf')
+    def test_show_graphical_help_for_screen(self, conf_mock, starter):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            conf_mock.ui.help_directory = tmp_dir
+            content_dir = os.path.join(tmp_dir, "en-US")
+
+            # No help.
+            self._create_file(tmp_dir, "anaconda-gui.json", GUI_MAPPING)
+            show_graphical_help_for_screen("installation-summary")
+            starter.assert_not_called()
+            starter.reset_mock()
+
+            # Help file.
+            self._create_file(content_dir, "SummaryHub.xml", "<summary>")
+            show_graphical_help_for_screen("installation-summary")
+
+            help_path = os.path.join(tmp_dir, "en-US", "SummaryHub.xml")
+            starter.assert_called_once_with(["yelp", help_path], reset_lang=False)
+            starter.reset_mock()
+
+            # Help file with anchor.
+            self._create_file(content_dir, "UserSpoke.xml", "<create-user>")
+            show_graphical_help_for_screen("user-configuration")
+
+            help_path = os.path.join(tmp_dir, "en-US", "UserSpoke.xml")
+            yelp_arg = "ghelp:" + help_path + "?create-user"
+            starter.assert_called_once_with(["yelp", yelp_arg], reset_lang=False)

--- a/tests/unit_tests/pyanaconda_tests/ui/test_help.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_help.py
@@ -65,6 +65,10 @@ TUI_MAPPING = """
 class HelpSupportTestCase(unittest.TestCase):
     """Test the built-in help support."""
 
+    def tearDown(self):
+        """Clean up after a test."""
+        _get_help_mapping.cache_clear()
+
     def _create_file(self, file_dir, file_name, file_content):
         """Create a file with the help mapping."""
         os.makedirs(file_dir, exist_ok=True)
@@ -79,11 +83,14 @@ class HelpSupportTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             conf_mock.ui.help_directory = tmp_dir
 
+            _get_help_mapping.cache_clear()
             assert _get_help_mapping(DisplayModes.TUI) == {}
 
+            _get_help_mapping.cache_clear()
             self._create_file(tmp_dir, "anaconda-tui.json", INVALID_MAPPING)
             assert _get_help_mapping(DisplayModes.TUI) == {}
 
+            _get_help_mapping.cache_clear()
             self._create_file(tmp_dir, "anaconda-gui.json", GUI_MAPPING)
             assert _get_help_mapping(DisplayModes.GUI) == {
                 "_default_": {
@@ -170,9 +177,11 @@ class HelpSupportTestCase(unittest.TestCase):
             content_dir = os.path.join(tmp_dir, "en-US")
 
             # No mapping.
+            _get_help_mapping.cache_clear()
             assert _get_help_args_for_screen(DisplayModes.GUI, "installation-summary") is None
 
             # No help and no default.
+            _get_help_mapping.cache_clear()
             self._create_file(tmp_dir, "anaconda-gui.json", GUI_MAPPING)
             assert _get_help_args_for_screen(DisplayModes.GUI, "installation-summary") is None
 
@@ -219,6 +228,7 @@ class HelpSupportTestCase(unittest.TestCase):
             content_dir = os.path.join(tmp_dir, "en-US")
 
             # No help.
+            _get_help_mapping.cache_clear()
             self._create_file(tmp_dir, "anaconda-tui.json", TUI_MAPPING)
             assert get_help_path_for_screen("installation-summary") is None
 
@@ -240,7 +250,9 @@ class HelpSupportTestCase(unittest.TestCase):
             content_dir = os.path.join(tmp_dir, "en-US")
 
             # No help.
+            _get_help_mapping.cache_clear()
             self._create_file(tmp_dir, "anaconda-gui.json", GUI_MAPPING)
+
             show_graphical_help_for_screen("installation-summary")
             starter.assert_not_called()
             starter.reset_mock()


### PR DESCRIPTION
Implement the unified help support and enable the built-in help content.

**Ported from:**
* https://github.com/rhinstaller/anaconda/pull/3576
* https://github.com/rhinstaller/anaconda/pull/3575
* https://github.com/rhinstaller/anaconda/pull/3674

**TODO:**
- [x] Test with the RHEL 9 help content.
- [x] Remove the mapping file.
- [x] Update the required version of `anaconda-user-help`.

Resolves: rhbz#1995945