### PR TITLE
webui: reduce progress animation repaints to save CPU (rhbz#1204242)

### DIFF
--- a/ui/webui/src/components/animations-workaround.css
+++ b/ui/webui/src/components/animations-workaround.css
@@ -1,0 +1,33 @@
+/*
+ * Animations in cockpit-client / webkit in VMs are causing excessive CPU load.
+ * See rhbz#1204242.
+ * Workaround it by decreasing the frame rate.
+ */
+
+.pf-c-skeleton {
+  --pf-c-skeleton--after--AnimationTimingFunction: steps(4);
+}
+
+span.pf-c-spinner {
+  --pf-c-spinner--AnimationTimingFunction: steps(0);
+  --pf-c-spinner__path--AnimationTimingFunction: steps(4);
+}
+
+svg.pf-c-spinner {
+  --pf-c-spinner--AnimationTimingFunction: steps(0);
+  --pf-c-spinner__path--AnimationTimingFunction: steps(4);
+}
+
+/* These spinners look too bad with reduced frame ratio and are less exposed
+.pf-c-spinner__clipper {
+  animation-timing-function: steps(4);
+}
+
+.pf-c-spinner__lead-ball {
+  animation-timing-function: steps(4);
+}
+
+.pf-c-spinner__tail-ball {
+  animation-timing-function: steps(4);
+}
+*/

--- a/ui/webui/src/index.js
+++ b/ui/webui/src/index.js
@@ -31,6 +31,7 @@ import { Application } from "./components/app.jsx";
  */
 import "./lib/patternfly/patternfly-4-overrides.scss";
 import "./components/app.scss";
+import "./components/animations-workaround.css";
 
 document.addEventListener("DOMContentLoaded", function () {
     ReactDOM.render(React.createElement(Application, {}), document.getElementById("app"));


### PR DESCRIPTION
We handled the spinner in the same way in Gtk GUI:

commit eead6838d69699a7f329305c119857301eab5122


Ideally, we should apply the reduction only if running
- in VM
- locally in cocpit-client/webkit

We need to figure out sane detection of these contidions, maybe passed to webui via anaconda configuration if possible ?

**NOTE** the recommendation from the desktop team is to use Firefox in kiosk mode.