### PR TITLE
dockerfile: stop using non-existing po-pull target (#infra)

### DIFF
--- a/dockerfile/anaconda-rhel-copr/copr-builder-rhel.conf
+++ b/dockerfile/anaconda-rhel-copr/copr-builder-rhel.conf
@@ -5,4 +5,4 @@ package = anaconda
 git_url = https://github.com/rhinstaller/anaconda
 git_branch = rhel-8
 pre_archive_cmd = ./autogen.sh && ./configure
-archive_cmd = make po-pull && make dist
+archive_cmd = make dist


### PR DESCRIPTION
Commit 593adf59204a81dd45d76a11e53acf21f725a001 removed this
target. No po files are pulled automatically on make dist.