### PR TITLE
Require createrepo_c only on boot.iso

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -196,8 +196,6 @@ Requires: hfsplus-tools
 %ifnarch riscv64
 Requires: kexec-tools
 %endif
-# needed for proper driver disk support - if RPMs must be installed, a repo is needed
-Requires: createrepo_c
 # run's on TTY1 in install env
 Requires: tmux
 # install time crash handling
@@ -231,6 +229,8 @@ Requires: zram-generator-defaults
 %else
 Requires: zram-generator
 %endif
+# needed for proper driver disk support - if RPMs must be installed, a repo is needed
+Requires: createrepo_c
 # Display stuff moved from lorax templates
 Requires: xorg-x11-drivers
 Requires: xorg-x11-server-Xorg

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -217,11 +217,6 @@ Requires: anaconda-install-env-deps = %{version}-%{release}
 %ifarch %{ix86} x86_64
 Requires: fcoe-utils >= %{fcoeutilsver}
 %endif
-%ifarch %{ix86} x86_64
-%if ! 0%{?rhel}
-Requires: hfsplus-tools
-%endif
-%endif
 # only WeakRequires elsewhere and not guaranteed to be present
 Requires: device-mapper-multipath
 %if ! 0%{?rhel}

--- a/pyanaconda/core/configuration/system.py
+++ b/pyanaconda/core/configuration/system.py
@@ -171,3 +171,8 @@ class SystemSection(Section):
     def provides_liveuser(self):
         """Is the user `liveuser` available?"""
         return self._is_live_os
+
+    @property
+    def can_use_driver_disks(self):
+        """Can the system use driver disks?"""
+        return self._is_boot_iso

--- a/pyanaconda/modules/payloads/installation.py
+++ b/pyanaconda/modules/payloads/installation.py
@@ -20,6 +20,7 @@ import shutil
 from glob import glob
 
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.path import make_directories
 from pyanaconda.modules.common.task import Task
@@ -112,6 +113,10 @@ class CopyDriverDisksFilesTask(Task):
 
     def run(self):
         """Copy files from the driver disks to the installed system."""
+        if not conf.system.can_use_driver_disks:
+            log.info("Skipping copying of driver disk files.")
+            return
+
         # Multiple driver disks may be loaded, so we need to glob for all
         # the firmware files in the common DD firmware directory
         for f in glob(self.DD_FIRMWARE_DIR + "/*"):

--- a/pyanaconda/modules/payloads/payload/dnf/repositories.py
+++ b/pyanaconda/modules/payloads/payload/dnf/repositories.py
@@ -22,6 +22,7 @@ from glob import glob
 from itertools import count
 
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import REPO_ORIGIN_TREEINFO, URL_TYPE_BASEURL
 from pyanaconda.core.path import join_paths
 from pyanaconda.core.util import execWithRedirect
@@ -40,6 +41,10 @@ def generate_driver_disk_repositories(path="/run/install"):
     :return: a list of repo configuration data
     """
     repositories = []
+
+    if not conf.system.can_use_driver_disks:
+        log.info("Skipping driver disk repository generation.")
+        return repositories
 
     # Iterate over all driver disk repositories.
     for i in count(start=1):


### PR DESCRIPTION
We don't have driver disks elsewhere, as far as I can tell.

Also, a bonus deduplication.