### PR TITLE
infra: Set branched fedora for packit correctly

### DIFF
--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -70,12 +70,12 @@ jobs:
   - job: tests
     trigger: pull_request
     targets:
-      - fedora-latest
+      - fedora-{$ distro_release $}
 
   - job: copr_build
     trigger: commit
     targets:
-      - fedora-latest
+      - fedora-{$ distro_release $}
     branch: fedora-{$ distro_release $}
     owner: "@rhinstaller"
     project: Anaconda-devel


### PR DESCRIPTION
The target "fedora-latest" does not get branched fedora before beta (as of writing this), and the actual number is available for templates, so let's be explicit and get the right fedora out of the box.

Port of #4609