### PR TITLE
Add the `installation_enabled` attribute to the repository configuration data

### DIFF
--- a/pyanaconda/modules/common/structures/payload.py
+++ b/pyanaconda/modules/common/structures/payload.py
@@ -84,6 +84,7 @@ class RepoConfigurationData(DBusData):
         self._cost = DNF_DEFAULT_REPO_COST
         self._exclude_packages = []
         self._included_packages = []
+        self._installation_enabled = False
 
     @classmethod
     def from_directory(cls, directory_path):
@@ -228,3 +229,18 @@ class RepoConfigurationData(DBusData):
     @included_packages.setter
     def included_packages(self, included_packages: List[Str]):
         self._included_packages = included_packages
+
+    @property
+    def installation_enabled(self) -> Bool:
+        """Should the repository be installed to the target system?
+
+        The installer will generate a repo file with a configuration
+        of this repository and write it to the target system.
+
+        :return: True or False
+        """
+        return self._installation_enabled
+
+    @installation_enabled.setter
+    def installation_enabled(self, value: Bool):
+        self._installation_enabled = value

--- a/pyanaconda/modules/payloads/kickstart.py
+++ b/pyanaconda/modules/payloads/kickstart.py
@@ -63,6 +63,7 @@ def convert_ks_repo_to_repo_data(ks_data):
     repo_data.cost = ks_data.cost or DNF_DEFAULT_REPO_COST
     repo_data.included_packages = ks_data.includepkgs
     repo_data.excluded_packages = ks_data.excludepkgs
+    repo_data.installation_enabled = ks_data.install
 
     repo_data.ssl_verification_enabled = not ks_data.noverifyssl
     repo_data.ssl_configuration.ca_cert_path = ks_data.sslcacert or ""
@@ -103,6 +104,7 @@ def convert_repo_data_to_ks_repo(repo_data):
 
     ks_data.includepkgs = repo_data.included_packages
     ks_data.excludepkgs = repo_data.excluded_packages
+    ks_data.install = repo_data.installation_enabled
 
     return ks_data
 

--- a/pyanaconda/modules/payloads/source/url/url.py
+++ b/pyanaconda/modules/payloads/source/url/url.py
@@ -47,9 +47,6 @@ class URLSourceModule(PayloadSourceBase, RPMSourceMixin):
 
         self._repo_configuration.name = self._url_source_name
 
-        self._install_repo_enabled = False
-        self.install_repo_enabled_changed = Signal()
-
     def __repr__(self):
         return "Source(type='URL', url='{}')".format(self._repo_configuration.url)
 
@@ -192,21 +189,3 @@ class URLSourceModule(PayloadSourceBase, RPMSourceMixin):
     def _validate_url(self, url_type):
         if url_type not in URL_TYPES:
             raise InvalidValueError("Invalid source type set '{}'".format(url_type))
-
-    @property
-    def install_repo_enabled(self):
-        """Get if this repository will be installed to the resulting system.
-
-        :rtype: bool
-        """
-        return self._install_repo_enabled
-
-    def set_install_repo_enabled(self, install_repo_enabled):
-        """Set if this repository will be installed to the resulting system.
-
-        :param install_repo_enabled: True if we want to have this repository installed
-        :type install_repo_enabled: bool
-        """
-        self._install_repo_enabled = install_repo_enabled
-        self.install_repo_enabled_changed.emit(self._install_repo_enabled)
-        log.debug("The install_repo_enabled has changed %s", install_repo_enabled)

--- a/pyanaconda/modules/payloads/source/url/url_interface.py
+++ b/pyanaconda/modules/payloads/source/url/url_interface.py
@@ -33,7 +33,6 @@ class URLSourceInterface(PayloadSourceBaseInterface):
     def connect_signals(self):
         super().connect_signals()
         self.watch_property("RepoConfiguration", self.implementation.repo_configuration_changed)
-        self.watch_property("InstallRepoEnabled", self.implementation.install_repo_enabled_changed)
 
     @property
     def RepoConfiguration(self) -> Structure:
@@ -55,13 +54,3 @@ class URLSourceInterface(PayloadSourceBaseInterface):
         self.implementation.set_repo_configuration(
             RepoConfigurationData.from_structure(repo_configuration)
         )
-
-    @property
-    def InstallRepoEnabled(self) -> Bool:
-        """Get if the repository should be installed to the target system."""
-        return self.implementation.install_repo_enabled
-
-    @emits_properties_changed
-    def SetInstallRepoEnabled(self, install_repo_enabled: Bool):
-        """Set if the repository should be installed to the target system."""
-        self.implementation.set_install_repo_enabled(install_repo_enabled)

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_repo.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_repo.py
@@ -33,7 +33,6 @@ class RepoConfigurationTestCase(unittest.TestCase):
     def setUp(self):
         """Set up the test."""
         self.repositories = []
