### PR TITLE
infra: Change branched fedora branch name

### DIFF
--- a/.github/workflows/container-autoupdate-fedora.yml.j2
+++ b/.github/workflows/container-autoupdate-fedora.yml.j2
@@ -21,11 +21,11 @@ jobs:
       branch: master
 
   {% if branched_fedora_version is defined and branched_fedora_version %}
-  f{$ branched_fedora_version $}-release:
+  fedora-{$ branched_fedora_version $}:
     uses: ./.github/workflows/container-rebuild-action.yml
     secrets: inherit
     with:
-      container-tag: f{$ branched_fedora_version $}-release
-      branch: f{$ branched_fedora_version $}-release
+      container-tag: fedora-{$ branched_fedora_version $}
+      branch: fedora-{$ branched_fedora_version $}
   {% endif %}
 {% endif %}

--- a/.github/workflows/container-rebuild-action.yml
+++ b/.github/workflows/container-rebuild-action.yml
@@ -9,7 +9,7 @@ name: Rebuild container images
 # Rebuilds both ci and rpm container images for a given "target". Currently known targets:
 #  - master
 #  - eln
-#  - fNN-release
+#  - fedora-NN
 #
 # Image is:
 # - built from the repo at ref <branch>,

--- a/.github/workflows/container-rebuild-action.yml.j2
+++ b/.github/workflows/container-rebuild-action.yml.j2
@@ -3,7 +3,7 @@ name: Rebuild container images
 # Rebuilds both ci and rpm container images for a given "target". Currently known targets:
 #  - master
 #  - eln
-#  - fNN-release
+#  - fedora-NN
 #
 # Image is:
 # - built from the repo at ref <branch>,

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -66,7 +66,7 @@ jobs:
           if [ "$TARGET_BRANCH" == "master" ]; then
             echo "skip_tests=skip-on-fedora" >> $GITHUB_OUTPUT
             echo "platform=fedora_rawhide" >> $GITHUB_OUTPUT
-          elif echo "$TARGET_BRANCH" | grep -qE "f[[:digit:]]+-release$"; then
+          elif echo "$TARGET_BRANCH" | grep -qE "fedora-[[:digit:]]+$"; then
             echo "skip_tests=skip-on-fedora" >> $GITHUB_OUTPUT
             echo "platform=fedora_rawhide" >> $GITHUB_OUTPUT
           elif echo "$TARGET_BRANCH" | grep -qE "rhel-8(\.[[:digit:]]+)?$"; then

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -60,7 +60,7 @@ jobs:
           if [ "$TARGET_BRANCH" == "master" ]; then
             echo "skip_tests=skip-on-fedora" >> $GITHUB_OUTPUT
             echo "platform=fedora_rawhide" >> $GITHUB_OUTPUT
-          elif echo "$TARGET_BRANCH" | grep -qE "f[[:digit:]]+-release$"; then
+          elif echo "$TARGET_BRANCH" | grep -qE "fedora-[[:digit:]]+$"; then
             echo "skip_tests=skip-on-fedora" >> $GITHUB_OUTPUT
             echo "platform=fedora_rawhide" >> $GITHUB_OUTPUT
           elif echo "$TARGET_BRANCH" | grep -qE "rhel-8(\.[[:digit:]]+)?$"; then

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches:
       - master
-      - f[0-9]+-release
+      - fedora-[0-9]+
 
 permissions:
   contents: read

--- a/.github/workflows/push-tests.yml.j2
+++ b/.github/workflows/push-tests.yml.j2
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - f[0-9]+-release
+      - fedora-[0-9]+
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -43,8 +43,8 @@ jobs:
         release: ['']
         include:
           - release: ''
-            target_branch: 'f{$ distro_release $}-release'
-            ci_tag: 'f{$ distro_release $}-release'
+            target_branch: 'fedora-{$ distro_release $}'
+            ci_tag: 'fedora-{$ distro_release $}'
         {% elif distro_name == "rhel" %}
         release: ['']
         include:
@@ -135,8 +135,8 @@ jobs:
         release: ['']
         include:
           - release: ''
-            target_branch: 'f{$ distro_release $}-release'
-            ci_tag: 'f{$ distro_release $}-release'
+            target_branch: 'fedora-{$ distro_release $}'
+            ci_tag: 'fedora-{$ distro_release $}'
         {% elif distro_name == "rhel" %}
         release: ['']
         include:

--- a/.github/workflows/try-release-daily.yml.j2
+++ b/.github/workflows/try-release-daily.yml.j2
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         {% if branched_fedora_version is defined and branched_fedora_version %}
-        branch: ['master', 'rhel-8', 'rhel-9', 'f{$ branched_fedora_version $}-release']
+        branch: ['master', 'rhel-8', 'rhel-9', 'fedora-{$ branched_fedora_version $}']
         {% else %}
         branch: ['master', 'rhel-8', 'rhel-9']
         {% endif %}

--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -76,7 +76,7 @@ jobs:
     trigger: commit
     targets:
       - fedora-latest
-    branch: f{$ distro_release $}-release
+    branch: fedora-{$ distro_release $}
     owner: "@rhinstaller"
     project: Anaconda-devel
     preserve_project: True

--- a/branch-config.mk
+++ b/branch-config.mk
@@ -27,7 +27,7 @@
 
 
 # Name of the expected current git branch.
-# This could be master, fXX-devel, fXX-release, rhelX-branch, rhel-X ...
+# This could be master, fedora-XX, rhel-X ...
 GIT_BRANCH ?= master
 
 # Directory for this anaconda branch in anaconda-l10n repository. This could be master, fXX, rhel-8 etc.

--- a/branch-config.mk.j2
+++ b/branch-config.mk.j2
@@ -21,7 +21,7 @@
 {% if distro_name == "fedora" and distro_release == "rawhide" %}
 
 # Name of the expected current git branch.
-# This could be master, fXX-devel, fXX-release, rhelX-branch, rhel-X ...
+# This could be master, fedora-XX, rhel-X ...
 GIT_BRANCH ?= master
 
 # Directory for this anaconda branch in anaconda-l10n repository. This could be master, fXX, rhel-8 etc.
@@ -36,7 +36,7 @@ COPR_REPO ?= \@rhinstaller/Anaconda
 
 {% elif distro_name == "fedora" %}
 
-GIT_BRANCH ?= f{$ distro_release $}-release
+GIT_BRANCH ?= fedora{-$ distro_release $}
 L10N_DIR ?= f{$ distro_release $}
 BASE_CONTAINER ?= registry.fedoraproject.org/fedora:{$ distro_release $}
 COPR_REPO ?= \@rhinstaller/Anaconda-devel


### PR DESCRIPTION
Let's change all infra to use the new fedora-NN branch name scheme.

See also: https://anaconda-installer.readthedocs.io/en/latest/release.html#branching-for-the-next-fedora-release