### PR TITLE
Rhel 9 - Ignore pykickstart network version test

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
+++ b/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
@@ -405,6 +405,8 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
 
     # Names of the kickstart commands and data that should be temporarily ignored.
     IGNORED_NAMES = {
+        "network",
+        "NetworkData"
     }
 
     # Names of shared kickstart commands and data that should be temporarily ignored.

--- a/tests/unit_tests/pyanaconda_tests/test_ks_version.py
+++ b/tests/unit_tests/pyanaconda_tests/test_ks_version.py
@@ -27,6 +27,7 @@ class CommandVersionTestCase(unittest.TestCase):
 
     # Names of the kickstart commands and data that should be temporarily ignored.
     IGNORED_NAMES = {
+        "network"
     }
 
     def assert_compare_versions(self, children, parents):


### PR DESCRIPTION
Ignore `network` new kickstart command version in tests.

It will be resolved after https://github.com/rhinstaller/anaconda/pull/4571 is merged but until then let's ignore this specific test.

As part of this fix I add possibility to ignore the test for new KickstartSpecifications.