### PR TITLE
infra: Use fully qualified names of exceptions in pylintrc

### DIFF
--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -512,5 +512,5 @@ known-third-party=enchant
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception


### PR DESCRIPTION
Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name instead.