### PR TITLE
Web UI: Reset the bootloader drive before we schedule partitions

### DIFF
--- a/ui/webui/src/apis/storage.js
+++ b/ui/webui/src/apis/storage.js
@@ -227,6 +227,22 @@ export const setInitializeLabelsEnabled = ({ enabled }) => {
 };
 
 /**
+ * @param {string} drive     A drive name
+ */
+export const setBootloaderDrive = ({ drive }) => {
+    return new StorageClient().client.call(
+        "/org/fedoraproject/Anaconda/Modules/Storage/Bootloader",
+        "org.freedesktop.DBus.Properties",
+        "Set",
+        [
+            "org.fedoraproject.Anaconda.Modules.Storage.Bootloader",
+            "Drive",
+            cockpit.variant("s", drive)
+        ]
+    );
+};
+
+/**
  * @param {Array.<string>} drives A list of drives names
  */
 export const setSelectedDisks = ({ drives }) => {

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -45,6 +45,7 @@ import {
     setInitializationMode,
     setInitializeLabelsEnabled,
     setSelectedDisks,
+    setBootloaderDrive,
 } from "../../apis/storage.js";
 
 const _ = cockpit.gettext;
@@ -225,6 +226,7 @@ export const applyDefaultStorage = ({ onFail, onSuccess }) => {
     // CLEAR_PARTITIONS_ALL = 1
     return setInitializationMode({ mode: 1 })
             .then(() => setInitializeLabelsEnabled({ enabled: true }))
+            .then(() => setBootloaderDrive({ drive: "" }))
             .then(() => createPartitioning({ method: "AUTOMATIC" }))
             .then(res => {
                 partitioning = res[0];


### PR DESCRIPTION
The bootloader drive is automatically set during the partitioning, so
make sure we always reset the previous value before we run another one,
so it can be automatically set again based on the current disk selection.
Otherwise, the partitioning can fail with an error.