### PR TITLE
Reset the goal during clearing the DNF cache (#2020754)

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -463,7 +463,7 @@ class DNFManager(object):
         """Clear the DNF cache."""
         shutil.rmtree(DNF_CACHE_DIR, ignore_errors=True)
         shutil.rmtree(DNF_PLUGINCONF_DIR, ignore_errors=True)
-        self._base.reset(sack=True, repos=True)
+        self._base.reset(sack=True, repos=True, goal=True)
         log.debug("The DNF cache has been cleared.")
 
     def is_package_available(self, package_spec):


### PR DESCRIPTION
We shouldn't keep data about the previous transaction. We will reset it anyway.

Resolves: rhbz#2020754