### PR TITLE
Bump pykickstart version for F38_AutoPart

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -42,7 +42,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.41-1
+%define pykickstartver 3.43-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.4.4-3
 %define rpmver 4.15.0

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -98,7 +98,7 @@ from pykickstart.commands.raid import F29_RaidData as RaidData
 from pykickstart.commands.repo import F30_RepoData as RepoData
 from pykickstart.commands.snapshot import F26_SnapshotData as SnapshotData
 from pykickstart.commands.sshpw import F24_SshPwData as SshPwData
-from pykickstart.commands.sshkey import F22_SshKeyData as SshKeyData
+from pykickstart.commands.sshkey import F38_SshKeyData as SshKeyData
 from pykickstart.commands.timesource import F33_TimesourceData as TimesourceData
 from pykickstart.commands.user import F19_UserData as UserData
 from pykickstart.commands.volgroup import F21_VolGroupData as VolGroupData

--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
@@ -25,7 +25,6 @@ from pyanaconda.modules.storage.partitioning.automatic.noninteractive_partitioni
 from pyanaconda.modules.storage.partitioning.automatic.utils import get_candidate_disks, \
     schedule_implicit_partitions, schedule_volumes, schedule_partitions, get_pbkdf_args, \
     get_default_partitioning, get_part_spec, get_disks_for_implicit_partitions
-from pyanaconda.modules.storage.partitioning.specification import PartSpec
 from pyanaconda.core.storage import suggest_swap_size
 
 log = get_module_logger(__name__)


### PR DESCRIPTION
Apart from using the correct pykickstart version, fix also pylint and ignore pykickstart's unreleased changes.

This should fix unit tests on master as far as possible.