### PR TITLE
Cleanup unneeded NFS repo with rd.live.ram parameter - rhel8

### DIFF
--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -50,7 +50,8 @@ dist_dracut_SCRIPTS = module-setup.sh \
                       anaconda-depmod.sh \
                       find-net-intfs-by-driver \
                       anaconda-ifdown \
-                      driver_updates.py
+                      driver_updates.py \
+                      anaconda-nfsrepo-cleanup.sh
 
 dist_dracut_DATA = driver-updates@.service
 

--- a/dracut/anaconda-nfsrepo-cleanup.sh
+++ b/dracut/anaconda-nfsrepo-cleanup.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# NFS mount can sometimes cause a hang, a delay, or a timeout problem after
+# switching root, since it needs to survive the network reconfiguration in
+# stage2 phase. So, it's better to umount the unneeded NFS mounts before
+# switching root.
+
+# When rd.live.ram boot parameter, the stage2 image is copied into memory
+# from the NFS repository. So, keeping NFS mount is not required after
+# the copy. The NFS repository can be mounted in the stage2 phase of package
+# installation if needed.
+
+type getargbool >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if getargbool 0 rd.live.ram -d -y live_ram; then
+    while read -r src mnt fs rest || [ -n "$src" ]; do
+        if [ "$mnt" = "/run/install/repo" ]; then
+            if [ "$fs" = "nfs" ] || [ "$fs" = "nfs4" ]; then
+                umount /run/install/repo
+                break
+            fi
+        fi
+        # inst.repo=nfs://dvd.iso case
+        if [ "$mnt" = "/run/install/isodir" ]; then
+            if [ "$fs" = "nfs" ] || [ "$fs" = "nfs4" ]; then
+                umount /run/install/repo
+                umount /run/install/isodir
+                break
+            fi
+        fi
+    done < /proc/mounts
+fi

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -50,6 +50,7 @@ install() {
     inst_hook pre-pivot 91 "$moddir/anaconda-copy-prefixdevname.sh"
     inst_hook pre-pivot 95 "$moddir/anaconda-set-kernel-hung-timeout.sh"
     inst_hook pre-pivot 99 "$moddir/save-initramfs.sh"
+    inst_hook cleanup 98 "$moddir/anaconda-nfsrepo-cleanup.sh"
     inst_hook pre-shutdown 50 "$moddir/anaconda-pre-shutdown.sh"
     # kickstart parsing, WOOOO
     inst_hook initqueue/online 11 "$moddir/fetch-kickstart-net.sh"


### PR DESCRIPTION
Resolves: [rhbz#1970726](https://bugzilla.redhat.com/show_bug.cgi?id=1970726)

(cherry picked from commit fda62d088e43f47ad5a121a743aed9a5cc3aef9e)

Port of #3440