### PR TITLE
webui: Don't save SSH key in command from VM script

### DIFF
--- a/ui/webui/test/webui_testvm.py
+++ b/ui/webui/test/webui_testvm.py
@@ -30,8 +30,9 @@ def cmd_cli():
     machine.start()
     machine.wait_boot()
 
+    print("You can connect to the VM in the following ways:")
     # print ssh command
-    print("ssh -o ControlPath=%s -p %s %s@%s" %
+    print("ssh -o ControlPath=%s -o UserKnownHostsFile=/dev/null -p %s %s@%s" %
           (machine.ssh_master, machine.ssh_port, machine.ssh_user, machine.ssh_address))
     # print Cockpit web address
     print(


### PR DESCRIPTION
Otherwise the key of the temporary system is saved in known_hosts and forces editing the file when the VM is started anew.