### PR TITLE
Use RHEL 9-specific ZFCP command from pykickstart 3.32.8

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -35,7 +35,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.32.7-1
+%define pykickstartver 3.32.8-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.4.0-10
 %define rpmver 4.10.0

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -80,7 +80,7 @@ from pykickstart.commands.vnc import F9_Vnc as Vnc
 from pykickstart.commands.volgroup import RHEL9_VolGroup as VolGroup
 from pykickstart.commands.xconfig import F14_XConfig as XConfig
 from pykickstart.commands.zerombr import F9_ZeroMbr as ZeroMbr
-from pykickstart.commands.zfcp import F14_ZFCP as ZFCP
+from pykickstart.commands.zfcp import RHEL9_ZFCP as ZFCP
 from pykickstart.commands.zipl import F32_Zipl as Zipl
 
 # Supported kickstart data.
@@ -103,4 +103,4 @@ from pykickstart.commands.sshkey import F22_SshKeyData as SshKeyData
 from pykickstart.commands.timesource import F33_TimesourceData as TimesourceData
 from pykickstart.commands.user import F19_UserData as UserData
 from pykickstart.commands.volgroup import RHEL9_VolGroupData as VolGroupData
-from pykickstart.commands.zfcp import F14_ZFCPData as ZFCPData
+from pykickstart.commands.zfcp import RHEL9_ZFCPData as ZFCPData


### PR DESCRIPTION
This solves the test failures on `rhel-9` branch. However, it also duplicates part of #4217.

It would be preferable if #4217 was merged immediately. Then, this could be removed.

Resolves: rhbz# ???? TODO !!!! (needs a bug in case we do need this as a standalone change)