### PR TITLE
There are no installation targets if bootloader devices are not set (#2131183)

### DIFF
--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -624,7 +624,12 @@ class BootLoader(object):
     @property
     def install_targets(self):
         """List of (stage1, stage2) tuples representing install targets."""
-        return [(self.stage1_device, self.stage2_device)]
+        targets = []
+
+        if self.stage1_device and self.stage2_device:
+            targets.append((self.stage1_device, self.stage2_device))
+
+        return targets
 
     def is_valid_stage2_device(self, device, linux=True, non_linux=False):
         """ Return True if the device is suitable as a stage2 target device.


### PR DESCRIPTION
If the stage1 and stage2 devices are not set yet (due to an invalid configuration), there are no installation targets to return.

This is an alternative to the commit 1ea4f30.

Resolves: rhbz#2131183