### PR TITLE
Make Anaconda Cockpit ui as optional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -272,9 +272,11 @@ ci:
 		exit $$status; \
 	fi
 
+# container-ci target will have disabled cockpit Makefiles by default
 container-ci:
 	$(CONTAINER_ENGINE) run \
 	--entrypoint /anaconda/dockerfile/anaconda-ci/run-build-and-arg \
+	-e CONFIGURE_ARGS="--disable-webui" \
 	$(CONTAINER_TEST_ARGS) \
 	$(CI_TEST_ARGS) \
 	$(CONTAINER_ADD_ARGS) \

--- a/configure.ac
+++ b/configure.ac
@@ -209,9 +209,21 @@ AC_CONFIG_FILES([Makefile
                  data/pixmaps/Makefile
                  tests/Makefile
                  ui/Makefile
-                 ui/webui/Makefile
                  utils/Makefile
                  utils/dd/Makefile])
+
+### Include Cockpit part to the make execution as optional ###
+# The main reason to have this is to speed up execution of the unit-tests by avoiding npm package download.
+AC_ARG_ENABLE([webui], AS_HELP_STRING([--disable-webui], [Build without the web ui; makes the build much faster]))
+
+# Do not include the ui/webui Makefile to the build process. Everything there will be ignored.
+AS_IF([test "x$enable_webui" != "xno"],
+      [AC_CONFIG_FILES([ui/webui/Makefile])])
+AS_IF([test "x$enable_webui" != "xno"],
+      [AC_SUBST(WEBUI_SUBDIR, "webui")],
+      [AC_SUBST(WEBUI_SUBDIR, "")])
+###
+
 AC_OUTPUT
 
 # Gently advise the user about the build failures they are about to encounter

--- a/dockerfile/anaconda-ci/run-build-and-arg
+++ b/dockerfile/anaconda-ci/run-build-and-arg
@@ -7,7 +7,8 @@ cd /tmp/anaconda
 rm -rf test-logs
 
 ./autogen.sh
-./configure
+# Enable us to change autotools configuration by ENV var.
+./configure ${CONFIGURE_ARGS:-}
 
 # always copy the results back to the host
 copy_logs() {

--- a/ui/Makefile.am
+++ b/ui/Makefile.am
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = webui
+# WebUI could be excluded by ./configure --disable-webui
+SUBDIRS = @WEBUI_SUBDIR@
 
 MAINTAINERCLEANFILES = Makefile.in


### PR DESCRIPTION
Right now running `make -f ./Makefile.am container-ci` taking a long time because the new cockpit part is downloading npm packages. To make situation worse the container-ci will always remove the intermediate results so the npm packages are downloaded for every call.

To improve the situation make the `ui/webui` part optional during the build when `./configure --disable-cockpit` is added. Use this for the `container-ci` make target as default because we don't run anything web UI related there anyway.