### PR TITLE
Report registration errors from kickstart

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -551,14 +551,17 @@ if __name__ == "__main__":
     #   key are available
     from pyanaconda.modules.common.util import is_module_available
     from pyanaconda.modules.common.constants.services import SUBSCRIPTION
+
     if is_module_available(SUBSCRIPTION):
-        from pyanaconda.ui.lib.subscription import org_keys_sufficient, register_and_subscribe
+        from pyanaconda.ui.lib.subscription import org_keys_sufficient, \
+            register_and_subscribe, kickstart_error_handler
         if org_keys_sufficient():
             threadMgr.add(
                 AnacondaThread(
                     name=constants.THREAD_SUBSCRIPTION,
                     target=register_and_subscribe,
-                    args=[anaconda.payload]
+                    args=[anaconda.payload],
+                    kwargs={"error_callback": kickstart_error_handler}
                 )
             )
 

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -115,6 +115,7 @@ class ErrorHandler(object):
             # Subscription related errors
             InsightsClientMissingError.__name__: self._insightsErrorHandler,
             InsightsConnectError.__name__: self._insightsErrorHandler,
+            "KickstartRegistrationError": self._kickstartRegistrationErrorHandler,
 
             # Satellite
             SatelliteProvisioningError.__name__: self._target_satellite_provisioning_error_handler,
@@ -239,6 +240,20 @@ class ErrorHandler(object):
                     "Would you like to ignore this and continue with "
                     "installation?")
         message += "\n\n" + str(exn)
+
+        if self.ui.showYesNoQuestion(message):
+            return ERROR_CONTINUE
+        else:
+            return ERROR_RAISE
+
+    def _kickstartRegistrationErrorHandler(self, exn):
+        message = _("An error occurred during registration attempt "
+                    "triggered by the rhsm kickstart command. "
+                    "This could have happened due to incorrect rhsm command arguments "
+                    "or subscription infrastructure issues. "
+                    "Would you like to ignore this and continue with "
+                    "installation?")
+        message += "\n\n" + _("Error detail: ") + str(exn)
 
         if self.ui.showYesNoQuestion(message):
             return ERROR_CONTINUE

--- a/pyanaconda/ui/lib/subscription.py
+++ b/pyanaconda/ui/lib/subscription.py
@@ -27,6 +27,7 @@ from pyanaconda.core.constants import PAYLOAD_TYPE_DNF
 from pyanaconda.ui.lib.payload import create_source, set_source, tear_down_sources
 from pyanaconda.ui.lib.storage import unmark_protected_device
 from pyanaconda.payload.manager import payloadMgr
+from pyanaconda.errors import errorHandler, ERROR_RAISE
 
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.modules.common import task
@@ -105,6 +106,20 @@ def check_cdn_is_installation_source(payload):
         # the CDN source pretty much only supports
         # DNF payload at the moment
         return False
+
+
+# Kickstart error handling
+
+class KickstartRegistrationError(Exception):
+    """Registration attempt from kickstart failed."""
+    pass
+
+
+def kickstart_error_handler(message):
+    """Helper function which raises exception if kickstart triggered registration fails."""
+    exn = KickstartRegistrationError(message)
+    if errorHandler.cb(exn) == ERROR_RAISE:
+        raise exn
 
 # Asynchronous registration + subscription & unregistration handling
 #


### PR DESCRIPTION
Show an interactive dialog when a registration attempt triggered
from kickstart fails & give the user option to continue or abort
the installation.

Resolves: rhbz#2000652