### PR TITLE
Fix the condition for entering the root configuration (#2026916)

### DIFF
--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -17,8 +17,6 @@
 # Red Hat, Inc.
 #
 from pyanaconda.core.constants import PASSWORD_POLICY_ROOT
-from pyanaconda.flags import flags
-from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.i18n import _, CN_
 from pyanaconda.core.users import crypt_password
 from pyanaconda import input_checking
@@ -32,6 +30,7 @@ from pyanaconda.ui.gui.utils import set_password_visibility
 from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.ui.lib.services import is_reconfiguration_mode
+from pyanaconda.ui.lib.users import can_modify_root_configuration
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -224,13 +223,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     @property
     def sensitive(self):
-        # A password set in kickstart can be changed in the GUI
-        # if the changesok password policy is set for the root password.
-        kickstarted_password_can_be_changed = conf.ui.can_change_root or \
-            self._users_module.CanChangeRootPassword
-
-        return not (self.completed and flags.automatedInstall
-                    and not kickstarted_password_can_be_changed)
+        return can_modify_root_configuration(self._users_module)
 
     def _checks_done(self, error_message):
         """Update the warning with the input validation error from the first

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -29,8 +29,7 @@ from pyanaconda.ui.gui.helpers import GUISpokeInputCheckHandler
 from pyanaconda.ui.gui.utils import set_password_visibility
 from pyanaconda.ui.common import FirstbootSpokeMixIn
 from pyanaconda.ui.communication import hubQ
-from pyanaconda.ui.lib.services import is_reconfiguration_mode
-from pyanaconda.ui.lib.users import can_modify_root_configuration
+from pyanaconda.ui.lib.users import can_modify_root_configuration, get_root_configuration_status
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -175,18 +174,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     @property
     def status(self):
-        if self._users_module.IsRootAccountLocked:
-            # reconfig mode currently allows re-enabling a locked root account if
-            # user sets a new root password
-            if is_reconfiguration_mode() and not self._lock.get_active():
-                return _("Disabled, set password to enable.")
-            else:
-                return _("Root account is disabled.")
-
-        elif self._users_module.IsRootPasswordSet:
-            return _("Root password is set")
-        else:
-            return _("Root password is not set")
+        return get_root_configuration_status(self._users_module)
 
     @property
     def mandatory(self):

--- a/pyanaconda/ui/lib/users.py
+++ b/pyanaconda/ui/lib/users.py
@@ -18,10 +18,25 @@
 #
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.core.i18n import _
 from pyanaconda.flags import flags
 from pyanaconda.modules.common.structures.user import UserData
 
 log = get_module_logger(__name__)
+
+
+def get_root_configuration_status(users_module):
+    """Get the status of the root configuration.
+
+    :param users_module: a DBus proxy of the Users module
+    :return: a translated message
+    """
+    if users_module.IsRootAccountLocked:
+        return _("Root account is disabled")
+    elif users_module.IsRootPasswordSet:
+        return _("Root password is set")
+    else:
+        return _("Root password is not set")
 
 
 def can_modify_root_configuration(users_module):

--- a/pyanaconda/ui/lib/users.py
+++ b/pyanaconda/ui/lib/users.py
@@ -16,10 +16,34 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.flags import flags
 from pyanaconda.modules.common.structures.user import UserData
 
-from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
+
+
+def can_modify_root_configuration(users_module):
+    """Is it allowed to modify the root configuration?
+
+    :param users_module: a DBus proxy of the Users module
+    :return: True or False
+    """
+    # Allow changes in the interactive mode.
+    if not flags.automatedInstall:
+        return True
+
+    # Does the configuration allow changes?
+    if conf.ui.can_change_root:
+        return True
+
+    # Allow changes if the root account isn't
+    # already configured by the kickstart file.
+    if users_module.CanChangeRootPassword:
+        return True
+
+    return False
 
 
 def get_user_list(users_module, add_default=False, add_if_not_empty=False):

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -19,14 +19,13 @@
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
 from pyanaconda.ui.lib.services import is_reconfiguration_mode
+from pyanaconda.ui.lib.users import can_modify_root_configuration
 from pyanaconda.ui.tui.tuiobject import PasswordDialog
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
-from pyanaconda.flags import flags
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.modules.common.constants.services import USERS
 from pyanaconda.core.constants import PASSWORD_POLICY_ROOT
-from pyanaconda.core.configuration.anaconda import conf
 
 from simpleline.render.widgets import TextWidget
 
@@ -64,7 +63,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     @property
     def showable(self):
-        return not (self.completed and flags.automatedInstall and not conf.ui.can_change_root)
+        return can_modify_root_configuration(self._users_module)
 
     @property
     def mandatory(self):

--- a/pyanaconda/ui/tui/spokes/root_password.py
+++ b/pyanaconda/ui/tui/spokes/root_password.py
@@ -18,8 +18,7 @@
 #
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.ui.categories.user_settings import UserSettingsCategory
-from pyanaconda.ui.lib.services import is_reconfiguration_mode
-from pyanaconda.ui.lib.users import can_modify_root_configuration
+from pyanaconda.ui.lib.users import can_modify_root_configuration, get_root_configuration_status
 from pyanaconda.ui.tui.tuiobject import PasswordDialog
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.common import FirstbootSpokeMixIn
@@ -72,18 +71,7 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
 
     @property
     def status(self):
-        if self._users_module.IsRootAccountLocked:
-            # reconfig mode currently allows re-enabling a locked root account if
-            # user sets a new root password
-            if is_reconfiguration_mode():
-                return _("Disabled. Set password to enable root account.")
-            else:
-                return _("Root account is disabled.")
-
-        elif self._users_module.IsRootPasswordSet:
-            return _("Password is set.")
-        else:
-            return _("Password is not set.")
+        return get_root_configuration_status(self._users_module)
 
     def refresh(self, args=None):
         NormalTUISpoke.refresh(self, args)

--- a/tests/unit_tests/pyanaconda_tests/modules/users/test_module_users.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/users/test_module_users.py
@@ -21,9 +21,7 @@ import os
 import tempfile
 import unittest
 from textwrap import dedent
-from unittest.mock import Mock
 
-from dasbus.structure import compare_data
 from tests.unit_tests.pyanaconda_tests import check_kickstart_interface, patch_dbus_publish_object, \
     PropertiesChangedCallback, check_dbus_property, check_task_creation_list, check_task_creation
 
@@ -36,7 +34,6 @@ from pyanaconda.modules.users.users_interface import UsersInterface
 from pyanaconda.modules.users.installation import ConfigureRootPasswordSSHLoginTask, \
     CreateGroupsTask, CreateUsersTask, SetRootPasswordTask, SetSshKeysTask
 from dasbus.typing import get_variant, List, Str, UInt32, Bool
-from pyanaconda.ui.lib.users import get_user_list, set_user_list
 
 
 class UsersInterfaceTestCase(unittest.TestCase):
@@ -777,125 +774,6 @@ class GroupsDataTestCase(unittest.TestCase):
         assert group_data.gid == 0
         assert group_data.gid_mode == ID_MODE_USE_DEFAULT
         assert group_data.get_gid() is None
-
-
-class SharedUICodeTestCase(unittest.TestCase):
-    """Test shared UI code related to user handling.
-
-    The shared code calls the Users module interface so it makes sense to test it here.
-    """
-
-    def test_get_empty_user_list(self):
-        """Test the shared get_user_list() method with no users."""
-        users_module_mock = Mock()
-        users_module_mock.Users = []
-        user_data_list = get_user_list(users_module_mock)
-        assert user_data_list == []
-
-    def test_get_default_user(self):
-        """Test that default user is correctly added by get_user_list()."""
-        users_module_mock = Mock()
-        users_module_mock.Users = []
-        user_data_list = get_user_list(users_module_mock, add_default=True)
-
-        assert len(user_data_list) == 1
-        assert isinstance(user_data_list[0], UserData)
-        assert compare_data(user_data_list[0], UserData())
-
-    def test_get_user_list(self):
-        """Test the shared get_user_list() method."""
-        user1 = UserData()
-        user1.name = "user1"
-        user1.uid = 123
-        user1.groups = ["foo", "bar"]
-        user1.gid = 321
-        user1.homedir = "user1_home"
-        user1.password = "swordfish"
-        user1.is_crypted = False
-        user1.lock = False
-        user1.shell = "zsh"
-        user1.gecos = "some stuff"
-
-        user2 = UserData()
-        user2.name = "user2"
-        user2.uid = 456
-        user2.groups = ["baz", "bar"]
-        user2.gid = 654
-        user2.homedir = "user2_home"
-        user2.password = "laksdjaskldjhasjhd"
-        user2.is_crypted = True
-        user2.lock = False
-        user2.shell = "csh"
-        user2.gecos = "some other stuff"
-
-        users_module_mock = Mock()
-        users_module_mock.Users = UserData.to_structure_list([user1, user2])
-        user_data_list = get_user_list(users_module_mock)
-
-        assert len(user_data_list) == 2
-        assert isinstance(user_data_list[0], UserData)
-        assert isinstance(user_data_list[1], UserData)
-        assert compare_data(user_data_list[0], user1)
-        assert compare_data(user_data_list[1], user2)
-
-        user_data_list = get_user_list(users_module_mock, add_default=True)
-
-        assert len(user_data_list) == 2
-        assert isinstance(user_data_list[0], UserData)
-        assert isinstance(user_data_list[1], UserData)
-        assert compare_data(user_data_list[0], user1)
-        assert compare_data(user_data_list[1], user2)
-
-        user_data_list = get_user_list(users_module_mock, add_default=True, add_if_not_empty=True)
-
-        assert len(user_data_list) == 3
-        assert isinstance(user_data_list[0], UserData)
-        assert isinstance(user_data_list[1], UserData)
-        assert isinstance(user_data_list[2], UserData)
-        assert compare_data(user_data_list[0], UserData())
-        assert compare_data(user_data_list[1], user1)
-        assert compare_data(user_data_list[2], user2)
-
-    def test_set_user_list(self):
-        """Test the shared set_user_list() method."""
-        user1 = UserData()
-        user1.name = "user1"
-        user1.uid = 123
-        user1.groups = ["foo", "bar"]
-        user1.gid = 321
-        user1.homedir = "user1_home"
-        user1.password = "swordfish"
-        user1.is_crypted = False
-        user1.lock = False
-        user1.shell = "zsh"
-        user1.gecos = "some stuff"
-
-        user2 = UserData()
-        user2.name = "user2"
-        user2.uid = 456
-        user2.groups = ["baz", "bar"]
-        user2.gid = 654
-        user2.homedir = "user2_home"
-        user2.password = "laksdjaskldjhasjhd"
-        user2.is_crypted = True
-        user2.lock = False
-        user2.shell = "csh"
-        user2.gecos = "some other stuff"
-
-        users_module_mock = Mock()
-        set_user_list(users_module_mock, [user1, user2])
-        user_data_list = users_module_mock.SetUsers.call_args[0][0]
-
-        assert len(user_data_list) == 2
-        assert user_data_list[0] == UserData.to_structure(user1)
-        assert user_data_list[1] == UserData.to_structure(user2)
-
-        user1.name = ""
-        set_user_list(users_module_mock, [user1, user2], remove_unset=True)
-        user_data_list = users_module_mock.SetUsers.call_args[0][0]
-
-        assert len(user_data_list) == 1
-        assert user_data_list[0] == UserData.to_structure(user2)
 
 
 class UsersModuleTasksTestCase(unittest.TestCase):

--- a/tests/unit_tests/pyanaconda_tests/ui/test_ui_users.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_ui_users.py
@@ -1,0 +1,140 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+from unittest.mock import Mock
+
+from dasbus.structure import compare_data
+
+from pyanaconda.modules.common.structures.user import UserData
+from pyanaconda.ui.lib.users import get_user_list, set_user_list
+
+
+class UsersUITestCase(unittest.TestCase):
+    """Test the UI functions and classes of the Users module."""
+
+    def test_get_empty_user_list(self):
+        """Test the shared get_user_list() method with no users."""
+        users_module_mock = Mock()
+        users_module_mock.Users = []
+        user_data_list = get_user_list(users_module_mock)
+        assert user_data_list == []
+
+    def test_get_default_user(self):
+        """Test that default user is correctly added by get_user_list()."""
+        users_module_mock = Mock()
+        users_module_mock.Users = []
+        user_data_list = get_user_list(users_module_mock, add_default=True)
+
+        assert len(user_data_list) == 1
+        assert isinstance(user_data_list[0], UserData)
+        assert compare_data(user_data_list[0], UserData())
+
+    def test_get_user_list(self):
+        """Test the shared get_user_list() method."""
+        user1 = UserData()
+        user1.name = "user1"
+        user1.uid = 123
+        user1.groups = ["foo", "bar"]
+        user1.gid = 321
+        user1.homedir = "user1_home"
+        user1.password = "swordfish"
+        user1.is_crypted = False
+        user1.lock = False
+        user1.shell = "zsh"
+        user1.gecos = "some stuff"
+
+        user2 = UserData()
+        user2.name = "user2"
+        user2.uid = 456
+        user2.groups = ["baz", "bar"]
+        user2.gid = 654
+        user2.homedir = "user2_home"
+        user2.password = "laksdjaskldjhasjhd"
+        user2.is_crypted = True
+        user2.lock = False
+        user2.shell = "csh"
+        user2.gecos = "some other stuff"
+
+        users_module_mock = Mock()
+        users_module_mock.Users = UserData.to_structure_list([user1, user2])
+        user_data_list = get_user_list(users_module_mock)
+
+        assert len(user_data_list) == 2
+        assert isinstance(user_data_list[0], UserData)
+        assert isinstance(user_data_list[1], UserData)
+        assert compare_data(user_data_list[0], user1)
+        assert compare_data(user_data_list[1], user2)
+
+        user_data_list = get_user_list(users_module_mock, add_default=True)
+
+        assert len(user_data_list) == 2
+        assert isinstance(user_data_list[0], UserData)
+        assert isinstance(user_data_list[1], UserData)
+        assert compare_data(user_data_list[0], user1)
+        assert compare_data(user_data_list[1], user2)
+
+        user_data_list = get_user_list(users_module_mock, add_default=True, add_if_not_empty=True)
+
+        assert len(user_data_list) == 3
+        assert isinstance(user_data_list[0], UserData)
+        assert isinstance(user_data_list[1], UserData)
+        assert isinstance(user_data_list[2], UserData)
+        assert compare_data(user_data_list[0], UserData())
+        assert compare_data(user_data_list[1], user1)
+        assert compare_data(user_data_list[2], user2)
+
+    def test_set_user_list(self):
+        """Test the shared set_user_list() method."""
+        user1 = UserData()
+        user1.name = "user1"
+        user1.uid = 123
+        user1.groups = ["foo", "bar"]
+        user1.gid = 321
+        user1.homedir = "user1_home"
+        user1.password = "swordfish"
+        user1.is_crypted = False
+        user1.lock = False
+        user1.shell = "zsh"
+        user1.gecos = "some stuff"
+
+        user2 = UserData()
+        user2.name = "user2"
+        user2.uid = 456
+        user2.groups = ["baz", "bar"]
+        user2.gid = 654
+        user2.homedir = "user2_home"
+        user2.password = "laksdjaskldjhasjhd"
+        user2.is_crypted = True
+        user2.lock = False
+        user2.shell = "csh"
+        user2.gecos = "some other stuff"
+
+        users_module_mock = Mock()
+        set_user_list(users_module_mock, [user1, user2])
+        user_data_list = users_module_mock.SetUsers.call_args[0][0]
+
+        assert len(user_data_list) == 2
+        assert user_data_list[0] == UserData.to_structure(user1)
+        assert user_data_list[1] == UserData.to_structure(user2)
+
+        user1.name = ""
+        set_user_list(users_module_mock, [user1, user2], remove_unset=True)
+        user_data_list = users_module_mock.SetUsers.call_args[0][0]
+
+        assert len(user_data_list) == 1
+        assert user_data_list[0] == UserData.to_structure(user2)

--- a/tests/unit_tests/pyanaconda_tests/ui/test_ui_users.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_ui_users.py
@@ -21,7 +21,8 @@ from unittest.mock import Mock, patch
 from dasbus.structure import compare_data
 
 from pyanaconda.modules.common.structures.user import UserData
-from pyanaconda.ui.lib.users import get_user_list, set_user_list, can_modify_root_configuration
+from pyanaconda.ui.lib.users import get_user_list, set_user_list, can_modify_root_configuration, \
+    get_root_configuration_status
 
 
 class UsersUITestCase(unittest.TestCase):
@@ -164,3 +165,23 @@ class UsersUITestCase(unittest.TestCase):
         users_module.CanChangeRootPassword = False
 
         assert not can_modify_root_configuration(users_module)
+
+    def test_get_root_configuration_status(self):
+        """Test the get_root_configuration_status function."""
+        users_module = Mock()
+
+        users_module.IsRootAccountLocked = False
+        users_module.IsRootPasswordSet = False
+        assert get_root_configuration_status(users_module) == "Root password is not set"
+
+        users_module.IsRootAccountLocked = False
+        users_module.IsRootPasswordSet = True
+        assert get_root_configuration_status(users_module) == "Root password is set"
+
+        users_module.IsRootAccountLocked = True
+        users_module.IsRootPasswordSet = False
+        assert get_root_configuration_status(users_module) == "Root account is disabled"
+
+        users_module.IsRootAccountLocked = True
+        users_module.IsRootPasswordSet = True
+        assert get_root_configuration_status(users_module) == "Root account is disabled"


### PR DESCRIPTION
Don't allow to enter the spoke if the root account is already configured
in the kickstart file in Anaconda. Just a note, the Initial Setup in the
reconfiguration mode always allows to enter this spoke.

(ported from https://github.com/rhinstaller/anaconda/pull/3701)

Resolves: rhbz#2026916