### PR TITLE
Add DNS search and ignore options from kickstart

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -39,7 +39,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.43-1
+%define pykickstartver 3.44-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.6.0-1
 %define rpmver 4.15.0

--- a/docs/release-notes/kickstart-dns-settings.rst
+++ b/docs/release-notes/kickstart-dns-settings.rst
@@ -1,0 +1,16 @@
+:Type: Kickstart
+:Summary: New kickstart options to control DNS handling
+
+:Description:
+    There are several new options for the ``network`` kickstart command to control handling of DNS:
+
+    - The ``--ipv4-dns-search`` and ``--ipv6-dns-search`` allow manual setting of DNS search domains. These options mirror their respective NetworkManager properties, for example:
+      ``network --device ens3 --ipv4-dns-search example.com,custom-intranet-domain.biz (...)``
+    - ``--ipv4-ignore-auto-dns`` and ``--ipv6-ignore-auto-dns`` allow ignoring DNS settings from DHCP. These options do not take any arguments.
+
+    All of these ``network`` command options must be used together with the ``--device`` option.
+
+:Links:
+    - https://github.com/pykickstart/pykickstart/pull/431
+    - https://github.com/rhinstaller/anaconda/pull/4519
+    - https://bugzilla.redhat.com/show_bug.cgi?id=1656662

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -52,7 +52,7 @@ from pykickstart.commands.url import F30_Url as Url
 from pykickstart.commands.updates import F34_Updates as Updates
 from pykickstart.commands.mediacheck import FC4_MediaCheck as MediaCheck
 from pykickstart.commands.driverdisk import F14_DriverDisk as DriverDisk
-from pykickstart.commands.network import F27_Network as Network
+from pykickstart.commands.network import F38_Network as Network
 from pykickstart.commands.displaymode import F26_DisplayMode as DisplayMode
 from pykickstart.commands.bootloader import F34_Bootloader as Bootloader
 

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -18,7 +18,7 @@
 # Red Hat, Inc.
 #
 
-# Diable unused imports for the whole module.
+# Disable unused imports for the whole module.
 # pylint:disable=unused-import
 
 # Supported kickstart commands.
@@ -50,7 +50,7 @@ from pykickstart.commands.logvol import F29_LogVol as LogVol
 from pykickstart.commands.mediacheck import FC4_MediaCheck as MediaCheck
 from pykickstart.commands.method import F34_Method as Method
 from pykickstart.commands.mount import F27_Mount as Mount
-from pykickstart.commands.network import F27_Network as Network
+from pykickstart.commands.network import F38_Network as Network
 from pykickstart.commands.nfs import FC6_NFS as NFS
 from pykickstart.commands.nvdimm import F28_Nvdimm as Nvdimm
 from pykickstart.commands.ostreesetup import F21_OSTreeSetup as OSTreeSetup
@@ -91,7 +91,7 @@ from pykickstart.commands.group import F12_GroupData as GroupData
 from pykickstart.commands.iscsi import F17_IscsiData as IscsiData
 from pykickstart.commands.logvol import F29_LogVolData as LogVolData
 from pykickstart.commands.mount import F27_MountData as MountData
-from pykickstart.commands.network import F27_NetworkData as NetworkData
+from pykickstart.commands.network import F38_NetworkData as NetworkData
 from pykickstart.commands.nvdimm import F28_NvdimmData as NvdimmData
 from pykickstart.commands.partition import F29_PartData as PartData
 from pykickstart.commands.raid import F29_RaidData as RaidData

--- a/pyanaconda/modules/network/nm_client.py
+++ b/pyanaconda/modules/network/nm_client.py
@@ -1,7 +1,7 @@
 #
 # utility functions using libnm
 #
-# Copyright (C) 2018 Red Hat, Inc.
+# Copyright (C) 2018-2023 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -835,6 +835,20 @@ def update_connection_ip_settings_from_ksdata(connection, network_data):
             else:
                 log.error("IP address %s is not valid", ns)
 
+    # DNS search domains
+    if network_data.ipv4_dns_search:
+        for domain in [str.strip(i) for i in network_data.ipv4_dns_search.split(",")]:
+            s_ip4.add_dns_search(domain)
+    if network_data.ipv6_dns_search:
+        for domain in [str.strip(i) for i in network_data.ipv6_dns_search.split(",")]:
+            s_ip6.add_dns_search(domain)
+
+    # ignore auto DNS
+    if network_data.ipv4_ignore_auto_dns:
+        s_ip4.ignore_auto_dns = network_data.ipv4_ignore_auto_dns
+    if network_data.ipv6_ignore_auto_dns:
+        s_ip6.ignore_auto_dns = network_data.ipv6_ignore_auto_dns
+
 
 def update_connection_wired_settings_from_ksdata(connection, network_data):
     """Update NM connection wired settings from kickstart in place.
@@ -1585,6 +1599,12 @@ def _update_ip4_config_kickstart_network_data(connection, network_data):
     if ip4_dhcp_hostname:
         network_data.hostname = ip4_dhcp_hostname
 
+    # dns
+    network_data.ipv4_ignore_auto_dns = s_ip4_config.get_ignore_auto_dns()
+    ip4_dns_search = s_ip4_config.get_dns_search()
+    if ip4_dns_search:
+        network_data.ipv4_dns_search = ip4_dns_search
+
 
 def _update_ip6_config_kickstart_network_data(connection, network_data):
     """Update IPv6 configuration of network data from connection.
@@ -1611,6 +1631,12 @@ def _update_ip6_config_kickstart_network_data(connection, network_data):
         gateway = s_ip6_config.get_gateway()
         if gateway:
             network_data.ipv6gateway = gateway
+
+    # dns
+    network_data.ipv6_ignore_auto_dns = s_ip6_config.get_ignore_auto_dns()
+    ip6_dns_search = s_ip6_config.get_dns_search()
+    if ip6_dns_search:
+        network_data.ipv6_dns_search = ip6_dns_search
 
 
 def _update_vlan_kickstart_network_data(nm_client, connection, network_data):


### PR DESCRIPTION
This is the anaconda part.

Blocked by waiting on https://github.com/pykickstart/pykickstart/pull/431, ~~which in turn is blocked by [rhbz#1656662](https://bugzilla.redhat.com/show_bug.cgi?id=1656662#c9)~~.

TODOs:
- [x] pykickstart PR opened: https://github.com/pykickstart/pykickstart/pull/431
- [x] pykickstart PR merged (tests will work)
- [x] pykickstart released (can merge)
- [x] release notes
- [x] testing
- [x] add tests