### PR TITLE
Save selected storage scenario in state

### DIFF
--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -30,7 +30,7 @@ import {
 } from "@patternfly/react-core";
 
 import { InstallationDestination, applyDefaultStorage } from "./storage/InstallationDestination.jsx";
-import { StorageConfiguration, getScenario } from "./storage/StorageConfiguration.jsx";
+import { StorageConfiguration, getScenario, getDefaultScenario } from "./storage/StorageConfiguration.jsx";
 import { DiskEncryption, StorageEncryptionState } from "./storage/DiskEncryption.jsx";
 import { InstallationLanguage } from "./localization/InstallationLanguage.jsx";
 import { InstallationProgress } from "./installation/InstallationProgress.jsx";
@@ -47,7 +47,7 @@ export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, titl
     const [isInProgress, setIsInProgress] = useState(false);
     const [storageEncryption, setStorageEncryption] = useState(new StorageEncryptionState());
     const [showPassphraseScreen, setShowPassphraseScreen] = useState(false);
-    const [storageScenarioId, setStorageScenarioId] = useState("use-free-space");
+    const [storageScenarioId, setStorageScenarioId] = useState(getDefaultScenario().id);
 
     const stepsOrder = [
         {

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -47,7 +47,7 @@ export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, titl
     const [isInProgress, setIsInProgress] = useState(false);
     const [storageEncryption, setStorageEncryption] = useState(new StorageEncryptionState());
     const [showPassphraseScreen, setShowPassphraseScreen] = useState(false);
-    const [storageScenarioId, setStorageScenarioId] = useState(getDefaultScenario().id);
+    const [storageScenarioId, setStorageScenarioId] = useState(window.sessionStorage.getItem("storage-scenario-id") || getDefaultScenario().id);
 
     const stepsOrder = [
         {
@@ -136,7 +136,11 @@ export const AnacondaWizard = ({ onAddErrorNotification, toggleContextHelp, titl
                           storageEncryption={storageEncryption}
                           setStorageEncryption={setStorageEncryption}
                           showPassphraseScreen={showPassphraseScreen}
-                          setStorageScenarioId={setStorageScenarioId}
+                          storageScenarioId={storageScenarioId}
+                          setStorageScenarioId={(scenarioId) => {
+                              window.sessionStorage.setItem("storage-scenario-id", scenarioId);
+                              setStorageScenarioId(scenarioId);
+                          }}
                         />
                     ),
                 });

--- a/ui/webui/src/components/review/ReviewConfiguration.jsx
+++ b/ui/webui/src/components/review/ReviewConfiguration.jsx
@@ -35,7 +35,6 @@ import {
     getDeviceData,
     getAppliedPartitioning,
     getPartitioningRequest,
-    getInitializationMode,
 } from "../../apis/storage.js";
 
 import {
@@ -43,7 +42,7 @@ import {
 } from "../../apis/localization.js";
 import { AnacondaPage } from "../AnacondaPage.jsx";
 
-import { scenarioForInitializationMode, getScenario } from "../storage/StorageConfiguration.jsx";
+import { getScenario } from "../storage/StorageConfiguration.jsx";
 
 const _ = cockpit.gettext;
 
@@ -65,13 +64,12 @@ export const ReviewDescriptionList = ({ children }) => {
     );
 };
 
-export const ReviewConfiguration = ({ idPrefix, setStorageScenarioId }) => {
+export const ReviewConfiguration = ({ idPrefix, storageScenarioId }) => {
     const [deviceData, setDeviceData] = useState({});
     const [selectedDisks, setSelectedDisks] = useState();
     const [systemLanguage, setSystemLanguage] = useState();
     const [disksExpanded, setDisksExpanded] = useState();
     const [encrypt, setEncrypt] = useState();
-    const [storageScenario, setStorageScenario] = useState();
 
     useEffect(() => {
         const initializeLanguage = async () => {
@@ -93,25 +91,13 @@ export const ReviewConfiguration = ({ idPrefix, setStorageScenarioId }) => {
             const request = await getPartitioningRequest({ partitioning }).catch(console.error);
             setEncrypt(request.encrypted.v);
         };
-        const initializeScenario = async () => {
-            const mode = await getInitializationMode().catch(console.error);
-            setStorageScenario(scenarioForInitializationMode(mode).id);
-        };
         initializeLanguage();
         initializeDisks();
         initializeEncrypt();
-        initializeScenario();
     }, []);
 
-    useEffect(() => {
-        if (typeof storageScenario !== "undefined") {
-            setStorageScenarioId(storageScenario);
-            console.log("Global storageScenario id set to", storageScenario);
-        }
-    }, [storageScenario, setStorageScenarioId]);
-
     // handle case of disks not (yet) loaded
-    if (!selectedDisks || !systemLanguage || !storageScenario) {
+    if (!selectedDisks || !systemLanguage) {
         return null;
     }
 
@@ -136,7 +122,7 @@ export const ReviewConfiguration = ({ idPrefix, setStorageScenarioId }) => {
               title={_("To prevent loss, make sure to backup your data. ")}
             >
                 <p>
-                    {getScenario(storageScenario).screenWarning}
+                    {getScenario(storageScenarioId).screenWarning}
                 </p>
             </Alert>
             <ExpandableSection
@@ -173,7 +159,7 @@ export const ReviewConfiguration = ({ idPrefix, setStorageScenarioId }) => {
                         {_("Storage Configuration")}
                     </DescriptionListTerm>
                     <DescriptionListDescription id={idPrefix + "-target-system-mode"}>
-                        {getScenario(storageScenario).label}
+                        {getScenario(storageScenarioId).label}
                     </DescriptionListDescription>
                     <DescriptionListTerm>
                         {_("Disk Encryption")}

--- a/ui/webui/src/components/storage/StorageConfiguration.jsx
+++ b/ui/webui/src/components/storage/StorageConfiguration.jsx
@@ -184,6 +184,10 @@ export const scenarioForInitializationMode = (mode) => {
     }
 };
 
+export const getDefaultScenario = () => {
+    return scenarios.filter(s => s.default)[0];
+};
+
 const scenarioDetailContent = (scenario, hint) => {
     return (
         <Flex direction={{ default: "column" }}>

--- a/ui/webui/src/components/storage/StorageConfiguration.jsx
+++ b/ui/webui/src/components/storage/StorageConfiguration.jsx
@@ -56,7 +56,6 @@ import {
     getDiskTotalSpace,
     getDiskFreeSpace,
     getSelectedDisks,
-    getInitializationMode,
     setInitializationMode,
 } from "../../apis/storage.js";
 
@@ -224,7 +223,7 @@ const predefinedStorageInfo = (
 );
 
 // TODO add aria items
-const GuidedPartitioning = ({ idPrefix, scenarios, setIsFormValid }) => {
+const GuidedPartitioning = ({ idPrefix, scenarios, storageScenarioId, setStorageScenarioId, setIsFormValid }) => {
     const [selectedScenario, setSelectedScenario] = useState();
     const [scenarioAvailability, setScenarioAvailability] = useState(Object.fromEntries(
         scenarios.map((s) => [s.id, new AvailabilityState()])
@@ -237,7 +236,6 @@ const GuidedPartitioning = ({ idPrefix, scenarios, setIsFormValid }) => {
             const requiredSpace = await getRequiredSpace();
             const requiredSize = await getRequiredDeviceSize({ requiredSpace });
             const selectedDisks = await getSelectedDisks();
-            const initializationMode = await getInitializationMode();
             let selectedScenarioId = "";
             let availableScenarioExists = false;
             for await (const scenario of scenarios) {
@@ -245,7 +243,7 @@ const GuidedPartitioning = ({ idPrefix, scenarios, setIsFormValid }) => {
                 setScenarioAvailability(ss => ({ ...ss, [scenario.id]: availability }));
                 if (availability.available) {
                     availableScenarioExists = true;
-                    if (scenario.initializationMode === initializationMode) {
+                    if (scenario.id === storageScenarioId) {
                         console.log(`Selecting backend scenario ${scenario.id}`);
                         selectedScenarioId = scenario.id;
                     }
@@ -260,18 +258,19 @@ const GuidedPartitioning = ({ idPrefix, scenarios, setIsFormValid }) => {
         };
 
         updateScenarioState(scenarios);
-    }, [scenarios, setIsFormValid]);
+    }, [scenarios, setIsFormValid, storageScenarioId]);
 
     useEffect(() => {
         const applyScenario = async (scenarioId) => {
             const scenario = getScenario(scenarioId);
+            setStorageScenarioId(scenarioId);
             console.log("Updating scenario selected in backend to", scenario.id);
             await setInitializationMode({ mode: scenario.initializationMode }).catch(console.error);
         };
         if (selectedScenario) {
             applyScenario(selectedScenario);
         }
-    }, [scenarios, selectedScenario]);
+    }, [scenarios, selectedScenario, setStorageScenarioId]);
 
     const updateDetailContent = (scenarioId) => {
         const scenario = getScenario(scenarioId);
@@ -364,7 +363,7 @@ const GuidedPartitioning = ({ idPrefix, scenarios, setIsFormValid }) => {
     );
 };
 
-export const StorageConfiguration = ({ idPrefix, setIsFormValid }) => {
+export const StorageConfiguration = ({ idPrefix, setIsFormValid, storageScenarioId, setStorageScenarioId }) => {
     return (
         <AnacondaPage title={_("Select a storage configuration")}>
             <TextContent>
@@ -374,6 +373,8 @@ export const StorageConfiguration = ({ idPrefix, setIsFormValid }) => {
               idPrefix={idPrefix}
               scenarios={scenarios}
               setIsFormValid={setIsFormValid}
+              storageScenarioId={storageScenarioId}
+              setStorageScenarioId={setStorageScenarioId}
             />
         </AnacondaPage>
     );


### PR DESCRIPTION
This is preparation work for the custom mount storage configuration, to not make a giant PR with a bunch of changes I've split this up into it's own PR.

Additionally as the initialisation method was stored by the Anaconda daemon, I wanted retain that behaviour in some form as a user could accidentally refresh the browser tab. I've opted to store the storage configuration in sessionstorage instead of localstorage as localstorage is more or less permanent. SessionStorage survives a refresh, but should go away once the user closes their browser session.