### PR TITLE
WebUI: Hide progress stepper after finishing

### DIFF
--- a/ui/webui/src/components/installation/InstallationProgress.jsx
+++ b/ui/webui/src/components/installation/InstallationProgress.jsx
@@ -23,7 +23,6 @@ import {
     ProgressStep,
     ProgressStepper,
     Stack,
-    TextContent,
     Text,
 } from "@patternfly/react-core";
 import {
@@ -137,7 +136,7 @@ export class InstallationProgress extends React.Component {
         let title;
         if (status === "success") {
             icon = CheckCircleIcon;
-            title = _("Installed");
+            title = _("Successfully installed");
         } else if (status === "danger") {
             icon = ExclamationCircleIcon;
             title = _("Installation failed");
@@ -152,58 +151,64 @@ export class InstallationProgress extends React.Component {
                   loading={!icon}
                   paragraph={
                       <Flex direction={{ default: "column" }}>
-                          <TextContent>
-                              {currentProgressStep < 4 ? progressSteps[currentProgressStep].description : null}
-                          </TextContent>
-                          <FlexItem spacer={{ default: "spacerXl" }} />
-                          <ProgressStepper isCenterAligned>
-                              {progressSteps.map((progressStep, index) => {
-                                  let variant = "pending";
-                                  let ariaLabel = _("pending step");
-                                  let phaseText = _("Pending");
-                                  let statusText = "";
-                                  let phaseIcon = <PendingIcon />;
-                                  if (index < currentProgressStep) {
-                                      variant = "success";
-                                      ariaLabel = _("completed step");
-                                      phaseText = _("Completed");
-                                      phaseIcon = <CheckCircleIcon />;
-                                  } else if (index === currentProgressStep) {
-                                      variant = status === "danger" ? status : "info";
-                                      ariaLabel = _("current step");
-                                      phaseText = _("In progress");
-                                      statusText = statusMessage;
-                                      if (status === "danger") {
-                                          phaseIcon = <ExclamationCircleIcon />;
-                                      } else {
-                                          phaseIcon = <InProgressIcon />;
-                                      }
-                                  }
-                                  return (
-                                      <ProgressStep
-                                        aria-label={ariaLabel}
-                                        id={idPrefix + "-step-" + index}
-                                        isCurrent={index === currentProgressStep}
-                                        icon={phaseIcon}
-                                        titleId={progressStep.id}
-                                        key={index}
-                                        variant={variant}
-                                        description={
-                                            <Flex direction={{ default: "column" }}>
-                                                <FlexItem spacer={{ default: "spacerNone" }}>
-                                                    <Text>{phaseText}</Text>
-                                                </FlexItem>
-                                                <FlexItem spacer={{ default: "spacerNone" }}>
-                                                    <Text>{statusText}</Text>
-                                                </FlexItem>
-                                            </Flex>
-                                        }
-                                      >
-                                          {progressStep.title}
-                                      </ProgressStep>
-                                  );
-                              })}
-                          </ProgressStepper>
+                          <Text>
+                              {currentProgressStep < 4
+                                  ? progressSteps[currentProgressStep].description
+                                  // TODO Replace the placeholder text with an actual product name.
+                                  : _("To begin using Fedora 39 (Workstation Edition), reboot your system.")}
+                          </Text>
+                          {currentProgressStep < 4 && (
+                              <>
+                                  <FlexItem spacer={{ default: "spacerXl" }} />
+                                  <ProgressStepper isCenterAligned>
+                                      {progressSteps.map((progressStep, index) => {
+                                          let variant = "pending";
+                                          let ariaLabel = _("pending step");
+                                          let phaseText = _("Pending");
+                                          let statusText = "";
+                                          let phaseIcon = <PendingIcon />;
+                                          if (index < currentProgressStep) {
+                                              variant = "success";
+                                              ariaLabel = _("completed step");
+                                              phaseText = _("Completed");
+                                              phaseIcon = <CheckCircleIcon />;
+                                          } else if (index === currentProgressStep) {
+                                              variant = status === "danger" ? status : "info";
+                                              ariaLabel = _("current step");
+                                              phaseText = _("In progress");
+                                              statusText = statusMessage;
+                                              if (status === "danger") {
+                                                  phaseIcon = <ExclamationCircleIcon />;
+                                              } else {
+                                                  phaseIcon = <InProgressIcon />;
+                                              }
+                                          }
+                                          return (
+                                              <ProgressStep
+                                                aria-label={ariaLabel}
+                                                id={idPrefix + "-step-" + index}
+                                                isCurrent={index === currentProgressStep}
+                                                icon={phaseIcon}
+                                                titleId={progressStep.id}
+                                                key={index}
+                                                variant={variant}
+                                                description={
+                                                    <Flex direction={{ default: "column" }}>
+                                                        <FlexItem spacer={{ default: "spacerNone" }}>
+                                                            <Text>{phaseText}</Text>
+                                                        </FlexItem>
+                                                        <FlexItem spacer={{ default: "spacerNone" }}>
+                                                            <Text>{statusText}</Text>
+                                                        </FlexItem>
+                                                    </Flex>
+                                                }
+                                              >
+                                                  {progressStep.title}
+                                              </ProgressStep>
+                                          );
+                                      })}
+                                  </ProgressStepper>
+                              </>)}
                       </Flex>
                   }
                   secondary={

--- a/ui/webui/src/components/installation/InstallationProgress.scss
+++ b/ui/webui/src/components/installation/InstallationProgress.scss
@@ -1,7 +1,6 @@
 .pf-c-empty-state__content {
     width: 100%
 }
-
 .installation-progress-status {
     &-success .pf-c-empty-state__icon {
         color: var(--pf-global--success-color--100);

--- a/ui/webui/test/check-progress
+++ b/ui/webui/test/check-progress
@@ -53,11 +53,6 @@ class TestInstallationProgress(MachineCase):
         with b.wait_timeout(600):
             b.wait_in_text("h2", "Installed")
 
-        b.wait_visible("#installation-progress-step-0[aria-label='completed step'] > div:first-child")
-        b.wait_visible("#installation-progress-step-1[aria-label='completed step'] > div:first-child")
-        b.wait_visible("#installation-progress-step-2[aria-label='completed step'] > div:first-child")
-        b.wait_visible("#installation-progress-step-3[aria-label='completed step'] > div:first-child")
-
         # Pixel test the complete progress step
         b.assert_pixels(
             "#app",


### PR DESCRIPTION
Hide progress stepper after installation finishes and show text instead.

The word Anaconda should be replaced with a real product name.

![TestInstallationProgress-testBasic-installation-progress-complete-pixels](https://user-images.githubusercontent.com/40278421/223736848-9aea845c-b290-42b7-8483-f67ef26aeaf0.png)