### PR TITLE
Port DNS kickstart options to RHEL 9

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -35,7 +35,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.32.9-1
+%define pykickstartver 3.32.10-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.6.0-4
 %define rpmver 4.10.0

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -52,7 +52,7 @@ from pykickstart.commands.url import F30_Url as Url
 from pykickstart.commands.updates import F34_Updates as Updates
 from pykickstart.commands.mediacheck import FC4_MediaCheck as MediaCheck
 from pykickstart.commands.driverdisk import F14_DriverDisk as DriverDisk
-from pykickstart.commands.network import F27_Network as Network
+from pykickstart.commands.network import RHEL9_Network as Network
 from pykickstart.commands.displaymode import F26_DisplayMode as DisplayMode
 from pykickstart.commands.bootloader import RHEL9_Bootloader as Bootloader
 

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -18,7 +18,7 @@
 # Red Hat, Inc.
 #
 
-# Diable unused imports for the whole module.
+# Disable unused imports for the whole module.
 # pylint:disable=unused-import
 
 # Supported kickstart commands.
@@ -51,7 +51,7 @@ from pykickstart.commands.logvol import RHEL9_LogVol as LogVol
 from pykickstart.commands.mediacheck import FC4_MediaCheck as MediaCheck
 from pykickstart.commands.method import F34_Method as Method
 from pykickstart.commands.mount import F27_Mount as Mount
-from pykickstart.commands.network import F27_Network as Network
+from pykickstart.commands.network import RHEL9_Network as Network
 from pykickstart.commands.nfs import FC6_NFS as NFS
 from pykickstart.commands.nvdimm import F28_Nvdimm as Nvdimm
 from pykickstart.commands.ostreesetup import RHEL9_OSTreeSetup as OSTreeSetup
@@ -92,7 +92,7 @@ from pykickstart.commands.group import F12_GroupData as GroupData
 from pykickstart.commands.iscsi import F17_IscsiData as IscsiData
 from pykickstart.commands.logvol import F29_LogVolData as LogVolData
 from pykickstart.commands.mount import F27_MountData as MountData
-from pykickstart.commands.network import F27_NetworkData as NetworkData
+from pykickstart.commands.network import RHEL9_NetworkData as NetworkData
 from pykickstart.commands.nvdimm import F28_NvdimmData as NvdimmData
 from pykickstart.commands.partition import F29_PartData as PartData
 from pykickstart.commands.raid import F29_RaidData as RaidData

--- a/pyanaconda/modules/network/nm_client.py
+++ b/pyanaconda/modules/network/nm_client.py
@@ -1,7 +1,7 @@
 #
 # utility functions using libnm
 #
-# Copyright (C) 2018 Red Hat, Inc.
+# Copyright (C) 2018-2023 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -839,6 +839,20 @@ def update_connection_ip_settings_from_ksdata(connection, network_data):
             else:
                 log.error("IP address %s is not valid", ns)
 
+    # DNS search domains
+    if network_data.ipv4_dns_search:
+        for domain in [str.strip(i) for i in network_data.ipv4_dns_search.split(",")]:
+            s_ip4.add_dns_search(domain)
+    if network_data.ipv6_dns_search:
+        for domain in [str.strip(i) for i in network_data.ipv6_dns_search.split(",")]:
+            s_ip6.add_dns_search(domain)
+
+    # ignore auto DNS
+    if network_data.ipv4_ignore_auto_dns:
+        s_ip4.props.ignore_auto_dns = network_data.ipv4_ignore_auto_dns
+    if network_data.ipv6_ignore_auto_dns:
+        s_ip6.props.ignore_auto_dns = network_data.ipv6_ignore_auto_dns
+
 
 def update_connection_wired_settings_from_ksdata(connection, network_data):
     """Update NM connection wired settings from kickstart in place.
@@ -1593,6 +1607,14 @@ def _update_ip4_config_kickstart_network_data(connection, network_data):
     if ip4_dhcp_hostname:
         network_data.hostname = ip4_dhcp_hostname
 
+    # dns
+    network_data.ipv4_ignore_auto_dns = s_ip4_config.get_ignore_auto_dns()
+    ip4_num_domains = s_ip4_config.get_num_dns_searches()
+    ip4_domains = [s_ip4_config.get_dns_search(i) for i in range(ip4_num_domains)]
+    ip4_dns_search = ",".join(ip4_domains)
+    if ip4_dns_search:
+        network_data.ipv4_dns_search = ip4_dns_search
+
 
 def _update_ip6_config_kickstart_network_data(connection, network_data):
     """Update IPv6 configuration of network data from connection.
