### PR TITLE
infra: Disable failing tests that call useradd and groupadd

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/core/test_user_create.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_user_create.py
@@ -71,6 +71,7 @@ class UserCreateTest(unittest.TestCase):
                     return fields
         return None
 
+    @pytest.mark.xfail(raises=OSError, reason="groupadd fails")
     def test_create_group(self):
         """Create a group."""
         users.create_group("test_group", root=self.tmpdir)
@@ -83,6 +84,7 @@ class UserCreateTest(unittest.TestCase):
         assert fields is not None
         assert fields[0] == "test_group"
 
+    @pytest.mark.xfail(raises=OSError, reason="groupadd fails")
     def test_create_group_gid(self):
         """Create a group with a specific GID."""
         users.create_group("test_group", gid=47, root=self.tmpdir)
@@ -109,6 +111,7 @@ class UserCreateTest(unittest.TestCase):
         with pytest.raises(ValueError):
             users.create_group("test_group", gid=47, root=self.tmpdir)
 
+    @pytest.mark.xfail(raises=OSError, reason="useradd fails")
     def test_create_user(self):
         """Create a user."""
         users.create_user("test_user", root=self.tmpdir)
@@ -150,6 +153,7 @@ class UserCreateTest(unittest.TestCase):
         assert gshadow_fields is not None
         assert gshadow_fields[0] == "test_user"
 
+    @pytest.mark.xfail(raises=OSError, reason="useradd fails")
     def test_create_user_text_options(self):
         """Create a user with the text fields set."""
         users.create_user("test_user", gecos="Test User", homedir="/home/users/testuser", shell="/bin/test", root=self.tmpdir)
@@ -164,6 +168,7 @@ class UserCreateTest(unittest.TestCase):
         # Check that the home directory was created
         assert os.path.isdir(self.tmpdir + "/home/users/testuser")
 
+    @pytest.mark.xfail(raises=OSError, reason="groupadd fails")
     def test_create_user_groups(self):
         """Create a user with a list of groups."""
         # Create one of the groups
@@ -183,6 +188,7 @@ class UserCreateTest(unittest.TestCase):
         grp_fields3 = self._readFields("/etc/group", "test3")
         assert grp_fields3[3] == "test_user"
 
+    @pytest.mark.xfail(raises=OSError, reason="groupadd fails")
     def test_create_user_groups_gid_conflict(self):
         """Create a user with a bad list of groups."""
         # Create one of the groups
@@ -192,6 +198,7 @@ class UserCreateTest(unittest.TestCase):
         with pytest.raises(ValueError):
             users.create_user("test_user", groups=["test3(5002)"], root=self.tmpdir)
 
+    @pytest.mark.xfail(raises=OSError, reason="useradd fails")
     def test_create_user_password(self):
         """Create a user with a password."""
 
@@ -214,6 +221,7 @@ class UserCreateTest(unittest.TestCase):
         assert shadow_fields is not None
         assert "" == shadow_fields[1]
 
+    @pytest.mark.xfail(raises=OSError, reason="useradd fails")
     def test_create_user_lock(self):
         """Create a locked user account."""
 
@@ -230,6 +238,7 @@ class UserCreateTest(unittest.TestCase):
         assert shadow_fields[1].startswith("!")
         assert crypt.crypt("password", shadow_fields[1][1:]) == shadow_fields[1][1:]
 
+    @pytest.mark.xfail(raises=OSError, reason="useradd fails")
     def test_create_user_uid(self):
         """Create a user with a specific UID."""
 
@@ -238,6 +247,7 @@ class UserCreateTest(unittest.TestCase):
         assert pwd_fields is not None
         assert pwd_fields[2] == "1047"
 
+    @pytest.mark.xfail(raises=OSError, reason="groupadd fails")
     def test_create_user_gid(self):
         """Create a user with a specific GID."""
 
@@ -259,6 +269,7 @@ class UserCreateTest(unittest.TestCase):
         with pytest.raises(ValueError):
             users.create_user("test_user", root=self.tmpdir)
 
+    @pytest.mark.xfail(raises=OSError, reason="useradd fails")
     def test_create_user_uid_exists(self):
         """Create a user with a UID that already exists."""
         with open(self.tmpdir + "/etc/passwd", "w") as f:
@@ -267,6 +278,7 @@ class UserCreateTest(unittest.TestCase):
         with pytest.raises(ValueError):
             users.create_user("test_user", uid=1000, root=self.tmpdir)
 
+    @pytest.mark.xfail(raises=OSError, reason="groupadd fails with 1")
     def test_create_user_gid_exists(self):
         """Create a user with a GID of an existing group."""
         users.create_group("test_group", gid=5000, root=self.tmpdir)
@@ -276,6 +288,7 @@ class UserCreateTest(unittest.TestCase):
         assert passwd_fields is not None
         assert passwd_fields[3] == "5000"
 
+    @pytest.mark.xfail(raises=OSError, reason="useradd fails")
     def test_set_user_ssh_key(self):
         keydata = "THIS IS TOTALLY A SSH KEY"
 
@@ -322,6 +335,7 @@ class UserCreateTest(unittest.TestCase):
         shadow_fields = self._readFields("/etc/shadow", "root")
         assert password == shadow_fields[1]
 
+    @pytest.mark.xfail(raises=OSError, reason="groupadd fails")
     def test_create_user_reuse_home(self):
         # Create a user, reusing an old home directory
 
@@ -348,6 +362,7 @@ class UserCreateTest(unittest.TestCase):
         assert stat_fields.st_uid == 1000
         assert stat_fields.st_gid == 1000
 
+    @pytest.mark.xfail(raises=OSError, reason="groupadd fails")
     def test_create_user_gid_in_group_list(self):
         """Create a user with a GID equal to that of one of the requested groups"""
 


### PR DESCRIPTION
These tests run in a very limited chroot environment that is probably missing some important files at this moment. Due the that the useradd and groupadd calls fail with the exit status 1 without any additional info. Let's disable them for now. We might consider replacing these unit tests with kickstart tests instead of keeping them alive.
