### PR TITLE
Port of cmurf PR for /var subvolume on Kinoite and Silverblue

### DIFF
--- a/data/profile.d/fedora-kinoite.conf
+++ b/data/profile.d/fedora-kinoite.conf
@@ -9,3 +9,9 @@ base_profile = fedora-kde
 # Match os-release values.
 os_id = fedora
 variant_id = kinoite
+
+[Storage]
+default_partitioning =
+    /     (min 1 GiB, max 70 GiB)
+    /home (min 500 MiB, free 50 GiB)
+    /var  (btrfs)

--- a/data/profile.d/fedora-silverblue.conf
+++ b/data/profile.d/fedora-silverblue.conf
@@ -10,5 +10,11 @@ base_profile = fedora-workstation
 os_id = fedora
 variant_id = silverblue
 
+[Storage]
+default_partitioning =
+    /     (min 1 GiB, max 70 GiB)
+    /home (min 500 MiB, free 50 GiB)
+    /var  (btrfs)
+
 [User Interface]
 custom_stylesheet = /usr/share/anaconda/pixmaps/silverblue/fedora-silverblue.css

--- a/tests/unit_tests/pyanaconda_tests/core/test_profile.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_profile.py
@@ -25,6 +25,7 @@ import pytest
 from textwrap import dedent
 from unittest.mock import patch
 from blivet.size import Size
+from pykickstart.constants import AUTOPART_TYPE_BTRFS
 
 from pyanaconda.modules.storage.partitioning.automatic.utils import get_default_partitioning
 from pyanaconda.modules.storage.partitioning.specification import PartSpec
@@ -66,6 +67,18 @@ WORKSTATION_PARTITIONING = [
         lv=True,
         thin=True,
         encrypted=True
+    ),
+]
+
+WORKSTATIONPLUS_PARTITIONING = WORKSTATION_PARTITIONING + [
+    PartSpec(
+        mountpoint="/var",
+        # size=Size("15GiB"),
+        btr=True,
+        lv=True,
+        thin=True,
+        encrypted=True,
+        schemes={AUTOPART_TYPE_BTRFS}
     ),
 ]
 
@@ -194,7 +207,10 @@ class ProfileConfigurationTestCase(unittest.TestCase):
             platform.partitions = []
 
             with patch("pyanaconda.modules.storage.partitioning.automatic.utils.conf", new=config):
-                assert get_default_partitioning() == partitioning
+                default = get_default_partitioning()
+                print("Default: " + repr(default))
+                print("Supplied: " + repr(partitioning))
+                assert default == partitioning
 
     def _check_default_profile(self, profile_id, os_release_values, file_names, partitioning):
         """Check a default profile."""
@@ -248,7 +264,7 @@ class ProfileConfigurationTestCase(unittest.TestCase):
             "fedora-silverblue",
             ("fedora", "silverblue"),
             ["fedora.conf", "fedora-workstation.conf", "fedora-silverblue.conf"],
-            WORKSTATION_PARTITIONING
+            WORKSTATIONPLUS_PARTITIONING
         )
         self._check_default_profile(
             "fedora-kde",
@@ -260,7 +276,7 @@ class ProfileConfigurationTestCase(unittest.TestCase):
             "fedora-kinoite",
             ("fedora", "kinoite"),
             ["fedora.conf", "fedora-kde.conf", "fedora-kinoite.conf"],
-            WORKSTATION_PARTITIONING
+            WORKSTATIONPLUS_PARTITIONING
         )
         self._check_default_profile(
             "fedora-iot",


### PR DESCRIPTION
Fixed and cleaned up #3845.

@cmurf please let me know if the config does specify sufficient size for the /var mount point. I saw you had 15 GB in your tests, which was not in the config.