### PR TITLE
master - Move loop device pre-creation to container (#infra)

### DIFF
--- a/.github/workflows/build-boot-iso.yml
+++ b/.github/workflows/build-boot-iso.yml
@@ -113,15 +113,6 @@ jobs:
           mkdir -p ./anaconda_rpms/
           cp -av ./result/build/01-rpm-build/*.rpm ./anaconda_rpms/
 
-      - name: Prepare environment for lorax run
-        run: |
-          mkdir -p images
-          # We have to pre-create loop devices because they are not namespaced in kernel so
-          # podman can't access newly created ones. That caused failures of tests when runners
-          # were rebooted.
-          sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
-          sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
-
       - name: Build the boot.iso
         run: |
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364

--- a/.github/workflows/build-boot-iso.yml.j2
+++ b/.github/workflows/build-boot-iso.yml.j2
@@ -107,15 +107,6 @@ jobs:
           mkdir -p ./anaconda_rpms/
           cp -av ./result/build/01-rpm-build/*.rpm ./anaconda_rpms/
 
-      - name: Prepare environment for lorax run
-        run: |
-          mkdir -p images
-          # We have to pre-create loop devices because they are not namespaced in kernel so
-          # podman can't access newly created ones. That caused failures of tests when runners
-          # were rebooted.
-          sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
-          sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
-
       - name: Build the boot.iso
         run: |
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -208,15 +208,6 @@ jobs:
           mkdir -p ${{ github.workspace }}/kickstart-tests/data/additional_repo/
           cp -av ./result/build/01-rpm-build/*.rpm ${{ github.workspace }}/kickstart-tests/data/additional_repo/
 
-      - name: Prepare environment for lorax run
-        run: |
-          mkdir images
-          # We have to pre-create loop devices because they are not namespaced in kernel so
-          # podman can't access newly created ones. That caused failures of tests when runners
-          # were rebooted.
-          sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
-          sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
-
       - name: Build boot.iso
         run: |
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
@@ -229,9 +220,6 @@ jobs:
       - name: Clean up after lorax
         if: always()
         run: |
-          sudo losetup -d /dev/loop0 2> /dev/null || true
-          sudo losetup -d /dev/loop1 2> /dev/null || true
-
           # remove container images together with the container
           sudo podman rmi -f $ISO_BUILD_CONTAINER_NAME:$CONTAINER_TAG || true
           sudo podman rmi -f $RPM_BUILD_CONTAINER_NAME:$CONTAINER_TAG || true

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -202,15 +202,6 @@ jobs:
           mkdir -p ${{ github.workspace }}/kickstart-tests/data/additional_repo/
           cp -av ./result/build/01-rpm-build/*.rpm ${{ github.workspace }}/kickstart-tests/data/additional_repo/
 
-      - name: Prepare environment for lorax run
-        run: |
-          mkdir images
-          # We have to pre-create loop devices because they are not namespaced in kernel so
-          # podman can't access newly created ones. That caused failures of tests when runners
-          # were rebooted.
-          sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
-          sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
-
       - name: Build boot.iso
         run: |
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
@@ -223,9 +214,6 @@ jobs:
       - name: Clean up after lorax
         if: always()
         run: |
-          sudo losetup -d /dev/loop0 2> /dev/null || true
-          sudo losetup -d /dev/loop1 2> /dev/null || true
-
           # remove container images together with the container
           sudo podman rmi -f $ISO_BUILD_CONTAINER_NAME:$CONTAINER_TAG || true
           sudo podman rmi -f $RPM_BUILD_CONTAINER_NAME:$CONTAINER_TAG || true

--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -8,10 +8,6 @@
 # make -f ./Makefile.am container-rpms-scratch # Create Anaconda RPM in `pwd`/result/... directory.
 # sudo make -f ./Makefile.am anaconda-iso-creator-build
 #
-# # pre-create loop devices because the container namespacing of /dev devices
-# sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
-# sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
-#
 # # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
 # sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:master
 #

--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -15,6 +15,10 @@
 
 set -eux
 
+# pre-create loop devices manually. In the container you can't use losetup for that.
+sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
+sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
+
 INPUT_RPMS=/anaconda-rpms/
 REPO_DIR=/tmp/anaconda-rpms/
 


### PR DESCRIPTION
We have to pre-create loop devices because they are not available in the containers. If they are created by `losetup` than the newly created loop device is not visible inside the container. However, it still could be created manually in the container and taken correctly by the losetup tooling.

We need to merge this to all supported branches because the GitHub workflow file is always used from the `master` branch.
Needs to merged together with:
- https://github.com/rhinstaller/anaconda/pull/4579
- https://github.com/rhinstaller/anaconda/pull/4580
- https://github.com/rhinstaller/anaconda/pull/4581