### PR TITLE
Improve Simple Content Access UX

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -40,7 +40,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define pythonblivetver 1:3.4.0-10
 %define rpmver 4.10.0
 %define simplelinever 1.1-1
-%define subscriptionmanagerver 1.26
+%define subscriptionmanagerver 1.29.24
 %define utillinuxver 2.15.1
 
 BuildRequires: audit-libs-devel

--- a/pyanaconda/modules/subscription/runtime.py
+++ b/pyanaconda/modules/subscription/runtime.py
@@ -255,6 +255,8 @@ class RegisterWithUsernamePasswordTask(Task):
         """Register the system with Red Hat account username and password.
 
         :raises: RegistrationError if calling the RHSM DBus API returns an error
+        :return: JSON string describing registration state
+        :rtype: str
         """
         if not self._organization:
             # If no organization id is specified check if the account is member of more than
@@ -283,13 +285,16 @@ class RegisterWithUsernamePasswordTask(Task):
                 locale = os.environ.get("LANG", "")
                 private_register_proxy = private_bus.get_proxy(RHSM.service_name,
                                                                RHSM_REGISTER.object_path)
-                private_register_proxy.Register(self._organization,
-                                                self._username,
-                                                self._password,
-                                                {},
-                                                {},
-                                                locale)
+                registration_data = private_register_proxy.Register(
+                    self._organization,
+                    self._username,
+                    self._password,
+                    {},
+                    {},
+                    locale
+                )
                 log.debug("subscription: registered with username and password")
+                return registration_data
             except DBusError as e:
                 log.debug("subscription: failed to register with username and password: %s",
                           str(e))
@@ -324,6 +329,8 @@ class RegisterWithOrganizationKeyTask(Task):
         """Register the system with organization name and activation key.
 
         :raises: RegistrationError if calling the RHSM DBus API returns an error
+        :return: JSON string describing registration state
+        :rtype: str
         """
         log.debug("subscription: registering with organization and activation key")
         with RHSMPrivateBus(self._rhsm_register_server_proxy) as private_bus:
@@ -331,12 +338,15 @@ class RegisterWithOrganizationKeyTask(Task):
                 locale = os.environ.get("LANG", "")
                 private_register_proxy = private_bus.get_proxy(RHSM.service_name,
                                                                RHSM_REGISTER.object_path)
-                private_register_proxy.RegisterWithActivationKeys(self._organization,
-                                                                  self._activation_keys,
-                                                                  {},
-                                                                  {},
-                                                                  locale)
+                registration_data = private_register_proxy.RegisterWithActivationKeys(
+                    self._organization,
+                    self._activation_keys,
+                    {},
+                    {},
+                    locale
+                )
                 log.debug("subscription: registered with organization and activation key")
+                return registration_data
             except DBusError as e:
                 log.debug("subscription: failed to register with organization & key: %s", str(e))
                 # RHSM exception contain details as JSON due to DBus exception handling limitations
