### PR TITLE
Don't start the Subscription module if unsupported

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -7,18 +7,29 @@
 debug = False
 
 # Enable Anaconda addons.
-addons_enabled = True
+# This option is deprecated and will be removed in in the future.
+# addons_enabled = True
 
 # List of enabled Anaconda DBus modules.
-kickstart_modules =
-    org.fedoraproject.Anaconda.Modules.Timezone
-    org.fedoraproject.Anaconda.Modules.Network
-    org.fedoraproject.Anaconda.Modules.Localization
-    org.fedoraproject.Anaconda.Modules.Security
-    org.fedoraproject.Anaconda.Modules.Users
-    org.fedoraproject.Anaconda.Modules.Payloads
-    org.fedoraproject.Anaconda.Modules.Storage
-    org.fedoraproject.Anaconda.Modules.Services
+# This option is deprecated and will be removed in in the future.
+# kickstart_modules =
+
+# List of Anaconda DBus modules that can be activated.
+# Supported patterns: MODULE.PREFIX.*, MODULE.NAME
+activatable_modules =
+    org.fedoraproject.Anaconda.Modules.*
+    org.fedoraproject.Anaconda.Addons.*
+
+# List of Anaconda DBus modules that are not allowed to run.
+# Supported patterns: MODULE.PREFIX.*, MODULE.NAME
+forbidden_modules =
+
+# List of Anaconda DBus modules that can fail to run.
+# The installation won't be aborted because of them.
+# Supported patterns: MODULE.PREFIX.*, MODULE.NAME
+optional_modules =
+    org.fedoraproject.Anaconda.Modules.Subscription
+    org.fedoraproject.Anaconda.Addons.*
 
 
 [Installation System]

--- a/data/product.d/almalinux.conf
+++ b/data/product.d/almalinux.conf
@@ -7,17 +7,8 @@ product_name = AlmaLinux
 product_name = Red Hat Enterprise Linux
 
 [Anaconda]
-# List of enabled Anaconda DBus modules for RHEL.
-#  but without org.fedoraproject.Anaconda.Modules.Subscription
-kickstart_modules =
-    org.fedoraproject.Anaconda.Modules.Timezone
-    org.fedoraproject.Anaconda.Modules.Network
-    org.fedoraproject.Anaconda.Modules.Localization
-    org.fedoraproject.Anaconda.Modules.Security
-    org.fedoraproject.Anaconda.Modules.Users
-    org.fedoraproject.Anaconda.Modules.Payloads
-    org.fedoraproject.Anaconda.Modules.Storage
-    org.fedoraproject.Anaconda.Modules.Services
+forbidden_modules =
+    org.fedoraproject.Anaconda.Modules.Subscription
 
 [Bootloader]
 efi_dir = almalinux

--- a/data/product.d/centos-stream.conf
+++ b/data/product.d/centos-stream.conf
@@ -7,17 +7,8 @@ product_name = CentOS Stream
 product_name = Red Hat Enterprise Linux
 
 [Anaconda]
-# List of enabled Anaconda DBus modules for RHEL.
-#  but without org.fedoraproject.Anaconda.Modules.Subscription
-kickstart_modules =
-    org.fedoraproject.Anaconda.Modules.Timezone
-    org.fedoraproject.Anaconda.Modules.Network
-    org.fedoraproject.Anaconda.Modules.Localization
-    org.fedoraproject.Anaconda.Modules.Security
-    org.fedoraproject.Anaconda.Modules.Users
-    org.fedoraproject.Anaconda.Modules.Payloads
-    org.fedoraproject.Anaconda.Modules.Storage
-    org.fedoraproject.Anaconda.Modules.Services
+forbidden_modules =
+    org.fedoraproject.Anaconda.Modules.Subscription
 
 [Bootloader]
 efi_dir = centos

--- a/data/product.d/fedora-eln.conf
+++ b/data/product.d/fedora-eln.conf
@@ -6,6 +6,10 @@ product_name = Fedora-ELN
 [Base Product]
 product_name = Red Hat Enterprise Linux
 
