### PR TITLE
Do not fail on nonexistent fs nodes in pstore

### DIFF
--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -291,8 +291,10 @@ def clean_pstore():
     """
     for (base, dirs, files) in os.walk("/sys/fs/pstore"):  # pylint: disable=unused-variable
         for file in files:
-            os.unlink(os.path.join(base, file))
-
+            try:
+                os.unlink(os.path.join(base, file))
+            except OSError:
+                pass
 
 def print_startup_note(options):
     """Print Anaconda version and short usage instructions.


### PR DESCRIPTION
The bug was introduced while removing `dir_tree_map`, in commit
8d3aa25785fe63824c3c45ae0aa756647276fda7

Related: [rhbz#2050715](https://bugzilla.redhat.com/show_bug.cgi?id=2050715)