### PR TITLE
Add easy way to build ISO from Anaconda

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -78,6 +78,37 @@ category. You can quickly list these by searching the Red Hat bugzilla for bugs 
 
 Patches for bugs without keywords are welcome, too!
 
+Testing Anaconda changes
+------------------------
+
+To test changes in Anaconda you have a few options based on what you need to do.
+
+WebUI development
+^^^^^^^^^^^^^^^^^
+See ``ui/webui/README.rst`` and ``ui/webui/test/README.rst`` for more details about how to develop and test Web UI interface of Anaconda.
+
+Backend and TUI development
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+There are two options to develop and test changes which are not yet released.
+
+To find out more information about quick way to propagate your changes into the existing installation ISO image see `this blogpost <https://rhinstaller.wordpress.com/2019/10/11/anaconda-debugging-and-testing-part-1/>`_.
+
+Another way is to build the boot.iso directly (takes more time but it's easier to do).
+
+Build Anaconda RPM files with our container::
+
+  make -f ./Makefile.am container-rpms-scratch
+
+Then build ISO from these RPMs by this call (beware because of loop device mounting it needs root priviledges)::
+
+  make -f ./Makefile.am container-iso-build
+
+or for Web UI image run::
+
+  make -f ./Makefile.am container-webui-iso-build
+
+The resulting ISO will be stored in ``./result/iso`` directory.
+
 
 Anaconda Installer Branching Policy (the long version)
 -------------------------------------------------------

--- a/Makefile.am
+++ b/Makefile.am
@@ -325,6 +325,28 @@ container-rpms:
 container-rpms-scratch:
 	$(MAKE) -f ./Makefile.am CONTAINER_ADD_ARGS="-e TEST_BUILD=true" container-rpms
 
+# Build ISO from Anaconda RPM files build here
+container-iso-build:
+	@sudo -nv 2>/dev/null || echo "You will be prompted for sudo password because of loop device mounting in Lorax!"
+
+	@if ! ls $(srcdir)/result/build/01-rpm-build/anaconda-*.rpm >/dev/null 2>/dev/null; then \
+		echo "You need to have anaconda RPMs build first. Please run 'make -f ./Makefile.am container-rpms-scratch' before this command."; \
+		exit 1; \
+	fi
+
+	mkdir -p result/iso
+	sudo $(CONTAINER_ENGINE) run \
+	--rm --privileged  --tmpfs /var/tmp:rw,mode=1777 \
+	-v $(srcdir)/result/build/01-rpm-build:/anaconda-rpms:ro \
+	-v $(srcdir)/result/iso:/images:z \
+	$(CONTAINER_ADD_ARGS) \
+	$(ISO_CREATOR_NAME):$(CI_TAG)
+	@echo "ISO is stored in $(scrdir)/result/iso/"
+
+# Build WebUI ISO from Anaconda RPM files build here
+container-webui-iso-build:
+	$(MAKE) -f ./Makefile.am container-iso-build-scratch CONTAINER_ADD_ARGS="--entrypoint=/lorax-build-webui"
+
 check-branching:
 # checking if branching can be finished and all the pieces are in place
 	@echo "===================================="


### PR DESCRIPTION
This is using our existing containers to build the ISO with a make call. It has to run as sudo to work because of the loop devices used by Lorax.