### PR TITLE
WebUI: avoid conflicting import with python-installer

### DIFF
--- a/ui/webui/test/anacondalib.py
+++ b/ui/webui/test/anacondalib.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+# import Cockpit's machinery for test VMs and its browser test API
+TEST_DIR = os.path.dirname(__file__)
+sys.path.append(os.path.join(TEST_DIR, "common"))
+sys.path.insert(0, os.path.join(TEST_DIR, "helpers"))
+sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
+
+from machine_install import VirtInstallMachine
+from testlib import MachineCase  # pylint: disable=import-error
+
+
+class VirtInstallMachineCase(MachineCase):
+    MachineCase.machine_class = VirtInstallMachine

--- a/ui/webui/test/check-basic
+++ b/ui/webui/test/check-basic
@@ -15,22 +15,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import sys
-
-# import Cockpit's machinery for test VMs and its browser test API
-TEST_DIR = os.path.dirname(__file__)
-sys.path.append(os.path.join(TEST_DIR, "common"))
-sys.path.append(os.path.join(TEST_DIR, "helpers"))
-sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
+import anacondalib
 
 from installer import Installer
-from testlib import MachineCase, nondestructive, test_main  # pylint: disable=import-error
-from machine_install import VirtInstallMachine
+from testlib import nondestructive, test_main  # pylint: disable=import-error
+
 
 @nondestructive
-class TestBasic(MachineCase):
-    MachineCase.machine_class = VirtInstallMachine
+class TestBasic(anacondalib.VirtInstallMachineCase):
 
     def testNavigation(self):
         b = self.browser
@@ -55,8 +47,7 @@ class TestBasic(MachineCase):
                 i.next()
 
 
-class TestQuit(MachineCase):
-    MachineCase.machine_class = VirtInstallMachine
+class TestQuit(anacondalib.VirtInstallMachineCase):
 
     def testQuitInstallation(self):
         b = self.browser

--- a/ui/webui/test/check-language
+++ b/ui/webui/test/check-language
@@ -15,23 +15,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import sys
-
-# import Cockpit's machinery for test VMs and its browser test API
-TEST_DIR = os.path.dirname(__file__)
-sys.path.append(os.path.join(TEST_DIR, "common"))
-sys.path.append(os.path.join(TEST_DIR, "helpers"))
-sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
+import anacondalib
 
 from installer import Installer
 from language import Language
-from testlib import MachineCase, nondestructive, test_main # pylint: disable=import-error
-from machine_install import VirtInstallMachine
+from testlib import nondestructive, test_main  # pylint: disable=import-error
+
 
 @nondestructive
-class TestLanguage(MachineCase):
-    MachineCase.machine_class = VirtInstallMachine
+class TestLanguage(anacondalib.VirtInstallMachineCase):
 
     def testOtherDefault(self):
         b = self.browser

--- a/ui/webui/test/check-progress
+++ b/ui/webui/test/check-progress
@@ -15,21 +15,13 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import sys
-
-# import Cockpit's machinery for test VMs and its browser test API
-TEST_DIR = os.path.dirname(__file__)
-sys.path.append(os.path.join(TEST_DIR, "helpers"))
-sys.path.append(os.path.join(TEST_DIR, "common"))
-sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
+import anacondalib
 
 from installer import Installer
-from testlib import MachineCase, test_main  # pylint: disable=import-error
-from machine_install import VirtInstallMachine
+from testlib import test_main  # pylint: disable=import-error
 
-class TestInstallationProgress(MachineCase):
-    MachineCase.machine_class = VirtInstallMachine
+
+class TestInstallationProgress(anacondalib.VirtInstallMachineCase):
 
     def testBasic(self):
         # HACK Ignore some selinux errors

--- a/ui/webui/test/check-review
+++ b/ui/webui/test/check-review
@@ -15,24 +15,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import sys
-
-# import Cockpit's machinery for test VMs and its browser test API
-TEST_DIR = os.path.dirname(__file__)
-sys.path.append(os.path.join(TEST_DIR, "common"))
-sys.path.append(os.path.join(TEST_DIR, "helpers"))
-sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
+import anacondalib
 
 from installer import Installer
 from storage import Storage  # pylint: disable=import-error
 from review import Review
-from testlib import MachineCase, nondestructive, test_main  # pylint: disable=import-error
-from machine_install import VirtInstallMachine
+from testlib import nondestructive, test_main  # pylint: disable=import-error
+
 
 @nondestructive
-class TestReview(MachineCase):
-    MachineCase.machine_class = VirtInstallMachine
+class TestReview(anacondalib.VirtInstallMachineCase):
 
     def testBasic(self):
         b = self.browser

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -15,23 +15,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import sys
-
-# import Cockpit's machinery for test VMs and its browser test API
-TEST_DIR = os.path.dirname(__file__)
-sys.path.append(os.path.join(TEST_DIR, "common"))
-sys.path.append(os.path.join(TEST_DIR, "helpers"))
-sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
+import anacondalib
 
 from installer import Installer
 from storage import Storage
-from testlib import MachineCase, nondestructive, test_main  # pylint: disable=import-error
-from machine_install import VirtInstallMachine
+from testlib import nondestructive, test_main  # pylint: disable=import-error
+
 
 @nondestructive
-class TestStorage(MachineCase):
-    MachineCase.machine_class = VirtInstallMachine
+class TestStorage(anacondalib.VirtInstallMachineCase):
 
     def testLocalStandardDisks(self):
         b = self.browser
@@ -172,8 +164,7 @@ class TestStorage(MachineCase):
 # We can't run this test case on an existing machine,
 # with --machine because MachineCase is not aware of add_disk method
 # TODO add next back test keeping the choice
-class TestStorageExtraDisks(MachineCase):
-    MachineCase.machine_class = VirtInstallMachine
+class TestStorageExtraDisks(anacondalib.VirtInstallMachineCase):
 
     def testLocalDisksSyncNew(self):
         b = self.browser


### PR DESCRIPTION
When python-installer is installed, the tests fail with:

ImportError: cannot import name 'Installer' from 'installer' (/usr/lib/python3.10/site-packages/installer/__init__.py)

I suppose ideally everything would use helpers for imports.