### PR TITLE
Show all logs of failed unit tests

### DIFF
--- a/tests/unit_tests/unit_tests.sh
+++ b/tests/unit_tests/unit_tests.sh
@@ -11,4 +11,4 @@ if [ $# -eq 0 ]; then
     set -- "$top_srcdir/tests/unit_tests"
 fi
 
-exec pytest -vv ${UNIT_TESTS_PATTERN:+-k $UNIT_TESTS_PATTERN} "$@"
+exec pytest -vv --log-level=NOTSET ${UNIT_TESTS_PATTERN:+-k $UNIT_TESTS_PATTERN} "$@"


### PR DESCRIPTION
Set the log level of unit tests to `UNSET` to get all messages.