### PR TITLE
Don't use progressQ in tasks of the installation queue

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -370,6 +370,12 @@ def run_installation(payload, ksdata):
     # FIXME: This is a temporary workaround.
     payload._progress_cb = lambda step, msg: progress_message(msg)
 
+    # Set the progress reporting callback of the DBus tasks.
+    # FIXME: This is a temporary workaround.
+    for item in queue.nested_items:
+        if isinstance(item, DBusTask):
+            item._progress_cb = lambda step, msg: progress_message(msg)
+
     # notify progress tracking about the number of steps
     progress_init(queue.task_count)
 

--- a/pyanaconda/installation_tasks.py
+++ b/pyanaconda/installation_tasks.py
@@ -24,7 +24,6 @@ from pyanaconda.core.signal import Signal
 from pyanaconda.errors import errorHandler, ERROR_RAISE
 from pyanaconda.modules.common.task import sync_run_task
 from pyanaconda.anaconda_loggers import get_module_logger
-from pyanaconda.progress import progress_message
 
 log = get_module_logger(__name__)
 
@@ -302,4 +301,8 @@ class DBusTask(BaseTask):
         self._msg_counter += 1
 
         if self._msg_counter > 1:
-            progress_message(msg)
+            self._progress_cb(0, msg)
+
+    def _progress_cb(self, step, message):
+        """Callback for task progress reporting."""
+        log.info(message)


### PR DESCRIPTION
Call `_progress_cb` to report installation progress of DBus tasks.
Set up this callback in the `pyanaconda.installation` module.