### PR TITLE
Enable Closest mirror on CentOS Stream 9

### DIFF
--- a/data/product.d/centos-stream.conf
+++ b/data/product.d/centos-stream.conf
@@ -21,3 +21,4 @@ default_help_pages =
 
 [Payload]
 default_source = CLOSEST_MIRROR
+enable_closest_mirror = True


### PR DESCRIPTION
It is disabled on RHEL 9 which is base for CentOS Stream 9.

*Related: rhbz#1955331*