### PR TITLE
Add the UpdatesEnabled DBus property

### DIFF
--- a/pyanaconda/modules/common/constants/interfaces.py
+++ b/pyanaconda/modules/common/constants/interfaces.py
@@ -108,6 +108,11 @@ PAYLOAD_SOURCE_REPO_FILES = DBusInterfaceIdentifier(
     basename="RepoFiles"
 )
 
+PAYLOAD_SOURCE_CLOSEST_MIRROR = DBusInterfaceIdentifier(
+    namespace=SOURCE_NAMESPACE,
+    basename="ClosestMirror"
+)
+
 PAYLOAD_SOURCE_NFS = DBusInterfaceIdentifier(
     namespace=SOURCE_NAMESPACE,
     basename="NFS"

--- a/pyanaconda/modules/payloads/source/closest_mirror/closest_mirror.py
+++ b/pyanaconda/modules/payloads/source/closest_mirror/closest_mirror.py
@@ -18,6 +18,7 @@
 # Red Hat, Inc.
 #
 from pyanaconda.core.i18n import _
+from pyanaconda.core.signal import Signal
 from pyanaconda.modules.payloads.constants import SourceType
 from pyanaconda.modules.payloads.source.closest_mirror.closest_mirror_interface import \
     ClosestMirrorSourceInterface
@@ -29,6 +30,12 @@ log = get_module_logger(__name__)
 
 class ClosestMirrorSourceModule(RepoFilesSourceModule):
     """The source payload module for the closest mirror."""
+
+    def __init__(self):
+        """Create the module."""
+        super().__init__()
+        self._updates_enabled = True
+        self.updates_enabled_changed = Signal()
 
     def for_publication(self):
         """Get the interface used to publish this source."""
@@ -43,3 +50,20 @@ class ClosestMirrorSourceModule(RepoFilesSourceModule):
     def description(self):
         """Get description of this source."""
         return _("Closest mirror")
+
+    @property
+    def updates_enabled(self):
+        """Should repositories that provide updates be enabled?
+
+        :return: True or False
+        """
+        return self._updates_enabled
+
+    def set_updates_enabled(self, enabled):
+        """Enable or disable repositories that provide updates.
+
+        :param enabled: True to enable, False to disable
+        """
+        self._updates_enabled = enabled
+        self.updates_enabled_changed.emit()
+        log.debug("Updates enabled is set to '%s'.", enabled)

--- a/pyanaconda/modules/payloads/source/closest_mirror/closest_mirror_interface.py
+++ b/pyanaconda/modules/payloads/source/closest_mirror/closest_mirror_interface.py
@@ -17,13 +17,37 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from dasbus.server.interface import dbus_class
+from dasbus.server.interface import dbus_interface
+from dasbus.server.property import emits_properties_changed
+from dasbus.typing import Bool
+
+from pyanaconda.modules.common.constants.interfaces import PAYLOAD_SOURCE_CLOSEST_MIRROR
 from pyanaconda.modules.payloads.source.source_base_interface import PayloadSourceBaseInterface
 
 __all__ = ["ClosestMirrorSourceInterface"]
 
 
-@dbus_class
+@dbus_interface(PAYLOAD_SOURCE_CLOSEST_MIRROR.interface_name)
 class ClosestMirrorSourceInterface(PayloadSourceBaseInterface):
     """Interface for the payload source for closest mirror."""
-    pass
+
+    def connect_signals(self):
+        """Connect DBus signals."""
+        super().connect_signals()
+        self.watch_property("UpdatesEnabled", self.implementation.updates_enabled_changed)
+
+    @property
+    def UpdatesEnabled(self) -> Bool:
+        """Should repositories that provide updates be enabled?
+
+        :return: True or False
+        """
+        return self.implementation.updates_enabled
+
+    @emits_properties_changed
+    def SetUpdatesEnabled(self, enabled: Bool):
+        """Enable or disable repositories that provide updates.
+
+        :param enabled: True to enable, False to disable
+        """
+        self.implementation.set_updates_enabled(enabled)

--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -160,12 +160,13 @@ class SourceSwitchHandler(object, metaclass=ABCMeta):
 
         set_source(self.payload.proxy, hmc_source_proxy)
 
-    def set_source_closest_mirror(self):
+    def set_source_closest_mirror(self, updates_enabled=True):
         """ Switch to the closest mirror install source """
         # clean any old HDD ISO sources
         self._tear_down_existing_source()
 
         repo_files_source_proxy = create_source(constants.SOURCE_TYPE_CLOSEST_MIRROR)
+        repo_files_source_proxy.SetUpdatesEnabled(updates_enabled)
 
         set_source(self.payload.proxy, repo_files_source_proxy)
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_closest_mirror.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_closest_mirror.py
@@ -18,6 +18,9 @@
 #
 import unittest
 
+from pyanaconda.modules.common.constants.interfaces import PAYLOAD_SOURCE_CLOSEST_MIRROR
+from tests.unit_tests.pyanaconda_tests import check_dbus_property
+
 from pyanaconda.core.constants import SOURCE_TYPE_CLOSEST_MIRROR
 from pyanaconda.modules.payloads.source.closest_mirror.closest_mirror import \
     ClosestMirrorSourceModule
@@ -31,6 +34,13 @@ class ClosestMirrorSourceInterfaceTestCase(unittest.TestCase):
     def setUp(self):
         self.module = ClosestMirrorSourceModule()
         self.interface = ClosestMirrorSourceInterface(self.module)
+
+    def _check_dbus_property(self, *args, **kwargs):
+        check_dbus_property(
+            PAYLOAD_SOURCE_CLOSEST_MIRROR,
+            self.interface,
+            *args, **kwargs
+        )
 
     def test_type(self):
         """Test the type of CDN."""
@@ -46,3 +56,10 @@ class ClosestMirrorSourceInterfaceTestCase(unittest.TestCase):
 
     def test_repr(self):
         assert repr(self.module) == "Source(type='CLOSEST_MIRROR')"
+
+    def test_updates_enabled(self):
+        """Test the UpdatesEnabled property."""
+        self._check_dbus_property(
+            "UpdatesEnabled",
+            True
+        )


### PR DESCRIPTION
Use the `UpdatesEnabled` property of the Closest Mirror module to enable
or disable system repositories that provide the latest updates.