### PR TITLE
Fix product config product_name for Rocky Linux (#2096046)

### DIFF
--- a/data/product.d/rocky.conf
+++ b/data/product.d/rocky.conf
@@ -1,7 +1,7 @@
 # Anaconda configuration file for Rocky Linux.
 
 [Product]
-product_name = Rocky
+product_name = Rocky Linux
 
 [Base Product]
 product_name = Red Hat Enterprise Linux

--- a/tests/unit_tests/pyanaconda_tests/test_product.py
+++ b/tests/unit_tests/pyanaconda_tests/test_product.py
@@ -308,7 +308,7 @@ class ProductConfigurationTestCase(unittest.TestCase):
             ENTERPRISE_PARTITIONING
         )
         self._check_default_product(
-            "Rocky", "",
+            "Rocky Linux", "",
             ["rhel.conf", "rocky.conf"],
             ENTERPRISE_PARTITIONING
         )


### PR DESCRIPTION
Currently, the Rocky Linux rocky.conf file for anaconda has inconsistent naming and does not match our previous versions. This caused us some issues during testing including our own automated pipeline. This PR is to try to bring it into consistency to state "Rocky Linux" instead of just "Rocky" in any anaconda installer references for future Enterprise Linux 9 versions.

The following bug report has also been opened for this: https://bugzilla.redhat.com/show_bug.cgi?id=2096046

Please let me know if the commits or changed files need to be addressed! Thank you so much!