### PR TITLE
Trim whitespaces from /kickstart-tests GH comment (#infra)

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -53,7 +53,7 @@ jobs:
           BODY: ${{ github.event.comment.body }}
         run: |
           # extract first line and cut out the "/kickstart-tests" first word
-          LAUNCH_ARGS=$(echo "$BODY" | sed -n '1 s/^[^ ]* *//p')
+          LAUNCH_ARGS=$(echo "$BODY" | sed -n '1 s/^[^ ]* *//p' | sed 's/[[:space:]]*$//')
           echo "launch arguments are: $LAUNCH_ARGS"
           echo "launch_args=${LAUNCH_ARGS}" >> $GITHUB_OUTPUT
 
@@ -340,7 +340,7 @@ jobs:
         env:
           BODY: ${{ github.event.comment.body }}
         run: |
-          REASON=$(echo "$BODY" | sed -e "s#/kickstart-test --waive ##")
+          REASON=$(echo "$BODY" | sed -e "s#/kickstart-test --waive ##" | sed 's/[[:space:]]*$//')
           echo "reason=Waived, $REASON" >> $GITHUB_OUTPUT
 
       - name: Set status

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -47,7 +47,7 @@ jobs:
           BODY: ${{ github.event.comment.body }}
         run: |
           # extract first line and cut out the "/kickstart-tests" first word
-          LAUNCH_ARGS=$(echo "$BODY" | sed -n '1 s/^[^ ]* *//p')
+          LAUNCH_ARGS=$(echo "$BODY" | sed -n '1 s/^[^ ]* *//p' | sed 's/[[:space:]]*$//')
           echo "launch arguments are: $LAUNCH_ARGS"
           echo "launch_args=${LAUNCH_ARGS}" >> $GITHUB_OUTPUT
 
@@ -334,7 +334,7 @@ jobs:
         env:
           BODY: ${{ github.event.comment.body }}
         run: |
-          REASON=$(echo "$BODY" | sed -e "s#/kickstart-test --waive ##")
+          REASON=$(echo "$BODY" | sed -e "s#/kickstart-test --waive ##" | sed 's/[[:space:]]*$//')
           echo "reason=Waived, $REASON" >> $GITHUB_OUTPUT
 
       - name: Set status


### PR DESCRIPTION
Right now the tests will fail in weird way when the comment on ends up with \n. Let's fix that by trimming not only start of the command but also end of it.

Should avoid issue like in https://github.com/rhinstaller/anaconda/actions/runs/4677570787/jobs/8285239264.