### PR TITLE
Don't log the output of journalctl -b

### DIFF
--- a/pyanaconda/modules/boss/installation.py
+++ b/pyanaconda/modules/boss/installation.py
@@ -150,7 +150,7 @@ class CopyLogsTask(Task):
         """Dump journal from the installation environment"""
         tempfile = "/tmp/journal.log"
         with open(tempfile, "w") as logfile:
-            execWithRedirect("journalctl", ["-b"], stdout=logfile)
+            execWithRedirect("journalctl", ["-b"], stdout=logfile, log_output=False)
         self._copy_file_to_sysroot(tempfile, join_paths(TARGET_LOG_DIR, "journal.log"))
 
     def _copy_kickstart(self):

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_copy_logs_task.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_copy_logs_task.py
@@ -69,11 +69,12 @@ class CopyLogsTaskTest(unittest.TestCase):
             call("/tmp/ks-script*.log")
         ])
         open_mock.assert_called_once_with("/tmp/journal.log", "w")
+        log_file = open_mock().__enter__.return_value
 
         exec_wr_mock.assert_has_calls([
             # Warning: Constructing the argument to the first call requires a call to one of the
             # mocks, altering its history. Any asserts about it should happen before this.
-            call("journalctl", ["-b"], stdout=open_mock().__enter__.return_value),
+            call("journalctl", ["-b"], stdout=log_file, log_output=False),
             call("restorecon", ["-ir", "/var/log/anaconda/"], root="/somewhere")
         ])
         assert exec_wr_mock.call_count == 2


### PR DESCRIPTION
Otherwise, this output is written back to journal and that complicates debugging.