### PR TITLE
Fix wrong dracut timeout message

### DIFF
--- a/dracut/anaconda-error-reporting.sh
+++ b/dracut/anaconda-error-reporting.sh
@@ -14,9 +14,13 @@ warn "Please also note that the 'inst.' prefix is now mandatory."
 warn "#                                                         #"
 warn "####     Installer errors encountered during boot:     ####"
 warn "#                                                         #"
-while read -r line; do
-    warn "$line"
-done < /run/anaconda/initrd_errors.txt
+if ! [ -e /run/anaconda/initrd_errors.txt ]; then
+    warn "Reason unknown"
+else
+    while read -r line; do
+        warn "$line"
+    done < /run/anaconda/initrd_errors.txt
+fi
 warn "#                                                         #"
 warn "############# Anaconda installer errors end ###############"
 


### PR DESCRIPTION
We added Anaconda error reporting when Dracut timeout during boot. If the reason is known issue we will print that to a user. However, in case it is not known the code failed with message:

... /run/anaconda/initrd_errors.txt: No such file or directory

To fix this just print "Reason unknown" and not execute rest of the code.