### PR TITLE
Don't check installation targets if bootloader devices are not set (#2131183)

### DIFF
--- a/pyanaconda/modules/storage/checker/utils.py
+++ b/pyanaconda/modules/storage/checker/utils.py
@@ -207,9 +207,15 @@ def verify_gpt_biosboot(storage, constraints, report_error, report_warning):
     :param report_error: a function for error reporting
     :param report_warning: a function for warning reporting
     """
+    # The bootloader is disabled.
     if not storage.bootloader or storage.bootloader.skip_bootloader:
         return
 
+    # The bootloader devices are not set.
+    if not storage.bootloader.stage1_device or not storage.bootloader.stage2_device:
+        return
+
+    # Check the installation targets.
     for stage1, _stage2 in storage.bootloader.install_targets:
         if arch.is_x86() and not arch.is_efi() and stage1 and stage1.is_disk \
                 and getattr(stage1.format, "label_type", None) == "gpt":


### PR DESCRIPTION
If we couldn't set the bootloader devices, the bootloader configuration is invalid and there is not need to verify biosboot partitions on installation targets at that point.

Resolves: rhbz#2131183