-        self.installed = set()
 
     def _test_kickstart(self, ks_in, ks_out):
         """Simulate the kickstart test.
@@ -53,10 +52,6 @@ class RepoConfigurationTestCase(unittest.TestCase):
             handler.repo.dataList()
         ))
 
-        self.installed = {
-            r.name for r in handler.repo.dataList() if r.install
-        }
-
         # Verify the DBus data.
         RepoConfigurationData.to_structure_list(self.repositories)
 
@@ -66,7 +61,6 @@ class RepoConfigurationTestCase(unittest.TestCase):
 
         for repo_data in self.repositories:
             ks_repo = convert_repo_data_to_ks_repo(repo_data)
-            ks_repo.install = repo_data.name in self.installed
             handler.repo.dataList().append(ks_repo)
 
         ks_generated = str(handler).strip()

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
@@ -494,11 +494,11 @@ class DNFInterfaceTestCase(unittest.TestCase):
         )
 
     @staticmethod
-    def _generate_expected_repo_configuration_dict(mount_path):
+    def _generate_expected_repo_configuration_dict(url=""):
         return {
             "name": get_variant(Str, ""),
             "enabled": get_variant(Bool, True),
-            "url": get_variant(Str, mount_path),
+            "url": get_variant(Str, url),
             "type": get_variant(Str, URL_TYPE_BASEURL),
             "ssl-verification-enabled": get_variant(Bool, True),
             "ssl-configuration": get_variant(Structure, {
@@ -509,7 +509,8 @@ class DNFInterfaceTestCase(unittest.TestCase):
             "proxy": get_variant(Str, ""),
             "cost": get_variant(Int, 1000),
             "excluded-packages": get_variant(List[Str], []),
-            "included-packages": get_variant(List[Str], [])
+            "included-packages": get_variant(List[Str], []),
+            "installation-enabled": get_variant(Bool, False),
         }
 
     @patch("pyanaconda.modules.payloads.source.cdrom.cdrom.CdromSourceModule.mount_point",
@@ -580,27 +581,17 @@ class DNFInterfaceTestCase(unittest.TestCase):
         data.proxy = "http://MannyBianco/"
 
         source.set_repo_configuration(data)
-
         self.shared_tests.set_sources([source])
 
-        expected = [{
+        expected = self._generate_expected_repo_configuration_dict()
+        expected.update({
             "name": get_variant(Str, "Bernard Black"),
-            "enabled": get_variant(Bool, True),
             "url": get_variant(Str, "http://library.uk"),
-            "type": get_variant(Str, URL_TYPE_BASEURL),
-            "ssl-verification-enabled": get_variant(Bool, False),
-            "ssl-configuration": get_variant(Structure, {
-                "ca-cert-path": get_variant(Str, ""),
-                "client-cert-path": get_variant(Str, ""),
-                "client-key-path": get_variant(Str, "")
-            }),
             "proxy": get_variant(Str, "http://MannyBianco/"),
-            "cost": get_variant(Int, 1000),
-            "excluded-packages": get_variant(List[Str], []),
-            "included-packages": get_variant(List[Str], [])
-        }]
+            "ssl-verification-enabled": get_variant(Bool, False),
+        })
 
-        assert self.interface.GetRepoConfigurations() == expected
+        assert self.interface.GetRepoConfigurations() == [expected]
 
 
 class DNFModuleTestCase(unittest.TestCase):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_url.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_url.py
@@ -267,7 +267,8 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
             ]),
             "included-packages": get_variant(List[Str], [
                 "Batman", "Robin", "Alfred", "Batgirl"
-            ])
+            ]),
+            "installation-enabled": get_variant(Bool, False),
         }
 
         self._check_dbus_property(

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_url.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_url.py
@@ -289,21 +289,6 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
         assert self.url_source_interface.RepoConfiguration == \
             RepoConfigurationData.to_structure(data)
 
-    def test_set_true_install_properties(self):
-        self._check_dbus_property(
-            "InstallRepoEnabled",
-            True
-        )
-
-    def test_set_false_install_properties(self):
-        self._check_dbus_property(
-            "InstallRepoEnabled",
-            False
-        )
-
-    def test_default_install_properties(self):
-        assert self.url_source_interface.InstallRepoEnabled is False
-
 
 class URLSourceTestCase(unittest.TestCase):
     """Test the URL source module."""


### PR DESCRIPTION
Extend the DBus data for the repository configuration with
the `installation_enabled` property.

Remove the `InstallRepoEnabled` DBus property of the URL source.