### PR TITLE
webui: update links for downloading cockpit-ws and cockpit-bridge RPMs

### DIFF
--- a/ui/webui/test/prepare-updates-img
+++ b/ui/webui/test/prepare-updates-img
@@ -6,8 +6,8 @@ set -eu
 # This will change once we include this changes upstream and start building boot.iso with the new dependencies
 # Then we can safely remove this workaround
 COCKPIT_URLS='
-    https://kojipkgs.fedoraproject.org//packages/cockpit/275/1.fc38/x86_64/cockpit-ws-275-1.fc38.x86_64.rpm
-    https://kojipkgs.fedoraproject.org//packages/cockpit/275/1.fc38/x86_64/cockpit-bridge-275-1.fc38.x86_64.rpm
+    https://kojipkgs.fedoraproject.org//packages/cockpit/287/1.fc39/x86_64/cockpit-ws-287-1.fc39.x86_64.rpm
+    https://kojipkgs.fedoraproject.org//packages/cockpit/287/1.fc39/x86_64/cockpit-bridge-287-1.fc39.x86_64.rpm
 '
 
 mkdir -p tmp/extra-rpms


### PR DESCRIPTION
As cockpit-ws and cockpit-bridge still don't exit in the fedora-image we need to install these manually. Update the links to f39 (rawhide) and the latest cockpit release as these are not valid anymore.


