### PR TITLE
Enable the pytest assert introspection in the helper functions

### DIFF
--- a/tests/unit_tests/__init__.py
+++ b/tests/unit_tests/__init__.py
@@ -17,6 +17,7 @@
 #
 import os
 import locale
+import pytest
 import gi.overrides
 
 # Apply overrides for the anaconda widgets.
@@ -27,3 +28,9 @@ if "ANACONDA_WIDGETS_OVERRIDES" in os.environ:
 
 # Set the default locale.
 locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+
+# Register modules with helper functions.
+pytest.register_assert_rewrite(
+    "tests.unit_tests.pyanaconda_tests",
+    "tests.unit_tests.pyanaconda_tests.modules.payloads.payload.module_payload_shared",
+)


### PR DESCRIPTION
The assert introspection works by default only for test modules. It means that
helper functions from other modules will raise the `AssertionError` exception
without any other useful information. These modules have to be explicitly
registered with the `register_assert_rewrite` function to make the assert
introspection work.

See: https://docs.pytest.org/en/6.2.x/writing_plugins.html#assertion-rewriting