### PR TITLE
Add missing period when concatenating password error strings (#2075419)

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -236,6 +236,8 @@ SECRET_ASCII = {
 }
 PASSWORD_DONE_TWICE = N_("You will have to press <b>Done</b> twice to confirm it.")
 PASSWORD_SET = N_("Password set.")
+# TRANSLATORS: Password error message from libreport library needs to be joined with "You will have to press <b>Done</b> twice to confirm it." add a missing '.'
+PASSWORD_ERROR_CONCATENATION = N_("{}. {}")
 
 
 class SecretStatus(Enum):

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -235,8 +235,11 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
                 self.show_warning_message(error_message)
             else:
                 # add suffix for the click twice logic
-                self.show_warning_message("{} {}".format(error_message,
-                                                         _(constants.PASSWORD_DONE_TWICE)))
+                self.show_warning_message(
+                    _(constants.PASSWORD_ERROR_CONCATENATION).format(
+                        error_message,
+                        _(constants.PASSWORD_DONE_TWICE))
+                )
 
         # check if the spoke can be exited after the latest round of checks
         self._check_spoke_exit_conditions(unwaivable_check_failed)

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -622,8 +622,11 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
                 self.show_warning_message(error_message)
             else:
                 # add suffix for the click twice logic
-                self.show_warning_message("{} {}".format(error_message,
-                                                         _(constants.PASSWORD_DONE_TWICE)))
+                self.show_warning_message(
+                    _(constants.PASSWORD_ERROR_CONCATENATION).format(
+                        error_message,
+                        _(constants.PASSWORD_DONE_TWICE))
+                )
 
         # check if the spoke can be exited after the latest round of checks
         self._check_spoke_exit_conditions(unwaivable_check_failed)


### PR DESCRIPTION
Without this change we have in the bottom line messages like:

"The password fails the dictionary check - it is too simplistic/systematic You will have to press Done twice to confirm it."

The missing period between sentences could be a big issue for understanding the sentence in languages like Chinese.

The fix here is not great one because we are not owners of both strings.

The first sentence comes from the libreport library the second one from us. Here we have two possible solutions. One would be to add translatable concatenation (what I'm doing here) and second is to add the period into the `...press Done twice...` message. I don't like to duplicate the second part so I rather add the new "{}. {}" for translations.

*Resolves: rhbz#2075419*