### PR TITLE
Remove RPM database cleanup

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -18,7 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import glob
 import os
 import os.path
 import subprocess
@@ -510,14 +509,6 @@ def reIPL(ipldev):
         log.info("reIPL configuration failed")
     else:
         log.info("reIPL configuration successful")
-
-
-def resetRpmDb():
-    for rpmfile in glob.glob("%s/var/lib/rpm/__db.*" % conf.target.system_root):
-        try:
-            os.unlink(rpmfile)
-        except OSError as e:
-            log.debug("error %s removing file: %s", e, rpmfile)
 
 
 def setup_translations():

--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -917,7 +917,6 @@ class BootLoader(object):
         except ImportError:
             pass
         else:
-            util.resetRpmDb()
             ts = rpm.TransactionSet(conf.target.system_root)
 
             # Only add "rhgb quiet" on non-s390, non-serial installs.


### PR DESCRIPTION
This was used to clean up RPM database using Berkeley DB, which has not been used since Fedora 33. The code just sat there and did nothing. It can go now.

Related: [rhbz#2050428](https://bugzilla.redhat.com/show_bug.cgi?id=2050428)