### PR TITLE
Fix generating of the kernel boot argument rd.znet= on s390x

### DIFF
--- a/pyanaconda/modules/network/nm_client.py
+++ b/pyanaconda/modules/network/nm_client.py
@@ -1331,9 +1331,10 @@ def _get_dracut_znet_argument_from_connection(connection):
     wired_setting = connection.get_setting_wired()
     if wired_setting and is_s390():
         nettype = wired_setting.get_s390_nettype()
+        # get_s390_subchannels() returns a list of subchannels
         subchannels = wired_setting.get_s390_subchannels()
         if nettype and subchannels:
-            argument = "rd.znet={},{}".format(nettype, subchannels)
+            argument = "rd.znet={},{}".format(nettype, ",".join(subchannels))
             options = wired_setting.get_property(NM.SETTING_WIRED_S390_OPTIONS)
             if options:
                 options_string = ','.join("{}={}".format(key, val) for key, val in options.items())

--- a/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_nm_client.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_nm_client.py
@@ -135,7 +135,7 @@ class NMClientTestCase(unittest.TestCase):
         is_s390.return_value = True
         wired_setting_attrs = {
             "get_s390_nettype.return_value": "",
-            "get_s390_subchannels.return_value": "",
+            "get_s390_subchannels.return_value": [],
             "get_property.return_value": {},
         }
         wired_setting = self._get_mock_objects_from_attrs([wired_setting_attrs])[0]
@@ -155,7 +155,7 @@ class NMClientTestCase(unittest.TestCase):
         is_s390.return_value = True
         wired_setting_attrs = {
             "get_s390_nettype.return_value": "qeth",
-            "get_s390_subchannels.return_value": "0.0.0900,0.0.0901,0.0.0902",
+            "get_s390_subchannels.return_value": ["0.0.0900", "0.0.0901", "0.0.0902"],
             "get_property.return_value": {"layer2": "1",
                                           "portname": "FOOBAR",
                                           "portno": "0"},
@@ -226,7 +226,7 @@ class NMClientTestCase(unittest.TestCase):
         wired_setting_attrs = {
             "get_mac_address.return_value": None,
             "get_s390_nettype.return_value": "qeth",
-            "get_s390_subchannels.return_value": "0.0.0900,0.0.0901,0.0.0902",
+            "get_s390_subchannels.return_value": ["0.0.0900", "0.0.0901", "0.0.0902"],
             "get_property.return_value": {"layer2": "1",
                                           "portname": "FOOBAR",
                                           "portno": "0"},
@@ -350,7 +350,7 @@ class NMClientTestCase(unittest.TestCase):
         wired_setting_attrs = {
             "get_mac_address.return_value": None,
             "get_s390_nettype.return_value": "qeth",
-            "get_s390_subchannels.return_value": "0.0.0900,0.0.0901,0.0.0902",
+            "get_s390_subchannels.return_value": ["0.0.0900", "0.0.0901", "0.0.0902"],
             "get_property.return_value": {"layer2": "1",
                                           "portname": "FOOBAR",
                                           "portno": "0"},
@@ -432,7 +432,7 @@ class NMClientTestCase(unittest.TestCase):
         wired_setting_attrs = {
             "get_mac_address.return_value": None,
             "get_s390_nettype.return_value": "qeth",
-            "get_s390_subchannels.return_value": "0.0.0900,0.0.0901,0.0.0902",
+            "get_s390_subchannels.return_value": ["0.0.0900", "0.0.0901", "0.0.0902"],
             "get_property.return_value": {"layer2": "1",
                                           "portname": "FOOBAR",
                                           "portno": "0"},


### PR DESCRIPTION
The get_s390_subchannels() method returns a list of subchannels and the
rd.znet= boot argument is incorrectly generated as:
rd.znet=qeth,['0.0.0a00', '0.0.0a01', '0.0.0a02'],layer2=1,portno=0

This change will fix it to:
rd.znet=qeth,0.0.0900,0.0.0901,0.0.0902,layer2=1,portno=0