### PR TITLE
Allow/improve displaying passwords in plain text

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/installation_source_helpers.glade
+++ b/pyanaconda/ui/gui/spokes/lib/installation_source_helpers.glade
@@ -461,6 +461,8 @@
                         <property name="invisible-char">●</property>
                         <property name="activates-default">True</property>
                         <signal name="changed" handler="on_proxyPasswordEntry_changed" swapped="no"/>
+                        <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                        <signal name="map" handler="on_password_entry_map" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>

--- a/pyanaconda/ui/gui/spokes/lib/installation_source_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/installation_source_helpers.py
@@ -34,7 +34,7 @@ from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.payload import utils as payload_utils
 from pyanaconda.ui.gui import GUIObject, really_hide
 from pyanaconda.ui.gui.helpers import GUIDialogInputCheckHandler
-from pyanaconda.ui.gui.utils import find_first_child
+from pyanaconda.ui.gui.utils import find_first_child, set_password_visibility
 from pyanaconda.ui.helpers import InputCheck
 
 import gi
@@ -355,6 +355,20 @@ class ProxyDialog(GUIObject, GUIDialogInputCheckHandler):
     def on_proxy_auth_toggled(self, button, *args):
         self._proxy_auth_box.set_sensitive(button.get_active())
         self._proxy_validate.update_check_status()
+
+    def on_password_icon_clicked(self, entry, icon_pos, event):
+        """Called by Gtk callback when the icon of a password entry is clicked."""
+        set_password_visibility(entry, not entry.get_visibility())
+
+    def on_password_entry_map(self, entry):
+        """Called when a proxy password entry widget is going to be displayed.
+
+        - Without this the password visibility toggle icon would not be shown.
+        - The password should be hidden every time the entry widget is displayed
+          to avoid showing the password in plain text in case the user previously
+          displayed the password and then closed the dialog.
+        """
+        set_password_visibility(entry, False)
 
     def refresh(self):
         GUIObject.refresh(self)

--- a/pyanaconda/ui/gui/spokes/root_password.glade
+++ b/pyanaconda/ui/gui/spokes/root_password.glade
@@ -235,6 +235,7 @@ The root user (also known as super user) has complete access to the entire syste
                                     <property name="width-chars">40</property>
                                     <signal name="changed" handler="on_password_changed" swapped="no"/>
                                     <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                                    <signal name="map" handler="on_password_entry_map" swapped="no"/>
                                     <child internal-child="accessible">
                                       <object class="AtkObject" id="password_entry-atkobject">
                                         <property name="AtkObject::accessible-name" translatable="yes">Password</property>
@@ -256,6 +257,7 @@ The root user (also known as super user) has complete access to the entire syste
                                     <property name="width-chars">40</property>
                                     <signal name="changed" handler="on_password_confirmation_changed" swapped="no"/>
                                     <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                                    <signal name="map" handler="on_password_entry_map" swapped="no"/>
                                     <child internal-child="accessible">
                                       <object class="AtkObject" id="password_confirmation_entry-atkobject">
                                         <property name="AtkObject::accessible-name" translatable="yes">Confirm Password</property>

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -140,12 +140,6 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self._password_bar.add_offset_value("medium", 3)
         self._password_bar.add_offset_value("high", 4)
 
-        # set visibility of the password entries
-        # - without this the password visibility toggle icon will
-        #   not be shown
-        set_password_visibility(self.password_entry, False)
-        set_password_visibility(self.password_confirmation_entry, False)
-
         # Send ready signal to main event loop
         hubQ.send_ready(self.__class__.__name__)
 
@@ -313,6 +307,16 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     def on_password_icon_clicked(self, entry, icon_pos, event):
         """Called by Gtk callback when the icon of a password entry is clicked."""
         set_password_visibility(entry, not entry.get_visibility())
+
+    def on_password_entry_map(self, entry):
+        """Called when a password entry widget is going to be displayed.
+
+        - Without this the password visibility toggle icon would not be shown.
+        - The password should be hidden every time the entry widget is displayed
+          to avoid showing the password in plain text in case the user previously
+          displayed the password and then left the spoke, for example.
+        """
+        set_password_visibility(entry, False)
 
     def on_back_clicked(self, button):
         # disable root if no password is entered

--- a/pyanaconda/ui/gui/spokes/subscription.glade
+++ b/pyanaconda/ui/gui/spokes/subscription.glade
@@ -193,6 +193,8 @@
                                                 <property name="visibility">False</property>
                                                 <property name="invisible_char">●</property>
                                                 <signal name="changed" handler="on_password_entry_changed" swapped="no"/>
