### PR TITLE
Qubes OS features

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -166,6 +166,7 @@ disable_grub_submenu = True
 # Set GRUB terminal type
 grub_terminal_type =
 
+# Additional default Grub options to be added
 additional_default_grub_options =
 
 [Storage]

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -221,6 +221,11 @@ default_scheme = LVM
 #
 luks_version = luks2
 
+# Default thin pool name
+thin_pool_name =
+
+# Default thin pool size
+thin_pool_size =
 
 [Storage Constraints]
 

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -74,6 +74,8 @@ can_save_installation_logs = True
 #
 default_on_boot = NONE
 
+# Set hostname
+hostname =
 
 [Payload]
 # Default package environment.

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -167,6 +167,9 @@ terminal_type =
 additional_default_grub_options =
 
 [Storage]
+# Set encryption
+encrypted = False
+
 # Enable dmraid usage during the installation.
 dmraid = True
 

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -161,10 +161,10 @@ preserved_arguments =
     nosmt
 
 # Disable the GRUB submenu
-disable_submenu = True
+disable_grub_submenu = True
 
 # Set GRUB terminal type
-terminal_type =
+grub_terminal_type =
 
 additional_default_grub_options =
 

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -158,6 +158,13 @@ preserved_arguments =
     biosdevname ipv6.disable net.ifnames net.ifnames.prefix
     nosmt
 
+# Disable the GRUB submenu
+disable_submenu = True
+
+# Set GRUB terminal type
+terminal_type =
+
+additional_default_grub_options =
 
 [Storage]
 # Enable dmraid usage during the installation.

--- a/data/profile.d/Makefile.am
+++ b/data/profile.d/Makefile.am
@@ -29,6 +29,7 @@ dist_config_DATA    = \
 	fedora-workstation.conf \
 	fedora.conf \
 	ovirt.conf \
+	qubesos.conf \
 	rhel.conf \
 	rhvh.conf \
 	rocky.conf \

--- a/data/profile.d/qubesos.conf
+++ b/data/profile.d/qubesos.conf
@@ -41,8 +41,8 @@ selinux = -1
 
 [Bootloader]
 efi_dir = qubes
-disable_submenu = False
-terminal_type = gfxterm
+disable_grub_submenu = False
+grub_terminal_type = gfxterm
 additional_default_grub_options =
     GRUB_THEME="/boot/grub2/themes/qubes/theme.txt"
     GRUB_CMDLINE_XEN_DEFAULT="console=none dom0_mem=min:1024M dom0_mem=max:4096M ucode=scan smt=off gnttab_max_frames=2048 gnttab_max_maptrack_frames=4096"

--- a/data/profile.d/qubesos.conf
+++ b/data/profile.d/qubesos.conf
@@ -1,0 +1,65 @@
+# Anaconda configuration file for Qubes OS.
+
+[Anaconda]
+forbidden_modules =
+    org.fedoraproject.Anaconda.Modules.Network
+
+[Profile]
+profile_id = qubesos
+
+[Profile Detection]
+os_id = qubesos
+
+[Product]
+product_name = Qubes OS
+
+[User Interface]
+hidden_spokes = NetworkSpoke
+default_help_pages =
+    QubesPlaceholder.txt
+    QubesPlaceholder.html
+    QubesPlaceholderWithLinks.html
+
+[Installation System]
+can_detect_unsupported_hardware = True
+
+[Installation Target]
+can_configure_network = False
+
+[Payload]
+ignored_packages = chrony
+default_rpm_gpg_keys =
+    /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+    /etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-primary
+
+[Network]
+default_on_boot = NONE
+hostname = dom0
+
+[Security]
+selinux = -1
+
+[Bootloader]
+efi_dir = qubes
+disable_submenu = False
+terminal_type = gfxterm
+additional_default_grub_options =
+    GRUB_THEME="/boot/grub2/themes/qubes/theme.txt"
+    GRUB_CMDLINE_XEN_DEFAULT="console=none dom0_mem=min:1024M dom0_mem=max:4096M ucode=scan smt=off gnttab_max_frames=2048 gnttab_max_maptrack_frames=4096"
+    GRUB_DISABLE_OS_PROBER="true"
+
+[Storage]
+encrypted = True
+default_scheme = LVM_THINP
+thin_pool_size = 20GiB
+thin_pool_name = dom0-pool
+default_partitioning =
+    /       (size 20 GiB)
+    swap
+default_partitioning_plain =
+    /       (size 20 GiB)
+    /var/lib/qubes (min 20 GiB)
+    swap
+default_partitioning_btrfs =
+    /       (btrfs, min 20 GiB)
+    swap

