### PR TITLE
Make pylint survive WebUI artifacts

### DIFF
--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -8,7 +8,13 @@ extension-pkg-whitelist=
 # Add files or directories to the denylist. They should be base names, not
 # paths.
 # This is auto-fetched from cockpit shared library
-ignore=inotify.py
+ignore=
+
+# Add files or directories matching the regex patterns to the ignore-list.
+# The regex matches against paths.
+ignore-paths=^.*ui/webui/bots/.*$,
+             ^.*ui/webui/src/lib/.*$,
+             ^.*ui/webui/test/common/.*$
 
 # Add files or directories matching the regex patterns to the denylist. The
 # regex matches against base names, not paths.

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -54,13 +54,7 @@ class AnacondaLintConfig(CensorshipConfig):
         for (root, dirnames, files) in os.walk(directory):
 
             # skip scanning of already added python modules
-            skip = False
-            for i in retval:
-                if root.startswith(i):
-                    skip = True
-                    break
-
-            if skip:
+            if any(root.startswith(i) for i in retval):
                 continue
 
             if "__init__.py" in files:

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -65,7 +65,7 @@ class AnacondaLintConfig(CensorshipConfig):
                 try:
                     with open(root + "/" + f) as fo:
                         line = fo.readline(1024)
-                except UnicodeDecodeError:
+                except (UnicodeDecodeError, FileNotFoundError):
                     # If we couldn't open this file, just skip it.  It wasn't
                     # going to be valid python anyway.
                     continue

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -64,7 +64,7 @@ class AnacondaLintConfig(CensorshipConfig):
             for f in files:
                 try:
                     with open(root + "/" + f) as fo:
-                        lines = fo.readlines()
+                        line = fo.readline(1024)
                 except UnicodeDecodeError:
                     # If we couldn't open this file, just skip it.  It wasn't
                     # going to be valid python anyway.
@@ -72,7 +72,7 @@ class AnacondaLintConfig(CensorshipConfig):
 
                 # Test any file that either ends in .py or contains #!/usr/bin/python
                 # in the first line.
-                if f.endswith(".py") or (lines and str(lines[0]).startswith("#!/usr/bin/python")):
+                if f.endswith(".py") or (line and str(line).startswith("#!/usr/bin/python")):
                     retval.append(root + "/" + f)
 
         return retval


### PR DESCRIPTION
tl;dr: SSIA.

As part of the current WebUI workflow, we need some other repositories, they contain python files, and our pylint script is greedy and checks them too. To make problems worse, the repos also contain symlinks that point to nowhere, until you use the scripts from these repos. Then some symlinks start pointing to ISOs. And of course, we try to detect python scripts by reading the whole file and finding hashbangs. This PR tries to fix this bag of problems as folows:

* Skip files that can't be opened,
* ~~Skip files that are over 10 MB,~~ Read only first line up to 1024 characters when detecting hashbangs,
* Add false positive matches for the repo subdirs.