### PR TITLE
[rhel-9] ovirt: move /var/tmp to its own partition

### DIFF
--- a/data/product.d/ovirt.conf
+++ b/data/product.d/ovirt.conf
@@ -12,18 +12,20 @@ default_partitioning =
     /              (min 6 GiB)
     /home          (size 1 GiB)
     /tmp           (size 1 GiB)
-    /var           (size 15 GiB)
+    /var           (size 5 GiB)
     /var/crash     (size 10 GiB)
     /var/log       (size 8 GiB)
     /var/log/audit (size 2 GiB)
+    /var/tmp       (size 10 GiB)
     swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP
 must_not_be_on_root = /var
 req_partition_sizes =
-    /var   10 GiB
-    /boot  1  GiB
+    /var     5  GiB
+    /var/tmp 10 GiB
+    /boot    1  GiB
 
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhel

--- a/data/product.d/rhvh.conf
+++ b/data/product.d/rhvh.conf
@@ -23,18 +23,20 @@ default_partitioning =
     /              (min 6 GiB)
     /home          (size 1 GiB)
     /tmp           (size 1 GiB)
-    /var           (size 15 GiB)
+    /var           (size 5 GiB)
     /var/crash     (size 10 GiB)
     /var/log       (size 8 GiB)
     /var/log/audit (size 2 GiB)
+    /var/tmp       (size 10 GiB)
     swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP
 must_not_be_on_root = /var
 req_partition_sizes =
-    /var   10 GiB
-    /boot  1  GiB
+    /var     5  GiB
+    /var/tmp 10 GiB
+    /boot    1  GiB
 
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhel

--- a/tests/unit_tests/pyanaconda_tests/test_product.py
+++ b/tests/unit_tests/pyanaconda_tests/test_product.py
@@ -126,7 +126,7 @@ VIRTUALIZATION_PARTITIONING = [
     ),
     PartSpec(
         mountpoint="/var",
-        size=Size("15GiB"),
+        size=Size("5GiB"),
         btr=True,
         lv=True,
         thin=True,
@@ -151,6 +151,14 @@ VIRTUALIZATION_PARTITIONING = [
     PartSpec(
         mountpoint="/var/log/audit",
         size=Size("2GiB"),
+        btr=True,
+        lv=True,
+        thin=True,
+        encrypted=True,
+    ),
+    PartSpec(
+        mountpoint="/var/tmp",
+        size=Size("10GiB"),
         btr=True,
         lv=True,
         thin=True,


### PR DESCRIPTION
Move /var/tmp to its own partition on oVirt and RHV for DISA-STIG support.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2058538
Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>