### PR TITLE
Fix pylint issues (#infra)

### DIFF
--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -259,13 +259,6 @@ max-line-length=99
 # Maximum number of lines in a module.
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -24,8 +24,6 @@ class AnacondaLintConfig(CensorshipConfig):
 
         self.false_positives = [
             FalsePositive(r"^E1101.*: Instance of 'KickstartSpecificationHandler' has no '.*' member$"),
-            FalsePositive(r"^E1101.*: FedoraGeoIPProvider._refresh: Instance of 'LookupDict' has no 'ok' member"),
-            FalsePositive(r"^E1101.*: HostipGeoIPProvider._refresh: Instance of 'LookupDict' has no 'ok' member"),
             FalsePositive(r"^E1101.*: Method 'PropertiesChanged' has no 'connect' member"),
 
             # TODO: BlockDev introspection needs to be added to pylint to handle these


### PR DESCRIPTION
* Remove unused pylint false positives.
* Remove the `no-space-check` option from `pylintrc`.