### PR TITLE
Map Anaconda exceptions to org.fedoraproject.Anaconda.Error 

### DIFF
--- a/pyanaconda/core/dbus.py
+++ b/pyanaconda/core/dbus.py
@@ -73,21 +73,19 @@ class DefaultMessageBus(AnacondaMessageBus):
         return super()._find_bus_address()
 
 
+# System bus.
+SystemBus = SystemMessageBus()
+
 # The mapper of DBus errors.
 error_mapper = ErrorMapper()
-
-# Default bus. Anaconda uses this connection.
-DBus = DefaultMessageBus(
-    error_mapper=error_mapper
-)
-
-# System bus.
-SystemBus = SystemMessageBus(
-    error_mapper=error_mapper
-)
 
 # The decorator for DBus errors.
 dbus_error = get_error_decorator(error_mapper)
 
 # Register all DBus errors.
 register_errors()
+
+# Default bus. Anaconda uses this connection.
+DBus = DefaultMessageBus(
+    error_mapper=error_mapper
+)

--- a/pyanaconda/core/dbus.py
+++ b/pyanaconda/core/dbus.py
@@ -20,7 +20,7 @@ import os
 
 from dasbus.connection import SystemMessageBus, MessageBus
 from dasbus.constants import DBUS_STARTER_ADDRESS
-from dasbus.error import ErrorMapper, get_error_decorator
+from dasbus.error import ErrorMapper, get_error_decorator, AbstractErrorRule
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.constants import DBUS_ANACONDA_SESSION_ADDRESS, ANACONDA_BUS_ADDR_FILE
 from pyanaconda.modules.common.errors import register_errors
@@ -73,11 +73,49 @@ class DefaultMessageBus(AnacondaMessageBus):
         return super()._find_bus_address()
 
 
+class AnacondaErrorMapper(ErrorMapper):
+    """Map Anaconda exceptions to DBus errors."""
+
+    def reset_rules(self):
+        """Reset rules in the error mapper."""
+        super().reset_rules()
+        self.add_rule(DefaultNameErrorRule(
+            "org.fedoraproject.Anaconda.Error"
+        ))
+
+
+class DefaultNameErrorRule(AbstractErrorRule):
+    """Default rule for mapping an unknown exception to a DBus error name."""
+
+    def __init__(self, default_name):
+        """Create a new rule.
+
+        :param default_name: a default name of a DBus error
+        """
+        self._default_name = default_name
+
+    def match_type(self, exception_type):
+        """Match every Python exception raised on the server side."""
+        return True
+
+    def get_name(self, exception_type):
+        """Return a default error name for every matched exception."""
+        return self._default_name
+
+    def match_name(self, error_name):
+        """Don't apply this rule on the client side."""
+        return False
+
+    def get_type(self, error_name):
+        """There is no default error type in this rule."""
+        return None
+
+
 # System bus.
 SystemBus = SystemMessageBus()
 
 # The mapper of DBus errors.
-error_mapper = ErrorMapper()
+error_mapper = AnacondaErrorMapper()
 
 # The decorator for DBus errors.
 dbus_error = get_error_decorator(error_mapper)

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_error.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_error.py
@@ -1,0 +1,81 @@
+#
+# Copyright (C) 2022  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+
+from dasbus.error import DBusError
+from pyanaconda.core.dbus import error_mapper
+from pyanaconda.modules.common.errors.module import UnavailableModuleError
+from pyanaconda.modules.common.errors.payload import SourceSetupError
+from pyanaconda.modules.common.errors.general import AnacondaError
+
+
+class DBusErrorTestCase(unittest.TestCase):
+    """Test Anaconda DBus errors."""
+
+    def _error_to_exception(self, error_name, exception_class):
+        """Check the mapping of a DBus error to a Python exception class."""
+        assert error_mapper.get_exception_type(error_name) == exception_class
+
+    def _exception_to_error(self, exception_class, error_name):
+        """Check the mapping of a Python exception class to a DBus error."""
+        assert error_mapper.get_error_name(exception_class) == error_name
+
+    def test_unknown_error_name(self):
+        """Test mapping of an unknown DBus error."""
+        self._error_to_exception(
+            "not.known.Error",
+            DBusError
+        )
+
+    def test_default_anaconda_error(self):
+        """Test default mapping of Anaconda errors."""
+        self._exception_to_error(
+            ValueError,
+            "org.fedoraproject.Anaconda.Error"
+        )
+        self._exception_to_error(
+            OSError,
+            "org.fedoraproject.Anaconda.Error"
+        )
+        self._exception_to_error(
+            AnacondaError,
+            "org.fedoraproject.Anaconda.Error"
+        )
+        self._error_to_exception(
+            "org.fedoraproject.Anaconda.Error",
+            AnacondaError
+        )
+
+    def test_defined_anaconda_errors(self):
+        """Test defined mapping of Anaconda errors."""
+        self._exception_to_error(
+            UnavailableModuleError,
+            "org.fedoraproject.Anaconda.UnavailableModuleError"
+        )
+        self._error_to_exception(
+            "org.fedoraproject.Anaconda.UnavailableModuleError",
+            UnavailableModuleError
+        )
+        self._exception_to_error(
+            SourceSetupError,
+            "org.fedoraproject.Anaconda.Modules.Payloads.SourceSetupError"
+        )
+        self._error_to_exception(
+            "org.fedoraproject.Anaconda.Modules.Payloads.SourceSetupError",
+            SourceSetupError
+        )


### PR DESCRIPTION
Add a rule that will map unknown exceptions raised in Anaconda modules
to the `org.fedoraproject.Anaconda.Error` DBus error name.