### PR TITLE
Implement EULA spoke based on initial-setup

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -316,9 +316,6 @@ password_policies =
 # If the given distribution has an EULA & feels the need to
 # tell the user about it fill in this variable by a path
 # pointing to a file with the EULA on the installed system.
-#
-# This is currently used just to show the path to the file to
-# the user at the end of the installation.
 eula =
 
 

--- a/pyanaconda/core/configuration/license.py
+++ b/pyanaconda/core/configuration/license.py
@@ -30,8 +30,5 @@ class LicenseSection(Section):
         If the given distribution has an EULA & feels the need to
         tell the user about it fill in this variable by a path
         pointing to a file with the EULA on the installed system.
-
-        This is currently used just to show the path to the file to
-        the user at the end of the installation.
         """
         return self._get_option("eula", str)

--- a/pyanaconda/core/eula.py
+++ b/pyanaconda/core/eula.py
@@ -1,0 +1,25 @@
+import os
+from pyanaconda.core.configuration.anaconda import conf
+
+def get_license_file_name():
+    """Get filename of the license file best matching current localization settings.
+
+    :return: filename of the license file or None if no license file found
+    :rtype: str or None
+    """
+    if not conf.license.eula:
+        return None
+
+    if not os.path.exists(conf.license.eula):
+        return None
+
+    return conf.license.eula
+
+
+def eula_available():
+    """Report if it looks like there is an EULA available on the system.
+
+    :return: True if an EULA seems to be available, False otherwise
+    :rtype: bool
+    """
+    return bool(get_license_file_name())

--- a/pyanaconda/ui/categories/eula.py
+++ b/pyanaconda/ui/categories/eula.py
@@ -1,0 +1,14 @@
+from pyanaconda.ui.categories import SpokeCategory
+from pyanaconda.core.i18n import _
+
+__all__ = ["LicensingCategory"]
+
+class LicensingCategory(SpokeCategory):
+
+    @staticmethod
+    def get_title():
+        return _("LICENSING")
+
+    @staticmethod
+    def get_sort_order():
+        return 900

--- a/pyanaconda/ui/gui/spokes/eula.glade
+++ b/pyanaconda/ui/gui/spokes/eula.glade
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <!-- interface-requires gtk+ 3.6 -->
+  <!-- interface-requires AnacondaWidgets 1.0 -->
+  <object class="GtkTextBuffer" id="eulaBuffer">
+    <property name="text">The license will go here</property>
+  </object>
+  <object class="AnacondaSpokeWindow" id="eulaWindow">
+    <property name="can_focus">False</property>
+    <property name="hexpand">True</property>
+    <property name="vexpand">True</property>
+    <property name="window_name" translatable="yes">License Information</property>
+    <signal name="button-clicked" handler="on_back_clicked" swapped="no"/>
+    <child internal-child="main_box">
+      <object class="GtkBox" id="AnacondaSpokeWindow-main_box1">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+        <child internal-child="nav_box">
+          <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
+            <property name="can_focus">False</property>
+            <child internal-child="nav_area">
+              <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">
+                <property name="can_focus">False</property>
+                <property name="margin_left">6</property>
+                <property name="margin_right">6</property>
+                <property name="margin_top">6</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child internal-child="alignment">
+          <object class="GtkAlignment" id="AnacondaSpokeWindow-alignment1">
+            <property name="can_focus">False</property>
+            <property name="xscale">0.8</property>
+            <property name="yscale">0.8</property>
+            <child internal-child="action_area">
+              <object class="GtkBox" id="mainBox">
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel" id="licenseAgreementLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin_top">24</property>
+                    <property name="margin_bottom">6</property>
+                    <property name="label" translatable="yes">License Agreement:</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="eulaBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkScrolledWindow" id="eulaScrolledWindow">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="shadow_type">in</property>
+                        <child>
+                          <object class="GtkTextView" id="eulaView">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="margin_bottom">18</property>
+                            <property name="hexpand">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="vscroll_policy">natural</property>
+                            <property name="pixels_above_lines">12</property>
+                            <property name="editable">False</property>
+                            <property name="wrap_mode">word</property>
+                            <property name="left_margin">12</property>
+                            <property name="right_margin">12</property>
+                            <property name="cursor_visible">False</property>
+                            <property name="buffer">eulaBuffer</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="agreeCheckButton">
+                        <property name="label" translatable="yes">I _accept the license agreement</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="xalign">0</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="on_check_button_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/pyanaconda/ui/gui/spokes/eula.py
+++ b/pyanaconda/ui/gui/spokes/eula.py
@@ -1,0 +1,107 @@
+import logging
+
+from pyanaconda.ui.common import FirstbootOnlySpokeMixIn
+from pyanaconda.ui.gui.spokes import NormalSpoke
+from pyanaconda.core.i18n import _, CN_
+from pyanaconda.core import eula
+from pyanaconda.ui.categories.eula import LicensingCategory
+from pyanaconda.anaconda_loggers import get_module_logger
+from pykickstart.constants import FIRSTBOOT_RECONFIG
+
+log = get_module_logger(__name__)
+__all__ = ["EULASpoke"]
+
+
+class EULASpoke(FirstbootOnlySpokeMixIn, NormalSpoke):
+    """The EULA spoke"""
+
+    builderObjects = ["eulaBuffer", "eulaWindow"]
+    mainWidgetName = "eulaWindow"
+    uiFile = "spokes/eula.glade"
+    icon = "application-certificate-symbolic"
+    title = CN_("GUI|Spoke", "_License Information")
+    category = LicensingCategory
+
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "license-information"
+
+    def initialize(self):
+        log.debug("initializing the EULA spoke")
+        NormalSpoke.initialize(self)
+
+        self._have_eula = True
+        self._eula_buffer = self.builder.get_object("eulaBuffer")
+        self._agree_check_button = self.builder.get_object("agreeCheckButton")
+        self._agree_label = self._agree_check_button.get_child()
+        self._agree_text = self._agree_label.get_text()
+
+        log.debug("looking for the license file")
+        license_file = eula.get_license_file_name()
+        if not license_file:
+            log.error("no license found")
+            self._have_eula = False
+            self._eula_buffer.set_text(_("No license found"))
+            return
+
+        # if there is "eula <...>" in kickstart, use its value
+        if self.data.eula.agreed is not None:
+            self._agree_check_button.set_active(self.data.eula.agreed)
+
+        self._eula_buffer.set_text("")
+        itr = self._eula_buffer.get_iter_at_offset(0)
+        log.debug("opening the license file")
+        with open(license_file, "r") as fobj:
+            # insert the first line without prefixing with space
+            try:
+                first_line = next(fobj)
+            except StopIteration:
+                # nothing in the file
+                return
+            self._eula_buffer.insert(itr, first_line.strip())
+
+            # EULA file may be preformatted for the console, we want to let Gtk
+            # format it (blank lines should be preserved)
+            for line in fobj:
+                stripped_line = line.strip()
+                if stripped_line:
+                    self._eula_buffer.insert(itr, " " + stripped_line)
+                else:
+                    self._eula_buffer.insert(itr, "\n\n")
+
+    def refresh(self):
+        self._agree_check_button.set_sensitive(self._have_eula)
+        self._agree_check_button.set_active(self.data.eula.agreed)
+
+    def apply(self):
+        self.data.eula.agreed = self._agree_check_button.get_active()
+
+    @property
+    def completed(self):
+        return not self._have_eula or self.data.eula.agreed
+
+    @property
+    def status(self):
+        if not self._have_eula:
+            return _("No license found")
+
+        return _("License accepted") if self.data.eula.agreed else _("License not accepted")
+
+    @classmethod
+    def should_run(cls, environment, data):
+        if eula.eula_available():
+            # don't run if we are in initial-setup in reconfig mode and the EULA has already been accepted
+            if FirstbootOnlySpokeMixIn.should_run(environment, data) and data and data.firstboot.firstboot == FIRSTBOOT_RECONFIG and data.eula.agreed:
+                log.debug("not running license spoke: reconfig mode & license already accepted")
+                return False
+            return True
+        return False
+
+    def on_check_button_toggled(self, *args):
+        if self._agree_check_button.get_active():
+            log.debug("license is now accepted")
+            self._agree_label.set_markup("<b>%s</b>" % self._agree_text)
+        else:
+            log.debug("license no longer accepted")
+            self._agree_label.set_markup(self._agree_text)

--- a/pyanaconda/ui/tui/spokes/eula.py
+++ b/pyanaconda/ui/tui/spokes/eula.py
@@ -1,0 +1,128 @@
+import logging
+
+from pyanaconda.ui.tui.spokes import NormalTUISpoke
+from simpleline.render.widgets import TextWidget, CheckboxWidget
+from simpleline.render.containers import ListRowContainer
+from simpleline.render.screen import UIScreen, InputState
+from simpleline.render.screen_handler import ScreenHandler
+from pyanaconda.ui.common import FirstbootOnlySpokeMixIn
+from pyanaconda.core import eula
+from pyanaconda.ui.categories.eula import LicensingCategory
+from pyanaconda.core.i18n import _, N_
+from pykickstart.constants import FIRSTBOOT_RECONFIG
+
+log = logging.getLogger("initial-setup")
+
+__all__ = ["EULASpoke"]
+
+
+class EULASpoke(FirstbootOnlySpokeMixIn, NormalTUISpoke):
+    """The EULA spoke providing ways to read the license and agree/disagree with it."""
+
+    category = LicensingCategory
+
+    @staticmethod
+    def get_screen_id():
+        """Return a unique id of this UI screen."""
+        return "license-information"
+
+    def __init__(self, *args, **kwargs):
+        NormalTUISpoke.__init__(self, *args, **kwargs)
+        self.title = _("License information")
+        self._container = None
+
+    def initialize(self):
+        NormalTUISpoke.initialize(self)
+
+    def refresh(self, args=None):
+        NormalTUISpoke.refresh(self, args)
+
+        self._container = ListRowContainer(1)
+
+        log.debug("license found")
+        # make the options aligned to the same column (the checkbox has the
+        # '[ ]' prepended)
+        self._container.add(TextWidget("%s\n" % _("Read the License Agreement")),
+                            self._show_license_screen_callback)
+
+        self._container.add(CheckboxWidget(title=_("I accept the license agreement"),
+                                           completed=self.data.eula.agreed),
+                            self._license_accepted_callback)
+        self.window.add_with_separator(self._container)
+
+    @property
+    def completed(self):
+        # Either there is no EULA available, or user agrees/disagrees with it.
+        return self.data.eula.agreed
+
+    @property
+    def mandatory(self):
+        # This spoke is always mandatory.
+        return True
+
+    @property
+    def status(self):
+        return _("License accepted") if self.data.eula.agreed else _("License not accepted")
+
+    @classmethod
+    def should_run(cls, environment, data):
+        if eula.eula_available():
+            # don't run if we are in initial-setup in reconfig mode and the EULA has already been accepted
+            if FirstbootOnlySpokeMixIn.should_run(environment, data) and data and data.firstboot.firstboot == FIRSTBOOT_RECONFIG and data.eula.agreed:
+                log.debug("not running license spoke: reconfig mode & license already accepted")
+                return False
+            return True
+        return False
+
+    def apply(self):
+        # nothing needed here, the agreed field is changed in the input method
+        pass
+
+    def input(self, args, key):
+        if not self._container.process_user_input(key):
+            return key
+
+        return InputState.PROCESSED
+
+    @staticmethod
+    def _show_license_screen_callback(data):
+        # show license
+        log.debug("showing the license")
+        eula_screen = LicenseScreen()
+        ScreenHandler.push_screen(eula_screen)
+
+    def _license_accepted_callback(self, data):
+        # toggle EULA agreed checkbox by changing ksdata
+        log.debug("license accepted state changed to: %s", self.data.eula.agreed)
+        self.data.eula.agreed = not self.data.eula.agreed
+        self.redraw()
+
+
+class LicenseScreen(UIScreen):
+    """Screen showing the License without any input from user requested."""
+
+    def __init__(self):
+        super().__init__()
+
+        self._license_file = eula.get_license_file_name()
+
+    def refresh(self, args=None):
+        super().refresh(args)
+
+        # read the license file and make it one long string so that it can be
+        # processed by the TextWidget to fit in the screen in a best possible
+        # way
+        log.debug("reading the license file")
+        with open(self._license_file, 'r') as f:
+            license_text = f.read()
+
+        self.window.add_with_separator(TextWidget(license_text))
+
+    def input(self, args, key):
+        """ Handle user input. """
+        return InputState.PROCESSED_AND_CLOSE
+
+    def prompt(self, args=None):
+        # we don't want to prompt user, just close the screen
+        self.close()
+        return None


### PR DESCRIPTION
Copied code from initial-setup and adapted it for Anaconda.

It makes sense to show EULA before installation, not just text that it is in some file after the installation.

TODO: It would be great to automatically choose license in the current language. Currently it is worked around in ROSA by creating a drop-in config: https://abf.io/import/anaconda/blob/6dc5b78efd/anaconda.sh#lc-77

Closes: https://github.com/rhinstaller/anaconda/discussions/4686

It looks like this:

![2023-04-07_15-59](https://user-images.githubusercontent.com/15802528/230613056-93a6ec11-8654-47bc-b2da-deef14e16c80.png)

![2023-04-07_16-00](https://user-images.githubusercontent.com/15802528/230613077-92be6ea5-20fb-441c-a47e-a3e3ab12e916.png)

![2023-04-07_14-55](https://user-images.githubusercontent.com/15802528/230612456-331c555c-3a8b-41e3-9d9a-886485afff1f.png)

![2023-04-07_14-56](https://user-images.githubusercontent.com/15802528/230612506-d2f8e6be-c451-474b-9144-3911a411dc6b.png)

![2023-04-07_16-13](https://user-images.githubusercontent.com/15802528/230614873-6b0a4048-41f3-4416-9b4c-1860850b7471.png)

Here is Russian translation of new strings (they were not inside po and pot files in initial-setup):
```po
msgid "LICENSING"
msgstr "ЛИЦЕНЗИРОВАНИЕ"

msgctxt "GUI|Spoke"
msgid "_License Information"
msgstr "О _лицензии"

msgid "License information"
msgstr "О лицензии"

msgid "License Information"
msgstr "О лицензии"

msgid "License accepted"
msgstr "Лицензия принята"

msgid "License not accepted"
msgstr "Лицензия не принята"

msgid "Read the License Agreement"
msgstr "Прочитайте лицензионное соглашение"

msgid "I accept the license agreement"
msgstr "Принимаю лицензионное соглашение"

msgid "I _accept the license agreement"
msgstr "_Принимаю лицензионное соглашение"

msgid "License Agreement:"
msgstr "Лицензионное соглашение:"
```

In some places translation is not exact because otherwise words will be too long.

ISO image (LiveCD + installer) with Anaconda with EULA spoke: https://file-store.rosalinux.ru/download/2aaf53506bc7c689fa81ab1de078619afa6db568 (ROSA_2021.1_XFCE_x86_64_8.iso)