### PR TITLE
Report registration errors from kickstart

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -534,14 +534,17 @@ if __name__ == "__main__":
     #   key are available
     from pyanaconda.modules.common.util import is_module_available
     from pyanaconda.modules.common.constants.services import SUBSCRIPTION
+
     if is_module_available(SUBSCRIPTION):
-        from pyanaconda.ui.lib.subscription import org_keys_sufficient, register_and_subscribe
+        from pyanaconda.ui.lib.subscription import org_keys_sufficient, \
+            register_and_subscribe, kickstart_error_handler
         if org_keys_sufficient():
             threadMgr.add(
                 AnacondaThread(
                     name=constants.THREAD_SUBSCRIPTION,
                     target=register_and_subscribe,
-                    args=[anaconda.payload]
+                    args=[anaconda.payload],
+                    kwargs={"error_callback": kickstart_error_handler}
                 )
             )
 

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -109,6 +109,7 @@ class ErrorHandler(object):
             # Subscription related errors
             InsightsClientMissingError.__name__: self._insightsErrorHandler,
             InsightsConnectError.__name__: self._insightsErrorHandler,
+            "KickstartRegistrationError": self._kickstartRegistrationErrorHandler,
 
             # General installation errors.
             NonCriticalInstallationError.__name__: self._non_critical_error_handler,
@@ -189,6 +190,20 @@ class ErrorHandler(object):
                     "Would you like to ignore this and continue with "
                     "installation?")
         message += "\n\n" + str(exn)
+
+        if self.ui.showYesNoQuestion(message):
+            return ERROR_CONTINUE
+        else:
+            return ERROR_RAISE
+
+    def _kickstartRegistrationErrorHandler(self, exn):
+        message = _("An error occurred during registration attempt "
+                    "triggered by the rhsm kickstart command. "
+                    "This could have happened due to incorrect rhsm command arguments "
+                    "or subscription infrastructure issues. "
+                    "Would you like to ignore this and continue with "
+                    "installation?")
+        message += "\n\n" + _("Error detail: ") + str(exn)
 
         if self.ui.showYesNoQuestion(message):
             return ERROR_CONTINUE

--- a/pyanaconda/ui/lib/subscription.py
+++ b/pyanaconda/ui/lib/subscription.py
@@ -24,6 +24,8 @@ from pyanaconda.core.constants import THREAD_WAIT_FOR_CONNECTING_NM, \
     SOURCE_TYPE_HDD, SOURCE_TYPE_CDN, SOURCE_TYPES_OVERRIDEN_BY_CDN, SECRET_TYPE_HIDDEN, \
     SECRET_TYPE_TEXT, PAYLOAD_TYPE_DNF
 from pyanaconda.core.i18n import _
+from pyanaconda.errors import errorHandler, ERROR_RAISE
+
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.modules.common import task
 from pyanaconda.modules.common.structures.subscription import SubscriptionRequest
@@ -121,6 +123,20 @@ def is_cdn_registration_required(payload):
 
     subscription_proxy = SUBSCRIPTION.get_proxy()
     return not subscription_proxy.IsSubscriptionAttached
+
+
+# Kickstart error handling
+
+class KickstartRegistrationError(Exception):
+    """Registration attempt from kickstart failed."""
+    pass
+
+
+def kickstart_error_handler(message):
+    """Helper function which raises exception if kickstart triggered registration fails."""
+    exn = KickstartRegistrationError(message)
+    if errorHandler.cb(exn) == ERROR_RAISE:
+        raise exn
 
 # Asynchronous registration + subscription & unregistration handling
 #


### PR DESCRIPTION
Show an interactive dialog when a registration attempt triggered
from kickstart fails & give the user option to continue or abort
the installation.

(cherry picked from commit 08aa6ec57bb27b66926cbba625b1b042342580cd)

Resolves: rhbz#2000652

Port from RHEL 9: #4181