### PR TITLE
Add the ValidatePackagesSelectionWithTask DBus method

### DIFF
--- a/pyanaconda/modules/common/task/__init__.py
+++ b/pyanaconda/modules/common/task/__init__.py
@@ -19,10 +19,10 @@ import math
 from time import sleep, perf_counter
 
 from pyanaconda.modules.common.task.task_interface import TaskInterface
-from pyanaconda.modules.common.task.task import Task, AbstractTask
+from pyanaconda.modules.common.task.task import Task, ValidationTask, AbstractTask
 
 __all__ = ["sync_run_task", "async_run_task", "wait_for_task", "AbstractTask", "Task",
-           "TaskInterface"]
+           "ValidationTask", "TaskInterface"]
 
 
 def sync_run_task(task_proxy, callback=None):

--- a/pyanaconda/modules/payloads/payload/dnf/dnf.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf.py
@@ -28,6 +28,7 @@ from pyanaconda.modules.payloads.kickstart import convert_ks_repo_to_repo_data, 
     convert_packages_selection_to_ksdata, convert_ks_data_to_packages_configuration, \
     convert_packages_configuration_to_ksdata
 from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager
+from pyanaconda.modules.payloads.payload.dnf.validation import CheckPackagesSelectionTask
 from pyanaconda.modules.payloads.payload.payload_base import PayloadBase
 from pyanaconda.modules.payloads.payload.dnf.dnf_interface import DNFInterface
 from pyanaconda.modules.payloads.source.factory import SourceFactory
@@ -308,6 +309,20 @@ class DNFModule(PayloadBase):
         :return: True if files haven't changed, otherwise False
         """
         return self.dnf_manager.verify_repomd_hashes()
+
+    def validate_packages_selection_with_task(self, data):
+        """Validate the specified packages selection.
+
+        Return a task for validation of the software selection.
+        The result of the task is a validation report.
+
+        :param PackagesSelectionData data: a packages selection
+        :return: a task
+        """
+        return CheckPackagesSelectionTask(
+            dnf_manager=self.dnf_manager,
+            selection=data,
+        )
 
     def get_repo_configurations(self):
         """Get RepoConfiguration structures for all sources.

--- a/pyanaconda/modules/payloads/payload/dnf/dnf_interface.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_interface.py
@@ -21,6 +21,7 @@ from dasbus.server.interface import dbus_interface
 from dasbus.server.property import emits_properties_changed
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
+from pyanaconda.modules.common.containers import TaskContainer
 from pyanaconda.modules.common.constants.interfaces import PAYLOAD_DNF
 from pyanaconda.modules.common.structures.comps import CompsEnvironmentData, CompsGroupData
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
@@ -200,6 +201,20 @@ class DNFInterface(PayloadBaseInterface):
         :return: True if files haven't changed, otherwise False
         """
         return self.implementation.verify_repomd_hashes()
+
+    def ValidatePackagesSelectionWithTask(self, data: Structure) -> ObjPath:
+        """Validate the specified packages selection.
+
+        Return a task for validation of the software selection.
+        The result of the task is a validation report.
+
+        :param data: a structure of the type PackagesSelectionData
+        :return: a DBus path of a task
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.validate_packages_selection_with_task(
+                PackagesSelectionData.from_structure(data))
+        )
 
     def GetRepoConfigurations(self) -> List[Structure]:
         """Get RepoConfigurationData structures for all attached sources.

--- a/pyanaconda/modules/payloads/payload/dnf/validation.py
+++ b/pyanaconda/modules/payloads/payload/dnf/validation.py
@@ -20,7 +20,7 @@ from contextlib import contextmanager
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.common.structures.packages import PackagesSelectionData
 from pyanaconda.modules.common.structures.validation import ValidationReport
-from pyanaconda.modules.common.task import Task
+from pyanaconda.modules.common.task import ValidationTask
 from pyanaconda.modules.payloads.payload.dnf.dnf_manager import MissingSpecsError, \
     BrokenSpecsError, InvalidSelectionError
 from pyanaconda.modules.payloads.payload.dnf.utils import get_installation_specs, \
@@ -29,7 +29,7 @@ from pyanaconda.modules.payloads.payload.dnf.utils import get_installation_specs
 log = get_module_logger(__name__)
 
 
-class CheckPackagesSelectionTask(Task):
+class CheckPackagesSelectionTask(ValidationTask):
     """Validation task to check the software selection."""
 
     def __init__(self, dnf_manager, selection: PackagesSelectionData):


### PR DESCRIPTION
Call the `ValidatePackagesSelectionWithTask` method of the DNF DBus module
to validate the specified software selection using the currently set up repositories.
