### PR TITLE
Use local spec file for container build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -174,6 +174,9 @@ release-and-tag:
 	$(MAKE) tag
 
 anaconda-ci-build:
+	TEMP=$$(mktemp -t -d anaconda-ci-build.XXXX) && \
+	cp $(srcdir)/anaconda.spec.in $(CI_DOCKERFILE)/* $$TEMP/ && \
+	echo "Build dir is $$TEMP" && \
 	$(CONTAINER_ENGINE) build \
 	$(CONTAINER_BUILD_ARGS) \
 	$(CONTAINER_ADD_ARGS) \
@@ -181,9 +184,13 @@ anaconda-ci-build:
 	--build-arg=image=$(BASE_CONTAINER) \
 	--build-arg=copr_repo=$(COPR_REPO) \
 	-t $(CI_NAME):$(CI_TAG) \
-	$(CI_DOCKERFILE)
+	$$TEMP/ && \
+	rm -rf $$TEMP
 
 anaconda-rpm-build:
+	TEMP=$$(mktemp -t -d anaconda-rpm-build.XXXX) && \
+	cp $(srcdir)/anaconda.spec.in $(CI_DOCKERFILE)/* $$TEMP/ && \
+	echo "Build dir is $$TEMP" && \
 	$(CONTAINER_ENGINE) build \
 	$(CONTAINER_BUILD_ARGS) \
 	$(CONTAINER_ADD_ARGS) \
@@ -191,7 +198,8 @@ anaconda-rpm-build:
 	--build-arg=image=$(BASE_CONTAINER) \
 	--build-arg=copr_repo=$(COPR_REPO) \
 	-t $(RPM_NAME):$(CI_TAG) \
-	$(RPM_DOCKERFILE)
+	$$TEMP/ && \
+	rm -rf $$TEMP
 
 anaconda-iso-creator-build:
 	$(CONTAINER_ENGINE) build \

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -27,13 +27,16 @@ LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 # On ELN, BaseOS+AppStream don't have all our build dependencies; this provides the "Everything" compose
 COPY ["eln.repo", "/etc/yum.repos.d"]
 
+# The anaconda.spec.in is in the repository root. This file will be copied automatically here if
+# the build is invoked by Makefile.
+COPY ["anaconda.spec.in", "/root/"]
+
 # Prepare environment and install build dependencies
 RUN set -ex; \
   if grep -q VARIANT.*eln /etc/os-release; then sed -i 's/enabled=0/enabled=1/' /etc/yum.repos.d/eln.repo; fi; \
   dnf update -y; \
   dnf install -y \
   'dnf-command(copr)' \
-  curl \
   /usr/bin/xargs \
   rpm-build \
   git \
@@ -58,7 +61,7 @@ RUN set -ex; \
   else \
     dnf copr enable -y ${copr_repo} fedora-eln-x86_64; \
   fi; \
-  curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/${git_branch}/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
+  cat /root/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   rpmspec -q --requires /tmp/anaconda.spec | grep -v anaconda | xargs -d '\n' dnf install -y; \
   dnf clean all

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -1,3 +1,6 @@
+# This container is used for runing Anaconda unit tests in the controlled environment.
+# To find out how to build this container please look on the ./tests/README.rst file.
+
 # The `image` arg will set base image for the build.
 # possible values:
 #   registry.fedoraproject.org/fedora:35

--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -1,4 +1,5 @@
 # Dockerfile to build boot.iso with Anaconda from the repository.
+# To find out how to build this container please look on the ./tests/README.rst file.
 # This container has to be started as --privileged and with precreated loop devices otherwise
 # lorax won't work correctly.
 #

--- a/dockerfile/anaconda-rhel-copr/Dockerfile
+++ b/dockerfile/anaconda-rhel-copr/Dockerfile
@@ -1,3 +1,5 @@
+# This container is used for building Anaconda RPM files on COPR.
+
 ARG image=quay.io/rhinstaller/anaconda-ci:master
 FROM ${image}
 # FROM starts a new build stage with new ARGs. Put any ARGs after FROM unless required by the FROM itself.

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -22,13 +22,16 @@ LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 # On ELN, BaseOS+AppStream don't have all our build dependencies; this provides the "Everything" compose
 COPY ["eln.repo", "/etc/yum.repos.d"]
 
+# The anaconda.spec.in is in the repository root. This file will be copied automatically here if
+# the build is invoked by Makefile.
+COPY ["anaconda.spec.in", "/root/"]
+
 # Prepare environment and install build dependencies
 RUN set -ex; \
   if grep -q VARIANT.*eln /etc/os-release; then sed -i 's/enabled=0/enabled=1/' /etc/yum.repos.d/eln.repo; fi; \
   dnf update -y; \
   dnf install -y \
   'dnf-command(copr)' \
-  curl \
   python3-pip \
   /usr/bin/xargs \
   rpm-build; \
@@ -44,7 +47,7 @@ RUN set -ex; \
   else \
     dnf copr enable -y ${copr_repo} fedora-eln-x86_64; \
   fi; \
-  curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/${git_branch}/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
+  cat /root/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   dnf clean all; \
   mkdir /anaconda

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -1,3 +1,6 @@
+# This container is used for runing Anaconda RPM tests in the controlled environment.
+# To find out how to build this container please look on the ./tests/README.rst file.
+
 # The `image` arg will set base image for the build.
 # possible values:
 #   registry.fedoraproject.org/fedora:35


### PR DESCRIPTION
Some of our containers needs dependencies of Anaconda installed in it and to get these we were downloading anaconda.spec.in from the rhinstaller/anaconda repository. This works, but it has a big drawbacks like not being able to use this correctly from a fork for testing or do not test spec file changes in PRs.

Spec file couldn't be read from the repository because podman/docker do allow only resources under the build directory.

To solve this, the Makefile will copy the anaconda.spec.in file to the dockerfile(s) directory before the build, so we don't have to care about this.