### PR TITLE
Add anaconda-release container image

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -60,36 +60,17 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
-      - name: Build anaconda-rpm container (for RPM build)
+      - name: Build anaconda container (to make the release)
         run: |
-          make -f Makefile.am anaconda-rpm-build
+          make -f Makefile.am anaconda-release-build
 
       - name: Run the build in the container
         run: |
           mkdir /tmp/results
-          podman run \
-            -i \
-            -v /tmp/results:/results \
-            -v `pwd`:/anaconda \
-            quay.io/rhinstaller/anaconda-rpm:master <<EOF
-
-          # prepare environment
-          set -eux
-
-          # install dependencies for translation canary
-          dnf install -y git python3-polib python3-pip
-          pip install --upgrade pip pocketlint
-
-          # build tarball
-          cd /anaconda
-          ./autogen.sh
-          ./configure
-          make release
+          make -f Makefile.am container-release
 
           # copy out stuff
-          cp anaconda-*.tar.bz2 /results
-
-          EOF
+          cp anaconda-*.tar.bz2 /tmp/results
 
       - name: Create the release
         id: create_release

--- a/Makefile.am
+++ b/Makefile.am
@@ -75,7 +75,7 @@ TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
 
 CONTAINER_ENGINE ?= podman
 # build/run tweaks for all containers, such as --cap-add
-CONTAINER_BUILD_ARGS ?= --no-cache --pull-always
+CONTAINER_BUILD_ARGS ?= --no-cache
 # HACK: bash's builtin `test -r` fails when running on Ubuntu host (GitHub) due to incompatible seccomp profile
 CONTAINER_TEST_ARGS ?= $(shell grep -q ID=ubuntu /etc/os-release && echo --security-opt=seccomp=unconfined)
 CONTAINER_REGISTRY ?= quay.io
