### PR TITLE
Satellite support - port to Fedora, batch nr. 2

### DIFF
--- a/pyanaconda/modules/subscription/satellite.py
+++ b/pyanaconda/modules/subscription/satellite.py
@@ -1,0 +1,166 @@
+#
+# Satellite support purpose library.
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import os
+import tempfile
+
+from requests import RequestException
+
+from pyanaconda.core import constants, util
+from pyanaconda.core.path import make_directories, join_paths
+
+from pyanaconda.core.payload import ProxyString, ProxyStringError
+from pyanaconda.core.configuration.anaconda import conf
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+# the well-known path of the Satellite instance URL where
+# the provisioning script should be located
+PROVISIONING_SCRIPT_SUB_PATH = "/pub/katello-rhsm-consumer"
+
+
+def download_satellite_provisioning_script(satellite_url, proxy_url=None):
+    """Download provisioning script from a Red Hat Satellite instance.
+
+    Download the provisioning script from a Satellite instance and return
+    it as a string.
+
+    Satellite instances usually have self signed certificates and also some tweaks
+    are usually required in rhsm.conf to connect to a customer run Satellite instance
+    instead of to Hosted Candlepin for subscription purposes.
+
+    Each Satellite instance thus hosts a provisioning script available over plain
+    HTTP that client machines can download and execute. This script has minimal dependencies
+    and provisions the machine to be able to talk to the one given Satellite instance
+    by installing it's self signed certificates and adjusting rhsm.conf.
+
+    NOTE: As the script is downloaded over plain HTTP it is advised to ever only
+          provision machines from a Satellite instance on a trusted network, to
+          avoid the possibility of the provisioning script being tempered with
+          during transit.
+
+    :param str satellite_url: Satellite instance URL
+    :param proxy_url: proxy URL to use when fetching the script
+    :type proxy_url: str or None if not set
+    :returns: True on success, False otherwise
+    """
+    # make sure the URL starts with protocol
+    if not satellite_url.startswith("http"):
+        satellite_url = "http://" + satellite_url
+
+    # construct the URL pointing to the provisioning script
+    script_url = satellite_url + PROVISIONING_SCRIPT_SUB_PATH
+
+    log.debug("subscription: fetching Satellite provisioning script from: %s", script_url)
+
+    headers = {"user-agent": constants.USER_AGENT}
+    proxies = {}
+    provisioning_script = ""
+
+    # process proxy URL (if any)
+    if proxy_url is not None:
+        try:
+            proxy = ProxyString(proxy_url)
+            proxies = {"http": proxy.url,
+                       "https": proxy.url}
+        except ProxyStringError as e:
+            log.info("subscription: failed to parse proxy when fetching Satellite"
+                     " provisioning script %s: %s",
+                     proxy_url, e)
+
+    with util.requests_session() as session:
+        try:
+            # NOTE: we explicitly don't verify SSL certificates while
+            #       downloading the provisioning script as the Satellite
+            #       instance will most likely have it's own self signed certs that
+            #       will only be trusted once the provisioning script runs
+            result = session.get(script_url, headers=headers,
+                                 proxies=proxies, verify=False,
+                                 timeout=constants.NETWORK_CONNECTION_TIMEOUT)
+            if result.ok:
+                provisioning_script = result.text
+                log.debug("subscription: Satellite provisioning script downloaded (%d characters)",
+                          len(provisioning_script))
+                return provisioning_script
+            else:
+                log.debug("subscription: server returned %i code when downloading"
+                          " Satellite provisioning script", result.status_code)
+                return None
+        except RequestException as e:
+            log.debug("subscription: can't download Satellite provisioning script"
+                      " from %s with proxy: %s. Error: %s", script_url, proxies, e)
+            return None
+
+
+def run_satellite_provisioning_script(provisioning_script=None, sysroot="/"):
+    """Run the Satellite provisioning script.
+
+    Each Satellite instance provides a provisioning script that will
+    enable the currently running environment to talk to the given
+    Satellite instance.
+
+    This means that the self-signed certificates of the given
+    Satellite instance will be installed to the system but also some
+    necessary changes will be done to rhsm.conf.
+
+    As we need to provision both the installation *and* target system
+    to talk to Satellite we need to run the provisioning script twice,
+    once in the installation environment and once on the target system.
+
+    This is achieved by running this function first in the installation environment
+    with run_on_target_system == False before a registration attempt.
+    And then in the installation phase with run_on_target_system == True.
+
+    Implementation wise we just always run the script from a tempfile.
+
+    That way we can easily run it in the installation environment as well
+    as in the target system chroot with minimum code needed to make sure
+    it exists where we need it
+
+    :param str provisioning_script: content of the Satellite provisioning script
+                                    or None if no script is available
+    :param str run_on_target_system: run in the target system chroot instead,
+                                     otherwise run in the installation environment
+    :return: True on success, False otherwise
+    :rtype: bool
+    """
+    # first check we actually have the script
+    if provisioning_script is None:
+        log.warning("subscription: satellite provisioning script not available")
+        return False
+
+    # create the tempfile containing the script in the sysroot in /tmp, just in case
+    sysroot_tmp = join_paths(sysroot, "/tmp")
+    # make sure the path exists
+    make_directories(sysroot_tmp)
+    with tempfile.NamedTemporaryFile(mode="w+t", dir=sysroot_tmp, prefix="satellite-") as tf:
+        # write the provisioning script to the tempfile & flush any caches, just in case
+        tf.write(provisioning_script)
+        tf.flush()
+        # We always set root to the correct sysroot, so the script will always
+        # look like it is in /tmp. So just split the randomly generated file name
+        # and combine it with /tmp to get sysroot specific script path.
+        filename = os.path.basename(tf.name)
+        chroot_script_path = os.path.join("/tmp", filename)
+        # and execute it in the sysroot
+        rc = util.execWithRedirect("bash", argv=[chroot_script_path], root=sysroot)
+        log.debug("subscription: satellite provisioning script return code: %s", rc)
+        return rc == 0

