### PR TITLE
Test release daily

### DIFF
--- a/.github/workflows/try-release-daily.yml
+++ b/.github/workflows/try-release-daily.yml
@@ -1,0 +1,70 @@
+name: Try building a release daily
+# Build a release tarball for all supported branches to verify the code is releasable.
+
+on:
+  schedule:
+    - cron: 0 3 * * *
+  # be able to start this action manually from a actions tab when needed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  daily-release-test:
+    runs-on: [self-hosted, kstest]
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ['master', 'rhel-8', 'rhel-9'] # depending on season, also: fNN-release
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Build anaconda container (to make the release)
+        run: |
+          make -f Makefile.am anaconda-release-build
+
+      - name: Run the build in the container
+        run: |
+          make -f Makefile.am container-release | tee release.log
+
+      - name: Check logs for malformed translations
+        continue-on-error: true
+        run: |
+          errors=$(grep -E "Unable to compile [^:]+: .*" release.log || true)  # grep exits with 1 if no lines found
+          if [ -n "$errors" ]; then
+            echo "Failed to compile some translations:"
+            echo "$errors"
+            exit 1
+          else
+            echo "No translation compilation errors found."
+          fi
+
+      - name: Check if translation files are present in tarball
+        continue-on-error: true
+        run: |
+          tarfiles=$(tar -tf anaconda-*.tar.bz2)
+          missing=0
+          required_languages="fr ja zh_CN es pt de ru ar"
+          # Languages that are presented first in the GUI.
+          # This list comes from langtable's list_common_languages, which in turn reportedly comes
+          # from gnome-control-center's cc_common_language_get_initial_languages.
+          if [[ "${{ matrix.branch }}" == *rhel-* ]]; then
+            required_languages="$required_languages ko it zh_TW"
+            # Additionally, we test languages that are supported and translated on RHEL.
+          fi
+          for translation in $required_languages ; do
+            if ! [[ $tarfiles == */po/$translation.po* ]]; then
+              echo "missing mandatory translation: $translation"
+              missing=1
+            fi
+          done
+          if [[ "$missing" == 0 ]]; then
+            echo "All mandatory translations found: $required_languages"
+          else
+            exit 1
+          fi

--- a/docs/ci-status.rst
+++ b/docs/ci-status.rst
@@ -19,6 +19,10 @@ Anaconda
    :alt: Release from tags
    :target: https://github.com/rhinstaller/anaconda/actions/workflows/tag-release.yml
 
+.. |try-release-daily| image:: https://github.com/rhinstaller/anaconda/actions/workflows/try-release-daily.yml/badge.svg
+   :alt: Test releasing and translations daily
+   :target: https://github.com/rhinstaller/anaconda/actions/workflows/try-release-daily.yml
+
 .. _releases: https://github.com/rhinstaller/anaconda/releases
 
 |container-autoupdate|
@@ -31,6 +35,9 @@ Anaconda
 
 |tag-release|
   Creates releases_ built automatically from tagged Anaconda versions for Fedora.
+
+|try-release-daily|
+  Tests the release process daily, including checks for missing important translations
 
 Kickstart-tests
 ---------------


### PR DESCRIPTION
This would let us proactively monitor the following:
* are we able to get a release tarball using the containerized make target
* are there any translation-related failures

Revival of #4075 