### PR TITLE
webui: Use ProgressStepper on the installation progress screen

### DIFF
--- a/ui/webui/package.json
+++ b/ui/webui/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@patternfly/patternfly": "4.183.1",
     "@patternfly/react-core": "4.198.19",
+    "@patternfly/react-log-viewer": "^4.43.19",
     "@patternfly/react-table": "^4.67.19",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -109,7 +109,6 @@ export const AnacondaWizard = ({ onAddErrorNotification, title }) => {
         {
             component: InstallationProgress,
             id: "installation-progress",
-            label: _("Installation progress"),
         }
     ];
 

--- a/ui/webui/src/components/installation/InstallationProgress.jsx
+++ b/ui/webui/src/components/installation/InstallationProgress.jsx
@@ -19,12 +19,14 @@ import cockpit from "cockpit";
 import React from "react";
 
 import {
-    Button, Flex,
+    Button,
+    ExpandableSection,
+    Flex,
     ProgressStepper, ProgressStep,
-    Text, TextVariants,
-    TextContent,
 } from "@patternfly/react-core";
 import { CheckCircleIcon, ExclamationCircleIcon } from "@patternfly/react-icons";
+import { LogViewer } from "@patternfly/react-log-viewer";
+
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import { AddressContext } from "../Common.jsx";
@@ -40,7 +42,8 @@ const _ = cockpit.gettext;
 export class InstallationProgress extends React.Component {
     constructor (props) {
         super(props);
-        this.state = {};
+        this.state = { messages: [], logsExpanded: false };
+        this.logViewerRef = React.createRef();
     }
 
     componentDidMount () {
@@ -77,7 +80,11 @@ export class InstallationProgress extends React.Component {
                             } else if (step >= 12) {
                                 this.setState({ currentProgressStep: 3 });
                             }
-                            this.setState({ message, step });
+                            if (message) {
+                                this.setState(state => ({ messages: [...state.messages, message], step }));
+                            } else {
+                                this.setState({ step });
+                            }
                         });
                         taskProxy.addEventListener("Failed", () => {
                             this.setState({ status: "danger" });
@@ -98,7 +105,7 @@ export class InstallationProgress extends React.Component {
 
     render () {
         const idPrefix = this.props.idPrefix;
-        const { steps, currentProgressStep, status, message } = this.state;
+        const { steps, currentProgressStep, status, messages } = this.state;
 
         const progressSteps = [
             { title: _("Storage configuration"), id: "installation-progress-step-storage" },
@@ -153,14 +160,19 @@ export class InstallationProgress extends React.Component {
                                   );
                               })}
                           </ProgressStepper>
-                          <TextContent>
-                              <Text
-                                component={TextVariants.p}
-                                id={idPrefix + "-status-text"}
-                              >
-                                  {message}
-                              </Text>
-                          </TextContent>
+                          {/* Force-update the component on toggling by using the key as there are some rendering issues on LogViewer otherwise. */}
+                          <ExpandableSection
+                            key={this.state.logsExpanded}
+                            toggleText={this.state.logsExpanded ? _("Hide logs") : _("Show logs")}
+                            onToggle={logsExpanded => this.setState({ logsExpanded })}
+                            isExpanded={this.state.logsExpanded}
+
+                          >
+                              <LogViewer
+                                data={messages}
+                                hasLineNumbers
+                              />
+                          </ExpandableSection>
                       </Flex>
                   }
                   secondary={

--- a/ui/webui/src/components/installation/InstallationProgress.jsx
+++ b/ui/webui/src/components/installation/InstallationProgress.jsx
@@ -129,7 +129,7 @@ export class InstallationProgress extends React.Component {
         }
 
         return (
-            <div id={idPrefix + "-status-" + status}>
+            <div className={idPrefix + "-status-" + status}>
                 <EmptyStatePanel
                   icon={icon}
                   loading={!icon}

--- a/ui/webui/src/components/installation/InstallationProgress.scss
+++ b/ui/webui/src/components/installation/InstallationProgress.scss
@@ -1,9 +1,9 @@
 .installation-progress-status {
-    &-success svg {
+    &-success .pf-c-empty-state__icon {
         color: var(--pf-global--success-color--100);
     }
 
-    &-danger svg {
+    &-danger .pf-c-empty-state__icon {
         color: var(--pf-global--danger-color--100);
     }
 }

--- a/ui/webui/src/components/installation/InstallationProgress.scss
+++ b/ui/webui/src/components/installation/InstallationProgress.scss
@@ -1,10 +1,3 @@
-#installation-progress-bar {
-    .pf-c-progress__description {
-        min-width: 40ch;
-        text-align: left;
-    }
-}
-
 .installation-progress-status {
     &-success svg {
         color: var(--pf-global--success-color--100);

--- a/ui/webui/test/check-progress
+++ b/ui/webui/test/check-progress
@@ -46,11 +46,13 @@ class TestInstallationProgress(MachineCase):
             else:
                 i.begin_installation()
 
-        b.wait_visible(f"#{i.progress_id}-bar:not(.pf-m-danger)")
-        b.wait_visible(f"#{i.progress_id}-bar.pf-m-danger")
-
         b.wait_in_text(".pf-c-alert.pf-m-danger", "No such file or directory: 'systemd-machine-id-setup'")
-        b.wait_in_text(f"#{i.progress_id}-bar-description + .pf-c-progress__status", "6 of 39")
+        b.wait_in_text("#installation-progress-step-storage", "Storage configuration")
+
+        b.wait_visible("#installation-progress-step-0[aria-label='completed step'] > div:first-child")
+        b.wait_visible("#installation-progress-step-1[aria-label='completed step'] > div:first-child")
+        b.wait_visible("#installation-progress-step-2[aria-label='current step'] > div:first-child")
+        b.wait_visible("#installation-progress-step-3[aria-label='pending step'] > div:first-child")
 
         # Pixel test the failed progress step
         b.assert_pixels("#app", "installation-progress-step-fail", ignore=["#betanag-icon"])


### PR DESCRIPTION
Use the PatternFly ProgressStepper component instead of a progress bar
on the installation progress screen.

**TODO:**
- [x] remove **Installation progress** in upper left
- [x] unit tests

![TestInstallationProgress-testBasic-installation-progress-step-fail-pixels](https://user-images.githubusercontent.com/14921356/162498357-4a388108-4ab2-486e-a4df-75ddb0a2f577.png)