### PR TITLE
anaconda-ci: Dockerfile: Force nodejs 18 on Rawhide

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -51,7 +51,6 @@ RUN set -ex; \
   # Install rest of the dependencies
   dnf install -y \
   /usr/bin/xargs \
-  npm \
   rpm-build \
   git \
   bzip2 \
@@ -70,7 +69,12 @@ RUN set -ex; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   # xisxwayland is specifically excluded because it isn't in ELN
   rpmspec -q --requires /tmp/anaconda.spec | grep -v anaconda | grep -v xisxwayland | xargs -d '\n' dnf install -y; \
-  dnf clean all
+  dnf clean all; \
+  if [ $BRANCH == "rawhide" ]; then \
+    # HACK: nodejs 20 is very segfaulty: https://bugzilla.redhat.com/show_bug.cgi?id=2190075
+    dnf install -y nodejs18; \
+    ln -sfn node-18 /usr/bin/node; \
+  fi;
 
 RUN pip install --no-cache-dir --upgrade pip; \
   pip install --no-cache-dir -r /root/requirements.txt

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -31,7 +31,6 @@ RUN set -ex; \
   # Install dependencies
   dnf install -y \
   'dnf-command(copr)' \
-  npm \
   git \
   curl \
   python3-polib \
@@ -51,6 +50,11 @@ RUN set -ex; \
   cat /root/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   dnf clean all; \
-  mkdir /anaconda
+  mkdir /anaconda; \
+  if [ $BRANCH == "rawhide" ]; then \
+    # HACK: nodejs 20 is very segfaulty: https://bugzilla.redhat.com/show_bug.cgi?id=2190075
+    dnf install -y nodejs18; \
+    ln -sfn node-18 /usr/bin/node; \
+  fi;
 
 WORKDIR /anaconda


### PR DESCRIPTION
nodejs 20 crashes left and right, see
https://bugzilla.redhat.com/show_bug.cgi?id=2190075

Install the previous nodejs 18 for now, and update the /usr/bin/node symlink to point to 18.

