### PR TITLE
dnf: apply the /etc/dnf/dnf.conf configuration file in the installer

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -116,9 +116,14 @@ class DNFManager(object):
     def _create_base(cls):
         """Create a new DNF base."""
         base = dnf.Base()
+        base.conf.read()
         base.conf.cachedir = DNF_CACHE_DIR
         base.conf.pluginconfpath = DNF_PLUGINCONF_DIR
         base.conf.logdir = '/tmp/'
+
+        # Set installer defaults
+        base.conf.gpgcheck = False
+        base.conf.skip_if_unavailable = False
 
         # Set the substitution variables.
         cls._reset_substitution(base)

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
@@ -89,6 +89,10 @@ class DNFManagerTestCase(unittest.TestCase):
     def test_set_default_configuration(self):
         """Test the default configuration of the DNF base."""
         self._check_configuration(
+            "gpgcheck = 0",
+            "skip_if_unavailable = 0"
+        )
+        self._check_configuration(
             "cachedir = /tmp/dnf.cache",
             "pluginconfpath = /tmp/dnf.pluginconf",
             "logdir = /tmp/",


### PR DESCRIPTION
The 'gpgcheck', 'skip_if_unavailable' and 'best' are the only options
for which the default Base() config value (which anaconda has been using)
differs from the configuration in /etc/dnf/dnf.conf.

For the 'best' the goal is to use the value specified by the config file
to resolve the bug 1899494 caused by change of the Base() config default
by dnf.

For the 'gpgcheck' and 'skip_if_unavailable' the patch overrides
/etc/dnf/dnf.conf to the values keeping the current behavior. The
options are not exposed in Anaconda configuration in this patch as the
value is the same across configurations.

Resolves: rhbz#1899494