### PR TITLE
Remove the %anaconda section

### DIFF
--- a/docs/kickstart.rst
+++ b/docs/kickstart.rst
@@ -4,13 +4,17 @@ Anaconda Kickstart Documentation
 :Authors:
     Brian C. Lane <bcl@redhat.com>
 
-Anaconda uses `kickstart <https://github.com/pykickstart/pykickstart>`_ to automate
-installation and as a data store for the user interface. It also extends the kickstart
-commands `documented here <https://pykickstart.readthedocs.io/>`_
-by adding a new kickstart section named ``%anaconda`` where commands to control the behavior
-of Anaconda will be defined.
+Anaconda uses `kickstart <https://github.com/pykickstart/pykickstart>`_ to parse and generate
+kickstart files.
+
+%anaconda
+---------
+
+The ``%anaconda`` kickstart section contains commands to control the behavior of Anaconda.
 
 *Deprecated since Fedora 34.*
+
+*Removed since Fedora 36.*
 
 pwpolicy
 --------

--- a/docs/release-notes/anaconda-section-removed.rst
+++ b/docs/release-notes/anaconda-section-removed.rst
@@ -1,0 +1,9 @@
+:Type: Kickstart
+:Summary: The `%anaconda` section is removed
+
+:Description:
+    The support for the deprecated `%anaconda` section is removed.
+    Please, use the Anaconda configuration files instead.
+
+:Links:
+    - https://anaconda-installer.readthedocs.io/en/latest/configuration-files.html

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -413,7 +413,6 @@ def process_kickstart(ksfile):
         log.debug("ksdevice argument is not available")
     parser = KickstartParser(handler, missingIncludeIsFatal=False, errorsAreFatal=False)
     parser.registerSection(NullSection(handler, sectionOpen="%addon"))
-    parser.registerSection(NullSection(handler, sectionOpen="%anaconda"))
     log.info("processing kickstart file %s", ksfile)
     processed_file = preprocessKickstart(ksfile)
     try:

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -368,7 +368,6 @@ class AnacondaPreParser(KickstartParser):
         self.registerSection(NullSection(self.handler, sectionOpen="%traceback"))
         self.registerSection(NullSection(self.handler, sectionOpen="%packages"))
         self.registerSection(NullSection(self.handler, sectionOpen="%addon"))
-        self.registerSection(NullSection(self.handler, sectionOpen="%anaconda"))
 
 
 class AnacondaKSParser(KickstartParser):
@@ -390,7 +389,6 @@ class AnacondaKSParser(KickstartParser):
         self.registerSection(OnErrorScriptSection(self.handler, dataObj=self.scriptClass))
         self.registerSection(UselessSection(self.handler, sectionOpen="%packages"))
         self.registerSection(UselessSection(self.handler, sectionOpen="%addon"))
-        self.registerSection(DeprecatedSection(self.handler, sectionOpen="%anaconda"))
 
 
 def preScriptPass(f):

--- a/pyanaconda/modules/boss/kickstart_manager/parser.py
+++ b/pyanaconda/modules/boss/kickstart_manager/parser.py
@@ -24,8 +24,9 @@ from pykickstart.sections import Section
 from pyanaconda.modules.boss.kickstart_manager.element import KickstartElement,\
     TrackedKickstartElements
 
-VALID_SECTIONS_ANACONDA = ["%pre", "%pre-install", "%post", "%onerror", "%traceback",
-                           "%packages", "%addon", "%anaconda"]
+VALID_SECTIONS_ANACONDA = [
+    "%pre", "%pre-install", "%post", "%onerror", "%traceback", "%packages", "%addon"
+]
 
 
 class StoreSection(Section):

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_kickstart_dispatcher.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_kickstart_dispatcher.py
@@ -26,12 +26,10 @@ from contextlib import contextmanager
 
 from pyanaconda.modules.boss.kickstart_manager.element import KickstartElement,\
     TrackedKickstartElements
-from pyanaconda.modules.boss.kickstart_manager.parser import SplitKickstartParser
+from pyanaconda.modules.boss.kickstart_manager.parser import SplitKickstartParser, \
+    VALID_SECTIONS_ANACONDA
 from pykickstart.version import makeVersion
 from pykickstart.errors import KickstartParseError, KickstartError
-
-VALID_SECTIONS_ANACONDA = ["%pre", "%pre-install", "%post", "%onerror", "%traceback",
-                           "%packages", "%addon", "%anaconda"]
 
 KICKSTART1 = """
 text

--- a/utils/handle-sshpw
+++ b/utils/handle-sshpw
@@ -37,7 +37,6 @@ if not os.path.exists(ksfile):
 handler = makeVersion(VERSION)
 ksparser = KickstartParser(handler, missingIncludeIsFatal=False)
 ksparser.registerSection(NullSection(handler, sectionOpen="%addon"))
-ksparser.registerSection(NullSection(handler, sectionOpen="%anaconda"))
 ksparser.readKickstart(ksfile)
 
 userdata = ksparser.handler.sshpw.dataList()


### PR DESCRIPTION
The support for the deprecated `%anaconda` section is removed.
Please, use the Anaconda configuration files instead.