### PR TITLE
Verify a biosboot partition on all installation targets

### DIFF
--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -621,6 +621,11 @@ class BootLoader(object):
     # boot/stage2 device access
     #
 
+    @property
+    def install_targets(self):
+        """List of (stage1, stage2) tuples representing install targets."""
+        return [(self.stage1_device, self.stage2_device)]
+
     def is_valid_stage2_device(self, device, linux=True, non_linux=False):
         """ Return True if the device is suitable as a stage2 target device.
 

--- a/pyanaconda/modules/storage/checker/utils.py
+++ b/pyanaconda/modules/storage/checker/utils.py
@@ -207,9 +207,10 @@ def verify_gpt_biosboot(storage, constraints, report_error, report_warning):
     :param report_error: a function for error reporting
     :param report_warning: a function for warning reporting
     """
-    if storage.bootloader and not storage.bootloader.skip_bootloader:
-        stage1 = storage.bootloader.stage1_device
+    if not storage.bootloader or storage.bootloader.skip_bootloader:
+        return
 
+    for stage1, _stage2 in storage.bootloader.install_targets:
         if arch.is_x86() and not arch.is_efi() and stage1 and stage1.is_disk \
                 and getattr(stage1.format, "label_type", None) == "gpt":
 
@@ -220,10 +221,12 @@ def verify_gpt_biosboot(storage, constraints, report_error, report_warning):
                     break
 
             if missing:
-                report_error(_("Your BIOS-based system needs a special "
-                               "partition to boot from a GPT disk label. "
-                               "To continue, please create a 1MiB "
-                               "'biosboot' type partition."))
+                report_error(_(
+                    "Your BIOS-based system needs a special "
+                    "partition to boot from a GPT disk label. "
+                    "To continue, please create a 1MiB "
+                    "'biosboot' type partition on the {} disk."
+                ).format(stage1.name))
 
 
 def verify_opal_compatibility(storage, constraints, report_error, report_warning):


### PR DESCRIPTION
Make the installation targets accessible for all types of bootloaders.
By default, there is only one installation target, but GRUB2 can have
multiple targets if stage2 is part of an array.

Don't run the `verify_gpt_biosboot` storage validation check only on the stage1
device. Check all installation targets.

Related: rhbz#2088113
**Ported from:** https://github.com/rhinstaller/anaconda/pull/4277