### PR TITLE
GUI kernel switcher for ARM 64k and Gemini

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -275,3 +275,16 @@ class DNFManager(object):
         return exception.error_group_specs \
             or exception.error_pkg_specs \
             or exception.module_depsolv_errors
+
+    def match_available_packages(self, pattern):
+        """Find available packages that match the specified pattern.
+
+        :param pattern: a pattern for package names
+        :return: a list of matched package names
+        """
+        if not self._base.sack:
+            log.warning("There is no metadata about packages!")
+            return []
+
+        packages = self._base.sack.query().available().filter(name__glob=pattern)
+        return [p.name for p in packages]

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -1547,3 +1547,6 @@ class DNFPayload(Payload):
     @property
     def kernel_version_list(self):
         return get_kernel_version_list()
+
+    def match_available_packages(self, pattern):
+        return self._dnf_manager.match_available_packages(pattern)

--- a/pyanaconda/ui/gui/spokes/software_selection.glade
+++ b/pyanaconda/ui/gui/spokes/software_selection.glade
@@ -1,27 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <requires lib="AnacondaWidgets" version="1.0"/>
   <object class="AnacondaSpokeWindow" id="softwareWindow">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="hexpand">True</property>
     <property name="vexpand">True</property>
-    <property name="window_name" translatable="yes">SOFTWARE SELECTION</property>
+    <property name="window-name" translatable="yes">SOFTWARE SELECTION</property>
     <signal name="button-clicked" handler="on_back_clicked" swapped="no"/>
     <signal name="info-bar-clicked" handler="on_info_bar_clicked" swapped="no"/>
     <child internal-child="main_box">
       <object class="GtkBox" id="AnacondaSpokeWindow-main_box1">
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="hexpand">True</property>
         <property name="vexpand">True</property>
         <property name="orientation">vertical</property>
         <child internal-child="nav_box">
           <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child internal-child="nav_area">
+              <!-- n-columns=3 n-rows=3 -->
               <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
               </object>
             </child>
           </object>
@@ -33,55 +34,36 @@
         </child>
         <child internal-child="alignment">
           <object class="GtkAlignment" id="AnacondaSpokeWindow-alignment1">
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
             <property name="xalign">0</property>
             <property name="yalign">0</property>
-            <property name="top_padding">12</property>
-            <property name="bottom_padding">48</property>
-            <property name="left_padding">24</property>
-            <property name="right_padding">24</property>
+            <property name="top-padding">12</property>
+            <property name="bottom-padding">48</property>
+            <property name="left-padding">24</property>
+            <property name="right-padding">24</property>
             <child internal-child="action_area">
               <object class="GtkBox" id="AnacondaSpokeWindow-action_area1">
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
                 <property name="orientation">vertical</property>
                 <child>
+                  <!-- n-columns=2 n-rows=3 -->
                   <object class="GtkGrid" id="grid1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
-                    <property name="column_spacing">24</property>
-                    <property name="column_homogeneous">True</property>
-                    <child>
-                      <object class="GtkLabel" id="label1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="valign">end</property>
-                        <property name="margin_bottom">6</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Base Environment</property>
-                        <property name="wrap">True</property>
-                        <property name="xalign">0</property>
-                        <attributes>
-                          <attribute name="font-desc" value="Cantarell 12"/>
-                          <attribute name="weight" value="normal"/>
-                        </attributes>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
-                      </packing>
-                    </child>
+                    <property name="column-spacing">24</property>
+                    <property name="column-homogeneous">True</property>
                     <child>
                       <object class="GtkLabel" id="label2">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="valign">end</property>
-                        <property name="margin_bottom">6</property>
+                        <property name="margin-bottom">6</property>
                         <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Additional software for Selected Environment</property>
                         <property name="wrap">True</property>
@@ -92,27 +74,27 @@
                         </attributes>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkScrolledWindow" id="addonScrolledWindow">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="vexpand">True</property>
-                        <property name="hscrollbar_policy">never</property>
-                        <property name="shadow_type">in</property>
+                        <property name="hscrollbar-policy">never</property>
+                        <property name="shadow-type">in</property>
                         <child>
                           <object class="GtkViewport" id="addonViewport">
