### PR TITLE
Update icon sizes for symbolic icons

### DIFF
--- a/pyanaconda/ui/gui/main.glade
+++ b/pyanaconda/ui/gui/main.glade
@@ -83,6 +83,7 @@
     <child internal-child="vbox">
       <object class="GtkBox" id="quitDialog-vbox1">
         <property name="can_focus">False</property>
+        <property name="border_width">6</property>
         <property name="orientation">vertical</property>
         <property name="spacing">24</property>
         <child internal-child="action_area">
@@ -136,7 +137,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="icon_name">application-exit-symbolic</property>
-                <property name="icon_size">6</property>
+                <property name="icon_size">5</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/pyanaconda/ui/gui/spokes/network.glade
+++ b/pyanaconda/ui/gui/spokes/network.glade
@@ -620,9 +620,8 @@
                                             <property name="halign">end</property>
                                             <property name="valign">start</property>
                                             <property name="xalign">1</property>
-                                            <property name="pixel_size">48</property>
                                             <property name="icon_name">network-wired-symbolic</property>
-                                            <property name="icon_size">6</property>
+                                            <property name="icon_size">3</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">0</property>
@@ -1003,9 +1002,8 @@
                                             <property name="halign">end</property>
                                             <property name="valign">start</property>
                                             <property name="xalign">1</property>
-                                            <property name="pixel_size">48</property>
                                             <property name="icon_name">network-wireless-symbolic</property>
-                                            <property name="icon_size">6</property>
+                                            <property name="icon_size">3</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">0</property>
@@ -1471,9 +1469,8 @@
                                             <property name="halign">end</property>
                                             <property name="valign">start</property>
                                             <property name="xalign">1</property>
-                                            <property name="pixel_size">48</property>
                                             <property name="icon_name">network-cellular-connected-symbolic</property>
-                                            <property name="icon_size">6</property>
+                                            <property name="icon_size">3</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">0</property>
@@ -1788,9 +1785,8 @@
                                             <property name="halign">end</property>
                                             <property name="valign">start</property>
                                             <property name="xalign">1</property>
-                                            <property name="pixel_size">48</property>
                                             <property name="icon_name">network-vpn-symbolic</property>
-                                            <property name="icon_size">6</property>
+                                            <property name="icon_size">3</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">0</property>
@@ -2054,9 +2050,8 @@
                                             <property name="halign">end</property>
                                             <property name="valign">start</property>
                                             <property name="xalign">1</property>
-                                            <property name="pixel_size">48</property>
                                             <property name="icon_name">preferences-system-network-symbolic</property>
-                                            <property name="icon_size">6</property>
+                                            <property name="icon_size">3</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">0</property>

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -370,9 +370,10 @@ class NetworkControlBox(GObject.GObject):
 
     def _add_device_columns(self, treeview):
         rnd = Gtk.CellRendererPixbuf()
-        rnd.set_property("stock-size", Gtk.IconSize.DND)
+        rnd.set_property("stock-size", Gtk.IconSize.MENU)
         # TODO Gtk3 icon-name? (also at other places)
         col = Gtk.TreeViewColumn("Icon", rnd, **{"icon-name":0})
+        col.set_min_width(27)
         treeview.append_column(col)
 
         rnd = Gtk.CellRendererText()
@@ -1032,7 +1033,7 @@ class NetworkControlBox(GObject.GObject):
         if dev_type_str == "wired":
             # update icon according to device status
             img = self.builder.get_object("image_wired_device")
-            img.set_from_icon_name(self._dev_icon_name(dev_cfg), Gtk.IconSize.DIALOG)
+            img.set_from_icon_name(self._dev_icon_name(dev_cfg), Gtk.IconSize.LARGE_TOOLBAR)
 
         # TODO: is this necessary? Isn't it static from glade?
         device_type_label = _(self.device_type_name.get(dev_cfg.device_type, ""))

--- a/pyanaconda/ui/gui/spokes/welcome.glade
+++ b/pyanaconda/ui/gui/spokes/welcome.glade
@@ -81,7 +81,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="icon_name">application-exit-symbolic</property>
-                <property name="icon_size">6</property>
+                <property name="icon_size">5</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>


### PR DESCRIPTION
I've checked the icons modified to symbolic versions in https://github.com/rhinstaller/anaconda/pull/3902 and there are 3 places where we could or should update icon size for the symbolic version so it looks better:

1) Betanag dialog (GTK_ICON_SIZE_DIALOG 48px ->  GTK_ICON_SIZE_DND 32px): here I am not sure, I would be fine with the bigger icon as well, maybe it is even better...
2) Quit dialog: (GTK_ICON_SIZE_DIALOG 48px ->  GTK_ICON_SIZE_DND 32px) I would definitely add the border, smaller size seems a bit better to me, but shouldn't we use _DIALOG in dialog?

Actually I think for the dialogs the real problem is not too big icons but icons being too close to the border but that would be something that would need to be addressed in another PR for all dialogs consistently.

3) Network spoke: Here we should definitely use smaller icons.

Note: my goal here was not to fix the places to be looking perfect but not much worse then it used to with non-symbolic icons.
Suggestions and opinions welcome.