### PR TITLE
Clean up tasks for setting up and tearing down sources

### DIFF
--- a/pyanaconda/modules/common/errors/payload.py
+++ b/pyanaconda/modules/common/errors/payload.py
@@ -31,12 +31,6 @@ class SourceSetupError(AnacondaError):
 class SourceTearDownError(AnacondaError):
     """Error raised during the source tear down."""
 
-    def __init__(self, message, errors=None):
-        if errors:
-            message = message + "\n" + "\n".join(errors)
-
-        super().__init__(message)
-
 
 @dbus_error("IncompatibleSourceError", namespace=PAYLOADS_NAMESPACE)
 class IncompatibleSourceError(AnacondaError):

--- a/pyanaconda/modules/payloads/installation.py
+++ b/pyanaconda/modules/payloads/installation.py
@@ -49,7 +49,7 @@ class PrepareSystemForInstallationTask(Task):
 
     @property
     def name(self):
-        return "Prepare System for Installation"
+        return "Prepare system for installation"
 
     def run(self):
         """Create a root and write module denylist."""
@@ -109,7 +109,7 @@ class CopyDriverDisksFilesTask(Task):
 
     @property
     def name(self):
-        return "Copy Driver Disks Files"
+        return "Copy driver disks files"
 
     def run(self):
         """Copy files from the driver disks to the installed system."""

--- a/pyanaconda/modules/payloads/source/cdrom/initialization.py
+++ b/pyanaconda/modules/payloads/source/cdrom/initialization.py
@@ -32,14 +32,14 @@ __all__ = ["SetUpCdromSourceTask"]
 
 
 class SetUpCdromSourceTask(SetUpMountTask):
-    """Task to setup installation source."""
+    """Task to set up a CD-ROM source."""
 
     @property
     def name(self):
-        return "Set up CD-ROM Installation Source"
+        return "Set up a CD-ROM source"
 
     def _do_mount(self):
-        """Run CD-ROM installation source setup.
+        """Set up an installation source.
 
         Try to discover installation media and mount that. Device used for booting (inst.stage2)
         has a priority.

