### PR TITLE
Improve Simple Content Access UX (RHEL 8)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -103,7 +103,7 @@ Requires: python3-dasbus >= %{dasbusver}
 Requires: flatpak-libs
 %if %{defined rhel} && %{undefined centos}
 Requires: python3-syspurpose
-Requires: subscription-manager >= 1.26
+Requires: subscription-manager >= 1.28.26
 %endif
 
 # pwquality only "recommends" the dictionaries it needs to do anything useful,

--- a/pyanaconda/modules/subscription/runtime.py
+++ b/pyanaconda/modules/subscription/runtime.py
@@ -231,6 +231,8 @@ class RegisterWithUsernamePasswordTask(Task):
         """Register the system with Red Hat account username and password.
 
         :raises: RegistrationError if calling the RHSM DBus API returns an error
+        :return: JSON string describing registration state
+        :rtype: str
         """
         log.debug("subscription: registering with username and password")
         with RHSMPrivateBus(self._rhsm_register_server_proxy) as private_bus:
@@ -241,13 +243,16 @@ class RegisterWithUsernamePasswordTask(Task):
                 # We do not yet support setting organization for username & password
                 # registration, so organization is blank for now.
                 organization = ""
-                private_register_proxy.Register(organization,
-                                                self._username,
-                                                self._password,
-                                                {},
-                                                {},
-                                                locale)
+                registration_data = private_register_proxy.Register(
+                    organization,
+                    self._username,
+                    self._password,
+                    {},
+                    {},
+                    locale
+                )
                 log.debug("subscription: registered with username and password")
+                return registration_data
             except DBusError as e:
                 log.debug("subscription: failed to register with username and password: %s",
                           str(e))
@@ -282,6 +287,8 @@ class RegisterWithOrganizationKeyTask(Task):
         """Register the system with organization name and activation key.
 
         :raises: RegistrationError if calling the RHSM DBus API returns an error
+        :return: JSON string describing registration state
+        :rtype: str
         """
         log.debug("subscription: registering with organization and activation key")
         with RHSMPrivateBus(self._rhsm_register_server_proxy) as private_bus:
@@ -289,12 +296,15 @@ class RegisterWithOrganizationKeyTask(Task):
                 locale = os.environ.get("LANG", "")
                 private_register_proxy = private_bus.get_proxy(RHSM.service_name,
                                                                RHSM_REGISTER.object_path)
-                private_register_proxy.RegisterWithActivationKeys(self._organization,
-                                                                  self._activation_keys,
-                                                                  {},
-                                                                  {},
-                                                                  locale)
+                registration_data = private_register_proxy.RegisterWithActivationKeys(
+                    self._organization,
+                    self._activation_keys,
+                    {},
+                    {},
+                    locale
+                )
                 log.debug("subscription: registered with organization and activation key")
+                return registration_data
             except DBusError as e:
                 log.debug("subscription: failed to register with organization & key: %s", str(e))
                 # RHSM exception contain details as JSON due to DBus exception handling limitations

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -43,6 +43,8 @@ class SubscriptionInterface(KickstartModuleInterface):
                             self.implementation.connect_to_insights_changed)
         self.watch_property("IsRegistered",
                             self.implementation.registered_changed)
+        self.watch_property("IsSimpleContentAccessEnabled",
+                            self.implementation.simple_content_access_enabled_changed)
         self.watch_property("IsSubscriptionAttached",
                             self.implementation.subscription_attached_changed)
 
@@ -143,6 +145,11 @@ class SubscriptionInterface(KickstartModuleInterface):
     def IsRegistered(self) -> Bool:
         """Report if the system is registered."""
         return self.implementation.registered
+
+    @property
+    def IsSimpleContentAccessEnabled(self) -> Bool:
+        """Report if Simple Content Access is enabled."""
+        return self.implementation.simple_content_access_enabled
 
     @property
     def IsSubscriptionAttached(self) -> Bool:

