### PR TITLE
Ignore non-quoted array expansion in ShellCheck

### DIFF
--- a/dockerfile/anaconda-ci/run-build-and-arg
+++ b/dockerfile/anaconda-ci/run-build-and-arg
@@ -21,4 +21,5 @@ copy_logs() {
 trap copy_logs EXIT INT QUIT PIPE
 
 # run user-supplied command (by default, `make ci`)
+# shellcheck disable=SC2068
 $@

--- a/scripts/log-capture
+++ b/scripts/log-capture
@@ -4,6 +4,7 @@ date=$(date +%F_%H%M%S)
 OUTDIR=/tmp/log-capture-${date}
 ARCHIVE=${1-/tmp/log-capture.tar.bz2}
 
+# shellcheck disable=SC2068
 _to_log() { local OutputFile=$(tr ' /' '_' <<<"$@"); $@ >${OUTDIR}/${OutputFile}; }
 
 mkdir -p ${OUTDIR}

--- a/scripts/testing/install_dependencies.sh
+++ b/scripts/testing/install_dependencies.sh
@@ -28,6 +28,7 @@
 
 set -eu
 
+# shellcheck disable=SC2068
 dnf install $@ make rpm-build npm virt-install
 
 TEMP=$(mktemp /tmp/anaconda.spec.XXXXXXX)
@@ -39,6 +40,7 @@ sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' ./
 # version could be problematic because of fedora version you are running and
 # they are mostly not important for automake
 deps=$(rpmspec -q --buildrequires $TEMP | sed 's/>=.*$//')
+# shellcheck disable=SC2068
 dnf install $@ $deps  # do NOT quote the list or it falls apart
 
 # clean up the temp file


### PR DESCRIPTION
The regular unit test does not trip on these, but the GitHub action would, once we start using it. See: https://github.com/rhinstaller/anaconda/pull/4510

Not #infra because these files are not all listed as infra.