### PR TITLE
Prefer GPT instead of legacy MBR, even on legacy BIOS systems

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -166,8 +166,8 @@ dmraid = True
 # Enable iBFT usage during the installation.
 ibft = True
 
-# Do you prefer creation of GPT disk labels?
-gpt = False
+# Do you prefer creation of MBR disk labels on BIOS systems?
+mbr = False
 
 # Tell multipathd to use user friendly names when naming devices during the installation.
 multipath_friendly_names = True

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -146,8 +146,9 @@ but when "inst.selinux=0" is used SELinux will only be disabled in the installed
 Also note that while SELinux is running in the installation environment by default, it is
 running in permissive mode so disabling it there does not make much sense.
 
-gpt
-Prefer creation of GPT disklabels.
+mbr
+Prefer creation of MBR disklabels on legacy BIOS boot systems. Ignored on
+EFI-based systems.
 
 nodmraid
 Disable dmraid usage during the installation.

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -694,12 +694,13 @@ Disable support for dmraid.
              it has some stale RAID metadata on it which must be removed using
              an appropriate tool (dmraid and/or wipefs).
 
-.. inst.gpt:
+.. inst.mbr:
 
-inst.gpt
+inst.mbr
 ^^^^^^^^
 
-Prefer creation of GPT disklabels.
+Prefer creation of MBR disklabels on legacy BIOS boot systems. Ignored on
+EFI-based systems.
 
 
 Other options

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -533,7 +533,8 @@ def getArgumentParser(version_string, boot_cmdline=None):
                     help=help_parser.help_text("nompath"))
     ap.add_argument("--mpath", action="store_true", help=help_parser.help_text("mpath"))
 
-    ap.add_argument("--gpt", action="store_true", default=SUPPRESS, help=help_parser.help_text("gpt"))
+    ap.add_argument("--mbr", action="store_true", default=SUPPRESS,
+                    help=help_parser.help_text("mbr"))
 
     ap.add_argument("--nodmraid", dest="dmraid", action="store_false", default=True,
                     help=help_parser.help_text("nodmraid"))

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -371,8 +371,8 @@ class AnacondaConfiguration(Configuration):
         # Set the storage flags.
         self.storage._set_option("dmraid", opts.dmraid)
         self.storage._set_option("ibft", opts.ibft)
-        if hasattr(opts, "gpt"):
-            self.storage._set_option("gpt", opts.gpt)
+        if hasattr(opts, "mbr"):
+            self.storage._set_option("mbr", opts.mbr)
         self.storage._set_option("multipath_friendly_names", opts.multipath_friendly_names)
 
         # Set up the rescue mode.

--- a/pyanaconda/core/configuration/storage.py
+++ b/pyanaconda/core/configuration/storage.py
@@ -61,9 +61,9 @@ class StorageSection(Section):
         return self._get_option("ibft", bool)
 
     @property
-    def gpt(self):
-        """Do you prefer creation of GPT disk labels?"""
-        return self._get_option("gpt", bool)
+    def mbr(self):
+        """Do you prefer creation of MBR disk labels on BIOS systems?"""
+        return self._get_option("mbr", bool)
 
     @property
     def multipath_friendly_names(self):

--- a/pyanaconda/modules/storage/initialization.py
+++ b/pyanaconda/modules/storage/initialization.py
@@ -78,7 +78,7 @@ def enable_installer_mode():
 
 def _set_default_label_type():
     """Set up the default label type."""
-    if not conf.storage.gpt:
+    if not conf.storage.mbr:
         return
 
     disklabel_class = get_device_format_class("disklabel")


### PR DESCRIPTION
As part of this change, convert the `inst.gpt` flag to `inst.mbr` to
allow optionally reverting back to the previous behavior.