### PR TITLE
ovirt: move /var/tmp and /var/crash to own partition

### DIFF
--- a/data/product.d/ovirt.conf
+++ b/data/product.d/ovirt.conf
@@ -4,7 +4,7 @@
 product_name = oVirt Node Next
 
 [Base Product]
-product_name = CentOS Linux
+product_name = CentOS Stream
 
 [Storage]
 default_scheme = LVM_THINP
@@ -12,17 +12,20 @@ default_partitioning =
     /              (min 6 GiB)
     /home          (size 1 GiB)
     /tmp           (size 1 GiB)
-    /var           (size 15 GiB)
+    /var           (size 5 GiB)
+    /var/crash     (size 10 GiB)
     /var/log       (size 8 GiB)
     /var/log/audit (size 2 GiB)
+    /var/tmp       (size 10 GiB)
     swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP
 must_not_be_on_root = /var
 req_partition_sizes =
-    /var   10 GiB
-    /boot  1  GiB
+    /var     5  GiB
+    /var/tmp 10 GiB
+    /boot    1  GiB
 
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhel

--- a/data/product.d/rhev.conf
+++ b/data/product.d/rhev.conf
@@ -12,17 +12,20 @@ default_partitioning =
     /              (min 6 GiB)
     /home          (size 1 GiB)
     /tmp           (size 1 GiB)
-    /var           (size 15 GiB)
+    /var           (size 5 GiB)
+    /var/crash     (size 10 GiB)
     /var/log       (size 8 GiB)
     /var/log/audit (size 2 GiB)
+    /var/tmp       (size 10 GiB)
     swap
 
 [Storage Constraints]
 root_device_types = LVM_THINP
 must_not_be_on_root = /var
 req_partition_sizes =
-    /var   10 GiB
-    /boot  1  GiB
+    /var     5  GiB
+    /var/tmp 10 GiB
+    /boot    1  GiB
 
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhel

--- a/tests/nosetests/pyanaconda_tests/product_test.py
+++ b/tests/nosetests/pyanaconda_tests/product_test.py
@@ -108,7 +108,15 @@ VIRTUALIZATION_PARTITIONING = [
     ),
     PartSpec(
         mountpoint="/var",
-        size=Size("15GiB"),
+        size=Size("5GiB"),
+        btr=True,
+        lv=True,
+        thin=True,
+        encrypted=True
+    ),
+    PartSpec(
+        mountpoint="/var/crash",
+        size=Size("10GiB"),
         btr=True,
         lv=True,
         thin=True,
@@ -125,6 +133,14 @@ VIRTUALIZATION_PARTITIONING = [
     PartSpec(
         mountpoint="/var/log/audit",
         size=Size("2GiB"),
+        btr=True,
+        lv=True,
+        thin=True,
+        encrypted=True
+    ),
+    PartSpec(
+        mountpoint="/var/tmp",
+        size=Size("10GiB"),
         btr=True,
         lv=True,
         thin=True,
@@ -256,7 +272,7 @@ class ProductConfigurationTestCase(unittest.TestCase):
         )
         self._check_default_product(
             "oVirt Node Next", "",
-            ["rhel.conf", "centos-stream.conf", "centos.conf", "ovirt.conf"],
+            ["rhel.conf", "centos-stream.conf", "ovirt.conf"],
             VIRTUALIZATION_PARTITIONING
         )
         self._check_default_product(


### PR DESCRIPTION
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2057475
Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>

Resolves: rhbz#2057475
**Ported from:** https://github.com/rhinstaller/anaconda/pull/3888