@@ -1619,6 +1641,14 @@ def _update_ip6_config_kickstart_network_data(connection, network_data):
         gateway = s_ip6_config.get_gateway()
         if gateway:
             network_data.ipv6gateway = gateway
+
+    # dns
+    network_data.ipv6_ignore_auto_dns = s_ip6_config.get_ignore_auto_dns()
+    ip6_num_domains = s_ip6_config.get_num_dns_searches()
+    ip6_domains = [s_ip6_config.get_dns_search(i) for i in range(ip6_num_domains)]
+    ip6_dns_search = ",".join(ip6_domains)
+    if ip6_dns_search:
+        network_data.ipv6_dns_search = ip6_dns_search
 
 
 def _update_vlan_kickstart_network_data(nm_client, connection, network_data):

--- a/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_nm_client.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_nm_client.py
@@ -21,14 +21,14 @@ import unittest
 import pytest
 import time
 import threading
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, call
 from textwrap import dedent
 
 from pyanaconda.modules.network.nm_client import get_slaves_from_connections, \
     get_dracut_arguments_from_connection, get_config_file_connection_of_device, \
     get_kickstart_network_data, NM_BRIDGE_DUMPED_SETTINGS_DEFAULTS, \
-    update_connection_wired_settings_from_ksdata, get_new_nm_client, GError
-
+    update_connection_wired_settings_from_ksdata, get_new_nm_client, GError, \
+    update_connection_ip_settings_from_ksdata
 from pyanaconda.core.kickstart.commands import NetworkData
 from pyanaconda.core.glib import MainContext, sync_call_glib
 from pyanaconda.modules.network.constants import NM_CONNECTION_TYPE_WIFI, \
@@ -741,9 +741,15 @@ class NMClientTestCase(unittest.TestCase):
             "get_setting_ip4_config.return_value.get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
             "get_setting_ip4_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip4_config.return_value.get_dhcp_hostname.return_value": None,
+            "get_setting_ip4_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip4_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip4_config.return_value.get_dns_search.return_value": "",
             "get_setting_ip6_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip6_config.return_value.get_method.return_value": NM.SETTING_IP6_CONFIG_METHOD_AUTO,
