### PR TITLE
master: move /var/tmp to its own partition

### DIFF
--- a/data/profile.d/ovirt.conf
+++ b/data/profile.d/ovirt.conf
@@ -16,18 +16,20 @@ default_partitioning =
     /              (min 6 GiB)
     /home          (size 1 GiB)
     /tmp           (size 1 GiB)
-    /var           (size 15 GiB)
+    /var           (size 5 GiB)
     /var/crash     (size 10 GiB)
     /var/log       (size 8 GiB)
     /var/log/audit (size 2 GiB)
+    /var/tmp       (size 10 GiB)
     swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP
 must_not_be_on_root = /var
 req_partition_sizes =
-    /var   10 GiB
-    /boot  1  GiB
+    /var     5  GiB
+    /var/tmp 10 GiB
+    /boot    1  GiB
 
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhel

--- a/data/profile.d/rhvh.conf
+++ b/data/profile.d/rhvh.conf
@@ -22,18 +22,20 @@ default_partitioning =
     /              (min 6 GiB)
     /home          (size 1 GiB)
     /tmp           (size 1 GiB)
-    /var           (size 15 GiB)
+    /var           (size 5 GiB)
     /var/crash     (size 10 GiB)
     /var/log       (size 8 GiB)
     /var/log/audit (size 2 GiB)
+    /var/tmp       (size 10 GiB)
     swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP
 must_not_be_on_root = /var
 req_partition_sizes =
-    /var   10 GiB
-    /boot  1  GiB
+    /var     5  GiB
+    /var/tmp 10 GiB
+    /boot    1  GiB
 
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhel

--- a/tests/unit_tests/pyanaconda_tests/core/test_profile.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_profile.py
@@ -137,7 +137,7 @@ VIRTUALIZATION_PARTITIONING = [
     ),
     PartSpec(
         mountpoint="/var",
-        size=Size("15GiB"),
+        size=Size("5GiB"),
         btr=True,
         lv=True,
         thin=True,
@@ -162,6 +162,14 @@ VIRTUALIZATION_PARTITIONING = [
     PartSpec(
         mountpoint="/var/log/audit",
         size=Size("2GiB"),
+        btr=True,
+        lv=True,
+        thin=True,
+        encrypted=True,
+    ),
+    PartSpec(
+        mountpoint="/var/tmp",
+        size=Size("10GiB"),
         btr=True,
         lv=True,
         thin=True,


### PR DESCRIPTION
Move /var/tmp to its own partition on oVirt and RHV for DISA-STIG support.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2057475
Signed-off-by: Sandro Bonazzola [sbonazzo@redhat.com](mailto:sbonazzo@redhat.com)