### PR TITLE
Don't protect unavailable devices

### DIFF
--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -19,7 +19,6 @@
 
 import os
 import sys
-from glob import glob
 from tempfile import mkstemp
 import threading
 
@@ -124,10 +123,6 @@ class Anaconda(object):
         for _repo_name, repo_url in opts.addRepo:
             if SourceFactory.is_harddrive(repo_url):
                 specs.append(repo_url[3:].split(":", 3)[0])
-
-        # zRAM swap devices need to be protected
-        for zram_dev in glob("/dev/zram*"):
-            specs.append(zram_dev)
 
         return specs
 


### PR DESCRIPTION
The zram deviced are excluded from the device tree by the Blivet's `ignored_device_names` filter, so it is not necessary to mark them as protected. There will be nothing to protect.

See the `enable_installer_mode` function from the Storage module:
https://github.com/rhinstaller/anaconda/blob/0a97b816536ed6af61c593130310e53f90c25ce4/pyanaconda/modules/storage/initialization.py#L72