### PR TITLE
Always set system purpose from the GUI

### DIFF
--- a/pyanaconda/modules/subscription/runtime.py
+++ b/pyanaconda/modules/subscription/runtime.py
@@ -96,7 +96,7 @@ SystemSubscriptionData = namedtuple("SystemSubscriptionData",
 
 
 class SystemPurposeConfigurationTask(Task):
-    """Installation task for setting system purpose."""
+    """Runtime task for setting system purpose."""
 
     def __init__(self, rhsm_syspurpose_proxy, system_purpose_data):
         """Create a new system purpose configuration task.

--- a/pyanaconda/modules/subscription/system_purpose.py
+++ b/pyanaconda/modules/subscription/system_purpose.py
@@ -198,6 +198,6 @@ def give_the_system_purpose(sysroot, rhsm_syspurpose_proxy, role, sla, usage, ad
             log.debug("subscription: failed to set system purpose: %s", str(e))
             return False
     else:
-        log.warning("subscription: not calling syspurpose as no fields have been provided")
+        log.warning("subscription: syspurpose will not be set as no fields have been provided")
         # doing nothing is still not a failure
         return True

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -95,15 +95,6 @@ class SubscriptionSpoke(NormalSpoke):
         # get initial data from the Subscription module
         self._subscription_request = self._get_subscription_request()
         self._system_purpose_data = self._get_system_purpose_data()
-        # Keep a copy of system purpose data that has been last applied to
-        # the installation environment.
-        # That way we can check if the main copy of the system purposed data
-        # changed since it was applied (for example due to user input)
-        # and needs to be reapplied.
-        # By default this variable is None and will only be set to a
-        # SystemPurposeData instance when first system purpose data is
-        # applied to the installation environment.
-        self._last_applied_system_purpose_data = None
 
         self._authentication_method = AuthenticationMethod.USERNAME_PASSWORD
 
@@ -846,12 +837,10 @@ class SubscriptionSpoke(NormalSpoke):
 
         If the last applied data is the same as current system purpose data, nothing is done.
         """
-        if self._last_applied_system_purpose_data != self.system_purpose_data:
-            log.debug("Subscription GUI: applying system purpose data to installation environment")
-            task_path = self._subscription_module.SetSystemPurposeWithTask()
-            task_proxy = SUBSCRIPTION.get_proxy(task_path)
-            sync_run_task(task_proxy)
-            self._last_applied_system_purpose_data = self.system_purpose_data
+        log.debug("Subscription GUI: applying system purpose data to installation environment")
+        task_path = self._subscription_module.SetSystemPurposeWithTask()
+        task_proxy = SUBSCRIPTION.get_proxy(task_path)
+        sync_run_task(task_proxy)
 
     def _get_subscription_request(self):
         """Get SubscriptionRequest from the Subscription module."""


### PR DESCRIPTION
Fix the issue of system purpose not being set if the system is re-registered - registered first without system purpose being set, unregistered and registered again with system purpose *being* set.

Also fixup some outdated system purpose related strings I've noticed when looking into this.