### PR TITLE
Allow manual releases (#infra)

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,11 +1,23 @@
 name: Release from tags
 # Create a GitHub release when a tag is pushed.
 
+# Input can ingest any string, but it will not work with arbitrary hashes. The code expects to get
+# a tag that sits on a release commit, so that commit is automatically skipped. Similarly, it
+# expects that the tag name conforms to a particular scheme.
+
 on:
   push:
     tags:
       # this is a glob, not a regexp
       - 'anaconda-*'
+
+  workflow_dispatch:
+    inputs:
+      tag-ref:
+        # it might be possible to release from arbitrary ref, but only tags work
+        description: Name of the tag to release from, such as "anaconda-33.12-1". Branch names or arbitrary commit hashes are not supported. Make sure to trim whitespace when copying.
+        type: string
+        required: true
 
 permissions:
   contents: write
@@ -13,19 +25,32 @@ permissions:
 jobs:
   release-from-tag:
     runs-on: ubuntu-latest
-
     steps:
+      - name: Resolve tag reference
+        id: get_ref
+        # Get reference of the tag that is to be released.
+        # The tag can be in two places, depending on how the workflow was started.
+        run: |
+          if [ -n "${{ github.event.inputs.tag-ref }}" ] ; then
+            echo "Using tag from manual input: ${{ github.event.inputs.tag-ref }}"
+            echo "::set-output name=ref::${{ github.event.inputs.tag-ref }}"
+          else
+            echo "Using tag from automatic input: ${{ github.ref }}"
+            echo "::set-output name=ref::${{ github.ref }}"
+          fi
+
       - name: Extract version from the tag
         id: get_version
+        # Get the actual version number from the tag, eg. anaconda-33.12-1 -> 33.12
         # If the version does not fit the regexp, we'll just fail. TODO maybe abort instead?
         run: |
-          echo "Checking pushed tag ref ${{ github.ref }}"
-          VER=$(echo ${{ github.ref }} | perl -ne '/^refs\/tags\/anaconda-([0-9]+(?:\.[0-9]+){1,3})-1$/ && print "$1\n";')
+          echo "Checking if ref ${{ steps.get_ref.outputs.ref }} is a valid release tag."
+          VER=$(echo ${{ steps.get_ref.outputs.ref }} | perl -ne '/^(?:refs\/tags\/)?anaconda-([0-9]+(?:\.[0-9]+){1,3})-1$/ && print "$1\n";')
           if [ -z "$VER" ] ; then
-            echo "Tag ref ${{ github.ref }} is not a valid release tag."
+            echo "Tag ref ${{ steps.get_ref.outputs.ref }} is not a valid release tag."
             exit 1
           else
-            echo "Tag ref ${{ github.ref }} detected as release version $VER."
+            echo "Tag ref ${{ steps.get_ref.outputs.ref }} detected as release version $VER."
             echo "::set-output name=version::$VER"
           fi
 
@@ -88,7 +113,7 @@ jobs:
 
           # create release with the release notes
           gh release create \
-            ${{ github.ref }} \
+            ${{ steps.get_ref.outputs.ref }} \
             --draft \
             --title "anaconda-$RELEASE_NAME" \
             --notes-file release.txt \


### PR DESCRIPTION
With this, we can go back in time and run the release process for a tag from the past... after fixing the action in the future!

Fix history and make it just flawless - at a press of a button.

Truly exciting.

However...

![Obligatory meme picture](https://i.kym-cdn.com/photos/images/newsfeed/001/848/694/5b4.jpg)

I am not sure what would happen if we tried this for a release too far back, with different `BuildRequires`. Let's not depend on this too much.

Tested here to ensure it would not explode too badly: https://github.com/VladimirSlavik/testing/actions The two green runs are manual and automatic respectively.

Thanks to @M4rtinK for inspiration by testing the previous iteration until it exploded.