+                                                <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                                                <signal name="map" handler="on_password_entry_map" swapped="no"/>
                                               </object>
                                               <packing>
                                                 <property name="left_attach">1</property>
@@ -605,6 +607,8 @@
                                                     <property name="visibility">False</property>
                                                     <property name="invisible_char">●</property>
                                                     <signal name="changed" handler="on_http_proxy_password_entry_changed" swapped="no"/>
+                                                    <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                                                    <signal name="map" handler="on_password_entry_map" swapped="no"/>
                                                   </object>
                                                   <packing>
                                                     <property name="left_attach">1</property>

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -41,6 +41,7 @@ from pyanaconda.modules.common.task import sync_run_task
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.spokes.lib.subscription import fill_combobox, \
     populate_attached_subscriptions_listbox
+from pyanaconda.ui.gui.utils import set_password_visibility
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.ui.lib.subscription import username_password_sufficient, org_keys_sufficient, \
@@ -322,6 +323,20 @@ class SubscriptionSpoke(NormalSpoke):
         self.subscription_request.account_password.set_secret(entered_text)
         self._update_registration_state()
 
+    def on_password_icon_clicked(self, entry, icon_pos, event):
+        """Called by Gtk callback when the icon of a password entry is clicked."""
+        set_password_visibility(entry, not entry.get_visibility())
+
+    def on_password_entry_map(self, entry):
+        """Called when a password entry widget is going to be displayed.
+
+        - Without this the password visibility toggle icon would not be shown.
+        - The password should be hidden every time the entry widget is displayed
+          to avoid showing the password in plain text in case the user previously
+          displayed the password and then left the spoke, for example.
+        """
+        set_password_visibility(entry, False)
+
     def on_organization_entry_changed(self, editable):
         self.subscription_request.organization = editable.get_text()
         self._update_registration_state()
@@ -455,6 +470,9 @@ class SubscriptionSpoke(NormalSpoke):
 
     def on_register_button_clicked(self, button):
         log.debug("Subscription GUI: register button clicked")
+        # hide the passwords during the registration process
+        set_password_visibility(self._password_entry, False)
+        set_password_visibility(self._http_proxy_password_entry, False)
         self._register()
 
     def on_unregister_button_clicked(self, button):

--- a/pyanaconda/ui/gui/spokes/user.glade
+++ b/pyanaconda/ui/gui/spokes/user.glade
@@ -170,6 +170,7 @@
                         <property name="invisible-char">●</property>
                         <signal name="changed" handler="on_password_changed" swapped="no"/>
                         <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                        <signal name="map" handler="on_password_entry_map" swapped="no"/>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="password_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Password</property>
@@ -189,6 +190,7 @@
                         <property name="invisible-char">●</property>
                         <signal name="changed" handler="on_password_confirmation_changed" swapped="no"/>
                         <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                        <signal name="map" handler="on_password_entry_map" swapped="no"/>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="password_confirmation_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Confirm Password</property>

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -377,12 +377,6 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         self._advanced_user_dialog = AdvancedUserDialog(self)
         self._advanced_user_dialog.initialize()
 
-        # set the visibility of the password entries
-        # - without this the password visibility toggle icon will
-        #   not be shown
-        set_password_visibility(self.password_entry, False)
-        set_password_visibility(self.password_confirmation_entry, False)
-
         # report that we are done
         self.initialize_done()
 
@@ -526,6 +520,16 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
     def on_password_icon_clicked(self, entry, icon_pos, event):
         """Called by Gtk callback when the icon of a password entry is clicked."""
         set_password_visibility(entry, not entry.get_visibility())
+
+    def on_password_entry_map(self, entry):
+        """Called when a password entry widget is going to be displayed.
+
+        - Without this the password visibility toggle icon would not be shown.
+        - The password should be hidden every time the entry widget is displayed
+          to avoid showing the password in plain text in case the user previously
+          displayed the password and then left the spoke, for example.
+        """
+        set_password_visibility(entry, False)
 
     def on_username_set_by_user(self, editable, data=None):
         """Called by Gtk on user-driven changes to the username field.


### PR DESCRIPTION
The root and user spokes already allowed to display the passwords in plain text, but they stayed displayed in plain text after re-entering the spokes. Fix this by always using the invisible characters by default when the entry widget is displayed.

Also allow to display plain text passwords on the subscription and installation source spokes.

The changes for the subscription spoke were tested only on RHEL-9.

Related: rhbz#2013190