### PR TITLE
Web UI: Fix Esperanto breaking webui

### DIFF
--- a/ui/webui/src/components/localization/InstallationLanguage.jsx
+++ b/ui/webui/src/components/localization/InstallationLanguage.jsx
@@ -102,12 +102,9 @@ class LanguageSelector extends React.Component {
         });
     }
 
-    updateDefaultSelection () {
-        const languageId = this.state.lang.split("_")[0];
-        const currentLangLocales = this.state.locales.find(langLocales => getLanguageId(langLocales[0]) === languageId);
-        const currentLocale = currentLangLocales.find(locale => getLocaleId(locale) === this.state.lang);
-
-        this.setState({ selectedItem: getLocaleNativeName(currentLocale) });
+    async updateDefaultSelection () {
+        const languageData = await getLocaleData({ locale: this.state.lang });
+        this.setState({ selectedItem: getLocaleNativeName(languageData) });
     }
 
     renderOptions (filter) {


### PR DESCRIPTION
Esperanto's locale does not contain a country code, which prevents locale id to be converted to a language id properly causing the UI to fail.
Add another split that makes sure the charset is removed.