### PR TITLE
Remove RpmDb setup for OSTree payloads

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -147,15 +147,13 @@ class PrepareOSTreeMountTargetsTask(Task):
 
         Next, run tmpfiles to make subdirectories of /var. We need this for both mounts like
         /home (really /var/home) and %post scripts might want to write to e.g. `/srv`, `/root`,
-        `/usr/local`, etc. The /var/lib/rpm symlink is also critical for having e.g. `rpm -qa`
-        work in %post. We don't iterate *all* tmpfiles because we don't have the matching NSS
+        `/usr/local`, etc. We don't iterate *all* tmpfiles because we don't have the matching NSS
         configuration inside Anaconda, and we can't "chroot" to get it because that would require
         mounting the API filesystems in the target.
         """
         make_directories(self._sysroot + '/var/lib')
         self._create_tmpfiles('/var/home')
         self._create_tmpfiles('/var/roothome')
-        self._create_tmpfiles('/var/lib/rpm')
         self._create_tmpfiles('/var/opt')
         self._create_tmpfiles('/var/srv')
         self._create_tmpfiles('/var/usrlocal')

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -148,8 +148,6 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
             call("systemd-tmpfiles",
                  ["--create", "--boot", "--root=/sysroot", "--prefix=/var/roothome"]),
             call("systemd-tmpfiles",
-                 ["--create", "--boot", "--root=/sysroot", "--prefix=/var/lib/rpm"]),
-            call("systemd-tmpfiles",
                  ["--create", "--boot", "--root=/sysroot", "--prefix=/var/opt"]),
             call("systemd-tmpfiles",
                  ["--create", "--boot", "--root=/sysroot", "--prefix=/var/srv"]),
@@ -167,7 +165,7 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
             call("mount", ["--bind", "/physroot/home", "/sysroot/home"]),
             call("mount", ["--bind", "/physroot/", "/sysroot/sysroot"])
         ])
-        assert len(exec_mock.mock_calls) == 20
+        assert len(exec_mock.mock_calls) == 19
         mkdir_mock.assert_called_once_with("/sysroot/var/lib")
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
@@ -176,7 +174,7 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
     @patch("os.path.exists", returns=True)
     def test_run_without_var(self, exists_mock, storage_mock, mkdir_mock, exec_mock):
         """Test OSTree mount target prepare task run() without /var"""
-        exec_mock.side_effect = [0] * 7 + [0, 65] * 5 + [0] * 3
+        exec_mock.side_effect = [0] * 7 + [0, 65] * 4 + [0] + [0] * 3
 
         data = _make_config_data()
         devicetree_mock = storage_mock.get_proxy()
@@ -203,8 +201,6 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
             call("systemd-tmpfiles",
                  ["--create", "--boot", "--root=/sysroot", "--prefix=/var/roothome"]),
             call("systemd-tmpfiles",
-                 ["--create", "--boot", "--root=/sysroot", "--prefix=/var/lib/rpm"]),
-            call("systemd-tmpfiles",
                  ["--create", "--boot", "--root=/sysroot", "--prefix=/var/opt"]),
             call("systemd-tmpfiles",
                  ["--create", "--boot", "--root=/sysroot", "--prefix=/var/srv"]),
@@ -222,7 +218,7 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
             call("mount", ["--bind", "/physroot/home", "/sysroot/home"]),
             call("mount", ["--bind", "/physroot/", "/sysroot/sysroot"])
         ])
-        assert len(exec_mock.mock_calls) == 20
+        assert len(exec_mock.mock_calls) == 19
         mkdir_mock.assert_called_once_with("/sysroot/var/lib")
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")


### PR DESCRIPTION
Related to https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr

Resolves: [rhbz#2050428](https://bugzilla.redhat.com/show_bug.cgi?id=2050428)

@cgwalters - Can you please take a look? Basically I have no idea what I'm doing, but it seems to work, except it somehow worked before too, so... `¯\_(ツ)_/¯`