### PR TITLE
dockerfile: stop specifying nodejs stream explicitely

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -41,6 +41,7 @@ RUN set -ex; \
   dnf install -y \
   'dnf-command(copr)' \
   /usr/bin/xargs \
+  nodejs \
   rpm-build \
   git \
   bzip2 \
@@ -68,7 +69,6 @@ RUN set -ex; \
   cat /root/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   rpmspec -q --requires /tmp/anaconda.spec | grep -v anaconda | xargs -d '\n' dnf install -y; \
-  dnf -y module enable nodejs:16 && dnf install -y @nodejs:16/default ; \
   dnf clean all
 
 RUN pip install --no-cache-dir --upgrade pip; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -37,6 +37,7 @@ RUN set -ex; \
   dnf update -y; \
   dnf install -y \
   'dnf-command(copr)' \
+  nodejs \
   git \
   curl \
   python3-pip \
@@ -58,7 +59,6 @@ RUN set -ex; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   dnf install -y https://kojipkgs.fedoraproject.org//packages/annobin/10.53/1.fc36/x86_64/annobin-plugin-gcc-10.53-1.fc36.x86_64.rpm \
                  https://kojipkgs.fedoraproject.org//packages/annobin/10.53/1.fc36/noarch/annobin-docs-10.53-1.fc36.noarch.rpm; \
-  dnf -y module enable nodejs:16 && dnf install -y @nodejs:16/default ; \
   dnf clean all; \
   mkdir /anaconda
 


### PR DESCRIPTION
This works with nodejs:16, which is default stream in f34, f35, rawhide.

Also move the installation line above with the rest, there is no need for special
treatment here.