### PR TITLE
webui: Date and time screen

### DIFF
--- a/pyanaconda/modules/timezone/timezone_interface.py
+++ b/pyanaconda/modules/timezone/timezone_interface.py
@@ -79,6 +79,15 @@ class TimezoneInterface(KickstartModuleInterface):
         """
         self.implementation.set_timezone_with_priority(timezone, priority)
 
+    def GetTimezones(self) -> Dict[Str, List[Str]]:
+        """Get valid timezones.
+
+        Return a dictionary, where keys are region ids and values are lists of timezone names in the region.
+
+        :return: a dictionary of timezone lists per region
+        """
+        return self.implementation.get_timezones()
+
     @property
     def IsUTC(self) -> Bool:
         """Is the hardware clock set to UTC?
@@ -157,3 +166,17 @@ class TimezoneInterface(KickstartModuleInterface):
         return GeolocationData.to_structure(
             self.implementation.geolocation_result
         )
+
+    def GetSystemDateTime(self) -> Str:
+        """Get the current local date and time of the system.
+        The timezone set via the Timezone property affects the returned data.
+        :return: a string representing the date and time in ISO 8601 format
+        """
+        return self.implementation.get_system_date_time()
+
+    def SetSystemDateTime(self, date_time_spec: Str):
+        """Set the current local date and time of the system.
+        The timezone set via the Timezone property will be applied to the received data.
+        :param date_time_spec: a string representing the date and time in ISO 8601 format
+        """
+        self.implementation.set_system_date_time(date_time_spec)

--- a/ui/webui/src/apis/timezone.js
+++ b/ui/webui/src/apis/timezone.js
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+
+export class TimezoneClient {
+    constructor (address) {
+        if (TimezoneClient.instance) {
+            return TimezoneClient.instance;
+        }
+        TimezoneClient.instance = this;
+
+        this.client = cockpit.dbus(
+            "org.fedoraproject.Anaconda.Modules.Timezone",
+            { superuser: "try", bus: "none", address }
+        );
+    }
+
+    init () {
+        this.client.addEventListener("close", () => console.error("Timezone client closed"));
+    }
+}
+
+/**
+ * @returns {Promise}           The current system Timezone
+ */
+export const getTimezone = () => {
+    return (
+        new TimezoneClient().client.call(
+            "/org/fedoraproject/Anaconda/Modules/Timezone",
+            "org.freedesktop.DBus.Properties",
+            "Get",
+            [
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "Timezone"
+            ]
+        )
+                .then(res => res[0].v)
+    );
+};
+
+/**
+ * @param {string} timezone         Timezone id
+ */
+export const setTimezone = ({ timezone }) => {
+    return new TimezoneClient().client.call(
+        "/org/fedoraproject/Anaconda/Modules/Timezone",
+        "org.freedesktop.DBus.Properties",
+        "Set",
+        [
+            "org.fedoraproject.Anaconda.Modules.Timezone",
+            "Timezone",
+            cockpit.variant("s", timezone)
+        ]
+    );
+};
+
+/**
+ * @returns {Promise}           Resolves a list of timezones
+ */
+export const getTimezones = () => {
+    return new TimezoneClient().client.call(
+        "/org/fedoraproject/Anaconda/Modules/Timezone",
+        "org.fedoraproject.Anaconda.Modules.Timezone",
+        "GetTimezones", []
+    );
+};
+
+/**
+ * @returns {Promise}           NTP enabled
+ */
+export const getNtpEnabled = () => {
+    return (
+        new TimezoneClient().client.call(
+            "/org/fedoraproject/Anaconda/Modules/Timezone",
+            "org.freedesktop.DBus.Properties",
+            "Get",
+            ["org.fedoraproject.Anaconda.Modules.Timezone", "NTPEnabled"]
+        )
+                .then(res => res[0].v)
+    );
+};
+
+/**
+ * @param {bool} enabled - enable/disable NTP
+ *
+ * @returns {Promise}           FIXME: what does it return in this case ??
+ */
+
+export const setNtpEnabled = ({ enabled }) => {
+    return (
+        new TimezoneClient().client.call(
+            "/org/fedoraproject/Anaconda/Modules/Timezone",
+            "org.freedesktop.DBus.Properties",
+            "Set",
+            [
+                "org.fedoraproject.Anaconda.Modules.Timezone",
+                "NTPEnabled",
+                cockpit.variant("b", enabled)
+            ]
+        )
+    );
+};
+
+/**
+ * @returns {Promise}           Resolves the DBus path to the partitioning
+ */
+export const getSystemDateTime = () => {
+    return new TimezoneClient().client.call(
+        "/org/fedoraproject/Anaconda/Modules/Timezone",
+        "org.fedoraproject.Anaconda.Modules.Timezone",
+        "GetSystemDateTime", []
+    );
+};
+
+/**
+ * @param {string} datetimespec date time specification in ISO 8601 format
+ *
+ * @returns {Promise}           FIXME: what does it ret
+ */
+export const setSystemDateTime = ({ datetimespec }) => {
+    return new TimezoneClient().client.call(
+        "/org/fedoraproject/Anaconda/Modules/Timezone",
+        "org.fedoraproject.Anaconda.Modules.Timezone",
+        "SetSystemDateTime", [datetimespec]
+    );
+};

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -36,6 +36,7 @@ import { InstallationDestination, applyDefaultStorage } from "./storage/Installa
 import { StorageConfiguration, getScenario, getDefaultScenario } from "./storage/StorageConfiguration.jsx";
 import { DiskEncryption, StorageEncryptionState } from "./storage/DiskEncryption.jsx";
 import { InstallationLanguage } from "./localization/InstallationLanguage.jsx";