+[Anaconda]
+forbidden_modules =
+    org.fedoraproject.Anaconda.Modules.Subscription
+
 [Bootloader]
 efi_dir = fedora
 
@@ -20,16 +24,3 @@ default_environment = custom-environment
 default_source = CLOSEST_MIRROR
 default_rpm_gpg_keys =
     /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
-
-[Anaconda]
-# List of enabled Anaconda DBus modules.
-kickstart_modules =
-    org.fedoraproject.Anaconda.Modules.Timezone
-    org.fedoraproject.Anaconda.Modules.Network
-    org.fedoraproject.Anaconda.Modules.Localization
-    org.fedoraproject.Anaconda.Modules.Security
-    org.fedoraproject.Anaconda.Modules.Users
-    org.fedoraproject.Anaconda.Modules.Payloads
-    org.fedoraproject.Anaconda.Modules.Storage
-    org.fedoraproject.Anaconda.Modules.Services
-

--- a/data/product.d/rhel.conf
+++ b/data/product.d/rhel.conf
@@ -3,19 +3,6 @@
 [Product]
 product_name = Red Hat Enterprise Linux
 
-[Anaconda]
-# List of enabled Anaconda DBus modules for RHEL.
-kickstart_modules =
-    org.fedoraproject.Anaconda.Modules.Timezone
-    org.fedoraproject.Anaconda.Modules.Network
-    org.fedoraproject.Anaconda.Modules.Localization
-    org.fedoraproject.Anaconda.Modules.Security
-    org.fedoraproject.Anaconda.Modules.Users
-    org.fedoraproject.Anaconda.Modules.Payloads
-    org.fedoraproject.Anaconda.Modules.Storage
-    org.fedoraproject.Anaconda.Modules.Services
-    org.fedoraproject.Anaconda.Modules.Subscription
-
 [Installation System]
 # The detection is disabled since #1645686.
 # can_detect_unsupported_hardware = True

--- a/data/product.d/scientific-linux.conf
+++ b/data/product.d/scientific-linux.conf
@@ -7,17 +7,8 @@ product_name = Scientific Linux
 product_name = Red Hat Enterprise Linux
 
 [Anaconda]
-# List of enabled Anaconda DBus modules for RHEL.
-#  but without org.fedoraproject.Anaconda.Modules.Subscription
-kickstart_modules =
-    org.fedoraproject.Anaconda.Modules.Timezone
-    org.fedoraproject.Anaconda.Modules.Network
-    org.fedoraproject.Anaconda.Modules.Localization
-    org.fedoraproject.Anaconda.Modules.Security
-    org.fedoraproject.Anaconda.Modules.Users
-    org.fedoraproject.Anaconda.Modules.Payloads
-    org.fedoraproject.Anaconda.Modules.Storage
-    org.fedoraproject.Anaconda.Modules.Services
+forbidden_modules =
+    org.fedoraproject.Anaconda.Modules.Subscription
 
 [Payload]
 default_source = CLOSEST_MIRROR

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -18,6 +18,7 @@
 #  Author(s):  Vendula Poncova <vponcova@redhat.com>
 #
 import os
+import warnings
 
 from pyanaconda.core.configuration.bootloader import BootloaderSection, BootloaderType
 from pyanaconda.core.configuration.license import LicenseSection
@@ -46,14 +47,87 @@ class AnacondaSection(Section):
         return self._get_option("debug", bool)
 
     @property
-    def addons_enabled(self):
-        """Enable Anaconda addons."""
-        return self._get_option("addons_enabled", bool)
+    def activatable_modules(self):
+        """List of Anaconda DBus modules that can be activated.
+
+        Supported patterns:
+
+            MODULE.PREFIX.*
+            MODULE.NAME
+
+        :return: a list of patterns
+        """
+        return self._get_deprecated_activatable_modules() \
+            or self._get_option("activatable_modules").split()
+
+    def _get_deprecated_activatable_modules(self):
+        """Get a list of deprecated activatable modules.
+
+        FIXME: This is a temporary workaround.
+
+        If the kickstart_modules option is defined in the configuration,
+        allow to activate only the specified modules and Anaconda addons.
+        """
+        if not self._has_option("kickstart_modules"):
+            return []
+
+        warnings.warn(
+            "The kickstart_modules configuration option is deprecated and "
+            "will be removed in in the future.", DeprecationWarning
+        )
+
+        return self._get_option("kickstart_modules").split() \
+            + ["org.fedoraproject.Anaconda.Addons.*"]
 
     @property
