### PR TITLE
Run eslint only in dev builds or when requested

### DIFF
--- a/ui/webui/webpack.config.js
+++ b/ui/webui/webpack.config.js
@@ -23,6 +23,9 @@ const packageJson = JSON.parse(fs.readFileSync('package.json'));
 /* A standard nodejs and webpack pattern */
 const production = process.env.NODE_ENV === 'production';
 
+/* Default to disable eslint for faster production builds */
+const eslint = process.env.ESLINT ? (process.env.ESLINT !== '0') : !production;
+
 // Non-JS files which are copied verbatim to dist/
 const copy_files = [
     "./src/index.html",
@@ -32,10 +35,13 @@ const copy_files = [
 const plugins = [
     new copy({ patterns: copy_files }),
     new extract({filename: "[name].css"}),
-    new ESLintPlugin({ extensions: ["js", "jsx"] }),
     new CockpitPoPlugin({ reference_patterns: ["ui/webui/src/.*"] }),
     new CockpitRsyncPlugin({ dest: packageJson.name }),
 ];
+
+if (eslint) {
+    plugins.push(new ESLintPlugin({ extensions: ["js", "jsx"] }));
+}
 
 /* Only minimize when in production mode */
 if (production) {


### PR DESCRIPTION
This by default resolves to running it for webui's 'make rsync', but not for anaconda's 'make rpms'.

I'm not sure if order of plugins matters... Things appear to work locally as they should, though.

We should talk about invoking eslint in a more systematic way. I propose we don't want it to run for actual RPM builds (this change), we want it to run with unit tests (#4055).