### PR TITLE
Fix the systemd generator for systemd 253 (#2165433)

### DIFF
--- a/data/systemd/anaconda-generator
+++ b/data/systemd/anaconda-generator
@@ -11,8 +11,8 @@ fi
 
 # set up dirs
 systemd_dir=/lib/systemd/system
-target_dir=$systemd_dir/anaconda.target.wants
-mkdir -p $target_dir
+target_dir="$1/anaconda.target.wants"
+mkdir -p "$target_dir"
 
 # create symlink anaconda.target.wants/SERVICE@TTY.service
 service_on_tty() {
@@ -41,6 +41,6 @@ for tty in hvc0 hvc1 xvc0 hvsi0 hvsi1 hvsi2; do
     fi
 done
 
-ln -sf $systemd_dir/anaconda-nm-config.service $target_dir/anaconda-nm-config.service
-ln -sf $systemd_dir/anaconda-nm-disable-autocons.service $target_dir/anaconda-nm-disable-autocons.service
-ln -sf $systemd_dir/anaconda-pre.service $target_dir/anaconda-pre.service
+ln -sf "$systemd_dir/anaconda-nm-config.service" "$target_dir/anaconda-nm-config.service"
+ln -sf "$systemd_dir/anaconda-nm-disable-autocons.service" "$target_dir/anaconda-nm-disable-autocons.service"
+ln -sf "$systemd_dir/anaconda-pre.service" "$target_dir/anaconda-pre.service"


### PR DESCRIPTION
As Zbyszek explained in
https://bugzilla.redhat.com/show_bug.cgi?id=2165433#c5 , generators aren't supposed to write outside the special locations passed to them as args. Just writing the files into the first of the provided locations seems to work fine (tested that this fixes both text install and rescue mode).