### PR TITLE
Rhel 8 wait on oemdrv

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -664,6 +664,22 @@ inst.zram
 
 Forces/disables (on/off) usage of zRAM swap for the installation process.
 
+.. inst.wait_for_disks:
+
+inst.wait_for_disks
+^^^^^^^^^^^^^^^^^^^
+
+Because disks can take some time to appear, an additional delay of 5 seconds
+has been added.  This can be overridden by boot argument
+`inst.wait_for_disks=<value>` to let dracut wait up to <value> additional
+seconds (0 turns the feature off, causing dracut to only wait up to 500ms).
+Alternatively, if the `OEMDRV` device is known to be present but too slow to be
+autodetected, the user can boot with an argument like `inst.dd=hd:LABEL=OEMDRV`
+to indicate that dracut should expect an `OEMDRV` device and not start the
+installer until it appears.
+
+This functionality could be used to load kickstart and driverdisks.
+
 
 Boot loader options
 -------------------

--- a/docs/driverdisc.rst
+++ b/docs/driverdisc.rst
@@ -56,6 +56,15 @@ Anaconda automatically looks for driverdiscs during startup.
 The DriverDisc has to be on partition or filesystem which has been labeled
 with 'OEMDRV' label.
 
+Because disks can take some time to appear, an additional delay of 5 seconds
+has been added.  This can be overridden by boot argument
+`inst.wait_for_disks=<value>` to let dracut wait up to <value> additional
+seconds (0 turns the feature off, causing dracut to only wait up to 500ms).
+Alternatively, if the `OEMDRV` device is known to be present but too slow to be
+autodetected, the user can boot with an argument like `inst.dd=hd:LABEL=OEMDRV`
+to indicate that dracut should expect an `OEMDRV` device and not start the
+installer until it appears.
+
 
 DDv3 structure
 --------------

--- a/dracut/README-driver-updates.md
+++ b/dracut/README-driver-updates.md
@@ -163,10 +163,14 @@ all devices have been found and declares the system "settled".
 If there's no response from any `OEMDRV` device by then, the installer starts
 normally.
 
-_If the `OEMDRV` device is present but too slow to be autodetected, the user
-can boot with an argument like `inst.dd=hd:LABEL=OEMDRV` to indicate that
-dracut should expect an `OEMDRV` device and not start the installer until it
-appears._
+_Because disks can take some time to appear, an additional delay of 5 seconds
+has been added.  This can be overridden by boot argument
+`inst.wait_for_disks=<value>` to let dracut wait up to <value> additional
+seconds (0 turns the feature off, causing dracut to only wait up to 500ms).
+Alternatively, if the `OEMDRV` device is known to be present but too slow to be
+autodetected, the user can boot with an argument like `inst.dd=hd:LABEL=OEMDRV`
+to indicate that dracut should expect an `OEMDRV` device and not start the
+installer until it appears._
 
 # DUD filesystem layout
 

--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -408,3 +408,18 @@ wait_for_updates() {
 wait_for_dd() {
     echo "[ -e /tmp/dd.done ]" > $hookdir/initqueue/finished/dd.sh
 }
+
+wait_for_disks() {
+    # Allow up to 'inst.wait_for_disks' seconds for disks to be enumerated and
+    # related udev rules to execute (defaults to 5 seconds, 0 disables the
+    # feature). This prevents dracut-initqueue from finishing early.
+    # Since a 0.5 second delay is used between two runs of dracut-initqueue, we
+    # force the latter to retry up to twice the value configured, e.g:
+    # 'inst.wait_for_disks=15' --> force looping 30 times at least
+    # 'inst.wait_for_disks=0'  --> force looping 0 times (so no wait time)
+    finished_hook="$hookdir/initqueue/finished/wait_for_disks.sh"
+    [ -e "$finished_hook" ] && return
+    DISKS_WAIT_DELAY=$(getargnum 5 0 10000 inst.wait_for_disks)
+    DISKS_WAIT_RETRIES=$((DISKS_WAIT_DELAY * 2))
+    echo "[ \"\$main_loop\" -ge \"$DISKS_WAIT_RETRIES\" ]" > "$finished_hook"
+}

--- a/dracut/driver-updates-genrules.sh
+++ b/dracut/driver-updates-genrules.sh
@@ -42,6 +42,7 @@ for dd in $DD_OEMDRV $DD_DISKS; do
             when_diskdev_appears "$(disk_to_dev_path $dd)" \
                 driver-updates --disk $dd_whitespace_fix \$devnode
         fi
+        wait_for_disks
     fi
 done
 

--- a/dracut/kickstart-genrules.sh
+++ b/dracut/kickstart-genrules.sh
@@ -34,6 +34,7 @@ case "${kickstart%%:*}" in
         if [ -z "$kickstart" -a -z "$(getarg ks= inst.ks=)" ]; then
             when_diskdev_appears $(disk_to_dev_path LABEL=OEMDRV) \
                 fetch-kickstart-disk \$env{DEVNAME} "/ks.cfg"
+            wait_for_disks
         fi
     ;;
 esac


### PR DESCRIPTION
OEMDRV disk is used for both Driver Update and Kickstart.
When booting with the DVD and an additional OEMDRV disk, it appears that
the udev rule setting the script to fetch the kickstart may not run at
the time /dev/root was found on the DVD, causing the kickstart to not be
processed at all.
This patch delays 'settled' initqueue by 5 seconds by default when no
'inst.ks' is specified on the kernel command line, which is enough to
process the OEMDRV disk.
Because the same issue may appear with Driver Updates, that same delay
applies unless 'inst.dd' is explicitly specified.
Old behavior can be restored with adding 'inst.wait_for_disks=0' on the
kernel command line.

Backport of https://github.com/rhinstaller/anaconda/pull/4586

*Resolves: rhbz#1770969*