### PR TITLE
Set environment in reusable workflow (#infra)

### DIFF
--- a/.github/workflows/container-rebuild-action.yml
+++ b/.github/workflows/container-rebuild-action.yml
@@ -33,7 +33,8 @@ on:
       base-container:
         required: false
         type: string
-     # secrets are inherited, so not explicitly listed
+    # secrets consumed: QUAY_USERNAME, QUAY_PASSWORD
+    # these are provided by using the quay.io environment below
 
 permissions:
   contents: read
@@ -42,6 +43,7 @@ jobs:
   refresh-container:
     name: Refresh anaconda container
     runs-on: ubuntu-20.04
+    environment: quay.io
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This fixes the container builds and propagates secrets correctly.

Turns out, this was a very simple omission. However, reusable workflows declare things exactly opposite of function calls, so that was a lesson to learn first...

Successful run with mock values for the secrets - still fails on login but you can see the masked secrets `***` actually present in the login command, as opposed to simply missing before. https://github.com/VladimirSlavik/anaconda/actions/runs/2827874013

See also:
https://colinsalmcorner.com/consuming-environment-secrets-in-reusable-workflows/
https://github.com/orgs/community/discussions/25238#discussioncomment-3247035