### PR TITLE
kstest on pr: disable Permian GH ReportSender temporarily (#infra)

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  checks: write
+  statuses: write
 
 jobs:
   pr-info:
@@ -77,7 +77,6 @@ jobs:
       allowed_user: ${{ steps.check_user_perm.outputs.allowed_user }}
       base_ref: ${{ fromJson(steps.pr_api.outputs.data).base.ref }}
       sha: ${{ fromJson(steps.pr_api.outputs.data).head.sha }}
-      pr_number: ${{ github.event.issue.number }}
       launch_args: ${{ steps.parse_launch_args.outputs.launch_args }}
       skip_tests: ${{ steps.ks_test_args.outputs.skip_tests }}
       platform: ${{ steps.ks_test_args.outputs.platform }}
@@ -97,6 +96,18 @@ jobs:
        SKIP_KS_TESTS: ${{ needs.pr-info.outputs.skip_tests }}
        TEST_JOBS: 16
     steps:
+      # we post statuses manually as this does not run from a pull_request event
+      # https://developer.github.com/v3/repos/statuses/#create-a-status
+      - name: Create in-progress status
+        uses: octokit/request-action@v2.x
+        with:
+          route: 'POST /repos/${{ github.repository }}/statuses/${{ needs.pr-info.outputs.sha }}'
+          context: '${{ env.STATUS_NAME }} ${{ needs.pr-info.outputs.launch_args }}'
+          state: pending
+          target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # self-hosted runners don't do this automatically; also useful to keep stuff around for debugging
       # need to run sudo as the launch script and the container create root/other user owned files
       - name: Clean up previous run
@@ -229,10 +240,6 @@ jobs:
           kstest_local_repo=${{ github.workspace }}/kickstart-tests
           [library]
           directPath=${{ github.workspace }}/kickstart-tests/testlib
-          [github]
-          pull-request=${{ needs.pr-info.outputs.pr_number }}
-          repository=${{ github.repository }}
-          token=${{ secrets.GITHUB_TOKEN }}
           EOF
 
       - name: Run kickstart tests in container
@@ -249,13 +256,6 @@ jobs:
               "everything_testplan":{
                 "configurations":[{"architecture":"x86_64"}],
                 "point_person":"rvykydal@redhat.com",
-                "reporting":[{
-                  "type":"github-pr",
-                  "data":{
-                    "pr-check-name":"${{ env.STATUS_NAME }} ${{ needs.pr-info.outputs.launch_args }}",
-                    "pr-check-summary":"Kickstart tests run on a pull request comment"
-                  }
-                }]
               },
               "bootIso":{"x86_64":"file://${{ github.workspace }}/images/boot.iso"},
               "kstestParams":{"platform":"${{ needs.pr-info.outputs.platform }}"}
@@ -285,3 +285,26 @@ jobs:
           name: 'logs-permian'
           path: |
             permian/permian.log
+
+
+      # Permian hides the exit code of launcher
+      - name: Pass the launch script exit code
+        working-directory: ./permian
+        run: |
+          rc=$( awk '/Runner return code: /{ print $4 }' permian.log)
+          if [ -n "$rc" ]; then
+            exit $rc
+          else
+            exit 111
+          fi
+
+      - name: Set result status
+        if: always()
+        uses: octokit/request-action@v2.x
+        with:
+          route: 'POST /repos/${{ github.repository }}/statuses/${{ needs.pr-info.outputs.sha }}'
+          context: '${{ env.STATUS_NAME }} ${{ needs.pr-info.outputs.launch_args }}'
+          state: ${{ job.status }}
+          target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There is missing status reporting and link to details before Permian
runs or if Permian does not run at all due to an error in other job of
the workflow (ie building rpms).