### PR TITLE
Build Anaconda RPMS for Web UI tests on Rawhide image

### DIFF
--- a/ui/webui/test/build-rpms
+++ b/ui/webui/test/build-rpms
@@ -50,7 +50,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--quick', '-q', action='store_true')
     parser.add_argument('--verbose', '-v', action='store_true')
-    parser.add_argument('--image', default='fedora-37')
+    parser.add_argument('--image', default='fedora-rawhide')
     parser.add_argument('srpm')
     args = parser.parse_args()
 


### PR DESCRIPTION
This should be more in sync with the Rawhide boot iso used for running
the Web UI tests.