### PR TITLE
Retire execInSysroot

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -33,6 +33,7 @@ import inspect
 import functools
 import importlib.util
 import importlib.machinery
+import warnings
 import blivet.arch
 
 import requests
@@ -367,11 +368,16 @@ def _run_program(argv, root='/', stdin=None, stdout=None, env_prune=None, log_ou
 
 def execInSysroot(command, argv, stdin=None):
     """ Run an external program in the target root.
+
+        TODO: Remove this function, it is used only by the OSCAP addon.
+
         :param command: The command to run
         :param argv: The argument list
         :param stdin: The file object to read stdin from.
         :return: The return code of the command
     """
+    warnings.warn("execInSysroot is deprecated and will be removed, use execWithRedirect instead",
+                  DeprecationWarning)
     return execWithRedirect(command, argv, stdin=stdin, root=conf.target.system_root)
 
 

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -365,18 +365,14 @@ def _run_program(argv, root='/', stdin=None, stdout=None, env_prune=None, log_ou
     return (proc.returncode, output_string)
 
 
-def execInSysroot(command, argv, stdin=None, root=None):
+def execInSysroot(command, argv, stdin=None):
     """ Run an external program in the target root.
         :param command: The command to run
         :param argv: The argument list
         :param stdin: The file object to read stdin from.
-        :param root: The directory to chroot to before running the command.
         :return: The return code of the command
     """
-    if root is None:
-        root = conf.target.system_root
-
-    return execWithRedirect(command, argv, stdin=stdin, root=root)
+    return execWithRedirect(command, argv, stdin=stdin, root=conf.target.system_root)
 
 
 def execWithRedirect(command, argv, stdin=None, stdout=None,

--- a/pyanaconda/modules/network/firewall/installation.py
+++ b/pyanaconda/modules/network/firewall/installation.py
@@ -17,7 +17,7 @@
 #
 import os
 
-from pyanaconda.core import util
+from pyanaconda.core.util import execWithRedirect
 from pyanaconda.modules.network.constants import FirewallMode
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.task import Task
@@ -102,4 +102,4 @@ class ConfigureFirewallTask(Task):
                 msg = _("%s is missing. Cannot setup firewall.") % (self.FIREWALL_OFFLINE_CMD,)
                 raise FirewallConfigurationError(msg)
         else:
-            util.execInSysroot(self.FIREWALL_OFFLINE_CMD, args, root=self._sysroot)
+            execWithRedirect(self.FIREWALL_OFFLINE_CMD, args, root=self._sysroot)

--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -219,7 +219,8 @@ class MacEFIGRUB(EFIGRUB):
 
     def mactel_config(self):
         if os.path.exists(conf.target.system_root + "/usr/libexec/mactel-boot-setup"):
-            rc = util.execInSysroot("/usr/libexec/mactel-boot-setup", [])
+            rc = util.execWithRedirect("/usr/libexec/mactel-boot-setup", [],
+                                       root=conf.target.system_root)
             if rc:
                 log.error("failed to configure Mac boot loader")
 

--- a/pyanaconda/modules/storage/bootloader/extlinux.py
+++ b/pyanaconda/modules/storage/bootloader/extlinux.py
@@ -19,7 +19,7 @@ import os
 
 from pyanaconda.modules.storage.bootloader.base import BootLoader, BootLoaderArguments,\
     BootLoaderError
-from pyanaconda.core import util
+from pyanaconda.core.util import execWithRedirect
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.product import productName
 
@@ -121,7 +121,7 @@ class EXTLINUX(BootLoader):
 
     def install(self, args=None):
         args = ["--install", self._config_dir]
-        rc = util.execInSysroot("extlinux", args)
+        rc = execWithRedirect("extlinux", args, root=conf.target.system_root)
 
         if rc:
             raise BootLoaderError("boot loader install failed")

--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -343,22 +343,31 @@ class GRUB2(BootLoader):
                 machine_id = fd.readline().strip()
 
             default_entry = "%s-%s" % (machine_id, self.default.version)
-            rc = util.execInSysroot("grub2-set-default", [default_entry])
+            rc = util.execWithRedirect(
+                "grub2-set-default",
+                [default_entry],
+                root=conf.target.system_root
+            )
             if rc:
                 log.error("failed to set default menu entry to %s", productName)
 
         # set menu_auto_hide grubenv variable if we should enable menu_auto_hide
         # set boot_success so that the menu is hidden on the boot after install
         if conf.bootloader.menu_auto_hide:
-            rc = util.execInSysroot("grub2-editenv",
-                                    ["-", "set", "menu_auto_hide=1",
-                                     "boot_success=1"])
+            rc = util.execWithRedirect(
+                "grub2-editenv",
+                ["-", "set", "menu_auto_hide=1", "boot_success=1"],
+                root=conf.target.system_root
+            )
             if rc:
                 log.error("failed to set menu_auto_hide=1")
 
         # now tell grub2 to generate the main configuration file
-        rc = util.execInSysroot("grub2-mkconfig",
-                                ["-o", self.config_file])
+        rc = util.execWithRedirect(
+            "grub2-mkconfig",
+            ["-o", self.config_file],
+            root=conf.target.system_root
+        )
         if rc:
             raise BootLoaderError("failed to write boot loader configuration")
 

--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -22,7 +22,7 @@ from blivet.devices import BTRFSDevice
 from pyanaconda.core.constants import PAYLOAD_TYPE_RPM_OSTREE, PAYLOAD_LIVE_TYPES
 from pyanaconda.modules.storage.bootloader import BootLoaderError
 
-from pyanaconda.core.util import execInSysroot
+from pyanaconda.core.util import execWithRedirect
 from pyanaconda.modules.common.errors.installation import BootloaderInstallationError
 from pyanaconda.modules.storage.constants import BootloaderMode
 
@@ -282,4 +282,4 @@ class FixZIPLBootloaderTask(Task):
             log.debug("The bootloader installation is disabled.")
             return
 
-        execInSysroot("zipl", [])
+        execWithRedirect("zipl", [], root=conf.target.system_root)

--- a/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network.py
@@ -792,8 +792,8 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
         assert obj.implementation._enabled_ports == []
         assert obj.implementation._trusts == []
 
-    @patch('pyanaconda.core.util.execInSysroot')
-    def test_firewall_config_task_enable_missing_tool(self, execInSysroot):
+    @patch('pyanaconda.modules.network.firewall.installation.execWithRedirect')
+    def test_firewall_config_task_enable_missing_tool(self, exec_mock):
         """Test the Firewall configuration task - enable & missing firewall-offline-cmd."""
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -808,11 +808,11 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
             # should raise an exception
             with pytest.raises(FirewallConfigurationError):
                 task.run()
-            # should not call execInSysroot
-            execInSysroot.assert_not_called()
+            # should not call execWithRedirect
+            exec_mock.assert_not_called()
 
-    @patch('pyanaconda.core.util.execInSysroot')
-    def test_firewall_config_task_disable_missing_tool(self, execInSysroot):
+    @patch('pyanaconda.modules.network.firewall.installation.execWithRedirect')
+    def test_firewall_config_task_disable_missing_tool(self, exec_mock):
         """Test the Firewall configuration task - disable & missing firewall-offline-cmd"""
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -826,11 +826,11 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
                                          trusts = [])
             # should not raise an exception
             task.run()
-            # should not call execInSysroot
-            execInSysroot.assert_not_called()
+            # should not call execWithRedirect
+            exec_mock.assert_not_called()
 
-    @patch('pyanaconda.core.util.execInSysroot')
-    def test_firewall_config_task_default_missing_tool(self, execInSysroot):
+    @patch('pyanaconda.modules.network.firewall.installation.execWithRedirect')
+    def test_firewall_config_task_default_missing_tool(self, exec_mock):
         """Test the Firewall configuration task - default & missing firewall-offline-cmd"""
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -844,11 +844,11 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
                                          trusts = [])
             # should not raise an exception
             task.run()
-            # should not call execInSysroot
-            execInSysroot.assert_not_called()
+            # should not call execWithRedirect
+            exec_mock.assert_not_called()
 
-    @patch('pyanaconda.core.util.execInSysroot')
-    def test_firewall_config_task_system_defaults_missing_tool(self, execInSysroot):
+    @patch('pyanaconda.modules.network.firewall.installation.execWithRedirect')
+    def test_firewall_config_task_system_defaults_missing_tool(self, exec_mock):
         """Test the Firewall configuration task - use-system-defaults & missing firewall-offline-cmd"""
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -862,11 +862,11 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
                                          trusts = [])
             # should not raise an exception
             task.run()
