### PR TITLE
Remove --ignore-broken test

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
@@ -194,11 +194,11 @@ class DNFKSTestCase(unittest.TestCase):
     def test_packages_attributes_ignore(self):
         """Test the packages section with attributes for ignoring."""
         ks_in = """
-        %packages --ignoremissing --ignorebroken
+        %packages --ignoremissing
         %end
         """
         ks_out = """
-        %packages --ignoremissing --ignorebroken
+        %packages --ignoremissing
 
         %end
         """


### PR DESCRIPTION
This has to be backported to rhel-9.0 branch.