### PR TITLE
F37 geoloc wait again

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -552,11 +552,7 @@ if __name__ == "__main__":
     payloadMgr.restart_thread(anaconda.payload, fallback=fallback)
 
     # initialize geolocation and start geolocation lookup if possible and enabled
-    use_geoloc = startup_utils.check_if_geolocation_should_be_used(opts)
-    from pyanaconda.modules.common.constants.services import TIMEZONE
-    if is_module_available(TIMEZONE) and use_geoloc:
-        timezone_proxy = TIMEZONE.get_proxy()
-        timezone_proxy.StartGeolocation()
+    geoloc_task_proxy = startup_utils.start_geolocation_conditionally(opts)
 
     # setup ntp servers and start NTP daemon if not requested otherwise
     startup_utils.start_chronyd()
@@ -583,6 +579,9 @@ if __name__ == "__main__":
 
         with check_kickstart_error():
             sync_run_task(snapshot_task_proxy)
+
+    # wait for geolocation, if needed
+    startup_utils.wait_for_geolocation(geoloc_task_proxy)
 
     anaconda.intf.setup(ksdata)
     anaconda.intf.run()

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -134,6 +134,8 @@ GEOLOC_DEFAULT_PROVIDER = GEOLOC_PROVIDER_FEDORA_GEOIP
 # geolocation URLs - values used by config file
 GEOLOC_URL_FEDORA_GEOIP = "https://geoip.fedoraproject.org/city"
 GEOLOC_URL_HOSTIP = "https://api.hostip.info/get_json.php"
+# timeout for the network connection used for geolocation (in seconds)
+GEOLOC_CONNECTION_TIMEOUT = 5
 
 ANACONDA_ENVIRON = "anaconda"
 FIRSTBOOT_ENVIRON = "firstboot"

--- a/pyanaconda/modules/common/task/__init__.py
+++ b/pyanaconda/modules/common/task/__init__.py
@@ -15,12 +15,14 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from time import sleep
+import math
+from time import sleep, perf_counter
 
 from pyanaconda.modules.common.task.task_interface import TaskInterface
 from pyanaconda.modules.common.task.task import Task, AbstractTask
 
-__all__ = ["sync_run_task", "async_run_task", "AbstractTask", "Task", "TaskInterface"]
+__all__ = ["sync_run_task", "async_run_task", "wait_for_task", "AbstractTask", "Task",
+           "TaskInterface"]
 
 
 def sync_run_task(task_proxy, callback=None):
@@ -67,3 +69,26 @@ def async_run_task(task_proxy, callback):
 
     task_proxy.Stopped.connect(_callback)
     task_proxy.Start()
+
+
+def wait_for_task(task_proxy, timeout=math.inf):
+    """Wait for an existing and running task with optional timeout.
+
+    If the timeout exception is raised, the task is not done. To call its Finish method and
+    receive potential errors from its run, you can attach callbacks to the tasks's signals.
+    Alternatively, you can give up re-raising the errors entirely.
+
+    :param task_proxy: a proxy of the remote task
+    :param float timeout: stop waiting after this time in seconds
+    :raise TimeoutError: when the task did not finish before timeout
+    """
+    start = perf_counter()
+    end = start + timeout
+
+    while task_proxy.IsRunning and perf_counter() <= end:
+        sleep(0.1)
+
+    if task_proxy.IsRunning:
+        raise TimeoutError()
+
+    task_proxy.Finish()

--- a/pyanaconda/modules/timezone/timezone.py
+++ b/pyanaconda/modules/timezone/timezone.py
@@ -48,7 +48,6 @@ class TimezoneService(KickstartService):
         self.timezone_changed = Signal()
         self._timezone = "America/New_York"
 
-        self._geoloc_task = None
         self.geolocation_result_changed = Signal()
         self._geoloc_result = GeolocationData()
 
@@ -222,23 +221,21 @@ class TimezoneService(KickstartService):
             )
         ]
 
-    def _set_geolocation_result(self):
+    def _set_geolocation_result(self, result):
         """Set geolocation result when the task finished."""
-        self._geoloc_result = self._geoloc_task.get_result()
+        self._geoloc_result = result
         self.geolocation_result_changed.emit()
-        self._geoloc_task = None
         log.debug("Geolocation result is set, valid=%s", not self._geoloc_result.is_empty())
 
-    def start_geolocation(self):
-        """Start geolocation, if not already started."""
-        if self._geoloc_task is not None:
-            log.info("Geoloc: already started")
-            return
+    def start_geolocation_with_task(self):
+        """Start geolocation.
 
-        self._geoloc_task = GeolocationTask()
-        self._geoloc_task.succeeded_signal.connect(self._set_geolocation_result)
-        log.info("Geoloc: starting lookup")
-        self._geoloc_task.start()
+        :return: task to run for geolocation
+        :rtype: Task
+        """
+        task = GeolocationTask()
+        task.succeeded_signal.connect(lambda: self._set_geolocation_result(task.get_result()))
+        return task
 
     @property
     def geolocation_result(self):

