### PR TITLE
Revert "Use RHEL 8.6 repositories for tests (#infra)"

### DIFF
--- a/dockerfile/anaconda-ci/rhel-8.repo
+++ b/dockerfile/anaconda-ci/rhel-8.repo
@@ -1,27 +1,27 @@
 [RHEL-8-CRB]
 name=crb
-baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.6/compose/CRB/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/compose/CRB/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
 
 [RHEL-8-BaseOS]
 name=baseos
-baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.6/compose/BaseOS/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/compose/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
 
 [RHEL-8-AppStream]
 name=appstream
-baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.6/compose/AppStream/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/compose/AppStream/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
 
 [RHEL-8-Buildroot]
 name=buildroot
-baseurl=http://download.eng.brq.redhat.com/rhel-8/nightly/BUILDROOT-8/latest-BUILDROOT-8.6-RHEL-8/compose/Buildroot/$basearch/os/
+baseurl=http://download.eng.brq.redhat.com/rhel-8/nightly/BUILDROOT-8/latest-BUILDROOT-8-RHEL-8/compose/Buildroot/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0

--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -30,9 +30,9 @@ MINOR_VERSION=${VERSION_ID#*.}
 # The --volid argument can cause different network interface naming: https://github.com/rhinstaller/kickstart-tests/issues/448
 lorax -p RHEL -v $MAJOR_VERSION -r $MINOR_VERSION --volid RHEL-$MAJOR_VERSION-$MINOR_VERSION-0-BaseOS-x86_64 \
       --nomacboot \
-      -s http://download.devel.redhat.com/nightly/rhel-8/RHEL-8/latest-RHEL-8.6/compose/BaseOS/x86_64/os/ \
-      -s http://download.devel.redhat.com/nightly/rhel-8/RHEL-8/latest-RHEL-8.6/compose/AppStream/x86_64/os/ \
-      -s http://download.devel.redhat.com/nightly/rhel-8/RHEL-8/latest-RHEL-8.6/compose/CRB/x86_64/os/ \
+      -s http://download.devel.redhat.com/nightly/rhel-8/RHEL-8/latest-RHEL-8/compose/BaseOS/x86_64/os/ \
+      -s http://download.devel.redhat.com/nightly/rhel-8/RHEL-8/latest-RHEL-8/compose/AppStream/x86_64/os/ \
+      -s http://download.devel.redhat.com/nightly/rhel-8/RHEL-8/latest-RHEL-8/compose/CRB/x86_64/os/ \
       -s file://$REPO_DIR/ \
       $@ \
       lorax

--- a/dockerfile/anaconda-iso-creator/rhel-8.repo
+++ b/dockerfile/anaconda-iso-creator/rhel-8.repo
@@ -1,13 +1,13 @@
 [RHEL-8-BaseOS]
 name=baseos
-baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.6/compose/BaseOS/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/compose/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
 
 [RHEL-8-AppStream]
 name=appstream
-baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.6/compose/AppStream/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8/compose/AppStream/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0


### PR DESCRIPTION
This reverts commit dc024f133ae1dc32aa58cb1cd18f196fb63d8ee1.

rhel-8 branch should really follow the current development branch.