### PR TITLE
rpm-ostree: set untrusted ostree pull flag

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -577,7 +577,10 @@ class PullRemoteAndDeleteTask(Task):
         progress = OSTree.AsyncProgress.new()
         progress.connect('changed', self._pull_progress_cb)
 
-        pull_opts = {'refs': Variant('as', [ref])}
+        # We use the UNTRUSTED flag as a way to help verification for potentially
+        # corrupted ISOs - this way ostree will validate the checksum of objects as
+        # it writes data.
+        pull_opts = {'refs': Variant('as', [ref]), 'flags': Variant('i', OSTree.RepoPullFlags.UNTRUSTED)}
         # If we're doing a kickstart, we can at least use the content as a reference:
         # See <https://github.com/rhinstaller/anaconda/issues/1117>
         # The first path here is used by <https://pagure.io/fedora-lorax-templates>

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -22,6 +22,7 @@ import pytest
 import unittest
 from unittest.mock import patch, call, MagicMock
 
+from gi.repository import OSTree
 from pyanaconda.core.glib import Variant, GError
 from pyanaconda.modules.common.errors.installation import PayloadInstallationError
 from pyanaconda.modules.common.structures.rpm_ostree import RPMOSTreeConfigurationData
@@ -650,7 +651,7 @@ class PullRemoteAndDeleteTaskTestCase(unittest.TestCase):
         name, args, kwargs = repo_mock.pull_with_options.mock_calls[0]
         opts = args[1]
         assert type(opts) == Variant
-        assert opts.unpack() == {"refs": ["ref"]}
+        assert opts.unpack() == {"refs": ["ref"], "flags": OSTree.RepoPullFlags.UNTRUSTED}
         repo_mock.remote_delete.assert_called_once_with("remote", None)
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.create_new_context")
@@ -679,7 +680,7 @@ class PullRemoteAndDeleteTaskTestCase(unittest.TestCase):
         name, args, kwargs = repo_mock.pull_with_options.mock_calls[0]
         opts = args[1]
         assert type(opts) == Variant
-        assert opts.unpack() == {"refs": ["ref"]}
+        assert opts.unpack() == {"refs": ["ref"], "flags": OSTree.RepoPullFlags.UNTRUSTED}
         repo_mock.remote_delete.assert_not_called()
 
     def test_pull_progress_report(self):


### PR DESCRIPTION
By default ostree validate checksum when pulling from remote repos, but not for local repos. Set the untrusted ostree pull flag to always validate files.