-            # should not call execInSysroot
-            execInSysroot.assert_not_called()
+            # should not call execWithRedirect
+            exec_mock.assert_not_called()
 
-    @patch('pyanaconda.core.util.execInSysroot')
-    def test_firewall_config_task_default(self, execInSysroot):
+    @patch('pyanaconda.modules.network.firewall.installation.execWithRedirect')
+    def test_firewall_config_task_default(self, exec_mock):
         """Test the Firewall configuration task - default."""
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -881,11 +881,14 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
                                          trusts = [])
             task.run()
 
-            execInSysroot.assert_called_once_with('/usr/bin/firewall-offline-cmd',
-                                                  ['--enabled', '--service=ssh'], root=sysroot)
+            exec_mock.assert_called_once_with(
+                '/usr/bin/firewall-offline-cmd',
+                ['--enabled', '--service=ssh'],
+                root=sysroot
+            )
 
-    @patch('pyanaconda.core.util.execInSysroot')
-    def test_firewall_config_task_enable(self, execInSysroot):
+    @patch('pyanaconda.modules.network.firewall.installation.execWithRedirect')
+    def test_firewall_config_task_enable(self, exec_mock):
         """Test the Firewall configuration task - enable."""
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -901,10 +904,14 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
                                          trusts = [])
             task.run()
 
