### PR TITLE
Don't remove existing BLS entries

### DIFF
--- a/pyanaconda/modules/storage/bootloader/utils.py
+++ b/pyanaconda/modules/storage/bootloader/utils.py
@@ -226,12 +226,6 @@ def create_bls_entries(sysroot, storage, kernel_versions):
     if os.path.exists(sysroot + "/usr/sbin/new-kernel-pkg"):
         return
 
-    # Remove any existing BLS entries, they will not match the new system's
-    # machine-id or /boot mountpoint.
-    for file in glob(sysroot + "/boot/loader/entries/*.conf"):
-        log.info("Removing old BLS entry: %s", file)
-        os.unlink(file)
-
     # Create new BLS entries for this system
     for kernel in kernel_versions:
         log.info("Regenerating BLS info for %s", kernel)


### PR DESCRIPTION
Boot Loader Specification expects this location to be shared among distros. We can't assume they can be deleted. The user can indicate they're no longer needed by reformatting the /boot volume.
http://systemd.io/BOOT_LOADER_SPECIFICATION/
Fixes RHBZ 1874724 - dual boot Fedora, 2nd installation erases 1st installation's /boot/loader/entries *conf files
https://bugzilla.redhat.com/show_bug.cgi?id=1874724