### PR TITLE
Simplify the HDD source

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -54,7 +54,6 @@ MOUNT_DIR = "/run/install"
 DRACUT_ISODIR = "/run/install/source"
 DRACUT_REPO_DIR = "/run/install/repo"
 ISO_DIR = MOUNT_DIR + "/isodir"
-INSTALL_TREE = MOUNT_DIR + "/source"
 SOURCES_DIR = MOUNT_DIR + "/sources"
 
 # Names of repositories.

--- a/pyanaconda/core/payload.py
+++ b/pyanaconda/core/payload.py
@@ -26,6 +26,7 @@ from pyanaconda.core.regexes import URL_PARSE
 from pyanaconda.core.string import split_in_two
 
 NFSUrl = namedtuple("NFSUrl", ["options", "host", "path"])
+HDDUrl = namedtuple("HDDUrl", ["device", "path"])
 
 rpm_version_key = cmp_to_key(rpm.labelCompare)  # pylint: disable=no-member
 
@@ -34,7 +35,7 @@ def parse_hdd_url(url):
     """Parse HDD URL into components.
 
     :param str url: a raw URL, including "hd:"
-    :return (str, str): a tuple with a device and a path
+    :return HDDUrl: a tuple with a device and a path
     """
     # Remove the prefix.
     url = url.removeprefix("hd:")
@@ -42,7 +43,23 @@ def parse_hdd_url(url):
     # Split the specified URL into two components.
     device, path = split_in_two(url, delimiter=":")
 
-    return device, path
+    # Return a named tuple.
+    return HDDUrl(device=device, path=path)
+
+
+def create_hdd_url(device, path=None):
+    """Compose the HDD URL from components.
+
+    :param str device: a device spec
+    :param str path: a path or None
+    """
+    if not device:
+        return ""
+
+    if path:
+        return ":".join(["hd", device, path])
+    else:
+        return ":".join(["hd", device])
 
 
 def parse_nfs_url(nfs_url):
@@ -92,13 +109,15 @@ def create_nfs_url(host, path, options=None):
     :return: NFS url created from the components given
     :rtype: str
     """
-    if host == "":
+    if not host:
         return ""
 
     if options:
-        return "nfs:{opts}:{server}:{path}".format(opts=options, server=host, path=path)
-
-    return "nfs:{server}:{path}".format(server=host, path=path)
+        return ":".join(["nfs", options, host, path])
+    elif path:
+        return ":".join(["nfs", host, path])
+    else:
+        return ":".join(["nfs", host])
 
 
 def split_protocol(url):

--- a/pyanaconda/modules/payloads/payload/dnf/utils.py
+++ b/pyanaconda/modules/payloads/payload/dnf/utils.py
@@ -373,11 +373,13 @@ def collect_installation_devices(sources, repositories):
     """
     devices = set()
 
-    for source in sources:
-        if source.type == SourceType.HDD:
-            devices.add(source.device)
+    configurations = [
+        s.configuration
+        for s in sources
+        if s.type == SourceType.HDD
+    ]
 
-    for repository in repositories:
+    for repository in configurations + repositories:
         if repository.url.startswith("hd:"):
             device, _path = parse_hdd_url(repository.url)
             devices.add(device)

--- a/pyanaconda/modules/payloads/source/harddrive/harddrive_interface.py
+++ b/pyanaconda/modules/payloads/source/harddrive/harddrive_interface.py
@@ -19,46 +19,29 @@
 #
 from dasbus.server.interface import dbus_interface
 from dasbus.typing import *  # pylint: disable=wildcard-import
-from dasbus.server.property import emits_properties_changed
 from pyanaconda.modules.common.constants.interfaces import PAYLOAD_SOURCE_HARDDRIVE
-from pyanaconda.modules.payloads.source.source_base_interface import PayloadSourceBaseInterface
+from pyanaconda.modules.payloads.source.source_base_interface import RepositorySourceInterface
+
+__all__ = ["HardDriveSourceInterface"]
 
 
 @dbus_interface(PAYLOAD_SOURCE_HARDDRIVE.interface_name)
-class HardDriveSourceInterface(PayloadSourceBaseInterface):
-    """Interface for the payload Hard drive image source."""
+class HardDriveSourceInterface(RepositorySourceInterface):
+    """Interface for the payload hard drive image source."""
 
