### PR TITLE
Enable TFTP support (#2071350)

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -66,7 +66,7 @@ different ways:
     Mount the given disk partition and install from ISO file on the given path.
     This installation method requires ISO file, which contains an installable tree.
 
-``inst.repo=[http,https,ftp]://<host>/<path>``
+``inst.repo=[http,https,ftp,tftp]://<host>/<path>``
     Look for an installable tree at the given URL.
 
 ``inst.repo=nfs:[<options>:]<server>:/<path>``
@@ -107,7 +107,7 @@ Add additional repository which can be used as another *Installation Source*
 next to the main repository (see `inst.repo`_). This option can be used multiple
 times during one boot. This can be specified in a few different ways:
 
-``inst.addrepo=REPO_NAME,[http,https,ftp]://<host>/<path>``
+``inst.addrepo=REPO_NAME,[http,https,ftp,tftp]://<host>/<path>``
     Look for the installable tree at the given URL.
 
 ``inst.addrepo=REPO_NAME,nfs://<server>:/<path>``
@@ -172,7 +172,7 @@ packages will be ignored. Otherwise the same as `inst.repo`_.
 inst.stage2.all
 ^^^^^^^^^^^^^^^
 
-All locations of type http, https or ftp specified with inst.stage2 will
+All locations of type http, https, ftp or tftp specified with inst.stage2 will
 be used sequentially one by one until the image is fetched. Other locations
 will be ignored.
 
@@ -237,7 +237,7 @@ For example:
 inst.ks.all
 ^^^^^^^^^^^
 
-Use all locations of type ``http``, ``https`` or ``ftp`` specified with
+Use all locations of type ``http``, ``https``, ``ftp`` or ``tftp`` specified with
 multiple ``inst.ks`` sequentially one by one until kickstart file is fetched.
 Locations of other types (eg. ``nfs``) will be ignored.
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -14,13 +14,13 @@ using the initial setup program.
 
 Anaconda is a fairly sophisticated installer. It supports installation from
 local and remote sources such as CDs and DVDs, images stored on a hard drive,
-NFS, HTTP, and FTP. Installation can be scripted with kickstart to provide a
-fully unattended installation that can be duplicated on scores of machines. It
-can also be run over VNC on headless machines. A variety of advanced storage
-devices including LVM, RAID, iSCSI, and multipath are supported from the
-partitioning program. Anaconda provides advanced debugging features such as
-remote logging, access to the python interactive debugger, and remote saving of
-exception dumps.
+NFS, HTTP, FTP, and TFTP. Installation can be scripted with kickstart to
+provide a fully unattended installation that can be duplicated on scores of
+machines. It can also be run over VNC on headless machines. A variety of
+advanced storage devices including LVM, RAID, iSCSI, and multipath are
+supported from the partitioning program. Anaconda provides advanced debugging
+features such as remote logging, access to the python interactive debugger, and
+remote saving of exception dumps.
 
 For more news about Anaconda development and planned features you can follow
 `our blog <https://rhinstaller.wordpress.com>`_.

--- a/dracut/README-driver-updates.md
+++ b/dracut/README-driver-updates.md
@@ -235,8 +235,8 @@ If any `inst.dd=...` (or `dd=...`) arguments are found, this scriptlet parses
 their values and writes appropriate values to `/tmp/dd_disk`, `/tmp/dd_net`, or
 `/tmp/dd_interactive`, as follows:
 
-1. Values that start with `http:`, `https:`, `ftp:`, or `nfs:` are assumed to
-   be network URLs and get written to `/tmp/dd_net`.
+1. Values that start with `http:`, `https:`, `ftp:`, `nfs:`, or `tftp:` are
+   assumed to be network URLs and get written to `/tmp/dd_net`.
 2. Values of the form `hd:<dev>`, `cdrom:<dev>`, `file:<path>`, or `path:<path>`
    will have the `<dev>` or `<path>` part written to `/tmp/dd_disk`.
 3. Any other value is assumed to be a disk device, and therefore also gets

--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -316,7 +316,7 @@ online_netdevs() {
     done
 }
 
-# Filter locations that are http, https or ftp urls.
+# Filter locations that are http, https, ftp or tftp urls.
 get_urls() {
     local locations="${1}"
     local location
@@ -324,7 +324,7 @@ get_urls() {
     # Filter locations.
     for location in $locations; do
         case "${location%%:*}" in
-            http|https|ftp)
+            http|https|ftp|tftp)
                 echo "$location"
             ;;
             *)

