### PR TITLE
infra: Use the Codecov upload token

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -41,3 +41,5 @@ jobs:
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/push-tests.yml.j2
+++ b/.github/workflows/push-tests.yml.j2
@@ -35,4 +35,6 @@ jobs:
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 {% endif %}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,8 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   rpm-tests:
     runs-on: ubuntu-20.04

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -108,6 +108,8 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   rpm-tests:
     {% if distro_name == "fedora" %}


### PR DESCRIPTION
Codecov is failing to upload code coverage with the following message: Unable to locate build via Github Actions API. It is recommended to use the Codecov upload token to upload to Codecov even if the repository is public to fix it.

See: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api
