### PR TITLE
Protect the stage2 device from the Storage module

### DIFF
--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -118,9 +118,6 @@ class Anaconda(object):
         if opts.method and SourceFactory.is_harddrive(opts.method):
             specs.append(opts.method[3:].split(":", 3)[0])
 
-        if opts.stage2 and SourceFactory.is_harddrive(opts.stage2):
-            specs.append(opts.stage2[3:].split(":", 3)[0])
-
         for _repo_name, repo_url in opts.addRepo:
             if SourceFactory.is_harddrive(repo_url):
                 specs.append(repo_url[3:].split(":", 3)[0])

--- a/pyanaconda/modules/storage/devicetree/model.py
+++ b/pyanaconda/modules/storage/devicetree/model.py
@@ -32,7 +32,7 @@ from pyanaconda.core.constants import shortProductName, DRACUT_REPO_DIR, LIVE_MO
 from pyanaconda.core.path import set_system_root
 from pyanaconda.modules.storage.devicetree.fsset import FSSet
 from pyanaconda.modules.storage.devicetree.utils import download_escrow_certificate, \
-    find_backing_device
+    find_backing_device, find_stage2_device
 from pyanaconda.modules.storage.devicetree.root import find_existing_installations
 from pyanaconda.modules.common.constants.services import NETWORK
 
@@ -288,6 +288,13 @@ class InstallerStorage(Blivet):
             if dev is not None:
                 log.debug("Protected device spec %s resolved to %s.", spec, dev.name)
                 protected.append(dev)
+
+        # Find the stage2 backing device and its parents.
+        stage2_device = find_stage2_device(self.devicetree)
+
+        if stage2_device:
+            log.debug("Resolved stage2 device to %s.", stage2_device.name)
+            protected.append(stage2_device)
 
         # Find the live backing device and its parents.
         live_device = find_backing_device(self.devicetree, LIVE_MOUNT_POINT)

--- a/pyanaconda/modules/storage/devicetree/utils.py
+++ b/pyanaconda/modules/storage/devicetree/utils.py
@@ -26,9 +26,11 @@ from bytesize.bytesize import MiB, ROUND_UP
 
 from pyanaconda.core import util
 from pyanaconda.core.i18n import _
+from pyanaconda.core.kernel import kernel_arguments
+from pyanaconda.core.payload import parse_hdd_url
 from pyanaconda.modules.common.constants.services import NETWORK
-
 from pyanaconda.anaconda_loggers import get_module_logger
+
 log = get_module_logger(__name__)
 
 
@@ -128,6 +130,21 @@ def find_backing_device(devicetree, mount_point):
 
         if disk:
             return disk
+
+    return None
+
+
+def find_stage2_device(devicetree):
+    """Find the backing device of the stage2 image.
+
+    :param devicetree: a device tree
+    :return: a device or None
+    """
+    url = kernel_arguments.get("stage2")
+
+    if url and url.startswith("hd:"):
+        device, _path = parse_hdd_url(url)
+        return devicetree.resolve_device(device)
 
     return None
 


### PR DESCRIPTION
Move the code for protection of the stage2 device to the Storage module.
The device will be detected and protected on every storage reset.

**Removal of the SourceFactory class - part 2**