### PR TITLE
Github codeql scanning

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,2 @@
+paths:
+  - ui/webui/src

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+on: [push, pull_request]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+          config-file: ./.github/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/ui/webui/src/components/installation/InstallationProgress.jsx
+++ b/ui/webui/src/components/installation/InstallationProgress.jsx
@@ -83,8 +83,6 @@ export class InstallationProgress extends React.Component {
                             }
                             if (message) {
                                 this.setState({ statusMessage: message });
-                            } else {
-                                this.setState({ step });
                             }
                         });
                         taskProxy.addEventListener("Failed", () => {

--- a/ui/webui/src/components/installation/InstallationProgress.jsx
+++ b/ui/webui/src/components/installation/InstallationProgress.jsx
@@ -131,7 +131,9 @@ export class InstallationProgress extends React.Component {
             },
         ];
 
-        if (steps === undefined) { return null }
+        if (steps === undefined) {
+            return null;
+        }
 
         let icon;
         let title;


### PR DESCRIPTION
Github has a codeql action which can scan JavaScript, Python, C code and report issues on PR's. This is similar to shellcheck it shows up in the Security tab and as a comment in a PR.

Example alert:

![image](https://user-images.githubusercontent.com/67428/230023632-25d99340-de48-4538-8ce2-00d5afe52bf3.png)

Cockpit projects already set this up and it found a bunch of bugs / state inconsistenties.