### PR TITLE
Load treeinfo metadata with a task

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/repositories.py
+++ b/pyanaconda/modules/payloads/payload/dnf/repositories.py
@@ -73,30 +73,25 @@ def generate_driver_disk_repositories(path="/run/install"):
     return repositories
 
 
-def generate_treeinfo_repositories(repo_data: RepoConfigurationData, tree_info_metadata):
+def generate_treeinfo_repository(repo_data: RepoConfigurationData, repo_md):
     """Generate repositories from tree metadata of the specified repository.
 
-    :param RepoConfigurationData repo_data: a repository with metadata
-    :param TreeInfoMetadata tree_info_metadata: metadata of the repository
-    :return: a list of generated repo configuration data
+    :param RepoConfigurationData repo_data: a repository with the .treeinfo file
+    :param TreeInfoRepoMetadata repo_md: a metadata of a treeinfo repository
+    :return RepoConfigurationData: a treeinfo repository
     """
-    repositories = []
+    repo = copy.deepcopy(repo_data)
 
-    for repo_md in tree_info_metadata.repositories:
-        repo = copy.deepcopy(repo_data)
+    repo.origin = REPO_ORIGIN_TREEINFO
+    repo.name = repo_md.name
 
-        repo.origin = REPO_ORIGIN_TREEINFO
-        repo.name = repo_md.name
+    repo.type = URL_TYPE_BASEURL
+    repo.url = repo_md.url
 
-        repo.type = URL_TYPE_BASEURL
-        repo.url = repo_md.url
+    repo.enabled = repo_md.enabled
+    repo.installation_enabled = False
 
-        repo.enabled = repo_md.enabled
-        repo.installation_enabled = False
-
-        repositories.append(repo)
-
-    return repositories
+    return repo
 
 
 def update_treeinfo_repositories(repositories, treeinfo_repositories):

--- a/pyanaconda/modules/payloads/payload/dnf/tree_info.py
+++ b/pyanaconda/modules/payloads/payload/dnf/tree_info.py
@@ -317,7 +317,7 @@ class TreeInfoMetadata(object):
 
         :return: True or False
         """
-        repo_md = self._get_base_repository() or self._get_root_repository()
+        repo_md = self.get_base_repository() or self.get_root_repository()
 
         if not repo_md:
             log.debug("There is no usable repository available")
@@ -340,7 +340,7 @@ class TreeInfoMetadata(object):
 
         :return: an URL of the base repo
         """
-        repo_md = self._get_base_repository()
+        repo_md = self.get_base_repository()
 
         if repo_md:
             log.debug("The treeinfo defines a base repository at: %s", repo_md.url)
@@ -349,7 +349,7 @@ class TreeInfoMetadata(object):
         log.debug("No base repository found in the treeinfo. Using installation tree root.")
         return self._root_url
 
-    def _get_base_repository(self):
+    def get_base_repository(self):
         """Return metadata of the base repository.
 
         :return: an instance of TreeInfoRepoMetadata or None
@@ -360,7 +360,7 @@ class TreeInfoMetadata(object):
 
         return None
 
-    def _get_root_repository(self):
+    def get_root_repository(self):
         """Return metadata of the root repository.
 
         :return: an instance of TreeInfoRepoMetadata or None

--- a/pyanaconda/modules/payloads/payload/dnf/tree_info.py
+++ b/pyanaconda/modules/payloads/payload/dnf/tree_info.py
@@ -18,9 +18,12 @@
 import configparser
 import os
 import time
+from collections import namedtuple
 
 from functools import partial
 from productmd.treeinfo import TreeInfo
+from pyanaconda.modules.common.task import Task
+from pyanaconda.modules.payloads.payload.dnf.repositories import generate_treeinfo_repository
 from requests import RequestException
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -39,6 +42,8 @@ __all__ = [
     "NoTreeInfoError",
     "InvalidTreeInfoError",
     "TreeInfoMetadata",
+    "LoadTreeInfoMetadataResult",
+    "LoadTreeInfoMetadataTask",
 ]
 
 
@@ -440,3 +445,92 @@ class TreeInfoRepoMetadata(object):
         # Normalize the URL to solve problems with a relative path.
         # This is especially useful for NFS (root/path/../new_path).
         return protocol + os.path.normpath(absolute_path)
