### PR TITLE
Add SYS_CHROOT capability to anaconda-ci (#infra)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -285,20 +285,27 @@ ci:
 		exit $$status; \
 	fi
 
+# container-ci target will have disabled cockpit Makefiles by default
+# The SYS_CHROOT capability is required for user creation tests and was dropped on podman 4.4.X
+# https://bugzilla.redhat.com/show_bug.cgi?id=2170568
 container-ci:
 	$(CONTAINER_ENGINE) run \
 	--entrypoint /anaconda/dockerfile/anaconda-ci/run-build-and-arg \
 	$(CONTAINER_TEST_ARGS) \
 	$(CI_TEST_ARGS) \
+	--cap-add=SYS_CHROOT \
 	$(CONTAINER_ADD_ARGS) \
 	$(CI_NAME):$(CI_TAG) \
 	$(CI_CMD)
 
+# The SYS_CHROOT capability is required for user creation tests and was dropped on podman 4.4.X
+# https://bugzilla.redhat.com/show_bug.cgi?id=2170568
 container-shell:
 	$(CONTAINER_ENGINE) run -it \
 	$(CONTAINER_TEST_ARGS) \
 	$(CONTAINER_ADD_ARGS) \
 	$(CI_TEST_ARGS) \
+	--cap-add=SYS_CHROOT \
 	$(CI_NAME):$(CI_TAG)
 
 container-rpm-test:


### PR DESCRIPTION
We have user creation container tests which are using chroot to be able to use tooling to create users. However, from podman 4.4 they removed this capability from default capabilities set. Let's put it back for this specific container.

Podman 4.4.1 is on Fedora 38+.

See https://bugzilla.redhat.com/show_bug.cgi?id=2170568 for more info.

(cherry picked from commit 19d861febeebd0c15592a12fa2ce80a1c45bc7b8)

Backport of https://github.com/rhinstaller/anaconda/pull/4563
