### PR TITLE
Improve Register button click feedback

### DIFF
--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -867,6 +867,13 @@ class SubscriptionSpoke(NormalSpoke):
 
     def _register(self):
         """Try to register a system."""
+        # set the registrastion phase right away to provide immediate feedback once the
+        # Register button is clicked
+        # - otherwise outdated status text might remain displayed for a while
+        #   before the background thread gets going
+        # - the stale status text might cause confusion to the users
+        self.registration_phase = SubscriptionPhase.REGISTER
+
         # update data in the Subscription DBUS module
         self._set_data_to_module()
 


### PR DESCRIPTION
Set the phase right after button click to avoid the registration status being outdated.

So far that has been handled by the registration thread, which could
result in the status message being out of date until the thread gets to
the status update.

Resolves: rhbz#2074636