### PR TITLE
Use cache when fetching organization data from the GUI

### DIFF
--- a/pyanaconda/modules/subscription/runtime.py
+++ b/pyanaconda/modules/subscription/runtime.py
@@ -269,7 +269,8 @@ class RegisterWithUsernamePasswordTask(Task):
             org_data_task = RetrieveOrganizationsTask(
                 rhsm_register_server_proxy=self._rhsm_register_server_proxy,
                 username=self._username,
-                password=self._password
+                password=self._password,
+                reset_cache=True
             )
             org_list = org_data_task.run()
             if len(org_list) > 1:
@@ -1033,17 +1034,23 @@ class RetrieveOrganizationsTask(Task):
     Satellite instances.
     """
 
-    def __init__(self, rhsm_register_server_proxy, username, password):
+    # the cache is used to serve last-known-good data if calling the GetOrgs()
+    # DBus method can't be called successfully in some scenarios
+    _org_data_list_cache = []
+
+    def __init__(self, rhsm_register_server_proxy, username, password, reset_cache=False):
         """Create a new organization data parsing task.
 
         :param rhsm_register_server_proxy: DBus proxy for the RHSM RegisterServer object
         :param str username: Red Hat account username
         :param str password: Red Hat account password
+        :param bool reset_cache: clear the cache before calling GetOrgs()
         """
         super().__init__()
         self._rhsm_register_server_proxy = rhsm_register_server_proxy
         self._username = username
         self._password = password
+        self._reset_cache = reset_cache
 
     @property
     def name(self):
@@ -1084,6 +1091,9 @@ class RetrieveOrganizationsTask(Task):
 
         :raises: RegistrationError if calling the RHSM DBus API returns an error
         """
+        # reset the data cache if requested
+        if self._reset_cache:
+            RetrieveOrganizationsTask._org_data_list_cache = []
         log.debug("subscription: getting data about organizations")
         with RHSMPrivateBus(self._rhsm_register_server_proxy) as private_bus:
             try:
@@ -1106,10 +1116,12 @@ class RetrieveOrganizationsTask(Task):
                 # parse the JSON strings into list of DBus data objects
                 org_data = self._parse_org_data_json(org_data_json)
 
+                log.debug("subscription: updating org data cache")
+                RetrieveOrganizationsTask._org_data_list_cache = org_data
                 # return the DBus structure list
                 return org_data
             except DBusError as e:
-                # Errors returned by the RHSM DBus API for this call are unfortunatelly
+                # Errors returned by the RHSM DBus API for this call are unfortunately
                 # quite ambiguous (especially if Hosted Candlepin is used) and we can't
                 # really decide which are fatal and which are not.
                 # So just log the full error JSON from the message field of the returned
@@ -1120,7 +1132,11 @@ class RetrieveOrganizationsTask(Task):
                 log.debug("subscription: failed to get organization data")
                 # log the raw exception JSON payload for debugging purposes
                 log.debug(str(e))
-                return []
+                # if we have something in cache, log the cache is being used,
+                # if there is nothing don't log anything as the cache is empty
+                if RetrieveOrganizationsTask._org_data_list_cache:
+                    log.debug("subscription: using cached organization data after failure")
+                return RetrieveOrganizationsTask._org_data_list_cache
 
     def for_publication(self):
         """Return a DBus representation."""

--- a/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription_tasks.py
@@ -707,8 +707,9 @@ class RegistrationTasksTestCase(unittest.TestCase):
             }
         ]
         org_data_json = json.dumps(org_data)
-        retrieve_orgs_task.return_value.run.return_value = \
-            RetrieveOrganizationsTask._parse_org_data_json(org_data_json)
+        org_data_list = RetrieveOrganizationsTask._parse_org_data_json(org_data_json)
+        retrieve_orgs_task.return_value.run.return_value = org_data_list
+        # prepare mock data callaback as well
         # instantiate the task and run it - we set organization to "" to make the task
         # fetch organization list
         task = RegisterWithUsernamePasswordTask(rhsm_register_server_proxy=register_server_proxy,
@@ -748,8 +749,8 @@ class RegistrationTasksTestCase(unittest.TestCase):
             }
         ]
         org_data_json = json.dumps(org_data)
