### PR TITLE
Set timezone from user choice if applicable

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -507,3 +507,10 @@ ID_MODE_USE_DEFAULT = "ID_MODE_USE_DEFAULT"
 
 # Path to the initrd critical warnings log file created by us in Dracut.
 DRACUT_ERRORS_PATH = "/run/anaconda/initrd_errors.txt"
+
+# Timezone setting priorities
+TIMEZONE_PRIORITY_DEFAULT = 0
+TIMEZONE_PRIORITY_LANGUAGE = 30
+TIMEZONE_PRIORITY_GEOLOCATION = 50
+TIMEZONE_PRIORITY_KICKSTART = 70
+TIMEZONE_PRIORITY_USER = 90

--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -408,6 +408,20 @@ def get_common_keyboard_layouts():
     return langtable.list_common_keyboards()
 
 
+def get_locale_timezones(locale):
+    """Function returning preferred timezones for the given locale.
+
+    :param locale: locale string
+    :type locale: str
+    :return: list of preferred timezones
+    :rtype: list of strings
+    :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
+    """
+    raise_on_invalid_locale(locale)
+
+    return langtable.list_timezones(languageId=locale)
+
+
 def get_locale_console_fonts(locale):
     """Function returning preferred console fonts for the given locale.
 

--- a/pyanaconda/modules/timezone/timezone_interface.py
+++ b/pyanaconda/modules/timezone/timezone_interface.py
@@ -47,17 +47,37 @@ class TimezoneInterface(KickstartModuleInterface):
     @Timezone.setter
     @emits_properties_changed
     def Timezone(self, timezone: Str):
-        """Set the timezone.
+        """Set the timezone with maximal priority.
 
-        Sets the system time zone to timezone. To view a list of
-        available time zones, use the timedatectl list-timezones
-        command.
-
-        Example: Europe/Prague
+        See SetTimezoneWithPriority for more details.
 
         :param timezone: a string with a timezone
         """
         self.implementation.set_timezone(timezone)
+
+    @emits_properties_changed
+    def SetTimezoneWithPriority(self, timezone: Str, priority: UInt16):
+        """Set the timezone with a given priority.
+
+        Sets the system time zone to timezone, if the already stored timezone does not have higher
+        priority.
+
+        To view a list of available time zones, use the `timedatectl list-timezones` command.
+
+        Example: Europe/Prague
+
+        The priority is a positive number. Use values defined in pyanaconda.core.constants
+        as TIMEZONE_PRIORITY_* :
+            TIMEZONE_PRIORITY_DEFAULT = 0
+            TIMEZONE_PRIORITY_LANGUAGE = 30
+            TIMEZONE_PRIORITY_GEOLOCATION = 50
+            TIMEZONE_PRIORITY_KICKSTART = 70
+            TIMEZONE_PRIORITY_USER = 90
+
+        :param timezone: a string with a timezone specification in the Olson db aka tzdata format
+        :param priority: priority for the timezone; see the respective constants
+        """
+        self.implementation.set_timezone_with_priority(timezone, priority)
 
     @property
     def IsUTC(self) -> Bool:

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -35,7 +35,7 @@ from pyanaconda.core.hw import minimal_memory_needed
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import TEXT_ONLY_TARGET, SETUP_ON_BOOT_DEFAULT, \
     SETUP_ON_BOOT_ENABLED, DRACUT_ERRORS_PATH, IPMI_ABORTED, STORAGE_MIN_RAM, SELINUX_DEFAULT, \
-    THREAD_TIME_INIT, DisplayModes, GEOLOC_CONNECTION_TIMEOUT
+    THREAD_TIME_INIT, DisplayModes, GEOLOC_CONNECTION_TIMEOUT, TIMEZONE_PRIORITY_GEOLOCATION
 from pyanaconda.core.i18n import _
 from pyanaconda.core.payload import ProxyString, ProxyStringError
 from pyanaconda.core.service import start_service
