### PR TITLE
Provide a command line option to install systemd-boot rather than grub2 on x86_64 and arm64

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -256,3 +256,13 @@ Below is a list of pure community features, their community maintainers, and mai
 * Description:
 
 ``Enable boot of the installed system from a BTRFS subvolume.``
+
+systemd-boot as a bootloader
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Origin: https://github.com/rhinstaller/anaconda/pull/4368
+* Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2135531
+* Maintainer: Jeremy Linton <jeremy.linton@arm.com>
+* Description:
+
+``Enable boot using systemd-boot rather than grub2.``

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -39,7 +39,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.44-1
+%define pykickstartver 3.45-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.6.0-1
 %define rpmver 4.15.0

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -138,6 +138,7 @@ selinux = -1
 #
 #   DEFAULT   Choose the type by platform.
 #   EXTLINUX  Use extlinux as the bootloader.
+#   SDBOOT    Use systemd-boot as the bootloader.
 #
 type = DEFAULT
 

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -225,6 +225,11 @@ Use extlinux as the bootloader. Note that there's no attempt to validate
 that this will work for your platform or anything; it assumes that if you
 ask for it, you want to try.
 
+sdboot
+Use systemd-boot as the bootloader. Note that there's no attempt to validate
+that this will work for your platform or anything; it assumes that if you
+ask for it, you want to try.
+
 nombr
 
 If nombr is specified the grub2 bootloader will be installed but the

--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -669,6 +669,15 @@ Use extlinux as the bootloader. Note that there's no attempt to validate that
 this will work for your platform or anything; it assumes that if you ask for it,
 you want to try.
 
+.. inst.sdboot:
+
+inst.sdboot
+^^^^^^^^^^^^^
+
+Use systemd-boot as the bootloader. Note that there's no attempt to validate that
+this will work for your platform or anything; it assumes that if you ask for it,
+you want to try.
+
 .. inst.leavebootorder:
 
 inst.leavebootorder

--- a/docs/release-notes/systemd-boot.rst
+++ b/docs/release-notes/systemd-boot.rst
@@ -1,0 +1,20 @@
+:Type: Kickstart Installation
+:Summary: Install an image using systemd-boot rather than grub (#2135531)
+
+:Description:
+    With this release, systemd-boot can be selected as an alternative boot
+    loader for testing and development purposes.
+
+    This can be done with 'inst.sdboot' from the grub/kernel command
+    line or with '--sdboot' in a kickstart file as part of the
+    bootloader command.  The resulting machine should be free of grub,
+    shim, and grubby packages, with all the boot files on the EFI
+    System Partition (ESP). This may mean that it is wise to dedicate
+    the space previously allocated for /boot to the ESP in order to
+    assure that future kernel upgrades will have sufficient space.
+
+    For more information, refer to the anaconda and systemd-boot documentation.
+
+:Links:
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2135531
+    - https://github.com/rhinstaller/anaconda/pull/4368

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -54,7 +54,7 @@ from pykickstart.commands.mediacheck import FC4_MediaCheck as MediaCheck
 from pykickstart.commands.driverdisk import F14_DriverDisk as DriverDisk
 from pykickstart.commands.network import F38_Network as Network
 from pykickstart.commands.displaymode import F26_DisplayMode as DisplayMode
-from pykickstart.commands.bootloader import F34_Bootloader as Bootloader
+from pykickstart.commands.bootloader import F39_Bootloader as Bootloader
 
 # Default logging: none
 log = logging.getLogger('parse-kickstart').addHandler(logging.NullHandler())

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -591,6 +591,8 @@ def getArgumentParser(version_string, boot_cmdline=None):
                     help=help_parser.help_text("noeject"))
     ap.add_argument("--extlinux", action="store_true", default=False,
                     help=help_parser.help_text("extlinux"))
