### PR TITLE
Fix boot options generated by the dracut module

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -157,7 +157,7 @@ class DracutURL(Url, DracutArgsMixin):
         if self.noverifyssl:
             args.append("rd.noverifyssl")
         if self.proxy:
-            args.append("proxy=%s" % self.proxy)
+            args.append("inst.proxy=%s" % self.proxy)
 
         return "\n".join(args)
 
@@ -249,7 +249,7 @@ class DracutDisplayMode(DisplayMode, DracutArgsMixin):
 class DracutBootloader(Bootloader, DracutArgsMixin):
     def dracut_args(self, args, lineno, obj):
         if self.extlinux:
-            return "extlinux"
+            return "inst.extlinux"
 
 # FUTURE: keymap, lang... device? selinux?
 

--- a/tests/unit_tests/dracut_tests/test_parse_kickstart.py
+++ b/tests/unit_tests/dracut_tests/test_parse_kickstart.py
@@ -94,7 +94,7 @@ class ParseKickstartTestCase(BaseTestCase):
         assert len(lines) == 3, lines
         assert lines[0] == "inst.repo=https://host.at.foo.com/path/to/tree", lines
         assert lines[1] == "rd.noverifyssl", lines
-        assert lines[2] == "proxy=http://localhost:8123", lines
+        assert lines[2] == "inst.proxy=http://localhost:8123", lines
 
     def test_updates(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
@@ -252,4 +252,4 @@ network --device=lo --vlanid=171 --interfacename=vlan171
             ks_file.flush()
             lines = self.execParseKickstart(ks_file.name)
 
-            assert lines[0] == "extlinux", lines
+            assert lines[0] == "inst.extlinux", lines


### PR DESCRIPTION
Add the inst. prefix to the anaconda boot options.

(cherry picked from commit b88e10fe3029602b369c719506588097fcbdf80b)

Resolves: rhbz#2003217

Based on/backport of: #3364

**TODO**
* [x] verify the changes in the Dracut dwelling code actually have the expected effect