### PR TITLE
Webui autopart wizard substeps

### DIFF
--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -51,8 +51,8 @@ export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, titl
         },
         {
             component: InstallationDestination,
-            id: "installation-destination",
-            label: _("Installation destination"),
+            id: "installation-desitnation",
+            label: _("Installation destination")
         },
         {
             component: ReviewConfiguration,
@@ -67,25 +67,40 @@ export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, titl
 
     const { path } = usePageLocation();
     const currentStepId = path[0] || "installation-language";
-    const steps = stepsOrder.map((s, idx) => {
-        return ({
-            id: s.id,
-            name: s.label,
-            component: (
-                <s.component
-                  idPrefix={s.id}
-                  setIsFormValid={setIsFormValid}
-                  onAddErrorNotification={onAddErrorNotification}
-                  toggleContextHelp={toggleContextHelp}
-                  stepNotification={stepNotification}
-                  isInProgress={isInProgress}
-                />
-            ),
-            stepNavItemProps: { id: s.id },
-            canJumpTo: idx <= stepsOrder.findIndex(s => s.id === currentStepId),
-            isFinishedStep: idx === stepsOrder.length - 1
+
+    const createSteps = (stepsOrder, subSteps = false) => {
+        const steps = stepsOrder.map((s, idx) => {
+            console.log(`creating step ${s.id}`);
+            let step = ({
+                id: s.id,
+                name: s.label,
+            });
+            if (s.component) {
+                step = ({
+                    ...step,
+                    component: (
+                        <s.component
+                          idPrefix={s.id}
+                          setIsFormValid={setIsFormValid}
+                          onAddErrorNotification={onAddErrorNotification}
+                          toggleContextHelp={toggleContextHelp}
+                          stepNotification={stepNotification}
+                          isInProgress={isInProgress}
+                        />
+                    ),
+                    stepNavItemProps: { id: s.id },
+                    canJumpTo: idx <= stepsOrder.findIndex(s => s.id === currentStepId),
+                    isFinishedStep: idx === stepsOrder.length - 1 && !subSteps
+                });
+            } else if (s.steps) {
+                step.steps = createSteps(s.steps, subSteps = true);
+            }
+            return step;
         });
-    });
+        console.log(steps);
+        return steps;
+    };
+    const steps = createSteps(stepsOrder);
 
     const startAtStep = steps.findIndex(step => step.id === path[0]) + 1;
     const goToStep = (newStep) => {
@@ -113,6 +128,7 @@ export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, titl
           onNext={goToStep}
           startAtStep={startAtStep}
           steps={steps}
+          isNavExpandable
         />
     );
 };


### PR DESCRIPTION
In Anaconda Wizard I am trying to split installation-destination step into sub-steps but I am failing with "Uncaught TypeError: activeStep is undefined".

It occurs when going to the expandable step (installation-destination / "Installation destination") as >= second step, for example from the first screen (installation-language / "Welcome"): [Next] [Back] [Next] or [Next] [Next] [Back] (as the first step, ie [Next] from the welcome screen the problem does not occur).

```
Uncaught TypeError: activeStep is undefined
    WizardToggle WizardToggle.js:12
    React 16
        renderWithHooks
        updateFunctionComponent
        beginWork
        callCallback
        invokeGuardedCallbackDev
        invokeGuardedCallback
        beginWork$1
        performUnitOfWork
        workLoopSync
        renderRootSync
        performSyncWorkOnRoot
        flushSyncCallbacks
        ensureRootIsScheduled
        ensureRootIsScheduled
        scheduleUpdateOnFiber
        dispatchSetState
    update hooks.js:67
    c cockpit.js:1
    value cockpit.js:1
    <anonymous> cockpit.js:1
    cockpit cockpit.js:1
    <anonymous> cockpit.js:1
    <anonymous> cockpit.js:1
```
Seems to be failing here in the WizardToggle:
https://github.com/patternfly/patternfly-react/blob/1fc22acee0db6b2da1efc42f7a4caccaa7dfeb40/packages/react-core/src/components/Wizard/WizardToggle.tsx#L60

I also tried to add some other substeps for debugging in (https://github.com/rvykydal/anaconda/tree/webui-autopart-wizard-substeps-try-other-steps) and the same issue appears (after [Next], [Next]).

So this is a draft calling (as a JS / React / PF newbie) for help.