### PR TITLE
Always pull the base image during container builds (#infra)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -75,7 +75,7 @@ TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
 
 CONTAINER_ENGINE ?= podman
 # build/run tweaks for all containers, such as --cap-add
-CONTAINER_BUILD_ARGS ?= --no-cache
+CONTAINER_BUILD_ARGS ?= --no-cache --pull-always
 # HACK: bash's builtin `test -r` fails when running on Ubuntu host (GitHub) due to incompatible seccomp profile
 CONTAINER_TEST_ARGS ?= $(shell grep -q ID=ubuntu /etc/os-release && echo --security-opt=seccomp=unconfined)
 CONTAINER_REGISTRY ?= quay.io


### PR DESCRIPTION
We want to pull the base image update to not build outdated images. Without this the base image is used from the cache if present.

Backport of https://github.com/rhinstaller/anaconda/pull/3812 .