### PR TITLE
packit: release: unset use_cockpit by sedding the specfile in packit script

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -6,6 +6,7 @@ actions:
   post-upstream-clone:
     - ./autogen.sh
     - ./configure
+    - sed -i 's/use_cockpit\ 1/use_cockpit 0/g' anaconda.spec
   create-archive:
     - "make release"
     - 'bash -c "ls -1 anaconda-*.tar.bz2"'

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -342,6 +342,11 @@ desktop-file-install --dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_d
 # If no langs found, keep going
 %find_lang %{name} || :
 
+%if ! %use_cockpit
+    rm -rf %{buildroot}/%{_datadir}/cockpit/anaconda-webui
+    rm -f %{buildroot}/%{_datadir}/metainfo/org.cockpit-project.anaconda-webui.metainfo.xml
+%endif
+
 
 # main package and install-env-deps are metapackages
 %files


### PR DESCRIPTION
Also, remove the unpackaged anaconda-webui files in the case `use_cockpit` is unset.