-            execInSysroot.assert_called_once_with('/usr/bin/firewall-offline-cmd', ['--enabled', '--service=ssh'], root=sysroot)
+            exec_mock.assert_called_once_with(
+                '/usr/bin/firewall-offline-cmd',
+                ['--enabled', '--service=ssh'],
+                root=sysroot
+            )
 
-    @patch('pyanaconda.core.util.execInSysroot')
-    def test_firewall_config_task_enable_with_options(self, execInSysroot):
+    @patch('pyanaconda.modules.network.firewall.installation.execWithRedirect')
+    def test_firewall_config_task_enable_with_options(self, exec_mock):
         """Test the Firewall configuration task - enable with options."""
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -920,13 +927,15 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
                                          trusts = ["eth1"])
             task.run()
 
-            execInSysroot.assert_called_once_with('/usr/bin/firewall-offline-cmd',
-                                                  ['--enabled', '--service=ssh', '--trust=eth1', '--port=22001:tcp',
-                                                   '--port=6400:udp', '--remove-service=tftp', '--service=smnp'],
-                                                  root=sysroot)
+            exec_mock.assert_called_once_with(
+                '/usr/bin/firewall-offline-cmd',
+                ['--enabled', '--service=ssh', '--trust=eth1', '--port=22001:tcp',
+                 '--port=6400:udp', '--remove-service=tftp', '--service=smnp'],
+                root=sysroot
+            )
 
-    @patch('pyanaconda.core.util.execInSysroot')
-    def test_firewall_config_task_disable_ssh(self, execInSysroot):
+    @patch('pyanaconda.modules.network.firewall.installation.execWithRedirect')
+    def test_firewall_config_task_disable_ssh(self, exec_mock):
         """Test the Firewall configuration task - test SSH can be disabled."""
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -942,12 +951,14 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
                                          trusts = [])
             task.run()
 
-            execInSysroot.assert_called_once_with('/usr/bin/firewall-offline-cmd',
-                                                  ['--enabled', '--remove-service=ssh'],
-                                                  root=sysroot)
+            exec_mock.assert_called_once_with(
+                '/usr/bin/firewall-offline-cmd',
+                ['--enabled', '--remove-service=ssh'],
+                root=sysroot
+            )
 
-    @patch('pyanaconda.core.util.execInSysroot')
-    def test_firewall_config_task_enable_disable_service(self, execInSysroot):
+    @patch('pyanaconda.modules.network.firewall.installation.execWithRedirect')
+    def test_firewall_config_task_enable_disable_service(self, exec_mock):
         """Test the Firewall configuration task - test enabling & disabling the same service"""
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -963,12 +974,14 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
                                          trusts = [])
             task.run()
 
