### PR TITLE
Run an installation task to close the DNF base

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -154,13 +154,24 @@ class DNFManager(object):
         base.conf.substitutions.update_from_etc("/")
 
     def reset_base(self):
-        """Reset the DNF base."""
+        """Reset the DNF base.
+
+        * Close the current DNF base if any.
+        * Reset all attributes of the DNF manager.
+        * The new DNF base will be created on demand.
+        """
+        base = self.__base
         self.__base = None
+
+        if base is not None:
+            base.close()
+
         self._ignore_missing_packages = False
         self._ignore_broken_packages = False
         self._download_location = None
         self._md_hashes = {}
         self._enabled_system_repositories = []
+
         log.debug("The DNF base has been reset.")
 
     def configure_base(self, data: PackagesConfigurationData):

--- a/pyanaconda/modules/payloads/payload/dnf/tear_down.py
+++ b/pyanaconda/modules/payloads/payload/dnf/tear_down.py
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2022  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.modules.common.task import Task
+
+__all__ = ["ResetDNFManagerTask"]
+
+
+class ResetDNFManagerTask(Task):
+    """The task for resetting the DNF manager."""
+
+    def __init__(self, dnf_manager):
+        """Create a new task.
+
+        :param dnf_manager: a DNF manager
+        """
+        super().__init__()
+        self._dnf_manager = dnf_manager
+
+    @property
+    def name(self):
+        return "Reset the DNF manager"
+
+    def run(self):
+        """Run the task.
+
+        The reset will close all data sources used by the current DNF base.
+        """
+        self._dnf_manager.reset_base()

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_tear_down.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_tear_down.py
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2022  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+
+from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager
+from pyanaconda.modules.payloads.payload.dnf.tear_down import ResetDNFManagerTask
+
+
+class ResetDNFManagerTaskTestCase(unittest.TestCase):
+    """Test the installation task for setting the RPM macros."""
+
+    def test_reset_dnf_manager_task(self):
+        """Test the ResetDNFManagerTask task."""
+        dnf_manager = DNFManager()
+        dnf_base = dnf_manager._base
+
+        task = ResetDNFManagerTask(
+            dnf_manager=dnf_manager
+        )
+        task.run()
+
+        assert dnf_base._closed

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
@@ -79,6 +79,9 @@ class DNFManagerTestCase(unittest.TestCase):
         assert self.dnf_manager._base == base_2
         assert self.dnf_manager._base != base_1
 
+        assert base_1._closed
+        assert not base_2._closed
+
     def test_clear_cache(self):
         """Test the clear_cache method."""
         self.dnf_manager.clear_cache()


### PR DESCRIPTION
Run the `ResetDNFManagerTask` task to close all data sources used by
the DNF base during the installation.