### PR TITLE
Unify the detection of the tar image

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -254,9 +254,6 @@ NOTICEABLE_FREEZE = 0.1
 # all ASCII characters
 PW_ASCII_CHARS = string.digits + string.ascii_letters + string.punctuation + " "
 
-# Recognizing a tarfile
-TAR_SUFFIX = (".tar", ".tbz", ".tgz", ".txz", ".tar.bz2", "tar.gz", "tar.xz")
-
 # screenshots
 SCREENSHOTS_DIRECTORY = "/tmp/anaconda-screenshots"
 

--- a/pyanaconda/modules/payloads/payload/live_image/initialization.py
+++ b/pyanaconda/modules/payloads/payload/live_image/initialization.py
@@ -17,6 +17,7 @@
 #
 import glob
 import os
+
 from requests.exceptions import RequestException
 
 from pyanaconda.core.constants import NETWORK_CONNECTION_TIMEOUT, IMAGE_DIR
@@ -24,7 +25,8 @@ from pyanaconda.core.util import execWithRedirect
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.payloads.payload.live_image.utils import get_local_image_path_from_url, \
-    get_proxies_from_option, url_target_is_tarfile
+    get_proxies_from_option
+from pyanaconda.modules.payloads.source.utils import is_tar
 from pyanaconda.payload.utils import mount, unmount
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -153,7 +155,7 @@ class SetupInstallationSourceImageTask(Task):
         else:
             self._download_image(self._url, self._image_path, self._session)
 
-        if not url_target_is_tarfile(self._url):
+        if not is_tar(self._url):
             self._mount_image(self._image_path, self._image_mount_point)
 
         log.debug("Source image file path: %s", self._image_path)
@@ -184,7 +186,7 @@ class TeardownInstallationSourceImageTask(Task):
 
     def run(self):
         """Run tear down of installation source image."""
-        if not url_target_is_tarfile(self._url):
+        if not is_tar(self._url):
             unmount(self._image_mount_point, raise_exc=True)
             # FIXME: Payload and LiveOS stuff
             # FIXME: do we need a task for this?

--- a/pyanaconda/modules/payloads/payload/live_image/live_image.py
+++ b/pyanaconda/modules/payloads/payload/live_image/live_image.py
@@ -87,7 +87,7 @@ class LiveImageModule(PayloadBase):
         # task.succeeded_signal.connect(lambda: self.set_image_path(task.get_result()))
         # return [task]
 
-        # if url_target_is_tarfile(self._url):
+        # if is_tar(self._url):
         #     task = InstallFromTarTask(
         #         self.image_path,
         #         conf.target.system_root,

--- a/pyanaconda/modules/payloads/payload/live_image/utils.py
+++ b/pyanaconda/modules/payloads/payload/live_image/utils.py
@@ -19,7 +19,6 @@ import tarfile
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.payload import ProxyString, ProxyStringError
-from pyanaconda.core.constants import TAR_SUFFIX
 from pyanaconda.modules.payloads.base.utils import sort_kernel_version_list
 
 log = get_module_logger(__name__)
@@ -56,8 +55,3 @@ def get_proxies_from_option(proxy_option):
         except ProxyStringError as e:
             log.info("Failed to parse proxy \"%s\": %s", proxy_option, e)
     return proxies
-
-
-def url_target_is_tarfile(url):
-    """Does the url point to a tarfile?"""
-    return any(url.endswith(suffix) for suffix in TAR_SUFFIX)

--- a/pyanaconda/modules/payloads/source/utils.py
+++ b/pyanaconda/modules/payloads/source/utils.py
@@ -29,6 +29,19 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
+def is_tar(url):
+    """Is the given URL a path to the tarball?
+
+    :param url: a string with URL
+    :return: True or False
+    """
+    if not url:
+        return False
+
+    tar_suffixes = (".tar", ".tbz", ".tgz", ".txz", ".tar.bz2", "tar.gz", "tar.xz")
+    return any(url.endswith(s) for s in tar_suffixes)
+
+
 def has_network_protocol(url):
     """Does the given URL have a network protocol?
 

--- a/pyanaconda/modules/payloads/source/utils.py
+++ b/pyanaconda/modules/payloads/source/utils.py
@@ -38,7 +38,7 @@ def is_tar(url):
     if not url:
         return False
 
-    tar_suffixes = (".tar", ".tbz", ".tgz", ".txz", ".tar.bz2", "tar.gz", "tar.xz")
+    tar_suffixes = (".tar", ".tbz", ".tgz", ".txz", ".tar.bz2", ".tar.gz", ".tar.xz")
     return any(url.endswith(s) for s in tar_suffixes)
 
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_utils.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_utils.py
@@ -34,6 +34,14 @@ class SourceUtilsTestCase(unittest.TestCase):
         assert not is_tar("http://my/path.img")
         assert not is_tar("https://my/path.tarball")
 
+        assert not is_tar("/my/tar")
+        assert not is_tar("file://my/tbz")
+        assert not is_tar("http://my/tgz")
+        assert not is_tar("https://my/txz")
+        assert not is_tar("/my/tar.bz2")
+        assert not is_tar("file://my/tar.gz")
+        assert not is_tar("http://my/tar.xz")
+
         assert is_tar("/my/path.tar")
         assert is_tar("file://my/path.tbz")
         assert is_tar("http://my/path.tgz")

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_utils.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_utils.py
@@ -19,10 +19,32 @@ from io import StringIO
 import unittest
 from unittest.mock import patch
 
-from pyanaconda.modules.payloads.source.utils import is_valid_install_disk
+from pyanaconda.modules.payloads.source.utils import is_valid_install_disk, is_tar
+
+
+class SourceUtilsTestCase(unittest.TestCase):
+    """Test the source utils."""
+
+    def test_is_tar(self):
+        """Test the is_tar function."""
+        assert not is_tar(None)
+        assert not is_tar("")
+        assert not is_tar("/my/path")
+        assert not is_tar("file://my/path.")
+        assert not is_tar("http://my/path.img")
+        assert not is_tar("https://my/path.tarball")
+
+        assert is_tar("/my/path.tar")
+        assert is_tar("file://my/path.tbz")
+        assert is_tar("http://my/path.tgz")
+        assert is_tar("https://my/path.txz")
+        assert is_tar("/my/path.tar.bz2")
+        assert is_tar("file://my/path.tar.gz")
+        assert is_tar("http://my/path.tar.xz")
 
 
 class IsValidMethodTestCase(unittest.TestCase):
+    """Test the is_valid_install_disk function."""
 
     @patch("pyanaconda.modules.payloads.source.utils.get_arch",
            return_value="test-arch")


### PR DESCRIPTION
Use the `is_tar` function to detect a tar image based on the given URL.