### PR TITLE
webui: tests: Change handling of steps and hide selectors in methods

### DIFF
--- a/ui/webui/test/check-basic
+++ b/ui/webui/test/check-basic
@@ -51,7 +51,7 @@ class TestBasic(MachineCase):
             # we at least iterate over them to check this works as expected
             i.wait_current_page(page)
             # Do not start the installation in non-destructive tests as this performs non revertible changes
-            if page != i.review_id:
+            if page != i.steps.REVIEW:
                 i.next()
 
         # Ensure that the 'actual' UI process is running/
@@ -66,7 +66,7 @@ class TestQuit(MachineCase):
         i = Installer(b, m)
 
         i.open()
-        b.click("#installation-quit-btn")
+        i.quit()
         m.wait_poweroff()
 
 if __name__ == '__main__':

--- a/ui/webui/test/check-language
+++ b/ui/webui/test/check-language
@@ -48,7 +48,7 @@ class TestLanguage(MachineCase):
         self.addCleanup(l.select_locale, "en_US")
 
         # Expect the backend set language to be preselected and the WebUI translated
-        b.wait_val(f"#{i.welcome_id}-menu-toggle-select-typeahead", "Deutsch (Deutschland)")
+        l.check_selected_locale("Deutsch (Deutschland)")
         b.wait_in_text("h1", "Anaconda-Installationsprogramm")
 
     def testLanguageSwitching(self):
@@ -64,32 +64,33 @@ class TestLanguage(MachineCase):
         # Expect the default language - this is en at this point - adjust the test when better guess is implemented
         b.wait_in_text("h1", "Anaconda Installer")
 
-        b.wait_val(f"#{i.welcome_id}-menu-toggle-select-typeahead", "English (United States)")
+        l.check_selected_locale("English (United States)")
 
         l.clear_language_selector()
-        b.wait_visible(f".{i.welcome_id}-menu.pf-m-invalid")
+        b.wait_visible(f".{i.steps.WELCOME}-menu.pf-m-invalid")
 
         # Check that the language menu shows all menu entries when clicking the toggle button
-        b.click(f"#{i.welcome_id}-menu-toggle")
-        b.wait_visible("#English--English-")
-        b.wait_visible("#Deutsch--German-")
+        l.open_locale_options()
+        l.locale_option_visible('en_US')
+        l.locale_option_visible('de_DE')
+        l.locale_option_visible('cs_CZ')
 
         # Check filtering on English names
-        b.set_input_text(f"#{i.welcome_id}-menu-toggle-select-typeahead", "cze")
-        b.wait_not_present("#Deutsch--German-")
-        b.wait_not_present("#English--English-")
-        b.wait_visible(f"#{i.welcome_id}-option-cs_CZ")
+        l.input_locale_select('cze')
+        l.locale_option_visible('en_US', False)
+        l.locale_option_visible('de_DE', False)
+        l.locale_option_visible('cs_CZ')
 
         # Check filtering on native names
-        b.set_input_text(f"#{i.welcome_id}-menu-toggle-select-typeahead", "Deutsch")
-        b.wait_not_present("#English--English-")
-        b.wait_not_present(f"#{i.welcome_id}-option-cs_CZ")
-        b.wait_visible("#Deutsch--German-")
-        b.click(f"#{i.welcome_id}-menu-toggle")
+        l.input_locale_select('Deutsch')
+        l.locale_option_visible('en_US', False)
+        l.locale_option_visible('de_DE')
+        l.locale_option_visible('cs_CZ', False)
+        l.clear_language_selector()
 
         # Select the 'German' language
         l.select_locale("de_DE")
-        b.wait_val(f"#{i.welcome_id}-menu-toggle-select-typeahead", "Deutsch (Deutschland)")
+        l.check_selected_locale("Deutsch (Deutschland)")
 
         # Pixel test the language step
         b.assert_pixels("#app", "language-step-basic", ignore=["#betanag-icon"])

