### PR TITLE
Increase the minimum EFI System Partition (ESP) size to 500MiB

### DIFF
--- a/docs/release-notes/bigger-esp.rst
+++ b/docs/release-notes/bigger-esp.rst
@@ -1,0 +1,14 @@
+:Type: Bootloader
+:Summary: Make the EFI System Partition at least 500MiB in size
+
+:Description:
+    The size of the EFI System Partition (ESP) created by Anaconda has changed from 200 MiB to 500 MiB.
+
+    The reasons for this change include:
+    - This partition is used to deploy firmware updates. These updates need free space of twice the SPI flash size, which will grow from 64 to 128 MiB in near future and make the current partition size too small.
+    - The larger space enables future changes to how the bootloader is deployed on Fedora.
+    - The new minimum is identical with what Microsoft mandates OEMs allocate for the partition.
+
+:Links:
+    - https://fedoraproject.org/wiki/Changes/BiggerESP
+    - https://github.com/rhinstaller/anaconda/pull/4711

--- a/pyanaconda/modules/storage/platform.py
+++ b/pyanaconda/modules/storage/platform.py
@@ -224,8 +224,8 @@ class EFI(Platform):
         return PartSpec(
             mountpoint="/boot/efi",
             fstype="efi",
-            size=Size("200MiB"),
-            max_size=Size("600MiB"),
+            size=Size("500MiB"),
+            max_size=Size("2GiB"),
             grow=True
         )
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
@@ -181,7 +181,7 @@ class PlatformTestCase(unittest.TestCase):
 
         self._check_partitions(
             PartSpec(mountpoint="/boot/efi", fstype="efi", grow=True,
-                     size=Size("200MiB"), max_size=Size("600MiB")),
+                     size=Size("500MiB"), max_size=Size("2GiB")),
             PartSpec(mountpoint="/boot", size=Size("1GiB"))
         )
 
@@ -256,7 +256,7 @@ class PlatformTestCase(unittest.TestCase):
 
         self._check_partitions(
             PartSpec(mountpoint="/boot/efi", fstype="efi", grow=True,
-                     size=Size("200MiB"), max_size=Size("600MiB")),
+                     size=Size("500MiB"), max_size=Size("2GiB")),
             PartSpec(mountpoint="/boot", size=Size("1GiB"))
         )
 
@@ -293,7 +293,7 @@ class PlatformTestCase(unittest.TestCase):
 
         self._check_partitions(
             PartSpec(mountpoint="/boot/efi", fstype="efi", grow=True,
-                     size=Size("200MiB"), max_size=Size("600MiB")),
+                     size=Size("500MiB"), max_size=Size("2GiB")),
             PartSpec(mountpoint="/boot", size=Size("1GiB"))
         )
 


### PR DESCRIPTION
Currently the default allocated space for the EFI System Partition (ESP) is a minimum of 200 MiB and a maximum of 600MiB. This smaller size is more than enough for storing the EFI binaries just needed to boot the machine.

The ESP is also used to deploy firmware updates which need 2x SPI flash size (typically 64MB, soon 128MB) as free space. We're also soon going to modernize how the bootloader is deployed, and this also is going to need more space again.

Microsoft mandates OEMs to allocate a minimum of 500MiB and so I think we should just do the same.
