### PR TITLE
ShellCheck: Quote also variables inside ${...}

### DIFF
--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -96,7 +96,7 @@ anaconda_live_root_dir() {
         info "anaconda: found $iso"
         mount --make-rprivate /
         mount --move "$mnt" $isodir
-        iso=${isodir}/${iso#$mnt}
+        iso=${isodir}/${iso#"$mnt"}
         mount -o loop,ro "$iso" $repodir
         img=$(find_runtime $repodir) || { warn "$iso has no suitable runtime"; }
         anaconda_auto_updates $repodir/images

--- a/dracut/anaconda-netroot.sh
+++ b/dracut/anaconda-netroot.sh
@@ -63,7 +63,7 @@ case $repo in
             anaconda_live_root_dir "$repodir"
         else
             iso="${repo##*/}"
-            mount_nfs "${repo%$iso}" "$repodir" "$netif" || \
+            mount_nfs "${repo%"$iso"}" "$repodir" "$netif" || \
                 warn "Couldn't mount $repo"
             anaconda_live_root_dir "$repodir" "$iso"
         fi


### PR DESCRIPTION
New ShellCheck finds new error [SC2295](https://github.com/koalaman/shellcheck/wiki/SC2295): Expansions inside ${...} need to be quoted separately, otherwise they will match as a pattern.

---

This fixes the CI container build on master.