### PR TITLE
Support bond device activated in initramfs from kickstart

### DIFF
--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -390,6 +390,9 @@ def ksnet_to_dracut(args, lineno, net, bootdev=False):
     if net.bridgeslaves:
         line.append("bridge=%s:%s" % (net.device, net.bridgeslaves))
 
+    if net.bondslaves:
+        line.append("bond=%s:%s:%s:%s" % (net.device, net.bondslaves, net.bondopts, net.mtu))
+
     return " ".join(line)
 
 def process_kickstart(ksfile):


### PR DESCRIPTION
Resolves: rhbz#2133053

Port of https://github.com/rhinstaller/anaconda/pull/3296 from Fedora