### PR TITLE
Add new dependency to our container required by copr from pip (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -12,6 +12,8 @@ RUN echo dnf update -y && \
   /usr/bin/xargs \
   rpm-build \
   e2fsprogs \
+  # the krb5-config binary is required for copr pip installation
+  krb5-devel \
   git \
   bzip2 \
   cppcheck \


### PR DESCRIPTION
Without this the pip install will fail.