### PR TITLE
Add Circle Linux profile to Anaconda(rhel-9)

### DIFF
--- a/data/product.d/circle.conf
+++ b/data/product.d/circle.conf
@@ -1,0 +1,21 @@
+# Anaconda configuration file for Circle Linux.
+
+[Product]
+product_name = Circle Linux
+
+[Base Product]
+product_name = Red Hat Enterprise Linux
+
+[Anaconda]
+forbidden_modules =
+    org.fedoraproject.Anaconda.Modules.Subscription
+
+[Bootloader]
+efi_dir = circle
+
+[Payload]
+enable_closest_mirror = True
+default_source = CLOSEST_MIRROR
+
+[License]
+eula = /usr/share/circle-release/EULA

--- a/tests/unit_tests/pyanaconda_tests/test_product.py
+++ b/tests/unit_tests/pyanaconda_tests/test_product.py
@@ -317,6 +317,11 @@ class ProductConfigurationTestCase(unittest.TestCase):
             ["rhel.conf", "virtuozzo-linux.conf"],
             ENTERPRISE_PARTITIONING
         )
+        self._check_default_product(
+            "Circle Linux", "",
+            ["rhel.conf", "circle.conf"],
+            ENTERPRISE_PARTITIONING
+        )
 
     def _compare_product_files(self, file_name, other_file_name):
         parser = create_parser()


### PR DESCRIPTION
The PR adds CircleLinux to the rhel-9 branch of anaconda.