@@ -188,7 +188,7 @@ anaconda-ci-build:
 	cp $(srcdir)/anaconda.spec.in $(CI_DOCKERFILE)/* $$TEMP/ && \
 	echo "Build dir is $$TEMP" && \
 	$(CONTAINER_ENGINE) build \
-	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_BUILD_ARGS) --pull-always \
 	$(CONTAINER_ADD_ARGS) \
 	--build-arg=git_branch=$(GIT_BRANCH) \
 	--build-arg=image=$(BASE_CONTAINER) \
@@ -202,7 +202,7 @@ anaconda-rpm-build:
 	cp $(srcdir)/anaconda.spec.in $(CI_DOCKERFILE)/* $$TEMP/ && \
 	echo "Build dir is $$TEMP" && \
 	$(CONTAINER_ENGINE) build \
-	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_BUILD_ARGS) --pull-always \
 	$(CONTAINER_ADD_ARGS) \
 	--build-arg=git_branch=$(GIT_BRANCH) \
 	--build-arg=image=$(BASE_CONTAINER) \
@@ -221,7 +221,7 @@ anaconda-release-build: anaconda-rpm-build
 
 anaconda-iso-creator-build:
 	$(CONTAINER_ENGINE) build \
-	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_BUILD_ARGS) --pull-always \
 	$(CONTAINER_ADD_ARGS) \
 	--build-arg=image=$(BASE_CONTAINER) \
 	-t $(ISO_CREATOR_NAME):$(CI_TAG) \

--- a/Makefile.am
+++ b/Makefile.am
@@ -85,9 +85,11 @@ CONTAINER_ADD_ARGS ?=
 # anaconda-ci container
 CI_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-ci
 RPM_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-rpm
+RELEASE_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-release
 ISO_CREATOR_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-iso-creator
 CI_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-ci
 RPM_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-rpm
+RELEASE_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-release
 ISO_CREATOR_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-iso-creator
 CI_TAG := $(or $(CI_TAG),$(GIT_BRANCH))
 CI_TEST_ARGS ?= --rm -v $(srcdir):/anaconda:z
@@ -169,6 +171,14 @@ release:
 	$(MAKE) po-pull
 	$(MAKE) dist
 
+container-release:
+	$(CONTAINER_ENGINE) run \
+	$(CONTAINER_TEST_ARGS) \
+	$(CI_TEST_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
+	$(RELEASE_NAME):$(CI_TAG) \
+	sh -exc './autogen.sh && ./configure && make release'
+
 release-and-tag:
 	$(MAKE) dist
 	$(MAKE) tag
@@ -200,6 +210,13 @@ anaconda-rpm-build:
 	-t $(RPM_NAME):$(CI_TAG) \
 	$$TEMP/ && \
 	rm -rf $$TEMP
+
+anaconda-release-build: anaconda-rpm-build
+	$(CONTAINER_ENGINE) build \
+	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_ADD_ARGS) \
+	-t $(RELEASE_NAME):$(CI_TAG) \
+	$(RELEASE_DOCKERFILE)
 
 anaconda-iso-creator-build:
 	$(CONTAINER_ENGINE) build \

--- a/Makefile.am
+++ b/Makefile.am
@@ -215,6 +215,7 @@ anaconda-release-build: anaconda-rpm-build
 	$(CONTAINER_ENGINE) build \
 	$(CONTAINER_BUILD_ARGS) \
 	$(CONTAINER_ADD_ARGS) \
+	--build-arg=image=$(RPM_NAME):$(CI_TAG) \
 	-t $(RELEASE_NAME):$(CI_TAG) \
 	$(RELEASE_DOCKERFILE)
 

--- a/dockerfile/anaconda-release/Dockerfile
+++ b/dockerfile/anaconda-release/Dockerfile
@@ -3,7 +3,8 @@
 # This will be based on our existing anaconda-rpm container because it has all the dependencies
 # required to build Anaconda.
 
-FROM quay.io/rhinstaller/anaconda-rpm:rhel-8
+ARG image
+FROM ${image}
 LABEL maintainer=anaconda-list@redhat.com
 
 # Add missing dependencies required to do the build.

--- a/dockerfile/anaconda-release/Dockerfile
+++ b/dockerfile/anaconda-release/Dockerfile
@@ -12,12 +12,12 @@ RUN set -e; \
   dnf update -y; \
   dnf install -y \
   git \
+  python3-polib \
   python3-pip; \
   dnf clean all;
 
 RUN pip3 install --no-cache-dir --upgrade pip; \
     pip3 install --no-cache-dir \
-    polib \
     pocketlint
 
 WORKDIR /anaconda

--- a/dockerfile/anaconda-release/Dockerfile
+++ b/dockerfile/anaconda-release/Dockerfile
@@ -1,0 +1,22 @@
+# Dockerfile to enable releases of Anaconda for RHEL independently of the host system.
+#
+# This will be based on our existing anaconda-rpm container because it has all the dependencies
+# required to build Anaconda.
+
+FROM quay.io/rhinstaller/anaconda-rpm:rhel-8
+LABEL maintainer=anaconda-list@redhat.com
+
+# Add missing dependencies required to do the build.
+RUN set -e; \
+  dnf update -y; \
+  dnf install -y \
+  git \
+  python3-pip; \
+  dnf clean all;
+
+RUN pip3 install --no-cache-dir --upgrade pip; \
+    pip3 install --no-cache-dir \
+    polib \
+    pocketlint
+
+WORKDIR /anaconda


### PR DESCRIPTION
Use this container in the tag-release workflow.

Tested here:
https://github.com/jkonecny12/anaconda/runs/5301979004?check_suite_focus=true
Output:
https://github.com/jkonecny12/anaconda/releases/tag/untagged-7fbee5da484094695804

*TODO:*
- [x] Test this properly.
- [x] ~Add https://github.com/rhinstaller/anaconda/pull/3868 to here~ Not required, it's already in the anaconda-rpm on master and not it's not mandatory on f36 branches because there is no npm.