### PR TITLE
Mount and unmount the live image with tasks

### DIFF
--- a/pyanaconda/modules/payloads/payload/live_image/installation.py
+++ b/pyanaconda/modules/payloads/payload/live_image/installation.py
@@ -439,3 +439,23 @@ class InstallFromImageTask(Task):
                 "Failed to install image: "
                 "{} exited with code {}".format(cmd, rc)
             )
+
+
+class RemoveImageTask(Task):
+    """Task to remove the downloaded image."""
+
+    def __init__(self, image_path):
+        """Create a new task."""
+        super().__init__()
+        self._image_path = image_path
+
+    @property
+    def name(self):
+        """Name of the task."""
+        return "Remove the downloaded image"""
+
+    def run(self):
+        """Run the task."""
+        if os.path.exists(self._image_path):
+            log.debug("Removing the image at %s.", self._image_path)
+            os.unlink(self._image_path)

--- a/pyanaconda/modules/payloads/payload/live_image/installation.py
+++ b/pyanaconda/modules/payloads/payload/live_image/installation.py
@@ -15,15 +15,17 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import glob
 import hashlib
 import os
 import stat
 import requests
+import blivet.util
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.constants import NETWORK_CONNECTION_TIMEOUT
 from pyanaconda.core.i18n import _
-from pyanaconda.core.util import execWithRedirect, requests_session
+from pyanaconda.core.util import execWithRedirect, requests_session, join_paths
 from pyanaconda.core.string import lower_ascii
 from pyanaconda.modules.common.structures.live_image import LiveImageConfigurationData
 from pyanaconda.modules.common.task import Task
@@ -196,6 +198,94 @@ class VerifyImageChecksum(Task):
         log.debug("sha256 of %s: %s", file_path, checksum)
         print(checksum)
         return checksum
+
+
+class MountImageTask(Task):
+    """Mount the image for the installation."""
+
+    def __init__(self, image_path, image_mount_point, iso_mount_point):
+        """Create a new task.
+
+        :param image_path: a path to the downloaded image
+        :param image_mount_point: a path to the image mount point
+        :param iso_mount_point: a path to the ISO mount point
+        """
+        super().__init__()
+        self._image_path = image_path
+        self._image_mount_point = image_mount_point
+        self._iso_mount_point = iso_mount_point
+
+    @property
+    def name(self):
+        """The name of the task."""
+        return "Mount the image"
+
+    def run(self):
+        """Run the task.
+
+        :return: a path to the content that should be installed
+        """
+        self._make_root_rprivate()
+
+        # Mount the downloaded image.
+        self._mount_image(self._image_path, self._image_mount_point)
+
+        # Mount the first .img in the LiveOS directory if any.
+        iso_path = self._find_live_os_image()
+
+        if iso_path:
+            self._mount_image(iso_path, self._iso_mount_point)
+            return self._iso_mount_point
+
+        # Otherwise, use the downloaded image.
+        return self._image_mount_point
+
+    @staticmethod
+    def _make_root_rprivate():
+        """Make the mount of '/' rprivate.
+
+        Work around inability to move shared filesystems. Also,
+        do not share the image mounts with /run bind-mounted to
+        physical target root during storage.mount_filesystems.
+        """
+        rc = execWithRedirect("mount", ["--make-rprivate", "/"])
+
+        if rc != 0:
+            raise PayloadInstallationError(
+                "Failed to make the '/' mount rprivate: {}".format(rc)
+            )
+
+    def _mount_image(self, image_path, mount_point):
+        """Mount the image."""
+        try:
+            rc = blivet.util.mount(
+                image_path,
+                mount_point,
+                fstype="auto",
+                options="ro"
+            )
+        except OSError as e:
+            raise PayloadInstallationError(str(e)) from e
+
+        if rc != 0:
+            raise PayloadInstallationError(
+                "Failed to mount '{}' at '{}': {}".format(image_path, mount_point, rc)
+            )
+
+    def _find_live_os_image(self):
+        """See if there is a LiveOS/*.img style squashfs image.
+
+        :return: a relative path to the image or None
+        """
+        if not os.path.exists(join_paths(self._image_mount_point, "LiveOS")):
+            return None
+
+        img_files = glob.glob(join_paths(self._image_mount_point, "LiveOS", "*.img"))
+
+        if not img_files:
+            return None
+
+        return img_files[0]
 
 
 class InstallFromTarTask(Task):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
