### PR TITLE
Skip /etc/machine-info during live installs (#2036199)

### DIFF
--- a/pyanaconda/modules/payloads/base/installation.py
+++ b/pyanaconda/modules/payloads/base/installation.py
@@ -57,7 +57,8 @@ class InstallFromImageTask(Task):
         args = ["-pogAXtlHrDx", "--exclude", "/dev/", "--exclude", "/proc/", "--exclude", "/tmp/*",
                 "--exclude", "/sys/", "--exclude", "/run/", "--exclude", "/boot/*rescue*",
                 "--exclude", "/boot/loader/", "--exclude", "/boot/efi/loader/",
-                "--exclude", "/etc/machine-id", INSTALL_TREE + "/", self._dest_path]
+                "--exclude", "/etc/machine-id", "--exclude", "/etc/machine-info",
+                INSTALL_TREE + "/", self._dest_path]
         try:
             rc = execWithRedirect(cmd, args)
         except (OSError, RuntimeError) as e:

--- a/pyanaconda/modules/payloads/payload/live_image/installation.py
+++ b/pyanaconda/modules/payloads/payload/live_image/installation.py
@@ -43,7 +43,8 @@ class InstallFromTarTask(Task):
                 "--exclude", "./dev/*", "--exclude", "./proc/*", "--exclude", "./tmp/*",
                 "--exclude", "./sys/*", "--exclude", "./run/*", "--exclude", "./boot/*rescue*",
                 "--exclude", "./boot/loader", "--exclude", "./boot/efi/loader",
-                "--exclude", "./etc/machine-id", "-xaf", self._tarfile_path, "-C", self._dest_path]
+                "--exclude", "./etc/machine-id", "--exclude", "./etc/machine-info",
+                "-xaf", self._tarfile_path, "-C", self._dest_path]
         try:
             rc = execWithRedirect(cmd, args)
         except (OSError, RuntimeError) as e:

--- a/pyanaconda/payload/live/payload_base.py
+++ b/pyanaconda/payload/live/payload_base.py
@@ -108,7 +108,8 @@ class BaseLivePayload(Payload):
         args = ["-pogAXtlHrDx", "--exclude", "/dev/", "--exclude", "/proc/", "--exclude", "/tmp/*",
                 "--exclude", "/sys/", "--exclude", "/run/", "--exclude", "/boot/*rescue*",
                 "--exclude", "/boot/loader/", "--exclude", "/boot/efi/loader/",
-                "--exclude", "/etc/machine-id", INSTALL_TREE + "/", conf.target.system_root]
+                "--exclude", "/etc/machine-id", "--exclude", "/etc/machine-info",
+                INSTALL_TREE + "/", conf.target.system_root]
         try:
             rc = util.execWithRedirect(cmd, args)
         except (OSError, RuntimeError) as e:

--- a/pyanaconda/payload/live/payload_liveimg.py
+++ b/pyanaconda/payload/live/payload_liveimg.py
@@ -292,7 +292,8 @@ class LiveImagePayload(BaseLivePayload):
                 "--exclude", "./dev/*", "--exclude", "./proc/*", "--exclude", "./tmp/*",
                 "--exclude", "./sys/*", "--exclude", "./run/*", "--exclude", "./boot/*rescue*",
                 "--exclude", "./boot/loader", "--exclude", "./boot/efi/loader",
-                "--exclude", "./etc/machine-id", "-xaf", self.image_path, "-C", conf.target.system_root]
+                "--exclude", "./etc/machine-id", "--exclude", "./etc/machine-info",
+                "-xaf", self.image_path, "-C", conf.target.system_root]
         try:
             rc = util.execWithRedirect(cmd, args)
         except (OSError, RuntimeError) as e:

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
@@ -90,7 +90,8 @@ class LiveTasksTestCase(unittest.TestCase):
                                "--exclude", "/tmp/*", "--exclude", "/sys/", "--exclude", "/run/",
                                "--exclude", "/boot/*rescue*", "--exclude", "/boot/loader/",
                                "--exclude", "/boot/efi/loader/",
-                               "--exclude", "/etc/machine-id", INSTALL_TREE + "/", dest_path]
+                               "--exclude", "/etc/machine-id", "--exclude", "/etc/machine-info",
+                               INSTALL_TREE + "/", dest_path]
 
         exec_with_redirect.assert_called_once_with("rsync", expected_rsync_args)
 
@@ -107,7 +108,8 @@ class LiveTasksTestCase(unittest.TestCase):
                                "--exclude", "/tmp/*", "--exclude", "/sys/", "--exclude", "/run/",
                                "--exclude", "/boot/*rescue*", "--exclude", "/boot/loader/",
                                "--exclude", "/boot/efi/loader/",
-                               "--exclude", "/etc/machine-id", INSTALL_TREE + "/", dest_path]
+                               "--exclude", "/etc/machine-id", "--exclude", "/etc/machine-info",
+                               INSTALL_TREE + "/", dest_path]
 
         exec_with_redirect.assert_called_once_with("rsync", expected_rsync_args)
 
@@ -128,7 +130,8 @@ class LiveTasksTestCase(unittest.TestCase):
                                "--exclude", "/tmp/*", "--exclude", "/sys/", "--exclude", "/run/",
                                "--exclude", "/boot/*rescue*", "--exclude", "/boot/loader/",
                                "--exclude", "/boot/efi/loader/",
-                               "--exclude", "/etc/machine-id", INSTALL_TREE + "/", dest_path]
+                               "--exclude", "/etc/machine-id", "--exclude", "/etc/machine-info",
+                               INSTALL_TREE + "/", dest_path]
 
         exec_with_redirect.assert_called_once_with("rsync", expected_rsync_args)
 
@@ -149,6 +152,7 @@ class LiveTasksTestCase(unittest.TestCase):
                                "--exclude", "/tmp/*", "--exclude", "/sys/", "--exclude", "/run/",
                                "--exclude", "/boot/*rescue*", "--exclude", "/boot/loader/",
                                "--exclude", "/boot/efi/loader/",
-                               "--exclude", "/etc/machine-id", INSTALL_TREE + "/", dest_path]
+                               "--exclude", "/etc/machine-id", "--exclude", "/etc/machine-info",
+                               INSTALL_TREE + "/", dest_path]
 
         exec_with_redirect.assert_called_once_with("rsync", expected_rsync_args)


### PR DESCRIPTION
`/etc/machine-info` should not be installed to the system, for the same reason we don't install `/etc/machine-id`: it should be system-specific, not the same for every install from the same live image.

This should fix live installs with systemd 250+ not booting due to the bootloader config snippets being named based on the `KERNEL_INSTALL_MACHINE_ID` from the live image `/etc/machine-info`, but `grub2-mkconfig` expecting them to be named according to the installed system's newly-generated `/etc/machine-id`.

Signed-off-by: Adam Williamson <awilliam@redhat.com>
(based on commit fe652add9733943a3476128a83b24b9a8c63b335)

Resolves: rhbz#2059565