### PR TITLE
Add WebUI image to anaconda-iso-container (#infra)

### DIFF
--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -10,6 +10,8 @@
 #
 # # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
 # sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:master
+# or to build WebUI image:
+# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z --entrypoint /lorax-build-webui quay.io/rhinstaller/anaconda-iso-creator:master
 #
 # note:
 # - add `--network=slirp4netns` if you need to share network with host computer to reach
@@ -33,10 +35,14 @@ RUN set -ex; \
   dnf update -y; \
   dnf install -y \
   createrepo_c \
+# required for lorax-build-webui script
+  patch \
   lorax; \
   dnf clean all
 
 COPY ["lorax-build", "/"]
+COPY ["lorax-build-webui", "/"]
+COPY ["adjust-templates-for-webui.patch", "/"]
 
 RUN mkdir /lorax /anaconda-rpms /images
 

--- a/dockerfile/anaconda-iso-creator/adjust-templates-for-webui.patch
+++ b/dockerfile/anaconda-iso-creator/adjust-templates-for-webui.patch
@@ -1,0 +1,107 @@
+From 592a784d0a7f85d921b030398d093186ebe29af4 Mon Sep 17 00:00:00 2001
+From: Martin Kolman <mkolman@redhat.com>
+Date: Fri, 6 May 2022 12:05:57 +0200
+Subject: [PATCH] Add boot options to the Web UI
+
+There does not seem to be an easy way to do this other than using a
+forked set of templates.
+
+Changes:
+- use boot options to start the Web UI & enable remote access
+- skip image checksum check
+- 5 second boot menu timeout
+- for better debugging drop quiet boot option
+- add anaconda-webui package
+---
+ .../99-generic/config_files/x86/grub2-efi.cfg | 15 ++++++++-----
+ .../99-generic/config_files/x86/isolinux.cfg  | 22 ++++++++++++++-----
+ 2 files changed, 26 insertions(+), 11 deletions(-)
+
+diff --git a/share/templates.d/99-generic/config_files/x86/grub2-efi.cfg b/share/templates.d/99-generic/config_files/x86/grub2-efi.cfg
+index 8c9adadd..e349d20a 100644
+--- a/share/templates.d/99-generic/config_files/x86/grub2-efi.cfg
++++ b/share/templates.d/99-generic/config_files/x86/grub2-efi.cfg
+@@ -1,4 +1,4 @@
+-set default="1"
++set default="0"
+ 
+ function load_video {
+   insmod efi_gop
+@@ -20,15 +20,20 @@ set timeout=60
+ search --no-floppy --set=root -l '@ISOLABEL@'
+ 
+ ### BEGIN /etc/grub.d/10_linux ###
+-menuentry 'Install @PRODUCT@ @VERSION@' --class fedora --class gnu-linux --class gnu --class os {
+-	linuxefi @KERNELPATH@ @ROOT@ quiet
++menuentry 'Install @PRODUCT@ @VERSION@ with Web UI' --class fedora --class gnu-linux --class gnu --class os {
++	linuxefi @KERNELPATH@ @ROOT@ inst.webui inst.webui.remote inst.resolution=1280x1024
+ 	initrdefi @INITRDPATH@
+ }
+-menuentry 'Test this media & install @PRODUCT@ @VERSION@' --class fedora --class gnu-linux --class gnu --class os {
+-	linuxefi @KERNELPATH@ @ROOT@ rd.live.check quiet
++menuentry 'Test this media & install @PRODUCT@ @VERSION@ with Web UI' --class fedora --class gnu-linux --class gnu --class os {
++	linuxefi @KERNELPATH@ @ROOT@ rd.live.check quiet inst.webui inst.webui.remote inst.resolution=1280x1024
+ 	initrdefi @INITRDPATH@
+ }
+ submenu 'Troubleshooting -->' {
++	menuentry 'Install @PRODUCT@ @VERSION@ with classis GTK3 GUI' --class fedora --class gnu-linux --class gnu --class os {
++		linuxefi @KERNELPATH@ @ROOT@ quiet inst.resolution=1280x1024
++
++		initrdefi @INITRDPATH@
++	}
+ 	menuentry 'Install @PRODUCT@ @VERSION@ in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
+ 		linuxefi @KERNELPATH@ @ROOT@ nomodeset quiet
+ 		initrdefi @INITRDPATH@
+diff --git a/share/templates.d/99-generic/config_files/x86/isolinux.cfg b/share/templates.d/99-generic/config_files/x86/isolinux.cfg
+index 216d36f2..3c516843 100644
+--- a/share/templates.d/99-generic/config_files/x86/isolinux.cfg
++++ b/share/templates.d/99-generic/config_files/x86/isolinux.cfg
+@@ -1,5 +1,5 @@
+ default vesamenu.c32
+-timeout 600
++timeout 50
+ 
+ display boot.msg
+ 
+@@ -58,16 +58,16 @@ menu tabmsg Press Tab for full configuration options on menu items.
+ menu separator # insert an empty line
+ menu separator # insert an empty line
+ 
+-label linux
+-  menu label ^Install @PRODUCT@ @VERSION@
++label linux-webui
++  menu label ^Install @PRODUCT@ @VERSION@ with Web UI
++  menu default
+   kernel vmlinuz
+-  append initrd=initrd.img @ROOT@ quiet
++  append initrd=initrd.img @ROOT@ inst.webui inst.webui.remote inst.resolution=1280x1024
+ 
+ label check
+   menu label Test this ^media & install @PRODUCT@ @VERSION@
+-  menu default
+   kernel vmlinuz
+-  append initrd=initrd.img @ROOT@ rd.live.check quiet
++  append initrd=initrd.img @ROOT@ rd.live.check quiet inst.webui inst.webui.remote inst.resolution=1280x1024
+ 
+ menu separator # insert an empty line
+ 
+@@ -75,6 +75,16 @@ menu separator # insert an empty line
+ menu begin ^Troubleshooting
+   menu title Troubleshooting @PRODUCT@ @VERSION@
+ 
++label linux-gtk3
++  menu indent count 5
++  menu label ^Install @PRODUCT@ @VERSION@ with classic GUI
++  text help
++	Try this option if you want to use the legacy
++	@PRODUCT@ @VERSION@ GTK3 installation GUI.
++  endtext
++  kernel vmlinuz
++  append initrd=initrd.img @ROOT@ quiet inst.resolution=1280x1024
++
+ label basic
+   menu indent count 5
+   menu label Install using ^basic graphics mode
+-- 
+2.40.1
+

--- a/dockerfile/anaconda-iso-creator/lorax-build-webui
+++ b/dockerfile/anaconda-iso-creator/lorax-build-webui
@@ -1,11 +1,17 @@
 #!/bin/bash
 #
-# Build a boot.iso by lorax. The boot.iso will be stored in the `/images/` directory.
+# Build a Web UI boot.iso by lorax. The boot.iso will be stored in the `/images/` directory.
 # We have to build the RPMs files of Anaconda first and then add them as volume
 # mount to /anaconda-rpms to the container (could be RO mount).
 #
+# Compared to the normal boot.iso we need to patch the templates but other than
+# that it's mostly the same.
+#
+# To run this please do:
+#
 #   sudo make -f ./Makefile.am container-rpms-scratch
-#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:master
+#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z --entrypoint /lorax-build-webui quay.io/rhinstaller/anaconda-iso-creator:master
+#
 #
 # Input directory:
 # /anaconda-rpms/ (Anaconda RPM files for the build)
@@ -28,14 +34,20 @@ mkdir -p $REPO_DIR
 cp -a $INPUT_RPMS/* $REPO_DIR || echo "RPM files can't be copied!"  # We could just do the build with official repositories only
 createrepo_c $REPO_DIR
 
+cp -r /usr/share/lorax/templates.d/ /lorax/
+patch -p2 -i /adjust-templates-for-webui.patch
+
 # build boot.iso with our rpms
 . /etc/os-release
 # The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; use a mirror
 # The --volid argument can cause different network interface naming: https://github.com/rhinstaller/kickstart-tests/issues/448
 lorax -p Fedora -v "$VERSION_ID" -r "$VERSION_ID" \
       --volid Fedora-S-dvd-x86_64-rawh \
+      --sharedir ./templates.d/99-generic/ \
       -s http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/ \
+      -s https://fedorapeople.org/groups/anaconda/webui_new_payload/repo/ \
       -s file://$REPO_DIR/ \
+      -i anaconda-webui -i webui_payload -i cockpit-ws -i cockpit-bridge --rootfs-size 5 \
       "$@" \
       output || cp *.log /images/
 


### PR DESCRIPTION
It behaves almost the same as the current boot.iso with difference that we need to patch the Lorax templates before executing the build.

To run WebUI ISO build you have to add `--entrypoint /lorax-build-webui` as the `podman run` argument, otherwise it will build standard ISO.

Next step would be to adjust workflow to build ISO from a PR.