### PR TITLE
infra: Always try to make artefacts cleanable

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -283,6 +283,7 @@ jobs:
       # Needed so that other jobs are able to clean the working dir
       # FIXME: we should investigate running permian/launch sudo-less
       - name: Make artefacts created by sudo cleanable
+        if: always()
         run:
           sudo chown -R github:github .
 

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -277,6 +277,7 @@ jobs:
       # Needed so that other jobs are able to clean the working dir
       # FIXME: we should investigate running permian/launch sudo-less
       - name: Make artefacts created by sudo cleanable
+        if: always()
         run:
           sudo chown -R github:github .
 


### PR DESCRIPTION
Timeout of the test step can make the job fail, and without this the files become uncleanable, and the next job can't clean them when initializing.
