### PR TITLE
Enable pylint

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -49,7 +49,10 @@ RUN set -ex; \
     BRANCH=${BRANCH#f}; \
     dnf copr enable -y ${copr_repo} fedora-${BRANCH}-x86_64; \
     dnf copr enable -y @storage/blivet-daily fedora-${BRANCH}-x86_64; \
-    dnf -y install cppcheck; \
+    dnf -y install \
+    cppcheck \
+    # TODO dill is patched in rawhide for python 3.11, remove once released in pip too
+    python3-dill; \
   else \
     dnf copr enable -y ${copr_repo} fedora-eln-x86_64; \
   fi; \
@@ -64,6 +67,8 @@ RUN set -ex; \
   bzip2 \
   rpm-ostree \
   python3-pip \
+  # TODO pylint is patched in rawhide for python 3.11, remove once released in pip too
+  python3-pylint \
   # Need to have restorecon for the tests execution
   policycoreutils \
   ShellCheck; \

--- a/pyanaconda/core/users.py
+++ b/pyanaconda/core/users.py
@@ -29,7 +29,7 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.path import make_directories, open_with_perm
 from pyanaconda.core.string import strip_accents
 from pyanaconda.core.regexes import GROUPLIST_FANCY_PARSE, NAME_VALID, PORTABLE_FS_CHARS, GROUPLIST_SIMPLE_VALID
-import crypt
+import crypt  # pylint: disable=deprecated-module
 from pyanaconda.core.i18n import _
 import re
 from random import SystemRandom as sr

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -48,6 +48,7 @@ dist_check_SCRIPTS = $(srcdir)/glade_tests/*.py \
 		     $(srcdir)/lib/*.sh \
 		     unit_tests/unit_tests.sh \
 		     rpm_tests/rpm_tests.sh \
+		     pylint/runpylint.py \
 		     cppcheck/runcppcheck.sh \
 		     testenv.sh \
 		     $(srcdir)/gettext_tests/*.py \
@@ -60,6 +61,7 @@ dist_check_SCRIPTS = $(srcdir)/glade_tests/*.py \
 
 
 TESTS = unit_tests/unit_tests.sh \
+	pylint/runpylint.py \
 	cppcheck/runcppcheck.sh \
 	gettext_tests/click.py \
 	gettext_tests/style_guide.py \

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -37,6 +37,10 @@ class AnacondaLintConfig(CensorshipConfig):
             FalsePositive(r"E1101.*: Instance of 'int' has no 'name_from_node' member"),
             FalsePositive(r"E1101.*: Instance of 'int' has no 'generate_backup_passphrase' member"),
             FalsePositive(r"E1101.*: Instance of 'int' has no 'dasd_is_ldl' member"),
+
+            # pylint/astroid has issues with GI modules https://github.com/PyCQA/pylint/issues/6352
+            FalsePositive(r"E1101.*: Module 'gi\.repository\..+' has no '.+' member"),
+            FalsePositive(r"E0611.*: No name '.+' in module 'gi\.repository\..+'"),
         ]
 
     def _files(self):

--- a/tests/unit_tests/pyanaconda_tests/core/test_user_create.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_user_create.py
@@ -22,7 +22,7 @@ from unittest.mock import patch
 import tempfile
 import shutil
 import os
-import crypt
+import crypt  # pylint: disable=deprecated-module
 import platform
 import glob
 import pytest


### PR DESCRIPTION
Let's install pylint and some of its deps from packages. The packages in rawhide are patched to work with the new python, ahead of what's in pip, so they do work.

That brings also another round of plugging holes in pylint false positives.

Finally, let's ignore the crypt module deprecation for now.