### PR TITLE
PLS DISCUSS BEFORE MERGING: webui: add npm-update workflow and introduce the deploy-keys script

### DIFF
--- a/.github/deploy-keys.sh
+++ b/.github/deploy-keys.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# (Re-)generate all deploy keys on https://github.com/rhinstaller/anaconda/settings/environments
+
+set -eux
+
+ORG=rhinstaller
+THIS=anaconda
+
+cd ui/webui
+
+[ -e bots ] || make -f Makefile.am bots
+
+# for workflows pushing to our own repo: npm-update.yml
+bots/github-upload-secrets --receiver "${ORG}/${THIS}" --env self --ssh-keygen DEPLOY_KEY --deploy-to "${ORG}/${THIS}"

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -1,0 +1,33 @@
+name: npm-update
+on:
+  schedule:
+    - cron: '0 2 * * 1,4'
+  workflow_dispatch:
+
+jobs:
+  npm-update:
+    runs-on: ubuntu-20.04
+    environment: self
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Set up dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y npm make
+
+      - name: Set up configuration and secrets
+        run: |
+          printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
+          echo '${{ github.token }}' > ~/.config/github-token
+
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Run npm-update bot
+        run: |
+          cd ui/webui
+          make -f Makefile.am bots
+          bots/npm-update


### PR DESCRIPTION
The npm-update workflow automates the process of keeping the
package.json file, in ui/webui directory up to date.
In other words, the dependencies for the webui subproject are not
updated automatically, by the means of creating PRs against this repository.

The PRs will be created by the npm-update workflow, after pushing the changes to a temporary branch
in this repository. For this to be possible, we need a deploy key
[1], that is put into place by the newly introduced deploy-keys.sh
script.

[1] https://docs.github.com/en/developers/overview/managing-deploy-keys