### PR TITLE
Correct liveinst SELinux status check

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -47,7 +47,7 @@ if [ -x /usr/sbin/getenforce ]; then
     /usr/sbin/setenforce 0
 fi
 
-if (sestatus | grep -q enabled) then
+if (! sestatus | grep -q enabled) then
     ANACONDA="$ANACONDA --noselinux"
 fi
 


### PR DESCRIPTION
b11de43 accidentally inverted the logic of this check. It now
adds `--noselinux` if SELinux is enabled, which obviously isn't
what we want.

Signed-off-by: Adam Williamson <awilliam@redhat.com>