### PR TITLE
Adjust release configuration and Packit configuration

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -13,8 +13,6 @@ actions:
 jobs:
   - job: propose_downstream
     trigger: release
-    metadata:
-      dist_git_branches: fedora-development
 
   - job: tests
     trigger: pull_request

--- a/.packit.yml
+++ b/.packit.yml
@@ -49,7 +49,7 @@ jobs:
     metadata:
       targets:
         - fedora-latest
-      branch: f35-devel
+      branch: f36-devel
       owner: "@rhinstaller"
       project: Anaconda-devel
       preserve_project: True


### PR DESCRIPTION
Let's do this in the PR:
* Fix Anaconda-devel COPR daily builds to f36-devel branch instead of f35-devel
* Propose downstream releases from this branch to Rawhide only. F36 releases should be solved by https://github.com/rhinstaller/anaconda/pull/3813