### PR TITLE
Port restorecon user dirs to rhel 8

### DIFF
--- a/pyanaconda/core/users.py
+++ b/pyanaconda/core/users.py
@@ -423,7 +423,7 @@ def create_user(username, password=False, is_crypted=False, lock=False,
             util.chown_dir_tree(root + homedir,
                                 int(pwent[2]), int(pwent[3]),
                                 orig_uid, orig_gid)
-            util.execWithRedirect("restorecon", ["-r", root + homedir])
+            util.restorecon([homedir], root=root)
         except OSError as e:
             log.critical("Unable to change owner of existing home directory: %s", e.strerror)
             raise
@@ -522,7 +522,12 @@ def set_user_ssh_key(username, key, root=None):
     with util.open_with_perm(authfile, "a", 0o600) as f:
         f.write(key + "\n")
 
+    if root and sshdir.startswith(root):
+        restore_dir = sshdir[len(root):]
+    else:
+        restore_dir = sshdir
+
     # Only change ownership if we created it
     if not authfile_existed:
         os.chown(authfile, int(uid), int(gid))
-        util.execWithRedirect("restorecon", ["-r", sshdir])
+        util.restorecon([restore_dir], root=root)

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1469,3 +1469,26 @@ def is_smt_enabled():
     except (IOError, ValueError):
         log.warning("Failed to detect SMT.")
         return False
+
+
+def restorecon(paths, root, skip_nonexistent=False):
+    """Try to restore contexts for a list of paths.
+
+    Do not fail if the program does not exist because it was not in the payload, just say so.
+
+    :param [str] paths: list of paths to restore
+    :param str root: root to run in; mandatory because we restore contexts only on the new system
+    :param bool skip_nonexistent: optionally, do not fail if some of the paths do not exist
+    :return bool: did anything run at all
+    """
+    if skip_nonexistent:
+        opts = ["-ir"]
+    else:
+        opts = ["-r"]
+
+    try:
+        execWithRedirect("restorecon", opts + paths, root=root)
+    except FileNotFoundError:
+        return False
+    else:
+        return True


### PR DESCRIPTION
Running restorecon needs chroot to sysroot so as to have correct absolute 
paths. At the point when users are handled, payload has been already
installed, so the SELinux policy is already present.

This is achieved by using a new restorecon utility function instead of running
restorecon directly with execWithRedirect. The helper can set root correctly.
It is also backported 1:1 from upstream and thus retains the "array of str"
parameter from upstream, even if it is not used with more than one path on
this branch.

Resolves: [rhbz#2069305](https://bugzilla.redhat.com/show_bug.cgi?id=2069305)

(cherry picked from commit a7a0713407baade6871486f7daf37863f4515c20)
(cherry picked from commit b511e61d7e5d46e79f133f767ded6f399bab9136)

(cherry picked from commit 65025ad94bb5c11005eda0fba3419563acf8c461)
(cherry picked from commit 3197d194a591fc21c2894b2da1137c425d2a7347)

Ported from #3993