### PR TITLE
UX: clarify meaning of "additional space" checkbox

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.glade
+++ b/pyanaconda/ui/gui/spokes/storage.glade
@@ -430,7 +430,7 @@
                                     <property name="reveal_child">True</property>
                                     <child>
                                       <object class="GtkCheckButton" id="reclaimCheckbox">
-                                        <property name="label" translatable="yes" context="GUI|Storage">I would like to _make additional space available.</property>
+                                        <property name="label" translatable="yes" context="GUI|Storage">Free up space by re_moving or shrinking existing partitions</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>


### PR DESCRIPTION
The phrase "I would like to make additional space available" is ambiguous. It could be interpreted in two ways:
1. I would like to delete existing partitions to reclaim space (the intended meaning)
2. I would like the automatic partitioning to leave some unused space (e.g. because I plan to install something else later)

I wanted to leave some unused space. I checked the box and was surprised when the result occupied my entire hard drive. This change removes the ambiguity.