### PR TITLE
Fix shell quotes in dracut

### DIFF
--- a/dracut/anaconda-copy-cmdline.sh
+++ b/dracut/anaconda-copy-cmdline.sh
@@ -2,6 +2,6 @@
 # Copy over cmdline(.d) files from the initrd to /run before pivot
 mkdir -p /run/install/cmdline.d
 for f in /etc/cmdline.d/*; do
-    [ -e $f ] && cp $f /run/install/cmdline.d/
+    [ -e "$f" ] && cp "$f" /run/install/cmdline.d/
 done
 [ -e /etc/cmdline ] && cp /etc/cmdline /run/install/

--- a/dracut/anaconda-depmod.sh
+++ b/dracut/anaconda-depmod.sh
@@ -2,4 +2,4 @@
 [ -e /run/install/DD-1 -o -e /tmp/DD-net ] || return 0
 
 # regenerate modules.* files
-depmod -b $NEWROOT
+depmod -b "$NEWROOT"

--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -9,18 +9,18 @@ command -v getargbool >/dev/null || . /lib/dracut-lib.sh
 run_checkisomd5() {
     livedev=$1
     if getargbool 0 rd.live.check -d check; then
-        [ -b $livedev ] && fs=$(blkid -s TYPE -o value $livedev)
+        [ -b "$livedev" ] && fs=$(blkid -s TYPE -o value "$livedev")
         if [ "$fs" = "iso9660" -o "$fs" = "udf" ]; then
             [ -x /bin/plymouth ] && /bin/plymouth --hide-splash
             if [ -n "$DRACUT_SYSTEMD" ]; then
                 p=$(dev_unit_name "$livedev")
-                systemctl start checkisomd5@${p}.service
-                retcode=$(systemctl -p ExecMainStatus show checkisomd5@${p}.service)
-                status=$(systemctl -p ActiveState show checkisomd5@${p}.service)
+                systemctl start "checkisomd5@${p}.service"
+                retcode=$(systemctl -p ExecMainStatus show "checkisomd5@${p}.service")
+                status=$(systemctl -p ActiveState show "checkisomd5@${p}.service")
                 splitsep "=" "$retcode" ignore rc
                 splitsep "=" "$status" ignore state
             else
-                checkisomd5 --verbose $livedev
+                checkisomd5 --verbose "$livedev"
                 rc=$?
                 state="inactive"
             fi
@@ -79,6 +79,6 @@ if [ -e /tmp/dd_interactive -a ! -e /tmp/dd.done ]; then
 fi
 
 info "anaconda using disk root at $dev"
-mount -o ro $dev $repodir || warn "Couldn't mount $dev"
-anaconda_live_root_dir $repodir $path
-run_checkisomd5 $dev
+mount -o ro "$dev" "$repodir" || warn "Couldn't mount $dev"
+anaconda_live_root_dir "$repodir" "$path"
+run_checkisomd5 "$dev"

--- a/dracut/anaconda-hmcroot
+++ b/dracut/anaconda-hmcroot
@@ -15,8 +15,8 @@ debug_msg "Trying SE/HMC access with $1."
 # Do we have SE/HMC file access?
 if /usr/sbin/lshmc ; then
     info "Anaconda using SE/HMC file access to root."
-    /usr/bin/hmcdrvfs $repodir || warn "Couldn't mount /dev/hmcdrv"
-    anaconda_live_root_dir $repodir
+    /usr/bin/hmcdrvfs "$repodir" || warn "Couldn't mount /dev/hmcdrv"
+    anaconda_live_root_dir "$repodir"
 else
     debug_msg "No SE/HMC access to files."
     exit 1

--- a/dracut/anaconda-ifcfg.sh
+++ b/dracut/anaconda-ifcfg.sh
@@ -5,4 +5,4 @@ command -v getarg >/dev/null || . /lib/dracut-lib.sh
 netif="$1"
 
 # make sure we get ifcfg for every interface that comes up
-save_netinfo $netif
+save_netinfo "$netif"

--- a/dracut/anaconda-ifdown
+++ b/dracut/anaconda-ifdown
@@ -7,10 +7,10 @@
 
 netif="$1"
 # ip down/flush ensures that routing info goes away as well
-ip link set $netif down
-ip addr flush dev $netif
-rm -f -- /tmp/*.$netif.*
-if [ -e /sys/class/net/$netif/address ]; then
-    address=$(cat /sys/class/net/$netif/address)
-    rm -f -- /tmp/*.$address.*
+ip link set "$netif" down
+ip addr flush dev "$netif"
+rm -f -- /tmp/*."$netif".*
+if [ -e "/sys/class/net/$netif/address" ]; then
+    address=$(cat "/sys/class/net/$netif/address")
+    rm -f -- /tmp/*."$address".*
 fi

--- a/dracut/anaconda-ks-sendheaders.sh
+++ b/dracut/anaconda-ks-sendheaders.sh
@@ -9,7 +9,7 @@ if getargbool 0 inst.ks.sendmac; then
     ifnum=0
     for ifname in /sys/class/net/*; do
         [ -e "$ifname/address" ] || continue
-        mac=$(cat $ifname/address)
+        mac=$(cat "$ifname/address")
         ifname=${ifname#/sys/class/net/}
         # TODO: might need to choose devices better
         if [ "$ifname" != "lo" ] && [ -n "$mac" ]; then

--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -24,10 +24,10 @@ config_get() {
         case "$line" in
             \#*) continue ;;
             \[*\]*) cursec="${line#[}"; cursec="${cursec%%]*}" ;;
-            *=*) k=$(echo ${line%%=*}); v=$(echo ${line#*=}) ;;
+            *=*) k=$(echo "${line%%=*}"); v=$(echo "${line#*=}") ;;
         esac
         if [ "$cursec" = "$section" ] && [ "$k" == "$key" ]; then
-            echo $v
+            echo "$v"
             break
         fi
     done
@@ -35,16 +35,16 @@ config_get() {
 
 find_iso() {
     local f="" p="" iso="" isodir="$1" tmpmnt=$(mkuniqdir /run/install tmpmnt)
-    for f in $isodir/*.iso; do
-        [ -e $f ] || continue
-        mount -o loop,ro $f $tmpmnt || continue
+    for f in "$isodir"/*.iso; do
+        [ -e "$f" ] || continue
+        mount -o loop,ro "$f" "$tmpmnt" || continue
         # Valid ISOs either have stage2 in one of the supported paths
         # or have a .treeinfo that might tell use where to find the stage2 image.
         # If it does not have any of those, it is not valid and will not be used.
         for p in $tmpmnt/LiveOS/squashfs.img $tmpmnt/images/install.img $tmpmnt/.treeinfo; do
-            if [ -e $p ]; then iso=$f; break; fi
+            if [ -e "$p" ]; then iso=$f; break; fi
         done
-        umount $tmpmnt
+        umount "$tmpmnt"
         if [ "$iso" ]; then echo "$iso"; return 0; fi
     done
     return 1
@@ -53,8 +53,8 @@ find_iso() {
 find_runtime() {
     [ -f "$1" ] && [ "${1%.iso}" == "$1" ] && echo "$1" && return
     local ti_img="" dir="$1"
-    [ -e $dir/.treeinfo ] && \
-        ti_img=$(config_get stage2 mainimage < $dir/.treeinfo)
+    [ -e "$dir"/.treeinfo ] && \
+        ti_img=$(config_get stage2 mainimage < "$dir/.treeinfo")
     for f in $ti_img images/install.img LiveOS/squashfs.img; do
         [ -e "$dir/$f" ] && echo "$dir/$f" && return
     done
@@ -67,7 +67,7 @@ find_tty() {
         tty=$(< /sys/class/tty/$tty/active)
         tty=${tty##* } # last item in the list
     done
-    echo $tty
+    echo "$tty"
 }
 
 
@@ -79,28 +79,28 @@ rulesfile="/etc/udev/rules.d/90-anaconda.rules"
 # if successful, move the mount(s) to $repodir/$isodir.
 anaconda_live_root_dir() {
     local img="" iso="" srcdir="" mnt="$1" path="$2"
-    img=$(find_runtime $mnt/$path)
+    img=$(find_runtime "$mnt/$path")
     if [ -n "$img" ]; then
         info "anaconda: found $img"
-        [ "$mnt" = "$repodir" ] || { mount --make-rprivate /; mount --move $mnt $isodir; }
-        anaconda_auto_updates $repodir/$path/images
+        [ "$mnt" = "$repodir" ] || { mount --make-rprivate /; mount --move "$mnt" $isodir; }
+        anaconda_auto_updates "$repodir/$path/images"
     else
         if [ "${path%.iso}" != "$path" ]; then
             iso=$path
             path=${path%/*.iso}
         else
-            iso=$(find_iso $mnt/$path)
+            iso=$(find_iso "$mnt/$path")
         fi
         [ -n "$iso" ] || { warn "no suitable images"; return 1; }
         info "anaconda: found $iso"
         mount --make-rprivate /
-        mount --move $mnt $isodir
+        mount --move "$mnt" $isodir
         iso=${isodir}/${iso#$mnt}
-        mount -o loop,ro $iso $repodir
+        mount -o loop,ro "$iso" $repodir
         img=$(find_runtime $repodir) || { warn "$iso has no suitable runtime"; }
         anaconda_auto_updates $repodir/images
     fi
-    anaconda_mount_sysroot $img
+    anaconda_mount_sysroot "$img"
 }
 
 anaconda_net_root() {
@@ -108,11 +108,11 @@ anaconda_net_root() {
     info "anaconda: fetching stage2 from $repo"
 
     # Try to get the local path to stage2 from treeinfo.
-    treeinfo=$(fetch_url $repo/.treeinfo 2> /tmp/treeinfo_err) && \
-        stage2=$(config_get stage2 mainimage < $treeinfo)
+    treeinfo=$(fetch_url "$repo/.treeinfo" 2> /tmp/treeinfo_err) && \
+        stage2=$(config_get stage2 mainimage < "$treeinfo")
 
     # No treeinfo available.
-    [ -z "$treeinfo" ] && debug_msg $(cat /tmp/treeinfo_err)
+    [ -z "$treeinfo" ] && debug_msg "$(cat /tmp/treeinfo_err)"
 
     # Use the default local path to stage2.
     if [ -z "$treeinfo" -o -z "$stage2" ]; then
@@ -121,21 +121,21 @@ anaconda_net_root() {
     fi
 
     # Fetch the stage2.
-    if runtime=$(fetch_url $repo/$stage2) \
-        || runtime=$(fetch_url $repo/LiveOS/squashfs.img); then
+    if runtime=$(fetch_url "$repo/$stage2") \
+        || runtime=$(fetch_url "$repo/LiveOS/squashfs.img"); then
 
         info "anaconda: successfully fetched stage2 from $repo"
 
         # NOTE: Should be the same as anaconda_auto_updates()
-        updates=$(fetch_url $repo/images/updates.img 2> /tmp/updates_err)
-        [ -z "$updates" ] && debug_msg $(cat /tmp/updates_err)
-        [ -n "$updates" ] && unpack_updates_img $updates /updates
+        updates=$(fetch_url "$repo/images/updates.img" 2> /tmp/updates_err)
+        [ -z "$updates" ] && debug_msg "$(cat /tmp/updates_err)"
+        [ -n "$updates" ] && unpack_updates_img "$updates" /updates
 
-        product=$(fetch_url $repo/images/product.img 2> /tmp/product_err)
-        [ -z "$product" ] && debug_msg $(cat /tmp/product_err)
-        [ -n "$product" ] && unpack_updates_img $product /updates
+        product=$(fetch_url "$repo/images/product.img" 2> /tmp/product_err)
+        [ -z "$product" ] && debug_msg "$(cat /tmp/product_err)"
+        [ -n "$product" ] && unpack_updates_img "$product" /updates
 
-        anaconda_mount_sysroot $runtime
+        anaconda_mount_sysroot "$runtime"
         return 0
     fi
 
@@ -146,7 +146,7 @@ anaconda_net_root() {
 anaconda_mount_sysroot() {
     local img="$1"
     if [ -e "$img" ]; then
-        /sbin/dmsquash-live-root $img
+        /sbin/dmsquash-live-root "$img"
         if [ -d /run/rootfsbase ]; then
             # /run/rootfsbase has been created
             # Which means that the Squash filesystem is plain
@@ -154,12 +154,12 @@ anaconda_mount_sysroot() {
             # Also known as flattened SquashFS or directly compressed SquashFS.
             printf "mount -t overlay LiveOS_rootfs \
                    -o lowerdir=/run/rootfsbase,upperdir=/run/overlayfs,workdir=/run/ovlwork \
-                   ${NEWROOT}" > ${hookdir}/mount/01-$$-anaconda.sh
+                   ${NEWROOT}" > "${hookdir}/mount/01-$$-anaconda.sh"
         else
             # Otherwise, assumption is that /dev/mapper/live-rw should have been created.
             # dracut & systemd only mount things with root=live: so we have to do this ourselves
             # See https://bugzilla.redhat.com/show_bug.cgi?id=1232411
-            printf 'mount /dev/mapper/live-rw %s\n' "$NEWROOT" > $hookdir/mount/01-$$-anaconda.sh
+            printf 'mount /dev/mapper/live-rw %s\n' "$NEWROOT" > "$hookdir/mount/01-$$-anaconda.sh"
         fi
     fi
 }
@@ -168,14 +168,14 @@ anaconda_mount_sysroot() {
 # end up in the location(s) that anaconda expects them
 anaconda_auto_updates() {
     local dir="$1"
-    if [ -d $dir/RHupdates ]; then
-        copytree $dir/RHupdates /updates
+    if [ -d "$dir/RHupdates" ]; then
+        copytree "$dir/RHupdates" /updates
     fi
-    if [ -e $dir/updates.img ]; then
-        unpack_updates_img $dir/updates.img /updates
+    if [ -e "$dir/updates.img" ]; then
+        unpack_updates_img "$dir/updates.img" /updates
     fi
-    if [ -e $dir/product.img ]; then
-        unpack_updates_img $dir/product.img /updates
+    if [ -e "$dir/product.img" ]; then
+        unpack_updates_img "$dir/product.img" /updates
     fi
 }
 
@@ -184,9 +184,9 @@ unpack_updates_img() {
     local img="$1" tmpdir="/tmp/${1##*/}.$$" outdir="${2:-/updates}"
     # NOTE: unpack_img $img $outdir can clobber existing subdirs in $outdir,
     # which is why we use a tmpdir and copytree (which doesn't clobber)
