### PR TITLE
Update grub2 and efibootmgr errors

### DIFF
--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -78,8 +78,9 @@ class EFIBase(object):
             root=conf.target.system_root
         )
         if rc:
-            raise BootLoaderError("Failed to set new efi boot target. This is most "
-                                  "likely a kernel or firmware bug.")
+            raise BootLoaderError("Failed to set new EFI boot target.  This is "
+                                  "likely a firmware bug; please file any issues "
+                                  "with efibootmgr rather than anaconda.")
 
     def add_efi_boot_target(self):
         if self.stage1_device.type == "partition":  # pylint: disable=no-member
@@ -105,8 +106,9 @@ class EFIBase(object):
 
                 rc = self.efibootmgr("-b", slot_id, "-B")
                 if rc:
-                    raise BootLoaderError("Failed to remove old efi boot entry. This is most "
-                                          "likely a kernel or firmware bug.")
+                    raise BootLoaderError("Failed to remove old EFI boot entry.  This is "
+                                          "likely a firmware bug; please file any issues "
+                                          "with efibootmgr rather than anaconda.")
 
     def write(self):
         """ Write the bootloader configuration and install the bootloader. """

--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -304,7 +304,7 @@ class GRUB2(BootLoader):
         os.close(pread)
         self.encrypted_password = buf.split()[-1].strip()
         if not self.encrypted_password.startswith("grub.pbkdf2."):
-            raise BootLoaderError("failed to encrypt boot loader password")
+            raise BootLoaderError("failed to encrypt boot loader password (grub2 bug?)")
 
     def write_password_config(self):
         if not self.password and not self.encrypted_password:
@@ -370,7 +370,7 @@ class GRUB2(BootLoader):
             root=conf.target.system_root
         )
         if rc:
-            raise BootLoaderError("failed to write boot loader configuration")
+            raise BootLoaderError("failed to write boot loader configuration (grub2 bug?)")
 
     #
     # installation
@@ -433,7 +433,7 @@ class GRUB2(BootLoader):
                                        root=conf.target.system_root,
                                        env_prune=['MALLOC_PERTURB_'])
             if rc:
-                raise BootLoaderError("boot loader install failed")
+                raise BootLoaderError("boot loader install failed (grub2 bug?)")
 
     def write(self):
         """Write the bootloader configuration and install the bootloader."""


### PR DESCRIPTION
Try to redirect issues requiring input from grub2 and efibootmgr more appropriately to reduce triage load on anaconda. 

[cc @poncovka , @marta-lewandowska ]