### PR TITLE
infra: Turn off infra rebuilds for Fedora 37

### DIFF
--- a/.branch-variables.yml
+++ b/.branch-variables.yml
@@ -10,4 +10,4 @@ distro_name: "fedora" # "fedora" or "rhel"
 distro_release: "rawhide" # "rawhide" or a number without quotation marks
 
 # The following only applies for rawhide.
-branched_fedora_version: 37 # number without quotation marks, or nothing if CI should not run for branched Fedora
+branched_fedora_version:  # number without quotation marks, or nothing if CI should not run for branched Fedora

--- a/.github/workflows/container-autoupdate-fedora.yml
+++ b/.github/workflows/container-autoupdate-fedora.yml
@@ -26,9 +26,3 @@ jobs:
       container-tag: master
       branch: master
 
-  f37-release:
-    uses: ./.github/workflows/container-rebuild-action.yml
-    secrets: inherit
-    with:
-      container-tag: f37-release
-      branch: f37-release

--- a/.github/workflows/try-release-daily.yml
+++ b/.github/workflows/try-release-daily.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['master', 'rhel-8', 'rhel-9', 'f37-release']
+        branch: ['master', 'rhel-8', 'rhel-9']
 
     steps:
       - name: Check out repo


### PR DESCRIPTION
This turns off scheduled container rebuilds and release rehearsals for F37. It has been released for a few months already. Any work on these branches will be an exception and require special handling anyway.