### PR TITLE
Set the use_cockpit RPM macro to 0

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -6,7 +6,7 @@ License: GPLv2+ and MIT
 URL:     http://fedoraproject.org/wiki/Anaconda
 
 # This should should only be set for development purposes for the time
-%global use_cockpit 1
+%global use_cockpit 0
 
 # To generate Source0 do:
 # git clone https://github.com/rhinstaller/anaconda


### PR DESCRIPTION
Otherwise the anaconda-webui package would end up on the Fedora
installation media and we don't want that just yet.