### PR TITLE
Remove bogus dependency on python3-dbus

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -98,7 +98,6 @@ Requires: python3-kickstart >= %{pykickstartver}
 Requires: python3-langtable >= %{langtablever}
 Requires: util-linux >= %{utillinuxver}
 Requires: python3-gobject-base
-Requires: python3-dbus
 Requires: python3-pwquality
 Requires: python3-systemd
 Requires: python3-productmd

--- a/pyanaconda/vnc.py
+++ b/pyanaconda/vnc.py
@@ -23,7 +23,6 @@ from pyanaconda import network, product
 from pyanaconda.core import util, constants
 import socket
 import subprocess
-import dbus
 
 from pyanaconda.core.i18n import _, P_
 from pyanaconda.ui.tui import tui_quit_callback
@@ -222,7 +221,7 @@ class VncServer(object):
         # Lets call it from here for now.
         try:
             self.initialize()
-        except (socket.herror, dbus.DBusException, ValueError) as e:
+        except (socket.herror, ValueError) as e:
             stdoutLog.critical("Could not initialize the VNC server: %s", e)
             util.ipmi_abort(scripts=self.anaconda.ksdata.scripts)
             sys.exit(1)


### PR DESCRIPTION
The only use is catching an exception that can't be raised by the guarded code.

(Or so I believe....)