### PR TITLE
WebUI: Updated wizard footer buttons

### DIFF
--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -186,6 +186,12 @@ const Footer = ({ isFormValid, setIsFormValid, setStepNotification, isInProgress
                             />}
                             <ActionList>
                                 <Button
+                                  variant="secondary"
+                                  isDisabled={isBackDisabled}
+                                  onClick={onBack}>
+                                    {_("Back")}
+                                </Button>
+                                <Button
                                   id="installation-next-btn"
                                   aria-describedby="next-tooltip-ref"
                                   variant={nextButtonVariant}
@@ -212,13 +218,8 @@ const Footer = ({ isFormValid, setIsFormValid, setStepNotification, isInProgress
                                       isVisible={!isFormValid}
                                     />}
                                 <Button
-                                  variant="secondary"
-                                  isDisabled={isBackDisabled}
-                                  onClick={onBack}>
-                                    {_("Back")}
-                                </Button>
-                                <Button
                                   id="installation-quit-btn"
+                                  style={ { marginLeft: "var(--pf-global--spacer--2xl)"  } }
                                   variant="link"
                                   onClick={() => {
                                       setQuitWaitsConfirmation(true);


### PR DESCRIPTION
Switch positions of next and back buttons.
Change label of the quit button to "Cancel" and added a left margin.