### PR TITLE
Disable hub and spoke user account for Fedora Design Suite

### DIFF
--- a/data/profile.d/Makefile.am
+++ b/data/profile.d/Makefile.am
@@ -20,6 +20,7 @@ dist_config_DATA    = \
 	almalinux.conf \
 	centos.conf \
 	circle.conf \
+	fedora-designsuite.conf \
 	fedora-eln.conf \
 	fedora-iot.conf \
 	fedora-kde.conf \

--- a/data/profile.d/fedora-designsuite.conf
+++ b/data/profile.d/fedora-designsuite.conf
@@ -1,0 +1,22 @@
+
+# Anaconda configuration file for Fedora Design Suite.
+
+[Profile]
+# Define the profile.
+profile_id = fedora-designsuite
+base_profile = fedora-workstation
+
+[Profile Detection]
+# Match os-release values.
+os_id = fedora
+variant_id = designsuite
+
+[Bootloader]
+menu_auto_hide = True
+
+[User Interface]
+custom_stylesheet = /usr/share/anaconda/pixmaps/workstation/fedora-workstation.css
+hidden_spokes =
+    NetworkSpoke
+    PasswordSpoke
+    UserSpoke

--- a/tests/unit_tests/pyanaconda_tests/core/test_profile.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_profile.py
@@ -293,6 +293,12 @@ class ProfileConfigurationTestCase(unittest.TestCase):
             WORKSTATIONPLUS_PARTITIONING
         )
         self._check_default_profile(
+            "fedora-designsuite",
+            ("fedora", "designsuite"),
+            ["fedora.conf", "fedora-workstation.conf", "fedora-designsuite.conf"],
+            WORKSTATION_PARTITIONING
+        )
+        self._check_default_profile(
             "fedora-iot",
             ("fedora", "iot"),
             ["fedora.conf", "fedora-iot.conf"],


### PR DESCRIPTION
This commit disables hub and spoke user account in favour of Fedora Workstation style approach. This pull requests also disable the pull apps that accidentally triggered the merge.
