### PR TITLE
Add ShellCheck to unit tests

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,4 +1,5 @@
 # ShellCheck config file
 
 disable=SC1090  # Can't follow non-constant source. Use a directive to specify location.
+disable=SC1091  # Not following: <some-file> was not specified as input (see shellcheck -x).
 disable=SC2230  # which is non-standard. Use builtin 'command -v' instead.

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -44,7 +44,8 @@ RUN set -ex; \
   python3-lxml \
   policycoreutils \
   python3-gobject-base \
-  python3-pip; \
+  python3-pip \
+  ShellCheck; \
   if ! grep -q VARIANT.*eln /etc/os-release; then \
     BRANCH="${git_branch}"; \
     if [ $BRANCH == "master" ]; then \

--- a/dracut/.shellcheckrc
+++ b/dracut/.shellcheckrc
@@ -1,6 +1,6 @@
 # ShellCheck config file
 
 disable=SC1090  # Can't follow non-constant source. Use a directive to specify location.
-disable=SC2230  # which is non-standard. Use builtin 'command -v' instead.
 disable=SC1091  # Not following: <some-file> was not specified as input (see shellcheck -x).
+disable=SC2230  # which is non-standard. Use builtin 'command -v' instead.
 disable=SC2154  # <variable-name> is referenced but not assigned.

--- a/dracut/fetch-driver-net.sh
+++ b/dracut/fetch-driver-net.sh
@@ -45,7 +45,7 @@ for dd in $DD_NET; do
             mntdir=$(nfs_already_mounted "$server" "$path")
             if [ -z "$mntdir" ]; then
                 mntdir="$(mkuniqdir /run nfs_mnt)"
-                mount_nfs "$nfs:$server:$path$(options:+:$options)" "$mntdir"
+                mount_nfs "$nfs:$server:$path$(options:+:"$options")" "$mntdir"
             fi
 
             # Get and process all rpm files in the mounted directory

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -49,7 +49,7 @@ check_depr_arg() {
 }
 check_depr_args() {
     local q=""
-    for i in $(getargs "$1"); do check_depr_arg $q "$i" "$2" && q="--quiet"; done
+    for i in $(getargs "$1"); do check_depr_arg "$q" "$i" "$2" && q="--quiet"; done
 }
 check_removed_arg() {
     local arg="$1"; shift

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -55,7 +55,9 @@ dist_check_SCRIPTS = $(srcdir)/glade_tests/*.py \
 		     gettext_tests/canary_tests.sh \
 		     $(srcdir)/*_tests/*.py \
 		     $(srcdir)/unit_tests/*_tests/*.py \
+		     shellcheck/*.sh \
 		     pep8/runpep8.sh
+
 
 TESTS = unit_tests/unit_tests.sh \
 	pylint/runpylint.py \
@@ -64,7 +66,8 @@ TESTS = unit_tests/unit_tests.sh \
 	gettext_tests/style_guide.py \
 	gettext_tests/contexts.py \
 	gettext_tests/canary_tests.sh \
-	glade_tests/glade_tests.sh
+	glade_tests/glade_tests.sh \
+	shellcheck/run_shellcheck.sh
 
 clean-local:
 	-rm -rf pylint/.pylint.d

--- a/tests/shellcheck/ignores.sh
+++ b/tests/shellcheck/ignores.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Paths to ignore in shellcheck tests; these are patterns passed to `grep -v`.
+# shellcheck disable=SC2034  # sourced by the unit test script
+ignore_patterns=(
+dockerfile/
+scripts/
+widgets/
+)

--- a/tests/shellcheck/run_shellcheck.sh
+++ b/tests/shellcheck/run_shellcheck.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# If $top_srcdir has not been set by automake, detect it
+if [ -z "$top_srcdir" ]; then
+    top_srcdir="$(realpath "$(dirname "$0")/../..")"
+fi
+
+source "${top_srcdir}/tests/shellcheck/ignores.sh"
+
+# Check if this test can be run
+if ! type shellcheck > /dev/null 2>&1 ; then
+    echo "SKIP - shellcheck must be installed to run it."
+    exit 77
+fi
+
+# Identify which shellcheck version is running to debug fails due to version bump
+shellcheck --version
+rpm -q ShellCheck
+echo
+
+# Ignore files according to path patterns
+pushd "${top_srcdir}" > /dev/null || return 1
+files=$(git ls-files)
+# shellcheck disable=SC2154  # comes from the file sourced earlier
+for ignore in "${ignore_patterns[@]}" ; do
+    files=$(echo "$files" | grep -v "$ignore")
+done
+
+# Find files that are shell scripts
+files=$(echo "$files" | xargs file | grep "shell script" | awk -F ":" '{print $1}')
+
+# List files being checked
+echo -e "Files to be checked:\n--------------------\n$files\n"
+
+# Do the actual linting
+echo -e "Warnings found:\n---------------"
+if ! echo "$files" | xargs shellcheck -f gcc ; then
+  exit 1
+fi


### PR DESCRIPTION
- This will automatically find all shell scripts tracked in the repository.
- Files and directories can be ignored according to a configuration file.
- The test is optional: If ShellCheck is not present, test will be skipped.
- This is very lightweight, runs take < 10 seconds on a contemporary machine.
- Currently not-fixed-yet scripts are ignored with this initial configuration.
