### PR TITLE
Prefer GPT instead of legacy MBR on Fedora (`inst.gpt` version)

### DIFF
--- a/data/profile.d/fedora.conf
+++ b/data/profile.d/fedora.conf
@@ -15,6 +15,7 @@ default_on_boot = FIRST_WIRED_WITH_LINK
 efi_dir = fedora
 
 [Storage]
+gpt = True
 default_scheme = BTRFS
 btrfs_compression = zstd:1
 

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -699,7 +699,8 @@ Disable support for dmraid.
 inst.gpt
 ^^^^^^^^
 
-Prefer creation of GPT disklabels.
+Prefer creation of GPT disk labels. Use ``inst.gpt=0`` to disable this behavior
+and to allow creation of legacy MBR partitioning.
 
 
 Other options


### PR DESCRIPTION
**This is an alternative to the `inst.disklabel=<gpt|mbr>` solution.**
Only one of these solutions will be merged. See https://github.com/rhinstaller/anaconda/pull/4104#issuecomment-1192445360.