### PR TITLE
Display keyboard accelerator properly

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.glade
+++ b/pyanaconda/ui/gui/spokes/storage.glade
@@ -442,6 +442,7 @@
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
+                                            <property name="use-underline">True</property>
                                             <property name="label" translatable="yes" context="GUI|Storage">Free up space by re_moving or shrinking existing partitions</property>
                                           </object>
                                         </child>


### PR DESCRIPTION
"Free up space by removing or shrinking existing partitions" could not be selected by a keyboard accelerator key and was not displayed properly.