### PR TITLE
Close stale pull requests (#infra)

### DIFF
--- a/.github/workflows/stale-pull-requests.yml
+++ b/.github/workflows/stale-pull-requests.yml
@@ -1,0 +1,24 @@
+name: Close stale pull requests
+on:
+  schedule:
+    - cron: 30 1 * * *
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Handle stale pull requests
+      - uses: actions/stale@v4
+      with:
+        days-before-stale: 60
+        days-before-close: 30
+        stale-pr-label: stale
+        stale-pr-message: |
+          This PR is stale because it has been open 60 days with no activity.
+          Remove stale label or comment or this will be closed in 30 days.
+        close-pr-message: |
+          This PR was closed because it has been stalled for 30 days with no activity.


### PR DESCRIPTION
* Add the `stale` label on pull requests after 60 days of inactivity.
* Close the stale pull requests after 30 days of inactivity.
* If an update or comment occurs on stale pull requests, the stale label
  will be removed and the timer will restart.