### PR TITLE
Don't attempt to add frozen python modules to initramfs

### DIFF
--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # module-setup.sh for anaconda
+set -eu -o pipefail
 
 check() {
     [[ $hostonly ]] && return 1
@@ -90,3 +91,5 @@ install() {
     esac
 }
 
+# revert back to the default in case this is sourced
+set +eu +o pipefail

--- a/dracut/python-deps
+++ b/dracut/python-deps
@@ -70,6 +70,10 @@ except AttributeError:
 while scripts:
     script = scripts.pop()
 
+    if script == 'frozen':
+        # https://docs.python.org/3.11/whatsnew/3.11.html#frozen-imports-static-code-objects
+        continue
+
     finder = ModuleFinder()
     finder.run_script(script) # parse the script
     for mod in finder.modules.values():


### PR DESCRIPTION
TODO:

 - [x] figure out if we need to add their unfrozen originals instead
 - [x] make `module-setup.sh` fail when `python-deps` fails in:

https://github.com/rhinstaller/anaconda/blob/35cffe00330c512f8729fc85980f9c89e7b2fd76/dracut/module-setup.sh#L75