-    def connect_signals(self):
-        super().connect_signals()
-        self.watch_property("Directory", self.implementation.directory_changed)
-        self.watch_property("Partition", self.implementation.device_changed)
+    def GetDevice(self) -> Str:
+        """Get a device that contains the installation source.
 
-    @property
-    def Directory(self) -> Str:
-        """Get the path to the repository on the partition."""
-        return self.implementation.directory
-
-    @Directory.setter
-    @emits_properties_changed
-    def Directory(self, directory: Str):
-        """Set the path to the repository on the partition."""
-        self.implementation.set_directory(directory)
-
-    @property
-    def Partition(self) -> Str:
-        """Get the partition containing the repository."""
-        return self.implementation.device
-
-    @Partition.setter
-    @emits_properties_changed
-    def Partition(self, partition: Str):
-        """Set the partition containing the repository."""
-        self.implementation.set_device(partition)
-
-    def GetIsoPath(self) -> Str:
-        """Get path to the ISO from the partition root.
-
-        This could be an empty string if the source is pointing to
-        installation tree instead of ISO.
+        :return str: a resolved device name
         """
-        return self.implementation.get_iso_path()
+        return self.implementation.get_device()
+
+    def GetISOFile(self) -> Str:
+        """Get a path to the ISO image from the device root.
+
+        Returns an empty string if the source is pointing
+        to an installation tree instead of an ISO image.
+
+        :return str: an absolute path
+        """
+        return self.implementation.get_iso_file()

--- a/pyanaconda/ui/gui/spokes/lib/installation_source_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/installation_source_helpers.py
@@ -26,6 +26,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core import glib, constants
 from pyanaconda.core.constants import REPO_ORIGIN_USER
 from pyanaconda.core.i18n import _, N_, C_
+from pyanaconda.core.path import join_paths
 from pyanaconda.core.payload import ProxyString, ProxyStringError, parse_nfs_url
 from pyanaconda.core.process_watchers import PidWatcher
 from pyanaconda.core.regexes import URL_PARSE, REPO_NAME_VALID, HOSTNAME_PATTERN_WITHOUT_ANCHORS
@@ -551,9 +552,12 @@ class IsoChooser(GUIObject):
     mainWidgetName = "isoChooserDialog"
     uiFile = "spokes/lib/installation_source_helpers.glade"
 
-    def __init__(self, data):
+    def __init__(self, data, current_file=None):
         super().__init__(data)
+        self._current_file = current_file or ""
         self._chooser = self.builder.get_object("isoChooserDialog")
+        self._chooser.connect("current-folder-changed", self.on_folder_changed)
+        self._chooser.set_filename(join_paths(constants.ISO_DIR, self._current_file))
 
         # Hide the places sidebar, since it makes no sense in this context
         # This is discouraged, but the alternative suggested is to reinvent the
@@ -562,12 +566,6 @@ class IsoChooser(GUIObject):
                                           lambda x: isinstance(x, Gtk.PlacesSidebar))
         if places_sidebar:
             really_hide(places_sidebar)
-
-    # pylint: disable=arguments-differ
-    def refresh(self, currentFile=""):
-        super().refresh()
-        self._chooser.connect("current-folder-changed", self.on_folder_changed)
-        self._chooser.set_filename(constants.ISO_DIR + "/" + currentFile)
 
     def run(self, device_name):
         retval = None

--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -58,7 +58,8 @@ from abc import ABCMeta, abstractmethod
 
 from pyanaconda.core import constants
 from pyanaconda.core.constants import DRACUT_REPO_DIR
-from pyanaconda.core.payload import create_nfs_url
+from pyanaconda.core.path import join_paths
+from pyanaconda.core.payload import create_nfs_url, create_hdd_url
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.ui.lib.payload import create_source, set_source, tear_down_sources
 
@@ -97,10 +98,11 @@ class SourceSwitchHandler(object, metaclass=ABCMeta):
         :param iso_path: full path to the source ISO file
         :type iso_path: string
         """
+        configuration = RepoConfigurationData()
+        configuration.url = create_hdd_url(device_name, join_paths("/", iso_path))
+
         source_proxy = create_source(constants.SOURCE_TYPE_HDD)
-        source_proxy.Partition = device_name
-        # the / gets stripped off by payload.ISO_image
-        source_proxy.Directory = "/" + iso_path
+        source_proxy.Configuration = RepoConfigurationData.to_structure(configuration)
         self._set_source(source_proxy)
 
     def set_source_url(self, url, url_type=constants.URL_TYPE_BASEURL, proxy=None):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
