### PR TITLE
webui: Make app/page span the whole viewport

### DIFF
--- a/ui/webui/src/components/app.scss
+++ b/ui/webui/src/components/app.scss
@@ -1,0 +1,10 @@
+// Copied from cockpit/pkg/lib/page.scss instead of including it in its entirety:
+// Let PF4 handle the scrolling through page component otherwise we might get double scrollbar
+html:not(.index-page) body {
+  overflow-y: hidden;
+
+  // Ensure UI fills the entire page (and does not run over)
+  .ct-page-fill {
+    height: 100% !important;
+  }
+}


### PR DESCRIPTION
Fixes the most visible regression after #4101 (a61ca8dd3037fd9563b2b227aaf18a58628f2fcc).