-                            <property name="width_request">250</property>
+                            <property name="width-request">250</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <object class="GtkListBox" id="addonListBox">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="hexpand">True</property>
                                 <signal name="row-activated" handler="on_addon_activated" swapped="no"/>
                               </object>
@@ -121,39 +103,159 @@
                         </child>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkScrolledWindow" id="environmentScrolledWindow">
+                      <object class="GtkLabel" id="label1">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="events">GDK_STRUCTURE_MASK | GDK_SCROLL_MASK</property>
+                        <property name="can-focus">False</property>
+                        <property name="valign">end</property>
+                        <property name="margin-bottom">6</property>
                         <property name="hexpand">True</property>
-                        <property name="vexpand">True</property>
-                        <property name="hscrollbar_policy">never</property>
-                        <property name="shadow_type">in</property>
+                        <property name="label" translatable="yes">Base Environment</property>
+                        <property name="wrap">True</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="font-desc" value="Cantarell 12"/>
+                          <attribute name="weight" value="normal"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="orientation">vertical</property>
                         <child>
-                          <object class="GtkViewport" id="environmentViewport">
-                            <property name="width_request">250</property>
+                          <object class="GtkScrolledWindow" id="environmentScrolledWindow">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="events">GDK_STRUCTURE_MASK | GDK_SCROLL_MASK</property>
+                            <property name="hexpand">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="hscrollbar-policy">never</property>
+                            <property name="shadow-type">in</property>
                             <child>
-                              <object class="GtkListBox" id="environmentListBox">
+                              <object class="GtkViewport" id="environmentViewport">
+                                <property name="width-request">250</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="hexpand">True</property>
-                                <signal name="row-activated" handler="on_environment_activated" swapped="no"/>
+                                <property name="can-focus">False</property>
+                                <child>
+                                  <object class="GtkListBox" id="environmentListBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="hexpand">True</property>
+                                    <signal name="row-activated" handler="on_environment_activated" swapped="no"/>
+                                  </object>
+                                </child>
                               </object>
                             </child>
                           </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="kernelBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkLabel" id="label3">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="valign">end</property>
+                                <property name="margin-top">12</property>
+                                <property name="hexpand">True</property>
+                                <property name="label" translatable="yes">Kernel Options</property>
+                                <property name="wrap">True</property>
+                                <property name="xalign">0</property>
+                                <attributes>
+                                  <attribute name="font-desc" value="Cantarell 12"/>
+                                  <attribute name="weight" value="normal"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <!-- n-columns=2 n-rows=1 -->
+                              <object class="GtkGrid" id="kernelComboGrid">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="row-spacing">12</property>
+                                <child>
+                                  <object class="GtkLabel" id="kernelPageSizeLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="label" translatable="yes">Page size:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkComboBox" id="kernelPageSizeCombo">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="active">0</property>
+                                    <property name="id-column">0</property>
+                                    <child>
+                                      <object class="GtkCellRendererText"/>
+                                      <attributes>
+                                        <attribute name="markup">1</attribute>
+                                        <attribute name="single-paragraph-mode">1</attribute>
+                                        <attribute name="text">1</attribute>
+                                      </attributes>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
                       </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>

--- a/pyanaconda/ui/gui/spokes/software_selection.glade
+++ b/pyanaconda/ui/gui/spokes/software_selection.glade
@@ -191,7 +191,7 @@
                               </packing>
                             </child>
                             <child>
-                              <!-- n-columns=2 n-rows=1 -->
+                              <!-- n-columns=2 n-rows=2 -->
                               <object class="GtkGrid" id="kernelComboGrid">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
@@ -208,6 +208,20 @@
                                   <packing>
                                     <property name="left-attach">0</property>
                                     <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="kernelVersionLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-start">12</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="label" translatable="yes">Version:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">1</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -229,6 +243,27 @@
                                   <packing>
                                     <property name="left-attach">1</property>
                                     <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkComboBox" id="kernelVersionCombo">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="active">0</property>
