### PR TITLE
Add anaconda-release container as release helper (#infra)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -85,9 +85,11 @@ CONTAINER_ADD_ARGS ?=
 # anaconda-ci container
 CI_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-ci
 RPM_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-rpm
+RELEASE_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-release
 ISO_CREATOR_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-iso-creator
 CI_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-ci
 RPM_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-rpm
+RELEASE_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-release
 ISO_CREATOR_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-iso-creator
 CI_TAG := $(or $(CI_TAG),$(GIT_BRANCH))
 CI_TEST_ARGS ?= --rm -v $(srcdir):/anaconda:Z
@@ -169,6 +171,14 @@ release:
 	$(MAKE) po-pull
 	$(MAKE) dist
 
+container-release:
+	$(CONTAINER_ENGINE) run \
+	$(CONTAINER_TEST_ARGS) \
+	$(CI_TEST_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
+	$(RELEASE_NAME):$(CI_TAG) \
+	sh -exc './autogen.sh && ./configure && make release'
+
 release-and-tag:
 	$(MAKE) dist
 	$(MAKE) tag
@@ -192,6 +202,13 @@ anaconda-rpm-build:
 	--build-arg=copr_repo=$(COPR_REPO) \
 	-t $(RPM_NAME):$(CI_TAG) \
 	$(RPM_DOCKERFILE)
+
+anaconda-release-build: anaconda-rpm-build
+	$(CONTAINER_ENGINE) build \
+	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
+	-t $(RELEASE_NAME):$(CI_TAG) \
+	$(RELEASE_DOCKERFILE)
 
 anaconda-iso-creator-build:
 	$(CONTAINER_ENGINE) build \

--- a/Makefile.am
+++ b/Makefile.am
@@ -75,7 +75,7 @@ TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
 
 CONTAINER_ENGINE ?= podman
 # build/run tweaks for all containers, such as --cap-add
-CONTAINER_BUILD_ARGS ?= --no-cache --pull-always
+CONTAINER_BUILD_ARGS ?= --no-cache
 # HACK: bash's builtin `test -r` fails when running on Ubuntu host (GitHub) due to incompatible seccomp profile
 CONTAINER_TEST_ARGS ?= $(shell grep -q ID=ubuntu /etc/os-release && echo --security-opt=seccomp=unconfined)
 CONTAINER_REGISTRY ?= quay.io
@@ -185,7 +185,7 @@ release-and-tag:
 
 anaconda-ci-build:
 	$(CONTAINER_ENGINE) build \
-	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_BUILD_ARGS) --pull-always \
 	$(CONTAINER_ADD_ARGS) \
 	--build-arg=git_branch=$(GIT_BRANCH) \
 	--build-arg=image=$(BASE_CONTAINER) \
@@ -195,7 +195,7 @@ anaconda-ci-build:
 
 anaconda-rpm-build:
 	$(CONTAINER_ENGINE) build \
-	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_BUILD_ARGS) --pull-always \
 	$(CONTAINER_ADD_ARGS) \
 	--build-arg=git_branch=$(GIT_BRANCH) \
 	--build-arg=image=$(BASE_CONTAINER) \
@@ -212,7 +212,7 @@ anaconda-release-build: anaconda-rpm-build
 
 anaconda-iso-creator-build:
 	$(CONTAINER_ENGINE) build \
-	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_BUILD_ARGS) --pull-always \
 	$(CONTAINER_ADD_ARGS) \
 	--build-arg=image=$(BASE_CONTAINER) \
 	-t $(ISO_CREATOR_NAME):$(CI_TAG) \

--- a/dockerfile/anaconda-ci/rhel-9.repo
+++ b/dockerfile/anaconda-ci/rhel-9.repo
@@ -4,7 +4,6 @@ baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/c
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-9-BaseOS]
 name=baseos
@@ -12,7 +11,6 @@ baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/c
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-9-AppStream]
 name=appstream
@@ -20,7 +18,6 @@ baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/c
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-9-Buildroot]
 name=buildroot
@@ -28,4 +25,3 @@ baseurl=http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9/latest-BUILD
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1

--- a/dockerfile/anaconda-iso-creator/rhel-9.repo
+++ b/dockerfile/anaconda-iso-creator/rhel-9.repo
@@ -4,7 +4,6 @@ baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/c
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-9-AppStream]
 name=appstream
@@ -12,4 +11,3 @@ baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/c
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1

--- a/dockerfile/anaconda-release/Dockerfile
+++ b/dockerfile/anaconda-release/Dockerfile
@@ -1,0 +1,22 @@
+# Dockerfile to enable releases of Anaconda for RHEL independently of the host system.
+#
+# This will be based on our existing anaconda-rpm container because it has all the dependencies
+# required to build Anaconda.
+
+FROM quay.io/rhinstaller/anaconda-rpm:rhel-9
+LABEL maintainer=anaconda-list@redhat.com
+
+# Add missing dependencies required to do the build.
+RUN set -e; \
+  dnf update -y; \
+  dnf install -y \
+  git \
+  python3-pip; \
+  dnf clean all;
+
+RUN pip3 install --no-cache-dir --upgrade pip; \
+  pip3 install --no-cache-dir \
+  polib \
+  pocketlint
+
+WORKDIR /anaconda

--- a/dockerfile/anaconda-rpm/rhel-9.repo
+++ b/dockerfile/anaconda-rpm/rhel-9.repo
@@ -4,7 +4,6 @@ baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/c
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-9-BaseOS]
 name=baseos
@@ -12,7 +11,6 @@ baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/c
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-9-AppStream]
 name=appstream
@@ -20,7 +18,6 @@ baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/c
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-9-Buildroot]
 name=buildroot
@@ -28,4 +25,3 @@ baseurl=http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9/latest-BUILD
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1


### PR DESCRIPTION
This will make release of RHEL Anaconda abstracted to the host machine. It will allow you to do RHEL-9 Anaconda release on Fedora or even Ubuntu if you prefer.

Backport of https://github.com/rhinstaller/anaconda/pull/3819 .