### PR TITLE
Speed up disk spoke

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -257,6 +257,8 @@ CMDLINE_LIST = ["addrepo"]
 # An estimated ratio for metadata size to total disk space.
 STORAGE_METADATA_RATIO = 0.1
 
+STORAGE_GROW_RATIO = 1.1
+
 # Constants for reporting status to IPMI.  These are from the IPMI spec v2 rev1.1, page 512.
 IPMI_STARTED = 0x7          # installation started
 IPMI_FINISHED = 0x8         # installation finished successfully

--- a/pyanaconda/core/storage.py
+++ b/pyanaconda/core/storage.py
@@ -30,6 +30,15 @@ from pykickstart.constants import AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_BTRFS, AUTO
 
 log = get_module_logger(__name__)
 
+# size - total size of all selected disks
+# free - total free space of all selected disks
+# need - needed space to install system on selected disks
+installation_info = {
+    "size" : Size(0),
+    "free" : Size(0),
+    "need" : Size(0)
+}
+
 # Maximum ratio of swap size to disk size (10 %).
 MAX_SWAP_DISK_RATIO = Decimal('0.1')
 
@@ -317,3 +326,17 @@ def suggest_swap_size(quiet=False, hibernation=False, disk_space=None):
         log.info("Swap attempt of %s", swap)
 
     return swap
+
+def set_installation_info(size, free, need : Size):
+    installation_info["size"] = size
+    installation_info["free"] = free
+    installation_info["need"] = need
+
+def get_selected_disks_total_size() -> Size:
+    return installation_info["size"]
+
+def get_selected_disks_total_free_space() -> Size:
+    return installation_info["size"]
+
+def get_selected_disks_need_space() -> Size:
+    return installation_info["need"]

--- a/pyanaconda/modules/payloads/source/live_os/live_os.py
+++ b/pyanaconda/modules/payloads/source/live_os/live_os.py
@@ -20,7 +20,7 @@
 from pyanaconda.core.i18n import _
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.payloads.base.utils import get_dir_size
-from pyanaconda.modules.payloads.constants import SourceType, SourceState
+from pyanaconda.modules.payloads.constants import SourceType, SourceState, DRACUT_ISODIR
 from pyanaconda.modules.payloads.source.mount_tasks import TearDownMountTask
 from pyanaconda.modules.payloads.source.source_base import PayloadSourceBase, MountingSourceMixin
 from pyanaconda.modules.payloads.source.live_os.live_os_interface import LiveOSSourceInterface
@@ -30,6 +30,7 @@ from pyanaconda.modules.payloads.source.live_os.initialization import SetUpLiveO
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
+from shutil import disk_usage
 
 class LiveOSSourceModule(PayloadSourceBase, MountingSourceMixin):
     """The Live OS source payload module."""
@@ -69,7 +70,11 @@ class LiveOSSourceModule(PayloadSourceBase, MountingSourceMixin):
         :rtype: int
         """
         # FIXME: Unify the required space with the installation size.
-        return get_dir_size("/") * 1024
+        try:
+		_, used, _ = disk_usage(DRACUT_ISODIR)
+		return used
+	except Exception:
+		return get_dir_size("/") * 1024
 
     @property
     def image_path(self):

--- a/pyanaconda/ui/lib/space.py
+++ b/pyanaconda/ui/lib/space.py
@@ -23,6 +23,7 @@ from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.structures.storage import DeviceData
+from pyanaconda.core.storage import get_selected_disks_need_space, get_selected_disks_total_size
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -88,16 +89,22 @@ class FileSystemSpaceChecker(object):
                             situation.  This message is suitable for putting
                             in the info bar at the bottom of a Hub.
         """
-        free = self._calculate_free_space()
-        needed = self._calculate_needed_space()
-        log.info("fs space: %s  needed: %s", free, needed)
 
-        if free > needed:
+        size = get_selected_disks_total_size()
+        needed = get_selected_disks_need_space()
+        log.info("fs space: %s  needed: %s", size, needed)
+
+        if size == Size(0):
+            size = self._calculate_free_space()
+        if needed == Size(0):
+            needed = self._calculate_needed_space()
+
+        if size > needed:
             result = True
             message = ""
         else:
             result = False
-            deficit = self._calculate_deficit(needed)
+            deficit = Size(needed - size)
 
             if deficit:
                 message = _("Not enough space in file systems for the current software selection. "


### PR DESCRIPTION
Fix Anaconda freeze for 6-8 sec when leaving the storage spoke
by calculating required space not by calculating size of each file inside /,
but by taking a ready to use size of the mounted squashfs image.

Idea and implementation by Oleg Solovev @Gel0bmstu 

P.S. It is a port of the patch for the rhel-9 branch (https://abf.io/import/anaconda/blob/573b765478/0030-ROSA-fix-aloithm-for-determining-required-disk-space.patch), I am not sure that I've ported it correctly, especially in the place of `return get_dir_size`, please check...