### PR TITLE
webui: expose webui.remote boot option

### DIFF
--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -228,7 +228,11 @@ class Anaconda(object):
         # from kernel boot command line like this
         if "webui" in kernel_arguments:
             from pyanaconda.ui.webui import CockpitUserInterface
-            self._intf = CockpitUserInterface(None, self.payload)
+            self._intf = CockpitUserInterface(
+                None,
+                self.payload,
+                "webui.remote" in kernel_arguments
+            )
 
             # needs to be refreshed now we know if gui or tui will take place
             # FIXME - what about Cockpit based addons ?

--- a/pyanaconda/ui/webui/__init__.py
+++ b/pyanaconda/ui/webui/__init__.py
@@ -30,7 +30,7 @@ log = get_module_logger(__name__)
 class CockpitUserInterface(ui.UserInterface):
     """This is the main class for Cockpit user interface."""
 
-    def __init__(self, storage, payload,
+    def __init__(self, storage, payload, remote,
                  productTitle="Anaconda", isFinal=True,
                  quitMessage=QUIT_MESSAGE):
         """
@@ -42,6 +42,10 @@ class CockpitUserInterface(ui.UserInterface):
 
         :param payload: payload (usually dnf) reference
         :type payload: instance of payload handler
+
+        :param remote: if used run a cockpit-ws process to allow
+                       passwordless remote access to the anaconda-webui for easier testing.
+        :type remote: bool
 
         :param productTitle: the name of the product
         :type productTitle: str
@@ -60,6 +64,7 @@ class CockpitUserInterface(ui.UserInterface):
 
         super().__init__(storage, payload)
         self.productTitle = productTitle
+        self.remote = remote
         self.isFinal = isFinal
         self.quitMessage = quitMessage
         self._meh_interface = meh.ui.text.TextIntf()
@@ -91,6 +96,12 @@ class CockpitUserInterface(ui.UserInterface):
     def run(self):
         """Run the interface."""
         log.debug("web-ui: starting cockpit web view")
+        if self.remote:
+            startProgram([
+                "/usr/libexec/cockpit-ws", "--no-tls",
+                "--port", "9090", "--local-session=cockpit-bridge"
+            ])
+
         proc = startProgram(["/usr/libexec/webui-desktop",
                             "/cockpit/@localhost/anaconda-webui/index.html"],
                             reset_lang=False)

--- a/ui/webui/test/machine_install.py
+++ b/ui/webui/test/machine_install.py
@@ -78,7 +78,7 @@ class VirtInstallMachine(VirtMachine):
                 "--noautoconsole "
                 f"--graphics vnc,listen={self.ssh_address} "
                 "--extra-args "
-                f"'inst.sshd inst.nokill inst.webui inst.updates=http://10.0.2.2:{http_port}/updates.img' "
+                f"'inst.sshd inst.nokill inst.webui.remote inst.webui inst.updates=http://10.0.2.2:{http_port}/updates.img' "
                 "--network none "
                 f"--qemu-commandline="
                 "'-netdev user,id=hostnet0,"
@@ -91,14 +91,6 @@ class VirtInstallMachine(VirtMachine):
                 f"--location {os.getcwd()}/bots/images/{self.image}"
             )
             Machine.wait_boot(self)
-
-            # For the non-remote installations cockpit-desktop is used to host the WebUI
-            # Spawn a cockpit-ws process to allow us unsafe remote access to the anaconda-webui to enable testing
-            if Machine.wait_execute(self, timeout_sec=15):
-                Machine.execute(self, command="/usr/libexec/cockpit-ws --no-tls --port 9090 --local-session=cockpit-bridge &>/dev/null &")
-            else:
-                raise Exception("Unable to reach machine {0} via ssh: {1}:{2}".format(
-                                self.label, self.ssh_address, self.ssh_port))
 
             for _ in range(30):
                 try:


### PR DESCRIPTION
Previously this was injected by the test VM runner.
However, anaconda contributors that just consume boot.isos for testing while working
on non-linux machines, can only rely on such a boot option to expose the
webui on their host's browser.