### PR TITLE
Remove execInSysroot

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -31,7 +31,6 @@ import inspect
 import functools
 import importlib.util
 import importlib.machinery
-import warnings
 import blivet.arch
 
 import requests
@@ -323,21 +322,6 @@ def _run_program(argv, root='/', stdin=None, stdout=None, env_prune=None, log_ou
         program_log.debug("Return code: %d", proc.returncode)
 
     return (proc.returncode, output_string)
-
-
-def execInSysroot(command, argv, stdin=None):
-    """ Run an external program in the target root.
-
-        TODO: Remove this function, it is used only by the OSCAP addon.
-
-        :param command: The command to run
-        :param argv: The argument list
-        :param stdin: The file object to read stdin from.
-        :return: The return code of the command
-    """
-    warnings.warn("execInSysroot is deprecated and will be removed, use execWithRedirect instead",
-                  DeprecationWarning)
-    return execWithRedirect(command, argv, stdin=stdin, root=conf.target.system_root)
 
 
 def execWithRedirect(command, argv, stdin=None, stdout=None,


### PR DESCRIPTION
The function has been deprecated and was not used anywhere any more.

See also #3752