### PR TITLE
Remove the tx_id functionality

### DIFF
--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -64,7 +64,6 @@ class SoftwareSpoke(NormalTUISpoke):
         super().__init__(data, storage, payload)
         self.title = N_("Software selection")
         self._container = None
-        self._tx_id = None
         self._errors = []
         self._warnings = []
 
@@ -146,7 +145,7 @@ class SoftwareSpoke(NormalTUISpoke):
     @property
     def _source_has_changed(self):
         """Has the installation source changed?"""
-        return self._tx_id != self.payload.tx_id
+        return self.payload.software_validation_required
 
     @property
     def _processing_data(self):
@@ -286,23 +285,10 @@ class SoftwareSpoke(NormalTUISpoke):
 
     def _check_software_selection(self):
         """Check the software selection."""
-        self.payload.bump_tx_id()
-
-        # Run the validation task.
-        from pyanaconda.modules.payloads.payload.dnf.validation import CheckPackagesSelectionTask
-
-        task = CheckPackagesSelectionTask(
-            dnf_manager=self._dnf_manager,
-            selection=self._selection,
-        )
-
-        # Get the validation report.
-        report = task.run()
+        report = self.payload.check_software_selection(self._selection)
 
         self._errors = list(report.error_messages)
         self._warnings = list(report.warning_messages)
-        self._tx_id = self.payload.tx_id
-
         print("\n".join(report.get_messages()))
 
     def closed(self):


### PR DESCRIPTION
Replace `tx_id` with a simple boolean property. Use `software_validation_required` to check if the validation of the software selection is required. The validation is required after every payload setup due to possible changes in configured repositories and their packages, groups and environments.