-            execInSysroot.assert_called_once_with('/usr/bin/firewall-offline-cmd',
-                                                  ['--enabled', '--service=ssh', '--remove-service=tftp', '--service=tftp'],
-                                                  root=sysroot)
+            exec_mock.assert_called_once_with(
+                '/usr/bin/firewall-offline-cmd',
+                ['--enabled', '--service=ssh', '--remove-service=tftp', '--service=tftp'],
+                root=sysroot
+            )
 
-    @patch('pyanaconda.core.util.execInSysroot')
-    def test_firewall_config_task_disable(self, execInSysroot):
+    @patch('pyanaconda.modules.network.firewall.installation.execWithRedirect')
+    def test_firewall_config_task_disable(self, exec_mock):
         """Test the Firewall configuration task - disable."""
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -984,10 +997,14 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
                                          trusts = [])
             task.run()
 
-            execInSysroot.assert_called_once_with('/usr/bin/firewall-offline-cmd', ['--disabled', '--service=ssh'], root=sysroot)
+            exec_mock.assert_called_once_with(
+                '/usr/bin/firewall-offline-cmd',
+                ['--disabled', '--service=ssh'],
+                root=sysroot
+            )
 
-    @patch('pyanaconda.core.util.execInSysroot')
-    def test_firewall_config_task_disable_with_options(self, execInSysroot):
+    @patch('pyanaconda.modules.network.firewall.installation.execWithRedirect')
+    def test_firewall_config_task_disable_with_options(self, exec_mock):
         """Test the Firewall configuration task - disable with options."""
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -1004,13 +1021,15 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
             task.run()
 
             # even in disable mode, we still forward all the options to firewall-offline-cmd
-            execInSysroot.assert_called_once_with('/usr/bin/firewall-offline-cmd',
-                                                  ['--disabled', '--service=ssh', '--trust=eth1', '--port=22001:tcp',
-                                                   '--port=6400:udp', '--remove-service=tftp', '--service=smnp'],
-                                                  root=sysroot)
+            exec_mock.assert_called_once_with(
+                '/usr/bin/firewall-offline-cmd',
+                ['--disabled', '--service=ssh', '--trust=eth1', '--port=22001:tcp',
+                 '--port=6400:udp', '--remove-service=tftp', '--service=smnp'],
+                root=sysroot
+            )
 
-    @patch('pyanaconda.core.util.execInSysroot')
-    def test_firewall_config_task_use_system_defaults(self, execInSysroot):
+    @patch('pyanaconda.modules.network.firewall.installation.execWithRedirect')
+    def test_firewall_config_task_use_system_defaults(self, exec_mock):
         """Test the Firewall configuration task - use system defaults."""
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -1027,7 +1046,7 @@ class FirewallConfigurationTaskTestCase(unittest.TestCase):
             task.run()
 
             # firewall-offline-cmd should not be called in use-system-defaults mode
-            execInSysroot.assert_not_called()
+            exec_mock.assert_not_called()
 
 
 class NetworkModuleTestCase(unittest.TestCase):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
@@ -647,7 +647,7 @@ class BootloaderTasksTestCase(unittest.TestCase):
 
     @patch('pyanaconda.modules.storage.bootloader.installation.conf')
     @patch("pyanaconda.modules.storage.bootloader.installation.arch.is_s390")
-    @patch("pyanaconda.modules.storage.bootloader.installation.execInSysroot")
+    @patch("pyanaconda.modules.storage.bootloader.installation.execWithRedirect")
     def test_fix_zipl(self, execute, is_s390, conf):
         """Test the installation task for the ZIPL fix."""
         is_s390.return_value = False
@@ -667,8 +667,9 @@ class BootloaderTasksTestCase(unittest.TestCase):
 
         is_s390.return_value = True
         conf.target.is_directory = False
+        conf.target.system_root = "/target/root"
         FixZIPLBootloaderTask(BootloaderMode.ENABLED).run()
-        execute.assert_called_once_with("zipl", [])
+        execute.assert_called_once_with("zipl", [], root="/target/root")
 
 
 class BootLoaderFactoryTestCase(unittest.TestCase):


### PR DESCRIPTION
Less code to watch, also no coverage. Part of `exec*` refactoring.

Can't remove yet, used by OSCAP. Let's dump the function once the final replacement is available. Now marked only as to be removed.

~~WIP - replacing parts one by one.~~