### PR TITLE
Move the po files download to the `make` call (#infra)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -53,11 +53,6 @@ ARCHIVE_TAG   = $(PACKAGE_NAME)-$(PACKAGE_VERSION)-$(PACKAGE_RELEASE)
 # Set this to "true" if you want to have SRPM archive with test version
 TEST_BUILD	?= "false"
 
-# LOCALIZATION SETTINGS
-L10N_REPOSITORY ?= https://github.com/rhinstaller/anaconda-l10n.git
-# Branch used in anaconda-l10n repository. This should be master all the time.
-GIT_L10N_BRANCH ?= master
-
 RC_RELEASE ?= $(shell date -u +0.1.%Y%m%d%H%M%S)
 
 PYTHON ?= python3
@@ -113,13 +108,6 @@ tag:
 	@git tag -s -a -m "Tag as $(ARCHIVE_TAG)" $(ARCHIVE_TAG)
 	@echo "Tagged as $(ARCHIVE_TAG)"
 
-po-pull:
-	TEMP_DIR=$$(mktemp --tmpdir -d anaconda-localization-XXXXXXXXXX) && \
-	git clone --depth 1 -b $(GIT_L10N_BRANCH) -- $(L10N_REPOSITORY) $$TEMP_DIR && \
-	cp $$TEMP_DIR/$(L10N_DIR)/*.po $(srcdir)/po/ && \
-	rm -rf $$TEMP_DIR && \
-	find $(srcdir)/po -type f -exec sed -ri '/^\"Plural-Forms:/ s/;(\\n")$$/\1/' {} +
-
 pot:
 	$(MAKE) -C po $(PACKAGE_NAME).pot-update
 	rm $(srcdir)/po/{main,main_js,extra}.pot
@@ -144,15 +132,10 @@ pot-update-check: pot
 		echo "Pot file needs update! Please update the pot file ./po/anaconda.pot in $(L10N_REPOSITORY)"; \
 	fi ;
 
-# Try to fetch translations, but if that fails just keep going
-po-fallback:
-	-$(MAKE) po-pull
-
 scratch:
 	if [ "$(TEST_BUILD)" == "true" ]; then \
 		sed -ri '/AC_INIT/ s/\[[0-9.]+\]/[999999999]/' $(srcdir)/configure.ac; \
 	fi
-	$(MAKE) po-pull
 	$(MAKE) ARCHIVE_TAG=HEAD dist
 
 scratch-bumpver:
@@ -170,7 +153,6 @@ scratch-bumpver:
 	$(MAKE) -C po $(PACKAGE_NAME).pot-update
 
 release:
-	$(MAKE) po-pull
 	$(MAKE) dist
 
 container-release:
@@ -241,7 +223,7 @@ anaconda-rpm-push:
 	$(CONTAINER_ADD_ARGS) \
 	$(RPM_NAME):$(CI_TAG)
 
-bumpver: po-pull
+bumpver:
 	@opts="-n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) -r $(PACKAGE_RELEASE) -b $(PACKAGE_BUGREPORT)" ; \
 	if [ ! -z "$(IGNORE)" ]; then \
 		opts="$${opts} -i $(IGNORE)" ; \

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -342,8 +342,8 @@ mkdir %{buildroot}%{_datadir}/anaconda/post-scripts
 # required for live installations
 desktop-file-install --dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_datadir}/applications/liveinst.desktop
 
-# If no langs found, keep going
-%find_lang %{name} || :
+# Add localization files
+%find_lang %{name}
 
 %if ! %use_cockpit
     rm -rf %{buildroot}/%{_datadir}/cockpit/anaconda-webui

--- a/po/.gitignore
+++ b/po/.gitignore
@@ -1,2 +1,3 @@
 *.mo
 *.po.new
+.po_downloaded

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -109,7 +109,7 @@ POTFILE = $(PACKAGE).pot
 # The translation files, provided by translators, pulled down from translation repository.
 # Use whatever we got from this repository, or nothing at all if no translations were
 # pulled.
-POFILES = $(wildcard $(srcdir)/*.po)
+POFILES = $(shell find $(srcdir) -type f -name '*.po')
 
 # The translations files after they have been merged with the latest copy of
 # the .pot file. These are written to $(builddir) as <lang>.mpo.
@@ -218,6 +218,9 @@ extra.pot: $(POTFILE_EXTRA)
 
 $(POTFILE): main_js.pot main.pot extra.pot
 	$(AM_V_GEN)$(MSGCAT) -o $@ main.pot main_js.pot extra.pot
+
+# Request po files download before collecting them in the POFILES variable.
+$(POFILES): $(PO_DOWNLOADED_FLAG)
 
 $(PO_DOWNLOADED_FLAG):
 	TEMP_DIR=$$(mktemp --tmpdir -d anaconda-localization-XXXXXXXXXX) && \

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -71,6 +71,10 @@
 COPYRIGHT_HOLDER = Red Hat, Inc.
 MSGID_BUGS_ADDRESS = anaconda-devel@lists.fedoraproject.org
 
+include $(top_srcdir)/branch-config.mk
+
+PO_DOWNLOADED_FLAG = $(srcdir)/.po_downloaded
+
 # What kind of files are we looking for?
 POTFILE_SUFFIXES = py c glade desktop
 # Specify seperate jsx and js files in order to pass --language=JavaScript as jsx extension is not auto-detected
@@ -182,12 +186,19 @@ MSGMERGE_V_OPTIONS_1 = $(MSGMERGE_OPTIONS) --verbose
 
 # Actually do stuff:
 # .po files get distributed but not installed
-dist_noinst_DATA = $(POFILES)
+# Let's also store a flag downloaded file which tells us that the translations are
+# already downloaded.
+dist_noinst_DATA = $(POFILES) $(PO_DOWNLOADED_FLAG)
 
 # Build the .mo files but don't actually do anything with them. The real
 # install part is in the install-data-local target below. Build the .pot file
 # as well, even if there are no .mo files to build, so it can be tested.
 nodist_noinst_DATA = $(MOFILES) $(POTFILE)
+
+# Localization specific settings
+L10N_REPOSITORY ?= https://github.com/rhinstaller/anaconda-l10n.git
+# Branch used in anaconda-l10n repository. This should be master all the time.
+GIT_L10N_BRANCH ?= master
 
 # How to build the .pot file. This needs to be regenerated if anything that
 # goes into it has changed.
@@ -207,6 +218,14 @@ extra.pot: $(POTFILE_EXTRA)
 
 $(POTFILE): main_js.pot main.pot extra.pot
 	$(AM_V_GEN)$(MSGCAT) -o $@ main.pot main_js.pot extra.pot
+
+$(PO_DOWNLOADED_FLAG):
+	TEMP_DIR=$$(mktemp --tmpdir -d anaconda-localization-XXXXXXXXXX) && \
+	git clone --depth 1 -b $(GIT_L10N_BRANCH) -- $(L10N_REPOSITORY) $$TEMP_DIR && \
+	cp $$TEMP_DIR/$(L10N_DIR)/*.po $(srcdir)/ && \
+	rm -rf $$TEMP_DIR && \
+	find $(srcdir)/ -type f -exec sed -ri '/^\"Plural-Forms:/ s/;(\\n")$$/\1/' {} +
+	touch $(PO_DOWNLOADED_FLAG)
 
 # Force a rebuild of the .pot file. Useful if something got removed, for
 # example.
@@ -246,4 +265,4 @@ uninstall-local:
 		rm -f $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(PACKAGE).mo ; \
 	done
 
-CLEANFILES = $(MERGED_POFILES) $(MOFILES) $(POTFILE) main.pot extra.pot
+CLEANFILES = $(MERGED_POFILES) $(MOFILES) $(POTFILE) main.pot extra.pot $(PO_DOWNLOADED_FLAG)


### PR DESCRIPTION
Right now if user will call:

`make && make rpms`

it will fail because webui needs to have translations and `make rpms` won't create them. To make this more optimized let's download the translations on the `make` call if they don't present already.

To do that use flag file, which will be created when the files are downloaded and removed on clean.

This is alternative solution to https://github.com/rhinstaller/anaconda/pull/3879 .