### PR TITLE
CI: Check that no commits forgot infra-reload (#infra)

### DIFF
--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -16,9 +16,10 @@ permissions:
   pull-requests: write
 
 jobs:
-  infra-check:
+  commit-message-check:
     if: contains(github.event.pull_request.labels.*.name, 'infrastructure')
     runs-on: ubuntu-20.04
+    name: Infra tags in commit messages
 
     steps:
       - name: Clone Anaconda repository
@@ -92,3 +93,53 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  infra-reload-check:
+    runs-on: ubuntu-20.04
+    name: Templates match results
+
+    steps:
+      - name: Clone Anaconda repository
+        uses: actions/checkout@v3
+        with:
+          # TODO: Are we able to remove ref, fetch-depth and Rebase task? Seems that the checkout
+          # without ref is doing the rebase for us.
+          # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Rebase to current
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git log --oneline -1 origin/${{ github.event.pull_request.base.ref }}
+          git rebase origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Determine commits to check
+        id: get_commits
+        run: |
+          COMMITS=$(git rev-list origin/${{ github.event.pull_request.base.ref }}..HEAD | tac)
+          # rev-list provides one hash per line, starting at HEAD, adding backwards.
+          # Why `tac` - commits are listed from HEAD backwards, which is reversed order, and need
+          # re-applying in the correct order.
+          echo -e "Commits found:\n$COMMITS"
+          COMMITS_ONELINE=$(echo $COMMITS | tr '\n' ' ')
+          # GH actions truncates plain multiline variables to first line when passing as output/input,
+          # so make it one line on our end and save the trouble.
+          echo "::set-output name=commits::$COMMITS_ONELINE"
+
+      - name: Check all commits
+        run: |
+          git checkout -b temp origin/${{ github.event.pull_request.base.ref }}
+          for COMMIT in ${{ steps.get_commits.outputs.commits }} ; do
+            echo "Checking $COMMIT"
+            git cherry-pick "$COMMIT"
+            make -f Makefile.am reload-infra
+            CHANGES=$(git status -s)
+            if [[ -n $CHANGES ]] ; then
+              echo "Templates out of sync after commit $COMMIT:"
+              git log -1 "$COMMIT"
+              git status
+              exit 1
+            fi
+          done


### PR DESCRIPTION
This will ensure that after each commit, state of the rendered files and templates is consistent.