### PR TITLE
Enable the Koji repository in the RPM tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -75,7 +75,7 @@ TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
 
 CONTAINER_ENGINE ?= podman
 # build/run tweaks for all containers, such as --cap-add
-CONTAINER_BUILD_ARGS ?= --no-cache
+CONTAINER_BUILD_ARGS ?= --no-cache --pull-always
 # HACK: bash's builtin `test -r` fails when running on Ubuntu host (GitHub) due to incompatible seccomp profile
 CONTAINER_TEST_ARGS ?= $(shell grep -q ID=ubuntu /etc/os-release && echo --security-opt=seccomp=unconfined)
 CONTAINER_REGISTRY ?= quay.io

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -24,6 +24,7 @@ LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 
 # On ELN, BaseOS+AppStream don't have all our build dependencies; this provides the "Everything" compose
 COPY ["eln.repo", "/etc/yum.repos.d"]
+COPY ["koji.repo", "/etc/yum.repos.d"]
 
 # The anaconda.spec.in is in the repository root. This file will be copied automatically here if
 # the build is invoked by Makefile.
@@ -57,8 +58,6 @@ RUN set -ex; \
   fi; \
   cat /root/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
-  dnf install -y https://kojipkgs.fedoraproject.org//packages/annobin/10.53/1.fc36/x86_64/annobin-plugin-gcc-10.53-1.fc36.x86_64.rpm \
-                 https://kojipkgs.fedoraproject.org//packages/annobin/10.53/1.fc36/noarch/annobin-docs-10.53-1.fc36.noarch.rpm; \
   dnf clean all; \
   mkdir /anaconda
 

--- a/dockerfile/anaconda-rpm/koji.repo
+++ b/dockerfile/anaconda-rpm/koji.repo
@@ -1,0 +1,5 @@
+[koji]
+name=Koji Rawhide
+baseurl=https://kojipkgs.fedoraproject.org/repos/rawhide/latest/$basearch/
+enabled=1
+gpgcheck=0


### PR DESCRIPTION
Use the latest updates to fix our issues with the RPM tests.