### PR TITLE
Release from detected tag, not starting branch (#infra)

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ steps.get_ref.outputs.ref }}
           fetch-depth: 0
 
       - name: Build anaconda container (to make the release)

--- a/.github/workflows/tag-release.yml.j2
+++ b/.github/workflows/tag-release.yml.j2
@@ -58,7 +58,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ steps.get_ref.outputs.ref }}
           fetch-depth: 0
 
       - name: Build anaconda container (to make the release)


### PR DESCRIPTION
Turns out this should have been changed with the rest of the workflow...

There is some chance that the new value won't work for manual input anyway, because it would be missing `refs/tags/` prefix.