### PR TITLE
infra: Use environment for releases

### DIFF
--- a/.github/workflows/release-periodically.yml
+++ b/.github/workflows/release-periodically.yml
@@ -27,6 +27,7 @@ permissions:
 jobs:
   make-release-tag:
     runs-on: ubuntu-latest
+    environment: releases
     steps:
 
       - name: Check out repo
@@ -60,6 +61,8 @@ jobs:
         if: ${{ steps.check-tag.outputs.can-tag }}
         # the repo should have an access token from the checkout action
         # https://github.com/actions/checkout#Push-a-commit-using-the-built-in-token
+        env:
+          GITHUB_TOKEN: ${{ secrets.INSTALLKER_TOKEN }}
         run: |
           git push --tags origin master
 

--- a/.github/workflows/release-periodically.yml.j2
+++ b/.github/workflows/release-periodically.yml.j2
@@ -21,6 +21,7 @@ permissions:
 jobs:
   make-release-tag:
     runs-on: ubuntu-latest
+    environment: releases
     steps:
 
       - name: Check out repo
@@ -54,6 +55,8 @@ jobs:
         if: ${{ steps.check-tag.outputs.can-tag }}
         # the repo should have an access token from the checkout action
         # https://github.com/actions/checkout#Push-a-commit-using-the-built-in-token
+        env:
+          GITHUB_TOKEN: ${{ secrets.INSTALLKER_TOKEN }}
         run: |
           git push --tags origin master
 


### PR DESCRIPTION
Github actions can not push to protected branches because it is not in the list of permitted teams and members. (Currently, it can not be so by design.)

Therefore, use a token generated by someone who can push to protected branches. Of course, the token must be generated by such a person in the first place.

The idea here is that the token is generated for the bot account, @InStallker.

----

NOTE: Not tested. I have no idea how to test this kind of change meaningfully.