### PR TITLE
The OPAL compatibility with XFS features is mandatory (#2008792)

### DIFF
--- a/pyanaconda/modules/storage/checker/utils.py
+++ b/pyanaconda/modules/storage/checker/utils.py
@@ -243,7 +243,7 @@ def verify_opal_compatibility(storage, constraints, report_error, report_warning
         # Is /boot on XFS?
         dev = storage.mountpoints.get("/boot") or storage.mountpoints.get("/")
         if dev and dev.format and dev.format.type == "xfs":
-            report_warning(_(
+            report_error(_(
                 "Your firmware doesn't support XFS file system features "
                 "on the /boot file system. The system will not be bootable. "
                 "Please, upgrade the firmware or change the file system type."


### PR DESCRIPTION
If the OPAL firmware is not compatible with XFS features, show a blocking error.

Resolves: rhbz#2008792