### PR TITLE
network:fix segmentfault within NMClient in multithreading(#1931389)

### DIFF
--- a/pyanaconda/modules/network/initialization.py
+++ b/pyanaconda/modules/network/initialization.py
@@ -21,11 +21,13 @@ import re
 from pyanaconda.core.regexes import NM_MAC_INITRAMFS_CONNECTION
 from pyanaconda.modules.common.task import Task
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.glib import create_new_context
 from pyanaconda.modules.network.network_interface import NetworkInitializationTaskInterface
 from pyanaconda.modules.network.nm_client import get_device_name_from_network_data, \
     update_connection_from_ksdata, add_connection_from_ksdata, bound_hwaddr_of_device, \
     update_connection_values, commit_changes_with_autoconnection_blocked, \
-    get_config_file_connection_of_device, clone_connection_sync
+    get_config_file_connection_of_device, clone_connection_sync, get_new_nm_client, \
+    activate_connection_sync
 from pyanaconda.modules.network.device_configuration import supported_wired_device_types, \
     virtual_device_types
 from pyanaconda.modules.network.utils import guard_by_system_configuration
@@ -40,11 +42,9 @@ from gi.repository import NM
 class ApplyKickstartTask(Task):
     """Task for application of kickstart network configuration."""
 
-    def __init__(self, nm_client, network_data, supported_devices, bootif, ifname_option_values):
+    def __init__(self, network_data, supported_devices, bootif, ifname_option_values):
         """Create a new task.
 
-        :param nm_client: NetworkManager client used as configuration backend
-        :type nm_client: NM.Client
         :param network_data: kickstart network data to be applied
         :type: list(NetworkData)
         :param supported_devices: list of names of supported network devices
@@ -55,7 +55,7 @@ class ApplyKickstartTask(Task):
         :type ifname_option_values: list(str)
         """
         super().__init__()
-        self._nm_client = nm_client
+        self._nm_client = None
         self._network_data = network_data
         self._supported_devices = supported_devices
         self._bootif = bootif
@@ -82,8 +82,13 @@ class ApplyKickstartTask(Task):
             log.debug("%s: No kickstart data.", self.name)
             return applied_devices
 
+        mainctx = create_new_context()
+        mainctx.push_thread_default()
+
+        self._nm_client = get_new_nm_client()
         if not self._nm_client:
             log.debug("%s: No NetworkManager available.", self.name)
+            mainctx.pop_thread_default()
             return applied_devices
 
         for network_data in self._network_data:
@@ -117,7 +122,7 @@ class ApplyKickstartTask(Task):
                 )
                 if network_data.activate:
                     device = self._nm_client.get_device_by_iface(device_name)
-                    self._nm_client.activate_connection_async(connection, device, None, None)
+                    activate_connection_sync(self._nm_client, connection, device)
                     log.debug("%s: activating updated connection %s with device %s",
                               self.name, connection.get_uuid(), device_name)
             else:
@@ -129,6 +134,8 @@ class ApplyKickstartTask(Task):
                     activate=network_data.activate,
                     ifname_option_values=self._ifname_option_values
                 )
+
+        mainctx.pop_thread_default()
 
         return applied_devices
 
@@ -145,18 +152,16 @@ class ApplyKickstartTask(Task):
 class DumpMissingConfigFilesTask(Task):
     """Task for dumping of missing config files."""
 
-    def __init__(self, nm_client, default_network_data, ifname_option_values):
+    def __init__(self, default_network_data, ifname_option_values):
         """Create a new task.
 
-        :param nm_client: NetworkManager client used as configuration backend
-        :type nm_client: NM.Client
         :param default_network_data: kickstart network data of default device configuration
         :type default_network_data: NetworkData
         :param ifname_option_values: list of ifname boot option values
         :type ifname_option_values: list(str)
         """
         super().__init__()
-        self._nm_client = nm_client
+        self._nm_client = None
         self._default_network_data = default_network_data
         self._ifname_option_values = ifname_option_values
 
