### PR TITLE
Open logical volume devices

### DIFF
--- a/pyanaconda/modules/storage/devicetree/model.py
+++ b/pyanaconda/modules/storage/devicetree/model.py
@@ -268,7 +268,7 @@ class InstallerStorage(Blivet):
         self.bootloader.reset()
 
         self.roots = []
-        self.roots = find_existing_installations(self.devicetree)
+        self.roots = find_existing_installations(self.devicetree, False)
         self.dump_state("initial")
 
     def _mark_protected_devices(self):


### PR DESCRIPTION
So that os-prober can recognize the system on other hard disks.
eg.
When /dev/sda has a complete system, the new system is installed on the /dev/sdb, and the grub.cfg of the /dev/sdb disk has the start menu of /dev/sda.