### PR TITLE
Delegate auto-attach handling to RHSM

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -40,7 +40,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define pythonblivetver 1:3.4.0-15
 %define rpmver 4.10.0
 %define simplelinever 1.8.3-1
-%define subscriptionmanagerver 1.29.24
+%define subscriptionmanagerver 1.29.31
 %define utillinuxver 2.15.1
 
 BuildRequires: audit-libs-devel

--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -140,11 +140,6 @@ RHSM_UNREGISTER = DBusObjectIdentifier(
     basename="Unregister"
 )
 
-RHSM_ATTACH = DBusObjectIdentifier(
-    namespace=RHSM_NAMESPACE,
-    basename="Attach"
-)
-
 RHSM_ENTITLEMENT = DBusObjectIdentifier(
     namespace=RHSM_NAMESPACE,
     basename="Entitlement"

--- a/pyanaconda/modules/common/errors/subscription.py
+++ b/pyanaconda/modules/common/errors/subscription.py
@@ -32,13 +32,6 @@ class UnregistrationError(AnacondaError):
     """Unregistration attempt failed."""
     pass
 
-
-@dbus_error("SubscriptionError", namespace=ANACONDA_NAMESPACE)
-class SubscriptionError(AnacondaError):
-    """Subscription attempt failed."""
-    pass
-
-
 @dbus_error("SatelliteProvisioningError", namespace=ANACONDA_NAMESPACE)
 class SatelliteProvisioningError(AnacondaError):
     """Failed to provision the installation environment for Satellite."""

--- a/pyanaconda/ui/lib/subscription.py
+++ b/pyanaconda/ui/lib/subscription.py
@@ -35,7 +35,7 @@ from pyanaconda.modules.common.structures.subscription import SubscriptionReques
 from pyanaconda.modules.common.structures.secret import SECRET_TYPE_HIDDEN, \
     SECRET_TYPE_TEXT
 from pyanaconda.modules.common.errors.subscription import RegistrationError, \
-    UnregistrationError, SubscriptionError, SatelliteProvisioningError, MultipleOrganizationsError
+    UnregistrationError, SatelliteProvisioningError, MultipleOrganizationsError
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -297,10 +297,6 @@ def register_and_subscribe(payload, progress_callback=None, error_callback=None,
         log.debug("registration attempt: registration attempt failed: %s", e)
         error_callback(e)
         return
-    except SubscriptionError as e:
-        log.debug("registration attempt: failed to attach subscription: %s", e)
-        error_callback(e)
-        return
 
     # check if the current installation source should be overridden by
     # the CDN source we can now use
@@ -320,8 +316,7 @@ def register_and_subscribe(payload, progress_callback=None, error_callback=None,
             log.debug("registration attempt: restarting payload after registration")
             _do_payload_restart(payload)
 
-    # and done, report attaching subscription was successful
-    log.debug("registration attempt: auto attach succeeded")
+    # and done, report subscription attempt was successful
     progress_callback(SubscriptionPhase.DONE)
 
 

--- a/tests/unit_tests/pyanaconda_tests/test_subscription_helpers.py
+++ b/tests/unit_tests/pyanaconda_tests/test_subscription_helpers.py
@@ -33,7 +33,7 @@ from pyanaconda.core.constants import RHSM_SYSPURPOSE_FILE_PATH, \
     SOURCE_TYPE_URL
 
 from pyanaconda.modules.common.errors.subscription import UnregistrationError, \
-    RegistrationError, SubscriptionError, SatelliteProvisioningError
+    RegistrationError, SatelliteProvisioningError
 from pyanaconda.modules.common.structures.subscription import SubscriptionRequest
 
 from pyanaconda.core.subscription import check_system_purpose_set
@@ -490,42 +490,6 @@ class AsynchronousRegistrationTestCase(unittest.TestCase):
         run_task.assert_called()
         # we told the payload not to restart
         restart_thread.assert_not_called()
-
-    @patch("pyanaconda.ui.lib.subscription.switch_source")
-    @patch("pyanaconda.modules.common.task.sync_run_task")
-    @patch("pyanaconda.threading.threadMgr.wait")
-    @patch("pyanaconda.modules.common.constants.services.SUBSCRIPTION.get_proxy")
-    def test_subscription_failed(self, get_proxy, thread_mgr_wait, run_task, switch_source):
-        """Test the register_and_subscribe() helper method - failed to attach subscription."""
-        payload = Mock()
-        progress_callback = Mock()
-        error_callback = Mock()
-        subscription_proxy = get_proxy.return_value
-        # simulate the system not being registered
-        subscription_proxy.IsRegistered = False
-        # make the second (RegisterAndSubscribe) task fail with SubscriptionError
-        subscription_error = SubscriptionError("failed to attach subscription")
-        run_task.side_effect = [True, subscription_error]
-        # run the function
-        register_and_subscribe(payload=payload,
-                               progress_callback=progress_callback,
-                               error_callback=error_callback)
-        # we should have waited on network
-        thread_mgr_wait.assert_called_once_with(THREAD_WAIT_FOR_CONNECTING_NM)
-        # there should be only the registration & subscription phase
-        progress_callback.assert_has_calls(
-            [call(SubscriptionPhase.REGISTER)]
-        )
-        # and the error callback should have been triggered
-        error_callback.assert_called_once_with(subscription_error)
-        # we should have requested the appropriate tasks
-        subscription_proxy.SetRHSMConfigWithTask.assert_called_once()
-        subscription_proxy.RegisterAndSubscribeWithTask.assert_called_once()
-        # and tried to run them
-        run_task.assert_called()
-        # setting CDN as installation source does not make sense
-        # when we were not able to attach a subscription
-        switch_source.assert_not_called()
 
     @patch("pyanaconda.modules.common.task.sync_run_task")
     @patch("pyanaconda.modules.common.constants.services.SUBSCRIPTION.get_proxy")


### PR DESCRIPTION
At the moment both Simple Content Access and "classic" entitlement based subscription access is supported by Anaconda.

This presents an issue due to auto-attach action handling - for entitlement subscription to work correctly, we need to register and then auto-attach.

For SCA to work correctly, we should register and *not* attempt to auto-attach - the registration action does all that's needed and auto-attach afterwards is actually not a valid action.

For now this is hot-fixed on Hosted Candlepin side (and likely also on Satellite side) by ignoring these unnecessary/invalid auto-attach calls in SCA mode, but longer term the Candlepin team would like to drop this workaround.

After discussing this issue with the RHSM team, it was decided to handle this on the RHSM DBus daemon side as the daemon has all the necessary data (eq. which subscription mode is used, etc.) readily available.

All that is needed on the Anaconda side is to set an option in the RHSM Register call for RHSM to take over the auto-attach handling & drop all the auto-attach handling code.

Resolves: rhbz#2083319