### PR TITLE
Delegate auto-attach handling to RHSM

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -103,7 +103,7 @@ Requires: python3-dasbus >= %{dasbusver}
 Requires: flatpak-libs
 %if %{defined rhel} && %{undefined centos}
 Requires: python3-syspurpose
-Requires: subscription-manager >= 1.28.26
+Requires: subscription-manager >= 1.28.33
 %endif
 
 # pwquality only "recommends" the dictionaries it needs to do anything useful,

--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -140,11 +140,6 @@ RHSM_UNREGISTER = DBusObjectIdentifier(
     basename="Unregister"
 )
 
-RHSM_ATTACH = DBusObjectIdentifier(
-    namespace=RHSM_NAMESPACE,
-    basename="Attach"
-)
-
 RHSM_ENTITLEMENT = DBusObjectIdentifier(
     namespace=RHSM_NAMESPACE,
     basename="Entitlement"

--- a/pyanaconda/modules/common/errors/subscription.py
+++ b/pyanaconda/modules/common/errors/subscription.py
@@ -31,9 +31,3 @@ class RegistrationError(AnacondaError):
 class UnregistrationError(AnacondaError):
     """Unregistration attempt failed."""
     pass
-
-
-@dbus_error("SubscriptionError", namespace=ANACONDA_NAMESPACE)
-class SubscriptionError(AnacondaError):
-    """Subscription attempt failed."""
-    pass

--- a/pyanaconda/modules/subscription/subscription_interface.py
+++ b/pyanaconda/modules/subscription/subscription_interface.py
@@ -192,15 +192,6 @@ class SubscriptionInterface(KickstartModuleInterface):
             self.implementation.unregister_with_task()
         )
 
