### PR TITLE
Create the LVM devices file (#2011329)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -44,7 +44,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define nmver 1.0
 %define pykickstartver 3.43-1
 %define pypartedver 2.5-2
-%define pythonblivetver 1:3.4.4-3
+%define pythonblivetver 1:3.5.0-1
 %define rpmver 4.15.0
 %define simplelinever 1.9.0-1
 %define subscriptionmanagerver 1.26

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
@@ -1533,7 +1533,7 @@ class StorageTasksTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.storage.installation.conf")
     def test_write_configuration(self, patched_conf, dbus):
         """Test WriteConfigurationTask."""
-        storage = Mock(devices=[])
+        storage = Mock(devices=[], devicetree=Mock(_hidden=[]))
 
         with tempfile.TemporaryDirectory() as d:
             patched_conf.target.system_root = d
@@ -1546,6 +1546,38 @@ class StorageTasksTestCase(unittest.TestCase):
             patched_conf.target.is_directory = False
             WriteConfigurationTask(storage).run()
             assert os.path.exists("{}/etc".format(d))
+
+    @patch("pyanaconda.modules.storage.installation.os.path.exists", return_value=False)
+    def test_lvm_devices_file(self, exists_mock):
+        """Test writing the LVM devices file"""
+        dev1 = Mock()
+        dev1.format.type = "lvmpv"
+        dev2 = Mock()
+        dev2.format.type = "blah"
+        dev3 = Mock()
+        dev3.format.type = "lvmpv"
+        dev4 = Mock()
+        dev4.format.type = "ext4"
+        storage = Mock(devices=[dev1, dev2], devicetree=Mock(_hidden=[dev3, dev4]))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # lvm devices file: disabled
+            with patch("pyanaconda.modules.storage.installation.HAVE_LVMDEVICES", new=False):
+                WriteConfigurationTask._write_lvm_devices_file(storage, tmp)
+                dev1.format.lvmdevices_add.assert_not_called()
+                dev2.format.lvmdevices_add.assert_not_called()
+                dev3.format.lvmdevices_add.assert_not_called()
+                dev4.format.lvmdevices_add.assert_not_called()
+                exists_mock.assert_not_called()
+
+            # lvm devices file: enabled
+            with patch("pyanaconda.modules.storage.installation.HAVE_LVMDEVICES", new=True):
+                WriteConfigurationTask._write_lvm_devices_file(storage, tmp)
+                dev1.format.lvmdevices_add.assert_called_once_with()
+                dev2.format.lvmdevices_add.assert_not_called()
+                dev3.format.lvmdevices_add.assert_called_once_with()
+                dev4.format.lvmdevices_add.assert_not_called()
+                exists_mock.assert_called_once_with("/etc/lvm/devices/system.devices")
 
 
 class StorageValidationTasksTestCase(unittest.TestCase):


### PR DESCRIPTION
Write the LVM devices file with all PVs, to keep the previous behavior.
Then, copy it to the new system.

Resolves: rhbz#2011329
Resolves: rhbz#2040302

(cherry picked from commit 8e3223a677a1813ba6c15faead5fb6759b0f80c0)
(cherry picked from commit 6dd7ebbd79103075061c19427737203163d78410)

----

Port of #3771 and #3792.

@vojtechtrefny, do you know if there's upstream support already? Do I need a specific Blivet version?