### PR TITLE
Always pull the base image during container builds (#infra)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -83,7 +83,7 @@ TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
 
 # build/run tweaks for all containers, such as --cap-add
 CONTAINER_ENGINE ?= podman
-CONTAINER_BUILD_ARGS ?= --no-cache
+CONTAINER_BUILD_ARGS ?= --no-cache --pull-always
 CONTAINER_TEST_ARGS ?=
 CONTAINER_REGISTRY ?= quay.io
 # Add additional args to the existing ones to container engine


### PR DESCRIPTION
We want to pull the base image update to not build outdated images. Without this the base image is used from the cache if present.

Backport of https://github.com/rhinstaller/anaconda/pull/3812 .