--- a/ui/webui/test/check-language
+++ b/ui/webui/test/check-language
@@ -44,7 +44,7 @@ class TestLanguage(MachineCase):
         m.execute(l.dbus_set_language_cmd("de_DE.UTF-8", bus_address))
 
         i.open()
-
+        self.addCleanup(m.execute, l.dbus_set_language_cmd("en_US.UTF-8", bus_address))
         self.addCleanup(l.select_locale, "en_US")
 
         # Expect the backend set language to be preselected and the WebUI translated

--- a/ui/webui/test/check-progress
+++ b/ui/webui/test/check-progress
@@ -41,7 +41,7 @@ class TestInstallationProgress(MachineCase):
             # with the pages basically empty of common elements (as those are provided by the top-level installer widget)
             # we at least iterate over them to check this works as expected
             i.wait_current_page(page)
-            if page != i.review_id:
+            if page != i.steps.REVIEW:
                 i.next()
             else:
                 i.begin_installation()

--- a/ui/webui/test/check-review
+++ b/ui/webui/test/check-review
@@ -26,6 +26,7 @@ sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 
 from installer import Installer
 from storage import Storage  # pylint: disable=import-error
+from review import Review
 from testlib import MachineCase, nondestructive, test_main  # pylint: disable=import-error
 from machine_install import VirtInstallMachine
 
@@ -38,6 +39,7 @@ class TestReview(MachineCase):
         m = self.machine
         i = Installer(b, m)
         s = Storage(b, m)
+        r = Review(b)
 
         i.open()
         i.next()
@@ -48,11 +50,11 @@ class TestReview(MachineCase):
         i.next()
 
         # check language is shown
-        b.wait_in_text(f"#{i.review_id}-target-system-language > .pf-c-description-list__text", "English (United States)")
+        r.check_language("English (United States)")
 
         # check selected disks are shown
-        b.wait_in_text(f"#{i.review_id}-disk-label-vda", "Local standard disk")
-        b.wait_in_text(f"#{i.review_id}-disk-description-vda", "0x1af4 (vda)")
+        r.check_disk_label("vda", "Local standard disk")
+        r.check_disk_description("vda", "0x1af4 (vda)")
 
         # Pixel test the review step
         b.assert_pixels("#app", "review-step-basic", ignore=["#betanag-icon"])
@@ -68,7 +70,7 @@ class TestReview(MachineCase):
         i.open()
 
         for _ in i.steps[:-1]:
-            if i.steps[i.get_current_page_id()] != i.review_id:
+            if i.steps[i.get_current_page_id()] != i.steps.REVIEW:
                 i.next()
             else:
                 i.begin_installation(should_fail=True, confirm_erase=False)

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -39,15 +39,13 @@ class TestStorage(MachineCase):
         s = Storage(b, self.machine)
 
         i.open()
-
         i.next()
 
         b.wait_visible('h3:contains(Local standard disks)')
 
         # Check disks table details
-        b.wait_text("#vda > th[data-label=Name]", "vda")
-        b.wait_text("#vda > td[data-label=Total]", "15 GiB")
-        b.wait_text("#vda > td[data-label=Free]", "15 GiB")
+        s.check_disk_visible("vda")
+        s.check_disk_capacity("vda", "15 GiB", "15 GiB")
 
         # Pixel test the storage step
         b.assert_pixels("#app", "storage-step-basic", ignore=["#betanag-icon", "#installation-destination-table-label"])
@@ -57,7 +55,7 @@ class TestStorage(MachineCase):
         i.next(should_fail=True)
         s.wait_no_disks()
         # Since storage configuration failed it's expected to be in the still in the storage step
-        b.wait_visible(f"#{i.storage_id}.pf-m-current")
+        b.wait_visible(f"#{i.steps.STORAGE}.pf-m-current")
 
 # We can't run this test case on an existing machine,
 # with --machine because MachineCase is not aware of add_disk method
@@ -68,6 +66,7 @@ class TestStorageExtraDisks(MachineCase):
         b = self.browser
         m = self.machine
         i = Installer(b, m)
