### PR TITLE
Remove 'module_hotfixes' in all our repositories (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/rhel-8.repo
+++ b/dockerfile/anaconda-ci/rhel-8.repo
@@ -4,7 +4,6 @@ baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/com
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-8-BaseOS]
 name=baseos
@@ -12,7 +11,6 @@ baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/com
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-8-AppStream]
 name=appstream
@@ -20,7 +18,6 @@ baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/com
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-8-Buildroot]
 name=buildroot
@@ -28,4 +25,3 @@ baseurl=http://download.eng.brq.redhat.com/rhel-8/nightly/BUILDROOT-8/latest-BUI
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1

--- a/dockerfile/anaconda-iso-creator/rhel-8.repo
+++ b/dockerfile/anaconda-iso-creator/rhel-8.repo
@@ -4,7 +4,6 @@ baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/com
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-8-AppStream]
 name=appstream
@@ -12,4 +11,3 @@ baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/com
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1

--- a/dockerfile/anaconda-rpm/rhel-8.repo
+++ b/dockerfile/anaconda-rpm/rhel-8.repo
@@ -4,7 +4,6 @@ baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/com
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-8-BaseOS]
 name=baseos
@@ -12,7 +11,6 @@ baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/com
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-8-AppStream]
 name=appstream
@@ -20,7 +18,6 @@ baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/com
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1
 
 [RHEL-8-Buildroot]
 name=buildroot
@@ -28,4 +25,3 @@ baseurl=http://download.eng.brq.redhat.com/rhel-8/nightly/BUILDROOT-8/latest-BUI
 enabled=1
 gpgcheck=0
 install_weak_deps=0
-module_hotfixes=1


### PR DESCRIPTION
We want to have modules enabled and this gives us default module versions which is recommended way. It's solving issue with missing Perl module during update.

*Suggested-by: skywalker*