### PR TITLE
Fix kickstart command order in new version

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -38,7 +38,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.39-1
+%define pykickstartver 3.41-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.4.0-1
 %define rpmver 4.15.0

--- a/tests/unit_tests/pyanaconda_tests/modules/users/test_module_users.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/users/test_module_users.py
@@ -471,9 +471,9 @@ class UsersInterfaceTestCase(unittest.TestCase):
         user --name=user1 --password=abcedf
         """
         ks_out = """
-        user --name=user1 --password=abcedf
         #Root password
         rootpw --lock
+        user --name=user1 --password=abcedf
         """
         self._test_kickstart(ks_in, ks_out)
 
@@ -491,9 +491,9 @@ class UsersInterfaceTestCase(unittest.TestCase):
         user --groups=wheel --name=user1 --password=abcedf
         """
         ks_out = """
-        user --groups=wheel --name=user1 --password=abcedf
         #Root password
         rootpw --lock
+        user --groups=wheel --name=user1 --password=abcedf
         """
         self._test_kickstart(ks_in, ks_out)
 
@@ -513,11 +513,11 @@ class UsersInterfaceTestCase(unittest.TestCase):
         user --name=user3 --lock
         """
         ks_out = """
+        #Root password
+        rootpw --lock
         user --groups=a,b,c,d --homedir=user1_home --name=user1 --password=foo --shell=ksh --uid=123 --gecos="baz" --gid=345
         user --groups=wheel,mockuser --homedir=user2_home --name=user2 --password=asasas --iscrypted --shell=csh --uid=321 --gecos="bar" --gid=543
         user --name=user3 --lock
-        #Root password
-        rootpw --lock
         """
         self._test_kickstart(ks_in, ks_out)
 
@@ -545,11 +545,11 @@ class UsersInterfaceTestCase(unittest.TestCase):
         sshkey --username=user3 "ccc"
         """
         ks_out = """
+        #Root password
+        rootpw --lock
         sshkey --username=user1 "aaa"
         sshkey --username=user2 "bbb"
         sshkey --username=user3 "ccc"
-        #Root password
-        rootpw --lock
         """
         self._test_kickstart(ks_in, ks_out)
 


### PR DESCRIPTION
After this bump, order of commands should be stable again.

This is required to build the master ci container.