### PR TITLE
infra: Make it possible to build webui boot.iso by comment

### DIFF
--- a/.github/workflows/build-boot-iso.yml
+++ b/.github/workflows/build-boot-iso.yml
@@ -6,6 +6,8 @@
 # The template is located in: build-boot-iso.yml.j2
 
 # Build a boot.iso from a PR triggered by a "/boot-iso" comment or manually.
+# You can use the --webui option to build a webui boot.iso instead
+
 name: Build boot.iso
 on:
   issue_comment:
@@ -50,6 +52,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Parse arguments
+        id: parse_args
+        # Do not use comment body directly in the shell command to avoid possible code injection.
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          # extract first line and cut out the "/boot-iso" first word
+          ARGS=$(echo "$BODY" | sed -n '1 s/^[^ ]* *//p' | sed 's/[[:space:]]*$//')
+          echo "arguments are: $ARGS"
+          echo "args=${ARGS}" >> $GITHUB_OUTPUT
+
       - name: Set outputs
         id: set_outputs
         run: |
@@ -66,6 +79,7 @@ jobs:
     outputs:
       allowed_user: ${{ steps.set_outputs.outputs.allowed_user }}
       sha: ${{ steps.set_outputs.outputs.sha }}
+      args: ${{ steps.parse_args.outputs.args }}
 
   run:
     needs: pr-info
@@ -116,11 +130,15 @@ jobs:
       - name: Build the boot.iso
         run: |
           mkdir -p images
+          if [[ "${{ needs.pr-info.outputs.args }}" == *"--webui"* ]] ; then
+            WEBUI_OPTIONAL_ARG="--entrypoint /lorax-build-webui"
+          fi
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
           sudo podman run -i --rm --privileged \
             --tmpfs /var/tmp:rw,mode=1777 \
             -v `pwd`/anaconda_rpms:/anaconda-rpms:ro \
             -v `pwd`/images:/images:z \
+            $WEBUI_OPTIONAL_ARG \
             $ISO_BUILD_CONTAINER_NAME:$CONTAINER_TAG
 
       - name: Collect logs

--- a/.github/workflows/build-boot-iso.yml.j2
+++ b/.github/workflows/build-boot-iso.yml.j2
@@ -1,5 +1,7 @@
 {% if distro_release == "rawhide" %}
 # Build a boot.iso from a PR triggered by a "/boot-iso" comment or manually.
+# You can use the --webui option to build a webui boot.iso instead
+
 name: Build boot.iso
 on:
   issue_comment:
@@ -44,6 +46,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Parse arguments
+        id: parse_args
+        # Do not use comment body directly in the shell command to avoid possible code injection.
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          # extract first line and cut out the "/boot-iso" first word
+          ARGS=$(echo "$BODY" | sed -n '1 s/^[^ ]* *//p' | sed 's/[[:space:]]*$//')
+          echo "arguments are: $ARGS"
+          echo "args=${ARGS}" >> $GITHUB_OUTPUT
+
       - name: Set outputs
         id: set_outputs
         run: |
@@ -60,6 +73,7 @@ jobs:
     outputs:
       allowed_user: ${{ steps.set_outputs.outputs.allowed_user }}
       sha: ${{ steps.set_outputs.outputs.sha }}
+      args: ${{ steps.parse_args.outputs.args }}
 
   run:
     needs: pr-info
@@ -110,11 +124,15 @@ jobs:
       - name: Build the boot.iso
         run: |
           mkdir -p images
+          if [[ "${{ needs.pr-info.outputs.args }}" == *"--webui"* ]] ; then
+            WEBUI_OPTIONAL_ARG="--entrypoint /lorax-build-webui"
+          fi
           # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
           sudo podman run -i --rm --privileged \
             --tmpfs /var/tmp:rw,mode=1777 \
             -v `pwd`/anaconda_rpms:/anaconda-rpms:ro \
             -v `pwd`/images:/images:z \
+            $WEBUI_OPTIONAL_ARG \
             $ISO_BUILD_CONTAINER_NAME:$CONTAINER_TAG
 
       - name: Collect logs


### PR DESCRIPTION
This lets us do `/boot-iso --webui`.

Successful runs:
- no params: https://github.com/VladimirSlavik/anaconda/actions/runs/5210514090
- webui: https://github.com/VladimirSlavik/anaconda/actions/runs/5210687543