### PR TITLE
Fix sorting of the potfile (#infra)

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -135,6 +135,7 @@ XGETTEXT_OPTIONS = --keyword=_ --keyword=N_ --keyword=P_:1,2 \
 		   --keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
 		   --keyword=ngettext:1,2,3t --keyword=ngettext:1c,2,3,4t \
 		   --add-comments=TRANSLATORS: \
+		   --sort-output \
 		   --from-code=UTF-8 --package-name=$(PACKAGE) \
 		   --package-version=$(PACKAGE_VERSION) \
 		   --copyright-holder="$(COPYRIGHT_HOLDER)" \


### PR DESCRIPTION
Right now when we generate potfile the output file is randomly sorted. By adding --sort-output keyword it should stay sorted always the same way. That will allow us easily detect if the potfile changed.

Potfile change detection can be then used in our potfile automation and also it's much better visible in the git history.

Later we can improve potfile change detection by similar [way as I have on simpleline](https://github.com/rhinstaller/python-simpleline-l10n/blob/master/.github/workflows/pot-file-update.yml#L66).