@@ -972,11 +972,9 @@ class DNFInterfaceTestCase(unittest.TestCase):
         """Test DNF GetRepoConfigurations for CDROM source."""
         mount_point.return_value = "/install_source/cdrom"
         source = self.shared_tests.prepare_source(SourceType.CDROM)
-
         self.shared_tests.set_sources([source])
 
         expected = [self._generate_repository_structure("file:///install_source/cdrom")]
-
         assert self.interface.GetRepoConfigurations() == expected
 
     @patch_dbus_publish_object
@@ -984,7 +982,6 @@ class DNFInterfaceTestCase(unittest.TestCase):
         """Test DNF GetRepoConfigurations for the repo path source."""
         source = self.shared_tests.prepare_source(SourceType.REPO_PATH)
         source.set_path("/install_source/path")
-
         self.shared_tests.set_sources([source])
 
         expected = [self._generate_repository_structure("file:///install_source/path")]
@@ -997,11 +994,9 @@ class DNFInterfaceTestCase(unittest.TestCase):
         """Test DNF GetRepoConfigurations for CDROM source."""
         mount_point.return_value = "/install_source/hmc"
         source = self.shared_tests.prepare_source(SourceType.HMC)
-
         self.shared_tests.set_sources([source])
 
         expected = [self._generate_repository_structure("file:///install_source/hmc")]
-
         assert self.interface.GetRepoConfigurations() == expected
 
     @patch_dbus_publish_object
@@ -1017,19 +1012,18 @@ class DNFInterfaceTestCase(unittest.TestCase):
         expected = [self._generate_repository_structure("file:///install_source/nfs")]
         assert self.interface.GetRepoConfigurations() == expected
 
-    @patch("pyanaconda.modules.payloads.source.harddrive.harddrive.HardDriveSourceModule.install_tree_path",
-           new_callable=PropertyMock)
     @patch_dbus_get_proxy
     @patch_dbus_publish_object
-    def test_harddrive_get_repo_configurations(self, publisher, proxy_getter, install_tree_path_mock):
-        """Test DNF GetRepoConfigurations for HARDDRIVE source."""
-        install_tree_path_mock.return_value = "/install_source/harddrive"
-        source = self.shared_tests.prepare_source(SourceType.HDD)
+    def test_harddrive_get_repo_configurations(self, publisher, proxy_getter):
+        """Test DNF GetRepoConfigurations for HDD source."""
+        configuration = RepoConfigurationData()
+        configuration.url = "file:///install_source/hdd"
 
+        source = self.shared_tests.prepare_source(SourceType.HDD)
+        source._set_repository(configuration)
         self.shared_tests.set_sources([source])
 
-        expected = [self._generate_repository_structure("file:///install_source/harddrive")]
-
+        expected = [self._generate_repository_structure("file:///install_source/hdd")]
         assert self.interface.GetRepoConfigurations() == expected
 
     @patch_dbus_publish_object
@@ -1104,7 +1098,7 @@ class DNFModuleTestCase(unittest.TestCase):
 
         # Make sure that HDD source will be protected.
         source = HardDriveSourceModule()
-        source.set_device("dev3")
+        source.configuration.url = "hd:dev3"
         self.module.set_sources([source])
 
         assert proxy.ProtectedDevices == ["dev1", "dev2", "dev3"]

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_utils.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_utils.py
@@ -437,13 +437,13 @@ class DNFUtilsPackagesTestCase(unittest.TestCase):
         s1 = CdromSourceModule()
 
         s2 = HardDriveSourceModule()
-        s2.set_device("dev3")
+        s2.configuration.url = "hd:dev3"
 
         s3 = URLSourceModule()
-        s3.set_configuration(r3)
+        s3.configuration.url = "ftp://test"
 
         s4 = HardDriveSourceModule()
-        s4.set_device("/dev/dev4")
+        s4.configuration.url = "hd:/dev/dev4:/some/path"
 
         devices = collect_installation_devices([s1, s2, s3, s4], [])
         assert devices == {"dev3", "/dev/dev4"}

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_harddrive.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_harddrive.py
@@ -16,89 +16,83 @@
 # Red Hat, Inc.
 #
 import unittest
+from unittest.mock import patch
+
 import pytest
 
