### PR TITLE
Remove the WriteResolvConfTask class

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -45,25 +45,6 @@ log = get_module_logger(__name__)
 __all__ = ["run_installation"]
 
 
-class WriteResolvConfTask(Task):
-    """Custom task subclass for handling the resolv.conf copy task.
-
-    The main reason is to resolve the sysroot path right before the
-    copy operation, not at task & task queue creation time.
-
-    Secondary reason is to demonstrate how a lightweight Task subclass can be used.
-    """
-
-    def run_task(self):
-        """Resolve the sysroot path only right before doing the copy operation.
-
-        If we just added the sysroot path as an argument, it would be resolved when the
-        task queue was created, not when the task is actually executed, which could
-        theoretically result in an incorrect path.
-        """
-        network.copy_resolv_conf_to_root(conf.target.system_root)
-
-
 def _writeKS(ksdata):
     path = conf.target.system_root + "/root/anaconda-ks.cfg"
 
@@ -311,9 +292,11 @@ def _prepare_installation(payload, ksdata):
 
     # make name resolution work for rpm scripts in chroot
     if conf.system.provides_resolver_config:
-        # we use a custom Task subclass as the sysroot path has to be resolved
-        # only when the task is actually started, not at task creation time
-        pre_install.append(WriteResolvConfTask("Copy resolv.conf to sysroot"))
+        pre_install.append(Task(
+            "Copy resolv.conf to sysroot",
+            network.copy_resolv_conf_to_root,
+            (conf.target.system_root, )
+        ))
 
     if is_module_available(SECURITY):
         security_proxy = SECURITY.get_proxy()


### PR DESCRIPTION
The path to the system root does not change during installation anymore,
so we can create a generic task from a callback and its arguments instead.