### PR TITLE
Rename arguments of the `restart_thread` method

### DIFF
--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -509,7 +509,7 @@ class DNFPayload(Payload):
         """
         return self.source_type == conf.payload.default_source
 
-    def update_base_repo(self, fallback=True, checkmount=True):
+    def update_base_repo(self, fallback=True, try_media=True):
         """Update the base repository from the DBus source."""
         log.debug("Tearing down sources")
         tear_down_sources(self.proxy)
@@ -532,7 +532,7 @@ class DNFPayload(Payload):
 
         # Change the default source to CDROM if there is a valid install media.
         # FIXME: Set up the default source earlier.
-        if checkmount and self._is_source_default() and find_optical_install_media():
+        if try_media and self._is_source_default() and find_optical_install_media():
             source_type = SOURCE_TYPE_CDROM
             source_proxy = create_source(source_type)
             set_source(self.proxy, source_proxy)

--- a/pyanaconda/payload/manager.py
+++ b/pyanaconda/payload/manager.py
@@ -112,7 +112,7 @@ class PayloadManager(object):
             elif event_id <= self._thread_state:
                 func()
 
-    def restart_thread(self, payload, fallback=False, checkmount=True, onlyOnChange=False):
+    def restart_thread(self, payload, fallback=False, checkmount=True, only_on_change=False):
         """Start or restart the payload thread.
 
         This method starts a new thread to restart the payload thread, so
@@ -123,8 +123,8 @@ class PayloadManager(object):
         :param payload.Payload payload: The payload instance
         :param bool fallback: Whether to fall back to the default repo in case of error
         :param bool checkmount: Whether to check for valid mounted media
-        :param bool onlyOnChange: Restart thread only if existing repositories changed.
-                                  This won't restart thread even when a new repository was added!!
+        :param bool only_on_change: Restart thread only if existing repositories changed.
+            This won't restart thread even when a new repository was added!!
         """
         log.debug("Restarting payload thread")
 
@@ -136,7 +136,7 @@ class PayloadManager(object):
         threadMgr.add(AnacondaThread(
             name=THREAD_PAYLOAD_RESTART,
             target=self._restart_thread,
-            args=(payload, fallback, checkmount, onlyOnChange)
+            args=(payload, fallback, checkmount, only_on_change)
         ))
 
     @property
@@ -144,7 +144,7 @@ class PayloadManager(object):
         """Is the payload thread running right now?"""
         return threadMgr.exists(THREAD_PAYLOAD_RESTART) or threadMgr.exists(THREAD_PAYLOAD)
 
-    def _restart_thread(self, payload, fallback, checkmount, onlyOnChange):
+    def _restart_thread(self, payload, fallback, checkmount, only_on_change):
         # Wait for the old thread to finish
         threadMgr.wait(THREAD_PAYLOAD)
 
@@ -152,7 +152,7 @@ class PayloadManager(object):
         threadMgr.add(AnacondaThread(
             name=THREAD_PAYLOAD,
             target=self._run_thread,
-            args=(payload, fallback, checkmount, onlyOnChange)
+            args=(payload, fallback, checkmount, only_on_change)
         ))
 
     def _set_state(self, event_id):
@@ -167,7 +167,7 @@ class PayloadManager(object):
             for func in self._event_listeners[event_id]:
                 func()
 
-    def _run_thread(self, payload, fallback, checkmount, onlyOnChange):
+    def _run_thread(self, payload, fallback, checkmount, only_on_change):
         # This is the thread entry
         # Set the initial state
         self._error = None
@@ -204,7 +204,7 @@ class PayloadManager(object):
             return
 
         # Test if any repository changed from the last update
-        if onlyOnChange:
+        if only_on_change:
             log.debug("Testing repositories availability")
             self._set_state(PayloadState.VERIFYING_AVAILABILITY)
             if payload.dnf_manager.verify_repomd_hashes():

--- a/pyanaconda/payload/manager.py
+++ b/pyanaconda/payload/manager.py
@@ -112,7 +112,7 @@ class PayloadManager(object):
             elif event_id <= self._thread_state:
                 func()
 
-    def restart_thread(self, payload, fallback=False, checkmount=True, only_on_change=False):
+    def restart_thread(self, payload, fallback=False, try_media=True, only_on_change=False):
         """Start or restart the payload thread.
 
         This method starts a new thread to restart the payload thread, so
@@ -122,7 +122,7 @@ class PayloadManager(object):
 
         :param payload.Payload payload: The payload instance
         :param bool fallback: Whether to fall back to the default repo in case of error
