### PR TITLE
Add test step logging and screenshots to WebUI tests

### DIFF
--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -16,6 +16,7 @@
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 from collections import UserList
 from time import sleep
+from step_logger import log_step
 
 
 class InstallerSteps(UserList):
@@ -35,6 +36,7 @@ class Installer():
         self.machine = machine
         self.steps = InstallerSteps()
 
+    @log_step(snapshot_before=True)
     def begin_installation(self, should_fail=False, confirm_erase=True):
         current_step_id = self.get_current_page_id()
         self.browser.click("button:contains('Erase disks and install')")
@@ -49,6 +51,7 @@ class Installer():
         else:
             self.wait_current_page(self.steps[current_step_id+1])
 
+    @log_step()
     def next(self, should_fail=False):
         current_step_id = self.get_current_page_id()
         current_page = self.steps[current_step_id]
@@ -62,6 +65,7 @@ class Installer():
         self.browser.click("button:contains(Next)")
         self.wait_current_page(current_page if should_fail else next_page)
 
+    @log_step()
     def check_next_disabled(self):
         """Check if the Next button is disabled.
 
@@ -70,6 +74,7 @@ class Installer():
         """
         self.browser.wait_visible("#installation-next-btn:not([aria-disabled=false]")
 
+    @log_step(snapshot_before=True)
     def back(self, should_fail=False):
         current_step_id = self.get_current_page_id()
         self.browser.click("button:contains(Back)")
@@ -79,6 +84,7 @@ class Installer():
         else:
             self.wait_current_page(self.steps[current_step_id-1])
 
+    @log_step()
     def open(self, step="installation-language"):
         self.browser.open(f"/cockpit/@localhost/anaconda-webui/index.html#/{step}")
         self.wait_current_page(step)
@@ -87,6 +93,7 @@ class Installer():
         page = self.browser.eval_js('window.location.hash;').replace('#/', '') or self.steps[0]
         return self.steps.index(page)
 
+    @log_step(snapshot_after=True)
     def wait_current_page(self, page):
         self.browser.wait_not_present("#installation-destination-next-spinner")
         self.browser.wait_js_cond(f'window.location.hash === "#/{page}"')
@@ -96,6 +103,7 @@ class Installer():
         else:
             self.browser.wait_visible(f"#{page}.pf-m-current")
 
