### PR TITLE
webui: Wrap Local disks heading row items in FlexItem

### DIFF
--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -150,19 +150,23 @@ const LocalStandardDisks = ({ idPrefix, onAddErrorNotification }) => {
     return (
         <>
             <Flex spaceItems={{ default: "spaceItemsLg" }}>
-                <Title headingLevel="h3" id={idPrefix + "-local-disks-title"} size="md">
-                    {_("Local standard disks")}
-                </Title>
-                <Label
-                  color="blue"
-                  id="installation-destination-table-label"
-                >
-                    {cockpit.format(
-                        cockpit.ngettext("$0 (of $1) disk selected", "$0 (of $1) disks selected", selectedDisksCnt),
-                        selectedDisksCnt,
-                        totalDisksCnt
-                    )}
-                </Label>
+                <FlexItem align={{ default: "alignLeft" }}>
+                    <Title headingLevel="h3" id={idPrefix + "-local-disks-title"} size="md">
+                        {_("Local standard disks")}
+                    </Title>
+                </FlexItem>
+                <FlexItem align={{ default: "alignLeft" }}>
+                    <Label
+                      color="blue"
+                      id="installation-destination-table-label"
+                    >
+                        {cockpit.format(
+                            cockpit.ngettext("$0 (of $1) disk selected", "$0 (of $1) disks selected", selectedDisksCnt),
+                            selectedDisksCnt,
+                            totalDisksCnt
+                        )}
+                    </Label>
+                </FlexItem>
                 <FlexItem align={{ default: "alignRight" }}>
                     <Button
                       aria-label={_("Rescan disks")}


### PR DESCRIPTION
This fixes the bunching-up of the "Local standard disks" heading and the "A (of B) disks selected" label.

I'm not sure when it appeared, but it's a regression so let's fix it.

Before:
![Screenshot from 2022-05-19 16-45-15](https://user-images.githubusercontent.com/15903878/169325489-19577b1c-ca11-46bf-90ae-bfb7f4bb16ea.png)

After:
![Screenshot from 2022-05-19 16-38-40](https://user-images.githubusercontent.com/15903878/169322989-48a75faf-d57a-4a67-9329-ab6c8782b2e0.png)
