### PR TITLE
Remove the blivet_gui_supported configuration option

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -272,9 +272,6 @@ custom_stylesheet =
 # The path to a directory with help files.
 help_directory = /usr/share/anaconda/help
 
-# Is the partitioning with blivet-gui supported?
-blivet_gui_supported = True
-
 # A list of spokes to hide in UI.
 # FIXME: Use other identification then names of the spokes.
 hidden_spokes =

--- a/data/profile.d/rhel.conf
+++ b/data/profile.d/rhel.conf
@@ -39,7 +39,6 @@ swap_is_recommended = True
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhel
 custom_stylesheet = /usr/share/anaconda/pixmaps/redhat.css
-blivet_gui_supported = False
 
 [License]
 eula = /usr/share/redhat-release/EULA

--- a/pyanaconda/core/configuration/ui.py
+++ b/pyanaconda/core/configuration/ui.py
@@ -35,11 +35,6 @@ class UserInterfaceSection(Section):
         return self._get_option("help_directory", str)
 
     @property
-    def blivet_gui_supported(self):
-        """Is the partitioning with blivet-gui supported?"""
-        return self._get_option("blivet_gui_supported", bool)
-
-    @property
     def hidden_spokes(self):
         """A list of spokes to hide in UI.
 

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -152,9 +152,18 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             self._custom_part_radio_button.set_visible(False)
             self._custom_part_radio_button.set_no_show_all(True)
 
-        if "BlivetGuiSpoke" in conf.ui.hidden_spokes or not conf.ui.blivet_gui_supported:
+        if "BlivetGuiSpoke" in conf.ui.hidden_spokes or not self._is_blivet_gui_supported():
             self._blivet_gui_radio_button.set_visible(False)
             self._blivet_gui_radio_button.set_no_show_all(True)
+
+    def _is_blivet_gui_supported(self):
+        """Is the partitioning with blivet-gui supported?"""
+        try:
+            import pyanaconda.ui.gui.spokes.blivet_gui  # pylint:disable=unused-import
+        except ImportError:
+            return False
+
+        return True
 
     def _get_selected_partitioning_method(self):
         """Get the selected partitioning method.


### PR DESCRIPTION
Automatically disable the support for Blivet-GUI if it is not installed. Or it can be
explicitly disabled using the `hidden_spokes` option of the User Interface section.

The `blivet_gui_supported` configuration option was never documented in the RHEL
documentation.