-from pyanaconda.core.constants import SOURCE_TYPE_HDD
-from unittest.mock import patch, Mock
-
-from pyanaconda.modules.common.constants.interfaces import PAYLOAD_SOURCE_HARDDRIVE
+from pyanaconda.core.constants import SOURCE_TYPE_HDD, URL_TYPE_MIRRORLIST
+from pyanaconda.modules.common.constants.interfaces import PAYLOAD_SOURCE_REPOSITORY
+from pyanaconda.modules.common.errors.general import InvalidValueError
+from pyanaconda.modules.common.errors.payload import SourceSetupError
+from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.payloads.constants import SourceType, SourceState
 from pyanaconda.modules.payloads.source.harddrive.harddrive import HardDriveSourceModule
-from pyanaconda.modules.payloads.source.harddrive.harddrive_interface import \
-    HardDriveSourceInterface
 from pyanaconda.modules.payloads.source.harddrive.initialization import SetUpHardDriveSourceTask, \
     SetupHardDriveResult
 from pyanaconda.modules.payloads.source.mount_tasks import TearDownMountTask
-from pyanaconda.modules.common.errors.payload import SourceSetupError
-
-from tests.unit_tests.pyanaconda_tests import check_dbus_property, PropertiesChangedCallback
-
-
-device_mount_location = "/mnt/put-harddrive-here_device"
-iso_mount_location = "/mnt/put-harddrive-here_iso"
-device_spec = "partition"
-path_on_device = "/direc/tory"
-
-
-def _create_setup_task():
-    return SetUpHardDriveSourceTask(
-        device_mount_location,
-        iso_mount_location,
-        device_spec,
-        path_on_device
-    )
+from tests.unit_tests.pyanaconda_tests import check_dbus_property
 
 
 class HardDriveSourceInterfaceTestCase(unittest.TestCase):
+    """Test the DBus interface of the HDD source module."""
 
     def setUp(self):
         self.module = HardDriveSourceModule()
-        self.interface = HardDriveSourceInterface(self.module)
-
-        self.callback = PropertiesChangedCallback()
-        self.interface.PropertiesChanged.connect(self.callback)
-
-    def _check_dbus_property(self, *args, **kwargs):
-        check_dbus_property(
-            PAYLOAD_SOURCE_HARDDRIVE,
-            self.interface,
-            *args, **kwargs
-        )
+        self.interface = self.module.for_publication()
 
     def test_type(self):
-        """Hard drive source has a correct type specified."""
-        assert SOURCE_TYPE_HDD == self.interface.Type
+        """Test the Type DBus property of the HDD source."""
+        assert self.interface.Type == SOURCE_TYPE_HDD
 
     def test_description(self):
-        """Hard drive source description."""
-        self.interface.Partition = "device"
-        self.interface.Directory = "/directory"
-        assert "device:/directory" == self.interface.Description
+        """Test the Description DBus property of the HDD source."""
+        self.module.configuration.url = "hd:/dev/sda1:/some/path"
+        assert self.interface.Description == "/dev/sda1:/some/path"
 
-    def test_empty_properties(self):
-        """Hard drive source properties are empty when not set."""
-        assert self.interface.Partition == ""
-        assert self.interface.Directory == ""
+    def test_configuration_property(self):
+        """Test the Configuration DBus property of the HDD source."""
+        configuration = RepoConfigurationData()
+        configuration.url = "hd:/dev/sda1:/some/path"
 
-    def test_setting_properties(self):
-        """Hard drive source properties are correctly set."""
-        self._check_dbus_property("Partition", "sdj9")
-        self._check_dbus_property("Directory", "somewhere/on/the/partition/is/iso.iso")
+        structure = RepoConfigurationData.to_structure(
+            configuration
+        )
 
-    def test_iso_path(self):
-        """Hard drive source has a correct iso path."""
-        assert self.interface.GetIsoPath() == ""
+        check_dbus_property(
+            PAYLOAD_SOURCE_REPOSITORY,
+            self.interface,
+            "Configuration",
+            structure
+        )
 
-        self.module._iso_name = "GLaDOS.iso"
-        self.interface.Directory = "/super/secret/base"
-        assert self.interface.GetIsoPath() == "/super/secret/base/GLaDOS.iso"
+    @patch("pyanaconda.modules.payloads.source.harddrive.harddrive.device_matches")
+    def test_get_device_defined(self, device_matches_mock):
+        """Test the GetDevice DBus method of the HDD source."""
+        device_matches_mock.return_value = []
+        assert self.interface.GetDevice() == ""
 
