### PR TITLE
Web UI: Fix betanag popover position

### DIFF
--- a/ui/webui/src/components/AnacondaHeader.jsx
+++ b/ui/webui/src/components/AnacondaHeader.jsx
@@ -22,7 +22,7 @@ import {
     Flex,
     Label,
     PageSection, PageSectionVariants,
-    Popover,
+    Popover, PopoverPosition,
     TextContent, Text, TextVariants
 } from "@patternfly/react-core";
 import { InfoCircleIcon } from "@patternfly/react-icons";
@@ -36,7 +36,8 @@ export const AnacondaHeader = ({ beta, title }) => {
         ? (
             <Popover
               headerContent={_("This is unstable, pre-release software")}
-              minWidth="40rem"
+              minWidth="30rem"
+              position={PopoverPosition.auto}
               bodyContent={
                   <TextContent>
                       <Text component={TextVariants.p}>


### PR DESCRIPTION
First set the popover placement priority to prefer the bottom direction
and then make it narrower so it actually fits if shown under the betanag
bubble.