### PR TITLE
Clean up the task for the checksum verification

### DIFF
--- a/pyanaconda/modules/payloads/payload/live_image/installation.py
+++ b/pyanaconda/modules/payloads/payload/live_image/installation.py
@@ -144,18 +144,19 @@ class DownloadImageTask(Task):
         progress.end()
 
 
-class VerifyImageChecksum(Task):
+class VerifyImageChecksumTask(Task):
     """Task to verify the checksum of the downloaded image."""
 
-    def __init__(self, image_path, checksum):
+    def __init__(self, configuration: LiveImageConfigurationData, image_path):
         """Create a new task.
 
+        :param configuration: a configuration of a remote image
+        :type configuration: an instance of LiveImageConfigurationData
         :param image_path: a path to the image
-        :param checksum: an expected sha256 checksum
         """
         super().__init__()
         self._image_path = image_path
-        self._checksum = checksum
+        self._checksum = configuration.checksum
 
     @property
     def name(self):
@@ -196,7 +197,6 @@ class VerifyImageChecksum(Task):
 
         checksum = sha256.hexdigest()
         log.debug("sha256 of %s: %s", file_path, checksum)
-        print(checksum)
         return checksum
 
 

--- a/pyanaconda/payload/live/payload_liveimg.py
+++ b/pyanaconda/payload/live/payload_liveimg.py
@@ -20,7 +20,7 @@ from pyanaconda.anaconda_loggers import get_packaging_logger
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import PAYLOAD_TYPE_LIVE_IMAGE, INSTALL_TREE, IMAGE_DIR
 from pyanaconda.modules.common.structures.live_image import LiveImageConfigurationData
-from pyanaconda.modules.payloads.payload.live_image.installation import VerifyImageChecksum, \
+from pyanaconda.modules.payloads.payload.live_image.installation import VerifyImageChecksumTask, \
     InstallFromTarTask, InstallFromImageTask, DownloadImageTask, MountImageTask, RemoveImageTask
 from pyanaconda.modules.payloads.payload.live_os.utils import get_kernel_version_list
 from pyanaconda.modules.payloads.payload.live_image.utils import get_kernel_version_list_from_tar
@@ -114,9 +114,9 @@ class LiveImagePayload(Payload):
             task.run()
 
         # Verify the checksum.
-        task = VerifyImageChecksum(
-            image_path=self.image_path,
-            checksum=self.data.liveimg.checksum
+        task = VerifyImageChecksumTask(
+            configuration=source_data,
+            image_path=self.image_path
         )
         task.progress_changed_signal.connect(self._progress_cb)
         task.run()


### PR DESCRIPTION
* Rename the class to `VerifyImageChecksumTask`.
* Change the arguments of the task.
* Remove a forgotten print statement.