### PR TITLE
Don't list attributes of SSLConfigurationData if empty

### DIFF
--- a/pyanaconda/modules/common/structures/payload.py
+++ b/pyanaconda/modules/common/structures/payload.py
@@ -67,7 +67,19 @@ class SSLConfigurationData(DBusData):
 
         :rtype: bool
         """
-        return not any([self._ca_cert_path, self._client_cert_path, self._client_key_path])
+        return not any([
+            self._ca_cert_path,
+            self._client_cert_path,
+            self._client_key_path]
+        )
+
+    def __repr__(self):
+        """Convert this data object to a string."""
+        if not self.is_empty():
+            return super().__repr__()
+
+        # Don't list attributes if none of them are set.
+        return "{}()".format(self.__class__.__name__)
 
 
 class RepoConfigurationData(DBusData):


### PR DESCRIPTION
If the attributes of the `SSLConfigurationData` class are not set, don't list them in the string represenation of this DBus structure. Return just `SSLConfigurationData()` in that case.

The unit tests are part of changes in https://github.com/rhinstaller/anaconda/pull/4498.