### PR TITLE
Install eslint during container build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -170,6 +170,7 @@ release-and-tag:
 anaconda-ci-build:
 	TEMP=$$(mktemp -t -d anaconda-ci-build.XXXX) && \
 	cp $(srcdir)/anaconda.spec.in $(CI_DOCKERFILE)/* $$TEMP/ && \
+	cp $(srcdir)/ui/webui/package.json $(CI_DOCKERFILE)/* $$TEMP/ && \
 	echo "Build dir is $$TEMP" && \
 	$(CONTAINER_ENGINE) build \
 	$(CONTAINER_BUILD_ARGS) --pull-always \

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -31,8 +31,8 @@ LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 COPY ["eln.repo", "/etc/yum.repos.d"]
 
 # The anaconda.spec.in is in the repository root. This file will be copied automatically here if
-# the build is invoked by Makefile.
-COPY ["anaconda.spec.in", "/root/"]
+# the build is invoked by Makefile. Same for package.json from webui.
+COPY ["anaconda.spec.in", "package.json", "/root/"]
 
 # Prepare environment and install build dependencies
 RUN set -ex; \
@@ -66,6 +66,8 @@ RUN set -ex; \
   python3-pip \
   # Need to have restorecon for the tests execution
   policycoreutils \
+  # to find versions of npm packages below
+  jq \
   ShellCheck; \
   # Install Anaconda dependencies
   cat /root/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
@@ -84,6 +86,15 @@ RUN pip install --no-cache-dir --upgrade pip; \
   rpmfluff \
   freezegun \
   pytest
+
+RUN set -ex; \
+    packages=""; \
+    for package in "eslint" "eslint-config-standard" "eslint-config-standard-jsx" "eslint-config-standard-react"; do \
+      version=$(jq -r --arg package "$package" '.["devDependencies"][$package]' /root/package.json); \
+      packages="$packages $package@$version"; \
+    done; \
+    npm install -g $packages # no quoting here since the string starts with space
+
 
 RUN mkdir /anaconda
 

--- a/tests/webui_eslint/run_webui_eslint.sh
+++ b/tests/webui_eslint/run_webui_eslint.sh
@@ -22,10 +22,6 @@ echo
 
 pushd "${top_srcdir}/ui/webui" > /dev/null || return 1
 
-echo "Installing npm packages:"
-npm install
-echo
-
 echo "Linting:"
 npx eslint --format stylish --no-color src/
 exit $?


### PR DESCRIPTION
Previously, it was installed on first test run, which with containers means always. Additionally, this installs only eslint, not all of the packages. The combined savings should be around a minute per test run, at a cost of ca. +17 MB container size.

This makes the test slightly less correct when run outside the container: Previously the version to install was taken from the config file. Now, eslint is automatically installed after invoking it via npx, but it cannot guess where the version file is, so it installs the latest. However, running the test without container is unusual, so this should be good enough.