### PR TITLE
WebUI: move alert under header for review screen

### DIFF
--- a/ui/webui/src/components/review/ReviewConfiguration.jsx
+++ b/ui/webui/src/components/review/ReviewConfiguration.jsx
@@ -103,6 +103,15 @@ export const ReviewConfiguration = ({ idPrefix, storageScenarioId }) => {
 
     return (
         <AnacondaPage title={_("Review and install")}>
+            <Alert
+              isInline
+              variant="warning"
+              title={_("To prevent loss, make sure to backup your data. ")}
+            >
+                <p>
+                    {getScenario(storageScenarioId).screenWarning}
+                </p>
+            </Alert>
             <ReviewDescriptionList>
                 <DescriptionListGroup>
                     <DescriptionListTerm>
@@ -116,15 +125,6 @@ export const ReviewConfiguration = ({ idPrefix, storageScenarioId }) => {
             <Title headingLevel="h3">
                 {_("Installation destination")}
             </Title>
-            <Alert
-              isInline
-              variant="warning"
-              title={_("To prevent loss, make sure to backup your data. ")}
-            >
-                <p>
-                    {getScenario(storageScenarioId).screenWarning}
-                </p>
-            </Alert>
             <ExpandableSection
               toggleText={_("Storage devices")}
               onToggle={() => setDisksExpanded(!disksExpanded)}


### PR DESCRIPTION
As part of the [re-designed review screen](https://issues.redhat.com/browse/INSTALLER-3486?focusedId=22300317&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22300317) the warning should be moved to the top.

Making this a separate PR as it's an easy independent change and I don't want to make the custom mount point PR too big :)