### PR TITLE
Fix broken GH workflows which are using ISO builds

### DIFF
--- a/.github/workflows/build-boot-iso.yml
+++ b/.github/workflows/build-boot-iso.yml
@@ -115,6 +115,7 @@ jobs:
 
       - name: Build the boot.iso
         run: |
+          mkdir -p images
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
           sudo podman run -i --rm --privileged \
             --tmpfs /var/tmp:rw,mode=1777 \

--- a/.github/workflows/build-boot-iso.yml.j2
+++ b/.github/workflows/build-boot-iso.yml.j2
@@ -109,6 +109,7 @@ jobs:
 
       - name: Build the boot.iso
         run: |
+          mkdir -p images
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
           sudo podman run -i --rm --privileged \
             --tmpfs /var/tmp:rw,mode=1777 \

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -210,6 +210,7 @@ jobs:
 
       - name: Build boot.iso
         run: |
+          mkdir -p images
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
           sudo podman run -i --rm --privileged \
             --tmpfs /var/tmp:rw,mode=1777 \

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -204,6 +204,7 @@ jobs:
 
       - name: Build boot.iso
         run: |
+          mkdir -p images
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
           sudo podman run -i --rm --privileged \
             --tmpfs /var/tmp:rw,mode=1777 \

--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -16,8 +16,8 @@
 set -eux
 
 # pre-create loop devices manually. In the container you can't use losetup for that.
-sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
-sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
+mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
+mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
 
 INPUT_RPMS=/anaconda-rpms/
 REPO_DIR=/tmp/anaconda-rpms/


### PR DESCRIPTION
After this change https://github.com/rhinstaller/anaconda/pull/4566 I broke the builds.

There are two issues:
- I accidentally removed directory creation together with the mknods from the workflow.
- The `sudo` calls are not necessary (could be hurtful) because we might be missing sudo app in the container (needs to be backported to other branches)