+
+
+LoadTreeInfoMetadataResult = namedtuple(
+    "LoadTreeInfoMetadataResult", [
+        "repository_data",
+        "release_version",
+        "treeinfo_repositories"
+    ]
+)
+LoadTreeInfoMetadataResult.__doc__ += """
+The result of the LoadTreeInfoMetadataTask task.
+"""
+
+
+class LoadTreeInfoMetadataTask(Task):
+    """Task to process treeinfo metadata of an installation source."""
+
+    def __init__(self, data: RepoConfigurationData):
+        """Create a task.
+
+        :param RepoConfigurationData data: a repo configuration data
+        """
+        super().__init__()
+        self._repository_data = data
+
+    @property
+    def name(self):
+        """The task name."""
+        return "Load treeinfo metadata"
+
+    def run(self):
+        """Run the task."""
+        log.debug("Reload treeinfo metadata.")
+        try:
+            return self._load_treeinfo_metadata()
+        except NoTreeInfoError as e:
+            log.debug("No treeinfo metadata to use: %s", str(e))
+        except TreeInfoMetadataError as e:
+            log.warning("Couldn't use treeinfo metadata: %s", str(e))
+
+        return self._handle_no_treeinfo_metadata()
+
+    def _load_treeinfo_metadata(self):
+        """Load treeinfo metadata if available."""
+        # Load the treeinfo metadata.
+        treeinfo_metadata = TreeInfoMetadata()
+        treeinfo_metadata.load_data(self._repository_data)
+
+        # Update the base repository. Use the base or root repository
+        # from the treeinfo metadata if available. Otherwise, use the
+        # original installation source.
+        repository_md = treeinfo_metadata.get_base_repository() \
+            or treeinfo_metadata.get_root_repository()
+
+        repository_data = self._generate_repository(repository_md) \
+            or self._repository_data
+
+        # Generate the treeinfo repositories from the metadata. Skip
+        # a repository that is used as a new base repository if any.
+        treeinfo_repositories = [
+            self._generate_repository(m)
+            for m in treeinfo_metadata.repositories
+            if m is not repository_md
+        ]
+
+        # Get values of substitution variables.
+        release_version = treeinfo_metadata.release_version or None
+
+        # Return the results.
+        return LoadTreeInfoMetadataResult(
+            repository_data=repository_data,
+            treeinfo_repositories=treeinfo_repositories,
+            release_version=release_version,
+        )
+
+    def _generate_repository(self, repo_md):
+        """Generate a repository from q treeinfo metadata."""
+        if not repo_md:
+            return None
+
+        return generate_treeinfo_repository(self._repository_data, repo_md)
+
+    def _handle_no_treeinfo_metadata(self):
+        """The treeinfo metadata couldn't be loaded."""
+        return LoadTreeInfoMetadataResult(
+            repository_data=None,
+            treeinfo_repositories=[],
+            release_version=None,
+        )

--- a/pyanaconda/modules/payloads/payload/dnf/tree_info.py
+++ b/pyanaconda/modules/payloads/payload/dnf/tree_info.py
@@ -340,20 +340,6 @@ class TreeInfoMetadata(object):
 
         return True
 
