### PR TITLE
RHEL-8 - Move loop device pre-creation to container (#infra)

### DIFF
--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -7,10 +7,6 @@
 # make -f ./Makefile.am container-rpms-scratch # Create Anaconda RPM in `pwd`/result/... directory.
 # sudo make -f ./Makefile.am anaconda-iso-creator-build
 #
-# # pre-create loop devices because the container namespacing of /dev devices
-# sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
-# sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
-#
 # # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
 # sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:rhel-8
 #

--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -15,6 +15,10 @@
 
 set -eux
 
+# pre-create loop devices manually. In the container you can't use losetup for that.
+sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
+sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
+
 INPUT_RPMS=/anaconda-rpms/
 REPO_DIR=/tmp/anaconda-rpms/
 


### PR DESCRIPTION
We have to pre-create loop devices because they are not available in the containers. If they are created by `losetup` than the newly created loop device is not visible inside the container. However, it still could be created manually in the container and taken correctly by the losetup tooling.

Thanks to the above discovery let's simplify our solution and create loop devices inside the lorax-build script intead of manually before.

Needs to be merged together with https://github.com/rhinstaller/anaconda/pull/4566