### PR TITLE
Import BlockDev from blivet instead of gi

### DIFF
--- a/pyanaconda/modules/storage/checker/utils.py
+++ b/pyanaconda/modules/storage/checker/utils.py
@@ -15,13 +15,9 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-import gi
-gi.require_version("BlockDev", "2.0")
-from gi.repository import BlockDev as blockdev
-
 from collections import defaultdict
 
-from blivet import arch, util
+from blivet import arch, blockdev, util
 from blivet.devicefactory import get_device_type
 from blivet.size import Size
 

--- a/pyanaconda/modules/storage/dasd/discover.py
+++ b/pyanaconda/modules/storage/dasd/discover.py
@@ -17,9 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-import gi
-gi.require_version("BlockDev", "2.0")
-from gi.repository import BlockDev as blockdev
+from blivet import blockdev
 
 from pyanaconda.core.regexes import DASD_DEVICE_NUMBER
 from pyanaconda.modules.common.task import Task

--- a/pyanaconda/modules/storage/dasd/format.py
+++ b/pyanaconda/modules/storage/dasd/format.py
@@ -20,9 +20,7 @@
 from pyanaconda.modules.common.task import Task
 from pyanaconda.anaconda_loggers import get_module_logger
 
-import gi
-gi.require_version("BlockDev", "2.0")
-from gi.repository import BlockDev as blockdev
+from blivet import blockdev
 
 log = get_module_logger(__name__)
 

--- a/pyanaconda/modules/storage/devicetree/fsset.py
+++ b/pyanaconda/modules/storage/devicetree/fsset.py
@@ -19,10 +19,7 @@ import os
 import shutil
 import time
 
-import gi
-gi.require_version("BlockDev", "2.0")
-from gi.repository import BlockDev as blockdev
-
+from blivet import blockdev
 from blivet.devices import NoDevice, DirectoryDevice, NFSDevice, FileDevice, MDRaidArrayDevice, \
     NetworkStorageDevice, OpticalDevice
 from blivet.errors import UnrecognizedFSTabEntryError, FSTabTypeMismatchError, SwapSpaceError

--- a/pyanaconda/modules/storage/initialization.py
+++ b/pyanaconda/modules/storage/initialization.py
@@ -15,6 +15,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from blivet import blockdev
 from blivet import util as blivet_util, udev, arch
 from blivet.devicelibs import crypto
 from blivet.flags import flags as blivet_flags
@@ -24,10 +25,6 @@ from blivet.static_data import luks_data
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.anaconda_logging import program_log_lock
 from pyanaconda.core.configuration.anaconda import conf
-
-import gi
-gi.require_version("BlockDev", "2.0")
-from gi.repository import BlockDev as blockdev
 
 __all__ = ["enable_installer_mode"]
 

--- a/pyanaconda/modules/storage/installation.py
+++ b/pyanaconda/modules/storage/installation.py
@@ -25,7 +25,7 @@ import parted
 from datetime import timedelta
 from time import sleep
 
-from blivet import callbacks as blivet_callbacks, util as blivet_util, arch
+from blivet import callbacks as blivet_callbacks, util as blivet_util, arch, blockdev
 from blivet.errors import FSResizeError, FormatResizeError, StorageError
 from blivet.util import get_current_entropy
 from blivet.devicelibs.lvm import HAVE_LVMDEVICES
@@ -39,10 +39,6 @@ from pyanaconda.modules.common.constants.objects import ISCSI, FCOE, ZFCP
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.errors.installation import StorageInstallationError
 from pyanaconda.modules.common.task import Task
-
-import gi
-gi.require_version("BlockDev", "2.0")
-from gi.repository import BlockDev as blockdev
 
 log = get_module_logger(__name__)
 

--- a/pyanaconda/modules/storage/nvdimm/nvdimm.py
+++ b/pyanaconda/modules/storage/nvdimm/nvdimm.py
@@ -17,7 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from blivet import udev
+from blivet import blockdev, udev
 from blivet.devices import NVDIMMNamespaceDevice
 from blivet.static_data import nvdimm
 
@@ -30,10 +30,6 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.common.constants.objects import NVDIMM
 from pyanaconda.modules.storage.nvdimm.nvdimm_interface import NVDIMMInterface
 from pyanaconda.modules.storage.nvdimm.reconfigure import NVDIMMReconfigureTask
-
-import gi
-gi.require_version("BlockDev", "2.0")
-from gi.repository import BlockDev as blockdev
 
 log = get_module_logger(__name__)
 

--- a/pyanaconda/modules/storage/zfcp/discover.py
+++ b/pyanaconda/modules/storage/zfcp/discover.py
@@ -17,10 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-import gi
-gi.require_version("BlockDev", "2.0")
-from gi.repository import BlockDev as blockdev
-
+from blivet import blockdev
 from blivet.zfcp import zfcp
 from pyanaconda.core.regexes import DASD_DEVICE_NUMBER, ZFCP_WWPN_NUMBER, ZFCP_LUN_NUMBER
 from pyanaconda.modules.common.task import Task

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_nvdimm.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_nvdimm.py
@@ -23,6 +23,7 @@ import pytest
 from textwrap import dedent
 from unittest.mock import patch, Mock
 
+from blivet import blockdev
 from blivet.devices import NVDIMMNamespaceDevice
 from blivet.formats import get_format
 from blivet.size import Size
@@ -37,10 +38,6 @@ from pyanaconda.modules.storage.nvdimm.nvdimm_interface import NVDIMMInterface
 from pyanaconda.modules.storage.nvdimm.reconfigure import NVDIMMReconfigureTask
 from pyanaconda.modules.storage.storage import StorageService
 from pykickstart.constants import NVDIMM_MODE_SECTOR, NVDIMM_ACTION_RECONFIGURE
-
-import gi
-gi.require_version("BlockDev", "2.0")
-from gi.repository import BlockDev as blockdev
 
 
 class NVDIMMInterfaceTestCase(unittest.TestCase):


### PR DESCRIPTION
We are planning to release a new major version of libblockdev soon and because version needs to be specified when importing from gi it would make the import unnecessarily complicated if we wanted to keep it backwards compatible. Anaconda is already using blivet so importing BlockDev from it instead of gi shouldn't change anything.