### PR TITLE
Web UI: Show the help drawer next to content

### DIFF
--- a/ui/webui/src/components/HelpDrawer.jsx
+++ b/ui/webui/src/components/HelpDrawer.jsx
@@ -89,7 +89,7 @@ export const HelpDrawer = ({ isExpanded, setIsExpanded, children }) => {
     );
 
     return (
-        <Drawer isExpanded={isExpanded} position="right" onExpand={onExpand}>
+        <Drawer isExpanded={isExpanded} isInline position="right" onExpand={onExpand}>
             <DrawerContent panelContent={panelContent}>
                 <DrawerContentBody>{children}</DrawerContentBody>
             </DrawerContent>


### PR DESCRIPTION
Currently the help drawer is displayed above step content while the
guidelines for its use specify it should be displayed next to the
content, so that the user sees both.