### PR TITLE
Allow to run an incomplete installation via DBus

### DIFF
--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -85,18 +85,18 @@ class Anaconda(object):
 
             if payload_type == PAYLOAD_TYPE_RPM_OSTREE:
                 from pyanaconda.payload.rpmostreepayload import RPMOSTreePayload
-                klass = RPMOSTreePayload
+                payload = RPMOSTreePayload()
             elif self.opts.liveinst:
                 from pyanaconda.payload.live import LiveOSPayload
-                klass = LiveOSPayload
+                payload = LiveOSPayload()
             elif payload_type == PAYLOAD_TYPE_LIVE_IMAGE:
                 from pyanaconda.payload.live import LiveImagePayload
-                klass = LiveImagePayload
+                payload = LiveImagePayload()
             else:
                 from pyanaconda.payload.dnf import DNFPayload
-                klass = DNFPayload
+                payload = DNFPayload(self.ksdata)
 
-            self._payload = klass(self.ksdata)
+            self._payload = payload
 
         return self._payload
 

--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -106,10 +106,28 @@ class Boss(Service):
         """
         return self._install_manager.collect_requirements()
 
+    def install_with_tasks(self):
+        """Return installation tasks of this module.
+
+        FIXME: This is a temporary workaround for the Web UI.
+
+        :return: a list of DBus paths of the installation tasks
+        """
+        from pyanaconda.installation import RunInstallationTask
+        from pyanaconda.payload.migrated import ActiveDBusPayload
+        from pyanaconda.kickstart import superclass
+
+        return [
+            RunInstallationTask(
+                payload=ActiveDBusPayload(),
+                ksdata=superclass(),
+            )
+        ]
+
     def collect_configure_runtime_tasks(self):
         """Collect tasks for configuration of the runtime environment.
 
-        FIXME: This method temporarily uses only addons.
+        FIXME: This is a temporary workaround for add-ons.
 
         :return: a list of task proxies
         """
@@ -118,8 +136,7 @@ class Boss(Service):
     def collect_configure_bootloader_tasks(self, kernel_versions):
         """Collect tasks for configuration of the bootloader.
 
-        FIXME: This method temporarily uses only addons.
-        FIXME: This is a temporary workaround. The method might change.
+        FIXME: This is a temporary workaround for add-ons.
 
         :param kernel_versions: a list of kernel versions
         :return: a list of task proxies
@@ -129,7 +146,7 @@ class Boss(Service):
     def collect_install_system_tasks(self):
         """Collect tasks for installation of the system.
 
-        FIXME: This method temporarily uses only addons.
+        FIXME: This is a temporary workaround for add-ons.
 
         :return: a list of task proxies
         """
@@ -146,6 +163,8 @@ class Boss(Service):
 
     def finish_installation_with_tasks(self):
         """Finish installation with tasks.
+
+        FIXME: This is a temporary workaround for the Boss module.
 
         :return: a list of installation tasks
         """

--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -97,10 +97,21 @@ class BossInterface(InterfaceTemplate):
             self.implementation.collect_requirements()
         )
 
+    def InstallWithTasks(self) -> List[ObjPath]:
+        """Returns installation tasks of this module.
+
+        FIXME: This is a temporary workaround for the Web UI.
+
+        :returns: list of object paths of installation tasks
+        """
+        return TaskContainer.to_object_path_list(
+            self.implementation.install_with_tasks()
+        )
+
     def CollectConfigureRuntimeTasks(self) -> List[Tuple[BusName, ObjPath]]:
         """Collect tasks for configuration of the runtime environment.
 
-        FIXME: This method temporarily uses only addons.
+        FIXME: This is a temporary workaround for add-ons.
 
         :return: a list of service names and object paths of tasks
         """
@@ -111,8 +122,7 @@ class BossInterface(InterfaceTemplate):
             -> List[Tuple[BusName, ObjPath]]:
         """Collect tasks for configuration of the bootloader.
 
-        FIXME: This method temporarily uses only addons.
-        FIXME: This is a temporary workaround. The method might change.
+        FIXME: This is a temporary workaround for add-ons.
 
         :param kernel_versions: a list of kernel versions
         :return: a list of service names and object paths of tasks
@@ -123,7 +133,7 @@ class BossInterface(InterfaceTemplate):
     def CollectInstallSystemTasks(self) -> List[Tuple[BusName, ObjPath]]:
         """Collect tasks for installation of the system.
 
-        FIXME: This method temporarily uses only addons.
+        FIXME: This is a temporary workaround for add-ons.
 
         :return: a list of service names and object paths of tasks
         """
@@ -132,6 +142,8 @@ class BossInterface(InterfaceTemplate):
 
     def FinishInstallationWithTasks(self) -> List[ObjPath]:
         """Finish installation with tasks.
+
+        FIXME: This is a temporary workaround for the Boss module.
 
         :return: a list of D-Bus paths of tasks
         """

--- a/pyanaconda/payload/base.py
+++ b/pyanaconda/payload/base.py
@@ -29,13 +29,9 @@ __all__ = ["Payload"]
 
 class Payload(metaclass=ABCMeta):
     """Payload is an abstract class for OS install delivery methods."""
-    def __init__(self, data):
-        """Initialize Payload class
 