-        retrieve_orgs_task.return_value.run.return_value = \
-            RetrieveOrganizationsTask._parse_org_data_json(org_data_json)
+        org_data_list = RetrieveOrganizationsTask._parse_org_data_json(org_data_json)
+        retrieve_orgs_task.return_value.run.return_value = org_data_list
         # instantiate the task and run it - we set organization to "" to make the task
         # fetch organization list
         task = RegisterWithUsernamePasswordTask(rhsm_register_server_proxy=register_server_proxy,
@@ -1874,3 +1875,195 @@ class RetrieveOrganizationsTaskTestCase(unittest.TestCase):
                                                                "bar_password",
                                                                {},
                                                                "en_US.UTF-8")
+
+    @patch("os.environ.get", return_value="en_US.UTF-8")
+    @patch("pyanaconda.modules.subscription.runtime.RHSMPrivateBus")
+    def test_get_org_data_cached(self, private_bus, environ_get):
+        """Test the RetrieveOrganizationsTask - return cached data on error."""
+        # register server proxy
+        register_server_proxy = Mock()
+        # private register proxy
+        get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
+        private_register_proxy = get_proxy.return_value
+        # simulate GetOrgs call failure
+        private_register_proxy.GetOrgs.side_effect = DBusError("org listing failed")
+        # create some dummy cached data
+        cached_structs_list = [
+            {
+                "id": get_variant(Str, "123a cached"),
+                "name": get_variant(Str, "Foo Org cached"),
+            },
+            {
+                "id": get_variant(Str, "123b cached"),
+                "name": get_variant(Str, "Bar Org cached"),
+            },
+            {
+                "id": get_variant(Str, "123c cached"),
+                "name": get_variant(Str, "Baz Org cached"),
+            }
+        ]
+        cached_structs = OrganizationData.from_structure_list(cached_structs_list)
+        RetrieveOrganizationsTask._org_data_list_cache = cached_structs
+
+        # instantiate the task and run it with cached data
+        task = RetrieveOrganizationsTask(rhsm_register_server_proxy=register_server_proxy,
+                                         username="foo_user",
+                                         password="bar_password")
+        org_data_structs = task.run()
+        # check the returned structs are based on the cache data, not the
+        # JSON data the mock-API would return
+        expected_struct_list = [
+            {
+                "id": "123a cached",
+                "name": "Foo Org cached",
+            },
+            {
+                "id": "123b cached",
+                "name": "Bar Org cached",
+            },
+            {
+                "id": "123c cached",
+                "name": "Baz Org cached",
+            }
+        ]
+        structs = get_native(
+            OrganizationData.to_structure_list(org_data_structs)
+        )
+        assert structs == expected_struct_list
+
+        # check the private register proxy Register method was *not* called
+        # as all data should come from the cache, if provided, with *no*
+        # DBus API access
+        private_register_proxy.GetOrgs.assert_called_once_with(
+            'foo_user', 'bar_password', {}, 'en_US.UTF-8'
+        )
+
+    @patch("os.environ.get", return_value="en_US.UTF-8")
+    @patch("pyanaconda.modules.subscription.runtime.RHSMPrivateBus")
+    def test_get_org_data_ignore_cache(self, private_bus, environ_get):
+        """Test the RetrieveOrganizationsTask - do not use cache on success."""
+        # register server proxy
+        register_server_proxy = Mock()
+        # private register proxy
+        get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
+        private_register_proxy = get_proxy.return_value
+        # mock the GetOrgs JSON output
+        multiple_org_data = [
+            {
+                "key": "123a",
+                "displayName": "Foo Org",
+                "contentAccessMode": "entitlement"
+            },
+            {
+                "key": "123b",
+                "displayName": "Bar Org",
+                "contentAccessMode": "org_environment"
+            },
+            {
+                "key": "123c",
+                "displayName": "Baz Org",
+                "contentAccessMode": "something_else"
+            }
+        ]
+        multiple_org_data_json = json.dumps(multiple_org_data)
+        private_register_proxy.GetOrgs.return_value = multiple_org_data_json
+        # create some dummy cached data
+        cached_structs_list = [
+            {
+                "id": get_variant(Str, "123a cached"),
+                "name": get_variant(Str, "Foo Org cached"),
+            },
+            {
+                "id": get_variant(Str, "123b cached"),
+                "name": get_variant(Str, "Bar Org cached"),
+            },
+            {
+                "id": get_variant(Str, "123c cached"),
+                "name": get_variant(Str, "Baz Org cached"),
+            }
+        ]
+        cached_structs = OrganizationData.from_structure_list(cached_structs_list)
+        RetrieveOrganizationsTask._org_data_list_cache = cached_structs
+
+        # instantiate the task and run it with cached data
+        task = RetrieveOrganizationsTask(rhsm_register_server_proxy=register_server_proxy,
+                                         username="foo_user",
+                                         password="bar_password")
+        org_data_structs = task.run()
+
+        # check the structs based on the GetOrgs returned JSON data look as expected
+        expected_struct_list = [
+            {
+                "id": "123a",
+                "name": "Foo Org",
+            },
+            {
+                "id": "123b",
+                "name": "Bar Org",
+            },
+            {
+                "id": "123c",
+                "name": "Baz Org",
+            }
+        ]
+        structs = get_native(
+            OrganizationData.to_structure_list(org_data_structs)
+        )
+        assert structs == expected_struct_list
+
+        # check the private register proxy Register method was *not* called
+        # as all data should come from the cache, if provided, with *no*
+        # DBus API access
+        private_register_proxy.GetOrgs.assert_called_once_with(
+            'foo_user', 'bar_password', {}, 'en_US.UTF-8'
+        )
+
+    @patch("os.environ.get", return_value="en_US.UTF-8")
+    @patch("pyanaconda.modules.subscription.runtime.RHSMPrivateBus")
+    def test_get_org_data_cache_reset(self, private_bus, environ_get):
+        """Test the RetrieveOrganizationsTask - test cache reset."""
+        # register server proxy
+        register_server_proxy = Mock()
+        # private register proxy
+        get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
+        private_register_proxy = get_proxy.return_value
+        # simulate GetOrgs call failure
+        private_register_proxy.GetOrgs.side_effect = DBusError("org listing failed")
+        # create some dummy cached data
+        cached_structs_list = [
+            {
+                "id": get_variant(Str, "123a cached"),
+                "name": get_variant(Str, "Foo Org cached"),
+            },
+            {
+                "id": get_variant(Str, "123b cached"),
+                "name": get_variant(Str, "Bar Org cached"),
+            },
+            {
+                "id": get_variant(Str, "123c cached"),
+                "name": get_variant(Str, "Baz Org cached"),
+            }
+        ]
+        cached_structs = OrganizationData.from_structure_list(cached_structs_list)
+        RetrieveOrganizationsTask._org_data_list_cache = cached_structs
+
+        # instantiate the task and run it with cached data
+        task = RetrieveOrganizationsTask(rhsm_register_server_proxy=register_server_proxy,
+                                         username="foo_user",
+                                         password="bar_password",
+                                         reset_cache=True)
+        org_data_structs = task.run()
+        # we dropped the cache and the GetOrgs() call failed, so we return the
+        # contents of the empty cache
+        expected_struct_list = []
+        structs = get_native(
+            OrganizationData.to_structure_list(org_data_structs)
+        )
+        assert structs == expected_struct_list
+
+        # check the private register proxy Register method was *not* called
+        # as all data should come from the cache, if provided, with *no*
+        # DBus API access
+        private_register_proxy.GetOrgs.assert_called_once_with(
+            'foo_user', 'bar_password', {}, 'en_US.UTF-8'
+        )


