### PR TITLE
webui: add title and icon to the empty-state component in the installation progress

### DIFF
--- a/ui/webui/src/components/installation/InstallationProgress.jsx
+++ b/ui/webui/src/components/installation/InstallationProgress.jsx
@@ -20,9 +20,11 @@ import React from "react";
 
 import {
     Bullseye, Button,
-    EmptyState, EmptyStateBody, EmptyStateSecondaryActions,
-    Progress
+    Progress,
+    Text,
 } from "@patternfly/react-core";
+import { CheckCircleIcon, ExclamationCircleIcon } from "@patternfly/react-icons";
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import { AddressContext } from "../Common.jsx";
 
@@ -81,26 +83,43 @@ export class InstallationProgress extends React.Component {
 
         if (steps === undefined) { return null }
 
+        let icon;
+        let title;
+        if (status === "success") {
+            icon = CheckCircleIcon;
+            title = _("Installed");
+        } else if (status === "danger") {
+            icon = ExclamationCircleIcon;
+            title = _("Installation failed");
+        } else {
+            title = _("Installing");
+        }
+
         return (
-            <Bullseye>
-                <EmptyState variant="large">
-                    <EmptyStateBody>
-                        <Progress
-                          id="installation-progress"
-                          label={cockpit.format("$0 of $1", step, steps)}
-                          max={steps}
-                          min={0}
-                          title={message}
-                          value={step}
-                          valueText={cockpit.format("$0 of $1", step, steps)}
-                          variant={status}
-                        />
-                    </EmptyStateBody>
-                    {status === "success" &&
-                    <EmptyStateSecondaryActions>
-                        <Button onClick={exitGui}>{_("Reboot")}</Button>
-                    </EmptyStateSecondaryActions>}
-                </EmptyState>
+            <Bullseye className={"installation-progress-status-" + status}>
+                <EmptyStatePanel
+                  icon={icon}
+                  loading={!icon}
+                  paragraph={
+                      status !== "success"
+                          ? <Progress
+                              id="installation-progress"
+                              label={cockpit.format("$0 of $1", step, steps)}
+                              max={steps}
+                              min={0}
+                              title={message}
+                              value={step}
+                              valueText={cockpit.format("$0 of $1", step, steps)}
+                              variant={status}
+                          />
+                          : <Text>{_("Fedora is successfully installed. To begin using it, reboot your system.")}</Text>
+                  }
+                  secondary={
+                      status === "success" &&
+                      <Button onClick={exitGui}>{_("Reboot")}</Button>
+                  }
+                  title={title}
+                />
             </Bullseye>
         );
     }

--- a/ui/webui/src/components/installation/InstallationProgress.scss
+++ b/ui/webui/src/components/installation/InstallationProgress.scss
@@ -4,3 +4,13 @@
         text-align: left;
     }
 }
+
+.installation-progress-status {
+    &-success svg {
+        color: var(--pf-global--success-color--100);
+    }
+
+    &-danger svg {
+        color: var(--pf-global--danger-color--100);
+    }
+}


### PR DESCRIPTION
Previously we where using Patternfly's 'EmptyState' component. This
commit moves to using 'EmptyStatePanel' wrapper component from cockpit's
component library. This results in slightly cleaner code.

As per mockups, we now show different icons per installation status.

For coloring the used icons, which are by default black, we use classes
of global patternfly colors (see scss file).

![Screen Shot 2022-04-01 at 10 52 17](https://user-images.githubusercontent.com/14921356/161231871-2115d4f8-1664-4cb1-bdba-cf3c6386c1f4.png)
![Screen Shot 2022-04-01 at 10 52 06](https://user-images.githubusercontent.com/14921356/161231879-9038645d-fd07-489a-be6e-d7587d3fd0d0.png)
![Screen Shot 2022-04-01 at 10 51 13](https://user-images.githubusercontent.com/14921356/161231881-ac850364-a347-435a-a63f-d8876b796fc5.png)
