### PR TITLE
dracut: include modprobed modules into initrd

### DIFF
--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # load modules needed by anaconda
+# keep in sync with module-setup.sh
 
 # load anaconda-lib for the subsequent scripts in this hook
 . /lib/anaconda-lib.sh

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -16,9 +16,21 @@ depends() {
 }
 
 installkernel() {
-    case "$(uname -m)" in
+	local arch
+	arch="$(uname -m)"
+	# anaconda-modprobe.sh will load these modules
+	# (instmods in the same order as there)
+	instmods squashfs iscsi_tcp
+    case "$arch" in
         s390*) instmods hmcdrv ;;
+        * ) instmods edd iscsi_ibft ;;
     esac
+    case "$arch" in
+        ppc*) instmods spufs ;;
+    esac
+    instmods raid0 raid1 raid5 raid6 raid456 raid10 linear dm-mod dm-zero \
+             dm-mirror dm-snapshot dm-multipath dm-round-robin dm-crypt cbc \
+             sha256 lrw xts
 }
 
 install() {


### PR DESCRIPTION
anaconda-modprobe.sh tries to load some modules, but everything relies on them being included into initrd by any other ways, not directly.

It leads to warnings printed on LiveCD startup that modules have not been found. Kernel 5.15.74-generic-1rosa2021.1-x86_64 is built with CONFIG_ISCSI_TCP=m, CONFIG_ISCSI_IBFT=m, but dracut module 90multipath did not include these modules into initrd.

A better way would be to somehow avoid duplicating lists of modules in 2 files, but I don't have ideas how to implement it beautifully.

Before:

![2022-10-28_16-30](https://user-images.githubusercontent.com/15802528/198828597-f2ba081a-47d6-4e85-a8ca-d08483f9afd8.png)

After:

![2022-10-29_14-18](https://user-images.githubusercontent.com/15802528/198828603-2223f7bb-d531-4076-9a7e-f1b87191bffc.png)

