### PR TITLE
Ignore dependabot commits in changelog

### DIFF
--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -343,7 +343,7 @@ class MakeBumpVer:
             body = self._getCommitDetail(commit, "%b")
             author = self._getCommitDetail(commit, "%aE")[0]
 
-            if re.match(r".*(#infra).*", summary):
+            if re.match(r".*(#infra).*", summary) or re.match(r"infra: bump .*", summary):
                 print("*** Ignoring (#infra) commit %s\n" % commit)
                 continue
 


### PR DESCRIPTION
Somehow we missed that bit, at some unspecified time earlier...