### PR TITLE
makebumpver: ignore commits with (#test) in summary (#infra)

### DIFF
--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -325,6 +325,10 @@ class MakeBumpVer:
                 print("*** Ignoring (#infra) commit %s\n" % commit)
                 continue
 
+            if re.match(r".*(#test).*", summary):
+                print("*** Ignoring (#test) commit %s\n" % commit)
+                continue
+
             if self.rhel:
                 rhbz = set()
                 bad = False


### PR DESCRIPTION
The #test should be used to mark changes to tests, which are not part of the rpm currently. Therefore they don't need a rhbz# reference.

Port from rhel-9 branch.