### PR TITLE
network: commit changes synchronously when dumping autoconnections

### DIFF
--- a/pyanaconda/modules/network/initialization.py
+++ b/pyanaconda/modules/network/initialization.py
@@ -515,7 +515,7 @@ class DumpMissingIfcfgFilesTask(Task):
                     )
                 log.debug("%s: dumping connection %s to ifcfg file for %s",
                           self.name, con.get_uuid(), iface)
-                con.commit_changes(True, None)
+                commit_changes_with_autoconnection_blocked(con, nm_client)
             else:
                 log.debug("%s: creating default connection for %s", self.name, iface)
                 network_data = copy.deepcopy(self._default_network_data)


### PR DESCRIPTION
We should make sure they are complete when creating device configuraitons in the next step.

Port of commit d8fd894d6c56383384609305ad3fd72b67ac1448

Related: rhbz#2127057