### PR TITLE
po: fix @echo command not found

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -237,8 +237,7 @@ $(MERGED_POFILES): $(POFILES) $(POTFILE)
 
 # OMP_NUM_THREADS=1; This helps to avoid 'libgomp: Thread creation failed: Resource temporarily unavailable' on Cockpit's CI
 .po.mpo:
-	export OMP_NUM_THREADS=1; \
-	$(GETTEXT_V_MERGE)$(MSGMERGE) $(MSGMERGE_V_OPTIONS) -o $@ $< $(POTFILE)
+	$(GETTEXT_V_MERGE) OMP_NUM_THREADS=1 $(MSGMERGE) $(MSGMERGE_V_OPTIONS) -o $@ $< $(POTFILE)
 
 # How to build the .mo files from the .mpo files
 $(MOFILES): $(MERGED_POFILES)


### PR DESCRIPTION
The added export line causes a lot of "@echo: command not found" as it is now executed. So instead pass the env variable directly to msgmerge.

Now it show as expected:

```
  GEN      anaconda.pot
  MERGE    af.mpo
  MERGE    am.mpo
  MERGE    ar.mpo
  MERGE    as.mpo
```