### PR TITLE
anaconda-modprobe: don't try and load cramfs

### DIFF
--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -7,7 +7,7 @@
 ARCH=$(uname -m)
 KERNEL=$(uname -r)
 
-MODULE_LIST="cramfs squashfs iscsi_tcp "
+MODULE_LIST="squashfs iscsi_tcp "
 
 # if no file matches the glob expand it to the empty string
 # we need this when any ko file cannot be found


### PR DESCRIPTION
This got included in the list of "modules needed by anaconda" in
18cf04a0faad854149abe1555e23fb03f710ba1f , but in fact AFAICT
anaconda already didn't need it any more then. It was used for
the ancient loader stuff that was nerfed around 2010, in
89036110fd306d9e771b3977e856cc9d96634a09 etc. If you watch early
boot of any current Fedora installer image carefully, it briefly
flashes an error:

anaconda-modprobe: Module cramfs not found

because cramfs is in kernel-modules, not kernel-core, and we
don't include that in the dracut-pre-udev environment. So loading
it probably hasn't actually worked since kernel-modules was split
out several years ago, but nothing has blown up! So let's just
drop it from the list and avoid the error.

Signed-off-by: Adam Williamson <awilliam@redhat.com>