### PR TITLE
Fix too shallow clone in release action (#infra)

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}
+          fetch-depth: 0
 
       - name: Build anaconda-rpm container (for RPM build)
         run: |


### PR DESCRIPTION
Running git describe needs history to work.