### PR TITLE
DNS kickstart options for RHEL 8

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -33,7 +33,7 @@ Source0: %{name}-%{version}.tar.bz2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.16.15-1
+%define pykickstartver 3.16.16-1
 %define pypartedver 2.5-2
 %define rpmver 4.10.0
 %define simplelinever 1.1.3-1

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -54,7 +54,7 @@ from pykickstart.commands.url import RHEL8_Url as Url
 from pykickstart.commands.updates import F7_Updates as Updates
 from pykickstart.commands.mediacheck import FC4_MediaCheck as MediaCheck
 from pykickstart.commands.driverdisk import F14_DriverDisk as DriverDisk
-from pykickstart.commands.network import F27_Network as Network
+from pykickstart.commands.network import RHEL8_Network as Network
 from pykickstart.commands.displaymode import F26_DisplayMode as DisplayMode
 from pykickstart.commands.bootloader import RHEL8_Bootloader as Bootloader
 
@@ -505,6 +505,16 @@ def ksnet_to_ifcfg(net, filename=None):
     if net.bootProto == 'dhcp':
         if net.hostname:
             ifcfg['DHCP_HOSTNAME'] = net.hostname
+
+    # DNS search domains etc.
+    if net.ipv4_dns_search:
+        ifcfg['DOMAIN'] = str(net.ipv4_dns_search).replace(",", " ")
+    if net.ipv6_dns_search:
+        ifcfg['IPV6_DOMAIN'] = str(net.ipv6_dns_search).replace(",", " ")
+    if net.ipv4_ignore_auto_dns:
+        ifcfg['PEERDNS'] = "no"
+    if net.ipv6_ignore_auto_dns:
+        ifcfg['IPV6_PEERDNS'] = "no"
 
     # ipv6 settings
     if net.noipv6:

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -18,7 +18,7 @@
 # Red Hat, Inc.
 #
 
-# Diable unused imports for the whole module.
+# Disable unused imports for the whole module.
 # pylint:disable=unused-import
 
 # Supported kickstart commands.
@@ -56,7 +56,7 @@ from pykickstart.commands.mediacheck import FC4_MediaCheck as MediaCheck
 from pykickstart.commands.method import F28_Method as Method
 from pykickstart.commands.mount import F27_Mount as Mount
 from pykickstart.commands.multipath import F24_MultiPath as MultiPath
-from pykickstart.commands.network import F27_Network as Network
+from pykickstart.commands.network import RHEL8_Network as Network
 from pykickstart.commands.nfs import FC6_NFS as NFS
 from pykickstart.commands.nvdimm import F28_Nvdimm as Nvdimm
 from pykickstart.commands.ostreesetup import RHEL8_OSTreeSetup as OSTreeSetup
@@ -99,7 +99,7 @@ from pykickstart.commands.iscsi import F17_IscsiData as IscsiData
 from pykickstart.commands.logvol import RHEL8_LogVolData as LogVolData
 from pykickstart.commands.mount import F27_MountData as MountData
 from pykickstart.commands.multipath import FC6_MultiPathData as MultiPathData
-from pykickstart.commands.network import F27_NetworkData as NetworkData
+from pykickstart.commands.network import RHEL8_NetworkData as NetworkData
 from pykickstart.commands.nvdimm import F28_NvdimmData as NvdimmData
 from pykickstart.commands.partition import RHEL8_PartData as PartData
 from pykickstart.commands.raid import RHEL8_RaidData as RaidData

--- a/pyanaconda/modules/network/ifcfg.py
+++ b/pyanaconda/modules/network/ifcfg.py
@@ -372,6 +372,16 @@ def get_kickstart_network_data(ifcfg, nm_client, network_data_class, root_path="
     if iface:
         kwargs["device"] = iface
 
+    # DNS search etc.
+    if ifcfg.get("DOMAIN"):
+        kwargs["ipv4_dns_search"] = ifcfg.get("DOMAIN").replace(" ", ",")
+    if ifcfg.get("IPV6_DOMAIN"):
+        kwargs["ipv6_dns_search"] = ifcfg.get("IPV6_DOMAIN").replace(" ", ",")
+    if ifcfg.get("PEERDNS") == "no":
+        kwargs["ipv4_ignore_auto_dns"] = True
+    if ifcfg.get("IPV6_PEERDNS") == "no":
+        kwargs["ipv6_ignore_auto_dns"] = True
+
     # bonding
     # FIXME: dracut has only BOND_OPTS
     if ifcfg.get("BONDING_MASTER") == "yes" or ifcfg.get("TYPE") == "Bond":

--- a/pyanaconda/modules/network/nm_client.py
+++ b/pyanaconda/modules/network/nm_client.py
@@ -1,7 +1,7 @@
 #
 # utility functions using libnm
 #
-# Copyright (C) 2018 Red Hat, Inc.
+# Copyright (C) 2018-2023 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -735,6 +735,20 @@ def update_connection_ip_settings_from_ksdata(connection, network_data):
                 s_ip4.add_dns(ns)
             else:
                 log.error("IP address %s is not valid", ns)
+
+    # DNS search domains
+    if network_data.ipv4_dns_search:
+        for domain in [str.strip(i) for i in network_data.ipv4_dns_search.split(",")]:
+            s_ip4.add_dns_search(domain)
+    if network_data.ipv6_dns_search:
+        for domain in [str.strip(i) for i in network_data.ipv6_dns_search.split(",")]:
+            s_ip6.add_dns_search(domain)
+
+    # ignore auto DNS
+    if network_data.ipv4_ignore_auto_dns:
+        s_ip4.props.ignore_auto_dns = network_data.ipv4_ignore_auto_dns
+    if network_data.ipv6_ignore_auto_dns:
+        s_ip6.props.ignore_auto_dns = network_data.ipv6_ignore_auto_dns
 
 
 def update_connection_wired_settings_from_ksdata(connection, network_data):


### PR DESCRIPTION
Sort-of-but-not-really-port of #4571 to RHEL-8.

This is a nearly complete rewrite, many thanks to @rvykydal's advice and guidance with ifcfg.