### PR TITLE
Change default swap size for large-memory systems

### DIFF
--- a/pyanaconda/core/storage.py
+++ b/pyanaconda/core/storage.py
@@ -283,7 +283,7 @@ def suggest_swap_size(quiet=False, hibernation=False, disk_space=None):
     # swap(mem) = 2 * mem, if mem < 2 GiB
     #           = mem,     if 2 GiB <= mem < 8 GiB
     #           = mem / 2, if 8 GIB <= mem < 64 GiB
-    #           = 4 GiB,   if mem >= 64 GiB
+    #           = 32 GiB,  if mem >= 64 GiB
     if mem < Size("2 GiB"):
         swap = 2 * mem
 
@@ -294,7 +294,7 @@ def suggest_swap_size(quiet=False, hibernation=False, disk_space=None):
         swap = mem / 2
 
     else:
-        swap = Size("4 GiB")
+        swap = Size("32 GiB")
 
     if hibernation:
         if mem <= sixty_four_gib:


### PR DESCRIPTION
It doesn't make much sense to have "almost"-32 GiB of swap in systems
with "almost"-64 GiB of RAM but limit it to 4 GiB in systems with
that amount of memory or higher, so stick to that minimum value.

Signed-off-by: Pablo Mendez Hernandez <pablomh@gmail.com>