### PR TITLE
Web UI: Make Pre-release label look clickable

### DIFF
--- a/ui/webui/src/components/AnacondaHeader.jsx
+++ b/ui/webui/src/components/AnacondaHeader.jsx
@@ -52,7 +52,10 @@ export const AnacondaHeader = ({ beta, title }) => {
                   </TextContent>
               }
             >
-                <Label color="orange" icon={<InfoCircleIcon />} id="betanag-icon"> {prerelease} </Label>
+                {/* HACK Patternfly currently doesn't implement clickable labels so the styling had to be done manually. */}
+                <div style={{ cursor: "pointer", userSelect: "none" }}>
+                    <Label color="orange" icon={<InfoCircleIcon />} id="betanag-icon"> {prerelease} </Label>
+                </div>
             </Popover>
         )
         : null;


### PR DESCRIPTION
Hovering over the Pre-release label displays text selection cursor
instead of a pointer. Since PF doesn't currently implement button-like
labels, I manually assigned it the necessary CSS tags. Once PF adds them
we should switch to using them instead.