### PR TITLE
GUI: Ask for a missing passphrase during automated installations

### DIFF
--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -273,12 +273,30 @@ class ErrorDialog(GUIObject):
 class MainWindow(Gtk.Window):
     """This is a top-level, full size window containing the Anaconda screens."""
 
+    __instance = None
+
+    @classmethod
+    def get(cls):
+        """Get the top-level main window.
+
+        Return the latest instance of this class.
+
+        :return MainWindow: the main window
+        :raise ValueError: if the window doesn't exist
+        """
+        if not cls.__instance:
+            raise ValueError("The main window doesn't exist!")
+
+        return cls.__instance
+
     def __init__(self, fullscreen=False, decorated=False):
         """Create a new anaconda main window.
 
           :param bool fullscreen: if True, fullscreen the window, if false maximize
         """
         super().__init__()
+        # Keep the latest main window.
+        self.__class__.__instance = self
 
         # Remove the title bar, resize controls and other stuff if the window manager
         # allows it and decorated is set to False. Otherwise, it has no effect.

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -21,7 +21,7 @@ import sys
 from blivet.size import Size
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core import util, constants
-from pyanaconda.core.async_utils import async_action_nowait
+from pyanaconda.core.async_utils import async_action_nowait, async_action_wait
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import CLEAR_PARTITIONS_NONE, BOOTLOADER_ENABLED, \
     STORAGE_METADATA_RATIO, WARNING_NO_DISKS_SELECTED, WARNING_NO_DISKS_DETECTED, \
@@ -54,7 +54,7 @@ from pyanaconda.ui.helpers import StorageCheckHandler
 from pyanaconda.ui.lib.format_dasd import DasdFormatting
 from pyanaconda.ui.lib.storage import find_partitioning, apply_partitioning, \
     select_default_disks, apply_disk_selection, get_disks_summary, create_partitioning, \
-    is_local_disk, filter_disks_by_names
+    is_local_disk, filter_disks_by_names, is_passphrase_required, set_required_passphrase
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -641,6 +641,7 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         # Do not set ready in the automated installation before
         # the execute method is run.
         if flags.automatedInstall and self._is_preconfigured:
+            self._check_required_passphrase()
             self.execute()
         else:
             self._ready = True
@@ -651,6 +652,20 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
 
     def _show_dasdfmt_report(self, msg):
         hubQ.send_message(self.__class__.__name__, msg)
+
+    @async_action_wait
+    def _check_required_passphrase(self):
+        """Ask a user for a default passphrase if required."""
+        if not is_passphrase_required(self._partitioning):
+            return
+
+        dialog = PassphraseDialog(self.data)
+        rc = dialog.run()
+
+        if rc != 1:
+            return
+
+        set_required_passphrase(self._partitioning, dialog.passphrase)
 
     def _update_summary(self):
         """ Update the summary based on the UI. """

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -41,7 +41,7 @@ from pyanaconda.core.storage import suggest_swap_size
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.communication import hubQ
-from pyanaconda.ui.gui import GUIObject
+from pyanaconda.ui.gui import GUIObject, MainWindow
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.spokes.lib.cart import SelectedDisksDialog
 from pyanaconda.ui.gui.spokes.lib.dasdfmt import DasdFormatDialog
@@ -660,7 +660,13 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             return
 
         dialog = PassphraseDialog(self.data)
-        rc = dialog.run()
+
+        # Use MainWindow.get() instead of self.main_window,
+        # because the main_window property returns SpokeWindow
+        # instead of MainWindow during the initialization.
+        # We need the main window for showing the enlight box.
+        with MainWindow.get().enlightbox(dialog.window):
+            rc = dialog.run()
 
         if rc != 1:
             return

--- a/pyanaconda/ui/lib/storage.py
+++ b/pyanaconda/ui/lib/storage.py
@@ -26,7 +26,8 @@ from dasbus.client.proxy import get_object_path
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.constants import PARTITIONING_METHOD_AUTOMATIC, BOOTLOADER_DRIVE_UNSET
+from pyanaconda.core.constants import PARTITIONING_METHOD_AUTOMATIC, BOOTLOADER_DRIVE_UNSET, \
+    PARTITIONING_METHOD_CUSTOM
 from pyanaconda.core.i18n import P_, _
 from pyanaconda.errors import errorHandler as error_handler, ERROR_RAISE
 from pyanaconda.flags import flags
