### PR TITLE
Rhel 9 fix inst proxy

### DIFF
--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -105,6 +105,11 @@ if getargbool 0 inst.noverifyssl; then
     echo "rd.noverifyssl" >> /etc/cmdline.d/75-anaconda-options.conf
 fi
 
+# add proxy= to the dracut so stage1 downloads (stage2,kickstart...) don't ignore inst.proxy
+if proxy=$(getarg inst.proxy); then
+    echo "proxy=$proxy" >> /etc/cmdline.d/75-anaconda-options.conf
+fi
+
 # updates
 check_removed_no_inst_arg "updates" "inst.updates"
 if updates=$(getarg inst.updates); then

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -157,7 +157,7 @@ class DracutURL(Url, DracutArgsMixin):
         if self.noverifyssl:
             args.append("rd.noverifyssl")
         if self.proxy:
-            args.append("inst.proxy=%s" % self.proxy)
+            args.append("proxy=%s" % self.proxy)
 
         return "\n".join(args)
 

--- a/tests/unit_tests/dracut_tests/test_parse_kickstart.py
+++ b/tests/unit_tests/dracut_tests/test_parse_kickstart.py
@@ -94,7 +94,7 @@ class ParseKickstartTestCase(BaseTestCase):
         assert len(lines) == 3, lines
         assert lines[0] == "inst.repo=https://host.at.foo.com/path/to/tree", lines
         assert lines[1] == "rd.noverifyssl", lines
-        assert lines[2] == "inst.proxy=http://localhost:8123", lines
+        assert lines[2] == "proxy=http://localhost:8123", lines
 
     def test_updates(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:


### PR DESCRIPTION
Fix proxy is not used when downloading stage2 image.

This fix is handling two cases:
- kickstart has `url --proxy` which should be used also to download stage2 image with proxy
- `inst.proxy` is not used by dracut to download stuff (like stage2 image)

*Resolves: rhbz#2177219*

To do:
- [ ] try to create some tests