### PR TITLE
Make text in custom_storage_helper more accurate

### DIFF
--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -1179,11 +1179,14 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         self.reset_state()
 
+        is_md = self._get_current_device_type() == DEVICE_TYPE_MD
+
         dialog = DisksDialog(
             self.data,
             self._device_tree,
             self._selected_disks,
-            self._request.disks
+            self._request.disks,
+            is_md
         )
         with self.main_window.enlightbox(dialog.window):
             rc = dialog.run()

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
@@ -183,10 +183,9 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="label11">
+              <object class="GtkLabel" id="disk_selection_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Select one or more disks this device may reside on.</property>
                 <property name="wrap">True</property>
               </object>
               <packing>
@@ -277,7 +276,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -409,21 +409,32 @@ class DisksDialog(GUIObject):
     mainWidgetName = "disks_dialog"
     uiFile = "spokes/lib/custom_storage_helpers.glade"
 
-    def __init__(self, data, device_tree, disks, selected_disks):
+    def __init__(self, data, device_tree, disks, selected_disks, is_md):
         super().__init__(data)
         self._device_tree = device_tree
         self._selected_disks = selected_disks
         self._disks = disks
+        self.is_md = is_md
+        self.instruction_label = self.builder.get_object("disk_selection_label")
         self._store = self.builder.get_object("disk_store")
         self._view = self.builder.get_object("disk_view")
         self._populate_disks()
         self._select_disks()
         self._view.set_tooltip_column(0)
+        self._set_instruction_label()
 
     @property
     def selected_disks(self):
         """Selected disks."""
         return self._selected_disks
+
+    def _set_instruction_label(self):
+        if self.is_md:
+            self.instruction_label.set_text(_("Select all of the drives you would like the "
+                                              "mount point to be created on."))
+        else:
+            self.instruction_label.set_text(_("Select a drive for the mount point to be created on. "
+                                              "If you select multiple, only 1 drive will be used."))
 
     def _populate_disks(self):
         for device_name in self._disks:


### PR DESCRIPTION
The window for selecting the disks to be used for a mount point doesn't say clearly that only one of the selected devices will be used. Added an additional label that explains this behaviour.

These changes will be backported to rhel8 and rhel9.



Resolves: [rhbz#2063288](https://bugzilla.redhat.com/show_bug.cgi?id=2063288)