### PR TITLE
Remove the no-space-check option from pylintrc (#infra)

### DIFF
--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -253,13 +253,6 @@ max-line-length=99
 # Maximum number of lines in a module.
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no


### PR DESCRIPTION
Port of #4161 to fix tests and thus also container builds on the f36 branches.

----

The no-space-check option was removed in Pylint 2.6.

(cherry picked from commit 6142a4d9d6709bbe52ab4969fa8a0239d1cbdd23)