### PR TITLE
dnf: apply the /etc/dnf/dnf.conf configuration file in the installer

### DIFF
--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -653,9 +653,13 @@ class DNFPayload(Payload):
     def _configure(self):
         self._base = dnf.Base()
         config = self._base.conf
+        config.read()
         config.cachedir = DNF_CACHE_DIR
         config.pluginconfpath = DNF_PLUGINCONF_DIR
         config.logdir = '/tmp/'
+        # set installer defaults
+        config.gpgcheck = False
+        config.skip_if_unavailable = False
         # enable depsolver debugging if in debug mode
         self._base.conf.debug_solver = flags.debug
         # set the platform id based on the /os/release


### PR DESCRIPTION
The 'gpgcheck', 'skip_if_unavailable' and 'best' are the only options
for which the default Base() config value (which anaconda has been using)
differs from the configuration in /etc/dnf/dnf.conf.

For the 'best' the goal is to use the value specified by the config file
to resolve the bug 1899494 caused by change of the Base() config default
by dnf.

For the 'gpgcheck' and 'skip_if_unavailable' the patch overrides
/etc/dnf/dnf.conf to the values keeping the current behavior. The
options are not exposed in Anaconda configuration in this patch as the
value is the same across configurations.

Resolves: rhbz#1899494