### PR TITLE
build: clean up webui dist before making scratch builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -150,6 +150,7 @@ scratch:
 	if [ "$(TEST_BUILD)" == "true" ]; then \
 		sed -ri '/AC_INIT/ s/\[[0-9.]+\]/[999999999]/' $(srcdir)/configure.ac; \
 	fi
+	rm -rf ui/webui/dist
 	$(MAKE) po-pull
 	$(MAKE) ARCHIVE_TAG=HEAD dist
 


### PR DESCRIPTION
If `ui/webui/dist` is present, the `make dist` command will be skipped
for the webui subtree. This is especially problematic, if the
translation files were not present when the `ui/webui/dist` was created
in the first place, as then RPM creation will always fail on missing
translation JS files.