### PR TITLE
Run yelp under liveuser if possible

### DIFF
--- a/pyanaconda/core/configuration/system.py
+++ b/pyanaconda/core/configuration/system.py
@@ -166,3 +166,8 @@ class SystemSection(Section):
     def provides_system_bus(self):
         """Can we access the system DBus?"""
         return self._is_boot_iso or self._is_live_os or self._is_booted_os
+
+    @property
+    def provides_liveuser(self):
+        """Is the user `liveuser` available?"""
+        return self._is_live_os

--- a/pyanaconda/ui/lib/help.py
+++ b/pyanaconda/ui/lib/help.py
@@ -22,6 +22,7 @@ import functools
 import os
 import json
 from collections import namedtuple
+from pwd import getpwnam
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
@@ -235,6 +236,29 @@ def _find_best_help_file(current_locale, available_files):
     return None
 
 
+# Help user data
+HelpUser = namedtuple("HelpUser", ["name", "uid"])
+
+
+def _get_help_user():
+    """Get the user name and uid to run help viewer under.
+
+    Currently, this means: Let's see if we can run yelp under liveuser on live.
+    For details, see: https://bugzilla.redhat.com/show_bug.cgi?id=2118832
+
+    :return: user name and uid
+    :rtype: HelpUser | None
+    """
+    if not conf.system.provides_liveuser:
+        return None
+
+    try:
+        user = getpwnam("liveuser")
+        return HelpUser(name="liveuser", uid=user.pw_uid)
+    except KeyError:
+        return None
+
+
 def show_graphical_help(help_path, help_anchor=None):
     """Start a new yelp process and make sure to kill any existing ones.
 
@@ -262,4 +286,24 @@ def show_graphical_help(help_path, help_anchor=None):
     else:
         args.append(help_path)
 
-    yelp_process = startProgram(["yelp", *args], reset_lang=False)
+    user = _get_help_user()
+    if user:
+        user_id = user.uid
+        env_prune = ("GDK_BACKEND",)
+        env_add = {
+            "XDG_RUNTIME_DIR": "/run/user/{}".format(user_id),
+            "USER": user.name,
+            "HOME": "/home/{}".format(user.name),
+        }
+    else:
+        user_id = None
+        env_prune = None
+        env_add = None
+
+    yelp_process = startProgram(
+        ["yelp", *args],
+        reset_lang=False,
+        user=user_id,
+        env_prune=env_prune,
+        env_add=env_add,
+    )

--- a/tests/unit_tests/pyanaconda_tests/ui/test_help.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_help.py
@@ -19,12 +19,12 @@ import os
 import tempfile
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from pyanaconda.core.constants import DisplayModes
 from pyanaconda.ui.lib.help import _get_help_mapping, show_graphical_help, _get_help_args, \
     HelpArguments, get_help_path_for_screen, show_graphical_help_for_screen, localize_help_file, \
-    _get_help_args_for_screen
+    _get_help_args_for_screen, _get_help_user, HelpUser
 
 INVALID_MAPPING = """
 This is an invalid mapping.
@@ -206,19 +206,37 @@ class HelpSupportTestCase(unittest.TestCase):
             assert _get_help_args_for_screen(DisplayModes.GUI, "user-configuration") == \
                 HelpArguments(help_path, "UserSpoke.xml", "create-user")
 
+    @patch("pyanaconda.ui.lib.help._get_help_user", return_value=None)
     @patch('pyanaconda.ui.lib.help.startProgram')
-    def test_show_graphical_help(self, starter):
+    def test_show_graphical_help(self, starter, user_mock):
         """Test the show_graphical_help function."""
         show_graphical_help("/my/file")
-        starter.assert_called_once_with(["yelp", "/my/file"], reset_lang=False)
+        starter.assert_called_once_with(
+            ["yelp", "/my/file"],
+            reset_lang=False,
+            user=None,
+            env_prune=None,
+            env_add=None,
+        )
+        user_mock.assert_called_once_with()
+        user_mock.reset_mock()
         starter.reset_mock()
 
         show_graphical_help("/my/file", "my-anchor")
