### PR TITLE
webui: reset storage backend before autopart test

### DIFF
--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -61,10 +61,16 @@ class TestStorage(anacondalib.VirtInstallMachineCase):
         i.check_next_disabled()
 
     # Test moving back and forth between screens.
+    # Disk initialization mode is applied to the backend in the test.
+    # Partitioning is not applied to the backend in the test.
     def testAutopartitioning(self):
         b = self.browser
         i = Installer(b, self.machine)
         s = Storage(b, self.machine)
+
+        # Reset the state of the backend
+        # CLEAR_PARTITIONS_DEFAULT = -1
+        s.dbus_set_initialization_mode(-1)
 
         i.open()
         # Language selection
@@ -75,6 +81,9 @@ class TestStorage(anacondalib.VirtInstallMachineCase):
         i.next()
         # Storage Configuration
 
+        # Check the default mode
+        s.check_partitioning_selected("erase-all")
+
         b.assert_pixels(
             "#app",
             "storage-step-autopart",
@@ -82,7 +91,6 @@ class TestStorage(anacondalib.VirtInstallMachineCase):
             wait_animations=False,
         )
 
-        s.check_partitioning_selected("erase-all")
         s.set_partitioning("use-free-space")
 
         i.next()


### PR DESCRIPTION
The test was failing during RETRY (caused by unrelated failure in the test) because of backend state initialization mode value changed by the previous try of the test.
