### PR TITLE
Fix anaconda-rpm container build (#infra)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -189,7 +189,7 @@ anaconda-ci-build:
 
 anaconda-rpm-build:
 	TEMP=$$(mktemp -t -d anaconda-rpm-build.XXXX) && \
-	cp $(srcdir)/anaconda.spec.in $(CI_DOCKERFILE)/* $$TEMP/ && \
+	cp $(srcdir)/anaconda.spec.in $(RPM_DOCKERFILE)/* $$TEMP/ && \
 	echo "Build dir is $$TEMP" && \
 	$(CONTAINER_ENGINE) build \
 	$(CONTAINER_BUILD_ARGS) \


### PR DESCRIPTION
Backporting this will make our `f36-devel` and `f36-release` about 200MB smaller. Also the tests will be more correct.

For some time already we are building anaconda-rpm container image from the anaconda-ci Dockerfile. Ups my bad :(.

(cherry picked from commit 9539801d10f275a2c800826cfc58ad78e67c8071)