### PR TITLE
Call the Blivet.copy method

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -41,7 +41,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define nmver 1.0
 %define pykickstartver 3.43-1
 %define pypartedver 2.5-2
-%define pythonblivetver 1:3.5.0-1
+%define pythonblivetver 1:3.6.0-1
 %define rpmver 4.15.0
 %define simplelinever 1.9.0-1
 %define subscriptionmanagerver 1.26

--- a/pyanaconda/modules/storage/devicetree/model.py
+++ b/pyanaconda/modules/storage/devicetree/model.py
@@ -17,11 +17,10 @@
 #
 # Red Hat Author(s): David Lehman <dlehman@redhat.com>
 #
-import copy
 import os
 
 from blivet.blivet import Blivet
-from blivet.devices import BTRFSSubVolumeDevice, PartitionDevice
+from blivet.devices import BTRFSSubVolumeDevice
 from blivet.formats import get_format
 from blivet.formats.disklabel import DiskLabel
 from blivet.size import Size
@@ -491,29 +490,9 @@ class InstallerStorage(Blivet):
     def copy(self):
         """Create a copy of the storage model."""
         log.debug("Creating a copy of the storage model.")
-        ###################################################
-        # FIXME: Replace this section with super().copy().
 
-        log.debug("starting Blivet copy")
-
-        new = copy.deepcopy(self)
-        # go through and re-get parted_partitions from the disks since they
-        # don't get deep-copied
-        hidden_partitions = [d for d in new.devicetree._hidden
-                             if isinstance(d, PartitionDevice)]
-        for partition in new.partitions + hidden_partitions:
-            if not partition._parted_partition:
-                continue
-
-            # update the refs in req_disks as well
-            req_disks = (new.devicetree.get_device_by_id(disk.id) for disk in partition.req_disks)
-            partition.req_disks = [disk for disk in req_disks if disk is not None]
-
-            p = partition.disk.format.parted_disk.getPartitionByPath(partition.path)
-            partition.parted_partition = p
-
-        log.debug("finished Blivet copy")
-        ###################################################
+        # Create a copy of the Blivet object.
+        new = super().copy()
 
         # Create proper copies of the collected installation roots.
         new.roots = [root.copy(storage=new) for root in new.roots]


### PR DESCRIPTION
Remove code that creates a copy of the Blivet object and call `super().copy()`
instead. This is a follow-up of the commit 4a437c3.

**Blocked by a release of** https://github.com/storaged-project/blivet/pull/1069.