-        self.module._iso_name = ""
-        self.interface.Directory = "/path/to/install/tree"
-        assert self.interface.GetIsoPath() == ""
+        self.module.configuration.url = "hd:/dev/sda1"
+        device_matches_mock.return_value = ["sda1"]
+        assert self.interface.GetDevice() == "sda1"
+
+        self.module.configuration.url = "hd:LABEL=TEST"
+        device_matches_mock.return_value = ["sda1", "sda2"]
+        assert self.interface.GetDevice() == "sda1"
+
+        self.module.configuration.url = "hd:sdb1"
+        device_matches_mock.return_value = []
+        assert self.interface.GetDevice() == ""
+
+    def test_get_iso_file(self):
+        """Test the GetISOFile DBus method of the HDD source."""
+        assert self.interface.GetISOFile() == ""
+
+        self.module._iso_file = "/some/path/example.iso"
+        assert self.interface.GetISOFile() == "/some/path/example.iso"
 
 
 class HardDriveSourceTestCase(unittest.TestCase):
+    """Test the HDD source module."""
 
     def setUp(self):
         self.module = HardDriveSourceModule()
@@ -111,24 +105,34 @@ class HardDriveSourceTestCase(unittest.TestCase):
         """Test the property network_required."""
         assert self.module.network_required is False
 
+    def test_required_space(self):
+        """Test the required_space property."""
+        assert self.module.required_space == 0
+
     def test_set_up_with_tasks(self):
         """Hard drive source set up task type and amount."""
-        task_classes = [
-            SetUpHardDriveSourceTask
-        ]
-
-        # task will not be public so it won't be published
         tasks = self.module.set_up_with_tasks()
 
-        # Check the number of the tasks
-        task_number = len(task_classes)
+        assert len(tasks) == 1
+        assert isinstance(tasks[0], SetUpHardDriveSourceTask)
+
+    def test_tear_down_with_tasks(self):
+        """Test tear down tasks of the HDD source."""
+        mount_points = [
+            self.module._iso_mount,
+            self.module._device_mount,
+        ]
+
+        tasks = self.module.tear_down_with_tasks()
+        task_number = len(mount_points)
         assert task_number == len(tasks)
 
         for i in range(task_number):
-            assert isinstance(tasks[i], task_classes[i])
+            assert isinstance(tasks[i], TearDownMountTask)
+            assert tasks[i]._target_mount == mount_points[i]
 
     @patch("os.path.ismount")
-    def test_ready_state(self, ismount):
+    def test_get_state(self, ismount):
         """Hard drive source ready state for set up."""
         ismount.return_value = False
 
@@ -138,178 +142,177 @@ class HardDriveSourceTestCase(unittest.TestCase):
         ismount.reset_mock()
         ismount.return_value = True
 
-        task = self.module.set_up_with_tasks()[0]
-        task.get_result = Mock(return_value=SetupHardDriveResult("/my/path", ""))
-        task.succeeded_signal.emit()
+        configuration = RepoConfigurationData()
+        configuration.url = "file:///mnt/path"
+
+        for task in self.module.set_up_with_tasks():
+            task._set_result(SetupHardDriveResult(configuration, None))
+            task.succeeded_signal.emit()
 
         assert self.module.get_state() == SourceState.READY
         ismount.assert_called_once_with(self.module._device_mount)
 
-    def test_return_handler(self):
-        """Hard drive source setup result propagates back."""
-        task = self.module.set_up_with_tasks()[0]
-        task.get_result = Mock(
-            return_value=SetupHardDriveResult(iso_mount_location, "iso_name.iso")
-        )
-        task.succeeded_signal.emit()
+    def test_configuration_invalid_protocol(self):
+        """Test the source configuration with an invalid protocol."""
+        configuration = RepoConfigurationData()
+        configuration.url = "cdrom"
 
-        assert self.module.install_tree_path == iso_mount_location
-        assert self.module._iso_name == "iso_name.iso"
+        with pytest.raises(InvalidValueError) as cm:
+            self.module.set_configuration(configuration)
 
