### PR TITLE
Use a task to set up an additional NFS repository

### DIFF
--- a/pyanaconda/core/payload.py
+++ b/pyanaconda/core/payload.py
@@ -28,12 +28,23 @@ def parse_nfs_url(nfs_url):
     :return: Tuple with options, host, and path
     :rtype: (str, str, str) or None
     """
+    prefixes = [
+        "nfs://",
+        "nfs:",
+    ]
     options = ''
     host = ''
     path = ''
+
+    # Remove the nfs prefix.
+    for prefix in prefixes:
+        if nfs_url.startswith(prefix):
+            nfs_url = nfs_url.removeprefix(prefix)
+            break
+
+    # Parse the nfs attributes.
     if nfs_url:
         s = nfs_url.split(":")
-        s.pop(0)
         if len(s) >= 3:
             (options, host, path) = s[:3]
         elif len(s) == 2:

--- a/tests/unit_tests/pyanaconda_tests/test_payload.py
+++ b/tests/unit_tests/pyanaconda_tests/test_payload.py
@@ -27,40 +27,30 @@ class PayloadUtilsTests(unittest.TestCase):
 
     def test_parse_nfs_url(self):
         """Test parseNfsUrl."""
-
         # empty NFS url should return 3 blanks
         assert util.parse_nfs_url("") == ("", "", "")
 
         # the string is delimited by :, there is one prefix and 3 parts,
         # the prefix is discarded and all parts after the 3th part
         # are also discarded
-        assert util.parse_nfs_url("discard:options:host:path") == \
+        assert util.parse_nfs_url("nfs:options:host:path") == \
             ("options", "host", "path")
-        assert util.parse_nfs_url("discard:options:host:path:foo:bar") == \
+        assert util.parse_nfs_url("nfs:options:host:path:foo:bar") == \
             ("options", "host", "path")
-        assert util.parse_nfs_url(":options:host:path::") == \
-            ("options", "host", "path")
-        assert util.parse_nfs_url(":::::") == \
-            ("", "", "")
 
         # if there is only prefix & 2 parts,
         # the two parts are host and path
-        assert util.parse_nfs_url("prefix:host:path") == \
+        assert util.parse_nfs_url("nfs://host:path") == \
             ("", "host", "path")
-        assert util.parse_nfs_url(":host:path") == \
+        assert util.parse_nfs_url("nfs:host:path") == \
             ("", "host", "path")
-        assert util.parse_nfs_url("::") == \
-            ("", "", "")
 
         # if there is only a prefix and single part,
         # the part is the host
-
-        assert util.parse_nfs_url("prefix:host") == \
+        assert util.parse_nfs_url("nfs://host") == \
             ("", "host", "")
-        assert util.parse_nfs_url(":host") == \
+        assert util.parse_nfs_url("nfs:host") == \
             ("", "host", "")
-        assert util.parse_nfs_url(":") == \
-            ("", "", "")
 
     def test_create_nfs_url(self):
         """Test create_nfs_url."""


### PR DESCRIPTION
Set up an additional NFS repository with a task. Collect generated mount points,
so we can unmount them when needed. This is just a temporary solution, because
the source management should be eventually handled by DBus source objects.