### PR TITLE
Revert "Download cockpit rpms during build"

### DIFF
--- a/ui/webui/test/build-rpms
+++ b/ui/webui/test/build-rpms
@@ -11,8 +11,6 @@ import sys
 BOTS_DIR = os.path.realpath(f'{__file__}/../../bots')
 sys.path.append(BOTS_DIR)
 
-missing_packages = "cockpit-ws cockpit-bridge firefox dbus-glib"
-
 from machine.machine_core import machine_virtual  # NOQA: imported through parent.py
 
 
@@ -30,12 +28,6 @@ def build_rpms(srpm, image, verbose, quick):
         mock_opts = ("--verbose" if verbose else "") + (" --nocheck" if quick else "")
         machine.execute("su builder -c 'mock --no-clean --disablerepo=* --offline --resultdir /var/tmp/build "
                         f"{mock_opts} --rebuild /var/tmp/build/SRPMS/*.src.rpm'", timeout=1800)
-
-        # download cockpit rpms
-        # FIXME boot.iso on rawhide does not currently contain the new cockpit dependencies
-        # This will change once we include this changes upstream and start building boot.iso with the new dependencies
-        # Then we can safely remove this workaround
-        machine.execute(f"dnf download --downloaddir /var/tmp/build/ {missing_packages}", stdout=sys.stdout)
 
         # download rpms
         vm_rpms = machine.execute("find /var/tmp/build -name '*.rpm' -not -name '*.src.rpm'").strip().split()

--- a/ui/webui/test/prepare-updates-img
+++ b/ui/webui/test/prepare-updates-img
@@ -2,6 +2,25 @@
 
 set -eu
 
+# FIXME boot.iso on rawhide does not currently contain the new cockpit dependencies
+# This will change once we include this changes upstream and start building boot.iso with the new dependencies
+# Then we can safely remove this workaround
+ANACONDA_WEBUI_DEPS_URLS='
+    https://kojipkgs.fedoraproject.org//packages/cockpit/292/1.fc39/x86_64/cockpit-ws-292-1.fc39.x86_64.rpm
+    https://kojipkgs.fedoraproject.org//packages/cockpit/292/1.fc39/x86_64/cockpit-bridge-292-1.fc39.x86_64.rpm
+    https://kojipkgs.fedoraproject.org/packages/firefox/114.0/1.fc39/x86_64/firefox-114.0-1.fc39.x86_64.rpm
+    https://kojipkgs.fedoraproject.org/packages/dbus-glib/0.112/5.fc38/x86_64/dbus-glib-0.112-5.fc38.x86_64.rpm
+'
+
+mkdir -p tmp/extra-rpms
+pushd tmp/extra-rpms
+for url in $ANACONDA_WEBUI_DEPS_URLS; do
+    test -e "$(basename "${url}")" || curl -LO "$url"
+done
+# shellcheck disable=SC2086,SC2046
+ANACONDA_WEBUI_DEPS_RPMS="$(realpath $(basename -a ${ANACONDA_WEBUI_DEPS_URLS}))"
+popd
+
 # switch to root of the repository
 pushd ../..
 # remove old rpms and build new srpm
@@ -9,11 +28,11 @@ rm -rf ../../result/build
 make srpm
 popd
 
-# build the anaconda srpm (and result RPMs go in `tmp/rpms`) && download cockpit RPMs
+# build the anaconda srpm (and result RPMs go in `tmp/rpms`)
 test/build-rpms -v ../../result/build/00-srpm-build/anaconda-*.src.rpm
 
 # makeupdates must be run from the top level of the anaconda source tree
 pushd ../../
 # shellcheck disable=SC2086,SC2046
-scripts/makeupdates --add ui/webui/tmp/rpms/anaconda-*.rpm ui/webui/tmp/rpms/cockpit-*.rpm ui/webui/tmp/rpms/firefox-*.rpm ui/webui/tmp/rpms/dbus-glib-*.rpm
+scripts/makeupdates --add ui/webui/tmp/rpms/anaconda-*.rpm ${ANACONDA_WEBUI_DEPS_RPMS}
 popd


### PR DESCRIPTION
This reverts commit 326cda0817ed2521716db6d1bc3dd90c165bfb23.

This commit that I revert here was hindering reproducability of the updates.img.

We need to get the same version of anaconda-webui dependencies RPMs every time, instead of these randomly/confusingly changing just because a new update passed bodhi.

The build-rpms script will likely be obsolete soon, when anaconda will start building their own ISO files, which will contains the anaconda-webui deps. Till then let's have:

* The dependencies gated
* The downloaded rpms cached

The only downside of the change is that now we need to manually update the versions of the deps, but it's much safer to gate this and the only guarantee for a green CI.