-    def get_base_repo_url(self):
-        """Return an URL of the base repository.
-
-        :return: an URL of the base repo
-        """
-        repo_md = self.get_base_repository()
-
-        if repo_md:
-            log.debug("The treeinfo defines a base repository at: %s", repo_md.url)
-            return repo_md.url
-
-        log.debug("No base repository found in the treeinfo. Using installation tree root.")
-        return self._root_url
-
     def get_base_repository(self):
         """Return metadata of the base repository.
 

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -30,7 +30,7 @@ from pyanaconda.modules.payloads.payload.dnf.installation import ImportRPMKeysTa
     CleanUpDownloadLocationTask, ResolvePackagesTask, UpdateDNFConfigurationTask, \
     WriteRepositoriesTask
 from pyanaconda.modules.payloads.payload.dnf.repositories import \
-    generate_driver_disk_repositories, generate_treeinfo_repositories, update_treeinfo_repositories
+    generate_driver_disk_repositories, generate_treeinfo_repository, update_treeinfo_repositories
 from pyanaconda.modules.payloads.payload.dnf.tear_down import ResetDNFManagerTask
 from pyanaconda.modules.payloads.payload.dnf.utils import get_kernel_version_list, \
     calculate_required_space
@@ -726,10 +726,10 @@ class DNFPayload(Payload):
             base_repo_url = tree_info_metadata.get_base_repo_url()
 
             # Add the treeinfo repositories.
-            repositories = generate_treeinfo_repositories(
-                repo_data,
-                tree_info_metadata
-            )
+            repositories = [
+                generate_treeinfo_repository(repo_data, m)
+                for m in tree_info_metadata.repositories
+            ]
 
             # Ignore treeinfo repositories with the url of the base repository.
             repositories = [r for r in repositories if r.url != base_repo_url]

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -30,7 +30,7 @@ from pyanaconda.modules.payloads.payload.dnf.installation import ImportRPMKeysTa
     CleanUpDownloadLocationTask, ResolvePackagesTask, UpdateDNFConfigurationTask, \
     WriteRepositoriesTask
 from pyanaconda.modules.payloads.payload.dnf.repositories import \
-    generate_driver_disk_repositories, generate_treeinfo_repository, update_treeinfo_repositories
+    generate_driver_disk_repositories, update_treeinfo_repositories
 from pyanaconda.modules.payloads.payload.dnf.tear_down import ResetDNFManagerTask
 from pyanaconda.modules.payloads.payload.dnf.utils import get_kernel_version_list, \
     calculate_required_space
@@ -44,7 +44,7 @@ from pyanaconda.anaconda_loggers import get_packaging_logger
 from pyanaconda.core import constants
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import INSTALL_TREE, ISO_DIR, PAYLOAD_TYPE_DNF, \
-    SOURCE_TYPE_URL, SOURCE_TYPE_CDROM, URL_TYPE_BASEURL, SOURCE_REPO_FILE_TYPES, \
+    SOURCE_TYPE_URL, SOURCE_TYPE_CDROM, SOURCE_REPO_FILE_TYPES, \
     SOURCE_TYPE_CDN, MULTILIB_POLICY_ALL, REPO_ORIGIN_SYSTEM, SOURCE_TYPE_CLOSEST_MIRROR, \
     REPO_ORIGIN_TREEINFO
 from pyanaconda.core.i18n import _
@@ -55,8 +55,7 @@ from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.payload.base import Payload
 from pyanaconda.payload.image import find_optical_install_media
-from pyanaconda.modules.payloads.payload.dnf.tree_info import TreeInfoMetadata, NoTreeInfoError, \
-    TreeInfoMetadataError
+from pyanaconda.modules.payloads.payload.dnf.tree_info import LoadTreeInfoMetadataTask
 from pyanaconda.ui.lib.payload import get_payload, get_source, create_source, set_source, \
     set_up_sources, tear_down_sources
 
@@ -605,18 +604,32 @@ class DNFPayload(Payload):
         data = RepoConfigurationData.from_structure(
             self.proxy.GetRepoConfigurations()[0]
         )
-
         log.debug("Using the repo configuration: %s", data)
-        data.name = constants.BASE_REPO_NAME
 
-        # Process the treeinfo metadata.
-        treeinfo_base_repo_url = self._reload_treeinfo_metadata(data)
+        # Load the treeinfo metadata.
+        task = LoadTreeInfoMetadataTask(data)
+        result = task.run()
 
-        if treeinfo_base_repo_url:
-            data.type = URL_TYPE_BASEURL
-            data.url = treeinfo_base_repo_url
+        # Update the repo configuration.
+        if result.repository_data:
+            data = result.repository_data
 
+        # Update the substitution variables.
+        if result.release_version:
+            self._dnf_manager.configure_substitution(
+                result.release_version
+            )
+
+        # Update the treeinfo repositories.
+        self.set_repo_configurations(update_treeinfo_repositories(
+            repositories=self.get_repo_configurations(),
+            treeinfo_repositories=result.treeinfo_repositories,
+        ))
+
+        # Add and load the base repository.
         log.debug("Add the base repository at %s.", data.url)
+        data.name = constants.BASE_REPO_NAME
+        data.enabled = True
 
         try:
             self._dnf_manager.add_repository(data)
@@ -702,51 +715,6 @@ class DNFPayload(Payload):
                 self.dnf_manager.load_repository(repo_id)
             except MetadataError as e:
                 self._report.warning_messages.append(str(e))
-
-    def _reload_treeinfo_metadata(self, repo_data):
-        """Reload treeinfo metadata.
-
-        :param RepoConfigurationData repo_data: configuration data of the base repo
-        :return: a URL of the base repository
-        """
-        log.debug("Reload treeinfo metadata.")
-        base_repo_url = None
-
-        try:
-            # Load the treeinfo metadata.
-            tree_info_metadata = TreeInfoMetadata()
-            tree_info_metadata.load_data(repo_data)
-
-            # Set up the substitutions.
-            self._dnf_manager.configure_substitution(
-                tree_info_metadata.release_version
-            )
-
-            # Get the new base repo URL.
-            base_repo_url = tree_info_metadata.get_base_repo_url()
-
-            # Add the treeinfo repositories.
-            repositories = [
-                generate_treeinfo_repository(repo_data, m)
-                for m in tree_info_metadata.repositories
-            ]
-
-            # Ignore treeinfo repositories with the url of the base repository.
-            repositories = [r for r in repositories if r.url != base_repo_url]
-
-            self.set_repo_configurations(update_treeinfo_repositories(
-                repositories=self.get_repo_configurations(),
-                treeinfo_repositories=repositories,
-            ))
-        except NoTreeInfoError as e:
-            log.debug("No treeinfo metadata to use: %s", str(e))
-            self._remove_treeinfo_repositories()
-
-        except TreeInfoMetadataError as e:
-            log.warning("Couldn't use treeinfo metadata: %s", str(e))
-            self._remove_treeinfo_repositories()
-
-        return base_repo_url
 
     def _remove_treeinfo_repositories(self):
         """Remove all old treeinfo repositories before loading new ones.

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_tree_info.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_tree_info.py
@@ -196,6 +196,8 @@ class TreeInfoMetadataTestCase(unittest.TestCase):
         assert self.metadata.release_version == ""
         assert self.metadata.repositories == []
         assert self.metadata.get_base_repo_url() == ""
