### PR TITLE
shellcheck: Double quote to prevent globbing and word splitting

### DIFF
--- a/data/systemd/anaconda-generator
+++ b/data/systemd/anaconda-generator
@@ -23,8 +23,8 @@ service_on_tty() {
 
 # find the real tty for /dev/console
 tty="console"
-while [ -f /sys/class/tty/$tty/active ]; do
-    tty=$(< /sys/class/tty/$tty/active)
+while [ -f "/sys/class/tty/$tty/active" ]; do
+    tty=$(< "/sys/class/tty/$tty/active")
     tty=${tty##* } # last item in the list
 done
 consoletty="$tty"

--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -64,8 +64,8 @@ find_runtime() {
 find_tty() {
     # find the real tty for /dev/console
     local tty="console"
-    while [ -f /sys/class/tty/$tty/active ]; do
-        tty=$(< /sys/class/tty/$tty/active)
+    while [ -f "/sys/class/tty/$tty/active" ]; do
+        tty=$(< "/sys/class/tty/$tty/active")
         tty=${tty##* } # last item in the list
     done
     echo "$tty"

--- a/dracut/save-initramfs.sh
+++ b/dracut/save-initramfs.sh
@@ -23,5 +23,5 @@ fi
 
 # Make sure dracut-shutdown.service can find the initramfs later.
 mkdir -p "$NEWROOT/boot"
-ln -s $initramfs "$NEWROOT/boot/initramfs-$(uname -r).img"
+ln -s "$initramfs" "$NEWROOT/boot/initramfs-$(uname -r).img"
 # NOTE: $repodir must also be somewhere under /run for this to work correctly


### PR DESCRIPTION
Fix warnings generated by a new release of the shellcheck tool.
It should fix the [failing container refresh](https://github.com/rhinstaller/anaconda/actions/runs/3819493107/jobs/6497096968).