### PR TITLE
.github: add Cockpit library update action

### DIFF
--- a/.github/workflows/cockpit-lib-update.yml
+++ b/.github/workflows/cockpit-lib-update.yml
@@ -1,0 +1,32 @@
+name: cockpit-lib-update
+on:
+  # Runs every Thursday at 2 AM
+  schedule:
+    - cron: '0 2 * * 4'
+  # can be run manually on https://github.com/rhinstaller/anaconda/actions
+  workflow_dispatch:
+jobs:
+  cockpit-lib-update:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y make
+
+      - name: Set up configuration and secrets
+        run: |
+          printf '[user]\n\tname = github-actions\n\temail=github-actions@github.com\n' > ~/.gitconfig
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
+
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Run cockpit-lib-update
+        run: |
+          make -f Makefile.am bots # HACK: to skip running autogen.sh/configure
+          bots/cockpit-lib-update Makefile.am
+        working-directory: ui/webui

--- a/docs/ci-status.rst
+++ b/docs/ci-status.rst
@@ -37,6 +37,10 @@ Anaconda
    :alt: Run unit and RPM tests daily
    :target: https://github.com/rhinstaller/anaconda/actions/workflows/tests-daily.yml
 
+.. |cockpit-lib-update| image:: https://github.com/rhinstaller/anaconda/actions/workflows/cockpit-lib-update.yml/badge.svg
+   :alt: Updates Cockpit library
+   :target: https://github.com/rhinstaller/anaconda/actions/workflows/cockpit-lib-update.yml
+
 .. _Dependabot: https://github.com/rhinstaller/anaconda/network/updates
 
 |container-autoupdate-fedora|
@@ -57,6 +61,9 @@ Anaconda
 
 |tests-daily|
   Runs unit and RPM tests every day, independent of any changes to code or containers.
+
+|cockpit-lib-update|
+  Updates the COCKPIT_REPO_COMMIT in ui/webui/Makefile.am and opens a pull request.
 
 Dependabot_
   Checks Anaconda dependencies and opens pull requests for new versions.


### PR DESCRIPTION
This action works similar to the npm-update workflow, it creates a PR every Thursday (usually after the Cockpit release) to update the COCKPIT_REPO_COMMIT to the latest version.

---

Tested this on my fork:

https://github.com/jelly/anaconda/actions/runs/4732456425/jobs/8398650535

Which creates the following PR

https://github.com/jelly/anaconda/pull/2


