### PR TITLE
Timezone spoke will not show timezone borders anymore (#2103657)

### DIFF
--- a/docs/release-notes/timezone-remove-borders.rst
+++ b/docs/release-notes/timezone-remove-borders.rst
@@ -1,0 +1,9 @@
+:Type: GUI
+:Summary: Remove timezone borders (#2103657)
+
+:Description:
+    Anaconda is not showing timezone borders in the Time & Date spoke. The map is white now.
+
+:Links:
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2103657
+    - https://github.com/dashea/timezonemap/pull/2


### PR DESCRIPTION
The change was implemented in the libtimezonemap package but the main impact will be Anaconda so we should have it documented anyway.

Related: rhbz#2103657