### PR TITLE
WebUI: Give "Quit" button correct margin

### DIFF
--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -219,7 +219,7 @@ const Footer = ({ isFormValid, setIsFormValid, setStepNotification, isInProgress
                                     />}
                                 <Button
                                   id="installation-quit-btn"
-                                  style={ { marginLeft: "var(--pf-global--spacer--2xl)"  } }
+                                  style={{ marginLeft: "var(--pf-c-wizard__footer-cancel--MarginLeft)" }}
                                   variant="link"
                                   onClick={() => {
                                       setQuitWaitsConfirmation(true);


### PR DESCRIPTION
From looking at the screen-shot I thought the distance was standard PF 2xl margin but as it turns out it is slightly shorter. 

Liz even commented on Jira that I should check the sources but I only noticed it now.

Sorry for not noticing this before. 

Left margin of the Quit button set in commit https://github.com/OndrejZobal/anaconda/commit/fe9efdebd931c661691388c66a6c49ccdf1702fb is inconsistent
with Cancle button in PF Wizard.
Change margin-left to "var(--pf-c-wizard__footer-cancel--MarginLeft)"