### PR TITLE
Replace one more icon after removal from adwaita

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/unsupported_hardware.glade
+++ b/pyanaconda/ui/gui/spokes/lib/unsupported_hardware.glade
@@ -80,7 +80,7 @@
               <object class="GtkImage" id="uhd-image">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="icon_name">dialog-warning</property>
+                <property name="icon_name">dialog-warning-symbolic</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>


### PR DESCRIPTION
This one was missed because it doesn't exists on Rawhide. Let's just fix the ~build~ tests quickly, no-one see this icon anyway.