### PR TITLE
Add missing documentation about OEMDRV (#2171811)

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -656,6 +656,22 @@ will be used by default, if found.
 
 See the |anacondalogging|_ for more info on setting up logging via virtio.
 
+.. inst.wait_for_disks:
+
+inst.wait_for_disks
+^^^^^^^^^^^^^^^^^^^
+
+Because disks can take some time to appear, an additional delay of 5 seconds
+has been added.  This can be overridden by boot argument
+`inst.wait_for_disks=<value>` to let dracut wait up to <value> additional
+seconds (0 turns the feature off, causing dracut to only wait up to 500ms).
+Alternatively, if the `OEMDRV` device is known to be present but too slow to be
+autodetected, the user can boot with an argument like `inst.dd=hd:LABEL=OEMDRV`
+to indicate that dracut should expect an `OEMDRV` device and not start the
+installer until it appears.
+
+This functionality could be used to load kickstart and driverdisks.
+
 
 Boot loader options
 -------------------

--- a/docs/driverdisc.rst
+++ b/docs/driverdisc.rst
@@ -56,6 +56,15 @@ Anaconda automatically looks for driverdiscs during startup.
 The DriverDisc has to be on partition or filesystem which has been labeled
 with 'OEMDRV' label.
 
+Because disks can take some time to appear, an additional delay of 5 seconds
+has been added.  This can be overridden by boot argument
+`inst.wait_for_disks=<value>` to let dracut wait up to <value> additional
+seconds (0 turns the feature off, causing dracut to only wait up to 500ms).
+Alternatively, if the `OEMDRV` device is known to be present but too slow to be
+autodetected, the user can boot with an argument like `inst.dd=hd:LABEL=OEMDRV`
+to indicate that dracut should expect an `OEMDRV` device and not start the
+installer until it appears.
+
 
 DDv3 structure
 --------------

--- a/docs/kickstart.rst
+++ b/docs/kickstart.rst
@@ -7,6 +7,13 @@ Anaconda Kickstart Documentation
 Anaconda uses `kickstart <https://github.com/pykickstart/pykickstart>`_ to parse and generate
 kickstart files.
 
+Automatically load the Kickstart file
+-------------------------------------
+
+If you need to load Kickstart file automatically you can store your Kickstart file as ``/ks.cfg``
+into the storage device which is accessible during the boot process and is labeled as ``OEMDRV``.
+Such a device is automatically discovered during boot and the Kickstart file will be used.
+
 %anaconda
 ---------
 

--- a/docs/release-notes/wait_5_secs_for_disks.rst
+++ b/docs/release-notes/wait_5_secs_for_disks.rst
@@ -1,0 +1,16 @@
+:Type: Kickstart / DriverDisc / Boot
+:Summary: Wait 5 secs during boot for OEMDRV devices (#2171811)
+
+:Description:
+    Because disks can take some time to appear, an additional delay of 5 seconds
+    has been added.  This can be overridden by boot argument
+    `inst.wait_for_disks=<value>` to let dracut wait up to <value> additional
+    seconds (0 turns the feature off, causing dracut to only wait up to 500ms).
+    Alternatively, if the `OEMDRV` device is known to be present but too slow to be
+    autodetected, the user can boot with an argument like `inst.dd=hd:LABEL=OEMDRV`
+    to indicate that dracut should expect an `OEMDRV` device and not start the
+    installer until it appears.
+
+:Links:
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2171811
+    - https://github.com/rhinstaller/anaconda/pull/4586


### PR DESCRIPTION
This is documentation part of the commit 1e33cbdbf45150308cef6b8c2b056c8cc41f0492.

Also add documentation of OEMDRV functionality for kickstart.

Extension of https://github.com/rhinstaller/anaconda/pull/4586 .

Related: rhbz#2171811