+import { DateAndTime } from "./time/DateAndTime.jsx";
 import { InstallationProgress } from "./installation/InstallationProgress.jsx";
 import { ReviewConfiguration, ReviewConfigurationConfirmModal } from "./review/ReviewConfiguration.jsx";
 import { exitGui } from "../helpers/exit.js";
@@ -64,8 +65,14 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, onAddE
             id: "installation-language",
             label: _("Welcome"),
         },
-        // TODO: rename InstallationDestination component and its file ?
         {
+            component: DateAndTime,
+            id: "date-and-time",
+            label: _("Date and time"),
+        },
+        {
+            component: InstallationDestination,
+            // TODO: rename InstallationDestination component and its file ?
             id: "installation-destination",
             label: _("Installation destination"),
             steps: [{

--- a/ui/webui/src/components/app.jsx
+++ b/ui/webui/src/components/app.jsx
@@ -33,6 +33,7 @@ import { HelpDrawer } from "./HelpDrawer.jsx";
 import { BossClient } from "../apis/boss.js";
 import { LocalizationClient } from "../apis/localization.js";
 import { StorageClient, startEventMonitorStorage } from "../apis/storage.js";
+import { TimezoneClient } from "../apis/timezone.js";
 import { PayloadsClient } from "../apis/payloads";
 
 import { readBuildstamp, getIsFinal } from "../helpers/betanag.js";
@@ -55,6 +56,7 @@ export const Application = () => {
             const clients = [
                 new LocalizationClient(address),
                 new StorageClient(address),
+                new TimezoneClient(address),
                 new PayloadsClient(address),
                 new BossClient(address)
             ];

--- a/ui/webui/src/components/time/DateAndTime.jsx
+++ b/ui/webui/src/components/time/DateAndTime.jsx
@@ -1,0 +1,500 @@
+/*
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useState, useEffect } from "react";
+
+import {
+    ActionGroup,
+    Button,
+    Card,
+    CardTitle,
+    CardBody,
+    DatePicker,
+    Divider,
+    Flex,
+    FlexItem,
+    Form,
+    FormGroup,
+    FormSection,
+    Grid,
+    GridItem,
+    Text,
+    TextContent,
+    TextVariants,
+    TimePicker,
+    Popover,
+    PopoverPosition,
+    Icon,
+    Label,
+    Switch,
+    Select,
+    SelectOption,
+    SelectVariant,
+} from "@patternfly/react-core";
+
+import {
+    InfoCircleIcon,
+    HelpIcon,
+} from "@patternfly/react-icons";
+
+import cockpit from "cockpit";
+
+import * as timeformat from "timeformat.js";
+
+import { AnacondaPage } from "../AnacondaPage.jsx";
+
+import "./DateAndTime.scss";
+
+import {
+    getTimezone,
+    setTimezone,
+    getTimezones,
+    getNtpEnabled,
+    setNtpEnabled,
+    getSystemDateTime,
+    setSystemDateTime,
+} from "../../apis/timezone.js";
+
+const _ = cockpit.gettext;
+
+const getTimezoneName = (region, city) => {
+    return region + "/" + city.replace("_", " ");
+};
+
+const TimezonePopover = ({ timezoneRegion, timezoneCity }) => {
+    return (
+        <Popover
+          position={PopoverPosition.auto}
+          bodyContent={
+              <Flex>
+                  <Flex>
+                      <Text component={TextVariants.p}>
+                          {_("Timezone")}
+                      </Text>
+                  </Flex>
+                  <Flex spaceItems={{ default: "spaceItemsSm" }}>
+                      <Text component={TextVariants.p}>
+                          {getTimezoneName(timezoneRegion, timezoneCity)}
+                      </Text>
+                  </Flex>
+              </Flex>
+          }
+        >
+            {/* HACK Patternfly currently doesn't implement clickable labels so the styling had to be done manually. */}
+            <div style={{ cursor: "pointer", userSelect: "none" }}>
+                <Label
+                  variant="outline"
+                  color="blue"
+                  icon={<InfoCircleIcon />}
+                  id="betanag-icon"
+                >
+                    {getTimezoneName(timezoneRegion, timezoneCity)}
+                </Label>
+            </div>
+        </Popover>
+    );
+};
+
+const CurrentSettingsCard = ({ idPrefix, timeString, dateString, setEditModeEnabled, timezoneRegion, timezoneCity }) => {
+    return (
+        <Card>
+            <CardTitle>
+                {_("Current settings")}
+            </CardTitle>
+            <CardBody>
+                <Flex direction={{ default: "column" }}>
+                    <FlexItem>
+                        <Flex direction={{ default: "row" }} alignSelf={{ default: "alignItemsCenter" }}>
+                            <FlexItem>
+                                <Text className="time-display-label">
+                                    {timeString}
+                                </Text>
+                            </FlexItem>
+                            <FlexItem>
+                                <TimezonePopover
+                                  timezoneRegion={timezoneRegion}
+                                  timezoneCity={timezoneCity}
+                                />
+                            </FlexItem>
+                        </Flex>
+                    </FlexItem>
+                    <FlexItem>
+                        <Text>
+                            {dateString}
+                        </Text>
+                    </FlexItem>
+                    <FlexItem spacer={{ default: "spacerMd" }} />
+                    <FlexItem>
+                        <Button
+                          id={idPrefix + "-edit"}
+                          onClick={() => {
+                              setEditModeEnabled(true);
+                          }}
+                          variant="secondary"
+                        >
+                            {_("Edit")}
+                        </Button>
+                    </FlexItem>
+                </Flex>
+            </CardBody>
+        </Card>
+    );
+};
+
+const EditSettingsCard = ({
+    idPrefix,
+    setEditModeEnabled,
+    automaticTimeEnabled,
+    setAutomaticTimeEnabled,
+    timezones,
+    timezoneRegion,
+    setTimezoneRegion,
+    timezoneCity,
+    setTimezoneCity,
+    regionSelected,
+    ntpSyncEnabled,
+    setNtpSyncEnabled,
+    systemDate,
+    setSystemDate,
+    setNewDate,
+}) => {
+    const [regionsOpen, setRegionsOpen] = useState(false);
+    const [citiesOpen, setCitiesOpen] = useState(false);
+    const handleRegionChange = (region) => {
+        setRegionsOpen(false);
+        setTimezoneRegion(region);
+        // clear city selection if region changes to avoid
+        // setting nonsense timezones to the backend
+        setTimezoneCity(null);
+    };
+    const handleCityChange = city => {
+        setCitiesOpen(false);
+        setTimezoneCity(city);
+    };
+    const handleNtpChange = ntpValue => {
+        setNtpSyncEnabled(ntpValue);
+    };
+    const handleDateChange = (_event, str, date) => {
+        // update the system date with the year, month and day set in the date picker
+        const newDate = systemDate;
+        newDate.setYear(date.getFullYear());
+        newDate.setMonth(date.getMonth());
+        newDate.setDate(date.getDate());
+        setNewDate(newDate);
+    };
+    const handleTimeChange = (_event, time, hours, minutes, seconds, isValid) => {
+        const newDate = systemDate;
+        newDate.setHours(hours);
+        newDate.setMinutes(minutes);
+        newDate.setSeconds(seconds);
+        setNewDate(newDate);
+    };
+    const handleSave = () => {
+        console.log("time & date - saving settings to backend");
+        // set NTP on/off
+        setAutomaticTimeEnabled(ntpSyncEnabled);
+        setNtpEnabled({ enabled: ntpSyncEnabled });
+        console.log("NTP sync set to: " + ntpSyncEnabled);
+        // set timezone
+        if (timezoneRegion && timezoneCity) {
+            const newTimezoneName = timezoneRegion + "/" + timezoneCity;
+            setTimezone({ timezone: newTimezoneName }).catch(console.error);
+            console.log("timezone set to: " + newTimezoneName);
+        }
+        // set date & time
+        setSystemDateTime({ datetimespec: systemDate.toISOString() });
+        console.log("system date time set to: " + systemDate.toISOString());
+        // finaly disable editing mode
+        setEditModeEnabled(false);
+    };
+    const handleCancel = () => {
+        console.log("time & date - cancel editing");
+        setEditModeEnabled(false);
+    };
+
+    return (
+        <Card>
+            <CardBody>
+                <Form>
+                    <FormSection title={_("Timezone")}>
+                        <Grid hasGutter>
+                            <GridItem span={6}>
+                                <FormGroup
+                                  label={_("Region")}
+                                  isRequired
+                                  fieldId={idPrefix + "-select-region"}
+                                >
+                                    <Select
+                                      id={idPrefix + "-select-region"}
+                                      variant={SelectVariant.typeahead}
+                                      placeholderText={_("Select region")}
+                                      isOpen={regionsOpen}
+                                      selections={timezoneRegion}
+                                      onToggle={(_, isOpen) => setRegionsOpen(isOpen)}
+                                      onSelect={(_, value) => handleRegionChange(value)}
+                                    >
+                                        {Object.keys(timezones).map(region => <SelectOption key={region} value={region}>{region}</SelectOption>)}
+                                    </Select>
+                                </FormGroup>
+                            </GridItem>
+                            <GridItem span={6}>
+                                <FormGroup
+                                  label={_("City")}
+                                  isRequired
+                                  fieldId={idPrefix + "-select-city"}
+                                >
+                                    <Select
+                                      id={idPrefix + "-select-city"}
+                                      variant={SelectVariant.typeahead}
+                                      placeholderText={_("Select city")}
+                                      isOpen={citiesOpen}
+                                      selections={timezoneCity}
+                                      onToggle={(_, isOpen) => setCitiesOpen(isOpen)}
+                                      onSelect={(_, value) => handleCityChange(value)}
+                                    >
+                                        {timezoneRegion
+                                            ? timezones[timezoneRegion].map(city =>
+                                                <SelectOption
+                                                  key={city}
+                                                  value={city}
+                                                >
+                                                    {city.replaceAll("_", " ")}
+                                                </SelectOption>)
+                                            : []}
+                                    </Select>
+                                </FormGroup>
+                            </GridItem>
+                        </Grid>
+                    </FormSection>
+                    <FormSection title={_("Date and time")}>
+                        <Grid>
+                            <GridItem span={4}>
+                                <FormGroup
+                                  label={_("Automatic time")}
+                                  labelIcon={
+                                      <Popover
+                                        bodyContent={_(
+                                            "To edit date and time, turn off automatic time."
+                                        )}
+                                      >
+                                          <Icon iconSize="sm">
+                                              <HelpIcon />
+                                          </Icon>
+                                      </Popover>
+                                  }
+                                  isRequired
+                                  fieldId={idPrefix + "-edit-NTP-enabled"}
+                                >
+                                    <Switch
+                                      label={_("On")}
+                                      labelOff={_("Off")}
+                                      id={idPrefix + "-switch-automatic-time"}
+                                      isChecked={ntpSyncEnabled}
+                                      onChange={handleNtpChange}
+                                      hasCheckIcon
+                                    />
+                                </FormGroup>
+                            </GridItem>
+                            <GridItem span={8}>
+                                <Flex
+                                  direction={{ default: "row" }}
+                                  spaceItems={{ default: "spaceItemsSm" }}
+                                >
+                                    <FormGroup
+                                      label={_("Date")}
+                                      isRequired
+                                      fieldId={idPrefix + "-edit-date"}
+                                    >
+                                        <DatePicker
+                                          isDisabled={ntpSyncEnabled}
+                                          dateFormat={timeformat.date}
+                                          dateParse={timeformat.parseDate}
+                                          value={timeformat.date(systemDate.valueOf())}
+                                          onChange={handleDateChange}
+                                        />
+                                    </FormGroup>
+                                    <FormGroup
+                                      label={_("Time")}
+                                      isRequired
+                                      fieldId={idPrefix + "-edit-time"}
+                                    >
+                                        <TimePicker
+                                          id={idPrefix + "-edit-time"}
+                                          isDisabled={ntpSyncEnabled}
+                                          time={systemDate}
+                                          onChange={handleTimeChange}
+                                        />
+                                    </FormGroup>
+                                </Flex>
+                            </GridItem>
+                        </Grid>
+                    </FormSection>
+                    <Divider />
+                    <Text className="time-edit-automatic-hint">
+                        {_("To edit date and time, turn off automatic time")}
+                    </Text>
+                    <ActionGroup>
+                        <Button
+                          id={idPrefix + "-btn-save"}
+                          variant="primary"
+                          onClick={handleSave}
+                        >
+                            {_("Save")}
+                        </Button>
+                        <Button
+                          id={idPrefix + "-btn-cancel"}
+                          variant="link"
+                          onClick={handleCancel}
+                        >
+                            {_("Cancel")}
+                        </Button>
+                    </ActionGroup>
+                </Form>
+            </CardBody>
+        </Card>
+    );
+};
+
+const AutomaticTimeNotification = ({ automaticTimeEnabled }) => {
+    return (
+        <Flex direction={{ default: "row" }} spaceItems={{ default: "spaceItemsSm" }} alignSelf={{ default: "alignItemsCenter" }}>
+            <FlexItem>
+                <Icon status="info">
+                    <InfoCircleIcon />
+                </Icon>
+            </FlexItem>
+            <FlexItem>
+                <Text className="automatic-time-label">
+                    {automaticTimeEnabled ? _("Automatic time is on.") : _("Automatic time is off.")}
+                </Text>
+            </FlexItem>
+            <FlexItem>
+                <Popover
+                  bodyContent={_(
+                      "Synchronizes your device with Network Time Protocol (NTP) server. " +
+                      "You must be connected to the Internet."
+                  )}
+                >
+                    <Icon iconSize="sm">
+                        <HelpIcon />
+                    </Icon>
+                </Popover>
+            </FlexItem>
+        </Flex>
+    );
+};
+
+export const DateAndTime = ({ idPrefix }) => {
+    // UI modes
+    const [editModeEnabled, setEditModeEnabled] = useState(false);
+    const [automaticTimeEnabled, setAutomaticTimeEnabled] = useState(true);
+    // timezones
+    const [timezones, setTimezones] = useState({});
+    const [timezoneRegion, setTimezoneRegion] = useState("");
+    const [timezoneCity, setTimezoneCity] = useState("");
+
+    // NTP
+    const [ntpSyncEnabled, setNtpSyncEnabled] = useState(true);
+    // system time
+    const [systemDate, setSystemDate] = useState("");
+    const [systemDateString, setSystemDateString] = useState("");
+    const [systemTimeString, setSystemTimeString] = useState("");
+
+    // fetch timezone data
+    useEffect(() => {
+        const fetchTimezoneData = async (setTimezones, setTimezoneRegion, setTimezoneCity) => {
+            // fetch timezone listing
+            const res = await getTimezones().catch(console.error);
+            const timezoneDict = res[0];
+            setTimezones(timezoneDict);
+            // fetch current timezone
+            const currentTimezone = await getTimezone().catch(console.error);
+            setTimezoneRegion(currentTimezone.split("/")[0]);
+            setTimezoneCity(currentTimezone.split("/")[1]);
+        };
+        fetchTimezoneData(setTimezones, setTimezoneRegion, setTimezoneCity);
+    }, [setTimezones, setTimezoneRegion, setTimezoneCity]);
+
+    // fetch NTP data
+    useEffect(() => {
+        const fetchNtpData = async (setAutomaticTimeEnabled) => {
+            const ntpEnableValue = await getNtpEnabled().catch(console.error);
+            setAutomaticTimeEnabled(ntpEnableValue);
+        };
+        fetchNtpData(setAutomaticTimeEnabled);
+    }, [setAutomaticTimeEnabled]);
+
+    // set new date to all the relevant places
+    const setNewDate = (newDate) => {
+        setSystemDate(newDate);
+        // localized display strings
+        const localizedDate = newDate.toLocaleString("default", { dateStyle: "full" });
+        const localizedTime = newDate.toLocaleString("default", { timeStyle: "short" });
+        setSystemDateString(localizedDate);
+        setSystemTimeString(localizedTime);
+    };
+
+    // fetch system time
+    useEffect(() => {
+        const fetchSystemDateTime = async (setSystemDate) => {
+            const systemDateValue = await getSystemDateTime();
+            setSystemDate(systemDateValue[0]);
+            // update time
+            const newDate = new Date(systemDateValue[0]);
+            setNewDate(newDate);
+        };
+        fetchSystemDateTime(setSystemDate);
+    }, [setSystemDate]);
+
+    return (
+        <AnacondaPage title={_("Date and time")}>
+            <TextContent>
+                <Text id={idPrefix + "-hint"}>
+                    {_("The time and date is set automatically, but you can edit it to any time.")}
+                </Text>
+            </TextContent>
+            {editModeEnabled
+                ? <EditSettingsCard
+                    idPrefix={idPrefix}
+                    setEditModeEnabled={setEditModeEnabled}
+                    automaticTimeEnabled={automaticTimeEnabled}
+                    setAutomaticTimeEnabled={setAutomaticTimeEnabled}
+                    timezones={timezones}
+                    timezoneRegion={timezoneRegion}
+                    setTimezoneRegion={setTimezoneRegion}
+                    timezoneCity={timezoneCity}
+                    setTimezoneCity={setTimezoneCity}
+                    ntpSyncEnabled={ntpSyncEnabled}
+                    setNtpSyncEnabled={setNtpSyncEnabled}
+                    systemDate={systemDate}
+                    setSystemDate={setSystemDate}
+                    setNewDate={setNewDate}
+                />
+                : <CurrentSettingsCard
+                    idPrefix={idPrefix}
+                    timeString={systemTimeString}
+                    dateString={systemDateString}
+                    setEditModeEnabled={setEditModeEnabled}
+                    timezoneRegion={timezoneRegion}
+                    timezoneCity={timezoneCity}
+                />}
+            <AutomaticTimeNotification
+              automaticTimeEnabled={automaticTimeEnabled}
+            />
+        </AnacondaPage>
+    );
+};

--- a/ui/webui/src/components/time/DateAndTime.scss
+++ b/ui/webui/src/components/time/DateAndTime.scss
@@ -1,0 +1,19 @@
+.time-display-label {
+    font-size: var(--pf-global--FontSize--4xl);
+    font-weight: var(--pf-global--FontWeight--bold);
+}
+.automatic-time-label {
+    font-weight: var(--pf-global--FontWeight--bold);
+}
+.time-edit-heading {
+    font-size: var(--pf-global--FontSize--md);
+    font-weight: var(--pf-global--FontWeight--bold);
+}
+.time-edit-subheading {
+    font-size: var(--pf-global--FontSize--sm);
+    font-weight: var(--pf-global--FontWeight--bold);
+}
+.time-edit-automatic-hint {
+    font-size: var(--pf-global--FontSize--sm);
+    color: var(--pf-global--Color--dark-200);
+}


### PR DESCRIPTION
Add the Date & time configuration screen, in the wizard flow it sits between the welcome screen & installation destination screen.

![Screenshot 2023-06-02 at 19-41-33 Anaconda Web UI](https://github.com/rhinstaller/anaconda/assets/829558/89c22003-8168-4544-a632-972e4212d505)
![Screenshot 2023-06-02 at 19-43-04 Anaconda Web UI](https://github.com/rhinstaller/anaconda/assets/829558/01ba5387-2e3b-4653-a582-cc03b117cba2)

All the major controls  are there UI wise, the main missing bits are test coverage & some remaining plumbing.

**followup PR/s**
- detailed timezone information for the timezone details popup (timezone offset & timezone pretty name)
  - look like this will need backend API changes/extension
- look into date & time display formatting & cockpit compatibility
- look into timezone display - _ vs " " in timezone names

**TODO**

- [x] backend test coverage
- [ ] frontend test coverage
- [x] pre-select region & city based on backend data
- [x] date & time configuration plumbing


- [x] find out why DBus calls from the Save button handler don't work