### PR TITLE
Inform users about the required space and the partitioning method

### DIFF
--- a/pyanaconda/modules/storage/devicetree/utils.py
+++ b/pyanaconda/modules/storage/devicetree/utils.py
@@ -19,11 +19,10 @@ import time
 import requests
 
 from blivet import udev
-from blivet.size import Size
 from blivet.errors import StorageError
 from blivet.formats import device_formats, get_format
 from blivet.formats.fs import FS
-from bytesize.bytesize import ROUND_HALF_UP
+from bytesize.bytesize import MiB, ROUND_UP
 
 from pyanaconda.core import util
 from pyanaconda.core.i18n import _
@@ -149,7 +148,7 @@ def get_required_device_size(required_space, format_class=None):
         format_class = FS.biggest_overhead_FS()
 
     device_size = format_class.get_required_size(required_space)
-    return device_size.round_to_nearest(Size("1 MiB"), ROUND_HALF_UP)
+    return device_size.round_to_nearest(MiB, ROUND_UP)
 
 
 def find_optical_media(devicetree):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -433,6 +433,14 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
     def test_get_required_device_size(self):
         """Test GetRequiredDeviceSize."""
+        assert self.interface.GetRequiredDeviceSize(0) == 0
+
+        required_size = self.interface.GetRequiredDeviceSize(Size("10 B").get_bytes())
+        assert Size("1 MiB").get_bytes() == required_size, Size(required_size)
+
+        required_size = self.interface.GetRequiredDeviceSize(Size("10 KiB").get_bytes())
+        assert Size("1 MiB").get_bytes() == required_size, Size(required_size)
+
         required_size = self.interface.GetRequiredDeviceSize(Size("1 GiB").get_bytes())
         assert Size("1280 MiB").get_bytes() == required_size, Size(required_size)
 

--- a/ui/webui/src/apis/payloads.js
+++ b/ui/webui/src/apis/payloads.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from "cockpit";
+
+export class PayloadsClient {
+    constructor (address) {
+        if (PayloadsClient.instance) {
+            return PayloadsClient.instance;
+        }
+        PayloadsClient.instance = this;
+
+        this.client = cockpit.dbus(
+            "org.fedoraproject.Anaconda.Modules.Payloads",
+            { superuser: "try", bus: "none", address }
+        );
+    }
+
+    init () {
+        this.client.addEventListener(
+            "close", () => console.error("Payloads client closed")
+        );
+    }
+}
+
+/**
+ *
+ * @returns {Promise}           Resolves the total space required by the payload
+ */
+export const getRequiredSpace = () => {
+    return new PayloadsClient().client.call(
+        "/org/fedoraproject/Anaconda/Modules/Payloads",
+        "org.fedoraproject.Anaconda.Modules.Payloads",
+        "CalculateRequiredSpace", []
+    )
+            .then(res => res[0]);
+};

--- a/ui/webui/src/apis/storage.js
+++ b/ui/webui/src/apis/storage.js
@@ -99,6 +99,20 @@ export const getDiskFreeSpace = ({ diskNames }) => {
 };
 
 /**
+ * @param {int} requiredSpace A required space in bytes
+ *
+ * @returns {Promise}           Resolves the total free space on the given disks
+ */
+export const getRequiredDeviceSize = ({ requiredSpace }) => {
+    return new StorageClient().client.call(
+        "/org/fedoraproject/Anaconda/Modules/Storage/DeviceTree",
+        "org.fedoraproject.Anaconda.Modules.Storage.DeviceTree.Viewer",
+        "GetRequiredDeviceSize", [requiredSpace]
+    )
+            .then(res => res[0]);
+};
+
+/**
  * @param {Array[string]} diskNames A list of disk names
  *
  * @returns {Promise}           Resolves the total space on the given disks

--- a/ui/webui/src/components/app.jsx
+++ b/ui/webui/src/components/app.jsx
@@ -30,6 +30,7 @@ import { AnacondaWizard } from "./AnacondaWizard.jsx";
 import { BossClient } from "../apis/boss.js";
 import { LocalizationClient } from "../apis/localization.js";
 import { StorageClient } from "../apis/storage.js";
+import { PayloadsClient } from "../apis/payloads";
 
 import { readBuildstamp, getIsFinal } from "../helpers/betanag.js";
 import { readConf } from "../helpers/conf.js";
@@ -47,6 +48,7 @@ export const Application = () => {
             const clients = [
                 new LocalizationClient(address),
                 new StorageClient(address),
+                new PayloadsClient(address),
                 new BossClient(address)
             ];
             clients.forEach(c => c.init());

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -37,6 +37,7 @@ import {
     getDeviceData,
     getDiskFreeSpace,
     getDiskTotalSpace,
+    getRequiredDeviceSize,
     getUsableDisks,
     partitioningConfigureWithTask,
     resetPartitioning,
@@ -47,6 +48,10 @@ import {
     setSelectedDisks,
     setBootloaderDrive,
 } from "../../apis/storage.js";
+
+import {
+    getRequiredSpace,
+} from "../../apis/payloads";
 
 const _ = cockpit.gettext;
 
@@ -208,10 +213,27 @@ const LocalStandardDisks = ({ idPrefix, onAddErrorNotification }) => {
 };
 
 export const InstallationDestination = ({ idPrefix, onAddErrorNotification }) => {
+    const [requiredSize, setRequiredSize] = useState(0);
+
+    useEffect(() => {
+        getRequiredSpace()
+                .then(res => {
+                    getRequiredDeviceSize({ requiredSpace: res }).then(res => {
+                        setRequiredSize(res);
+                    }, console.error);
+                }, console.error);
+    }, []);
+
     return (
         <>
             <HelperText>
-                <HelperTextItem>{_("Select the device(s) you would like to install to")}</HelperTextItem>
+                <HelperTextItem>{
+                    cockpit.format(_(
+                        "Select the device(s) to install to. The installation requires " +
+                        "$0 of available space. Storage will be automatically partitioned."
+                    ), cockpit.format_bytes(requiredSize))
+                }
+                </HelperTextItem>
             </HelperText>
             <LocalStandardDisks
               idPrefix={idPrefix}


### PR DESCRIPTION
The Installation destination screen should inform users about
the required space and the partitioning method.

The required device size shouldn't be rounded down to zero,
so always round it up to the nearest MiB.