### PR TITLE
ci(lint): add shell linter - Differential ShellCheck

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -1,0 +1,40 @@
+---
+
+name: Differential ShellCheck
+on:
+  push:
+  pull_request:
+    branches: [ master, rhel-* ]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      security-events: write
+      pull-requests: write
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - id: ShellCheck
+        name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v4
+        with:
+          severity: warning
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ always() }}
+        name: Upload artifact with ShellCheck defects in SARIF format
+        uses: actions/upload-artifact@v3
+        with:
+          name: Differential ShellCheck SARIF
+          path: ${{ steps.ShellCheck.outputs.sarif }}
+
+...


### PR DESCRIPTION
A follow-up to the discussion in kickstart-tests PR:

- https://github.com/rhinstaller/kickstart-tests/pull/785

TL;DR Differential ShellCheck is a GitHub Action that performs differential ShellCheck scans on shell scripts changed via PR or in a commit and reports results directly in PR or in the Security tab.

/cc @VladimirSlavik

Based on the run in my fork, ShellCheck reports only [the following defects](https://github.com/jamacku/anaconda/security/code-scanning):

![Screenshot from 2023-01-17 14-04-38](https://user-images.githubusercontent.com/2879818/212906392-35cb013c-d38b-4367-be22-1b8a8c62ded4.png)
