### PR TITLE
Run restorecon in chroot when handling home dirs

### DIFF
--- a/pyanaconda/core/users.py
+++ b/pyanaconda/core/users.py
@@ -327,7 +327,8 @@ def _reown_homedir(root, homedir, username):
                                         from_ids, to_ids, root + homedir])
 
         # Restore also SELinux contexts
-        util.execWithRedirect("restorecon", ["-r", root + homedir])
+        util.restorecon([homedir], root=root)
+
     except OSError as e:
         log.critical("Unable to change owner of existing home directory: %s", e.strerror)
         raise
@@ -561,4 +562,4 @@ def set_user_ssh_key(username, key, root=None):
     # Only change ownership if we created it
     if not authfile_existed:
         os.chown(authfile, int(uid), int(gid))
-        util.execWithRedirect("restorecon", ["-r", sshdir])
+        util.restorecon([sshdir.removeprefix(root)], root=root)

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1013,3 +1013,26 @@ def get_os_release_value(name, sysroot="/"):
     # No value found.
     log.debug("%s not found in os-release files", name[:-1])
     return None
+
+
+def restorecon(paths, root, skip_nonexistent=False):
+    """Try to restore contexts for a list of paths.
+
+    Do not fail if the program does not exist because it was not in the payload, just say so.
+
+    :param [str] paths: list of paths to restore
+    :param str root: root to run in; mandatory because we restore contexts only on the new system
+    :param bool skip_nonexistent: optionally, do not fail if some of the paths do not exist
+    :return bool: did anything run at all
+    """
+    if skip_nonexistent:
+        opts = ["-ir"]
+    else:
+        opts = ["-r"]
+
+    try:
+        execWithRedirect("restorecon", opts + paths, root=root)
+    except FileNotFoundError:
+        return False
+    else:
+        return True

--- a/tests/unit_tests/pyanaconda_tests/core/test_util.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_util.py
@@ -720,6 +720,29 @@ class MiscTests(unittest.TestCase):
         mock_open.return_value = StringIO(dedent(cpu_info))
         assert util.is_lpae_available() is True
 
+    @patch("pyanaconda.core.util.execWithRedirect")
+    def test_restorecon(self, exec_mock):
+        """Test restorecon helper normal function"""
+        # default behavior
+        assert util.restorecon(["foo"], root="/root")
+        exec_mock.assert_called_once_with("restorecon", ["-r", "foo"], root="/root")
+
+        # also skip
+        exec_mock.reset_mock()
+        assert util.restorecon(["bar"], root="/root", skip_nonexistent=True)
+        exec_mock.assert_called_once_with("restorecon", ["-ir", "bar"], root="/root")
+
+        # explicitly don't skip
+        exec_mock.reset_mock()
+        assert util.restorecon(["bar"], root="/root", skip_nonexistent=False)
+        exec_mock.assert_called_once_with("restorecon", ["-r", "bar"], root="/root")
+
+        # missing restorecon
+        exec_mock.reset_mock()
+        exec_mock.side_effect = FileNotFoundError
+        assert not util.restorecon(["baz"], root="/root")
+        exec_mock.assert_called_once_with("restorecon", ["-r", "baz"], root="/root")
+
 
 class LazyObjectTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Running `restorecon` needs chroot to sysroot so as to have correct absolute paths. At the point when users are handled, payload has been already installed, so the SELinux policy is already present and we can just do it.

Related: [rhbz#2069305](https://bugzilla.redhat.com/show_bug.cgi?id=2069305) - to be ported for that, eventually. Note that some parts of this change require Python 3.9+, so this can't be ported 1:1 to RHEL 8 where the problem has been originally reported.
