### PR TITLE
WebUI: close embedded panel when clicking prev/next

### DIFF
--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -41,7 +41,7 @@ import { resetPartitioning } from "../apis/storage.js";
 
 const _ = cockpit.gettext;
 
-export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, title, conf }) => {
+export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, hideContextHelp, title, conf }) => {
     const [isFormValid, setIsFormValid] = useState(true);
     const [stepNotification, setStepNotification] = useState();
     const [isInProgress, setIsInProgress] = useState(false);
@@ -154,6 +154,7 @@ export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, titl
         setIsFormValid(true);
 
         cockpit.location.go([newStep.id]);
+        hideContextHelp();
     };
 
     return (

--- a/ui/webui/src/components/app.jsx
+++ b/ui/webui/src/components/app.jsx
@@ -133,6 +133,7 @@ export const Application = () => {
                 <AnacondaWizard
                   onAddErrorNotification={onAddErrorNotification}
                   toggleContextHelp={toggleContextHelp}
+                  hideContextHelp={() => setIsHelpExpanded(false)}
                   title={title}
                   conf={conf}
                 />

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -465,7 +465,7 @@ export const InstallationDestination = ({ idPrefix, setIsFormValid, onAddErrorNo
                         "$0 of available space. Storage will be automatically partitioned."
                     ), cockpit.format_bytes(requiredSize))}
                     {" "}
-                    <Button variant="link" isInline onClick={toggleHelpStorageOptions}>
+                    <Button id="learn-more-about-storage-options" variant="link" isInline onClick={toggleHelpStorageOptions}>
                         {_("Learn more about your storage options.")}
                     </Button>
                 </Text>

--- a/ui/webui/test/check-progress
+++ b/ui/webui/test/check-progress
@@ -18,6 +18,7 @@
 import anacondalib
 
 from installer import Installer
+from storage import Storage
 from testlib import test_main  # pylint: disable=import-error
 
 
@@ -29,13 +30,21 @@ class TestInstallationProgress(anacondalib.VirtInstallMachineCase):
 
         b = self.browser
         i = Installer(b, self.machine)
+        s = Storage(b, self.machine)
 
         i.open()
+        drawer_open = False
 
         for page in i.steps[:-1]:
             # with the pages basically empty of common elements (as those are provided by the top-level installer widget)
             # we at least iterate over them to check this works as expected
             i.wait_current_page(page)
+            if drawer_open:
+                self.assertFalse(i.is_drawer_open())
+            if page == i.steps.STORAGE_DEVICES:
+                # Open the help drawer, which should go away when pressing next.
+                s.open_storage_options_help_drawer()
+                drawer_open = True
             if page != i.steps.REVIEW:
                 i.next()
             else:

--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -131,3 +131,6 @@ class Installer():
         self.browser.click("#installation-quit-btn")
         self.browser.wait_visible("#installation-quit-confirm-dialog")
         self.browser.click("#installation-quit-confirm-btn")
+
+    def is_drawer_open(self):
+        return self.browser.is_present(".pf-c-drawer__panel-main")

--- a/ui/webui/test/helpers/storage.py
+++ b/ui/webui/test/helpers/storage.py
@@ -204,3 +204,7 @@ class Storage():
             fi
         ''')
         self.machine.execute('chroot /mnt/sysroot bash /root/add_keyfile.sh')
+
+    def open_storage_options_help_drawer(self):
+        self.browser.click(".pf-c-wizard__main-body #learn-more-about-storage-options")
+        self.browser.wait_visible(".pf-c-drawer__panel-main")


### PR DESCRIPTION
When the Storage drawer is opened, automatically close it when clicking previous or next.

Resolves: INSTALLER-3405