### PR TITLE
spec: Add dependency on libblockdev-lvm-dbus to install-env-deps

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -176,6 +176,9 @@ for live installations.
 Summary: Installation environment specific dependencies
 Requires: udisks2-iscsi
 Requires: libblockdev-plugins-all >= %{libblockdevver}
+%if ! 0%{?rhel}
+Requires: libblockdev-lvm-dbus
+%endif
 # active directory/freeipa join support
 Requires: realmd
 Requires: isomd5sum >= %{isomd5sumver}


### PR DESCRIPTION
We want to use the LVM DBus API (on Fedora), libblockdev-lvm-dbus
is currently brought in by the Lorax template.

-----

This showed during a discussion with LVM team, they were trying to find out what depends on lvm2-dbusd and nothing showed up. And in general I think ti's better for Anaconda to depend on it (it already depends on the other libblockdev plugins) rather than having it randomly installed by Lorax.