### PR TITLE
Fedora 38 keep vga boot option

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -156,7 +156,7 @@ preserved_arguments =
     speakup_synth apic noapic apm ide noht acpi video
     pci nodmraid nompath nomodeset noiswmd fips selinux
     biosdevname ipv6.disable net.ifnames net.ifnames.prefix
-    nosmt
+    nosmt vga
 
 
 [Storage]


### PR DESCRIPTION
To address problems with KDE on Wayland on BIOS boots with "basic mode" graphics, we need to set a framebuffer mode in the bootloader (vga=791). This should also be passed through to the installed system so SDDM will work there as well.

Backport to F38.