-        :param bool checkmount: Whether to check for valid mounted media
+        :param bool try_media: Whether to check for valid mounted media
         :param bool only_on_change: Restart thread only if existing repositories changed.
             This won't restart thread even when a new repository was added!!
         """
@@ -136,7 +136,7 @@ class PayloadManager(object):
         threadMgr.add(AnacondaThread(
             name=THREAD_PAYLOAD_RESTART,
             target=self._restart_thread,
-            args=(payload, fallback, checkmount, only_on_change)
+            args=(payload, fallback, try_media, only_on_change)
         ))
 
     @property
@@ -144,7 +144,7 @@ class PayloadManager(object):
         """Is the payload thread running right now?"""
         return threadMgr.exists(THREAD_PAYLOAD_RESTART) or threadMgr.exists(THREAD_PAYLOAD)
 
-    def _restart_thread(self, payload, fallback, checkmount, only_on_change):
+    def _restart_thread(self, payload, fallback, try_media, only_on_change):
         # Wait for the old thread to finish
         threadMgr.wait(THREAD_PAYLOAD)
 
@@ -152,7 +152,7 @@ class PayloadManager(object):
         threadMgr.add(AnacondaThread(
             name=THREAD_PAYLOAD,
             target=self._run_thread,
-            args=(payload, fallback, checkmount, only_on_change)
+            args=(payload, fallback, try_media, only_on_change)
         ))
 
     def _set_state(self, event_id):
@@ -167,7 +167,7 @@ class PayloadManager(object):
             for func in self._event_listeners[event_id]:
                 func()
 
-    def _run_thread(self, payload, fallback, checkmount, only_on_change):
+    def _run_thread(self, payload, fallback, try_media, only_on_change):
         # This is the thread entry
         # Set the initial state
         self._error = None
@@ -220,7 +220,7 @@ class PayloadManager(object):
         from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManagerError
 
         try:
-            payload.update_base_repo(fallback=fallback, checkmount=checkmount)
+            payload.update_base_repo(fallback=fallback, try_media=try_media)
         except (OSError, DBusError, DNFManagerError) as e:
             log.error("Payload error: %s", e)
             self._error = self.ERROR_SETUP

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -139,7 +139,7 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         if cdn_source and not self.subscribed:
             log.debug("CDN source but no subscribtion attached - skipping payload restart.")
         elif source_changed or repo_changed or self._error:
-            payloadMgr.restart_thread(self.payload, checkmount=False)
+            payloadMgr.restart_thread(self.payload, try_media=False)
         else:
             log.debug("Nothing has changed - skipping payload restart.")
 

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1517,7 +1517,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
                 if ANACONDA_ENVIRON in anaconda_flags.environs:
                     log.debug("network spoke (apply), network configuration changed - restarting payload thread")
                     from pyanaconda.payload.manager import payloadMgr
-                    payloadMgr.restart_thread(self.payload, fallback=not anaconda_flags.automatedInstall, onlyOnChange=True)
+                    payloadMgr.restart_thread(self.payload, fallback=not anaconda_flags.automatedInstall, only_on_change=True)
                 else:
                     log.debug("network spoke (apply), network configuration changed - "
                               "skipping restart of payload thread, outside of Anaconda environment")

--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1515,17 +1515,28 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         if self.networking_changed:
             if self.payload and self.payload.needs_network:
                 if ANACONDA_ENVIRON in anaconda_flags.environs:
-                    log.debug("network spoke (apply), network configuration changed - restarting payload thread")
+                    log.debug(
+                        "network spoke (apply), network configuration changed - "
+                        "restarting payload thread"
+                    )
                     from pyanaconda.payload.manager import payloadMgr
-                    payloadMgr.restart_thread(self.payload, fallback=not anaconda_flags.automatedInstall, only_on_change=True)
+                    payloadMgr.restart_thread(
+                        payload=self.payload,
+                        fallback=not anaconda_flags.automatedInstall,
+                        only_on_change=True
+                    )
                 else:
-                    log.debug("network spoke (apply), network configuration changed - "
-                              "skipping restart of payload thread, outside of Anaconda environment")
+                    log.debug(
+                        "network spoke (apply), network configuration changed - "
+                        "skipping restart of payload thread, outside of Anaconda environment"
+                    )
             else:
-                log.debug("network spoke (apply), network configuration changed - "
-                          "skipping restart of payload thread, payload does not need network")
-        self.networking_changed = False
+                log.debug(
+                    "network spoke (apply), network configuration changed - "
+                    "skipping restart of payload thread, payload does not need network"
+                )
 
+        self.networking_changed = False
         self.network_control_box.kill_nmce(msg="leaving network spoke")
 
     @property

--- a/pyanaconda/ui/lib/subscription.py
+++ b/pyanaconda/ui/lib/subscription.py
@@ -89,7 +89,7 @@ def _do_payload_restart(payload):
     payloadMgr.restart_thread(payload,
                               fallback=False,
                               checkmount=False,
-                              onlyOnChange=False)
+                              only_on_change=False)
 
 
 def check_cdn_is_installation_source(payload):

--- a/pyanaconda/ui/lib/subscription.py
+++ b/pyanaconda/ui/lib/subscription.py
@@ -88,7 +88,7 @@ def _do_payload_restart(payload):
     # restart payload
     payloadMgr.restart_thread(payload,
                               fallback=False,
-                              checkmount=False,
+                              try_media=False,
                               only_on_change=False)
 
 

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -225,7 +225,7 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
         # clear them at this point
         self._error = False
 
-        payloadMgr.restart_thread(self.payload, checkmount=False)
+        payloadMgr.restart_thread(self.payload, try_media=False)
 
 
 class SpecifyRepoSpoke(NormalTUISpoke, SourceSwitchHandler):

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -437,7 +437,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
             self._apply = False
             if ANACONDA_ENVIRON in flags.environs:
                 from pyanaconda.payload.manager import payloadMgr
-                payloadMgr.restart_thread(self.payload, checkmount=False)
+                payloadMgr.restart_thread(self.payload, try_media=False)
 
 
 class ConfigureDeviceSpoke(NormalTUISpoke):


### PR DESCRIPTION
* Rename the `onlyOnChange` argument. Use `only_on_change` instead.
* Rename the `checkmount` argument. Use `try_media` instead.