### PR TITLE
conf: Missing geolocation provider URL disables it

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -331,4 +331,6 @@ eula =
 #   https://geoip.fedoraproject.org/city
 #   https://api.hostip.info/get_json.php
 #
+# If left empty, geolocation does not run.
+#
 geolocation_provider = https://geoip.fedoraproject.org/city

--- a/pyanaconda/modules/timezone/initialization.py
+++ b/pyanaconda/modules/timezone/initialization.py
@@ -39,6 +39,10 @@ class GeolocationTask(Task):
     def run(self):
         url = conf.timezone.geolocation_provider
 
+        if not url:
+            log.info("Geoloc: skipping because no provider was set")
+            return GeolocationData()
+
         log.info("Geoloc: starting lookup using provider: %s", url)
         start_time = time.time()
 

--- a/tests/unit_tests/pyanaconda_tests/modules/timezone/test_timezone_geoloc.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/timezone/test_timezone_geoloc.py
@@ -190,6 +190,22 @@ class GeolocationTaskRunTest(TestCase):
         wfn_mock.assert_called_once_with()
         loc_mock.assert_called_once()
 
+    @patch("pyanaconda.modules.timezone.initialization.conf")
+    def test_empty_url(self, conf_mock):
+        """Test GeolocationTask with no viable result"""
+        conf_mock.timezone.geolocation_provider = ""
+        retval = GeolocationData()  # empty by default
+
+        with patch.object(GeolocationTask, "_wait_for_network", return_value=True) as wfn_mock:
+            with patch.object(GeolocationTask, "_locate", return_value=retval) as loc_mock:
+                task = GeolocationTask()
+                result = task.run()
+
+        assert isinstance(result, GeolocationData)
+        assert result.is_empty()
+        wfn_mock.assert_not_called()
+        loc_mock.assert_not_called()
+
 
 class MockNetworkProxy:
     """A mock Network module proxy with the Connected property


### PR DESCRIPTION
SSIA. This adds a quick and simple way of disabling geolocation.