### PR TITLE
Replace legacy adwaita icons removed in adwaita-icon-theme 42

### DIFF
--- a/pyanaconda/ui/gui/helpers.py
+++ b/pyanaconda/ui/gui/helpers.py
@@ -155,7 +155,7 @@ class GUIDialogInputCheckHandler(GUIInputCheckHandler, metaclass=ABCMeta):
             inputcheck.input_obj.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY, "")
         else:
             inputcheck.input_obj.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY,
-                    "dialog-error")
+                    "dialog-error-symbolic")
             inputcheck.input_obj.set_icon_tooltip_text(Gtk.EntryIconPosition.SECONDARY,
                 inputcheck.check_status)
 

--- a/pyanaconda/ui/gui/main.glade
+++ b/pyanaconda/ui/gui/main.glade
@@ -135,7 +135,7 @@
               <object class="GtkImage" id="image1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="icon_name">application-exit</property>
+                <property name="icon_name">application-exit-symbolic</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/pyanaconda/ui/gui/spokes/advstorage/dasd.glade
+++ b/pyanaconda/ui/gui/spokes/advstorage/dasd.glade
@@ -198,7 +198,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="xalign">1</property>
-                            <property name="icon_name">dialog-error</property>
+                            <property name="icon_name">dialog-error-symbolic</property>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>

--- a/pyanaconda/ui/gui/spokes/advstorage/fcoe.glade
+++ b/pyanaconda/ui/gui/spokes/advstorage/fcoe.glade
@@ -172,7 +172,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="xalign">1</property>
-                    <property name="icon_name">dialog-error</property>
+                    <property name="icon_name">dialog-error-symbolic</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>

--- a/pyanaconda/ui/gui/spokes/advstorage/iscsi.glade
+++ b/pyanaconda/ui/gui/spokes/advstorage/iscsi.glade
@@ -228,7 +228,7 @@
                       <object class="GtkImage" id="image1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="icon_name">dialog-information</property>
+                        <property name="icon_name">dialog-information-symbolic</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -527,7 +527,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="xalign">1</property>
-                                <property name="icon_name">dialog-error</property>
+                                <property name="icon_name">dialog-error-symbolic</property>
                               </object>
                               <packing>
                                 <property name="left_attach">0</property>
@@ -1055,7 +1055,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="xalign">1</property>
-                                    <property name="icon_name">dialog-error</property>
+                                    <property name="icon_name">dialog-error-symbolic</property>
                                   </object>
                                   <packing>
                                     <property name="left_attach">0</property>

--- a/pyanaconda/ui/gui/spokes/advstorage/nvdimm.glade
+++ b/pyanaconda/ui/gui/spokes/advstorage/nvdimm.glade
@@ -164,7 +164,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="xalign">1</property>
-                        <property name="icon_name">dialog-error</property>
+                        <property name="icon_name">dialog-error-symbolic</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -237,7 +237,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="xalign">1</property>
-                        <property name="icon_name">emblem-default</property>
+                        <property name="icon_name">emblem-default-symbolic</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>

--- a/pyanaconda/ui/gui/spokes/advstorage/zfcp.glade
+++ b/pyanaconda/ui/gui/spokes/advstorage/zfcp.glade
@@ -239,7 +239,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="xalign">1</property>
-                            <property name="icon_name">dialog-error</property>
+                            <property name="icon_name">dialog-error-symbolic</property>
                           </object>
                           <packing>
                             <property name="left_attach">0</property>

--- a/pyanaconda/ui/gui/spokes/installation_source.glade
+++ b/pyanaconda/ui/gui/spokes/installation_source.glade
@@ -1111,7 +1111,7 @@
                                         <property name="tooltip_text" translatable="yes">Revert to the previous list of repositories.</property>
                                         <property name="label" translatable="yes" context="GUI|Software Source">Rese_t</property>
                                         <property name="use_underline">True</property>
-                                        <property name="icon_name">view-refresh</property>
+                                        <property name="icon_name">view-refresh-symbolic</property>
                                         <signal name="clicked" handler="on_resetRepos_clicked" swapped="no"/>
                                       </object>
                                       <packing>

--- a/pyanaconda/ui/gui/spokes/keyboard.glade
+++ b/pyanaconda/ui/gui/spokes/keyboard.glade
@@ -80,7 +80,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="no_show_all">True</property>
-                        <property name="icon_name">dialog-warning</property>
+                        <property name="icon_name">dialog-warning-symbolic</property>
                         <property name="icon_size">1</property>
                       </object>
                       <packing>

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
@@ -445,7 +445,7 @@ after creating the mount point below.</property>
                   <object class="GtkImage" id="image1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="icon_name">dialog-warning</property>
+                    <property name="icon_name">dialog-warning-symbolic</property>
                     <property name="icon_size">2</property>
                   </object>
                   <packing>
@@ -896,7 +896,7 @@ use.  Try something else?</property>
                   <object class="GtkImage" id="containerErrorImage">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="icon_name">dialog-warning</property>
+                    <property name="icon_name">dialog-warning-symbolic</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/pyanaconda/ui/gui/spokes/lib/dasdfmt.glade
+++ b/pyanaconda/ui/gui/spokes/lib/dasdfmt.glade
@@ -121,7 +121,7 @@
               <object class="GtkImage" id="warnIcon">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="icon_name">dialog-warning</property>
+                <property name="icon_name">dialog-warning-symbolic</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/pyanaconda/ui/gui/spokes/lib/ntp_dialog.py
+++ b/pyanaconda/ui/gui/spokes/lib/ntp_dialog.py
@@ -67,11 +67,11 @@ class NTPConfigDialog(GUIObject):
         value = self._serversStore[itr][SERVER_WORKING]
 
         if value == constants.NTP_SERVER_QUERY:
