### PR TITLE
Clean up the code that adds a base repository

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -838,6 +838,20 @@ class DNFManager(object):
 
         return repo
 
+    def remove_repository(self, repo_id):
+        """Remove a repository.
+
+        Remove a repository with the specified name.
+        Do nothing if the repository doesn't exist.
+
+        :param repo_id: an identifier of a repository
+        """
+        with self._lock:
+            if repo_id in self._base.repos:
+                self._base.repos.pop(repo_id)
+
+        log.info("Removed the '%s' repository.", repo_id)
+
     def generate_repo_file(self, data: RepoConfigurationData):
         """Generate a content of the .repo file.
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
@@ -1196,6 +1196,24 @@ class DNFManagerReposTestCase(unittest.TestCase):
             "baseurl = http://u2",
         ])
 
+    def test_remove_repository(self):
+        """Test the remove_repository method."""
+        assert self.dnf_manager.repositories == []
+
+        self._add_repo("r1")
+        self._add_repo("r2")
+
+        assert self.dnf_manager.repositories == ["r1", "r2"]
+
+        self.dnf_manager.remove_repository("r1")
+        assert self.dnf_manager.repositories == ["r2"]
+
+        self.dnf_manager.remove_repository("r3")
+        assert self.dnf_manager.repositories == ["r2"]
+
+        self.dnf_manager.remove_repository("r2")
+        assert self.dnf_manager.repositories == []
+
     def test_generate_repo_file_baseurl(self):
         """Test the generate_repo_file method with baseurl."""
         data = RepoConfigurationData()


### PR DESCRIPTION
Call the `_add_base_repository` method of the DNF payload class to set up a base repository.