### PR TITLE
Remove the is_complete method of the DNF payload class

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -267,6 +267,8 @@ X_DISPLAY_NUMBER = 1
 # Payload status messages
 PAYLOAD_STATUS_PROBING_STORAGE = N_("Probing storage...")
 PAYLOAD_STATUS_SETTING_SOURCE = N_("Setting up installation source...")
+PAYLOAD_STATUS_INVALID_SOURCE = N_("Error setting up repositories")
+PAYLOAD_STATUS_CHECKING_SOFTWARE = N_("Checking software dependencies...")
 
 # Window title text
 WINDOW_TITLE_TEXT = N_("Anaconda Installer")

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -305,10 +305,6 @@ class DNFPayload(Payload):
         return repo_id == constants.BASE_REPO_NAME \
             or repo_id in constants.DEFAULT_REPOS
 
-    def is_complete(self):
-        """Is the payload complete?"""
-        return self.source_type not in SOURCE_REPO_FILE_TYPES or self.is_ready()
-
     def unsetup(self):
         self._dnf_manager.reset_base()
         tear_down_sources(self.proxy)

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -20,7 +20,7 @@ import sys
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.constants import PAYLOAD_TYPE_DNF, THREAD_SOFTWARE_WATCHER, THREAD_PAYLOAD, \
-    THREAD_CHECK_SOFTWARE
+    THREAD_CHECK_SOFTWARE, PAYLOAD_STATUS_CHECKING_SOFTWARE
 from pyanaconda.core.i18n import _, C_, CN_
 from pyanaconda.core.util import ipmi_abort
 from pyanaconda.flags import flags
@@ -316,7 +316,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
         ))
 
     def _check_software_selection(self):
-        hubQ.send_message(self.__class__.__name__, _("Checking software dependencies..."))
+        hubQ.send_message(self.__class__.__name__, _(PAYLOAD_STATUS_CHECKING_SOFTWARE))
         self.payload.bump_tx_id()
 
         # Run the validation task.

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -18,7 +18,6 @@
 #
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.payload import parse_nfs_url
-from pyanaconda.flags import flags
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
@@ -35,7 +34,8 @@ from pyanaconda.ui.lib.payload import find_potential_hdiso_sources, get_hdiso_so
     get_hdiso_source_description
 
 from pyanaconda.core.constants import THREAD_SOURCE_WATCHER, THREAD_PAYLOAD, PAYLOAD_TYPE_DNF, \
-    SOURCE_TYPE_URL, SOURCE_TYPE_NFS, SOURCE_TYPE_HMC
+    SOURCE_TYPE_URL, SOURCE_TYPE_NFS, SOURCE_TYPE_HMC, PAYLOAD_STATUS_SETTING_SOURCE, \
+    PAYLOAD_STATUS_INVALID_SOURCE
 from pyanaconda.core.constants import THREAD_STORAGE_WATCHER
 from pyanaconda.core.constants import THREAD_CHECK_SOFTWARE, ISO_DIR, DRACUT_ISODIR
 from pyanaconda.core.constants import PAYLOAD_STATUS_PROBING_STORAGE
@@ -125,22 +125,20 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
 
     @property
     def status(self):
-        if self._error:
-            return _("Error setting up software source")
-        elif not self.ready:
-            return _("Processing...")
-        elif not self.payload.is_complete():
-            return _("Nothing selected")
-        else:
-            source_proxy = self.payload.get_source_proxy()
-            return source_proxy.Description
+        """The status of the spoke."""
+        if not self.ready:
+            return _(PAYLOAD_STATUS_SETTING_SOURCE)
+
+        if not self.completed:
+            return _(PAYLOAD_STATUS_INVALID_SOURCE)
+
+        source_proxy = self.payload.get_source_proxy()
+        return source_proxy.Description
 
     @property
     def completed(self):
-        if flags.automatedInstall and self.ready and not self.payload.is_ready():
-            return False
-
-        return not self._error and self.ready and self.payload.is_complete()
+        """Is the spoke complete?"""
+        return self.ready and not self._error and self.payload.is_ready()
 
     def refresh(self, args=None):
         NormalTUISpoke.refresh(self, args)


### PR DESCRIPTION
Don't use the `is_complete` method of the DNF payload class. Instead, use
the `is_ready` method to verify if the payload is correctly set up.

Simplify the `status` and `completed` properties of the source spokes to show
a correct completeness of these spokes after the initialization. Previously,
the spoke could be shown as complete, but its status said otherwise.

I couldn't figure out why these checks should be different for automated
installations and the commit messages didn't provide any clues. There are
only three conditions we should care about:

1. All payload actions are finished (`self.ready`).
2. The latest payload setup didn't fail with an error (`self._error`).
3. The payload has some usable repositories enabled (`self.payload.is_ready()`).