--- a/dracut/anaconda-netroot.sh
+++ b/dracut/anaconda-netroot.sh
@@ -68,7 +68,7 @@ case $repo in
             anaconda_live_root_dir "$repodir" "$iso"
         fi
     ;;
-    http*|ftp*)
+    http*|ftp*|tftp*)
         info "anaconda: stage2 locations are: $repo"
         anaconda_net_root "$repo"
     ;;

--- a/dracut/fetch-kickstart-net.sh
+++ b/dracut/fetch-kickstart-net.sh
@@ -42,7 +42,7 @@ case $kickstart in
         # Use the prepared url.
         locations="$kickstart"
     ;;
-    http*|ftp*)
+    http*|ftp*|tftp*)
         # Use the location from the variable.
         locations="$kickstart"
     ;;

--- a/dracut/kickstart-genrules.sh
+++ b/dracut/kickstart-genrules.sh
@@ -4,7 +4,7 @@
 . /lib/anaconda-lib.sh
 
 case "${kickstart%%:*}" in
-    http|https|ftp|nfs|urls)
+    http|https|ftp|nfs|tftp|urls)
         # handled by fetch-kickstart-net in the online hook
         wait_for_kickstart
     ;;

--- a/dracut/parse-anaconda-dd.sh
+++ b/dracut/parse-anaconda-dd.sh
@@ -16,7 +16,7 @@ for dd in $(getargs inst.dd=); do
         # plain 'dd'/'inst.dd': Engage interactive mode!
         dd|inst.dd) echo menu > /tmp/dd_interactive ;;
         # network URLs: require net, add to dd_net
-        http:*|https:*|ftp:*|nfs:*|nfs4:*) set_neednet; echo "$dd" >> /tmp/dd_net ;;
+        http:*|https:*|ftp:*|nfs:*|nfs4:*|tftp:*) set_neednet; echo "$dd" >> /tmp/dd_net ;;
         # disks: strip "cdrom:" or "hd:" and add to dd_disk
         cdrom:*|hd:*) echo "${dd#*:}" >> /tmp/dd_disk ;;
         # images crammed into initrd: strip "file:" or "path:"

--- a/dracut/parse-anaconda-kickstart.sh
+++ b/dracut/parse-anaconda-kickstart.sh
@@ -21,7 +21,7 @@ rm -f /tmp/ks_urls
 getargbool 0 inst.ks.all && kickstart="urls"
 
 case "${kickstart%%:*}" in
-    http|https|ftp|nfs|nfs4) # network kickstart? set "neednet"!
+    http|https|ftp|nfs|nfs4|tftp) # network kickstart? set "neednet"!
         set_neednet
     ;;
     urls) # multiple network kickstarts?

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -112,7 +112,7 @@ if updates=$(getarg inst.updates); then
     if [ -n "$updates" ]; then
         export anac_updates=$updates
         case $updates in
-            http*|ftp*|nfs*)
+            http*|ftp*|nfs*|tftp*)
                 echo "live.updates=$updates" \
                   >> /etc/cmdline.d/75-anaconda-options.conf ;;
         esac

--- a/dracut/parse-anaconda-repo.sh
+++ b/dracut/parse-anaconda-repo.sh
@@ -22,7 +22,7 @@ getargbool 0 inst.stage2.all && repo="urls"
 if [ -n "$repo" ]; then
     splitsep ":" "$repo" repotype rest
     case "$repotype" in
-        http|https|ftp|nfs|nfs4)
+        http|https|ftp|nfs|nfs4|tftp)
             root="anaconda-net:$repo"
             set_neednet
         ;;

--- a/dracut/updates-genrules.sh
+++ b/dracut/updates-genrules.sh
@@ -7,7 +7,7 @@ updates=$anac_updates
 [ -n "$updates" ] || return
 case $updates in
     # updates=<url>: handled by livenet's fetch-liveupdate.sh
-    http*|ftp*|nfs*)
+    http*|ftp*|nfs*|tftp*)
         wait_for_updates
     ;;
     # updates=<disk>:<path>


### PR DESCRIPTION
Anaconda now makes use of dracuts capability to fetch files via TFTP. This enables the installer to fetch kickstart configurations from a TFTP server.