### PR TITLE
efi: deal with verbose by default output from efibootmgr

### DIFF
--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -93,6 +93,8 @@ class EFIBase(object):
         for line in buf.splitlines():
             try:
                 (slot, _product) = line.split(None, 1)
+                # keep only the name, if verbose output is default in this version
+                _product = _product.split("\t")[0]
             except ValueError:
                 continue
 


### PR DESCRIPTION
efibootmgr version 18 uses verbose format by default. This includes boot entry details, not only their name. Strip it when looking for names to remove.