+    @log_step(snapshot_after=True)
     def check_prerelease_info(self, is_expected=None):
         """ Checks whether the pre-release information is visible or not.
 
@@ -115,6 +123,7 @@ class Installer():
         else:
             self.browser.wait_not_present("#betang-icon")
 
+    @log_step()
     def quit(self):
         self.browser.click("#installation-quit-btn")
         self.browser.wait_visible("#installation-quit-confirm-dialog")

--- a/ui/webui/test/helpers/integration.py
+++ b/ui/webui/test/helpers/integration.py
@@ -32,6 +32,7 @@ from review import Review
 from progress import Progress
 from testlib import MachineCase  # pylint: disable=import-error
 from machine_install import VirtInstallMachine
+from step_logger import log_step
 
 
 class IntegrationTest(MachineCase):
@@ -90,7 +91,9 @@ class IntegrationTest(MachineCase):
         self._progress.reboot()
         self.machine.wait_reboot()
 
+    @log_step(docstring=True)
     def check_installed_system(self):
+        """ Tries to set root password """
         self.machine.execute('echo "test" | passwd --stdin root') # Workaround for locked root account
 
     def run_integration_test(self):

--- a/ui/webui/test/helpers/language.py
+++ b/ui/webui/test/helpers/language.py
@@ -22,6 +22,8 @@ HELPERS_DIR = os.path.dirname(__file__)
 sys.path.append(HELPERS_DIR)
 
 from installer import InstallerSteps  # pylint: disable=import-error
+from step_logger import log_step
+
 
 LOCALIZATION_INTERFACE = "org.fedoraproject.Anaconda.Modules.Localization"
 LOCALIZATION_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Localization"
@@ -33,29 +35,35 @@ class Language():
         self._step = InstallerSteps.WELCOME
         self._bus_address = self.machine.execute("cat /run/anaconda/bus.address")
 
+    @log_step()
     def select_locale(self, locale):
         if self.browser.val(f"#{self._step}-language-search .pf-c-text-input-group__text-input") != "":
             self.input_locale_search("")
         self.browser.click(f"#{self._step}-option-common-{locale} > button")
 
+    @log_step()
     def get_locale_search(self):
         return self.browser.val(f"#{self._step}-language-search .pf-c-text-input-group__text-input")
 
+    @log_step()
     def input_locale_search(self, text):
         self.browser.set_input_text(f"#{self._step}-language-search .pf-c-text-input-group__text-input", text)
 
+    @log_step()
     def locale_option_visible(self, locale, visible=True):
         if visible:
             self.browser.wait_visible(f"#{self._step}-option-alpha-{locale}")
         else:
             self.browser.wait_not_present(f"#{self._step}-option-alpha-{locale}")
 
+    @log_step()
     def locale_common_option_visible(self, locale, visible=True):
         if visible:
             self.browser.wait_visible(f"#{self._step}-option-common-{locale}")
         else:
             self.browser.wait_not_present(f"#{self._step}-option-common-{locale}")
 
+    @log_step(snapshot_before=True)
     def check_selected_locale(self, locale):
         self.browser.wait_visible(f"#{self._step}-option-alpha-{locale} .pf-m-selected")
 

--- a/ui/webui/test/helpers/progress.py
+++ b/ui/webui/test/helpers/progress.py
@@ -23,6 +23,8 @@ HELPERS_DIR = os.path.dirname(__file__)
 sys.path.append(HELPERS_DIR)
 
 from installer import InstallerSteps  # pylint: disable=import-error
+from step_logger import log_step
+
 
 class Progress():
     def __init__(self, browser):
@@ -30,6 +32,7 @@ class Progress():
         self.steps = InstallerSteps()
         self._reboot_selector = "button:contains(Reboot)"
 
+    @log_step(snapshot_after=True)
     def wait_done(self, timeout=1200):
         timeout += time.time()
         while timeout > time.time():
@@ -41,6 +44,7 @@ class Progress():
         else:
             self.browser.wait_visible(self._reboot_selector)
 
+    @log_step()
     def reboot(self):
         self.browser.click(self._reboot_selector)
 

--- a/ui/webui/test/helpers/review.py
+++ b/ui/webui/test/helpers/review.py
@@ -22,6 +22,7 @@ HELPERS_DIR = os.path.dirname(__file__)
 sys.path.append(HELPERS_DIR)
 
 from installer import InstallerSteps  # pylint: disable=import-error
+from step_logger import log_step
 
 
 class Review():
@@ -29,11 +30,14 @@ class Review():
         self.browser = browser
         self._step = InstallerSteps.REVIEW
 
+    @log_step()
     def check_language(self, lang):
         self.browser.wait_in_text(f"#{self._step}-target-system-language > .pf-c-description-list__text", lang)
 
+    @log_step()
     def check_disk_label(self, disk, label):
         self.browser.wait_in_text(f"#{self._step}-disk-label-{disk}", label)
 
+    @log_step()
     def check_disk_description(self, disk, description):
         self.browser.wait_in_text(f"#{self._step}-disk-description-{disk}", description)

--- a/ui/webui/test/helpers/step_logger.py
+++ b/ui/webui/test/helpers/step_logger.py
@@ -1,0 +1,48 @@
+
+class BrowserSnapshot():
+    SNAPSHOT_NUMBER = 0
+
+    @classmethod
+    def new(cls, browser):
+        browser.snapshot(f'snapshot-{browser.label}', str(cls.SNAPSHOT_NUMBER))
+        cls.SNAPSHOT_NUMBER += 1
+
+
+def log_step(snapshots=False, snapshot_before=False, snapshot_after=False, docstring=False):
+    """ Decorator for logging steps durring testing.
+
+    Decorated function needs to be part of class with self.browser.
+
+    :param snapshots: Create snapshots before and after function call, defaults to False
+    :type snapshots: bool, optional
+    :param snapshot_before: Create snapshots before function call, defaults to False
+    :type snapshot_before: bool, optional
+    :param snapshot_after: Create snapshots after function call, defaults to False
+    :type snapshot_after: bool, optional
+    :param docstring: Print docstring of the function, defaults to False
+    :type docstring: bool, optional
+    """
+    def decorator(function):
+
+        def wrapper(*args, **kwargs):
+            nice_args = ', '.join(str(a) for a in args[1:])
+            if kwargs:
+                nice_args += ', ' + ', '.join(f'{k}: {v}' for k, v in kwargs.items())
+            if nice_args:
+                nice_args = ', with ' + nice_args
+
+            print(f'[TEST STEP] {function.__name__}{nice_args}')
+            if docstring:
+                print(f'[DOC] {function.__doc__}')
+            if snapshots or snapshot_before:
+                BrowserSnapshot.new(args[0].browser)
+            
+            result = function(*args, **kwargs)
+            
+            if snapshots or snapshot_after:
+                BrowserSnapshot.new(args[0].browser)
+
+            return result
+        return wrapper
+    return decorator
+

--- a/ui/webui/test/helpers/storage.py
+++ b/ui/webui/test/helpers/storage.py
@@ -22,6 +22,7 @@ HELPERS_DIR = os.path.dirname(__file__)
 sys.path.append(HELPERS_DIR)
 
 from installer import InstallerSteps  # pylint: disable=import-error
+from step_logger import log_step
 
 
 STORAGE_INTERFACE = "org.fedoraproject.Anaconda.Modules.Storage"
@@ -39,38 +40,46 @@ class Storage():
         for disk in output.splitlines():
             yield disk.split()[0]
 
+    @log_step()
     def select_disk(self, disk, selected=True):
         self.browser.set_checked(f"#{disk} input", selected)
         self.check_disk_selected(disk, selected)
 
+    @log_step()
     def select_all_disks_and_check(self, disks):
         self.browser.click("#local-disks-bulk-select-toggle")
         self.browser.click("#local-disks-bulk-select-all")
         for disk in disks:
             self.check_disk_selected(disk)
 
+    @log_step()
     def select_none_disks_and_check(self, disks):
         self.browser.click("#local-disks-bulk-select-toggle")
         self.browser.click("#local-disks-bulk-select-none")
         for disk in disks:
             self.check_disk_selected(disk, False)
 
+    @log_step()
     def click_checkbox_and_check_all_disks(self, disks, selected):
         self.browser.click("#select-multiple-split-checkbox")
         for disk in disks:
             self.check_disk_selected(disk, selected)
 
+    @log_step(snapshot_before=True)
     def check_disk_selected(self, disk, selected=True):
         assert self.browser.get_checked(f"#{disk} input") == selected
 
+    @log_step()
     def wait_no_disks(self):
         self.browser.wait_in_text("#next-tooltip-ref",
                                   "To continue, select the devices(s) to install to.")
 
+    @log_step()
     def wait_no_disks_detected(self):
         self.browser.wait_in_text("#no-disks-detected-alert",
                                   "No additional disks detected")
 
+    @log_step()
     def wait_no_disks_detected_not_present(self):
         self.browser.wait_not_present("#no-disks-detected-alert")
 
@@ -81,15 +90,18 @@ class Storage():
             {STORAGE_OBJECT_PATH} \
             {STORAGE_INTERFACE}.ResetPartitioning')
 
+    @log_step(snapshots=True)
     def rescan_disks(self):
         self.browser.click(f"#{self._step}-rescan-disks")
 
+    @log_step(snapshot_before=True)
     def check_disk_visible(self, disk, visible=True):
         if visible:
             self.browser.wait_text(f"#{disk} > th[data-label=Name]", f"{disk}")
         else:
             self.browser.wait_not_present(f"#{disk}")
 
+    @log_step(snapshot_before=True)
     def check_disk_capacity(self, disk, total=None, free=None):
         if total:
             self.browser.wait_text(f"#{disk} > td[data-label=Total]", total)


### PR DESCRIPTION
Adding decorator that prints the name of a function and its parameters (test step), and optionally prints docstring and creates screenshots. Also decorating all existing helper functions that interact with the WebUI.

From now on we should use the decorator for any new helper function that we create.