### PR TITLE
Fix growing installation size requirement

### DIFF
--- a/pyanaconda/modules/payloads/base/utils.py
+++ b/pyanaconda/modules/payloads/base/utils.py
@@ -18,54 +18,11 @@
 # Red Hat, Inc.
 #
 import functools
-import os
-import stat
 
 from packaging.version import LegacyVersion as parse_version
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
-
-
-def get_dir_size(directory):
-    """Get the size of a directory and all its subdirectories.
-
-    :param str directory: the name of the directory to find the size of
-    :return: the size of the directory in kilobytes
-    """
-    def get_subdir_size(directory):
-        # returns size in bytes
-        try:
-            mydev = os.lstat(directory)[stat.ST_DEV]
-        except OSError as e:
-            log.debug("failed to stat %s: %s", directory, e)
-            return 0
-
-        try:
-            dirlist = os.listdir(directory)
-        except OSError as e:
-            log.debug("failed to listdir %s: %s", directory, e)
-            return 0
-
-        dsize = 0
-        for f in dirlist:
-            curpath = '%s/%s' % (directory, f)
-            try:
-                sinfo = os.lstat(curpath)
-            except OSError as e:
-                log.debug("failed to stat %s/%s: %s", directory, f, e)
-                continue
-
-            if stat.S_ISDIR(sinfo[stat.ST_MODE]):
-                if os.path.ismount(curpath):
-                    continue
-                if mydev == sinfo[stat.ST_DEV]:
-                    dsize += get_subdir_size(curpath)
-            elif stat.S_ISREG(sinfo[stat.ST_MODE]):
-                dsize += sinfo[stat.ST_SIZE]
-
-        return dsize
-    return get_subdir_size(directory) // 1024
 
 
 def sort_kernel_version_list(kernel_version_list):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/test_module_payload_base_utils.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/test_module_payload_base_utils.py
@@ -17,27 +17,10 @@
 #
 from unittest.case import TestCase
 
-from pyanaconda.modules.payloads.base.utils import get_dir_size, sort_kernel_version_list
+from pyanaconda.modules.payloads.base.utils import sort_kernel_version_list
 
 
 class PayloadBaseUtilsTest(TestCase):
-
-    def test_get_dir_size(self):
-        """Test the get_dir_size function."""
-
-        # dev null should have a size == 0
-        assert get_dir_size('/dev/null') == 0
-
-        # incorrect path should also return 0
-        assert get_dir_size('/dev/null/foo') == 0
-
-        # check if an int is always returned
-        assert isinstance(get_dir_size('/dev/null'), int)
-        assert isinstance(get_dir_size('/dev/null/foo'), int)
-
-        # TODO: mock some dirs and check if their size is
-        # computed correctly
-
     def test_sort_kernel_version_list(self):
         """Test the sort_kernel_version_list function."""
         # Test fake versions.


### PR DESCRIPTION
Fix issue where the additional space needed for installation (shown
in the hub if the root partition didn't have enough space) would
slightly increase as time went on.

This happened because the size was calculated from the running
file system and included growing log files and other changes done in the
live session.

Delete old method for calculating installation size that uses running
file system and replace it with one that uses the payload file size.
Also modified tests accordingly.