### PR TITLE
Rhel 9.0 port dracut arguments fix

### DIFF
--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -793,12 +793,13 @@ class BootLoader(object):
                 else:
                     setup_args = dep.dracut_setup_args()
 
+                done.append(dep)
+
                 if not setup_args:
                     continue
 
                 self.boot_args.update(setup_args)
                 self.dracut_args.update(setup_args)
-                done.append(dep)
 
                 # network configuration arguments
                 if isinstance(dep, NetworkStorageDevice):

--- a/pyanaconda/modules/storage/iscsi/iscsi.py
+++ b/pyanaconda/modules/storage/iscsi/iscsi.py
@@ -220,6 +220,10 @@ class ISCSIModule(KickstartBaseModule):
 
         blivet_node = iscsi.get_node(node.name, node.address, node.port, node.iface)
 
+        if not blivet_node:
+            log.error("No iSCSI node %s found for device", node)
+            return []
+
         address = blivet_node.address
         # surround ipv6 addresses with []
         if ":" in address:


### PR DESCRIPTION
Port of https://github.com/rhinstaller/anaconda/pull/3885 to rhel-9.0