### PR TITLE
Simplify creation of a source based on its URL

### DIFF
--- a/pyanaconda/modules/common/structures/payload.py
+++ b/pyanaconda/modules/common/structures/payload.py
@@ -114,6 +114,17 @@ class RepoConfigurationData(DBusData):
 
         return data
 
+    @classmethod
+    def from_url(cls, url):
+        """Create a new configuration for the specified URL.
+
+        :param str url: a URL of the installation source
+        :return RepoConfigurationData: a new configuration
+        """
+        data = RepoConfigurationData()
+        data.url = url
+        return data
+
     @property
     def name(self) -> Str:
         """Get name of this repository.


### PR DESCRIPTION
Call the `_create_source_from_url` method of the DNF payload object
to create a new source for the URL specified via boot options.

**Removal of the SourceFactory class - part 4**