--- a/data/profile.d/qubesos.conf
+++ b/data/profile.d/qubesos.conf
@@ -15,10 +15,7 @@ product_name = Qubes OS
 
 [User Interface]
 hidden_spokes = NetworkSpoke
-default_help_pages =
-    QubesPlaceholder.txt
-    QubesPlaceholder.html
-    QubesPlaceholderWithLinks.html
+help_directory = /usr/share/anaconda/help/qubesos
 
 [Installation System]
 can_detect_unsupported_hardware = True

--- a/data/profile.d/qubesos.conf
+++ b/data/profile.d/qubesos.conf
@@ -49,7 +49,7 @@ additional_default_grub_options =
 encrypted = True
 default_scheme = LVM_THINP
 thin_pool_size = 20GiB
-thin_pool_name = dom0-pool
+thin_pool_name = root-pool
 default_partitioning =
     /       (size 20 GiB)
     swap

--- a/data/profile.d/qubesos.conf
+++ b/data/profile.d/qubesos.conf
@@ -8,7 +8,7 @@ forbidden_modules =
 profile_id = qubesos
 
 [Profile Detection]
-os_id = qubesos
+os_id = qubes
 
 [Product]
 product_name = Qubes OS

--- a/pyanaconda/core/configuration/bootloader.py
+++ b/pyanaconda/core/configuration/bootloader.py
@@ -83,4 +83,9 @@ class BootloaderSection(Section):
     @property
     def additional_default_grub_options(self):
         """List of additional default GRUB options"""
-        return self._get_option("additional_default_grub_options", str).strip("\n").split("\n")
+        options = []
+        parsed_options = self._get_option("additional_default_grub_options", str)
+        # We don't split directly as there is spaces in Grub option values
+        if parsed_options not in ("", "\n"):
+            options = parsed_options.strip("\n").split("\n")
+        return options

--- a/pyanaconda/core/configuration/bootloader.py
+++ b/pyanaconda/core/configuration/bootloader.py
@@ -54,9 +54,9 @@ class BootloaderSection(Section):
         return self._get_option("menu_auto_hide", bool)
 
     @property
-    def disable_submenu(self):
+    def disable_grub_submenu(self):
         """Disable the GRUB submenu."""
-        return self._get_option("disable_submenu", bool)
+        return self._get_option("disable_grub_submenu", bool)
 
     @property
     def nonibft_iscsi_boot(self):
@@ -76,9 +76,9 @@ class BootloaderSection(Section):
         return self._get_option("preserved_arguments", str).split()
 
     @property
-    def terminal_type(self):
+    def grub_terminal_type(self):
         """Terminal type."""
-        return self._get_option("terminal_type", str)
+        return self._get_option("grub_terminal_type", str)
 
     @property
     def additional_default_grub_options(self):

--- a/pyanaconda/core/configuration/bootloader.py
+++ b/pyanaconda/core/configuration/bootloader.py
@@ -54,6 +54,11 @@ class BootloaderSection(Section):
         return self._get_option("menu_auto_hide", bool)
 
     @property
+    def disable_submenu(self):
+        """Disable the GRUB submenu."""
+        return self._get_option("disable_submenu", bool)
+
+    @property
     def nonibft_iscsi_boot(self):
         """Are non-iBFT iSCSI disks allowed?
 
@@ -69,3 +74,13 @@ class BootloaderSection(Section):
         :return: a list of kernel arguments
         """
         return self._get_option("preserved_arguments", str).split()
