### PR TITLE
Rhel 8 tweak kickstart version test

### DIFF
--- a/tests/nosetests/pyanaconda_tests/kickstart_specification_test.py
+++ b/tests/nosetests/pyanaconda_tests/kickstart_specification_test.py
@@ -18,6 +18,7 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+import warnings
 from textwrap import dedent
 
 from pykickstart.errors import KickstartParseError
@@ -395,6 +396,10 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
         UsersKickstartSpecification,
     ]
 
+    # Names of the kickstart commands and data that should be temporarily ignored.
+    IGNORED_NAMES = {
+    }
+
     def setUp(self):
         pykickstart_handler = kickstart.superclass
         self.pykickstart_commands = pykickstart_handler.commandMap
@@ -404,6 +409,11 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
         """Check if children inherit from parents."""
         for name in children:
             print("Checking command {}...".format(name))
+
+            if name in self.IGNORED_NAMES:
+                warnings.warn("Skipping the kickstart name {}.".format(name))
+                continue
+
             self.assertIsInstance(children[name](), parents[name])
 
     def version_test(self):

--- a/tests/nosetests/pyanaconda_tests/kickstart_specification_test.py
+++ b/tests/nosetests/pyanaconda_tests/kickstart_specification_test.py
@@ -398,6 +398,8 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
 
     # Names of the kickstart commands and data that should be temporarily ignored.
     IGNORED_NAMES = {
+        "network",
+        "NetworkData"
     }
 
     def setUp(self):

--- a/tests/nosetests/pyanaconda_tests/ks_version_test.py
+++ b/tests/nosetests/pyanaconda_tests/ks_version_test.py
@@ -27,6 +27,7 @@ class CommandVersionTestCase(unittest.TestCase):
 
     # Names of the kickstart commands and data that should be temporarily ignored.
     IGNORED_NAMES = {
+        "network"
     }
 
     def assert_compare_versions(self, children, parents):


### PR DESCRIPTION
Ignore `network` new kickstart command version in tests.

It will be resolved after https://github.com/rhinstaller/anaconda/pull/4736 is merged but until then let's ignore this specific test.

As part of this fix I add possibility to ignore the test for new KickstartSpecifications.