### PR TITLE
Remove redundant return

### DIFF
--- a/pyanaconda/modules/common/base/base_interface.py
+++ b/pyanaconda/modules/common/base/base_interface.py
@@ -119,7 +119,7 @@ class KickstartModuleInterface(KickstartModuleInterfaceTemplate):
 
         Examples: "cs_CZ.UTF-8", "fr_FR"
         """
-        return self.implementation.set_locale(locale)
+        self.implementation.set_locale(locale)
 
     def ConfigureWithTasks(self) -> List[ObjPath]:
         """Configure the runtime environment.


### PR DESCRIPTION
This is a minor bugfix.

- There is no declared return type, so the return was not used anywhere.
- The implementation does not return anything.
- Documentation does not mention any returns.
- The implicit `return None` from implementation was taken by interface and returned instead of implicit `return None`, so there was no observable effect.