### PR TITLE
bootloader/zipl.py: update for zipl >= 2.25.0

### DIFF
--- a/pyanaconda/modules/storage/bootloader/zipl.py
+++ b/pyanaconda/modules/storage/bootloader/zipl.py
@@ -152,10 +152,12 @@ class ZIPL(BootLoader):
     def install(self, args=None):
         buf = util.execWithCapture("zipl", [], root=conf.target.system_root)
         for line in buf.splitlines():
-            if line.startswith("Preparing boot device: "):
+            if line.startswith("Preparing boot device"):
                 # Output here may look like:
                 #     Preparing boot device: dasdb (0200).
                 #     Preparing boot device: dasdl.
+                # and since s390utils 2.25.0 as:
+                #     Preparing boot device for LD-IPL: vda (0000).
                 # We want to extract the device name and pass that.
                 name = re.sub(r".+?: ", "", line)
                 self.stage1_name = re.sub(r"(\s\(.+\))?\.$", "", name)


### PR DESCRIPTION
The output of the zipl tool has been changed in version 2.25.0 [1], thus adapt the line prefix in the anaconda check as well.

[1] https://github.com/ibm-s390-linux/s390-tools/commit/f7d2339c6ad6c0adf1902a1a97a30b3168bc2c46

Resolves: rhbz#2157917