### PR TITLE
Remove the enable_ignore_broken_packages configuration option

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -38,7 +38,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.32-1
+%define pykickstartver 3.37-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.4.0-1
 %define rpmver 4.15.0

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -97,9 +97,6 @@ enabled_repositories_from_treeinfo = addon optional variant
 # Enable installation from the closest mirror.
 enable_closest_mirror = True
 
-# Enable possibility to skip packages with conflicts and broken dependencies.
-enable_ignore_broken_packages = True
-
 # Default installation source.
 # Valid values:
 #

--- a/data/profile.d/rhel.conf
+++ b/data/profile.d/rhel.conf
@@ -23,12 +23,6 @@ ignored_packages =
 enable_closest_mirror = False
 default_source = CDN
 
-# This feature may result in an installed system which won't have everything installed
-# as expected. Because of this problem this feature will be disabled on RHEL based variants.
-# When disabled the installation won't be started with --ignorebroken, instead it will inform user
-# that the feature is not supported on their product. This will also block usage of related DBus API.
-enable_ignore_broken_packages = False
-
 [Bootloader]
 efi_dir = redhat
 

--- a/pyanaconda/core/configuration/payload.py
+++ b/pyanaconda/core/configuration/payload.py
@@ -90,19 +90,6 @@ class PayloadSection(Section):
         return value
 
     @property
-    def enable_ignore_broken_packages(self):
-        """Enable possibility to skip packages with conflicts and broken dependencies.
-
-        This enables --ignorebroken parameter of the packages section and related DBus API.
-
-        If this feature is disabled Anaconda won't start the installation when
-        --ignorebroken paramater is used. Instead print error message to user
-        when Anaconda is started and quit the installation process.
-        It will also block use of related DBus API.
-        """
-        return self._get_option("enable_ignore_broken_packages", bool)
-
-    @property
     def verify_ssl(self):
         """Global option if the ssl verification is enabled.
 

--- a/pyanaconda/modules/payloads/kickstart.py
+++ b/pyanaconda/modules/payloads/kickstart.py
@@ -17,18 +17,15 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.core.constants import URL_TYPE_BASEURL, URL_TYPE_MIRRORLIST, URL_TYPE_METALINK, \
-    DNF_DEFAULT_REPO_COST
-from pyanaconda.kickstart import RepoData
-from pyanaconda.modules.common.structures.payload import RepoConfigurationData
-from pykickstart.errors import KickstartParseError
 from pykickstart.parser import Packages, Group
 from pykickstart.sections import PackageSection
-from pykickstart.constants import KS_BROKEN_IGNORE, GROUP_DEFAULT
+from pykickstart.constants import GROUP_DEFAULT
 
-from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.i18n import _
+from pyanaconda.core.constants import URL_TYPE_BASEURL, URL_TYPE_MIRRORLIST, URL_TYPE_METALINK, \
+    DNF_DEFAULT_REPO_COST
 from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
+from pyanaconda.kickstart import RepoData
+from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 
 
 def convert_ks_repo_to_repo_data(ks_data):
@@ -109,24 +106,6 @@ def convert_repo_data_to_ks_repo(repo_data):
     return ks_data
 
 
-class AnacondaPackageSection(PackageSection):
-    """The parser of the %packages kickstart section."""
-
-    def handleHeader(self, lineno, args):
-        """Process packages section header.
-
-        Add checks based on configuration settings.
-        """
-        super().handleHeader(lineno, args)
-
-        if not conf.payload.enable_ignore_broken_packages \
-           and self.handler.packages.handleBroken == KS_BROKEN_IGNORE:
-            raise KickstartParseError(
-                _("The %packages --ignorebroken feature is not supported on your product!"),
-                lineno=lineno
-            )
-
-
 class AnacondaPackages(Packages):
     """The representation of the %packages kickstart section."""
 
@@ -158,7 +137,7 @@ class PayloadKickstartSpecification(KickstartSpecification):
     }
 
     sections = {
-        "packages": AnacondaPackageSection
+        "packages": PackageSection
     }
 
     sections_data = {


### PR DESCRIPTION
The `%packages --ignorebroken` feature is not supported on RHEL. Handle
this use case in pykickstart, so we don't have to deal with it in anaconda.

The `enable_ignore_broken_packages` configuration option was never documented
in the RHEL documentation.

Tested on F37 and RHEL9.

**Depends on:** https://github.com/pykickstart/pykickstart/pull/403