### PR TITLE
Do not print error on inst.ks=cdrom|hd (#2211857)

### DIFF
--- a/dracut/fetch-kickstart-net.sh
+++ b/dracut/fetch-kickstart-net.sh
@@ -51,6 +51,11 @@ case $kickstart in
         # We will try them one by one until we succeed.
         locations="$(</tmp/ks_urls)"
     ;;
+    cdrom*|hd*)
+        # do not print the unknown network kickstart in case the local kickstart file
+        # is processed in the fetch-kickstart-disk script
+        return 0
+    ;;
     *)
         warn "unknown network kickstart URL: $kickstart"
         return 1


### PR DESCRIPTION
In Dracut we have two places where the kickstart file is processed:

- fetch-kickstart-disk
- fetch-kickstart-net.sh

These two places are started independently.

What happens is that fetch-kickstart-disk detects that there is kickstart file to process (inst.ks=) but because it's not on network the script doesn't recognize this and print error.

Let's solve this by early return in case it's cdrom or hd localization of the kickstart file.

*Resolves: rhbz#2211857*