### PR TITLE
Show multiple bootloader devices on the Manual Partitioning screen

### DIFF
--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -389,8 +389,8 @@ class OSData(DBusData):
 
     def __init__(self):
         self._os_name = ""
+        self._devices = []
         self._mount_points = {}
-        self._swap_devices = []
 
     @property
     def os_name(self) -> Str:
@@ -405,8 +405,26 @@ class OSData(DBusData):
         self._os_name = name
 
     @property
+    def devices(self) -> List[Str]:
+        """Devices used by the OS.
+
+        For example:
+
+        * bootloader devices
+        * mount point sources
+        * swap devices
+
+        :return: a list of device names
+        """
+        return self._devices
+
+    @devices.setter
+    def devices(self, devices: List[Str]):
+        self._devices = devices
+
+    @property
     def mount_points(self) -> Dict[Str, Str]:
-        """Mount points.
+        """Mount points defined by the OS.
 
         :return: a dictionary of mount points and device names
         """
@@ -416,31 +434,9 @@ class OSData(DBusData):
     def mount_points(self, mount_points: Dict[Str, Str]):
         self._mount_points = mount_points
 
-    @property
-    def swap_devices(self) -> List[Str]:
-        """Swap devices.
-
-        :return: a list of device names
-        """
-        return self._swap_devices
-
-    @swap_devices.setter
-    def swap_devices(self, devices: List[Str]):
-        self._swap_devices = devices
-
     def get_root_device(self):
         """Get the root device.
 
         :return: a device name or None
         """
         return self.mount_points.get("/")
-
-    def get_devices(self):
-        """Get all devices.
-
-        :return: a list of device names
-        """
-        devices = []
-        devices.extend(self.swap_devices)
-        devices.extend(self.mount_points.values())
-        return devices

--- a/pyanaconda/modules/storage/devicetree/model.py
+++ b/pyanaconda/modules/storage/devicetree/model.py
@@ -515,25 +515,8 @@ class InstallerStorage(Blivet):
         log.debug("finished Blivet copy")
         ###################################################
 
-        for root in new.roots:
-            root.swaps = [new.devicetree.get_device_by_id(d.id, hidden=True) for d in root.swaps]
-            root.swaps = [s for s in root.swaps if s]
-
-            removed = set()
-            for (mountpoint, old_dev) in root.mounts.items():
-                if old_dev is None:
-                    continue
-
-                new_dev = new.devicetree.get_device_by_id(old_dev.id, hidden=True)
-                if new_dev is None:
-                    # if the device has been removed don't include this
-                    # mountpoint at all
-                    removed.add(mountpoint)
-                else:
-                    root.mounts[mountpoint] = new_dev
-
-            for mnt in removed:
-                del root.mounts[mnt]
+        # Create proper copies of the collected installation roots.
+        new.roots = [root.copy(storage=new) for root in new.roots]
 
         log.debug("Finished a copy of the storage model.")
         return new

--- a/pyanaconda/modules/storage/devicetree/model.py
+++ b/pyanaconda/modules/storage/devicetree/model.py
@@ -56,6 +56,7 @@ class InstallerStorage(Blivet):
 
     def __init__(self):
         super().__init__()
+        self.roots = []
         self.protected_devices = []
         self._escrow_certificates = {}
         self._bootloader = None

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -458,8 +458,8 @@ class DeviceTreeViewer(ABC):
         """
         data = OSData()
         data.os_name = root.name or ""
