### PR TITLE
webui: Use f38 on the f38 branch

### DIFF
--- a/ui/webui/Makefile.am
+++ b/ui/webui/Makefile.am
@@ -26,7 +26,7 @@ WEBPACK_TEST_PRODUCTION=dist/index.css.gz
 PACKAGE_NAME=anaconda-webui
 # stamp file to check if/when npm install ran
 NODE_MODULES_TEST=package-lock.json
-TEST_OS=fedora-rawhide-boot
+TEST_OS=fedora-38-boot
 GITHUB_BASE=rhinstaller/anaconda
 UPDATES_IMG=../../updates.img
 

--- a/ui/webui/test/build-rpms
+++ b/ui/webui/test/build-rpms
@@ -50,7 +50,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--quick', '-q', action='store_true')
     parser.add_argument('--verbose', '-v', action='store_true')
-    parser.add_argument('--image', default='fedora-37')
+    parser.add_argument('--image', default='fedora-38')
     parser.add_argument('srpm')
     args = parser.parse_args()
 


### PR DESCRIPTION
Let's switch our end to use f38, too.

Our side of https://github.com/cockpit-project/bots/pull/4436 and https://github.com/cockpit-project/bots/pull/4437.

BTW, this part of the branching docs will need updating after we're finished here, because this is still uncharted territory.