### PR TITLE
bootloader/base.py: enable resume on arm64

### DIFF
--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -795,9 +795,9 @@ class BootLoader(object):
         swap_devices = storage.fsset.swap_devices
         dracut_devices.extend(swap_devices)
 
-        # Add resume= option to enable hibernation on x86.
+        # Add resume= option to enable hibernation for x86 and arm.
         # Choose the largest swap device for that.
-        if blivet.arch.is_x86() and swap_devices:
+        if (blivet.arch.is_x86() or blivet.arch.is_arm()) and swap_devices:
             resume_device = max(swap_devices, key=lambda x: x.size)
             self.boot_args.add("resume=%s" % resume_device.fstab_spec)
 


### PR DESCRIPTION
resume=swap_device is only added for x86, thus on arm64 systems resume from hibernation fails because of that missing kernel command line paramter.

This issue appears on distros that have systemd: systemd uses systemd-hibernate-resume-generator which sends the parameter of the device to systemd-hibernate-resume; systemd-hibernate-resume-generator checks the kernel command line only for the resume device.