### PR TITLE
Improve development experience for the WebUI

### DIFF
--- a/pyanaconda/ui/webui/__init__.py
+++ b/pyanaconda/ui/webui/__init__.py
@@ -93,9 +93,20 @@ class CockpitUserInterface(ui.UserInterface):
         """Run the interface."""
         log.debug("web-ui: starting cockpit web view")
         if self.remote:
+            # Override the cockpit.service unit to allow root
+            with open("/etc/systemd/system/cockpit.service", "w") as f:
+                f.write("""
+[Unit]
+Description=Cockpit Web Service
+
+[Service]
+ExecStart=/usr/libexec/cockpit-ws --no-tls --port 9090 --local-session=cockpit-bridge
+""")
             startProgram([
-                "/usr/libexec/cockpit-ws", "--no-tls",
-                "--port", "9090", "--local-session=cockpit-bridge"
+                "/usr/bin/systemctl", "daemon-reload"
+            ])
+            startProgram([
+                "/usr/bin/systemctl", "enable", "--now", "cockpit.socket"
             ])
 
         proc = startProgram(["/usr/libexec/cockpit-desktop",


### PR DESCRIPTION
A normal workflow would be to start the VM, start `make rsync`, kill cockpit-ws and restart it to pick up the development files. With the new `--rsync` switch this is no longer required as the initial rsync and restart of cockpit-ws is already automatically done.

https://issues.redhat.com/browse/INSTALLER-3420

@M4rtinK would love to have your feedback on this PR. For development the workflow would be:

```./test/webui_testvm.py --rsync fedora-rawhide-boot```