-        :param data: This param is a kickstart.AnacondaKSHandler class.
-        """
-        self.data = data
-
+    def __init__(self):
+        """Initialize the payload."""
         # A DBus proxy of the Payloads service.
         self._service_proxy = PAYLOADS.get_proxy()
 

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -69,8 +69,10 @@ log = get_packaging_logger()
 
 class DNFPayload(Payload):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, data):
+        super().__init__()
+        self.data = data
+
         # A list of verbose error strings
         self.verbose_errors = []
 

--- a/pyanaconda/payload/migrated.py
+++ b/pyanaconda/payload/migrated.py
@@ -32,8 +32,8 @@ __all__ = ["MigratedDBusPayload"]
 class MigratedDBusPayload(Payload, metaclass=ABCMeta):
     """An abstract class for payloads that migrated on DBus."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self):
+        super().__init__()
         self._payload_proxy = get_payload(self.type)
 
     @property

--- a/pyanaconda/payload/migrated.py
+++ b/pyanaconda/payload/migrated.py
@@ -26,7 +26,7 @@ from pyanaconda.ui.lib.payload import get_payload, get_source, set_up_sources
 
 log = get_module_logger(__name__)
 
-__all__ = ["MigratedDBusPayload"]
+__all__ = ["MigratedDBusPayload", "ActiveDBusPayload"]
 
 
 class MigratedDBusPayload(Payload, metaclass=ABCMeta):
@@ -34,7 +34,11 @@ class MigratedDBusPayload(Payload, metaclass=ABCMeta):
 
     def __init__(self):
         super().__init__()
-        self._payload_proxy = get_payload(self.type)
+        self._payload_proxy = self._create_payload_proxy()
+
+    def _create_payload_proxy(self):
+        """Create a DBus proxy of the requested payload."""
+        return get_payload(self.type)
 
     @property
     @abstractmethod
@@ -105,3 +109,23 @@ class MigratedDBusPayload(Payload, metaclass=ABCMeta):
                 task_proxy.ProgressChanged.connect(progress_cb)
 
             sync_run_task(task_proxy)
+
+
+class ActiveDBusPayload(MigratedDBusPayload):
+    """Payload class for the active DBus payload."""
+
+    def _create_payload_proxy(self):
+        """Create a DBus proxy of the active payload."""
+        object_path = self.service_proxy.ActivePayload
+        return PAYLOADS.get_proxy(object_path)
+
+    @property
+    def type(self):
+        """Get a type of the active payload."""
+        return self._payload_proxy.Type
+
+    @property
+    def default_source_type(self):
+        """Get a default source type of the active payload."""
+        source_types = self._payload_proxy.SupportedSourceTypes
+        return source_types[0] if source_types else ""

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
@@ -20,16 +20,19 @@ import unittest
 from unittest.mock import Mock, patch
 
 from dasbus.typing import *  # pylint: disable=wildcard-import
+from pykickstart.base import KickstartHandler
 
 from pyanaconda.core.constants import DEFAULT_LANG
+from pyanaconda.installation import RunInstallationTask
 from pyanaconda.modules.boss.boss import Boss
 from pyanaconda.modules.boss.boss_interface import BossInterface
 from pyanaconda.modules.boss.installation import CopyLogsTask, SetContextsTask
 from pyanaconda.modules.boss.module_manager.start_modules import StartModulesTask
 from pyanaconda.modules.common.structures.requirement import Requirement
+from pyanaconda.payload.migrated import ActiveDBusPayload
 
 from tests.unit_tests.pyanaconda_tests import patch_dbus_publish_object, check_task_creation, \
-    patch_dbus_get_proxy
+    patch_dbus_get_proxy, check_task_creation_list
 
 
 class BossInterfaceTestCase(unittest.TestCase):
@@ -163,6 +166,17 @@ class BossInterfaceTestCase(unittest.TestCase):
             }
         ]
 
+    @patch_dbus_publish_object
+    @patch_dbus_get_proxy
+    def test_install_with_tasks(self, proxy_getter, publisher):
+        """Test InstallWithTasks."""
+        task_paths = self.interface.InstallWithTasks()
+        task_proxies = check_task_creation_list(task_paths, publisher, [RunInstallationTask])
+        task = task_proxies[0].implementation
+
+        assert isinstance(task._payload, ActiveDBusPayload)
+        assert isinstance(task._ksdata, KickstartHandler)
+
     @patch("pyanaconda.modules.boss.boss_interface.get_object_handler")
     @patch_dbus_get_proxy
     def test_collect_configure_runtime_tasks(self, proxy_getter, handler_getter):
@@ -225,7 +239,7 @@ class BossInterfaceTestCase(unittest.TestCase):
         ]
 
     @patch_dbus_publish_object
-    def test_install_with_tasks(self, publisher):
+    def test_finish_installation_with_tasks(self, publisher):
         """Test FinishInstallationWithTasks."""
         task_list = self.interface.FinishInstallationWithTasks()
 


### PR DESCRIPTION
Call the `InstallWithTasks` method of the Boss module to create tasks for
the system installation. This is a temporary workaround for the Web UI.