### PR TITLE
Don't use progressQ in the Flatpak manager

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_installation.py
@@ -39,7 +39,11 @@ class InstallFlatpaksTask(Task):
 
     def run(self):
         self.report_progress(_("Installing Flatpak applications"))
-        flatpak_manager = FlatpakManager(self._sysroot)
+
+        flatpak_manager = FlatpakManager(
+            sysroot=self._sysroot,
+            callback=self.report_progress
+        )
 
         # Initialize new repo on the installed system
         flatpak_manager.initialize_with_system_path()

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_manager.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_manager.py
@@ -31,8 +31,7 @@ from pyanaconda.modules.common.errors.installation import PayloadInstallationErr
 gi.require_version("Flatpak", "1.0")
 gi.require_version("Gio", "2.0")
 
-from gi.repository.Flatpak import Transaction, Installation, Remote, \
-    TransactionOperationType, TransactionErrorDetails
+from gi.repository.Flatpak import Transaction, Installation, Remote, TransactionOperationType
 from gi.repository.Gio import File
 
 log = get_module_logger(__name__)
@@ -229,8 +228,7 @@ class FlatpakManager(object):
         :type details: int value of Flatpak.TransactionErrorDetails
         """
         self._log_operation(operation, "failed")
-        log.error("Flatpak installation failed with message: '%s' -- error is fatal %s",
-                  error.message, details == TransactionErrorDetails.FATAL)
+        log.error("Flatpak operation has failed with a message: '%s'", error.message)
 
     def _report_progress(self, message):
         """Report a progress message."""


### PR DESCRIPTION
* It doesn't work in a DBus module. Use progress reporting of a DBus task instead.
* Simplify the error message about a failed Flatpak operation.
* Extend the unite tests for the Flatpak manager