### PR TITLE
Don't use Cockpit style overrides

### DIFF
--- a/ui/webui/src/components/app.scss
+++ b/ui/webui/src/components/app.scss
@@ -1,1 +1,0 @@
-@import 'page.scss';


### PR DESCRIPTION
Cockpit modify the PatternFly style, so let's drop it.