### PR TITLE
Run yelp under liveuser with the right environment

### DIFF
--- a/pyanaconda/ui/lib/help.py
+++ b/pyanaconda/ui/lib/help.py
@@ -236,21 +236,25 @@ def _find_best_help_file(current_locale, available_files):
     return None
 
 
+# Help user data
+HelpUser = namedtuple("HelpUser", ["name", "uid"])
+
+
 def _get_help_user():
-    """Get the uid to run help viewer under.
+    """Get the user name and uid to run help viewer under.
 
     Currently, this means: Let's see if we can run yelp under liveuser on live.
     For details, see: https://bugzilla.redhat.com/show_bug.cgi?id=2118832
 
-    :return: user
-    :rtype: int | None
+    :return: user name and uid
+    :rtype: HelpUser | None
     """
     if not conf.system.provides_liveuser:
         return None
 
     try:
         user = getpwnam("liveuser")
-        return user.pw_uid
+        return HelpUser(name="liveuser", uid=user.pw_uid)
     except KeyError:
         return None
 
@@ -283,5 +287,23 @@ def show_graphical_help(help_path, help_anchor=None):
         args.append(help_path)
 
     user = _get_help_user()
+    if user:
+        user_id = user.uid
+        env_prune = ("GDK_BACKEND",)
+        env_add = {
+            "XDG_RUNTIME_DIR": "/run/user/{}".format(user_id),
+            "USER": user.name,
+            "HOME": "/home/{}".format(user.name),
+        }
+    else:
+        user_id = None
+        env_prune = None
+        env_add = None
 
-    yelp_process = startProgram(["yelp", *args], reset_lang=False, user=user)
+    yelp_process = startProgram(
+        ["yelp", *args],
+        reset_lang=False,
+        user=user_id,
+        env_prune=env_prune,
+        env_add=env_add,
+    )

--- a/tests/unit_tests/pyanaconda_tests/ui/test_help.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_help.py
@@ -24,7 +24,7 @@ from unittest.mock import patch, Mock
 from pyanaconda.core.constants import DisplayModes
 from pyanaconda.ui.lib.help import _get_help_mapping, show_graphical_help, _get_help_args, \
     HelpArguments, get_help_path_for_screen, show_graphical_help_for_screen, localize_help_file, \
-    _get_help_args_for_screen, _get_help_user
+    _get_help_args_for_screen, _get_help_user, HelpUser
 
 INVALID_MAPPING = """
 This is an invalid mapping.
@@ -214,7 +214,9 @@ class HelpSupportTestCase(unittest.TestCase):
         starter.assert_called_once_with(
             ["yelp", "/my/file"],
             reset_lang=False,
-            user=None
+            user=None,
+            env_prune=None,
+            env_add=None,
         )
         user_mock.assert_called_once_with()
         user_mock.reset_mock()
@@ -224,7 +226,9 @@ class HelpSupportTestCase(unittest.TestCase):
         starter.assert_called_once_with(
             ["yelp", "ghelp:/my/file?my-anchor"],
             reset_lang=False,
-            user=None
+            user=None,
+            env_prune=None,
+            env_add=None,
         )
         user_mock.assert_called_once_with()
         user_mock.reset_mock()
@@ -279,7 +283,13 @@ class HelpSupportTestCase(unittest.TestCase):
             show_graphical_help_for_screen("installation-summary")
 
             help_path = os.path.join(tmp_dir, "en-US", "SummaryHub.xml")
-            starter.assert_called_once_with(["yelp", help_path], reset_lang=False, user=None)
+            starter.assert_called_once_with(
+                ["yelp", help_path],
+                reset_lang=False,
+                user=None,
+                env_prune=None,
+                env_add=None,
+            )
             user_mock.assert_called_once_with()
             starter.reset_mock()
             user_mock.reset_mock()
@@ -291,7 +301,13 @@ class HelpSupportTestCase(unittest.TestCase):
             help_path = os.path.join(tmp_dir, "en-US", "UserSpoke.xml")
             yelp_arg = "ghelp:" + help_path + "?create-user"
             user_mock.assert_called_once_with()
-            starter.assert_called_once_with(["yelp", yelp_arg], reset_lang=False, user=None)
+            starter.assert_called_once_with(
+                ["yelp", yelp_arg],
+                reset_lang=False,
+                user=None,
+                env_prune=None,
+                env_add=None,
+            )
 
     @patch("pyanaconda.ui.lib.help.conf")
     @patch("pyanaconda.ui.lib.help.getpwnam")
@@ -304,7 +320,7 @@ class HelpSupportTestCase(unittest.TestCase):
         # live and has user
         conf_mock.system.provides_liveuser = True
         getpwnam_mock.return_value = Mock(pw_uid=1024)
-        assert _get_help_user() == 1024
+        assert _get_help_user() == HelpUser(name="liveuser", uid=1024)
         getpwnam_mock.assert_called_once_with("liveuser")
         getpwnam_mock.reset_mock()
 


### PR DESCRIPTION
The `XAUTHORITY` variable is not handled, but that is not needed as of now.

Resolves: [rhbz#2124097](https://bugzilla.redhat.com/show_bug.cgi?id=2124097)