### PR TITLE
exception: only attach existent and non-empty files (#2185827)

### DIFF
--- a/pyanaconda/exception.py
+++ b/pyanaconda/exception.py
@@ -138,6 +138,10 @@ class AnacondaExceptionHandler(ExceptionHandler):
         """
 
         log.debug("running handleException")
+        # don't try and attach empty or non-existent files (#2185827)
+        self.conf.fileList = [
+            fn for fn in self.conf.fileList if os.path.exists(fn) and os.path.getsize(fn) > 0
+        ]
         exception_lines = traceback.format_exception(*dump_info.exc_info)
         log.critical("\n".join(exception_lines))
 


### PR DESCRIPTION
libreport barfs (in a non-fatal but scary way) if a file we try to attach does not exist or is empty. Let's make sure all the files exist and aren't empty before we try to attach them. In a current F38+ live install, for instance, both packaging.log and dnf.librepo.log are usually empty.