### PR TITLE
Fix unit tests for python 3.11

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -48,7 +48,6 @@ dist_check_SCRIPTS = $(srcdir)/glade_tests/*.py \
 		     $(srcdir)/lib/*.sh \
 		     unit_tests/unit_tests.sh \
 		     rpm_tests/rpm_tests.sh \
-		     pylint/runpylint.py \
 		     cppcheck/runcppcheck.sh \
 		     testenv.sh \
 		     $(srcdir)/gettext_tests/*.py \
@@ -61,7 +60,6 @@ dist_check_SCRIPTS = $(srcdir)/glade_tests/*.py \
 
 
 TESTS = unit_tests/unit_tests.sh \
-	pylint/runpylint.py \
 	cppcheck/runcppcheck.sh \
 	gettext_tests/click.py \
 	gettext_tests/style_guide.py \

--- a/tests/unit_tests/pyanaconda_tests/test_payload_source.py
+++ b/tests/unit_tests/pyanaconda_tests/test_payload_source.py
@@ -50,21 +50,21 @@ class TestValues(enum.Enum):
     broken_ftp = "ftp2://broken.server.com/test"
 
     def map_to_classes(self):
-        if self == self.http:
+        if self == TestValues.http:
             return HTTPSource
-        elif self == self.https:
+        elif self == TestValues.https:
             return HTTPSSource
-        elif self == self.ftp:
+        elif self == TestValues.ftp:
             return FTPSource
-        elif self in (self.nfs_ks, self.nfs_main_repo, self.nfs_main_repo2):
+        elif self in (TestValues.nfs_ks, TestValues.nfs_main_repo, TestValues.nfs_main_repo2):
             return NFSSource
-        elif self == self.file:
+        elif self == TestValues.file:
             return FileSource
-        elif self in (self.cdrom, self.cdrom_test):
+        elif self in (TestValues.cdrom, TestValues.cdrom_test):
             return CDRomSource
-        elif self in (self.harddrive, self.harddrive_label, self.harddrive_uuid):
+        elif self in (TestValues.harddrive, TestValues.harddrive_label, TestValues.harddrive_uuid):
             return HDDSource
-        elif self == self.hmc:
+        elif self == TestValues.hmc:
             return HMCSource
         else:
             return None


### PR DESCRIPTION
With this, unit tests can succeed.

Pylint is not fixed - its most current breakage is due to interface changes in the new Python disagreeing with `dill`, whatever that is. See https://github.com/uqfoundation/dill/issues/514 and https://github.com/uqfoundation/dill/issues/480. Note that this PR does not change anything requiring rebuild of containers, so pylint appears to work here, but it's just stale container being used.