-    def test_return_handler_without_iso(self):
-        """Hard drive source setup result propagates back when no ISO is involved.
+        assert str(cm.value) == "Invalid protocol of a HDD source: 'cdrom'"
 
-        This is happening when installation tree is used instead of ISO image.
-        """
-        task = self.module.set_up_with_tasks()[0]
-        task.get_result = Mock(
-            return_value=SetupHardDriveResult(iso_mount_location, "")
-        )
-        task.succeeded_signal.emit()
+    def test_configuration_invalid_url_type(self):
+        """Test the source configuration with an invalid URL type."""
+        configuration = RepoConfigurationData()
+        configuration.url = "hd:/dev/sda1:/some/path"
+        configuration.type = URL_TYPE_MIRRORLIST
 
-        assert self.module.install_tree_path == iso_mount_location
-        assert self.module._iso_name == ""
+        with pytest.raises(InvalidValueError) as cm:
+            self.module.set_configuration(configuration)
+
+        assert str(cm.value) == "Invalid URL type of a HDD source: 'MIRRORLIST'"
+
+    def test_repository_configuration(self):
+        """Test the repository configuration."""
+        configuration = RepoConfigurationData()
+        configuration.url = "file:///mnt/image"
+        iso_file = "/some/path/example.iso"
+
+        for task in self.module.set_up_with_tasks():
+            task._set_result(SetupHardDriveResult(configuration, iso_file))
+            task.succeeded_signal.emit()
+
+        assert self.module.repository is configuration
+        assert self.module.get_iso_file() == iso_file
 
     def test_repr(self):
-        self.module.set_device("device")
-        self.module.set_directory("directory")
-        self.module._install_tree_path = "install-tree-path"
-        assert repr(self.module) == \
-            "Source(type='HDD', partition='device', directory='directory')"
+        """Test the string representation of the HDD source."""
+        self.module.configuration.url = "hd:/dev/sda1:/some/path"
+        assert repr(self.module) == "Source(type='HDD', url='hd:/dev/sda1:/some/path')"
 
 
 class HardDriveSourceSetupTaskTestCase(unittest.TestCase):
+    """Test the SetUpHardDriveSourceTask task."""
 
-    def test_setup_install_source_task_name(self):
-        """Hard drive source setup task name."""
-        task = _create_setup_task()
+    def _run_task(self, url, expected_location=None, expected_iso_file=None):
+        """Run the set-up task of the HDD source."""
+        configuration = RepoConfigurationData()
+        configuration.url = url
+
+        task = SetUpHardDriveSourceTask(
+            configuration=configuration,
+            device_mount="/mnt/device",
+            iso_mount="/mnt/image",
+        )
+        result = task.run()
+
         assert task.name == "Set up a hard drive source"
+        assert isinstance(result, SetupHardDriveResult)
+        assert isinstance(result.repository, RepoConfigurationData)
+        assert result.repository.url == expected_location
+        assert result.repository is not configuration
+        assert result.iso_file == expected_iso_file
 
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
-           return_value=True)
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_iso_image",
-           return_value="skynet.iso")
-    def test_success_find_iso(self,
-                              find_and_mount_iso_image_mock,
-                              find_and_mount_device_mock):
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device")
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_iso_image")
+    def test_success_find_iso(self, find_image_mock, find_device_mock):
         """Hard drive source setup iso found."""
-        task = _create_setup_task()
-        result = task.run()
+        find_device_mock.return_value = True
+        find_image_mock.return_value = "example.iso"
 
-        find_and_mount_device_mock.assert_called_once_with(
-            device_spec,
-            device_mount_location
+        self._run_task(
+            "hd:/dev/sda1:/some/path",
+            expected_location="file:///mnt/image",
+            expected_iso_file="/some/path/example.iso",
         )
-        find_and_mount_iso_image_mock.assert_called_once_with(
-            device_mount_location + path_on_device, iso_mount_location
+        find_device_mock.assert_called_once_with(
+            "/dev/sda1",
+            "/mnt/device",
         )
-        assert result == SetupHardDriveResult(iso_mount_location, "skynet.iso")
+        find_image_mock.assert_called_once_with(
+            "/mnt/device/some/path",
+            "/mnt/image",
+        )
 
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
-           return_value=True)
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_iso_image",
-           return_value="")
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.verify_valid_repository",
-           return_value=True)
-    def test_success_find_dir(self,
-                              verify_valid_repository_mock,
-                              find_and_mount_iso_image_mock,
-                              find_and_mount_device_mock):
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device")
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_iso_image")
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.verify_valid_repository")
+    def test_success_find_dir(self, verify_mock, find_image_mock, find_device_mock):
         """Hard drive source setup dir found."""