-    unpack_img $img $tmpdir
-    copytree $tmpdir $outdir
-    rm -rf $tmpdir
+    unpack_img "$img" "$tmpdir"
+    copytree "$tmpdir" "$outdir"
+    rm -rf "$tmpdir"
 }
 
 # These could probably be in dracut-lib or similar
@@ -207,9 +207,9 @@ disk_to_dev_path() {
 }
 
 find_mount() {
-    local dev mnt etc wanted_dev="$(readlink -e -q $1)"
+    local dev mnt etc wanted_dev="$(readlink -e -q "$1")"
     while read dev mnt etc; do
-        [ "$dev" = "$wanted_dev" ] && echo $mnt && return 0
+        [ "$dev" = "$wanted_dev" ] && echo "$mnt" && return 0
     done < /proc/mounts
     return 1
 }
@@ -260,7 +260,7 @@ debug_msg() {
 }
 
 dev_is_cdrom() {
-    udevadm info --query=property --name=$1 | grep -q 'ID_CDROM=1'
+    udevadm info --query=property --name="$1" | grep -q 'ID_CDROM=1'
 }
 
 dev_is_on_disk_with_iso9660() {
@@ -268,19 +268,19 @@ dev_is_on_disk_with_iso9660() {
     local dev_name="${1}"
 
     # Get the path of the device.
-    local dev_path="$(udevadm info -q path --name ${dev_name})"
+    local dev_path="$(udevadm info -q path --name "${dev_name}")"
 
     # Is the device a partition?
-    udevadm info -q property --path ${dev_path} | grep -q 'DEVTYPE=partition' || return 1
+    udevadm info -q property --path "${dev_path}" | grep -q 'DEVTYPE=partition' || return 1
 
     # Get the path of the parent.
     local disk_path="${dev_path%/*}"
 
     # Is the parent a disk?
-    udevadm info -q property --path ${disk_path} | grep -q 'DEVTYPE=disk' || return 1
+    udevadm info -q property --path "${disk_path}" | grep -q 'DEVTYPE=disk' || return 1
 
     # Does the parent has the iso9660 filesystem?
-    udevadm info -q property --path ${disk_path} | grep -q 'ID_FS_TYPE=iso9660' || return 1
+    udevadm info -q property --path "${disk_path}" | grep -q 'ID_FS_TYPE=iso9660' || return 1
 
     return 0
 }
@@ -297,10 +297,10 @@ set_neednet() {
 }
 
 parse_kickstart() {
-    PYTHONHASHSEED=42 /sbin/parse-kickstart $1 > /etc/cmdline.d/80-kickstart.conf
+    PYTHONHASHSEED=42 /sbin/parse-kickstart "$1" > /etc/cmdline.d/80-kickstart.conf
     unset CMDLINE  # re-read the commandline
     . /tmp/ks.info # save the parsed kickstart
-    [ -e "$parsed_kickstart" ] && cp $parsed_kickstart /run/install/ks.cfg
+    [ -e "$parsed_kickstart" ] && cp "$parsed_kickstart" /run/install/ks.cfg
 }
 
 # print a list of net devices that dracut says are set up.
@@ -308,7 +308,7 @@ online_netdevs() {
     local netif=""
     for netif in /tmp/net.*.did-setup; do
         netif=${netif#*.}; netif=${netif%.*}
-        [ -d "/sys/class/net/$netif" ] && echo $netif
+        [ -d "/sys/class/net/$netif" ] && echo "$netif"
     done
 }
 
@@ -351,9 +351,9 @@ run_kickstart() {
     kickstart=""
 
     # re-parse new cmdline stuff from the kickstart
-    . $hookdir/cmdline/*parse-anaconda-repo.sh
-    . $hookdir/cmdline/*parse-livenet.sh
-    . $hookdir/cmdline/*parse-anaconda-dd.sh
+    . "$hookdir"/cmdline/*parse-anaconda-repo.sh
+    . "$hookdir"/cmdline/*parse-livenet.sh
+    . "$hookdir"/cmdline/*parse-anaconda-dd.sh
 
     # Kickstart network configuration (which might even be empty) should be
     # applied to get installer image or driver disks only if the tasks haven't
@@ -372,8 +372,8 @@ run_kickstart() {
     # disk: replay udev events to trigger actions
     if [ "$do_disk" ]; then
         # set up new rules
-        . $hookdir/pre-trigger/*repo-genrules.sh
-        . $hookdir/pre-trigger/*driver-updates-genrules.sh
+        . "$hookdir"/pre-trigger/*repo-genrules.sh
+        . "$hookdir"/pre-trigger/*driver-updates-genrules.sh
         udevadm control --reload
         # trigger the rules for all the block devices we see
         udevadm trigger --action=change --subsystem-match=block
@@ -382,18 +382,18 @@ run_kickstart() {
     # net: re-run online hooks
     if [ "$do_net" ]; then
         # If NetworkManager is used in initramfs
-        if [ -e $hookdir/cmdline/*-nm-config.sh ]; then
+        if [ -e "$hookdir"/cmdline/*-nm-config.sh ]; then
             # First try to re-run online hooks on any online device.
             # We don't want to reconfigure the network by applying kickstart config
             # so use existing network connections if there are any.
             # Based on nm-run.sh
             for _i in /sys/class/net/*/
             do
-                state=/run/NetworkManager/devices/$(cat $_i/ifindex)
-                grep -q connection-uuid= $state 2>/dev/null || continue
+                state=/run/NetworkManager/devices/$(cat "$_i/ifindex")
+                grep -q connection-uuid= "$state" 2>/dev/null || continue
                 nm_connected_device_found="yes"
-                ifname=$(basename $_i)
-                source_hook initqueue/online $ifname
+                ifname=$(basename "$_i")
+                source_hook initqueue/online "$ifname"
             done
 
             if [ "${nm_connected_device_found}" != "yes" ]; then
@@ -401,15 +401,15 @@ run_kickstart() {
                 # The configuration will be applied by the next run of NM
                 # via settled hook in *-nm-run.sh script which also calls the
                 # online hooks.
-                . $hookdir/cmdline/*-nm-config.sh
+                . "$hookdir"/cmdline/*-nm-config.sh
             fi
         else
             # make dracut create the net udev rules (based on the new cmdline)
-            . $hookdir/pre-udev/*-net-genrules.sh
+            . "$hookdir"/pre-udev/*-net-genrules.sh
             udevadm control --reload
             udevadm trigger --action=add --subsystem-match=net
             for netif in $(online_netdevs); do
-                source_hook initqueue/online $netif
+                source_hook initqueue/online "$netif"
             done
         fi
     fi
@@ -419,13 +419,13 @@ run_kickstart() {
 }
 
 wait_for_kickstart() {
-    echo "[ -e /tmp/ks.cfg.done ]" > $hookdir/initqueue/finished/kickstart.sh
+    echo "[ -e /tmp/ks.cfg.done ]" > "$hookdir/initqueue/finished/kickstart.sh"
 }
 
 wait_for_updates() {
-    echo "[ -e /tmp/liveupdates.done ]" > $hookdir/initqueue/finished/updates.sh
+    echo "[ -e /tmp/liveupdates.done ]" > "$hookdir/initqueue/finished/updates.sh"
 }
 
 wait_for_dd() {
-    echo "[ -e /tmp/dd.done ]" > $hookdir/initqueue/finished/dd.sh
+    echo "[ -e /tmp/dd.done ]" > "$hookdir/initqueue/finished/dd.sh"
 }

--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -14,7 +14,7 @@ MODULE_LIST="cramfs squashfs iscsi_tcp "
 shopt -s nullglob
 
 SCSI_MODULES=/lib/modules/$KERNEL/kernel/drivers/scsi/device_handler/
-for m in $SCSI_MODULES/*.ko; do
+for m in "$SCSI_MODULES"/*.ko; do
     # Shell spew to work around not having basename
     # Trim the paths off the prefix, then the . suffix
     a="${m##*/}"
@@ -38,11 +38,11 @@ MODULE_LIST+=" raid0 raid1 raid5 raid6 raid456 raid10 linear dm-mod dm-zero  \
               sha256 lrw xts "
 
 for m in $MODULE_LIST; do
-    if ! modinfo $m >/dev/null 2>&1 ; then
+    if ! modinfo "$m" >/dev/null 2>&1 ; then
         echo "anaconda-modprobe: Module $m not found" >&2
         continue
     fi
-    if modprobe $m ; then
+    if modprobe "$m" ; then
         debug_msg "$m was loaded"
     else
         debug_msg "$m was NOT loaded"

--- a/dracut/anaconda-netroot.sh
+++ b/dracut/anaconda-netroot.sh
@@ -13,7 +13,7 @@ splitsep ":" "$root" prefix repo
 
 # repo not set? make sure we are using fresh repo information
 if [ -z "$repo" ]; then
-     . $hookdir/cmdline/*parse-anaconda-repo.sh
+     . "$hookdir"/cmdline/*parse-anaconda-repo.sh
      splitsep ":" "$root" prefix repo
 fi
 
@@ -45,14 +45,14 @@ case $repo in
         # dracut's nfs_to_var  has a special case to handle anaconda's nfs: form but not nfs4:
         if str_starts "$repo" "nfs4:"; then
             repo=nfs:${repo#nfs4:}
-            nfs_to_var "$repo" $netif
+            nfs_to_var "$repo" "$netif"
             if ! strstr "$options" "vers="; then
                 repo="nfs:${options:+$options,}nfsvers=4:$server:$path"
             fi
         else
             # HACK: work around some Mysterious NFS4 Badness (#811242 and friends)
             # by defaulting to nfsvers=3 when no version is requested
-            nfs_to_var "$repo" $netif
+            nfs_to_var "$repo" "$netif"
             if ! strstr "$options" "vers="; then
                 repo="nfs:${options:+$options,}nfsvers=3:$server:$path"
             fi
@@ -60,12 +60,12 @@ case $repo in
         fi
         if [ "${repo%.iso}" == "$repo" ]; then
             mount_nfs "$repo" "$repodir" "$netif" || warn "Couldn't mount $repo"
-            anaconda_live_root_dir $repodir
+            anaconda_live_root_dir "$repodir"
         else
             iso="${repo##*/}"
             mount_nfs "${repo%$iso}" "$repodir" "$netif" || \
                 warn "Couldn't mount $repo"
-            anaconda_live_root_dir $repodir $iso
+            anaconda_live_root_dir "$repodir" "$iso"
         fi
     ;;
     http*|ftp*)

--- a/dracut/anaconda-pre-shutdown.sh
+++ b/dracut/anaconda-pre-shutdown.sh
@@ -17,5 +17,5 @@
 for mnt in $repodir $isodir; do
     # systemd-shutdown puts old root at /oldroot
     oldmnt=/oldroot$mnt
-    grep -qw $oldmnt /proc/mounts && mount --move $oldmnt $mnt
+    grep -qw "$oldmnt" /proc/mounts && mount --move "$oldmnt" "$mnt"
 done

--- a/dracut/anaconda-set-kernel-hung-timeout.sh
+++ b/dracut/anaconda-set-kernel-hung-timeout.sh
@@ -5,5 +5,5 @@
 hung_timeout=$(getarg inst.kernel.hung_task_timeout_secs=)
 
 if [ -n "$hung_timeout" ]; then
-    echo ${hung_timeout} > /proc/sys/kernel/hung_task_timeout_secs
+    echo "${hung_timeout}" > /proc/sys/kernel/hung_task_timeout_secs
 fi

--- a/dracut/driver-updates-genrules.sh
+++ b/dracut/driver-updates-genrules.sh
@@ -8,7 +8,7 @@ command -v wait_for_dd >/dev/null || . /lib/anaconda-lib.sh
 DD_OEMDRV=""
 if [ -f /tmp/dd_interactive ]; then
     initqueue --onetime --settled --name zz_dd_interactive \
-        systemctl start driver-updates@$(find_tty).service
+        systemctl start "driver-updates@$(find_tty).service"
 else
     # Only process OEMDRV in non-interactive mode
     DD_OEMDRV="LABEL=OEMDRV"
@@ -24,10 +24,10 @@ fi
 # Run driver-updates for LABEL=OEMDRV and any other requested disk/image
 for dd in $DD_OEMDRV $DD_DISKS; do
     # ..is this actually a disk image that already exists inside initramfs?
-    if [ -f $dd ]; then
+    if [ -f "$dd" ]; then
         # if so, no need to wait for udev - add it to initqueue now
         initqueue --onetime --name dd_initrd \
-            driver-updates --disk $dd $dd
+            driver-updates --disk "$dd" "$dd"
     # otherwise, tell udev to do driver-updates when the device appears
     else
         # replace '\' with '\\' for udev rules
@@ -36,17 +36,17 @@ for dd in $DD_OEMDRV $DD_DISKS; do
         # this is a disk with path to specific RPM file on it
         if [ "${dd##*.}" = "rpm" ]; then
             splitsep ":" "$dd" dd_type dd_dev dd_path
-            when_diskdev_appears "$(disk_to_dev_path $dd_type)" \
-                driver-updates --disk $dd_whitespace_fix \$devnode $dd_dev
+            when_diskdev_appears "$(disk_to_dev_path "$dd_type")" \
+                driver-updates --disk "$dd_whitespace_fix" \$devnode "$dd_dev"
         else
-            when_diskdev_appears "$(disk_to_dev_path $dd)" \
-                driver-updates --disk $dd_whitespace_fix \$devnode
+            when_diskdev_appears "$(disk_to_dev_path "$dd")" \
+                driver-updates --disk "$dd_whitespace_fix" \$devnode
         fi
     fi
 done
 
 # force us to wait at least until we've settled at least once
-echo '> /tmp/settle.done' > $hookdir/initqueue/settled/settle_done.sh
-echo '[ -f /tmp/settle.done ]' > $hookdir/initqueue/finished/wait_for_settle.sh
+echo '> /tmp/settle.done' > "$hookdir/initqueue/settled/settle_done.sh"
+echo '[ -f /tmp/settle.done ]' > "$hookdir/initqueue/finished/wait_for_settle.sh"
 
 # NOTE: dd_net is handled by fetch-driver-net.sh

--- a/dracut/fetch-driver-net.sh
+++ b/dracut/fetch-driver-net.sh
@@ -50,7 +50,7 @@ for dd in $DD_NET; do
             fi
 
             # Get and process all rpm files in the mounted directory
-            for rpm_file in $mntdir/*.rpm; do
+            for rpm_file in "$mntdir"/*.rpm; do
                 # If no file is found bash still loops once
                 # Hence to prevent this:
                 if [[ ! -e "$rpm_file" ]]; then

--- a/dracut/fetch-kickstart-disk
+++ b/dracut/fetch-kickstart-disk
@@ -12,16 +12,16 @@ kickstart="$(getarg inst.ks=)"
 [ -b "$dev" ] || exit 1
 
 info "anaconda: fetching kickstart from $dev:$path"
-mnt="$(find_mount $dev)"
+mnt="$(find_mount "$dev")"
 
 if [ -n "$mnt" ]; then
-    cp $mnt$path /tmp/ks.cfg 2>&1
+    cp "$mnt$path" /tmp/ks.cfg 2>&1
 else
     tmpmnt="$(mkuniqdir /run/install tmpmnt)"
-    if mount -o ro $dev $tmpmnt; then
-        cp $tmpmnt/$path /tmp/ks.cfg 2>&1
-        umount $tmpmnt
-        rmdir $tmpmnt
+    if mount -o ro "$dev" "$tmpmnt"; then
+        cp "$tmpmnt/$path" /tmp/ks.cfg 2>&1
+        umount "$tmpmnt"
+        rmdir "$tmpmnt"
     fi
 fi
 

--- a/dracut/fetch-kickstart-net.sh
+++ b/dracut/fetch-kickstart-net.sh
@@ -28,7 +28,7 @@ case $kickstart in
             # Construct kickstart URL from dhcp info.
             # Filename is dhcp 'filename' option, or '/kickstart/' if missing.
             filename="/kickstart/"
-            . /tmp/net.$netif.dhcpopts
+            . "/tmp/net.$netif.dhcpopts"
             # Server is next_server, or the dhcp server itself if missing.
             server="${new_next_server:-$new_dhcp_server_identifier}"
             kickstart="nfs:$server:$filename"
@@ -36,7 +36,7 @@ case $kickstart in
 
         # URLs that end in '/' get '$IP_ADDR-kickstart' appended.
         if [[ $kickstart == nfs*/ ]]; then
