### PR TITLE
Fix anaconda-widget crash when loaded on Wayland

### DIFF
--- a/widgets/src/LayoutIndicator.c
+++ b/widgets/src/LayoutIndicator.c
@@ -172,8 +172,7 @@ static void anaconda_layout_indicator_init(AnacondaLayoutIndicator *self) {
            class-wide stuff */
 
         /* initialize XklEngine instance that will be used by all LayoutIndicator instances */
-        display = gdk_display_get_default();
-        klass->engine = xkl_engine_get_instance(GDK_DISPLAY_XDISPLAY(display));
+        klass->engine = xkl_engine_get_instance(XOpenDisplay(NULL));
 
         /* make XklEngine listening */
         xkl_engine_start_listen(klass->engine, XKLL_TRACK_KEYBOARD_STATE);


### PR DESCRIPTION
The `GDK_DISPLAY_XDISPLAY` function will return `NULL` on Wayland. That will than crash when put into the `xkl_engine_get_instance()` function. To avoid the crash let's open the display here directly.

Just for clarification this is not fixing usability on Wayland system, just that it's not crashing. It still not work correctly.

*Resolves: rhbz#1959521*
*Suggested-by: Ray Strode*

**TODO:**
- [ ] Increase version of the anaconda-widgets
- [ ] Test this manually on Live
- [ ] Test this manually on netinst