### PR TITLE
Drop packit override for webui package build

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -21,7 +21,6 @@ actions:
   post-upstream-clone:
     - ./autogen.sh
     - ./configure
-    - sed -i 's/use_cockpit\ 1/use_cockpit 0/g' anaconda.spec
   create-archive:
     - "make release"
     - 'bash -c "ls -1 anaconda-*.tar.bz2"'


### PR DESCRIPTION
The anaconda-webui sub-package is gated by the spec file use_cockpit macro.

So far we have changed this macro via packit to disable the
anaconda-webui package from being build in the official Fedora builds.

This is no longer necessary & we are ready for the anaconda-webui
package to be part of the official Anaconda builds, so lets drop
the override.