### PR TITLE
If system uses nano as default editor, do the same

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -149,6 +149,11 @@ def setup_environment():
     else:
         os.environ["DISPLAY"] = ":%s" % constants.X_DISPLAY_NUMBER
 
+    # We mostly don't run from bash, so it won't load the file for us, and libreport will then
+    # show vi instead of nano. Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1889674
+    if "EDITOR" not in os.environ and os.path.isfile("/etc/profile.d/nano-default-editor.sh"):
+        os.environ["EDITOR"] = "/usr/bin/nano"
+
 
 if __name__ == "__main__":
     # check if the CLI help is requested and return it at once,


### PR DESCRIPTION
This affects meh and libreport in text mode.

It is not possible to source the bash file, because we run python, not bash. The file is hardcoded because there is no way to walk over the whole system and find if nano is being used.

Doing it this way also preserves the ability to not have the file, and use vi as before.

Resolves: [rhbz#1889674](https://bugzilla.redhat.com/show_bug.cgi?id=1889674)