### PR TITLE
infra: Fix branch name handling in container builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -330,7 +330,7 @@ check-branching:
 		CURRENT_BRANCH=$$(git rev-parse --abbrev-ref HEAD); \
 		if [ "$$CURRENT_BRANCH" != "$(GIT_BRANCH)" ]; then \
 			echo "*** Configuration is not adjusted for current branch!"; \
-			echo "This check will work only on main development branch fXX-release, rhel-X ..."; \
+			echo "This check will work only on main development branch fedora-XX, rhel-X ..."; \
 			echo "current branch:  $$CURRENT_BRANCH"; \
 			echo "expected branch: $(GIT_BRANCH)"; \
 			exit 1; \

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -3,7 +3,7 @@
 
 # The `image` arg will set base image for the build.
 # possible values:
-#   registry.fedoraproject.org/fedora:35
+#   registry.fedoraproject.org/fedora:38
 #   registry.fedoraproject.org/fedora:rawhide
 #   registry-proxy.engineering.redhat.com/rh-osbs/ubi9:latest # private source
 #   registry.access.redhat.com/ubi8/ubi # public source
@@ -16,7 +16,7 @@ FROM ${image}
 # dependencies.
 # possible values:
 #   master
-#   f35-release
+#   fedora-38
 ARG git_branch
 
 # The `copr_repo` arg will set Anaconda daily builds copr repository.
@@ -40,8 +40,7 @@ RUN set -ex; \
     if [ $BRANCH == "master" ]; then \
       BRANCH="rawhide"; \
     fi; \
-    BRANCH=${BRANCH%%-*}; \
-    BRANCH=${BRANCH#f}; \
+    BRANCH=${BRANCH#fedora-}; \
     dnf copr enable -y ${copr_repo} fedora-${BRANCH}-x86_64; \
     dnf copr enable -y @storage/blivet-daily fedora-${BRANCH}-x86_64; \
   else \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -3,7 +3,7 @@
 
 # The `image` arg will set base image for the build.
 # possible values:
-#   registry.fedoraproject.org/fedora:35
+#   registry.fedoraproject.org/fedora:38
 #   registry.fedoraproject.org/fedora:rawhide
 #   registry-proxy.engineering.redhat.com/rh-osbs/ubi9:latest # private source
 #   registry.access.redhat.com/ubi8/ubi # public source
@@ -16,7 +16,7 @@ FROM ${image}
 # dependencies.
 # possible values:
 #   master
-#   f35-release
+#   fedora-38
 ARG git_branch
 ARG copr_repo=@rhinstaller/Anaconda
 LABEL maintainer=anaconda-devel@lists.fedoraproject.org
@@ -42,8 +42,7 @@ RUN set -ex; \
     if [ $BRANCH == "master" ]; then \
       BRANCH="rawhide"; \
     fi; \
-    BRANCH=${BRANCH%%-*}; \
-    BRANCH=${BRANCH#f}; \
+    BRANCH=${BRANCH#fedora-}; \
     dnf copr enable -y ${copr_repo} fedora-${BRANCH}-x86_64; \
     dnf copr enable -y @storage/blivet-daily fedora-${BRANCH}-x86_64; \
   else \


### PR DESCRIPTION
We now have `fedora-XX` instead of `fXX-<release|devel>`. Adjust accordingly.

@M4rtinK this would be great to get before branching too, or we'd have to port it.