### PR TITLE
Add anaconda-release container

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,9 +92,11 @@ CONTAINER_ADD_ARGS ?=
 # anaconda-ci container
 CI_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-ci
 RPM_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-rpm
+RELEASE_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-release
 ISO_CREATOR_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-iso-creator
 CI_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-ci
 RPM_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-rpm
+RELEASE_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-release
 ISO_CREATOR_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-iso-creator
 CI_TAG ?= $(GIT_BRANCH)
 CI_TEST_ARGS ?= --rm -v $(srcdir):/anaconda:Z
@@ -183,6 +185,14 @@ release:
 	$(MAKE) po-pull
 	$(MAKE) dist
 
+container-release:
+	$(CONTAINER_ENGINE) run \
+	$(CONTAINER_TEST_ARGS) \
+	$(CI_TEST_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
+	$(RELEASE_NAME):$(CI_TAG) \
+	sh -exc './autogen.sh && ./configure && make release'
+
 release-and-tag:
 	$(MAKE) dist
 	$(MAKE) tag
@@ -200,6 +210,13 @@ anaconda-rpm-build:
 	$(CONTAINER_ADD_ARGS) \
 	-t $(RPM_NAME):$(CI_TAG) \
 	$(RPM_DOCKERFILE)
+
+anaconda-release-build: anaconda-rpm-build
+	$(CONTAINER_ENGINE) build \
+	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
+	-t $(RELEASE_NAME):$(CI_TAG) \
+	$(RELEASE_DOCKERFILE)
 
 anaconda-iso-creator-build:
 	$(CONTAINER_ENGINE) build \

--- a/dockerfile/anaconda-release/Dockerfile
+++ b/dockerfile/anaconda-release/Dockerfile
@@ -1,0 +1,22 @@
+# Dockerfile to enable releases of Anaconda for RHEL independently of the host system.
+#
+# This will be based on our existing anaconda-rpm container because it has all the dependencies
+# required to build Anaconda.
+
+FROM quay.io/rhinstaller/anaconda-rpm:rhel-8
+LABEL maintainer=anaconda-list@redhat.com
+
+# Add missing dependencies required to do the build.
+RUN set -e; \
+  dnf update -y; \
+  dnf install -y \
+  git \
+  python3-pip; \
+  dnf clean all;
+
+RUN pip3 install --no-cache-dir --upgrade pip; \
+  pip3 install --no-cache-dir \
+  polib \
+  pocketlint
+
+WORKDIR /anaconda

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -14,6 +14,7 @@ RUN set -e; \
   rpm-build; \
   curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/rhel-8/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
+  dnf clean all; \
   mkdir /anaconda
 
 WORKDIR /anaconda


### PR DESCRIPTION
Add new container `anaconda-release` to help us to do releases on Fedora of RHEL Anaconda.