### PR TITLE
infra: Pylint should use the GTK 3 library to analyze our code

### DIFF
--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -512,5 +512,5 @@ known-third-party=enchant
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/tests/pylint/pylintrc
+++ b/tests/pylint/pylintrc
@@ -22,7 +22,12 @@ ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-init-hook='import gi.overrides, os; gi.overrides.__path__[0:0] = (os.environ["ANACONDA_WIDGETS_OVERRIDES"].split(":") if "ANACONDA_WIDGETS_OVERRIDES" in os.environ else [])'
+init-hook=
+    import gi.overrides, os
+    gi.overrides.__path__[0:0] = os.environ.get("ANACONDA_WIDGETS_OVERRIDES", "").split(":")
+
+    import gi
+    gi.require_version("Gtk", "3.0")
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use.

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -37,10 +37,6 @@ class AnacondaLintConfig(CensorshipConfig):
             FalsePositive(r"E1101.*: Instance of 'int' has no 'name_from_node' member"),
             FalsePositive(r"E1101.*: Instance of 'int' has no 'generate_backup_passphrase' member"),
             FalsePositive(r"E1101.*: Instance of 'int' has no 'dasd_is_ldl' member"),
-
-            # pylint/astroid has issues with GI modules https://github.com/PyCQA/pylint/issues/6352
-            FalsePositive(r"E1101.*: Module 'gi\.repository\..+' has no '.+' member"),
-            FalsePositive(r"E0611.*: No name '.+' in module 'gi\.repository\..+'"),
         ]
 
     def _files(self):


### PR DESCRIPTION
Ported from https://github.com/rhinstaller/anaconda/pull/4572 and https://github.com/rhinstaller/anaconda/pull/4568.