### PR TITLE
Fix virt-install cockpit run on fedora-X images

### DIFF
--- a/ui/webui/test/machine_install.py
+++ b/ui/webui/test/machine_install.py
@@ -73,7 +73,7 @@ class VirtInstallMachine(VirtMachine):
                 "--connect qemu:///session "
                 "--quiet "
                 f"--name {self.label} "
-                f"--os-variant {self.image.rstrip('-boot')} "
+                f"--os-variant=detect=on "
                 "--memory 2048 "
                 "--noautoconsole "
                 f"--graphics vnc,listen={self.ssh_address} "


### PR DESCRIPTION
The issue is that your system (the one running virt-install) needs to known the fedora you want to test.

Example:
My system is Fedora 37
I want to run fedora-38 test
\=
virt-install doesn't know fedora-38 because it's fedora-37 virt-install

So instead of giving them the link let's virt-install be smart and try to detect the os variant.

(cherry picked from commit 9487223ce2f9afb6b7e823efa3274a9288d1ba7b)
