### PR TITLE
Create downstream release changelog from GitHub releases (#infra)

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,6 +1,7 @@
 specfile_path: anaconda.spec
 upstream_package_name: anaconda
 upstream_tag_template: anaconda-{version}-1
+copy_upstream_release_description: true
 actions:
   post-upstream-clone:
     - ./autogen.sh


### PR DESCRIPTION
Right now automated releases are created from a commits between the last release and the new one. That works good but if we want to play with formatting and removing something it's better to use GitHub releases than the commits.