### PR TITLE
Decorate installer window on Live

### DIFF
--- a/data/profile.d/fedora-workstation.conf
+++ b/data/profile.d/fedora-workstation.conf
@@ -18,6 +18,7 @@ menu_auto_hide = True
 
 [User Interface]
 custom_stylesheet = /usr/share/anaconda/pixmaps/workstation/fedora-workstation.css
+decorated_window = True
 hidden_spokes =
     NetworkSpoke
     PasswordSpoke


### PR DESCRIPTION
Live has the GNOME bar at top, and dragging down from it will "restore" the window to a nonsensical small size. Without decorations, the window cannot be maximized again except for keyboard shortcuts.

Resolves: [rhbz#1998720](https://bugzilla.redhat.com/show_bug.cgi?id=1998720)