-          }],
+            "get_setting_ip6_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip6_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip6_config.return_value.get_dns_search.return_value": "",
+         }],
           "network  --bootproto=dhcp --device=ens3 --mtu=1500 --ipv6=auto"),
          # dhcp-hostname setting the hostname is debatable and should be reviewed
          ([{
@@ -755,9 +761,15 @@ class NMClientTestCase(unittest.TestCase):
             "get_setting_ip4_config.return_value.get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
             "get_setting_ip4_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip4_config.return_value.get_dhcp_hostname.return_value": "dhcp.hostname",
+            "get_setting_ip4_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip4_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip4_config.return_value.get_dns_search.return_value": "",
             "get_setting_ip6_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip6_config.return_value.get_method.return_value": NM.SETTING_IP6_CONFIG_METHOD_DHCP,
-          }],
+            "get_setting_ip6_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip6_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip6_config.return_value.get_dns_search.return_value": "",
+         }],
           "network  --bootproto=dhcp --device=ens3 --hostname=dhcp.hostname --ipv6=dhcp"),
          ([{
             "get_connection_type.return_value": NM_CONNECTION_TYPE_ETHERNET,
@@ -772,9 +784,15 @@ class NMClientTestCase(unittest.TestCase):
             "get_setting_ip4_config.return_value.get_gateway.return_value": "192.168.141.1",
             "get_setting_ip4_config.return_value.get_address.side_effect": lambda i: ip4_addr_1,
             "get_setting_ip4_config.return_value.get_dhcp_hostname.return_value": None,
+            "get_setting_ip4_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip4_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip4_config.return_value.get_dns_search.return_value": "",
             "get_setting_ip6_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip6_config.return_value.get_method.return_value": NM.SETTING_IP6_CONFIG_METHOD_DISABLED,
-          }],
+            "get_setting_ip6_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip6_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip6_config.return_value.get_dns_search.return_value": "",
+         }],
           "network  --bootproto=static --device=ens7 --gateway=192.168.141.1 --ip=192.168.141.131 --nameserver=192.168.154.3,10.216.106.3 --netmask=255.255.255.0 --onboot=off --noipv6"),
          ([{
             "get_connection_type.return_value": NM_CONNECTION_TYPE_ETHERNET,
@@ -786,13 +804,19 @@ class NMClientTestCase(unittest.TestCase):
             "get_setting_ip4_config.return_value.get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
             "get_setting_ip4_config.return_value.get_num_dns.return_value": 2,
             "get_setting_ip4_config.return_value.get_dns.side_effect": lambda i: ip4_dns_list[i],
+            "get_setting_ip4_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip4_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip4_config.return_value.get_dns_search.return_value": "",
             "get_setting_ip6_config.return_value.get_num_addresses.return_value": 1,
             "get_setting_ip6_config.return_value.get_address.side_effect": lambda i: ip6_addr_1,
             "get_setting_ip6_config.return_value.get_num_dns.return_value": 2,
             "get_setting_ip6_config.return_value.get_gateway.return_value": "2400:c980:0000:0002::1",
             "get_setting_ip6_config.return_value.get_dns.side_effect": lambda i: ip6_dns_list[i],
             "get_setting_ip6_config.return_value.get_method.return_value": NM.SETTING_IP6_CONFIG_METHOD_MANUAL,
-          }],
+            "get_setting_ip6_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip6_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip6_config.return_value.get_dns_search.return_value": "",
+         }],
           "network  --bootproto=dhcp --device=ens7 --nameserver=192.168.154.3,10.216.106.3,2001:cafe::1,2001:cafe::2 --ipv6=2400:c980:0000:0002::3/64 --ipv6gateway=2400:c980:0000:0002::1"),
          ([{
             "get_connection_type.return_value": NM_CONNECTION_TYPE_BOND,
@@ -803,8 +827,14 @@ class NMClientTestCase(unittest.TestCase):
             "get_setting_ip4_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip4_config.return_value.get_dhcp_hostname.return_value": None,
             "get_setting_ip4_config.return_value.get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
+            "get_setting_ip4_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip4_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip4_config.return_value.get_dns_search.return_value": "",
             "get_setting_ip6_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip6_config.return_value.get_method.return_value": NM.SETTING_IP6_CONFIG_METHOD_AUTO,
+            "get_setting_ip6_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip6_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip6_config.return_value.get_dns_search.return_value": "",
             "get_setting_bond.return_value.get_num_options.return_value": 2,
             "get_setting_bond.return_value.get_option.side_effect": lambda i: bond_options_1[i],
           }],
@@ -818,8 +848,14 @@ class NMClientTestCase(unittest.TestCase):
             "get_setting_ip4_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip4_config.return_value.get_dhcp_hostname.return_value": None,
             "get_setting_ip4_config.return_value.get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
+            "get_setting_ip4_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip4_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip4_config.return_value.get_dns_search.return_value": "",
             "get_setting_ip6_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip6_config.return_value.get_method.return_value": NM.SETTING_IP6_CONFIG_METHOD_AUTO,
+            "get_setting_ip6_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip6_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip6_config.return_value.get_dns_search.return_value": "",
             "get_setting_bridge.return_value.get_property.side_effect": lambda i: bridge_properties_1[i],
           }],
           "network  --bootproto=dhcp --device=bridge0 --onboot=off --ipv6=auto --bridgeslaves=ens8 --bridgeopts=priority=32769,forward-delay=16,max-age=21"),
@@ -832,8 +868,14 @@ class NMClientTestCase(unittest.TestCase):
             "get_setting_ip4_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip4_config.return_value.get_dhcp_hostname.return_value": None,
             "get_setting_ip4_config.return_value.get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
+            "get_setting_ip4_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip4_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip4_config.return_value.get_dns_search.return_value": "",
             "get_setting_ip6_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip6_config.return_value.get_method.return_value": NM.SETTING_IP6_CONFIG_METHOD_AUTO,
