### PR TITLE
Validate the CDN source early

### DIFF
--- a/pyanaconda/modules/payloads/source/cdn/cdn.py
+++ b/pyanaconda/modules/payloads/source/cdn/cdn.py
@@ -19,6 +19,7 @@
 #
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.payloads.constants import SourceType
+from pyanaconda.modules.payloads.source.cdn.initialization import SetUpCDNSourceTask
 from pyanaconda.modules.payloads.source.repo_files.repo_files import RepoFilesSourceModule
 from pyanaconda.modules.payloads.source.cdn.cdn_interface import CDNSourceInterface
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -45,3 +46,10 @@ class CDNSourceModule(RepoFilesSourceModule):
     def description(self):
         """Get description of this source."""
         return _("Red Hat CDN")
+
+    def set_up_with_tasks(self):
+        """Set up the installation source.
+
+        :return [Task]: a list of tasks
+        """
+        return [SetUpCDNSourceTask()]

--- a/pyanaconda/modules/payloads/source/cdn/initialization.py
+++ b/pyanaconda/modules/payloads/source/cdn/initialization.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.i18n import _
+from pyanaconda.modules.common.constants.services import SUBSCRIPTION
+from pyanaconda.modules.common.errors.payload import SourceSetupError
+from pyanaconda.modules.common.task import Task
+from pyanaconda.modules.common.util import is_module_available
+
+log = get_module_logger(__name__)
+
+__all__ = ["SetUpCDNSourceTask"]
+
+
+class SetUpCDNSourceTask(Task):
+    """Task to set up the CDN source."""
+
+    @property
+    def name(self):
+        """Name of the task."""
+        return "Set up the CDN source"
+
+    def run(self):
+        """Run the task."""
+        log.debug("Validating the CDN source.")
+
+        if not is_module_available(SUBSCRIPTION):
+            raise SourceSetupError(_(
+                "Red Hat CDN is unavailable for this installation."
+            ))
+
+        subscription_proxy = SUBSCRIPTION.get_proxy()
+        if not subscription_proxy.IsSubscriptionAttached:
+            raise SourceSetupError(_(
+                "To access the Red Hat CDN, a valid Red Hat subscription is required."
+            ))

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -50,7 +50,6 @@ from pyanaconda.core.constants import INSTALL_TREE, ISO_DIR, PAYLOAD_TYPE_DNF, \
 from pyanaconda.core.i18n import _
 from pyanaconda.core.payload import parse_hdd_url
 from pyanaconda.errors import errorHandler as error_handler, ERROR_RAISE
-from pyanaconda.flags import flags
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.payload.base import Payload
@@ -580,13 +579,6 @@ class DNFPayload(Payload):
         if source_type in SOURCE_REPO_FILE_TYPES:
             # Remove all treeinfo repositories.
             self._remove_treeinfo_repositories()
-
-            # If this is a kickstart install, just return now as we normally do not
-            # want to read the on media repo files in such a case. On the other hand,
-            # the local repo files are a valid use case if the system is subscribed
-            # and the CDN is selected as the installation source.
-            if flags.automatedInstall and not self._is_cdn_set_up():
-                return
 
             # Otherwise, fall back to the default repos that we disabled above
             self._enable_system_repositories()


### PR DESCRIPTION
Check if the CDN source is usable in early stages of the payload setup, so we don't have deal with an invalid source later.
This doesn't change the behaviour of the spokes, because the CDN source is treated as a special case.

**TESTED ON RHEL 9** 