### PR TITLE
Fix Source0 in spec to point to upstream source URL

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -10,7 +10,7 @@ URL:     http://fedoraproject.org/wiki/Anaconda
 # git checkout -b archive-branch anaconda-%%{version}-%%{release}
 # ./autogen.sh
 # make dist
-Source0: %{name}-%{version}.tar.bz2
+Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{version}-1/%{name}-%{version}.tar.bz2
 
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).


### PR DESCRIPTION
It should be like that all the time. Also this change is required by Packit for creating downstream releases (it download tarball from there).