### PR TITLE
Fix the Dependabot configuration file (#infra)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,22 +19,11 @@ updates:
       - "infrastructure"
       - "manual testing required"
 
-  # update our npm development dependencies monthly
-  - package-ecosystem: "npm"
-    directory: "/ui/webui"
-    schedule:
-      interval: "monthly"
-    allow:
-      - dependency-type: "development"
-    labels:
-      - "sanity check required"
-
-  # update our npm production dependencies weekly
+  # FIXME: Update our npm development dependencies monthly.
+  # See: https://github.com/dependabot/dependabot-core/issues/2390
   - package-ecosystem: "npm"
     directory: "/ui/webui"
     schedule:
       interval: "weekly"
-    allow:
-      - dependency-type: "production"
     labels:
       - "sanity check required"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
     commit-message:
-      prefix: "infra:"
+      prefix: "infra"
     labels:
       - "infrastructure"
       - "manual testing required"
@@ -25,5 +25,7 @@ updates:
     directory: "/ui/webui"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "infra"
     labels:
       - "sanity check required"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,16 @@
-# Dependabot will check our GitHub actions and if there will be a new version of any action
-# Dependabot will create a pull request to update these.
-#
-# FIXME: Unfortunately, the Dependabot is checking only the default branch right now.
-#        Could be solved by https://github.com/dependabot/dependabot-core/issues/2511.
+# Dependabot checks our dependencies and opens pull requests for new versions.
+# See the current status: https://github.com/rhinstaller/anaconda/network/updates
 
-# Set update schedule for GitHub Actions
+# FIXME: Unfortunately, Dependabot is checking only the default branch right now.
+#        See: https://github.com/dependabot/dependabot-core/issues/2511
+
 version: 2
 updates:
 
+  # Set update schedule for GitHub actions.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
       interval: "daily"
     commit-message:
       prefix: "infra"
@@ -19,6 +18,7 @@ updates:
       - "infrastructure"
       - "manual testing required"
 
+  # Set update schedule for npm packages.
   # FIXME: Update our npm development dependencies monthly.
   # See: https://github.com/dependabot/dependabot-core/issues/2390
   - package-ecosystem: "npm"

--- a/docs/ci-status.rst
+++ b/docs/ci-status.rst
@@ -25,6 +25,8 @@ Anaconda
 
 .. _releases: https://github.com/rhinstaller/anaconda/releases
 
+.. _Dependabot: https://github.com/rhinstaller/anaconda/network/updates
+
 |container-autoupdate|
   CI test container images, built daily. The containers are used in unit and rpm tests.
 
@@ -38,6 +40,9 @@ Anaconda
 
 |try-release-daily|
   Tests the release process daily, including checks for missing important translations
+
+Dependabot_
+  Checks Anaconda dependencies and opens pull requests for new versions.
 
 Kickstart-tests
 ---------------


### PR DESCRIPTION
Dependabot doesn't work, because there is an error in the configuration file.
The `updates` entries must have a unique combination of `package-ecosystem`,
`directory`, and `target-branch`.

It means that our configuration for `npm` development and product dependencies
is not supported at this moment.

**See:** https://github.com/dependabot/dependabot-core/issues/2390