### PR TITLE
Workaround to packit srpm builds npm issue (#infra)

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -23,7 +23,7 @@ srpm_build_deps:
   - libarchive-devel
   - rpm-devel
   - nss_wrapper
-  - npm
+  - nodejs-npm
 
 actions:
   post-upstream-clone:

--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -16,7 +16,7 @@ srpm_build_deps:
   - libarchive-devel
   - rpm-devel
   - nss_wrapper
-  - npm
+  - nodejs-npm
 
 actions:
   post-upstream-clone:


### PR DESCRIPTION
Right now srpm packit build failing because of missing npm tool.

Fedora should be standard install nodejs-npm but in COPR for some reason it installs nodejs20-npm. That seems to provoke an error during build that npm tool is missing.

Require nodejs-npm directly as solution for now.