### PR TITLE
Remove --pull-always from default podman build (#infra)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -83,7 +83,7 @@ TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
 
 # build/run tweaks for all containers, such as --cap-add
 CONTAINER_ENGINE ?= podman
-CONTAINER_BUILD_ARGS ?= --no-cache --pull-always
+CONTAINER_BUILD_ARGS ?= --no-cache
 CONTAINER_TEST_ARGS ?=
 CONTAINER_REGISTRY ?= quay.io
 # Add additional args to the existing ones to container engine
@@ -199,14 +199,14 @@ release-and-tag:
 
 anaconda-ci-build:
 	$(CONTAINER_ENGINE) build \
-	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_BUILD_ARGS) --pull-always \
 	$(CONTAINER_ADD_ARGS) \
 	-t $(CI_NAME):$(CI_TAG) \
 	$(CI_DOCKERFILE)
 
 anaconda-rpm-build:
 	$(CONTAINER_ENGINE) build \
-	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_BUILD_ARGS) --pull-always \
 	$(CONTAINER_ADD_ARGS) \
 	-t $(RPM_NAME):$(CI_TAG) \
 	$(RPM_DOCKERFILE)
@@ -220,7 +220,7 @@ anaconda-release-build: anaconda-rpm-build
 
 anaconda-iso-creator-build:
 	$(CONTAINER_ENGINE) build \
-	$(CONTAINER_BUILD_ARGS) \
+	$(CONTAINER_BUILD_ARGS) --pull-always \
 	$(CONTAINER_ADD_ARGS) \
 	--build-arg=image=registry.access.redhat.com/ubi8:latest \
 	-t $(ISO_CREATOR_NAME):$(CI_TAG) \


### PR DESCRIPTION
The --pull-always is great but it will always pull the remote repository to get the base image. It's great to have this for the RHEL/Fedora etc. base images so you don't work with outdated ones but not that great if you have a container image based on the something build locally (as anaconda-release container image).

(cherry picked from commit 8ab8f20fbd7c4b13828013a77f9a479842d7cb02)

Backport missed commit from PR https://github.com/rhinstaller/anaconda/pull/3821 .