### PR TITLE
Fix automated releases

### DIFF
--- a/.github/workflows/release-periodically.yml
+++ b/.github/workflows/release-periodically.yml
@@ -35,8 +35,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: "master"
-          fetch-depth: 20
-          tags: true
+          fetch-depth: 0
           token: ${{ secrets.INSTALLKER_TOKEN }}
 
       - name: Check if already tagged

--- a/.github/workflows/release-periodically.yml
+++ b/.github/workflows/release-periodically.yml
@@ -37,6 +37,7 @@ jobs:
           ref: "master"
           fetch-depth: 20
           tags: true
+          token: ${{ secrets.INSTALLKER_TOKEN }}
 
       - name: Check if already tagged
         id: check-tag
@@ -62,8 +63,6 @@ jobs:
         if: ${{ steps.check-tag.outputs.can-tag }}
         # the repo should have an access token from the checkout action
         # https://github.com/actions/checkout#Push-a-commit-using-the-built-in-token
-        env:
-          GITHUB_TOKEN: ${{ secrets.INSTALLKER_TOKEN }}
         run: |
           git push --tags origin master
 

--- a/.github/workflows/release-periodically.yml
+++ b/.github/workflows/release-periodically.yml
@@ -45,21 +45,20 @@ jobs:
           # 128 -> fatal: no tag exactly matches 'c88a1272ffbc002042fd62ed409734c1c150cc5f'
           # 0 -> anaconda-38.6-1
           if git describe --tags --exact-match ; then
-            echo "Already tagged at HEAD, will not push another tag."
-            echo "::set-output name=can-tag::false"
+            echo "::warning:: Already tagged at HEAD, will not push a release commit."
           else
-            echo "::set-output name=can-tag::true"
+            echo "can_bump_version=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Run makebumpver
-        if: ${{ steps.check-tag.outputs.can-tag }}
+      - name: Prepare and tag a release commit
+        if: steps.check-tag.outputs.can_bump_version
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
           ./scripts/makebumpver -c
 
-      - name: Push tag to repo
-        if: ${{ steps.check-tag.outputs.can-tag }}
+      - name: Push the release commit with the tag to repo
+        if: steps.check-tag.outputs.can_bump_version
         # the repo should have an access token from the checkout action
         # https://github.com/actions/checkout#Push-a-commit-using-the-built-in-token
         run: |

--- a/.github/workflows/release-periodically.yml
+++ b/.github/workflows/release-periodically.yml
@@ -23,9 +23,10 @@ on:
 permissions:
   contents: write
 
-
 jobs:
   make-release-tag:
+    # Don't run scheduled workflows on forks.
+    if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'
     runs-on: ubuntu-latest
     environment: releases
     steps:

--- a/.github/workflows/release-periodically.yml.j2
+++ b/.github/workflows/release-periodically.yml.j2
@@ -17,9 +17,10 @@ on:
 permissions:
   contents: write
 
-
 jobs:
   make-release-tag:
+    # Don't run scheduled workflows on forks.
+    if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'
     runs-on: ubuntu-latest
     environment: releases
     steps:

--- a/.github/workflows/release-periodically.yml.j2
+++ b/.github/workflows/release-periodically.yml.j2
@@ -31,6 +31,7 @@ jobs:
           ref: "master"
           fetch-depth: 20
           tags: true
+          token: ${{ secrets.INSTALLKER_TOKEN }}
 
       - name: Check if already tagged
         id: check-tag
@@ -56,8 +57,6 @@ jobs:
         if: ${{ steps.check-tag.outputs.can-tag }}
         # the repo should have an access token from the checkout action
         # https://github.com/actions/checkout#Push-a-commit-using-the-built-in-token
-        env:
-          GITHUB_TOKEN: ${{ secrets.INSTALLKER_TOKEN }}
         run: |
           git push --tags origin master
 

--- a/.github/workflows/release-periodically.yml.j2
+++ b/.github/workflows/release-periodically.yml.j2
@@ -39,21 +39,20 @@ jobs:
           # 128 -> fatal: no tag exactly matches 'c88a1272ffbc002042fd62ed409734c1c150cc5f'
           # 0 -> anaconda-38.6-1
           if git describe --tags --exact-match ; then
-            echo "Already tagged at HEAD, will not push another tag."
-            echo "::set-output name=can-tag::false"
+            echo "::warning:: Already tagged at HEAD, will not push a release commit."
           else
-            echo "::set-output name=can-tag::true"
+            echo "can_bump_version=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Run makebumpver
-        if: ${{ steps.check-tag.outputs.can-tag }}
+      - name: Prepare and tag a release commit
+        if: steps.check-tag.outputs.can_bump_version
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
           ./scripts/makebumpver -c
 
-      - name: Push tag to repo
-        if: ${{ steps.check-tag.outputs.can-tag }}
+      - name: Push the release commit with the tag to repo
+        if: steps.check-tag.outputs.can_bump_version
         # the repo should have an access token from the checkout action
         # https://github.com/actions/checkout#Push-a-commit-using-the-built-in-token
         run: |

--- a/.github/workflows/release-periodically.yml.j2
+++ b/.github/workflows/release-periodically.yml.j2
@@ -29,8 +29,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: "master"
-          fetch-depth: 20
-          tags: true
+          fetch-depth: 0
           token: ${{ secrets.INSTALLKER_TOKEN }}
 
       - name: Check if already tagged


### PR DESCRIPTION
* Never run scheduled workflows on forks.
* Set up the access token during the code checkout.
* Fix the generated changelog. It is necessary to fetch all tags.
* Fix the condition for bumping a release version.

Tested with a fine-grained personal access token (Repository permissions -> Contents  -> Access: Read and write) on a protected branch in my fork: [successful run](https://github.com/poncovka/anaconda/actions/runs/3541904444/jobs/5946749334), [aborted run](https://github.com/poncovka/anaconda/actions/runs/3541913472/jobs/5946769916), [release commit](https://github.com/poncovka/anaconda/commit/52213d2a724828e0585f7ff8bbaec1f794972d15)