### PR TITLE
tests: webui: Increate timeout for accessible webui to 5 minutes

### DIFF
--- a/ui/webui/test/machine_install.py
+++ b/ui/webui/test/machine_install.py
@@ -89,7 +89,7 @@ class VirtInstallMachine(VirtMachine):
                 f"--location {os.getcwd()}/bots/images/{self.image}"
             )
 
-            for _ in range(10):
+            for _ in range(30):
                 try:
                     requests.get(
                         f"http://{self.web_address}:{self.web_port}/"
@@ -97,7 +97,7 @@ class VirtInstallMachine(VirtMachine):
                     )
                     break
                 except requests.exceptions.RequestException:
-                    time.sleep(5)
+                    time.sleep(10)
             else:
                 raise Exception("Anaconda webui is not reachable")
         except Exception as e:


### PR DESCRIPTION
This will solve the 'Anaconda webui is not reachable' failure in the CI.

The previous timeout for the webui to become rechable in the test VM was 50seconds,
and was often leading to timeout failures.