+        assert self.metadata.get_base_repository() is None
+        assert self.metadata.get_root_repository() is None
 
     def test_release_version(self):
         """Test the release_version property."""
@@ -224,6 +226,9 @@ class TreeInfoMetadataTestCase(unittest.TestCase):
         assert repo_md.relative_path == "../baseos"
         assert repo_md.url == "file:///tmp/baseos"
 
+        assert self.metadata.get_base_repository() is repo_md
+        assert self.metadata.get_root_repository() is None
+
     def test_fedora_treeinfo(self):
         """Test the Fedora metadata."""
         root_url = self._load_treeinfo(TREE_INFO_FEDORA)
@@ -235,6 +240,9 @@ class TreeInfoMetadataTestCase(unittest.TestCase):
         assert repo_md.enabled is True
         assert repo_md.relative_path == "."
         assert repo_md.url == root_url
+
+        assert self.metadata.get_base_repository() is None
+        assert self.metadata.get_root_repository() is repo_md
 
     @patch("pyanaconda.modules.payloads.payload.dnf.tree_info.conf")
     def test_custom_treeinfo(self, mock_conf):
@@ -258,6 +266,9 @@ class TreeInfoMetadataTestCase(unittest.TestCase):
         assert repo_md.enabled is True
         assert repo_md.relative_path == "./variant"
         assert repo_md.url == root_url + "/variant"
+
+        assert self.metadata.get_base_repository() is None
+        assert self.metadata.get_root_repository() is None
 
     def test_verify_image_base_repo(self):
         """Test the verify_image_base_repo method."""

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_tree_info.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_tree_info.py
@@ -193,7 +193,6 @@ class TreeInfoMetadataTestCase(unittest.TestCase):
 
         assert self.metadata.release_version == ""
         assert self.metadata.repositories == []
-        assert self.metadata.get_base_repo_url() == ""
         assert self.metadata.get_base_repository() is None
         assert self.metadata.get_root_repository() is None
 
@@ -297,16 +296,6 @@ class TreeInfoMetadataTestCase(unittest.TestCase):
             self._create_directory(path, "repodata")
             self.metadata.load_file(path)
             assert self.metadata.verify_image_base_repo()
-
-    def test_get_base_repo_url(self):
-        """Test the get_base_repo_url method."""
-        # Use the root repository.
-        root_url = self._load_treeinfo(TREE_INFO_FEDORA)
-        assert self.metadata.get_base_repo_url() == root_url
-
-        # Use the base repository.
-        self._load_treeinfo(TREE_INFO_RHEL)
-        assert self.metadata.get_base_repo_url() == "file:///tmp/baseos"
 
     def test_load_file(self):
         """Test the load_file method."""


### PR DESCRIPTION
Use the `LoadTreeInfoMetadataTask` task to load the treeinfo metadata
of an installation source and to process the collected data. Clean up
the related code to make it ready for the modularization.