-            kickstart="${kickstart}${new_ip_address:=$(ip -4 addr show ${netif} | sed -n -e '/^ *inet / s|^ *inet \([^/]\+\)/.*$|\1|p')}-kickstart"
+            kickstart="${kickstart}${new_ip_address:=$(ip -4 addr show "${netif}" | sed -n -e '/^ *inet / s|^ *inet \([^/]\+\)/.*$|\1|p')}-kickstart"
         fi
 
         # Use the prepared url.
@@ -65,7 +65,7 @@ else
 fi
 
 # Create a new job.
-cat > $newjob <<__EOT__
+cat > "$newjob" <<__EOT__
 . /lib/url-lib.sh
 . /lib/anaconda-lib.sh
 locations="$locations"

--- a/dracut/fetch-updates-disk
+++ b/dracut/fetch-updates-disk
@@ -12,16 +12,16 @@ path="${2:-/updates.img}"
 
 info "anaconda: fetching updates from $dev:$path"
 
-mnt="$(find_mount $dev)"
+mnt="$(find_mount "$dev")"
 if [ -n "$mnt" ]; then
-    cp $mnt$path /tmp/updates.img
+    cp "$mnt$path" /tmp/updates.img
 else
     tmpmnt="$(mkuniqdir /run/install tmpmnt)"
