### PR TITLE
Disable ELN containers (#infra)

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -18,14 +18,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container-tag: ['master', 'eln'] #, 'f36-devel', 'f36-release']
+        container-tag: ['master'] #, 'eln', 'f36-devel', 'f36-release']
         container-type: ['ci', 'rpm']
         include:
           - container-tag: master
             branch: master
-          - container-tag: eln
-            branch: master
-            base-container: 'quay.io/fedoraci/fedora:eln-x86_64'
+          #- container-tag: eln
+          #  branch: master
+          #  base-container: 'quay.io/fedoraci/fedora:eln-x86_64'
           #- container-tag: f36-devel
           #  branch: f36-devel
           #- container-tag: f36-release


### PR DESCRIPTION
~~ELN is too disorderly at the moment.~~

This does not prevent building the containers locally, just turns off building them daily and failing.every.single.time.