--- a/pyanaconda/modules/subscription/utils.py
+++ b/pyanaconda/modules/subscription/utils.py
@@ -1,0 +1,60 @@
+#
+# Utility functions for network module
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import json
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+
+def detect_sca_from_registration_data(registration_data_json):
+    """Detect SCA/entitlement mode from registration data.
+
+    This function checks JSON data describing registration state as returned
+    by the the Register() or RegisterWithActivationKeys() RHSM DBus methods.
+    Based on the value of the "contentAccessMode" key present in a dictionary available
+    under the "owner" top level key.
+
+    :param str registration_data_json: registration data in JSON format
+    :return: True if data inicates SCA enabled, False otherwise
+    """
+    # we can't try to detect SCA mode if we don't have any registration data
+    if not registration_data_json:
+        log.warning("no registraton data provided, skipping SCA mode detection attempt")
+        return False
+    registration_data = json.loads(registration_data_json)
+    owner_data = registration_data.get("owner")
+
+    if owner_data:
+        content_access_mode = owner_data.get("contentAccessMode")
+        if content_access_mode == "org_environment":
+            # SCA explicitely noted as enabled
+            return True
+        elif content_access_mode == "entitlement":
+            # SCA explicitely not enabled
+            return False
+        else:
+            log.warning("contentAccessMode mode not set to known value:")
+            log.warning(content_access_mode)
+            # unknown mode or missing data -> not SCA
+            return False
+    else:
+        # we have no data indicating SCA is enabled
+        return False

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -1081,7 +1081,10 @@ class SubscriptionSpoke(NormalSpoke):
         # check how many we have & set the subscription status string accordingly
         subscription_count = len(attached_subscriptions)
         if subscription_count == 0:
-            subscription_string = _("No subscriptions are attached to the system")
+            if self._subscription_module.IsSimpleContentAccessEnabled:
+                subscription_string = _("Subscribed in Simple Content Access mode.")
+            else:
+                subscription_string = _("No subscriptions are attached to the system")
         elif subscription_count == 1:
             subscription_string = _("1 subscription attached to the system")
         else:

--- a/tests/nosetests/pyanaconda_tests/module_subscription_utils_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_utils_test.py
@@ -1,0 +1,113 @@
+#
+# Copyright (C) 2022  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Martin Kolman <mkolman@redhat.com>
+#
+
+import json
+import unittest
+
+from pyanaconda.modules.subscription.utils import detect_sca_from_registration_data
+
+
+class DetectSCATestCase(unittest.TestCase):
+
+    def test_registration_data_json_parsing(self):
+        """Test the detect_sca_from_registration_data() method."""
+        parse_method = detect_sca_from_registration_data
+        # the parsing method should be able to survive also getting an empty string
+        # or even None, returning False
+        self.assertFalse(parse_method(""))
+        self.assertFalse(parse_method(None))
+
+        # registration data without owner key
+        no_owner_data = {
+            "foo": "123",
+            "bar": "456",
+            "baz": "789"
+        }
+        self.assertFalse(parse_method(json.dumps(no_owner_data)))
+
+        # registration data with owner key but without the necessary
+        # contentAccessMode key
+        no_access_mode_data = {
+            "foo": "123",
+            "owner": {
+                "id": "abc",
+                "key": "admin",
+                "displayName": "Admin Owner"
+            },
+            "bar": "456",
+            "baz": "789"
+        }
+        self.assertFalse(parse_method(json.dumps(no_access_mode_data)))
+
+        # registration data with owner key but without the necessary
+        # contentAccessMode key
+        no_access_mode_data = {
+            "foo": "123",
+            "owner": {
+                "id": "abc",
+                "key": "admin",
+                "displayName": "Admin Owner"
+            },
+            "bar": "456",
+            "baz": "789"
+        }
+        self.assertFalse(parse_method(json.dumps(no_access_mode_data)))
+
+        # registration data for SCA mode
+        sca_mode_data = {
+            "foo": "123",
+            "owner": {
+                "id": "abc",
+                "key": "admin",
+                "displayName": "Admin Owner",
+                "contentAccessMode": "org_environment"
+            },
+            "bar": "456",
+            "baz": "789"
+        }
+        self.assertTrue(parse_method(json.dumps(sca_mode_data)))
+
+        # registration data for entitlement mode
+        entitlement_mode_data = {
+            "foo": "123",
+            "owner": {
+                "id": "abc",
+                "key": "admin",
+                "displayName": "Admin Owner",
+                "contentAccessMode": "entitlement"
+            },
+            "bar": "456",
+            "baz": "789"
+        }
+        self.assertFalse(parse_method(json.dumps(entitlement_mode_data)))
+
+        # registration data for unknown mode
+        unknown_mode_data = {
+            "foo": "123",
+            "owner": {
+                "id": "abc",
+                "key": "admin",
+                "displayName": "Admin Owner",
+                "contentAccessMode": "something_else"
+            },
+            "bar": "456",
+            "baz": "789"
+        }
+        self.assertFalse(parse_method(json.dumps(unknown_mode_data)))


### PR DESCRIPTION
Show a proper status message instead of a confusing (even if correct) message about no subscription being attached if install time registration is done in Simple Content Access mode.

This is achieved by parsing the data returned by the register methods of the RHSM DBus, exposing this via a DBus property of the Subscription module, which is then used by the GUI to display the appropriate string.

This is the RHEL 8 version of #3828.