### PR TITLE
Fix the --ignore-broken unit test

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
@@ -21,12 +21,14 @@ import unittest
 from unittest.mock import patch, PropertyMock
 
 from dasbus.typing import *  # pylint: disable=wildcard-import
+from pykickstart.version import isRHEL as is_rhel
 
 from pyanaconda.core.constants import SOURCE_TYPE_CDROM, SOURCE_TYPE_HDD, SOURCE_TYPE_HMC, \
     SOURCE_TYPE_NFS, SOURCE_TYPE_REPO_FILES, SOURCE_TYPE_URL, URL_TYPE_BASEURL, \
     SOURCE_TYPE_CLOSEST_MIRROR, SOURCE_TYPE_CDN, GROUP_PACKAGE_TYPES_REQUIRED, \
     GROUP_PACKAGE_TYPES_ALL, MULTILIB_POLICY_ALL
 from pyanaconda.core.kickstart.specification import KickstartSpecificationHandler
+from pyanaconda.core.kickstart.version import VERSION
 from pyanaconda.modules.common.constants.interfaces import PAYLOAD_DNF
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.common.structures.packages import PackagesConfigurationData, \
@@ -211,8 +213,8 @@ class DNFKSTestCase(unittest.TestCase):
             ks_in, ks_out
         )
 
-    def test_packages_attributes_ignore(self):
-        """Test the packages section with attributes for ignoring."""
+    def test_packages_attributes_ignore_missing(self):
+        """Test the packages section with ignored missing packages."""
         ks_in = """
         %packages --ignoremissing
         %end
@@ -224,6 +226,21 @@ class DNFKSTestCase(unittest.TestCase):
         """
         self.shared_ks_tests.check_kickstart(
             ks_in, ks_out
+        )
+
+    def test_packages_attributes_ignore_broken(self):
+        """Test the packages section with ignored broken packages."""
+        ks_in = """
+        %packages --ignorebroken
+        %end
+        """
+        ks_out = """
+        %packages --ignorebroken
+
+        %end
+        """
+        self.shared_ks_tests.check_kickstart(
+            ks_in, ks_out, ks_valid=not is_rhel(VERSION)
         )
 
     def test_packages_attributes_exclude(self):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
@@ -214,11 +214,11 @@ class DNFKSTestCase(unittest.TestCase):
     def test_packages_attributes_ignore(self):
         """Test the packages section with attributes for ignoring."""
         ks_in = """
-        %packages --ignoremissing --ignorebroken
+        %packages --ignoremissing
         %end
         """
         ks_out = """
-        %packages --ignoremissing --ignorebroken
+        %packages --ignoremissing
 
         %end
         """


### PR DESCRIPTION
The `--ignore-broken` option of the `%packages` section is invalid on RHEL,
so make sure that the unit tests can handle that.

Tested on RHEL 9 and Fedora 37.

**Ported from:** https://github.com/rhinstaller/anaconda/pull/3944