--- a/pyanaconda/modules/payloads/source/harddrive/initialization.py
+++ b/pyanaconda/modules/payloads/source/harddrive/initialization.py
@@ -35,7 +35,7 @@ SetupHardDriveResult = namedtuple("SetupHardDriveResult", ["install_tree_path", 
 
 
 class SetUpHardDriveSourceTask(Task):
-    """Task to setup installation source."""
+    """Task to set up the hard drive installation source."""
 
     def __init__(self, device_mount, iso_mount, partition, directory):
         super().__init__()
@@ -46,10 +46,10 @@ class SetUpHardDriveSourceTask(Task):
 
     @property
     def name(self):
-        return "Set up Hard drive installation source"
+        return "Set up a hard drive source"
 
     def run(self):
-        """Run Hard drive installation source setup.
+        """Set up an installation source.
 
         Always sets up two mount points: First for the device, and second for the ISO image or a
         bind for unpacked ISO. These depend on each other, and must be destroyed in the correct
@@ -59,7 +59,7 @@ class SetUpHardDriveSourceTask(Task):
         :return: named tuple with path to the install tree and name of ISO if set or empty string
         :rtype: SetupHardDriveResult instance
         """
-        log.debug("Setting up Hard drive source")
+        log.debug("Setting up a hard drive source...")
 
         for mount_point in [self._device_mount, self._iso_mount]:
             if os.path.ismount(mount_point):

--- a/pyanaconda/modules/payloads/source/live_os/initialization.py
+++ b/pyanaconda/modules/payloads/source/live_os/initialization.py
@@ -89,7 +89,7 @@ class DetectLiveOSImageTask(Task):
 
 
 class SetUpLiveOSSourceTask(SetUpMountTask):
-    """Task to setup installation source."""
+    """Task to set up a Live OS image."""
 
     def __init__(self, image_path, target_mount):
         """Create a new task.

--- a/pyanaconda/modules/payloads/source/mount_tasks.py
+++ b/pyanaconda/modules/payloads/source/mount_tasks.py
@@ -41,7 +41,7 @@ class TearDownMountTask(Task):
 
     @property
     def name(self):
-        return "Tear down mount installation source"
+        return "Unmount an installation source"
 
     def run(self):
         """Run source un-setup."""

--- a/pyanaconda/modules/payloads/source/nfs/initialization.py
+++ b/pyanaconda/modules/payloads/source/nfs/initialization.py
@@ -42,11 +42,11 @@ class SetUpNFSSourceTask(Task):
 
     @property
     def name(self):
-        return "Set up NFS installation source"
+        return "Set up a NFS source"
 
     def run(self):
         """Set up the installation source."""
-        log.debug("Setting up NFS source: %s", self._url)
+        log.debug("Setting up a NFS source: %s", self._url)
 
         for mount_point in [self._device_mount, self._iso_mount]:
             if os.path.ismount(mount_point):

--- a/pyanaconda/modules/payloads/source/repo_files/initialization.py
+++ b/pyanaconda/modules/payloads/source/repo_files/initialization.py
@@ -28,7 +28,7 @@ __all__ = ["SetUpRepoFilesSourceTask"]
 
 
 class SetUpRepoFilesSourceTask(Task):
-    """Task to setup installation source."""
+    """Task to set up local repositories."""
 
     def __init__(self, repo_dirs):
         super().__init__()
@@ -36,12 +36,14 @@ class SetUpRepoFilesSourceTask(Task):
 
     @property
     def name(self):
-        return "Set up Repo files Installation Source"
+        return "Set up local repositories"
 
     def run(self):
-        """Run Repo files installation source setup."""
+        """Set up an installation source."""
         log.debug("Trying to detect repo files automatically")
+
         for repo_dir in self._repo_dirs:
             if len(glob.glob(join_paths(repo_dir, "*.repo"))) > 0:
                 return
-        raise SourceSetupError("repo files not found")
+
+        raise SourceSetupError("No .repo files found.")

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_base.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_base.py
@@ -84,7 +84,7 @@ class TearDownMountTaskTestCase(unittest.TestCase):
     def test_name(self):
         """Tear down mount source task name."""
         task = TearDownMountTask(mount_location)
-        assert task.name == "Tear down mount installation source"
+        assert task.name == "Unmount an installation source"
 
     @patch("pyanaconda.modules.payloads.source.mount_tasks.os.path.ismount", return_value=False)
     @patch("pyanaconda.modules.payloads.source.mount_tasks.unmount", return_value=True)

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_cdrom.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_cdrom.py
@@ -136,8 +136,7 @@ class CdromSourceSetupTaskTestCase(unittest.TestCase):
     def test_setup_install_source_task_name(self):
         """Test CD-ROM Source setup installation source task name."""
         task = SetUpCdromSourceTask(self.mount_location)
-
-        assert task.name == "Set up CD-ROM Installation Source"
+        assert task.name == "Set up a CD-ROM source"
 
     @staticmethod
     def set_up_device_tree(num_cdroms):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_harddrive.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_harddrive.py
@@ -183,7 +183,7 @@ class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
     def test_setup_install_source_task_name(self):
         """Hard drive source setup task name."""
         task = _create_setup_task()
-        assert task.name == "Set up Hard drive installation source"
+        assert task.name == "Set up a hard drive source"
 
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
            return_value=True)

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_nfs.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_nfs.py
@@ -159,7 +159,7 @@ class NFSSourceSetupTaskTestCase(unittest.TestCase):
     def test_setup_install_source_task_name(self):
         """Test NFS Source setup installation source task name."""
         task = SetUpNFSSourceTask(DEVICE_MOUNT_LOCATION, ISO_MOUNT_LOCATION, NFS_URL)
-        assert task.name == "Set up NFS installation source"
+        assert task.name == "Set up a NFS source"
 
     @patch("pyanaconda.modules.payloads.source.nfs.initialization.find_and_mount_iso_image",
            return_value="trojan.iso")

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_repo_files.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_repo_files.py
@@ -88,7 +88,7 @@ class RepoFilesSourceSetupTaskTestCase(unittest.TestCase):
     def test_setup_install_source_task_name(self):
         """Test Repo files Source setup installation source task name."""
         task = SetUpRepoFilesSourceTask([""])
-        assert task.name == "Set up Repo files Installation Source"
+        assert task.name == "Set up local repositories"
 
     def test_setup_install_source_task_success(self):
         with TemporaryDirectory() as temp_dir_name:
@@ -100,4 +100,4 @@ class RepoFilesSourceSetupTaskTestCase(unittest.TestCase):
             with pytest.raises(SourceSetupError) as cm:
                 SetUpRepoFilesSourceTask([temp_dir_name]).run()
 
-            assert str(cm.value) == "repo files not found"
+            assert str(cm.value) == "No .repo files found."


### PR DESCRIPTION
Make the set up and tear down tasks easier to extend in the future.
Change some of the task names, doc strings, logs and exception messages.