### PR TITLE
Stop infinite wait for CDROM when KS is processed (#2209599)

### DIFF
--- a/dracut/kickstart-genrules.sh
+++ b/dracut/kickstart-genrules.sh
@@ -23,7 +23,12 @@ case "${kickstart%%:*}" in
         if [ "$kstype" = "cdrom" ]; then
             # if we reset main_loop to 0 every loop, we never hit the timeout.
             # (see dracut's dracut-initqueue.sh for details on the mainloop)
-            echo "main_loop=0" > "$hookdir/initqueue/ks-cdrom-wait-forever.sh"
+            #
+            # Stop this behavior when kickstart is already processed otherwise we
+            # will get into infinite loop in Dracut because of 5 sec wait for OEMDRV
+            # feature.
+            # See rbhz#2209599 for more info
+            echo "[ -e /tmp/ks.cfg.done ] || main_loop=0" > "$hookdir/initqueue/ks-cdrom-wait-forever.sh"
         fi
         wait_for_kickstart
     ;;


### PR DESCRIPTION
Recently we introduced startup wait about 5 secs to give OEMDRV disks posibility to show up before we switch out from initrd. It was implemented by rhbz#1770969.

This unfortunately conflicts with our older feature implemented where we wait infinitely on CDROM device if kickstart is specified to come from a disk implemented by rhbz#1168902.

What happens is that waiting for OEMDRV checks the `main_loop` variable from dracut which is increased when Dracut even loop cycle without new input. However, the infinite wait on kickstart on CDROM resets this value to avoid dracut timeout.

The fix will avoid reseting the `main_loop` variable if the kickstart is already processed. Drawback of this solution is that we will wait another 5 seconds before moving the processing further but because we are not sure how many times the event loop iterated before this seems like the most robust solution.

Resolves: rhbz#2209599
(cherry picked from commit 6ba5b8caaeac432e94407ffa3473f8f430eeb5f7)