### PR TITLE
WebUI: Fix keyboard navigation on welcome screen

### DIFF
--- a/ui/webui/src/components/localization/InstallationLanguage.jsx
+++ b/ui/webui/src/components/localization/InstallationLanguage.jsx
@@ -250,7 +250,6 @@ class LanguageSelector extends React.Component {
         }
 
         const options = this.renderOptions(this.state.search);
-        const inputRef = React.createRef(null);
 
         return (
             <Menu
@@ -282,9 +281,6 @@ class LanguageSelector extends React.Component {
                     </Title>
                     <SearchInput
                       id={this.props.idPrefix + "-language-search"}
-                      ref={inputRef}
-                      // Select all text on click
-                      onFocus={() => inputRef && inputRef.current && inputRef.current.select()}
                       value={this.state.search}
                       onChange={value => this.setState({ ...this.state, search: value })}
                       onClear={() => this.setState({ ...this.state, search: "" })}


### PR DESCRIPTION
 Remove `onFocus` event for automatic selection of all text in the field, basically if you click the field the text immediately became highlighted.

This feature really shouldn't have been there in the first place and it was preventing from tabbing out of the element.