### PR TITLE
Don't override blivet's preferred disk label type by default

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -41,7 +41,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define nmver 1.0
 %define pykickstartver 3.47-1
 %define pypartedver 2.5-2
-%define pythonblivetver 1:3.6.0-1
+%define pythonblivetver 1:3.7.1-4
 %define rpmver 4.15.0
 %define simplelinever 1.9.0-1
 %define subscriptionmanagerver 1.26

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -181,7 +181,7 @@ btrfs_compression =
 #
 #    If not specified, use whatever Blivet uses by default.
 #
-disk_label_type = gpt
+disk_label_type =
 
 # Default file system type. Use whatever Blivet uses by default.
 file_system_type =

--- a/docs/release-notes/respect-blivet-label-type.rst
+++ b/docs/release-notes/respect-blivet-label-type.rst
@@ -1,0 +1,19 @@
+:Type: Partitioning
+:Summary: Respect preferred disk label type provided by blivet (#2092091, #2209760)
+
+:Description:
+    In Fedora 37, anaconda was changed to always format disks with GPT
+    disk labels, so long as blivet reported that the platform supports
+    them at all (even if blivet indicated that MBR labels should be
+    preferred). This was intended to implement a plan to prefer GPT
+    disk labels on x86_64 BIOS installs, but in fact resulted in GPT
+    disk labels also being used in other cases. Now, we go back to
+    respecting the preferred disk label type indicated by blivet, by
+    default (a corresponding change has been made to blivet to make it
+    prefer GPT labels on x86_64 BIOS systems). The inst.disklabel
+    option can still be used to force a preference for gpt or mbr if
+    desired.
+
+:Links:
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2092091
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2209760


### PR DESCRIPTION
https://github.com/rhinstaller/anaconda/pull/4232 made anaconda prefer GPT disk labels by default. This was intended to implement the Change called "Install Using GPT on x86_64 BIOS by Default": https://fedoraproject.org/wiki/Changes/GPTforBIOSbyDefault https://bugzilla.redhat.com/show_bug.cgi?id=2092091 However, it actually does more than that Change requested. It prefers GPT in other cases - it's quite hard to parse out every possible case this changes, but for example, it also prefers GPT on ppc64le installs, which previously preferred MBR. It's also just an odd approach, when blivet already goes to some lengths specifically to provide a list of supported label types in a preferred order. It makes much more sense for anaconda to keep respecting the order of the list blivet provides, and adjust blivet to list GPT first on x86_64. The config setting and `inst.disklabel` boot option can still be used to force a preference; this just makes the default config value unset rather than 'gpt'.

This goes with this blivet PR that implements preferring GPT on x86_64 (even on BIOS):
https://github.com/storaged-project/blivet/pull/1132