-        data.swap_devices = [
-            device.name for device in root.swaps
+        data.devices = [
+            device.name for device in root.devices
         ]
         data.mount_points = {
             path: device.name for path, device in root.mounts.items()

--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -61,7 +61,7 @@ def collect_used_devices(storage):
     used_devices = []
 
     for root in storage.roots:
-        for device in list(root.mounts.values()) + root.swaps:
+        for device in root.devices:
             if device not in storage.devices:
                 continue
             used_devices.extend(device.ancestors)
@@ -177,9 +177,9 @@ def collect_roots(storage):
         # Get the name.
         name = root.name
 
-        # Get the supported swap devices.
-        swaps = [
-            d for d in root.swaps
+        # Get the supported devices.
+        devices = [
+            d for d in root.devices
             if d in supported_devices
             and (d.format.exists or root.name == new_root_name)
         ]
@@ -192,14 +192,14 @@ def collect_roots(storage):
             and d.disks
         }
 
-        if not swaps and not mounts:
+        if not devices and not mounts:
             continue
 
         # Add a root with supported devices.
         roots.append(Root(
             name=name,
+            devices=devices,
             mounts=mounts,
-            swaps=swaps
         ))
 
     return roots
@@ -227,29 +227,15 @@ def create_new_root(storage, boot_drive):
         boot_drive=boot_drive
     )
 
-    bootloader_devices = collect_bootloader_devices(
-        storage=storage,
-        boot_drive=boot_drive
-    )
-
-    swaps = [
-        d for d in devices
-        if d.format.type == "swap"
-    ]
-
     mounts = {
         d.format.mountpoint: d for d in devices
         if getattr(d.format, "mountpoint", None)
     }
 
-    for device in devices:
-        if device in bootloader_devices:
-            mounts[device.format.name] = device
-
     return Root(
         name=get_new_root_name(),
+        devices=devices,
         mounts=mounts,
-        swaps=swaps
     )
 
 

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -440,7 +440,12 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             )
             page.add_selector(selector, self.on_selector_clicked)
 