@@ -268,6 +269,32 @@ def try_populate_devicetree():
         else:
             # No need to retry.
             break
+
+
+def is_passphrase_required(partitioning):
+    """Is a passphrase required by the partitioning?
+
+    If the partitioning defines an encrypted device without
+    a passphrase, it is necessary to provide a passphrase
+    that will be used by all such devices.
+
+    :param partitioning: a DBus proxy of a partitioning
+    """
+    return partitioning.PartitioningMethod in (
+        PARTITIONING_METHOD_AUTOMATIC,
+        PARTITIONING_METHOD_CUSTOM
+    ) and partitioning.RequiresPassphrase()
+
+
+def set_required_passphrase(partitioning, passphrase):
+    """Set a passphrase required by the partitioning.
+
+    See the is_passphrase_required function.
+
+    :param partitioning: a DBus proxy of a partitioning
+    :param passphrase: a string with the passphrase
+    """
+    partitioning.SetPassphrase(passphrase)
 
 
 def apply_partitioning(partitioning, show_message):

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -30,7 +30,7 @@ from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.ui.categories.system import SystemCategory
 from pyanaconda.ui.lib.storage import find_partitioning, reset_storage, \
     select_default_disks, apply_disk_selection, get_disks_summary, apply_partitioning, \
-    create_partitioning, filter_disks_by_names
+    create_partitioning, filter_disks_by_names, is_passphrase_required, set_required_passphrase
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.ui.tui.tuiobject import Dialog, PasswordDialog
 from pyanaconda.core.storage import get_supported_autopart_choices
@@ -44,7 +44,7 @@ from pyanaconda.core.constants import THREAD_STORAGE, THREAD_STORAGE_WATCHER, \
     PAYLOAD_STATUS_PROBING_STORAGE, CLEAR_PARTITIONS_ALL, \
     CLEAR_PARTITIONS_LINUX, CLEAR_PARTITIONS_NONE, CLEAR_PARTITIONS_DEFAULT, \
     BOOTLOADER_LOCATION_MBR, SecretType, WARNING_NO_DISKS_DETECTED, WARNING_NO_DISKS_SELECTED, \
-    PARTITIONING_METHOD_AUTOMATIC, PARTITIONING_METHOD_CUSTOM, PARTITIONING_METHOD_MANUAL
+    PARTITIONING_METHOD_AUTOMATIC, PARTITIONING_METHOD_MANUAL
 from pyanaconda.core.i18n import _, N_, C_
 
 from simpleline.render.containers import ListColumnContainer
@@ -340,7 +340,7 @@ class StorageSpoke(NormalTUISpoke):
 
     def run_passphrase_dialog(self):
         """Ask user for a default passphrase."""
-        if not self._is_passphrase_required():
+        if not is_passphrase_required(self._partitioning):
             return
 
         dialog = PasswordDialog(
@@ -356,18 +356,7 @@ class StorageSpoke(NormalTUISpoke):
         while passphrase is None:
             passphrase = dialog.run()
 
-        self._set_required_passphrase(passphrase)
-
-    def _is_passphrase_required(self):
-        """Is the default passphrase required?"""
-        return self._partitioning.PartitioningMethod in (
-            PARTITIONING_METHOD_AUTOMATIC,
-            PARTITIONING_METHOD_CUSTOM
-        ) and self._partitioning.RequiresPassphrase()
-
-    def _set_required_passphrase(self, passphrase):
-        """Set the required passphrase."""
-        self._partitioning.SetPassphrase(passphrase)
+        set_required_passphrase(self._partitioning, passphrase)
 
     def apply(self):
         self._bootloader_module.SetPreferredLocation(BOOTLOADER_LOCATION_MBR)


### PR DESCRIPTION
If the kickstart file defines a partitioning that requires a passphrase,
show a dialog that will allow users to provide the missing passphrase.

Resolves: rhbz#2029101