### PR TITLE
webui: use the reason in title of disabled partitioing warning

### DIFF
--- a/ui/webui/src/components/storage/StorageConfiguration.jsx
+++ b/ui/webui/src/components/storage/StorageConfiguration.jsx
@@ -117,9 +117,9 @@ const checkEraseAll = async (selectedDisks, requiredSize) => {
         availability.available = false;
         availability.reason = _("Not enough space on selected disks.");
         availability.hint = cockpit.format(_(
-            "There is not enough space on the selected disks. " +
-            "The installation requires $1 of available space " +
-            "while there is only $0 of space available."
+            "There is not enough space on the disks to install. " +
+            "The installation needs $1 of disk space; " +
+            "however, the capacity of the selected disks is only $0."
         ), cockpit.format_bytes(size), cockpit.format_bytes(requiredSize));
         availability.shortHint = _("To enable select bigger disks");
     }
@@ -131,11 +131,11 @@ const checkUseFreeSpace = async (selectedDisks, requiredSize) => {
     const availability = new AvailabilityState();
     if (size < requiredSize) {
         availability.available = false;
-        availability.reason = _("Not enough space on selected disks.");
+        availability.reason = _("Not enough free space.");
         availability.hint = cockpit.format(_(
-            "There is not enough free space on the selected disks. " +
-            "The installation requires $1 of available space " +
-            "while there is only $0 of free space available."
+            "There is not enough available free space to install. " +
+            "The installation needs $1 of available disk space; " +
+            "however, only $0 is currently available on the selected disks."
         ), cockpit.format_bytes(size), cockpit.format_bytes(requiredSize));
         availability.shortHint = _("To enable free up disk space");
     }
@@ -187,7 +187,7 @@ export const getDefaultScenario = () => {
     return scenarios.filter(s => s.default)[0];
 };
 
-const scenarioDetailContent = (scenario, hint) => {
+const scenarioDetailContent = (scenario, reason, hint) => {
     return (
         <Flex direction={{ default: "column" }}>
             <Title headingLevel="h3">
@@ -197,7 +197,7 @@ const scenarioDetailContent = (scenario, hint) => {
                 <Alert
                   id="scenario-disabled-hint"
                   isInline
-                  title={_("This option is disabled")}
+                  title={reason}
                   variant="warning"
                 >
                     {hint}
@@ -274,8 +274,9 @@ const GuidedPartitioning = ({ idPrefix, scenarios, storageScenarioId, setStorage
 
     const updateDetailContent = (scenarioId) => {
         const scenario = getScenario(scenarioId);
+        const reason = scenarioAvailability[scenarioId].reason;
         const hint = scenarioAvailability[scenarioId].hint;
-        setDetailContent(scenarioDetailContent(scenario, hint));
+        setDetailContent(scenarioDetailContent(scenario, reason, hint));
     };
 
     const onScenarioToggled = (scenarioId) => {


### PR DESCRIPTION
Microcopy update suggested by Allison and Sagar.
The title in help panel is using the reason for disabling.
The warning text in help panel was updated.
For Use free space also the alert text under the option was updated.

INSTALLER-3406

"Erase data and install"
Old:
![erase_data_old](https://github.com/rhinstaller/anaconda/assets/1220237/15688c2e-71b9-44a1-adfa-af4d5586fdce)
New:
![erase_data_new](https://github.com/rhinstaller/anaconda/assets/1220237/3df99f02-00ec-490a-8c31-d02bfb62f10f)

"Use free space..."
Old:
![use_free_space_old](https://github.com/rhinstaller/anaconda/assets/1220237/779aa95c-2384-4cfc-811c-f87dbd722163)
New:
![use_free_space_new](https://github.com/rhinstaller/anaconda/assets/1220237/90da6a00-4a90-4e1b-b128-82667344f0a6)