### PR TITLE
Fix the documentation of the languages attribute in packages configuration

### DIFF
--- a/pyanaconda/modules/common/structures/packages.py
+++ b/pyanaconda/modules/common/structures/packages.py
@@ -289,9 +289,10 @@ class PackagesConfigurationData(DBusData):
             all   - Do not change the default settings.
 
         In case multiple languages are specified they are separated
-        by ',' in the string returned.
+        by ':' in the string returned. See the `%_install_langs`
+        macro at https://github.com/rpm-software-management/rpm.
 
-        :return: 'none' or 'all' or a list of languages separated by ','
+        :return: 'none' or 'all' or a list of languages separated by ':'
         :rtype: str
         """
         return self._languages

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
@@ -488,7 +488,7 @@ class DNFInterfaceTestCase(unittest.TestCase):
             "weakdeps-excluded": get_variant(Bool, True),
             "missing-ignored": get_variant(Bool, True),
             "broken-ignored": get_variant(Bool, True),
-            "languages": get_variant(Str, "en,es"),
+            "languages": get_variant(Str, "en:es"),
             "multilib-policy": get_variant(Str, MULTILIB_POLICY_ALL),
             "timeout": get_variant(Int, 10),
             "retries": get_variant(Int, 5),

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
@@ -81,11 +81,11 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.payloads.payload.dnf.installation.rpm")
     def test_set_rpm_macros_install_langs(self, mock_rpm):
         data = PackagesConfigurationData()
-        data.languages = "en,es"
+        data.languages = "en:es"
 
         macros = [
             ('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}'),
-            ('_install_langs', 'en,es'),
+            ('_install_langs', 'en:es'),
         ]
 
         task = self._run_task(data)


### PR DESCRIPTION
Multiple languages should be specified by "a colon separated list of desired
locales". Fix the documentation and examples in the unit tests.

See: https://github.com/rpm-software-management/rpm/blob/master/macros.in

Related: rhbz#2066784