### PR TITLE
`set_layouts`: don't append empty variants

### DIFF
--- a/pyanaconda/modules/localization/localed.py
+++ b/pyanaconda/modules/localization/localed.py
@@ -171,7 +171,8 @@ class LocaledWrapper(object):
                 parsing_failed = True
                 continue
             layouts.append(layout)
-            variants.append(variant)
+            if variant:
+                variants.append(variant)
 
         if not layouts and parsing_failed:
             return


### PR DESCRIPTION
This fixes a problem observed in
https://bugzilla.redhat.com/show_bug.cgi?id=2121106 . Kamil set the X layouts to ['cz (qwerty)', 'us']. Then when we called localed's SetX11Keyboard , this is what happened:

Changed X11 keyboard layout to 'cz,us' model '' variant 'qwerty,' options ''

Note the trailing comma on the variant string. That shouldn't be there. What that means is we literally told localed to set the variant string to "qwerty,".

I think the cause is that when we called `parse_layout_variant` for "cz (qwerty)" and then "us", the results would be:

("cz", "qwerty")
("us", "")

so then we'd wind up with `variants` as `["qwerty, ""]`. Then we do `variants_str = ",".join(variants)`, and that gives us the bad string "qwerty," because of the empty string in the list.

To avoid this happening, we should just not add empty strings to the variants list.

Signed-off-by: Adam Williamson <awilliam@redhat.com>