### PR TITLE
Remove sudo for mknod calls in the container (#infra)

### DIFF
--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -16,8 +16,8 @@
 set -eux
 
 # pre-create loop devices manually. In the container you can't use losetup for that.
-sudo mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
-sudo mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
+mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
+mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
 
 INPUT_RPMS=/anaconda-rpms/
 REPO_DIR=/tmp/anaconda-rpms/


### PR DESCRIPTION
We don't need to run sudo there. This could be even harmful if the sudo is not available in the container.

Backport of https://github.com/rhinstaller/anaconda/pull/4600.