### PR TITLE
Fix the missing npm package (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -62,6 +62,9 @@ RUN set -ex; \
   dnf install -y \
   /usr/bin/xargs \
   npm \
+  # FIXME: Temporarily add missing dependencies for npm-8.13.2-1.18.6.0.1.
+  https://kojipkgs.fedoraproject.org//packages/nodejs/18.6.0/1.fc37/x86_64/nodejs-18.6.0-1.fc37.x86_64.rpm \
+  https://kojipkgs.fedoraproject.org//packages/nodejs/18.6.0/1.fc37/x86_64/nodejs-libs-18.6.0-1.fc37.x86_64.rpm \
   rpm-build \
   git \
   bzip2 \

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -61,7 +61,7 @@ RUN set -ex; \
   # Install rest of the dependencies
   dnf install -y \
   /usr/bin/xargs \
-  nodejs \
+  npm \
   rpm-build \
   git \
   bzip2 \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -36,6 +36,9 @@ RUN set -ex; \
   dnf install -y \
   'dnf-command(copr)' \
   npm \
+  # FIXME: Temporarily add missing dependencies for npm-8.13.2-1.18.6.0.1.
+  https://kojipkgs.fedoraproject.org//packages/nodejs/18.6.0/1.fc37/x86_64/nodejs-18.6.0-1.fc37.x86_64.rpm \
+  https://kojipkgs.fedoraproject.org//packages/nodejs/18.6.0/1.fc37/x86_64/nodejs-libs-18.6.0-1.fc37.x86_64.rpm \
   git \
   curl \
   python3-polib \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex; \
   dnf update -y; \
   dnf install -y \
   'dnf-command(copr)' \
-  nodejs \
+  npm \
   git \
   curl \
   python3-polib \


### PR DESCRIPTION
The current solution worked, because the `npm` package is a weak dependency
of the `nodejs` package. Now it is broken due to some inconsistencies in the
Rawhide compose. It means that `npm` cannot be installed, but the CI doesn't
fail until it actually tries to use it. Let's install `npm` instead of `nodejs`.
The `nodejs` package will be installed as its required dependency.

As a temporary fix, include some missing packages into the installation.
The Rawhide compose contains incompatible versions.