### PR TITLE
Use the Bugzilla API key in the `makebumpver` script

### DIFF
--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -28,7 +28,6 @@ log.setLevel(logging.INFO)
 import bugzilla  # pylint: disable=import-error
 import datetime
 import argparse
-import getpass
 import os
 import re
 import subprocess
@@ -144,22 +143,8 @@ class MakeBumpVer:
         log.debug("%s", self.args)
         self.bzserver = 'bugzilla.redhat.com'
         self.bzurl = "https://%s/xmlrpc.cgi" % self.bzserver
-        self.username = None
-        self.password = None
         self.bz = None
         self._bz_cache = {}
-
-        authfile = os.path.realpath(os.getenv('HOME') + '/.rhbzauth')
-        if os.path.isfile(authfile):
-            f = open(authfile, 'r')
-            lines = map(lambda x: x.strip(), f.readlines())
-            f.close()
-
-            for line in lines:
-                if line.startswith('RHBZ_USER='):
-                    self.username = line[10:].strip('"\'')
-                elif line.startswith('RHBZ_PASSWORD='):
-                    self.password = line[14:].strip('"\'')
 
         self.gituser = self._gitConfig('user.name')
         self.gitemail = self._gitConfig('user.email')
@@ -247,21 +232,14 @@ class MakeBumpVer:
     def _queryBug(self, bugid):
         if not self.bz:
             sys.stdout.write("Connecting to %s...\n" % self.bzserver)
-
-            if not self.username:
-                sys.stdout.write('Username: ')
-                self.username = sys.stdin.readline()
-                self.username = self.username.strip()
-
-            if not self.password:
-                self.password = getpass.getpass()
-
-            bzclass = bugzilla.Bugzilla
-            self.bz = bzclass(url=self.bzurl)
+            self.bz = bugzilla.Bugzilla(url=self.bzurl)
 
         if not self.bz.logged_in:
-            rc = self.bz.login(self.username, self.password)
-            log.debug("login rc = %s", rc)
+            sys.stdout.write(
+                "Provide an API key from https://{}/userprefs.cgi?tab=apikey"
+                "\n".format(self.bzserver)
+            )
+            self.bz.interactive_save_api_key()
 
         if bugid in self._bz_cache:
             return self._bz_cache[bugid]


### PR DESCRIPTION
The `~/.rhbzauth` configuration file is no longer supported. Use the configuration file supported directly by `python-bugzilla` instead. The support for username and password was removed. Use the API key instead.

The `makebumpver` script will ask for the API key interactively if none is available. The key will be saved to a configuration file and reused next time. Alternatively, you can create the `~/.bugzillarc` file with the API key yourself with the following content:
```
    [bugzilla.redhat.com]
    api_key = <API-KEY>
```