### PR TITLE
Web UI: Tests should ignore the volatile space requirement message

### DIFF
--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -475,7 +475,7 @@ export const InstallationDestination = ({ idPrefix, setIsFormValid, onAddErrorNo
     return (
         <AnacondaPage title={_("Installation destination")}>
             <TextContent>
-                <Text component={TextVariants.p}>
+                <Text id={idPrefix + "-hint"} component={TextVariants.p}>
                     {cockpit.format(_(
                         "Select the device(s) to install to. The installation requires " +
                         "$0 of available space. Storage will be automatically partitioned."

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -51,7 +51,7 @@ class TestStorage(MachineCase):
         b.assert_pixels(
             "#app",
             "storage-step-basic",
-            ignore=["#betanag-icon", "#installation-destination-table-label"],
+            ignore=["#betanag-icon", "#installation-destination-table-label", "#installation-destination-hint"],
             wait_animations=False,
         )
 


### PR DESCRIPTION
This broke the tests with new fedora-rawhide-boot [1]. In the pixel tests, the hint text has changed from "The installation requires 1.73 GB of available space" to "The installation requires 1.74 GB of available space".
Since this value can change again in the future, the tests should ignore it.

[1] https://github.com/cockpit-project/bots/pull/4113