### PR TITLE
Prefer GPT instead of legacy MBR

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -183,7 +183,7 @@ btrfs_compression =
 #
 #    If not specified, use whatever Blivet uses by default.
 #
-disk_label_type =
+disk_label_type = gpt
 
 # Default file system type. Use whatever Blivet uses by default.
 file_system_type =

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -166,9 +166,6 @@ dmraid = True
 # Enable iBFT usage during the installation.
 ibft = True
 
-# Do you prefer creation of GPT disk labels?
-gpt = False
-
 # Tell multipathd to use user friendly names when naming devices during the installation.
 multipath_friendly_names = True
 
@@ -177,6 +174,16 @@ allow_imperfect_devices = False
 
 # Btrfs compression algorithm and level. e.g. zstd:1
 btrfs_compression =
+
+# Default disk label type.
+# Valid values:
+#
+#    gpt  Prefer creation of GPT disk labels.
+#    mbr  Prefer creation of MBR disk labels.
+#
+#    If not specified, use whatever Blivet uses by default.
+#
+disk_label_type =
 
 # Default file system type. Use whatever Blivet uses by default.
 file_system_type =

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -147,7 +147,11 @@ Also note that while SELinux is running in the installation environment by defau
 running in permissive mode so disabling it there does not make much sense.
 
 gpt
-Prefer creation of GPT disklabels.
+Prefer creation of GPT disklabels. This option is deprecated and will be removed in future releases.
+
+disklabel
+Prefer creation of the specified disk label type. Specify "gpt" to prefer creation of GPT disk
+labels. Specify "mbr" to prefer creation of MBR disk labels if supported.
 
 nodmraid
 Disable dmraid usage during the installation.

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -694,12 +694,22 @@ Disable support for dmraid.
              it has some stale RAID metadata on it which must be removed using
              an appropriate tool (dmraid and/or wipefs).
 
+
+.. inst.disklabel:
+
+inst.disklabel
+^^^^^^^^^^^^^^
+
+Prefer creation of the specified disk label type. Specify ``gpt`` to prefer creation of GPT disk
+labels. Specify ``mbr`` to prefer creation of MBR disk labels if supported.
+
 .. inst.gpt:
 
 inst.gpt
 ^^^^^^^^
 
-Prefer creation of GPT disklabels.
+Prefer creation of GPT disk labels. This option is deprecated and will be removed in future
+releases. Use ``inst.disklabel=gpt`` instead.
 
 
 Other options

--- a/docs/release-notes/default_disk_label_type.rst
+++ b/docs/release-notes/default_disk_label_type.rst
@@ -1,0 +1,19 @@
+:Type: Storage configuration
+:Summary: Change the default disk label type
+
+:Description:
+    Use the `inst.disklabel` boot option to specify a preferred disk label type. Specify
+    `gpt` to prefer creation of GPT disk labels. Specify `mbr` to prefer creation of MBR
+    disk labels if supported. The `inst.gpt` boot option is deprecated and will be removed
+    in future releases.
+
+    The default value of the preferred disk label type is specified by the `disk_label_type`
+    option in the Anaconda configuration files. The `gpt` configuration option is no longer
+    supported.
+
+    Fedora Linux systems installed on legacy x86 BIOS systems should get GPT partitioning by
+    default instead of legacy MBR partitioning. This should be a new default for all products.
+
+:Links:
+    - https://github.com/rhinstaller/anaconda/pull/4232
+    - https://fedoraproject.org/wiki/Changes/GPTforBIOSbyDefault

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -533,7 +533,9 @@ def getArgumentParser(version_string, boot_cmdline=None):
                     help=help_parser.help_text("nompath"))
     ap.add_argument("--mpath", action="store_true", help=help_parser.help_text("mpath"))
 
-    ap.add_argument("--gpt", action="store_true", default=SUPPRESS, help=help_parser.help_text("gpt"))
+    ap.add_argument("--disklabel", default=SUPPRESS, help=help_parser.help_text("disklabel"))
+    ap.add_argument("--gpt", dest="disklabel", action="store_const", const="gpt",
+                    default=SUPPRESS, help=help_parser.help_text("gpt"))
 
     ap.add_argument("--nodmraid", dest="dmraid", action="store_false", default=True,
                     help=help_parser.help_text("nodmraid"))

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -382,9 +382,11 @@ class AnacondaConfiguration(Configuration):
         # Set the storage flags.
         self.storage._set_option("dmraid", opts.dmraid)
         self.storage._set_option("ibft", opts.ibft)
-        if hasattr(opts, "gpt"):
-            self.storage._set_option("gpt", opts.gpt)
         self.storage._set_option("multipath_friendly_names", opts.multipath_friendly_names)
+
+        # Set the disk label type.
+        if hasattr(opts, "disklabel"):
+            self.storage._set_option("disk_label_type", opts.disklabel)
 
         # Set up the rescue mode.
         if opts.rescue:

--- a/pyanaconda/core/configuration/storage.py
+++ b/pyanaconda/core/configuration/storage.py
@@ -61,11 +61,6 @@ class StorageSection(Section):
         return self._get_option("ibft", bool)
 
     @property
-    def gpt(self):
-        """Do you prefer creation of GPT disk labels?"""
-        return self._get_option("gpt", bool)
-
-    @property
     def multipath_friendly_names(self):
         """Use user friendly names for multipath devices.
 
@@ -93,6 +88,21 @@ class StorageSection(Section):
         For example: "zstd:1"
         """
         return self._get_option("btrfs_compression", str) or None
