### PR TITLE
Re-enable tag release for branched fedora (#infra)

### DIFF
--- a/.github/workflows/tag-release.yml.j2
+++ b/.github/workflows/tag-release.yml.j2
@@ -1,4 +1,3 @@
-{% if distro_release == "rawhide" %}
 name: Release from tags
 # Create a GitHub release when a tag is pushed.
 
@@ -102,4 +101,3 @@ jobs:
             --title "Anaconda $RELEASE_NAME" \
             --notes-file release.txt \
             /tmp/results/*
-{% endif %}


### PR DESCRIPTION
This is how it works: The workflow to react to a tag is taken from that tag's ref.

(cherry picked from commit 60cda265c9564a35c9f6e3ccadf5c6d8a0bc8dd5)

---

Port of the new parts in #4336. This should be the final piece to enable automatic releases on branched Fedora with just `infra-reload`. To be tested on `f37-release` with #4336 and another release.