### PR TITLE
Fix infobar colors in GTK GUI

### DIFF
--- a/data/anaconda-gtk.css
+++ b/data/anaconda-gtk.css
@@ -46,35 +46,35 @@ levelbar.discrete trough block.filled.high {
 @define-color error_fg_color black;
 @define-color error_bg_color rgb (237, 54, 54);
 
-infobar.info {
+infobar.info box {
     background-color: @info_bg_color;
-    border-color: darker(@info_bg_color);
+    border: none;
 }
 
 infobar.info label {
     color: @info_fg_color;
 }
 
-infobar.warning {
+infobar.warning box {
     background-color: @warning_bg_color;
-    border-color: darker(@warning_bg_color);
+    border: none;
 }
 
 infobar.warning label {
     color: @warning_fg_color;
 }
 
-infobar.question {
+infobar.question box {
     background-color: @question_bg_color;
-    border-color: darker(@question_bg_color);
+    border: none;
 }
 infobar.question label {
     color: @question_fg_color;
 }
 
-infobar.error {
+infobar.error box {
     background-color: @error_bg_color;
-    border-color: darker(@error_bg_color);
+    border: none;
 }
 
 infobar.error label {
@@ -84,7 +84,7 @@ infobar.error label {
 infobar.info,
 infobar.warning,
 infobar.question,
-infobar.error {
+infobar.error box {
     text-shadow: none;
 }
 


### PR DESCRIPTION
Fix infobar CSS after GTK update broke it.

Resolves: [rhbz#2074827](https://bugzilla.redhat.com/show_bug.cgi?id=2074827)

## Screenshots
This is how it looks now! By the way I didn't change any of the color values.
### Warning
![warning](https://user-images.githubusercontent.com/40278421/202224955-26d56ef6-e44e-499b-a2b7-55fdaa4aafb2.png)

### Error
![Screenshot_20221116_122207](https://user-images.githubusercontent.com/40278421/202225080-90a01ff9-a21a-47f6-97ac-d339c26f2195.png)

### RHEL 8
![rhel8-screenshot](https://user-images.githubusercontent.com/40278421/202227912-21c202a3-2efd-4cf3-996c-1ddfe5357d88.png)

The info bar doesn't look 100% like in the RHEL 8. For example the icon is now monochrome and the hyperlink has a different color, the original is light grey.

Right now I just fixed the old CSS so that it now applies again. Is this fine or should I make it look 1:1 to the RHEL-8 screenshot or are we going to use a different color scheme?

