### PR TITLE
Fix the condition for completing the root configuration (#1981807)

### DIFF
--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -196,10 +196,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     @property
     def completed(self):
-        return bool(
-            self._users_module.IsRootPasswordSet or
-            (self._users_module.IsRootAccountLocked and flags.automatedInstall)
-        )
+        return self._users_module.IsRootPasswordSet
 
     @property
     def sensitive(self):

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -31,7 +31,6 @@ from pyanaconda.ui.gui.helpers import GUISpokeInputCheckHandler
 from pyanaconda.ui.gui.utils import set_password_visibility
 from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.ui.communication import hubQ
-from pyanaconda.ui.lib.services import is_reconfiguration_mode
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -153,13 +152,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     @property
     def status(self):
         if self._users_module.IsRootAccountLocked:
-            # reconfig mode currently allows re-enabling a locked root account if
-            # user sets a new root password
-            if is_reconfiguration_mode():
-                return _("Disabled, set password to enable.")
-            else:
-                return _("Root account is disabled.")
-
+            return _("Root account is disabled.")
         elif self._users_module.IsRootPasswordSet:
             return _("Root password is set")
         else:

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -200,11 +200,20 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     @property
     def sensitive(self):
-        # A password set in kickstart can only be changed in the GUI
-        # if the changesok password policy is set for the root password.
-        kickstarted_password_cant_be_changed = not self._users_module.CanChangeRootPassword \
-                                and not self.checker.policy.changesok
-        return not (self.completed and flags.automatedInstall and kickstarted_password_cant_be_changed)
+        # Allow changes in the interactive mode.
+        if not flags.automatedInstall:
+            return True
+
+        # Does the configuration allow changes?
+        if self._checker.policy.changesok:
+            return True
+
+        # Allow changes if the root account isn't
+        # already configured by the kickstart file.
+        if self._users_module.CanChangeRootPassword:
+            return True
+
+        return False
 
     def _checks_done(self, error_message):
         """Update the warning with the input validation error from the first

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -63,7 +63,20 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     @property
     def showable(self):
-        return not (self.completed and flags.automatedInstall and not self._policy.changesok)
+        # Allow changes in the interactive mode.
+        if not flags.automatedInstall:
+            return True
+
+        # Does the configuration allow changes?
+        if self._policy.changesok:
+            return True
+
+        # Allow changes if the root account isn't
+        # already configured by the kickstart file.
+        if self._users_module.CanChangeRootPassword:
+            return True
+
+        return False
 
     @property
     def mandatory(self):

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -18,7 +18,6 @@
 #
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
-from pyanaconda.ui.lib.services import is_reconfiguration_mode
 from pyanaconda.ui.tui.tuiobject import PasswordDialog
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
@@ -86,13 +85,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
     @property
     def status(self):
         if self._users_module.IsRootAccountLocked:
-            # reconfig mode currently allows re-enabling a locked root account if
-            # user sets a new root password
-            if is_reconfiguration_mode():
-                return _("Disabled. Set password to enable root account.")
-            else:
-                return _("Root account is disabled.")
-
+            return _("Root account is disabled.")
         elif self._users_module.IsRootPasswordSet:
             return _("Password is set.")
         else:

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -59,10 +59,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     @property
     def completed(self):
-        return bool(
-            self._users_module.IsRootPasswordSet or
-            (self._users_module.IsRootAccountLocked and flags.automatedInstall)
-        )
+        return self._users_module.IsRootPasswordSet
 
     @property
     def showable(self):


### PR DESCRIPTION
Revert changes in the `completed` property of the root configuration spoke
that were done in the commits e1dd6aa and 862eee2. They were never necessary.

Resolves: rhbz#1981807