### PR TITLE
Add support for NPIV enabled zFCP devices

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -35,9 +35,9 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.32.7-1
+%define pykickstartver 3.32.8-1
 %define pypartedver 2.5-2
-%define pythonblivetver 1:3.4.0-10
+%define pythonblivetver 1:3.4.0-15
 %define rpmver 4.10.0
 %define simplelinever 1.1-1
 %define subscriptionmanagerver 1.29.24

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -80,7 +80,7 @@ from pykickstart.commands.vnc import F9_Vnc as Vnc
 from pykickstart.commands.volgroup import RHEL9_VolGroup as VolGroup
 from pykickstart.commands.xconfig import F14_XConfig as XConfig
 from pykickstart.commands.zerombr import F9_ZeroMbr as ZeroMbr
-from pykickstart.commands.zfcp import F14_ZFCP as ZFCP
+from pykickstart.commands.zfcp import RHEL9_ZFCP as ZFCP
 from pykickstart.commands.zipl import F32_Zipl as Zipl
 
 # Supported kickstart data.
@@ -103,4 +103,4 @@ from pykickstart.commands.sshkey import F22_SshKeyData as SshKeyData
 from pykickstart.commands.timesource import F33_TimesourceData as TimesourceData
 from pykickstart.commands.user import F19_UserData as UserData
 from pykickstart.commands.volgroup import RHEL9_VolGroupData as VolGroupData
-from pykickstart.commands.zfcp import F14_ZFCPData as ZFCPData
+from pykickstart.commands.zfcp import RHEL9_ZFCPData as ZFCPData

--- a/pyanaconda/modules/storage/zfcp/discover.py
+++ b/pyanaconda/modules/storage/zfcp/discover.py
@@ -51,18 +51,29 @@ class ZFCPDiscoverTask(Task):
         if not DASD_DEVICE_NUMBER.match(self._device_number):
             raise StorageDiscoveryError("Incorrect format of the given device number.")
 
-        if not ZFCP_WWPN_NUMBER.match(self._wwpn):
+        if self._wwpn and not ZFCP_WWPN_NUMBER.match(self._wwpn):
             raise StorageDiscoveryError("Incorrect format of the given WWPN number.")
 
-        if not ZFCP_LUN_NUMBER.match(self._lun):
+        if self._lun and not ZFCP_LUN_NUMBER.match(self._lun):
             raise StorageDiscoveryError("Incorrect format of the given LUN number.")
+
+        # Zfcp automatic LUN scan requires just the device number to be provided by the user.
+        # If zfcp auto LUN scan is not available, the user has to specify the device number, WWPN
+        # and LUN.
+        if not ((self._device_number and not self._wwpn and not self._lun)
+                or (self._device_number and self._wwpn and self._lun)):
+            raise StorageDiscoveryError(
+                "Only device number or device number with WWPN and LUN are allowed."
+            )
 
     def _sanitize_input(self):
         """Sanitize the input values."""
         try:
             self._device_number = blockdev.s390.sanitize_dev_input(self._device_number)
-            self._wwpn = blockdev.s390.zfcp_sanitize_wwpn_input(self._wwpn)
-            self._lun = blockdev.s390.zfcp_sanitize_lun_input(self._lun)
+            if self._wwpn:
+                self._wwpn = blockdev.s390.zfcp_sanitize_wwpn_input(self._wwpn)
+            if self._lun:
+                self._lun = blockdev.s390.zfcp_sanitize_lun_input(self._lun)
         except (blockdev.S390Error, ValueError) as err:
             raise StorageDiscoveryError(str(err)) from err
 

--- a/pyanaconda/ui/gui/spokes/advstorage/zfcp.glade
+++ b/pyanaconda/ui/gui/spokes/advstorage/zfcp.glade
@@ -103,7 +103,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="margin_bottom">6</property>
-                    <property name="label" translatable="yes">To use zFCP disks, you must provide the device number, WWPN, and LUN configured for the device.</property>
+                    <property name="label" translatable="yes">To use zFCP-attached SCSI disks, you must provide the FCP device number. Storage WWPN and FCP LUN are necessary if the zFCP adapter is not configured in NPIV mode or when automatic LUN scanning is disabled via a kernel module parameter.</property>
                     <property name="wrap">True</property>
                     <property name="xalign">0</property>
                   </object>

--- a/pyanaconda/ui/gui/spokes/advstorage/zfcp.glade
+++ b/pyanaconda/ui/gui/spokes/advstorage/zfcp.glade
@@ -23,6 +23,7 @@
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <property name="default-width">600</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can_focus">False</property>

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_zfcp.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_zfcp.py
@@ -75,9 +75,6 @@ class ZFCPTasksTestCase(unittest.TestCase):
             ZFCPDiscoverTask("", "", "").run()
 
         with pytest.raises(StorageDiscoveryError):
-            ZFCPDiscoverTask("0.0.fc00", "", "").run()
-
-        with pytest.raises(StorageDiscoveryError):
             ZFCPDiscoverTask("0.0.fc00", "0x5105074308c212e9", "").run()
 
     @patch('pyanaconda.modules.storage.zfcp.discover.zfcp')
@@ -95,3 +92,17 @@ class ZFCPTasksTestCase(unittest.TestCase):
         sanitized_lun = blockdev.s390.zfcp_sanitize_lun_input.return_value
 
         zfcp.add_fcp.assert_called_once_with(sanitized_dev, sanitized_wwpn, sanitized_lun)
+
+    @patch('pyanaconda.modules.storage.zfcp.discover.zfcp')
+    @patch('pyanaconda.modules.storage.zfcp.discover.blockdev')
+    def test_discovery_npiv(self, blockdev, zfcp):
+        """Test the discovery task for an NPIV enabled zFCP."""
+        ZFCPDiscoverTask("0.0.fc00", "", "").run()
+
+        blockdev.s390.sanitize_dev_input.assert_called_once_with("0.0.fc00")
+        blockdev.s390.zfcp_sanitize_wwpn_input.assert_not_called()
+        blockdev.s390.zfcp_sanitize_lun_input.assert_not_called()
+
+        sanitized_dev = blockdev.s390.sanitize_dev_input.return_value
+
+        zfcp.add_fcp.assert_called_once_with(sanitized_dev, "", "")


### PR DESCRIPTION
This change allows to use NPIV-enabled zFCP devices in anaconda. Such devices can be configured just based on their device number, WWPN and LUN are useless.
Also update the width of the "Add zFCP" dialog, since with additional text it would use the whole with of the screen.

Ported from https://github.com/rhinstaller/anaconda/pull/4188

Resolves: rhbz#1937032