### PR TITLE
Disable packit smoke test on TFT (#infra)

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -14,12 +14,6 @@ jobs:
     metadata:
       dist_git_branches: fedora-development
 
-  - job: tests
-    trigger: pull_request
-    metadata:
-      targets:
-        - fedora-rawhide
-
   - job: copr_build
     trigger: pull_request
     metadata:


### PR DESCRIPTION
This test is not really helpful and TFT won't be working through packit for some time.