### PR TITLE
TUI software spoke is ready with failing repos, too

### DIFF
--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -303,7 +303,7 @@ class SoftwareSpoke(NormalTUISpoke):
         return not threadMgr.get(THREAD_SOFTWARE_WATCHER) \
             and not threadMgr.get(THREAD_PAYLOAD) \
             and not threadMgr.get(THREAD_CHECK_SOFTWARE) \
-            and self.payload.base_repo is not None
+            and ((self.payload.base_repo is not None) or self.errors)
 
     def apply(self):
         """Apply the changes."""


### PR DESCRIPTION
If some repos fail to load, the PayloadManager thread will report error and base repo will not be set, so consider errors as the spoke state being resolved (ready), too.

Resolves: [rhbz#2070182](https://bugzilla.redhat.com/show_bug.cgi?id=2070182)
Resolves: [rhbz#2020299](https://bugzilla.redhat.com/show_bug.cgi?id=2020299)

(Bugs to be deduplicated if possible)