### PR TITLE
Migrate anaconda-devel mailing list under Fedora

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@
 m4_define(python_required_version, 3.4)
 
 AC_PREREQ([2.63])
-AC_INIT([anaconda], [36.11], [anaconda-devel-list@redhat.com])
+AC_INIT([anaconda], [36.11], [anaconda-devel@lists.fedoraproject.org])
 
 # make it possible to set build info at build time
 # (patch only builds, modular builds, mass-rebuilds, etc.)

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -22,7 +22,7 @@ ARG git_branch
 #   @rhinstaller/Anaconda
 #   @rhinstaller/Anaconda-devel
 ARG copr_repo
-LABEL maintainer=anaconda-list@redhat.com
+LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 
 # On ELN, BaseOS+AppStream don't have all our build dependencies; this provides the "Everything" compose
 COPY ["eln.repo", "/etc/yum.repos.d"]

--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -29,7 +29,7 @@ ARG image
 FROM ${image}
 # FROM starts a new build stage with new ARGs. Put any ARGs after FROM unless required by the FROM itself.
 # see https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
-LABEL maintainer=anaconda-list@redhat.com
+LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 
 # Prepare environment and install build dependencies
 RUN set -ex; \

--- a/dockerfile/anaconda-rhel-copr/Dockerfile
+++ b/dockerfile/anaconda-rhel-copr/Dockerfile
@@ -3,7 +3,7 @@ FROM ${image}
 # FROM starts a new build stage with new ARGs. Put any ARGs after FROM unless required by the FROM itself.
 # see https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 
-LABEL maintainer=anaconda-list@redhat.com
+LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 
 # Install build dependencies
 RUN set -e; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -17,7 +17,7 @@ FROM ${image}
 #   f35-release
 ARG git_branch
 ARG copr_repo=@rhinstaller/Anaconda
-LABEL maintainer=anaconda-list@redhat.com
+LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 
 # On ELN, BaseOS+AppStream don't have all our build dependencies; this provides the "Everything" compose
 COPY ["eln.repo", "/etc/yum.repos.d"]

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -2,7 +2,7 @@ Anaconda Boot Options
 =====================
 
 :Authors:
-    Anaconda Developers <anaconda-devel-list@redhat.com>
+    Anaconda Developers <anaconda-devel@lists.fedoraproject.org>
     Will Woods <wwoods@redhat.com>
     Anne Mulhern <amulhern@redhat.com>
 

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -69,7 +69,7 @@
 
 # Variables used in xgettext arguments
 COPYRIGHT_HOLDER = Red Hat, Inc.
-MSGID_BUGS_ADDRESS = anaconda-devel-list@redhat.com
+MSGID_BUGS_ADDRESS = anaconda-devel@lists.fedoraproject.org
 
 # What kind of files are we looking for?
 POTFILE_SUFFIXES = py c glade desktop js


### PR DESCRIPTION
Let's change the old variant to a new variant everywhere in our code base. Also fix Dockerfiles which has non-existing mailing list in the LABELs.