### PR TITLE
webui: rewrite language selection component to a class component

### DIFF
--- a/ui/webui/test/check-installation-language
+++ b/ui/webui/test/check-installation-language
@@ -38,6 +38,10 @@ class TestLanguage(MachineCase):
 
         b.wait_val("#language-menu-toggle-select-typeahead", "English (United States)")
 
+        # Check that the [x] button clears the input text
+        b.click(".pf-c-select__toggle-clear")
+        b.wait_val("#language-menu-toggle-select-typeahead", "")
+
         # Check that the language menu shows all menu entries when clicking the toggle button
         b.click("#language-menu-toggle")
         b.wait_visible("#English--English-")


### PR DESCRIPTION
Usually I prefer using functional components, as they require less
boilerblate code, thus increasing the code reability.
However, when complicated state management needs to be done in the
inialization (in the component mounting), the usage of useEffect hook can get quite
complicated.

Let's convert the LanguageSelector component to be a class component for
this reason, and use the more straightforward componentDidMount
lifecycle method for doing the initialization.

Lastly, this fixes one bug, and thus clicking on the [x] button on the
typeahead select previously did not clear the state.