@@ -777,8 +787,9 @@ class RegisterAndSubscribeTask(Task):
 
     def __init__(self, rhsm_observer, subscription_request, system_purpose_data,
                  registered_callback, registered_to_satellite_callback,
-                 subscription_attached_callback, subscription_data_callback,
-                 satellite_script_callback, config_backup_callback):
+                 simple_content_access_callback, subscription_attached_callback,
+                 subscription_data_callback, satellite_script_callback,
+                 config_backup_callback):
         """Create a register-and-subscribe task.
 
         :param rhsm_observer: DBus service observer for talking to RHSM
@@ -787,6 +798,7 @@ class RegisterAndSubscribeTask(Task):
 
         :param registered_callback: called when registration tasks finishes successfully
         :param registered_to_satellite_callback: called after successful Satellite provisioning
+        :param simple_content_access_callback: called when registration tasks finishes successfully
         :param subscription_attached_callback: called after subscription is attached
         :param subscription_data_callback: called after subscription data is parsed
         :param satellite_script_callback: called after Satellite provisioning script
@@ -806,6 +818,7 @@ class RegisterAndSubscribeTask(Task):
         # callback for nested tasks
         self._registered_callback = registered_callback
         self._registered_to_satellite_callback = registered_to_satellite_callback
+        self._simple_content_access_callback = simple_content_access_callback
         self._subscription_attached_callback = subscription_attached_callback
         self._subscription_data_callback = subscription_data_callback
         self._satellite_script_downloaded_callback = satellite_script_callback
@@ -996,8 +1009,14 @@ class RegisterAndSubscribeTask(Task):
                 )
         if register_task:
             # Now that we know we can do a registration attempt:
-            # 1) Connect task success callback.
+            # 1) Connect task success callbacks.
             register_task.succeeded_signal.connect(lambda: self._registered_callback(True))
+            # set SCA state based on data returned by the registration task
+            register_task.succeeded_signal.connect(
+                lambda: self._simple_content_access_callback(
+                    self._detect_sca_from_registration_data(register_task.get_result())
+                )
+            )
 
             # 2) Check if custom server hostname is set, which would indicate we are most
             #    likely talking to a Satellite instance. If so, provision the installation

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -63,6 +63,8 @@ class SubscriptionInterface(KickstartModuleInterface):
                             self.implementation.registered_changed)
         self.watch_property("IsRegisteredToSatellite",
                             self.implementation.registered_to_satellite_changed)
+        self.watch_property("IsSimpleContentAccessEnabled",
+                            self.implementation.simple_content_access_enabled_changed)
         self.watch_property("IsSubscriptionAttached",
                             self.implementation.subscription_attached_changed)
 
@@ -168,6 +170,11 @@ class SubscriptionInterface(KickstartModuleInterface):
     def IsRegisteredToSatellite(self) -> Bool:
         """Report if the system is registered to a Satellite instance."""
         return self.implementation.registered_to_satellite
+
+    @property
+    def IsSimpleContentAccessEnabled(self) -> Bool:
+        """Report if Simple Content Access is enabled."""
+        return self.implementation.simple_content_access_enabled
 
     @property
     def IsSubscriptionAttached(self) -> Bool:

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -1130,7 +1130,10 @@ class SubscriptionSpoke(NormalSpoke):
         # check how many we have & set the subscription status string accordingly
         subscription_count = len(attached_subscriptions)
         if subscription_count == 0:
-            subscription_string = _("No subscriptions are attached to the system")
+            if self._subscription_module.IsSimpleContentAccessEnabled:
+                subscription_string = _("Subscribed in Simple Content Access mode.")
+            else:
+                subscription_string = _("No subscriptions are attached to the system")
         elif subscription_count == 1:
             subscription_string = _("1 subscription attached to the system")
         else:

--- a/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription_tasks.py
@@ -648,12 +648,14 @@ class RegistrationTasksTestCase(unittest.TestCase):
         # private register proxy
         get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
         private_register_proxy = get_proxy.return_value
+        # make the Register() method return some JSON data
+        private_register_proxy.Register.return_value = '{"json":"stuff"}'
         # instantiate the task and run it
         task = RegisterWithUsernamePasswordTask(rhsm_register_server_proxy=register_server_proxy,
                                                 username="foo_user",
                                                 password="bar_password",
                                                 organization="foo_org")
-        task.run()
+        assert task.run() == '{"json":"stuff"}'
         # check the private register proxy Register method was called correctly
         private_register_proxy.Register.assert_called_once_with("foo_org",
                                                                 "foo_user",
@@ -699,6 +701,8 @@ class RegistrationTasksTestCase(unittest.TestCase):
         # private register proxy
         get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
         private_register_proxy = get_proxy.return_value
+        # make the Register() method return some JSON data
+        private_register_proxy.Register.return_value = '{"json":"stuff"}'
         # mock the org data retrieval task to return single organization
         org_data = [
             {
@@ -717,7 +721,7 @@ class RegistrationTasksTestCase(unittest.TestCase):
                                                 organization="")
         # if we get just a single organization, we don't actually have to feed
         # it to the RHSM API, its only a problem if there are more than one
-        task.run()
+        assert task.run() == '{"json":"stuff"}'
         # check the private register proxy Register method was called correctly
         private_register_proxy.Register.assert_called_once_with("",
                                                                 "foo_user",
@@ -771,11 +775,13 @@ class RegistrationTasksTestCase(unittest.TestCase):
         get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
         private_register_proxy = get_proxy.return_value
         private_register_proxy.Register.return_value = True, ""
+        # make the Register() method return some JSON data
+        private_register_proxy.RegisterWithActivationKeys.return_value = '{"json":"stuff"}'
         # instantiate the task and run it
         task = RegisterWithOrganizationKeyTask(rhsm_register_server_proxy=register_server_proxy,
                                                organization="123456789",
                                                activation_keys=["foo", "bar", "baz"])
-        task.run()
+        assert task.run() == '{"json":"stuff"}'
         # check private register proxy RegisterWithActivationKeys method was called correctly
         private_register_proxy.RegisterWithActivationKeys.assert_called_with(
             "123456789",
@@ -1365,6 +1371,7 @@ class RegisterandSubscribeTestCase(unittest.TestCase):
             system_purpose_data=Mock(),
             registered_callback=Mock(),
             registered_to_satellite_callback=Mock(),
+            simple_content_access_callback=Mock(),
             subscription_attached_callback=Mock(),
             subscription_data_callback=Mock(),
             satellite_script_callback=Mock(),
@@ -1389,6 +1396,7 @@ class RegisterandSubscribeTestCase(unittest.TestCase):
             system_purpose_data=Mock(),
             registered_callback=Mock(),
             registered_to_satellite_callback=Mock(),
+            simple_content_access_callback=Mock(),
             subscription_attached_callback=Mock(),
             subscription_data_callback=Mock(),
             satellite_script_callback=satellite_script_callback,
@@ -1423,6 +1431,7 @@ class RegisterandSubscribeTestCase(unittest.TestCase):
             system_purpose_data=Mock(),
             registered_callback=Mock(),
             registered_to_satellite_callback=Mock(),
+            simple_content_access_callback=Mock(),
             subscription_attached_callback=Mock(),
             subscription_data_callback=Mock(),
             satellite_script_callback=satellite_script_callback,
@@ -1476,6 +1485,7 @@ class RegisterandSubscribeTestCase(unittest.TestCase):
             system_purpose_data=Mock(),
             registered_callback=Mock(),
             registered_to_satellite_callback=Mock(),
+            simple_content_access_callback=Mock(),
             subscription_attached_callback=Mock(),
             subscription_data_callback=Mock(),
             satellite_script_callback=satellite_script_callback,
@@ -1523,6 +1533,7 @@ class RegisterandSubscribeTestCase(unittest.TestCase):
             system_purpose_data=Mock(),
             registered_callback=Mock(),
             registered_to_satellite_callback=Mock(),
+            simple_content_access_callback=Mock(),
             subscription_attached_callback=Mock(),
             subscription_data_callback=Mock(),
             satellite_script_callback=Mock(),
@@ -1558,6 +1569,7 @@ class RegisterandSubscribeTestCase(unittest.TestCase):
             system_purpose_data=Mock(),
             registered_callback=Mock(),
             registered_to_satellite_callback=Mock(),
+            simple_content_access_callback=Mock(),
             subscription_attached_callback=Mock(),
             subscription_data_callback=Mock(),
             satellite_script_callback=Mock(),
@@ -1604,6 +1616,7 @@ class RegisterandSubscribeTestCase(unittest.TestCase):
             system_purpose_data=system_purpose_data,
             registered_callback=Mock(),
             registered_to_satellite_callback=Mock(),
+            simple_content_access_callback=Mock(),
             subscription_attached_callback=subscription_attached_callback,
             subscription_data_callback=Mock(),
             satellite_script_callback=Mock(),
@@ -1665,6 +1678,7 @@ class RegisterandSubscribeTestCase(unittest.TestCase):
             system_purpose_data=system_purpose_data,
             registered_callback=Mock(),
             registered_to_satellite_callback=Mock(),
+            simple_content_access_callback=Mock(),
             subscription_attached_callback=subscription_attached_callback,
             subscription_data_callback=Mock(),
             satellite_script_callback=Mock(),
@@ -1726,6 +1740,7 @@ class RegisterandSubscribeTestCase(unittest.TestCase):
             system_purpose_data=system_purpose_data,
             registered_callback=Mock(),
             registered_to_satellite_callback=Mock(),
+            simple_content_access_callback=Mock(),
             subscription_attached_callback=subscription_attached_callback,
             subscription_data_callback=Mock(),
             satellite_script_callback=Mock(),
@@ -1787,6 +1802,7 @@ class RegisterandSubscribeTestCase(unittest.TestCase):
             system_purpose_data=system_purpose_data,
             registered_callback=Mock(),
             registered_to_satellite_callback=Mock(),
+            simple_content_access_callback=Mock(),
             subscription_attached_callback=subscription_attached_callback,
             subscription_data_callback=Mock(),
             satellite_script_callback=Mock(),


### PR DESCRIPTION
Show a proper status message instead of a confusing (even if correct) message about no subscription being attached if install time registration is done in Simple Content Access mode.

This is achieved by parsing the data returned by the register methods of the RHSM DBus, exposing this via a DBus property of the Subscription module, which is then used by the GUI to display the appropriate string.