### PR TITLE
infra: Notify to Slack about new releases

### DIFF
--- a/.github/workflows/release-periodically.yml
+++ b/.github/workflows/release-periodically.yml
@@ -80,6 +80,16 @@ jobs:
             '${{ secrets.GCHAT_URL }}' \
             -d "{\"text\": \"New release tagged, please review the Packit dist-git PR soon to be found at https://src.fedoraproject.org/rpms/anaconda/pull-requests\"}"
 
+      - name: Notify in Slack
+        if: steps.check-tag.outputs.can_bump_version
+        # https://api.slack.com/messaging/webhooks
+        run: |
+          curl \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            --data '{"text":"New release tagged, please review the Packit dist-git PR soon to be found at https://src.fedoraproject.org/rpms/anaconda/pull-requests"}' \
+            '${{ secrets.SLACK_URL }}'
+
 # This only makes a tag and pushes it, which is then picked up by another action that builds
 # the tarball and posts the actual release entity/page with it.
 #

--- a/.github/workflows/release-periodically.yml.j2
+++ b/.github/workflows/release-periodically.yml.j2
@@ -74,6 +74,16 @@ jobs:
             '${{ secrets.GCHAT_URL }}' \
             -d "{\"text\": \"New release tagged, please review the Packit dist-git PR soon to be found at https://src.fedoraproject.org/rpms/anaconda/pull-requests\"}"
 
+      - name: Notify in Slack
+        if: steps.check-tag.outputs.can_bump_version
+        # https://api.slack.com/messaging/webhooks
+        run: |
+          curl \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            --data '{"text":"New release tagged, please review the Packit dist-git PR soon to be found at https://src.fedoraproject.org/rpms/anaconda/pull-requests"}' \
+            '${{ secrets.SLACK_URL }}'
+
 # This only makes a tag and pushes it, which is then picked up by another action that builds
 # the tarball and posts the actual release entity/page with it.
 #


### PR DESCRIPTION
Let's notify to Slack, since that's where we should be.

Notice how the code is pretty much the same as the gchat notifications. Interoperability!

I'm not removing the gchat part yet, so that we have a plan B for the first run(s). However, hard-earned lessons about quoting in shell in yaml were applied right away this time.