### PR TITLE
Web UI: Add a log viewer

### DIFF
--- a/ui/webui/src/components/AnacondaHeader.jsx
+++ b/ui/webui/src/components/AnacondaHeader.jsx
@@ -19,7 +19,8 @@ import cockpit from "cockpit";
 import React from "react";
 
 import {
-    Flex,
+    Button,
+    Flex, FlexItem,
     Label,
     PageSection, PageSectionVariants,
     Popover, PopoverPosition,
@@ -31,7 +32,7 @@ const _ = cockpit.gettext;
 
 const prerelease = _("Pre-release");
 
-export const AnacondaHeader = ({ beta, title }) => {
+export const AnacondaHeader = ({ beta, title, setShowLogViewer }) => {
     const betanag = beta
         ? (
             <Popover
@@ -64,6 +65,18 @@ export const AnacondaHeader = ({ beta, title }) => {
                     <Text component="h1">{title}</Text>
                 </TextContent>
                 {betanag}
+                <FlexItem align={{ default: "alignRight" }}>
+                    <Button
+                      aria-label={_("Show log")}
+                      id="global-show-log-btn"
+                      variant="tertiary"
+                      onClick={() => {
+                          setShowLogViewer(true);
+                      }}
+                    >
+                        {_("Show log")}
+                    </Button>
+                </FlexItem>
             </Flex>
         </PageSection>
     );

--- a/ui/webui/src/components/LogViewerModal.jsx
+++ b/ui/webui/src/components/LogViewerModal.jsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from "cockpit";
+
+import React, { useEffect, useState } from "react";
+
+import { LogViewer, LogViewerSearch } from "@patternfly/react-log-viewer";
+
+import { watchLogFile } from "../helpers/logs.js";
+
+import {
+    Button,
+    Modal, ModalVariant,
+    Toolbar, ToolbarContent, ToolbarItem,
+    Text, TextContent, TextVariants,
+    Flex,
+} from "@patternfly/react-core";
+
+const _ = cockpit.gettext;
+
+const AnacondaLogViewer = () => {
+    const [logData, setLogData] = useState("");
+
+    useEffect(() => {
+        const appendLogData = (newLogData, dataTag, error) => {
+            setLogData(l => l + newLogData);
+            if (error) {
+                console.log("Log file read failed.");
+                console.log(error);
+            }
+        };
+        watchLogFile("/tmp/anaconda.log", appendLogData);
+    }, []);
+
+    return (
+        <LogViewer
+          // see CSS file for a PF workaround needed
+          // for line numbers to work correctly
+          hasLineNumbers
+          isTextWrapped={false}
+          height={450}
+          data={logData}
+          id="log-viewer-element"
+          toolbar={
+              <Toolbar>
+                  <ToolbarContent>
+                      <ToolbarItem>
+                          <LogViewerSearch placeholder={_("Search value")} />
+                      </ToolbarItem>
+                  </ToolbarContent>
+              </Toolbar>
+          }
+        />
+    );
+};
+
+export const LogViewerModal = ({ setShowLogViewer }) => {
+    return (
+        <Modal
+          id="log-viewer-modal"
+          actions={[
+              <Button
+                id="log-viewer-exit-btn"
+                key="cancel"
+                onClick={() => setShowLogViewer(false)}
+                variant="primary">
+                  {_("Close")}
+              </Button>
+          ]}
+          isOpen
+          onClose={() => setShowLogViewer(false)}
+          title={_("Installer log")}
+          variant={ModalVariant.medium}
+        >
+            <Flex direction={{ default: "column" }}>
+                <TextContent
+                  id="anaconda-version-label"
+                >
+                    <Text component={TextVariants.p}>
+                        {_("Installer version") + " 38.5"}
+                    </Text>
+                </TextContent>
+                <AnacondaLogViewer />
+            </Flex>
+        </Modal>
+    );
+};

--- a/ui/webui/src/components/app.jsx
+++ b/ui/webui/src/components/app.jsx
@@ -27,6 +27,7 @@ import { AddressContext } from "./Common.jsx";
 import { AnacondaHeader } from "./AnacondaHeader.jsx";
 import { AnacondaWizard } from "./AnacondaWizard.jsx";
 import { HelpDrawer } from "./HelpDrawer.jsx";
+import { LogViewerModal } from "./LogViewerModal.jsx";
 
 import { BossClient } from "../apis/boss.js";
 import { LocalizationClient } from "../apis/localization.js";
@@ -44,6 +45,7 @@ export const Application = () => {
     const [conf, setConf] = useState();
     const [notifications, setNotifications] = useState({});
     const [isHelpExpanded, setIsHelpExpanded] = useState(false);
+    const [showLogViewer, setShowLogViewer] = useState(false);
 
     useEffect(() => {
         cockpit.file("/run/anaconda/bus.address").watch(address => {
@@ -96,7 +98,7 @@ export const Application = () => {
         <Page
           data-debug={conf.Anaconda.debug}
           additionalGroupedContent={
-              <AnacondaHeader beta={beta} title={title} />
+              <AnacondaHeader beta={beta} title={title} setShowLogViewer={setShowLogViewer} />
           }
           groupProps={{
               sticky: "top"
@@ -141,6 +143,9 @@ export const Application = () => {
           setIsExpanded={setIsHelpExpanded}
         >
             {page}
+            {showLogViewer && <LogViewerModal
+              setShowLogViewer={setShowLogViewer}
+            />}
         </HelpDrawer>
     );
 };

--- a/ui/webui/src/components/app.scss
+++ b/ui/webui/src/components/app.scss
@@ -15,3 +15,10 @@ html:not(.index-page) body {
 #installation-wizard .pf-c-wizard__main-body {
   flex: 1 1 auto;
 }
+
+// workaround for a LogViewer bug
+// - without this the line number column is too narrow
+//   and line numbers quickly become unreadable
+.pf-c-log-viewer__index {
+  width: auto;
+}

--- a/ui/webui/src/helpers/logs.js
+++ b/ui/webui/src/helpers/logs.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from "cockpit";
+
+export const watchLogFile = (logFilePath, callback) => {
+    const file = cockpit.file(logFilePath);
+    file.watch(callback);
+};

--- a/ui/webui/test/check-log-viewer
+++ b/ui/webui/test/check-log-viewer
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+# import Cockpit's machinery for test VMs and its browser test API
+TEST_DIR = os.path.dirname(__file__)
+sys.path.append(os.path.join(TEST_DIR, "common"))
+sys.path.append(os.path.join(TEST_DIR, "helpers"))
+sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
+
+from installer import Installer
+from testlib import MachineCase, nondestructive, test_main  # pylint: disable=import-error
+from machine_install import VirtInstallMachine
+
+@nondestructive
+class TestLogViewer(MachineCase):
+    MachineCase.machine_class = VirtInstallMachine
+
+    def testShowLog(self):
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+
+        i.open()
+
+        # check log viewer is not open by default
+        b.wait_not_present("#log-viewer-modal")
+
+        # open the log viewer
+        i.show_log()
+
+        # check log view modal is open and shows expected content
+        b.wait_in_text("#log-viewer-modal", "Installer log")
+
+        # try to close the modal dialog
+        i.close_log()
+
+        # check log viewer is not open
+        b.wait_not_present("#log-viewer-modal")
+ 
+
+if __name__ == '__main__':
+    test_main()       

--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -106,6 +106,15 @@ class Installer():
         else:
             self.browser.wait_not_present("#betang-icon")
 
+    def show_log(self):
+        """Show the log viewer modal."""
+        self.browser.click("#global-show-log-btn")
+        self.browser.wait_visible("#log-viewer-modal")
+
+    def close_log(self):
+        """Close a modal dialog by pressing Esc."""
+        self.browser.click("#log-viewer-exit-btn")
+
     def quit(self):
         self.browser.click("#installation-quit-btn")
         self.browser.wait_visible("#installation-quit-confirm-dialog")


### PR DESCRIPTION
Add a log viewer that opens in a modal window when the
"Show logs" button in the upper right corner of the screen
is clicked.

The log viewer is currently hardcoded to follow /tmp/anaconda.log.