### PR TITLE
Add a mnemonic (alt-s) to the LUKS version dropdown

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom_storage.glade
+++ b/pyanaconda/ui/gui/spokes/custom_storage.glade
@@ -935,7 +935,7 @@
                                                         <property name="visible">True</property>
                                                         <property name="can_focus">False</property>
                                                         <property name="xalign">0</property>
-                                                        <property name="label" translatable="yes" context="GUI|Custom Partitioning|Configure">LUKS Version:</property>
+                                                        <property name="label" translatable="yes" context="GUI|Custom Partitioning|Configure">LUK_S Version:</property>
                                                         <property name="use_underline">True</property>
                                                         <property name="mnemonic_widget">luksVersionCombo</property>
                                                         <attributes>


### PR DESCRIPTION
SSIA.

Unfortunately there's nothing to screenshot, the underline is visible only when you hold down alt.