### PR TITLE
Enable automatic proposing of Fedora releases in Packit (#infa)

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -9,6 +9,11 @@ actions:
     - "make release"
     - 'bash -c "ls -1 anaconda-*.tar.bz2"'
 jobs:
+  - job: propose_downstream
+    trigger: release
+    metadata:
+      dist_git_branches: fedora-development
+
   - job: tests
     trigger: pull_request
     metadata:


### PR DESCRIPTION
I wasn't able to test this locally which may be expected behavior. So or so, it will create a PR where we see the proposed change and then we can do more modification / fixes based on that.

Next part of this change will remove `%changelog` from the upstream spec file. Packit should handle that from us. It will generate `%changelog` from commit headers.

Filed an issue to [Packit](https://github.com/packit/packit/issues/1413) about not working `packit propose-downstream`.