### PR TITLE
Revert "Use RHEL 9.0 repositories for tests (#infra)"

### DIFF
--- a/dockerfile/anaconda-ci/rhel-9.repo
+++ b/dockerfile/anaconda-ci/rhel-9.repo
@@ -1,27 +1,27 @@
 [RHEL-9-CRB]
 name=crb
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/CRB/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/CRB/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
 
 [RHEL-9-BaseOS]
 name=baseos
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
 
 [RHEL-9-AppStream]
 name=appstream
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/AppStream/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
 
 [RHEL-9-Buildroot]
 name=buildroot
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9/latest-BUILDROOT-9.0-RHEL-9/compose/Buildroot/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9/latest-BUILDROOT-9-RHEL-9/compose/Buildroot/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0

--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -30,8 +30,8 @@ MINOR_VERSION=${VERSION_ID#*.}
 # The --volid argument can cause different network interface naming: https://github.com/rhinstaller/kickstart-tests/issues/448
 lorax -p RHEL -v $MAJOR_VERSION -r $MINOR_VERSION --volid RHEL-$MAJOR_VERSION-$MINOR_VERSION-0-BaseOS-x86_64 \
       --nomacboot \
-      -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/x86_64/os/ \
-      -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/x86_64/os/ \
+      -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/BaseOS/x86_64/os/ \
+      -s http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/AppStream/x86_64/os/ \
       -s file://$REPO_DIR/ \
       $@ \
       lorax

--- a/dockerfile/anaconda-iso-creator/rhel-9.repo
+++ b/dockerfile/anaconda-iso-creator/rhel-9.repo
@@ -1,13 +1,13 @@
 [RHEL-9-BaseOS]
 name=baseos
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
 
 [RHEL-9-AppStream]
 name=appstream
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/AppStream/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0

--- a/dockerfile/anaconda-rpm/rhel-9.repo
+++ b/dockerfile/anaconda-rpm/rhel-9.repo
@@ -1,27 +1,27 @@
 [RHEL-9-CRB]
 name=crb
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/CRB/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/CRB/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
 
 [RHEL-9-BaseOS]
 name=baseos
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
 
 [RHEL-9-AppStream]
 name=appstream
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9/compose/AppStream/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0
 
 [RHEL-9-Buildroot]
 name=buildroot
-baseurl=http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9/latest-BUILDROOT-9.0-RHEL-9/compose/Buildroot/$basearch/os/
+baseurl=http://download.devel.redhat.com/rhel-9/nightly/BUILDROOT-9/latest-BUILDROOT-9-RHEL-9/compose/Buildroot/$basearch/os/
 enabled=1
 gpgcheck=0
 install_weak_deps=0


### PR DESCRIPTION
This reverts commit 28969f3a074e740b87a8abb92bb6be229aa15308.

rhel-9 branch should really follow the current rhel-9 development
minor branch.