### PR TITLE
fix the failure to mount ISO with UDF filesystem

### DIFF
--- a/pyanaconda/modules/payloads/source/cdrom/initialization.py
+++ b/pyanaconda/modules/payloads/source/cdrom/initialization.py
@@ -19,7 +19,7 @@ from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.errors.payload import SourceSetupError
-from pyanaconda.modules.common.structures.storage import DeviceData
+from pyanaconda.modules.common.structures.storage import DeviceData, DeviceFormatData
 from pyanaconda.modules.payloads.source.mount_tasks import SetUpMountTask
 from pyanaconda.modules.payloads.source.utils import is_valid_install_disk
 from pyanaconda.payload.source.factory import SourceFactory, PayloadSourceTypeUnrecognized
@@ -97,7 +97,8 @@ class SetUpCdromSourceTask(SetUpMountTask):
         for dev_name in devices_candidates:
             try:
                 device_data = DeviceData.from_structure(device_tree.GetDeviceData(dev_name))
-                mount(device_data.path, self._target_mount, "iso9660", "ro")
+                format_data = DeviceFormatData.from_structure(device_tree.GetFormatData(dev_name))
+                mount(device_data.path, self._target_mount, format_data.type, "ro")
             except OSError as e:
                 log.debug("Failed to mount %s: %s", dev_name, str(e))
                 continue

--- a/pyanaconda/modules/payloads/source/cdrom/initialization.py
+++ b/pyanaconda/modules/payloads/source/cdrom/initialization.py
@@ -98,7 +98,10 @@ class SetUpCdromSourceTask(SetUpMountTask):
             try:
                 device_data = DeviceData.from_structure(device_tree.GetDeviceData(dev_name))
                 format_data = DeviceFormatData.from_structure(device_tree.GetFormatData(dev_name))
-                mount(device_data.path, self._target_mount, format_data.type, "ro")
+                if format_data is not None:
+                    mount(device_data.path, self._target_mount, format_data.type, "ro")
+                else:
+                    mount(device_data.path, self._target_mount, "iso9660", "ro")
             except OSError as e:
                 log.debug("Failed to mount %s: %s", dev_name, str(e))
                 continue


### PR DESCRIPTION
Blivet has added support for UDF file system, which makes it possible to install OS by using UDF ISO. However, anaconda forces the file system to be set to iso9660 when mounting /run/install/resources/mount-0000-cdrom, which will cause the mount to fail. Let's fix it.
