### PR TITLE
Require admin user

### DIFF
--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -193,7 +193,10 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     @property
     def mandatory(self):
-        """Only mandatory if no admin user has been requested."""
+        """Only mandatory if no admin user has been requested.
+
+        See also doc for the property completed().
+        """
         return not self._users_module.CheckAdminUserExists()
 
     def apply(self):
@@ -222,7 +225,14 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
 
     @property
     def completed(self):
-        return self._users_module.IsRootPasswordSet
+        """Is the spoke completed?
+
+        For root and user, the mandatory+completed pair is a complicated hack. Having an usable
+        admin user is mandatory, but it is not clear if it should be an unlocked root, or a sudoer.
+        Thus, mandatory on both spokes checks admin user, and complete then checks again: Both the
+        spoke-specific completion condition, as well as existence of an admin.
+        """
+        return self._users_module.IsRootPasswordSet and self._users_module.CheckAdminUserExists()
 
     @property
     def sensitive(self):

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -461,7 +461,10 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
 
     @property
     def mandatory(self):
-        """Only mandatory if no admin user has been requested."""
+        """Only mandatory if no admin user has been requested.
+
+        See also doc for the property completed().
+        """
         return not self._users_module.CheckAdminUserExists()
 
     def apply(self):
@@ -505,7 +508,15 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
 
     @property
     def completed(self):
-        return bool(get_user_list(self._users_module))
+        """Is the spoke completed?
+
+        For root and user, the mandatory+completed pair is a complicated hack. Having an usable
+        admin user is mandatory, but it is not clear if it should be an unlocked root, or a sudoer.
+        Thus, mandatory on both spokes checks admin user, and complete then checks again: Both the
+        spoke-specific completion condition, as well as existence of an admin.
+        """
+        return bool(get_user_list(self._users_module)) \
+               and self._users_module.CheckAdminUserExists()
 
     def on_password_required_toggled(self, togglebutton=None, data=None):
         """Called by Gtk callback when the "Use password" check


### PR DESCRIPTION
Previously, it was possible to satisfy the conditions just by setting root password, even if root was locked.

This changes both root and user spoke to signal the incomplete user.

Resolves: rhbz#2015508
Resolves: [rhbz#2047713](https://bugzilla.redhat.com/show_bug.cgi?id=2047713)

(cherry picked from commit 4cd6cd5e751c0f2aec923584c66090ced7e818fb - this backports #3665.)