### PR TITLE
Clean up the code that includes additional repositories

### DIFF
--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -571,12 +571,10 @@ class DNFPayload(Payload):
         if source_type not in SOURCE_REPO_FILE_TYPES:
             try:
                 self._add_base_repository()
-            except DNFManagerError:
+            except DNFManagerError as e:
+                # Fail if the fallback is not enabled.
                 if not fallback:
-                    with self._repos_lock:
-                        for repo in self._base.repos.iter_enabled():
-                            self._set_repo_enabled(repo.id, False)
-                    return
+                    raise e
 
                 # Fallback to the default source
                 #


### PR DESCRIPTION
Clean up the code that includes additional repositories:

* Remove the `_add_repo_to_dnf` method.
* Simplify the `_include_additional_repositories` method.
* Reorganize checks of invalid repo configurations.

If a base repository is invalid and the fallback to a default source is not 
enabled, raise an exception and stop the payload restart with an error.