### PR TITLE
Betanag for web ui

### DIFF
--- a/ui/webui/src/components/AnacondaHeader.jsx
+++ b/ui/webui/src/components/AnacondaHeader.jsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from "cockpit";
+
+import React from "react";
+
+import {
+    Flex,
+    Label,
+    PageSection, PageSectionVariants,
+    Popover,
+    TextContent, Text, TextVariants
+} from "@patternfly/react-core";
+import { InfoCircleIcon } from "@patternfly/react-icons";
+
+const _ = cockpit.gettext;
+
+const prerelease = _("Pre-release");
+
+export const AnacondaHeader = ({ beta, title }) => {
+    let betanag;
+    if (beta) {
+        betanag = (
+            <Popover
+              headerContent={_("This is unstable, pre-release software")}
+              minWidth="40rem"
+              bodyContent={
+                  <TextContent>
+                      <Text component={TextVariants.p}>
+                          {_("Notice: This is pre-released software that is intended for development and testing purposes only. Do NOT use this software for any critical work or for production environments.")}
+                      </Text>
+                      <Text component={TextVariants.p}>
+                          {_("By continuing to use this software, you understand and accept the risks associated with pre-released software, that you intend to use this for testing and development purposes only and are willing to report any bugs or issues in order to enhance this work.")}
+                      </Text>
+                      <Text component={TextVariants.p}>
+                          {_("If you do not understand or accept the risks, then please exit this program.")}
+                      </Text>
+                  </TextContent>
+              }
+            >
+                <Label color="orange" icon={<InfoCircleIcon />} id="betanag-icon"> {prerelease} </Label>
+            </Popover>
+        );
+    }
+    return (
+        <PageSection variant={PageSectionVariants.light}>
+            <Flex spaceItems={{ default: "spaceItemsSm" }} alignItems={{ default: "alignItemsCenter" }}>
+                <TextContent>
+                    <Text component="h1">{title}</Text>
+                </TextContent>
+                {betanag}
+            </Flex>
+        </PageSection>
+    );
+};

--- a/ui/webui/src/helpers/betanag.js
+++ b/ui/webui/src/helpers/betanag.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from "cockpit";
+
+import { parseIni } from "./conf.js";
+
+export const readBuildstamp = () => {
+    const file = cockpit.file("/.buildstamp", { superuser: "try", });
+    return file.read()
+            .then(parseIni)
+            .finally(file.close);
+};
+
+export const getIsFinal = (buildstamp) => {
+    let isFinal = buildstamp.Main.IsFinal;
+    // If the value is not present, we get undefined which fails the test below and results
+    // the intended fallback default of false.
+    if ((isFinal === "true") || (isFinal === "True")) isFinal = true; else isFinal = false;
+    return isFinal;
+};

--- a/ui/webui/src/helpers/conf.js
+++ b/ui/webui/src/helpers/conf.js
@@ -23,7 +23,7 @@ const isEmpty = (inStr) => {
     return !(inStr || inStr.trim());
 };
 
-const parseIni = (content, tag) => {
+export const parseIni = (content, tag) => {
     /*
     Anaconda config files are a dialect of INI files based on Python's configparser. Unfortunately,
     that parser extends the commonly understood format with multi-line values, which is treated
@@ -32,7 +32,7 @@ const parseIni = (content, tag) => {
     const lines = content.split(/\r\n|\r|\n/);
     const dataStore = {};
     const rxHeader = /\[([^\]]+)\].*/;
-    const rxKeyValue = /(\w+) = (.*)/;
+    const rxKeyValue = /(\w+) ?= ?(.*)/;
 
     let curHeader = "";
     let curKey = "";

--- a/ui/webui/test/check-basic
+++ b/ui/webui/test/check-basic
@@ -51,7 +51,9 @@ class TestBasic(MachineCase):
             # we at least iterate over them to check this works as expected
             b.wait_js_cond(f'window.location.hash === "#/{page}"')
             b.wait_visible("#" + page + ".pf-m-current")
-            b.click("button.pf-m-primary")
+            # Do not start the installation in non-destructive tests as this performs non revertible changes
+            if page != 'review-configuration':
+                b.click("button.pf-m-primary")
             if page == 'installation-language':
                 b.expect_load()
 

--- a/ui/webui/test/check-basic
+++ b/ui/webui/test/check-basic
@@ -32,6 +32,7 @@ class TestBasic(MachineCase):
 
     def testNavigation(self):
         b = self.browser
+        m = self.machine
 
         b.open("/cockpit/@localhost/anaconda-webui/index.html#/installation-language")
 
@@ -39,6 +40,11 @@ class TestBasic(MachineCase):
             b.attr("#app > .pf-c-page", "data-debug"),
             ["False", "false", "True", "true"]
         )
+
+        # Check betanag
+        value = m.execute("cat /.buildstamp | grep IsFinal=")
+        if value.split("=", 1)[1] in ("False", "false"):
+            b.wait_visible("#betanag-icon")
 
         for page in ['installation-language', 'installation-destination', 'review-configuration']:
             # with the pages basically empty of common elements (as those are provided by the top-level wizard widget)


### PR DESCRIPTION
This adds a label with popup, as specified in the mockups. The label is shown or hidden dynamically, based on the contents of the `/.buildstamp` file.

The large light blue warning pane (?) at startup is not yet part of this, I will need to check how to make it appear as intended (before wizard step label/heading).

TODOs left:
- [x] Meaningful texts
- [x] Tests
- [ ] In-page warning at language selection or so

----

To summarize, this is the new thing:

![betanag](https://user-images.githubusercontent.com/15903878/158392985-99b48378-02f1-475e-aa01-23188c6041a1.png)

----
Thank you @KKoukiou for the wizard changes!