@@ -218,8 +223,13 @@ class DumpMissingConfigFilesTask(Task):
         """
         new_configs = []
 
+        mainctx = create_new_context()
+        mainctx.push_thread_default()
+
+        self._nm_client = get_new_nm_client()
         if not self._nm_client:
             log.debug("%s: No NetworkManager available.", self.name)
+            mainctx.pop_thread_default()
             return new_configs
 
         dumped_device_types = supported_wired_device_types + virtual_device_types
@@ -285,7 +295,7 @@ class DumpMissingConfigFilesTask(Task):
                     )
                 log.debug("%s: dumping connection %s to config file for %s",
                           self.name, con.get_uuid(), iface)
-                commit_changes_with_autoconnection_blocked(con)
+                commit_changes_with_autoconnection_blocked(con, mainctx=mainctx)
             else:
                 log.debug("%s: none of the connections can be dumped as persistent",
                           self.name)
@@ -306,6 +316,8 @@ class DumpMissingConfigFilesTask(Task):
                 )
 
             new_configs.append(iface)
+
+        mainctx.pop_thread_default()
 
         return new_configs
 

--- a/pyanaconda/modules/network/installation.py
+++ b/pyanaconda/modules/network/installation.py
@@ -18,12 +18,13 @@
 import os
 import shutil
 
+from pyanaconda.core.glib import create_new_context
 from pyanaconda.core.path import make_directories, join_paths
 from pyanaconda.modules.common.errors.installation import NetworkInstallationError
 from pyanaconda.modules.common.task import Task
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.network.nm_client import update_connection_values, \
-    commit_changes_with_autoconnection_blocked
+    commit_changes_with_autoconnection_blocked, get_new_nm_client
 from pyanaconda.modules.network.utils import guard_by_system_configuration
 from pyanaconda.modules.network.nm_client import get_config_file_connection_of_device
 from pyanaconda.modules.network.config_file import IFCFG_DIR, KEYFILE_DIR
@@ -281,16 +282,14 @@ Name={}
 class ConfigureActivationOnBootTask(Task):
     """Task for configuration of automatic activation of devices on boot"""
 
-    def __init__(self, nm_client, onboot_ifaces):
+    def __init__(self, onboot_ifaces):
         """Create a new task.
 
-        :param nm_client: NetworkManager client used as configuration backend
-        :type nm_client: NM.Client
         :param onboot_ifaces: interfaces that should be autoactivated on boot
         :type onboot_ifaces: list(str)
         """
         super().__init__()
-        self._nm_client = nm_client
+        self._nm_client = None
         self._onboot_ifaces = onboot_ifaces
 
     @property
@@ -299,8 +298,13 @@ class ConfigureActivationOnBootTask(Task):
 
     @guard_by_system_configuration(return_value=None)
     def run(self):
+        mainctx = create_new_context()
+        mainctx.push_thread_default()
+
+        self._nm_client = get_new_nm_client()
         if not self._nm_client:
             log.debug("%s: No NetworkManager available.", self.name)
+            mainctx.pop_thread_default()
             return None
 
         for iface in self._onboot_ifaces:
@@ -311,6 +315,8 @@ class ConfigureActivationOnBootTask(Task):
                     con,
                     [("connection", NM.SETTING_CONNECTION_AUTOCONNECT, True)]
                 )
-                commit_changes_with_autoconnection_blocked(con)
+                commit_changes_with_autoconnection_blocked(con, mainctx=mainctx)
             else:
                 log.warning("Configure ONBOOT: can't find config for %s", iface)
+
+        mainctx.pop_thread_default()


### PR DESCRIPTION
Anaconda got segmentfault during PXE-ks install, and this is a low probability problem. With my own test, it will show up about 1/100 PXE-ks install tests. 
There is a draft PR(https://github.com/rhinstaller/anaconda/pull/3207), but this can not solve probelm. According to Thomas's suggestions(https://bugzilla.redhat.com/show_bug.cgi?id=1931389#c11), and based on rvykydal's PR, I did a little changes and fix this problem:
1. anaconda started multithreading task for network module, and we should create new nmclient for every thread. (also, we can only use nmclient in single thread，but it is difficult for anaconda with multithreading mechanism )
2. create new main-context for nmclient and push it thread default. 
3. iterating the main-context for all of the async actions. 

fix: #1931389