### PR TITLE
Container rebuilds as a reusable workflow (#infra)

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -9,73 +9,34 @@ permissions:
   contents: read
 
 jobs:
-  refresh-containers:
-    name: Refresh anaconda containers
-    runs-on: ubuntu-20.04
-    environment: quay.io
-    # we need to have matrix to cover all branches because schedule is run only on default branch
-    # we can add here fedora branches (e.g. f33-devel) to cover their support when needed
-    strategy:
-      fail-fast: false
-      matrix:
-        container-tag: ['master', 'eln'] #, 'f36-devel', 'f36-release']
-        container-type: ['ci', 'rpm']
-        include:
-          - container-tag: master
-            branch: master
-          - container-tag: eln
-            branch: master
-            base-container: 'quay.io/fedoraci/fedora:eln-x86_64'
-          #- container-tag: f36-devel
-          #  branch: f36-devel
-          #- container-tag: f36-release
-          #  branch: f36-release
-    env:
-      CI_TAG: '${{ matrix.container-tag }}'
-    timeout-minutes: 60
-    steps:
-      - name: Checkout anaconda repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ matrix.branch }}
 
-      - name: Build anaconda-${{ matrix.container-type }} container
-        run: |
-          BASE_CONTAINER=${{ matrix.base-container }}
-          make -f Makefile.am anaconda-${{ matrix.container-type }}-build ${BASE_CONTAINER:+BASE_CONTAINER=}${BASE_CONTAINER:-}
+  master:
+    uses: ./.github/workflows/container-rebuild-action.yml
+    secrets: inherit
+    with:
+      container-tag: master
+      branch: master
 
-      - name: Run tests in anaconda-ci container
-        if: matrix.container-type == 'ci'
-        run: |
-          # put the log in the output, where it's easy to read and link to
-          make -f Makefile.am container-ci || { cat test-logs/test-suite.log; exit 1; }
+  eln:
+    uses: ./.github/workflows/container-rebuild-action.yml
+    secrets: inherit
+    with:
+      container-tag: eln
+      branch: master
+      base-container: 'quay.io/fedoraci/fedora:eln-x86_64'
 
-      - name: Run tests in anaconda-rpm container
-        if: matrix.container-type == 'rpm'
-        run: |
-          # put the log in the output, where it's easy to read and link to
-          make -f Makefile.am container-rpm-test || { cat test-logs/test-suite.log; exit 1; }
+  f36-devel:
+    if: false
+    uses: ./.github/workflows/container-rebuild-action.yml
+    secrets: inherit
+    with:
+      container-tag: f36-devel
+      branch: f36-devel
 
-      - name: Upload test and coverage logs from local testing
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.container-tag }}-${{ matrix.container-type }}-logs
-          path: |
-            test-logs/test-suite.log
-            test-logs/unit_tests.log
-            test-logs/pylint/runpylint*.log
-            test-logs/coverage-*.log
-
-      - name: Login to container registry
-        run: podman login -u ${{ secrets.QUAY_USERNAME }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
-
-        # we can hardcode the path to the image here because this will be executed only for master image
-      - name: Add latest tag for master container
-        if: ${{ matrix.container-tag == 'master' }}
-        run: |
-          podman tag quay.io/rhinstaller/anaconda-${{ matrix.container-type }}:master quay.io/rhinstaller/anaconda-${{ matrix.container-type }}:latest
-          CI_TAG=latest make -f Makefile.am anaconda-${{ matrix.container-type }}-push
-
-      - name: Push container to registry
-        run: make -f Makefile.am anaconda-${{ matrix.container-type }}-push
+  f36-release:
+    if: false
+    uses: ./.github/workflows/container-rebuild-action.yml
+    secrets: inherit
+    with:
+      container-tag: f36-release
+      branch: f36-release

--- a/.github/workflows/container-rebuild-action.yml
+++ b/.github/workflows/container-rebuild-action.yml
@@ -1,0 +1,97 @@
+name: Rebuild container images
+# Rebuilds both ci and rpm container images for a given "target". Currently known targets:
+#  - master
+#  - eln
+#  - fNN-devel
+#  - fNN-release
+#
+# Image is:
+# - built from the repo at ref <branch>,
+# - based on the right container according to branch settings, or optionally on <base-container> if set,
+# - tagged as quay.io/rhinstaller/anaconda-{ci|rpm}:<container-tag>.
+#
+# See also inputs below.
+
+# Reusable workflow, does not run on its own. Typically, use in an action this way:
+# jobs:
+#   foo:
+#     uses: ./.github/workflows/container-rebuild-action.yml
+#     secrets: inherit
+#     with:
+#       container-tag: foo
+#       branch: foo
+
+on:
+  workflow_call:
+    inputs:
+      container-tag:
+        required: true
+        type: string
+      branch:
+        required: true
+        type: string
+      base-container:
+        required: false
+        type: string
+     # secrets are inherited, so not explicitly listed
+
+permissions:
+  contents: read
+
+jobs:
+  refresh-container:
+    name: Refresh anaconda container
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        container-type: ['ci', 'rpm']
+    env:
+      CI_TAG: '${{ inputs.container-tag }}'
+    timeout-minutes: 60
+    steps:
+      - name: Checkout anaconda repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Build anaconda-${{ matrix.container-type }} container
+        run: |
+          BASE_CONTAINER=${{ inputs.base-container }}
+          make -f Makefile.am anaconda-${{ matrix.container-type }}-build ${BASE_CONTAINER:+BASE_CONTAINER=}${BASE_CONTAINER:-}
+
+      - name: Run tests in anaconda-ci container
+        if: matrix.container-type == 'ci'
+        run: |
+          # put the log in the output, where it's easy to read and link to
+          make -f Makefile.am container-ci || { cat test-logs/test-suite.log; exit 1; }
+
+      - name: Run tests in anaconda-rpm container
+        if: matrix.container-type == 'rpm'
+        run: |
+          # put the log in the output, where it's easy to read and link to
+          make -f Makefile.am container-rpm-test || { cat test-logs/test-suite.log; exit 1; }
+
+      - name: Upload test and coverage logs from local testing
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.container-tag }}-${{ matrix.container-type }}-logs
+          path: |
+            test-logs/test-suite.log
+            test-logs/unit_tests.log
+            test-logs/pylint/runpylint*.log
+            test-logs/coverage-*.log
+
+      - name: Login to container registry
+        run: podman login -u ${{ secrets.QUAY_USERNAME }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
+
+        # we can hardcode the path to the image here because this will be executed only for master image
+      - name: Add latest tag for master container
+        if: ${{ inputs.container-tag == 'master' }}
+        run: |
+          podman tag quay.io/rhinstaller/anaconda-${{ matrix.container-type }}:master quay.io/rhinstaller/anaconda-${{ matrix.container-type }}:latest
+          CI_TAG=latest make -f Makefile.am anaconda-${{ matrix.container-type }}-push
+
+      - name: Push container to registry
+        run: make -f Makefile.am anaconda-${{ matrix.container-type }}-push


### PR DESCRIPTION
This reorganizes the code but it should stay the same.

This enables the following:
- Read the whole thing with out having to mentally parse the matrix.
- Enable and disable the `fNN-{devel|release}` containers with one line per each, no repeated commenting and uncommenting parts of the file.
- The top-level single workflow can be split into multiple ones, eg. separate ELN so we know the failures are of a different kind.
- If the templated branching idea is implemented, generating the file in this format should be far easier.