### PR TITLE
Remove --ignore-broken test (#test)

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
@@ -194,11 +194,11 @@ class DNFKSTestCase(unittest.TestCase):
     def test_packages_attributes_ignore(self):
         """Test the packages section with attributes for ignoring."""
         ks_in = """
-        %packages --ignoremissing --ignorebroken
+        %packages --ignoremissing
         %end
         """
         ks_out = """
-        %packages --ignoremissing --ignorebroken
+        %packages --ignoremissing
 
         %end
         """


### PR DESCRIPTION
In the past the --ignore-broken was disabled on RHEL by Anaconda configuration file, however, in the tests the RHEL conf is not loaded so the test still worked here.

After change b24574113fce6895e32af5f8171e732a3dab134f in pykickstart this functionality was moved to the pykickstart project so it's not allowed to be used on RHEL anymore.

Anaconda code should work as expected because we are disabling this anyhow by the configuration but we have to remove the test to fix our tests right now.

(cherry picked from commit 7e611107d92a6b658586557f82de29ba0776f9b1)
Backport of https://github.com/rhinstaller/anaconda/pull/3944.