-        task = _create_setup_task()
-        result = task.run()
+        find_device_mock.return_value = True
+        verify_mock.return_value = True
+        find_image_mock.return_value = ""
 
-        find_and_mount_device_mock.assert_called_once_with(
-            device_spec,
-            device_mount_location
+        self._run_task(
+            "hd:/dev/sda1:/some/path",
+            expected_location="file:///mnt/device/some/path",
+            expected_iso_file=None,
         )
-        find_and_mount_iso_image_mock.assert_called_once_with(
-            device_mount_location + path_on_device, iso_mount_location
+        find_device_mock.assert_called_once_with(
+            "/dev/sda1",
+            "/mnt/device",
         )
-        verify_valid_repository_mock.assert_called_once_with(
-            device_mount_location + path_on_device
+        find_image_mock.assert_called_once_with(
+            "/mnt/device/some/path",
+            "/mnt/image",
         )
-        assert result == SetupHardDriveResult(device_mount_location + path_on_device, "")
+        verify_mock.assert_called_once_with(
+            "/mnt/device/some/path",
+        )
 
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
-           return_value=True)
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_iso_image",
-           return_value="")
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.verify_valid_repository",
-           return_value=False)
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device")
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_iso_image")
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.verify_valid_repository")
     @patch("pyanaconda.modules.payloads.source.harddrive.initialization.unmount")
-    def test_failure_to_find_anything(self,
-                                      unmount_mock,
-                                      verify_valid_repository_mock,
-                                      find_and_mount_iso_image_mock,
-                                      find_and_mount_device_mock):
+    def test_failure_to_find_anything(self, unmount_mock, verify_mock, find_image_mock, find_device_mock):
         """Hard drive source setup failure to find anything."""
-        task = _create_setup_task()
-        with pytest.raises(SourceSetupError) as cm:
-            task.run()
+        find_device_mock.return_value = True
+        verify_mock.return_value = False
+        find_image_mock.return_value = ""
 