+
+    @property
+    def terminal_type(self):
+        """Terminal type."""
+        return self._get_option("terminal_type", str)
+
+    @property
+    def additional_default_grub_options(self):
+        """List of additional default GRUB options"""
+        return self._get_option("additional_default_grub_options", str).strip("\n").split("\n")

--- a/pyanaconda/core/configuration/network.py
+++ b/pyanaconda/core/configuration/network.py
@@ -45,3 +45,8 @@ class NetworkSection(Section):
         :return: an instance of NetworkOnBoot
         """
         return self._get_option("default_on_boot", NetworkOnBoot)
+
+    @property
+    def hostname(self):
+        """Hostname"""
+        return self._get_option("hostname", str)

--- a/pyanaconda/core/configuration/storage.py
+++ b/pyanaconda/core/configuration/storage.py
@@ -147,6 +147,18 @@ class StorageSection(Section):
         return value
 
     @property
+    def thin_pool_name(self):
+        """The name of the default thin pool."""
+        return self._get_option("thin_pool_name", str) or None
+
+    @property
+    def thin_pool_size(self):
+        """The size of the default thin pool."""
+        value = self._get_option("thin_pool_size", str) or None
+        if value:
+            return Size(value)
+
+    @property
     def default_partitioning(self):
         """Default partitioning.
 

--- a/pyanaconda/core/configuration/storage.py
+++ b/pyanaconda/core/configuration/storage.py
@@ -51,6 +51,11 @@ class StorageSection(Section):
     """The Storage section."""
 
     @property
+    def encrypted(self):
+        """Is encryption set?"""
+        return self._get_option("encrypted", bool)
+
+    @property
     def dmraid(self):
         """Enable dmraid usage during the installation."""
         return self._get_option("dmraid", bool)

