### PR TITLE
Do not copy resolv.conf to target system at the end of installation

### DIFF
--- a/pyanaconda/modules/network/installation.py
+++ b/pyanaconda/modules/network/installation.py
@@ -98,7 +98,6 @@ class NetworkInstallationTask(Task):
 
     SYSCONF_NETWORK_FILE_PATH = "/etc/sysconfig/network"
     ANACONDA_SYSCTL_FILE_PATH = "/etc/sysctl.d/anaconda.conf"
-    RESOLV_CONF_FILE_PATH = "/etc/resolv.conf"
     NETWORK_SCRIPTS_DIR_PATH = IFCFG_DIR
     PREFIXDEVNAME_CONFIG_FILE_PREFIX = "71-net-ifnames-prefix-"
     NETWORK_SCRIPTS_CONFIG_FILE_PREFIXES = ("ifcfg-", "keys-", "route-")
@@ -154,7 +153,6 @@ Name={}
             self._disable_ipv6_on_system(self._sysroot)
         self._copy_device_config_files(self._sysroot)
         self._copy_dhclient_config_files(self._sysroot, self._network_ifaces)
-        self._copy_resolv_conf(self._sysroot, self._overwrite)
         if self._configure_persistent_device_names:
             self._copy_prefixdevname_files(self._sysroot)
 
@@ -216,16 +214,6 @@ Name={}
         except OSError as e:
             msg = "Cannot disable ipv6 on the system: {}".format(e.strerror)
             raise NetworkInstallationError(msg) from e
-
-    def _copy_resolv_conf(self, root, overwrite):
-        """Copy resolf.conf file to target system.
-
-        :param root: path to the root of the target system
-        :type root: str
-        :param overwrite: overwrite existing configuration file
-        :type overwrite: bool
-        """
-        self._copy_file_to_root(root, self.RESOLV_CONF_FILE_PATH, follow_symlinks=False)
 
     def _copy_file_to_root(self, root, config_file, overwrite=False, follow_symlinks=True):
         """Copy the file to target system.

--- a/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network.py
@@ -1171,7 +1171,6 @@ class InstallationTaskTestCase(unittest.TestCase):
         # Will be created as existing or not in tests
         self._sysconf_dir = os.path.dirname(NetworkInstallationTask.SYSCONF_NETWORK_FILE_PATH)
         self._sysctl_dir = os.path.dirname(NetworkInstallationTask.ANACONDA_SYSCTL_FILE_PATH)
-        self._resolv_conf_dir = os.path.dirname(NetworkInstallationTask.RESOLV_CONF_FILE_PATH)
         self._network_scripts_dir = NetworkInstallationTask.NETWORK_SCRIPTS_DIR_PATH
         self._nm_syscons_dir = NetworkInstallationTask.NM_SYSTEM_CONNECTIONS_DIR_PATH
         self._systemd_network_dir = NetworkInstallationTask.SYSTEMD_NETWORK_CONFIG_DIR
@@ -1218,7 +1217,6 @@ class InstallationTaskTestCase(unittest.TestCase):
         # Mock the paths in the task
         task.SYSCONF_NETWORK_FILE_PATH = self._mocked_root + type(task).SYSCONF_NETWORK_FILE_PATH
         task.ANACONDA_SYSCTL_FILE_PATH = self._mocked_root + type(task).ANACONDA_SYSCTL_FILE_PATH
-        task.RESOLV_CONF_FILE_PATH = self._mocked_root + type(task).RESOLV_CONF_FILE_PATH
         task.NETWORK_SCRIPTS_DIR_PATH = self._mocked_root + type(task).NETWORK_SCRIPTS_DIR_PATH
         task.NM_SYSTEM_CONNECTIONS_DIR_PATH = self._mocked_root + \
             type(task).NM_SYSTEM_CONNECTIONS_DIR_PATH
@@ -1232,7 +1230,6 @@ class InstallationTaskTestCase(unittest.TestCase):
             installer_dirs=[
                 self._sysconf_dir,
                 self._sysctl_dir,
-                self._resolv_conf_dir,
                 self._network_scripts_dir,
                 self._nm_syscons_dir,
                 self._systemd_network_dir,
@@ -1241,7 +1238,6 @@ class InstallationTaskTestCase(unittest.TestCase):
             target_system_dirs=[
                 self._sysconf_dir,
                 self._sysctl_dir,
-                self._resolv_conf_dir,
                 self._network_scripts_dir,
                 self._nm_syscons_dir,
                 self._systemd_network_dir,
@@ -1331,10 +1327,6 @@ class InstallationTaskTestCase(unittest.TestCase):
             (("network", "Zeug"),)
         )
         self._dump_config_files(
-            self._resolv_conf_dir,
-            (("resolv.conf", "nomen"),)
-        )
-        self._dump_config_files(
             self._systemd_network_dir,
             (
                 ("71-net-ifnames-prefix-XYZ", "bla"),
@@ -1374,13 +1366,6 @@ class InstallationTaskTestCase(unittest.TestCase):
             # Anaconda disabling ipv6 (noipv6 option)
             net.ipv6.conf.all.disable_ipv6=1
             net.ipv6.conf.default.disable_ipv6=1
-            """
-        )
-        self._check_config_file(
-            self._resolv_conf_dir,
-            "resolv.conf",
-            """
-            nomen
             """
         )
         self._check_config_file(
@@ -1481,10 +1466,6 @@ class InstallationTaskTestCase(unittest.TestCase):
 
     def _create_config_files_to_check_overwrite(self):
         self._dump_config_files_in_target(
-            self._resolv_conf_dir,
-            (("resolv.conf", "original target system content"),)
-        )
-        self._dump_config_files_in_target(
             self._sysconf_dir,
             (("network", "original target system content"),)
         )
@@ -1509,10 +1490,6 @@ class InstallationTaskTestCase(unittest.TestCase):
             (("71-net-ifnames-prefix-XYZ", "original target system content"),)
         )
 
-        self._dump_config_files(
-            self._resolv_conf_dir,
-            (("resolv.conf", "installer environment content"),)
-        )
         self._dump_config_files(
             self._network_scripts_dir,
             (("ifcfg-ens3", "installer environment content"),)
@@ -1565,13 +1542,6 @@ class InstallationTaskTestCase(unittest.TestCase):
         # Files that are copied are not actually overwritten in spite of the
         # task argument
         self._check_config_file(
-            self._resolv_conf_dir,
-            "resolv.conf",
-            """
-            original target system content
-            """
-        )
-        self._check_config_file(
             self._network_scripts_dir,
             "ifcfg-ens3",
             """
@@ -1620,13 +1590,6 @@ class InstallationTaskTestCase(unittest.TestCase):
         self._check_config_file(
             self._sysconf_dir,
             "network",
-            """
-            original target system content
-            """
-        )
-        self._check_config_file(
-            self._resolv_conf_dir,
-            "resolv.conf",
             """
             original target system content
             """


### PR DESCRIPTION
An /etc/resolv.conf symlink is created on target system by
systemd-resolved in postin rpm script.  And if it is not (bug #2018913)
it would be crated during boot of installed system (by systemd-resolved).

The only case where anaconda copying the resolv.conf could have actually
effect would be overwriting /etc/resolv.conf on target system in non-rpm
payload installations (image installations). But even in this case
Anaconda should not interfere into management of /etc/resolv.conf on the
target system. It is a business of either the image creator or a service
on starting installed system (systemd-resolved or NM).