### PR TITLE
Fix unit tests of the treeinfo support

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/tree_info.py
+++ b/pyanaconda/modules/payloads/payload/dnf/tree_info.py
@@ -158,6 +158,7 @@ class TreeInfoMetadata(object):
                 tree_info.load(file_path)
 
             tree_info.validate()
+            log.debug("Loaded treeinfo metadata:\n%s", tree_info.dumps())
 
             # Load the release version.
             release_version = tree_info.release.version.lower()
@@ -166,6 +167,8 @@ class TreeInfoMetadata(object):
             repo_list = []
 
             for name in tree_info.variants:
+                log.debug("Processing the '%s' variant.", name)
+
                 # Get the variant metadata.
                 data = tree_info.variants[name]
 

--- a/pyanaconda/modules/payloads/payload/dnf/tree_info.py
+++ b/pyanaconda/modules/payloads/payload/dnf/tree_info.py
@@ -332,8 +332,8 @@ class TreeInfoMetadata(object):
         repo_md = self._get_base_repository()
 
         if repo_md:
-            log.debug("The treeinfo defines a base repository at: %s", repo_md.path)
-            return repo_md.path
+            log.debug("The treeinfo defines a base repository at: %s", repo_md.absolute_path)
+            return repo_md.absolute_path
 
         log.debug("No base repository found in the treeinfo. Using installation tree root.")
         return self._root_path
@@ -375,6 +375,10 @@ class TreeInfoRepoMetadata(object):
         self._type = tree_info.type
         self._root_path = root_path
         self._relative_path = tree_info.paths.repository
+        self._absolute_path = self._get_absolute_path(
+            root_path=root_path,
+            relative_path=self._relative_path
+        )
 
     @property
     def type(self):
@@ -403,7 +407,7 @@ class TreeInfoRepoMetadata(object):
 
         :return: True or False
         """
-        return os.access(os.path.join(self.path, "repodata"), os.R_OK)
+        return os.access(os.path.join(self.absolute_path, "repodata"), os.R_OK)
 
     @property
     def relative_path(self):
@@ -411,13 +415,18 @@ class TreeInfoRepoMetadata(object):
         return self._relative_path
 
     @property
-    def path(self):
+    def absolute_path(self):
         """Absolute path of the repository."""
-        if self._relative_path == ".":
-            return self._root_path
+        return self._absolute_path
+
+    @staticmethod
+    def _get_absolute_path(root_path, relative_path):
+        """Get the absolute path of the repository."""
+        if relative_path == ".":
+            return root_path
 
         # Create the absolute path.
-        full_path = os.path.join(self._root_path, self._relative_path)
+        full_path = os.path.join(root_path, relative_path)
         protocol, url = split_protocol(full_path)
 
         # Normalize the URL to solve problems with a relative path.

--- a/pyanaconda/modules/payloads/payload/dnf/tree_info.py
+++ b/pyanaconda/modules/payloads/payload/dnf/tree_info.py
@@ -163,7 +163,8 @@ class TreeInfoMetadata(object):
             # Load the release version.
             release_version = tree_info.release.version.lower()
 
-            # Load the repositories.
+            # Create repositories for variants and optional variants.
+            # Child variants (like addons) will be ignored.
             repo_list = []
 
             for name in tree_info.variants:

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -765,7 +765,7 @@ class DNFPayload(Payload):
             existing_urls.append(baseurl)
 
         for repo_md in tree_info_metadata.repositories:
-            if repo_md.path in existing_urls:
+            if repo_md.absolute_path in existing_urls:
                 continue
 
             # disable repositories disabled by user manually before
@@ -774,7 +774,7 @@ class DNFPayload(Payload):
 
             repo = RepoData(
                 name=repo_md.name,
-                baseurl=repo_md.path,
+                baseurl=repo_md.absolute_path,
                 noverifyssl=not data.ssl_verification_enabled,
                 proxy=data.proxy,
                 sslcacert=data.ssl_configuration.ca_cert_path,

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_tree_info.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_tree_info.py
@@ -212,18 +212,18 @@ class TreeInfoMetadataTestCase(unittest.TestCase):
 
         repo_md = self.metadata.repositories[0]
         assert repo_md.relative_path == "."
-        assert repo_md.path == root_path
+        assert repo_md.absolute_path == root_path
 
         self._load_treeinfo(TREE_INFO_RHEL)
         assert len(self.metadata.repositories) == 2
 
         repo_md = self.metadata.repositories[0]
         assert repo_md.relative_path == "../appstream"
-        assert repo_md.path == "/tmp/appstream"
+        assert repo_md.absolute_path == "/tmp/appstream"
 
         repo_md = self.metadata.repositories[1]
         assert repo_md.relative_path == "../baseos"
-        assert repo_md.path == "/tmp/baseos"
+        assert repo_md.absolute_path == "/tmp/baseos"
 
     @patch("pyanaconda.modules.payloads.payload.dnf.tree_info.conf")
     def test_enabled_repo(self, mock_conf):


### PR DESCRIPTION
* Define a valid addon variant in the tested .treeinfo example.
* Update and extend unit tests of the treeinfo support.
* Document why the addon variant is not processed.