@@ -33,7 +33,7 @@ from pyanaconda.modules.common.errors.installation import PayloadInstallationErr
 from pyanaconda.modules.common.structures.live_image import LiveImageConfigurationData
 from pyanaconda.modules.payloads.payload.live_image.download_progress import DownloadProgress
 from pyanaconda.modules.payloads.payload.live_image.installation import VerifyImageChecksum, \
-    InstallFromImageTask, InstallFromTarTask, DownloadImageTask, MountImageTask
+    InstallFromImageTask, InstallFromTarTask, DownloadImageTask, MountImageTask, RemoveImageTask
 from pyanaconda.modules.payloads.payload.live_os.utils import get_kernel_version_list
 
 
@@ -549,3 +549,34 @@ class MountImageTaskTestCase(unittest.TestCase):
                 self._run_task()
 
             assert str(cm.value) == "Fake!"
+
+
+class RemoveImageTaskTestCase(unittest.TestCase):
+    """Test the RemoveImageTask class."""
+
+    def test_delete_existing_file(self):
+        """Delete a file that exists."""
+        with tempfile.TemporaryDirectory() as d:
+            image_path = join_paths(d, "image.img")
+            touch(image_path)
+
+            assert os.path.exists(image_path)
+
+            # Delete the file.
+            task = RemoveImageTask(image_path)
+            task.run()
+
+            assert not os.path.exists(image_path)
+
+    def test_delete_missing_file(self):
+        """Delete a file that doesn't exist."""
+        with tempfile.TemporaryDirectory() as d:
+            image_path = join_paths(d, "image.img")
+
+            assert not os.path.exists(image_path)
+
+            # Don't fail.
+            task = RemoveImageTask(image_path)
+            task.run()
+
+            assert not os.path.exists(image_path)

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
@@ -28,12 +28,12 @@ from requests_file import FileAdapter
 from unittest.mock import patch, Mock, call
 
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.util import join_paths
+from pyanaconda.core.util import join_paths, touch
 from pyanaconda.modules.common.errors.installation import PayloadInstallationError
 from pyanaconda.modules.common.structures.live_image import LiveImageConfigurationData
 from pyanaconda.modules.payloads.payload.live_image.download_progress import DownloadProgress
 from pyanaconda.modules.payloads.payload.live_image.installation import VerifyImageChecksum, \
-    InstallFromImageTask, InstallFromTarTask, DownloadImageTask
+    InstallFromImageTask, InstallFromTarTask, DownloadImageTask, MountImageTask
 from pyanaconda.modules.payloads.payload.live_os.utils import get_kernel_version_list
 
 
@@ -414,3 +414,138 @@ class DownloadImageTaskTestCase(unittest.TestCase):
                 self._run_task()
 
             assert str(cm.value) == "Error while downloading the image: Fake!"
