### PR TITLE
webui: checkout last release instead of main for cockpit's test library

### DIFF
--- a/ui/webui/Makefile.am
+++ b/ui/webui/Makefile.am
@@ -79,9 +79,8 @@ integration-test: bots test/common $(UPDATES_IMG)
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest release, and update it from time to time
-# FIXME: When https://github.com/cockpit-project/cockpit/pull/16914 is a release s/main/$(release)
 test/common:
-	git clone -b main --depth=1 https://github.com/cockpit-project/cockpit.git tmp/cockpit
+	git clone -b 263 --depth=1 https://github.com/cockpit-project/cockpit.git tmp/cockpit
 	mv tmp/cockpit/test/common test/common
 	rm -rf tmp/cockpit
 


### PR DESCRIPTION
Main now already contains code that breaks our tests, let's adjust tests
when a new cockpit release is available.

** This fixes the failing webui tests on master.

Example test failure on master:
https://logs.cockpit-project.org/logs/pull-3807-20220221-151618-6df42d11-fedora-rawhide-boot/log.html