+        s = Storage(b, m)
 
         # This attaches a disk to the running VM
         # However, since the storage module initialization is long completed
@@ -76,18 +75,17 @@ class TestStorageExtraDisks(MachineCase):
         m.add_disk(2)
 
         i.open()
-
         i.next()
 
-        b.wait_visible("#vda")
-        b.wait_not_present("#vdb")
+        s.check_disk_visible("vda")
+        s.check_disk_visible("vdb", False)
 
-        b.click(f"#{i.storage_id}-rescan-disks")
-        b.wait_visible("#vda")
-        b.wait_visible("#vdb")
+        s.rescan_disks()
+        s.check_disk_visible("vda")
+        s.check_disk_visible("vdb")
 
-        self.assertEqual(b.get_checked("#vda input"), False)
-        self.assertEqual(b.get_checked("#vdb input"), False)
+        s.check_disk_selected("vda", False)
+        s.check_disk_selected("vdb", False)
 
 if __name__ == '__main__':
     test_main()

--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -14,25 +14,32 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
+from collections import UserList
+
+
+class InstallerSteps(UserList):
+    WELCOME = "installation-language"
+    STORAGE = "installation-destination"
+    REVIEW = "installation-review"
+    PROGRESS = "installation-progress"
+    _steps_list = (WELCOME, STORAGE, REVIEW, PROGRESS)
+
+    def __init__(self, initlist=_steps_list):
+        super().__init__(initlist)
 
 
 class Installer():
-    welcome_id = "installation-language"
-    storage_id = "installation-destination"
-    review_id = "installation-review"
-    progress_id = "installation-progress"
-    steps = [welcome_id, storage_id, review_id, progress_id]
-
     def __init__(self, browser, machine):
         self.browser = browser
         self.machine = machine
+        self.steps = InstallerSteps()
 
     def begin_installation(self, should_fail=False, confirm_erase=True):
         current_step_id = self.get_current_page_id()
         self.browser.click("button:contains('Begin installation')")
 
         if confirm_erase:
-            self.browser.click(f"#{self.review_id}-disk-erase-confirm")
+            self.browser.click(f"#{self.steps.REVIEW}-disk-erase-confirm")
         else:
             self.browser.click(".pf-c-modal-box button:contains(Back)")
 
@@ -60,7 +67,7 @@ class Installer():
 
     def wait_current_page(self, page):
         self.browser.wait_js_cond(f'window.location.hash === "#/{page}"')
-        if page == self.progress_id:
+        if page == self.steps.PROGRESS:
             self.browser.wait_visible(".pf-c-progress-stepper")
         else:
             self.browser.wait_visible(f"#{page}.pf-m-current")
@@ -83,3 +90,6 @@ class Installer():
             self.browser.wait_visible("#betanag-icon")
         else:
             self.browser.wait_not_present("#betang-icon")
+
+    def quit(self):
+        self.browser.click("#installation-quit-btn")

--- a/ui/webui/test/helpers/review.py
+++ b/ui/webui/test/helpers/review.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+HELPERS_DIR = os.path.dirname(__file__)
+sys.path.append(HELPERS_DIR)
+
+from installer import InstallerSteps  # pylint: disable=import-error
+
+
+class Review():
+    def __init__(self, browser):
+        self.browser = browser
+        self._step = InstallerSteps.REVIEW
+
+    def check_language(self, lang):
+        self.browser.wait_in_text(f"#{self._step}-target-system-language > .pf-c-description-list__text", lang)
+
+    def check_disk_label(self, disk, label):
+        self.browser.wait_in_text(f"#{self._step}-disk-label-{disk}", label)
+
+    def check_disk_description(self, disk, description):
+        self.browser.wait_in_text(f"#{self._step}-disk-description-{disk}", description)


### PR DESCRIPTION
This should improve maintainability. JS selectors should not be used
directly in the unit tests. This PR moves most of them to helper
methods.