### PR TITLE
Don't set LC_ALL for live installations

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -125,12 +125,6 @@ if [ -n "$UPDATES" ]; then
 
 fi
 
-if [ -z "$LC_ALL" ]; then
-    # LC_ALL not set, set it to $LANG to make Python's default encoding
-    # detection work
-    export LC_ALL=$LANG
-fi
-
 # Force the X11 backend since sudo and wayland do not mix
 export GDK_BACKEND=x11
 


### PR DESCRIPTION
The commit 4d686f1 was created as a fix for the bug 1169019. However, the fix
was rejected and the commit was supposed to be reverted (see the comment 37).

`LC_ALL` takes precedence over `LANG` during translations. Anaconda eventually
removes `LC_ALL` from its environment to get the expected translations, but
it might still affect processes started before that (see the bug 2071098).

Related: rhbz#2071098