### PR TITLE
Do not require the anaconda-webui package

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -5,9 +5,6 @@ Release: @PACKAGE_RELEASE@%{?dist}
 License: GPLv2+ and MIT
 URL:     http://fedoraproject.org/wiki/Anaconda
 
-# This should should only be set for development purposes for the time
-%global use_cockpit 1
-
 # To generate Source0 do:
 # git clone https://github.com/rhinstaller/anaconda
 # git checkout -b archive-branch anaconda-%%{version}-%%{release}
@@ -77,9 +74,6 @@ BuildRequires: libtimezonemap-devel >= %{libtimezonemapver}
 BuildRequires: gdk-pixbuf2-devel
 BuildRequires: libxml2
 
-%if %{use_cockpit}
-Requires: anaconda-webui = %{version}-%{release}
-%endif
 Requires: anaconda-gui = %{version}-%{release}
 Requires: anaconda-tui = %{version}-%{release}
 
@@ -167,9 +161,6 @@ system.
 Summary: Live installation specific files and dependencies
 BuildRequires: desktop-file-utils
 # live installation currently implies a graphical installation
-%if %{use_cockpit}
-Requires: anaconda-webui = %{version}-%{release}
-%endif
 Requires: anaconda-gui = %{version}-%{release}
 Requires: usermode
 Requires: zenity
@@ -256,7 +247,6 @@ Requires: brltty
 The anaconda-install-img-deps metapackage lists all boot.iso installation image dependencies.
 Add this package to an image build (eg. with lorax) to ensure all Anaconda capabilities are supported in the resulting image.
 
-%if %use_cockpit
 %package webui
 Summary: Cockpit based user interface for the Anaconda installer
 Requires: cockpit-bridge >= %{cockpitver}
@@ -268,8 +258,6 @@ Requires: webkit2gtk4.1
 
 %description webui
 This package contains Cockpit based user interface for the Anaconda installer.
-
-%endif
 
 %package gui
 Summary: Graphical user interface for the Anaconda installer
@@ -376,12 +364,6 @@ rm -rf \
 # Add localization files
 %find_lang %{name}
 
-%if ! %use_cockpit
-    rm -rf %{buildroot}/%{_datadir}/cockpit/anaconda-webui
-    rm -f %{buildroot}/%{_datadir}/metainfo/org.cockpit-project.anaconda-webui.metainfo.xml
-    rm -f %{buildroot}/%{_libexecdir}/webui-desktop
-%endif
-
 # main package and install-env-deps are metapackages
 %files
 
@@ -441,7 +423,6 @@ rm -rf \
 
 %endif
 
-%if %use_cockpit
 %files webui
 %dir %{_datadir}/cockpit/anaconda-webui
 %{_datadir}/cockpit/anaconda-webui/index.js.LICENSE.txt.gz
@@ -452,8 +433,6 @@ rm -rf \
 %{_datadir}/metainfo/org.cockpit-project.anaconda-webui.metainfo.xml
 %{_datadir}/cockpit/anaconda-webui/po.*.js.gz
 %{_libexecdir}/webui-desktop
-
-%endif
 
 %files gui
 %{python3_sitearch}/pyanaconda/ui/gui/*


### PR DESCRIPTION
We don't want the package to end up on Rawhide images just yet.

Also drop the use_cockpit macro as it is not really needed now.