### PR TITLE
Improve infra-check workflow to not fail but comment about the non-ifra files

### DIFF
--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -29,6 +29,17 @@ jobs:
           git log --oneline -1 origin/${{ github.event.pull_request.base.ref }}
           git rebase origin/${{ github.event.pull_request.base.ref }}
 
+      - name: Check if all commits have (#infra)
+        run: |
+          # match (#infra) at the end of the commit message
+          for i in "$(git log --oneline origin/${{ github.event.pull_request.base.ref }}..HEAD)"; do
+
+            if ! [[ $i =~ \(#infra\)$ ]]; then
+              echo "$i --> Is missing (#infra!)"
+              exit 1
+            fi
+          done
+
       - name: Check if all changed files are infra related
         run: |
           changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}..HEAD)
@@ -62,14 +73,3 @@ jobs:
           if [ "$failed_check" == "yes" ]; then
             exit 1
           fi
-
-      - name: Check if all commits have (#infra)
-        run: |
-          # match (#infra) at the end of the commit message
-          for i in "$(git log --oneline origin/${{ github.event.pull_request.base.ref }}..HEAD)"; do
-
-            if ! [[ $i =~ \(#infra\)$ ]]; then
-              echo "$i --> Is missing (#infra!)"
-              exit 1
-            fi
-          done

--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -46,9 +46,10 @@ jobs:
           set -eu
           changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}..HEAD)
           # print for debugging
-          echo "----- Changed files -----"
+          echo "-------- Changed files --------"
           echo "$changed_files"
-          echo "-------------------------"
+          echo "-------------------------------"
+          echo "--- Files with failed check ---"
 
           # load infrastructure file list
           . .structure-config

--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   infra-check:
@@ -42,6 +43,7 @@ jobs:
 
       - name: Check if all changed files are infra related
         run: |
+          set -eu
           changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}..HEAD)
           # print for debugging
           echo "----- Changed files -----"
@@ -52,6 +54,7 @@ jobs:
           . .structure-config
 
           failed_check="no"
+          echo -e 'Infrastructure check **failed** on these files. Please do a double check of these files before merge!\n' > ./message.txt
 
           for f in $changed_files; do
             matched="no"
@@ -64,12 +67,14 @@ jobs:
             done
 
             if [ $matched == "no" ]; then
-              echo "$f is not part of the infrastructure"
+              echo "$f" | tee -a ./message.txt
               failed_check="yes"
             fi
 
           done
 
           if [ "$failed_check" == "yes" ]; then
-            exit 1
+            gh pr comment ${{ github.event.pull_request.number }} -F ./message.txt
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Most of the infrastructure PRs are failing now which is wrong. Let's improve the state by instead of fail just comment with a message that these files should be double checked.


![2022-02-04T14:13:15,581244481+01:00](https://user-images.githubusercontent.com/1643889/152535036-dd5f2b34-4677-4c23-a6e2-bf02c39a1eec.png)