### PR TITLE
webui: Test both betanag states

### DIFF
--- a/ui/webui/test/check-basic
+++ b/ui/webui/test/check-basic
@@ -45,6 +45,8 @@ class TestBasic(MachineCase):
         value = m.execute("cat /.buildstamp | grep IsFinal=")
         if value.split("=", 1)[1] in ("False", "false"):
             b.wait_visible("#betanag-icon")
+        else:
+            b.wait_not_present("#betang-icon")
 
         for page in ['installation-language', 'installation-destination', 'review-configuration']:
             # with the pages basically empty of common elements (as those are provided by the top-level wizard widget)


### PR DESCRIPTION
Test also that it's not visible when not needed.

Followup to https://github.com/rhinstaller/anaconda/pull/3960#discussion_r829032648.

----

The betanag test could also be invasive - try manipulating the file and reloading the ui - but I'm not sure that's a good fit for the test.