+
+
+class MountImageTaskTestCase(unittest.TestCase):
+    """Test the MountImageTask class."""
+
+    def setUp(self):
+        """Set up the test."""
+        self.image_path = None
+        self.image_mount = None
+        self.iso_mount = None
+
+    @contextmanager
+    def _create_directory(self):
+        """Create a temporary directory."""
+        with tempfile.TemporaryDirectory() as d:
+            self.image_path = join_paths(d, "image.img")
+            self.image_mount = join_paths(d, "image")
+            self.iso_mount = join_paths(d, "iso")
+            yield d
+
+    def _run_task(self):
+        """Run the task."""
+        task = MountImageTask(
+            image_path=self.image_path,
+            image_mount_point=self.image_mount,
+            iso_mount_point=self.iso_mount
+        )
+        return task.run()
+
+    @patch("pyanaconda.modules.payloads.payload.live_image.installation.blivet.util.mount")
+    @patch("pyanaconda.modules.payloads.payload.live_image.installation.execWithRedirect")
+    def test_mount_image_no_dir(self, exec_mock, mount_mock):
+        """Mount an image without the LiveOS directory."""
+        exec_mock.return_value = 0
+        mount_mock.return_value = 0
+
+        with self._create_directory():
+            assert self._run_task() == self.image_mount
+
+            exec_mock.assert_called_once_with(
+                "mount", ["--make-rprivate", "/"]
+            )
+
+            mount_mock.assert_called_once_with(
+                self.image_path,
+                self.image_mount,
+                fstype="auto",
+                options="ro"
+            )
+
+    @patch("pyanaconda.modules.payloads.payload.live_image.installation.blivet.util.mount")
+    @patch("pyanaconda.modules.payloads.payload.live_image.installation.execWithRedirect")
+    def test_mount_image_no_iso(self, exec_mock, mount_mock):
+        """Mount an image without ISO files in the LiveOS directory."""
+        exec_mock.return_value = 0
+        mount_mock.return_value = 0
+
+        with self._create_directory():
+            iso_dir = join_paths(self.image_mount, "LiveOS")
+            os.makedirs(iso_dir)
+
+            assert self._run_task() == self.image_mount
+
+    @patch("pyanaconda.modules.payloads.payload.live_image.installation.blivet.util.mount")
+    @patch("pyanaconda.modules.payloads.payload.live_image.installation.execWithRedirect")
+    def test_mount_iso(self, exec_mock, mount_mock):
+        """Mount an ISO file in the LiveOS directory."""
+        exec_mock.return_value = 0
+        mount_mock.return_value = 0
+
+        with self._create_directory():
+            iso_dir = join_paths(self.image_mount, "LiveOS")
+            os.makedirs(iso_dir)
+
+            iso_path = join_paths(iso_dir, "iso.img")
+            touch(iso_path)
+
+            assert self._run_task() == self.iso_mount
+
+            exec_mock.assert_called_once_with(
+                "mount", ["--make-rprivate", "/"]
+            )
+
+            assert mount_mock.mock_calls == [
+                call(
+                    self.image_path,
+                    self.image_mount,
+                    fstype="auto",
+                    options="ro"
+                ),
+                call(
+                    iso_path,
+                    self.iso_mount,
+                    fstype="auto",
+                    options="ro"
+                )
+            ]
+
+    @patch("pyanaconda.modules.payloads.payload.live_image.installation.execWithRedirect")
+    def test_rprivate_fail(self, exec_mock):
+        """Test a failure of the rprivate mount call."""
+        exec_mock.return_value = 1
+
+        with self._create_directory():
+            with pytest.raises(PayloadInstallationError) as cm:
+                self._run_task()
+
+            assert str(cm.value) == "Failed to make the '/' mount rprivate: 1"
+
+    @patch("pyanaconda.modules.payloads.payload.live_image.installation.blivet.util.mount")
+    @patch("pyanaconda.modules.payloads.payload.live_image.installation.execWithRedirect")
+    def test_mount_fail(self, exec_mock, mount_mock):
+        """Test a failure of the mount tool."""
+        exec_mock.return_value = 0
+        mount_mock.return_value = 1
+
+        with self._create_directory():
+            with pytest.raises(PayloadInstallationError) as cm:
+                self._run_task()
+
+            msg = "Failed to mount '{}' at '{}': {}".format(self.image_path, self.image_mount, 1)
+            assert str(cm.value) == msg
+
+    @patch("pyanaconda.modules.payloads.payload.live_image.installation.blivet.util.mount")
+    @patch("pyanaconda.modules.payloads.payload.live_image.installation.execWithRedirect")
+    def test_mount_exec_fail(self, exec_mock, mount_mock):
+        """Test a failure of the mount call."""
+        exec_mock.return_value = 0
+        mount_mock.side_effect = OSError("Fake!")
+
+        with self._create_directory():
+            with pytest.raises(PayloadInstallationError) as cm:
+                self._run_task()
+
+            assert str(cm.value) == "Fake!"


### PR DESCRIPTION
Run a task to mount a live image. Originally, the mount point for the installation
of the image was always `/run/install/source` and we had to sometimes move mounts
to achieve that. That is too complicated. The task can just return a mount point
that should be used for the installation and that's it.

Run tasks for unmounting and deleting the live image. Don't fail if the mount
points or files don't exist.