### PR TITLE
webui: tests: introduce webui code coverage

### DIFF
--- a/ui/webui/.gitignore
+++ b/ui/webui/.gitignore
@@ -3,3 +3,5 @@ src/lib
 node_modules/
 package-lock.json
 /test/images
+/lcov/
+/Coverage

--- a/ui/webui/Makefile.am
+++ b/ui/webui/Makefile.am
@@ -81,12 +81,13 @@ $(UPDATES_IMG):
 	test/prepare-updates-img
 
 integration-test: bots test/common $(UPDATES_IMG)
-	test/run-tests
+	test/run-tests --coverage
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest release, and update it from time to time
+# FIXME: workaround for including code coverage support, not yet contained in a released cockpit version
 test/common:
-	git clone -b 266 --depth=1 https://github.com/cockpit-project/cockpit.git tmp/cockpit
+	git clone -b main --depth=1 https://github.com/cockpit-project/cockpit.git tmp/cockpit
 	mv tmp/cockpit/test/common test/common
 	rm -rf tmp/cockpit
 

--- a/ui/webui/test/run-tests
+++ b/ui/webui/test/run-tests
@@ -180,6 +180,8 @@ def build_command(filename, test, opts):
         cmd.append("--nonet")
     if opts.list:
         cmd.append("-l")
+    if opts.coverage:
+        cmd.append("--coverage")
     cmd.append(test)
     return cmd
 
@@ -197,6 +199,10 @@ class GlobalMachine:
 
 
 def run(opts, image):
+    if opts.coverage:
+        # This gives us a convenient link at the top of the logs, see link-patterns.json
+        print("Code coverage report in Coverage")
+
     # Build the list of tests we'll parallelize and the ones we'll run serially
     test_loader = unittest.TestLoader()
     parallel_tests = []
@@ -398,6 +404,17 @@ def run(opts, image):
         # Sleep if we didn't make progress
         if not made_progress and not opts.list:
             time.sleep(0.5)
+
+    # Create coverage report
+    if opts.coverage:
+        base_dir = os.path.realpath(f'{__file__}/../../..')
+        output = os.environ.get("TEST_ATTACHMENTS", base_dir)
+        lcov_files = glob.glob(f"{base_dir}/lcov/*.info.gz")
+        if len(lcov_files) > 0:
+            try:
+                subprocess.check_call(["genhtml", "--no-function-coverage", "--output-dir", f"{output}/Coverage"] + lcov_files)
+            except subprocess.CalledProcessError as e:
+                print(f"Failed to create coverage report: {e}")
 
     if not opts.list:
         for b in batch_tests.values():


### PR DESCRIPTION
This is not ready, as we are not yet building RPMs with the NODE_ENV=developement scenario.

This will be challenging, see https://github.com/cockpit-project/cockpit-machines/pull/650/files for reference.