### PR TITLE
Show an error message when subscription token transfer fails

### DIFF
--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -116,6 +116,7 @@ class ErrorHandler(object):
             InsightsClientMissingError.__name__: self._insightsErrorHandler,
             InsightsConnectError.__name__: self._insightsErrorHandler,
             "KickstartRegistrationError": self._kickstartRegistrationErrorHandler,
+            "SubscriptionTokenTransferError": self._subscriptionTokenTransferErrorHandler,
 
             # Satellite
             SatelliteProvisioningError.__name__: self._target_satellite_provisioning_error_handler,
@@ -254,6 +255,21 @@ class ErrorHandler(object):
                     "Would you like to ignore this and continue with "
                     "installation?")
         message += "\n\n" + _("Error detail: ") + str(exn)
+
+        if self.ui.showYesNoQuestion(message):
+            return ERROR_CONTINUE
+        else:
+            return ERROR_RAISE
+
+    def _subscriptionTokenTransferErrorHandler(self, exn):
+        message = _("Failed to enable Red Hat subscription on the "
+                    "installed system."
+                    "\n\n"
+                    "Your Red Hat subscription might be invalid "
+                    "(such as due to an expired developer subscription)."
+                    "\n\n"
+                    "Would you like to ignore this and continue with "
+                    "installation?")
 
         if self.ui.showYesNoQuestion(message):
             return ERROR_CONTINUE


### PR DESCRIPTION
Instead of a hard failure and confusing traceback show an error message when subscription token transfer fails.

The main expected trigger for this happening is users with an expired free Red Hat developer account, so we mention that in the error message.

Also if we actually get to the token transfer attempt, there must be a working installation source and the system will be most likely functional. It will just not have a subscription - so make the error non-fatal and make it possible to continue with the installation.

Resolves: rhbz#2057472