-    if mount -o ro $dev $tmpmnt; then
-        cp $tmpmnt$path /tmp/updates.img
-        umount $tmpmnt
+    if mount -o ro "$dev" "$tmpmnt"; then
+        cp "$tmpmnt$path" /tmp/updates.img
+        umount "$tmpmnt"
     fi
-    rmdir $tmpmnt
+    rmdir "$tmpmnt"
 fi
 
 if [ -f /tmp/updates.img ]; then

--- a/dracut/find-net-intfs-by-driver
+++ b/dracut/find-net-intfs-by-driver
@@ -9,11 +9,11 @@ driver="$1"
 
 # List all interfaces in system
 for i in /sys/class/net/*/device/modalias; do
-    if [ -z $i ]; then
+    if [ -z "$i" ]; then
         exit 0
     fi
     # Get kernel mods on which the interface is dependent
-    d=$(modprobe -R $(cat "$i"))
+    d=$(modprobe -R "$(cat "$i")")
 
     # Test if this is the mod we are looking for. If so return name of the interface.
     if [[ " $d " == *\ $driver\ * ]]; then

--- a/dracut/kickstart-genrules.sh
+++ b/dracut/kickstart-genrules.sh
@@ -15,7 +15,7 @@ case "${kickstart%%:*}" in
             when_any_cdrom_appears \
                 fetch-kickstart-disk "\$env{DEVNAME}" "$kspath"
         else
-            ksdev=$(disk_to_dev_path $ksdev)
+            ksdev=$(disk_to_dev_path "$ksdev")
             when_diskdev_appears "$ksdev" \
                 fetch-kickstart-disk "\$env{DEVNAME}" "$kspath"
         fi
@@ -29,7 +29,7 @@ case "${kickstart%%:*}" in
     ;;
     "")
         if [ -z "$kickstart" -a -z "$(getarg inst.ks=)" ]; then
-            when_diskdev_appears $(disk_to_dev_path LABEL=OEMDRV) \
+            when_diskdev_appears "$(disk_to_dev_path LABEL=OEMDRV)" \
                 fetch-kickstart-disk "\$env{DEVNAME}" "/ks.cfg"
         fi
     ;;

--- a/dracut/parse-anaconda-dd.sh
+++ b/dracut/parse-anaconda-dd.sh
@@ -16,13 +16,13 @@ for dd in $(getargs inst.dd=); do
         # plain 'dd'/'inst.dd': Engage interactive mode!
         dd|inst.dd) echo menu > /tmp/dd_interactive ;;
         # network URLs: require net, add to dd_net
-        http:*|https:*|ftp:*|nfs:*|nfs4:*) set_neednet; echo $dd >> /tmp/dd_net ;;
+        http:*|https:*|ftp:*|nfs:*|nfs4:*) set_neednet; echo "$dd" >> /tmp/dd_net ;;
         # disks: strip "cdrom:" or "hd:" and add to dd_disk
-        cdrom:*|hd:*) echo ${dd#*:} >> /tmp/dd_disk ;;
+        cdrom:*|hd:*) echo "${dd#*:}" >> /tmp/dd_disk ;;
         # images crammed into initrd: strip "file:" or "path:"
-        file:*|path:*) echo ${dd#*:} >> /tmp/dd_disk ;;
+        file:*|path:*) echo "${dd#*:}" >> /tmp/dd_disk ;;
         # anything else is assumed to be a disk (or disk image)
-        *) echo $dd >> /tmp/dd_disk ;;
+        *) echo "$dd" >> /tmp/dd_disk ;;
     esac
 done
 

--- a/dracut/parse-anaconda-kickstart.sh
+++ b/dracut/parse-anaconda-kickstart.sh
@@ -33,7 +33,7 @@ case "${kickstart%%:*}" in
         splitsep ":" "$kickstart" kstype kspath
         if [ -f "$kspath" ]; then
             info "anaconda: parsing kickstart $kspath"
-            cp $kspath /tmp/ks.cfg
+            cp "$kspath" /tmp/ks.cfg
             parse_kickstart /tmp/ks.cfg
             [ "$root" = "anaconda-kickstart" ] && root=""
             > /tmp/ks.cfg.done

--- a/dracut/parse-anaconda-net.sh
+++ b/dracut/parse-anaconda-net.sh
@@ -8,10 +8,10 @@ check_depr_arg "dns" "nameserver=%s"
 mac_to_bootif() {
     local bootif=${1}
     local IFS=':'
-    bootif=$(for i in ${bootif} ; do echo -n $i-; done)
+    bootif=$(for i in ${bootif} ; do echo -n "$i-"; done)
     bootif=${bootif%-}
     bootif="01-$bootif"
-    echo $bootif
+    echo "$bootif"
 }
 
 # handle ksdevice (tell us which device to use for ip= stuff later)

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -5,7 +5,7 @@
 . /lib/url-lib.sh
 
 # create the repodir and isodir that anaconda will look for
-mkdir -p $repodir $isodir
+mkdir -p "$repodir" "$isodir"
 
 # add some modules
 modprobe -q edd
@@ -23,7 +23,7 @@ else
     strstr "$uuid" "." && arch=${uuid##*.}
 fi
 [ -z "$arch" ] && arch=$(uname -m)
-echo Loading $product $version $arch installer...
+echo Loading "$product" "$version" "$arch" installer...
 
 # set HTTP headers so server(s) will recognize us
 set_http_header "X-Anaconda-Architecture" "$arch"
@@ -32,7 +32,7 @@ set_http_header "X-Anaconda-System-Release" "$product"
 # convenience function to warn the user about old argument names.
 warn_renamed_arg() {
     local arg=""
-    arg="$(getarg $1)" && warn_critical "'$1=$arg'" && \
+    arg="$(getarg "$1")" && warn_critical "'$1=$arg'" && \
         warn_critical "$1 has been deprecated and will be removed. Please use $2 instead."
 }
 
@@ -40,7 +40,7 @@ warn_renamed_arg() {
 check_depr_arg() {
     local arg="" quiet="" newval=""
     if [ "$1" == "--quiet" ]; then quiet=1; shift; fi
-    arg="$(getarg $1)"
+    arg="$(getarg "$1")"
     [ "$arg" ] || return 1
     newval=$(printf "$2" "$arg")
     [ "$quiet" ] || warn_critical "'$1' is deprecated. Using '$newval' instead."
@@ -48,7 +48,7 @@ check_depr_arg() {
 }
 check_depr_args() {
     local q=""
-    for i in $(getargs $1); do check_depr_arg $q "$i" "$2" && q="--quiet"; done
+    for i in $(getargs "$1"); do check_depr_arg $q "$i" "$2" && q="--quiet"; done
 }
 check_removed_arg() {
     local arg="$1"; shift

--- a/dracut/repo-genrules.sh
+++ b/dracut/repo-genrules.sh
@@ -8,9 +8,9 @@ case "$root" in
   anaconda-disk:*)
     # anaconda-disk:<device>[:<path>]
     splitsep ":" "$root" f diskdev diskpath
-    diskdev=$(disk_to_dev_path $diskdev)
-    when_diskdev_appears $diskdev \
-        anaconda-diskroot "\$env{DEVNAME}" $diskpath
+    diskdev=$(disk_to_dev_path "$diskdev")
+    when_diskdev_appears "$diskdev" \
+        anaconda-diskroot "\$env{DEVNAME}" "$diskpath"
   ;;
   anaconda-auto-cd)
     # special catch-all rule for CDROMs

--- a/dracut/save-initramfs.sh
+++ b/dracut/save-initramfs.sh
@@ -6,7 +6,7 @@ initramfs=""
 
 # First, check to see if we can find a copy of initramfs laying around
 for i in images/pxeboot/initrd.img ppc/ppc64/initrd.img images/initrd.img; do
-    [ -f $repodir/$i ] && initramfs=$repodir/$i && break
+    [ -f "$repodir/$i" ] && initramfs=$repodir/$i && break
 done
 
 
@@ -22,6 +22,6 @@ fi
 
 
 # Make sure dracut-shutdown.service can find the initramfs later.
-mkdir -p $NEWROOT/boot
-ln -s $initramfs $NEWROOT/boot/initramfs-$(uname -r).img
+mkdir -p "$NEWROOT/boot"
+ln -s $initramfs "$NEWROOT/boot/initramfs-$(uname -r).img"
 # NOTE: $repodir must also be somewhere under /run for this to work correctly

--- a/dracut/updates-genrules.sh
+++ b/dracut/updates-genrules.sh
@@ -17,8 +17,8 @@ case $updates in
         # accept hd:<dev>:<path> (or cdrom:<dev>:<path>)
         updates=${updates#hd:}; updates=${updates#cdrom:}
         splitsep ":" "$updates" dev path
-        dev=$(disk_to_dev_path $dev)
-        when_diskdev_appears $dev fetch-updates-disk "\$env{DEVNAME}" $path
+        dev=$(disk_to_dev_path "$dev")
+        when_diskdev_appears "$dev" fetch-updates-disk "\$env{DEVNAME}" "$path"
         wait_for_updates
     ;;
 esac


### PR DESCRIPTION
Shellcheck is more happy now: No SC2068 "Double quote to prevent globbing and word splitting."

This should not change anything, but we will see. Kickstart tests to run:
- [x] smoke
- [x] coverage
- [x] network (rvykydal says: maybe random choice, include bootopts, exclude bindtomac)
- [x] driverdisk-related ones