### PR TITLE
rpm-ostree: Setup readonly sysroot for ostree & rw karg

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -475,6 +475,8 @@ class ConfigureBootloader(Task):
         if root_data.type == "btrfs subvolume":
             set_kargs_args.append("rootflags=subvol=" + root_name)
 
+        set_kargs_args.append("rw")
+
         safe_exec_with_redirect("ostree", set_kargs_args, root=self._sysroot)
 
 
@@ -518,6 +520,17 @@ class DeployOSTreeTask(Task):
              "deploy",
              "--os=" + self._data.osname,
              self._data.remote + ':' + ref]
+        )
+
+        log.info("ostree config set sysroot.readonly true")
+
+        safe_exec_with_redirect(
+            "ostree",
+            ["config",
+             "--repo=" + self._physroot + "/ostree/repo",
+             "set",
+             "sysroot.readonly",
+             "true"]
         )
 
         log.info("ostree admin deploy complete")

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -540,7 +540,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
             exec_mock.assert_called_once_with(
                 "ostree",
                 ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC",
-                 "rootflags=subvol=device-name"],
+                 "rootflags=subvol=device-name", "rw"],
                 root=sysroot
             )
 
@@ -576,7 +576,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
             )
             exec_mock.assert_called_once_with(
                 "ostree",
-                ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC"],
+                ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC", "rw"],
                 root=sysroot
             )
 


### PR DESCRIPTION
- Enable read only sysroot in the ostree repo config.
- Add `rw` to the kernel arguments to keep statefull parts of the system
  (/var & /etc) writable.

See: https://fedoraproject.org/wiki/Changes/Silverblue_Kinoite_readonly_sysroot
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2086489