### PR TITLE
Always use `blivet.arch.is_s390()` to detect s390

### DIFF
--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -28,6 +28,8 @@ import struct
 
 from argparse import ArgumentParser, ArgumentError, HelpFormatter, Namespace, Action, SUPPRESS
 
+from blivet.arch import is_s390
+
 from pyanaconda.core.kernel import KernelArguments
 from pyanaconda.core.constants import DisplayModes, X_TIMEOUT, VIRTIO_PORT
 
@@ -53,11 +55,7 @@ def get_help_width():
     # don't do terminal size detection on s390, it is not supported
     # by its arcane TTY system and only results in cryptic error messages
     # ending on the standard output
-    # (we do the s390 detection here directly to avoid
-    #  the delay caused by importing the Blivet module
-    #  just for this single call)
-    is_s390 = os.uname()[4].startswith('s390')
-    if is_s390:
+    if is_s390():
         return DEFAULT_HELP_WIDTH
 
     try:

--- a/pyanaconda/modules/network/nm_client.py
+++ b/pyanaconda/modules/network/nm_client.py
@@ -24,6 +24,7 @@ from gi.repository import NM
 from contextlib import contextmanager
 
 import socket
+from blivet.arch import is_s390
 from pykickstart.constants import BIND_TO_MAC
 from pyanaconda.core.glib import create_new_context, GError, sync_call_glib
 from pyanaconda.modules.network.constants import NM_CONNECTION_UUID_LENGTH, \
@@ -31,8 +32,7 @@ from pyanaconda.modules.network.constants import NM_CONNECTION_UUID_LENGTH, \
     NM_CONNECTION_TYPE_VLAN, NM_CONNECTION_TYPE_BOND,  NM_CONNECTION_TYPE_TEAM, \
     NM_CONNECTION_TYPE_BRIDGE, NM_CONNECTION_TYPE_INFINIBAND
 from pyanaconda.modules.network.kickstart import default_ks_vlan_interface_name
-from pyanaconda.modules.network.utils import is_s390, get_s390_settings, netmask2prefix, \
-    prefix2netmask
+from pyanaconda.modules.network.utils import get_s390_settings, netmask2prefix, prefix2netmask
 from pyanaconda.modules.network.config_file import is_config_file_for_system
 from pyanaconda.core.dbus import SystemBus
 

--- a/pyanaconda/modules/network/utils.py
+++ b/pyanaconda/modules/network/utils.py
@@ -29,11 +29,6 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-# TODO use anaconda.core
-def is_s390():
-    return os.uname()[4].startswith('s390')
-
-
 # TODO move somewhwere
 # We duplicate this in dracut/parse-kickstart
 def get_s390_settings(devname):


### PR DESCRIPTION
Let's do it the same way everywhere. The (decade old) comments about import speed should not matter, we do the same in `startup_utils` and it's fine.