### PR TITLE
WebUI: force symlink re-creation

### DIFF
--- a/ui/webui/Makefile.am
+++ b/ui/webui/Makefile.am
@@ -88,7 +88,7 @@ $(COCKPIT_REPO_STAMP): Makefile.am
 # https://github.com/cockpit-project/cockpit/blob/main/test/common/testlib.py#L1118
 bots: tools/make-bots
 	GITHUB_BASE="cockpit-project/cockpit" tools/make-bots
-	cd test && ln -s ../bots/images images
+	cd test && ln -sf ../bots/images images
 
 prepare-test-deps: bots test/common
 


### PR DESCRIPTION
Re-running the bots target will error out, as the symlink might already exists.

For example:

```
[jelle@⬢ anaconda][~/projects/anaconda/ui/webui]%make create-updates.img

 cd ../.. && /bin/sh /home/jelle/projects/anaconda/missing automake-1.16 --foreign ui/webui/Makefile
 cd ../.. && /bin/sh ./config.status ui/webui/Makefile
config.status: creating ui/webui/Makefile
git -C ../../ archive '54a8ebd2dfe4d53bcfa5db660701469e3f21dbba^{tree}' -- pkg/lib test/common tools/git-utils.sh tools/make-bots  | tar x
GITHUB_BASE="cockpit-project/cockpit" tools/make-bots
bots/ already exists, skipping
cd test && ln -s ../bots/images images
ln: failed to create symbolic link 'images/images': File exists
make: *** [Makefile:738: bots] Error 1
```