### PR TITLE
Fix Web UI VM startup on F37

### DIFF
--- a/ui/webui/test/machine_install.py
+++ b/ui/webui/test/machine_install.py
@@ -84,7 +84,7 @@ class VirtInstallMachine(VirtMachine):
                 "'-netdev user,id=hostnet0,"
                 f"hostfwd=tcp:{self.ssh_address}:{self.ssh_port}-:22,"
                 f"hostfwd=tcp:{self.web_address}:{self.web_port}-:9090 "
-                "-device virtio-net-pci,netdev=hostnet0,id=net0' "
+                "-device virtio-net-pci,netdev=hostnet0,id=net0,addr=0x4' "
                 f"--initrd-inject {os.getcwd()}/test/ks.cfg "
                 "--extra-args 'inst.ks=file:/ks.cfg' "
                 "--disk size=15,format=qcow2 "


### PR DESCRIPTION
Looks like some virt-install or qemu changes break our current config for starting the Web UI test VM.

The error looks like this:

ERROR    internal error: process exited while connecting to monitor:
2022-09-22T12:01:17.165149Z qemu-system-x86_64:
-device virtio-net-pci,netdev=hostnet0,id=net0,mac=52:54:00:51:4b:77,addr=0x0:
PCI: slot 0 function 0 not available for virtio-net-pci, in use by mch,id=(null)

Basically, it looks like the virtual graphical hardware now clashes with our virtual network hardware on the virtual machine virtual bus.

To fix this, we need to specify an address other than 0x0 for the network hardware, this fixing the issue.