### PR TITLE
Web UI: Update language selection screen

### DIFF
--- a/ui/webui/src/components/localization/InstallationLanguage.scss
+++ b/ui/webui/src/components/localization/InstallationLanguage.scss
@@ -1,3 +1,8 @@
 #language-alert {
-    margin-top: 2em;
+    margin-bottom: 1.25rem;
+}
+
+#installation-language-language-menu {
+    margin-top: 1rem;
+    margin-bottom: 2rem;
 }

--- a/ui/webui/test/helpers/language.py
+++ b/ui/webui/test/helpers/language.py
@@ -34,15 +34,15 @@ class Language():
         self._bus_address = self.machine.execute("cat /run/anaconda/bus.address")
 
     def select_locale(self, locale):
-        if self.browser.val(f"#{self._step}-language-search") != "":
+        if self.browser.val(f"#{self._step}-language-search .pf-c-text-input-group__text-input") != "":
             self.input_locale_search("")
         self.browser.click(f"#{self._step}-option-common-{locale} > button")
 
     def get_locale_search(self):
-        return self.browser.val(f"#{self._step}-language-search")
+        return self.browser.val(f"#{self._step}-language-search .pf-c-text-input-group__text-input")
 
     def input_locale_search(self, text):
-        self.browser.set_input_text(f"#{self._step}-language-search", text)
+        self.browser.set_input_text(f"#{self._step}-language-search .pf-c-text-input-group__text-input", text)
 
     def locale_option_visible(self, locale, visible=True):
         if visible:


### PR DESCRIPTION
 - Move alert above the menu
 - Selected items now have different backgrounds
 - Replace the input field with a proper search bar

![language-selector](https://user-images.githubusercontent.com/40278421/198336432-20f35aef-ab2f-4d12-82ed-1c89c26939a0.png)
*In the screenshot I was hovering my mouse above Japanese.*

I am not able to add the pre-filling of the default language, that @lclay2 suggested, due to technical reasons.
