### PR TITLE
Do not pass rd.znet on to installed system unconditionally

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -152,7 +152,7 @@ nonibft_iscsi_boot = False
 
 # Arguments preserved from the installation system.
 preserved_arguments =
-    cio_ignore rd.znet rd_ZNET zfcp.allow_lun_scan
+    cio_ignore zfcp.allow_lun_scan
     speakup_synth apic noapic apm ide noht acpi video
     pci nodmraid nompath nomodeset noiswmd fips selinux
     biosdevname ipv6.disable net.ifnames net.ifnames.prefix

--- a/docs/release-notes/no-rd-znet.rst
+++ b/docs/release-notes/no-rd-znet.rst
@@ -1,0 +1,12 @@
+:Type: Architecture support
+:Summary: Do not pass the `rd.znet` boot argument on to the installed system unconditionally
+
+:Description:
+    With this change, the `rd.znet` boot argument is no longer passed on to the installed
+    system unconditionally on IBM Z systems and the network device is configured and
+    activated after switchroot by udev/NetworkManager. When networking is needed early in
+    initramfs (like in a case of the root file system on iSCSI), `rd.znet` is automatically
+    added to the kernel command line of the installed via a different mechanism.
+
+:Links:
+    - https://github.com/rhinstaller/anaconda/pull/4303


### PR DESCRIPTION
Passing the rd.znet boot argument to the installed was implemented as a
workaround for bug https://bugzilla.redhat.com/show_bug.cgi?id=1087502,
commit 64fb106734413550985dcd568ab6b3baba76603e.

With this change, the rd.znet boot argument is no longer passed on to
the installed system unconditionally and the network device is
configured and activated after switchroot by udev/NetworkManager
(tested). When networking is needed in initramfs (like in case of
iSCSI), rd.znet is automatically added to the kernel command line of
the installed via a different mechanism (tested). Also the original
problem in bug 1087502 (installation via a VLAN network interface and
network availability on the installed system) was successfully proven
to be working fine with this change.

This change will also prevent confusing issues we have seen:
https://bugzilla.redhat.com/show_bug.cgi?id=1726060
https://bugzilla.redhat.com/show_bug.cgi?id=1966345