### PR TITLE
Use the DNF manager to gather metadata

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -916,6 +916,26 @@ class DNFManager(object):
 
         log.info("Loaded metadata from '%s'.", url)
 
+    def load_packages_metadata(self):
+        """Load metadata about packages in available repositories.
+
+        Load all enabled repositories and process their metadata.
+        It will update the cache that provides information about
+        available packages, modules, groups and environments.
+        """
+        # Load all enabled repositories.
+        # Set up the package sack.
+        self._base.fill_sack(
+            load_system_repo=False,
+            load_available_repos=True,
+        )
+        # Load the comps metadata.
+        self._base.read_comps(
+            arch_filter=True
+        )
+
+        log.info("Loaded packages and group metadata.")
+
     def load_repomd_hashes(self):
         """Load a hash of the repomd.xml file for each enabled repository."""
         self._md_hashes = self._get_repomd_hashes()

--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -895,7 +895,7 @@ class DNFManager(object):
     def load_repository(self, repo_id):
         """Download repo metadata.
 
-        Enable the repo and load its metadata to verify that
+        If the repo is enabled, load its metadata to verify that
         the repo is valid. An invalid repo will be disabled.
 
         :param str repo_id: an identifier of a repository
@@ -906,8 +906,11 @@ class DNFManager(object):
         repo = self._get_repository(repo_id)
         url = repo.baseurl or repo.mirrorlist or repo.metalink
 
+        if not repo.enabled:
+            log.debug("Don't load metadata from a disabled repository.")
+            return
+
         try:
-            repo.enable()
             repo.load()
         except dnf.exceptions.RepoError as e:
             log.debug("Failed to load metadata from '%s': %s", url, str(e))

--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -898,6 +898,9 @@ class DNFManager(object):
         If the repo is enabled, load its metadata to verify that
         the repo is valid. An invalid repo will be disabled.
 
+        This method will by default not try to refresh already
+        loaded data if called repeatedly.
+
         :param str repo_id: an identifier of a repository
         :raise: MetadataError if the metadata cannot be loaded
         """

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -476,8 +476,8 @@ class DNFPayload(Payload):
         with self._repos_lock:
             for repo in self._base.repos.iter_enabled():
                 self._sync_metadata(repo)
-        self._base.fill_sack(load_system_repo=False)
-        self._base.read_comps(arch_filter=True)
+
+        self.dnf_manager.load_packages_metadata()
 
     def install(self):
         self._progress_cb(0, _('Starting package installation process'))

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -369,26 +369,6 @@ class DNFPayload(Payload):
 
         return repo
 
-    def _add_repo_to_dnf_and_ks(self, ksrepo):
-        """Add an enabled repo to dnf and kickstart repo lists.
-
-        Add the repo given by the pykickstart Repo object ksrepo to the
-        system.
-
-        Duplicate repos will not raise an error.  They should just silently
-        take the place of the previous value.
-
-        :param ksrepo: Kickstart Repository to add
-        :type ksrepo: Kickstart RepoData object.
-        :returns: None
-        """
-        if ksrepo.enabled:
-            self._add_repo_to_dnf(ksrepo)
-            self._dnf_manager.load_repository(ksrepo.name)
-
-        # Add the repo to the ksdata so it'll appear in the output ks file.
-        self.data.repo.dataList().append(ksrepo)
-
     def _add_repo_to_dnf(self, ksrepo):
         """Add a repo to the dnf repo object.
 
@@ -892,7 +872,14 @@ class DNFPayload(Payload):
             log.debug("Adding new treeinfo repository: %s enabled: %s",
                       repo_md.name, repo_enabled)
 
-            self._add_repo_to_dnf_and_ks(repo)
+            # Validate the repository.
+            if repo.enabled:
+                self._add_repo_to_dnf(repo)
+                self._dnf_manager.load_repository(repo.name)
+
+            # Add the repository to user repositories,
+            # so it'll appear in the output ks file.
+            self.data.repo.dataList().append(repo)
 
     def _cleanup_old_treeinfo_repositories(self):
         """Remove all old treeinfo repositories before loading new ones.

--- a/pyanaconda/payload/manager.py
+++ b/pyanaconda/payload/manager.py
@@ -231,7 +231,7 @@ class PayloadManager(object):
 
         # Gather the group data
         self._set_state(PayloadState.DOWNLOADING_GROUP_METADATA)
-        payload.gather_repo_metadata()
+        payload.dnf_manager.load_packages_metadata()
 
         # Check if that failed
         if not payload.is_ready():

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
@@ -1236,6 +1236,7 @@ class DNFManagerReposTestCase(unittest.TestCase):
         """Test the load_repository method with a failure."""
         repo = self._add_repo("r1")
         repo.load = Mock(side_effect=RepoError("Fake error!"))
+        repo.enable()
 
         with pytest.raises(MetadataError) as cm:
             self.dnf_manager.load_repository("r1")
@@ -1244,10 +1245,22 @@ class DNFManagerReposTestCase(unittest.TestCase):
         assert repo.enabled is False
         assert str(cm.value) == "Fake error!"
 
+    def test_load_repository_disabled(self):
+        """Test the load_repository method with a disabled repo."""
+        repo = self._add_repo("r1")
+        repo.load = Mock()
+        repo.disable()
+
+        self.dnf_manager.load_repository("r1")
+
+        repo.load.assert_not_called()
+        assert repo.enabled is False
+
     def test_load_repository(self):
         """Test the load_repository method."""
         repo = self._add_repo("r1")
         repo.load = Mock()
+        repo.enable()
 
         self.dnf_manager.load_repository("r1")
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
@@ -1254,6 +1254,17 @@ class DNFManagerReposTestCase(unittest.TestCase):
         repo.load.assert_called_once()
         assert repo.enabled is True
 
+    def test_load_packages_metadata(self):
+        """Test the load_packages_metadata method."""
+        sack = self.dnf_manager._base.sack
+        comps = self.dnf_manager._base.comps
+
+        self.dnf_manager.load_packages_metadata()
+
+        # The metadata should be reloaded.
+        assert sack != self.dnf_manager._base.sack
+        assert comps != self.dnf_manager._base.comps
+
     def _create_repo(self, repo, repo_dir):
         """Generate fake metadata for the repo."""
         # Create the repodata directory.


### PR DESCRIPTION
Reorganize the code that collects metadata about available packages and groups.