### PR TITLE
Load translations on the fly - eval approach

### DIFF
--- a/ui/webui/src/components/Common.jsx
+++ b/ui/webui/src/components/Common.jsx
@@ -20,6 +20,7 @@ import { Popover, PopoverPosition } from "@patternfly/react-core";
 
 export const AddressContext = createContext("");
 export const ConfContext = createContext();
+export const LanguageContext = createContext("");
 
 export const sleep = ({ seconds }) => {
     return new Promise(resolve => setTimeout(resolve, seconds * 1000));

--- a/ui/webui/src/components/app.jsx
+++ b/ui/webui/src/components/app.jsx
@@ -23,7 +23,7 @@ import {
     Page,
 } from "@patternfly/react-core";
 
-import { AddressContext } from "./Common.jsx";
+import { AddressContext, LanguageContext } from "./Common.jsx";
 import { AnacondaHeader } from "./AnacondaHeader.jsx";
 import { AnacondaWizard } from "./AnacondaWizard.jsx";
 import { HelpDrawer } from "./HelpDrawer.jsx";
@@ -42,6 +42,7 @@ export const Application = () => {
     const [address, setAddress] = useState();
     const [beta, setBeta] = useState();
     const [conf, setConf] = useState();
+    const [language, setLanguage] = useState();
     const [notifications, setNotifications] = useState({});
     const [isHelpExpanded, setIsHelpExpanded] = useState(false);
     const [helpContent, setHelpContent] = useState("");
@@ -141,12 +142,14 @@ export const Application = () => {
     );
 
     return (
-        <HelpDrawer
-          isExpanded={isHelpExpanded}
-          setIsExpanded={setIsHelpExpanded}
-          helpContent={helpContent}
-        >
-            {page}
-        </HelpDrawer>
+        <LanguageContext.Provider value={{ language, setLanguage }}>
+            <HelpDrawer
+              isExpanded={isHelpExpanded}
+              setIsExpanded={setIsHelpExpanded}
+              helpContent={helpContent}
+            >
+                {page}
+            </HelpDrawer>
+        </LanguageContext.Provider>
     );
 };

--- a/ui/webui/src/components/localization/InstallationLanguage.jsx
+++ b/ui/webui/src/components/localization/InstallationLanguage.jsx
@@ -34,7 +34,7 @@ import {
 } from "@patternfly/react-core";
 
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
-import { AddressContext } from "../Common.jsx";
+import { AddressContext, LanguageContext } from "../Common.jsx";
 import { setLocale } from "../../apis/boss.js";
 
 import {
@@ -299,6 +299,7 @@ LanguageSelector.contextType = AddressContext;
 
 export const InstallationLanguage = ({ idPrefix, setIsFormValid, onAddErrorNotification }) => {
     const [nativeName, setNativeName] = React.useState(false);
+    const { setLanguage } = React.useContext(LanguageContext);
 
     return (
         <AnacondaPage title={_("Welcome to the Anaconda installer")}>
@@ -326,6 +327,7 @@ export const InstallationLanguage = ({ idPrefix, setIsFormValid, onAddErrorNotif
                       setIsFormValid={setIsFormValid}
                       onAddErrorNotification={onAddErrorNotification}
                       getNativeName={setNativeName}
+                      reRenderApp={setLanguage}
                     />
                 </FormGroup>
             </Form>

--- a/ui/webui/src/components/localization/InstallationLanguage.jsx
+++ b/ui/webui/src/components/localization/InstallationLanguage.jsx
@@ -236,7 +236,19 @@ class LanguageSelector extends React.Component {
                                 .catch(this.props.onAddErrorNotification);
                         this.setState({ lang: item });
                         this.updateNativeName(localeItem);
-                        window.location.reload(true);
+                        fetch("po.js").then(response => response.text())
+                                .then(body => {
+                                    // always reset old translations
+                                    cockpit.locale(null);
+                                    // en_US is always null
+                                    if (body.trim() === "") {
+                                        cockpit.locale(null);
+                                    } else {
+                                        // eslint-disable-next-line no-eval
+                                        eval(body);
+                                    }
+                                    this.props.reRenderApp(item);
+                                });
                         return;
                     }
                 }

--- a/ui/webui/src/manifest.json
+++ b/ui/webui/src/manifest.json
@@ -3,6 +3,7 @@
         "cockpit": "137"
     },
 
+    "content-security-policy": "default-src 'self' 'unsafe-eval'",
     "tools": {
         "index": {
             "label": "Anaconda"


### PR DESCRIPTION
Cockpit's translations are served as `po.js` which returns the language depending on the set browser cookie. The served `po.js` is a JavaScript file which executes `cockpit.locale({ ...locale data })`.

To make the application reload on the fly three things need to happen:
- set the relevant cookie
- fetch the new translations and execute them. As well it's a JavaScript file.
- force React to re-render the whole application

The `eval()` here is quite evil, even serving po's as json won't be an easy task as it's the locale data content is a JavaScript Object with a function which cannot be serialised to JSON. There is a function in the translation data as `cockpit.ngettext` needs to figure out which variant to pick which can have multiple forms for example in Polish it is `"plural-forms": (n) => n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2,`