### PR TITLE
webui: show inline per - step alerts and stay in the same step when configuration is invalid

### DIFF
--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -158,7 +158,7 @@ export const InstallationDestination = ({ onAddErrorNotification }) => {
     );
 };
 
-export const applyDefaultStorage = ({ onAddErrorNotification, onSuccess }) => {
+export const applyDefaultStorage = ({ onFail, onSuccess }) => {
     let partitioning;
     // CLEAR_PARTITIONS_ALL = 1
     return setInitializationMode({ mode: 1 })
@@ -174,10 +174,10 @@ export const applyDefaultStorage = ({ onAddErrorNotification, onSuccess }) => {
                     onSuccess: () => (
                         applyPartitioning({ partitioning })
                                 .then(onSuccess)
-                                .catch(onAddErrorNotification)
+                                .catch(onFail)
                     ),
-                    onFail: onAddErrorNotification
+                    onFail
                 });
             })
-            .catch(onAddErrorNotification);
+            .catch(onFail);
 };

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -35,13 +35,18 @@ class TestStorage(MachineCase):
 
         b.open("/cockpit/@localhost/anaconda-webui/index.html")
 
-        b.click('#installation-destination')
+        b.click("button.pf-m-primary")
         b.expect_load()
 
         b.wait_visible('article:contains(Local standard disks)')
-        # We can't check the checked state of the checkboxes because of
-        # https://github.com/patternfly/patternfly-react/issues/6762
-        # b.wait_visible('#local-disks-checkbox-vda:checked')
+
+        # Try unselecting the single disk and expect and error
+        b.set_checked('input[name=checkbox-check-vda]', False)
+        b.click("button.pf-m-primary")
+        b.wait_in_text(".pf-c-alert.pf-m-danger", "No usable disks")
+        # Since storage configuration failed it's expected to be in the still in the storage step
+        b.wait_js_cond('window.location.hash === "#/installation-destination"')
+        b.wait_visible("#installation-destination.pf-m-current")
 
 if __name__ == '__main__':
     test_main()

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -43,7 +43,7 @@ class TestStorage(MachineCase):
         # Try unselecting the single disk and expect and error
         b.set_checked('input[name=checkbox-check-vda]', False)
         b.click("button.pf-m-primary")
-        b.wait_in_text(".pf-c-alert.pf-m-danger", "No usable disks")
+        b.wait_in_text(".pf-c-alert.pf-m-danger.pf-m-inline", "No usable disks")
         # Since storage configuration failed it's expected to be in the still in the storage step
         b.wait_js_cond('window.location.hash === "#/installation-destination"')
         b.wait_visible("#installation-destination.pf-m-current")


### PR DESCRIPTION
For example when the user has an invalid disk selection step, the page looks like this when clicking 'Next':

![Screen Shot 2022-03-15 at 17 45 45](https://user-images.githubusercontent.com/14921356/158432735-b1a3d554-3c8c-4c61-8a1e-3d4a5edb2b3c.png)