+            "get_setting_ip6_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip6_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip6_config.return_value.get_dns_search.return_value": "",
             "get_setting_team.return_value.get_config.return_value": '{\n    "runner": {\n        "name": "activebackup",\n        "hwaddr_policy": "same_all"\n    },\n    "link_watch": {\n        "name": "ethtool"\n    }\n}',
           }],
           "network  --bootproto=dhcp --device=team0 --ipv6=auto --teamslaves=\"ens7'{\\\"prio\\\":100,\\\"sticky\\\":true}',ens8'{\\\"prio\\\":200}'\" --teamconfig=\"{\\\"runner\\\":{\\\"name\\\":\\\"activebackup\\\",\\\"hwaddr_policy\\\":\\\"same_all\\\"},\\\"link_watch\\\":{\\\"name\\\":\\\"ethtool\\\"}}\""),
@@ -848,8 +890,14 @@ class NMClientTestCase(unittest.TestCase):
             "get_setting_ip4_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip4_config.return_value.get_dhcp_hostname.return_value": None,
             "get_setting_ip4_config.return_value.get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
+            "get_setting_ip4_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip4_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip4_config.return_value.get_dns_search.return_value": "",
             "get_setting_ip6_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip6_config.return_value.get_method.return_value": NM.SETTING_IP6_CONFIG_METHOD_AUTO,
+            "get_setting_ip6_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip6_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip6_config.return_value.get_dns_search.return_value": "",
             "get_setting_vlan.return_value.get_id.return_value": 233,
             "get_setting_vlan.return_value.get_parent.return_value": "ens7",
           }],
@@ -865,8 +913,14 @@ class NMClientTestCase(unittest.TestCase):
             "get_setting_ip4_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip4_config.return_value.get_dhcp_hostname.return_value": None,
             "get_setting_ip4_config.return_value.get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
+            "get_setting_ip4_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip4_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip4_config.return_value.get_dns_search.return_value": "",
             "get_setting_ip6_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip6_config.return_value.get_method.return_value": NM.SETTING_IP6_CONFIG_METHOD_AUTO,
+            "get_setting_ip6_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip6_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip6_config.return_value.get_dns_search.return_value": "",
             "get_setting_vlan.return_value.get_id.return_value": 233,
             "get_setting_vlan.return_value.get_parent.return_value": ENS7_UUID,
           }],
@@ -882,8 +936,14 @@ class NMClientTestCase(unittest.TestCase):
             "get_setting_ip4_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip4_config.return_value.get_dhcp_hostname.return_value": None,
             "get_setting_ip4_config.return_value.get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
+            "get_setting_ip4_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip4_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip4_config.return_value.get_dns_search.return_value": "",
             "get_setting_ip6_config.return_value.get_num_dns.return_value": 0,
             "get_setting_ip6_config.return_value.get_method.return_value": NM.SETTING_IP6_CONFIG_METHOD_AUTO,
+            "get_setting_ip6_config.return_value.get_ignore_auto_dns.return_value": False,
+            "get_setting_ip6_config.return_value.get_num_dns_searches.return_value": 0,
+            "get_setting_ip6_config.return_value.get_dns_search.return_value": "",
             "get_setting_vlan.return_value.get_id.return_value": 233,
             "get_setting_vlan.return_value.get_parent.return_value": ENS7_UUID,
           }],
@@ -903,6 +963,25 @@ class NMClientTestCase(unittest.TestCase):
             "get_setting_bond.return_value.get_option.side_effect": lambda i: bond_options_1[i],
           }],
           "network  --bootproto=dhcp --device=bond0 --bondslaves=ens7,ens8 --bondopts=mode=active-backup,primary=ens8"),
