### PR TITLE
WebUI: Remove centering from loading screen

### DIFF
--- a/ui/webui/src/components/storage/DiskEncryption.jsx
+++ b/ui/webui/src/components/storage/DiskEncryption.jsx
@@ -19,7 +19,6 @@ import cockpit from "cockpit";
 import React, { useState, useEffect } from "react";
 
 import {
-    Bullseye,
     Button,
     Checkbox,
     EmptyState,
@@ -206,19 +205,17 @@ const getRuleLength = (password) => {
 const getRuleConfirmMatches = (password, confirm) => (password.length > 0 ? (password === confirm ? "success" : "error") : "indeterminate");
 
 const CheckDisksSpinner = (
-    <Bullseye>
-        <EmptyState id="installation-destination-next-spinner">
-            <EmptyStateIcon variant="container" component={Spinner} />
-            <Title size="lg" headingLevel="h4">
-                {_("Checking storage configuration")}
-            </Title>
-            <TextContent>
-                <Text component={TextVariants.p}>
-                    {_("This may take a moment")}
-                </Text>
-            </TextContent>
-        </EmptyState>
-    </Bullseye>
+    <EmptyState id="installation-destination-next-spinner">
+        <EmptyStateIcon variant="container" component={Spinner} />
+        <Title size="lg" headingLevel="h4">
+            {_("Checking storage configuration")}
+        </Title>
+        <TextContent>
+            <Text component={TextVariants.p}>
+                {_("This may take a moment")}
+            </Text>
+        </TextContent>
+    </EmptyState>
 );
 
 export const DiskEncryption = ({


### PR DESCRIPTION
Remove centering from the loading screen that appears after finishing installation destination as per [PF design guidelines.](https://www.patternfly.org/v4/components/empty-state/design-guidelines#full-page-empty-states).

![obrazek](https://github.com/rhinstaller/anaconda/assets/40278421/6ff54795-5a44-4ac1-a1b1-ed06a2937a10)
*pardon my French*