### PR TITLE
Fix tests after blivet rebase to RHEL-8

### DIFF
--- a/tests/nosetests/pyanaconda_tests/clearpart_test.py
+++ b/tests/nosetests/pyanaconda_tests/clearpart_test.py
@@ -45,7 +45,8 @@ class ClearPartTestCase(unittest.TestCase):
                                parents=[sda])
         sda1._parted_partition = mock.Mock(**{'type': PARTITION_NORMAL,
                                               'getLength.return_value': int(sda1.size),
-                                              'getFlag.return_value': 0})
+                                              'getFlag.return_value': 0,
+                                              'number': 1})
         sda1.format = blivet.formats.get_format("ext4", mountpoint="/boot",
                                                 device=sda1.path,
                                                 exists=True)
@@ -56,7 +57,8 @@ class ClearPartTestCase(unittest.TestCase):
                                parents=[sda])
         sda2._parted_partition = mock.Mock(**{'type': PARTITION_NORMAL,
                                               'getLength.return_value': int(sda2.size),
-                                              'getFlag.return_value': 0})
+                                              'getFlag.return_value': 0,
+                                              'number': 2})
         sda2.format = blivet.formats.get_format("vfat", mountpoint="/foo",
                                                 device=sda2.path,
                                                 exists=True)

--- a/tests/nosetests/pyanaconda_tests/module_scheduler_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_scheduler_test.py
@@ -193,7 +193,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         """Test GetSupportedRaidLevels."""
         self.assertEqual(
             self.interface.GetSupportedRaidLevels(DEVICE_TYPE_LVM),
-            ['linear', 'raid1', 'raid10', 'raid4', 'raid5', 'raid6', 'striped']
+            ['linear', 'raid0', 'raid1', 'raid10', 'raid4', 'raid5', 'raid6', 'striped']
         )
 
     @patch('pyanaconda.modules.storage.partitioning.interactive.utils.get_format')


### PR DESCRIPTION
Backport of https://github.com/rhinstaller/anaconda/pull/4108 and https://github.com/rhinstaller/anaconda/pull/3554 because blivet did a rebase in RHEL-8.

(cherry picked from commit fabab04e4b8a584eefd16ed22ac27f8f723bdb11)