### PR TITLE
Do not try to load the floppy kernel module

### DIFF
--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -24,7 +24,7 @@ done
 shopt -u nullglob
 
 if [ "$ARCH" != "s390" ] && [ "$ARCH" != "s390x" ]; then
-    MODULE_LIST+=" floppy edd iscsi_ibft "
+    MODULE_LIST+=" edd iscsi_ibft "
 else
     MODULE_LIST+=" hmcdrv "
 fi


### PR DESCRIPTION
* Get rid of the "ERROR: could not insert 'floppy': No such device"
  boot message on systems without a floppy drive.
* "modprobe floppy" takes 3 seconds on systems without a floppy drive,
  this change speeds up the boot process by ~3 seconds.
* Even without explicitly loading the floppy kernel module, it's still
  possible to load a kickstart file from a floppy device using
  inst.ks=hd:fd0:ks.cfg. The floppy module gets loaded automatically.
  (This was tested only in a VM)
* If this change breaks something, "rd.driver.pre=floppy" on the kernel
  command line might be a possible workaround, although it loads the
  module a bit later than the current solution.