### PR TITLE
Create self contained Web UI boot iso

### DIFF
--- a/.github/workflows/build-boot-iso.yml
+++ b/.github/workflows/build-boot-iso.yml
@@ -53,7 +53,7 @@ jobs:
     env:
        STATUS_NAME: boot-iso
        CONTAINER_TAG: 'lorax'
-       ISO_BUILD_CONTAINER_NAME: 'quay.io/rhinstaller/anaconda-iso-creator'
+       ISO_BUILD_CONTAINER_NAME: 'quay.io/rhinstaller/anaconda-iso-creator-webui'
     steps:
       # we post statuses manually as this does not run from a pull_request event
       # https://developer.github.com/v3/repos/statuses/#create-a-status
@@ -73,10 +73,10 @@ jobs:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 0
 
-      - name: Build anaconda-iso-creator container image
+      - name: Build anaconda-iso-creator-webui container image
         run: |
           # set static tag to avoid complications when looking what tag is used
-          sudo make -f ./Makefile.am anaconda-iso-creator-build CI_TAG=$CONTAINER_TAG
+          sudo make -f ./Makefile.am anaconda-iso-creator-build CI_TAG=$CONTAINER_TAG ISO_CREATOR_NAME=$ISO_BUILD_CONTAINER_NAME
 
       - name: Build anaconda-rpm container (for RPM build)
         run: |

--- a/dockerfile/anaconda-iso-creator-webui/Dockerfile
+++ b/dockerfile/anaconda-iso-creator-webui/Dockerfile
@@ -1,0 +1,49 @@
+# Dockerfile to build self-contained boot.iso with Anaconda Web UI.
+# To find out how to build this container please look on the ./tests/README.rst file.
+# This container has to be started as --privileged and with precreated loop devices otherwise
+# lorax won't work correctly.
+#
+# Execution example:
+#
+# make -f ./Makefile.am container-rpms-scratch # Create Anaconda RPM in `pwd`/result/... directory.
+# sudo make -f ./Makefile.am anaconda-iso-creator-build
+#
+# # pre-create loop devices because the container namespacing of /dev devices
+# sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
+# sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
+#
+# # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
+# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:master
+#
+# note:
+# - add `--network=slirp4netns` if you need to share network with host computer to reach
+#   repositories (VPN for example)
+#
+
+# The `image` arg will set base image for the build.
+# possible values:
+#   registry.fedoraproject.org/fedora:35
+#   registry.fedoraproject.org/fedora:rawhide
+#   registry-proxy.engineering.redhat.com/rh-osbs/ubi9:latest # private source
+#   registry.access.redhat.com/ubi8/ubi # public source
+ARG image
+FROM ${image}
+# FROM starts a new build stage with new ARGs. Put any ARGs after FROM unless required by the FROM itself.
+# see https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+LABEL maintainer=anaconda-devel@lists.fedoraproject.org
+
+# Prepare environment and install build dependencies
+RUN set -ex; \
+  dnf update -y; \
+  dnf install -y \
+  createrepo_c \
+  lorax; \
+  dnf clean all
+
+COPY ["lorax-build", "/"]
+
+RUN mkdir /lorax /anaconda-rpms /images
+
+WORKDIR /lorax
+
+ENTRYPOINT /lorax-build

--- a/dockerfile/anaconda-iso-creator-webui/lorax-build
+++ b/dockerfile/anaconda-iso-creator-webui/lorax-build
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Build a boot.iso by lorax. The boot.iso will be stored in the `/images/` directory.
+# We have to build the RPMs files of Anaconda first and then add them as volume
+# mount to /anaconda-rpms to the container (could be RO mount).
+#
+#   make -f ./Makefile.am container-rpms-scratch
+#
+# Input directory:
+# /anaconda-rpms/ (Anaconda RPM files for the build)
+#
+# Output directory:
+# /images (Where the boot.iso will be stored)
+#
+
+set -eux
+
+INPUT_RPMS=/anaconda-rpms/
+REPO_DIR=/tmp/anaconda-rpms/
+
+# create repo from provided Anaconda RPMs
+mkdir -p $REPO_DIR
+cp -a $INPUT_RPMS/* $REPO_DIR || echo "RPM files can't be copied!"  # We could just do the build with official repositories only
+createrepo_c $REPO_DIR
+
+# clone Lorax fork with modified templates, which manipulate BIOS & EFI boot options to boot into the Web UI
+git clone --branch master-webui_boot_options https://github.com/M4rtinK/lorax/ /tmp/lorax
+
+# build boot.iso with our rpms
+. /etc/os-release
+# The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; use a mirror
+# The --volid argument can cause different network interface naming: https://github.com/rhinstaller/kickstart-tests/issues/448
+lorax -p Fedora -v "$VERSION_ID" -r "$VERSION_ID" \
+      --volid Fedora-S-dvd-x86_64-rawh \
+      -s http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/ \
+      -s file://$REPO_DIR/ \
+      -s https://fedorapeople.org/groups/anaconda/repos/webui_payload_repo/ \
+      -i anaconda-webui \
+      -i webui_payload \
+      --sharedir /tmp/lorax/share/
+      --rootfs-size 5 \
+      "$@" \
+      output || cp *.log /images/
+
+cp output/images/boot.iso /images/


### PR DESCRIPTION
As we need to set quite a few Lorax options to build the self contained
Web UI boot iso, lets create a new container variant for it instead of
overloading the existing iso creator container.

The new container does a couple custom things:
- makes the rootfs 5 GB to make the payload tarball fit in
- use custom Lorax templates to set boot options
- use a repo with the payload RPM
- make sure payload RPM is installed