### PR TITLE
webui: Don't check SSH key in command from VM script

### DIFF
--- a/ui/webui/test/webui_testvm.py
+++ b/ui/webui/test/webui_testvm.py
@@ -32,7 +32,7 @@ def cmd_cli():
 
     print("You can connect to the VM in the following ways:")
     # print ssh command
-    print("ssh -o ControlPath=%s -o UserKnownHostsFile=/dev/null -p %s %s@%s" %
+    print("ssh -o ControlPath=%s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p %s %s@%s" %
           (machine.ssh_master, machine.ssh_port, machine.ssh_user, machine.ssh_address))
     # print Cockpit web address
     print(


### PR DESCRIPTION
Addendum to #3889. This makes it so the command just gives the inst. env. root prompt immediately, no confirmations, no typing, nothing.

----

@KKoukiou , there is one thing that might need clarifying before this is merged or instead dropped:

> Cockpit has it here https://github.com/cockpit-project/cockpit/tree/main/test#helpful-tips

I tried that and it did not work for me, unless I hardcode in that config the string that comes out of the VM script... And that is a variable in the script. I am not sure what that means - is the address a variable or a constant?