### PR TITLE
Enable fingerprint authentication using enable-feature

### DIFF
--- a/pyanaconda/modules/security/installation.py
+++ b/pyanaconda/modules/security/installation.py
@@ -415,7 +415,7 @@ class ConfigureFingerprintAuthTask(Task):
         log.debug("Enabling fingerprint authentication.")
         run_auth_tool(
             AUTHSELECT_TOOL_PATH,
-            ["select", "sssd", "with-fingerprint", "with-silent-lastlog", "--force"],
+            ["enable-feature", "with-fingerprint"],
             self._sysroot,
             required=False
         )

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
@@ -788,7 +788,7 @@ class SecurityTasksTestCase(unittest.TestCase):
             task.run()
             execWithRedirect.assert_called_once_with(
                 AUTHSELECT_TOOL_PATH,
-                ["select", "sssd", "with-fingerprint", "with-silent-lastlog", "--force"],
+                ["enable-feature", "with-fingerprint"],
                 root=sysroot
             )
             os.remove(pam_so_path)
@@ -805,7 +805,7 @@ class SecurityTasksTestCase(unittest.TestCase):
             task.run()
             execWithRedirect.assert_called_once_with(
                 AUTHSELECT_TOOL_PATH,
-                ["select", "sssd", "with-fingerprint", "with-silent-lastlog", "--force"],
+                ["enable-feature", "with-fingerprint"],
                 root=sysroot
             )
             os.remove(pam_so_64_path)


### PR DESCRIPTION
Don't select a profile to enable fingerprint authentication. Call `enable-feature`
to enable the `with-fingerprint` feature in the currently selected profile instead.

Related: rhbz#2056927
Resolves: rhbz#2069899