### PR TITLE
webui: do not expose context menu in local Web UI

### DIFF
--- a/ui/webui/src/components/app.jsx
+++ b/ui/webui/src/components/app.jsx
@@ -34,7 +34,7 @@ import { StorageClient } from "../apis/storage.js";
 import { PayloadsClient } from "../apis/payloads";
 
 import { readBuildstamp, getIsFinal } from "../helpers/betanag.js";
-import { readConf } from "../helpers/conf.js";
+import { readConf, runningLocally } from "../helpers/conf.js";
 
 const _ = cockpit.gettext;
 
@@ -68,6 +68,10 @@ export const Application = () => {
             buildstamp => setBeta(!getIsFinal(buildstamp)),
             ex => console.error("Failed to parse anaconda buildstamp file")
         );
+
+        if (runningLocally()) {
+            window.oncontextmenu = () => { return false };
+        }
     }, []);
 
     const onAddNotification = (notificationProps) => {

--- a/ui/webui/src/helpers/conf.js
+++ b/ui/webui/src/helpers/conf.js
@@ -17,6 +17,7 @@
 import cockpit from "cockpit";
 
 const CONF_PATH = "/run/anaconda/anaconda.conf";
+const LOCAL_IP_ADDRESS = "127.0.0.90";
 
 const isEmpty = (inStr) => {
     // is string empty?
@@ -78,4 +79,8 @@ export const readConf = () => {
     return confFile.read()
             .then(parseIni)
             .finally(confFile.close);
+};
+
+export const runningLocally = () => {
+    return window.origin.startsWith(`http://${LOCAL_IP_ADDRESS}`);
 };


### PR DESCRIPTION
The IP address used to identify local installation is set in cockpit-desktop script.