### PR TITLE
Fix network configuration from kickstart in intramfs

### DIFF
--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -402,6 +402,9 @@ run_kickstart() {
                 # via settled hook in *-nm-run.sh script which also calls the
                 # online hooks.
                 . $hookdir/cmdline/*-nm-config.sh
+                if [ -n "$DRACUT_SYSTEMD" ]; then
+                    systemctl start nm-initrd
+                fi
             fi
         else
             # make dracut create the net udev rules (based on the new cmdline)


### PR DESCRIPTION
Resolves: rhbz#2153361

In case of late network activation based on kickstart (fetched from storage) we need to start the nm-initrd service manually by anaconda.

Follow-up of
https://github.com/redhat-plumbers/dracut-rhel9/commit/c17c5b7604c8d61dd1c00ee22d