### PR TITLE
Fix logging to packaging.log

### DIFF
--- a/pyanaconda/anaconda_loggers.py
+++ b/pyanaconda/anaconda_loggers.py
@@ -57,7 +57,3 @@ def get_stdout_logger():
 
 def get_program_logger():
     return logging.getLogger(constants.LOGGER_PROGRAM)
-
-
-def get_packaging_logger():
-    return logging.getLogger(constants.LOGGER_PACKAGING)

--- a/pyanaconda/anaconda_logging.py
+++ b/pyanaconda/anaconda_logging.py
@@ -38,8 +38,6 @@ ANACONDA_SYSLOG_FORMAT = "anaconda: %(log_prefix)s: %(message)s"
 
 MAIN_LOG_FILE = "/tmp/anaconda.log"
 PROGRAM_LOG_FILE = "/tmp/program.log"
-PACKAGING_LOG_FILE = "/tmp/packaging.log"
-LIBREPO_LOG_FILE = "/tmp/dnf.librepo.log"
 ANACONDA_SYSLOG_FACILITY = SysLogHandler.LOG_LOCAL1
 ANACONDA_SYSLOG_IDENTIFIER = "anaconda"
 
@@ -179,25 +177,6 @@ class AnacondaLog(object):
         program_logger.setLevel(logging.DEBUG)
         self.addFileHandler(PROGRAM_LOG_FILE, program_logger)
         self.forwardToJournal(program_logger)
-
-        # Create the packaging logger.
-        packaging_logger = logging.getLogger(constants.LOGGER_PACKAGING)
-        packaging_logger.setLevel(logging.DEBUG)
-        packaging_logger.propagate = False
-        self.addFileHandler(PACKAGING_LOG_FILE, packaging_logger)
-        self.forwardToJournal(packaging_logger)
-
-        # Create the dnf logger and link it to packaging
-        dnf_logger = logging.getLogger(constants.LOGGER_DNF)
-        dnf_logger.setLevel(logging.DEBUG)
-        self.addFileHandler(PACKAGING_LOG_FILE, dnf_logger)
-        self.forwardToJournal(dnf_logger)
-
-        # Create the librepo logger.
-        librepo_logger = logging.getLogger(constants.LOGGER_LIBREPO)
-        librepo_logger.setLevel(logging.DEBUG)
-        self.addFileHandler(LIBREPO_LOG_FILE, librepo_logger)
-        self.forwardToJournal(librepo_logger)
 
         # Create the simpleline logger and link it to anaconda
         simpleline_logger = logging.getLogger(constants.LOGGER_SIMPLELINE)

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -328,9 +328,6 @@ LOGGER_ANACONDA_ROOT = "anaconda"
 LOGGER_MAIN = "anaconda.main"
 LOGGER_STDOUT = "anaconda.stdout"
 LOGGER_PROGRAM = "program"
-LOGGER_PACKAGING = "packaging"
-LOGGER_DNF = "dnf"
-LOGGER_LIBREPO = "librepo"  # second DNF logger for librepo
 LOGGER_SIMPLELINE = "simpleline"
 
 # Timeout for starting X

--- a/pyanaconda/modules/payloads/__main__.py
+++ b/pyanaconda/modules/payloads/__main__.py
@@ -18,7 +18,7 @@
 # Red Hat, Inc.
 #
 from pyanaconda.modules.common import init
-init()
+init("/tmp/packaging.log")
 
 import os
 if "LD_PRELOAD" in os.environ:

--- a/pyanaconda/modules/payloads/payload/dnf/download_progress.py
+++ b/pyanaconda/modules/payloads/payload/dnf/download_progress.py
@@ -23,10 +23,10 @@ import dnf.callback
 
 from blivet.size import Size
 
-from pyanaconda.anaconda_loggers import get_packaging_logger
+from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
 
-log = get_packaging_logger()
+log = get_module_logger(__name__)
 
 __all__ = ["DownloadProgress"]
 

--- a/pyanaconda/payload/live/payload_liveos.py
+++ b/pyanaconda/payload/live/payload_liveos.py
@@ -15,13 +15,13 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pyanaconda.anaconda_loggers import get_packaging_logger
+from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.constants import PAYLOAD_TYPE_LIVE_OS
 from pyanaconda.modules.common.constants.services import PAYLOADS
 from pyanaconda.modules.common.task import sync_run_task
 from pyanaconda.payload.migrated import MigratedDBusPayload
 
-log = get_packaging_logger()
+log = get_module_logger(__name__)
 
 __all__ = ["LiveOSPayload"]
 


### PR DESCRIPTION
* The Payloads module should enable logging to the `/tmp/packaging.log` file.
* Remove the unused code that sets up packaging logging for the ui process.
