### PR TITLE
Fix `make dist` with parallel build

### DIFF
--- a/ui/webui/Makefile.am
+++ b/ui/webui/Makefile.am
@@ -31,6 +31,9 @@ UPDATES_IMG=../../updates.img
 
 export TEST_OS
 
+# we ship built files in dist/
+distdir: $(WEBPACK_TEST)
+
 dist_libexec_SCRIPTS = webui-desktop
 # makes sure it gets built as part of `make` and `make dist`
 dist_noinst_DATA = \


### PR DESCRIPTION
`make dist` (and hence also `make rpms` and friends) fails with parallel
make, either with `make -j4` directly, or by having `MAKEFLAGS=-j4` set:

    NODE_ENV=production /var/home/martin/upstream/anaconda/ui/webui/node_modules/.bin/webpack
    make[6]: *** No rule to make target 'dist', needed by 'distdir-am'.  Stop.

As we dist built files, add a dependency for dist to the built webpack,
so that make waits for it to finish building before collecting the files
for the tarball.

---

Reproducer: `rm -rf ui/webui/dist/; make -j4 dist`