### PR TITLE
containers: Don't downgrade npm (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -71,8 +71,6 @@ RUN set -ex; \
   cat /root/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   rpmspec -q --requires /tmp/anaconda.spec | grep -v anaconda | xargs -d '\n' dnf install -y; \
-  # FIXME: Install older npm version - the version from the package manager leads to timeouts
-  npm install -g npm@8.1.0; \
   dnf clean all
 
 RUN pip install --no-cache-dir --upgrade pip; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -60,8 +60,6 @@ RUN set -ex; \
   dnf install -y https://kojipkgs.fedoraproject.org//packages/annobin/10.53/1.fc36/x86_64/annobin-plugin-gcc-10.53-1.fc36.x86_64.rpm \
                  https://kojipkgs.fedoraproject.org//packages/annobin/10.53/1.fc36/noarch/annobin-docs-10.53-1.fc36.noarch.rpm; \
   dnf clean all; \
-  # FIXME: Install older npm version - the version from the package manager leads to timeouts
-  npm install -g npm@8.1.0; \
   mkdir /anaconda
 
 WORKDIR /anaconda

--- a/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
+++ b/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
@@ -406,6 +406,7 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
     # Names of the kickstart commands and data that should be temporarily ignored.
     IGNORED_NAMES = {
         "zfcp",
+        "ZFCPData",
     }
 
     # Names of shared kickstart commands and data that should be temporarily ignored.


### PR DESCRIPTION
It appears that the former fix is now a bug: Now it's the older npm that fails to connect to the registry. This manifests only on Fedora, which means developer machines and kstest runners. Anything running on the Github hosted runners did not fail, though.

This de facto reverts commits:
  701539bb600ed728e7dccd229b32c9c20b3f8a40
  aae34587bc246d31eff2b229f40b1ccc87adb9b5