### PR TITLE
dockerfile: ci: rpm: install nodejs instead of NPM directly

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -43,7 +43,6 @@ RUN set -ex; \
   /usr/bin/xargs \
   rpm-build \
   git \
-  npm \
   bzip2 \
   rpm-ostree \
   pykickstart \
@@ -69,6 +68,7 @@ RUN set -ex; \
   cat /root/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   rpmspec -q --requires /tmp/anaconda.spec | grep -v anaconda | xargs -d '\n' dnf install -y; \
+  dnf -y module enable nodejs:16 && dnf install -y @nodejs:16/default ; \
   dnf clean all
 
 RUN pip install --no-cache-dir --upgrade pip; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -38,7 +38,6 @@ RUN set -ex; \
   dnf install -y \
   'dnf-command(copr)' \
   git \
-  npm \
   curl \
   python3-pip \
   /usr/bin/xargs \
@@ -59,6 +58,7 @@ RUN set -ex; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   dnf install -y https://kojipkgs.fedoraproject.org//packages/annobin/10.53/1.fc36/x86_64/annobin-plugin-gcc-10.53-1.fc36.x86_64.rpm \
                  https://kojipkgs.fedoraproject.org//packages/annobin/10.53/1.fc36/noarch/annobin-docs-10.53-1.fc36.noarch.rpm; \
+  dnf -y module enable nodejs:16 && dnf install -y @nodejs:16/default ; \
   dnf clean all; \
   mkdir /anaconda
 


### PR DESCRIPTION
To solve some dependency issues that appeared on the CI recently.

This will install npm anyway.

https://developer.fedoraproject.org/tech/languages/nodejs/nodejs.html