### PR TITLE
localization: allow to turn off geolocation by configuration

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -334,3 +334,8 @@ eula =
 # If left empty, geolocation does not run.
 #
 geolocation_provider = https://geoip.fedoraproject.org/city
+
+[Localization]
+# Should geolocation be used when setting the language ?
+#
+use_geolocation = True

--- a/docs/release-notes/lang-configuration-setting.rst
+++ b/docs/release-notes/lang-configuration-setting.rst
@@ -1,0 +1,11 @@
+:Type: Configuration
+:Summary: Allow to turn off geolocation for language selection (#INSTALLER-3472)
+
+:Description:
+New Localization section with use_geolocation option is added to Anaconda
+configuration.
+
+The option allows to turn off geolocation for language selection.
+
+:Links:
+    - https://github.com/rhinstaller/anaconda/pull/4719

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -34,6 +34,7 @@ from pyanaconda.core.configuration.base import Section, Configuration, Configura
 from pyanaconda.core.configuration.profile import ProfileLoader
 from pyanaconda.core.configuration.ui import UserInterfaceSection
 from pyanaconda.core.configuration.timezone import TimezoneSection
+from pyanaconda.core.configuration.localization import LocalizationSection
 from pyanaconda.core.constants import ANACONDA_CONFIG_TMP, ANACONDA_CONFIG_DIR, \
     GEOLOC_PROVIDER_FEDORA_GEOIP, GEOLOC_PROVIDER_HOSTIP, GEOLOC_DEFAULT_PROVIDER, \
     GEOLOC_URL_FEDORA_GEOIP, GEOLOC_URL_HOSTIP
@@ -188,6 +189,10 @@ class AnacondaConfiguration(Configuration):
             "Timezone", self.get_parser()
         )
 
+        self._localization = LocalizationSection(
+            "Localization", self.get_parser()
+        )
+
     @property
     def anaconda(self):
         """The Anaconda section."""
@@ -247,6 +252,11 @@ class AnacondaConfiguration(Configuration):
     def timezone(self):
         """The Timezone section."""
         return self._timezone
+
+    @property
+    def localization(self):
+        """The Localization section."""
+        return self._localization
 
     def set_from_defaults(self):
         """Set the configuration from the default configuration files.

--- a/pyanaconda/core/configuration/localization.py
+++ b/pyanaconda/core/configuration/localization.py
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.core.configuration.base import Section
+
+
+class LocalizationSection(Section):
+    """The Localization section."""
+
+    @property
+    def use_geolocation(self):
+        """Use geolocation when setting language."""
+        return self._get_option("use_geolocation", bool)

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -736,6 +736,10 @@ def apply_geolocation_result(display_mode):
         # by geolocation before continuing the installation.
         timezone_module.Kickstarted = True
 
+    if not conf.localization.use_geolocation:
+        log.info("Geoloc: skipping locale because of use_geolocation configuration")
+        return
+
     # skip language setup if already set by boot options or kickstart
     language = localization_module.Language
     if language and localization_module.LanguageKickstarted:


### PR DESCRIPTION
New Localization section with use_geolocation boolean option is added to
Anaconda configuration.

Intended use: On Fedora Workstation (Gnome) the language will be set by
environment initial setup and Anaconda will take over this value.
This option set to False in the Workstation configuration profile would
prevent overriding the value from environment with geolocation.

INSTALLER-3472
