### PR TITLE
Don't generate a repository name of the URL source

### DIFF
--- a/pyanaconda/modules/payloads/source/url/url.py
+++ b/pyanaconda/modules/payloads/source/url/url.py
@@ -17,8 +17,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.core.constants import BASE_REPO_NAME, URL_TYPE_BASEURL, URL_TYPE_METALINK, \
-    URL_TYPE_MIRRORLIST, URL_TYPES
+from pyanaconda.core.constants import URL_TYPE_BASEURL, URL_TYPE_METALINK, URL_TYPE_MIRRORLIST, \
+    URL_TYPES
 from pyanaconda.core.signal import Signal
 from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.modules.common.errors.general import InvalidValueError
@@ -39,13 +39,8 @@ class URLSourceModule(PayloadSourceBase, RPMSourceMixin):
 
     def __init__(self):
         super().__init__()
-        self._url_source_name = ""
-        self._generate_source_name()
-
         self._repo_configuration = RepoConfigurationData()
         self.repo_configuration_changed = Signal()
-
-        self._repo_configuration.name = self._url_source_name
 
     def __repr__(self):
         return "Source(type='URL', url='{}')".format(self._repo_configuration.url)
@@ -53,12 +48,6 @@ class URLSourceModule(PayloadSourceBase, RPMSourceMixin):
     def for_publication(self):
         """Get the interface used to publish this source."""
         return URLSourceInterface(self)
-
-    def _generate_source_name(self):
-        source_id = URLSourceModule.REPO_NAME_ID
-        URLSourceModule.REPO_NAME_ID = URLSourceModule.REPO_NAME_ID + 1
-
-        self._url_source_name = "{}-{}".format(BASE_REPO_NAME, source_id)
 
     def get_state(self):
         """Get state of this source."""
@@ -94,7 +83,6 @@ class URLSourceModule(PayloadSourceBase, RPMSourceMixin):
     def process_kickstart(self, data):
         """Process the kickstart data."""
         repo_data = RepoConfigurationData()
-        repo_data.name = self._url_source_name
 
         if data.url.url:
             repo_data.url = data.url.url
@@ -169,10 +157,6 @@ class URLSourceModule(PayloadSourceBase, RPMSourceMixin):
         self._validate_proxy(repo_configuration.proxy)
 
         self._repo_configuration = repo_configuration
-
-        if not self._repo_configuration.name:
-            self._repo_configuration.name = self._url_source_name
-
         self.repo_configuration_changed.emit(self._repo_configuration)
         log.debug("The repo_configuration is set to %s", self._repo_configuration)
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_url.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_url.py
@@ -42,20 +42,12 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
         self.url_source_interface = URLSourceInterface(self.url_source_module)
 
     def _check_dbus_property(self, property_name, in_value):
-        if type(in_value) is dict and not in_value["name"]:
-            name = self._generate_repo_name()
-            in_value["name"] = get_variant(Str, name)
-
         check_dbus_property(
             PAYLOAD_SOURCE_URL,
             self.url_source_interface,
             property_name,
             in_value
         )
-
-    def _generate_repo_name(self):
-        """Set offset +1 for each time name wasn't set to structure."""
-        return self.url_source_module._url_source_name
 
     def test_type(self):
         """Test URL source has a correct type specified."""
@@ -76,18 +68,6 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
             "RepoConfiguration",
             RepoConfigurationData.to_structure(data)
         )
-
-    def test_name_uniqueness_properties(self):
-        module1 = URLSourceModule()
-        interface1 = URLSourceInterface(module1)
-
-        module2 = URLSourceModule()
-        interface2 = URLSourceInterface(module2)
-
-        conf1 = RepoConfigurationData.from_structure(interface1.RepoConfiguration)
-        conf2 = RepoConfigurationData.from_structure(interface2.RepoConfiguration)
-
-        assert conf1.name != conf2.name
 
     def test_set_url_base_source_properties(self):
         data = RepoConfigurationData()
@@ -284,7 +264,6 @@ class URLSourceInterfaceTestCase(unittest.TestCase):
 
     def test_default_repo_configuration_properties(self):
         data = RepoConfigurationData()
-        data.name = self._generate_repo_name()
 
         assert self.url_source_interface.RepoConfiguration == \
             RepoConfigurationData.to_structure(data)


### PR DESCRIPTION
The generated name is never user, because we always rename it to "anaconda" during the payload setup. That is fine, because the source without a repository name is a base repository and there can be only one base repository anyway.

We cannot really use a generated name without further modifications of the code, because the validation and verification checks expect the "anaconda" name at this moment. If we ever do need generated names, we can generate them during the payload setup anyway.