--- a/pyanaconda/core/configuration/storage.py
+++ b/pyanaconda/core/configuration/storage.py
@@ -179,6 +179,22 @@ class StorageSection(Section):
         """
         return self._get_option("default_partitioning", self._convert_partitioning)
 
+    def get_default_partitioning(self, scheme=None):
+        option = None
+        if scheme == AUTOPART_TYPE_PLAIN:
+            option = "default_partitioning_plain"
+        elif scheme == AUTOPART_TYPE_BTRFS:
+            option = "default_partitioning_btrfs"
+        elif scheme == AUTOPART_TYPE_LVM:
+            option = "default_partitioning_lvm"
+        elif scheme == AUTOPART_TYPE_LVM_THINP:
+            option = "default_partitioning_lvm_thinp"
+        if option and self._has_option(option):
+            partitioning = self._get_option(option, self._convert_partitioning)
+        else:
+            partitioning = self.default_partitioning
+        return partitioning
+
     def _convert_partitioning(self, value):
         """Convert a partitioning string into a list of dictionaries."""
         return list(map(self._convert_partitioning_line, value.strip().split("\n")))

--- a/pyanaconda/modules/common/structures/partitioning.py
+++ b/pyanaconda/modules/common/structures/partitioning.py
@@ -34,7 +34,7 @@ class PartitioningRequest(DBusData):
         self._excluded_mount_points = []
         self._hibernation = False
 
-        self._encrypted = False
+        self._encrypted = conf.storage.encrypted
         self._passphrase = ""
         self._cipher = ""
         self._luks_version = ""

--- a/pyanaconda/modules/network/network.py
+++ b/pyanaconda/modules/network/network.py
@@ -64,7 +64,7 @@ class NetworkService(KickstartService):
         self._firewall_module = FirewallModule()
 
         self.hostname_changed = Signal()
-        self._hostname = ""
+        self._hostname = conf.network.hostname
 
         self.current_hostname_changed = Signal()
         self._hostname_service_proxy = self._get_hostname_proxy()

--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -256,12 +256,12 @@ class GRUB2(BootLoader):
         defaults.write("GRUB_TIMEOUT=%d\n" % self.timeout)
         defaults.write("GRUB_DISTRIBUTOR=\"$(sed 's, release .*$,,g' /etc/system-release)\"\n")
         defaults.write("GRUB_DEFAULT=saved\n")
-        defaults.write("GRUB_DISABLE_SUBMENU=%s\n" % str(conf.bootloader.disable_submenu).lower())
+        defaults.write("GRUB_DISABLE_SUBMENU=%s\n" % str(conf.bootloader.disable_grub_submenu).lower())
         if self.console and self.has_serial_console:
             defaults.write("GRUB_TERMINAL=\"serial console\"\n")
             defaults.write("GRUB_SERIAL_COMMAND=\"%s\"\n" % self.serial_command)
         else:
-            defaults.write("GRUB_TERMINAL_OUTPUT=\"%s\"\n" % conf.bootloader.terminal_type or self.terminal_type)
+            defaults.write("GRUB_TERMINAL_OUTPUT=\"%s\"\n" % conf.bootloader.grub_terminal_type or self.terminal_type)
 
         # this is going to cause problems for systems containing multiple
         # linux installations or even multiple boot entries with different

--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -256,12 +256,12 @@ class GRUB2(BootLoader):
         defaults.write("GRUB_TIMEOUT=%d\n" % self.timeout)
         defaults.write("GRUB_DISTRIBUTOR=\"$(sed 's, release .*$,,g' /etc/system-release)\"\n")
         defaults.write("GRUB_DEFAULT=saved\n")
-        defaults.write("GRUB_DISABLE_SUBMENU=true\n")
+        defaults.write("GRUB_DISABLE_SUBMENU=%s\n" % str(conf.bootloader.disable_submenu).lower())
         if self.console and self.has_serial_console:
             defaults.write("GRUB_TERMINAL=\"serial console\"\n")
             defaults.write("GRUB_SERIAL_COMMAND=\"%s\"\n" % self.serial_command)
         else:
-            defaults.write("GRUB_TERMINAL_OUTPUT=\"%s\"\n" % self.terminal_type)
+            defaults.write("GRUB_TERMINAL_OUTPUT=\"%s\"\n" % conf.bootloader.terminal_type or self.terminal_type)
 
         # this is going to cause problems for systems containing multiple
         # linux installations or even multiple boot entries with different
@@ -269,7 +269,9 @@ class GRUB2(BootLoader):
         log.info("bootloader.py: used boot args: %s ", self.boot_args)
         defaults.write("GRUB_CMDLINE_LINUX=\"%s\"\n" % self.boot_args)
         defaults.write("GRUB_DISABLE_RECOVERY=\"true\"\n")
-        #defaults.write("GRUB_THEME=\"/boot/grub2/themes/system/theme.txt\"\n")
+        # defaults.write("GRUB_THEME=\"/boot/grub2/themes/system/theme.txt\"\n")
+        for option in conf.bootloader.additional_default_grub_options:
+            defaults.write("%s\n" % option)
 
         if self.use_bls and os.path.exists(conf.target.system_root + "/usr/sbin/new-kernel-pkg"):
             log.warning("BLS support disabled due new-kernel-pkg being present")

--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
@@ -134,7 +134,7 @@ class AutomaticPartitioningTask(NonInteractivePartitioningTask):
         swap = None
 
         # Create partitioning specs based on the default configuration.
-        for spec in get_default_partitioning():
+        for spec in get_default_partitioning(scheme):
             # Skip mount points excluded from the chosen scheme.
             if spec.schemes and scheme not in spec.schemes:
                 continue

--- a/pyanaconda/modules/storage/partitioning/automatic/utils.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/utils.py
@@ -498,7 +498,14 @@ def schedule_volumes(storage, devices, scheme, requests, encrypted=False):
 
         if thinlv and pool is None:
             # create a single thin pool in the vg
-            pool = storage.new_lv(parents=[container], thin_pool=True, grow=True)
+            kwargs = {'parents': [container], 'thin_pool': True}
+            if conf.storage.thin_pool_name:
+                kwargs['name'] = conf.storage.thin_pool_name
+            if conf.storage.thin_pool_size:
+                kwargs['size'] = conf.storage.thin_pool_size
+            else:
+                kwargs['grow'] = True
+            pool = storage.new_lv(**kwargs)
             storage.create_device(pool)
 
             # make sure VG reserves space for the pool to grow if needed

--- a/pyanaconda/modules/storage/partitioning/automatic/utils.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/utils.py
@@ -255,8 +255,7 @@ def schedule_implicit_partitions(storage, disks, scheme, encrypted=False, luks_f
 
     return devs
 
-
-def get_default_partitioning():
+def get_default_partitioning(scheme=None):
     """Get the default partitioning requests.
 
     :return: a list of partitioning specs