@@ -724,7 +724,10 @@ def apply_geolocation_result(display_mode):
         # (the geolocation module makes sure that the returned timezone is
         # either a valid timezone or empty string)
         log.info("Geoloc: using timezone determined by geolocation")
-        timezone_module.Timezone = geoloc_result.timezone
+        timezone_module.SetTimezoneWithPriority(
+            geoloc_result.timezone,
+            TIMEZONE_PRIORITY_GEOLOCATION
+        )
         # Either this is an interactive install and timezone.seen propagates
         # from the interactive default kickstart, or this is a kickstart
         # install where the user explicitly requested geolocation to be used.

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -313,7 +313,10 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
             log.warning("%s is not a valid timezone, falling back to default (%s)",
                         kickstart_timezone, DEFAULT_TZ)
             self._set_timezone(DEFAULT_TZ)
-            self._timezone_module.Timezone = DEFAULT_TZ
+            self._timezone_module.SetTimezoneWithPriority(
+                DEFAULT_TZ,
+                constants.TIMEZONE_PRIORITY_KICKSTART
+            )
 
         time_init_thread = thread_manager.get(constants.THREAD_TIME_INIT)
         if time_init_thread is not None:
@@ -354,7 +357,10 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
         if not region or not city:
             return
 
-        self._timezone_module.Timezone = region + "/" + city
+        self._timezone_module.SetTimezoneWithPriority(
+            region + "/" + city,
+            constants.TIMEZONE_PRIORITY_USER
+        )
         self._timezone_module.NTPEnabled = self._ntpSwitch.get_active()
         self._kickstarted = False
 

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.py
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.py
@@ -309,14 +309,6 @@ class DatetimeSpoke(FirstbootSpokeMixIn, NormalSpoke):
         kickstart_timezone = self._timezone_module.Timezone
         if is_valid_timezone(kickstart_timezone):
             self._set_timezone(kickstart_timezone)
-        elif not flags.flags.automatedInstall:
-            log.warning("%s is not a valid timezone, falling back to default (%s)",
-                        kickstart_timezone, DEFAULT_TZ)
-            self._set_timezone(DEFAULT_TZ)
-            self._timezone_module.SetTimezoneWithPriority(
-                DEFAULT_TZ,
-                constants.TIMEZONE_PRIORITY_KICKSTART
-            )
 
         time_init_thread = thread_manager.get(constants.THREAD_TIME_INIT)
         if time_init_thread is not None:

--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -37,7 +37,7 @@ from pyanaconda.product import distributionText, isFinal, productName, productVe
 from pyanaconda import flags
 from pyanaconda.core.i18n import _
 from pyanaconda.core.util import ipmi_abort
-from pyanaconda.core.constants import DEFAULT_LANG, WINDOW_TITLE_TEXT
+from pyanaconda.core.constants import DEFAULT_LANG, WINDOW_TITLE_TEXT, TIMEZONE_PRIORITY_LANGUAGE
 from pyanaconda.modules.common.constants.services import TIMEZONE, LOCALIZATION
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -99,6 +99,7 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
         """Apply the selected locale."""
         locale = localization.setup_locale(locale, self._l12_module, text_mode=False)
         self._set_lang(locale)
+        self._try_set_timezone(locale)
 
     @property
     def completed(self):
@@ -306,3 +307,7 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
 
         # pylint: disable=environment-modify
         os.environ["LANG"] = lang
+
+    def _try_set_timezone(self, locale):
+        loc_timezones = localization.get_locale_timezones(locale)
+        self._tz_module.SetTimezoneWithPriority(loc_timezones[0], TIMEZONE_PRIORITY_LANGUAGE)

--- a/pyanaconda/ui/tui/spokes/time_spoke.py
+++ b/pyanaconda/ui/tui/spokes/time_spoke.py
@@ -303,7 +303,10 @@ class TimeZoneSpoke(NormalTUISpoke):
         return prompt
 
     def apply(self):
-        self._timezone_module.Timezone = self._selection
+        self._timezone_module.SetTimezoneWithPriority(
+            self._selection,
+            constants.TIMEZONE_PRIORITY_USER
+        )
         self._timezone_module.Kickstarted = False
 
 

