### PR TITLE
Use RHEL 9.0 repositories for tests (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/rhel-9.repo
+++ b/dockerfile/anaconda-ci/rhel-9.repo
@@ -1,6 +1,6 @@
 [RHEL-9-CRB]
 name=crb
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/CRB/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/CRB/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
@@ -8,7 +8,7 @@ module_hotfixes=1
 
 [RHEL-9-BaseOS]
 name=baseos
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/BaseOS/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
@@ -16,7 +16,7 @@ module_hotfixes=1
 
 [RHEL-9-AppStream]
 name=appstream
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/AppStream/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
@@ -24,7 +24,7 @@ module_hotfixes=1
 
 [RHEL-9-Buildroot]
 name=buildroot
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9/latest-BUILDROOT-9-RHEL-9/compose/Buildroot/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9/latest-BUILDROOT-9.0-RHEL-9/compose/Buildroot/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0

--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -30,8 +30,8 @@ MINOR_VERSION=${VERSION_ID#*.}
 # The --volid argument can cause different network interface naming: https://github.com/rhinstaller/kickstart-tests/issues/448
 lorax -p RHEL -v $MAJOR_VERSION -r $MINOR_VERSION --volid RHEL-$MAJOR_VERSION-$MINOR_VERSION-0-BaseOS-x86_64 \
       --nomacboot \
-      -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/BaseOS/x86_64/os/ \
-      -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/AppStream/x86_64/os/ \
+      -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/x86_64/os/ \
+      -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/x86_64/os/ \
       -s file://$REPO_DIR/ \
       $@ \
       lorax

--- a/dockerfile/anaconda-iso-creator/rhel-9.repo
+++ b/dockerfile/anaconda-iso-creator/rhel-9.repo
@@ -1,6 +1,6 @@
 [RHEL-9-BaseOS]
 name=baseos
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/BaseOS/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
@@ -8,7 +8,7 @@ module_hotfixes=1
 
 [RHEL-9-AppStream]
 name=appstream
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/AppStream/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0

--- a/dockerfile/anaconda-rpm/rhel-9.repo
+++ b/dockerfile/anaconda-rpm/rhel-9.repo
@@ -1,6 +1,6 @@
 [RHEL-9-CRB]
 name=crb
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/CRB/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/CRB/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
@@ -8,7 +8,7 @@ module_hotfixes=1
 
 [RHEL-9-BaseOS]
 name=baseos
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/BaseOS/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
@@ -16,7 +16,7 @@ module_hotfixes=1
 
 [RHEL-9-AppStream]
 name=appstream
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/AppStream/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
@@ -24,7 +24,7 @@ module_hotfixes=1
 
 [RHEL-9-Buildroot]
 name=buildroot
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9/latest-BUILDROOT-9-RHEL-9/compose/Buildroot/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9/latest-BUILDROOT-9.0-RHEL-9/compose/Buildroot/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0


### PR DESCRIPTION
The rhel-9 branch is used for RHEL 9.0 development while RHEL-9
repositories point to RHEL-9.1 now.