### PR TITLE
packit: Fix target names for builds and tests

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -35,19 +35,19 @@ jobs:
     trigger: pull_request
     metadata:
       targets:
-        - f36
+        - fedora-36
 
   - job: copr_build
     trigger: pull_request
     metadata:
       targets:
-        - f36
+        - fedora-36
 
   - job: copr_build
     trigger: commit
     metadata:
       targets:
-        - f36
+        - fedora-36
       branch: f36-devel
       owner: "@rhinstaller"
       project: Anaconda


### PR DESCRIPTION
While 'f36' is a valid value for 'dist_git_branches', the correct target
name for Fedora Linux 36 is 'fedora-36', as it is derived from 'copr-cli
list-chroots' output.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>