--- a/tests/unit_tests/pyanaconda_tests/core/test_startup_utils.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_startup_utils.py
@@ -27,7 +27,7 @@ from textwrap import dedent
 
 from pyanaconda.startup_utils import print_dracut_errors, check_if_geolocation_should_be_used, \
     start_geolocation_conditionally, wait_for_geolocation_and_use, apply_geolocation_result
-from pyanaconda.core.constants import GEOLOC_CONNECTION_TIMEOUT
+from pyanaconda.core.constants import GEOLOC_CONNECTION_TIMEOUT, TIMEZONE_PRIORITY_GEOLOCATION
 from pyanaconda.modules.common.structures.timezone import GeolocationData
 
 class StartupUtilsTestCase(unittest.TestCase):
@@ -215,13 +215,15 @@ class StartupUtilsGeolocApplyTestCase(unittest.TestCase):
             timezone="Europe/Madrid"
         )
         tz_proxy = tz_mock.get_proxy.return_value
-        tz_proxy.Timezone = ""
         loc_proxy = loc_mock.get_proxy.return_value
         loc_proxy.Language = ""
 
         apply_geolocation_result(None)
 
-        assert tz_proxy.Timezone == "Europe/Madrid"
+        tz_proxy.SetTimezoneWithPriority.assert_called_once_with(
+            "Europe/Madrid",
+            TIMEZONE_PRIORITY_GEOLOCATION
+        )
         setup_locale_mock.assert_called_once_with("es_ES.UTF-8", loc_proxy, text_mode=False)
         assert os.environ == {"LANG": "es_ES.UTF-8"}
 
@@ -239,13 +241,15 @@ class StartupUtilsGeolocApplyTestCase(unittest.TestCase):
             timezone="Europe/Madrid"
         )
         tz_proxy = tz_mock.get_proxy.return_value
-        tz_proxy.Timezone = ""
         loc_proxy = loc_mock.get_proxy.return_value
         loc_proxy.Language = ""
 
         apply_geolocation_result(None)
 
-        assert tz_proxy.Timezone == "Europe/Madrid"
+        tz_proxy.SetTimezoneWithPriority.assert_called_once_with(
+            "Europe/Madrid",
+            TIMEZONE_PRIORITY_GEOLOCATION
+        )
         setup_locale_mock.assert_not_called()
         assert not os.environ
 
@@ -263,14 +267,16 @@ class StartupUtilsGeolocApplyTestCase(unittest.TestCase):
             timezone="Europe/Madrid"
         )
         tz_proxy = tz_mock.get_proxy.return_value
-        tz_proxy.Timezone = ""
         loc_proxy = loc_mock.get_proxy.return_value
         loc_proxy.Language = "ko_KO.UTF-8"
         loc_proxy.LanguageKickstarted = True
 
         apply_geolocation_result(None)
 
-        assert tz_proxy.Timezone == "Europe/Madrid"
+        tz_proxy.SetTimezoneWithPriority.assert_called_once_with(
+            "Europe/Madrid",
+            TIMEZONE_PRIORITY_GEOLOCATION
+        )
         setup_locale_mock.assert_not_called()
         assert not os.environ
 

--- a/tests/unit_tests/pyanaconda_tests/test_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/test_localization.py
@@ -87,6 +87,9 @@ class LangcodeLocaleParsingTests(unittest.TestCase):
         assert "fr(oss)" in layouts
         assert "de(nodeadkeys)" in layouts
 
+    def test_locale_timezones(self):
+        assert "Europe/Oslo" in localization.get_locale_timezones("no")
+
     @patch.dict("pyanaconda.localization.os.environ", dict())
     def test_xlated_tz(self):
         localization.os.environ["LANG"] = "en_US"


### PR DESCRIPTION
This attempts to set timezone with the user choice on welcome screen, but only when there is no better choice.

----

Note to self: If/when porting to RHEL 9, this will drag in the geolocation modularization, and probably also the welcome spoke translation fixes.