### PR TITLE
Fix generation of commit range for release notes (#infra)

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -74,7 +74,7 @@ jobs:
           echo -e "Anaconda release $RELEASE_NAME.\n\n" > release.txt
 
           # find version tags
-          CURRENT_VERSION=${{ github.ref }}
+          CURRENT_VERSION="anaconda-$RELEASE_NAME-1"
           PREVIOUS_VERSION="$(git describe --tags --abbrev=0 --exclude="$CURRENT_VERSION")"
 
           # print commit details; skip the last = release commit


### PR DESCRIPTION
Github gives us `${{ github.ref }}` as `refs/tags/***` which apparently does not work in `git describe --exclude`.

See the soft failure in "Generate release" in https://github.com/rhinstaller/anaconda/runs/4395925639?check_suite_focus=true