### PR TITLE
tests: Get list of supported LVM RAID levels from blivet

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
@@ -168,8 +168,8 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
 
     def test_get_supported_raid_levels(self):
         """Test GetSupportedRaidLevels."""
-        assert self.interface.GetSupportedRaidLevels(DEVICE_TYPE_LVM) == \
-            ['linear', 'raid1', 'raid10', 'raid4', 'raid5', 'raid6', 'striped']
+        assert self.interface.GetSupportedRaidLevels(DEVICE_TYPE_MD) == \
+            ['linear', 'raid0', 'raid1', 'raid10', 'raid4', 'raid5', 'raid6']
 
     @patch('pyanaconda.modules.storage.partitioning.interactive.utils.get_format')
     @patch('pyanaconda.modules.storage.partitioning.interactive.utils.platform', new_callable=EFI)


### PR DESCRIPTION
We are adding LVM RAID raid0 support to blivet so the harcoded
list of supported levels won't work anymore.

See https://github.com/storaged-project/blivet/pull/1047 for
details.

Note: Anaconda doesn't support LVM RAID so the Blivet change shouldn't affect it.