### PR TITLE
WebUI: correct setState calls for SearchInput

### DIFF
--- a/ui/webui/package.json
+++ b/ui/webui/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@patternfly/patternfly": "4.224.2",
-    "@patternfly/react-core": "4.267.6",
+    "@patternfly/react-core": "4.276.8",
     "@patternfly/react-log-viewer": "^4.51.2",
     "@patternfly/react-table": "^4.75.2",
     "react": "18.2.0",

--- a/ui/webui/src/components/localization/InstallationLanguage.jsx
+++ b/ui/webui/src/components/localization/InstallationLanguage.jsx
@@ -234,7 +234,7 @@ class LanguageSelector extends React.Component {
                         setLanguage({ lang: getLocaleId(localeItem) })
                                 .then(() => setLocale({ locale: getLocaleId(localeItem) }))
                                 .catch(this.props.onAddErrorNotification);
-                        this.setState({ ...this.state, lang: item });
+                        this.setState({ lang: item });
                         this.updateNativeName(localeItem);
                         window.location.reload(true);
                         return;
@@ -282,8 +282,8 @@ class LanguageSelector extends React.Component {
                     <SearchInput
                       id={this.props.idPrefix + "-language-search"}
                       value={this.state.search}
-                      onChange={value => this.setState({ ...this.state, search: value })}
-                      onClear={() => this.setState({ ...this.state, search: "" })}
+                      onChange={(_, value) => this.setState({ search: value })}
+                      onClear={() => this.setState({ search: "" })}
                     />
                 </MenuInput>
                 <MenuContent maxMenuHeight="25vh">


### PR DESCRIPTION
The onChange callback has two parameters, event and the string. We want to set the string not the event, furthermore simplify the clearing of state, there is no need to merge the old state, set state can work with keys.

@M4rtinK  This fixes the test failures in https://github.com/rhinstaller/anaconda/pull/4657

**Thank you** for your contribution!

Please check that your PR follows these rules:

* [x] [**Code conventions**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#code-conventions). tl;dr: Follow PEP8, wrap at 100 chars, and provide docstrings.

* [x] [**Commit message conventions**](https://anaconda-installer.readthedocs.io/en/latest/commit-log.html). tl;dr: Heading, empty line, longer explanations, all wrapped manually. If in doubt, write a longer commit message with more details.

* [x] **Tests** pass and cover your changes. You can [run tests locally manually](https://anaconda-installer.readthedocs.io/en/latest/testing.html), or have them run as part of the PR. A team member will have to enable tests manually after inspecting the PR.
  *If you don't know how, ask us for help!*

* [x] [**Release notes**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#release-notes) and **docs** if the PR adds something major or changes existing behavior.
  *If you don't know how, ask us for help!*

* [x] **RHEL** rules: If your PR is for a `rhel-*` branch, pay special attention to commit messages. Make sure **all** commit messages include a line linking the commit to a bug, such as `Resolves: rhbz#123456`. For more information, see [the complete rules](https://anaconda-installer.readthedocs.io/en/latest/commit-log.html).
  *If you don't know how, ask us for help!*

Don't forget - *if you don't know how, ask us for help!*

And now that you read this all, you can delete it and type your own description of your changes :-)