-    def kickstart_modules(self):
-        """List of enabled kickstart modules."""
-        return self._get_option("kickstart_modules").split()
+    def forbidden_modules(self):
+        """List of Anaconda DBus modules that are not allowed to run.
+
+        Supported patterns:
+
+            MODULE.PREFIX.*
+            MODULE.NAME
+
+        :return: a list of patterns
+        """
+        return self._get_deprecated_forbidden_modules() \
+            + self._get_option("forbidden_modules").split()
+
+    def _get_deprecated_forbidden_modules(self):
+        """Get a list of deprecated forbidden modules.
+
+        FIXME: This is a temporary workaround.
+
+        If the addons_enabled option is defined in the configuration
+        and set to False, don't allow to activate Anaconda addons.
+        """
+        if not self._has_option("addons_enabled"):
+            return []
+
+        warnings.warn(
+            "The addons_enabled configuration option is deprecated and "
+            "will be removed in in the future.", DeprecationWarning
+        )
+
+        if self._get_option("addons_enabled", bool):
+            return []
+
+        return ["org.fedoraproject.Anaconda.Addons.*"]
+
+    @property
+    def optional_modules(self):
+        """List of Anaconda DBus modules that can fail to run.
+
+        The installation won't be aborted because of them.
+
+        Supported patterns:
+
+            MODULE.PREFIX.*
+            MODULE.NAME
+
+        :return: a list of patterns
+        """
+        return self._get_option("optional_modules").split()
 
 
 class AnacondaConfiguration(Configuration):

--- a/pyanaconda/core/configuration/base.py
+++ b/pyanaconda/core/configuration/base.py
@@ -145,6 +145,14 @@ class Section(ABC):
         self._section_name = section_name
         self._parser = parser
 
+    def _has_option(self, option_name):
+        """Is the specified option defined?.
+
+        :param option_name: an option name
+        :return: True or False
+        """
+        return self._parser.has_option(self._section_name, option_name)
+
     def _get_option(self, option_name, converter=None):
         """Get a converted value of the option.
 

--- a/pyanaconda/modules/boss/module_manager/module_manager.py
+++ b/pyanaconda/modules/boss/module_manager/module_manager.py
@@ -45,9 +45,10 @@ class ModuleManager(object):
     def start_modules_with_task(self):
         """Start modules with the task."""
         task = StartModulesTask(
-            DBus,
-            conf.anaconda.kickstart_modules,
-            conf.anaconda.addons_enabled
+            message_bus=DBus,
+            activatable=conf.anaconda.activatable_modules,
+            forbidden=conf.anaconda.forbidden_modules,
+            optional=conf.anaconda.optional_modules,
         )
         task.succeeded_signal.connect(
             lambda: self.set_module_observers(task.get_result())

--- a/pyanaconda/modules/boss/module_manager/module_observer.py
+++ b/pyanaconda/modules/boss/module_manager/module_observer.py
@@ -14,9 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from pyanaconda.anaconda_loggers import get_module_logger
-from dasbus.namespace import get_namespace_from_name, get_dbus_path
+from dasbus.namespace import get_namespace_from_name, get_dbus_path, get_dbus_name
 from dasbus.client.observer import DBusObserver, DBusObserverError
+
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.modules.common.constants.namespaces import ADDONS_NAMESPACE
 
 log = get_module_logger(__name__)
 
@@ -24,16 +26,15 @@ log = get_module_logger(__name__)
 class ModuleObserver(DBusObserver):
     """Observer of an Anaconda module."""
 
-    def __init__(self, message_bus, service_name, is_addon=False):
+    def __init__(self, message_bus, service_name):
         """Creates a module observer.
 
         :param message_bus: a message bus
         :param service_name: a DBus name of a service