-        for device_name in root.swap_devices:
+        for device_name in root.devices:
+
+            # Skip devices that already have a selector.
+            if device_name in root.mount_points.values():
+                continue
+
             selector = MountPointSelector()
             self._update_selector(
                 selector,

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
@@ -86,9 +86,9 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
 
         os_data = self.interface.GenerateSystemData("dev1")
         assert get_native(os_data) == {
-            'mount-points': {'/boot': 'dev1', '/': 'dev2'},
             'os-name': 'New anaconda bluesky Installation',
-            'swap-devices': ['dev3']
+            'devices': ['dev1', 'dev2', 'dev3'],
+            'mount-points': {'/boot': 'dev1', '/': 'dev2'},
         }
 
     def test_collect_new_devices(self):
@@ -151,15 +151,15 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
 
         self.storage.roots = [Root(
             name="My Linux",
+            devices=[dev2, dev3],
             mounts={"/": dev2},
-            swaps=[dev3]
         )]
 
         os_data_list = self.interface.CollectSupportedSystems()
         assert get_native(os_data_list) == [{
             'os-name': 'My Linux',
+            'devices': ['dev2', 'dev3'],
             'mount-points': {'/': 'dev2'},
-            'swap-devices': ['dev3']
         }]
 
     def test_get_default_file_system(self):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_model.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_model.py
@@ -1,0 +1,151 @@
+#
+# Copyright (C) 2022  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+
+from blivet.devices import StorageDevice
+
+from pyanaconda.modules.storage.devicetree import create_storage
+from pyanaconda.modules.storage.devicetree.root import Root
+
+
+class InstallerStorageTestCase(unittest.TestCase):
+    """Test the InstallerStorage class."""
+
+    def setUp(self):
+        """Set up the test."""
+        self.maxDiff = None
+        self.storage = create_storage()
+
+    def _add_device(self, device):
+        """Add a device to the device tree."""
+        self.storage.devicetree._add_device(device)
+
+    def _check_device_copy(self, original_device, device):
+        """Check a copy of the device."""
+        assert device
+        assert device.name == original_device.name
+        assert device.id == original_device.id
+        assert device is not original_device
+
+    def test_copy_no_devices(self):
+        """Test the copy method with no devices."""
+        storage_copy = self.storage.copy()
+        assert not storage_copy.devices
+        assert not storage_copy.roots
+
+    def test_copy_devices(self):
+        """Test the copy method with some devices."""
+        dev1 = StorageDevice("dev1")
+        self._add_device(dev1)
+
+        dev2 = StorageDevice("dev2")
+        self._add_device(dev2)
+
+        storage_copy = self.storage.copy()
+        assert len(storage_copy.devices) == 2
+        assert len(storage_copy.roots) == 0
+
+        dev1_copy = storage_copy.devicetree.get_device_by_name("dev1")
+        self._check_device_copy(dev1, dev1_copy)
+
+        dev2_copy = storage_copy.devicetree.get_device_by_name("dev2")
+        self._check_device_copy(dev2, dev2_copy)
+
+    def test_copy_root_no_devices(self):
+        """Test the copy method with a root and no devices."""
+        root1 = Root(name="Linux 1")
+        self.storage.roots.append(root1)
+
+        storage_copy = self.storage.copy()
+        assert len(storage_copy.roots) == 1
+
+        root1_copy = storage_copy.roots[0]
+        assert root1_copy.name == root1.name
+        assert not root1_copy.devices
+        assert not root1_copy.mounts
+
+    def test_copy_root_missing_devices(self):
+        """Test the copy method with a root and missing devices."""
+        dev1 = StorageDevice("dev1")
+        self._add_device(dev1)
+
+        dev2 = StorageDevice("dev2")
+        dev3 = StorageDevice("dev3")
+
+        root1 = Root(
+            name="Linux 1",
+            devices=[dev1, dev2, dev3],
+            mounts={"/": dev1, "/home": dev2},
+        )
+        self.storage.roots.append(root1)
+
+        storage_copy = self.storage.copy()
+        assert len(storage_copy.roots) == 1
+        root1_copy = storage_copy.roots[0]
+        assert root1_copy.name == "Linux 1"
+
+        assert len(root1_copy.devices) == 1
+        dev1_copy = root1_copy.devices[0]
+        assert dev1_copy in storage_copy.devices
+        self._check_device_copy(dev1, dev1_copy)
+
+        assert len(root1_copy.mounts) == 1
+        dev1_copy = root1_copy.mounts["/"]
+        assert dev1_copy in storage_copy.devices
+        self._check_device_copy(dev1, dev1_copy)
+
+    def test_copy_roots(self):
+        """Test the copy method with several roots and devices."""
+        dev1 = StorageDevice("dev1")
+        self._add_device(dev1)
+
+        dev2 = StorageDevice("dev2")
+        self._add_device(dev2)
+
+        dev3 = StorageDevice("dev3")
+        self._add_device(dev3)
+
+        root1 = Root(
+            name="Linux 1",
+            devices=[dev2],
+            mounts={"/": dev2},
+        )
+        self.storage.roots.append(root1)
+
+        root2 = Root(
+            name="Linux 2",
+            devices=[dev1, dev3],
+            mounts={"/": dev1, "/home": dev3},
+        )
+        self.storage.roots.append(root2)
+
+        storage_copy = self.storage.copy()
+        assert len(storage_copy.roots) == 2
+
+        root1_copy = storage_copy.roots[0]
+        assert root1_copy.name == "Linux 1"
+        assert len(root1_copy.devices) == 1
+        assert len(root1_copy.mounts) == 1
+        assert "/" in root1_copy.mounts
+
+        root2_copy = storage_copy.roots[1]
+        assert root2_copy.name == "Linux 2"
+        assert len(root2_copy.devices) == 2
+        assert len(root2_copy.mounts) == 2
+        assert "/" in root2_copy.mounts
+        assert "/home" in root2_copy.mounts

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -750,14 +750,14 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
         self.storage.roots = [Root(
             name="My Linux",
+            devices=[root_device, swap_device],
             mounts={"/": root_device},
-            swaps=[swap_device]
         )]
 
         assert self.interface.GetExistingSystems() == [{
             'os-name': get_variant(Str, 'My Linux'),
+            'devices': get_variant(List[Str], ['dev1', 'dev2']),
             'mount-points': get_variant(Dict[Str, Str], {'/': 'dev1'}),
-            'swap-devices': get_variant(List[Str], ['dev2'])
         }]
 
     @patch_dbus_publish_object


### PR DESCRIPTION
Don't keep bootloader devices in a dictionary of mount points. Otherwise, we
can loose information about bootloader devices of the same type (like biosboot)
and show only one of them on the Manual Partitioning screen in GUI.

Related: rhbz#2088113

**Ported from:** https://github.com/rhinstaller/anaconda/pull/4271
