### PR TITLE
Fix reset of DBus containers in the unit tests

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/__init__.py
+++ b/tests/unit_tests/pyanaconda_tests/__init__.py
@@ -291,6 +291,16 @@ def patch_dbus_get_proxy_with_cache(func):
     return patch('pyanaconda.core.dbus.DBus.get_proxy', side_effect=mock_get)(func)
 
 
+def reset_dbus_container(container):
+    """Reset a DBus container.
+
+    :param DBusContainer container: a container to reset
+    """
+    container._container = {}
+    container._published = set()
+    container._counter = 0
+
+
 class reset_boot_loader_factory(ContextDecorator):
     """Reset the boot loader factory.
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_interactive.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_interactive.py
@@ -47,7 +47,7 @@ from pyanaconda.modules.storage.partitioning.interactive.scheduler_module import
 from pyanaconda.modules.storage.devicetree import create_storage
 
 from tests.unit_tests.pyanaconda_tests import patch_dbus_publish_object, check_task_creation, \
-    check_dbus_object_creation
+    check_dbus_object_creation, reset_dbus_container
 
 
 class InteractivePartitioningInterfaceTestCase(unittest.TestCase):
@@ -94,7 +94,7 @@ class InteractivePartitioningInterfaceTestCase(unittest.TestCase):
     @patch_dbus_publish_object
     def test_get_device_tree(self, publisher):
         """Test GetDeviceTree."""
-        DeviceTreeContainer._counter = 0
+        reset_dbus_container(DeviceTreeContainer)
         self.module.on_storage_changed(create_storage())
 
         tree_path = self.interface.GetDeviceTree()

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
@@ -48,7 +48,8 @@ from pyanaconda.modules.storage.partitioning.interactive.interactive_module impo
 from pyanaconda.modules.storage.devicetree import create_storage
 from pyanaconda.modules.storage.platform import S390
 from tests.unit_tests.pyanaconda_tests import check_kickstart_interface, check_task_creation, \
-    patch_dbus_publish_object, check_dbus_property, patch_dbus_get_proxy, reset_boot_loader_factory
+    patch_dbus_publish_object, check_dbus_property, patch_dbus_get_proxy, \
+    reset_boot_loader_factory, reset_dbus_container
 
 from pyanaconda.modules.storage.bootloader.grub2 import IPSeriesGRUB2, GRUB2
 from pyanaconda.modules.storage.bootloader.zipl import ZIPL
@@ -151,7 +152,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
     @patch_dbus_publish_object
     def test_create_partitioning(self, published):
         """Test CreatePartitioning."""
-        PartitioningContainer._counter = 0
+        reset_dbus_container(PartitioningContainer)
 
         path = self.storage_interface.CreatePartitioning(PARTITIONING_METHOD_AUTOMATIC)
         assert path == "/org/fedoraproject/Anaconda/Modules/Storage/Partitioning/1"
@@ -182,7 +183,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
     @patch_dbus_publish_object
     def test_created_partitioning(self, publisher):
         """Test the property CreatedPartitioning."""
-        PartitioningContainer._counter = 0
+        reset_dbus_container(PartitioningContainer)
 
         self._check_dbus_property(
             "CreatedPartitioning",


### PR DESCRIPTION
If we need to reset a DBus container for testing purposes, do it properly.
Otherwise, the container can stay in an inconsistent state and affect other
tests.