+                                    <property name="id-column">0</property>
+                                    <child>
+                                      <object class="GtkCellRendererText"/>
+                                      <attributes>
+                                        <attribute name="markup">1</attribute>
+                                        <attribute name="single-paragraph-mode">1</attribute>
+                                        <attribute name="text">1</attribute>
+                                      </attributes>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">1</property>
                                   </packing>
                                 </child>
                               </object>

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -37,8 +37,9 @@ from pyanaconda.ui.gui.spokes.lib.detailederror import DetailedErrorDialog
 from pyanaconda.ui.gui.utils import blockedHandler, escape_markup
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.lib.subscription import check_cdn_is_installation_source
-from pyanaconda.ui.lib.software import FEATURE_64K, KernelFeatures, \
+from pyanaconda.ui.lib.software import FEATURE_UPSTREAM, FEATURE_64K, KernelFeatures, \
     get_kernel_from_properties, get_available_kernel_features, get_kernel_titles_and_descriptions
+
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.modules.common.util import is_module_available
 
@@ -134,17 +135,25 @@ class SoftwareSelectionSpoke(NormalSpoke):
         self._kernel_box = self.builder.get_object("kernelBox")
         self._combo_kernel_page_size = self.builder.get_object("kernelPageSizeCombo")
         self._label_kernel_page_size = self.builder.get_object("kernelPageSizeLabel")
+        self._combo_kernel_version = self.builder.get_object("kernelVersionCombo")
+        self._label_kernel_version = self.builder.get_object("kernelVersionLabel")
 
         # Normally I would create these in the .glade file but due to a bug they weren't
         # created properly
         self._model_kernel_page_size = Gtk.ListStore(str, str)
+        self._model_kernel_version = Gtk.ListStore(str, str)
 
         kernel_labels = get_kernel_titles_and_descriptions()
         for i in ["4k", "64k"]:
             self._model_kernel_page_size.append([i, "<b>%s</b>\n%s" % \
                                                 (escape_markup(kernel_labels[i][0]),
                                                 escape_markup(kernel_labels[i][1]))])
+        for i in ["upstream", "standard"]:
+            self._model_kernel_version.append([i, "<b>%s</b>\n%s" % \
+                                              (escape_markup(kernel_labels[i][0]),
+                                              escape_markup(kernel_labels[i][1]))])
         self._combo_kernel_page_size.set_model(self._model_kernel_page_size)
+        self._combo_kernel_version.set_model(self._model_kernel_version)
         self._available_kernels = get_available_kernel_features(self.payload)
 
     # Payload event handlers
@@ -215,7 +224,10 @@ class SoftwareSelectionSpoke(NormalSpoke):
         # Select kernel
         property_64k = self._available_kernels[FEATURE_64K] and \
             self._combo_kernel_page_size.get_active_id() == FEATURE_64K
-        kernel_properties = KernelFeatures(property_64k)
+        property_upstream = self._available_kernels[FEATURE_UPSTREAM] and \
+            self._combo_kernel_version.get_active_id() == FEATURE_UPSTREAM
+
+        kernel_properties = KernelFeatures(property_upstream, property_64k)
         kernel = get_kernel_from_properties(kernel_properties)
         if kernel is not None:
             log.debug("Selected kernel package: %s", kernel)
@@ -587,6 +599,12 @@ class SoftwareSelectionSpoke(NormalSpoke):
         if show_kernels:
             self._kernel_box.set_visible(True)
             self._kernel_box.set_no_show_all(False)
+
+            # Kernel version combo
+            self._combo_kernel_version.set_visible(self._available_kernels[FEATURE_UPSTREAM])
+            self._combo_kernel_version.set_no_show_all(not self._available_kernels[FEATURE_UPSTREAM])
+            self._label_kernel_version.set_visible(self._available_kernels[FEATURE_UPSTREAM])
+            self._label_kernel_version.set_no_show_all(not self._available_kernels[FEATURE_UPSTREAM])
 
             # Arm 64k page size kernel combo
             self._combo_kernel_page_size.set_visible(self._available_kernels[FEATURE_64K])

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -37,7 +37,8 @@ from pyanaconda.ui.gui.spokes.lib.detailederror import DetailedErrorDialog
 from pyanaconda.ui.gui.utils import blockedHandler, escape_markup
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.lib.subscription import check_cdn_is_installation_source
-
+from pyanaconda.ui.lib.software import FEATURE_64K, KernelFeatures, \
+    get_kernel_from_properties, get_available_kernel_features, get_kernel_titles_and_descriptions
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.modules.common.util import is_module_available
 
