### PR TITLE
Backport hotfix for the npm issue to anaconda-ci container (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -68,6 +68,8 @@ RUN set -ex; \
   cat /root/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   rpmspec -q --requires /tmp/anaconda.spec | grep -v anaconda | xargs -d '\n' dnf install -y; \
+  # FIXME: Install older npm version - the version from the package manager leads to timeouts
+  npm install -g npm@8.1.0; \
   dnf clean all
 
 RUN pip install --no-cache-dir --upgrade pip; \


### PR DESCRIPTION
We don't need that because we don't build the Anaconda in the anaconda-ci container, however, blivet using our containers for their testing and they are doing that. So or so, this will also fix the `container-shell` Makefile target in the similar cases.

The original fix is done by aae34587bc246d31eff2b229f40b1ccc87adb9b5 .

Resolves https://github.com/storaged-project/blivet/pull/1020 .