### PR TITLE
Add Virtuozzo Linux profile to Anaconda, Resolves: rhbz#2067195

### DIFF
--- a/data/profile.d/Makefile.am
+++ b/data/profile.d/Makefile.am
@@ -31,7 +31,8 @@ dist_config_DATA    = \
 	rhel.conf \
 	rhvh.conf \
 	rocky.conf \
-	scientific-linux.conf
+	scientific-linux.conf \
+	virtuozzo-linux.conf
 
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/data/profile.d/virtuozzo-linux.conf
+++ b/data/profile.d/virtuozzo-linux.conf
@@ -1,0 +1,24 @@
+# Anaconda configuration file for Virtuozzo Linux.
+
+[Profile]
+# Define the profile.
+profile_id = virtuozzo-linux
+base_profile = rhel
+
+[Profile Detection]
+# Match os-release values.
+os_id = virtuozzo
+
+[Anaconda]
+forbidden_modules =
+    org.fedoraproject.Anaconda.Modules.Subscription
+
+[Bootloader]
+efi_dir = virtuozzo
+
+[Payload]
+enable_closest_mirror = True
+default_source = CLOSEST_MIRROR
+
+[License]
+eula = /usr/share/licenses/vzlinux-release/EULA

--- a/tests/unit_tests/pyanaconda_tests/core/test_profile.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_profile.py
@@ -342,6 +342,12 @@ class ProfileConfigurationTestCase(unittest.TestCase):
             ["rhel.conf", "rocky.conf"],
             ENTERPRISE_PARTITIONING
         )
+        self._check_default_profile(
+            "virtuozzo-linux",
+            ("virtuozzo", ""),
+            ["rhel.conf", "virtuozzo-linux.conf"],
+            ENTERPRISE_PARTITIONING
+        )
 
     def _compare_profile_files(self, file_name, other_file_name, ignored_sections=()):
         parser = create_parser()


### PR DESCRIPTION
Virtuozzo uses Anaconda in its free Virtuozzo Linux, OpenVZ and other products. It would be useful for us to have a product configuration file for VzLinux in upstream.