@@ -129,6 +130,23 @@ class SoftwareSelectionSpoke(NormalSpoke):
         self._fake_radio = Gtk.RadioButton(group=None)
         self._fake_radio.set_active(True)
 
+        # Display a group of options for selecting desired properties of a kernel
+        self._kernel_box = self.builder.get_object("kernelBox")
+        self._combo_kernel_page_size = self.builder.get_object("kernelPageSizeCombo")
+        self._label_kernel_page_size = self.builder.get_object("kernelPageSizeLabel")
+
+        # Normally I would create these in the .glade file but due to a bug they weren't
+        # created properly
+        self._model_kernel_page_size = Gtk.ListStore(str, str)
+
+        kernel_labels = get_kernel_titles_and_descriptions()
+        for i in ["4k", "64k"]:
+            self._model_kernel_page_size.append([i, "<b>%s</b>\n%s" % \
+                                                (escape_markup(kernel_labels[i][0]),
+                                                escape_markup(kernel_labels[i][1]))])
+        self._combo_kernel_page_size.set_model(self._model_kernel_page_size)
+        self._available_kernels = get_available_kernel_features(self.payload)
+
     # Payload event handlers
     def _downloading_package_md(self):
         # Reset the error state from previous payloads
@@ -193,6 +211,16 @@ class SoftwareSelectionSpoke(NormalSpoke):
 
         for group_name in self._get_selected_addons():
             self._selection.groups.append(group_name)
+
+        # Select kernel
+        property_64k = self._available_kernels[FEATURE_64K] and \
+            self._combo_kernel_page_size.get_active_id() == FEATURE_64K
+        kernel_properties = KernelFeatures(property_64k)
+        kernel = get_kernel_from_properties(kernel_properties)
+        if kernel is not None:
+            log.debug("Selected kernel package: %s", kernel)
+            self._selection.packages.append(kernel)
+            self._selection.excluded_packages.append("kernel")
 
         log.debug("Setting new software selection: %s", self._selection)
         self.payload.set_packages_data(self._selection)
@@ -426,6 +454,7 @@ class SoftwareSelectionSpoke(NormalSpoke):
         self.refresh_addons()
         self._environment_list_box.show_all()
         self._addon_list_box.show_all()
+        self._refresh_kernel_features()
 
     def _add_addon(self, grp):
         (name, desc) = self.payload.group_description(grp)
@@ -543,6 +572,31 @@ class SoftwareSelectionSpoke(NormalSpoke):
         for child in listbox.get_children():
             listbox.remove(child)
             del(child)
+
+    def _refresh_kernel_features(self):
+        """Display options for selecting kernel features."""
+
+        # Only showing parts of kernel box relevant for current system.
+        self._available_kernels = get_available_kernel_features(self.payload)
+        show_kernels = False
+        for (_key, val) in self._available_kernels.items():
+            if val:
+                show_kernels = True
+                break
+
+        if show_kernels:
+            self._kernel_box.set_visible(True)
+            self._kernel_box.set_no_show_all(False)
+
+            # Arm 64k page size kernel combo
+            self._combo_kernel_page_size.set_visible(self._available_kernels[FEATURE_64K])
+            self._combo_kernel_page_size.set_no_show_all(not self._available_kernels[FEATURE_64K])
+            self._label_kernel_page_size.set_visible(self._available_kernels[FEATURE_64K])
+            self._label_kernel_page_size.set_no_show_all(not self._available_kernels[FEATURE_64K])
+        else:
+            # Hide the entire box.
+            self._kernel_box.set_visible(False)
+            self._kernel_box.set_no_show_all(True)
 
     @property
     def txid_valid(self):

--- a/pyanaconda/ui/lib/software.py
+++ b/pyanaconda/ui/lib/software.py
@@ -19,13 +19,16 @@ from collections import namedtuple
 from blivet.arch import is_arm
 from pyanaconda.core.i18n import _
 