@@ -265,7 +264,7 @@ def get_default_partitioning():
     partitioning = list(platform.partitions)
 
     # Get the product-specific partitioning.
-    for attrs in conf.storage.default_partitioning:
+    for attrs in conf.storage.get_default_partitioning(scheme=scheme):
         partitioning.append(get_part_spec(attrs))
 
     return partitioning
@@ -299,6 +298,7 @@ def get_part_spec(attrs):
         schemes=schemes,
     )
     return spec
+
 
 def schedule_partitions(storage, disks, implicit_devices, scheme, requests, encrypted=False,
                         luks_fmt_args=None):

--- a/pyanaconda/modules/storage/partitioning/automatic/utils.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/utils.py
@@ -255,9 +255,12 @@ def schedule_implicit_partitions(storage, disks, scheme, encrypted=False, luks_f
 
     return devs
 
+
 def get_default_partitioning(scheme=None):
     """Get the default partitioning requests.
 
+    :param scheme: a type of the partitioning scheme
+    :type scheme: int
     :return: a list of partitioning specs
     """
     # Get the platform-specific partitioning.

--- a/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
@@ -539,6 +539,10 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
             }
         ]
 
+    def test_storage_encryption(self):
+        config = AnacondaConfiguration.from_defaults()
+        assert not config.storage.encrypted
+
     def test_convert_partitioning(self):
         convert_line = StorageSection._convert_partitioning_line
 

--- a/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
@@ -502,7 +502,7 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
     def test_bootloader(self):
         conf = AnacondaConfiguration.from_defaults()
         assert "selinux" in conf.bootloader.preserved_arguments
-        assert conf.bootloader.disable_submenu
+        assert conf.bootloader.disable_grub_submenu
         assert not conf.bootloader.additional_default_grub_options
 
     def test_bootloader_options(self):
@@ -517,8 +517,8 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
 
         config.validate()
 
-        assert config.bootloader.terminal_type == "gfxterm"
-        assert not config.bootloader.disable_submenu
+        assert config.bootloader.grub_terminal_type == "gfxterm"
+        assert not config.bootloader.disable_grub_submenu
         assert set(config.bootloader.additional_default_grub_options) == {
             'GRUB_THEME="/boot/grub2/themes/qubes/theme.txt"',
             'GRUB_CMDLINE_XEN_DEFAULT="console=none dom0_mem=min:1024M dom0_mem=max:4096M ucode=scan smt=off gnttab_max_frames=2048 gnttab_max_maptrack_frames=4096"',

--- a/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
@@ -543,6 +543,20 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
         config = AnacondaConfiguration.from_defaults()
         assert not config.storage.encrypted
 
+    def test_network_hostname(self):
+        config = AnacondaConfiguration.from_defaults()
+        assert config.network.hostname == ""
+
+        profile = ProfileLoader()
+        profile.load_profiles(PROFILE_DIR)
+
+        paths = profile.collect_configurations("qubesos")
+        for path in paths:
+            config.read(path)
+        config.validate()
+
+        assert config.network.hostname == "dom0"
+
     def test_convert_partitioning(self):
         convert_line = StorageSection._convert_partitioning_line
 


### PR DESCRIPTION
I propose a set of features allowing to reduce modifications we need for Qubes OS:

- Allow to specify default thin pool name and size,
- Allow to provide default partitioning based on scheme,
- Support for adding bootloader options in configuration file
- Support for setting encryption from configuration file
- Support for setting hostname from configuration file

We think that would benefit other parties, that's the reason of this PR.