### PR TITLE
Use faulthandler instead of isys signal handlers

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -239,8 +239,6 @@ if __name__ == "__main__":
     # print errors encountered during boot
     startup_utils.print_dracut_errors(stdout_log)
 
-    from pyanaconda import isys
-
     util.ipmi_report(constants.IPMI_STARTED)
 
     if (opts.images or opts.dirinstall) and opts.liveinst:
@@ -273,10 +271,10 @@ if __name__ == "__main__":
     signal.signal(signal.SIGINT, signal.SIG_IGN)
     signal.signal(signal.SIGTERM, lambda num, frame: sys.exit(1))
 
-    # synchronously-delivered signals such as SIGSEGV and SIGILL cannot be
-    # handled properly from python, so install signal handlers from the C
-    # function in isys.
-    isys.installSyncSignalHandlers()
+    # synchronously-delivered signals such as SIGSEGV and SIGILL cannot be handled properly from
+    # Python, so install signal handlers from the faulthandler stdlib module.
+    import faulthandler
+    faulthandler.enable()
 
     setup_environment()
 

--- a/pyanaconda/isys/__init__.py
+++ b/pyanaconda/isys/__init__.py
@@ -76,7 +76,3 @@ def set_system_date_time(year=None, month=None, day=None, hour=None, minute=None
 
     set_date = datetime.datetime(year, month, day, hour, minute, second, tzinfo=tz)
     set_system_time(int(set_date.timestamp()))
-
-
-# pylint: disable=no-member
-installSyncSignalHandlers = _isys.installSyncSignalHandlers

--- a/pyanaconda/isys/isys.c
+++ b/pyanaconda/isys/isys.c
@@ -32,11 +32,9 @@
 #include <fcntl.h>
 #include <syslog.h>
 
-static PyObject * doSignalHandlers(PyObject *s, PyObject *args);
 static PyObject * doSetSystemTime(PyObject *s, PyObject *args);
 
 static PyMethodDef isysModuleMethods[] = {
-    { "installSyncSignalHandlers", doSignalHandlers, METH_NOARGS, "Install synchronous signal handlers"},
     { "set_system_time", doSetSystemTime, METH_VARARGS, "set system time"},
     { NULL, NULL, 0, NULL }
 };
@@ -53,127 +51,6 @@ PyMODINIT_FUNC
 // cppcheck-suppress unusedFunction
 PyInit__isys(void) {
     return PyModule_Create(&moduledef);
-}
-
-static void sync_signal_handler(int signum) {
-    void *array[20];
-    size_t size;
-
-    sigset_t sigset;
-
-    pid_t child_pid;
-    char *pid_str;
-    int pid_size;
-    int exit_status;
-
-    /* Doing stuff in signal handlers is tricky. The program has been
-     * interupted, probably in the middle of something going wrong with
-     * memory access, so we're in a weird state to begin with, and errors
-     * that happen during the signal handler can cause some gnarly things
-     * to happen.
-     *
-     * POSIX defines a set of functions (listed in man 7 signal) that are
-     * safe to call from within a signal handler, and glibc adds a few more.
-     * Do the safe things first, then reset the signal handler so that further
-     * receipts of the signal (probably SIGSEGV) will just crash the program
-     * instead of getting stuck in a loop, and then enter the danger zone.
-     */
-
-    /* First say that something went wrong. That's easy! (but we can't use printf or strlen) */
-    const char err_prefix[] = "Anaconda received signal ";
-    char sigstr[2];
-    write(STDOUT_FILENO, err_prefix, sizeof(err_prefix) - 1);
-
-    /* Convert signum to ascii without using anything that allocates memory */
-    /* Assume the signal is <= 99 */
-    sigstr[0] = (signum / 10 % 10) + '0';
-    sigstr[1] = (signum % 10) + '0';
-    write(STDOUT_FILENO, sigstr, sizeof(sigstr));
-    write(STDOUT_FILENO, "!.\n", 3);
-
-    /* And that's about all the safe things we can do. Time to reset the handler,
-     * unblock the signal and go wild */
-    signal(signum, SIG_DFL);
-    sigemptyset(&sigset);
-    sigaddset(&sigset, signum);
-    pthread_sigmask(SIG_UNBLOCK, &sigset, NULL);
-
-    /* Print the backtrace */
-    /* backtrace_symbols_fd is signal-safe, but backtrace is not. */
-    size = backtrace (array, 20);
-    backtrace_symbols_fd(array, size, STDOUT_FILENO);
-
-    /* Log the crash. Hopefully this is happening after logging has started
-     * and livemedia-creator will get the message. */
-    openlog("anaconda", 0, LOG_USER);
-    syslog(LOG_CRIT, "Anaconda crashed on signal %d", signum);
-    closelog();
-
-
-    /* Try call gcore on ourself to write out a core file */
-    pid_size = snprintf(NULL, 0, "%d", getpid());
-    if (pid_size <= 0) {
-        perror("Unable to current PID");
-        exit(1);
-    }
-    pid_size++;
-    pid_str = malloc(pid_size);
-    snprintf(pid_str, pid_size, "%d", getpid());
-
-    child_pid = fork();
-    if (0 == child_pid) {
-        /* Disable stderr to suppress all the garbage about debuginfo packages */
-        int fd;
-        fd = open("/dev/null", O_WRONLY);
-        if (fd < 0) {
-            perror("Unable to open /dev/null");
-            exit(1);
-        }
-        dup2(fd, STDERR_FILENO);
-
-        execlp("gcore", "gcore", "-o", "/tmp/anaconda.core", pid_str, NULL);
-        perror("Unable to exec gcore");
-        exit(1);
-    }
-    else if (child_pid < 0) {
-        perror("Unable to fork");
-        exit(1);
-    }
-
-    if (waitpid(child_pid, &exit_status, 0) < 0) {
-        perror("Error waiting on gcore");
-        exit(1);
-    }
-
-    if (!WIFEXITED(exit_status) || WEXITSTATUS(exit_status) != 0) {
-        printf("gcore exited with status %d\n", exit_status);
-        exit(1);
-    }
-
-    exit(1);
-}
-
-static PyObject * doSignalHandlers(PyObject *s, PyObject *args) {
-    /* Install a signal handler for all synchronous signals */
-    struct sigaction sa;
-
-    memset(&sa, 0, sizeof(struct sigaction));
-    sa.sa_handler = sync_signal_handler;
-
-    if (sigaction(SIGILL, &sa, NULL) != 0) {
-        return PyErr_SetFromErrno(PyExc_SystemError);
-    }
-
-    if (sigaction(SIGFPE, &sa, NULL) != 0) {
-        return PyErr_SetFromErrno(PyExc_SystemError);
-    }
-
-    if (sigaction(SIGSEGV, &sa, NULL) != 0) {
-        return PyErr_SetFromErrno(PyExc_SystemError);
-    }
-
-    Py_INCREF(Py_None);
-    return Py_None;
 }
 
 static PyObject * doSetSystemTime(PyObject *s, PyObject  *args) {


### PR DESCRIPTION
This significantly changes outputs, but provides eventually the same kinds of information, only in different order.

Previously:
- Print that a signal was received, and which one.
- Log to syslog that this happened.
- Print userland stack trace of main process.
- Save core dump:
  - always to /tmp/anaconda.core.<PID>
  - always, independent of system settings
  - somehow very slowly - maybe forking python and running gcore isn't the most performant idea
  - file size ca. 1 GB
- Journal gets only the syslog message.

Now:
- Print that a fatal error happened, no mention of signals.
- No unique message in syslog and journal to identify that "anaconda" crashed.
- Print python stack of all the threads in the main process.
- Save core dump:
  - to default location
  - according to system settings
  - needs invoking coredumpctl manually to work with the actual core dump
  - blazing fast saving compared to previous state
  - size ca. 430 MB, initally stored compressed to ca. 60 MB
  - apparently requires more debuginfo downloads, system can run out of space or memory
- Print userland stack traces of all threads to journal.

In both cases, using the (coredumpctl+)gdb+debuginfod+dnf toolchain leads to a successful interactive debugging session.