### PR TITLE
Web UI: Make context help reusable

### DIFF
--- a/ui/webui/src/components/HelpDrawer.jsx
+++ b/ui/webui/src/components/HelpDrawer.jsx
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with This program; If not, see <http://www.gnu.org/licenses/>.
  */
-import cockpit from "cockpit";
 import React, { useRef } from "react";
 
 import {
@@ -25,15 +24,9 @@ import {
     DrawerContentBody,
     DrawerHead,
     DrawerPanelContent,
-    Text,
-    TextContent,
-    TextVariants,
-    Title
 } from "@patternfly/react-core";
 
-const _ = cockpit.gettext;
-
-export const HelpDrawer = ({ isExpanded, setIsExpanded, children }) => {
+export const HelpDrawer = ({ isExpanded, setIsExpanded, helpContent, children }) => {
     const drawerRef = useRef(null);
 
     const onExpand = () => {
@@ -44,42 +37,11 @@ export const HelpDrawer = ({ isExpanded, setIsExpanded, children }) => {
         setIsExpanded(false);
     };
 
-    const content = (
-        <TextContent>
-            <Title headingLevel="h2">
-                {_("Storage options")}
-            </Title>
-            <Text component={TextVariants.p}>
-                {_("Installation destination allows you to configure which disks will be used " +
-                "as the installation target for your Fedora installation. At least 1 disk must " +
-                "be selected for the installation to proceed.")}
-            </Text>
-            <Text component={TextVariants.p}>
-                {_("All locally available storage devices (SATA, IDE and SCSI hard drives, USB " +
-                "flash drives, etc.) are displayed in the Local Standard Disks section. Local " +
-                "disks are detected when the installer starts - any storage devices connected " +
-                "after the installation has started will not be shown.")}
-            </Text>
-            <Text component={TextVariants.p}>
-                {_("If you need to configure additional local storage devices, refresh the " +
-                "page using the refresh icon. All detected disks, including any new ones, " +
-                "will be displayed in the Local Standard Disks section.")}
-            </Text>
-            <Text>
-                {_("The installer will determine the total amount of space on all selected " +
-                "disks, and it will create a Btrfs layout suitable for your system. The " +
-                "specifics of this layout depend on whether your system uses BIOS or UEFI " +
-                "firmware, and the total amount of free space on your disks. A ZRAM-based " +
-                "swap will be used instead of a disk-based swap partition.")}
-            </Text>
-        </TextContent>
-    );
-
     const panelContent = (
         <DrawerPanelContent isResizable defaultSize="450px" minSize="150px">
             <DrawerHead>
                 <span tabIndex={isExpanded ? 0 : -1} ref={drawerRef}>
-                    {content}
+                    {helpContent}
                 </span>
                 <DrawerActions>
                     <DrawerCloseButton onClick={onCloseClick} />

--- a/ui/webui/src/components/app.jsx
+++ b/ui/webui/src/components/app.jsx
@@ -44,6 +44,7 @@ export const Application = () => {
     const [conf, setConf] = useState();
     const [notifications, setNotifications] = useState({});
     const [isHelpExpanded, setIsHelpExpanded] = useState(false);
+    const [helpContent, setHelpContent] = useState("");
 
     useEffect(() => {
         cockpit.file("/run/anaconda/bus.address").watch(address => {
@@ -80,7 +81,10 @@ export const Application = () => {
         onAddNotification({ title: ex.name, message: ex.message, variant: "danger" });
     };
 
-    const toggleContextHelp = () => {
+    const toggleContextHelp = (content) => {
+        if (!isHelpExpanded) {
+            setHelpContent(content);
+        }
         setIsHelpExpanded(!isHelpExpanded);
     };
 
@@ -139,6 +143,7 @@ export const Application = () => {
         <HelpDrawer
           isExpanded={isHelpExpanded}
           setIsExpanded={setIsHelpExpanded}
+          helpContent={helpContent}
         >
             {page}
         </HelpDrawer>

--- a/ui/webui/src/components/storage/HelpStorageOptions.jsx
+++ b/ui/webui/src/components/storage/HelpStorageOptions.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import cockpit from "cockpit";
+
+import {
+    Text,
+    TextContent,
+    TextVariants,
+    Title,
+} from "@patternfly/react-core";
+
+const _ = cockpit.gettext;
+
+export const helpStorageOptions = (
+    <TextContent>
+        <Title headingLevel="h2">
+            {_("Storage options")}
+        </Title>
+        <Text component={TextVariants.p}>
+            {_("Installation destination allows you to configure which disks will be used " +
+            "as the installation target for your Fedora installation. At least 1 disk must " +
+            "be selected for the installation to proceed.")}
+        </Text>
+        <Text component={TextVariants.p}>
+            {_("All locally available storage devices (SATA, IDE and SCSI hard drives, USB " +
+            "flash drives, etc.) are displayed in the Local Standard Disks section. Local " +
+            "disks are detected when the installer starts - any storage devices connected " +
+            "after the installation has started will not be shown.")}
+        </Text>
+        <Text component={TextVariants.p}>
+            {_("If you need to configure additional local storage devices, refresh the " +
+            "page using the refresh icon. All detected disks, including any new ones, " +
+            "will be displayed in the Local Standard Disks section.")}
+        </Text>
+        <Text>
+            {_("The installer will determine the total amount of space on all selected " +
+            "disks, and it will create a Btrfs layout suitable for your system. The " +
+            "specifics of this layout depend on whether your system uses BIOS or UEFI " +
+            "firmware, and the total amount of free space on your disks. A ZRAM-based " +
+            "swap will be used instead of a disk-based swap partition.")}
+        </Text>
+    </TextContent>
+);

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -50,6 +50,8 @@ import { HelpIcon } from "@patternfly/react-icons";
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 import { ListingTable } from "cockpit-components-table.jsx";
 
+import { helpStorageOptions } from "./HelpStorageOptions.jsx";
+
 import {
     applyPartitioning,
     createPartitioning,
@@ -377,6 +379,10 @@ const LocalStandardDisks = ({ idPrefix, setIsFormValid, onAddErrorNotification }
 export const InstallationDestination = ({ idPrefix, setIsFormValid, onAddErrorNotification, toggleContextHelp, stepNotification, isInProgress }) => {
     const [requiredSize, setRequiredSize] = useState(0);
 
+    const toggleHelpStorageOptions = () => {
+        toggleContextHelp(helpStorageOptions);
+    };
+
     useEffect(() => {
         getRequiredSpace()
                 .then(res => {
@@ -413,7 +419,7 @@ export const InstallationDestination = ({ idPrefix, setIsFormValid, onAddErrorNo
                         "$0 of available space. Storage will be automatically partitioned."
                     ), cockpit.format_bytes(requiredSize))}
                     {" "}
-                    <Button variant="link" isInline onClick={toggleContextHelp}>
+                    <Button variant="link" isInline onClick={toggleHelpStorageOptions}>
                         {_("Learn more about your storage options.")}
                     </Button>
                 </Text>


### PR DESCRIPTION
Context help drawer used to only show storage options help. Added a help toggle function to AnacondaWizzard arguments that can set content of the help and can be used from any page.