-        :param is_addon: is the observed module an addon?
         """
         super().__init__(message_bus, service_name)
         self._proxy = None
-        self._is_addon = is_addon
+        self._is_addon = service_name.startswith(get_dbus_name(*ADDONS_NAMESPACE))
         self._namespace = get_namespace_from_name(service_name)
         self._object_path = get_dbus_path(*self._namespace)
 

--- a/pyanaconda/modules/subscription/__main__.py
+++ b/pyanaconda/modules/subscription/__main__.py
@@ -17,9 +17,15 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+# Initialize the service.
 from pyanaconda.modules.common import init
 init()
 
+# Check the initial conditions.
+from pyanaconda.modules.subscription.initialization import check_initial_conditions
+check_initial_conditions()
+
+# Start the service.
 from pyanaconda.modules.subscription.subscription import SubscriptionService
 service = SubscriptionService()
 service.run()

--- a/pyanaconda/modules/subscription/initialization.py
+++ b/pyanaconda/modules/subscription/initialization.py
@@ -19,8 +19,10 @@
 #
 
 import os
+import sys
 
 from dasbus.typing import get_variant, Str
+from pyanaconda.core.configuration.anaconda import conf
 
 from pyanaconda.core import util
 from pyanaconda.core.constants import RHSM_SERVICE_TIMEOUT
@@ -34,6 +36,26 @@ from pyanaconda.modules.subscription.constants import RHSM_SERVICE_NAME
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
+
+
+def check_initial_conditions():
+    """Can the Subscription service run?"""
+
+    # Exclude the dir and image installations.
+    if not conf.target.is_hardware:
+        log.debug(
+            "subscription: Unsupported type of the installation target. "
+            "The Subscription module won't be started."
+        )
+        sys.exit(1)
+
+    # Exclude environments without the rhsm service.
+    if not util.is_service_installed(RHSM_SERVICE_NAME, root="/"):
+        log.debug(
+            "subscription: The required rhsm systemd service is not available. "
+            "The Subscription module won't be started."
+        )
+        sys.exit(1)
 
 
 class StartRHSMTask(Task):

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -299,32 +299,6 @@ class ProductConfigurationTestCase(unittest.TestCase):
             ENTERPRISE_PARTITIONING
         )
 
-    def product_module_list_difference_fedora_rhel_test(self):
-        """Test for expected Fedora & RHEL module list differences."""
-        fedora_config = self._get_config("Fedora")
-        fedora_modules = fedora_config.anaconda.kickstart_modules
-
-        rhel_config = self._get_config("Red Hat Enterprise Linux")
-        rhel_modules = rhel_config.anaconda.kickstart_modules
-
-        difference = list(set(rhel_modules) - set(fedora_modules))
-        expected_difference = ["org.fedoraproject.Anaconda.Modules.Subscription"]
-
-        self.assertListEqual(difference, expected_difference)
-
-    def product_module_difference_centos_rhel_test(self):
-        """Test for expected CentOS & RHEL module list differences."""
-        centos_config = self._get_config("CentOS Linux")
-        centos_modules = centos_config.anaconda.kickstart_modules
-
-        rhel_config = self._get_config("Red Hat Enterprise Linux")
-        rhel_modules = rhel_config.anaconda.kickstart_modules
-
-        difference = list(set(rhel_modules) - set(centos_modules))
-        expected_difference = ["org.fedoraproject.Anaconda.Modules.Subscription"]
-
-        self.assertListEqual(difference, expected_difference)
-
     def _compare_product_files(self, file_name, other_file_name):
         parser = create_parser()
         read_config(parser, os.path.join(PRODUCT_DIR, file_name))


### PR DESCRIPTION
Use the `activatable_modules` option to specify Anaconda DBus modules that can be
activated. Use the `forbidden_modules` option to specify modules that are not
allowed to run. Use the `optional_modules` to specify modules that can fail to
run without aborting the installation.

The `addons_enabled` and `kickstart_modules` options are deprecated and will be
removed in the future.

Don't start the Subscription module if the initial conditions are not met.

(chery-picked from https://github.com/rhinstaller/anaconda/pull/3464)

**Resolves: rhbz#1957063**
