### PR TITLE
Update branching settings for rhel-9.0 branch (#infra)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,8 @@ jobs:
         release: ['']
         include:
           - release: ''
-            target_branch: 'rhel-9'
-            ci_tag: 'rhel-9'
+            target_branch: 'rhel-9.0'
+            ci_tag: 'rhel-9.0'
     env:
       CI_TAG: '${{ matrix.ci_tag }}'
       TARGET_BRANCH_NAME: 'origin/${{ matrix.target_branch }}'
@@ -69,8 +69,8 @@ jobs:
         release: ['']
         include:
           - release: ''
-            target_branch: 'rhel-9'
-            ci_tag: 'rhel-9'
+            target_branch: 'rhel-9.0'
+            ci_tag: 'rhel-9.0'
     env:
       CI_TAG: '${{ matrix.ci_tag }}'
       TARGET_BRANCH_NAME: 'origin/${{ matrix.target_branch }}'

--- a/branch-config.mk
+++ b/branch-config.mk
@@ -21,10 +21,10 @@
 
 # Name of the expected current git branch.
 # This could be master, fXX-devel, fXX-release, rhelX-branch, rhel-X ...
-GIT_BRANCH ?= rhel-9
+GIT_BRANCH ?= rhel-9.0
 
 # Directory for this anaconda branch in anaconda-l10n repository. This could be master, fXX, rhel-8 etc.
-L10N_DIR ?= rhel-9
+L10N_DIR ?= rhel-9.0
 
 # Base container for our containers.
 BASE_CONTAINER ?= registry-proxy.engineering.redhat.com/rh-osbs/ubi9:latest


### PR DESCRIPTION
This PR attempts to do the same what https://github.com/rhinstaller/anaconda/pull/3936 is for 8.6.
No need to update the repos here as this already happened on rhel-9 before forking 9.0.
I am not sure it is ok, it differs from the 8.6 PR a bit. I haven't tested it.
Also it requires also creating of 9.0 branch in weblate.