### PR TITLE
fsset: Catch SwapSpaceError when trying to activate swaps

### DIFF
--- a/pyanaconda/modules/storage/devicetree/fsset.py
+++ b/pyanaconda/modules/storage/devicetree/fsset.py
@@ -25,7 +25,7 @@ from gi.repository import BlockDev as blockdev
 
 from blivet.devices import NoDevice, DirectoryDevice, NFSDevice, FileDevice, MDRaidArrayDevice, \
     NetworkStorageDevice, OpticalDevice
-from blivet.errors import UnrecognizedFSTabEntryError, FSTabTypeMismatchError
+from blivet.errors import UnrecognizedFSTabEntryError, FSTabTypeMismatchError, SwapSpaceError
 from blivet.formats import get_format, get_device_format_class
 from blivet.storage_log import log_exception_info
 
@@ -530,7 +530,7 @@ class FSSet(object):
                 try:
                     device.setup()
                     device.format.setup()
-                except blockdev.SwapActivateError as e:
+                except (SwapSpaceError, blockdev.SwapActivateError) as e:
                     log.error("Failed to activate swap on '%s': %s", device.name, str(e))
                     break
                 else:


### PR DESCRIPTION
Blivet now raises blivet.errors.SwapSpaceError when swap setup fails instead of just relaying the libblockdev exception.

We decided that raising libblockdev exceptions isn't probably the best idea so starting from blivet 3.8.0 you'll need to catch the blivet exception here. This should be the only place where libblockdev exceptions are being caught in Anaconda.