### PR TITLE
Update review screen for v1 of autopart

### DIFF
--- a/ui/webui/src/apis/storage.js
+++ b/ui/webui/src/apis/storage.js
@@ -197,6 +197,24 @@ export const getPartitioningRequest = ({ partitioning }) => {
 };
 
 /**
+ * @returns {Promise}           The applied partitioning
+ */
+export const getAppliedPartitioning = () => {
+    return (
+        new StorageClient().client.call(
+            "/org/fedoraproject/Anaconda/Modules/Storage",
+            "org.freedesktop.DBus.Properties",
+            "Get",
+            [
+                "org.fedoraproject.Anaconda.Modules.Storage",
+                "AppliedPartitioning",
+            ]
+        )
+                .then(res => res[0].v)
+    );
+};
+
+/**
  * @param {string} partitioning     DBus path to a partitioning
  * @param {Object} request          A data object with the request
  */

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -30,7 +30,7 @@ import {
 } from "@patternfly/react-core";
 
 import { InstallationDestination, applyDefaultStorage } from "./storage/InstallationDestination.jsx";
-import { StorageConfiguration } from "./storage/StorageConfiguration.jsx";
+import { StorageConfiguration, getScenario } from "./storage/StorageConfiguration.jsx";
 import { DiskEncryption, StorageEncryptionState } from "./storage/DiskEncryption.jsx";
 import { InstallationLanguage } from "./localization/InstallationLanguage.jsx";
 import { InstallationProgress } from "./installation/InstallationProgress.jsx";
@@ -46,6 +46,7 @@ export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, titl
     const [isInProgress, setIsInProgress] = useState(false);
     const [storageEncryption, setStorageEncryption] = useState(new StorageEncryptionState());
     const [showPassphraseScreen, setShowPassphraseScreen] = useState(false);
+    const [storageScenarioId, setStorageScenarioId] = useState("use-free-space");
 
     const stepsOrder = [
         {
@@ -134,6 +135,7 @@ export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, titl
                           storageEncryption={storageEncryption}
                           setStorageEncryption={setStorageEncryption}
                           showPassphraseScreen={showPassphraseScreen}
+                          setStorageScenarioId={setStorageScenarioId}
                         />
                     ),
                 });
@@ -165,6 +167,7 @@ export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, titl
             storageEncryption={storageEncryption}
             showPassphraseScreen={showPassphraseScreen}
             setShowPassphraseScreen={setShowPassphraseScreen}
+            storageScenarioId={storageScenarioId}
             isQuitReboot={conf["Installation System"].type === "BOOT_ISO"}
           />}
           hideClose
