### PR TITLE
Webui autopart v1

### DIFF
--- a/ui/webui/src/apis/storage.js
+++ b/ui/webui/src/apis/storage.js
@@ -155,6 +155,65 @@ export const getSelectedDisks = () => {
 };
 
 /**
+ * @param {string} partitioning    DBus path to a partitioning
+ * @param {string} passphrase      passphrase for disk encryption
+ */
+export const partitioningSetPassphrase = ({ partitioning, passphrase }) => {
+    return new StorageClient().client.call(
+        partitioning,
+        "org.fedoraproject.Anaconda.Modules.Storage.Partitioning.Automatic",
+        "SetPassphrase", [passphrase]
+    );
+};
+
+/**
+ * @param {string} partitioning     DBus path to a partitioning
+ * @param {boolean} encrypt         True if partitions should be encrypted, False otherwise
+ */
+export const partitioningSetEncrypt = ({ partitioning, encrypt }) => {
+    return getPartitioningRequest({ partitioning })
+            .then(request => {
+                request.encrypted = cockpit.variant("b", encrypt);
+                return setPartitioningRequest({ partitioning, request });
+            });
+};
+
+/**
+ * @returns {Promise}           The request of automatic partitioning
+ */
+export const getPartitioningRequest = ({ partitioning }) => {
+    return (
+        new StorageClient().client.call(
+            partitioning,
+            "org.freedesktop.DBus.Properties",
+            "Get",
+            [
+                "org.fedoraproject.Anaconda.Modules.Storage.Partitioning.Automatic",
+                "Request",
+            ]
+        )
+                .then(res => res[0].v)
+    );
+};
+
+/**
+ * @param {string} partitioning     DBus path to a partitioning
+ * @param {Object} request          A data object with the request
+ */
+export const setPartitioningRequest = ({ partitioning, request }) => {
+    return new StorageClient().client.call(
+        partitioning,
+        "org.freedesktop.DBus.Properties",
+        "Set",
+        [
+            "org.fedoraproject.Anaconda.Modules.Storage.Partitioning.Automatic",
+            "Request",
+            cockpit.variant("a{sv}", request)
+        ]
+    );
+};
+
+/**
  * @param {string} partitioning DBus path to a partitioning
  *
  * @returns {Promise}           Resolves a DBus path to a task

--- a/ui/webui/src/apis/storage.js
+++ b/ui/webui/src/apis/storage.js
@@ -209,6 +209,24 @@ export const scanDevicesWithTask = () => {
 };
 
 /**
+ * @returns {Promise}           The number of the mode
+ */
+export const getInitializationMode = () => {
+    return (
+        new StorageClient().client.call(
+            "/org/fedoraproject/Anaconda/Modules/Storage/DiskInitialization",
+            "org.freedesktop.DBus.Properties",
+            "Get",
+            [
+                "org.fedoraproject.Anaconda.Modules.Storage.DiskInitialization",
+                "InitializationMode",
+            ]
+        )
+                .then(res => res[0].v)
+    );
+};
+
+/**
  * @param {int} mode            The number of the mode
  */
 export const setInitializationMode = ({ mode }) => {

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -183,6 +183,7 @@ const Footer = ({ isFormValid, setIsFormValid, setStepNotification, isInProgress
 
             applyDefaultStorage({
                 onFail: ex => {
+                    console.error(ex);
                     setIsInProgress(false);
                     setStepNotification({ step: activeStep.id, ...ex });
                 },

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -30,6 +30,7 @@ import {
 } from "@patternfly/react-core";
 
 import { InstallationDestination, applyDefaultStorage } from "./storage/InstallationDestination.jsx";
+import { StorageConfiguration } from "./storage/StorageConfiguration.jsx";
 import { InstallationLanguage } from "./localization/InstallationLanguage.jsx";
 import { InstallationProgress } from "./installation/InstallationProgress.jsx";
 import { ReviewConfiguration, ReviewConfigurationConfirmModal } from "./review/ReviewConfiguration.jsx";
@@ -57,6 +58,10 @@ export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, titl
                 component: InstallationDestination,
                 id: "storage-devices",
                 label: _("Storage devices")
+            }, {
+                component: StorageConfiguration,
+                id: "storage-configuration",
+                label: _("Storage configuration")
             }]
         },
         {

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -178,7 +178,7 @@ const Footer = ({ isFormValid, setIsFormValid, setStepNotification, isInProgress
         // first reset validation state to default
         setIsFormValid(true);
 
-        if (activeStep.id === "storage-devices") {
+        if (activeStep.id === "disk-encryption") {
             setIsInProgress(true);
 
             applyDefaultStorage({

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -294,7 +294,7 @@ const Footer = ({
                                       id="next-tooltip-ref"
                                       content={
                                           <div>
-                                              {_("To continue, select the devices(s) to install to.")}
+                                              {_("To continue, select the devices to install to.")}
                                           </div>
                                       }
                                       // Only show the tooltip on installation destination spoke that is not valid (no disks selected).

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -31,6 +31,7 @@ import {
 
 import { InstallationDestination, applyDefaultStorage } from "./storage/InstallationDestination.jsx";
 import { StorageConfiguration } from "./storage/StorageConfiguration.jsx";
+import { DiskEncryption } from "./storage/DiskEncryption.jsx";
 import { InstallationLanguage } from "./localization/InstallationLanguage.jsx";
 import { InstallationProgress } from "./installation/InstallationProgress.jsx";
 import { ReviewConfiguration, ReviewConfigurationConfirmModal } from "./review/ReviewConfiguration.jsx";
@@ -62,6 +63,10 @@ export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, titl
                 component: StorageConfiguration,
                 id: "storage-configuration",
                 label: _("Storage configuration")
+            }, {
+                component: DiskEncryption,
+                id: "disk-encryption",
+                label: _("Disk encryption")
             }]
         },
         {

--- a/ui/webui/src/components/storage/DiskEncryption.jsx
+++ b/ui/webui/src/components/storage/DiskEncryption.jsx
@@ -58,7 +58,7 @@ const strengthLevels = [{
     icon: <ExclamationCircleIcon />,
     lower_bound: 0,
     higher_bound: 29,
-    valid: false,
+    valid: true,
 }, {
     id: "medium",
     label: _("Medium"),
@@ -66,7 +66,7 @@ const strengthLevels = [{
     icon: <ExclamationTriangleIcon />,
     lower_bound: 30,
     higher_bound: 69,
-    valid: false,
+    valid: true,
 }, {
     id: "strong",
     label: _("Strong"),

--- a/ui/webui/src/components/storage/DiskEncryption.jsx
+++ b/ui/webui/src/components/storage/DiskEncryption.jsx
@@ -16,24 +16,255 @@
  */
 
 import cockpit from "cockpit";
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 import {
     Bullseye,
+    Button,
+    Checkbox,
     EmptyState,
     EmptyStateIcon,
+    Form,
+    FormGroup,
+    FormSection,
+    FormHelperText,
+    HelperText,
+    HelperTextItem,
+    InputGroup,
     Spinner,
+    TextInput,
     TextContent,
     TextVariants,
     Text,
     Title,
 } from "@patternfly/react-core";
 
+// eslint-disable-next-line camelcase
+import { password_quality } from "cockpit-components-password.jsx";
+import EyeIcon from "@patternfly/react-icons/dist/esm/icons/eye-icon";
+import EyeSlashIcon from "@patternfly/react-icons/dist/esm/icons/eye-slash-icon";
+import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
+import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
+import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
+
 import { AnacondaPage } from "../AnacondaPage.jsx";
 
 const _ = cockpit.gettext;
 
-export const DiskEncryption = ({ isInProgress }) => {
+const strengthLevels = [{
+    id: "weak",
+    label: _("Weak"),
+    variant: "error",
+    icon: <ExclamationCircleIcon />,
+    lower_bound: 0,
+    higher_bound: 29,
+    valid: false,
+}, {
+    id: "medium",
+    label: _("Medium"),
+    variant: "warning",
+    icon: <ExclamationTriangleIcon />,
+    lower_bound: 30,
+    higher_bound: 69,
+    valid: false,
+}, {
+    id: "strong",
+    label: _("Strong"),
+    variant: "success",
+    icon: <CheckCircleIcon />,
+    lower_bound: 70,
+    higher_bound: 100,
+    valid: true,
+}];
+
+export function StorageEncryptionState (password = "", confirmPassword = "", encrypt = false) {
+    this.password = password;
+    this.confirmPassword = confirmPassword;
+    this.encrypt = encrypt;
+}
+
+const passwordStrengthLabel = (strength) => {
+    const level = strengthLevels.filter(l => l.id === strength)[0];
+    if (level) {
+        return (
+            <HelperText>
+                <HelperTextItem variant={level.variant} icon={level.icon}>
+                    {level.label}
+                </HelperTextItem>
+            </HelperText>
+        );
+    }
+};
+
+// TODO create strengthLevels object with methods passed to the component ?
+const PasswordFormFields = ({
+    password,
+    passwordLabel,
+    onChange,
+    passwordConfirm,
+    passwordConfirmLabel,
+    onConfirmChange,
+    passwordStrength,
+    ruleLength,
+    ruleConfirmMatches
+}) => {
+    const [passwordHidden, setPasswordHidden] = useState(true);
+    const [confirmHidden, setConfirmHidden] = useState(true);
+    return (
+        <>
+            <FormGroup
+              label={passwordLabel}
+              labelInfo={ruleLength === "success" && passwordStrengthLabel(passwordStrength)}
+            >
+                <InputGroup>
+                    <TextInput
+                      type={passwordHidden ? "password" : "text"}
+                      value={password}
+                      onChange={onChange}
+                      id="password-field"
+                    />
+                    <Button
+                      variant="control"
+                      onClick={() => setPasswordHidden(!passwordHidden)}
+                      aria-label={passwordHidden ? _("Show password") : _("Hide password")}
+                    >
+                        {passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+                    </Button>
+                </InputGroup>
+                <FormHelperText isHidden={false} component="div">
+                    <HelperText component="ul" aria-live="polite" id="password-field-helper">
+                        <HelperTextItem isDynamic variant={ruleLength} component="li">
+                            {_("Must be at least 8 characters")}
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>
+            </FormGroup>
+            <FormGroup
+              label={passwordConfirmLabel}
+            >
+                <InputGroup>
+                    <TextInput
+                      type={confirmHidden ? "password" : "text"}
+                      value={passwordConfirm}
+                      onChange={onConfirmChange}
+                      id="password-confirm-field"
+                    />
+                    <Button
+                      variant="control"
+                      onClick={() => setConfirmHidden(!confirmHidden)}
+                      aria-label={confirmHidden ? _("Show confirmed password") : _("Hide confirmed password")}
+                    >
+                        {confirmHidden ? <EyeIcon /> : <EyeSlashIcon />}
+                    </Button>
+                </InputGroup>
+                <FormHelperText isHidden={false} component="div">
+                    <HelperText component="ul" aria-live="polite" id="password-confirm-field-helper">
+                        <HelperTextItem isDynamic variant={ruleConfirmMatches} component="li">
+                            {_("Passphrases must match")}
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>
+            </FormGroup>
+        </>
+    );
+};
+
+const getPasswordStrength = async (password) => {
+    // In case of unacceptable password just return 0
+    const force = true;
+    const quality = await password_quality(password, force);
+    const level = strengthLevels.filter(l => l.lower_bound <= quality.value && l.higher_bound >= quality.value)[0];
+    return level.id;
+};
+
+const isValidStrength = (strength) => {
+    const level = strengthLevels.filter(l => l.id === strength)[0];
+    return level ? level.valid : false;
+};
+
+const getRuleLength = (password) => {
+    let ruleState = "indeterminate";
+    if (password.length > 0 && password.length <= 7) {
+        ruleState = "error";
+    } else if (password.length > 7) {
+        ruleState = "success";
+    }
+    return ruleState;
+};
+
+const getRuleConfirmMatches = (password, confirm) => (password.length > 0 ? (password === confirm ? "success" : "error") : "indeterminate");
+
+export const DiskEncryption = ({
+    isInProgress,
+    setIsFormValid,
+    storageEncryption,
+    setStorageEncryption,
+    showPassphraseScreen,
+}) => {
+    const [password, setPassword] = useState(storageEncryption.password);
+    const [confirmPassword, setConfirmPassword] = useState(storageEncryption.confirmPassword);
+    const [passwordStrength, setPasswordStrength] = useState("");
+    const [ruleLength, setRuleLength] = useState("indeterminate");
+    const [ruleConfirmMatches, setRuleConfirmMatches] = useState("indeterminate");
+    const encryptedDevicesCheckbox = (
+        <Checkbox
+          id="encrypt_devices"
+          label={_("Yes, I want device encryption (optional)")}
+          description={_(
+              "If you select this option you will be asked to create an encryption passphrase." +
+              " You will use the passphrase to access your data when you start your computer." +
+              " You won't be able to switch between keyboard layouts (from the default one)" +
+              " when you decrypt your disks after install."
+          )}
+          isChecked={storageEncryption.encrypt}
+          onChange={(encrypt) => setStorageEncryption(se => ({ ...se, encrypt }))}
+        />
+    );
+
+    const passphraseForm = (
+        <Form>
+            <FormSection
+              title={_("Create a passphrase")}
+              titleElement="h3"
+            >
+                <PasswordFormFields
+                  password={password}
+                  passwordLabel={_("Passphrase")}
+                  passwordStrength={passwordStrength}
+                  passwordConfirm={confirmPassword}
+                  passwordConfirmLabel={_("Confirm passphrase")}
+                  ruleLength={ruleLength}
+                  ruleConfirmMatches={ruleConfirmMatches}
+                  onChange={setPassword}
+                  onConfirmChange={setConfirmPassword}
+                />
+            </FormSection>
+        </Form>
+    );
+
+    useEffect(() => {
+        const updateValidity = async (password, confirmPassword, showPassphraseScreen) => {
+            const passwordStrength = await getPasswordStrength(password);
+            setPasswordStrength(passwordStrength);
+            const ruleLength = getRuleLength(password);
+            setRuleLength(ruleLength);
+            const ruleConfirmMatches = getRuleConfirmMatches(password, confirmPassword);
+            setRuleConfirmMatches(ruleConfirmMatches);
+            const passphraseValid = (
+                ruleLength === "success" &&
+                ruleConfirmMatches === "success" &&
+                isValidStrength(passwordStrength)
+            );
+            setIsFormValid(!showPassphraseScreen || passphraseValid);
+        };
+
+        updateValidity(password, confirmPassword, showPassphraseScreen);
+    }, [setIsFormValid, showPassphraseScreen, password, confirmPassword]);
+
+    useEffect(() => {
+        setStorageEncryption(se => ({ ...se, password, confirmPassword }));
+    }, [password, confirmPassword, setStorageEncryption]);
+
     if (isInProgress) {
         return (
             <Bullseye>
@@ -54,7 +285,14 @@ export const DiskEncryption = ({ isInProgress }) => {
 
     return (
         <AnacondaPage title={_("Encrypt the selected devices?")}>
-            <p>TODO</p>
+            <TextContent>
+                {_(
+                    "You can create encrypted devices during installation." +
+                    " This allows you to easily configure a system with ecrypted partitions." +
+                    " To enable block device encryption, check the \"Encrypt System\" checkbox"
+                )}
+            </TextContent>
+            {showPassphraseScreen ? passphraseForm : encryptedDevicesCheckbox}
         </AnacondaPage>
 
     );

--- a/ui/webui/src/components/storage/DiskEncryption.jsx
+++ b/ui/webui/src/components/storage/DiskEncryption.jsx
@@ -194,6 +194,22 @@ const getRuleLength = (password) => {
 
 const getRuleConfirmMatches = (password, confirm) => (password.length > 0 ? (password === confirm ? "success" : "error") : "indeterminate");
 
+const CheckDisksSpinner = (
+    <Bullseye>
+        <EmptyState id="installation-destination-next-spinner">
+            <EmptyStateIcon variant="container" component={Spinner} />
+            <Title size="lg" headingLevel="h4">
+                {_("Checking storage configuration")}
+            </Title>
+            <TextContent>
+                <Text component={TextVariants.p}>
+                    {_("This may take a moment")}
+                </Text>
+            </TextContent>
+        </EmptyState>
+    </Bullseye>
+);
+
 export const DiskEncryption = ({
     isInProgress,
     setIsFormValid,
@@ -266,21 +282,7 @@ export const DiskEncryption = ({
     }, [password, confirmPassword, setStorageEncryption]);
 
     if (isInProgress) {
-        return (
-            <Bullseye>
-                <EmptyState id="installation-destination-next-spinner">
-                    <EmptyStateIcon variant="container" component={Spinner} />
-                    <Title size="lg" headingLevel="h4">
-                        {_("Checking storage configuration")}
-                    </Title>
-                    <TextContent>
-                        <Text component={TextVariants.p}>
-                            {_("This may take a moment")}
-                        </Text>
-                    </TextContent>
-                </EmptyState>
-            </Bullseye>
-        );
+        return CheckDisksSpinner;
     }
 
     return (

--- a/ui/webui/src/components/storage/DiskEncryption.jsx
+++ b/ui/webui/src/components/storage/DiskEncryption.jsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+
+import { AnacondaPage } from "../AnacondaPage.jsx";
+
+const _ = cockpit.gettext;
+
+export const DiskEncryption = () => {
+    return (
+        <AnacondaPage title={_("Encrypt the selected devices?")}>
+            <p>TODO</p>
+        </AnacondaPage>
+
+    );
+};

--- a/ui/webui/src/components/storage/DiskEncryption.jsx
+++ b/ui/webui/src/components/storage/DiskEncryption.jsx
@@ -83,12 +83,12 @@ export function StorageEncryptionState (password = "", confirmPassword = "", enc
     this.encrypt = encrypt;
 }
 
-const passwordStrengthLabel = (strength) => {
+const passwordStrengthLabel = (idPrefix, strength) => {
     const level = strengthLevels.filter(l => l.id === strength)[0];
     if (level) {
         return (
             <HelperText>
-                <HelperTextItem variant={level.variant} icon={level.icon}>
+                <HelperTextItem id={idPrefix + "-password-strength-label"} variant={level.variant} icon={level.icon}>
                     {level.label}
                 </HelperTextItem>
             </HelperText>
@@ -98,6 +98,7 @@ const passwordStrengthLabel = (strength) => {
 
 // TODO create strengthLevels object with methods passed to the component ?
 const PasswordFormFields = ({
+    idPrefix,
     password,
     passwordLabel,
     onChange,
@@ -114,14 +115,14 @@ const PasswordFormFields = ({
         <>
             <FormGroup
               label={passwordLabel}
-              labelInfo={ruleLength === "success" && passwordStrengthLabel(passwordStrength)}
+              labelInfo={ruleLength === "success" && passwordStrengthLabel(idPrefix, passwordStrength)}
             >
                 <InputGroup>
                     <TextInput
                       type={passwordHidden ? "password" : "text"}
                       value={password}
                       onChange={onChange}
-                      id="password-field"
+                      id={idPrefix + "-password-field"}
                     />
                     <Button
                       variant="control"
@@ -132,8 +133,13 @@ const PasswordFormFields = ({
                     </Button>
                 </InputGroup>
                 <FormHelperText isHidden={false} component="div">
-                    <HelperText component="ul" aria-live="polite" id="password-field-helper">
-                        <HelperTextItem isDynamic variant={ruleLength} component="li">
+                    <HelperText component="ul" aria-live="polite" id={idPrefix + "-password-field-helper"}>
+                        <HelperTextItem
+                          id={idPrefix + "-password-rule-8-chars"}
+                          isDynamic
+                          variant={ruleLength}
+                          component="li"
+                        >
                             {_("Must be at least 8 characters")}
                         </HelperTextItem>
                     </HelperText>
@@ -147,7 +153,7 @@ const PasswordFormFields = ({
                       type={confirmHidden ? "password" : "text"}
                       value={passwordConfirm}
                       onChange={onConfirmChange}
-                      id="password-confirm-field"
+                      id={idPrefix + "-password-confirm-field"}
                     />
                     <Button
                       variant="control"
@@ -159,7 +165,12 @@ const PasswordFormFields = ({
                 </InputGroup>
                 <FormHelperText isHidden={false} component="div">
                     <HelperText component="ul" aria-live="polite" id="password-confirm-field-helper">
-                        <HelperTextItem isDynamic variant={ruleConfirmMatches} component="li">
+                        <HelperTextItem
+                          id={idPrefix + "-password-rule-match"}
+                          isDynamic
+                          variant={ruleConfirmMatches}
+                          component="li"
+                        >
                             {_("Passphrases must match")}
                         </HelperTextItem>
                     </HelperText>
@@ -211,6 +222,7 @@ const CheckDisksSpinner = (
 );
 
 export const DiskEncryption = ({
+    idPrefix,
     isInProgress,
     setIsFormValid,
     storageEncryption,
@@ -224,7 +236,7 @@ export const DiskEncryption = ({
     const [ruleConfirmMatches, setRuleConfirmMatches] = useState("indeterminate");
     const encryptedDevicesCheckbox = (
         <Checkbox
-          id="encrypt_devices"
+          id={idPrefix + "-encrypt-devices"}
           label={_("Yes, I want device encryption (optional)")}
           description={_(
               "If you select this option you will be asked to create an encryption passphrase." +
@@ -244,6 +256,7 @@ export const DiskEncryption = ({
               titleElement="h3"
             >
                 <PasswordFormFields
+                  idPrefix={idPrefix}
                   password={password}
                   passwordLabel={_("Passphrase")}
                   passwordStrength={passwordStrength}

--- a/ui/webui/src/components/storage/DiskEncryption.jsx
+++ b/ui/webui/src/components/storage/DiskEncryption.jsx
@@ -18,11 +18,40 @@
 import cockpit from "cockpit";
 import React from "react";
 
+import {
+    Bullseye,
+    EmptyState,
+    EmptyStateIcon,
+    Spinner,
+    TextContent,
+    TextVariants,
+    Text,
+    Title,
+} from "@patternfly/react-core";
+
 import { AnacondaPage } from "../AnacondaPage.jsx";
 
 const _ = cockpit.gettext;
 
-export const DiskEncryption = () => {
+export const DiskEncryption = ({ isInProgress }) => {
+    if (isInProgress) {
+        return (
+            <Bullseye>
+                <EmptyState id="installation-destination-next-spinner">
+                    <EmptyStateIcon variant="container" component={Spinner} />
+                    <Title size="lg" headingLevel="h4">
+                        {_("Checking storage configuration")}
+                    </Title>
+                    <TextContent>
+                        <Text component={TextVariants.p}>
+                            {_("This may take a moment")}
+                        </Text>
+                    </TextContent>
+                </EmptyState>
+            </Bullseye>
+        );
+    }
+
     return (
         <AnacondaPage title={_("Encrypt the selected devices?")}>
             <p>TODO</p>

--- a/ui/webui/src/components/storage/HelpAutopartOptions.jsx
+++ b/ui/webui/src/components/storage/HelpAutopartOptions.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import cockpit from "cockpit";
+
+import {
+    Text,
+    TextContent,
+    TextVariants,
+} from "@patternfly/react-core";
+
+const _ = cockpit.gettext;
+
+export const helpEraseAll = (
+    <TextContent>
+        <Text component={TextVariants.p}>
+            {_("Removes all partitions on the selected devices. " +
+            "This includes partitions created by other operating systems.")}
+        </Text>
+
+        <Text component={TextVariants.p}>
+            {_("This option will remove data from the selected devices. " +
+            "Make sure you have backups.")}
+        </Text>
+    </TextContent>
+);
+
+export const helpUseFreeSpace = (
+    <TextContent>
+        <Text component={TextVariants.p}>
+            {_("Retains your current data and partitions and uses " +
+            "only the unpartitioned space on the selected devices, " +
+            "assuming you have enough free space available.")}
+        </Text>
+    </TextContent>
+);

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -461,7 +461,7 @@ export const InstallationDestination = ({ idPrefix, setIsFormValid, onAddErrorNo
             <TextContent>
                 <Text id={idPrefix + "-hint"} component={TextVariants.p}>
                     {cockpit.format(_(
-                        "Select the device(s) to install to. The installation requires " +
+                        "Select the devices to install to. The installation requires " +
                         "$0 of available space. Storage will be automatically partitioned."
                     ), cockpit.format_bytes(requiredSize))}
                     {" "}

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -63,7 +63,6 @@ import {
     resetPartitioning,
     runStorageTask,
     scanDevicesWithTask,
-    setInitializationMode,
     setInitializeLabelsEnabled,
     setSelectedDisks,
     setBootloaderDrive,
@@ -482,8 +481,7 @@ export const InstallationDestination = ({ idPrefix, setIsFormValid, onAddErrorNo
 export const applyDefaultStorage = ({ onFail, onSuccess }) => {
     let partitioning;
     // CLEAR_PARTITIONS_ALL = 1
-    return setInitializationMode({ mode: 1 })
-            .then(() => sleep({ seconds: 2 }))
+    return sleep({ seconds: 2 })
             .then(() => setInitializeLabelsEnabled({ enabled: true }))
             .then(() => setBootloaderDrive({ drive: "" }))
             .then(() => createPartitioning({ method: "AUTOMATIC" }))

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -91,7 +91,8 @@ const _ = cockpit.gettext;
 const selectDefaultDisks = ({ ignoredDisks, selectedDisks, usableDisks }) => {
     if (selectedDisks.length) {
         // Do nothing if there are some disks selected
-        return [];
+        console.log("Selecting disks selected in backend:", selectedDisks.join(","));
+        return selectedDisks;
     } else {
         const availableDisks = usableDisks.filter(disk => !ignoredDisks.includes(disk));
         console.log("Selecting one or less disks by default:", availableDisks.join(","));
@@ -243,9 +244,14 @@ const LocalStandardDisks = ({ idPrefix, setIsFormValid, onAddErrorNotification }
 
     // When the selected disks change in the UI, update in the backend as well
     useEffect(() => {
+        // Do not update on the inital value, wait for initialization by the other effect
+        if (Object.keys(disks).length === 0) {
+            return;
+        }
         setIsFormValid(selectedDisksCnt > 0);
 
         const selected = Object.keys(disks).filter(disk => disks[disk]);
+        console.log("Updating storage backend with selected disks:", selected.join(","));
 
         setSelectedDisks({ drives: selected }).catch(onAddErrorNotification);
     }, [disks, onAddErrorNotification, selectedDisksCnt, setIsFormValid]);

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -20,15 +20,12 @@ import React, { useEffect, useState } from "react";
 import {
     Alert,
     AlertActionCloseButton,
-    Bullseye,
     Button,
     Divider,
     Dropdown,
     DropdownItem,
     DropdownToggle,
     DropdownToggleCheckbox,
-    EmptyState,
-    EmptyStateIcon,
     Flex,
     FlexItem,
     Form,
@@ -36,12 +33,10 @@ import {
     FormSection,
     Popover,
     PopoverPosition,
-    Spinner,
     Skeleton,
     Text,
     TextContent,
     TextVariants,
-    Title,
     Toolbar,
     ToolbarContent,
     ToolbarItem,
@@ -453,24 +448,6 @@ export const InstallationDestination = ({ idPrefix, setIsFormValid, onAddErrorNo
                     }, console.error);
                 }, console.error);
     }, []);
-
-    if (isInProgress) {
-        return (
-            <Bullseye>
-                <EmptyState id="installation-destination-next-spinner">
-                    <EmptyStateIcon variant="container" component={Spinner} />
-                    <Title size="lg" headingLevel="h4">
-                        {_("Checking disks")}
-                    </Title>
-                    <TextContent>
-                        <Text component={TextVariants.p}>
-                            {_("This may take a moment")}
-                        </Text>
-                    </TextContent>
-                </EmptyState>
-            </Bullseye>
-        );
-    }
 
     return (
         <AnacondaPage title={_("Select storage devices")}>

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -66,6 +66,8 @@ import {
     setInitializeLabelsEnabled,
     setSelectedDisks,
     setBootloaderDrive,
+    partitioningSetPassphrase,
+    partitioningSetEncrypt,
 } from "../../apis/storage.js";
 
 import {
@@ -484,7 +486,8 @@ export const InstallationDestination = ({ idPrefix, setIsFormValid, onAddErrorNo
     );
 };
 
-export const applyDefaultStorage = ({ onFail, onSuccess }) => {
+export const applyDefaultStorage = ({ onFail, onSuccess, encrypt, encryptPassword }) => {
+    console.log(`applyDefaultStorage, encrypt: ${encrypt}`);
     let partitioning;
     // CLEAR_PARTITIONS_ALL = 1
     return sleep({ seconds: 2 })
@@ -493,8 +496,12 @@ export const applyDefaultStorage = ({ onFail, onSuccess }) => {
             .then(() => createPartitioning({ method: "AUTOMATIC" }))
             .then(res => {
                 partitioning = res[0];
-                return partitioningConfigureWithTask({ partitioning });
+                return partitioningSetEncrypt({ partitioning, encrypt });
             })
+            .then(() => {
+                return partitioningSetPassphrase({ partitioning, passphrase: encryptPassword });
+            })
+            .then(() => partitioningConfigureWithTask({ partitioning }))
             .then(tasks => {
                 runStorageTask({
                     task: tasks[0],

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -473,7 +473,7 @@ export const InstallationDestination = ({ idPrefix, setIsFormValid, onAddErrorNo
     }
 
     return (
-        <AnacondaPage title={_("Installation destination")}>
+        <AnacondaPage title={_("Select storage devices")}>
             <TextContent>
                 <Text id={idPrefix + "-hint"} component={TextVariants.p}>
                     {cockpit.format(_(

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -486,6 +486,8 @@ export const InstallationDestination = ({ idPrefix, setIsFormValid, onAddErrorNo
     );
 };
 
+// TODO move to the right place (new or StorageConfiguration) when renaming this file
+// TODO migrate to async
 export const applyDefaultStorage = ({ onFail, onSuccess, encrypt, encryptPassword }) => {
     console.log(`applyDefaultStorage, encrypt: ${encrypt}`);
     let partitioning;

--- a/ui/webui/src/components/storage/StorageConfiguration.jsx
+++ b/ui/webui/src/components/storage/StorageConfiguration.jsx
@@ -157,8 +157,46 @@ export const scenarios = [{
     initializationMode: 0,
 }];
 
+const scenarioDetailContent = (scenario, hint) => {
+    return (
+        <Flex direction={{ default: "column" }}>
+            <Title headingLevel="h3">
+                {scenario.label}
+            </Title>
+            {hint &&
+                <Alert
+                  id="scenario-disabled-hint"
+                  isInline
+                  title={_("This option is disabled")}
+                  variant="warning"
+                >
+                    {hint}
+                </Alert>}
+            <TextContent>
+                <Text>
+                    {scenario.detail}
+                </Text>
+            </TextContent>
+        </Flex>
+    );
+};
+
+const predefinedStorageInfo = (
+    <Popover
+      bodyContent={_(
+          "Pre-defined scenarios of the selected disks partitioning."
+      )}
+      position={PopoverPosition.auto}
+    >
+        <Button
+          variant="link"
+          aria-label={_("Pre-defined storage label info")}
+          icon={<HelpIcon />}
+        />
+    </Popover>
+);
+
 // TODO add aria items
-// TODO put everything you can (and should) outside the component
 // TODO add prefixes to ids (for tests)
 const GuidedPartitioning = ({ scenarios, setIsFormValid }) => {
     const [selectedScenario, setSelectedScenario] = useState();
@@ -208,30 +246,6 @@ const GuidedPartitioning = ({ scenarios, setIsFormValid }) => {
             applyScenario(selectedScenario);
         }
     }, [scenarios, selectedScenario]);
-
-    const scenarioDetailContent = (scenario, hint) => {
-        return (
-            <Flex direction={{ default: "column" }}>
-                <Title headingLevel="h3">
-                    {scenario.label}
-                </Title>
-                {hint &&
-                    <Alert
-                      id="scenario-disabled-hint"
-                      isInline
-                      title={_("This option is disabled")}
-                      variant="warning"
-                    >
-                        {hint}
-                    </Alert>}
-                <TextContent>
-                    <Text>
-                        {scenario.detail}
-                    </Text>
-                </TextContent>
-            </Flex>
-        );
-    };
 
     const updateDetailContent = (scenarioId) => {
         const scenario = scenarios.filter(s => s.id === scenarioId)[0];
@@ -301,21 +315,6 @@ const GuidedPartitioning = ({ scenarios, setIsFormValid }) => {
         <DataList>
             {scenarioItems}
         </DataList>
-    );
-
-    const predefinedStorageInfo = (
-        <Popover
-          bodyContent={_(
-              "Pre-defined scenarios of the selected disks partitioning."
-          )}
-          position={PopoverPosition.auto}
-        >
-            <Button
-              variant="link"
-              aria-label={_("Pre-defined storage label info")}
-              icon={<HelpIcon />}
-            />
-        </Popover>
     );
 
     return (

--- a/ui/webui/src/components/storage/StorageConfiguration.jsx
+++ b/ui/webui/src/components/storage/StorageConfiguration.jsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+
+import {
+    TextContent,
+} from "@patternfly/react-core";
+
+import { AnacondaPage } from "../AnacondaPage.jsx";
+
+const _ = cockpit.gettext;
+
+export const StorageConfiguration = () => {
+    return (
+        <AnacondaPage title={_("Select a storage configuration")}>
+            <TextContent>
+                {_("Configure the partitioning scheme to be used on the selected disks.")}
+            </TextContent>
+        </AnacondaPage>
+
+    );
+};

--- a/ui/webui/src/components/storage/StorageConfiguration.jsx
+++ b/ui/webui/src/components/storage/StorageConfiguration.jsx
@@ -43,6 +43,7 @@ import {
     TextContent,
     Text,
     Title,
+    Tooltip,
     Radio,
 } from "@patternfly/react-core";
 
@@ -102,10 +103,11 @@ const DetailDrawer = ({ isExpanded, setIsExpanded, detailContent, children }) =>
     );
 };
 
-function AvailabilityState (available = true, reason = null, hint = null) {
+function AvailabilityState (available = true, reason = null, hint = null, shortHint = null) {
     this.available = available;
     this.reason = reason;
     this.hint = hint;
+    this.shortHint = shortHint;
 }
 
 // TODO total size check could go also to disk selection screen
@@ -118,6 +120,7 @@ const checkEraseAll = async (selectedDisks, requiredSize) => {
         availability.hint = cockpit.format(_(
             "Total size: $0 Required size: $1"
         ), cockpit.format_bytes(size), cockpit.format_bytes(requiredSize));
+        availability.shortHint = _("To enable select bigger disks");
     }
     return availability;
 };
@@ -131,6 +134,7 @@ const checkUseFreeSpace = async (selectedDisks, requiredSize) => {
         availability.hint = cockpit.format(_(
             "Free size: $0 Required size: $1"
         ), cockpit.format_bytes(size), cockpit.format_bytes(requiredSize));
+        availability.shortHint = _("To enable free up disk space");
     }
     return availability;
 };
@@ -250,8 +254,14 @@ const GuidedPartitioning = ({ scenarios, setIsFormValid }) => {
             <DataListItemRow>
                 <DataListItemCells dataListCells={[
                     <DataListAction key="radio">
+                        {!scenarioAvailability[scenario.id].available &&
+                        <Tooltip
+                          aria-live="polite"
+                          content={scenarioAvailability[scenario.id].shortHint}
+                          reference={() => document.getElementById("autopart-scenario" + scenario.id)}
+                        />}
                         <Radio
-                          id={scenario.id}
+                          id={"autopart-scenario" + scenario.id}
                           value={scenario.id}
                           name="autopart-scenario"
                           label={scenario.label}

--- a/ui/webui/src/components/storage/StorageConfiguration.jsx
+++ b/ui/webui/src/components/storage/StorageConfiguration.jsx
@@ -119,7 +119,9 @@ const checkEraseAll = async (selectedDisks, requiredSize) => {
         availability.available = false;
         availability.reason = _("Not enough space on selected disks.");
         availability.hint = cockpit.format(_(
-            "Total size: $0 Required size: $1"
+            "There is not enough space on the selected disks. " +
+            "The installation requires $1 of available space " +
+            "while there is only $0 of space available."
         ), cockpit.format_bytes(size), cockpit.format_bytes(requiredSize));
         availability.shortHint = _("To enable select bigger disks");
     }
@@ -133,7 +135,9 @@ const checkUseFreeSpace = async (selectedDisks, requiredSize) => {
         availability.available = false;
         availability.reason = _("Not enough space on selected disks.");
         availability.hint = cockpit.format(_(
-            "Free size: $0 Required size: $1"
+            "There is not enough free space on the selected disks. " +
+            "The installation requires $1 of available space " +
+            "while there is only $0 of free space available."
         ), cockpit.format_bytes(size), cockpit.format_bytes(requiredSize));
         availability.shortHint = _("To enable free up disk space");
     }

--- a/ui/webui/src/components/storage/StorageConfiguration.jsx
+++ b/ui/webui/src/components/storage/StorageConfiguration.jsx
@@ -198,8 +198,7 @@ const predefinedStorageInfo = (
 );
 
 // TODO add aria items
-// TODO add prefixes to ids (for tests)
-const GuidedPartitioning = ({ scenarios, setIsFormValid }) => {
+const GuidedPartitioning = ({ idPrefix, scenarios, setIsFormValid }) => {
     const [selectedScenario, setSelectedScenario] = useState();
     const [scenarioAvailability, setScenarioAvailability] = useState(Object.fromEntries(
         scenarios.map((s) => [s.id, new AvailabilityState()])
@@ -273,10 +272,10 @@ const GuidedPartitioning = ({ scenarios, setIsFormValid }) => {
                         <Tooltip
                           aria-live="polite"
                           content={scenarioAvailability[scenario.id].shortHint}
-                          reference={() => document.getElementById("autopart-scenario" + scenario.id)}
+                          reference={() => document.getElementById(idPrefix + "-autopart-scenario-" + scenario.id)}
                         />}
                         <Radio
-                          id={"autopart-scenario" + scenario.id}
+                          id={idPrefix + "-autopart-scenario-" + scenario.id}
                           value={scenario.id}
                           name="autopart-scenario"
                           label={scenario.label}
@@ -335,13 +334,17 @@ const GuidedPartitioning = ({ scenarios, setIsFormValid }) => {
     );
 };
 
-export const StorageConfiguration = ({ setIsFormValid }) => {
+export const StorageConfiguration = ({ idPrefix, setIsFormValid }) => {
     return (
         <AnacondaPage title={_("Select a storage configuration")}>
             <TextContent>
                 {_("Configure the partitioning scheme to be used on the selected disks.")}
             </TextContent>
-            <GuidedPartitioning scenarios={scenarios} setIsFormValid={setIsFormValid} />
+            <GuidedPartitioning
+              idPrefix={idPrefix}
+              scenarios={scenarios}
+              setIsFormValid={setIsFormValid}
+            />
         </AnacondaPage>
     );
 };

--- a/ui/webui/src/components/storage/StorageConfiguration.jsx
+++ b/ui/webui/src/components/storage/StorageConfiguration.jsx
@@ -41,7 +41,6 @@ import {
     Popover,
     PopoverPosition,
     TextContent,
-    Text,
     Title,
     Tooltip,
     Radio,
@@ -50,6 +49,8 @@ import {
 import { HelpIcon } from "@patternfly/react-icons";
 
 import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
+
+import { helpEraseAll, helpUseFreeSpace } from "./HelpAutopartOptions.jsx";
 
 import {
     getRequiredDeviceSize,
@@ -142,7 +143,7 @@ const checkUseFreeSpace = async (selectedDisks, requiredSize) => {
 export const scenarios = [{
     id: "erase-all",
     label: _("Erase devices and install"),
-    detail: _("Erase devices details ..."),
+    detail: helpEraseAll,
     check: checkEraseAll,
     default: true,
     // CLEAR_PARTITIONS_ALL = 1
@@ -150,7 +151,7 @@ export const scenarios = [{
 }, {
     id: "use-free-space",
     label: _("Use free space for the installation"),
-    detail: _("Use free space details ..."),
+    detail: helpUseFreeSpace,
     check: checkUseFreeSpace,
     default: false,
     // CLEAR_PARTITIONS_NONE = 0
@@ -172,11 +173,7 @@ const scenarioDetailContent = (scenario, hint) => {
                 >
                     {hint}
                 </Alert>}
-            <TextContent>
-                <Text>
-                    {scenario.detail}
-                </Text>
-            </TextContent>
+            {scenario.detail}
         </Flex>
     );
 };

--- a/ui/webui/test/check-review
+++ b/ui/webui/test/check-review
@@ -43,6 +43,8 @@ class TestReview(MachineCase):
 
         i.open()
         i.next()
+        i.next()
+        i.next()
 
         # After clicking 'Next' on the storage step, partitioning is done, thus changing the available space on the disk
         # Since this is a non-destructive test we need to make sure the we reset partitioning to how it was before the test started

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -82,11 +82,27 @@ class TestStorage(MachineCase):
 
         i.next()
         # Storage Configuration
+
+        b.assert_pixels(
+            "#app",
+            "storage-step-autopart",
+            ignore=["#betanag-icon"],
+            wait_animations=False,
+        )
+
         s.check_partitioning_selected("erase-all")
         s.set_partitioning("use-free-space")
 
         i.next()
         # Disk Encryption
+
+        b.assert_pixels(
+            "#app",
+            "storage-step-encrypt",
+            ignore=["#betanag-icon"],
+            wait_animations=False,
+        )
+
         s.check_encryption_selected(False)
         encrypt = True
         s.set_encryption_selected(encrypt)
@@ -104,6 +120,13 @@ class TestStorage(MachineCase):
         # Encryption password is on the same page
         i.next(subpage=encrypt)
         # Disk Encryption / password screen
+
+        b.assert_pixels(
+            "#app",
+            "storage-step-password",
+            ignore=["#betanag-icon"],
+            wait_animations=False,
+        )
 
         # No password set
         s.check_pw_rule("8-chars", "indeterminate")

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -105,5 +105,15 @@ class TestStorageExtraDisks(MachineCase):
         s.rescan_disks()
         s.wait_no_disks_detected()
 
+        # Check that disk selection is kept on Next and Back
+        disks = ["vdb"]
+        for disk in disks:
+            s.select_disk(disk)
+        i.next()
+        i.back()
+        for disk in disks:
+            s.check_disk_selected(disk)
+
+
 if __name__ == '__main__':
     test_main()

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -68,8 +68,87 @@ class TestStorage(MachineCase):
         # Check the next button is disabled if no disks are selected
         i.check_next_disabled()
 
+    # Test moving back and forth between screens.
+    def testAutopartitioning(self):
+        b = self.browser
+        i = Installer(b, self.machine)
+        s = Storage(b, self.machine)
+
+        i.open()
+        # Language selection
+
+        i.next()
+        # Storage Devices
+
+        i.next()
+        # Storage Configuration
+        s.check_partitioning_selected("erase-all")
+        s.set_partitioning("use-free-space")
+
+        i.next()
+        # Disk Encryption
+        s.check_encryption_selected(False)
+        encrypt = True
+        s.set_encryption_selected(encrypt)
+
+        i.back()
+        # Storage Configuration
+        # The choice is preserved (stored in the backend).
+        s.check_partitioning_selected("use-free-space")
+
+        i.next()
+        # Disk Encryption
+        # The value is preserved
+        s.check_encryption_selected(encrypt)
+
+        # Encryption password is on the same page
+        i.next(subpage=encrypt)
+        # Disk Encryption / password screen
+
+        # No password set
+        s.check_pw_rule("8-chars", "indeterminate")
+        s.check_pw_rule("match", "indeterminate")
+        i.check_next_disabled()
+
+        # Set pw which is too short
+        s.set_password("abcd")
+        s.check_pw_strength(None)
+        i.check_next_disabled()
+        s.check_pw_rule("8-chars", "error")
+        s.check_pw_rule("match", "error")
+
+        # Make the pw 8 chars long
+        s.set_password("efgh", append=True, value_check=False)
+        i.check_next_disabled()
+        s.check_password("abcdefgh")
+        s.check_pw_rule("8-chars", "success")
+        s.check_pw_rule("match", "error")
+        s.check_pw_strength("weak")
+
+        # Set the password confirm
+        s.set_password_confirm("abcdefg")
+        s.check_pw_rule("match", "error")
+        s.set_password_confirm("abcdefgh")
+        s.check_pw_rule("match", "success")
+        i.check_next_disabled(disabled=False)
+
+        # Check the values are preserved on Back and Next
+        i.back(subpage=True)
+        i.next(subpage=encrypt)
+        s.check_pw_rule("8-chars", "success")
+        s.check_pw_rule("match", "success")
+        s.check_pw_strength("weak")
+        s.check_password("abcdefgh")
+        s.check_password_confirm("abcdefgh")
+        i.check_next_disabled(disabled=False)
+
+        # Check setting strong password
+        s.set_password("Rwce82ybF7dXtCzFumanchu!!!!!!!!")
+        s.check_pw_strength("strong")
+
 # We can't run this test case on an existing machine,
 # with --machine because MachineCase is not aware of add_disk method
+# TODO add next back test keeping the choice
 class TestStorageExtraDisks(MachineCase):
     MachineCase.machine_class = VirtInstallMachine
 

--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -21,10 +21,12 @@ from step_logger import log_step
 
 class InstallerSteps(UserList):
     WELCOME = "installation-language"
-    STORAGE = "installation-destination"
+    STORAGE_DEVICES = "storage-devices"
+    STORAGE_CONFIGURATION = "storage-configuration"
+    DISK_ENCRYPTION = "disk-encryption"
     REVIEW = "installation-review"
     PROGRESS = "installation-progress"
-    _steps_list = (WELCOME, STORAGE, REVIEW, PROGRESS)
+    _steps_list = (WELCOME, STORAGE_DEVICES, STORAGE_CONFIGURATION, DISK_ENCRYPTION, REVIEW, PROGRESS)
 
     def __init__(self, initlist=_steps_list):
         super().__init__(initlist)
@@ -59,7 +61,7 @@ class Installer():
 
         # Wait for a disk to be pre-selected before clicking 'Next'.
         # FIXME: Find a better way.
-        if current_page == self.steps.STORAGE:
+        if current_page == self.steps.STORAGE_DEVICES:
             sleep(2)
 
         self.browser.click("button:contains(Next)")

--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -54,7 +54,7 @@ class Installer():
             self.wait_current_page(self.steps[current_step_id+1])
 
     @log_step()
-    def next(self, should_fail=False):
+    def next(self, should_fail=False, subpage=False):
         current_step_id = self.get_current_page_id()
         current_page = self.steps[current_step_id]
         next_page = self.steps[current_step_id+1]
@@ -65,23 +65,24 @@ class Installer():
             sleep(2)
 
         self.browser.click("button:contains(Next)")
-        self.wait_current_page(current_page if should_fail else next_page)
+        self.wait_current_page(current_page if should_fail or subpage else next_page)
 
     @log_step()
-    def check_next_disabled(self):
+    def check_next_disabled(self, disabled=True):
         """Check if the Next button is disabled.
 
-        :return: True if Next is enabled, False otherwise
-        :rtype: bool
+        :param disabled: True if Next button should be disabled, False if not
+        :type disabled: bool, optional
         """
-        self.browser.wait_visible("#installation-next-btn:not([aria-disabled=false]")
+        value = "false" if disabled else "true"
+        self.browser.wait_visible(f"#installation-next-btn:not([aria-disabled={value}]")
 
     @log_step(snapshot_before=True)
-    def back(self, should_fail=False):
+    def back(self, should_fail=False, subpage=False):
         current_step_id = self.get_current_page_id()
         self.browser.click("button:contains(Back)")
 
-        if should_fail:
+        if should_fail or subpage:
             self.wait_current_page(self.steps[current_step_id])
         else:
             self.wait_current_page(self.steps[current_step_id-1])

--- a/ui/webui/test/helpers/storage.py
+++ b/ui/webui/test/helpers/storage.py
@@ -107,3 +107,62 @@ class Storage():
             self.browser.wait_text(f"#{disk} > td[data-label=Total]", total)
         if free:
             self.browser.wait_text(f"#{disk} > td[data-label=Free]", free)
+
+    def _partitioning_selector(self, scenario):
+        return "#storage-configuration-autopart-scenario-" + scenario
+
+    def check_partitioning_selected(self, scenario):
+        self.browser.wait_visible(self._partitioning_selector(scenario) + ":checked")
+
+    def set_partitioning(self, scenario):
+        self.browser.set_checked(self._partitioning_selector(scenario), True)
+
+    def check_encryption_selected(self, selected):
+        sel = "#disk-encryption-encrypt-devices"
+        if selected:
+            self.browser.wait_visible(sel + ':checked')
+        else:
+            self.browser.wait_visible(sel + ':not([checked])')
+
+    def set_encryption_selected(self, selected):
+        sel = "#disk-encryption-encrypt-devices"
+        self.browser.set_checked(sel, selected)
+
+    def check_pw_rule(self, rule, value):
+        sel = "#disk-encryption-password-rule-" + rule
+        cls_value = "pf-m-" + value
+        self.browser.wait_visible(sel)
+        self.browser.wait_attr_contains(sel, "class", cls_value)
+
+    def set_password(self, password, append=False, value_check=True):
+        sel = "#disk-encryption-password-field"
+        self.browser.set_input_text(sel, password, append=append, value_check=value_check)
+
+    def check_password(self, password):
+        sel = "#disk-encryption-password-field"
+        self.browser.wait_val(sel, password)
+
+    def set_password_confirm(self, password):
+        sel = "#disk-encryption-password-confirm-field"
+        self.browser.set_input_text(sel, password)
+
+    def check_password_confirm(self, password):
+        sel = "#disk-encryption-password-confirm-field"
+        self.browser.wait_val(sel, password)
+
+    def check_pw_strength(self, strength):
+        sel = "#disk-encryption-password-strength-label"
+
+        if strength is None:
+            self.browser.wait_not_present(sel)
+            return
+
+        variant = ""
+        if strength == "weak":
+            variant = "error"
+        elif strength == "medium":
+            variant = "warning"
+        elif strength == "strong":
+            variant = "success"
+
+        self.browser.wait_attr_contains(sel, "class", "pf-m-" + variant)

--- a/ui/webui/test/helpers/storage.py
+++ b/ui/webui/test/helpers/storage.py
@@ -72,7 +72,7 @@ class Storage():
     @log_step()
     def wait_no_disks(self):
         self.browser.wait_in_text("#next-tooltip-ref",
-                                  "To continue, select the devices(s) to install to.")
+                                  "To continue, select the devices to install to.")
 
     @log_step()
     def wait_no_disks_detected(self):

--- a/ui/webui/test/helpers/storage.py
+++ b/ui/webui/test/helpers/storage.py
@@ -33,7 +33,7 @@ class Storage():
     def __init__(self, browser, machine):
         self.browser = browser
         self.machine = machine
-        self._step = InstallerSteps.STORAGE
+        self._step = InstallerSteps.STORAGE_DEVICES
 
     def get_disks(self):
         output = self.machine.execute('list-harddrives')


### PR DESCRIPTION
First iteration of guided partitioning (autopartitioning) in WebUI.

There is a number of issues that need to be done either in scope of this PR or (preferably) as a follow-up tasks.
In this PR I would like to focus on doing the things correctly code-wise. 

Outstanding issues:

Must address in this PR:
- [x] Fix existing tests.
- [x] Add tests for the new functionality.
- [x] Test that the installation really works.
- [x] Add `idPrefix` to some ids.
- [x] Address unit tests failures related to strings.
- [x] Fix the devices(s) typos

May address here or separately:
- [ ] Change "Checking disks" to "Checking storage configuration" (applyConfiguration on Next after setting password) Related to [INSTALLER-3419](https://issues.redhat.com/browse/INSTALLER-3419)
- [ ] [INSTALLER-3447](https://issues.redhat.com/browse/INSTALLER-3447) Fix tooltip on hover over partitionong option radio does not work on the preview image. Consider also removing the no-entry symbol.
- [ ]  [INSTALLER-3443](https://issues.redhat.com/browse/INSTALLER-3443) Fix spacing of the alert info for disabled choices on Storage Configuration screen.
- [ ] [INSTALLER-3444](https://issues.redhat.com/browse/INSTALLER-3444) Fix vertical centering of the Storage Configuration choices.
- [ ] [INSTALLER-3445](https://issues.redhat.com/browse/INSTALLER-3445) Implement "Review and install" screen according to the mockup (show selections).
- [x] Update autopart option details / drawer content (there are just placeholders / raw phrases on some places)
- [ ] [INSTALLER-3405](https://issues.redhat.com/browse/INSTALLER-3405) Fix help drawer to be closed on leaving a screen (to prevent https://rvykydal.fedorapeople.org/webui/autopart/autopart_partitioning_choice_drawer.webm) 
- [ ] [INSTALLER-3446](https://issues.redhat.com/browse/INSTALLER-3446) Fix the state of disk selection screen after applying partitioning and going back (https://rvykydal.fedorapeople.org/webui/autopart_pr1/v1/screencasts/pr_autopart1_going_back_after_applying_part.webm) ? We should perhaps re-initialize the partitioning in the backend on "Back". Also add test for this.
- [ ] [INSTALLER-3449](https://issues.redhat.com/browse/INSTALLER-3449) Improve visibility of the partitioning choice (something like blue outline...).
- [x] Require the (more or less) same pw quality as in current Anaconda.
- [ ] [INSTALLER-3448](https://issues.redhat.com/browse/INSTALLER-3448) Add rules to passphrase checking (static and/or dynamic based on output of the pw checker (taken from cockpit))  
- [ ] InstallationDestination file and component could be renamed (commented in the PR)
- [ ] Audit error handling of promise calls.
- [ ] Move `applyConfiguration` to a better place.
- [ ] Migrate `applyConfiguration` to `async` syntax.
- [ ] Use total disk space check already on `Storage Devices` screen.
- [ ] Unify `HelpDrawer` and `DetailDrawer` component.
- [ ] Add missing aria properties.
- [ ] Consider encapsulating wizard steps into object with methods.

 
Notes:
- An issue independent of this PR [INSTALLER-3029](https://issues.redhat.com/browse/INSTALLER-3029) (Keeping the disk selection when going back) is fixed in `webui: Keep selection... ` of this set, also a test has been added (`webui: test that disk selection...`)