### PR TITLE
Add --hibernation option for Kickstart autopart

### DIFF
--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -23,7 +23,7 @@
 
 # Supported kickstart commands.
 from pykickstart.commands.authselect import F28_Authselect as Authselect
-from pykickstart.commands.autopart import F29_AutoPart as AutoPart
+from pykickstart.commands.autopart import F38_AutoPart as AutoPart
 from pykickstart.commands.autostep import F34_AutoStep as AutoStep
 from pykickstart.commands.bootloader import F34_Bootloader as Bootloader
 from pykickstart.commands.btrfs import F23_BTRFS as BTRFS

--- a/pyanaconda/modules/common/structures/partitioning.py
+++ b/pyanaconda/modules/common/structures/partitioning.py
@@ -32,6 +32,7 @@ class PartitioningRequest(DBusData):
         self._partitioning_scheme = conf.storage.default_scheme
         self._file_system_type = ""
         self._excluded_mount_points = []
+        self._hibernation = False
 
         self._encrypted = False
         self._passphrase = ""
@@ -90,6 +91,21 @@ class PartitioningRequest(DBusData):
         :return: a list of mount points
         """
         return self._excluded_mount_points
+
+    @property
+    def hibernation(self) -> Bool:
+        """Should the partitioning include hibernation swap?
+
+        If True a swap partition large enough for hibernation will be created
+        even if swap was not configured in the Anaconda configuration file.
+
+        :return: True or False
+        """
+        return self._hibernation
+
+    @hibernation.setter
+    def hibernation(self, value: Bool):
+        self._hibernation = value
 
     @excluded_mount_points.setter
     def excluded_mount_points(self, mount_points: List[Str]):

--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_module.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_module.py
@@ -76,6 +76,8 @@ class AutoPartitioningModule(PartitioningModule):
         if data.autopart.noswap:
             request.excluded_mount_points.append("swap")
 
+        request.hibernation = data.autopart.hibernation
+
         if data.autopart.encrypted:
             request.encrypted = True
             request.passphrase = data.autopart.passphrase
@@ -103,6 +105,8 @@ class AutoPartitioningModule(PartitioningModule):
         data.autopart.nohome = "/home" in self.request.excluded_mount_points
         data.autopart.noboot = "/boot" in self.request.excluded_mount_points
         data.autopart.noswap = "swap" in self.request.excluded_mount_points
+
+        data.autopart.hibernation = self.request.hibernation
 
         data.autopart.encrypted = self.request.encrypted
 

--- a/pyanaconda/modules/storage/partitioning/automatic/utils.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/utils.py
@@ -266,31 +266,39 @@ def get_default_partitioning():
 
     # Get the product-specific partitioning.
     for attrs in conf.storage.default_partitioning:
-        name = attrs.get("name")
-        swap = name == "swap"
-        schemes = set()
-
-        if attrs.get("btrfs"):
-            schemes.add(AUTOPART_TYPE_BTRFS)
-
-        spec = PartSpec(
-            mountpoint=name if not swap else None,
-            fstype=None if not swap else "swap",
-            lv=True,
-            thin=not swap,
-            btr=not swap,
-            size=attrs.get("min") or attrs.get("size"),
-            max_size=attrs.get("max"),
-            grow="min" in attrs,
-            required_space=attrs.get("free") or 0,
-            encrypted=True,
-            schemes=schemes,
-        )
-
-        partitioning.append(spec)
+        partitioning.append(get_part_spec(attrs))
 
     return partitioning
 
+
+def get_part_spec(attrs):
+    """Creates an instance of PartSpec.
+
+    :param attrs: A dictionary containing the configuration
+    :return: a partitioning spec
+    :rtype: PartSpec
+    """
+    name = attrs.get("name")
+    swap = name == "swap"
+    schemes = set()
+
+    if attrs.get("btrfs"):
+        schemes.add(AUTOPART_TYPE_BTRFS)
+
+    spec = PartSpec(
+        mountpoint=name if not swap else None,
+        fstype=None if not swap else "swap",
+        lv=True,
+        thin=not swap,
+        btr=not swap,
+        size=attrs.get("min") or attrs.get("size"),
+        max_size=attrs.get("max"),
+        grow="min" in attrs,
+        required_space=attrs.get("free") or 0,
+        encrypted=True,
+        schemes=schemes,
+    )
+    return spec
 
 def schedule_partitions(storage, disks, implicit_devices, scheme, requests, encrypted=False,
                         luks_fmt_args=None):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
@@ -882,6 +882,19 @@ class StorageInterfaceTestCase(unittest.TestCase):
         self._check_dbus_partitioning(publisher, PartitioningMethod.AUTOMATIC)
 
     @patch_dbus_publish_object
+    def test_autopart_hibernation_kickstart(self, publisher):
+        """Test the autopart command with the hibernation option."""
+        ks_in = """
+        autopart --hibernation
+        """
+        ks_out = """
+        autopart --hibernation
+        """
+        self._apply_partitioning_when_created()
+        self._test_kickstart(ks_in, ks_out)
+        self._check_dbus_partitioning(publisher, PartitioningMethod.AUTOMATIC)
+
+    @patch_dbus_publish_object
     def test_mount_kickstart(self, publisher):
         """Test the mount command."""
         ks_in = """


### PR DESCRIPTION
Previously it wasn't possible to create a hibernation swap using
autopart.

Add a --hibernation flag that will force autopart to
create a swap partition for hibernation even if swap isn't
configured in anaconda.conf.

Corresponding changes to pykickstart: https://github.com/pykickstart/pykickstart/pull/420 

Resolves: [rhbz#882989](https://bugzilla.redhat.com/show_bug.cgi?id=882989)