### PR TITLE
Restore contexts also in /usr/lib

### DIFF
--- a/pyanaconda/modules/boss/installation.py
+++ b/pyanaconda/modules/boss/installation.py
@@ -244,6 +244,7 @@ class SetContextsTask(Task):
             "/etc",
             "/lib64",
             "/root",
+            "/usr/lib",
             "/usr/lib64",
             "/var/cache/yum",
             "/var/home",

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_set_file_contexts_task.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_set_file_contexts_task.py
@@ -37,6 +37,7 @@ class SetContextsTaskTest(unittest.TestCase):
                 "/etc",
                 "/lib64",
                 "/root",
+                "/usr/lib",
                 "/usr/lib64",
                 "/var/cache/yum",
                 "/var/home",


### PR DESCRIPTION
New RPM stores its database there. See also:
https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr

Resolves: [rhbz#2052038](https://bugzilla.redhat.com/show_bug.cgi?id=2052038)