### PR TITLE
Clarify which Anaconda profile is used by CentOS Stream

### DIFF
--- a/data/profile.d/centos.conf
+++ b/data/profile.d/centos.conf
@@ -1,4 +1,4 @@
-# Anaconda configuration file for CentOS.
+# Anaconda configuration file for CentOS Stream.
 
 [Profile]
 # Define the profile.


### PR DESCRIPTION
Extend the description of the related configuration file.