### PR TITLE
docs: Document the distribution component

### DIFF
--- a/docs/common-bugs.rst
+++ b/docs/common-bugs.rst
@@ -118,7 +118,8 @@ Changes in package groups and environments
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :Issue: The reporter wants a new package to be installed by default.
-:Solution: Reassigning to comps.
+:Solution: The package groups and environments are defined by comps (see
+    https://pagure.io/fedora-comps/). Reassigning to distribution.
 :Example: `rhbz#1787018 <https://bugzilla.redhat.com/show_bug.cgi?id=1787018>`_
 
 Corrupted ISO


### PR DESCRIPTION
Bugs related to changes in package groups and environments should be reassigned to the `distribution` component instead of the `comps` component.