### PR TITLE
UI: Show error messages if the payload setup finishes early

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -413,6 +413,11 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         payloadMgr.failed_signal.connect(self._on_payload_failed)
         payloadMgr.succeeded_signal.connect(self._on_payload_succeeded)
 
+        # It is possible that the payload manager is finished by now. In that case,
+        # trigger the failed callback manually to set up the error messages.
+        if not payloadMgr.is_running and not self.payload.report.is_valid():
+            self._on_payload_failed()
+
         # Report progress messages of the payload manager.
         payloadMgr.progress_changed_signal.connect(self._on_payload_progress_changed)
 

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -93,10 +93,19 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
         NormalTUISpoke.initialize(self)
         self.initialize_start()
 
-        threadMgr.add(AnacondaThread(name=THREAD_SOURCE_WATCHER,
-                                     target=self._initialize))
-
+        # Register callbacks to signals of the payload manager.
         payloadMgr.failed_signal.connect(self._on_payload_failed)
+
+        # It is possible that the payload manager is finished by now. In that case,
+        # trigger the failed callback manually to set up the error messages.
+        if not payloadMgr.is_running and not self.payload.report.is_valid():
+            self._on_payload_failed()
+
+        # Finish the initialization.
+        threadMgr.add(AnacondaThread(
+            name=THREAD_SOURCE_WATCHER,
+            target=self._initialize
+        ))
 
     def _initialize(self):
         """ Private initialize. """


### PR DESCRIPTION
When we register callbacks to signals of the payload manager in GUI and TUI, it is possible that the payload manager is already finished with the payload setup. In that case, we have to trigger the failed callback manually to set up the error messages. Otherwise, the error messages won't be visible in the UI.