### PR TITLE
Add 'eln-baseos' to the DEFAULT_REPOS

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -55,8 +55,9 @@ BASE_REPO_NAME = "anaconda"
 DEFAULT_REPOS = [productName.split('-')[0].lower(),  # pylint: disable=no-member
                  "fedora-modular-server",
                  "rawhide",
-                 "BaseOS",  # Used by RHEL
-                 "baseos"]  # Used by CentOS Stream
+                 "BaseOS",      # Used by RHEL
+                 "baseos",      # Used by CentOS Stream
+                 "eln-baseos"]  # Used by Fedora ELN
 
 DBUS_ANACONDA_SESSION_ADDRESS = "DBUS_ANACONDA_SESSION_BUS_ADDRESS"
 


### PR DESCRIPTION
Since ELN doesn't have a mirrorlist or .treeinfo, without this it
fails to identify the installation tree, requiring the user to
enter it manually.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>

/cc @jkonecny12 