--- a/tests/unit_tests/pyanaconda_tests/modules/subscription/test_satellite.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/subscription/test_satellite.py
@@ -1,0 +1,238 @@
+#
+# Copyright (C) 2021  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+
+import unittest
+import tempfile
+import glob
+import os
+
+from unittest.mock import patch
+
+from requests import RequestException
+
+from pyanaconda.modules.subscription.satellite import download_satellite_provisioning_script, \
+    run_satellite_provisioning_script, PROVISIONING_SCRIPT_SUB_PATH
+from pyanaconda.core.constants import USER_AGENT, NETWORK_CONNECTION_TIMEOUT
+
+
+class SatelliteLibraryTestCase(unittest.TestCase):
+    """Test the Satellite provisioning code."""
+    # this code at the moment basically just downloads the Satellite provisioning
+    # script from the Satellite instance with one method, then runs it with the other
+
+    @patch("pyanaconda.core.util.requests_session")
+    def test_script_download_no_prefix(self, get_session):
+        """Test the download_satellite_provisioning_script function - no prefix."""
+        # mock the Python Request session
+        session = get_session.return_value.__enter__.return_value
+        result = session.get.return_value
+        result.ok = True
+        result.text = "foo script text"
+        # run the download method
+        script_text = download_satellite_provisioning_script("satellite.example.com")
+        # check script text was returned
+        assert "foo script text" == script_text
+        # check the session was called correctly
+        session.get.assert_called_once_with(
+            'http://satellite.example.com' + PROVISIONING_SCRIPT_SUB_PATH,
+            headers={"user-agent": USER_AGENT},
+            proxies={},
+            verify=False,
+            timeout=NETWORK_CONNECTION_TIMEOUT
+        )
+
+    @patch("pyanaconda.core.util.requests_session")
+    def test_script_download_http(self, get_session):
+        """Test the download_satellite_provisioning_script function - http prefix."""
+        # mock the Python Request session
+        session = get_session.return_value.__enter__.return_value
+        result = session.get.return_value
+        result.ok = True
+        result.text = "foo script text"
+        # run the download method
+        script_text = download_satellite_provisioning_script("http://satellite.example.com")
+        # check script text was returned
+        assert "foo script text" == script_text
+        # check the session was called correctly
+        session.get.assert_called_once_with(
+            'http://satellite.example.com' + PROVISIONING_SCRIPT_SUB_PATH,
+            headers={"user-agent": USER_AGENT},
+            proxies={},
+            verify=False,
+            timeout=NETWORK_CONNECTION_TIMEOUT
+        )
+
+    @patch("pyanaconda.core.util.requests_session")
+    def test_script_download_https(self, get_session):
+        """Test the download_satellite_provisioning_script function - https prefix."""
+        # mock the Python Request session
+        session = get_session.return_value.__enter__.return_value
+        result = session.get.return_value
+        result.ok = True
+        result.text = "foo script text"
+        # run the download method
+        script_text = download_satellite_provisioning_script("https://satellite.example.com")
+        # check script text was returned
+        assert "foo script text" == script_text
+        # check the session was called correctly
+        session.get.assert_called_once_with(
+            'https://satellite.example.com' + PROVISIONING_SCRIPT_SUB_PATH,
+            headers={"user-agent": USER_AGENT},
+            proxies={},
+            verify=False,
+            timeout=NETWORK_CONNECTION_TIMEOUT
+        )
+
+    @patch("pyanaconda.core.util.requests_session")
+    def test_script_download_not_ok(self, get_session):
+        """Test the download_satellite_provisioning_script function - result not ok."""
+        # mock the Python Request session
+        session = get_session.return_value.__enter__.return_value
+        result = session.get.return_value
+        result.ok = False
+        result.text = "foo script text"
+        # run the download method
+        script_text = download_satellite_provisioning_script("satellite.example.com")
+        # if result has ok == False, None should be returned instead of script text
+        assert script_text is None
+        # check the session was called correctly
+        session.get.assert_called_once_with(
+            'http://satellite.example.com' + PROVISIONING_SCRIPT_SUB_PATH,
+            headers={"user-agent": USER_AGENT},
+            proxies={},
+            verify=False,
+            timeout=NETWORK_CONNECTION_TIMEOUT
+        )
+
+    @patch("pyanaconda.core.util.requests_session")
+    def test_script_download_exception(self, get_session):
+        """Test the download_satellite_provisioning_script function - exception."""
+        # mock the Python Request session
+        session = get_session.return_value.__enter__.return_value
+        session.get.side_effect = RequestException()
+        # run the download method
+        script_text = download_satellite_provisioning_script("satellite.example.com")
+        # if requests throw an exception, None should be returned instead of script text
+        assert script_text is None
+        # check the session was called correctly
+        session.get.assert_called_once_with(
+            'http://satellite.example.com' + PROVISIONING_SCRIPT_SUB_PATH,
+            headers={"user-agent": USER_AGENT},
+            proxies={},
+            verify=False,
+            timeout=NETWORK_CONNECTION_TIMEOUT
+        )
+
+    def test_script_download_local_file(self):
+        """Test the download_satellite_provisioning_script function - local file."""
+        # test download a local file to make sure we are using requests right
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            with open(os.path.join(sysroot, "foo-script.sh"), "wt") as sat_script:
+                sat_script.write("foo bar")
+
+            # run the download method
+            script_text = download_satellite_provisioning_script(
+                "file://foo-script.sh"
+            )
+
+            # check script text was returned
+            assert "foo bar" == script_text
+
+    def test_run_satellite_provisioning_script_no_script(self):
+        """Test the run_satellite_provisioning_script function - no script."""
+        # if no script is provided, False should be returned
+        assert run_satellite_provisioning_script(provisioning_script=None) == False
+
+    def test_run_satellite_provisioning_script_success(self):
+        """Test the run_satellite_provisioning_script function - success."""
+        with tempfile.TemporaryDirectory() as sysroot:
+            # successful run should return True
+            assert run_satellite_provisioning_script(
+                provisioning_script='touch /tmp/bar.txt',
+                sysroot=sysroot
+            )
+            # check temp directory was created successfully
+            assert os.path.exists(os.path.join(sysroot, "tmp"))
+            # check the script tempfile was created correctly
+            assert len(glob.glob(os.path.join(sysroot, "tmp/satellite-*"))) == 1
+            # test the script was executed properly
+            assert os.path.exists(os.path.join(sysroot, "tmp/bar.txt"))
+
+    @patch("pyanaconda.modules.subscription.satellite.conf")
+    @patch('pyanaconda.modules.subscription.satellite.util.mkdirChain')
+    @patch('tempfile.NamedTemporaryFile')
+    @patch('pyanaconda.core.util.execWithRedirect')
+    def test_run_satellite_provisioning_script_success_chroot(self,
+                                                              exec_with_redirect,
+                                                              named_tempfile,
+                                                              mkdirChain,
+                                                              patched_conf):
+        """Test the run_satellite_provisioning_script function - success in chroot."""
+        # mock sysroot
+        patched_conf.target.system_root = "/foo/sysroot"
+        # simulate successful script run
+        exec_with_redirect.return_value = 0
+        # get the actual file object
+        file_object = named_tempfile.return_value.__enter__.return_value
+        # fake a random name
+        file_object.name = "totally_random_name"
+        file_object = named_tempfile.return_value.__enter__.return_value
+        # successful run should return True
+        assert run_satellite_provisioning_script(
+            provisioning_script="foo script",
+            run_on_target_system=True) == True
+        # check temp directory was created successfully
+        mkdirChain.assert_called_once_with("/foo/sysroot/tmp")
+        # check the tempfile was created correctly
+        named_tempfile.assert_called_once_with(mode='w+t',
+                                               dir='/foo/sysroot/tmp',
+                                               prefix='satellite-')
+        # check the temp file was written out
+        file_object.write.assert_called_once_with("foo script")
+        # test the script was executed properly
+        exec_with_redirect.assert_called_once_with('bash',
+                                                   argv=['/tmp/totally_random_name'],
+                                                   root='/foo/sysroot')
+
+    @patch('pyanaconda.modules.subscription.satellite.util.mkdirChain')
+    @patch('tempfile.NamedTemporaryFile')
+    @patch('pyanaconda.core.util.execWithRedirect')
+    def test_run_satellite_provisioning_script_failure(self, exec_with_redirect,
+                                                       named_tempfile, mkdirChain):
+        """Test the run_satellite_provisioning_script function - failure."""
+        # simulate unsuccessful script run
+        exec_with_redirect.return_value = 1
+        # get the actual file object
+        file_object = named_tempfile.return_value.__enter__.return_value
+        # fake a random name
+        file_object.name = "totally_random_name"
+        file_object = named_tempfile.return_value.__enter__.return_value
+        # failed run should return False
+        assert run_satellite_provisioning_script(provisioning_script="foo script") == False
+        # check temp directory was created successfully
+        mkdirChain.assert_called_once_with("/tmp")
+        # check the tempfile was created correctly
+        named_tempfile.assert_called_once_with(mode='w+t', dir='/tmp', prefix='satellite-')
+        # check the temp file was written out
+        file_object.write.assert_called_once_with("foo script")
+        # test the script was executed properly
+        exec_with_redirect.assert_called_once_with('bash',
+                                                   argv=['/tmp/totally_random_name'],
+                                                   root='/')


### PR DESCRIPTION
Add a Python module with helper code for Satellite support &
untit tests for it.

(cherry picked from commit a92f8de965da69dc9603662e65d0c53d123c6d25)
(cherry picked from commit 0f20f62d5d5c40ae61da04335a77e88db5acfee2)
(cherry picked from commit 7ae12116014fbf5e2dee93ecb98eb478b114ffbd)

Related: rhbz#1951709

**NOTE**
* this is the second PR in the Satellite support upstreaming series
* this PR contains the Satellite support utility module and it's unit tests
* previous PR in the series: #3684 
* RHEL 9 Satellite support PR: #3485 