### PR TITLE
Don't set the global domain to `anaconda`

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -269,7 +269,6 @@ if __name__ == "__main__":
 
     from pyanaconda.anaconda import Anaconda
     anaconda = Anaconda()
-    util.setup_translations()
 
     # reset python's default SIGINT handler
     signal.signal(signal.SIGINT, signal.SIG_IGN)

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -24,7 +24,6 @@ import subprocess
 # Used for ascii_lowercase, ascii_uppercase constants
 import tempfile
 import re
-import gettext
 import signal
 import sys
 import types
@@ -511,10 +510,6 @@ def reIPL(ipldev):
         log.info("reIPL configuration failed")
     else:
         log.info("reIPL configuration successful")
-
-
-def setup_translations():
-    gettext.textdomain("anaconda")
 
 
 def dracut_eject(device):


### PR DESCRIPTION
* We always specify the domain when we call gettext functions.
* The domain is later changed by pykickstart to `pykickstart` anyway.

See: https://github.com/pykickstart/pykickstart/issues/405