### PR TITLE
Temporarily ignore the new version of the zfcp command

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
+++ b/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
@@ -405,6 +405,7 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
 
     # Names of the kickstart commands and data that should be temporarily ignored.
     IGNORED_NAMES = {
+        "zfcp",
     }
 
     # Names of shared kickstart commands and data that should be temporarily ignored.


### PR DESCRIPTION
Skip the version check of the `zfcp` kickstart command.