### PR TITLE
Add missing npm dependency to the install_dependencies

### DIFF
--- a/scripts/testing/install_dependencies.sh
+++ b/scripts/testing/install_dependencies.sh
@@ -28,7 +28,7 @@
 
 set -eu
 
-dnf install $@ rpm-build /usr/bin/xargs
+dnf install $@ make rpm-build /usr/bin/xargs npm virt-install
 
 TEMP=$(mktemp /tmp/anaconda.spec.XXXXXXX)
 


### PR DESCRIPTION
This will enable us to use toolbox containers pretty easily for the new UI
development.

Just do:

toolbox create anaconda
toolbox enter anaconda
sudo ./scripts/testing/install_dependencies.sh

Then you have everything you need.