### PR TITLE
Improve btrfs handling in custom partitioning

### DIFF
--- a/pyanaconda/modules/storage/devicetree/root.py
+++ b/pyanaconda/modules/storage/devicetree/root.py
@@ -299,6 +299,11 @@ def _parse_fstab(devicetree, chroot):
             if device is None:
                 continue
 
+            # If a btrfs volume is found but a subvolume is expected, ignore the volume.
+            if device.type == "btrfs volume" and "subvol=" in options:
+                log.debug("subvolume from %s for %s not found", options, devspec)
+                continue
+
             if fstype != "swap":
                 mounts[mountpoint] = device
 

--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -1110,9 +1110,9 @@ def _destroy_device(storage, device):
         # Configure the factory's devices.
         factory.configure()
 
-    # Finally, remove empty parents of the device.
+    # Finally, remove empty parents of the device, except for btrfs subvolumes.
     for parent in device.parents:
-        if not parent.children and not parent.is_disk:
+        if not parent.children and not parent.is_disk and not parent.type == "btrfs subvolume":
             destroy_device(storage, parent)
 
 


### PR DESCRIPTION
The patches should improve the manipulation with btrfs subvolumes in GUI Custom partitioning as reported in https://bugzilla.redhat.com/show_bug.cgi?id=2186158.

One of the patches should fix removing of btrfs subvolumes:
Original (parent subvolume /root is removed incorrectly):
https://rvykydal.fedorapeople.org/btrfs/rhbz2186158/removing_parent_subvolume.webm
Patched:
https://rvykydal.fedorapeople.org/btrfs/rhbz2186158/preserving_parent_subvolume.webm

The other one fixes displaying btrfs subvolumes in Custom partitioning:
Original:
https://bugzilla.redhat.com/show_bug.cgi?id=2186158#c6
Patched:
https://rvykydal.fedorapeople.org/btrfs/rhbz2186158/remove_btrfs_home.webm

Although the patches don't solve btrfs volume reformatting, they should allow to reuse /home subvolume by mounting it, removing and adding root subvolume and reformatting other non-btrfs partitions as in:
https://rvykydal.fedorapeople.org/btrfs/rhbz2186158/reuse_home_by_removing_and_adding_btrfs_root.webm

