### PR TITLE
gui: fix summary hub layout for Japanese translations

### DIFF
--- a/widgets/src/SpokeSelector.c
+++ b/widgets/src/SpokeSelector.c
@@ -301,6 +301,7 @@ static void anaconda_spoke_selector_init(AnacondaSpokeSelector *spoke) {
     /* Create the status label. */
     spoke->priv->status_label = gtk_label_new(_(DEFAULT_STATUS));
     gtk_label_set_justify(GTK_LABEL(spoke->priv->status_label), GTK_JUSTIFY_LEFT);
+    gtk_label_set_line_wrap(GTK_LABEL(spoke->priv->status_label), TRUE);
     gtk_label_set_xalign(GTK_LABEL(spoke->priv->status_label), 0.0);
     gtk_label_set_yalign(GTK_LABEL(spoke->priv->status_label), 0.0);
     gtk_label_set_ellipsize(GTK_LABEL(spoke->priv->status_label), PANGO_ELLIPSIZE_MIDDLE);


### PR DESCRIPTION
The patch makes the spoke buttons more compact vertically (same as with
other languages), making User spoke accessible without scrolling.

Resolves: rhbz#2120293