### PR TITLE
Ignore deps-dev commits by dependabot

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -107,6 +107,7 @@ jobs:
             --pretty=format:"- %s (%aL)" \
             "$PREVIOUS_VERSION..$CURRENT_VERSION~1" \
               | grep -v "#infra" \
+              | grep -v "build(deps-dev)" \
               | tee release.txt
 
           # drop line ending

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -347,6 +347,10 @@ class MakeBumpVer:
                 print("*** Ignoring (#infra) commit %s\n" % commit)
                 continue
 
+            if re.match(r".*(build\(deps-dev\)).*", summary):
+                print("*** Ignoring (deps-dev) commit %s\n" % commit)
+                continue
+
             if self.rhel:
                 rhbz = set()
                 bad = False


### PR DESCRIPTION
The deps-dev commits are for development-only dependencies and not relevant for users, so they should not be in the changelog.

----

Please advise:
- should this be `#infra` or not?
- should I put this on f36 branch too?