### PR TITLE
WebUI: re-design the review screen for custom mount point

### DIFF
--- a/ui/webui/src/components/review/ReviewConfiguration.scss
+++ b/ui/webui/src/components/review/ReviewConfiguration.scss
@@ -1,0 +1,27 @@
+/* Style a PF expandable section as a header not a link  */
+.review-expandable-section .pf-c-expandable-section__toggle-text {
+	color: var(--pf-global--Color--100);
+}
+
+/* Override description bold look */
+.description-list-term {
+	font-weight: var(--pf-global--FontWeight--normal);
+}
+
+.description-list-description {
+	font-size: var(--pf-c-description-list__term--FontSize);
+}
+
+.storage-devices-configuration-title {
+	margin-top: var(--pf-global--spacer--md);
+	margin-bottom: var(--pf-global--spacer--sm);
+}
+
+.storage-devices-divider {
+	--pf-c-divider--BorderColor--base: var(--pf-global--Color--100);
+	--pf-c-divider--BackgroundColor: var(--pf-global--Color--100);
+}
+
+.review-disk-label {
+	font-weight: var(--pf-global--FontWeight--bold);
+}

--- a/ui/webui/test/check-review
+++ b/ui/webui/test/check-review
@@ -47,8 +47,8 @@ class TestReview(anacondalib.VirtInstallMachineCase):
         r.check_language("English (United States)")
 
         # check selected disks are shown
-        r.check_disk_label("vda", "Local standard disk")
-        r.check_disk_description("vda", "0x1af4 (vda)")
+        r.check_disk_label("vda", "vda")
+        r.check_disk_description("vda", "0x1af4")
 
         # check encryption choice
         r.check_encryption("Disabled")


### PR DESCRIPTION
Implemented the rest of the review screen changes for the current supported storage scenarios. The design is here:
https://issues.redhat.com/browse/INSTALLER-3486?focusedId=22300317&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22300317

Screenshot of the redesign in action :)
![image](https://github.com/rhinstaller/anaconda/assets/67428/3d2a2559-332d-40e7-9bd4-1081b6c016f4)

Note that the used size is not shown, as I am not 100% sure how to get that from Anaconda would be a candidate for a follow up.