### PR TITLE
Generate the ostreesetup kickstart command

### DIFF
--- a/pyanaconda/modules/payloads/source/rpm_ostree/rpm_ostree.py
+++ b/pyanaconda/modules/payloads/source/rpm_ostree/rpm_ostree.py
@@ -111,6 +111,7 @@ class RPMOSTreeSourceModule(PayloadSourceBase):
         data.ostreesetup.url = self.configuration.url
         data.ostreesetup.ref = self.configuration.ref
         data.ostreesetup.nogpg = not self.configuration.gpg_verification_enabled
+        data.ostreesetup.seen = True
 
     def set_up_with_tasks(self):
         """Set up the installation source for installation.


### PR DESCRIPTION
Pykickstart requires to set the `seen` attribute of this kickstart command
since 3.46 to make it visible in the output kickstart file.

See: https://github.com/pykickstart/pykickstart/commit/8d85411

**Ported from:** https://github.com/rhinstaller/anaconda/pull/4620
