### PR TITLE
webui: Disable check for unexpected SELinux denials

### DIFF
--- a/ui/webui/Makefile.am
+++ b/ui/webui/Makefile.am
@@ -80,8 +80,10 @@ bots:
 $(UPDATES_IMG): bots
 	test/prepare-updates-img
 
+# test runs in kernel_t context and triggers massive amounts of SELinux
+# denials; SELinux gets disabled, but would still trigger unexpected messages
 integration-test: bots test/common test/reference $(UPDATES_IMG)
-	test/run-tests
+	TEST_AUDIT_NO_SELINUX=1 test/run-tests
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest release, and update it from time to time


### PR DESCRIPTION
data/liveinst/liveinst disables SELinux for the installer. Correspondingly, disable cockpit's SELinux message checks, otherwise tests fail on tons of messages like

    avc: denied { create } for pid=4896 comm="bash" name="cockpit.conf" scontext=system_u:system_r:kernel_t:s0 tcontext=unconfined_u:object_r:user_tmp_t:s0 tclass=file permissive=1

----

See https://github.com/cockpit-project/bots/pull/4287 , this blocks the image refresh. However, I don't know if that's really the right thing to do. Please let's discuss in the image refresh PR.