### PR TITLE
Split container refresh: Fedora and ELN (#infra)

### DIFF
--- a/.github/workflows/container-autoupdate-eln.yml
+++ b/.github/workflows/container-autoupdate-eln.yml
@@ -1,0 +1,20 @@
+# a smaller sibling of the Fedora refresh; split to provide cleaner statuses
+name: Refresh ELN container images
+on:
+  schedule:
+    - cron: 0 0 * * *
+  # be able to start this action manually from a actions tab when needed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+
+  eln:
+    uses: ./.github/workflows/container-rebuild-action.yml
+    secrets: inherit
+    with:
+      container-tag: eln
+      branch: master
+      base-container: 'quay.io/fedoraci/fedora:eln-x86_64'

--- a/.github/workflows/container-autoupdate-fedora.yml
+++ b/.github/workflows/container-autoupdate-fedora.yml
@@ -1,4 +1,4 @@
-name: Refresh container images
+name: Refresh Fedora container images
 on:
   schedule:
     - cron: 0 0 * * *
@@ -16,14 +16,6 @@ jobs:
     with:
       container-tag: master
       branch: master
-
-  eln:
-    uses: ./.github/workflows/container-rebuild-action.yml
-    secrets: inherit
-    with:
-      container-tag: eln
-      branch: master
-      base-container: 'quay.io/fedoraci/fedora:eln-x86_64'
 
   f36-devel:
     if: false

--- a/docs/ci-status.rst
+++ b/docs/ci-status.rst
@@ -7,9 +7,13 @@ This page shows current status of CI jobs that are expected to be stable.
 Anaconda
 --------
 
-.. |container-autoupdate| image:: https://github.com/rhinstaller/anaconda/actions/workflows/container-autoupdate.yml/badge.svg
-   :alt: Refresh container images
-   :target: https://github.com/rhinstaller/anaconda/actions/workflows/container-autoupdate.yml
+.. |container-autoupdate-fedora| image:: https://github.com/rhinstaller/anaconda/actions/workflows/container-autoupdate-fedora.yml/badge.svg
+   :alt: Refresh Fedora container images
+   :target: https://github.com/rhinstaller/anaconda/actions/workflows/container-autoupdate-fedora.yml
+
+.. |container-autoupdate-eln| image:: https://github.com/rhinstaller/anaconda/actions/workflows/container-autoupdate-eln.yml/badge.svg
+   :alt: Refresh ELN container images
+   :target: https://github.com/rhinstaller/anaconda/actions/workflows/container-autoupdate-eln.yml
 
 .. |container-daily-rhel-copr| image:: https://github.com/rhinstaller/anaconda/actions/workflows/daily-rhel-copr.yml/badge.svg
    :alt: Build current anaconda rhel-8 branch in RHEL COPR
@@ -27,10 +31,11 @@ Anaconda
 
 .. _Dependabot: https://github.com/rhinstaller/anaconda/network/updates
 
-|container-autoupdate|
-  CI test container images, built daily. The containers are used in unit and rpm tests.
+|container-autoupdate-fedora|
+  Fedora CI test container images, built daily. The containers are used in unit and rpm tests.
 
-  ELN can often fail to build, this is sort of expected.
+|container-autoupdate-eln|
+  Same as above but for ELN. It is expected this can often fail.
 
 |container-daily-rhel-copr|
   Daily builds of Anaconda in RHEL 8 COPR (internal).


### PR DESCRIPTION
This provides cleaner statuses. If ELN fails, we know at a glance that the Fedora containers are still OK.