### PR TITLE
Add support for NPIV enabled zFCP devices

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -33,7 +33,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.16.11-1
+%define pykickstartver 3.16.15-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 1.1-1
@@ -81,7 +81,7 @@ The anaconda package is a metapackage for the Anaconda installer.
 Summary: Core of the Anaconda installer
 Requires: python3-libs
 Requires: python3-dnf >= %{dnfver}
-Requires: python3-blivet >= 1:3.4.0-1
+Requires: python3-blivet >= 1:3.4.0-12
 Requires: python3-blockdev >= %{libblockdevver}
 Requires: python3-meh >= %{mehver}
 Requires: libreport-anaconda >= 2.0.21-1

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -84,7 +84,7 @@ from pykickstart.commands.vnc import F9_Vnc as Vnc
 from pykickstart.commands.volgroup import RHEL8_VolGroup as VolGroup
 from pykickstart.commands.xconfig import F14_XConfig as XConfig
 from pykickstart.commands.zerombr import F9_ZeroMbr as ZeroMbr
-from pykickstart.commands.zfcp import F14_ZFCP as ZFCP
+from pykickstart.commands.zfcp import RHEL8_ZFCP as ZFCP
 from pykickstart.commands.zipl import RHEL8_Zipl as Zipl
 
 # Supported kickstart data.
@@ -109,4 +109,4 @@ from pykickstart.commands.sshpw import F24_SshPwData as SshPwData
 from pykickstart.commands.sshkey import F22_SshKeyData as SshKeyData
 from pykickstart.commands.user import F19_UserData as UserData
 from pykickstart.commands.volgroup import RHEL8_VolGroupData as VolGroupData
-from pykickstart.commands.zfcp import F14_ZFCPData as ZFCPData
+from pykickstart.commands.zfcp import RHEL8_ZFCPData as ZFCPData

--- a/pyanaconda/ui/gui/spokes/advstorage/zfcp.glade
+++ b/pyanaconda/ui/gui/spokes/advstorage/zfcp.glade
@@ -103,7 +103,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="margin_bottom">6</property>
-                    <property name="label" translatable="yes">To use zFCP disks, you must provide the device number, WWPN, and LUN configured for the device.</property>
+                    <property name="label" translatable="yes">To use zFCP-attached SCSI disks, you must provide the FCP device number. Storage WWPN and FCP LUN are necessary if the zFCP adapter is not configured in NPIV mode or when automatic LUN scanning is disabled via a kernel module parameter.</property>
                     <property name="wrap">True</property>
                     <property name="xalign">0</property>
                   </object>

--- a/pyanaconda/ui/gui/spokes/advstorage/zfcp.glade
+++ b/pyanaconda/ui/gui/spokes/advstorage/zfcp.glade
@@ -23,6 +23,7 @@
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <property name="default-width">600</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can_focus">False</property>

--- a/tests/nosetests/pyanaconda_tests/module_zfcp_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_zfcp_test.py
@@ -73,9 +73,6 @@ class ZFCPTasksTestCase(unittest.TestCase):
             ZFCPDiscoverTask("", "", "").run()
 
         with self.assertRaises(StorageDiscoveryError):
-            ZFCPDiscoverTask("0.0.fc00", "", "").run()
-
-        with self.assertRaises(StorageDiscoveryError):
             ZFCPDiscoverTask("0.0.fc00", "0x5105074308c212e9", "").run()
 
     @patch('pyanaconda.modules.storage.zfcp.discover.zfcp')
@@ -93,3 +90,17 @@ class ZFCPTasksTestCase(unittest.TestCase):
         sanitized_lun = blockdev.s390.zfcp_sanitize_lun_input.return_value
 
         zfcp.add_fcp.assert_called_once_with(sanitized_dev, sanitized_wwpn, sanitized_lun)
+
+    @patch('pyanaconda.modules.storage.zfcp.discover.zfcp')
+    @patch('pyanaconda.modules.storage.zfcp.discover.blockdev')
+    def discovery_test_npiv(self, blockdev, zfcp):
+        """Test the discovery task for an NPIV enabled zFCP."""
+        ZFCPDiscoverTask("0.0.fc00", "", "").run()
+
+        blockdev.s390.sanitize_dev_input.assert_called_once_with("0.0.fc00")
+        blockdev.s390.zfcp_sanitize_wwpn_input.assert_not_called()
+        blockdev.s390.zfcp_sanitize_lun_input.assert_not_called()
+
+        sanitized_dev = blockdev.s390.sanitize_dev_input.return_value
+
+        zfcp.add_fcp.assert_called_once_with(sanitized_dev, "", "")


### PR DESCRIPTION
This change allows to use NPIV-enabled zFCP devices in anaconda. Such devices can be configured just based on their device number, WWPN and LUN are useless.
Also update the width of the "Add zFCP" dialog, since with additional text it would use the whole with of the screen.

Ported from https://github.com/rhinstaller/anaconda/pull/4188

Resolves: rhbz#1497086