### PR TITLE
Use another type to make new GCC warnings go away

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,12 +89,8 @@ PKG_CHECK_MODULES([PYTHON3], [python3], [], ANACONDA_SOFT_FAILURE([Unable to fin
 ANACONDA_PKG_CHECK_MODULES([RPM], [rpm >= 4.10.0])
 ANACONDA_PKG_CHECK_MODULES([LIBARCHIVE], [libarchive >= 3.0.4])
 
-# GCC likes to bomb out on some ridiculous warnings.  Add your favorites
-# here.
-SHUT_UP_GCC="-Wno-unused-result"
-
 # Add remaining compiler flags we want to use
-CFLAGS="$CFLAGS -Wall -Werror $SHUT_UP_GCC -fanalyzer"
+CFLAGS="$CFLAGS -Wall -Werror -fanalyzer"
 
 # Localization specific settings (used in main and po Makefile.am)
 AC_SUBST(L10N_REPOSITORY, [https://github.com/rhinstaller/anaconda-l10n.git])

--- a/utils/dd/rpmutils.c
+++ b/utils/dd/rpmutils.c
@@ -81,7 +81,7 @@ int init_rpm() {
 
 /* read data from RPM header */
 
-const char * headerGetString(Header h, rpmTag tag)
+const char * headerGetString(Header h, rpmTagVal tag)
 {
     const char *res = NULL;
     struct rpmtd_s td;

--- a/utils/dd/rpmutils.h
+++ b/utils/dd/rpmutils.h
@@ -64,7 +64,7 @@ typedef int (*dependencyfunc)(const char* depname, const char* depversion, const
 */
 typedef int (*okfunc)(const char* filename, Header *rpmheader, int packageflags);
 
-const char * headerGetString(Header h, rpmTag tag);
+const char * headerGetString(Header h, rpmTagVal tag);
 int init_rpm();
 int checkDDRPM(const char *source,
                 dependencyfunc provides,


### PR DESCRIPTION
This should work.

I'm not a C type system guru, so I have only a hazy idea why this was the right thing. Feel free to point out why this is incorrect!