### PR TITLE
infra: Reorder unit tests

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -63,8 +63,7 @@ dist_check_SCRIPTS = $(srcdir)/glade_tests/*.py \
 		     pep8/runpep8.sh
 
 
-TESTS = unit_tests/unit_tests.sh \
-	pylint/runpylint.py \
+TESTS = \
 	cppcheck/runcppcheck.sh \
 	gettext_tests/click.py \
 	gettext_tests/style_guide.py \
@@ -72,6 +71,8 @@ TESTS = unit_tests/unit_tests.sh \
 	gettext_tests/canary_tests.sh \
 	glade_tests/glade_tests.sh \
 	shellcheck/run_shellcheck.sh \
+	unit_tests/unit_tests.sh \
+	pylint/runpylint.py \
 	webui_eslint/run_webui_eslint.sh
 
 clean-local:


### PR DESCRIPTION
With this, the fast few-second tests come first and the slowest stuff comes last. The actual heavy tests that take 99% of time stay in the same order.

The improvement is that running tests locally now produces some output soon after the initial make bootstrapping, so it's clear that things are not stuck.