### PR TITLE
WebUI: touch dist/manifest.json explicitly

### DIFF
--- a/ui/webui/Makefile.am
+++ b/ui/webui/Makefile.am
@@ -44,6 +44,7 @@ dist_noinst_DATA = \
 
 $(WEBPACK_TEST): $(COCKPIT_REPO_STAMP) $(shell find src/ -type f) $(NODE_MODULES_TEST) package.json webpack.config.js
 	NODE_ENV=production $(CURDIR)/node_modules/.bin/webpack
+	touch $(WEBPACK_TEST)  # HACK: Explicit touch as webpack does not touch files if nothing changed
 
 watch:
 	rm -f dist/*


### PR DESCRIPTION
In a checkout one can end up with pkg/lib/cockpit-po-plugin.js being newer then dist/manifest.json as git archive does not preserve timestamps.

A failing build is usually:
```
$ make rpms

DEBUG: make[2]: Entering directory '/builddir/build/BUILD/anaconda-39.10/ui'
DEBUG: Making all in webui
DEBUG: make[3]: Entering directory '/builddir/build/BUILD/anaconda-39.10/ui/webui'
DEBUG: make[4]: Entering directory '/builddir/build/BUILD/anaconda-39.10/ui/webui'
DEBUG: NODE_ENV=production /builddir/build/BUILD/anaconda-39.10/ui/webui/node_modules/.bin/webpack
DEBUG: /bin/sh: line 1: /builddir/build/BUILD/anaconda-39.10/ui/webui/node_modules/.bin/webpack: No such file or directory
DEBUG: make[4]: *** [Makefile:709: dist/manifest.json] Error 127
DEBUG: make[4]: Leaving directory '/builddir/build/BUILD/anaconda-39.10/ui/webui'
DEBUG: make[3]: *** [Makefile:433: all-recursive] Error 1
DEBUG: make[3]: Leaving directory '/builddir/build/BUILD/anaconda-39.10/ui/webui'
DEBUG: make[2]: *** [Makefile:397: all-recursive] Error 1
DEBUG: make[2]: Leaving directory '/builddir/build/BUILD/anaconda-39.10/ui'
DEBUG: make[1]: *** [Makefile:564: all-recursive] Error 1
DEBUG: make[1]: Leaving directory '/builddir/build/BUILD/anaconda-39.10'
DEBUG: make: *** [Makefile:458: all] Error 2
DEBUG: error: Bad exit status from /var/tmp/rpm-tmp.mXQlbQ (%build)
DEBUG: RPM build errors:
DEBUG:     Bad exit status from /var/tmp/rpm-tmp.mXQlbQ (%build)
```

make -d gives
```
    Finished prerequisites of target file 'dist/manifest.json'.
    Prerequisite 'pkg/lib/cockpit-po-plugin.js' is newer than target 'dist/manifest.json'.
    Prerequisite 'src/apis/boss.js' is older than target 'dist/manifest.json'.
```