### PR TITLE
Fix keyboard spoke issue if Live system changed keyboard layouts (#20…

### DIFF
--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -344,12 +344,20 @@ class KeyboardSpoke(NormalSpoke):
         if flags.flags.automatedInstall and not self._seen:
             return False
 
-        # The currently activated layout is a different from the
-        # selected ones. Ignore VNC, since VNC keymaps are weird
-        # and more on the client side.
-        if not self._confirmed and not flags.flags.usevnc \
-                and self._xkl_wrapper.get_current_layout() not in self._l12_module.XLayouts:
-            return False
+        # Not confirmed by a user should we request the check?
+        if not self._confirmed:
+            # Not an issue where system keyboard configuration is not allowed
+            # This have to be before the `_xkl_wrapper.get_current_layout()` because on Wayland
+            # that call can fail in case when system has multiple layouts set.
+            if not keyboard.can_configure_keyboard():
+                return True
+
+            # Current activated layout is a different from the selected ones
+            if self._xkl_wrapper.get_current_layout() not in self._l12_module.XLayouts:
+                # Not an issue for VNC, since VNC keymaps are weird and more on the client side.
+                if flags.flags.usevnc:
+                    return True
+                return False
 
         return True
 


### PR DESCRIPTION
…72941)

Fix two issues with the keyboard configuration split on the Fedora Live on Wayland.

- Anaconda will force user to go into the keyboard spoke when system keyboard is not default ("en-US")
 
This issue is happening because Anaconda is not able to correctly read the system settings. In this case we have a check that user has to adjust keyboard configuration when system != Anaconda configuration. That is not valid anymore in case of Wayland where Anaconda is no longer able to control system keyboard configuration.

- Anaconda will crash in case the Live system has multiple keyboard layouts set and selected something else than the first one

This bug seems to be there a long time already. As before Anaconda can't read system keyboard layouts on Wayland so we are looking into the list on a position get from the system and have shorter list -> we are reading out of the list.

Both issues are solved by one shot. Move the `can_configure_keyboard()` check before this check. We can't control system layout so in this case we shouldn't really force user to check if the configuration is correct.

*Resolves: rhbz#2072941*

-------------

The question to you, do we want to have tests for this PR? It's changing code which is in general not tested and ideally we are planning to drop that.