### PR TITLE
Skip /etc/machine-info during live installs (#2036199)

### DIFF
--- a/pyanaconda/modules/payloads/payload/live_image/installation.py
+++ b/pyanaconda/modules/payloads/payload/live_image/installation.py
@@ -363,6 +363,7 @@ class InstallFromTarTask(Task):
             "--exclude", "./boot/loader",
             "--exclude", "./boot/efi/loader",
             "--exclude", "./etc/machine-id",
+            "--exclude", "./etc/machine-info",
             "-xaf", self._tarfile,
             "-C", self._sysroot
         ]
@@ -437,6 +438,7 @@ class InstallFromImageTask(Task):
             "--exclude", "/boot/loader/",
             "--exclude", "/boot/efi/loader/",
             "--exclude", "/etc/machine-id",
+            "--exclude", "/etc/machine-info",
             os.path.normpath(self._mount_point) + "/",
             self._sysroot
         ]

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
@@ -109,6 +109,7 @@ class InstallFromImageTaskTestCase(unittest.TestCase):
             "--exclude", "/boot/loader/",
             "--exclude", "/boot/efi/loader/",
             "--exclude", "/etc/machine-id",
+            "--exclude", "/etc/machine-info",
             mount_point + "/",
             "/mnt/root"
         ])
@@ -181,6 +182,7 @@ class InstallFromTarTaskTestCase(unittest.TestCase):
             "--exclude", "./boot/loader",
             "--exclude", "./boot/efi/loader",
             "--exclude", "./etc/machine-id",
+            "--exclude", "./etc/machine-info",
             "-xaf", f.name,
             "-C", "/mnt/root"
         ])


### PR DESCRIPTION
/etc/machine-info should not be installed to the system, for
the same reason we don't install /etc/machine-id: it should be
system-specific, not the same for every install from the same
live image.

This should fix live installs with systemd 250+ not booting due
to the bootloader config snippets being named based on the
KERNEL_INSTALL_MACHINE_ID from the live image /etc/machine-info,
but grub2-mkconfig expecting them to be named according to the
installed system's newly-generated /etc/machine-id.

Signed-off-by: Adam Williamson <awilliam@redhat.com>