-        find_and_mount_device_mock.assert_called_once_with(
-            device_spec,
-            device_mount_location
+        with pytest.raises(SourceSetupError) as cm:
+            self._run_task("hd:/dev/sda1:/some/path")
+
+        find_device_mock.assert_called_once_with(
+            "/dev/sda1",
+            "/mnt/device"
         )
-        find_and_mount_iso_image_mock.assert_called_once_with(
-            device_mount_location + path_on_device, iso_mount_location
+        find_image_mock.assert_called_once_with(
+            "/mnt/device/some/path",
+            "/mnt/image"
         )
-        verify_valid_repository_mock.assert_called_once_with(
-            device_mount_location + path_on_device
+        verify_mock.assert_called_once_with(
+            "/mnt/device/some/path"
         )
         unmount_mock.assert_called_once_with(
-            device_mount_location
-        )
-        assert str(cm.value).startswith(
-            "Nothing useful found for Hard drive ISO source"
+            "/mnt/device"
         )
 
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device",
-           return_value=False)
-    def test_failure_to_find_mount_device(self, find_and_mount_device_mock):
+        msg = "Nothing useful found for the HDD source at '/dev/sda1:/some/path'."
+        assert str(cm.value) == msg
+
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.find_and_mount_device")
+    def test_failure_to_find_mount_device(self, find_device_mock):
         """Hard drive source setup failure to find partition device."""
-        task = _create_setup_task()
+        find_device_mock.return_value = False
+
         with pytest.raises(SourceSetupError) as cm:
-            task.run()
+            self._run_task("hd:/dev/sda1:/some/path")
 
-        find_and_mount_device_mock.assert_called_once_with(
-            device_spec,
-            device_mount_location
+        find_device_mock.assert_called_once_with(
+            "/dev/sda1",
+            "/mnt/device",
         )
-        assert str(cm.value).startswith(
-            "Could not mount device specified as"
-        )
+        assert str(cm.value) == "Failed to mount the '/dev/sda1' HDD source."
 
-    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.os.path.ismount",
-           return_value=True)
+    @patch("pyanaconda.modules.payloads.source.harddrive.initialization.os.path.ismount")
     def test_failure_mount_already_used(self, ismount_mock):
         """Hard drive source setup failure to mount partition device."""
-        task = _create_setup_task()
+        ismount_mock.return_value = True
+
         with pytest.raises(SourceSetupError) as cm:
-            task.run()
+            self._run_task("hd:/dev/sda1:/some/path")
 
-        ismount_mock.assert_called_once()  # must die on first check
-        assert str(cm.value).startswith(
-            "The mount point"
-        )
-
-
-class HardDriveSourceTearDownTestCase(unittest.TestCase):
-
-    def setUp(self):
-        self.source_module = HardDriveSourceModule()
-
-    def test_required_space(self):
-        """Test the required_space property."""
-        assert self.source_module.required_space == 0
-
-    def test_tear_down_task_order(self):
-        """Hard drive source tear down task order."""
-        tasks = self.source_module.tear_down_with_tasks()
-        assert len(tasks) == 2
-        assert isinstance(tasks[0], TearDownMountTask)
-        assert isinstance(tasks[1], TearDownMountTask)
-        name_suffixes = ["-iso", "-device"]
-        for task, fragment in zip(tasks, name_suffixes):
-            assert task._target_mount.endswith(fragment)
+        ismount_mock.assert_called_once()
+        assert str(cm.value) == "The mount point /mnt/device is already in use."

--- a/tests/unit_tests/pyanaconda_tests/test_payload.py
+++ b/tests/unit_tests/pyanaconda_tests/test_payload.py
@@ -209,5 +209,5 @@ class DNFPayloadOptionsTests(unittest.TestCase):
         create_source("hd:UUID=8176c7bf-04ff-403a:/path/to/iso.iso")
 
         proxy = create_source("hd:/dev/sda2:/path/to/iso.iso")
-        assert proxy.Partition == "/dev/sda2"
-        assert proxy.Directory == "/path/to/iso.iso"
+        configuration = RepoConfigurationData.from_structure(proxy.Configuration)
+        assert configuration.url == "hd:/dev/sda2:/path/to/iso.iso"

--- a/tests/unit_tests/pyanaconda_tests/test_payload.py
+++ b/tests/unit_tests/pyanaconda_tests/test_payload.py
@@ -25,7 +25,7 @@ import pytest
 import pyanaconda.core.payload as util
 from pyanaconda.core.constants import SOURCE_TYPE_CDROM, SOURCE_TYPE_URL, SOURCE_TYPE_NFS, \
     SOURCE_TYPE_HDD, SOURCE_TYPE_HMC
-from pyanaconda.core.payload import parse_hdd_url
+from pyanaconda.core.payload import parse_hdd_url, create_hdd_url
 from pyanaconda.modules.common.constants.services import PAYLOADS
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.payload.dnf import DNFPayload
@@ -69,7 +69,7 @@ class PayloadUtilsTests(unittest.TestCase):
         assert util.create_nfs_url("", "", None) == ""
         assert util.create_nfs_url("", "", "") == ""
 
-        assert util.create_nfs_url("host", "") == "nfs:host:"
+        assert util.create_nfs_url("host", "") == "nfs:host"
         assert util.create_nfs_url("host", "", "options") == "nfs:options:host:"
 
         assert util.create_nfs_url("host", "path") == "nfs:host:path"
@@ -117,6 +117,17 @@ class PayloadUtilsTests(unittest.TestCase):
         assert parse_hdd_url("hd:/dev/test:/absolute") == ("/dev/test", "/absolute")
         assert parse_hdd_url("hd:/dev/test:relative/path") == ("/dev/test", "relative/path")
         assert parse_hdd_url("hd:/dev/test:/absolute/path") == ("/dev/test", "/absolute/path")
+
+    def test_create_hdd_url(self):
+        """Test the create_hdd_url function."""
+        assert create_hdd_url("") == ""
+        assert create_hdd_url("", "") == ""
+        assert create_hdd_url("test") == "hd:test"
+        assert create_hdd_url("/dev/test") == "hd:/dev/test"
+        assert create_hdd_url("/dev/test", "relative") == "hd:/dev/test:relative"
+        assert create_hdd_url("/dev/test", "/absolute") == "hd:/dev/test:/absolute"
+        assert create_hdd_url("/dev/test", "relative/path") == "hd:/dev/test:relative/path"
+        assert create_hdd_url("/dev/test", "/absolute/path") == "hd:/dev/test:/absolute/path"
 
 
 class DNFPayloadOptionsTests(unittest.TestCase):


### PR DESCRIPTION
Use a new support for sources that provide access to a repository.
Update the code for the HDD source in the DNF payload, GUI and TUI.
Use the source as an internal representation of additional repositories.