### PR TITLE
webui: :fire:  webpack: process all assets when compressing

### DIFF
--- a/ui/webui/webpack.config.js
+++ b/ui/webui/webpack.config.js
@@ -41,7 +41,9 @@ const plugins = [
 if (production) {
     plugins.unshift(new CompressionPlugin({
         test: /\.(js|html|css)$/,
-        deleteOriginalAssets: true
+        deleteOriginalAssets: true,
+        // Compress all assets
+        minRatio: Infinity
     }));
 }
 


### PR DESCRIPTION
By default, only assets that compress better than this ratio (0.8) are
processed.

https://github.com/webpack-contrib/compression-webpack-plugin#minratio

That ended up leaving some of our translation files uncompressed, as
they contained just a few lines, resulting in minimal compression
difference.