### PR TITLE
Apply --noverifyssl option for liveimg kickstart command

### DIFF
--- a/pyanaconda/modules/payloads/source/live_image/initialization.py
+++ b/pyanaconda/modules/payloads/source/live_image/initialization.py
@@ -90,6 +90,7 @@ class SetUpRemoteImageSourceTask(Task):
         super().__init__()
         self._url = configuration.url
         self._proxy = configuration.proxy
+        self._ssl_verify = configuration.ssl_verification_enabled
 
     @property
     def name(self):
@@ -125,7 +126,7 @@ class SetUpRemoteImageSourceTask(Task):
         response = session.head(
             url=self._url,
             proxies=proxies,
-            verify=True,
+            verify=self._ssl_verify,
             timeout=NETWORK_CONNECTION_TIMEOUT
         )
 

--- a/pyanaconda/payload/live/payload_liveimg.py
+++ b/pyanaconda/payload/live/payload_liveimg.py
@@ -89,10 +89,11 @@ class LiveImagePayload(BaseLivePayload):
 
         error = None
         try:
+            ssl_verify = not self.data.liveimg.noverifyssl
             response = self._session.head(
                 self.data.liveimg.url,
                 proxies=self._proxies,
-                verify=True,
+                verify=ssl_verify,
                 timeout=NETWORK_CONNECTION_TIMEOUT
             )
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_image.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_image.py
@@ -23,10 +23,9 @@ from unittest.mock import patch, Mock
 
 from dasbus.typing import get_variant, Str, Bool
 from requests import RequestException
-
 from pyanaconda.modules.common.errors.payload import SourceSetupError
 
-from pyanaconda.core.constants import SOURCE_TYPE_LIVE_IMAGE
+from pyanaconda.core.constants import SOURCE_TYPE_LIVE_IMAGE, NETWORK_CONNECTION_TIMEOUT
 from pyanaconda.modules.common.constants.interfaces import PAYLOAD_SOURCE_LIVE_IMAGE
 from pyanaconda.modules.common.structures.live_image import LiveImageConfigurationData
 from pyanaconda.modules.payloads.constants import SourceType, SourceState
@@ -292,3 +291,30 @@ class SetUpRemoteImageSourceTaskTestCase(unittest.TestCase):
         # Check the result.
         assert isinstance(result, SetupImageResult)
         assert result == SetupImageResult(4000)
+
+    @patch("pyanaconda.modules.payloads.source.live_image.initialization.requests_session")
+    def test_https_no_verify_ssl(self, session_getter):
+        """Test a request with ssl verification disabled."""
+        # Prepare the session.
+        session = session_getter.return_value.__enter__.return_value
+        response = session.head.return_value
+
+        response.status_code = 200
+        response.headers = {'content-length': 1000}
+
+        # Run the task.
+        configuration = LiveImageConfigurationData()
+        configuration.url = "https://my/fake/path"
+        configuration.ssl_verification_enabled = False
+
+        task = SetUpRemoteImageSourceTask(configuration)
+        result = task.run()
+
+        # Check the result.
+        assert isinstance(result, SetupImageResult)
+        session.head.assert_called_once_with(
+            url="https://my/fake/path",
+            proxies={},
+            verify=False,
+            timeout=NETWORK_CONNECTION_TIMEOUT
+        )


### PR DESCRIPTION
Resolves: rhbz#2157921

Note: A simple backport of https://github.com/rhinstaller/anaconda/pull/4532 from the master branch didn't resolve the problem on RHEL-9, so I had to make additional changes in [pyanaconda/payload/live/payload_liveimg.py](https://github.com/rhinstaller/anaconda/compare/rhel-9...jstodola:anaconda:liveimg_noverifyssl_rhel9?expand=1#diff-a196f6e0524eab35afae8713c902fde4ccff2400341d8c0a8f81b9cc25382158). I'm leaving the change in [pyanaconda/modules/payloads/source/live_image/initialization.py](https://github.com/rhinstaller/anaconda/compare/rhel-9...jstodola:anaconda:liveimg_noverifyssl_rhel9?expand=1#diff-16b1a93e0b6ed5c26392f7c9700cf52ff2d7c4f999e50fda90bf6ff4b3fbc277) from https://github.com/rhinstaller/anaconda/pull/4532 in this PR just to keep this branch and master in sync.