### PR TITLE
Change driver_updates exit info messages to debug (#2154904)

### DIFF
--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -917,6 +917,6 @@ if __name__ == '__main__':
     try:
         main(sys.argv[1:])
     except KeyboardInterrupt:
-        log.info("exiting.")
+        log.debug("exiting.")
 
-    log.info("leaving the driver_updates script")
+    log.debug("leaving the driver_updates script")


### PR DESCRIPTION
Users don't care about information that the script ended. Let's leave this just for debugging purpose.

Related: rhbz#2154904
(cherry picked from commit dde0b97ba953c480931c08881224ef6c20055c23)