### PR TITLE
webui: tests: add support for adding a second disk to the test VM

### DIFF
--- a/ui/webui/src/apis/storage.js
+++ b/ui/webui/src/apis/storage.js
@@ -135,6 +135,14 @@ export const partitioningConfigureWithTask = ({ partitioning }) => {
     );
 };
 
+export const resetPartitioning = () => {
+    return new StorageClient().client.call(
+        "/org/fedoraproject/Anaconda/Modules/Storage",
+        "org.fedoraproject.Anaconda.Modules.Storage",
+        "ResetPartitioning", []
+    );
+};
+
 /**
  * @param {string} task         DBus path to a task
  * @param {string} onSuccess    Callback to run after Succeeded signal is received
@@ -155,6 +163,17 @@ export const runStorageTask = ({ task, onSuccess, onFail }) => {
         addEventListeners();
         taskProxy.Start().catch(onFail);
     });
+};
+
+/**
+ * @returns {Promise}           Resolves a DBus path to a task
+ */
+export const scanDevicesWithTask = () => {
+    return new StorageClient().client.call(
+        "/org/fedoraproject/Anaconda/Modules/Storage",
+        "org.fedoraproject.Anaconda.Modules.Storage",
+        "ScanDevicesWithTask", []
+    );
 };
 
 /**

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -53,5 +53,36 @@ class TestStorage(MachineCase):
         b.wait_js_cond('window.location.hash === "#/installation-destination"')
         b.wait_visible("#installation-destination.pf-m-current")
 
+# We can't run this test case on an existing machine,
+# with --machine because MachineCase is not aware of add_disk method
+class TestStorageExtraDisks(MachineCase):
+    MachineCase.machine_class = VirtInstallMachine
+
+    def testLocalDisksSyncNew(self):
+        b = self.browser
+        m = self.machine
+        i = Installer(b)
+
+        # This attaches a disk to the running VM
+        # However, since the storage module initialization is long completed
+        # the newly added disk, will not be visible in the UI,
+        # until the test clicks on the re-scan button
+        m.add_disk(2)
+
+        i.open()
+
+        i.next()
+        b.expect_load()
+
+        b.wait_visible("#vda")
+        b.wait_not_present("#vdb")
+
+        b.click("#rescan-disks")
+        b.wait_visible("#vda")
+        b.wait_visible("#vdb")
+
+        self.assertEqual(b.get_checked("#vda input"), False)
+        self.assertEqual(b.get_checked("#vdb input"), False)
+
 if __name__ == '__main__':
     test_main()

--- a/ui/webui/test/machine_install.py
+++ b/ui/webui/test/machine_install.py
@@ -113,3 +113,9 @@ class VirtInstallMachine(VirtMachine):
         )
         if self.http_server:
             self.http_server.kill()
+
+    def add_disk(self, size=2):
+        image = f"/var/tmp/disk-{self.label}.qcow2"
+
+        self._execute(f"qemu-img create -f qcow2 {image} {size}G")
+        self._execute(f"virt-xml -c qemu:///session {self.label} --update --add-device --disk {image},format=qcow2,size={size}")


### PR DESCRIPTION
    webui: add support and tests for offering more than one disks in the UI
    
    This commit adds add_disk method to the machine_install script.
    Machine.add_disk() is a method specific to our custom VM creation scipt and
    not part of MachineCase, and thus is not available for @nondestructive tests.
    
    This commit also fixes displaying more than one disks which was
    previously broken generally.
    
    Since the disk get's added after the anaconda initialization is
    finished, we also added a 'disks rescan' button in the UI, as
    implemented in the mockups, to allow us re-scan available disks.
    
    Note: This commit can be used as a reference to also add other device types on
    request to the test VM.

![Screen Shot 2022-03-31 at 17 26 29](https://user-images.githubusercontent.com/14921356/161103836-0edb97a5-f73e-4db2-b4f2-d2fa8c8ff8f5.png)