### PR DESCRIPTION
```
Use cache when fetching organization data from the GUI

Bug 2044258 is caused by GetOrgs() call at registration time
via RetrieveOrganizationsTask triggering MultipleOrganizationsError
- the user is member of more than one organization yet no organization
has been specified.

This fails the registration attempt, which triggers cleanup tasks,
such as un-provisioning from Satellite.

As Satellite is the only known environment where users that are
members of multiple organizations exist, this causes an issue when
the GetOrgs() calling DBus task is called again from the GUI.

The system will no longer be provisioned for Satellite at this point &
the GetOrgs() call will fail - it will go to Hosted Canlepin, which
knowns nothing about this user.

The end result is the behavior described in the bug - the GUI fails to
list organizations for the user to choose from.

To fix this issue, we now always cache the org data list returned by
GetOrgs() when called via RetrieveOrganizationsTask at registration time.
For this the task is called directly, not via its DBus interface and
we make sure the cache is always cleared before calling GetOrgs().

The only case where RetrieveOrganizationsTask is called via it's DBus interface
(RetrieveOrganizationsWithTask) is when GUI needs to list organizations after
handling MultipleOrganizationsError. In this case the existing cached
value will be used when the GetOrgs() call fails due to Satellite being
no longer available.

This way if GUI calls RetrieveOrganizationsWithTask() after handling
the MultipleOrganizationsError, it will get the cached data from the
initial GetOrgs() call, which triggered the MultipleOrganizationsError.

Resolves: rhbz#2044258
```