### PR TITLE
Tune auto-releases

### DIFF
--- a/.github/workflows/release-periodically.yml
+++ b/.github/workflows/release-periodically.yml
@@ -73,7 +73,7 @@ jobs:
             -X POST \
             -H 'Content-Type: application/json' \
             ${{ secrets.GCHAT_URL }} \
-            -d "{\"text\": \"New release tagged, please review at https://github.com/rhinstaller/anaconda/releases\"}"
+            -d "{\"text\": \"New release tagged, please review the Packit dist-git PR soon to be found at https://src.fedoraproject.org/rpms/anaconda/pull-requests"}"
 
 # This only makes a tag and pushes it, which is then picked up by another action that builds
 # the tarball and posts the actual release entity/page with it.

--- a/.github/workflows/release-periodically.yml
+++ b/.github/workflows/release-periodically.yml
@@ -72,7 +72,7 @@ jobs:
           curl \
             -X POST \
             -H 'Content-Type: application/json' \
-            ${{ secrets.GCHAT_URL }} \
+            '${{ secrets.GCHAT_URL }}' \
             -d "{\"text\": \"New release tagged, please review the Packit dist-git PR soon to be found at https://src.fedoraproject.org/rpms/anaconda/pull-requests"}"
 
 # This only makes a tag and pushes it, which is then picked up by another action that builds

--- a/.github/workflows/release-periodically.yml
+++ b/.github/workflows/release-periodically.yml
@@ -62,7 +62,12 @@ jobs:
         # the repo should have an access token from the checkout action
         # https://github.com/actions/checkout#Push-a-commit-using-the-built-in-token
         run: |
-          git push --tags origin master
+          tag_to_push=$(git describe --tags --exact-match)
+          if [ -n "${tag_to_push}" ] ; then
+            git push --atomic origin master "$tag_to_push"
+          else
+            exit 1
+          fi
 
       - name: Notify in Google chat
         if: steps.check-tag.outputs.can_bump_version

--- a/.github/workflows/release-periodically.yml.j2
+++ b/.github/workflows/release-periodically.yml.j2
@@ -56,7 +56,12 @@ jobs:
         # the repo should have an access token from the checkout action
         # https://github.com/actions/checkout#Push-a-commit-using-the-built-in-token
         run: |
-          git push --tags origin master
+          tag_to_push=$(git describe --tags --exact-match)
+          if [ -n "${tag_to_push}" ] ; then
+            git push --atomic origin master "$tag_to_push"
+          else
+            exit 1
+          fi
 
       - name: Notify in Google chat
         if: steps.check-tag.outputs.can_bump_version

--- a/.github/workflows/release-periodically.yml.j2
+++ b/.github/workflows/release-periodically.yml.j2
@@ -66,7 +66,7 @@ jobs:
           curl \
             -X POST \
             -H 'Content-Type: application/json' \
-            ${{ secrets.GCHAT_URL }} \
+            '${{ secrets.GCHAT_URL }}' \
             -d "{\"text\": \"New release tagged, please review the Packit dist-git PR soon to be found at https://src.fedoraproject.org/rpms/anaconda/pull-requests"}"
 
 # This only makes a tag and pushes it, which is then picked up by another action that builds

--- a/.github/workflows/release-periodically.yml.j2
+++ b/.github/workflows/release-periodically.yml.j2
@@ -67,7 +67,7 @@ jobs:
             -X POST \
             -H 'Content-Type: application/json' \
             ${{ secrets.GCHAT_URL }} \
-            -d "{\"text\": \"New release tagged, please review at https://github.com/rhinstaller/anaconda/releases\"}"
+            -d "{\"text\": \"New release tagged, please review the Packit dist-git PR soon to be found at https://src.fedoraproject.org/rpms/anaconda/pull-requests"}"
 
 # This only makes a tag and pushes it, which is then picked up by another action that builds
 # the tarball and posts the actual release entity/page with it.

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -97,7 +97,6 @@ jobs:
           # create release with the release notes
           gh release create \
             ${{ steps.get_ref.outputs.ref }} \
-            --draft \
             --title "Anaconda $RELEASE_NAME" \
             --notes-file release.txt \
             /tmp/results/*

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -78,18 +78,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_NAME: ${{ steps.get_version.outputs.version }}
         run: |
-          # find version tags
-          CURRENT_VERSION="anaconda-$RELEASE_NAME-1"
-          PREVIOUS_VERSION="$(git describe --tags --abbrev=0 --exclude="$CURRENT_VERSION")"
-
-          # print commit details; skip the last = release commit
-          git log \
-            --no-merges \
-            --pretty=format:"- %s (%aL)" \
-            "$PREVIOUS_VERSION..$CURRENT_VERSION~1" \
-              | grep -v "#infra" \
-              | grep -v "build(deps-dev)" \
-              | tee release.txt
+          # get changelog from spec file
+          # - get lines starting with %changelog, up to but excluding first following empty line
+          # - then drop the first two lines (start at 3rd) which are %changelog and *DATE COMMITTER
+          sed -n '/%changelog/,/^$/{/^$/!p}' anaconda.spec.in | sed -n '3,$ p' | tee release.txt
+          echo "- Update translations from Weblate" >> release.txt
 
           # drop line ending
           truncate -s -1 release.txt

--- a/docs/ci-status.rst
+++ b/docs/ci-status.rst
@@ -29,6 +29,10 @@ Anaconda
    :alt: Test releasing and translations daily
    :target: https://github.com/rhinstaller/anaconda/actions/workflows/try-release-daily.yml
 
+.. |release-periodically| image:: https://github.com/rhinstaller/anaconda/actions/workflows/release-periodically/badge.svg
+   :alt: Make a rawhide/master release periodically
+   :target: https://github.com/rhinstaller/anaconda/actions/workflows/release-periodically.yml
+
 .. _Dependabot: https://github.com/rhinstaller/anaconda/network/updates
 
 |container-autoupdate-fedora|
@@ -41,7 +45,10 @@ Anaconda
   Daily builds of Anaconda in RHEL 8 COPR (internal).
 
 |try-release-daily|
-  Tests the release process daily, including checks for missing important translations
+  Tests the release process daily, including checks for missing important translations.
+
+|release-periodically|
+  Makes a master/rawhide release periodically with no human oversight for the upstream/non-Fedora part of the process.
 
 Dependabot_
   Checks Anaconda dependencies and opens pull requests for new versions.


### PR DESCRIPTION
This fixes a lot of small kinks in the release machinery, and realizes the agreed change for dist-git as the only place to review.
- Release immediately on GH, no drafts
- Make the gChat reporting work
- Tell people in gChat to go to dist-git, since that's the first non-automated stop
- Push the new tag safely/correctly
- Do not reinvent the changelog, just propagate it
- Mention translations in changelog
- Include the auto-releases in CI dashboard

---

Tested on my fork (and messed it up really thoroughly).

Tagging action run: https://github.com/VladimirSlavik/anaconda/actions/runs/3687228579/jobs/6240709895
Resulting commit: https://github.com/VladimirSlavik/anaconda/commit/8796a7ebefdaf523fa951b9c2c2497edfc6675f6
Triggered release action run: https://github.com/VladimirSlavik/anaconda/actions/runs/3687308684/jobs/6240723227
Resulting release: https://github.com/VladimirSlavik/anaconda/releases/tag/anaconda-38.13-1

(This also shows how nothing breaks when there are no non-infra changes = empty changelog.)

Individual parts have been tested on real data, too.