+FEATURE_UPSTREAM = "upstream"
 FEATURE_64K = "64k"
-KernelFeatures = namedtuple("KernelFeatures", ["page_size_64k"])
+
+KernelFeatures = namedtuple("KernelFeatures", ["upstream", "page_size_64k"])
 
 def get_available_kernel_features(payload):
     """Returns a dictionary with that shows which kernels should be shown in the UI.
     """
     features = {
+        FEATURE_UPSTREAM: any(payload.match_available_packages("kernel-redhat")),
         FEATURE_64K: is_arm() and any(payload.match_available_packages("kernel-64k"))
     }
 
@@ -35,6 +38,8 @@ def get_kernel_titles_and_descriptions():
     """Returns a dictionary with descriptions and titles for different kernel options.
     """
     kernel_features = {
+        "standard": (_("kernel"), _("Optimized for stability")),
+        "upstream": (_("kernel-redhat"), _("Access newer kernel features")),
         "4k": (_("4k"), _("More efficient memory usage in smaller environments")),
         "64k": (_("64k"), _("System performance gains for memory-intensive workloads")),
     }
@@ -46,10 +51,11 @@ def get_kernel_from_properties(features):
     or returns None if no properties were selected.
     """
     kernels = {
-        # ARM 64k    Package Name
-        ( False   ): None,
-        ( True    ): "kernel-64k",
+        # RedHat Kernel  ARM 64k    Package Name
+        ( False,         False   ): None,
+        ( True,          False   ): "kernel-redhat",
+        ( False,         True    ): "kernel-64k",
+        ( True,          True    ): "kernel-redhat-64k",
     }
-
-    kernel_package = kernels[features[0]]
+    kernel_package = kernels[features]
     return kernel_package

--- a/pyanaconda/ui/lib/software.py
+++ b/pyanaconda/ui/lib/software.py
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from collections import namedtuple
+from blivet.arch import is_arm
+from pyanaconda.core.i18n import _
+
+FEATURE_64K = "64k"
+KernelFeatures = namedtuple("KernelFeatures", ["page_size_64k"])
+
+def get_available_kernel_features(payload):
+    """Returns a dictionary with that shows which kernels should be shown in the UI.
+    """
+    features = {
+        FEATURE_64K: is_arm() and any(payload.match_available_packages("kernel-64k"))
+    }
+
+    return features
+
+def get_kernel_titles_and_descriptions():
+    """Returns a dictionary with descriptions and titles for different kernel options.
+    """
+    kernel_features = {
+        "4k": (_("4k"), _("More efficient memory usage in smaller environments")),
+        "64k": (_("64k"), _("System performance gains for memory-intensive workloads")),
+    }
+
+    return kernel_features
+
+def get_kernel_from_properties(features):
+    """Translates the selection of required properties into a kernel package name and returns it
+    or returns None if no properties were selected.
+    """
+    kernels = {
+        # ARM 64k    Package Name
+        ( False   ): None,
+        ( True    ): "kernel-64k",
+    }
+
+    kernel_package = kernels[features[0]]
+    return kernel_package

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -20,8 +20,9 @@ from pyanaconda.flags import flags
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.context import context
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
-from pyanaconda.ui.lib.software import FEATURE_64K, KernelFeatures, \
+from pyanaconda.ui.lib.software import FEATURE_UPSTREAM, FEATURE_64K, KernelFeatures, \
     get_kernel_from_properties, get_available_kernel_features, get_kernel_titles_and_descriptions
+
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload.manager import payloadMgr, PayloadState
 from pyanaconda.payload.errors import DependencyError, NoSuchGroup
@@ -102,6 +103,10 @@ class SoftwareSpoke(NormalTUISpoke):
 
         self._available_kernels = get_available_kernel_features(self.payload)
         self._kernel_selection = dict.fromkeys(self._available_kernels, False)
+
+        # kernel-redhat should be the default when available
+        if FEATURE_UPSTREAM in self._kernel_selection:
+            self._kernel_selection[FEATURE_UPSTREAM] = True
 
         # Initialize and check the software selection.
         self._initialize_selection()
@@ -310,10 +315,12 @@ class SoftwareSpoke(NormalTUISpoke):
         self._available_kernels = get_available_kernel_features(self.payload)
 
         # Processing chosen kernel
+        feature_upstream = self._available_kernels[FEATURE_UPSTREAM] and \
+            self._kernel_selection[FEATURE_UPSTREAM]
         feature_64k = self._available_kernels[FEATURE_64K] and \
             self._kernel_selection[FEATURE_64K]
 
-        features = KernelFeatures(feature_64k)
+        features = KernelFeatures(feature_upstream, feature_64k)
         kernel = get_kernel_from_properties(features)
         if kernel:
             log.debug("Selected kernel package: %s", kernel)

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -20,6 +20,8 @@ from pyanaconda.flags import flags
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.context import context
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
+from pyanaconda.ui.lib.software import FEATURE_64K, KernelFeatures, \
+    get_kernel_from_properties, get_available_kernel_features, get_kernel_titles_and_descriptions
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload.manager import payloadMgr, PayloadState
 from pyanaconda.payload.errors import DependencyError, NoSuchGroup
@@ -69,6 +71,9 @@ class SoftwareSpoke(NormalTUISpoke):
         self.errors = []
         self._tx_id = None
 
+        self._available_kernels = None
+        self._kernel_selection = None
+
         # Get the packages configuration.
         self._selection = self.payload.get_packages_data()
 
@@ -78,6 +83,8 @@ class SoftwareSpoke(NormalTUISpoke):
         # Register event listeners to update our status on payload events
         payloadMgr.add_listener(PayloadState.STARTED, self._payload_start)
         payloadMgr.add_listener(PayloadState.ERROR, self._payload_error)
+
+        self.shown_environment = False
 
     def initialize(self):
         """Initialize the spoke."""
@@ -92,6 +99,9 @@ class SoftwareSpoke(NormalTUISpoke):
     def _initialize(self):
         """Initialize the spoke in a separate thread."""
         threadMgr.wait(THREAD_PAYLOAD)
+
+        self._available_kernels = get_available_kernel_features(self.payload)
+        self._kernel_selection = dict.fromkeys(self._available_kernels, False)
 
         # Initialize and check the software selection.
         self._initialize_selection()
@@ -220,15 +230,7 @@ class SoftwareSpoke(NormalTUISpoke):
         threadMgr.wait(THREAD_CHECK_SOFTWARE)
         self._container = ListColumnContainer(2, columns_width=38, spacing=2)
 
-        if args is None:
-            msg = self._refresh_environments()
-        else:
-            msg = self._refresh_addons(args)
-
-        self.window.add_with_separator(TextWidget(msg))
-        self.window.add_with_separator(self._container)
-
-    def _refresh_environments(self):
+        # Environment selection screen
         environments = self.payload.environments
 
         for env in environments:
@@ -237,57 +239,42 @@ class SoftwareSpoke(NormalTUISpoke):
             widget = CheckboxWidget(title="%s" % name, completed=selected)
             self._container.add(widget, callback=self._set_environment_callback, data=env)
 
-        return _("Base environment")
-
-    def _refresh_addons(self, available_addons):
-        for addon_id in available_addons:
-            name = self.payload.group_description(addon_id)[0]
-            selected = addon_id in self._selection.groups
-            widget = CheckboxWidget(title="%s" % name, completed=selected)
-            self._container.add(widget, callback=self._set_addons_callback, data=addon_id)
-
-        if available_addons:
-            return _("Additional software for selected environment")
-        else:
-            return _("No additional software to select.")
+        text = TextWidget(_("Base environment"))
+        self.window.add_with_separator(text)
+        self.window.add_with_separator(self._container)
 
     def _set_environment_callback(self, data):
         self._selection.environment = data
-
-    def _set_addons_callback(self, data):
-        if data not in self._selection.groups:
-            self._selection.groups.append(data)
-        else:
-            self._selection.groups.remove(data)
 
     def input(self, args, key):
         """ Handle the input; this chooses the desktop environment. """
         if self._container is not None and self._container.process_user_input(key):
             self.redraw()
-        else:
-            if key.lower() == Prompt.CONTINUE:
+            return InputState.PROCESSED
 
-                # No environment was selected, close
-                if not self._selection.environment:
-                    self.close()
+        if key.lower() == Prompt.CONTINUE:
+            # No environment was selected, close
+            if not self._selection.environment:
+                self.close()
 
-                # The environment was selected, switch screen
-                elif args is None:
-                    # Get addons for the selected environment
-                    environment = self._selection.environment
-                    environment_id = self._translate_env_name_to_id(environment)
-                    addons = self._get_available_addons(environment_id)
-
-                    # Switch the screen
-                    ScreenHandler.replace_screen(self, addons)
-
-                # The addons were selected, apply and close
-                else:
-                    self.apply()
-                    self.execute()
-                    self.close()
+            # The environment was selected, switch screen
             else:
-                return super().input(args, key)
+                environment = self._selection.environment
+                environment_id = self._translate_env_name_to_id(environment)
+                addons = self._get_available_addons(environment_id)
+                spoke = AdditionalSoftwareSpoke(
+                    self.data,
+                    self.storage,
+                    self.payload,
+                    self._selection,
+                    self._kernel_selection,
+                )
+                ScreenHandler.push_screen_modal(spoke, addons)
+                self.apply()
+                self.execute()
+                self.close()
+        else:
+            return super().input(args, key)
 
         return InputState.PROCESSED
 
@@ -320,6 +307,19 @@ class SoftwareSpoke(NormalTUISpoke):
         # Select valid groups.
         # FIXME: Remove invalid groups from selected groups.
 
+        self._available_kernels = get_available_kernel_features(self.payload)
+
+        # Processing chosen kernel
+        feature_64k = self._available_kernels[FEATURE_64K] and \
+            self._kernel_selection[FEATURE_64K]
+
+        features = KernelFeatures(feature_64k)
+        kernel = get_kernel_from_properties(features)
+        if kernel:
+            log.debug("Selected kernel package: %s", kernel)
+            self._selection.packages.append(kernel)
+            self._selection.excluded_packages.append("kernel")
+
         log.debug("Setting new software selection: %s", self._selection)
         self.payload.set_packages_data(self._selection)
 
@@ -345,3 +345,121 @@ class SoftwareSpoke(NormalTUISpoke):
     def txid_valid(self):
         """ Whether we have a valid dnf tx id. """
         return self._tx_id == self.payload.tx_id
+
+
+class AdditionalSoftwareSpoke(NormalTUISpoke):
+    """The spoke for choosing the additional software."""
+    category = SoftwareCategory
+
+    def __init__(self, data, storage, payload, selection, kernel_selection):
+        super().__init__(data, storage, payload)
+        self.title = N_("Software selection")
+        self._container = None
+        self._selection = selection
+        self._kernel_selection = kernel_selection
+
+    def refresh(self, args=None):
+        """Refresh the screen."""
+        NormalTUISpoke.refresh(self, args)
+
+        self._container = ListColumnContainer(
+            columns=2,
+            columns_width=38,
+            spacing=2
+        )
+
+        if args:
+            msg = _("Additional software for selected environment")
+        else:
+            msg = _("No additional software to select.")
+
+        for addon_id in args:
+            name = self.payload.group_description(addon_id)[0]
+            selected = addon_id in self._selection.groups
+            widget = CheckboxWidget(title="%s" % name, completed=selected)
+            self._container.add(widget, callback=self._set_addons_callback, data=addon_id)
+
+        self.window.add_with_separator(TextWidget(msg))
+        self.window.add_with_separator(self._container)
+
+    def _set_addons_callback(self, data):
+        if data not in self._selection.groups:
+            self._selection.groups.append(data)
+        else:
+            self._selection.groups.remove(data)
+
+    def _show_kernel_features_screen(self, kernels):
+        """Returns True if at least one non-standard kernel is available.
+        """
+        for val in kernels.values():
+            if val:
+                return True
+        return False
+
+    def input(self, args, key):
+        if self._container.process_user_input(key):
+            return InputState.PROCESSED_AND_REDRAW
+
+        if key.lower() == Prompt.CONTINUE:
+            available_kernels = get_available_kernel_features(self.payload)
+            if self._show_kernel_features_screen(available_kernels):
+                spoke = KernelSelectionSpoke(self.data, self.storage, self.payload,
+                                             self._selection, self._kernel_selection,
+                                             available_kernels)
+                ScreenHandler.push_screen_modal(spoke)
+            self.execute()
+            self.close()
+            return InputState.PROCESSED
+
+        return super().input(args, key)
+
+    def apply(self):
+        pass
+
+
+class KernelSelectionSpoke(NormalTUISpoke):
+    """A subspoke for selecting kernel features.
+    """
+    def __init__(self, data, storage, payload, selection, kernel_selection, available_kernels):
+        super().__init__(data, storage, payload)
+        self.title = N_("Kernel Options")
+        self._container = None
+        self._selection = selection
+        self._kernel_selection = kernel_selection
+        self._available_kernels = available_kernels
+
+    def refresh(self, args=None):
+        NormalTUISpoke.refresh(self)
+
+        # Retrieving translated UI strings
+        labels = get_kernel_titles_and_descriptions()
+        # Updating kernel availability
+        self._available_kernels = get_available_kernel_features(self.payload)
+        self._container = ListColumnContainer(2, columns_width=38, spacing=2)
+
+        # Rendering kernel checkboxes
+        for (name, val) in self._kernel_selection.items():
+            if not self._available_kernels[name]:
+                continue
+            (title, text) = labels[name]
+            widget = CheckboxWidget(title="%s" % title, text="%s" % text, completed=val)
+            self._container.add(widget, callback=self._set_kernel_callback, data=name)
+
+        self.window.add_with_separator(TextWidget(_("Kernel options")))
+        self.window.add_with_separator(self._container)
+
+    def _set_kernel_callback(self, data):
+        self._kernel_selection[data] = not self._kernel_selection[data]
+
+    def input(self, args, key):
+        if self._container.process_user_input(key):
+            return InputState.PROCESSED_AND_REDRAW
+
+        if key.lower() == Prompt.CONTINUE:
+            self.close()
+            return InputState.PROCESSED
+
+        return super().input(args, key)
+
+    def apply(self):
+        pass

--- a/tests/unit_tests/pyanaconda_tests/ui/test_ui_software.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_ui_software.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2023  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+from unittest.mock import patch
+from pyanaconda.ui.lib.software import get_kernel_from_properties, get_available_kernel_features, KernelFeatures
+class SoftwareUITestCase(unittest.TestCase):
+    """Test the UI functions and classes of the software-selection object."""
+    def test_get_kernel_from_properties(self):
+        assert get_kernel_from_properties(KernelFeatures(upstream=False, page_size_64k=False)) is None
+        assert get_kernel_from_properties(KernelFeatures(upstream=True, page_size_64k=False)) == "kernel-redhat"
+        assert get_kernel_from_properties(KernelFeatures(upstream=False, page_size_64k=True)) == "kernel-64k"
+        assert get_kernel_from_properties(KernelFeatures(upstream=True, page_size_64k=True)) == "kernel-redhat-64k"
+
+    @patch("pyanaconda.payload.dnf.payload")
+    @patch("pyanaconda.ui.lib.software.is_arm")
+    def test_get_available_kernel_features(self, is_arm, payload):
+        payload.match_available_packages.return_value = ["ntoskrnl"]
+        is_arm.return_value = False
+
+        res = get_available_kernel_features(payload)
+        assert isinstance(res, dict)
+        assert len(res) > 0
+        assert res["upstream"]
+        assert res["64k"] is False
+        is_arm.assert_called_once()
+
+        is_arm.return_value = True
+        assert is_arm()
+        res = get_available_kernel_features(payload)
+        assert res["upstream"]
+        assert res["64k"]
+
+        payload.match_available_packages.return_value = []
+        res = get_available_kernel_features(payload)
+        assert not res["upstream"]
+        assert not res["64k"]


### PR DESCRIPTION
**outdated**
Implementation for the Kernel switcher GUI inside the Software selection spoke.

Since the Gemini kernel isn't in the repos at the moment, it's kernel name is set to "kernel-rt" to make testing easier, this should change before this gets merged.

This implementation doesn't set the special kernel as default, yet.