+    ap.add_argument("--sdboot", action="store_true", default=False,
+                    help=help_parser.help_text("sdboot"))
     ap.add_argument("--nombr", action="store_true", default=False,
                     help=help_parser.help_text("nombr"))
     ap.add_argument("--mpathfriendlynames", dest="multipath_friendly_names", action="store_true",

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -375,6 +375,8 @@ class AnacondaConfiguration(Configuration):
         # Set the bootloader type.
         if opts.extlinux:
             self.bootloader._set_option("type", BootloaderType.EXTLINUX.value)
+        if opts.sdboot:
+            self.bootloader._set_option("type", BootloaderType.SDBOOT.value)
 
         # Set the boot loader flags.
         self.bootloader._set_option("nonibft_iscsi_boot", opts.nonibftiscsiboot)

--- a/pyanaconda/core/configuration/bootloader.py
+++ b/pyanaconda/core/configuration/bootloader.py
@@ -23,8 +23,9 @@ from pyanaconda.core.configuration.base import Section
 
 class BootloaderType(Enum):
     """Type of the bootloader."""
-    DEFAULT = "DEFAULT"
+    DEFAULT  = "DEFAULT"
     EXTLINUX = "EXTLINUX"
+    SDBOOT   = "SDBOOT"
 
 
 class BootloaderSection(Section):
@@ -38,6 +39,7 @@ class BootloaderSection(Section):
 
             DEFAULT   Choose the type by platform.
             EXTLINUX  Use extlinux as the bootloader.
+            SDBOOT    Use systemd-boot as the bootloader.
 
         :return: an instance of BootloaderType
         """

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -25,7 +25,7 @@
 from pykickstart.commands.authselect import F28_Authselect as Authselect
 from pykickstart.commands.autopart import F38_AutoPart as AutoPart
 from pykickstart.commands.autostep import F34_AutoStep as AutoStep
-from pykickstart.commands.bootloader import F34_Bootloader as Bootloader
+from pykickstart.commands.bootloader import F39_Bootloader as Bootloader
 from pykickstart.commands.btrfs import F23_BTRFS as BTRFS
 from pykickstart.commands.cdrom import FC3_Cdrom as Cdrom
 from pykickstart.commands.clearpart import F28_ClearPart as ClearPart

--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -176,6 +176,7 @@ class BootLoader(object):
     image_label_attr = "label"
     encryption_support = False
     stage2_is_valid_stage1 = False
+    stage2_required = True
 
     # requirements for stage2 devices
     stage2_device = None
@@ -644,6 +645,10 @@ class BootLoader(object):
             return False
 
         log.debug("Is %s a valid stage2 target device?", device.name)
+
+        if not self.stage2_required:
+            log.debug("stage2 not required")
+            return True
 
         if device.protected:
             valid = False

--- a/pyanaconda/modules/storage/bootloader/bootloader.py
+++ b/pyanaconda/modules/storage/bootloader/bootloader.py
@@ -129,6 +129,9 @@ class BootloaderModule(KickstartBaseModule):
         if data.bootloader.extlinux:
             self.set_default_type(BootloaderType.EXTLINUX)
 
+        if data.bootloader.sdboot:
+            self.set_default_type(BootloaderType.SDBOOT)
+
         if data.bootloader.bootDrive:
             self.set_drive(data.bootloader.bootDrive)
 
@@ -183,6 +186,9 @@ class BootloaderModule(KickstartBaseModule):
         """Setup the kickstart data."""
         if self.get_default_type() == BootloaderType.EXTLINUX:
             data.bootloader.extlinux = True
+
+        if self.get_default_type() == BootloaderType.SDBOOT:
+            data.bootloader.sdboot = True
 
         if self.bootloader_mode == BootloaderMode.DISABLED:
             data.bootloader.disabled = True
@@ -503,6 +509,7 @@ class BootloaderModule(KickstartBaseModule):
         """
         return [
             RecreateInitrdsTask(
+                storage=self.storage,
                 payload_type=payload_type,
                 kernel_versions=kernel_versions,
                 sysroot=conf.target.system_root

--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -147,7 +147,7 @@ class EFIBase(object):
 class EFIGRUB(EFIBase, GRUB2):
     """EFI GRUBv2"""
     _packages32 = [ "grub2-efi-ia32", "shim-ia32" ]
-    _packages_common = [ "efibootmgr", "grub2-tools" ]
+    _packages_common = ["efibootmgr", "grub2-tools", "grub2-tools-extra", "grubby" ]
     stage2_is_valid_stage1 = False
     stage2_bootable = False
 
@@ -249,7 +249,7 @@ class Aarch64EFIGRUB(EFIGRUB):
 
     def __init__(self):
         super().__init__()
-        self._packages64 = ["grub2-efi-aa64", "shim-aa64"]
+        self._packages64 = ["grub2-efi-aa64", "shim-aa64", "grub2-efi-aa64-cdboot"]
 
 
 class Aarch64EFISystemdBoot(EFISystemdBoot):

--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -31,7 +31,7 @@ from pyanaconda.product import productName
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
-__all__ = ["EFIBase", "EFIGRUB", "Aarch64EFIGRUB", "ArmEFIGRUB", "MacEFIGRUB", "Aarch64EFISystemdBoot"]
+__all__ = ["EFIBase", "EFIGRUB", "Aarch64EFIGRUB", "ArmEFIGRUB", "MacEFIGRUB", "Aarch64EFISystemdBoot", "X64EFISystemdBoot"]
 
 
 class EFIBase(object):
@@ -259,6 +259,14 @@ class Aarch64EFISystemdBoot(EFISystemdBoot):
     def __init__(self):
         super().__init__()
         self._packages64 = []
+
+class X64EFISystemdBoot(EFISystemdBoot):
+    _efi_binary = "\\systemd-bootx64.efi"
+
+    def __init__(self):
+        super().__init__()
+        self._packages64 = []
+
 
 
 class ArmEFIGRUB(EFIGRUB):

--- a/pyanaconda/modules/storage/bootloader/factory.py
+++ b/pyanaconda/modules/storage/bootloader/factory.py
@@ -82,6 +82,7 @@ class BootLoaderFactory(object):
 
         Supported values:
             EXTLINUX
+            SDBOOT
 
         :param name: a boot loader name or None
         :return: a boot loader class or None
@@ -89,6 +90,15 @@ class BootLoaderFactory(object):
         if name == "EXTLINUX":
             from pyanaconda.modules.storage.bootloader.extlinux import EXTLINUX
             return EXTLINUX
+
+        if name == "SDBOOT":
+            platform_class = platform.platform.__class__
+            if platform_class is platform.Aarch64EFI:
+                from pyanaconda.modules.storage.bootloader.efi import Aarch64EFISystemdBoot
+                return Aarch64EFISystemdBoot
+            if platform_class is platform.EFI:
+                from pyanaconda.modules.storage.bootloader.efi import X64EFISystemdBoot
+                return X64EFISystemdBoot
 
         return None
 

--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -21,7 +21,7 @@ from blivet import arch
 from blivet.devices import BTRFSDevice
 from pyanaconda.core.constants import PAYLOAD_TYPE_RPM_OSTREE, PAYLOAD_LIVE_TYPES
 from pyanaconda.modules.storage.bootloader import BootLoaderError
-
+from pyanaconda.modules.storage.bootloader.systemd import SystemdBoot
 from pyanaconda.core.util import execWithRedirect
 from pyanaconda.modules.common.errors.installation import BootloaderInstallationError
 from pyanaconda.modules.storage.constants import BootloaderMode
@@ -173,9 +173,10 @@ class CreateBLSEntriesTask(Task):
 class RecreateInitrdsTask(Task):
     """Installation task that recreates the initrds."""
 
-    def __init__(self, payload_type, kernel_versions, sysroot):
+    def __init__(self, storage, payload_type, kernel_versions, sysroot):
         """Create a new task."""
         super().__init__()
+        self._storage = storage
         self._payload_type = payload_type
         self._versions = kernel_versions
         self._sysroot = sysroot
@@ -191,6 +192,9 @@ class RecreateInitrdsTask(Task):
         # them per-machine.
         if self._payload_type == PAYLOAD_TYPE_RPM_OSTREE:
             log.debug("Don't regenerate initramfs on rpm-ostree systems.")
+            return
+        if isinstance(self._storage.bootloader, SystemdBoot):
+            log.debug("Don't regenerate initramfs on systemd-boot systems.")
             return
 
         recreate_initrds(

--- a/pyanaconda/modules/storage/bootloader/systemd.py
+++ b/pyanaconda/modules/storage/bootloader/systemd.py
@@ -1,0 +1,147 @@
+#
+# Copyright (C) 2022 Arm
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from pyanaconda.modules.storage.bootloader.base import BootLoader, BootLoaderError
+from pyanaconda.core import util
+from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.core.i18n import _
+from pyanaconda.core.path import join_paths
+from pyanaconda.product import productName
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+__all__ = ["SystemdBoot"]
+
+class SystemdBoot(BootLoader):
+    """Systemd-boot.
+
+    Systemd-boot is dead simple, it basically provides a second boot menu
+    and injects the kernel parms into an efi stubbed kernel, which in turn
+    (optionally) loads it's initrd. As such there aren't any filesystem or
+    drivers to worry about as everything needed is provided by UEFI. Even the
+    console remains on the UEFI framebuffer, or serial as selected by UEFI.
+    Basically rather than trying to be another mini-os (like grub) and duplicate
+    much of what UEFI provides, it simply utilizes the existing services.
+
+    Further, while we could keep stage1 (ESP) and stage2 (/boot) seperate it
+    simplifies things just to merge them and place the kernel/initrd on the
+    ESP. This requires a larger than normal ESP, but for now we assume that
+    this linux installer is creating the partitions, so where the space
+    is allocated doesn't matter.
+
+    """
+    name = "SDBOOT"
+    # oddly systemd-boot files are part of the systemd-udev package
+    # and in /usr/lib/systemd/boot/efi/systemd-boot[aa64].efi
+    # and the systemd stubs are in /usr/lib/systemd/linuxaa64.efi.stub
+    _config_file = "loader.conf"
+    _config_dir = "/loader"
+
+    # systemd-boot doesn't require a stage2 as
+    # everything is stored on the ESP
+    stage2_max_end = None
+    stage2_is_valid_stage1 = True
+    stage2_required = False
+
+    #
+    # configuration
+    #
+
+    @property
+    def config_dir(self):
+        """ Full path to configuration directory. """
+        esp = util.execWithCapture("bootctl", [ "--print-esp-path" ],
+                                   root=conf.target.system_root)
+        return esp.strip() + self._config_dir
+
+    @property
+    def config_file(self):
+        """ Full path to configuration file. """
+        return "%s/%s" % (self.config_dir, self._config_file)
+
+    # copy console update from grub2.py
+    def write_config_console(self, config):
+        log.info("systemd.py: write_config_console")
+        if not self.console:
+            return
+
+        console_arg = "console=%s" % self.console
+        if self.console_options:
+            console_arg += ",%s" % self.console_options
+        self.boot_args.add(console_arg)
+
+    def write_config(self):
+        log.info("systemd.py: write_config systemd start")
+        self.write_config_console(None)
+
+        # Rewrite the loader.conf
+        # For now we are just updating the timeout to actually
+        # implement the bootloader --timeout option
+        config_path = join_paths(conf.target.system_root, self.config_file)
+        log.info("systemd.py: write_config systemd loader conf : %s ", config_path)
+
+        with open(config_path, "w") as config:
+            config.write("timeout "+ str(self.timeout) + "\n")
+            config.write("#console-mode keep\n")
+
+        # update /etc/kernel/cmdline
+        # should look something like "root=UUID=45b931b7-592a-46dc-9c33-d38d5901ec29 ro resume=/dev/sda3"
+        config_path = join_paths(conf.target.system_root, "/etc/kernel/cmdline")
+        log.info("systemd.py: write_config systemd commandline : %s ", config_path)
+        with open(config_path, "w") as config:
+            args = str(self.boot_args)
+            log.info("systemd.py: systemd used boot args: %s ", args)
+
+            # pick up the UUID of the mounted rootfs,
+            root_uuid = util.execWithCapture("findmnt", [ "-sfn", "-oUUID", "/" ],
+                                             root=conf.target.system_root)
+            args += " root=UUID=" + root_uuid
+            config.write(args)
+
+        # rather than creating a mess in python lets just
+        # write the options above, and run a script which will merge the
+        # boot cmdline (after stripping inst. and BOOT_) with the anaconda
+        # settings and the kernel-install recovery/etc options.
+        rc = util.execWithRedirect(
+            "/usr/sbin/updateloaderentries",
+            [" "],
+            root=conf.target.system_root
+        )
+        if rc:
+            raise BootLoaderError(_("Failed to write boot loader configuration. "
+                                    "More information may be found in the log files stored in /tmp"))
+
+    #
+    # installation
+    #
+    def install(self, args=None):
+        log.info("systemd.py: install systemd boot install (root=%s)", conf.target.system_root)
+
+        # the --esp-path= isn't strictly required, but we want to be explicit about it.
+        rc = util.execWithRedirect("bootctl", [ "install", "--esp-path=/boot/efi",
+                                                "--efi-boot-option-description=" + productName.split("-")[0] ],
+                                   root=conf.target.system_root,
+                                   env_prune=['MALLOC_PERTURB_'])
+        if rc:
+            raise BootLoaderError(_("bootctl failed to install UEFI boot loader. "
+                                    "More information may be found in the log files stored in /tmp"))
+
+
+    def write_config_images(self, config):
+        return True

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
@@ -483,10 +483,12 @@ class BootloaderTasksTestCase(unittest.TestCase):
     @patch('pyanaconda.modules.storage.bootloader.utils.conf')
     def test_recreate_initrds(self, conf_mock, exec_mock):
         """Test the installation task that recreates initrds."""
+        storage = Mock(bootloader=EFIGRUB())
         version = "4.17.7-200.fc28.x86_64"
 
         with tempfile.TemporaryDirectory() as root:
             task = RecreateInitrdsTask(
+                storage=storage,
                 sysroot=root,
                 payload_type=PAYLOAD_TYPE_RPM_OSTREE,
                 kernel_versions=[version]
@@ -499,6 +501,7 @@ class BootloaderTasksTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as root:
             task = RecreateInitrdsTask(
+                storage=storage,
                 sysroot=root,
                 payload_type=PAYLOAD_TYPE_LIVE_IMAGE,
                 kernel_versions=[version]
@@ -526,6 +529,7 @@ class BootloaderTasksTestCase(unittest.TestCase):
             open(root + "/usr/sbin/new-kernel-pkg", 'wb').close()
 
             task = RecreateInitrdsTask(
+                storage=storage,
                 sysroot=root,
                 payload_type=PAYLOAD_TYPE_LIVE_IMAGE,
                 kernel_versions=[version]
@@ -546,6 +550,7 @@ class BootloaderTasksTestCase(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as root:
             task = RecreateInitrdsTask(
+                storage=storage,
                 sysroot=root,
                 payload_type=PAYLOAD_TYPE_LIVE_IMAGE,
                 kernel_versions=[version]


### PR DESCRIPTION
systemd-boot is a lightweight bootloader utility that understands the Linux loader syntax and populates a menu of installed boot options. It then utilizes UEFI-provided system services to run the given image. In the case of x86, arm64, riscv and others the linux kernel can be (is on fedora/RH distros) a standalone EFI executable image. With the initrd= option, the kernel loads its own initrd as well. 

This simplifies the boot process significantly as UEFI already provides a fairly heavyweight environment and signing systemd-boot with platform-enrolled keys avoids much of the complexity of shim+grub loading linux filesystem drivers, console and keyboard mgmt, etc.

This set of patches has been tested on x86_64 and arm64, but it requires either an updated set of systemd packages (to name the bootloader, a stubby (aka systemd grubby) package which provides dnf ownership of some of the /boot/efi/ files, and removal of all the grub packages in the -comps.xml files. Once the system has been installed it should behave mostly as one would expect with 'dnf upgrade' and the like.

It's sorta RFC quality at the moment, as the root= options need some further tweaking, and there remains some stubby work for kdump and the like). I've also not included anything that modifies the default partitioning setups, but in the future, picking this option should remove the need for a dedicated /boot partition.

In theory, systemd-boot can then be used along with the systemd-stub to create unified signed images (as is being done at some large companies today!), but I've not tested anything in that path, and the short term goal is simply to clean up all the bits and pieces so that its possible in the F38/39 timeframe to clean install a fedora system without grub on x86 and arm while maintaining grub as the default bootloader. 
