### PR TITLE
Fix Makefile targets using L10N Makefile variables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,10 @@ SHUT_UP_GCC="-Wno-unused-result"
 # Add remaining compiler flags we want to use
 CFLAGS="$CFLAGS -Wall -Werror $SHUT_UP_GCC -fanalyzer"
 
+# Localization specific settings (used in main and po Makefile.am)
+AC_SUBST(L10N_REPOSITORY, [https://github.com/rhinstaller/anaconda-l10n.git])
+# Branch used in anaconda-l10n repository. This should be master all the time.
+AC_SUBST(GIT_L10N_BRANCH, [master])
 
 # Perform arch related tests
 AC_CANONICAL_BUILD

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -195,11 +195,6 @@ dist_noinst_DATA = $(POFILES) $(PO_DOWNLOADED_FLAG)
 # as well, even if there are no .mo files to build, so it can be tested.
 nodist_noinst_DATA = $(MOFILES) $(POTFILE)
 
-# Localization specific settings
-L10N_REPOSITORY ?= https://github.com/rhinstaller/anaconda-l10n.git
-# Branch used in anaconda-l10n repository. This should be master all the time.
-GIT_L10N_BRANCH ?= master
-
 # How to build the .pot file. This needs to be regenerated if anything that
 # goes into it has changed.
 # Build in two parts so that the bulk of the files are saved as relative to


### PR DESCRIPTION
Move of L10N specific variables to po/Makefile.am break some make targets which are using these variables in the root Makefile.am. To fix this, move the variables to configure.ac to have them available everywhere.

This will fix issues with pot file check we have now on the localization repository.

Fixing https://github.com/rhinstaller/anaconda-l10n/runs/5441892439?check_suite_focus=true.