@@ -188,6 +191,7 @@ const Footer = ({
     storageEncryption,
     showPassphraseScreen,
     setShowPassphraseScreen,
+    storageScenarioId,
     isQuitReboot,
 }) => {
     const [nextWaitsConfirmation, setNextWaitsConfirmation] = useState(false);
@@ -251,7 +255,7 @@ const Footer = ({
                     );
                     const nextButtonText = (
                         activeStep.id === "installation-review"
-                            ? _("Erase disks and install")
+                            ? getScenario(storageScenarioId).buttonLabel
                             : _("Next")
                     );
                     const nextButtonVariant = (
@@ -267,6 +271,7 @@ const Footer = ({
                               idPrefix={activeStep.id}
                               onNext={onNext}
                               setNextWaitsConfirmation={setNextWaitsConfirmation}
+                              storageScenarioId={storageScenarioId}
                             />}
                             {quitWaitsConfirmation &&
                             <QuitInstallationConfirmModal

--- a/ui/webui/src/components/storage/StorageConfiguration.jsx
+++ b/ui/webui/src/components/storage/StorageConfiguration.jsx
@@ -143,7 +143,7 @@ const checkUseFreeSpace = async (selectedDisks, requiredSize) => {
     return availability;
 };
 
-export const scenarios = [{
+const scenarios = [{
     id: "erase-all",
     label: _("Erase devices and install"),
     detail: helpEraseAll,
@@ -151,6 +151,12 @@ export const scenarios = [{
     default: true,
     // CLEAR_PARTITIONS_ALL = 1
     initializationMode: 1,
+    buttonLabel: _("Erase disks and install"),
+    buttonVariant: "danger",
+    screenWarning: _("Erasing the disks cannot be undone."),
+    dialogTitleIconVariant: "warning",
+    dialogWarningTitle: _("Erase disks and install?"),
+    dialogWarning: _("The selected disks will be erased, this cannot be undone. Are you sure you want to continue with the installation?"),
 }, {
     id: "use-free-space",
     label: _("Use free space for the installation"),
@@ -159,7 +165,24 @@ export const scenarios = [{
     default: false,
     // CLEAR_PARTITIONS_NONE = 0
     initializationMode: 0,
+    buttonLabel: _("Install"),
+    buttonVariant: "primary",
+    screenWarning: "",
+    dialogTitleIconVariant: "",
+    dialogWarningTitle: _("Install on the free space?"),
+    dialogWarning: _("The installation will use the available space on your devices and will not erase any device data."),
 }];
+
+export const getScenario = (scenarioId) => {
+    return scenarios.filter(s => s.id === scenarioId)[0];
+};
+
+export const scenarioForInitializationMode = (mode) => {
+    const ss = scenarios.filter(s => s.initializationMode === mode);
+    if (ss.length > 0) {
+        return ss[0];
+    }
+};
 
 const scenarioDetailContent = (scenario, hint) => {
     return (
@@ -237,7 +260,7 @@ const GuidedPartitioning = ({ idPrefix, scenarios, setIsFormValid }) => {
 
     useEffect(() => {
         const applyScenario = async (scenarioId) => {
-            const scenario = scenarios.filter(s => s.id === scenarioId)[0];
+            const scenario = getScenario(scenarioId);
             console.log("Updating scenario selected in backend to", scenario.id);
             await setInitializationMode({ mode: scenario.initializationMode }).catch(console.error);
         };
@@ -247,7 +270,7 @@ const GuidedPartitioning = ({ idPrefix, scenarios, setIsFormValid }) => {
     }, [scenarios, selectedScenario]);
 
     const updateDetailContent = (scenarioId) => {
-        const scenario = scenarios.filter(s => s.id === scenarioId)[0];
+        const scenario = getScenario(scenarioId);
         const hint = scenarioAvailability[scenarioId].hint;
         setDetailContent(scenarioDetailContent(scenario, hint));
     };

--- a/ui/webui/test/check-review
+++ b/ui/webui/test/check-review
@@ -50,6 +50,12 @@ class TestReview(anacondalib.VirtInstallMachineCase):
         r.check_disk_label("vda", "Local standard disk")
         r.check_disk_description("vda", "0x1af4 (vda)")
 
+        # check encryption choice
+        r.check_encryption("Disabled")
+
+        # check storage configuration
+        r.check_storage_config("Erase devices and install")
+
         # Pixel test the review step
         b.assert_pixels(
             "#app",

--- a/ui/webui/test/helpers/review.py
+++ b/ui/webui/test/helpers/review.py
@@ -39,5 +39,13 @@ class Review():
         self.browser.wait_in_text(f"#{self._step}-disk-label-{disk}", label)
 
     @log_step()
+    def check_encryption(self, state):
+        self.browser.wait_in_text(f"#{self._step}-target-system-encrypt > .pf-c-description-list__text", state)
+
+    @log_step()
+    def check_storage_config(self, scenario):
+        self.browser.wait_in_text(f"#{self._step}-target-system-mode > .pf-c-description-list__text", scenario)
+
+    @log_step()
     def check_disk_description(self, disk, description):
         self.browser.wait_in_text(f"#{self._step}-disk-description-{disk}", description)


### PR DESCRIPTION
This is a follow-up task [INSTALLER-3445](https://issues.redhat.com/browse/INSTALLER-3445) of https://github.com/rhinstaller/anaconda/pull/4599.
It updates the review screen to include information about the selected autopartitioning scenario and encryption choice. Also the list of disks used is expandable now. The warnings, button labels and warning dialog for the newly added autopartioning option (Use free space) was added.

Notes and issues needing UX expert feedback / suggestions:

- The list of selected disk is automatically expanded in case there is only a single disk.
- The on-screen warning is there also in case of "Use free space" scenario. I think advice to backup is valid even in this case.
- The button label and warning dialog microcopy for "Use free space..." can be perhaps improved.
- The button label ("Erase disks and install") and scenario description ("Erase devices and install" which is the same as the Storage Configuration screen option label) should be the unified. (Moreover there is "Erase data and install" in play suggested in microcopy task [INSTALLER-3406](https://issues.redhat.com/browse/INSTALLER-3406) but I'd prefer to address the "Erase data" suggestion separately not to block this PR)

TODO:
- [x] tests for review screen

Screenshots:

For "Erase devices and install" option:
https://rvykydal.fedorapeople.org/webui/autopart_pr1/v1/screenshots/review_screen/erase_all/
![erase_all4](https://user-images.githubusercontent.com/1220237/233961041-92c18c14-b3db-4e42-aa59-7d06aba76612.png)
![erase_all5](https://user-images.githubusercontent.com/1220237/233961079-14623de9-74df-4792-a1b8-a772c04b919a.png)

For "Use free space for the installation" option:
https://rvykydal.fedorapeople.org/webui/autopart_pr1/v1/screenshots/review_screen/use_free_space/
![use_free_space3](https://user-images.githubusercontent.com/1220237/233961323-76dd7e9f-c18a-4e99-9ce3-95a75afbe47f.png)
![use_free_space4](https://user-images.githubusercontent.com/1220237/233961336-4463456a-ea90-4f6d-b946-e17df862dce9.png)

For multiple disks:
https://rvykydal.fedorapeople.org/webui/autopart_pr1/v1/screenshots/review_screen/multiple_disks/
![multiple_disks4](https://user-images.githubusercontent.com/1220237/233961488-55a41b63-5c20-4d87-b9e7-785fb73c467a.png)
![multiple_disks5](https://user-images.githubusercontent.com/1220237/233961510-edba5d3a-63ce-44c6-aec5-2af6727d020e.png)


- [implementation] For modification of button labels and warning dialogs we need to keep the choice of autopart scenario in the AnacondaWizard component (`storageScenarioId`). So it could make sense not to update the scenario in the backend right on the Storage Configureation screen (`setInitializationMode`) but instead keep the value in the `storageScenarioId` component state and update the backend only when the whole partitioning is applied (at the end of the Installation destination steps - on Next from the Disk Encryption step). We do something similar with disk encryption options (keeping state in AnacondaWizard `storageEncryption`) but in that case the main reason is we are not able to keep these settings in the backend.