### PR TITLE
Improve dependabot handling of the infra-check (#infra)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,10 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    commit-message:
+      prefix: "infra:"
     labels:
-      # Don't merge the pull request without #infra.
-      # TODO: Add the (#infra) suffix once supported.
       - "infrastructure"
-      - "blocked"
 
   # update our npm development dependencies monthly
   - package-ecosystem: "npm"

--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -30,13 +30,13 @@ jobs:
           git log --oneline -1 origin/${{ github.event.pull_request.base.ref }}
           git rebase origin/${{ github.event.pull_request.base.ref }}
 
-      - name: Check if all commits have (#infra)
+      - name: Check if all commits have infra postfix or prefix
         run: |
-          # match (#infra) at the end of the commit message
-          for i in "$(git log --oneline origin/${{ github.event.pull_request.base.ref }}..HEAD)"; do
+          # get commit headers of all the commits added in this PR
+          for i in "$(git log --oneline --pretty=format:%s origin/${{ github.event.pull_request.base.ref }}..HEAD)"; do
 
-            if ! [[ $i =~ \(#infra\)$ ]]; then
-              echo "$i --> Is missing (#infra!)"
+            if ! ( [[ $i =~ \(#infra\)$ ]]  || [[ $i =~ ^infra: ]] ); then
+              echo "$i --> Is missing 'infra:' prefix or '(#infra)' postfix"
               exit 1
             fi
           done


### PR DESCRIPTION
Dependabot will not allow to add your custom postfix which is required by the infra-check. Because of that we will have a failed check or we have to manually adjust the commit message.

Let's solve that by allowing `infra:` prefix in the infra-check workflow and adjust the dependabot configuration to add the prefix.

Unfortunately I'm not able to test dependabot on my fork because of rebasing issues https://github.com/jkonecny12/anaconda/pull/30 .

Tested the infra-check changes [here](https://github.com/jkonecny12/anaconda/runs/6009019318?check_suite_focus=true), [here](https://github.com/jkonecny12/anaconda/runs/6009049985?check_suite_focus=true) and [here](https://github.com/jkonecny12/anaconda/runs/6009066768?check_suite_focus=true)