### PR TITLE
Fix double quotes in dracut package module-setup

### DIFF
--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -72,11 +72,11 @@ install() {
     # timeout script for errors reporting
     inst_hook initqueue/timeout 50 "$moddir/anaconda-error-reporting.sh"
     # python deps for parse-kickstart. DOUBLE WOOOO
-    PYTHONHASHSEED=42 $moddir/python-deps $moddir/parse-kickstart $moddir/driver_updates.py | while read dep; do
+    PYTHONHASHSEED=42 "$moddir/python-deps" "$moddir/parse-kickstart" "$moddir/driver_updates.py" | while read dep; do
         case "$dep" in
-            *.so) inst_library $dep ;;
-            *.py) inst_simple $dep ;;
-            *) inst $dep ;;
+            *.so) inst_library "$dep" ;;
+            *.py) inst_simple "$dep" ;;
+            *) inst "$dep" ;;
         esac
     done
 


### PR DESCRIPTION
Shellcheck approved.

This is the easy part. It's a separate commit and PR because the failure would manifest in yet another place.

I believe the full ISO build during kickstart tests should be enough to test this, but I'm not sure.