--- a/pyanaconda/modules/timezone/timezone_interface.py
+++ b/pyanaconda/modules/timezone/timezone_interface.py
@@ -21,6 +21,7 @@ from dasbus.server.property import emits_properties_changed
 from dasbus.typing import *  # pylint: disable=wildcard-import
 from dasbus.server.interface import dbus_interface
 
+from pyanaconda.modules.common.containers import TaskContainer
 from pyanaconda.modules.common.base import KickstartModuleInterface
 from pyanaconda.modules.common.constants.services import TIMEZONE
 from pyanaconda.modules.common.structures.timezone import TimeSourceData, GeolocationData
@@ -118,9 +119,14 @@ class TimezoneInterface(KickstartModuleInterface):
             TimeSourceData.from_structure_list(sources)
         )
 
-    def StartGeolocation(self):
-        """Start geolocation, if not started yet."""
-        self.implementation.start_geolocation()
+    def StartGeolocationWithTask(self) -> ObjPath:
+        """Start geolocation with task.
+
+        :return: a DBus path of the task
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.start_geolocation_with_task()
+        )
 
     @property
     def GeolocationResult(self) -> Structure:

--- a/tests/unit_tests/pyanaconda_tests/modules/timezone/test_module_timezone.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/timezone/test_module_timezone.py
@@ -18,7 +18,6 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
-from unittest.mock import patch
 
 from dasbus.structure import compare_data
 from dasbus.typing import *  # pylint: disable=wildcard-import
@@ -33,6 +32,7 @@ from pyanaconda.modules.common.structures.kickstart import KickstartReport
 from pyanaconda.modules.common.structures.timezone import GeolocationData
 from pyanaconda.modules.timezone.timezone import TimezoneService
 from pyanaconda.modules.timezone.timezone_interface import TimezoneInterface
+from pyanaconda.modules.timezone.initialization import GeolocationTask
 from tests.unit_tests.pyanaconda_tests import check_kickstart_interface, \
     patch_dbus_publish_object, check_task_creation_list, check_dbus_property
 
@@ -317,31 +317,18 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         assert len(report.warning_messages) == 1
         assert report.warning_messages[0].message == warning
 
-    @patch("pyanaconda.modules.timezone.timezone.GeolocationTask")
-    def test_geoloc_interface(self, geoloc_mock):
+    @patch_dbus_publish_object
+    def test_geoloc_interface(self, publisher):
         """Test geolocation-related interface and implementation of Timezone"""
+        task_path = self.timezone_interface.StartGeolocationWithTask()
+        check_task_creation_list([task_path], publisher, [GeolocationTask])
 
         # without any actions, we should get empty GeolocationData
         new = GeolocationData.from_structure(self.timezone_interface.GeolocationResult)
         assert new.is_empty()
 
-        # let's "run" geolocation
-        self.timezone_interface.StartGeolocation()
-
-        # the task should have been instantiated, signal connected, and started
-        geoloc_mock.assert_called_once_with()
-        mock_task = geoloc_mock.return_value
-        mock_task.start.assert_called_once_with()
-        mock_task.succeeded_signal.connect.assert_called_once_with(
-            self.timezone_module._set_geolocation_result
-        )
-
-        # running the callback for finishing should also save result
-        self.timezone_module._set_geolocation_result()
-        mock_task.get_result.assert_called_once_with()
-        assert self.timezone_module.geolocation_result == mock_task.get_result.return_value
-
-        # try re-running, same as earlier
-        geoloc_mock.reset_mock()
-        self.timezone_interface.StartGeolocation()
-        geoloc_mock.assert_called_once_with()
+    def test_geoloc_result_callback(self):
+        """Test geolocation task result callback"""
+        result = GeolocationData.from_values(territory="", timezone="")
+        self.timezone_module._set_geolocation_result(result)
+        assert self.timezone_module.geolocation_result == result


### PR DESCRIPTION
From user point of view, this makes anaconda geolocate again, with roughly the same chances.

From testing point of view, this waits again, so it fixes the bug.

From development point of view:
- The waiting is back, but moved into the anaconda code before initializing UI. That means the actual timeout is different. Previously it was some init + load gtk + load gui + timeout. Now it's only some init + timeout + load gtk + load gui. It's unclear if the different order might make a difference or not. What it makes different for debugging is that logs might report failure to geolocate but as the actual use is after loading GUI, it will still succeed. The reporting makes little sense, but read on.
- In f37, we stop here. When porting to master/rawhide, we'll move also the part setting locales etc. into the main script, so that all UIs get geolocation equally. However, this will remove all the GUI delays, so technically, weak machines on connections with very high latency might fail to geolocate on f38/rawhide, but succeed on f36.
- ~~The new Task helper is not tested. That's also to be resolved when porting to master - the tests for these parts are pretty spaghettized and need more work that is unnecessary for f37. The branch with some work is `geoloc-wait-again-to-port`.~~