### PR TITLE
sync_run_task: Poll proxy state faster

### DIFF
--- a/pyanaconda/modules/common/task/__init__.py
+++ b/pyanaconda/modules/common/task/__init__.py
@@ -41,7 +41,7 @@ def sync_run_task(task_proxy, callback=None):
         if callback:
             callback(task_proxy)
 
-        sleep(1)
+        sleep(0.1)
 
     task_proxy.Finish()
 


### PR DESCRIPTION
That means, now every 100 ms instead of the previous 1 second. This is possible, because getting the `IsRunning` property is fast on the backend, and the wait/exec time ratio doesn't change much. In return, we get faster return from small tasks.

This is a simple change but has a lot of potential to shake up hidden races, assumptions about timing etc.

cc @AdamWill ^^