+         ([{
+            "get_connection_type.return_value": NM_CONNECTION_TYPE_ETHERNET,
+            "get_setting_connection.return_value.get_autoconnect.return_value": True,
+            "get_setting_connection.return_value.get_master.return_value": None,
+            "get_uuid.return_value": ENS3_UUID,
+            "get_setting_wired.return_value.get_mtu.return_value": None,
+            "get_setting_ip4_config.return_value.get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
+            "get_setting_ip4_config.return_value.get_num_dns.return_value": 0,
+            "get_setting_ip4_config.return_value.get_dhcp_hostname.return_value": None,
+            "get_setting_ip4_config.return_value.get_ignore_auto_dns.return_value": True,
+            "get_setting_ip4_config.return_value.get_num_dns_searches.return_value": 1,
+            "get_setting_ip4_config.return_value.get_dns_search.return_value": "fedoraproject.org",
+            "get_setting_ip6_config.return_value.get_num_dns.return_value": 0,
+            "get_setting_ip6_config.return_value.get_method.return_value": NM.SETTING_IP6_CONFIG_METHOD_AUTO,
+            "get_setting_ip6_config.return_value.get_ignore_auto_dns.return_value": True,
+            "get_setting_ip6_config.return_value.get_num_dns_searches.return_value": 2,
+            "get_setting_ip6_config.return_value.get_dns_search.side_effect": ["example.com", "example2.com"],
+          }],
+          "network  --bootproto=dhcp --device=ens3 --ipv6=auto --ipv4-dns-search=fedoraproject.org --ipv6-dns-search=example.com,example2.com --ipv4-ignore-auto-dns --ipv6-ignore-auto-dns"),
         ]
 
         for cons_specs, expected_ks in cons_to_test:
@@ -1063,3 +1142,62 @@ class NMClientTestCase(unittest.TestCase):
         thread = threading.Thread(target = self.test_sync_call_glib)
         thread.start()
         thread.join()
+
+    @patch("pyanaconda.modules.network.nm_client.NM.SettingIP4Config.new")
+    @patch("pyanaconda.modules.network.nm_client.NM.SettingIP6Config.new")
+    def _dns_ksdata_to_ip_sets(self, ipv4_search, ipv6_search, ipv4_ignoreauto, ipv6_ignoreauto,
+                               new6, new4):
+        connection = Mock()
+        ksdata = NetworkData(
+            ipv4_dns_search=ipv4_search,
+            ipv6_dns_search=ipv6_search,
+            ipv4_ignore_auto_dns=ipv4_ignoreauto,
+            ipv6_ignore_auto_dns=ipv6_ignoreauto
+        )
+
+        update_connection_ip_settings_from_ksdata(connection, ksdata)
+        new4.assert_called_once_with()
+        new6.assert_called_once_with()
+        connection.remove_setting.assert_called()
+        connection.add_setting.assert_called()
+
+        s_ipv4 = connection.add_setting.mock_calls[0].args[0]
+        s_ipv6 = connection.add_setting.mock_calls[1].args[0]
+        assert new4.return_value == s_ipv4
+        assert new6.return_value == s_ipv6
+
+        # these are set only if True, so skip comparing False with the implicitly present Mock
+        if ipv4_ignoreauto is True:
+            assert s_ipv4.props.ignore_auto_dns == ipv4_ignoreauto
+        if ipv6_ignoreauto is True:
+            assert s_ipv6.props.ignore_auto_dns == ipv6_ignoreauto
+
+        return s_ipv4, s_ipv6
+
+    def test_dns_update_connection_ip_settings_from_ksdata(self):
+        """Test DNS handling in update_connection_ip_settings_from_ksdata()"""
+        # pylint: disable=no-value-for-parameter
+        # first search domains
+        sv4, sv6 = self._dns_ksdata_to_ip_sets("fedoraproject.org,getfedora.org", "redhat.com", False, False)
+        sv4.add_dns_search.assert_has_calls([
+            call("fedoraproject.org"),
+            call("getfedora.org")
+        ])
+        sv6.add_dns_search.assert_called_once_with("redhat.com")
+
+        # then check permutations of the ignore_auto_dns props + no search domains
+        sv4, sv6 = self._dns_ksdata_to_ip_sets(None, None, False, False)
+        sv4.add_dns_search.assert_not_called()
+        sv6.add_dns_search.assert_not_called()
+
+        sv4, sv6 = self._dns_ksdata_to_ip_sets(None, None, True, True)
+        sv4.add_dns_search.assert_not_called()
+        sv6.add_dns_search.assert_not_called()
+
+        sv4, sv6 = self._dns_ksdata_to_ip_sets(None, None, True, False)
+        sv4.add_dns_search.assert_not_called()
+        sv6.add_dns_search.assert_not_called()
+
+        sv4, sv6 = self._dns_ksdata_to_ip_sets(None, None, False, False)
+        sv4.add_dns_search.assert_not_called()
+        sv6.add_dns_search.assert_not_called()


### PR DESCRIPTION
Port of #4519.

Needs coordination with pykickstart https://github.com/pykickstart/pykickstart/pull/440 tracked in https://bugzilla.redhat.com/show_bug.cgi?id=2172531