### PR TITLE
Revert "Temporarily keep setter methods for the Kdump add-on"

### DIFF
--- a/pyanaconda/modules/storage/bootloader/bootloader_interface.py
+++ b/pyanaconda/modules/storage/bootloader/bootloader_interface.py
@@ -171,18 +171,6 @@ class BootloaderInterface(KickstartModuleInterfaceTemplate):
         """List of extra bootloader arguments."""
         return self.implementation.extra_arguments
 
-    @emits_properties_changed
-    def SetExtraArguments(self, args: List[Str]):
-        """Set the extra bootloader arguments.
-
-        Specifies kernel parameters. The default set of bootloader
-        arguments is “rhgb quiet”. You will get this set of arguments
-        regardless of what extra parameters you set.
-
-        :param args: list of arguments
-        """
-        self.implementation.set_extra_arguments(args)
-
     @ExtraArguments.setter
     @emits_properties_changed
     def ExtraArguments(self, args: List[Str]):


### PR DESCRIPTION
This reverts commit a39d33f70ee95946d307dbcce780e12a1546a5e8.

**Depends on:** https://github.com/daveyoung/kdump-anaconda-addon/pull/33