### PR TITLE
Fix duplicate alt-D accelerator on root account screen

### DIFF
--- a/pyanaconda/ui/gui/spokes/root_password.glade
+++ b/pyanaconda/ui/gui/spokes/root_password.glade
@@ -98,7 +98,7 @@ The root user (also known as super user) has complete access to the entire syste
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="margin-start">4</property>
-                            <property name="label" translatable="yes" context="GUI|Password">_Disable root account</property>
+                            <property name="label" translatable="yes" context="GUI|Password">D_isable root account</property>
                             <property name="use-underline">True</property>
                             <property name="xalign">0</property>
                             <property name="accel-widget">disable_root_radio</property>


### PR DESCRIPTION
The root account screen has duplicate Alt-D accelerators. One for the "Done" button that matches the rest of the anaconda screens and one for the "Disable root account" radio. Lets change that latter option to use alt-i instead so the UI remains consistent that alt-d is "done".

Signed-off-by: Jeremy Linton <jeremy.linton@arm.com>