### PR TITLE
Deprecate the ANA_INSTALL_PATH environment variable

### DIFF
--- a/docs/release-notes/ana-install-path-deprecated.rst
+++ b/docs/release-notes/ana-install-path-deprecated.rst
@@ -1,0 +1,9 @@
+:Type: Kickstart scripts
+:Summary: `ANA_INSTALL_PATH` is deprecated
+
+:Description:
+    The `ANA_INSTALL_PATH` environment variable is deprecated. The support for this variable
+    will be removed in future releases. Please, use the `/mnt/sysroot` path instead.
+
+:Links:
+    - https://anaconda-installer.readthedocs.io/en/latest/mount-points.html

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -73,6 +73,7 @@ def setenv(name, value):
 
 def augmentEnv():
     env = os.environ.copy()
+    # FIXME: Remove the support for the ANA_INSTALL_PATH variable.
     env.update({"ANA_INSTALL_PATH": conf.target.system_root})
     env.update(_child_env)
     return env


### PR DESCRIPTION
The support for the `ANA_INSTALL_PATH` environment variable will be removed
in future releases. Please, use the `/mnt/sysroot` path instead.