+
+    @property
+    def disk_label_type(self):
+        """Default disk label type.
+
+        Valid values:
+
+          gpt  Prefer creation of GPT disk labels.
+          mbr  Prefer creation of MBR disk labels.
+
+        If no type is specified, we will use whatever Blivet uses by default.
+
+        :return: a string with the disk label type
+        """
+        return self._get_option("disk_label_type", str)
 
     @property
     def file_system_type(self):

--- a/pyanaconda/modules/storage/initialization.py
+++ b/pyanaconda/modules/storage/initialization.py
@@ -78,18 +78,25 @@ def enable_installer_mode():
 
 def _set_default_label_type():
     """Set up the default label type."""
-    if not conf.storage.gpt:
+    if not conf.storage.disk_label_type:
         return
 
     disklabel_class = get_device_format_class("disklabel")
-    disklabel_types = disklabel_class.get_platform_label_types()
+    supported_types = disklabel_class.get_platform_label_types()
+    default_type = supported_types[0] if supported_types else None
+    requested_type = conf.storage.disk_label_type
 
-    if "gpt" not in disklabel_types:
-        log.warning("GPT is not a supported disklabel on this platform. "
-                    "Using default disklabel %s instead.", disklabel_types[0])
-        return
+    if requested_type == "mbr":
+        requested_type = "msdos"
 
-    disklabel_class.set_default_label_type("gpt")
+    if requested_type in supported_types:
+        disklabel_class.set_default_label_type(requested_type)
+    else:
+        log.warning(
+            "The requested disk label type '%s' is not supported on "
+            "this platform. Using the default disk label '%s' instead.",
+            conf.storage.disk_label_type, default_type
+        )
 
 
 def _load_plugin_s390():

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_initialization.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_initialization.py
@@ -1,0 +1,86 @@
+#
+# Copyright (C) 2022  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+from unittest.mock import patch
+
+from blivet.formats import get_device_format_class
+from pyanaconda.modules.storage.initialization import _set_default_label_type
+
+
+class DefaultDiskLabelTypeTestCase(unittest.TestCase):
+    """Test the initialization of the default disk label type."""
+
+    def setUp(self):
+        """Set up the test."""
+        self.disklabel.set_default_label_type(None)
+
+    def tearDown(self):
+        """Tear down the test."""
+        self.disklabel.set_default_label_type(None)
+
+    @property
+    def disklabel(self):
+        """The disk label class."""
+        return get_device_format_class("disklabel")
+
+    def test_set_default_label_type(self):
+        """Don't crash by default."""
+        _set_default_label_type()
+
+    @patch("pyanaconda.modules.storage.initialization.conf")
+    @patch("blivet.formats.disklabel.DiskLabel.get_platform_label_types")
+    def test_set_default_label_type_unsupported(self, supported_types_getter, mocked_conf):
+        """Test the unsupported disk label type initialization."""
+        mocked_conf.storage.disk_label_type = "gpt"
+        supported_types_getter.return_value = ["mac"]
+
+        with self.assertLogs(level="WARNING") as cm:
+            _set_default_label_type()
+
+        msg = "The requested disk label type 'gpt' is not supported on " \
+              "this platform. Using the default disk label 'mac' instead."
+
+        assert msg in "\n".join(cm.output)
+        assert self.disklabel._default_label_type is None
+
+    @patch("pyanaconda.modules.storage.initialization.conf")
+    @patch("blivet.formats.disklabel.DiskLabel.get_platform_label_types")
+    def test_set_default_label_type_none(self, label_types_getter, mocked_conf):
+        """Test the unset disk label type initialization."""
+        mocked_conf.storage.disk_label_type = ""
+        label_types_getter.return_value = ["msdos", "gpt"]
+        _set_default_label_type()
+        assert self.disklabel._default_label_type is None
+
+    @patch("pyanaconda.modules.storage.initialization.conf")
+    @patch("blivet.formats.disklabel.DiskLabel.get_platform_label_types")
+    def test_set_default_label_type_gpt(self, label_types_getter, mocked_conf):
+        """Test the unsupported disk label type initialization."""
+        mocked_conf.storage.disk_label_type = "gpt"
+        label_types_getter.return_value = ["msdos", "gpt"]
+        _set_default_label_type()
+        assert self.disklabel._default_label_type == "gpt"
+
+    @patch("pyanaconda.modules.storage.initialization.conf")
+    @patch("blivet.formats.disklabel.DiskLabel.get_platform_label_types")
+    def test_set_default_label_type_mbr(self, label_types_getter, mocked_conf):
+        """Test the mbr disk label type initialization."""
+        mocked_conf.storage.disk_label_type = "mbr"
+        label_types_getter.return_value = ["gpt", "msdos"]
+        _set_default_label_type()
+        assert self.disklabel._default_label_type == "msdos"


### PR DESCRIPTION
Use the `inst.disklabel` boot option to specify a preferred disk label type. Specify
`gpt` to prefer creation of GPT disk labels. Specify `mbr` to prefer creation of MBR
disk labels if supported. The `inst.gpt` boot option is deprecated and will be removed
in future releases.

The default value of the preferred disk label type is specified by the `disk_label_type`
option in the Anaconda configuration files. The `gpt` configuration option is no longer
supported.

Fedora Linux systems installed on legacy x86 BIOS systems should get GPT partitioning by
default instead of legacy MBR partitioning. This should be a new default for all products.


See: https://fedoraproject.org/wiki/Changes/GPTforBIOSbyDefault