### PR TITLE
webui: Disable "Next" button if no disks are selected

### DIFF
--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -23,6 +23,7 @@ import {
     Modal,
     ModalVariant,
     Stack,
+    Tooltip,
     Wizard,
     WizardFooter,
     WizardContextConsumer,
@@ -87,6 +88,9 @@ export const AnacondaWizard = ({ onAddErrorNotification, title }) => {
 
     const startAtStep = steps.findIndex(step => step.id === path[0]) + 1;
     const goToStep = (newStep) => {
+        // first reset validation state to default
+        setIsFormValid(true);
+
         cockpit.location.go([newStep.id]);
     };
 
@@ -95,6 +99,7 @@ export const AnacondaWizard = ({ onAddErrorNotification, title }) => {
           id="installation-wizard"
           footer={<Footer
             isFormValid={isFormValid}
+            setIsFormValid={setIsFormValid}
             setStepNotification={setStepNotification}
             isInProgress={isInProgress}
             setIsInProgress={setIsInProgress}
@@ -111,11 +116,14 @@ export const AnacondaWizard = ({ onAddErrorNotification, title }) => {
     );
 };
 
-const Footer = ({ isFormValid, setStepNotification, isInProgress, setIsInProgress }) => {
+const Footer = ({ isFormValid, setIsFormValid, setStepNotification, isInProgress, setIsInProgress }) => {
     const [nextWaitsConfirmation, setNextWaitsConfirmation] = useState(false);
     const [quitWaitsConfirmation, setQuitWaitsConfirmation] = useState(false);
 
     const goToStep = (activeStep, onNext) => {
+        // first reset validation state to default
+        setIsFormValid(true);
+
         if (activeStep.id === "installation-destination") {
             setIsInProgress(true);
 
@@ -173,6 +181,8 @@ const Footer = ({ isFormValid, setStepNotification, isInProgress, setIsInProgres
                             />}
                             <ActionList>
                                 <Button
+                                  id="installation-next-btn"
+                                  aria-describedby="next-tooltip-ref"
                                   variant="primary"
                                   isDisabled={
                                       !isFormValid ||
@@ -181,6 +191,21 @@ const Footer = ({ isFormValid, setStepNotification, isInProgress, setIsInProgres
                                   onClick={() => goToStep(activeStep, onNext)}>
                                     {nextButtonText}
                                 </Button>
+                                {activeStep.id === "installation-destination" &&
+                                    <Tooltip
+                                      id="next-tooltip-ref"
+                                      content={
+                                          <div>
+                                              {_("To continue, select the devices(s) to install to.")}
+                                          </div>
+                                      }
+                                      // Only show the tooltip on installation destination spoke that is not valid (no disks selected).
+                                      // NOTE: As PatternFly Button with isDisabled set apprently does not get any mouse events anymore,
+                                      //       we need to manually trigger the tooltip.
+                                      reference={() => document.getElementById("installation-next-btn")}
+                                      trigger="manual"
+                                      isVisible={!isFormValid}
+                                    />}
                                 <Button
                                   variant="secondary"
                                   isDisabled={isBackDisabled}

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -95,7 +95,7 @@ const selectDefaultDisks = ({ ignoredDisks, selectedDisks, usableDisks }) => {
     }
 };
 
-const LocalStandardDisks = ({ idPrefix, onAddErrorNotification }) => {
+const LocalStandardDisks = ({ idPrefix, setIsFormValid, onAddErrorNotification }) => {
     const [deviceData, setDeviceData] = useState({});
     const [disks, setDisks] = useState({});
     const [refreshCnt, setRefreshCnt] = useState(0);
@@ -140,15 +140,17 @@ const LocalStandardDisks = ({ idPrefix, onAddErrorNotification }) => {
                 }, console.error);
     }, [refreshCnt]);
 
+    const totalDisksCnt = Object.keys(disks).length;
+    const selectedDisksCnt = Object.keys(disks).filter(disk => !!disks[disk]).length;
+
     // When the selected disks change in the UI, update in the backend as well
     useEffect(() => {
+        setIsFormValid(selectedDisksCnt > 0);
+
         const selected = Object.keys(disks).filter(disk => disks[disk]);
 
         setSelectedDisks({ drives: selected }).catch(onAddErrorNotification);
-    }, [disks, onAddErrorNotification]);
-
-    const totalDisksCnt = Object.keys(disks).length;
-    const selectedDisksCnt = Object.keys(disks).filter(disk => !!disks[disk]).length;
+    }, [disks, onAddErrorNotification, selectedDisksCnt, setIsFormValid]);
 
     if (totalDisksCnt === 0) {
         return <EmptyStatePanel loading />;
@@ -256,7 +258,7 @@ const LocalStandardDisks = ({ idPrefix, onAddErrorNotification }) => {
     );
 };
 
-export const InstallationDestination = ({ idPrefix, onAddErrorNotification, stepNotification, isInProgress }) => {
+export const InstallationDestination = ({ idPrefix, setIsFormValid, onAddErrorNotification, stepNotification, isInProgress }) => {
     const [requiredSize, setRequiredSize] = useState(0);
 
     useEffect(() => {
@@ -314,6 +316,7 @@ export const InstallationDestination = ({ idPrefix, onAddErrorNotification, step
             </Alert>
             <LocalStandardDisks
               idPrefix={idPrefix}
+              setIsFormValid={setIsFormValid}
               onAddErrorNotification={onAddErrorNotification}
             />
         </AnacondaPage>

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -52,10 +52,9 @@ class TestStorage(MachineCase):
 
         # Try unselecting the single disk and expect and error
         s.select_disk("vda", False)
-        i.next(should_fail=True)
         s.wait_no_disks()
-        # Since storage configuration failed it's expected to be in the still in the storage step
-        b.wait_visible(f"#{i.steps.STORAGE}.pf-m-current")
+        # Check the next button is disabled if no disks are selected
+        i.check_next_disabled()
 
 # We can't run this test case on an existing machine,
 # with --machine because MachineCase is not aware of add_disk method

--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -62,6 +62,14 @@ class Installer():
         self.browser.click("button:contains(Next)")
         self.wait_current_page(current_page if should_fail else next_page)
 
+    def check_next_disabled(self):
+        """Check if the Next button is disabled.
+
+        :return: True if Next is enabled, False otherwise
+        :rtype: bool
+        """
+        self.browser.wait_visible("#installation-next-btn:not([aria-disabled=false]")
+
     def open(self, step="installation-language"):
         self.browser.open(f"/cockpit/@localhost/anaconda-webui/index.html#/{step}")
         self.wait_current_page(step)

--- a/ui/webui/test/helpers/storage.py
+++ b/ui/webui/test/helpers/storage.py
@@ -42,7 +42,8 @@ class Storage():
         assert self.browser.get_checked(f"#{disk} input") == selected
 
     def wait_no_disks(self):
-        self.browser.wait_in_text(".pf-c-alert.pf-m-danger.pf-m-inline", "No usable disks")
+        self.browser.wait_in_text("#next-tooltip-ref",
+                                  "To continue, select the devices(s) to install to.")
 
     def dbus_reset_partitioning(self):
         bus_address = self.machine.execute("cat /run/anaconda/bus.address")


### PR DESCRIPTION
Disable the "Next" button in the Wizard if no disks are selected
in the installation destination step.

This is using the isFormValid property, which is already used by
the language selection step.

But in this case as the installation destination step is not the first one,
we need to ale take care to reset form validation status back to default
when the step is exited.

The idea is that we always set it to default (true) in the functions
that govern step switching & each step can then do the validation
in their refresh handler (usually the useEffect() call).

As this also changes the UI workflow, adjust the unit test accordingly.