### PR TITLE
Modernize javascript (fedora-welcome)

### DIFF
--- a/data/liveinst/gnome/fedora-welcome.js
+++ b/data/liveinst/gnome/fedora-welcome.js
@@ -37,9 +37,9 @@ let anacondaApp = null;
 function makeLabel(label, button) {
     let widget = new Gtk.Label();
 
-    if (button)
+    if (button) {
         widget.set_markup('<b><span size="x-large">' + label + '</span></b>');
-    else {
+    } else {
         widget.set_line_wrap(true);
         widget.set_justify(Gtk.Justification.CENTER);
         widget.set_margin_top(32);

--- a/data/liveinst/gnome/fedora-welcome.js
+++ b/data/liveinst/gnome/fedora-welcome.js
@@ -22,12 +22,10 @@ imports.gi.versions.Gdk = "3.0";
 imports.gi.versions.Gtk = "3.0";
 
 const Gdk = imports.gi.Gdk;
-const GdkPixbuf = imports.gi.GdkPixbuf;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
 const Lang = imports.lang;
-const Pango = imports.gi.Pango;
 
 const Gettext = imports.gettext;
 const _ = imports.gettext.gettext;

--- a/data/liveinst/gnome/fedora-welcome.js
+++ b/data/liveinst/gnome/fedora-welcome.js
@@ -164,29 +164,38 @@ class WelcomeWindow extends Gtk.ApplicationWindow {
     }
 }
 
+class WelcomeApp extends Gtk.Application {
+    static {
+        GObject.registerClass(this);
+    }
+
+    constructor() {
+        super({application_id: 'org.fedoraproject.welcome-screen'});
+    }
+
+    vfunc_startup() {
+        GLib.set_prgname('fedora-welcome');
+
+        super.vfunc_startup();
+
+        Gtk.Settings.get_default().gtk_application_prefer_dark_theme = true;
+    }
+
+    vfunc_activate() {
+        let {activeWindow} = this;
+        if (!activeWindow)
+            activeWindow = new WelcomeWindow(this);
+        activeWindow.present();
+    }
+}
+
 Gettext.bindtextdomain('anaconda', LOCALE_DIR);
 Gettext.textdomain('anaconda');
-
-GLib.set_prgname('fedora-welcome');
-Gtk.init(null, null);
-Gtk.Settings.get_default().gtk_application_prefer_dark_theme = true;
 
 // provided by the 'anaconda' package
 anacondaApp = Gio.DesktopAppInfo.new('anaconda.desktop');
 if (!anacondaApp)
     anacondaApp = Gio.DesktopAppInfo.new('liveinst.desktop');
 
-if (anacondaApp) {
-    let application = new Gtk.Application({ application_id: 'org.fedoraproject.welcome-screen',
-                                            flags: Gio.ApplicationFlags.FLAGS_NONE });
-    let welcomeWindow = null;
-
-    application.connect('startup', () => {
-        welcomeWindow = new WelcomeWindow(application);
-    });
-    application.connect('activate', () => {
-        welcomeWindow.present();
-    });
-
-    application.run(ARGV);
-}
+if (anacondaApp)
+    new WelcomeApp().run(ARGV);

--- a/data/liveinst/gnome/fedora-welcome.js
+++ b/data/liveinst/gnome/fedora-welcome.js
@@ -38,14 +38,14 @@ function makeLabel(label, button) {
     let widget = new Gtk.Label();
 
     if (button) {
-        widget.set_markup('<b><span size="x-large">' + label + '</span></b>');
+        widget.set_markup(`<b><span size="x-large">${label}</span></b>`);
     } else {
         widget.set_line_wrap(true);
         widget.set_justify(Gtk.Justification.CENTER);
         widget.set_margin_top(32);
         widget.set_margin_bottom(32);
 
-        widget.set_markup('<span size="large">' + label + '</span>');
+        widget.set_markup(`<span size="large">${label}</span>`);
     }
 
     return widget;

--- a/data/liveinst/gnome/fedora-welcome.js
+++ b/data/liveinst/gnome/fedora-welcome.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env gjs-console
+#!/usr/bin/gjs -m
 
 /*
  * Copyright (C) 2012 Red Hat, Inc.
@@ -18,17 +18,14 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-imports.gi.versions.Gdk = '3.0';
-imports.gi.versions.Gtk = '3.0';
+import Gdk from 'gi://Gdk?version=3.0';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk?version=3.0';
 
-const Gdk = imports.gi.Gdk;
-const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
-const GObject = imports.gi.GObject;
-const Gtk = imports.gi.Gtk;
-
-const Gettext = imports.gettext;
-const _ = imports.gettext.gettext;
+import {gettext as _} from 'gettext';
+import Gettext from 'gettext';
 
 const LOCALE_DIR = '/usr/share/locale';
 

--- a/data/liveinst/gnome/fedora-welcome.js
+++ b/data/liveinst/gnome/fedora-welcome.js
@@ -52,95 +52,117 @@ function makeLabel(label, button) {
 }
 
 const WelcomeWindow = new Lang.Class({
-  Name: 'WelcomeWindow',
+    Name: 'WelcomeWindow',
 
-  _init: function(application) {
-      this.window = new Gtk.ApplicationWindow({ application: application,
-                                                type: Gtk.WindowType.TOPLEVEL,
-                                                default_width: 600,
-                                                default_height: 550,
-                                                skip_taskbar_hint: true,
-                                                title: _('Welcome to Fedora'),
-                                                window_position: Gtk.WindowPosition.CENTER });
-      this.window.connect('key-press-event', Lang.bind(this,
-          function(w, event) {
-              let key = event.get_keyval()[1];
+    _init: function(application) {
+        this.window = new Gtk.ApplicationWindow({
+            application,
+            type: Gtk.WindowType.TOPLEVEL,
+            default_width: 600,
+            default_height: 550,
+            skip_taskbar_hint: true,
+            title: _('Welcome to Fedora'),
+            window_position: Gtk.WindowPosition.CENTER,
+        });
+        this.window.connect('key-press-event', Lang.bind(this,
+            function(w, event) {
+                let key = event.get_keyval()[1];
 
-              if (key == Gdk.KEY_Escape)
-                  this.window.destroy();
+                if (key === Gdk.KEY_Escape)
+                    this.window.destroy();
 
-              return false;
-          }));
+                return Gdk.EVENT_CONTINUE;
+            }));
 
-      let mainGrid = new Gtk.Grid({ orientation: Gtk.Orientation.VERTICAL,
-                                    row_spacing: 16,
-                                    vexpand: true,
-                                    hexpand: true,
-                                    halign: Gtk.Align.CENTER,
-                                    valign: Gtk.Align.CENTER });
-      this.window.add(mainGrid);
+        const mainGrid = new Gtk.Grid({
+            orientation: Gtk.Orientation.VERTICAL,
+            row_spacing: 16,
+            vexpand: true,
+            hexpand: true,
+            halign: Gtk.Align.CENTER,
+            valign: Gtk.Align.CENTER,
+        });
+        this.window.add(mainGrid);
 
-      let buttonBox = new Gtk.Grid({ orientation: Gtk.Orientation.HORIZONTAL,
-                                     column_spacing: 16,
-                                     halign: Gtk.Align.CENTER });
-      mainGrid.add(buttonBox);
+        const buttonBox = new Gtk.Grid({
+            orientation: Gtk.Orientation.HORIZONTAL,
+            column_spacing: 16,
+            halign: Gtk.Align.CENTER,
+        });
+        mainGrid.add(buttonBox);
 
-      let tryContent = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL,
-                                     spacing: 16 });
-      tryContent.add(new Gtk.Image({ icon_name: 'media-optical',
-                                     pixel_size: 256 }));
-      tryContent.add(makeLabel(_('Try Fedora'), true));
+        const tryContent = new Gtk.Box({
+            orientation: Gtk.Orientation.VERTICAL,
+            spacing: 16,
+        });
+        tryContent.add(new Gtk.Image({
+            icon_name: 'media-optical',
+            pixel_size: 256,
+        }));
+        tryContent.add(makeLabel(_('Try Fedora'), true));
 
-      let tryButton = new Gtk.Button({ child: tryContent });
-      buttonBox.add(tryButton);
+        const tryButton = new Gtk.Button({child: tryContent});
+        buttonBox.add(tryButton);
 
-      let installContent = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL,
-                                         spacing: 16 });
+        const installContent = new Gtk.Box({
+            orientation: Gtk.Orientation.VERTICAL,
+            spacing: 16,
+        });
 
-      // provided by the 'fedora-logos' package
-      installContent.add(new Gtk.Image({ icon_name: 'org.fedoraproject.AnacondaInstaller',
-                                         pixel_size: 256 }));
-      installContent.add(makeLabel(anacondaApp.get_name(), true));
+        // provided by the 'fedora-logos' package
+        installContent.add(new Gtk.Image({
+            icon_name: 'org.fedoraproject.AnacondaInstaller',
+            pixel_size: 256,
+        }));
+        installContent.add(makeLabel(anacondaApp.get_name(), true));
 
-      let installButton = new Gtk.Button({ child: installContent });
-      buttonBox.add(installButton);
+        const installButton = new Gtk.Button({child: installContent});
+        buttonBox.add(installButton);
 
-      this._label = makeLabel(_('You are currently running Fedora from live media.\nYou can install Fedora now, or choose "Install to Hard Drive" in the Activities Overview at any later time.'), false);
-      mainGrid.add(this._label);
+        this._label = makeLabel(
+            _('You are currently running Fedora from live media.\nYou can install Fedora now, or choose "Install to Hard Drive" in the Activities Overview at any later time.'),
+            false);
+        mainGrid.add(this._label);
 
-      installButton.connect('clicked', Lang.bind(this,
-          function() {
-              GLib.spawn_command_line_async('liveinst');
-              this.window.destroy();
-          }));
+        installButton.connect('clicked', Lang.bind(this,
+            function() {
+                GLib.spawn_command_line_async('liveinst');
+                this.window.destroy();
+            }));
 
-      tryButton.connect('clicked', Lang.bind(this,
-          function() {
-              buttonBox.destroy();
-              this._label.destroy();
+        tryButton.connect('clicked', Lang.bind(this,
+            function() {
+                buttonBox.destroy();
+                this._label.destroy();
 
-              // provided by the 'fedora-logos' package
-              let image = new Gtk.Image({ icon_name: 'org.fedoraproject.AnacondaInstaller',
-                                          pixel_size: 256,
-                                          halign: Gtk.Align.CENTER });
-              mainGrid.add(image);
+                // provided by the 'fedora-logos' package
+                const image = new Gtk.Image({
+                    icon_name: 'org.fedoraproject.AnacondaInstaller',
+                    pixel_size: 256,
+                    halign: Gtk.Align.CENTER,
+                });
+                mainGrid.add(image);
 
-              this._label = makeLabel(_('You can choose "Install to Hard Drive"\nin the Activities Overview at any later time.'), false);
-              mainGrid.add(this._label);
+                this._label = makeLabel(
+                    _('You can choose "Install to Hard Drive"\nin the Activities Overview at any later time.'),
+                    false);
+                mainGrid.add(this._label);
 
-              let closeLabel = makeLabel(_('Close'), true);
-              closeLabel.margin = 10;
-              let button = new Gtk.Button({ child: closeLabel,
-                                            halign: Gtk.Align.CENTER });
-              button.connect('clicked', Lang.bind(this,
-                  function() {
-                      this.window.destroy();
-                  }));
-              mainGrid.add(button);
+                const closeLabel = makeLabel(_('Close'), true);
+                closeLabel.margin = 10;
+                const button = new Gtk.Button({
+                    child: closeLabel,
+                    halign: Gtk.Align.CENTER,
+                });
+                button.connect('clicked', Lang.bind(this,
+                    function() {
+                        this.window.destroy();
+                    }));
+                mainGrid.add(button);
 
-              mainGrid.show_all();
-          }));
-  }
+                mainGrid.show_all();
+            }));
+    }
 });
 
 Gettext.bindtextdomain('anaconda', LOCALE_DIR);

--- a/data/liveinst/gnome/fedora-welcome.js
+++ b/data/liveinst/gnome/fedora-welcome.js
@@ -18,8 +18,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-imports.gi.versions.Gdk = "3.0";
-imports.gi.versions.Gtk = "3.0";
+imports.gi.versions.Gdk = '3.0';
+imports.gi.versions.Gtk = '3.0';
 
 const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
@@ -60,7 +60,7 @@ const WelcomeWindow = new Lang.Class({
                                                 default_width: 600,
                                                 default_height: 550,
                                                 skip_taskbar_hint: true,
-                                                title: _("Welcome to Fedora"),
+                                                title: _('Welcome to Fedora'),
                                                 window_position: Gtk.WindowPosition.CENTER });
       this.window.connect('key-press-event', Lang.bind(this,
           function(w, event) {
@@ -89,7 +89,7 @@ const WelcomeWindow = new Lang.Class({
                                      spacing: 16 });
       tryContent.add(new Gtk.Image({ icon_name: 'media-optical',
                                      pixel_size: 256 }));
-      tryContent.add(makeLabel(_("Try Fedora"), true));
+      tryContent.add(makeLabel(_('Try Fedora'), true));
 
       let tryButton = new Gtk.Button({ child: tryContent });
       buttonBox.add(tryButton);
@@ -105,7 +105,7 @@ const WelcomeWindow = new Lang.Class({
       let installButton = new Gtk.Button({ child: installContent });
       buttonBox.add(installButton);
 
-      this._label = makeLabel(_("You are currently running Fedora from live media.\nYou can install Fedora now, or choose \"Install to Hard Drive\" in the Activities Overview at any later time."), false);
+      this._label = makeLabel(_('You are currently running Fedora from live media.\nYou can install Fedora now, or choose "Install to Hard Drive" in the Activities Overview at any later time.'), false);
       mainGrid.add(this._label);
 
       installButton.connect('clicked', Lang.bind(this,
@@ -125,10 +125,10 @@ const WelcomeWindow = new Lang.Class({
                                           halign: Gtk.Align.CENTER });
               mainGrid.add(image);
 
-              this._label = makeLabel(_("You can choose \"Install to Hard Drive\"\nin the Activities Overview at any later time."), false);
+              this._label = makeLabel(_('You can choose "Install to Hard Drive"\nin the Activities Overview at any later time.'), false);
               mainGrid.add(this._label);
 
-              let closeLabel = makeLabel(_("Close"), true);
+              let closeLabel = makeLabel(_('Close'), true);
               closeLabel.margin = 10;
               let button = new Gtk.Button({ child: closeLabel,
                                             halign: Gtk.Align.CENTER });

--- a/data/liveinst/gnome/fedora-welcome.js
+++ b/data/liveinst/gnome/fedora-welcome.js
@@ -27,6 +27,8 @@ import Gtk from 'gi://Gtk?version=3.0';
 import {gettext as _} from 'gettext';
 import Gettext from 'gettext';
 
+import {programArgs, programInvocationName} from 'system';
+
 const LOCALE_DIR = '/usr/share/locale';
 
 let anacondaApp = null;
@@ -195,4 +197,4 @@ if (!anacondaApp)
     anacondaApp = Gio.DesktopAppInfo.new('liveinst.desktop');
 
 if (anacondaApp)
-    new WelcomeApp().run(ARGV);
+    new WelcomeApp().run([programInvocationName, ...programArgs]);

--- a/data/liveinst/gnome/fedora-welcome.js
+++ b/data/liveinst/gnome/fedora-welcome.js
@@ -159,6 +159,8 @@ class WelcomeWindow extends Gtk.ApplicationWindow {
 
             mainGrid.show_all();
         });
+
+        mainGrid.show_all();
     }
 }
 
@@ -183,7 +185,7 @@ if (anacondaApp) {
         welcomeWindow = new WelcomeWindow(application);
     });
     application.connect('activate', () => {
-        welcomeWindow.show_all();
+        welcomeWindow.present();
     });
 
     application.run(ARGV);


### PR DESCRIPTION
Both the javascript standards and support in gjs/gnome have changed quite a bit since the code was originally written. Update the code to match the current best practices (without changing any of the logic or UI).