### PR TITLE
webui: fix spacing of Storage Congfiguration options

### DIFF
--- a/ui/webui/src/components/storage/StorageConfiguration.jsx
+++ b/ui/webui/src/components/storage/StorageConfiguration.jsx
@@ -22,7 +22,6 @@ import {
     Alert,
     Button,
     DataList,
-    DataListAction,
     DataListCell,
     DataListItem,
     DataListItemRow,
@@ -267,45 +266,49 @@ const GuidedPartitioning = ({ idPrefix, scenarios, setIsFormValid }) => {
         <DataListItem key={scenario.id}>
             <DataListItemRow>
                 <DataListItemCells dataListCells={[
-                    <DataListAction key="radio">
+                    <DataListCell key="radio">
                         {!scenarioAvailability[scenario.id].available &&
                         <Tooltip
                           aria-live="polite"
                           content={scenarioAvailability[scenario.id].shortHint}
                           reference={() => document.getElementById(idPrefix + "-autopart-scenario-" + scenario.id)}
                         />}
-                        <Radio
-                          id={idPrefix + "-autopart-scenario-" + scenario.id}
-                          value={scenario.id}
-                          name="autopart-scenario"
-                          label={scenario.label}
-                          isDisabled={!scenarioAvailability[scenario.id].available}
-                          isChecked={selectedScenario === scenario.id}
-                          onChange={() => onScenarioToggled(scenario.id)}
-                        />
-                    </DataListAction>,
-                    <DataListCell key="more">
-                        {scenarioAvailability[scenario.id].reason &&
-                        <Flex spaceItems={{ default: "spaceItems2xl" }}>
-                            <FlexItem />
+                        <Flex direction={{ default: "column" }} spaceItems={{ default: "spaceItemsSm" }}>
                             <FlexItem>
-                                <HelperText>
-                                    <HelperTextItem variant="warning" icon=<ExclamationTriangleIcon />>
-                                        {scenarioAvailability[scenario.id].reason}
-                                    </HelperTextItem>
-                                </HelperText>
+                                <Radio
+                                  id={idPrefix + "-autopart-scenario-" + scenario.id}
+                                  value={scenario.id}
+                                  name="autopart-scenario"
+                                  label={scenario.label}
+                                  isDisabled={!scenarioAvailability[scenario.id].available}
+                                  isChecked={selectedScenario === scenario.id}
+                                  onChange={() => onScenarioToggled(scenario.id)}
+                                />
                             </FlexItem>
-                            <FlexItem />
-                        </Flex>}
+                            {scenarioAvailability[scenario.id].reason &&
+                            <FlexItem>
+                                <Flex spaceItems={{ default: "spaceItemsLg" }}>
+                                    <FlexItem />
+                                    <FlexItem>
+                                        <HelperText>
+                                            <HelperTextItem variant="warning" icon=<ExclamationTriangleIcon />>
+                                                {scenarioAvailability[scenario.id].reason}
+                                            </HelperTextItem>
+                                        </HelperText>
+                                    </FlexItem>
+                                </Flex>
+                            </FlexItem>}
+                        </Flex>
                     </DataListCell>,
-                    <DataListAction key="details">
+                    <DataListCell isFilled={false} key="details">
                         <Button
                           variant="link"
-                          isInline onClick={() => showScenarioDetails(scenario.id)}
+                          isInline
+                          onClick={() => showScenarioDetails(scenario.id)}
                         >
                             {_("Learn more")}
                         </Button>
-                    </DataListAction>,
+                    </DataListCell>
                 ]} />
             </DataListItemRow>
         </DataListItem>


### PR DESCRIPTION
Addresses [INSTALLER-3450](https://issues.redhat.com/browse/INSTALLER-3450)

![Screenshot from 2023-04-04 13-08-42](https://user-images.githubusercontent.com/1220237/229839536-401f4b08-494b-43bd-94fa-71245ef44ca8.png)


Screenshots: https://rvykydal.fedorapeople.org/webui/autopart_pr1/v1/screenshots/partitioning_spacing_update_v2/
Screencast: https://rvykydal.fedorapeople.org/webui/autopart_pr1/v1/screencasts/autopart_choices_alignment/Screencast%20from%2004-04-2023%2004:43:58%20PM.webm

Should improve this original state: https://rvykydal.fedorapeople.org/webui/autopart_pr1/v1/screenshots/Screenshot%20from%202023-03-08%2011-11-39.png