-        starter.assert_called_once_with(["yelp", "ghelp:/my/file?my-anchor"], reset_lang=False)
+        starter.assert_called_once_with(
+            ["yelp", "ghelp:/my/file?my-anchor"],
+            reset_lang=False,
+            user=None,
+            env_prune=None,
+            env_add=None,
+        )
+        user_mock.assert_called_once_with()
+        user_mock.reset_mock()
         starter.reset_mock()
 
         show_graphical_help("")
         starter.assert_not_called()
+        user_mock.assert_not_called()
 
     @patch('pyanaconda.ui.lib.help.conf')
     def test_get_help_path_for_screen(self, conf_mock):
@@ -242,9 +260,10 @@ class HelpSupportTestCase(unittest.TestCase):
             assert get_help_path_for_screen("user-configuration") == \
                 os.path.join(tmp_dir, "en-US", "UserSpoke.txt")
 
+    @patch("pyanaconda.ui.lib.help._get_help_user", return_value=None)
     @patch('pyanaconda.ui.lib.help.startProgram')
     @patch('pyanaconda.ui.lib.help.conf')
-    def test_show_graphical_help_for_screen(self, conf_mock, starter):
+    def test_show_graphical_help_for_screen(self, conf_mock, starter, user_mock):
         with tempfile.TemporaryDirectory() as tmp_dir:
             conf_mock.ui.help_directory = tmp_dir
             content_dir = os.path.join(tmp_dir, "en-US")
@@ -255,15 +274,25 @@ class HelpSupportTestCase(unittest.TestCase):
 
             show_graphical_help_for_screen("installation-summary")
             starter.assert_not_called()
+            user_mock.assert_not_called()
             starter.reset_mock()
+            user_mock.reset_mock()
 
             # Help file.
             self._create_file(content_dir, "SummaryHub.xml", "<summary>")
             show_graphical_help_for_screen("installation-summary")
 
             help_path = os.path.join(tmp_dir, "en-US", "SummaryHub.xml")
-            starter.assert_called_once_with(["yelp", help_path], reset_lang=False)
+            starter.assert_called_once_with(
+                ["yelp", help_path],
+                reset_lang=False,
+                user=None,
+                env_prune=None,
+                env_add=None,
+            )
+            user_mock.assert_called_once_with()
             starter.reset_mock()
+            user_mock.reset_mock()
 
             # Help file with anchor.
             self._create_file(content_dir, "UserSpoke.xml", "<create-user>")
@@ -271,4 +300,31 @@ class HelpSupportTestCase(unittest.TestCase):
 
             help_path = os.path.join(tmp_dir, "en-US", "UserSpoke.xml")
             yelp_arg = "ghelp:" + help_path + "?create-user"
-            starter.assert_called_once_with(["yelp", yelp_arg], reset_lang=False)
+            user_mock.assert_called_once_with()
+            starter.assert_called_once_with(
+                ["yelp", yelp_arg],
+                reset_lang=False,
+                user=None,
+                env_prune=None,
+                env_add=None,
+            )
+
+    @patch("pyanaconda.ui.lib.help.conf")
+    @patch("pyanaconda.ui.lib.help.getpwnam")
+    def test_get_help_username(self, getpwnam_mock, conf_mock):
+        # not live = early exit
+        conf_mock.system.provides_liveuser = False
+        assert _get_help_user() is None
+        getpwnam_mock.assert_not_called()
+
+        # live and has user
+        conf_mock.system.provides_liveuser = True
+        getpwnam_mock.return_value = Mock(pw_uid=1024)
+        assert _get_help_user() == HelpUser(name="liveuser", uid=1024)
+        getpwnam_mock.assert_called_once_with("liveuser")
+        getpwnam_mock.reset_mock()
+
+        # supposedly live but missing user
+        getpwnam_mock.side_effect = KeyError
+        assert _get_help_user() is None
+        getpwnam_mock.assert_called_once_with("liveuser")


### PR DESCRIPTION
Adjust the environment as needed, too.

The `XAUTHORITY` variable is not handled, but that is not needed as of now.

Resolves: [rhbz#2118832](https://bugzilla.redhat.com/show_bug.cgi?id=2118832)
Resolves: [rhbz#2124097](https://bugzilla.redhat.com/show_bug.cgi?id=2124097)

(cherry picked from commit c33152e814fca9742aa8775679a0388e93d641c0)
(cherry picked from commit ac0ce9717f5ac4eaeb0fda81d96a76b6f36a20cd)

---

Ported from #4302 and  #4317.