### PR TITLE
Add SYS_CHROOT capability to anaconda-ci (#infra)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -276,21 +276,27 @@ ci:
 	fi
 
 # container-ci target will have disabled cockpit Makefiles by default
+# The SYS_CHROOT capability is required for user creation tests and was dropped on podman 4.4.X
+# https://bugzilla.redhat.com/show_bug.cgi?id=2170568
 container-ci:
 	$(CONTAINER_ENGINE) run \
 	--entrypoint /anaconda/dockerfile/anaconda-ci/run-build-and-arg \
 	-e CONFIGURE_ARGS="--disable-webui" \
 	$(CONTAINER_TEST_ARGS) \
 	$(CI_TEST_ARGS) \
+	--cap-add=SYS_CHROOT \
 	$(CONTAINER_ADD_ARGS) \
 	$(CI_NAME):$(CI_TAG) \
 	$(CI_CMD)
 
+# The SYS_CHROOT capability is required for user creation tests and was dropped on podman 4.4.X
+# https://bugzilla.redhat.com/show_bug.cgi?id=2170568
 container-shell:
 	$(CONTAINER_ENGINE) run -it \
 	$(CONTAINER_TEST_ARGS) \
 	$(CONTAINER_ADD_ARGS) \
 	$(CI_TEST_ARGS) \
+	--cap-add=SYS_CHROOT \
 	$(CI_NAME):$(CI_TAG)
 
 container-rpm-test:


### PR DESCRIPTION
We have user creation container tests which are using chroot to be able to use tooling to create users. However, from podman 4.4 they removed this capability from default capabilities set. Let's put it back for this specific container.

Podman 4.4.1 is on Fedora 38+.

See https://bugzilla.redhat.com/show_bug.cgi?id=2170568 for more info.