### PR TITLE
Support Btrfs-only mount points in the default partitioning

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -191,6 +191,7 @@ file_system_type =
 #   min <MIN_SIZE> The size will grow from MIN_SIZE to MAX_SIZE.
 #   max <MAX_SIZE> The max size is unlimited by default.
 #   free <SIZE>    The required available space.
+#   btrfs          The mount point will be created only for the Btrfs scheme
 #
 default_partitioning =
     /     (min 1 GiB, max 70 GiB)

--- a/pyanaconda/core/configuration/storage.py
+++ b/pyanaconda/core/configuration/storage.py
@@ -151,6 +151,7 @@ class StorageSection(Section):
             min        The size will grow from min size to max size.
             max        The max size is unlimited by default.
             free       The required available space.
+            btrfs      The mount point will be created only for the Btrfs scheme
 
         :return: a list of dictionaries with mount point attributes
         """
@@ -170,7 +171,10 @@ class StorageSection(Section):
         attrs = {"name": name}
 
         for name, value in raw_attrs.items():
-            if value and name in ("size", "min", "max", "free"):
+            if not value and name in ("btrfs", ):
+                # Handle a boolean attribute.
+                attrs[name] = True
+            elif value and name in ("size", "min", "max", "free"):
                 # Handle a size attribute.
                 attrs[name] = Size(value)
             else:

--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
@@ -85,7 +85,7 @@ class AutomaticPartitioningTask(NonInteractivePartitioningTask):
             luks_data.pbkdf_args = pbkdf_args
 
         # Get the autopart requests.
-        requests = self._get_partitioning(storage, self._request.excluded_mount_points)
+        requests = self._get_partitioning(storage, scheme, self._request.excluded_mount_points)
 
         # Do the autopart.
         self._do_autopart(storage, scheme, requests, encrypted, luks_format_args)
@@ -122,16 +122,21 @@ class AutomaticPartitioningTask(NonInteractivePartitioningTask):
         }
 
     @staticmethod
-    def _get_partitioning(storage, excluded_mount_points=()):
+    def _get_partitioning(storage, scheme, excluded_mount_points=()):
         """Get the partitioning requests for autopart.
 
         :param storage: blivet.Blivet instance
+        :param scheme: a type of the partitioning scheme
         :param excluded_mount_points: a list of mount points to exclude
         :return: a list of full partitioning specs
         """
         requests = []
 
         for request in get_default_partitioning():
+            # Skip mount points excluded from the chosen scheme.
+            if request.schemes and scheme not in request.schemes:
+                continue
+
             # Skip excluded mount points.
             if (request.mountpoint or request.fstype) in excluded_mount_points:
                 continue

--- a/pyanaconda/modules/storage/partitioning/automatic/utils.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/utils.py
@@ -268,6 +268,11 @@ def get_default_partitioning():
     for attrs in conf.storage.default_partitioning:
         name = attrs.get("name")
         swap = name == "swap"
+        schemes = set()
+
+        if attrs.get("btrfs"):
+            schemes.add(AUTOPART_TYPE_BTRFS)
+
         spec = PartSpec(
             mountpoint=name if not swap else None,
             fstype=None if not swap else "swap",
@@ -279,6 +284,7 @@ def get_default_partitioning():
             grow="min" in attrs,
             required_space=attrs.get("free") or 0,
             encrypted=True,
+            schemes=schemes,
         )
 
         partitioning.append(spec)

--- a/pyanaconda/modules/storage/partitioning/specification.py
+++ b/pyanaconda/modules/storage/partitioning/specification.py
@@ -27,7 +27,7 @@ class PartSpec(object):
 
     def __init__(self, mountpoint=None, fstype=None, size=None, max_size=None,
                  grow=False, btr=False, lv=False, thin=False, weight=0,
-                 required_space=0, encrypted=False):
+                 required_space=0, encrypted=False, schemes=None):
         """ Create a new storage specification.  These are used to specify
             the default partitioning layout as an object before we have the
             storage system up and running.  The attributes are obvious
@@ -55,6 +55,7 @@ class PartSpec(object):
             encrypted -- Should this request be encrypted? For logical volume
                          requests, this is satisfied if the PVs are encrypted
                          as in the case of encrypted LVM autopart.
+            schemes -- Create the mount point only for specific schemes if any.
         """
 
         self.mountpoint = mountpoint
@@ -68,6 +69,7 @@ class PartSpec(object):
         self.weight = weight
         self.required_space = required_space
         self.encrypted = encrypted
+        self.schemes = schemes or set()
 
     # Force str and unicode types in case any of the properties are unicode
     def _to_string(self):

--- a/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
@@ -527,6 +527,11 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
             "size": Size("1 GiB")
         }
 
+        assert convert_line("/var (btrfs)") == {
+            "name": "/var",
+            "btrfs": True,
+        }
+
         assert convert_line("swap") == {
             "name": "swap"
         }


### PR DESCRIPTION
The `default_partitioning` configuration option now allows to specify mount
points that will be created only for the Btrfs scheme. Use the `btrfs` attribute.