### PR TITLE
Fix missing tests in release archive

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -54,6 +54,9 @@ dist_check_SCRIPTS = $(srcdir)/glade_tests/*.py \
 		     $(srcdir)/gettext_tests/*.py \
 		     gettext_tests/canary_tests.sh \
 		     $(srcdir)/*_tests/*.py \
+		     $(srcdir)/*_tests/*/*.py \
+		     $(srcdir)/*_tests/*/*/*.py \
+		     $(srcdir)/*_tests/*/*/*/*.py \
 		     $(srcdir)/unit_tests/*_tests/*.py \
 		     shellcheck/*.sh \
 		     webui_eslint/run_webui_eslint.sh \


### PR DESCRIPTION
pyanaconda_tests has deep directory structure. Since makefile syntax doesn't support recursive wildcards, list up to 4-level deep dirs (the current layout).

Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>