### PR TITLE
Adjust dependencies of the anaconda-webui package

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -24,6 +24,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %else
 %bcond_with live
 %endif
+%define cockpitver 274
 %define dasbusver 1.3
 %define dbusver 1.2.3
 %define dnfver 3.6.0
@@ -258,8 +259,12 @@ Add this package to an image build (eg. with lorax) to ensure all Anaconda capab
 %if %use_cockpit
 %package webui
 Summary: Cockpit based user interface for the Anaconda installer
-Requires: cockpit-bridge
-Requires: cockpit-ws
+Requires: cockpit-bridge >= %{cockpitver}
+Requires: cockpit-ws >= %{cockpitver}
+# WebKit dependency needs to be specified there as cockpit web-view does not have a hard dependency on webkit as
+# it can normally fall back to a regular browser. This does not work in the limited installer
+# environment, so we need to make sure the WebKit API is available.
+Requires: webkit2gtk4.1
 
 %description webui
 This package contains Cockpit based user interface for the Anaconda installer.

--- a/ui/webui/test/prepare-updates-img
+++ b/ui/webui/test/prepare-updates-img
@@ -9,8 +9,8 @@ set -e
     # store these separately so we don't need to download them each time
     mkdir -p tmp/extra-rpms
     cd tmp/extra-rpms
-    test -e tmp/rpms/cockpit-ws*.rpm || curl -LO https://kojipkgs.fedoraproject.org//packages/cockpit/259/1.fc35/x86_64/cockpit-ws-259-1.fc35.x86_64.rpm
-    test -e cockpit-bridge*.rpm || curl -LO https://kojipkgs.fedoraproject.org//packages/cockpit/259/1.fc35/x86_64/cockpit-bridge-259-1.fc35.x86_64.rpm
+    test -e tmp/rpms/cockpit-ws*.rpm || dnf download cockpit-ws --best
+    test -e cockpit-bridge*.rpm || dnf download cockpit-bridge --best
 )
 
 # build the anaconda srpm (and result RPMs go in `tmp/rpms`)


### PR DESCRIPTION
Set minimum cockpit version to make sure we have cockpit-client
with correct WebKit API support.

Also require the correct WebKit API to be available as cockpit-client
does not have a hard requires on it itself due to its fallback mechanism,
which does not really work in the installation environment
(eq. we don't have a Firefox or Chrome browsers to fall back to).