### PR TITLE
bootloader: do not consider non-ibft iscsi disk as usable for bootloader

### DIFF
--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -86,6 +86,10 @@ def _is_node_from_ibft(node):
     return False
 
 
+def is_on_non_ibft_sw_iscsi(device):
+    return _is_on_sw_iscsi(device) and not _is_on_ibft(device)
+
+
 class BootLoaderError(Exception):
     """An exception for boot loader errors."""
     pass
@@ -507,16 +511,15 @@ class BootLoader(object):
             log.debug("stage1 device cannot be of type %s", device.type)
             return False
 
-        if _is_on_sw_iscsi(device):
-            if not _is_on_ibft(device):
-                if conf.bootloader.nonibft_iscsi_boot:
-                    log.debug("stage1 device on non-iBFT iSCSI disk allowed "
-                              "by boot option inst.iscsi.nonibftboot")
-                else:
-                    log.debug("stage1 device cannot be on an non-iBFT iSCSI disk")
-                    self.errors.append(_("Boot loader stage1 device cannot be on "
-                                         "an iSCSI disk which is not configured in iBFT."))
-                    return False
+        if is_on_non_ibft_sw_iscsi(device):
+            if conf.bootloader.nonibft_iscsi_boot:
+                log.debug("stage1 device on non-iBFT iSCSI disk allowed "
+                          "by boot option inst.iscsi.nonibftboot")
+            else:
+                log.debug("stage1 device cannot be on an non-iBFT iSCSI disk")
+                self.errors.append(_("Boot loader stage1 device cannot be on "
+                                     "an iSCSI disk which is not configured in iBFT."))
+                return False
 
         description = self.get_stage1_device_description(device)
 
@@ -632,17 +635,16 @@ class BootLoader(object):
         if device.protected:
             valid = False
 
-        if _is_on_sw_iscsi(device):
-            if not _is_on_ibft(device):
-                if conf.bootloader.nonibft_iscsi_boot:
-                    log.info("%s on non-iBFT iSCSI disk allowed by boot option inst.nonibftiscsiboot",
-                             self.stage2_description)
-                else:
-                    self.errors.append(_("%(bootloader_stage2_description)s cannot be on "
-                                         "an iSCSI disk which is not configured in iBFT.")
-                                       % {"bootloader_stage2_description":
-                                          self.stage2_description})
-                    valid = False
+        if is_on_non_ibft_sw_iscsi(device):
+            if conf.bootloader.nonibft_iscsi_boot:
+                log.info("%s on non-iBFT iSCSI disk allowed by boot option inst.nonibftiscsiboot",
+                         self.stage2_description)
+            else:
+                self.errors.append(_("%(bootloader_stage2_description)s cannot be on "
+                                     "an iSCSI disk which is not configured in iBFT.")
+                                   % {"bootloader_stage2_description":
+                                      self.stage2_description})
+                valid = False
 
         if not self._device_type_match(device, self.stage2_device_types):
             self.errors.append(_("%(desc)s cannot be of type %(type)s")

--- a/pyanaconda/modules/storage/bootloader/execution.py
+++ b/pyanaconda/modules/storage/bootloader/execution.py
@@ -17,7 +17,8 @@
 #
 import blivet.arch
 from blivet.devices import iScsiDiskDevice
-from pyanaconda.modules.storage.bootloader.base import BootLoaderError
+from pyanaconda.modules.storage.bootloader.base import BootLoaderError, \
+    is_on_non_ibft_sw_iscsi
 from pykickstart.errors import KickstartParseError
 
 from pyanaconda.core.configuration.anaconda import conf
@@ -135,7 +136,8 @@ class BootloaderExecutor(object):
         return \
             not d.format.hidden and \
             not d.protected and \
-            not (blivet.arch.is_s390() and isinstance(d, iScsiDiskDevice))
+            not (blivet.arch.is_s390() and isinstance(d, iScsiDiskDevice)) and \
+            (not is_on_non_ibft_sw_iscsi(d) or conf.bootloader.nonibft_iscsi_boot)
 
     def _get_usable_disks(self, storage):
         """Get a list of usable disks."""


### PR DESCRIPTION
Resolves: rhbz#2003519