### PR TITLE
Progress step improvements

### DIFF
--- a/ui/webui/src/components/installation/InstallationProgress.scss
+++ b/ui/webui/src/components/installation/InstallationProgress.scss
@@ -1,3 +1,7 @@
+.pf-c-empty-state__content {
+    width: 100%
+}
+
 .installation-progress-status {
     &-success .pf-c-empty-state__icon {
         color: var(--pf-global--success-color--100);


### PR DESCRIPTION
A couple of progress screen improvements based on usability studies and user feedback:
- better phase icons
- proper installation phase microcopy
- current step status under the step currently being processed

TODO:

- [x] fixup tests
- [x] add screenshots/screencast
- ~[ ] report bug to PatternFly for progress stepper space allocation~ fixed in CSS
- [x] find why there is a blank screen when installation finishes

