### PR TITLE
webui: tests: add missing machine_class to the check-language

### DIFF
--- a/ui/webui/test/check-language
+++ b/ui/webui/test/check-language
@@ -27,12 +27,14 @@ sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 from installer import Installer
 from language import Language
 from testlib import MachineCase, nondestructive, test_main  # pylint: disable=import-error
+from machine_install import VirtInstallMachine
 
 LOCALIZATION_INTERFACE = "org.fedoraproject.Anaconda.Modules.Localization"
 LOCALIZATION_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Localization"
 
 @nondestructive
 class TestLanguage(MachineCase):
+    MachineCase.machine_class = VirtInstallMachine
 
     def testLanguageSwitching(self):
         b = self.browser


### PR DESCRIPTION
machine_class essentially tells the VM setUp which script to use for
creating the test VM.

Therefore, this is not used when running the tests with --machine
--browser.

It's however used when we run the test with expecting it to create
its own VM, for example:

TEST_OS=fedora-rawhide-boot test/check-language  -st