### PR TITLE
Fix %onerror scripts not invoked in non-interactive mode

### DIFF
--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -106,6 +106,7 @@ class AnacondaExceptionHandler(ExceptionHandler):
                              "The exact error message is:\n\n%s.\n\n "
                              "The installer will now terminate.") % str(value)
             self.intf.messageWindow(_("Hardware error occurred"), hw_error_msg)
+            super(AnacondaExceptionHandler, self).handleException(dump_info)
             sys.exit(0)
         else:
             try:
@@ -159,6 +160,8 @@ class AnacondaExceptionHandler(ExceptionHandler):
                         # to acknowledge the error; instead, print the error out and sleep
                         # for a few seconds before exiting the installer
                         print(cmdline_error_msg)
+                        super(AnacondaExceptionHandler, self).handleException(
+                                                                dump_info)
                         time.sleep(180)
                         sys.exit(1)
                     else:


### PR DESCRIPTION
When kickstart's 'cmdline' or 'text' mode is used to
automate the installation if an error is raised due to
incorrect storage configuration or hardware error, it
is not handled properly by anaconda and any scripts
in %onerror section of the kickstart file are not invoked.

This change fixes the issue by handling the exception
properly in those scenarios.

Note: This bug only affects rhel7