-    def AttachSubscriptionWithTask(self) -> ObjPath:
-        """Attach subscription using a runtime DBus task.
-
-        :return: a DBus path of an installation task
-        """
-        return TaskContainer.to_object_path(
-            self.implementation.attach_subscription_with_task()
-        )
-
     def ParseAttachedSubscriptionsWithTask(self) -> ObjPath:
         """Parse attached subscriptions using a runtime DBus task.
 

--- a/pyanaconda/ui/lib/subscription.py
+++ b/pyanaconda/ui/lib/subscription.py
@@ -37,7 +37,7 @@ from pyanaconda.modules.common.structures.subscription import SubscriptionReques
 from pyanaconda.modules.common.structures.secret import SECRET_TYPE_HIDDEN, \
     SECRET_TYPE_TEXT
 from pyanaconda.modules.common.errors.subscription import RegistrationError, \
-    UnregistrationError, SubscriptionError
+    UnregistrationError
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -293,25 +293,12 @@ def register_and_subscribe(payload, progress_callback=None, error_callback=None,
             task.sync_run_task(task_proxy)
         except RegistrationError as e:
             log.debug("subscription thread: registration attempt failed: %s", e)
-            log.debug("subscription thread: skipping auto attach due to registration error")
             error_callback(str(e))
             return
         log.debug("subscription thread: registration succeeded")
     else:
         log.debug("subscription thread: credentials insufficient, skipping registration attempt")
         error_callback(_("Registration failed due to insufficient credentials."))
-        return
-
-    # try to attach subscription
-    log.debug("subscription thread: attempting to auto attach an entitlement")
-    progress_callback(SubscriptionPhase.ATTACH_SUBSCRIPTION)
-    task_path = subscription_proxy.AttachSubscriptionWithTask()
-    task_proxy = SUBSCRIPTION.get_proxy(task_path)
-    try:
-        task.sync_run_task(task_proxy)
-    except SubscriptionError as e:
-        log.debug("subscription thread: failed to attach subscription: %s", e)
-        error_callback(str(e))
         return
 
     # parse attached subscription data
@@ -338,8 +325,7 @@ def register_and_subscribe(payload, progress_callback=None, error_callback=None,
             log.debug("subscription thread: restarting payload after registration")
             _do_payload_restart(payload)
 
-    # and done, report attaching subscription was successful
-    log.debug("subscription thread: auto attach succeeded")
+    # and done, report subscription attempt was successful
     progress_callback(SubscriptionPhase.DONE)
 
 

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tasks_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tasks_tests.py
@@ -24,7 +24,7 @@ from unittest.mock import patch, Mock, call
 
 import tempfile
 
-from dasbus.typing import get_variant, get_native, Str
+from dasbus.typing import get_variant, get_native, Str, Bool
 from dasbus.error import DBusError
 
 from pyanaconda.core import util
@@ -33,8 +33,7 @@ from pyanaconda.core.constants import SUBSCRIPTION_REQUEST_TYPE_ORG_KEY, \
 
 from pyanaconda.modules.common.errors.installation import InsightsConnectError, \
     InsightsClientMissingError, SubscriptionTokenTransferError
-from pyanaconda.modules.common.errors.subscription import RegistrationError, \
-    SubscriptionError
+from pyanaconda.modules.common.errors.subscription import RegistrationError
 from pyanaconda.modules.common.structures.subscription import SystemPurposeData, \
     SubscriptionRequest, AttachedSubscription
 from pyanaconda.modules.common.constants.services import RHSM
@@ -45,7 +44,7 @@ from pyanaconda.modules.subscription.installation import ConnectToInsightsTask, 
 
 from pyanaconda.modules.subscription.runtime import SetRHSMConfigurationTask, \
     RHSMPrivateBus, RegisterWithUsernamePasswordTask, RegisterWithOrganizationKeyTask, \
-    UnregisterTask, AttachSubscriptionTask, SystemPurposeConfigurationTask, \
+    UnregisterTask, SystemPurposeConfigurationTask, \
     ParseAttachedSubscriptionsTask
 
 import gi
@@ -602,7 +601,7 @@ class RegistrationTasksTestCase(unittest.TestCase):
         private_register_proxy.Register.assert_called_once_with("",
                                                                 "foo_user",
                                                                 "bar_password",
-                                                                {},
+                                                                {'enable_content': get_variant(Bool, True)} ,
                                                                 {},
                                                                 "en_US.UTF-8")
         # check the returned registration data is properly forwarded from
@@ -631,7 +630,7 @@ class RegistrationTasksTestCase(unittest.TestCase):
         private_register_proxy.Register.assert_called_with("",
                                                            "foo_user",
                                                            "bar_password",
-                                                           {},
+                                                           {'enable_content': get_variant(Bool, True)},
                                                            {},
                                                            "en_US.UTF-8")
 
@@ -720,36 +719,6 @@ class UnregisterTaskTestCase(unittest.TestCase):
             task.run()
         # check the unregister proxy Unregister method was called correctly
         rhsm_unregister_proxy.Unregister.assert_called_once_with({}, "en_US.UTF-8")
-
-
-class AttachSubscriptionTaskTestCase(unittest.TestCase):
-    """Test the subscription task."""
-
-    @patch("os.environ.get", return_value="en_US.UTF-8")
-    def attach_subscription_task_success_test(self, environ_get):
-        """Test the AttachSubscriptionTask - success."""
-        rhsm_attach_proxy = Mock()
-        task = AttachSubscriptionTask(rhsm_attach_proxy=rhsm_attach_proxy,
-                                      sla="foo_sla")
-        task.run()
-        rhsm_attach_proxy.AutoAttach.assert_called_once_with("foo_sla",
-                                                             {},
-                                                             "en_US.UTF-8")
-
-    @patch("os.environ.get", return_value="en_US.UTF-8")
-    def attach_subscription_task_failure_test(self, environ_get):
-        """Test the AttachSubscriptionTask - failure."""
-        rhsm_attach_proxy = Mock()
-        # raise DBusError with error message in JSON
-        json_error = '{"message": "Failed to attach subscription."}'
-        rhsm_attach_proxy.AutoAttach.side_effect = DBusError(json_error)
-        task = AttachSubscriptionTask(rhsm_attach_proxy=rhsm_attach_proxy,
-                                      sla="foo_sla")
-        with self.assertRaises(SubscriptionError):
-            task.run()
-        rhsm_attach_proxy.AutoAttach.assert_called_once_with("foo_sla",
-                                                             {},
-                                                             "en_US.UTF-8")
 
 
 class ParseAttachedSubscriptionsTaskTestCase(unittest.TestCase):

--- a/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
+++ b/tests/nosetests/pyanaconda_tests/module_subscription_tests.py
@@ -42,7 +42,7 @@ from pyanaconda.modules.subscription.installation import ConnectToInsightsTask, 
     RestoreRHSMDefaultsTask, TransferSubscriptionTokensTask
 from pyanaconda.modules.subscription.runtime import SetRHSMConfigurationTask, \
     RegisterWithUsernamePasswordTask, RegisterWithOrganizationKeyTask, \
-    UnregisterTask, AttachSubscriptionTask, SystemPurposeConfigurationTask, \
+    UnregisterTask, SystemPurposeConfigurationTask, \
     ParseAttachedSubscriptionsTask, SystemSubscriptionData
 
 from tests.nosetests.pyanaconda_tests import check_kickstart_interface, check_dbus_property, \
@@ -1348,36 +1348,6 @@ class SubscriptionInterfaceTestCase(unittest.TestCase):
         self.assertFalse(self.subscription_interface.IsRegistered)
         self.assertFalse(self.subscription_interface.IsSubscriptionAttached)
         self.assertFalse(self.subscription_interface.IsSimpleContentAccessEnabled)
-
-    @patch_dbus_publish_object
-    def attach_subscription_test(self, publisher):
-        """Test AttachSubscriptionTask creation."""
-        # create the SystemPurposeData structure
-        system_purpose_data = SystemPurposeData()
-        system_purpose_data.role = "foo"
-        system_purpose_data.sla = "bar"
-        system_purpose_data.usage = "baz"
-        system_purpose_data.addons = ["a", "b", "c"]
-        # feed it to the DBus interface
-        self.subscription_interface.SetSystemPurposeData(
-            SystemPurposeData.to_structure(system_purpose_data)
-        )
-        # make sure system is not subscribed
-        self.assertFalse(self.subscription_interface.IsSubscriptionAttached)
-        # make sure the task gets dummy rhsm attach proxy
-        observer = Mock()
-        self.subscription_module._rhsm_observer = observer
-        rhsm_attach_proxy = observer.get_proxy.return_value
-        # check the task is created correctly
-        task_path = self.subscription_interface.AttachSubscriptionWithTask()
-        obj = check_task_creation(self, task_path, publisher, AttachSubscriptionTask)
-        # check all the data got propagated to the module correctly
-        self.assertEqual(obj.implementation._rhsm_attach_proxy, rhsm_attach_proxy)
-        self.assertEqual(obj.implementation._sla, "bar")
-        # trigger the succeeded signal
-        obj.implementation.succeeded_signal.emit()
-        # check this set subscription_attached to True
-        self.assertTrue(self.subscription_interface.IsSubscriptionAttached)
 
     @patch_dbus_publish_object
     def parse_attached_subscriptions_test(self, publisher):


### PR DESCRIPTION
At the moment both Simple Content Access and "classic" entitlement based subscription access is supported by Anaconda.

This presents an issue due to auto-attach action handling - for entitlement subscription to work correctly, we need to register and then auto-attach.

For SCA to work correctly, we should register and *not* attempt to auto-attach - the registration action does all that's needed and auto-attach afterwards is actually not a valid action.

For now this is hot-fixed on Hosted Candlepin side (and likely also on Satellite side) by ignoring these unnecessary/invalid auto-attach calls in SCA mode, but longer term the Candlepin team would like to drop this workaround.

After discussing this issue with the RHSM team, it was decided to handle this on the RHSM DBus daemon side as the daemon has all the necessary data (eq. which subscription mode is used, etc.) readily available.

All that is needed on the Anaconda side is to set an option in the RHSM Register call for RHSM to take over the auto-attach handling & drop all the auto-attach handling code.

Resolves: rhbz#2083318