-            return "dialog-question"
+            return "dialog-question-symbolic"
         elif value == constants.NTP_SERVER_OK:
-            return "emblem-default"
+            return "emblem-default-symbolic"
         else:
-            return "dialog-error"
+            return "dialog-error-symbolic"
 
     def refresh(self):
         # Update the store.

--- a/pyanaconda/ui/gui/spokes/lib/passphrase.glade
+++ b/pyanaconda/ui/gui/spokes/lib/passphrase.glade
@@ -260,7 +260,7 @@
               <object class="GtkImage" id="image2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="icon_name">dialog-warning</property>
+                <property name="icon_name">dialog-warning-symbolic</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/pyanaconda/ui/gui/spokes/lib/passphrase.py
+++ b/pyanaconda/ui/gui/spokes/lib/passphrase.py
@@ -152,10 +152,10 @@ class PassphraseDialog(GUIObject):
         else:
             if not self._ascii_check.result.success:
                 # ASCII check runs last, so if just it has failed the result is only a warning
-                result_icon = "dialog-warning"
+                result_icon = "dialog-warning-symbolic"
             else:
                 # something else failed and that's a critical error
-                result_icon = "dialog-error"
+                result_icon = "dialog-error-symbolic"
             self._passphrase_warning_image.set_from_icon_name(result_icon, Gtk.IconSize.BUTTON)
             self._passphrase_warning_label.set_text(error_message)
             really_show(self._passphrase_warning_image)

--- a/pyanaconda/ui/gui/spokes/lib/refresh.glade
+++ b/pyanaconda/ui/gui/spokes/lib/refresh.glade
@@ -102,7 +102,7 @@
                   <object class="GtkImage" id="image1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="icon_name">dialog-warning</property>
+                    <property name="icon_name">dialog-warning-symbolic</property>
                     <property name="icon_size">2</property>
                   </object>
                   <packing>

--- a/pyanaconda/ui/gui/spokes/network.glade
+++ b/pyanaconda/ui/gui/spokes/network.glade
@@ -621,7 +621,7 @@
                                             <property name="valign">start</property>
                                             <property name="xalign">1</property>
                                             <property name="pixel_size">48</property>
-                                            <property name="icon_name">network-wired</property>
+                                            <property name="icon_name">network-wired-symbolic</property>
                                             <property name="icon_size">6</property>
                                           </object>
                                           <packing>
@@ -1004,7 +1004,7 @@
                                             <property name="valign">start</property>
                                             <property name="xalign">1</property>
                                             <property name="pixel_size">48</property>
-                                            <property name="icon_name">network-wireless</property>
+                                            <property name="icon_name">network-wireless-symbolic</property>
                                             <property name="icon_size">6</property>
                                           </object>
                                           <packing>
@@ -1789,7 +1789,7 @@
                                             <property name="valign">start</property>
                                             <property name="xalign">1</property>
                                             <property name="pixel_size">48</property>
-                                            <property name="icon_name">network-vpn</property>
+                                            <property name="icon_name">network-vpn-symbolic</property>
                                             <property name="icon_size">6</property>
                                           </object>
                                           <packing>
@@ -2055,7 +2055,7 @@
                                             <property name="valign">start</property>
                                             <property name="xalign">1</property>
                                             <property name="pixel_size">48</property>
-                                            <property name="icon_name">preferences-system-network</property>
+                                            <property name="icon_name">preferences-system-network-symbolic</property>
                                             <property name="icon_size">6</property>
                                           </object>
                                           <packing>

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -784,13 +784,13 @@ class NetworkControlBox(GObject.GObject):
             device = self.client.get_device_by_iface(dev_cfg.device_name)
             if device:
                 if device.get_state() == NM.DeviceState.UNAVAILABLE:
-                    icon_name = "network-wired-disconnected"
+                    icon_name = "network-wired-disconnected-symbolic"
                 else:
-                    icon_name = "network-wired"
+                    icon_name = "network-wired-symbolic"
             else:
-                icon_name = "network-wired-disconnected"
+                icon_name = "network-wired-disconnected-symbolic"
         elif dev_cfg.device_type == NM.DeviceType.WIFI:
-            icon_name = "network-wireless"
+            icon_name = "network-wireless-symbolic"
 
         return icon_name
 

--- a/pyanaconda/ui/gui/spokes/welcome.glade
+++ b/pyanaconda/ui/gui/spokes/welcome.glade
@@ -80,7 +80,7 @@
               <object class="GtkImage" id="image1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="icon_name">application-exit</property>
+                <property name="icon_name">application-exit-symbolic</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/widgets/src/BaseWindow.c
+++ b/widgets/src/BaseWindow.c
@@ -638,7 +638,7 @@ static void anaconda_base_window_set_info_bar(AnacondaBaseWindow *win, GtkMessag
 
     content_area = gtk_info_bar_get_content_area(GTK_INFO_BAR(win->priv->info_staging));
 
-    image = gtk_image_new_from_icon_name("dialog-warning", GTK_ICON_SIZE_MENU);
+    image = gtk_image_new_from_icon_name("dialog-warning-symbolic", GTK_ICON_SIZE_MENU);
     gtk_widget_show(image);
     gtk_container_add(GTK_CONTAINER(content_area), image);
 


### PR DESCRIPTION
adwaita-icon-theme 42 removes a lot of the 'legacy' fullcolor
icons (but not all of them). This replaces all the removed names
with their symbolic equivalents. Even without this change GTK+
automatically gives us the symbolic icons where the non-symbolic
one is missing, but cleaning up the names seems good.

Signed-off-by: Adam Williamson <awilliam@redhat.com>